### PR TITLE
feat(github): review enhancements — fix reply truncation, PR-level comments, author filter

### DIFF
--- a/src/github/commands/activity.ts
+++ b/src/github/commands/activity.ts
@@ -166,9 +166,13 @@ export async function activityCommand(options: ActivityCommandOptions): Promise<
         const events = data as GitHubEvent[];
         allEvents.push(...events);
 
-        if (events.length < 100) break;
+        if (events.length < 100) {
+            break;
+        }
         page++;
-        if (page > 5) break; // Safety: max 500 events
+        if (page > 5) {
+            break; // Safety: max 500 events
+        }
     }
 
     verbose(options, `Fetched ${allEvents.length} raw events`);

--- a/src/github/commands/issue.ts
+++ b/src/github/commands/issue.ts
@@ -64,8 +64,12 @@ const KNOWN_BOTS = [
  * Check if a user is a bot
  */
 function isBot(username: string, userType?: string): boolean {
-    if (userType === "Bot") return true;
-    if (username.endsWith("[bot]")) return true;
+    if (userType === "Bot") {
+        return true;
+    }
+    if (username.endsWith("[bot]")) {
+        return true;
+    }
     const lowerName = username.toLowerCase();
     return KNOWN_BOTS.some((bot) => lowerName.includes(bot));
 }
@@ -320,7 +324,9 @@ export async function issueCommand(input: string, options: IssueCommandOptions):
         .filter(Boolean);
     if (inputs.length > 1) {
         for (let i = 0; i < inputs.length; i++) {
-            if (i > 0) console.log(chalk.dim("\n---\n"));
+            if (i > 0) {
+                console.log(chalk.dim("\n---\n"));
+            }
             await issueSingleCommand(inputs[i], options);
         }
         return;
@@ -400,7 +406,10 @@ async function issueSingleCommand(input: string, options: IssueCommandOptions): 
     }
 
     // Get issue ID from cache
-    const issueRecord = getIssue(repoRecord.id, number)!;
+    const issueRecord = getIssue(repoRecord.id, number);
+    if (!issueRecord) {
+        throw new Error(`Issue #${number} not found in cache`);
+    }
 
     // Check issue body reaction thresholds
     if (issue.reactions) {
@@ -512,17 +521,16 @@ async function issueSingleCommand(input: string, options: IssueCommandOptions): 
         }
 
         if (options.minCommentReactions !== undefined) {
-            comments = comments.filter((c) => sumReactions(c.reactions) >= options.minCommentReactions!);
+            const min = options.minCommentReactions;
+            comments = comments.filter((c) => sumReactions(c.reactions) >= min);
         }
         if (options.minCommentReactionsPositive !== undefined) {
-            comments = comments.filter(
-                (c) => sumPositiveReactions(c.reactions) >= options.minCommentReactionsPositive!
-            );
+            const min = options.minCommentReactionsPositive;
+            comments = comments.filter((c) => sumPositiveReactions(c.reactions) >= min);
         }
         if (options.minCommentReactionsNegative !== undefined) {
-            comments = comments.filter(
-                (c) => sumNegativeReactions(c.reactions) >= options.minCommentReactionsNegative!
-            );
+            const min = options.minCommentReactionsNegative;
+            comments = comments.filter((c) => sumNegativeReactions(c.reactions) >= min);
         }
 
         if (options.author) {
@@ -563,9 +571,10 @@ async function issueSingleCommand(input: string, options: IssueCommandOptions): 
 
     // Resolve cross-references (automatic unless --no-resolve-refs)
     const linkedIssues: LinkedIssue[] = [];
-    const shouldResolveRefs = !options.noResolveRefs && issue.body;
+    const issueBody = issue.body;
+    const shouldResolveRefs = !options.noResolveRefs && issueBody;
     if (shouldResolveRefs) {
-        const refs = detectCrossReferences(issue.body!);
+        const refs = detectCrossReferences(issueBody);
         if (refs.length > 0) {
             verbose(options, `Found ${refs.length} cross-references to resolve`);
             console.log(chalk.dim(`Resolving ${refs.length} cross-references...`));

--- a/src/github/commands/notifications.ts
+++ b/src/github/commands/notifications.ts
@@ -85,9 +85,13 @@ export async function notificationsCommand(options: NotificationsCommandOptions)
         const notifications = data as GitHubNotification[];
         allNotifications.push(...notifications);
 
-        if (notifications.length < 50) break;
+        if (notifications.length < 50) {
+            break;
+        }
         page++;
-        if (page > 10) break; // Safety: max 500 notifications
+        if (page > 10) {
+            break; // Safety: max 500 notifications
+        }
     }
 
     verbose(options, `Fetched ${allNotifications.length} raw notifications`);

--- a/src/github/commands/pr.ts
+++ b/src/github/commands/pr.ts
@@ -14,6 +14,7 @@ import type {
     PRCommandOptions,
     PRData,
     ReviewCommentData,
+    ReviewThreadStats,
 } from "@app/github/types";
 import logger from "@app/logger";
 import { getOctokit } from "@app/utils/github/octokit";
@@ -40,8 +41,12 @@ const KNOWN_BOTS = [
 ];
 
 function isBot(username: string, userType?: string): boolean {
-    if (userType === "Bot") return true;
-    if (username.endsWith("[bot]")) return true;
+    if (userType === "Bot") {
+        return true;
+    }
+    if (username.endsWith("[bot]")) {
+        return true;
+    }
     const lowerName = username.toLowerCase();
     return KNOWN_BOTS.some((bot) => lowerName.includes(bot));
 }
@@ -290,7 +295,7 @@ export async function prCommand(input: string, options: PRCommandOptions): Promi
     }
 
     let reviewThreads: ParsedReviewThread[] | undefined;
-    let reviewThreadStats;
+    let reviewThreadStats: ReviewThreadStats | undefined;
     if (options.reviews) {
         verbose(options, "Fetching review threads (GraphQL)...");
         console.log(chalk.dim("Fetching review threads..."));

--- a/src/github/commands/review.ts
+++ b/src/github/commands/review.ts
@@ -118,12 +118,18 @@ export async function reviewCommand(input: string, options: ReviewCommandOptions
 
     const prInfo = await fetchPRReviewThreads(owner, repo, prNumber);
 
-    // Parse threads and compute stats on ALL threads
+    // Parse threads, apply author filter, then compute stats
     const allThreads = parseThreads(prInfo.threads);
-    const stats = calculateReviewStats(allThreads);
+    const authorLogin = options.author?.toLowerCase();
+    const authorFilteredThreads = authorLogin
+        ? allThreads.filter((t) => t.author.toLowerCase() === authorLogin)
+        : allThreads;
+    const stats = calculateReviewStats(authorFilteredThreads);
 
-    // Filter if requested
-    const displayThreads = options.unresolvedOnly ? allThreads.filter((t) => t.status === "unresolved") : allThreads;
+    // Filter by resolution status if requested
+    const displayThreads = options.unresolvedOnly
+        ? authorFilteredThreads.filter((t) => t.status === "unresolved")
+        : authorFilteredThreads;
 
     // Build review data
     const reviewData: ReviewData = {
@@ -134,6 +140,7 @@ export async function reviewCommand(input: string, options: ReviewCommandOptions
         state: prInfo.state,
         threads: displayThreads,
         stats,
+        prComments: options.prComments !== false ? prInfo.prComments : undefined,
     };
 
     // JSON output
@@ -188,6 +195,8 @@ Examples:
         .option("-R, --resolve-thread", "Mark a thread as resolved", false)
         .option("--resolve", "Alias for --resolve-thread", false)
         .option("-v, --verbose", "Enable verbose logging")
+        .option("--no-pr-comments", "Hide PR-level review summaries and conversation comments")
+        .option("-a, --author <login>", "Filter threads by reviewer login (case-insensitive)")
         .action(async (input, opts) => {
             try {
                 await reviewCommand(input, opts);

--- a/src/github/commands/review.ts
+++ b/src/github/commands/review.ts
@@ -140,7 +140,11 @@ export async function reviewCommand(input: string, options: ReviewCommandOptions
         state: prInfo.state,
         threads: displayThreads,
         stats,
-        prComments: options.prComments !== false ? prInfo.prComments : undefined,
+        prComments: options.prComments !== false
+            ? (authorLogin
+                ? prInfo.prComments?.filter((c) => c.author.toLowerCase() === authorLogin)
+                : prInfo.prComments)
+            : undefined,
     };
 
     // JSON output
@@ -152,7 +156,7 @@ export async function reviewCommand(input: string, options: ReviewCommandOptions
     // Markdown output (save to file)
     if (options.md) {
         const mdContent = formatReviewMarkdown(reviewData, options.groupByFile ?? false);
-        const filePath = saveReviewMarkdown(mdContent, prNumber);
+        const filePath = await saveReviewMarkdown(mdContent, prNumber);
         console.log(filePath);
         return;
     }

--- a/src/github/commands/review.ts
+++ b/src/github/commands/review.ts
@@ -92,7 +92,7 @@ export async function reviewCommand(input: string, options: ReviewCommandOptions
                 console.error(chalk.red(`Failed: ${result.failed.join(", ")}`));
             }
         } else {
-            const result = await batchReply(threadIds, options.respond!, {
+            const result = await batchReply(threadIds, options.respond ?? "", {
                 onProgress: showProgress
                     ? (done, total) => console.error(chalk.dim(`  [${done}/${total}]`))
                     : undefined,
@@ -140,11 +140,12 @@ export async function reviewCommand(input: string, options: ReviewCommandOptions
         state: prInfo.state,
         threads: displayThreads,
         stats,
-        prComments: options.prComments !== false
-            ? (authorLogin
-                ? prInfo.prComments?.filter((c) => c.author.toLowerCase() === authorLogin)
-                : prInfo.prComments)
-            : undefined,
+        prComments:
+            options.prComments !== false
+                ? authorLogin
+                    ? prInfo.prComments?.filter((c) => c.author.toLowerCase() === authorLogin)
+                    : prInfo.prComments
+                : undefined,
     };
 
     // JSON output

--- a/src/github/commands/search.ts
+++ b/src/github/commands/search.ts
@@ -307,12 +307,14 @@ export async function searchCommand(query: string, options: SearchCommandOptions
 
     // Client-side safety filter for issue-level reactions
     if (options.minReactions !== undefined) {
-        results = results.filter((r) => r.reactions >= options.minReactions!);
+        const min = options.minReactions;
+        results = results.filter((r) => r.reactions >= min);
     }
 
     // GraphQL-based comment reaction filter
     let preFilterResults: SearchResult[] | undefined;
     if (options.minCommentReactions !== undefined && results.length > 0) {
+        const minCommentReactions = options.minCommentReactions;
         // Estimate cost using actual comment counts from search results (capped at 100 since GraphQL fetches first:100)
         const totalComments = results.reduce((sum, r) => sum + Math.min(r.comments, 100), 0);
         const estimatedCost = results.length * 2 + totalComments; // 2 per issue (node + connection) + 1 per comment node
@@ -351,7 +353,7 @@ export async function searchCommand(query: string, options: SearchCommandOptions
             const reactions = await batchFetchCommentReactions(repoOwner, repoName, numbers);
 
             for (const [num, info] of reactions) {
-                if (info.maxCommentReactions >= options.minCommentReactions!) {
+                if (info.maxCommentReactions >= minCommentReactions) {
                     keep.add(`${repoFullName}#${num}`);
                 }
             }

--- a/src/github/lib/output.ts
+++ b/src/github/lib/output.ts
@@ -107,7 +107,9 @@ function formatRepoMarkdown(repos: RepoSearchResult[]): string {
 }
 
 function formatStarCount(n: number): string {
-    if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+    if (n >= 1000) {
+        return `${(n / 1000).toFixed(1)}k`;
+    }
     return String(n);
 }
 
@@ -206,11 +208,13 @@ function formatPRSummary(data: PRData, options: FormatOptions): string {
         prStats.push("");
         prStats.push(`- **Branch:** ${data.pr.head.ref} → ${data.pr.base.ref}`);
         prStats.push(`- **Changes:** +${data.pr.additions} -${data.pr.deletions} in ${data.pr.changed_files} files`);
-        if (data.pr.draft) prStats.push("- **Status:** Draft");
-        if (data.pr.merged)
-            prStats.push(
-                `- **Merged:** ${formatDate(data.pr.merged_at!)} by @${data.pr.merged_by?.login ?? "unknown"}`
-            );
+        if (data.pr.draft) {
+            prStats.push("- **Status:** Draft");
+        }
+        if (data.pr.merged) {
+            const mergedAt = data.pr.merged_at ?? "";
+            prStats.push(`- **Merged:** ${formatDate(mergedAt)} by @${data.pr.merged_by?.login ?? "unknown"}`);
+        }
         prStats.push("");
 
         // Insert before _Fetched
@@ -433,7 +437,8 @@ function formatPRMarkdown(data: PRData, options: FormatOptions): string {
         }
 
         if (data.pr.merged) {
-            prInfo.push(`**Merged:** ${formatDate(data.pr.merged_at!)} by @${data.pr.merged_by?.login ?? "unknown"}`);
+            const mergedAt = data.pr.merged_at ?? "";
+            prInfo.push(`**Merged:** ${formatDate(mergedAt)} by @${data.pr.merged_by?.login ?? "unknown"}`);
         }
     }
 
@@ -566,7 +571,9 @@ function formatSearchMarkdown(results: SearchResult[]): string {
 // Notification and Activity formatters
 
 export function formatNotifications(items: NotificationItem[], format: "ai" | "md" | "json"): string {
-    if (format === "json") return JSON.stringify(items, null, 2);
+    if (format === "json") {
+        return JSON.stringify(items, null, 2);
+    }
 
     const lines: string[] = [];
     lines.push(`# Notifications (${items.length})\n`);
@@ -601,7 +608,9 @@ export function formatNotifications(items: NotificationItem[], format: "ai" | "m
 }
 
 export function formatActivity(items: ActivityItem[], format: "ai" | "md" | "json"): string {
-    if (format === "json") return JSON.stringify(items, null, 2);
+    if (format === "json") {
+        return JSON.stringify(items, null, 2);
+    }
 
     const lines: string[] = [];
     lines.push(`# Activity Feed (${items.length})\n`);
@@ -708,16 +717,24 @@ function buildIndex(data: IssueData): IndexEntry[] {
 // Helper functions
 
 function formatDate(dateStr: string): string {
-    if (!dateStr) return "-";
+    if (!dateStr) {
+        return "-";
+    }
     const date = new Date(dateStr);
-    if (Number.isNaN(date.getTime())) return "-";
+    if (Number.isNaN(date.getTime())) {
+        return "-";
+    }
     return date.toISOString().replace("T", " ").slice(0, 16);
 }
 
 function formatDateShort(dateStr: string): string {
-    if (!dateStr) return "-";
+    if (!dateStr) {
+        return "-";
+    }
     const date = new Date(dateStr);
-    if (Number.isNaN(date.getTime())) return "-";
+    if (Number.isNaN(date.getTime())) {
+        return "-";
+    }
     const day = date.getDate().toString().padStart(2, "0");
     const month = (date.getMonth() + 1).toString().padStart(2, "0");
     const year = date.getFullYear();
@@ -754,7 +771,9 @@ function formatReactions(reactions: GitHubReactions): string {
 }
 
 function _truncate(text: string, maxLength: number): string {
-    if (text.length <= maxLength) return text;
+    if (text.length <= maxLength) {
+        return text;
+    }
     return `${text.slice(0, maxLength - 3)}...`;
 }
 

--- a/src/github/lib/quotes.ts
+++ b/src/github/lib/quotes.ts
@@ -176,13 +176,14 @@ export function detectCrossReferences(body: string): {
     ];
 
     for (const { regex, type } of patterns) {
-        let match;
-        while ((match = regex.exec(body)) !== null) {
+        let match = regex.exec(body);
+        while (match !== null) {
             const number = parseInt(match[1], 10);
             // Avoid duplicates
             if (!refs.some((r) => r.number === number)) {
                 refs.push({ type, number });
             }
+            match = regex.exec(body);
         }
     }
 

--- a/src/github/lib/review-output.ts
+++ b/src/github/lib/review-output.ts
@@ -257,12 +257,12 @@ function formatMarkdownThread(thread: ParsedReviewThread): string {
     if (thread.replies.length > 0) {
         output += `**Replies:**\n\n`;
         for (const reply of thread.replies) {
-            const firstLine = reply.body.split("\n")[0];
-            const replyPreview = firstLine.substring(0, 100);
-            const truncated = firstLine.length > 100 || reply.body.length > firstLine.length;
-            output += `- **@${reply.author}** (\`${reply.id}\`): ${replyPreview}${truncated ? "..." : ""}\n`;
+            const indentedBody = reply.body
+                .split("\n")
+                .map((line) => `  ${line}`)
+                .join("\n");
+            output += `- **@${reply.author}** (\`${reply.id}\`):\n${indentedBody}\n\n`;
         }
-        output += "\n";
     }
 
     output += "---\n\n";

--- a/src/github/lib/review-output.ts
+++ b/src/github/lib/review-output.ts
@@ -129,10 +129,10 @@ function formatThread(thread: ParsedReviewThread): string {
         output += `\n${chalk.bold.cyan("Replies:")}\n`;
         for (const reply of thread.replies) {
             const bodyLines = reply.body.split("\n");
-            output += chalk.dim(`  > ${reply.author} (`) + chalk.dim(reply.id) + chalk.dim("): ") + bodyLines[0] + "\n";
+            output += `${chalk.dim(`  > ${reply.author} (`)}${chalk.dim(reply.id)}${chalk.dim("): ")}${bodyLines[0]}\n`;
             for (const line of bodyLines.slice(1)) {
                 if (line.trim()) {
-                    output += chalk.dim("  > ") + line + "\n";
+                    output += `${chalk.dim("  > ")}${line}\n`;
                 } else {
                     output += "\n";
                 }

--- a/src/github/lib/review-output.ts
+++ b/src/github/lib/review-output.ts
@@ -128,10 +128,16 @@ function formatThread(thread: ParsedReviewThread): string {
     if (thread.replies.length > 0) {
         output += `\n${chalk.bold.cyan("Replies:")}\n`;
         for (const reply of thread.replies) {
-            output +=
-                chalk.dim(`  > ${reply.author} (${chalk.dim(reply.id)}): `) +
-                reply.body.split("\n")[0].substring(0, 60) +
-                "\n";
+            const bodyLines = reply.body.split("\n");
+            output += chalk.dim(`  > ${reply.author} (`) + chalk.dim(reply.id) + chalk.dim("): ") + bodyLines[0] + "\n";
+            for (const line of bodyLines.slice(1)) {
+                if (line.trim()) {
+                    output += chalk.dim("  > ") + line + "\n";
+                } else {
+                    output += "\n";
+                }
+            }
+            output += "\n";
         }
     }
 

--- a/src/github/lib/review-output.ts
+++ b/src/github/lib/review-output.ts
@@ -15,7 +15,9 @@ function formatDiffHunk(
     targetLine: number | null = null,
     startLine: number | null = null
 ): string {
-    if (!diffHunk) return "";
+    if (!diffHunk) {
+        return "";
+    }
 
     const lines = diffHunk.split("\n");
 
@@ -32,7 +34,9 @@ function formatDiffHunk(
 
     return lines
         .map((line, idx) => {
-            if (line.startsWith("@@")) return chalk.cyan(line);
+            if (line.startsWith("@@")) {
+                return chalk.cyan(line);
+            }
 
             let isTarget = false;
             if (canTrackLines && idx > 0) {
@@ -45,15 +49,21 @@ function formatDiffHunk(
             }
 
             const marker = isTarget ? chalk.bold.white("-> ") : "   ";
-            if (line.startsWith("+")) return marker + chalk.green(line);
-            if (line.startsWith("-")) return `   ${chalk.red(line)}`;
+            if (line.startsWith("+")) {
+                return marker + chalk.green(line);
+            }
+            if (line.startsWith("-")) {
+                return `   ${chalk.red(line)}`;
+            }
             return marker + chalk.dim(line);
         })
         .join("\n");
 }
 
 function formatSuggestion(suggestion: string | null, diffHunk: string | null): string {
-    if (!suggestion) return "";
+    if (!suggestion) {
+        return "";
+    }
 
     const suggestionLines = suggestion.split("\n");
 

--- a/src/github/lib/review-threads.ts
+++ b/src/github/lib/review-threads.ts
@@ -1,7 +1,13 @@
 // Shared review thread library - GraphQL queries, fetching, parsing, mutations
 // Extracted from src/github-pr/index.ts, adapted to use shared octokit
 
-import type { ParsedReviewThread, PRLevelComment, ReviewThread, ReviewThreadComment, ReviewThreadStats } from "@app/github/types";
+import type {
+    ParsedReviewThread,
+    PRLevelComment,
+    ReviewThread,
+    ReviewThreadComment,
+    ReviewThreadStats,
+} from "@app/github/types";
 import { getGhCliToken, getOctokit } from "@app/utils/github/octokit";
 import { Octokit } from "octokit";
 
@@ -647,14 +653,20 @@ function trimDiffHunk(
     startLine: number | null = null,
     contextLines: number = 3
 ): string | null {
-    if (!diffHunk || !targetLine) return diffHunk;
+    if (!diffHunk || !targetLine) {
+        return diffHunk;
+    }
 
     const lines = diffHunk.split("\n");
-    if (lines.length === 0) return diffHunk;
+    if (lines.length === 0) {
+        return diffHunk;
+    }
 
     // Parse the @@ header to get starting line number
     const headerMatch = lines[0].match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-    if (!headerMatch) return diffHunk;
+    if (!headerMatch) {
+        return diffHunk;
+    }
 
     const newStartLine = parseInt(headerMatch[2], 10);
 
@@ -703,7 +715,9 @@ function trimDiffHunk(
         }
     }
 
-    if (relevantLines.length === 0) return diffHunk;
+    if (relevantLines.length === 0) {
+        return diffHunk;
+    }
 
     // Build new header with separate old/new line counts
     const firstLineNum = relevantLines.find((r) => r.lineNum !== null)?.lineNum ?? targetLine;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -371,6 +371,16 @@ export interface ReviewData {
     state: string;
     threads: ParsedReviewThread[];
     stats: ReviewThreadStats;
+    prComments?: PRLevelComment[];
+}
+
+export interface PRLevelComment {
+    id: string;
+    author: string;
+    body: string;
+    createdAt: string;
+    type: "review" | "comment";
+    reviewState?: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED";
 }
 
 export interface ReviewCommandOptions {
@@ -384,6 +394,8 @@ export interface ReviewCommandOptions {
     resolveThread?: boolean;
     resolve?: boolean;
     verbose?: boolean;
+    prComments?: boolean;
+    author?: string;
 }
 
 export interface RepoSearchResult {


### PR DESCRIPTION
## Summary

- **Fix reply truncation** — terminal output was cutting replies to 60 chars (first line only); markdown to 100 chars. Both now show the full body with proper indentation
- **PR-level comments** — fetch and display review submission summaries (APPROVED, CHANGES_REQUESTED, COMMENTED) and conversation comments alongside thread reviews. Full pagination supported. Hidden with `--no-pr-comments`
- **Author filter** — new `-a / --author <login>` flag filters displayed threads to a specific reviewer (case-insensitive); stats recomputed on the filtered set

## New CLI flags

```
tools github review <pr> --no-pr-comments        # hide PR-level comments section
tools github review <pr> -a coderabbitai          # only coderabbitai threads
tools github review <pr> -a coderabbitai -u       # only coderabbitai unresolved
```

## Test plan

- [ ] Run against a PR with multi-line replies — verify full body shows in terminal and markdown
- [ ] Verify `PR-LEVEL COMMENTS` section appears at end of terminal output
- [ ] Verify `## PR-Level Comments` section appears in saved markdown file
- [ ] `--no-pr-comments` suppresses the section
- [ ] `-a <login>` filters threads and stats correctly
- [ ] `--json` output includes `prComments` array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added author filter (-a/--author) for review views and a --no-pr-comments flag to hide PR-level comments.
  * Review outputs (terminal, Markdown, JSON) now optionally include PR-level review comments.

* **Improvements**
  * Markdown output is reliably written before completion.
  * Multi-line replies and thread replies preserve line breaks and indentation.
  * "Unresolved-only" views respect the author filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->