### PR TITLE
feat(json): passthrough invalid input instead of erroring

### DIFF
--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -130,6 +130,7 @@ async function main(): Promise<void> {
         .option("-t, --to-toon", "Force conversion to TOON format")
         .option("-j, --to-json", "Force conversion to JSON format")
         .option("-v, --verbose", "Enable verbose logging (shows format detection, size comparison, etc.)")
+        .option("--validate", "Error on invalid JSON/TOON input (default: passthrough)")
         .parse();
 
     const options = program.opts();
@@ -138,6 +139,7 @@ async function main(): Promise<void> {
     const forceToToon = options.toToon || false;
     const forceToJson = options.toJson || false;
     const verbose = options.verbose || false;
+    const validate = options.validate || false;
 
     // Validate flags
     if (forceToToon && forceToJson) {
@@ -159,10 +161,15 @@ async function main(): Promise<void> {
         const detectedFormat = detectFormat(input);
 
         if (detectedFormat === "unknown") {
-            console.error(
-                "Error: Input is neither valid JSON, JSONL, nor TOON format. Please check your input and try again."
-            );
-            process.exit(1);
+            if (validate) {
+                console.error(
+                    "Error: Input is neither valid JSON, JSONL, nor TOON format. Please check your input and try again."
+                );
+                process.exit(1);
+            }
+            // Passthrough: output original input unchanged
+            console.log(input);
+            return;
         }
 
         // Normalize JSONL to JSON array for processing


### PR DESCRIPTION
## Summary
- Invalid JSON/TOON input is now passed through unchanged instead of erroring
- Added `--validate` flag to opt-in to the old strict behavior

## Test plan
- [x] Valid JSON input still converts properly
- [x] Invalid input passes through without error
- [x] `--validate` flag restores strict error behavior