### PR TITLE
feat: github review enhancements, macos sleep command, utils test suite

### DIFF
--- a/src/github/commands/comments.ts
+++ b/src/github/commands/comments.ts
@@ -297,7 +297,11 @@ export async function commentsCommand(input: string, options: CommentsCommandOpt
         // Incremental fetch - get new comments since last fetch, merge with cache
         verbose(options, `Incremental fetch: getting comments since ${metadata.last_comment_date}`);
 
-        const sinceDate = metadata.last_comment_date ?? "";
+        const sinceDate = metadata.last_comment_date;
+        if (!sinceDate) {
+            throw new Error("Expected last_comment_date for incremental fetch");
+        }
+
         const apiComments = await fetchComments(owner, repo, number, {
             since: sinceDate,
         });

--- a/src/github/lib/output.ts
+++ b/src/github/lib/output.ts
@@ -211,6 +211,7 @@ function formatPRSummary(data: PRData, options: FormatOptions): string {
         if (data.pr.draft) {
             prStats.push("- **Status:** Draft");
         }
+
         if (data.pr.merged) {
             const mergedAt = data.pr.merged_at ?? "";
             prStats.push(`- **Merged:** ${formatDate(mergedAt)} by @${data.pr.merged_by?.login ?? "unknown"}`);

--- a/src/github/lib/review-output.ts
+++ b/src/github/lib/review-output.ts
@@ -248,10 +248,6 @@ export function formatReviewTerminal(data: ReviewData, groupByFile: boolean): st
         }
     }
 
-    if (data.prComments && data.prComments.length > 0) {
-        output += formatPrLevelComments(data.prComments);
-    }
-
     return output;
 }
 
@@ -366,10 +362,6 @@ export function formatReviewMarkdown(data: ReviewData, groupByFile: boolean): st
     if (threads.length === 0) {
         output += `*No review comments found.*\n`;
         return output;
-    }
-
-    if (data.prComments && data.prComments.length > 0) {
-        output += formatPrLevelCommentsMarkdown(data.prComments);
     }
 
     output += `## Review Threads\n\n`;

--- a/src/github/lib/review-output.ts
+++ b/src/github/lib/review-output.ts
@@ -248,6 +248,10 @@ export function formatReviewTerminal(data: ReviewData, groupByFile: boolean): st
         }
     }
 
+    if (data.prComments && data.prComments.length > 0) {
+        output += formatPrLevelComments(data.prComments);
+    }
+
     return output;
 }
 
@@ -362,6 +366,10 @@ export function formatReviewMarkdown(data: ReviewData, groupByFile: boolean): st
     if (threads.length === 0) {
         output += `*No review comments found.*\n`;
         return output;
+    }
+
+    if (data.prComments && data.prComments.length > 0) {
+        output += formatPrLevelCommentsMarkdown(data.prComments);
     }
 
     output += `## Review Threads\n\n`;

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -73,7 +73,13 @@ if (options.verbose) {
 const log = {
     info: (message: string) => logger.info(chalk.blue("ℹ️ ") + message),
     debug: (message: string) => (options.verbose ? logger.info(chalk.gray("🔍 ") + message) : null),
-    error: (message: string, err?: unknown) => logger.error(chalk.red("❌ ") + message + (err ? `: ${err}` : "")),
+    error: (message: string, err?: unknown) => {
+        if (err) {
+            logger.error({ err }, chalk.red("❌ ") + message);
+        } else {
+            logger.error(chalk.red("❌ ") + message);
+        }
+    },
     warn: (message: string) => logger.info(chalk.yellow("⚠️ ") + message),
     file: {
         new: (filepath: string) => logger.info(chalk.green(`\n📄 NEW FILE: ${filepath}`)),

--- a/src/watchman/index.ts
+++ b/src/watchman/index.ts
@@ -249,7 +249,7 @@ async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
                             logger.info(
                                 `Watch established on ${watchResp.watch} relative_path: ${watchResp.relative_path}`
                             );
-                            makeSubscription(client, watchResp.watch, watchResp.relative_path);
+                            makeSubscription(client, watchResp.watch ?? "", watchResp.relative_path);
                             attempt = maxRetries;
                             resolve(undefined);
                         }

--- a/src/watchman/index.ts
+++ b/src/watchman/index.ts
@@ -203,6 +203,7 @@ function makeSubscription(
 async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
     let attempt = 0;
     let lastError: unknown = null;
+    let succeeded = false;
     while (attempt < maxRetries) {
         const client = new (require("fb-watchman").Client)();
         await new Promise((resolve) => {
@@ -249,19 +250,19 @@ async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
                             logger.info(
                                 `Watch established on ${watchResp.watch} relative_path: ${watchResp.relative_path}`
                             );
-                            makeSubscription(client, watchResp.watch ?? "", watchResp.relative_path);
-                            attempt = maxRetries;
+                            makeSubscription(client, watchResp.watch, watchResp.relative_path);
+                            succeeded = true;
                             resolve(undefined);
                         }
                     );
                 }
             );
         });
-        if (attempt === maxRetries) {
+        if (succeeded) {
             return;
         }
     }
-    logger.error(`Failed to establish watch after 15 attempts. Exiting. ${lastError}`);
+    logger.error(`Failed to establish watch after ${maxRetries} attempts. Exiting. ${lastError}`);
     process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- **GitHub review command enhancements**: PR-level comments display, `--no-pr-comments` and `--author` flags, full pagination for review threads
- **macOS sleep command**: `tools macos sleep --after "30m"` with countdown timer, compound duration parsing (`1h30m15s`)
- **Comprehensive utils test suite**: 227 unit tests across 14 test files covering all `src/utils/` modules (format, string, async, date, url, table, json-schema, fuzzy-match, storage, etc.)
- **Codebase cleanup**: biome lint fixes, Bun.spawn→Executor migration, clipboard utility dedup, azure-devops utils split

## Test plan
- [x] `bun test src/utils/` — 227 tests, 0 failures
- [x] `biome check` — all test files clean
- [ ] Manual: `tools macos sleep --after "10s"` triggers sleep after countdown
- [ ] Manual: `tools github review <pr-url>` shows PR-level comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer comment fetching and caching with guards against missing data and more robust reaction filtering.
  * Watch establishment now stops retries on success and reports failure counts correctly.

* **Refactor**
  * Logging updated to emit structured error objects for clearer diagnostic output.

* **Style**
  * Minor formatting tweak to PR summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->