### PR TITLE
feat(claude-resume, cc): cc session finder/tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ cd GenesisTools
 | Component | Name | Description |
 |-----------|------|-------------|
 | **Command** | `setup` | Interactive setup guide for installing GenesisTools globally |
-| **Skill** | `azure-devops` | Automatically helps with Azure DevOps work items and queries |
+| **Command** | `claude-history` | Search Claude Code conversation history by keywords, files, or time |
+| **Command** | `claude-resume` | Resume Claude Code sessions by short ID, name, or content search |
+| **Command** | `cc` | Alias for `claude-resume` |
+| **Command** | `github-pr` | Fetch PR review comments, select fixes, implement and commit |
+| **Skill** | `azure-devops` | Fetch and manage Azure DevOps work items, queries, and time logging |
 | **Skill** | `react-compiler-debug` | Debug and inspect React Compiler output for memoization issues |
 
 To use the plugin in Claude Code:

--- a/src/cc/index.ts
+++ b/src/cc/index.ts
@@ -1,0 +1,11 @@
+// Alias for claude-resume — pass all args through
+import { resolve } from "node:path";
+
+const claudeResume = resolve(import.meta.dir, "../claude-resume/index.ts");
+const proc = Bun.spawn({
+	cmd: ["bun", "run", claudeResume, ...process.argv.slice(2)],
+	stdio: ["inherit", "inherit", "inherit"],
+});
+
+const exitCode = await proc.exited;
+process.exit(exitCode);

--- a/src/claude-history/cache.ts
+++ b/src/claude-history/cache.ts
@@ -97,9 +97,25 @@ function initSchema(db: Database): void {
       last_updated TEXT NOT NULL
     );
 
+    -- Session metadata cache (for claude-resume fast lookup)
+    CREATE TABLE IF NOT EXISTS session_metadata (
+      file_path TEXT PRIMARY KEY,
+      session_id TEXT,
+      custom_title TEXT,
+      summary TEXT,
+      first_prompt TEXT,
+      git_branch TEXT,
+      project TEXT,
+      cwd TEXT,
+      mtime INTEGER NOT NULL,
+      first_timestamp TEXT,
+      is_subagent INTEGER NOT NULL DEFAULT 0
+    );
+
     CREATE INDEX IF NOT EXISTS idx_daily_stats_date ON daily_stats(date);
     CREATE INDEX IF NOT EXISTS idx_file_index_mtime ON file_index(mtime);
     CREATE INDEX IF NOT EXISTS idx_file_index_project ON file_index(project);
