### PR TITLE
feat(azure-devops): add work item attachment listing and download

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "author": {
                 "name": "GenesisTools"
             },

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -38,12 +38,25 @@ tools azure-devops timelog import <file>         # Bulk import time logs (with p
 | `--download-workitems` | Download all items from query |
 | `--category <name>` | Save to tasks/<category>/ |
 | `--task-folders` | Save in tasks/<id>/ subfolder |
+| `--attachments-from <datetime>` | Download attachments created after this date |
+| `--attachments-to <datetime>` | Download attachments created before this date (default: now) |
+| `--attachments-prefix <prefix>` | Only attachments starting with this name |
+| `--attachments-suffix <suffix>` | Only attachments ending with this (e.g. .har) |
+| `--output-dir <path>` | Custom directory for downloaded attachments |
 
 ### Output Paths
 
 - **Tasks**: `.claude/azure/tasks/` → `<id>-<Slug-Title>.md`
 - With `--category react19`: `.claude/azure/tasks/react19/<id>-<Slug>.md`
 - With `--task-folders`: `.claude/azure/tasks/<id>/<id>-<Slug>.md`
+
+### Attachment Output Paths
+
+Attachments are downloaded when any `--attachments-*` filter flag is provided. Without filters, attachments are listed in output with a suggested download command.
+
+- **Default**: Same folder as task file: `.claude/azure/tasks/<taskid>-<attachment-name>`
+- With `--task-folders`: `.claude/azure/tasks/<id>/<taskid>-<attachment-name>`
+- With `--output-dir /custom/path`: `/custom/path/<taskid>-<attachment-name>`
 
 ## Operations
 
@@ -157,6 +170,9 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
 | "Download React19 bugs" | `tools azure-devops query "React19 Bugs" --download-workitems --category react19` |
 | "Analyze task 261575" | Fetch → Explore agent → Write .analysis.md |
 | "Analyze all active bugs" | Fetch query with --download-workitems → Parallel Explore agents → Write .analysis.md files |
+| "Download .har files from task 12345" | `tools azure-devops workitem 12345 --attachments-suffix .har` |
+| "Get attachments from last hour for 12345" | Compute datetime 1h ago, then `tools azure-devops workitem 12345 --attachments-from "2026-02-12T10:00:00"` |
+| "Download all attachments for task 12345" | `tools azure-devops workitem 12345 --attachments-from 2000-01-01` |
 
 ## Creating Work Items
 

