### PR TITLE
feat(github-pr): analysis report with Explore agents before thread selection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.9",
+    "version": "1.0.11",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.9",
+            "version": "1.0.11",
             "author": {
                 "name": "GenesisTools"
             },

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.9",
+    "version": "1.0.11",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/commands/github-pr.md
+++ b/plugins/genesis-tools/commands/github-pr.md
@@ -162,7 +162,7 @@ value inconsistency across reservations table, timeslots table, and PersonsType 
 
 ---
 
-#### #5 [HIGH] `ReservationPossibleBugs.md:24` — @copilot
+#### #5 [LOW] `ReservationPossibleBugs.md:24` — @copilot
 
 **Concern:** Plan flags negative persons_filled as a bug, but code intentionally allows
 negatives as a "corruption canary".
@@ -175,13 +175,13 @@ negatives as a "corruption canary".
 ```
 
 **Analysis:** Reviewer is correct — the code comment explicitly says negatives are intentional.
-The plan incorrectly treats this as a bug to fix.
+The plan incorrectly treats this as a bug to fix. No code change needed.
 
-**Verdict:** VALID
-**Action:** Downgrade from MEDIUM to LOW, reword to acknowledge the canary pattern,
-suggest adding tests instead of adding a floor check.
-**Proposed reply:** Good catch — updated the plan to acknowledge the intentional canary
-pattern. Changed to recommend tests for the canary→fix flow instead of a GREATEST(0,...) guard.
+**Verdict:** BY_DESIGN
+**Action:** Downgrade severity to LOW and note that negatives are intentional — no behavior
+change required. Update the plan's wording to acknowledge the canary pattern.
+**Proposed reply:** Good catch — negatives are intentional as a corruption canary for
+TimeslotFixer. Downgraded severity and updated the plan wording accordingly.
 
 ---
 

--- a/plugins/genesis-tools/commands/github-pr.md
+++ b/plugins/genesis-tools/commands/github-pr.md
@@ -185,6 +185,32 @@ pattern. Changed to recommend tests for the canary→fix flow instead of a GREAT
 
 ---
 
+#### #8 [MED] `utils/cache.ts:45-52` — @gemini-code-assist
+
+**Concern:** The cache TTL defaults to `0`, which means entries never expire.
+This is likely a bug — most callers expect a reasonable default like 300 seconds.
+
+**Suggested change:**
+```suggestion
+- const DEFAULT_TTL = 0;
++ const DEFAULT_TTL = 300;
+```
+
+**Code context:**
+```typescript
+const DEFAULT_TTL = 0;
+export function createCache(ttl = DEFAULT_TTL) { ... }
+```
+
+**Analysis:** Reviewer is correct — `0` disables expiry entirely, which causes unbounded
+memory growth. The callers in `src/api/` all pass explicit TTLs, but the default is a footgun.
+
+**Verdict:** VALID
+**Action:** Apply the reviewer's suggested change (DEFAULT_TTL = 300).
+**Proposed reply:** Fixed in [abc1234](url) — changed default TTL from 0 to 300 seconds.
+
+---
+
 #### #12 [MED] `some-file.ts:42` — @coderabbitai
 
 **Concern:** Missing null check on `user.profile` before accessing `.name`.

--- a/plugins/genesis-tools/commands/github-pr.md
+++ b/plugins/genesis-tools/commands/github-pr.md
@@ -43,10 +43,12 @@ The script outputs the file path to stdout (e.g., `.claude/github/reviews/pr-137
 
 > **CRITICAL — READ THIS FIRST:** To read the review file, you MUST use the **Read** tool. NEVER use `cat`, `Bash(cat ...)`, `head`, `tail`, or ANY Bash command to read it. Bash output gets truncated at ~50 lines, then auto-persisted to `tool-results/`, forcing 5+ chunked Read calls on the persisted file — wasting thousands of tokens and minutes of time. The Read tool gets the full file in one call.
 
-Use the **Read** tool to read the generated markdown file:
+Use the **Read** tool to read the generated markdown file — **always try reading the entire file first** (no `offset`/`limit` parameters). Only if the Read tool returns an error because the file exceeds the token limit, fall back to chunked reads of **1000 lines** at a time. If 1000-line chunks still fail, fall back to **500 lines**:
 
-```bash
-Read <generated-file-path>
+```
+Read <generated-file-path>                    # Try whole file first
+Read <generated-file-path> offset=1 limit=1000   # Fallback: 1000-line chunks
+Read <generated-file-path> offset=1 limit=500    # Last resort: 500-line chunks
 ```
 
 **If `--open-only` flag is present:**


### PR DESCRIPTION
## Summary
- **Analysis-first flow**: Before asking which threads to fix, the skill now analyzes every thread by reading source code, assigning verdicts (VALID/FALSE_POSITIVE/BY_DESIGN/ALREADY_FIXED/NEEDS_CLARIFICATION), and presenting a rich report with code context, analysis, actions, and proposed GitHub replies
- **Explore agents**: Uses parallel Explore agents to verify reviewer claims against actual source code, grouped by file or problem domain
- **Enforced Read tool**: Moved the "never use cat" instruction to the top of Step 2 with CRITICAL marker to prevent the truncation→persist→chunked-read cascade

## Test plan
- [ ] Run `/genesis-tools:github-pr <pr-url> -u` and verify threads are analyzed before the selection prompt
- [ ] Verify the analysis report shows code context, verdicts, and proposed replies for each thread
- [ ] Verify the Read tool is used (not cat) to read the review file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub PR review workflow to an analysis-first process with structured per-thread analysis, analysis reports, and revised decision steps before applying fixes.

* **Chores**
  * Release/version bumped to 1.0.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->