### PR TITLE
feat(skills): delegate PR review replies to background haiku agent

### DIFF
--- a/plugins/genesis-tools/commands/github-pr.md
+++ b/plugins/genesis-tools/commands/github-pr.md
@@ -86,9 +86,33 @@ Options:
 
 If user chooses "specify thread numbers", ask for comma-separated thread numbers (e.g., "1, 3, 5, 7").
 
+### Step 3.5: Critically Evaluate Each Thread Before Fixing
+
+**Do not blindly implement every review comment.** Reviewers make mistakes. Before touching any code, evaluate each thread:
+
+1. **Read the actual code** at the referenced file and line — don't rely solely on the reviewer's description
+2. **Verify the claim** — is the reviewer correct? Does the bug/issue actually exist?
+3. **Check for false positives** — common reviewer mistakes include:
+   - Flagging patterns that are correct for the runtime (e.g., Bun vs. Node.js APIs)
+   - Misreading control flow or missing existing guards (e.g., claiming `clearTimeout` is missing when it's present)
+   - Suggesting `JSON.stringify` replacer doesn't recurse (it does, by spec)
+   - Flagging intentional design choices (local CLI security model, YAGNI, by-design behavior)
+   - Missing framework/library guarantees that make the concern moot
+4. **Categorize each thread** before doing anything:
+   - `VALID` — reviewer is correct, fix needed
+   - `FALSE_POSITIVE` — reviewer is wrong; push back with a clear technical explanation
+   - `BY_DESIGN` — intentional choice; decline with rationale
+   - `ALREADY_FIXED` — addressed in a prior commit
+
+**When you're unsure about a thread** — use `AskUserQuestion` to ask the user rather than guessing. For example:
+- "Thread #5 claims X — I see the guard on line 42 which looks like it addresses this. Is this intentional or should I still fix it?"
+- "Thread #12 suggests using vm2 for sandboxing — this is a local CLI where the user writes their own presets. Should I decline this or implement it?"
+
+**Never assume intent.** If a thread is ambiguous (e.g., the reviewer's suggested fix would change behavior in a way that might or might not be desired), stop and ask before implementing.
+
 ### Step 4: Implement Fixes
 
-For each selected thread:
+For each thread marked `VALID`:
 
 1. Read the file mentioned in the thread
 2. Understand the issue from the review comment
@@ -99,7 +123,7 @@ For each selected thread:
 
 **Important:**
 - Fix threads one by one, validating each fix works
-- If a fix is unclear, ask the user for clarification
+- If a fix is unclear, use `AskUserQuestion` — do not assume
 - Run linting/type checking on modified files if applicable
 
 ### Step 5: Commit Changes
@@ -164,7 +188,7 @@ When resolving in batch:
 tools github review <pr> --respond "Fixed in abc1234" --resolve-thread -t <thread-id1>,<thread-id2>,<thread-id3>
 ```
 
-**Permission note:** `--resolve-thread` requires a GitHub PAT with `pull_requests:write` scope. If it fails with "Resource not accessible by personal access token", the `--respond` reply will still succeed. Report the permission issue to the user so they can resolve threads manually on GitHub.
+**Permission note:** `--resolve-thread` uses `resolveReviewThread` GraphQL mutation. Fine-grained PATs may fail with "Resource not accessible by personal access token" even with `pull_requests:write` set, because GitHub does not support this mutation for fine-grained PATs. The tool now automatically falls back to the `gh` CLI token (classic OAuth with `repo` scope) which always has the needed permission. No manual action required.
 
 ### Step 7: Report Summary
 
@@ -190,11 +214,201 @@ User: /github-pr 137 -u
 8. Report: "Fixed 14 threads, modified 5 files, commit abc1234"
 ```
 
+---
+
+## Multi-PR Analysis Workflow
+
+When the user provides **multiple PR URLs/numbers**, switch to analysis-first mode: spawn parallel agents to evaluate each PR's review comments, write structured plans, and present a consolidated report before touching any code.
+
+### When to use this mode
+
+- User provides 2+ PR URLs in the same message
+- User says "analyze these PRs", "review all of these", "write plans for..."
+- User explicitly asks for a report before implementing
+
+### Step 1: Setup
+
+```bash
+mkdir -p .claude/plans/reviews
+```
+
+Get the current datetime for filenames:
+```bash
+date -u +"%Y-%m-%dT%H-%M-%S"   # e.g. 2026-02-18T23-18-22
+```
+
+Plan files go to: `.claude/plans/reviews/PR-<id>-<datetime>.md`
+
+### Step 2: Fetch All PR Reviews in Parallel
+
+Run simultaneously for all PRs:
+
+```bash
+tools github review <pr-url> -g --md        # all threads (default)
+tools github review <pr-url> -g --md -u     # unresolved only (if requested)
+```
+
+**Special case — if user says "resolve threads where `<author>` replied first":**
+1. Fetch all threads (without `-u`) to find threads where that author has a reply
+2. Batch-resolve: `tools github review <pr> --resolve-thread -t id1,id2,...`
+   - Note: `--resolve-thread` automatically falls back to `gh` CLI token if the primary token lacks permission — no manual action needed
+3. Re-fetch with `-u` to get the remaining unresolved threads for analysis
+
+### Step 3: Dispatch One Agent Per PR (in parallel)
+
+Use the `superpowers:dispatching-parallel-agents` skill to structure parallel dispatch. Each agent:
+
+1. **Must invoke** `superpowers:receiving-code-review` skill to guide evaluation
+2. **Must invoke** `superpowers:writing-plans` skill to structure the output plan
+3. Reads the generated review markdown file
+4. Reads the actual source files referenced in each thread (using Glob/Grep/Read)
+5. For each thread, assigns a verdict:
+   - `VALID_FIX_NEEDED` — real issue, needs a fix
+   - `FALSE_POSITIVE` — reviewer is wrong or lacks context
+   - `BY_DESIGN` — intentional, no fix needed
+   - `ALREADY_FIXED` — addressed in a prior commit
+6. Writes plan to `.claude/plans/reviews/PR-<id>-<datetime>.md`
+
+**Agent prompt template:**
+
+```
+You are analyzing PR #<id> review comments for the <repo> repository.
+
+1. Invoke the `superpowers:receiving-code-review` skill to guide your evaluation
+2. Read the PR review file: `<path-to-review-md>`
+3. For each thread, READ THE ACTUAL SOURCE FILES at the referenced location before
+   forming any opinion. Then assign a verdict:
+   - VALID_FIX_NEEDED — reviewer is correct, a real fix is needed
+   - FALSE_POSITIVE — reviewer is wrong (misread the code, wrong about the API,
+     doesn't understand the runtime, etc.) — push back with evidence
+   - BY_DESIGN — intentional choice; decline with rationale
+   - ALREADY_FIXED — addressed in a prior commit
+4. Invoke the `superpowers:writing-plans` skill to structure the output
+5. Write a plan to `.claude/plans/reviews/PR-<id>-<datetime>.md`
+
+CRITICAL EVALUATION RULES:
+- Do NOT blindly accept reviewer claims. Reviewers make mistakes. Verify by
+  reading the actual code at the referenced line.
+- Common false positives to watch for:
+  - Claiming a guard/check is missing when it exists
+  - Misunderstanding Bun vs. Node.js APIs
+  - Flagging intentional security model for local CLI tools
+  - Suggesting JSON.stringify replacer "only hits top-level" (it recurses)
+  - Flagging YAGNI concerns for features that are out of scope
+  - Misreading control flow or variable scope
+- If you are UNSURE about a thread's verdict (the code is ambiguous or the
+  design intent is unclear), flag it as NEEDS_CLARIFICATION in the plan and
+  note exactly what question needs answering — do not guess.
+
+CONSTRAINTS:
+- DO NOT modify any source files
+- DO NOT switch branches or run git operations (use `git show <branch>:<file>`
+  or `gh api` to read code on other branches without checking out)
+- DO NOT commit anything
+- Plans are for LATER execution, not now
+
+Plan must include:
+- PR title and branch
+- Per-thread: Thread ID, file/line, concern, verdict, justification (with code evidence)
+- If VALID_FIX_NEEDED: exact file, what to change, how (code snippet if applicable)
+- If FALSE_POSITIVE/BY_DESIGN: the technical reply text to post on GitHub
+- Summary verdict table
+- Prioritized fix list (HIGH → MED → LOW)
+- GitHub reply text for every thread (fixed, won't fix, already fixed, needs clarification)
+```
+
+**Important constraints for agents:**
+- Agents must NOT switch branches — read code as-is on the current branch
+- If a PR's files are on a different branch, use `gh api` or `git show <branch>:<file>` to read them without checking out
+- Plans stay in this repo's `.claude/plans/reviews/` regardless of which branch holds the PR code
+
+### Step 4: Collect Results and Present Report
+
+After all agents complete, read each plan file and compile a consolidated report using this template:
+
+---
+
+### Report Template
+
+```markdown
+## PR Review Analysis Report — <date>
+
+> Plans saved to `.claude/plans/reviews/`
+> [Any warnings: resolve failures, branch issues, description updates, etc.]
+
+---
+
+## PR #<id> — `<title>`
+**Branch:** `<branch>` | **Threads analyzed:** <N>
+
+| Verdict | Count |
+|---------|-------|
+| VALID_FIX_NEEDED | X |
+| FALSE_POSITIVE | X |
+| BY_DESIGN | X |
+| ALREADY_FIXED | X |
+
+### Fixes Required:
+
+| Priority | Thread | File | Issue |
+|----------|--------|------|-------|
+| 🔴 HIGH | #N | `file:line` | One-line description of bug/issue. Fix: brief description |
+| 🟡 MED  | #N | `file:line` | ... |
+| 🟢 LOW  | #N | `file:line` | ... |
+
+---
+
+## Grand Summary
+
+| PR | Branch | Valid Fixes | Total Threads |
+|----|--------|-------------|---------------|
+| #id | `branch` | N | N |
+```
+
+---
+
+### Step 5: Ask What to Do Next
+
+After presenting the report, ask:
+
+```
+What would you like to do?
+
+1. Implement all PRs in parallel (separate worktrees per PR)
+2. Implement one PR at a time (you choose order)
+3. Just post replies now, implement later
+4. Skip to replying on a specific PR
+```
+
+If implementing: use `superpowers:using-git-worktrees` skill when PRs are on different branches.
+If replying: use the reply text prepared in each plan (see Step 6 of the single-PR flow above).
+
+---
+
+## Example Flow (Multi-PR)
+
+```
+User: analyze these PRs and write plans:
+  - https://github.com/org/repo/pull/29
+  - https://github.com/org/repo/pull/33
+  - https://github.com/org/repo/pull/31 (resolve threads where I replied first)
+
+1. mkdir -p .claude/plans/reviews
+2. Fetch all 3 PR reviews in parallel
+3. PR #31: resolve author-replied threads, re-fetch -u
+4. Spawn 3 parallel agents (one per PR)
+5. Agents write plans to .claude/plans/reviews/PR-{29,33,31}-2026-02-18T23-18-22.md
+6. Compile and present consolidated report
+7. Ask user what to do next
+```
+
 ## Key Rules
 
-1. **Always cat the full markdown file** - don't truncate
-2. **Ask before fixing** - let user choose what to fix
-3. **Follow commit message style** - match existing repo patterns
-4. **Run linting** - validate fixes don't break types
-5. **One commit** - group all PR review fixes into a single commit
-6. **Reference PR** - include PR number in commit message
+1. **Always cat the full markdown file** — don't truncate
+2. **Ask before fixing** — let user choose what to fix
+3. **Follow commit message style** — match existing repo patterns
+4. **Run linting** — validate fixes don't break types
+5. **One commit** — group all PR review fixes into a single commit
+6. **Reference PR** — include PR number in commit message
+7. **Push back on wrong reviews** — read the actual code before accepting a reviewer's claim. If the issue doesn't exist, the fix is already present, or the concern contradicts the design, say so clearly in your reply with a technical explanation. Don't implement fixes that aren't needed.
+8. **Ask, don't assume** — whenever a thread is ambiguous, its intent is unclear, or implementing it could have unintended consequences, use `AskUserQuestion` to clarify with the user before proceeding. Assumptions that turn out wrong waste more time than asking.

--- a/plugins/genesis-tools/skills/github/SKILL.md
+++ b/plugins/genesis-tools/skills/github/SKILL.md
@@ -266,7 +266,7 @@ tools github review 137 --resolve-thread -t <thread-id>
 1. Reply to each addressed thread with: what was fixed, how it was fixed, and a **clickable link** to the commit using markdown: `[short-sha](https://github.com/owner/repo/commit/full-sha)` (e.g. "Fixed in [abc1234](https://github.com/owner/repo/commit/abc1234def5678) — scoped stale cleanup to current project directory.")
 2. Reply "Won't fix" to deliberately skipped threads with a detailed explanation of why the change isn't warranted (technical reasoning, not just a dismissal)
 3. Do NOT resolve threads automatically — only resolve when the user explicitly asks to resolve them
-4. **Tag the review author** in replies: `@coderabbitai` for CodeRabbit, `/gemini` for Gemini Code Assist, `@<username>` for others
+4. **Tag the review author** in replies: `@coderabbitai` for CodeRabbit, `/gemini` for Gemini Code Assist. **Do not tag Copilot** (`@copilot-pull-request-reviewer`) as it doesn't respond to @mentions. For human reviewers, use `@<username>`
 5. **Delegate replies to a background haiku agent** — thread replies are independent shell commands that don't need main context. Spawn a `Bash` agent with `model: "haiku"` and `run_in_background: true` containing all the `tools github review --respond` commands. Don't wait for it — continue immediately.
 
 ### Review Fix Workflow (End-to-End)

--- a/plugins/genesis-tools/skills/github/SKILL.md
+++ b/plugins/genesis-tools/skills/github/SKILL.md
@@ -266,6 +266,8 @@ tools github review 137 --resolve-thread -t <thread-id>
 1. Reply to each addressed thread with: what was fixed, how it was fixed, and a **clickable link** to the commit using markdown: `[short-sha](https://github.com/owner/repo/commit/full-sha)` (e.g. "Fixed in [abc1234](https://github.com/owner/repo/commit/abc1234def5678) — scoped stale cleanup to current project directory.")
 2. Reply "Won't fix" to deliberately skipped threads with a detailed explanation of why the change isn't warranted (technical reasoning, not just a dismissal)
 3. Do NOT resolve threads automatically — only resolve when the user explicitly asks to resolve them
+4. **Tag the review author** in replies: `@coderabbitai` for CodeRabbit, `/gemini` for Gemini Code Assist, `@<username>` for others
+5. **Delegate replies to a background haiku agent** — thread replies are independent shell commands that don't need main context. Spawn a `Bash` agent with `model: "haiku"` and `run_in_background: true` containing all the `tools github review --respond` commands. Don't wait for it — continue immediately.
 
 ### Review Fix Workflow (End-to-End)
 

--- a/plugins/genesis-tools/skills/github/SKILL.md
+++ b/plugins/genesis-tools/skills/github/SKILL.md
@@ -11,8 +11,8 @@ description: |
   - User wants to search code in a repository (e.g. "find how X is implemented")
   - User wants to find issues or discussions about a library or framework
   - User asks "how does library X handle Y" or "are there issues about Z"
-  - User asks to fix/address/review PR review comments → invoke the `genesis-tools:github-pr` skill instead
-  - User provides multiple PR URLs to analyze → invoke the `genesis-tools:github-pr` skill instead
+  - User asks to fix/address/review PR review comments → use the `/genesis-tools:github-pr` command instead
+  - User provides multiple PR URLs to analyze → use the `/genesis-tools:github-pr` command instead
 ---
 
 # GitHub Tool Usage Guide
@@ -243,7 +243,7 @@ tools github review 137 --respond "Fixed in abc1234" -t PRRT_id1,PRRT_id2
 tools github review 137 --respond "Fixed" --resolve-thread -t PRRT_id1,PRRT_id2,PRRT_id3
 ```
 
-> **PR review fix workflow:** If the user asks to fix, address, or analyze PR review comments — or provides multiple PR URLs — invoke the `genesis-tools:github-pr` skill. It handles the full end-to-end flow: fetch threads, critically evaluate each comment (pushing back on false positives), implement fixes, commit, reply to reviewers, and for multiple PRs: spawn parallel agents and produce a consolidated report.
+> **PR review fix workflow:** If the user asks to fix, address, or analyze PR review comments — or provides multiple PR URLs — use the `/genesis-tools:github-pr` command (via the `Skill` tool). It handles the full end-to-end flow: fetch threads, critically evaluate each comment (pushing back on false positives), implement fixes, commit, reply to reviewers, and for multiple PRs: spawn parallel agents and produce a consolidated report.
 
 ### Resolving Review Threads
 
@@ -278,7 +278,7 @@ When fixing PR review comments:
 5. **Reply to threads:** `tools github review <pr> --respond "Fixed in [sha](url)" -t <thread-ids>`
 6. **Resolve threads** (only when user explicitly approves): `tools github review <pr> --resolve-thread -t <thread-ids>`
 
-> For the full automated flow (fetch, triage, fix, commit, reply), invoke the `genesis-tools:github-pr` skill instead.
+> For the full automated flow (fetch, triage, fix, commit, reply), use the `/genesis-tools:github-pr` command instead.
 
 ## Caching Behavior
 

--- a/plugins/genesis-tools/skills/github/SKILL.md
+++ b/plugins/genesis-tools/skills/github/SKILL.md
@@ -11,6 +11,8 @@ description: |
   - User wants to search code in a repository (e.g. "find how X is implemented")
   - User wants to find issues or discussions about a library or framework
   - User asks "how does library X handle Y" or "are there issues about Z"
+  - User asks to fix/address/review PR review comments → invoke the `genesis-tools:github-pr` skill instead
+  - User provides multiple PR URLs to analyze → invoke the `genesis-tools:github-pr` skill instead
 ---
 
 # GitHub Tool Usage Guide
@@ -241,7 +243,7 @@ tools github review 137 --respond "Fixed in abc1234" -t PRRT_id1,PRRT_id2
 tools github review 137 --respond "Fixed" --resolve-thread -t PRRT_id1,PRRT_id2,PRRT_id3
 ```
 
-> **Full PR review workflow:** For an end-to-end flow (fetch review threads, triage, implement fixes, commit, reply to threads), use the `/github-pr <pr>` command instead of manual `tools github review` calls.
+> **PR review fix workflow:** If the user asks to fix, address, or analyze PR review comments — or provides multiple PR URLs — invoke the `genesis-tools:github-pr` skill. It handles the full end-to-end flow: fetch threads, critically evaluate each comment (pushing back on false positives), implement fixes, commit, reply to reviewers, and for multiple PRs: spawn parallel agents and produce a consolidated report.
 
 ### Resolving Review Threads
 
@@ -276,7 +278,7 @@ When fixing PR review comments:
 5. **Reply to threads:** `tools github review <pr> --respond "Fixed in [sha](url)" -t <thread-ids>`
 6. **Resolve threads** (only when user explicitly approves): `tools github review <pr> --resolve-thread -t <thread-ids>`
 
-> For the full automated flow (fetch, triage, fix, commit, reply), use the `/github-pr <pr>` command instead.
+> For the full automated flow (fetch, triage, fix, commit, reply), invoke the `genesis-tools:github-pr` skill instead.
 
 ## Caching Behavior
 


### PR DESCRIPTION
## Summary

- **github-pr command**: Step 6 (Reply to Threads) now delegates all `tools github review --respond` commands to a background haiku Bash agent instead of running them inline, saving significant tokens and time
- **Author tagging**: replies now tag the review bot (`@coderabbitai`, `/gemini`) so they can process the response
- **github skill**: matching guidance added for tagging and background delegation

## Test plan

- [ ] Invoke `/github-pr <pr>` and verify thread replies are dispatched to a background haiku agent
- [ ] Verify `@coderabbitai` and `/gemini` tags appear in reply messages
- [ ] Confirm main agent doesn't block waiting for reply agent to finish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced structured PR review fix workflow with critical evaluation step for review threads
  * Added support for parallel multi-PR analysis with consolidated reporting
  * Implemented background agent delegation for generating and dispatching review replies

* **Bug Fixes**
  * Enhanced thread resolution reliability with automatic fallback mechanism for permission issues

* **Documentation**
  * Updated workflow documentation with detailed steps for PR review automation and multi-PR handling
  * Expanded command guidance for end-to-end PR review fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->