+    CREATE INDEX IF NOT EXISTS idx_session_metadata_session_id ON session_metadata(session_id);
   `);
 
     // Migrations: Add columns that may be missing from older schemas
@@ -140,6 +156,20 @@ export interface DailyStats {
     tokenUsage: TokenUsage;
     modelCounts: Record<string, number>; // { "opus": 50, "sonnet": 30, "haiku": 10 }
     branchCounts: Record<string, number>; // { "main": 100, "feat/xyz": 50 }
+}
+
+export interface SessionMetadataRecord {
+    filePath: string;
+    sessionId: string | null;
+    customTitle: string | null;
+    summary: string | null;
+    firstPrompt: string | null;
+    gitBranch: string | null;
+    project: string | null;
+    cwd: string | null;
+    mtime: number;
+    firstTimestamp: string | null;
+    isSubagent: boolean;
 }
 
 export interface FileIndexRecord {
@@ -585,4 +615,160 @@ export function getCacheStats(): {
         newestDate: newest,
         lastUpdated,
     };
+}
+
+// =============================================================================
+// Session Metadata Operations
+// =============================================================================
+
+export function getSessionMetadata(filePath: string): SessionMetadataRecord | null {
+    const db = getDatabase();
+    const row = db.query("SELECT * FROM session_metadata WHERE file_path = ?").get(filePath) as {
+        file_path: string;
+        session_id: string | null;
+        custom_title: string | null;
+        summary: string | null;
+        first_prompt: string | null;
+        git_branch: string | null;
+        project: string | null;
+        cwd: string | null;
+        mtime: number;
+        first_timestamp: string | null;
+        is_subagent: number;
+    } | null;
+
+    if (!row) return null;
+
+    return {
+        filePath: row.file_path,
+        sessionId: row.session_id,
+        customTitle: row.custom_title,
+        summary: row.summary,
+        firstPrompt: row.first_prompt,
+        gitBranch: row.git_branch,
+        project: row.project,
+        cwd: row.cwd,
+        mtime: row.mtime,
+        firstTimestamp: row.first_timestamp,
+        isSubagent: row.is_subagent === 1,
+    };
+}
+
+export function upsertSessionMetadata(record: SessionMetadataRecord): void {
+    const db = getDatabase();
+    db.query(`
+    INSERT OR REPLACE INTO session_metadata
+      (file_path, session_id, custom_title, summary, first_prompt, git_branch, project, cwd, mtime, first_timestamp, is_subagent)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+        record.filePath,
+        record.sessionId,
+        record.customTitle,
+        record.summary,
+        record.firstPrompt,
+        record.gitBranch,
+        record.project,
+        record.cwd,
+        record.mtime,
+        record.firstTimestamp,
+        record.isSubagent ? 1 : 0
+    );
+}
+
+export function getAllSessionMetadata(): SessionMetadataRecord[] {
+    const db = getDatabase();
+    const rows = db.query("SELECT * FROM session_metadata ORDER BY first_timestamp DESC").all() as Array<{
+        file_path: string;
+        session_id: string | null;
+        custom_title: string | null;
+        summary: string | null;
+        first_prompt: string | null;
+        git_branch: string | null;
+        project: string | null;
+        cwd: string | null;
+        mtime: number;
+        first_timestamp: string | null;
+        is_subagent: number;
+    }>;
+
+    return rows.map((row) => ({
+        filePath: row.file_path,
+        sessionId: row.session_id,
+        customTitle: row.custom_title,
+        summary: row.summary,
+        firstPrompt: row.first_prompt,
+        gitBranch: row.git_branch,
+        project: row.project,
+        cwd: row.cwd,
+        mtime: row.mtime,
+        firstTimestamp: row.first_timestamp,
+        isSubagent: row.is_subagent === 1,
+    }));
+}
+
+export function getSessionMetadataByDir(dirPath: string): SessionMetadataRecord[] {
+    const db = getDatabase();
+    const prefix = dirPath.endsWith("/") ? dirPath : `${dirPath}/`;
+    const rows = db
+        .query("SELECT * FROM session_metadata WHERE file_path LIKE ? ORDER BY first_timestamp DESC")
+        .all(`${prefix}%`) as Array<{
+        file_path: string;
+        session_id: string | null;
+        custom_title: string | null;
+        summary: string | null;
+        first_prompt: string | null;
+        git_branch: string | null;
+        project: string | null;
+        cwd: string | null;
+        mtime: number;
+        first_timestamp: string | null;
+        is_subagent: number;
+    }>;
+
+    return rows.map((row) => ({
+        filePath: row.file_path,
+        sessionId: row.session_id,
+        customTitle: row.custom_title,
+        summary: row.summary,
+        firstPrompt: row.first_prompt,
+        gitBranch: row.git_branch,
+        project: row.project,
+        cwd: row.cwd,
+        mtime: row.mtime,
+        firstTimestamp: row.first_timestamp,
+        isSubagent: row.is_subagent === 1,
+    }));
+}
+
+export function getSessionMetadataByProject(project: string): SessionMetadataRecord[] {
+    const db = getDatabase();
+    const rows = db
+        .query("SELECT * FROM session_metadata WHERE project = ? ORDER BY first_timestamp DESC")
+        .all(project) as Array<{
+        file_path: string;
+        session_id: string | null;
+        custom_title: string | null;
+        summary: string | null;
+        first_prompt: string | null;
+        git_branch: string | null;
+        project: string | null;
+        cwd: string | null;
+        mtime: number;
+        first_timestamp: string | null;
+        is_subagent: number;
+    }>;
+
+    return rows.map((row) => ({
+        filePath: row.file_path,
+        sessionId: row.session_id,
+        customTitle: row.custom_title,
+        summary: row.summary,
+        firstPrompt: row.first_prompt,
+        gitBranch: row.git_branch,
+        project: row.project,
+        cwd: row.cwd,
+        mtime: row.mtime,
+        firstTimestamp: row.first_timestamp,
+        isSubagent: row.is_subagent === 1,
+    }));
 }

