### PR TITLE
fix(claude-history): full metadata extraction, rg search, auto-reindex

### DIFF
--- a/src/claude-history/cache.ts
+++ b/src/claude-history/cache.ts
@@ -5,13 +5,13 @@
 
 import { Database } from "bun:sqlite";
 import logger from "@app/logger";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, unlinkSync } from "fs";
 import { stat } from "fs/promises";
 import { homedir } from "os";
 import { join, sep } from "path";
 
 const DEFAULT_CACHE_DIR = join(homedir(), ".genesis-tools", "claude-history");
-const DB_NAME = "stats-cache.db";
+const DB_NAME = "index.db";
 
 let _db: Database | null = null;
 
@@ -123,6 +123,7 @@ function initSchema(db: Database): void {
         "ALTER TABLE daily_stats ADD COLUMN token_usage TEXT",
         "ALTER TABLE daily_stats ADD COLUMN model_counts TEXT",
         "ALTER TABLE daily_stats ADD COLUMN branch_counts TEXT",
+        "ALTER TABLE session_metadata ADD COLUMN all_user_text TEXT",
     ];
 
     for (const migration of migrations) {
@@ -170,6 +171,7 @@ export interface SessionMetadataRecord {
     mtime: number;
     firstTimestamp: string | null;
     isSubagent: boolean;
+    allUserText: string | null;
 }
 
 export interface FileIndexRecord {
@@ -633,6 +635,7 @@ interface SessionMetadataRow {
     mtime: number;
     first_timestamp: string | null;
     is_subagent: number;
+    all_user_text: string | null;
 }
 
 function rowToSessionMetadataRecord(row: SessionMetadataRow): SessionMetadataRecord {
@@ -648,6 +651,7 @@ function rowToSessionMetadataRecord(row: SessionMetadataRow): SessionMetadataRec
         mtime: row.mtime,
         firstTimestamp: row.first_timestamp,
         isSubagent: row.is_subagent === 1,
+        allUserText: row.all_user_text,
     };
 }
 
@@ -661,8 +665,8 @@ export function upsertSessionMetadata(record: SessionMetadataRecord): void {
     const db = getDatabase();
     db.query(`
     INSERT OR REPLACE INTO session_metadata
-      (file_path, session_id, custom_title, summary, first_prompt, git_branch, project, cwd, mtime, first_timestamp, is_subagent)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (file_path, session_id, custom_title, summary, first_prompt, git_branch, project, cwd, mtime, first_timestamp, is_subagent, all_user_text)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
         record.filePath,
         record.sessionId,
@@ -674,7 +678,8 @@ export function upsertSessionMetadata(record: SessionMetadataRecord): void {
         record.cwd,
         record.mtime,
         record.firstTimestamp,
-        record.isSubagent ? 1 : 0
+        record.isSubagent ? 1 : 0,
+        record.allUserText
     );
 }
 
@@ -701,4 +706,39 @@ export function getSessionMetadataByProject(project: string): SessionMetadataRec
         .query("SELECT * FROM session_metadata WHERE project = ? ORDER BY COALESCE(first_timestamp, '') DESC")
         .all(project) as SessionMetadataRow[];
     return rows.map(rowToSessionMetadataRecord);
+}
+
+// =============================================================================
+// Database Reset & Cleanup
+// =============================================================================
+
+export function resetDatabase(): void {
+    closeDatabase();
+    const dbPath = join(DEFAULT_CACHE_DIR, DB_NAME);
+    try { unlinkSync(dbPath); } catch { /* may not exist */ }
+    try { unlinkSync(`${dbPath}-wal`); } catch { /* may not exist */ }
+    try { unlinkSync(`${dbPath}-shm`); } catch { /* may not exist */ }
+}
+
+export function clearSessionMetadata(): void {
+    const db = getDatabase();
+    db.run("DELETE FROM session_metadata");
+}
+
+export function getAllSessionMetadataFilePaths(): string[] {
+    const db = getDatabase();
+    const rows = db.query("SELECT file_path FROM session_metadata").all() as Array<{ file_path: string }>;
+    return rows.map((r) => r.file_path);
+}
+
+export function removeSessionMetadataBatch(filePaths: string[]): void {
+    if (filePaths.length === 0) return;
+    const db = getDatabase();
+    const stmt = db.prepare("DELETE FROM session_metadata WHERE file_path = ?");
+    const transaction = db.transaction((paths: string[]) => {
+        for (const path of paths) {
+            stmt.run(path);
+        }
+    });
+    transaction(filePaths);
 }

--- a/src/claude-history/cache.ts
+++ b/src/claude-history/cache.ts
@@ -5,7 +5,7 @@
 
 import { Database } from "bun:sqlite";
 import logger from "@app/logger";
-import { existsSync, mkdirSync, unlinkSync } from "fs";
+import { existsSync, mkdirSync, rmSync } from "fs";
 import { stat } from "fs/promises";
 import { homedir } from "os";
 import { join, sep } from "path";
@@ -715,9 +715,9 @@ export function getSessionMetadataByProject(project: string): SessionMetadataRec
 export function resetDatabase(): void {
     closeDatabase();
     const dbPath = join(DEFAULT_CACHE_DIR, DB_NAME);
-    try { unlinkSync(dbPath); } catch { /* may not exist */ }
-    try { unlinkSync(`${dbPath}-wal`); } catch { /* may not exist */ }
-    try { unlinkSync(`${dbPath}-shm`); } catch { /* may not exist */ }
+    for (const suffix of ["", "-wal", "-shm"]) {
+        rmSync(`${dbPath}${suffix}`, { force: true });
+    }
 }
 
 export function clearSessionMetadata(): void {

--- a/src/claude-history/lib.ts
+++ b/src/claude-history/lib.ts
@@ -6,6 +6,7 @@
 import { createHash } from "crypto";
 import { createReadStream, existsSync, readFileSync, readdirSync } from "fs";
 import { stat } from "fs/promises";
+import logger from "@app/logger";
 import { glob } from "glob";
 import { homedir } from "os";
 import { basename, resolve, sep } from "path";
@@ -58,12 +59,18 @@ export * from "./types";
 /**
  * Auto-derived metadata version — hash of lib.ts + cache.ts source.
  * When ANY extraction/cache logic changes, this hash changes, forcing re-index.
+ * Falls back to "v1" in bundled environments where source files aren't on disk.
  */
-const METADATA_VERSION = createHash("md5")
-    .update(readFileSync(new URL("./lib.ts", import.meta.url), "utf-8"))
-    .update(readFileSync(new URL("./cache.ts", import.meta.url), "utf-8"))
-    .digest("hex")
-    .slice(0, 8);
+let METADATA_VERSION: string;
+try {
+    METADATA_VERSION = createHash("md5")
+        .update(readFileSync(new URL("./lib.ts", import.meta.url), "utf-8"))
+        .update(readFileSync(new URL("./cache.ts", import.meta.url), "utf-8"))
+        .digest("hex")
+        .slice(0, 8);
+} catch {
+    METADATA_VERSION = "v1";
+}
 
 export const CLAUDE_DIR = resolve(homedir(), ".claude");
 export const PROJECTS_DIR = resolve(CLAUDE_DIR, "projects");
@@ -1079,10 +1086,13 @@ export async function getSessionListing(options: SessionListingOptions = {}): Pr
         }
     }
 
-    // Clean up stale entries for deleted files
+    // Clean up stale entries for deleted files (scoped to current listing)
     const diskFiles = new Set(files);
     const cachedPaths = getAllSessionMetadataFilePaths();
-    const stalePaths = cachedPaths.filter((p) => !diskFiles.has(p));
+    const cachedPathsInScope = projectDir
+        ? cachedPaths.filter((p) => p.startsWith(projectDir + sep) || p === projectDir)
+        : cachedPaths;
+    const stalePaths = cachedPathsInScope.filter((p) => !diskFiles.has(p));
     if (stalePaths.length > 0) {
         removeSessionMetadataBatch(stalePaths);
     }
@@ -1182,6 +1192,10 @@ async function extractSessionMetadataFromFile(
     const isSubagent = filePath.includes(`${sep}subagents${sep}`) || basename(filePath).startsWith("agent-");
 
     try {
+        // Skip extremely large session files to avoid performance issues
+        const fileStat = await stat(filePath);
+        if (fileStat.size > 10 * 1024 * 1024) return null;
+
         const fileStream = createReadStream(filePath);
         const rl = createInterface({ input: fileStream, crlfDelay: Number.POSITIVE_INFINITY });
 
@@ -1240,6 +1254,12 @@ async function extractSessionMetadataFromFile(
                         userTextLen += text.length;
                     }
                 }
+
+                // Early exit: all metadata found and user text cap reached
+                if (summary && customTitle && sessionId && gitBranch && firstTimestamp && userTextLen >= USER_TEXT_CAP) {
+                    fileStream.destroy();
+                    break;
+                }
             } catch {
                 // Skip unparseable lines
             }
@@ -1285,27 +1305,39 @@ export async function rgSearchFiles(
         ? resolveProjectDir(options.project) || PROJECTS_DIR
         : PROJECTS_DIR;
 
-    const proc = Bun.spawn({
-        cmd: [
-            "rg", "-l", "--glob", "*.jsonl",
-            "-i",
-            "--max-count", "1",
-            query,
-            searchDir,
-        ],
-        stdio: ["ignore", "pipe", "pipe"],
-    });
+    try {
+        const proc = Bun.spawn({
+            cmd: [
+                "rg", "-l", "--glob", "*.jsonl",
+                "-i", "-F",
+                "--max-count", "1",
+                "--", query,
+                searchDir,
+            ],
+            stdio: ["ignore", "pipe", "pipe"],
+        });
 
-    const output = await new Response(proc.stdout).text();
-    await proc.exited;
+        const output = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
 
-    let files = output.trim().split("\n").filter(Boolean);
+        // rg exit 1 = no matches (OK), 2+ = actual error
+        if (exitCode > 1) {
+            const stderr = await new Response(proc.stderr).text();
+            logger.warn(`rgSearchFiles failed (exit ${exitCode}): ${stderr.trim()}`);
+            return [];
+        }
 
-    if (options.limit && files.length > options.limit) {
-        files = files.slice(0, options.limit);
+        let files = output.trim().split("\n").filter(Boolean);
+
+        if (options.limit && files.length > options.limit) {
+            files = files.slice(0, options.limit);
+        }
+
+        return files;
+    } catch (error) {
+        logger.warn(`rgSearchFiles error: ${error}`);
+        return [];
     }
-
-    return files;
 }
 
 /**
@@ -1315,59 +1347,50 @@ export async function rgExtractSnippet(
     query: string,
     filePath: string,
 ): Promise<string | undefined> {
-    const proc = Bun.spawn({
-        cmd: ["rg", "-i", "-m", "1", "--no-filename", "--no-line-number", query, filePath],
-        stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const output = await new Response(proc.stdout).text();
-    await proc.exited;
-
-    const line = output.trim();
-    if (!line) return undefined;
-
-    // Try to extract readable text from the JSON line
     try {
-        const obj = JSON.parse(line);
-        let text = "";
-        if (obj.type === "user" && typeof obj.message?.content === "string") {
-            text = obj.message.content;
-        } else if (obj.type === "user" && Array.isArray(obj.message?.content)) {
-            text = obj.message.content
-                .filter((b: { type: string }) => b.type === "text")
-                .map((b: { text: string }) => b.text)
-                .join(" ");
-        } else if (obj.type === "assistant" && Array.isArray(obj.message?.content)) {
-            text = obj.message.content
-                .filter((b: { type: string }) => b.type === "text")
-                .map((b: { text: string }) => b.text)
-                .join(" ");
-        } else if (obj.type === "summary") {
-            text = obj.summary || "";
+        const proc = Bun.spawn({
+            cmd: ["rg", "-i", "-F", "-m", "1", "--no-filename", "--no-line-number", "--", query, filePath],
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        const output = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+
+        if (exitCode > 1) return undefined;
+
+        const line = output.trim();
+        if (!line) return undefined;
+
+        // Try to extract readable text from the JSON line
+        try {
+            const obj = JSON.parse(line);
+            const text = extractTextFromMessage(obj as ConversationMessage, true);
+
+            if (!text) return undefined;
+
+            const lowerText = text.toLowerCase();
+            const lowerQuery = query.toLowerCase();
+            const idx = lowerText.indexOf(lowerQuery);
+            if (idx === -1) return text.slice(0, 100);
+
+            const start = Math.max(0, idx - 40);
+            const end = Math.min(text.length, idx + query.length + 60);
+            return (start > 0 ? "..." : "") +
+                text.slice(start, end).replace(/\n/g, " ").trim() +
+                (end < text.length ? "..." : "");
+        } catch {
+            // If JSON parsing fails, try to extract from raw text
+            const lowerLine = line.toLowerCase();
+            const lowerQuery = query.toLowerCase();
+            const idx = lowerLine.indexOf(lowerQuery);
+            if (idx === -1) return undefined;
+
+            const start = Math.max(0, idx - 40);
+            const end = Math.min(line.length, idx + query.length + 60);
+            return "..." + line.slice(start, end).replace(/\\n/g, " ").trim() + "...";
         }
-
-        if (!text) return undefined;
-
-        const lowerText = text.toLowerCase();
-        const lowerQuery = query.toLowerCase();
-        const idx = lowerText.indexOf(lowerQuery);
-        if (idx === -1) return text.slice(0, 100);
-
-        const start = Math.max(0, idx - 40);
-        const end = Math.min(text.length, idx + query.length + 60);
-        return (start > 0 ? "..." : "") +
-            text.slice(start, end).replace(/\n/g, " ").trim() +
-            (end < text.length ? "..." : "");
     } catch {
-        // If JSON parsing fails, try to extract from raw text
-        const lowerLine = line.toLowerCase();
-        const lowerQuery = query.toLowerCase();
-        const idx = lowerLine.indexOf(lowerQuery);
-        if (idx === -1) return undefined;
-
-        const start = Math.max(0, idx - 40);
-        const end = Math.min(line.length, idx + query.length + 60);
-        return "..." + line.slice(start, end).replace(/\\n/g, " ").trim() + "...";
+        return undefined;
     }
 }
 

--- a/src/claude-history/lib.ts
+++ b/src/claude-history/lib.ts
@@ -65,13 +65,26 @@ let METADATA_VERSION: string;
 try {
     METADATA_VERSION = createHash("md5")
         .update(readFileSync(new URL("./lib.ts", import.meta.url), "utf-8"))
-        .update(readFileSync(new URL("./cache.ts", import.meta.url), "utf-8"))
-        .digest("hex")
-        .slice(0, 8);
-} catch {
-    METADATA_VERSION = "v1";
+ *
+ * In some deployment environments (e.g. bundlers, transpilers), the source
+ * files may not be available at runtime. In that case, we fall back to a
+ * stable default version string instead of throwing at module load time.
+ */
+function getMetadataVersion(): string {
+    try {
+        const hash = createHash("md5")
+            .update(readFileSync(new URL("./lib.ts", import.meta.url), "utf-8"))
+            .update(readFileSync(new URL("./cache.ts", import.meta.url), "utf-8"))
+            .digest("hex")
+            .slice(0, 8);
+        return hash;
+    } catch {
+        // Fallback: manually bump this string if metadata extraction logic changes
+        return "v1";
+    }
 }
 
+const METADATA_VERSION = getMetadataVersion();
 export const CLAUDE_DIR = resolve(homedir(), ".claude");
 export const PROJECTS_DIR = resolve(CLAUDE_DIR, "projects");
 

--- a/src/claude-resume/index.ts
+++ b/src/claude-resume/index.ts
@@ -203,7 +203,8 @@ async function searchByContent(query: string, spinner: Spinner, project?: string
 	}
 
 	const rgSessions: DisplaySession[] = [];
-	for (const filePath of rgOnlyFiles.slice(0, 20 - metaSessions.length)) {
+	const remainingSlots = Math.max(5, 20 - metaSessions.length);
+	for (const filePath of rgOnlyFiles.slice(0, remainingSlots)) {
 		const cached = getSessionMetadata(filePath);
 		const snippet = await rgExtractSnippet(query, filePath);
 
@@ -387,7 +388,9 @@ async function main(query: string | undefined, opts: Options) {
 				candidates = dedup(
 					result.sessions.map((h) => {
 						const cached = sessions.find((s) => s.sessionId === h.sessionId);
-						return cached ? { ...cached, source: "search" as const } : h;
+						return cached
+							? { ...cached, source: "search" as const, matchSnippet: h.matchSnippet }
+							: h;
 					}),
 				);
 			}

--- a/src/utils/claude/index.ts
+++ b/src/utils/claude/index.ts
@@ -91,7 +91,7 @@ export function detectCurrentProject(): string | undefined {
 
 /**
  * Get the encoded project directory name for a cwd path.
- * Claude encodes /Users/Martin/Projects/Foo as -Users-Martin-Projects-Foo.
+ * Claude encodes /Users/jane/Projects/Foo as -Users-jane-Projects-Foo.
  */
 export function encodedProjectDir(cwd?: string): string {
     const p = cwd ?? process.cwd();


### PR DESCRIPTION
## Summary

- **Fix broken search**: `tools cc "/oidc/logout"` now finds results (was 0 before — 36.5% of summaries were missed, content search never actually searched content)
- **Full metadata extraction**: reads entire JSONL files, stores full first prompt (was truncated to 120 chars), indexes ALL user messages into `allUserText` field (5000 char cap)
- **Ripgrep full-content search**: both metadata (SQLite) and `rg` search run in parallel — catches matches in assistant messages, tool output, and deep user text that metadata misses
- **Auto-reindex**: MD5 hash of `lib.ts` + `cache.ts` detects code changes and auto-deletes/recreates the DB (renamed from `stats-cache.db` to `index.db`)
- **Stale cleanup**: removes cache entries for deleted session files
- **Fix dashed project names**: `col-fe` was showing as `fe` — now resolves encoded paths against filesystem
- **Nerdy stats**: shows session count, project count, scope, index/stale/reindex status
- **Conversation excerpts**: session picker shows summary/first prompt below each session name, plus match snippets for search results

## Test plan
- [ ] `tools cc "/oidc/logout" --all-projects` — should find matching sessions
- [ ] `tools cc --list` — check nerdy stats line and project names
- [ ] `tools cc "extractSessionMetadataFromFile" --all-projects` — should find via rg (assistant-only content)
- [ ] Verify `col-fe` shows correctly (not `fe`)
- [ ] Delete `~/.genesis-tools/claude-history/index.db` and re-run — should auto-rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-text ripgrep search and snippet extraction for content hits.
  * Enriched session metadata surfaced in UI: summaries, first prompts, match snippets, and captured user text.
  * Session listing now reports indexed/stale/reindexed counts, project counts and scope.

* **Improvements**
  * Parallel metadata + content search with dedup/merge and contextual excerpts.
  * Controls to reset/clear session metadata and batch-remove metadata files; automatic reindexing on metadata-version changes.
* **Documentation**
  * Updated example path in a doc comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->