### PR TITLE
feat(claude): OAuth login + watch mode notification rewrite

### DIFF
--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import clipboard from "clipboardy";
 import { loadConfig, saveConfig, type ClaudeConfig } from "../lib/config";
 import { getKeychainCredentials, fetchUsage } from "../lib/usage/api";
 import {
@@ -42,8 +43,13 @@ async function addAccountViaOAuth(config: ClaudeConfig): Promise<void> {
 		message: "Open URL in browser?",
 		initialValue: true,
 	});
-	if (!p.isCancel(openBrowser) && openBrowser) {
+	if (p.isCancel(openBrowser)) return;
+	if (openBrowser) {
 		Bun.spawn(["open", authUrl], { stdio: ["ignore", "ignore", "ignore"] });
+	} else {
+		// Copy to clipboard instead
+		await clipboard.write(authUrl);
+		p.log.info("URL copied to clipboard.");
 	}
 
 	// Get code from user

--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -578,9 +578,14 @@ export function registerConfigCommand(program: Command): void {
 			// Read code from stdin
 			process.stdout.write("Paste authorization code: ");
 			const reader = Bun.stdin.stream().getReader();
-			const { value } = await reader.read();
-			reader.releaseLock();
-			const code = new TextDecoder().decode(value).trim();
+			let value: Uint8Array | undefined;
+			try {
+				const result = await reader.read();
+				value = result.value;
+			} finally {
+				reader.releaseLock();
+			}
+			const code = new TextDecoder().decode(value ?? new Uint8Array()).trim();
 
 			if (!code) {
 				console.error(pc.red("No code provided."));
@@ -610,6 +615,7 @@ export function registerConfigCommand(program: Command): void {
 				const tier = profile.organization.rate_limit_tier;
 				if (tier.includes("max")) label = "max";
 				else if (tier.includes("pro")) label = "pro";
+				else label = profile.organization.billing_type;
 			}
 
 			// Save

--- a/src/claude/lib/config/index.ts
+++ b/src/claude/lib/config/index.ts
@@ -2,6 +2,8 @@ import { Storage } from "@app/utils/storage/storage";
 
 export interface AccountConfig {
 	accessToken: string;
+	refreshToken?: string;
+	expiresAt?: number; // Unix timestamp in ms
 	label?: string;
 }
 

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -67,7 +67,13 @@ async function ensureValidToken(
 	// Token expired or expiring soon — refresh it
 	const refreshed = await refreshOAuthToken(account.refreshToken);
 
-	// Update config with new tokens
+	// Update in-memory account so subsequent polls use fresh tokens
+	// (Critical: refresh tokens are single-use, old RT is now invalid)
+	account.accessToken = refreshed.accessToken;
+	account.refreshToken = refreshed.refreshToken;
+	account.expiresAt = refreshed.expiresAt;
+
+	// Also persist to disk for restarts
 	const config = await loadConfig();
 	if (config.accounts[accountName]) {
 		config.accounts[accountName].accessToken = refreshed.accessToken;

--- a/src/claude/lib/usage/watch.ts
+++ b/src/claude/lib/usage/watch.ts
@@ -12,9 +12,6 @@ const BUCKET_THRESHOLD_MAP: Record<string, "sessionThresholds" | "weeklyThreshol
 	seven_day_oauth_apps: "weeklyThresholds",
 };
 
-// Minimum utilization increase (in %) before sending another notification for same bucket
-const MIN_NOTIFICATION_GAP = 5;
-
 export async function watchUsage(
 	accounts: Record<string, AccountConfig>,
 	notifications: NotificationConfig,
@@ -23,7 +20,6 @@ export async function watchUsage(
 	const notifiedBuckets = new Set<string>();
 	const lastResetsAt = new Map<string, string | null>();
 	const intervalMs = (notifications.watchInterval || 60) * 1000;
-	let isFirstPoll = true;
 
 	while (true) {
 		// Clear screen
@@ -82,8 +78,6 @@ export async function watchUsage(
 				}
 			}
 		}
-
-		isFirstPoll = false;
 
 		// Send notifications asynchronously (don't await, fire and forget)
 		if (pendingNotifications.length > 0) {

--- a/src/claude/lib/usage/watch.ts
+++ b/src/claude/lib/usage/watch.ts
@@ -44,6 +44,8 @@ export async function watchUsage(
 				if (!data || typeof data !== "object" || !("utilization" in data)) continue;
 				const thresholdKey = BUCKET_THRESHOLD_MAP[bucket];
 				if (!thresholdKey) continue;
+				// Skip null/undefined buckets (e.g. seven_day_opus when not using opus)
+				if (data.utilization === null || data.utilization === undefined) continue;
 
 				const bucketKey = `${account.accountName}:${bucket}`;
 				const utilization = data.utilization;

--- a/src/claude/lib/usage/watch.ts
+++ b/src/claude/lib/usage/watch.ts
@@ -1,6 +1,6 @@
 import type { AccountConfig } from "../config";
 import type { NotificationConfig } from "../config";
-import { fetchAllAccountsUsage } from "./api";
+import { fetchAllAccountsUsage, type AccountUsage } from "./api";
 import { renderAllAccounts } from "./display";
 import { sendNotification } from "@app/utils/macos/notifications";
 
@@ -12,86 +12,188 @@ const BUCKET_THRESHOLD_MAP: Record<string, "sessionThresholds" | "weeklyThreshol
 	seven_day_oauth_apps: "weeklyThresholds",
 };
 
-export async function watchUsage(
-	accounts: Record<string, AccountConfig>,
-	notifications: NotificationConfig,
-): Promise<never> {
-	const notifiedBuckets = new Set<string>();
-	const lastResetsAt = new Map<string, string | null>();
-	const intervalMs = (notifications.watchInterval || 60) * 1000;
+/**
+ * Tracks notification state for a single bucket (e.g., "Livinka:seven_day")
+ */
+class BucketTracker {
+	private lastNotifiedPct: number | null = null;
+	private lastResetAt: string | null = null;
 
-	while (true) {
-		// Clear screen
-		process.stdout.write("\x1B[2J\x1B[H");
+	constructor(
+		public readonly accountName: string,
+		public readonly bucketName: string,
+	) {}
 
-		const results = await fetchAllAccountsUsage(accounts);
-		console.log(renderAllAccounts(results));
-		console.log(
-			`\n${new Date().toLocaleTimeString()} — refreshing every ${notifications.watchInterval}s (Ctrl+C to stop)`,
-		);
+	get key(): string {
+		return `${this.accountName}:${this.bucketName}`;
+	}
 
-		// Check thresholds and queue notifications
-		const pendingNotifications: Array<{ title: string; message: string }> = [];
+	get label(): string {
+		return this.bucketName === "five_hour" ? "Session" : this.bucketName.replace(/_/g, " ");
+	}
+
+	/**
+	 * Check if we should notify for this bucket.
+	 * Returns notification reason or null if no notification needed.
+	 */
+	shouldNotify(
+		currentPct: number,
+		resetAt: string | null,
+		thresholds: number[],
+		isFirstPoll: boolean,
+	): "INIT" | "+5%" | null {
+		const normalizedReset = this.normalizeResetTime(resetAt);
+
+		// Period reset detection - clear state if reset timestamp changed
+		if (this.lastResetAt !== null && this.lastResetAt !== normalizedReset) {
+			this.lastNotifiedPct = null;
+		}
+		this.lastResetAt = normalizedReset;
+
+		// Check if any threshold is crossed
+		const crossedThreshold = thresholds.some((t) => currentPct >= t);
+		if (!crossedThreshold) {
+			return null;
+		}
+
+		// First poll: always notify if threshold crossed
+		if (isFirstPoll) {
+			this.lastNotifiedPct = currentPct;
+			return "INIT";
+		}
+
+		// Never notified before (new bucket mid-session): notify
+		if (this.lastNotifiedPct === null) {
+			this.lastNotifiedPct = currentPct;
+			return "INIT";
+		}
+
+		// Subsequent: only notify if 5% increase
+		if (currentPct >= this.lastNotifiedPct + 5) {
+			this.lastNotifiedPct = currentPct;
+			return "+5%";
+		}
+
+		return null;
+	}
+
+	private normalizeResetTime(t: string | null): string | null {
+		if (!t) return null;
+		// Round to nearest hour - API returns jittery timestamps (17:59:59 vs 18:00:00)
+		const d = new Date(t);
+		if (d.getMinutes() >= 30) {
+			d.setHours(d.getHours() + 1);
+		}
+		d.setMinutes(0, 0, 0);
+		return d.toISOString().slice(0, 13); // "2026-02-19T18"
+	}
+}
+
+/**
+ * Manages all bucket trackers and notification logic
+ */
+class UsageWatcher {
+	private trackers = new Map<string, BucketTracker>();
+	private isFirstPoll = true;
+
+	constructor(private notifications: NotificationConfig) {}
+
+	/**
+	 * Process usage results and return notifications to send
+	 */
+	processResults(results: AccountUsage[]): Array<{ message: string; reason: string }> {
+		const notifications: Array<{ message: string; reason: string }> = [];
 
 		for (const account of results) {
 			if (!account.usage) continue;
+
 			for (const [bucket, data] of Object.entries(account.usage)) {
 				if (!data || typeof data !== "object" || !("utilization" in data)) continue;
-				const thresholdKey = BUCKET_THRESHOLD_MAP[bucket];
-				if (!thresholdKey) continue;
-				// Skip null/undefined buckets (e.g. seven_day_opus when not using opus)
 				if (data.utilization === null || data.utilization === undefined) continue;
 
-				const bucketKey = `${account.accountName}:${bucket}`;
-				const utilization = data.utilization;
+				const thresholdKey = BUCKET_THRESHOLD_MAP[bucket];
+				if (!thresholdKey) continue;
 
-				// Clear state when the period resets (compare only up to minutes, ignore seconds/ms)
-				const normalizeResetTime = (t: string | null) => t?.slice(0, 16) ?? null; // "2026-02-19T19:00"
-				const prevReset = lastResetsAt.get(bucketKey);
-				const currReset = normalizeResetTime(data.resets_at);
-				const prevResetNorm = normalizeResetTime(prevReset ?? null);
-				if (prevResetNorm !== null && prevResetNorm !== currReset) {
-					notifiedBuckets.delete(bucketKey);
+				// Get or create tracker
+				const trackerKey = `${account.accountName}:${bucket}`;
+				let tracker = this.trackers.get(trackerKey);
+				if (!tracker) {
+					tracker = new BucketTracker(account.accountName, bucket);
+					this.trackers.set(trackerKey, tracker);
 				}
-				lastResetsAt.set(bucketKey, data.resets_at);
 
-				// Find the highest threshold that's been crossed
-				const thresholds = notifications[thresholdKey];
-				const crossedThreshold = thresholds
-					.filter((t) => utilization >= t)
-					.sort((a, b) => b - a)[0];
+				// Check if notification needed
+				const thresholds = this.notifications[thresholdKey];
+				const reason = tracker.shouldNotify(
+					data.utilization,
+					data.resets_at,
+					thresholds,
+					this.isFirstPoll,
+				);
 
-				// No threshold crossed? Skip
-				if (crossedThreshold === undefined) continue;
-
-				// Already notified about this bucket? Skip (until period resets)
-				if (notifiedBuckets.has(bucketKey)) continue;
-
-				// Mark as notified
-				notifiedBuckets.add(bucketKey);
-
-				// Queue notification
-				if (notifications.channels.macos) {
-					const bucketLabel = bucket === "five_hour" ? "Session" : bucket.replace(/_/g, " ");
-					pendingNotifications.push({
-						title: "Claude Usage Alert",
-						message: `${account.accountName}: ${bucketLabel} ${Math.round(utilization)}%`,
+				if (reason) {
+					notifications.push({
+						message: `${account.accountName}: ${tracker.label} ${Math.round(data.utilization)}%`,
+						reason,
 					});
 				}
 			}
 		}
 
-		// Send notifications asynchronously (don't await, fire and forget)
-		if (pendingNotifications.length > 0) {
-			// Send all as one batch — don't spam with multiple notifications
-			const notification = pendingNotifications[0];
-			sendNotification({
-				title: notification.title,
-				message: pendingNotifications.length > 1
-					? `${notification.message} (+${pendingNotifications.length - 1} more)`
-					: notification.message,
-				sound: "Purr",
-			}); // No await — async fire and forget
+		// Mark first poll as done AFTER processing all buckets
+		this.isFirstPoll = false;
+
+		return notifications;
+	}
+}
+
+export async function watchUsage(
+	accounts: Record<string, AccountConfig>,
+	notifications: NotificationConfig,
+): Promise<never> {
+	const watcher = new UsageWatcher(notifications);
+	const intervalMs = (notifications.watchInterval || 60) * 1000;
+
+	while (true) {
+		// Fetch while showing old data, then clear and render
+		const results = await fetchAllAccountsUsage(accounts);
+
+		// Clear and render fresh data
+		process.stdout.write("\x1B[2J\x1B[H");
+		console.log(renderAllAccounts(results));
+		console.log(
+			`\n${new Date().toLocaleTimeString()} — refreshing every ${notifications.watchInterval}s (Ctrl+C to stop)`,
+		);
+
+		// Process and get notifications
+		const pending = watcher.processResults(results);
+
+		// Send notifications (fire and forget)
+		if (pending.length > 0 && notifications.channels.macos) {
+			const initNotifs = pending.filter((n) => n.reason === "INIT");
+			const increaseNotifs = pending.filter((n) => n.reason === "+5%");
+
+			// INIT: send each notification individually so user sees all warnings
+			for (const notif of initNotifs) {
+				sendNotification({
+					title: "Claude Usage Alert",
+					message: `[INIT] ${notif.message}`,
+					sound: "Purr",
+				});
+			}
+
+			// +5%: batch these to avoid spam during normal operation
+			if (increaseNotifs.length > 0) {
+				const first = increaseNotifs[0];
+				sendNotification({
+					title: "Claude Usage Alert",
+					message:
+						increaseNotifs.length > 1
+							? `[+5%] ${first.message} (+${increaseNotifs.length - 1} more)`
+							: `[+5%] ${first.message}`,
+					sound: "Purr",
+				});
+			}
 		}
 
 		await Bun.sleep(intervalMs);

--- a/src/claude/lib/usage/watch.ts
+++ b/src/claude/lib/usage/watch.ts
@@ -79,8 +79,9 @@ class BucketTracker {
 
 	private normalizeResetTime(t: string | null): string | null {
 		if (!t) return null;
-		// Round to nearest hour - API returns jittery timestamps (17:59:59 vs 18:00:00)
 		const d = new Date(t);
+		if (Number.isNaN(d.getTime())) return t; // fallback to raw string
+		// Round to nearest hour - API returns jittery timestamps (17:59:59 vs 18:00:00)
 		if (d.getMinutes() >= 30) {
 			d.setHours(d.getHours() + 1);
 		}

--- a/src/utils/claude/auth.ts
+++ b/src/utils/claude/auth.ts
@@ -42,9 +42,182 @@ export interface AccountInfo {
 
 export interface KeychainCredentials {
 	accessToken: string;
+	refreshToken?: string;
+	expiresAt?: number; // Unix timestamp in ms
+	scopes?: string[];
 	subscriptionType?: string;
 	rateLimitTier?: string;
 	account: AccountInfo;
+}
+
+// Claude Code's official OAuth client ID
+const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const AUTH_URL = "https://claude.ai/oauth/authorize";
+const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
+const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
+
+// Full scopes for usage monitoring (same as Claude Code login)
+const FULL_SCOPES = "user:inference user:profile user:mcp_servers user:sessions:claude_code";
+
+export interface PKCEChallenge {
+	verifier: string;
+	challenge: string;
+	state: string;
+}
+
+export interface OAuthTokens {
+	accessToken: string;
+	refreshToken: string;
+	expiresAt: number; // Unix timestamp in ms
+	scopes: string[];
+	account?: { uuid: string; email: string };
+	organization?: { uuid: string; name: string };
+}
+
+/**
+ * Claude OAuth client for managing authentication flows.
+ * Handles PKCE generation, authorization URL creation, token exchange, and refresh.
+ */
+export class ClaudeOAuthClient {
+	private pendingSession: { verifier: string; state: string } | null = null;
+
+	/**
+	 * Start a new OAuth login flow.
+	 * Opens the authorization URL and stores session for code exchange.
+	 */
+	async startLogin(scopes: string = FULL_SCOPES): Promise<string> {
+		const pkce = await this.generatePKCE();
+		this.pendingSession = { verifier: pkce.verifier, state: pkce.state };
+
+		const params = new URLSearchParams({
+			code: "true",
+			client_id: CLAUDE_CODE_CLIENT_ID,
+			response_type: "code",
+			redirect_uri: REDIRECT_URI,
+			scope: scopes,
+			code_challenge: pkce.challenge,
+			code_challenge_method: "S256",
+			state: pkce.state,
+		});
+
+		return `${AUTH_URL}?${params.toString()}`;
+	}
+
+	/**
+	 * Exchange the authorization code for tokens.
+	 * Call this after the user authorizes and pastes the code.
+	 */
+	async exchangeCode(codeInput: string): Promise<OAuthTokens> {
+		if (!this.pendingSession) {
+			throw new Error("No pending OAuth session. Call startLogin() first.");
+		}
+
+		const { verifier } = this.pendingSession;
+		this.pendingSession = null; // Clear session after use
+
+		// Claude returns "code#state" format
+		const [code, state] = codeInput.includes("#")
+			? codeInput.split("#")
+			: [codeInput, ""];
+
+		const res = await fetch(TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "authorization_code",
+				client_id: CLAUDE_CODE_CLIENT_ID,
+				code,
+				state,
+				redirect_uri: REDIRECT_URI,
+				code_verifier: verifier,
+			}),
+		});
+
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Token exchange failed: ${res.status} ${text}`);
+		}
+
+		const data = await res.json();
+		return {
+			accessToken: data.access_token,
+			refreshToken: data.refresh_token,
+			expiresAt: Date.now() + data.expires_in * 1000,
+			scopes: (data.scope ?? "").split(" ").filter(Boolean),
+			account: data.account ? { uuid: data.account.uuid, email: data.account.email_address } : undefined,
+			organization: data.organization ? { uuid: data.organization.uuid, name: data.organization.name } : undefined,
+		};
+	}
+
+	/**
+	 * Refresh tokens using a refresh token.
+	 * WARNING: This invalidates the old refresh token.
+	 */
+	async refresh(refreshToken: string): Promise<OAuthTokens> {
+		const res = await fetch(TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+				client_id: CLAUDE_CODE_CLIENT_ID,
+			}),
+		});
+
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Token refresh failed: ${res.status} ${text}`);
+		}
+
+		const data = await res.json();
+		return {
+			accessToken: data.access_token,
+			refreshToken: data.refresh_token,
+			expiresAt: Date.now() + data.expires_in * 1000,
+			scopes: (data.scope ?? "").split(" ").filter(Boolean),
+		};
+	}
+
+	/**
+	 * Check if tokens need refresh (expired or expiring within buffer).
+	 */
+	needsRefresh(expiresAt: number, bufferMs: number = 5 * 60 * 1000): boolean {
+		return Date.now() + bufferMs >= expiresAt;
+	}
+
+	private async generatePKCE(): Promise<PKCEChallenge> {
+		const verifierBytes = new Uint8Array(32);
+		crypto.getRandomValues(verifierBytes);
+		const verifier = this.base64UrlEncode(verifierBytes);
+
+		const encoder = new TextEncoder();
+		const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(verifier));
+		const challenge = this.base64UrlEncode(new Uint8Array(hashBuffer));
+
+		return { verifier, challenge, state: verifier };
+	}
+
+	private base64UrlEncode(bytes: Uint8Array): string {
+		const base64 = btoa(String.fromCharCode(...bytes));
+		return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+	}
+}
+
+// Singleton instance for convenience
+export const claudeOAuth = new ClaudeOAuthClient();
+
+// Legacy function exports for backwards compatibility
+export async function startOAuthLogin(scopes: string = FULL_SCOPES) {
+	const authUrl = await claudeOAuth.startLogin(scopes);
+	return { authUrl, verifier: "", state: "" }; // verifier/state managed internally now
+}
+
+export async function exchangeOAuthCode(codeInput: string, _verifier?: string) {
+	return claudeOAuth.exchangeCode(codeInput);
+}
+
+export async function refreshOAuthToken(refreshToken: string) {
+	return claudeOAuth.refresh(refreshToken);
 }
 
 const PROFILE_URL = "https://api.anthropic.com/api/oauth/profile";
@@ -105,6 +278,9 @@ export async function getKeychainCredentials(): Promise<KeychainCredentials | nu
 
 		return {
 			accessToken: oauth.accessToken,
+			refreshToken: oauth.refreshToken,
+			expiresAt: oauth.expiresAt,
+			scopes: oauth.scopes,
 			subscriptionType: oauth.subscriptionType,
 			rateLimitTier: oauth.rateLimitTier,
 			account: { api, claudeJson },

--- a/src/utils/claude/auth.ts
+++ b/src/utils/claude/auth.ts
@@ -139,10 +139,11 @@ export class ClaudeOAuthClient {
 		}
 
 		const data = await res.json();
+		const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 3600;
 		return {
 			accessToken: data.access_token,
 			refreshToken: data.refresh_token,
-			expiresAt: Date.now() + data.expires_in * 1000,
+			expiresAt: Date.now() + expiresIn * 1000,
 			scopes: (data.scope ?? "").split(" ").filter(Boolean),
 			account: data.account ? { uuid: data.account.uuid, email: data.account.email_address } : undefined,
 			organization: data.organization ? { uuid: data.organization.uuid, name: data.organization.name } : undefined,
@@ -170,10 +171,11 @@ export class ClaudeOAuthClient {
 		}
 
 		const data = await res.json();
+		const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 3600;
 		return {
 			accessToken: data.access_token,
 			refreshToken: data.refresh_token,
-			expiresAt: Date.now() + data.expires_in * 1000,
+			expiresAt: Date.now() + expiresIn * 1000,
 			scopes: (data.scope ?? "").split(" ").filter(Boolean),
 		};
 	}
@@ -194,7 +196,11 @@ export class ClaudeOAuthClient {
 		const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(verifier));
 		const challenge = this.base64UrlEncode(new Uint8Array(hashBuffer));
 
-		return { verifier, challenge, state: verifier };
+		const stateBytes = new Uint8Array(32);
+		crypto.getRandomValues(stateBytes);
+		const state = this.base64UrlEncode(stateBytes);
+
+		return { verifier, challenge, state };
 	}
 
 	private base64UrlEncode(bytes: Uint8Array): string {

--- a/src/utils/macos/notifications.ts
+++ b/src/utils/macos/notifications.ts
@@ -1,5 +1,3 @@
-import { spawnSync } from "node:child_process";
-
 export interface NotificationOptions {
 	title: string;
 	message: string;
@@ -7,6 +5,9 @@ export interface NotificationOptions {
 	sound?: string;
 }
 
+/**
+ * Send a macOS notification asynchronously (fire and forget).
+ */
 export function sendNotification(opts: NotificationOptions): void {
 	const escaped = (s: string) =>
 		s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
@@ -19,5 +20,9 @@ export function sendNotification(opts: NotificationOptions): void {
 		.filter(Boolean)
 		.join(" ");
 
-	spawnSync("osascript", ["-e", `display notification ${params}`]);
+	// Fire and forget — don't block
+	Bun.spawn(["osascript", "-e", `display notification ${params}`], {
+		stdout: "ignore",
+		stderr: "ignore",
+	});
 }


### PR DESCRIPTION
## Summary

- **OAuth login flow**: `tools claude login [name]` - generates OAuth URL, exchanges code for tokens, stores with refresh token support
- **Auto-refresh**: Tokens auto-refresh before expiry when calling usage API
- **Watch mode rewrite**: Class-based architecture with proper notification logic
  - First poll: individual notifications for all crossed thresholds
  - Subsequent polls: only notify on 5% increase
  - Fixed API timestamp jitter (17:59:59 vs 18:00:00)
  - Instant-feeling updates (old data visible during fetch)

## Test plan

- [ ] `tools claude login personal` - OAuth flow works
- [ ] `tools claude usage` - shows all accounts
- [ ] `tools claude usage --watch --interval 5` - notifications work correctly
  - First poll: multiple [INIT] notifications
  - Subsequent: no spam, only [+5%] on actual increase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth-based account onboarding with automatic refresh and profile-driven labeling
  * New login command for quick OAuth sign-in outside interactive flow
  * Token forking to create independent copies of refreshable accounts

* **Updates**
  * Account display shows refresh capability and fork notes
  * Account setup now prefers OAuth; keychain import preserved with refresh metadata
  * Added --no-fork option
  * Usage notifications refactored and macOS notifications made asynchronous
<!-- end of auto-generated comment: release notes by coderabbit.ai -->