### PR TITLE
feat(github): add get command and dual-backend advanced search

### DIFF
--- a/.claude/plans/2026-02-04-Github-Get.md
+++ b/.claude/plans/2026-02-04-Github-Get.md
@@ -1,0 +1,637 @@
+# GitHub Get Command Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `get` command to the GitHub CLI tool that fetches raw file content from any GitHub file URL
+
+**Architecture:** Parse various GitHub URL formats (blob, blame, raw, etc.), extract owner/repo/path/ref, then fetch content via GitHub API (`/repos/{owner}/{repo}/contents/{path}?ref={ref}`) or raw.githubusercontent.com. Output to stdout, clipboard, or file.
+
+**Tech Stack:** TypeScript, Commander.js, Octokit (existing), Bun runtime
+
+---
+
+## GitHub URL Formats to Support
+
+The command must handle these URL patterns:
+
+| URL Type | Example |
+|----------|---------|
+| Blob (branch) | `https://github.com/owner/repo/blob/main/path/to/file.ts` |
+| Blob (tag) | `https://github.com/owner/repo/blob/v1.0.0/path/to/file.ts` |
+| Blob (commit) | `https://github.com/owner/repo/blob/abc123/path/to/file.ts` |
+| Blame (branch) | `https://github.com/owner/repo/blame/master/package.json` |
+| Blame (tag) | `https://github.com/owner/repo/blame/v3.5.0/package.json` |
+| Raw (branch) | `https://raw.githubusercontent.com/owner/repo/main/file.ts` |
+| Raw (refs/heads) | `https://raw.githubusercontent.com/owner/repo/refs/heads/main/file.ts` |
+| Raw (refs/tags) | `https://raw.githubusercontent.com/owner/repo/refs/tags/v1.0.0/file.ts` |
+| With line numbers | `https://github.com/owner/repo/blob/main/file.ts#L10-L20` |
+
+**All patterns decompose to:** `{ owner, repo, path, ref }`
+
+---
+
+## Task 1: Add URL Parser for File URLs
+
+**Files:**
+- Modify: `src/github/lib/url-parser.ts:15-58`
+- Modify: `src/github/types.ts` (add new type)
+
+**Step 1: Add GitHubFileUrl type to types.ts**
+
+Add after line ~50 in types.ts:
+```typescript
+/**
+ * Parsed GitHub file URL
+ */
+export interface GitHubFileUrl {
+  owner: string;
+  repo: string;
+  path: string;
+  ref: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+```
+
+**Step 2: Add parseGitHubFileUrl function to url-parser.ts**
+
+Add at end of file:
+```typescript
+import type { GitHubFileUrl } from '../types';
+
+/**
+ * Parse a GitHub file URL into its components
+ *
+ * Supported formats:
+ * - https://github.com/owner/repo/blob/ref/path/to/file
+ * - https://github.com/owner/repo/blame/ref/path/to/file
+ * - https://raw.githubusercontent.com/owner/repo/ref/path/to/file
+ * - https://raw.githubusercontent.com/owner/repo/refs/heads/branch/path
+ * - https://raw.githubusercontent.com/owner/repo/refs/tags/tag/path
+ * - All above with optional #L10 or #L10-L20 line references
+ */
+export function parseGitHubFileUrl(input: string): GitHubFileUrl | null {
+  // Extract line numbers if present (e.g., #L10 or #L10-L20)
+  let lineStart: number | undefined;
+  let lineEnd: number | undefined;
+  const lineMatch = input.match(/#L(\d+)(?:-L(\d+))?$/);
+  if (lineMatch) {
+    lineStart = parseInt(lineMatch[1], 10);
+    lineEnd = lineMatch[2] ? parseInt(lineMatch[2], 10) : undefined;
+    input = input.replace(/#L\d+(?:-L\d+)?$/, '');
+  }
+
+  // Pattern 1: github.com blob/blame URLs
+  // https://github.com/owner/repo/blob/ref/path/to/file
+  // https://github.com/owner/repo/blame/ref/path/to/file
+  const githubMatch = input.match(
+    /github\.com\/([^/]+)\/([^/]+)\/(?:blob|blame)\/([^/]+)\/(.+)/
+  );
+  if (githubMatch) {
+    return {
+      owner: githubMatch[1],
+      repo: githubMatch[2],
+      ref: githubMatch[3],
+      path: githubMatch[4],
+      lineStart,
+      lineEnd,
+    };
+  }
+
+  // Pattern 2: raw.githubusercontent.com with refs/heads or refs/tags
+  // https://raw.githubusercontent.com/owner/repo/refs/heads/branch/path
+  // https://raw.githubusercontent.com/owner/repo/refs/tags/tag/path
+  const rawRefsMatch = input.match(
+    /raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/refs\/(heads|tags)\/([^/]+)\/(.+)/
+  );
+  if (rawRefsMatch) {
+    return {
+      owner: rawRefsMatch[1],
+      repo: rawRefsMatch[2],
+      ref: rawRefsMatch[4], // branch or tag name
+      path: rawRefsMatch[5],
+      lineStart,
+      lineEnd,
+    };
+  }
+
+  // Pattern 3: raw.githubusercontent.com simple format
+  // https://raw.githubusercontent.com/owner/repo/ref/path/to/file
+  const rawSimpleMatch = input.match(
+    /raw\.githubusercontent\.com\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)/
+  );
+  if (rawSimpleMatch) {
+    return {
+      owner: rawSimpleMatch[1],
+      repo: rawSimpleMatch[2],
+      ref: rawSimpleMatch[3],
+      path: rawSimpleMatch[4],
+      lineStart,
+      lineEnd,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build raw.githubusercontent.com URL from components
+ */
+export function buildRawGitHubUrl(owner: string, repo: string, ref: string, path: string): string {
+  return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`;
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/github/types.ts src/github/lib/url-parser.ts
+git commit -m "feat(github): add file URL parser for blob/blame/raw URLs"
+```
+
+---
+
+## Task 2: Create the Get Command
+
+**Files:**
+- Create: `src/github/commands/get.ts`
+
+**Step 1: Create get.ts command file**
+
+```typescript
+// Get file content command implementation
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import clipboardy from 'clipboardy';
+import { getOctokit } from '@app/github/lib/octokit';
+import { withRetry } from '@app/github/lib/rate-limit';
+import { parseGitHubFileUrl, buildRawGitHubUrl } from '@app/github/lib/url-parser';
+import { verbose, setGlobalVerbose } from '@app/github/lib/utils';
+import logger from '@app/logger';
+
+interface GetOptions {
+  ref?: string;
+  output?: string;
+  clipboard?: boolean;
+  lines?: string;
+  raw?: boolean;
+  verbose?: boolean;
+}
+
+interface FileContent {
+  content: string;
+  path: string;
+  ref: string;
+  size: number;
+  sha: string;
+  url: string;
+}
+
+/**
+ * Fetch file content from GitHub
+ */
+async function fetchFileContent(
+  owner: string,
+  repo: string,
+  path: string,
+  ref: string,
+  useRaw: boolean
+): Promise<FileContent> {
+  if (useRaw) {
+    // Fetch via raw.githubusercontent.com (faster, no base64 decoding)
+    const rawUrl = buildRawGitHubUrl(owner, repo, ref, path);
+    verbose({ verbose: true }, `Fetching from: ${rawUrl}`);
+
+    const response = await fetch(rawUrl);
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`File not found: ${path} at ref ${ref}`);
+      }
+      throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
+    }
+
+    const content = await response.text();
+    return {
+      content,
+      path,
+      ref,
+      size: content.length,
+      sha: '', // Not available from raw URL
+      url: `https://github.com/${owner}/${repo}/blob/${ref}/${path}`,
+    };
+  }
+
+  // Fetch via GitHub API (includes metadata, handles larger files)
+  const octokit = getOctokit();
+
+  verbose({ verbose: true }, `Fetching via API: ${owner}/${repo}/${path}@${ref}`);
+
+  const { data } = await withRetry(
+    () =>
+      octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path,
+        ref,
+      }),
+    { label: `GET /repos/${owner}/${repo}/contents/${path}` }
+  );
+
+  // Handle directory response
+  if (Array.isArray(data)) {
+    throw new Error(`Path is a directory, not a file: ${path}`);
+  }
+
+  // Handle file response
+  if (data.type !== 'file') {
+    throw new Error(`Unexpected content type: ${data.type}`);
+  }
+
+  // Decode base64 content
+  const content = Buffer.from(data.content, 'base64').toString('utf-8');
+
+  return {
+    content,
+    path: data.path,
+    ref,
+    size: data.size,
+    sha: data.sha,
+    url: data.html_url || `https://github.com/${owner}/${repo}/blob/${ref}/${path}`,
+  };
+}
+
+/**
+ * Extract specific lines from content
+ */
+function extractLines(content: string, lineStart?: number, lineEnd?: number): string {
+  if (!lineStart) {
+    return content;
+  }
+
+  const lines = content.split('\n');
+  const start = Math.max(0, lineStart - 1); // Convert to 0-indexed
+  const end = lineEnd ? Math.min(lines.length, lineEnd) : lineStart;
+
+  return lines.slice(start, end).join('\n');
+}
+
+/**
+ * Format output with optional metadata header
+ */
+function formatOutput(file: FileContent, content: string, showHeader: boolean): string {
+  if (!showHeader) {
+    return content;
+  }
+
+  const lines = [
+    `# ${file.path}`,
+    `# URL: ${file.url}`,
+    `# Ref: ${file.ref}`,
+    file.sha ? `# SHA: ${file.sha}` : null,
+    `# Size: ${file.size} bytes`,
+    '',
+    content,
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}
+
+export async function getCommand(
+  input: string,
+  options: GetOptions
+): Promise<void> {
+  if (options.verbose) {
+    setGlobalVerbose(true);
+  }
+
+  // Parse URL
+  const parsed = parseGitHubFileUrl(input);
+  if (!parsed) {
+    console.error(chalk.red('Invalid GitHub file URL.'));
+    console.error(chalk.dim('\nSupported formats:'));
+    console.error(chalk.dim('  https://github.com/owner/repo/blob/branch/path/to/file'));
+    console.error(chalk.dim('  https://github.com/owner/repo/blame/tag/path/to/file'));
+    console.error(chalk.dim('  https://raw.githubusercontent.com/owner/repo/ref/path'));
+    console.error(chalk.dim('  Any of the above with #L10 or #L10-L20 line references'));
+    process.exit(1);
+  }
+
+  // Override ref if provided via option
+  const ref = options.ref || parsed.ref;
+
+  // Parse line range from --lines option if provided
+  let lineStart = parsed.lineStart;
+  let lineEnd = parsed.lineEnd;
+
+  if (options.lines) {
+    const lineMatch = options.lines.match(/^(\d+)(?:-(\d+))?$/);
+    if (lineMatch) {
+      lineStart = parseInt(lineMatch[1], 10);
+      lineEnd = lineMatch[2] ? parseInt(lineMatch[2], 10) : undefined;
+    } else {
+      console.error(chalk.red('Invalid --lines format. Use: 10 or 10-20'));
+      process.exit(1);
+    }
+  }
+
+  verbose(options, `Parsed: ${parsed.owner}/${parsed.repo}/${parsed.path}@${ref}`);
+  if (lineStart) {
+    verbose(options, `Lines: ${lineStart}${lineEnd ? `-${lineEnd}` : ''}`);
+  }
+
+  try {
+    // Fetch file content
+    const file = await fetchFileContent(
+      parsed.owner,
+      parsed.repo,
+      parsed.path,
+      ref,
+      options.raw ?? false
+    );
+
+    // Extract lines if specified
+    let content = extractLines(file.content, lineStart, lineEnd);
+
+    // Output
+    if (options.clipboard) {
+      await clipboardy.write(content);
+      console.log(chalk.green(`✔ Copied ${file.path} to clipboard`));
+      if (lineStart) {
+        console.log(chalk.dim(`  Lines: ${lineStart}${lineEnd ? `-${lineEnd}` : ''}`));
+      }
+    } else if (options.output) {
+      await Bun.write(options.output, content);
+      console.log(chalk.green(`✔ Written to ${options.output}`));
+    } else {
+      // Output to stdout
+      console.log(content);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(chalk.red(`Error: ${message}`));
+    process.exit(1);
+  }
+}
+
+export function createGetCommand(): Command {
+  const cmd = new Command('get')
+    .description('Get file content from a GitHub URL')
+    .argument('<url>', 'GitHub file URL (blob, blame, or raw)')
+    .option('-r, --ref <ref>', 'Override branch/tag/commit ref')
+    .option('-l, --lines <range>', 'Line range (e.g., 10 or 10-20)')
+    .option('-o, --output <file>', 'Write to file')
+    .option('-c, --clipboard', 'Copy to clipboard')
+    .option('--raw', 'Fetch via raw.githubusercontent.com (faster, less metadata)')
+    .option('-v, --verbose', 'Enable verbose logging')
+    .addHelpText('after', `
+Examples:
+  # Get file from blob URL
+  tools github get https://github.com/owner/repo/blob/main/package.json
+
+  # Get specific lines
+  tools github get https://github.com/owner/repo/blob/main/src/index.ts --lines 10-50
+
+  # Get from blame URL (same content, different source)
+  tools github get https://github.com/owner/repo/blame/v1.0.0/README.md
+
+  # Get from raw URL
+  tools github get https://raw.githubusercontent.com/owner/repo/main/data.json
+
+  # Override ref to get different version
+  tools github get https://github.com/owner/repo/blob/main/file.ts --ref v2.0.0
+
+  # Copy to clipboard
+  tools github get https://github.com/owner/repo/blob/main/file.ts -c
+
+  # Use URL with line references
+  tools github get "https://github.com/owner/repo/blob/main/file.ts#L10-L20"
+`)
+    .action(async (url, opts) => {
+      try {
+        await getCommand(url, opts);
+      } catch (error) {
+        logger.error({ error }, 'Get command failed');
+        console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/github/commands/get.ts
+git commit -m "feat(github): add get command for fetching file content"
+```
+
+---
+
+## Task 3: Register the Get Command
+
+**Files:**
+- Modify: `src/github/index.ts:7-29`
+
+**Step 1: Add import for get command**
+
+After line 11, add:
+```typescript
+import { createGetCommand, getCommand } from '@app/github/commands/get';
+```
+
+**Step 2: Register the command**
+
+After line 29 (after `createCodeSearchCommand()`), add:
+```typescript
+program.addCommand(createGetCommand());
+```
+
+**Step 3: Add to interactive mode**
+
+In the `interactiveMode` function, add a new choice. After line 89 (the 'search' choice), add:
+```typescript
+          { value: 'get', name: '📄 Get File Content' },
+```
+
+And add handler after the search action handling (around line 149), add:
+```typescript
+      if (action === 'get') {
+        const fileUrl = await input({
+          message: 'Enter GitHub file URL:',
+        });
+
+        if (!fileUrl.trim()) {
+          console.log(chalk.yellow('No URL provided.'));
+          continue;
+        }
+
+        const toClipboard = await confirm({
+          message: 'Copy to clipboard?',
+          default: false,
+        });
+
+        await getCommand(fileUrl, { clipboard: toClipboard });
+        continue;
+      }
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/github/index.ts
+git commit -m "feat(github): register get command in CLI"
+```
+
+---
+
+## Task 4: Update the Skill Documentation
+
+**Files:**
+- Modify: `plugins/genesis-tools/skills/github/SKILL.md`
+
+**Step 1: Add Get command section to Quick Reference table**
+
+After the "Check auth status" row, add:
+```markdown
+| Get file content | `tools github get <file-url>` |
+| Get specific lines | `tools github get <file-url> --lines 10-50` |
+| Get file to clipboard | `tools github get <file-url> -c` |
+```
+
+**Step 2: Add new section after URL Parsing section**
+
+After the "URL Parsing" section (around line 39), add:
+```markdown
+## Get File Content
+
+Fetch raw file content from any GitHub file URL.
+
+### Supported URL Formats
+- `https://github.com/owner/repo/blob/branch/path/to/file`
+- `https://github.com/owner/repo/blob/tag/path/to/file`
+- `https://github.com/owner/repo/blob/commit/path/to/file`
+- `https://github.com/owner/repo/blame/ref/path/to/file`
+- `https://raw.githubusercontent.com/owner/repo/ref/path/to/file`
+- `https://raw.githubusercontent.com/owner/repo/refs/heads/branch/path`
+- `https://raw.githubusercontent.com/owner/repo/refs/tags/tag/path`
+- All above with `#L10` or `#L10-L20` line references
+
+### Examples
+```bash
+# Get file from blob URL
+tools github get https://github.com/facebook/react/blob/main/package.json
+
+# Get specific lines from a file
+tools github get https://github.com/owner/repo/blob/main/src/index.ts --lines 10-50
+
+# Get file from blame URL
+tools github get https://github.com/owner/repo/blame/v1.0.0/README.md
+
+# Get file from raw URL
+tools github get https://raw.githubusercontent.com/owner/repo/main/data.json
+
+# Override the ref to get a different version
+tools github get https://github.com/owner/repo/blob/main/file.ts --ref v2.0.0
+
+# Copy to clipboard instead of stdout
+tools github get https://github.com/owner/repo/blob/main/file.ts -c
+
+# URL with line references (quotes needed for shell)
+tools github get "https://github.com/owner/repo/blob/main/file.ts#L10-L20"
+
+# Faster fetch via raw URL (skips API, less metadata)
+tools github get https://github.com/owner/repo/blob/main/file.ts --raw
+```
+```
+
+**Step 3: Add Get Command section in CLI Options**
+
+After the Search Command section (around line 226), add:
+```markdown
+### Get Command
+```
+tools github get <url> [options]
+
+Options:
+  -r, --ref <ref>         Override branch/tag/commit ref
+  -l, --lines <range>     Line range (e.g., 10 or 10-20)
+  -o, --output <file>     Write to file
+  -c, --clipboard         Copy to clipboard
+  --raw                   Fetch via raw.githubusercontent.com (faster)
+  -v, --verbose           Enable verbose logging
+```
+```
+
+**Step 4: Commit**
+
+```bash
+git add plugins/genesis-tools/skills/github/SKILL.md
+git commit -m "docs(github): add get command documentation"
+```
+
+---
+
+## Task 5: Test the Implementation
+
+**Step 1: Test blob URL parsing**
+
+```bash
+tools github get https://github.com/grigorii-horos/cli-markdown/blob/master/package.json
+```
+
+Expected: File content output to stdout
+
+**Step 2: Test blame URL parsing**
+
+```bash
+tools github get https://github.com/grigorii-horos/cli-markdown/blame/master/package.json
+```
+
+Expected: Same file content (blame URL converted correctly)
+
+**Step 3: Test raw URL parsing**
+
+```bash
+tools github get https://raw.githubusercontent.com/grigorii-horos/cli-markdown/refs/heads/master/package.json
+```
+
+Expected: File content from raw URL
+
+**Step 4: Test line extraction**
+
+```bash
+tools github get "https://github.com/grigorii-horos/cli-markdown/blob/master/package.json#L1-L5"
+```
+
+Expected: Only first 5 lines
+
+**Step 5: Test clipboard output**
+
+```bash
+tools github get https://github.com/grigorii-horos/cli-markdown/blob/master/package.json -c
+```
+
+Expected: Content copied to clipboard, confirmation message
+
+**Step 6: Test ref override**
+
+```bash
+tools github get https://github.com/facebook/react/blob/main/package.json --ref v18.2.0
+```
+
+Expected: package.json from v18.2.0 tag, not main
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Add URL parser | `types.ts`, `url-parser.ts` |
+| 2 | Create get command | `commands/get.ts` |
+| 3 | Register command | `index.ts` |
+| 4 | Update docs | `SKILL.md` |
+| 5 | Test | Manual testing |

--- a/plugins/genesis-tools/skills/github/SKILL.md
+++ b/plugins/genesis-tools/skills/github/SKILL.md
@@ -26,6 +26,9 @@ Search, fetch, and analyze GitHub issues, PRs, and comments with caching.
 | Search issues | `tools github search "error" --repo owner/repo --state open` |
 | Get PR with review comments | `tools github pr <url> --review-comments` |
 | Check auth status | `tools github status` |
+| Get file content | `tools github get <file-url>` |
+| Get specific lines | `tools github get <file-url> --lines 10-50` |
+| Get file to clipboard | `tools github get <file-url> -c` |
 
 ## URL Parsing
 
@@ -37,6 +40,47 @@ The tool automatically parses these URL formats:
 - `#123` or `123` (when in a git repo)
 
 When user provides a URL with `#issuecomment-XXX`, use `--since XXX` to fetch from that point.
+
+## Get File Content
+
+Fetch raw file content from any GitHub file URL.
+
+### Supported URL Formats
+- `https://github.com/owner/repo/blob/branch/path/to/file`
+- `https://github.com/owner/repo/blob/tag/path/to/file`
+- `https://github.com/owner/repo/blob/commit/path/to/file`
+- `https://github.com/owner/repo/blame/ref/path/to/file`
+- `https://raw.githubusercontent.com/owner/repo/ref/path/to/file`
+- `https://raw.githubusercontent.com/owner/repo/refs/heads/branch/path`
+- `https://raw.githubusercontent.com/owner/repo/refs/tags/tag/path`
+- All above with `#L10` or `#L10-L20` line references
+
+### Examples
+```bash
+# Get file from blob URL
+tools github get https://github.com/facebook/react/blob/main/package.json
+
+# Get specific lines from a file
+tools github get https://github.com/owner/repo/blob/main/src/index.ts --lines 10-50
+
+# Get file from blame URL
+tools github get https://github.com/owner/repo/blame/v1.0.0/README.md
+
+# Get file from raw URL
+tools github get https://raw.githubusercontent.com/owner/repo/main/data.json
+
+# Override the ref to get a different version
+tools github get https://github.com/owner/repo/blob/main/file.ts --ref v2.0.0
+
+# Copy to clipboard instead of stdout
+tools github get https://github.com/owner/repo/blob/main/file.ts -c
+
+# URL with line references (quotes needed for shell)
+tools github get "https://github.com/owner/repo/blob/main/file.ts#L10-L20"
+
+# Faster fetch via raw URL (skips API, less metadata)
+tools github get https://github.com/owner/repo/blob/main/file.ts --raw
+```
 
 ## Common Use Cases
 
@@ -223,6 +267,19 @@ Options:
   --sort <field>            Sort: created|updated|comments|reactions
   -L, --limit <n>           Max results (default: 30)
   -f, --format <format>     Output format
+```
+
+### Get Command
+```
+tools github get <url> [options]
+
+Options:
+  -r, --ref <ref>         Override branch/tag/commit ref
+  -l, --lines <range>     Line range (e.g., 10 or 10-20)
+  -o, --output <file>     Write to file
+  -c, --clipboard         Copy to clipboard
+  --raw                   Fetch via raw.githubusercontent.com (faster)
+  -v, --verbose           Enable verbose logging
 ```
 
 ## Interactive Mode

--- a/src/github/commands/code-search.ts
+++ b/src/github/commands/code-search.ts
@@ -56,6 +56,9 @@ async function searchCode(
       octokit.rest.search.code({
         q: searchQuery,
         per_page: options.limit || 30,
+        headers: {
+          accept: 'application/vnd.github.text-match+json',
+        },
       }),
     { label: `GET /search/code?q=${encodeURIComponent(searchQuery.slice(0, 50))}...` }
   );

--- a/src/github/commands/get.ts
+++ b/src/github/commands/get.ts
@@ -1,0 +1,239 @@
+// Get file content command implementation
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import clipboardy from 'clipboardy';
+import { getOctokit } from '@app/github/lib/octokit';
+import { withRetry } from '@app/github/lib/rate-limit';
+import { parseGitHubFileUrl, buildRawGitHubUrl } from '@app/github/lib/url-parser';
+import { verbose, setGlobalVerbose } from '@app/github/lib/utils';
+import logger from '@app/logger';
+
+interface GetOptions {
+  ref?: string;
+  output?: string;
+  clipboard?: boolean;
+  lines?: string;
+  raw?: boolean;
+  verbose?: boolean;
+}
+
+interface FileContent {
+  content: string;
+  path: string;
+  ref: string;
+  size: number;
+  sha: string;
+  url: string;
+}
+
+/**
+ * Fetch file content from GitHub
+ */
+async function fetchFileContent(
+  owner: string,
+  repo: string,
+  path: string,
+  ref: string,
+  useRaw: boolean
+): Promise<FileContent> {
+  if (useRaw) {
+    // Fetch via raw.githubusercontent.com (faster, no base64 decoding)
+    const rawUrl = buildRawGitHubUrl(owner, repo, ref, path);
+    verbose({ verbose: true }, `Fetching from: ${rawUrl}`);
+
+    const response = await fetch(rawUrl);
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`File not found: ${path} at ref ${ref}`);
+      }
+      throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
+    }
+
+    const content = await response.text();
+    return {
+      content,
+      path,
+      ref,
+      size: content.length,
+      sha: '', // Not available from raw URL
+      url: `https://github.com/${owner}/${repo}/blob/${ref}/${path}`,
+    };
+  }
+
+  // Fetch via GitHub API (includes metadata, handles larger files)
+  const octokit = getOctokit();
+
+  verbose({ verbose: true }, `Fetching via API: ${owner}/${repo}/${path}@${ref}`);
+
+  const { data } = await withRetry(
+    () =>
+      octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path,
+        ref,
+      }),
+    { label: `GET /repos/${owner}/${repo}/contents/${path}` }
+  );
+
+  // Handle directory response
+  if (Array.isArray(data)) {
+    throw new Error(`Path is a directory, not a file: ${path}`);
+  }
+
+  // Handle file response
+  if (data.type !== 'file') {
+    throw new Error(`Unexpected content type: ${data.type}`);
+  }
+
+  // Decode base64 content
+  const content = Buffer.from(data.content, 'base64').toString('utf-8');
+
+  return {
+    content,
+    path: data.path,
+    ref,
+    size: data.size,
+    sha: data.sha,
+    url: data.html_url || `https://github.com/${owner}/${repo}/blob/${ref}/${path}`,
+  };
+}
+
+/**
+ * Extract specific lines from content
+ */
+function extractLines(content: string, lineStart?: number, lineEnd?: number): string {
+  if (!lineStart) {
+    return content;
+  }
+
+  const lines = content.split('\n');
+  const start = Math.max(0, lineStart - 1); // Convert to 0-indexed
+  const end = lineEnd ? Math.min(lines.length, lineEnd) : lineStart;
+
+  return lines.slice(start, end).join('\n');
+}
+
+export async function getCommand(
+  input: string,
+  options: GetOptions
+): Promise<void> {
+  if (options.verbose) {
+    setGlobalVerbose(true);
+  }
+
+  // Parse URL
+  const parsed = parseGitHubFileUrl(input);
+  if (!parsed) {
+    console.error(chalk.red('Invalid GitHub file URL.'));
+    console.error(chalk.dim('\nSupported formats:'));
+    console.error(chalk.dim('  https://github.com/owner/repo/blob/branch/path/to/file'));
+    console.error(chalk.dim('  https://github.com/owner/repo/blame/tag/path/to/file'));
+    console.error(chalk.dim('  https://raw.githubusercontent.com/owner/repo/ref/path'));
+    console.error(chalk.dim('  Any of the above with #L10 or #L10-L20 line references'));
+    process.exit(1);
+  }
+
+  // Override ref if provided via option
+  const ref = options.ref || parsed.ref;
+
+  // Parse line range from --lines option if provided
+  let lineStart = parsed.lineStart;
+  let lineEnd = parsed.lineEnd;
+
+  if (options.lines) {
+    const lineMatch = options.lines.match(/^(\d+)(?:-(\d+))?$/);
+    if (lineMatch) {
+      lineStart = parseInt(lineMatch[1], 10);
+      lineEnd = lineMatch[2] ? parseInt(lineMatch[2], 10) : undefined;
+    } else {
+      console.error(chalk.red('Invalid --lines format. Use: 10 or 10-20'));
+      process.exit(1);
+    }
+  }
+
+  verbose(options, `Parsed: ${parsed.owner}/${parsed.repo}/${parsed.path}@${ref}`);
+  if (lineStart) {
+    verbose(options, `Lines: ${lineStart}${lineEnd ? `-${lineEnd}` : ''}`);
+  }
+
+  try {
+    // Fetch file content
+    const file = await fetchFileContent(
+      parsed.owner,
+      parsed.repo,
+      parsed.path,
+      ref,
+      options.raw ?? false
+    );
+
+    // Extract lines if specified
+    const content = extractLines(file.content, lineStart, lineEnd);
+
+    // Output
+    if (options.clipboard) {
+      await clipboardy.write(content);
+      console.log(chalk.green(`✔ Copied ${file.path} to clipboard`));
+      if (lineStart) {
+        console.log(chalk.dim(`  Lines: ${lineStart}${lineEnd ? `-${lineEnd}` : ''}`));
+      }
+    } else if (options.output) {
+      await Bun.write(options.output, content);
+      console.log(chalk.green(`✔ Written to ${options.output}`));
+    } else {
+      // Output to stdout
+      console.log(content);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(chalk.red(`Error: ${message}`));
+    process.exit(1);
+  }
+}
+
+export function createGetCommand(): Command {
+  const cmd = new Command('get')
+    .description('Get file content from a GitHub URL')
+    .argument('<url>', 'GitHub file URL (blob, blame, or raw)')
+    .option('-r, --ref <ref>', 'Override branch/tag/commit ref')
+    .option('-l, --lines <range>', 'Line range (e.g., 10 or 10-20)')
+    .option('-o, --output <file>', 'Write to file')
+    .option('-c, --clipboard', 'Copy to clipboard')
+    .option('--raw', 'Fetch via raw.githubusercontent.com (faster, less metadata)')
+    .option('-v, --verbose', 'Enable verbose logging')
+    .addHelpText('after', `
+Examples:
+  # Get file from blob URL
+  tools github get https://github.com/owner/repo/blob/main/package.json
+
+  # Get specific lines
+  tools github get https://github.com/owner/repo/blob/main/src/index.ts --lines 10-50
+
+  # Get from blame URL (same content, different source)
+  tools github get https://github.com/owner/repo/blame/v1.0.0/README.md
+
+  # Get from raw URL
+  tools github get https://raw.githubusercontent.com/owner/repo/main/data.json
+
+  # Override ref to get different version
+  tools github get https://github.com/owner/repo/blob/main/file.ts --ref v2.0.0
+
+  # Copy to clipboard
+  tools github get https://github.com/owner/repo/blob/main/file.ts -c
+
+  # Use URL with line references
+  tools github get "https://github.com/owner/repo/blob/main/file.ts#L10-L20"
+`)
+    .action(async (url, opts) => {
+      try {
+        await getCommand(url, opts);
+      } catch (error) {
+        logger.error({ error }, 'Get command failed');
+        console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}

--- a/src/github/commands/search.ts
+++ b/src/github/commands/search.ts
@@ -33,18 +33,11 @@ function extractRepoFromUrl(url: string): string {
 }
 
 /**
- * Search issues and PRs
+ * Build base query with repo and state filters (shared by both backends)
  */
-async function searchGitHub(
-  query: string,
-  options: SearchCommandOptions
-): Promise<SearchResult[]> {
-  const octokit = getOctokit();
-
-  // Build search query
+function buildBaseQuery(query: string, options: SearchCommandOptions): string {
   let searchQuery = query;
 
-  // Add repo filter
   if (options.repo) {
     const parsed = parseRepo(options.repo);
     if (parsed) {
@@ -52,24 +45,55 @@ async function searchGitHub(
     }
   }
 
-  // Add type filter - REQUIRED by GitHub API
-  if (options.type === 'issue') {
-    searchQuery += ' is:issue';
-  } else if (options.type === 'pr') {
-    searchQuery += ' is:pr';
-  } else {
-    // Default: search both issues and PRs (API requires at least one)
-    searchQuery += ' is:issue is:pr';
-  }
-
-  // Add state filter
   if (options.state === 'open') {
     searchQuery += ' is:open';
   } else if (options.state === 'closed') {
     searchQuery += ' is:closed';
   }
 
-  console.log(chalk.dim(`Searching: ${searchQuery}`));
+  return searchQuery;
+}
+
+/**
+ * Map API response items to SearchResult
+ */
+function mapItems(items: GitHubSearchItem[], source: 'advanced' | 'legacy'): SearchResult[] {
+  return items.map((item) => ({
+    type: item.pull_request ? 'pr' as const : 'issue' as const,
+    number: item.number,
+    title: item.title,
+    state: item.state,
+    author: item.user?.login || 'unknown',
+    createdAt: item.created_at,
+    updatedAt: item.updated_at,
+    comments: item.comments,
+    reactions: item.reactions?.total_count || 0,
+    repo: extractRepoFromUrl(item.repository_url),
+    url: item.html_url,
+    source,
+  }));
+}
+
+/**
+ * Search using legacy backend (current behavior)
+ */
+async function searchLegacy(
+  query: string,
+  options: SearchCommandOptions
+): Promise<SearchResult[]> {
+  const octokit = getOctokit();
+  let searchQuery = buildBaseQuery(query, options);
+
+  // Legacy uses is: for type filtering
+  if (options.type === 'issue') {
+    searchQuery += ' is:issue';
+  } else if (options.type === 'pr') {
+    searchQuery += ' is:pr';
+  } else {
+    searchQuery += ' is:issue is:pr';
+  }
+
+  console.log(chalk.dim(`Searching (legacy): ${searchQuery}`));
 
   const { data } = await withRetry(
     () =>
@@ -82,19 +106,87 @@ async function searchGitHub(
     { label: `GET /search/issues?q=${encodeURIComponent(searchQuery.slice(0, 50))}...` }
   );
 
-  return data.items.map((item: GitHubSearchItem) => ({
-    type: item.pull_request ? 'pr' as const : 'issue' as const,
-    number: item.number,
-    title: item.title,
-    state: item.state,
-    author: item.user?.login || 'unknown',
-    createdAt: item.created_at,
-    updatedAt: item.updated_at,
-    comments: item.comments,
-    reactions: item.reactions?.total_count || 0,
-    repo: extractRepoFromUrl(item.repository_url),
-    url: item.html_url,
-  }));
+  return mapItems(data.items as GitHubSearchItem[], 'legacy');
+}
+
+/**
+ * Search using advanced backend (advanced_search=true, type: qualifiers)
+ * See: gh CLI PR #11638
+ */
+async function searchAdvanced(
+  query: string,
+  options: SearchCommandOptions
+): Promise<SearchResult[]> {
+  const octokit = getOctokit();
+  let searchQuery = buildBaseQuery(query, options);
+
+  // Advanced uses type: instead of is: for issue/pr filtering
+  if (options.type === 'issue') {
+    searchQuery += ' type:issue';
+  } else if (options.type === 'pr') {
+    searchQuery += ' type:pr';
+  } else {
+    searchQuery += ' type:issue type:pr';
+  }
+
+  console.log(chalk.dim(`Searching (advanced): ${searchQuery}`));
+
+  const { data } = await withRetry(
+    () =>
+      octokit.request('GET /search/issues', {
+        q: searchQuery,
+        sort: (options.sort || undefined) as 'comments' | 'reactions' | 'interactions' | 'created' | 'updated' | undefined,
+        order: 'desc' as const,
+        per_page: options.limit || 30,
+        advanced_search: 'true',
+      }),
+    { label: `GET /search/issues?advanced_search=true&q=${encodeURIComponent(searchQuery.slice(0, 50))}...` }
+  );
+
+  return mapItems(data.items as GitHubSearchItem[], 'advanced');
+}
+
+interface MergeResult {
+  results: SearchResult[];
+  duplicates: Array<{ repo: string; number: number }>;
+  advancedCount: number;
+  legacyCount: number;
+}
+
+/**
+ * Merge results from both backends and deduplicate by repo#number.
+ * Advanced results take priority in ordering.
+ */
+function mergeAndDeduplicate(
+  advancedResults: SearchResult[],
+  legacyResults: SearchResult[],
+): MergeResult {
+  const seen = new Map<string, SearchResult>();
+  const duplicates: Array<{ repo: string; number: number }> = [];
+
+  // Advanced results first (newer backend, potentially better ranking)
+  for (const r of advancedResults) {
+    const key = `${r.repo}#${r.number}`;
+    seen.set(key, { ...r, source: 'advanced' });
+  }
+
+  for (const r of legacyResults) {
+    const key = `${r.repo}#${r.number}`;
+    const existing = seen.get(key);
+    if (existing) {
+      existing.source = 'both';
+      duplicates.push({ repo: r.repo, number: r.number });
+    } else {
+      seen.set(key, { ...r, source: 'legacy' });
+    }
+  }
+
+  return {
+    results: [...seen.values()],
+    duplicates,
+    advancedCount: advancedResults.length,
+    legacyCount: legacyResults.length,
+  };
 }
 
 /**
@@ -112,7 +204,35 @@ export async function searchCommand(
   verbose(options, `Search query: ${query}`);
   verbose(options, `Options: type=${options.type || 'all'}, repo=${options.repo || 'any'}, state=${options.state || 'all'}`);
 
-  const results = await searchGitHub(query, options);
+  // Determine which backends to run
+  const runAdvanced = options.advanced || (!options.advanced && !options.legacy);
+  const runLegacy = options.legacy || (!options.advanced && !options.legacy);
+
+  let results: SearchResult[];
+  let footer = '';
+
+  if (runAdvanced && runLegacy) {
+    // Run BOTH in parallel, then merge & deduplicate
+    const [advancedResults, legacyResults] = await Promise.all([
+      searchAdvanced(query, options),
+      searchLegacy(query, options),
+    ]);
+    const merged = mergeAndDeduplicate(advancedResults, legacyResults);
+    results = merged.results;
+
+    const parts: string[] = [];
+    parts.push(`Advanced: ${merged.advancedCount}, Legacy: ${merged.legacyCount}, Combined: ${results.length}`);
+    if (merged.duplicates.length > 0) {
+      const dedupIds = merged.duplicates.map(d => `#${d.number}`).join(', ');
+      parts.push(`Deduplicated (${merged.duplicates.length}): ${dedupIds}`);
+    }
+    footer = parts.join('\n');
+  } else if (runAdvanced) {
+    results = await searchAdvanced(query, options);
+  } else {
+    results = await searchLegacy(query, options);
+  }
+
   verbose(options, `Found ${results.length} results`);
 
   if (results.length === 0) {
@@ -131,6 +251,11 @@ export async function searchCommand(
   } else {
     console.log(output);
   }
+
+  if (footer) {
+    console.log(chalk.dim(`\n${footer}`));
+  }
+
   verbose(options, `Completed: ${results.length} results displayed`);
 }
 
@@ -147,6 +272,8 @@ export function createSearchCommand(): Command {
     .option('--sort <field>', 'Sort: created|updated|comments|reactions')
     .option('-L, --limit <n>', 'Max results', parseInt, 30)
     .option('-f, --format <format>', 'Output format: ai|md|json', 'ai')
+    .option('--advanced', 'Use only advanced search backend')
+    .option('--legacy', 'Use only legacy search backend')
     .option('-o, --output <file>', 'Output path')
     .option('-v, --verbose', 'Enable verbose logging')
     .action(async (query, opts) => {

--- a/src/github/docs/github-search-api.md
+++ b/src/github/docs/github-search-api.md
@@ -1,0 +1,92 @@
+# GitHub Search REST API Reference
+
+## Endpoints
+
+### Issue & PR Search (`GET /search/issues`)
+
+Search issues and pull requests across repositories.
+
+**Rate limit:** 30 requests/min (authenticated), 10/min (unauthenticated)
+
+**Max results:** 1000 total, 100 per page
+
+#### Query Qualifiers
+
+| Qualifier | Example | Description |
+|-----------|---------|-------------|
+| `is:issue` / `is:pr` | `is:issue` | Filter by type (legacy) |
+| `type:issue` / `type:pr` | `type:issue` | Filter by type (advanced) |
+| `is:open` / `is:closed` | `is:open` | Filter by state |
+| `repo:owner/name` | `repo:expo/expo` | Limit to repository |
+| `org:name` | `org:facebook` | Limit to organization |
+| `author:user` | `author:brentvatne` | Filter by author |
+| `assignee:user` | `assignee:me` | Filter by assignee |
+| `label:name` | `label:bug` | Filter by label |
+| `milestone:title` | `milestone:"v1.0"` | Filter by milestone |
+| `in:title,body,comments` | `in:title` | Where to search |
+
+#### Sort Options
+
+`created`, `updated`, `comments`, `reactions`, `interactions`
+
+Order: `asc` or `desc` (default: `desc`)
+
+#### Advanced Search (`advanced_search=true`)
+
+Append `advanced_search=true` as a **query parameter** (not in the `q` string) to activate the newer search backend.
+
+**Key differences:**
+- Uses `type:issue`/`type:pr` instead of `is:issue`/`is:pr`
+- Supports `OR` operators: `(repo:cli/cli OR repo:cli/go-gh)`
+- Supports grouped qualifiers: `(is:open OR is:closed)`
+- Better relevance ranking for natural language queries
+- Only for issues/PRs, NOT code search
+
+**Reference:** gh CLI PR [#11638](https://github.com/cli/cli/pull/11638) (merged Sept 2025)
+
+### Code Search (`GET /search/code`)
+
+Search code content in repositories.
+
+**Rate limit:** 10 requests/min (most restrictive)
+
+**Max results:** 1000 total, 100 per page
+
+#### Query Qualifiers
+
+| Qualifier | Example | Description |
+|-----------|---------|-------------|
+| `repo:owner/name` | `repo:facebook/react` | Limit to repository |
+| `path:glob` | `path:src/**/*.ts` | Filter by file path |
+| `language:lang` | `language:typescript` | Filter by language |
+| `extension:ext` | `extension:json` | Filter by extension |
+| `filename:name` | `filename:package.json` | Filter by filename |
+| `size:range` | `size:>1000` | Filter by file size |
+
+#### Limitations
+
+- **Legacy engine only** — does NOT use the newer search engine from github.com
+- Default branch only
+- Files must be < 384 KB
+- No regex support via API (web UI only)
+- No sort options (best match only)
+- Must include at least one search term (qualifiers alone are insufficient)
+
+> **gh CLI disclaimer:** "Note that these search results are powered by what is now a legacy GitHub code search engine. The results might not match what is seen on github.com."
+
+#### Text Match Metadata
+
+Add header to get highlighted text fragments:
+
+```
+Accept: application/vnd.github.text-match+json
+```
+
+Returns `text_matches` array with `fragment` and `matches` for each result.
+
+## General Limits
+
+- Max query length: 256 characters
+- Max AND/OR operators: 5
+- Max total results: 1000 (pagination ceiling)
+- Authentication recommended for higher rate limits

--- a/src/github/docs/semantic-search-status.md
+++ b/src/github/docs/semantic-search-status.md
@@ -1,0 +1,76 @@
+# GitHub Semantic Search Status
+
+*Last updated: February 2026*
+
+## Overview
+
+GitHub has three separate "semantic/improved search" efforts. Only one is partially accessible via REST API.
+
+| Feature | Status | Public API? | Where Available |
+|---------|--------|-------------|-----------------|
+| Copilot semantic code search | GA (March 2025) | No | VS Code, GitHub.com Copilot Chat |
+| New code search engine | GA on web (2023+) | No | github.com web UI only |
+| Improved Issue search | Public preview (Jan 29, 2026) | No (web UI only) | Issues tab on github.com |
+| Advanced issue search (`advanced_search=true`) | GA (Sept 2025) | **Yes** | REST API, gh CLI |
+
+## What Works via API
+
+### `advanced_search=true` Query Parameter
+
+The **only** API-accessible improvement. Append to `GET /search/issues`:
+
+```
+GET /search/issues?q=deep+linking+type:issue+repo:expo/expo&advanced_search=true
+```
+
+- Uses newer search backend with better relevance ranking
+- Supports OR operators and grouped qualifiers
+- Uses `type:issue`/`type:pr` instead of `is:issue`/`is:pr`
+- Merged in gh CLI [PR #11638](https://github.com/cli/cli/pull/11638) (Sept 8, 2025)
+- Results genuinely differ from legacy — natural language queries return different (often more relevant) results
+
+## What Does NOT Work via API
+
+### Copilot Semantic Code Search
+
+Vector embeddings that find code by meaning. GA since March 12, 2025.
+
+- Copilot-internal feature, no public API
+- Works in VS Code Copilot Chat, GitHub.com Copilot Chat
+- [Changelog announcement](https://github.blog/changelog/2025-03-12-instant-semantic-code-search-indexing-now-generally-available-for-github-copilot/)
+
+### New Code Search Engine
+
+Supports regex, symbol search, boolean operators on github.com web UI.
+
+- NOT exposed via REST API — API still uses legacy engine
+- gh CLI maintainer confirmed (issue [#8522](https://github.com/cli/cli/issues/8522)):
+  > "The code search used on the web is using a newer search engine to power the queries, this search engine does not have API endpoints."
+- `gh search code --help` disclaimer: "these search results are powered by what is now a legacy GitHub code search engine"
+
+### Improved Issue Search (Jan 2026)
+
+Semantic index for issue search. 39% better results in testing.
+
+- Public preview (Jan 29, 2026)
+- Web UI only — no REST API endpoints, headers, or parameters
+- Natural language queries → semantic matching; quoted queries → lexical matching
+- [Changelog announcement](https://github.blog/changelog/2026-01-29-improved-search-for-github-issues-in-public-preview/)
+
+## What to Watch For
+
+If GitHub exposes more search capabilities via API, look for:
+- New REST API endpoints or API versions
+- Preview headers like `application/vnd.github.<feature>-preview+json`
+- `gh` CLI removing the "legacy engine" disclaimer from `gh search code --help`
+- New parameters on existing `/search/code` endpoint
+- GraphQL `SearchType` enum gaining new values (like `ISSUE_ADVANCED` did)
+
+## Sources
+
+- [gh CLI PR #11638: Use advanced issue search](https://github.com/cli/cli/pull/11638)
+- [gh CLI issue #8522: search code not returning all results](https://github.com/cli/cli/issues/8522)
+- [GitHub Changelog: Improved Issue search preview (Jan 2026)](https://github.blog/changelog/2026-01-29-improved-search-for-github-issues-in-public-preview/)
+- [GitHub Changelog: Copilot semantic code search (March 2025)](https://github.blog/changelog/2025-03-12-instant-semantic-code-search-indexing-now-generally-available-for-github-copilot/)
+- [GitHub REST API: Search endpoints](https://docs.github.com/en/rest/search/search)
+- [GitHub Docs: About GitHub Code Search](https://docs.github.com/en/search-github/github-code-search/about-github-code-search)

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -9,6 +9,7 @@ import { createPRCommand, prCommand } from '@app/github/commands/pr';
 import { createCommentsCommand, commentsCommand } from '@app/github/commands/comments';
 import { createSearchCommand, searchCommand } from '@app/github/commands/search';
 import { createCodeSearchCommand } from '@app/github/commands/code-search';
+import { createGetCommand, getCommand } from '@app/github/commands/get';
 import { checkAuth, getRateLimit } from '@app/github/lib/octokit';
 import { parseGitHubUrl, detectRepoFromGit } from '@app/github/lib/url-parser';
 import { getCacheStats, closeDatabase } from '@app/github/lib/cache';
@@ -27,6 +28,7 @@ program.addCommand(createPRCommand());
 program.addCommand(createCommentsCommand());
 program.addCommand(createSearchCommand());
 program.addCommand(createCodeSearchCommand());
+program.addCommand(createGetCommand());
 
 // Status command
 program
@@ -87,6 +89,7 @@ async function interactiveMode(): Promise<void> {
           { value: 'pr', name: '🔀 Fetch Pull Request' },
           { value: 'comments', name: '💬 Fetch Comments' },
           { value: 'search', name: '🔍 Search Issues/PRs' },
+          { value: 'get', name: '📄 Get File Content' },
           { value: 'status', name: 'ℹ️  Show Status' },
           { value: 'exit', name: '👋 Exit' },
         ],
@@ -146,6 +149,25 @@ async function interactiveMode(): Promise<void> {
           format: 'ai',
         });
 
+        continue;
+      }
+
+      if (action === 'get') {
+        const fileUrl = await input({
+          message: 'Enter GitHub file URL:',
+        });
+
+        if (!fileUrl.trim()) {
+          console.log(chalk.yellow('No URL provided.'));
+          continue;
+        }
+
+        const toClipboard = await confirm({
+          message: 'Copy to clipboard?',
+          default: false,
+        });
+
+        await getCommand(fileUrl, { clipboard: toClipboard });
         continue;
       }
 

--- a/src/github/lib/output.ts
+++ b/src/github/lib/output.ts
@@ -406,18 +406,33 @@ function formatPRMarkdown(data: PRData, options: FormatOptions): string {
 
 function formatSearchMarkdown(results: SearchResult[]): string {
   const lines: string[] = [];
+  const hasSource = results.some(r => r.source);
 
   lines.push(`# Search Results (${results.length})`);
   lines.push('');
-  lines.push('| # | Type | Title | State | Author | Repo |');
-  lines.push('|---|------|-------|-------|--------|------|');
+
+  if (hasSource) {
+    lines.push('| # | Type | Title | State | Author | Repo | Src |');
+    lines.push('|---|------|-------|-------|--------|------|-----|');
+  } else {
+    lines.push('| # | Type | Title | State | Author | Repo |');
+    lines.push('|---|------|-------|-------|--------|------|');
+  }
 
   for (const result of results) {
     const typeIcon = result.type === 'pr' ? '🔀' : '📋';
     const stateIcon = result.state === 'open' ? '🟢' : '🔴';
-    lines.push(
-      `| [#${result.number}](${result.url}) | ${typeIcon} | ${truncate(result.title, 50)} | ${stateIcon} ${result.state} | @${result.author} | ${result.repo} |`
-    );
+    const baseRow = `| [#${result.number}](${result.url}) | ${typeIcon} | ${truncate(result.title, 50)} | ${stateIcon} ${result.state} | @${result.author} | ${result.repo} |`;
+
+    if (hasSource) {
+      const sourceTag = result.source === 'both' ? 'A+L'
+        : result.source === 'advanced' ? 'A'
+        : result.source === 'legacy' ? 'L'
+        : '';
+      lines.push(`${baseRow} ${sourceTag} |`);
+    } else {
+      lines.push(baseRow);
+    }
   }
 
   lines.push('');

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -220,6 +220,8 @@ export interface SearchCommandOptions {
   format?: 'ai' | 'md' | 'json';
   output?: string;
   verbose?: boolean;
+  advanced?: boolean;
+  legacy?: boolean;
 }
 
 // Output data structures
@@ -318,4 +320,5 @@ export interface SearchResult {
   reactions: number;
   repo: string;
   url: string;
+  source?: 'advanced' | 'legacy' | 'both';
 }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -51,6 +51,18 @@ export interface TimelineEventRecord {
   data_json: string;
 }
 
+/**
+ * Parsed GitHub file URL
+ */
+export interface GitHubFileUrl {
+  owner: string;
+  repo: string;
+  path: string;
+  ref: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
 export interface FetchMetadataRecord {
   id: number;
   issue_id: number;


### PR DESCRIPTION
## Summary
- Add `get` command for fetching file content from GitHub URLs (blob, blame, raw)
- Add `code` command for code search across repositories
- Add dual-backend advanced search with deduplication (combines REST + legacy search APIs)
- Add URL parser for GitHub file URLs
- Add search documentation

## Test plan
- [x] `get` command help renders correctly
- [x] `code` command help renders correctly
- [x] `search` command works with deduplication
- [x] GitHub CLI tool registers all commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Get" command to fetch and retrieve GitHub file content with support for line range extraction, output to file/clipboard, or stdout.
  * GitHub search now supports dual backend modes (advanced and legacy) with automatic deduplication of results across sources.
  * Search results now display source indicators showing which backend returned each result.
  * Interactive mode extended with new file content retrieval option.

* **Enhancements**
  * Code search API now includes text-match headers for improved result metadata.

* **Documentation**
  * Added comprehensive GitHub Search API reference guide.
  * Added semantic search feature status documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->