--- a/src/azure-devops/api.ts
+++ b/src/azure-devops/api.ts
@@ -241,6 +241,32 @@ export class Api {
     }
 
     /**
+     * Download binary content from Azure DevOps (for attachments).
+     * Returns ArrayBuffer (caller saves to disk).
+     */
+    async fetchBinary(url: string, description?: string): Promise<ArrayBuffer> {
+        const shortUrl = url.replace(this.config.org, "").slice(0, 80);
+        logger.debug(`[api] GET binary ${shortUrl}${description ? ` (${description})` : ""}`);
+        const startTime = Date.now();
+
+        const token = await this.getAccessToken();
+        const response = await fetch(url, {
+            method: "GET",
+            headers: { Authorization: `Bearer ${token}` },
+        });
+
+        const elapsed = Date.now() - startTime;
+        logger.debug(`[api] GET binary response: ${response.status} ${response.statusText} (${elapsed}ms)`);
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`API Error ${response.status}: ${errorText}`);
+        }
+
+        return response.arrayBuffer();
+    }
+
+    /**
      * Generate the URL for a work item in Azure DevOps web UI
      */
     generateWorkItemUrl(id: number): string {

--- a/src/azure-devops/api.ts
+++ b/src/azure-devops/api.ts
@@ -392,6 +392,85 @@ export class Api {
     }
 
     /**
+     * Batch fetch full work items (all fields + relations) in one REST call.
+     * Batches of 200 (API limit). Comments NOT included — use batchGetComments().
+     */
+    async batchGetFullWorkItems(ids: number[]): Promise<Map<number, Omit<WorkItemFull, "comments">>> {
+        const result = new Map<number, Omit<WorkItemFull, "comments">>();
+        const batchSize = 200;
+
+        for (let i = 0; i < ids.length; i += batchSize) {
+            const batchIds = ids.slice(i, i + batchSize);
+            const url = Api.orgUrl(this.config, ["wit", "workitems"], {
+                ids: batchIds.join(","),
+                "$expand": "all",
+            });
+            const response = await this.get<{ value: AzWorkItemRaw[] }>(
+                url,
+                `batch full ${Math.floor(i / batchSize) + 1}/${Math.ceil(ids.length / batchSize)}`
+            );
+
+            for (const item of response.value) {
+                const fields = item.fields ?? {};
+                result.set(item.id, {
+                    id: item.id,
+                    rev: item.rev,
+                    title: fields["System.Title"] as string,
+                    state: fields["System.State"] as string,
+                    changed: fields["System.ChangedDate"] as string,
+                    severity: fields["Microsoft.VSTS.Common.Severity"] as string | undefined,
+                    assignee: (fields["System.AssignedTo"] as { displayName?: string } | undefined)?.displayName,
+                    tags: fields["System.Tags"] as string | undefined,
+                    description: fields["System.Description"] as string | undefined,
+                    created: fields["System.CreatedDate"] as string | undefined,
+                    createdBy: (fields["System.CreatedBy"] as { displayName?: string } | undefined)?.displayName,
+                    changedBy: (fields["System.ChangedBy"] as { displayName?: string } | undefined)?.displayName,
+                    url: this.generateWorkItemUrl(item.id),
+                    relations: item.relations,
+                    rawFields: fields,
+                });
+            }
+        }
+
+        logger.debug(`[api] Batch fetched ${result.size} full work items`);
+        return result;
+    }
+
+    /**
+     * Fetch comments for multiple work items in parallel with concurrency limit.
+     */
+    async batchGetComments(ids: number[], concurrency = 5): Promise<Map<number, Comment[]>> {
+        const result = new Map<number, Comment[]>();
+
+        for (let i = 0; i < ids.length; i += concurrency) {
+            const batch = ids.slice(i, i + concurrency);
+            const promises = batch.map(async (id) => {
+                const commentsUrl = Api.witUrlPreview(this.config, ["workItems", String(id), "comments"]);
+                const commentsData = await this.get<{
+                    comments: Array<{ id: number; createdBy: { displayName: string }; createdDate: string; text: string }>;
+                }>(commentsUrl, `comments for #${id}`);
+
+                const comments: Comment[] = (commentsData.comments || []).map((c) => ({
+                    id: c.id,
+                    author: c.createdBy?.displayName,
+                    date: c.createdDate,
+                    text: c.text,
+                }));
+                return { id, comments };
+            });
+
+            const results = await Promise.all(promises);
+            for (const { id, comments } of results) {
+                result.set(id, comments);
+                logger.debug(`[api] Work item #${id} has ${comments.length} comments`);
+            }
+        }
+
+        logger.debug(`[api] Batch fetched comments for ${result.size} work items`);
+        return result;
+    }
+
+    /**
      * Get dashboard information including all queries it contains
      */
     async getDashboard(dashboardId: string): Promise<Dashboard> {

--- a/src/azure-devops/api.ts
+++ b/src/azure-devops/api.ts
@@ -7,14 +7,14 @@
 
 import { loadTeamMembersCache, saveTeamMembersCache } from "@app/azure-devops/cache";
 import type {
-	CommentsResponse,
-	Dashboard,
-	DashboardDetailResponse,
-	DashboardsListResponse,
-	GetWorkItemsOptions,
-	QueryNode,
-	TeamMembersResponse,
-	TeamsListResponse,
+    CommentsResponse,
+    Dashboard,
+    DashboardDetailResponse,
+    DashboardsListResponse,
+    GetWorkItemsOptions,
+    QueryNode,
+    TeamMembersResponse,
+    TeamsListResponse,
 } from "@app/azure-devops/api.types";
 import { concurrentMap } from "@app/utils/async";
 import type {

--- a/src/azure-devops/api.types.ts
+++ b/src/azure-devops/api.types.ts
@@ -1,0 +1,71 @@
+/**
+ * Azure DevOps API Response Types
+ *
+ * This file contains type definitions for raw API responses from Azure DevOps.
+ * These types represent the exact structure returned by the API endpoints,
+ * before transformation into domain types.
+ */
+
+import type { IdentityRef } from "@app/azure-devops/types";
+
+/** Raw response from WIQL query execution */
+export interface WiqlQueryResponse {
+	workItems?: Array<{ id: number; url: string }>;
+}
+
+/** Raw response from work item comments endpoint */
+export interface CommentsResponse {
+	comments: Array<{
+		id: number;
+		createdBy: { displayName: string };
+		createdDate: string;
+		text: string;
+	}>;
+}
+
+/** Raw response from dashboards list */
+export interface DashboardsListResponse {
+	value: Array<{ id: string; name: string; groupId?: string }>;
+}
+
+/** Raw response from dashboard detail (with widgets) */
+export interface DashboardDetailResponse {
+	name: string;
+	widgets: Array<{ name: string; settings: string }>;
+}
+
+/** Raw response from teams list */
+export interface TeamsListResponse {
+	value: Array<{ id: string; name: string }>;
+}
+
+/** Raw response from team members */
+export interface TeamMembersResponse {
+	value: Array<{ identity: IdentityRef }>;
+}
+
+/** Raw response from projects list */
+export interface ProjectsListResponse {
+	value: Array<{ id: string; name: string }>;
+}
+
+/** Raw response from project detail */
+export interface ProjectDetailResponse {
+	id: string;
+}
+
+/** Dashboard info (domain type, constructed from API calls) */
+export interface Dashboard {
+	name: string;
+	queries: Array<{ name: string; queryId: string }>;
+}
+
+/** Query tree node from Queries API (internal to recursive traversal) */
+export interface QueryNode {
+	id: string;
+	name: string;
+	path: string;
+	isFolder: boolean;
+	hasChildren?: boolean;
+	children?: QueryNode[];
+}

--- a/src/azure-devops/api.types.ts
+++ b/src/azure-devops/api.types.ts
@@ -10,70 +10,70 @@ import type { IdentityRef } from "@app/azure-devops/types";
 
 /** Raw response from WIQL query execution */
 export interface WiqlQueryResponse {
-	workItems?: Array<{ id: number; url: string }>;
+    workItems?: Array<{ id: number; url: string }>;
 }
 
 /** Raw response from work item comments endpoint */
 export interface CommentsResponse {
-	comments: Array<{
-		id: number;
-		createdBy: { displayName: string };
-		createdDate: string;
-		text: string;
-	}>;
+    comments: Array<{
+        id: number;
+        createdBy: { displayName: string };
+        createdDate: string;
+        text: string;
+    }>;
 }
 
 /** Raw response from dashboards list */
 export interface DashboardsListResponse {
-	value: Array<{ id: string; name: string; groupId?: string }>;
+    value: Array<{ id: string; name: string; groupId?: string }>;
 }
 
 /** Raw response from dashboard detail (with widgets) */
 export interface DashboardDetailResponse {
-	name: string;
-	widgets: Array<{ name: string; settings: string }>;
+    name: string;
+    widgets: Array<{ name: string; settings: string }>;
 }
 
 /** Raw response from teams list */
 export interface TeamsListResponse {
-	value: Array<{ id: string; name: string }>;
+    value: Array<{ id: string; name: string }>;
 }
 
 /** Raw response from team members */
 export interface TeamMembersResponse {
-	value: Array<{ identity: IdentityRef }>;
+    value: Array<{ identity: IdentityRef }>;
 }
 
 /** Raw response from projects list */
 export interface ProjectsListResponse {
-	value: Array<{ id: string; name: string }>;
+    value: Array<{ id: string; name: string }>;
 }
 
 /** Raw response from project detail */
 export interface ProjectDetailResponse {
-	id: string;
+    id: string;
 }
 
 /** Dashboard info (domain type, constructed from API calls) */
 export interface Dashboard {
-	name: string;
-	queries: Array<{ name: string; queryId: string }>;
+    name: string;
+    queries: Array<{ name: string; queryId: string }>;
 }
 
 /** Options for getWorkItems — controls which extra data to fetch */
 export interface GetWorkItemsOptions {
-	/** Fetch comments for each item (parallel, concurrency=5). Default: true */
-	comments?: boolean;
-	/** Fetch field change updates/history for each item (parallel). Default: false */
-	updates?: boolean;
+    /** Fetch comments for each item (parallel, concurrency=5). Default: true */
+    comments?: boolean;
+    /** Fetch field change updates/history for each item (parallel). Default: false */
+    updates?: boolean;
 }
 
 /** Query tree node from Queries API (internal to recursive traversal) */
 export interface QueryNode {
-	id: string;
-	name: string;
-	path: string;
-	isFolder: boolean;
-	hasChildren?: boolean;
-	children?: QueryNode[];
+    id: string;
+    name: string;
+    path: string;
+    isFolder: boolean;
+    hasChildren?: boolean;
+    children?: QueryNode[];
 }

--- a/src/azure-devops/api.types.ts
+++ b/src/azure-devops/api.types.ts
@@ -60,6 +60,14 @@ export interface Dashboard {
 	queries: Array<{ name: string; queryId: string }>;
 }
 
+/** Options for getWorkItems — controls which extra data to fetch */
+export interface GetWorkItemsOptions {
+	/** Fetch comments for each item (parallel, concurrency=5). Default: true */
+	comments?: boolean;
+	/** Fetch field change updates/history for each item (parallel). Default: false */
+	updates?: boolean;
+}
+
 /** Query tree node from Queries API (internal to recursive traversal) */
 export interface QueryNode {
 	id: string;

--- a/src/azure-devops/commands/attachments.ts
+++ b/src/azure-devops/commands/attachments.ts
@@ -1,0 +1,135 @@
+/**
+ * Azure DevOps CLI Tool - Attachment Download Module
+ *
+ * Downloads work item attachments with optional filtering by date range
+ * and filename prefix/suffix. Used by the workitem command.
+ */
+
+import type { Api } from "@app/azure-devops/api";
+import type { AttachmentFilter, AttachmentInfo, Relation, WorkItemFull, WorkItemSettings } from "@app/azure-devops/types";
+import { filterAttachments, getTaskFilePath } from "@app/azure-devops/utils";
+import { concurrentMap } from "@app/utils/async";
+import logger, { consoleLog } from "@app/logger";
+import { existsSync, mkdirSync, statSync } from "fs";
+import { dirname, join, resolve } from "path";
+
+/** Extract attachment GUID from Azure DevOps attachment URL */
+function extractAttachmentId(url: string): string {
+    const match = url.match(/\/attachments\/([a-f0-9-]+)/i);
+    return match?.[1] ?? "";
+}
+
+/** Resolve the output directory for a work item's attachments */
+function resolveOutputDir(
+    workItemId: number,
+    title: string,
+    settings: WorkItemSettings,
+    override?: string,
+): string {
+    if (override) return resolve(override);
+    // Default: same directory as the task .md file
+    const taskPath = getTaskFilePath(workItemId, title, "md", settings.category, settings.taskFolder);
+    return dirname(taskPath);
+}
+
+/** Download a single attachment, skipping if already exists with matching size */
+async function downloadSingleAttachment(
+    api: Api,
+    relation: Relation,
+    workItemId: number,
+    outputDir: string,
+): Promise<AttachmentInfo> {
+    const attrs = relation.attributes!;
+    const attachmentId = extractAttachmentId(relation.url);
+    const filename = attrs.name!;
+    const size = attrs.resourceSize ?? 0;
+    const createdDate = attrs.resourceCreatedDate ?? "";
+    const targetPath = join(outputDir, `${workItemId}-${filename}`);
+
+    // Skip if already downloaded with matching size
+    if (existsSync(targetPath) && size > 0) {
+        const stat = statSync(targetPath);
+        if (stat.size === size) {
+            logger.debug(`[attachments] Skipping ${filename} (already exists, size match)`);
+            return {
+                id: attachmentId,
+                filename,
+                size,
+                createdDate,
+                localPath: targetPath,
+                downloaded: false,
+            };
+        }
+        logger.debug(`[attachments] Size mismatch for ${filename}, re-downloading`);
+    }
+
+    // Build download URL
+    const downloadUrl = `${relation.url}${relation.url.includes("?") ? "&" : "?"}download=true`;
+    const buffer = await api.fetchBinary(downloadUrl, filename);
+
+    // Save to disk
+    await Bun.write(targetPath, buffer);
+    logger.debug(`[attachments] Downloaded ${filename} (${size} bytes) to ${targetPath}`);
+
+    return {
+        id: attachmentId,
+        filename,
+        size: size || buffer.byteLength,
+        createdDate,
+        localPath: targetPath,
+        downloaded: true,
+    };
+}
+
+/** Download attachments for a single work item */
+async function downloadWorkItemAttachments(
+    api: Api,
+    item: WorkItemFull,
+    settings: WorkItemSettings,
+    filter: AttachmentFilter,
+): Promise<AttachmentInfo[]> {
+    if (!item.relations?.length) return [];
+
+    const filtered = filterAttachments(item.relations, filter);
+    if (filtered.length === 0) return [];
+
+    const outputDir = resolveOutputDir(item.id, item.title, settings, filter.outputDir);
+    if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+    }
+
+    consoleLog.info(`   Downloading ${filtered.length} attachment(s) for #${item.id}...`);
+
+    const results = await concurrentMap({
+        items: filtered,
+        fn: async (rel) => downloadSingleAttachment(api, rel, item.id, outputDir),
+        onError: (rel, error) =>
+            logger.warn(`[attachments] Failed to download ${rel.attributes?.name} for #${item.id}: ${error}`),
+    });
+
+    return Array.from(results.values());
+}
+
+/**
+ * Download attachments for multiple work items matching the filter.
+ * Returns Map<workItemId, AttachmentInfo[]> with localPath set on each.
+ */
+export async function downloadAttachments(
+    api: Api,
+    items: Map<number, WorkItemFull>,
+    settingsMap: Map<number, WorkItemSettings>,
+    filter: AttachmentFilter,
+): Promise<Map<number, AttachmentInfo[]>> {
+    const result = new Map<number, AttachmentInfo[]>();
+
+    for (const [id, item] of items) {
+        const settings = settingsMap.get(id);
+        if (!settings) continue;
+        const attachments = await downloadWorkItemAttachments(api, item, settings, filter);
+        if (attachments.length > 0) {
+            result.set(id, attachments);
+        }
+    }
+
+    return result;
+}

--- a/src/azure-devops/commands/history-search.ts
+++ b/src/azure-devops/commands/history-search.ts
@@ -159,7 +159,7 @@ async function wiqlSearch(options: SearchOptions, api: Api, config: AzureConfig)
 /** Fetch work items by IDs using az rest (since Api.get is private) */
 async function fetchWorkItemsBatch(config: AzureConfig, idsParam: string, fields: string): Promise<WorkItem[]> {
     const { $ } = await import("bun");
-    const url = `${config.org}/_apis/wit/workitems?ids=${idsParam}&fields=${fields}&api-version=7.1`;
+    const url = Api.orgUrl(config, ["wit", "workitems"], { ids: idsParam, fields });
 
     // Get a token via az CLI
     const tokenResult =
@@ -187,7 +187,7 @@ async function fetchWorkItemsBatch(config: AzureConfig, idsParam: string, fields
             state: (f["System.State"] as string) ?? "",
             changed: (f["System.ChangedDate"] as string) ?? "",
             assignee: (f["System.AssignedTo"] as { displayName?: string } | undefined)?.displayName,
-            url: `${config.org}/${encodeURIComponent(config.project)}/_workitems/edit/${item.id}`,
+            url: Api.workItemWebUrl(config, item.id),
         };
     });
 }

--- a/src/azure-devops/commands/query.ts
+++ b/src/azure-devops/commands/query.ts
@@ -191,7 +191,8 @@ export type WorkItemHandler = (
     forceRefresh: boolean,
     category?: string,
     taskFolders?: boolean,
-    queryMetadata?: Map<number, QueryItemMetadata>
+    queryMetadata?: Map<number, QueryItemMetadata>,
+    fetchOptions?: { comments?: boolean; updates?: boolean }
 ) => Promise<void>;
 
 let workItemHandler: WorkItemHandler | null = null;
@@ -357,7 +358,7 @@ export async function handleQuery(
         );
         const ids = items.map((item) => item.id).join(",");
         // Pass queryMetadata for smart comparison (ignores forceRefresh when metadata available)
-        await workItemHandler(ids, format, false, effectiveCategory, effectiveTaskFolders, queryMetadata);
+        await workItemHandler(ids, format, false, effectiveCategory, effectiveTaskFolders, queryMetadata, { comments: true });
     }
 }
 