--- a/src/claude-history/types.ts
+++ b/src/claude-history/types.ts
@@ -221,6 +221,8 @@ export interface SearchFilters {
     commitHash?: string;
     commitMessage?: string;
     sortByRelevance?: boolean;
+    /** Progress callback: (processed, total, currentFile) */
+    onProgress?: (processed: number, total: number, currentFile: string) => void;
 }
 
 export interface SearchResult {

--- a/src/claude-resume/index.ts
+++ b/src/claude-resume/index.ts
@@ -1,0 +1,286 @@
+import { Command } from "commander";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { basename } from "node:path";
+import { formatRelativeTime } from "@app/utils/format";
+import { detectCurrentProject, findClaudeCommand } from "@app/utils/claude";
+import logger from "@app/logger";
+import {
+	getSessionListing,
+	searchConversations,
+	type SessionMetadataRecord,
+} from "@app/claude-history/lib";
+
+// --- Constants ---
+
+const NAME_MAX_LEN = 45;
+const ID_PREFIX_LEN = 8;
+const PROMPT_PREVIEW_LEN = 60;
+
+// --- Types ---
+
+interface DisplaySession {
+	sessionId: string;
+	name: string;
+	branch: string;
+	project: string;
+	modified: string;
+	source: "cache" | "search";
+}
+
+interface Options {
+	list?: boolean;
+	allProjects?: boolean;
+	limit: string;
+}
+
+// --- Helpers ---
+
+function toDisplay(
+	sessionId: string,
+	opts: {
+		title?: string | null;
+		summary?: string | null;
+		firstPrompt?: string | null;
+		branch?: string | null;
+		project?: string | null;
+		timestamp?: string | null;
+		source?: "cache" | "search";
+	},
+): DisplaySession {
+	return {
+		sessionId,
+		name:
+			opts.title ||
+			opts.summary ||
+			opts.firstPrompt?.slice(0, PROMPT_PREVIEW_LEN) ||
+			"(unnamed)",
+		branch: opts.branch || "",
+		project: opts.project || "",
+		modified: opts.timestamp || "",
+		source: opts.source ?? "cache",
+	};
+}
+
+function formatDate(iso: string): string {
+	if (!iso) return "";
+	return formatRelativeTime(new Date(iso), { compact: true });
+}
+
+function dedup(sessions: DisplaySession[]): DisplaySession[] {
+	const seen = new Set<string>();
+	return sessions.filter((s) => {
+		if (seen.has(s.sessionId)) return false;
+		seen.add(s.sessionId);
+		return true;
+	});
+}
+
+// --- Data ---
+
+type Spinner = ReturnType<typeof p.spinner>;
+
+function progressUpdater(spinner: Spinner) {
+	return (processed: number, total: number, file: string) => {
+		const pct = Math.round((processed / total) * 100);
+		const shortId = file.length > 8 ? file.slice(0, 8) : file;
+		spinner.message(`${processed}/${total} (${pct}%) ${shortId}...`);
+	};
+}
+
+interface LoadResult {
+	sessions: DisplaySession[];
+	total: number;
+	subagents: number;
+	project: string | undefined;
+}
+
+async function loadSessions(allProjects: boolean, spinner: Spinner): Promise<LoadResult> {
+	const project = allProjects ? undefined : detectCurrentProject();
+	const result = await getSessionListing({
+		project,
+		excludeSubagents: true,
+		onProgress: progressUpdater(spinner),
+	});
+	return {
+		sessions: result.sessions.map((s: SessionMetadataRecord) =>
+			toDisplay(s.sessionId || basename(s.filePath, ".jsonl"), {
+				title: s.customTitle,
+				summary: s.summary,
+				firstPrompt: s.firstPrompt,
+				branch: s.gitBranch,
+				project: s.project,
+				timestamp: s.firstTimestamp,
+			}),
+		),
+		total: result.total,
+		subagents: result.subagents,
+		project,
+	};
+}
+
+function matchByIdOrName(all: DisplaySession[], query: string): DisplaySession[] {
+	const q = query.toLowerCase();
+	const byId = all.filter((s) => s.sessionId.toLowerCase().startsWith(q));
+	if (byId.length > 0) return byId;
+
+	return all.filter(
+		(s) =>
+			s.name.toLowerCase().includes(q) ||
+			s.branch.toLowerCase().includes(q) ||
+			s.project.toLowerCase().includes(q),
+	);
+}
+
+async function searchByContent(query: string, spinner: Spinner, project?: string): Promise<DisplaySession[]> {
+	const results = await searchConversations({
+		query,
+		project,
+		sortByRelevance: true,
+		limit: 20,
+		summaryOnly: true,
+		onProgress: progressUpdater(spinner),
+	});
+	return results.map((r) =>
+		toDisplay(r.sessionId, {
+			title: r.customTitle,
+			summary: r.summary,
+			branch: r.gitBranch,
+			project: r.project,
+			timestamp: r.timestamp.toISOString(),
+			source: "search",
+		}),
+	);
+}
+
+// --- UI ---
+
+function sessionOption(s: DisplaySession) {
+	return {
+		value: s,
+		label: s.name.slice(0, NAME_MAX_LEN),
+		hint: [
+			pc.dim(s.sessionId.slice(0, ID_PREFIX_LEN)),
+			s.branch ? pc.magenta(s.branch) : "",
+			s.project ? pc.blue(s.project) : "",
+			pc.dim(formatDate(s.modified)),
+			s.source === "search" ? pc.yellow("[search]") : "",
+		]
+			.filter(Boolean)
+			.join(" "),
+	};
+}
+
+async function selectSession(candidates: DisplaySession[]): Promise<DisplaySession> {
+	if (candidates.length === 1) {
+		const s = candidates[0];
+		p.log.info(
+			`${pc.bold(s.name)} ${pc.dim(s.sessionId.slice(0, ID_PREFIX_LEN))} ${pc.magenta(s.branch)} ${pc.dim(formatDate(s.modified))}`,
+		);
+		return s;
+	}
+
+	const result = await p.select({
+		message: "Select session to resume:",
+		options: candidates.map(sessionOption),
+	});
+
+	if (p.isCancel(result)) {
+		p.cancel("Cancelled");
+		process.exit(0);
+	}
+	return result;
+}
+
+async function resumeSession(session: DisplaySession): Promise<never> {
+	const cmd = await findClaudeCommand();
+	p.outro(`${pc.green("Resuming:")} ${cmd} --resume ${session.sessionId}`);
+
+	const shell = process.env.SHELL || "/bin/zsh";
+	const proc = Bun.spawn({
+		cmd: [shell, "-ic", `exec ${cmd} --resume '${session.sessionId}'`],
+		stdio: ["inherit", "inherit", "inherit"],
+	});
+
+	const exitCode = await proc.exited;
+	process.exit(exitCode);
+}
+
+// --- Main ---
+
+async function main(query: string | undefined, opts: Options) {
+	p.intro(pc.bgCyan(pc.black(" claude-resume ")));
+	const limit = parseInt(opts.limit, 10);
+
+	const spinner = p.spinner();
+	spinner.start("Loading sessions...");
+	const { sessions, total, subagents, project } = await loadSessions(opts.allProjects ?? false, spinner);
+	const statsLine = subagents > 0
+		? `${sessions.length} sessions (+ ${subagents} subagents, total ${total})`
+		: `${sessions.length} sessions`;
+	spinner.stop(statsLine);
+
+	if (sessions.length === 0) {
+		p.log.error("No sessions found");
+		process.exit(1);
+	}
+
+	let candidates: DisplaySession[];
+
+	if (!query || opts.list) {
+		candidates = sessions.slice(0, limit);
+	} else {
+		candidates = matchByIdOrName(sessions, query);
+
+		if (candidates.length === 0) {
+			p.log.info(`No index match for "${query}", searching content...`);
+			const searchSpinner = p.spinner();
+			searchSpinner.start("Searching...");
+			const found = await searchByContent(query, searchSpinner, project);
+			searchSpinner.stop(found.length ? `${found.length} matches` : "No matches");
+
+			if (found.length > 0) {
+				candidates = dedup(
+					found.map((h) => {
+						const indexed = sessions.find((s) => s.sessionId === h.sessionId);
+						return indexed ? { ...indexed, source: "search" as const } : h;
+					}),
+				);
+			}
+		}
+
+		if (candidates.length === 0) {
+			p.log.warn("No matches. Showing recent:");
+			candidates = sessions.slice(0, limit);
+		}
+	}
+
+	const selected = await selectSession(candidates);
+	await resumeSession(selected);
+}
+
+// --- CLI ---
+
+const program = new Command();
+
+program
+	.name("claude-resume")
+	.description("Resume a Claude Code session by short ID, name, or content search")
+	.argument("[query]", "Session ID prefix, name, or search term")
+	.option("-l, --list", "List recent sessions")
+	.option("-a, --all-projects", "Search all projects (default: current project only)")
+	.option("-n, --limit <n>", "Number of sessions to show", "20")
+	.action(async (query: string | undefined, opts: Options) => {
+		try {
+			await main(query, opts);
+		} catch (error) {
+			if (error instanceof Error && error.name === "ExitPromptError") {
+				process.exit(0);
+			}
+			logger.error(`claude-resume error: ${error}`);
+			p.log.error(String(error));
+			process.exit(1);
+		}
+	});
+
+program.parse();

--- a/src/utils/claude/index.ts
+++ b/src/utils/claude/index.ts
@@ -47,3 +47,43 @@ export async function parseJsonlTranscript<T = Record<string, unknown>>(
 
     return messages;
 }
+
+/**
+ * Find the claude CLI command name available on this system.
+ * Checks for `ccc`, `cc` (aliases/functions) first, then falls back to `claude`.
+ * Uses interactive shell to resolve functions/aliases from ~/.zshrc,
+ * and verifies the command is actually Claude (not e.g. the C compiler for `cc`).
+ */
+export async function findClaudeCommand(): Promise<string> {
+    const shell = process.env.SHELL || "/bin/zsh";
+
+    for (const cmd of ["ccc", "cc", "claude"]) {
+        const proc = Bun.spawn({
+            cmd: [shell, "-ic", `${cmd} --version 2>&1`],
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        const stdout = await new Response(proc.stdout).text();
+        await proc.exited;
+
+        if (proc.exitCode === 0 && stdout.includes("Claude Code")) {
+            return cmd;
+        }
+    }
+    return "claude";
+}
+
+/**
+ * Detect the current project name from cwd.
+ * Returns the last path segment (directory name), e.g. "GenesisTools".
+ */
+export function detectCurrentProject(): string | undefined {
+    return process.cwd().split("/").pop();
+}
+
+/**
+ * Get the encoded project directory name for a cwd path.
+ * Claude encodes /Users/Martin/Projects/Foo as -Users-Martin-Projects-Foo.
+ */
+export function encodedProjectDir(cwd?: string): string {
+    return (cwd ?? process.cwd()).replaceAll("/", "-");
+}

--- a/src/utils/claude/index.ts
+++ b/src/utils/claude/index.ts
@@ -85,5 +85,7 @@ export function detectCurrentProject(): string | undefined {
  * Claude encodes /Users/Martin/Projects/Foo as -Users-Martin-Projects-Foo.
  */
 export function encodedProjectDir(cwd?: string): string {
-    return (cwd ?? process.cwd()).replaceAll("/", "-");
+    const path = cwd ?? process.cwd();
+    // Prepend a dash to match the observed encoding format.
+    return `-${path.replace(/^\//, "").replaceAll("/", "-")}`;
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -90,16 +90,19 @@ interface FormatRelativeTimeOptions {
     fallbackFormat?: (date: Date) => string;
     /** Rounding mode for time units. Default: "floor" */
     rounding?: "floor" | "round";
+    /** Compact output: "5m ago", "3h ago", "2d ago". Default: false */
+    compact?: boolean;
 }
 
 /**
  * Format a Date as a relative time string like "5 minutes ago".
+ * With compact: true, returns "5m ago", "3h ago", "2d ago".
  *
  * @param date - The date to format
  * @param options - Formatting options
  */
 export function formatRelativeTime(date: Date, options?: FormatRelativeTimeOptions): string {
-    const { maxDays = Infinity, fallbackFormat, rounding = "floor" } = options ?? {};
+    const { maxDays = Infinity, fallbackFormat, rounding = "floor", compact = false } = options ?? {};
     const round = rounding === "round" ? Math.round : Math.floor;
 
     const diffMs = Date.now() - date.getTime();
@@ -109,6 +112,14 @@ export function formatRelativeTime(date: Date, options?: FormatRelativeTimeOptio
 
     if (maxDays !== Infinity && diffDays >= maxDays && fallbackFormat) {
         return fallbackFormat(date);
+    }
+
+    if (compact) {
+        if (diffMinutes < 1) return "now";
+        if (diffHours < 1) return `${diffMinutes}m ago`;
+        if (diffDays < 1) return `${diffHours}h ago`;
+        if (diffDays < 7) return `${diffDays}d ago`;
+        return date.toISOString().slice(0, 10);
     }
 
     if (diffMinutes < 1) return "just now";


### PR DESCRIPTION
## Summary
- Add `claude-resume` command and `cc` alias for resuming Claude Code sessions
- Shell-based command detection for `findClaudeCommand` to properly resolve aliases/functions
- Updated README plugin table with new commands

## Test plan
- [ ] Verify `tools cc` launches session finder
- [ ] Verify `tools claude-resume` works identically
- [ ] Verify `findClaudeCommand` correctly detects `ccc`/`cc`/`claude`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `claude-resume` command to browse and resume previous sessions with project filtering and search capabilities.
  * Added `cc` alias for quick access to session resumption.
  * Added `claude-history` and `github-pr` commands (documented in CLI reference).
  * Implemented real-time progress indicators when loading sessions.
  * Enhanced session display with compact time formatting and session metadata (branch, project, modification date).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->