--- a/src/azure-devops/commands/timelog/configure.ts
+++ b/src/azure-devops/commands/timelog/configure.ts
@@ -1,5 +1,6 @@
 import type { AzureConfigWithTimeLog, TimeLogConfig } from "@app/azure-devops/types";
 import { findConfigPath, loadConfig } from "@app/azure-devops/utils";
+import { buildUrl } from "@app/utils/url";
 import * as p from "@clack/prompts";
 import { $ } from "bun";
 import type { Command } from "commander";
@@ -65,7 +66,11 @@ function extractOrgName(config: AzureConfigWithTimeLog): string {
 
 async function fetchFunctionsKey(orgName: string): Promise<string> {
     const result =
-        await $`az rest --method GET --resource "499b84ac-1321-427f-aa17-267ca6975798" --uri "https://extmgmt.dev.azure.com/${orgName}/_apis/ExtensionManagement/InstalledExtensions/TimeLog/time-logging/Data/Scopes/Default/Current/Collections/%24settings/Documents?api-version=7.1-preview"`.quiet();
+        await $`az rest --method GET --resource "499b84ac-1321-427f-aa17-267ca6975798" --uri "${buildUrl({
+            base: "https://extmgmt.dev.azure.com",
+            segments: [orgName, "_apis", "ExtensionManagement", "InstalledExtensions", "TimeLog", "time-logging", "Data", "Scopes", "Default", "Current", "Collections", "%24settings", "Documents"],
+            queryParams: { "api-version": "7.1-preview" },
+        })}"`.quiet();
 
     const data = JSON.parse(result.text());
     const configDoc = data.find((d: { id: string }) => d.id === "Config");

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -179,7 +179,8 @@ export async function handleWorkItem(
     forceRefresh: boolean,
     categoryArg?: string,
     taskFoldersArg?: boolean,
-    queryMetadata?: Map<number, QueryItemMetadata>
+    queryMetadata?: Map<number, QueryItemMetadata>,
+    fetchOptions?: { comments?: boolean; updates?: boolean }
 ): Promise<void> {
     silentMode = format === "json";
     logger.debug(
@@ -267,7 +268,10 @@ export async function handleWorkItem(
     if (needsFetch.length > 0) {
         logger.debug(`[workitem] Batch fetching ${needsFetch.length} work items...`);
 
-        const fetched = await api.getWorkItems(needsFetch, { comments: true });
+        const fetched = await api.getWorkItems(needsFetch, {
+            comments: fetchOptions?.comments !== false,
+            updates: fetchOptions?.updates,
+        });
 
         for (const id of needsFetch) {
             const item = fetched.get(id);

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -267,21 +267,14 @@ export async function handleWorkItem(
     if (needsFetch.length > 0) {
         logger.debug(`[workitem] Batch fetching ${needsFetch.length} work items...`);
 
-        const [batchFields, batchComments] = await Promise.all([
-            api.batchGetFullWorkItems(needsFetch),
-            api.batchGetComments(needsFetch),
-        ]);
+        const fetched = await api.getWorkItems(needsFetch, { comments: true });
 
         for (const id of needsFetch) {
-            const fields = batchFields.get(id);
-            const comments = batchComments.get(id) ?? [];
-
-            if (!fields) {
+            const item = fetched.get(id);
+            if (!item) {
                 logger.warn(`[workitem] #${id} not found in batch response, skipping`);
                 continue;
             }
-
-            const item: WorkItemFull = { ...fields, comments };
             fetchedItems.set(id, item);
             downloadedCount++;
         }

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -471,7 +471,8 @@ export function registerWorkitemCommand(program: Command): void {
             ) => {
                 const hasAttachmentFilter =
                     options.attachmentsFrom || options.attachmentsTo ||
-                    options.attachmentsPrefix || options.attachmentsSuffix;
+                    options.attachmentsPrefix || options.attachmentsSuffix ||
+                    options.outputDir;
 
                 const parseDate = (s: string | undefined): Date | undefined => {
                     if (!s) return undefined;

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -12,7 +12,10 @@ import {
     saveGlobalCache,
     WORKITEM_FRESHNESS_MINUTES,
 } from "@app/azure-devops/cache";
+import { downloadAttachments } from "@app/azure-devops/commands/attachments";
 import type {
+    AttachmentFilter,
+    AttachmentInfo,
     OutputFormat,
     QueryItemMetadata,
     WorkItemCache,
@@ -23,10 +26,12 @@ import {
     extractWorkItemIds,
     findTaskFile,
     findTaskFileAnywhere,
+    formatBytes,
     getRelativeTime,
     getTaskFilePath,
     getTasksDir,
     htmlToMarkdown,
+    parseAttachments,
     parseRelations,
     requireConfig,
 } from "@app/azure-devops/utils";
@@ -43,7 +48,12 @@ const log = (msg: string) => {
 
 // ============= Output Formatters =============
 
-function formatWorkItemAI(item: WorkItemFull, taskPath: string, cacheTime?: Date): string {
+function formatWorkItemAI(
+    item: WorkItemFull,
+    taskPath: string,
+    cacheTime?: Date,
+    downloadedAttachments?: AttachmentInfo[],
+): string {
     const lines: string[] = [];
 
     lines.push(`# Work Item #${item.id}`);
@@ -97,7 +107,34 @@ function formatWorkItemAI(item: WorkItemFull, taskPath: string, cacheTime?: Date
             lines.push(`- **Related**: ${parsed.related.map((id) => `#${id}`).join(", ")}`);
         }
         if (parsed.other.length > 0) {
-            lines.push(`- **Other links**: ${parsed.other.length} (attachments, hyperlinks, etc.)`);
+            lines.push(`- **Other links**: ${parsed.other.length} (hyperlinks, etc.)`);
+        }
+    }
+
+    // Attachments section
+    const attachments = parseAttachments(item.relations ?? []);
+    if (attachments.length > 0) {
+        lines.push("");
+        if (downloadedAttachments && downloadedAttachments.length > 0) {
+            const dlCount = downloadedAttachments.filter((a) => a.downloaded).length;
+            const existCount = downloadedAttachments.length - dlCount;
+            const parts = [];
+            if (dlCount > 0) parts.push(`${dlCount} downloaded`);
+            if (existCount > 0) parts.push(`${existCount} already existed`);
+            lines.push(`## Attachments (${parts.join(", ")})`);
+            for (const att of downloadedAttachments) {
+                const status = att.downloaded ? "Downloaded" : "Already exists";
+                lines.push(`- ${att.filename} (${formatBytes(att.size)}) ${status}`);
+                lines.push(`  ${att.localPath}`);
+            }
+        } else {
+            lines.push(`## Attachments (${attachments.length})`);
+            for (const att of attachments) {
+                const date = att.createdDate ? new Date(att.createdDate).toLocaleDateString() : "";
+                lines.push(`- ${att.filename} (${formatBytes(att.size)}${date ? `, ${date}` : ""})`);
+            }
+            lines.push("");
+            lines.push(`Download: tools azure-devops workitem ${item.id} --attachments-suffix .har`);
         }
     }
 
@@ -146,6 +183,18 @@ function generateWorkItemMarkdown(item: WorkItemFull): string {
         }
     }
 
+    // Attachments listing in markdown
+    const attachments = parseAttachments(item.relations ?? []);
+    if (attachments.length > 0) {
+        lines.push("");
+        lines.push("## Attachments");
+        lines.push("");
+        for (const att of attachments) {
+            const date = att.createdDate ? new Date(att.createdDate).toLocaleDateString() : "";
+            lines.push(`- ${att.filename} (${formatBytes(att.size)}${date ? `, ${date}` : ""})`);
+        }
+    }
+
     if (item.comments.length > 0) {
         lines.push("");
         lines.push(`## Comments (${item.comments.length})`);
@@ -180,7 +229,8 @@ export async function handleWorkItem(
     categoryArg?: string,
     taskFoldersArg?: boolean,
     queryMetadata?: Map<number, QueryItemMetadata>,
-    fetchOptions?: { comments?: boolean; updates?: boolean }
+    fetchOptions?: { comments?: boolean; updates?: boolean },
+    attachmentFilter?: AttachmentFilter,
 ): Promise<void> {
     silentMode = format === "json";
     logger.debug(
@@ -284,6 +334,15 @@ export async function handleWorkItem(
         }
     }
 
+    // Phase 2.5: Download attachments if filter provided
+    let attachmentsMap = new Map<number, AttachmentInfo[]>();
+    if (attachmentFilter) {
+        const allItems = new Map<number, WorkItemFull>([...cachedResults, ...fetchedItems]);
+        if (allItems.size > 0) {
+            attachmentsMap = await downloadAttachments(api, allItems, settingsMap, attachmentFilter);
+        }
+    }
+
     // Phase 3: Save fetched items to disk + update cache
     for (const [id, item] of fetchedItems) {
         const existingJsonPath = existingFilePaths.get(id) ?? null;
@@ -362,7 +421,7 @@ export async function handleWorkItem(
 
         switch (format) {
             case "ai":
-                console.log(formatWorkItemAI(item, taskPath, cacheTime));
+                console.log(formatWorkItemAI(item, taskPath, cacheTime, attachmentsMap.get(item.id)));
                 break;
             case "md":
                 console.log(
@@ -390,17 +449,56 @@ export function registerWorkitemCommand(program: Command): void {
         .option("--force", "Force refresh, ignore cache")
         .option("--category <name>", "Save to tasks/<category>/")
         .option("--task-folders", "Save in tasks/<id>/ subfolder")
+        .option("--attachments-from <datetime>", "Download attachments created after this date")
+        .option("--attachments-to <datetime>", "Download attachments created before this date")
+        .option("--attachments-prefix <prefix>", "Only attachments starting with this name")
+        .option("--attachments-suffix <suffix>", "Only attachments ending with this (e.g. .har)")
+        .option("--output-dir <path>", "Custom directory for downloaded attachments")
         .action(
             async (
                 input: string,
-                options: { format: OutputFormat; force?: boolean; category?: string; taskFolders?: boolean }
+                options: {
+                    format: OutputFormat;
+                    force?: boolean;
+                    category?: string;
+                    taskFolders?: boolean;
+                    attachmentsFrom?: string;
+                    attachmentsTo?: string;
+                    attachmentsPrefix?: string;
+                    attachmentsSuffix?: string;
+                    outputDir?: string;
+                },
             ) => {
+                const hasAttachmentFilter =
+                    options.attachmentsFrom || options.attachmentsTo ||
+                    options.attachmentsPrefix || options.attachmentsSuffix;
+
+                const parseDate = (s: string | undefined): Date | undefined => {
+                    if (!s) return undefined;
+                    const d = new Date(s);
+                    if (Number.isNaN(d.getTime())) throw new Error(`Invalid date format: ${s}`);
+                    return d;
+                };
+
+                const attachmentFilter: AttachmentFilter | undefined = hasAttachmentFilter
+                    ? {
+                          from: parseDate(options.attachmentsFrom),
+                          to: parseDate(options.attachmentsTo),
+                          prefix: options.attachmentsPrefix,
+                          suffix: options.attachmentsSuffix,
+                          outputDir: options.outputDir,
+                      }
+                    : undefined;
+
                 await handleWorkItem(
                     input,
                     options.format,
                     options.force ?? false,
                     options.category,
-                    options.taskFolders
+                    options.taskFolders,
+                    undefined,
+                    undefined,
+                    attachmentFilter,
                 );
             }
         );

--- a/src/azure-devops/timelog-api.ts
+++ b/src/azure-devops/timelog-api.ts
@@ -15,6 +15,7 @@ import type {
     TimeType,
 } from "@app/azure-devops/types";
 import logger from "@app/logger";
+import type { QueryParams } from "@app/utils/url";
 import { buildUrl } from "@app/utils/url";
 
 export class TimeLogApi {
@@ -33,8 +34,8 @@ export class TimeLogApi {
     /**
      * Make an HTTP request to the TimeLog API
      */
-    private async request<T>(method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, body?: unknown): Promise<T> {
-        const url = buildUrl({ base: this.baseUrl, segments: [endpoint] });
+    private async request<T>(method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, body?: unknown, queryParams?: QueryParams): Promise<T> {
+        const url = buildUrl({ base: this.baseUrl, segments: [endpoint], queryParams });
         const shortUrl = endpoint.slice(0, 60);
 
         logger.debug(`[timelog-api] ${method} ${shortUrl}`);
@@ -153,18 +154,15 @@ export class TimeLogApi {
      * Uses the /timelog/query endpoint
      */
     async queryTimeLogs(params: TimeLogQueryParams): Promise<TimeLogQueryEntry[]> {
-        const endpoint = buildUrl({
-            base: "/timelog/query",
-            queryParams: {
-                FromDate: params.FromDate,
-                ToDate: params.ToDate,
-                projectId: params.projectId,
-                workitemId: params.workitemId ? String(params.workitemId) : undefined,
-                userId: params.userId,
-            },
-        });
-        logger.debug(`[timelog-api] Querying time logs: ${endpoint}`);
-        return this.request<TimeLogQueryEntry[]>("GET", endpoint);
+        const queryParams = {
+            FromDate: params.FromDate,
+            ToDate: params.ToDate,
+            projectId: params.projectId,
+            workitemId: params.workitemId ? String(params.workitemId) : undefined,
+            userId: params.userId,
+        };
+        logger.debug(`[timelog-api] Querying time logs: /timelog/query ${JSON.stringify(queryParams)}`);
+        return this.request<TimeLogQueryEntry[]>("GET", "/timelog/query", undefined, queryParams);
     }
 
     /**

--- a/src/azure-devops/types.ts
+++ b/src/azure-devops/types.ts
@@ -70,6 +70,11 @@ export interface Relation {
     attributes?: {
         name?: string;
         comment?: string;
+        // Attachment-specific fields (populated when rel === "AttachedFile")
+        resourceCreatedDate?: string;
+        resourceModifiedDate?: string;
+        resourceSize?: number;
+        id?: number;
     };
 }
 
@@ -78,6 +83,28 @@ export interface ParsedRelations {
     children: number[];
     related: number[];
     other: string[];
+}
+
+// ============= Attachment Types =============
+
+export interface AttachmentInfo {
+    /** GUID extracted from attachment URL */
+    id: string;
+    filename: string;
+    size: number;
+    createdDate: string;
+    /** Full path on disk (set after download or if already exists) */
+    localPath?: string;
+    /** Whether this invocation downloaded the file (false = already existed) */
+    downloaded?: boolean;
+}
+
+export interface AttachmentFilter {
+    from?: Date;
+    to?: Date;
+    prefix?: string;
+    suffix?: string;
+    outputDir?: string;
 }
 
 // ============= Cache Types =============

--- a/src/azure-devops/types.ts
+++ b/src/azure-devops/types.ts
@@ -328,29 +328,6 @@ export interface UsedValuesCache {
     parents: { id: number; title: string }[]; // Common parent work items
 }
 
-/** Options for the --create command */
-export interface CreateOptions {
-    interactive: boolean;
-    fromFile?: string;
-    type?: WorkItemType;
-    sourceInput?: string;
-    title?: string;
-    description?: string;
-    area?: string;
-    iteration?: string;
-    severity?: string;
-    tags?: string;
-    assignee?: string;
-    parent?: string;
-}
-
-/** Cached work item type definitions */
-export interface TypeDefinitionCache {
-    project: string;
-    types: Record<string, WorkItemTypeDefinition>;
-    fetchedAt: string;
-}
-
 /** Query information from Azure DevOps */
 export interface QueryInfo {
     id: string;
@@ -367,9 +344,6 @@ export interface QueriesCache {
 }
 
 // ============= TimeLog Types (Third-Party Extension) =============
-
-/** TimeLog API base URL */
-export const TIMELOG_API_BASE = "https://boznet-timelogapi.azurewebsites.net/api";
 
 /** Time type definition from TimeLog API */
 export interface TimeType {

--- a/src/azure-devops/types.ts
+++ b/src/azure-devops/types.ts
@@ -53,6 +53,8 @@ export interface WorkItemFull extends WorkItem {
     relations?: Relation[];
     /** Raw field values from Azure DevOps API (keyed by reference name, e.g., "System.AreaPath") */
     rawFields?: Record<string, unknown>;
+    /** Field change history (deltas). Populated when fetched with { updates: true } */
+    updates?: WorkItemUpdate[];
 }
 
 export interface Comment {

--- a/src/azure-devops/utils.ts
+++ b/src/azure-devops/utils.ts
@@ -453,23 +453,18 @@ export function filterAttachments(relations: Relation[], filter: AttachmentFilte
         .filter((r) => r.rel === "AttachedFile" && r.attributes?.name)
         .filter((r) => {
             const attrs = r.attributes!;
-            if (filter.from && attrs.resourceCreatedDate && new Date(attrs.resourceCreatedDate) < filter.from)
+            if (filter.from && (!attrs.resourceCreatedDate || new Date(attrs.resourceCreatedDate) < filter.from))
                 return false;
-            if (filter.to && attrs.resourceCreatedDate && new Date(attrs.resourceCreatedDate) > filter.to) return false;
+            if (filter.to && (!attrs.resourceCreatedDate || new Date(attrs.resourceCreatedDate) > filter.to))
+                return false;
             if (filter.prefix && !attrs.name!.startsWith(filter.prefix)) return false;
             if (filter.suffix && !attrs.name!.endsWith(filter.suffix)) return false;
             return true;
         });
 }
 
-/** Format bytes to human-readable string */
-export function formatBytes(bytes: number): string {
-    if (bytes === 0) return "0 B";
-    const k = 1024;
-    const sizes = ["B", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
-}
+// formatBytes re-exported from shared utility
+export { formatBytes } from "@app/utils/format";
 
 export function detectChanges(oldItems: CacheEntry[], newItems: WorkItem[]): ChangeInfo[] {
     const changes: ChangeInfo[] = [];

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -131,3 +131,46 @@ export function withTimeout<T>(
         clearTimeout(timer);
     });
 }
+
+// ============= Concurrent Map =============
+
+interface ConcurrentMapOptions<T, R> {
+    /** Items to process */
+    items: T[];
+    /** Async function to apply to each item */
+    fn: (item: T) => Promise<R>;
+    /** Max concurrent operations. Default: 5 */
+    concurrency?: number;
+    /** Called for each rejected item. If omitted, failures are silently skipped. */
+    onError?: (item: T, error: unknown) => void;
+}
+
+/**
+ * Map over items with bounded concurrency using Promise.allSettled.
+ * Failed items are skipped (logged via onError) — a single failure doesn't abort the batch.
+ */
+export async function concurrentMap<T, R>({
+    items,
+    fn,
+    concurrency = 5,
+    onError,
+}: ConcurrentMapOptions<T, R>): Promise<Map<T, R>> {
+    const result = new Map<T, R>();
+
+    for (let i = 0; i < items.length; i += concurrency) {
+        const batch = items.slice(i, i + concurrency);
+        const settled = await Promise.allSettled(
+            batch.map(async (item) => ({ item, value: await fn(item) }))
+        );
+
+        for (const entry of settled) {
+            if (entry.status === "fulfilled") {
+                result.set(entry.value.item, entry.value.value);
+            } else {
+                onError?.(batch[settled.indexOf(entry)], entry.reason);
+            }
+        }
+    }
+
+    return result;
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,5 @@
-type QueryParamValue = string | string[] | undefined;
-type QueryParams = Record<string, QueryParamValue>;
+export type QueryParamValue = string | string[] | undefined;
+export type QueryParams = Record<string, QueryParamValue>;
 
 interface BuildUrlOptions {
     base: string;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,62 @@
+type QueryParamValue = string | string[] | undefined;
+type QueryParams = Record<string, QueryParamValue>;
+
+interface BuildUrlOptions {
+    base: string;
+    segments?: string[];
+    queryParams?: QueryParams;
+    keepTrailingSlash?: boolean;
+}
+
+export function appendQueryParamsToSearchParams(
+    params: QueryParams,
+    searchParams: URLSearchParams = new URLSearchParams()
+): URLSearchParams {
+    Object.entries(params).forEach(([key, value]) => {
+        if (value === undefined) {
+            return;
+        }
+        if (Array.isArray(value)) {
+            value.forEach((v) => searchParams.append(key, v));
+        } else {
+            searchParams.set(key, value);
+        }
+    });
+    return searchParams;
+}
+
+export function buildUrl({ base, segments = [], queryParams, keepTrailingSlash = true }: BuildUrlOptions): string {
+    const [basePath, existingQuery] = base.split("?");
+    const hasBase = basePath.trim().length > 0;
+    const normalizedSegments = segments.map((segment) => {
+        if (hasBase && (segment.startsWith("http://") || segment.startsWith("https://"))) {
+            try {
+                return new URL(segment).pathname;
+            } catch {
+                return segment;
+            }
+        }
+        return segment;
+    });
+    const lastSegment = segments.length > 0 ? segments[segments.length - 1] : basePath;
+    const hadTrailingSlash = lastSegment.endsWith("/");
+    let normalizedPath = [basePath, ...normalizedSegments]
+        .map((segment) => segment.replace(/^\/+|\/+$/g, ""))
+        .filter(Boolean)
+        .join("/");
+    if (keepTrailingSlash && hadTrailingSlash && normalizedPath.length > 0) {
+        normalizedPath += "/";
+    }
+    const searchParams = new URLSearchParams(existingQuery ?? "");
+    if (queryParams && Object.keys(queryParams).length > 0) {
+        appendQueryParamsToSearchParams(queryParams, searchParams);
+    }
+    const queryString = searchParams.toString();
+    return queryString ? `${normalizedPath}?${queryString}` : normalizedPath;
+}
+
+export function withQueryParams(urlString: string, params: QueryParams): string {
+    const url = new URL(urlString);
+    appendQueryParamsToSearchParams(params, url.searchParams);
+    return url.toString();
+}


### PR DESCRIPTION
## Summary
- Add attachment listing and download to `tools azure-devops workitem` command
- Attachments are always shown in output with a suggested download command
- Any `--attachments-*` filter flag triggers actual download with full path output
- Bump genesis-tools plugin version to 1.0.6

## Changes
- **types.ts**: Expand `Relation.attributes` with attachment metadata, add `AttachmentInfo`/`AttachmentFilter` types
- **utils.ts**: Add `parseAttachments()`, `filterAttachments()`, `formatBytes()`, exclude `AttachedFile` from `other[]` in `parseRelations()`
- **api.ts**: Add `fetchBinary()` method for binary downloads with auth
- **commands/attachments.ts**: New module — concurrent attachment downloads with size-based skip
- **commands/workitem.ts**: Wire `--attachments-from/to/prefix/suffix` + `--output-dir` CLI options, Phase 2.5 integration, attachment display in AI/MD output
- **SKILL.md**: Document new options, output paths, examples

## CLI Usage
```bash
# List attachments (always shown by default)
tools azure-devops workitem 12345

# Download .har files
tools azure-devops workitem 12345 --attachments-suffix .har

# Download attachments from last week
tools azure-devops workitem 12345 --attachments-from "2026-02-05"

# Custom output directory
tools azure-devops workitem 12345 --attachments-suffix .png --output-dir /tmp/test
```

## Test plan
- [ ] `tools azure-devops workitem <id-with-attachments>` shows attachment list with suggested command
- [ ] `--attachments-suffix .har` downloads matching files with full paths
- [ ] `--attachments-from <date>` filters by creation date
- [ ] `--output-dir <path>` saves to custom directory
- [ ] Running download twice skips already-existing files (size match)
- [ ] Work items without attachments show no attachments section
- [ ] `tsgo --noEmit` passes (no new type errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attachment download functionality with filtering by date range, filename prefix/suffix, and custom output directories.
  * Enabled comments fetching for work items by default.

* **Documentation**
  * Updated Azure DevOps skill documentation with attachment-related CLI options and example commands.

* **Changes**
  * Removed `--without-history` CLI flag; automatic history fetching is no longer performed.

* **Chores**
  * Version bump to 1.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->