### PR TITLE
feat(claude): Migrate to codex command

### DIFF
--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -58,6 +58,8 @@ Interactive migration wizard for moving/syncing Claude assets into Codex-compati
   - Project: `./.codex/prompts/`
   - Global: `~/.codex/prompts/`
 - **Instructions** (`CLAUDE.md`) -> `AGENTS.md`
+  - Project scope: `./AGENTS.md`
+  - Global scope: `~/.codex/AGENTS.md`
 
 ### Wizard behavior
 

--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -43,9 +43,9 @@ Interactive migration wizard for moving/syncing Claude assets into Codex-compati
   - Project plugins: `.claude-plugin/marketplace.json` + `plugins/*/.claude-plugin/plugin.json`
   - Global: `~/.claude/skills/*/SKILL.md`
 - **Commands**
-  - Project: `./.claude/commands/*.md`
+  - Project: `./.claude/commands/**/*.md`
   - Plugin command markdown folders from plugin manifests
-  - Global: `~/.claude/commands/*.md`
+  - Global: `~/.claude/commands/**/*.md`
 - **Instructions**
   - Project and global `CLAUDE.md`
 

--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -1,0 +1,123 @@
+# Claude Tool (`tools claude`)
+
+Claude-focused utilities for local Claude Code workflows:
+
+- Search and summarize conversation history
+- Resume past sessions
+- Sync skills to Claude Desktop
+- Inspect Claude usage/quota
+- Manage Claude auth/config
+- Migrate Claude assets to Codex (`migrate-to codex`)
+
+---
+
+## Quick Start
+
+```bash
+# General help
+tools claude --help
+
+# History search
+tools claude history "mcp manager"
+
+# Resume session
+tools claude resume
+
+# Claude usage
+tools claude usage
+
+# Migrate Claude assets to Codex (interactive wizard)
+tools claude migrate-to codex
+```
+
+---
+
+## `migrate-to codex`
+
+Interactive migration wizard for moving/syncing Claude assets into Codex-compatible locations.
+
+### What it discovers
+
+- **Skills**
+  - Project: `./.claude/skills/*/SKILL.md`
+  - Project plugins: `.claude-plugin/marketplace.json` + `plugins/*/.claude-plugin/plugin.json`
+  - Global: `~/.claude/skills/*/SKILL.md`
+- **Commands**
+  - Project: `./.claude/commands/*.md`
+  - Plugin command markdown folders from plugin manifests
+  - Global: `~/.claude/commands/*.md`
+- **Instructions**
+  - Project and global `CLAUDE.md`
+
+### Target mapping
+
+- **Skills** -> Codex skills folders:
+  - Project: `./.agents/skills/`
+  - Global: `~/.codex/skills/`
+- **Commands** -> Codex prompt files:
+  - Project: `./.codex/prompts/`
+  - Global: `~/.codex/prompts/`
+- **Instructions** (`CLAUDE.md`) -> `AGENTS.md`
+
+### Wizard behavior
+
+- `ESC` goes back one step (instead of cancelling immediately)
+- Steps:
+  1. Choose source scope (`project`, `global`, `both`)
+  2. Choose components (`skills`, `commands`, `instructions`)
+  3. Choose target scope (`project`, `global`, `both`)
+  4. Choose transfer mode (`symlink` or `copy`)
+  5. Choose naming strategy (`prefixed` or `preserve`)
+  6. Confirm plan
+
+### Modes
+
+- **symlink** (recommended): always-in-sync
+- **copy**: one-time snapshot
+
+### CLI options
+
+```bash
+tools claude migrate-to codex [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `--source <scope>` | Source scope: `project`, `global`, `both` |
+| `--target <scope>` | Target scope: `project`, `global`, `both` |
+| `--components <list>` | Comma list: `skills,commands,instructions` |
+| `--mode <mode>` | `symlink` or `copy` |
+| `--name-style <style>` | `prefixed` or `preserve` |
+| `--force` | Overwrite existing destination entries |
+| `--dry-run` | Show planned actions without writing |
+| `--list` | Print discovered assets and exit |
+| `-y, --yes` | Skip final confirmation |
+| `--non-interactive` | Skip wizard and run from flags |
+
+### Examples
+
+```bash
+# Guided migration
+tools claude migrate-to codex
+
+# See what would be migrated
+tools claude migrate-to codex --list
+
+# Global sync via symlinks (non-interactive)
+tools claude migrate-to codex \
+  --source global \
+  --target global \
+  --components skills,commands \
+  --mode symlink \
+  --non-interactive \
+  -y
+
+# Instructions only, preview
+tools claude migrate-to codex \
+  --source project \
+  --target project \
+  --components instructions \
+  --mode copy \
+  --dry-run \
+  --non-interactive
+```

--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -62,6 +62,11 @@ Interactive migration wizard for moving/syncing Claude assets into Codex-compati
 ### Wizard behavior
 
 - `ESC` goes back one step (instead of cancelling immediately)
+- Existing-target conflicts are resolved interactively:
+  - show diff (`src/utils/diff.ts` helper)
+  - overwrite
+  - skip
+  - rename target path
 - Steps:
   1. Choose source scope (`project`, `global`, `both`)
   2. Choose components (`skills`, `commands`, `instructions`)

--- a/src/claude/commands/migrate.ts
+++ b/src/claude/commands/migrate.ts
@@ -1,0 +1,519 @@
+import {
+    buildMigrationPlan,
+    type DiscoveredSources,
+    discoverMigrationSources,
+    executeMigrationPlan,
+    type MigrationComponent,
+    type MigrationMode,
+    type MigrationScope,
+    type NameStyle,
+    summarizeDiscovery,
+    summarizeExecution,
+    summarizePlan,
+} from "@app/claude/lib/migrate-to-codex";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+interface MigrateCodexOptions {
+    source?: string;
+    target?: string;
+    components?: string;
+    mode?: string;
+    nameStyle?: string;
+    force?: boolean;
+    dryRun?: boolean;
+    list?: boolean;
+    yes?: boolean;
+    nonInteractive?: boolean;
+}
+
+interface WizardState {
+    sourceScope: MigrationScope;
+    targetScope: MigrationScope;
+    components: MigrationComponent[];
+    mode: MigrationMode;
+    nameStyle: NameStyle;
+}
+
+const ALL_COMPONENTS: MigrationComponent[] = ["skills", "commands", "instructions"];
+
+export function registerMigrateCommand(program: Command): void {
+    const migrateTo = program.command("migrate-to").description("Migration helpers");
+
+    migrateTo
+        .command("codex")
+        .description("Guide Claude -> Codex migration (ESC goes one step back in the wizard)")
+        .option("--source <scope>", "Source scope: project | global | both")
+        .option("--target <scope>", "Target scope: project | global | both", "project")
+        .option(
+            "--components <list>",
+            "Comma-separated components: skills,commands,instructions (default: all components)"
+        )
+        .option("--mode <mode>", "Transfer mode: symlink | copy", "symlink")
+        .option("--name-style <style>", "Target naming style: prefixed | preserve", "prefixed")
+        .option("--force", "Overwrite existing destination entries")
+        .option("--dry-run", "Preview migration without writing files")
+        .option("--list", "List discovered Claude assets and exit")
+        .option("-y, --yes", "Apply without final confirmation")
+        .option("--non-interactive", "Run without interactive wizard")
+        .addHelpText(
+            "after",
+            `
+Examples:
+  tools claude migrate-to codex
+  tools claude migrate-to codex --list
+  tools claude migrate-to codex --source global --target global --components skills,commands --mode symlink -y
+  tools claude migrate-to codex --source project --target project --components instructions --mode copy --dry-run
+`
+        )
+        .action(async (options: MigrateCodexOptions) => {
+            await runMigrateToCodex(options);
+        });
+}
+
+async function runMigrateToCodex(options: MigrateCodexOptions): Promise<void> {
+    p.intro(pc.bgCyan(pc.black(" claude migrate-to codex ")));
+
+    const projectRoot = process.cwd();
+    const discovered = discoverMigrationSources(projectRoot);
+
+    if (options.list) {
+        renderDiscoveryList(discovered);
+        p.outro("Discovery complete.");
+        return;
+    }
+
+    const initialState: WizardState = {
+        sourceScope: parseScope(options.source, "project"),
+        targetScope: parseScope(options.target, "project"),
+        components: parseComponents(options.components),
+        mode: parseMode(options.mode),
+        nameStyle: parseNameStyle(options.nameStyle),
+    };
+
+    const interactive = process.stdout.isTTY && process.stdin.isTTY && !options.nonInteractive;
+    const state = interactive ? await runWizard(discovered, initialState, options) : initialState;
+    if (!state) {
+        return;
+    }
+
+    const plan = buildMigrationPlan(discovered, {
+        projectRoot,
+        sourceScope: state.sourceScope,
+        targetScope: state.targetScope,
+        components: state.components,
+        mode: state.mode,
+        nameStyle: state.nameStyle,
+    });
+
+    if (plan.operations.length === 0) {
+        p.log.warn("No operations to apply. Try broader source/target scopes or different components.");
+        if (plan.warnings.length > 0) {
+            p.note(plan.warnings.join("\n"), "Warnings");
+        }
+        p.outro("Nothing changed.");
+        return;
+    }
+
+    if (!options.yes && !interactive) {
+        p.log.warn("Non-interactive mode without -y defaults to preview only. Use -y to apply changes.");
+    }
+
+    if (!options.yes && !interactive && !options.dryRun) {
+        p.note(summarizePlan(plan), "Planned operations");
+        p.outro("Preview complete.");
+        return;
+    }
+
+    if (!options.yes && interactive) {
+        p.note(summarizePlan(plan), "Final plan");
+        const confirmed = await p.confirm({
+            message: options.dryRun ? "Run dry run?" : "Apply migration now?",
+            initialValue: true,
+        });
+
+        if (p.isCancel(confirmed) || !confirmed) {
+            p.cancel("Migration cancelled.");
+            return;
+        }
+    }
+
+    const results = executeMigrationPlan(plan, {
+        dryRun: !!options.dryRun,
+        force: !!options.force,
+    });
+
+    p.note(summarizeExecution(results), options.dryRun ? "Dry run summary" : "Migration summary");
+
+    const failed = results.filter((item) => item.status === "failed");
+    if (failed.length > 0) {
+        p.note(
+            failed
+                .slice(0, 20)
+                .map((item) => `${item.operation.targetPath} -> ${item.message}`)
+                .join("\n"),
+            "Failures"
+        );
+        process.exitCode = 1;
+    }
+
+    const skipped = results.filter((item) => item.status === "skipped");
+    if (skipped.length > 0) {
+        p.note(
+            skipped
+                .slice(0, 20)
+                .map((item) => `${item.operation.targetPath} -> ${item.message}`)
+                .join("\n"),
+            "Skipped"
+        );
+    }
+
+    if (plan.warnings.length > 0) {
+        p.note(plan.warnings.join("\n"), "Warnings");
+    }
+
+    p.outro(options.dryRun ? "Dry run completed." : "Migration completed.");
+}
+
+async function runWizard(
+    discovered: DiscoveredSources,
+    initialState: WizardState,
+    options: MigrateCodexOptions
+): Promise<WizardState | null> {
+    const state: WizardState = {
+        sourceScope: initialState.sourceScope,
+        targetScope: initialState.targetScope,
+        components: [...initialState.components],
+        mode: initialState.mode,
+        nameStyle: initialState.nameStyle,
+    };
+
+    const steps = ["source", "components", "target", "mode", "name-style", "confirm"] as const;
+    let currentStep = 0;
+
+    while (currentStep < steps.length) {
+        const step = steps[currentStep];
+
+        if (step === "source") {
+            const choice = await p.select({
+                message: "Choose Claude source scope:",
+                options: [
+                    {
+                        value: "project",
+                        label: `Project only (${countScope(discovered, "project")} assets)`,
+                    },
+                    {
+                        value: "global",
+                        label: `Global ~/.claude only (${countScope(discovered, "global")} assets)`,
+                    },
+                    {
+                        value: "both",
+                        label: `Project + global (${countScope(discovered, "project") + countScope(discovered, "global")} assets)`,
+                    },
+                ],
+                initialValue: state.sourceScope,
+            });
+
+            if (p.isCancel(choice)) {
+                p.cancel("Migration cancelled.");
+                return null;
+            }
+
+            state.sourceScope = choice as MigrationScope;
+            currentStep += 1;
+            continue;
+        }
+
+        if (step === "components") {
+            const selected = await p.multiselect({
+                message: "Select components to migrate:",
+                options: [
+                    {
+                        value: "skills",
+                        label: "Skills",
+                        hint: "Claude SKILL.md folders -> Codex skill folders",
+                        selected: state.components.includes("skills"),
+                    },
+                    {
+                        value: "commands",
+                        label: "Commands",
+                        hint: "Claude command markdown -> Codex prompt files",
+                        selected: state.components.includes("commands"),
+                    },
+                    {
+                        value: "instructions",
+                        label: "Instructions",
+                        hint: "CLAUDE.md -> AGENTS.md (copy or symlink)",
+                        selected: state.components.includes("instructions"),
+                    },
+                ],
+                required: false,
+            });
+
+            if (p.isCancel(selected)) {
+                currentStep -= 1;
+                continue;
+            }
+
+            const components = selected as MigrationComponent[];
+            if (components.length === 0) {
+                p.log.warn("Select at least one component.");
+                continue;
+            }
+
+            state.components = components;
+            currentStep += 1;
+            continue;
+        }
+
+        if (step === "target") {
+            const choice = await p.select({
+                message: "Choose Codex target scope:",
+                options: [
+                    { value: "project", label: "Project (.agents + .codex in current repository)" },
+                    { value: "global", label: "Global (~/.codex)" },
+                    { value: "both", label: "Project + global" },
+                ],
+                initialValue: state.targetScope,
+            });
+
+            if (p.isCancel(choice)) {
+                currentStep -= 1;
+                continue;
+            }
+
+            state.targetScope = choice as MigrationScope;
+            currentStep += 1;
+            continue;
+        }
+
+        if (step === "mode") {
+            const choice = await p.select({
+                message: "Choose transfer mode:",
+                options: [
+                    {
+                        value: "symlink",
+                        label: "Symlink (recommended for always-in-sync)",
+                        hint: "No duplication, Codex reads the source files directly",
+                    },
+                    {
+                        value: "copy",
+                        label: "Copy (snapshot)",
+                        hint: "Independent files, rerun migration for updates",
+                    },
+                ],
+                initialValue: state.mode,
+            });
+
+            if (p.isCancel(choice)) {
+                currentStep -= 1;
+                continue;
+            }
+
+            state.mode = choice as MigrationMode;
+            currentStep += 1;
+            continue;
+        }
+
+        if (step === "name-style") {
+            const choice = await p.select({
+                message: "Choose target naming style:",
+                options: [
+                    {
+                        value: "prefixed",
+                        label: "Prefixed (recommended)",
+                        hint: "Avoids collisions across project/global/plugin sources",
+                    },
+                    {
+                        value: "preserve",
+                        label: "Preserve original names",
+                        hint: "Closest to original names, may collide",
+                    },
+                ],
+                initialValue: state.nameStyle,
+            });
+
+            if (p.isCancel(choice)) {
+                currentStep -= 1;
+                continue;
+            }
+
+            state.nameStyle = choice as NameStyle;
+            currentStep += 1;
+            continue;
+        }
+
+        const plan = buildMigrationPlan(discovered, {
+            projectRoot: process.cwd(),
+            sourceScope: state.sourceScope,
+            targetScope: state.targetScope,
+            components: state.components,
+            mode: state.mode,
+            nameStyle: state.nameStyle,
+        });
+
+        const detailLines = [
+            `Mode: ${state.mode}`,
+            `Source scope: ${state.sourceScope}`,
+            `Target scope: ${state.targetScope}`,
+            `Components: ${state.components.join(", ")}`,
+            `Force overwrite: ${options.force ? "yes" : "no"}`,
+            `Dry run: ${options.dryRun ? "yes" : "no"}`,
+            "",
+            summarizePlan(plan),
+        ];
+
+        if (plan.warnings.length > 0) {
+            detailLines.push("");
+            detailLines.push(`Warnings: ${plan.warnings.length}`);
+        }
+
+        p.note(detailLines.join("\n"), "Migration plan");
+
+        const confirmed = await p.confirm({
+            message: options.dryRun ? "Run dry run with this plan?" : "Apply this migration plan?",
+            initialValue: true,
+        });
+
+        if (p.isCancel(confirmed)) {
+            currentStep -= 1;
+            continue;
+        }
+
+        if (!confirmed) {
+            currentStep -= 1;
+            continue;
+        }
+
+        return state;
+    }
+
+    return null;
+}
+
+function renderDiscoveryList(discovered: DiscoveredSources): void {
+    const lines: string[] = [];
+    lines.push(summarizeDiscovery(discovered));
+    lines.push("");
+
+    lines.push("Project skills:");
+    for (const item of discovered.skills.filter((entry) => entry.scope === "project")) {
+        lines.push(`- ${item.path}`);
+    }
+    if (discovered.skills.filter((entry) => entry.scope === "project").length === 0) {
+        lines.push("- (none)");
+    }
+
+    lines.push("");
+    lines.push("Global skills:");
+    for (const item of discovered.skills.filter((entry) => entry.scope === "global")) {
+        lines.push(`- ${item.path}`);
+    }
+    if (discovered.skills.filter((entry) => entry.scope === "global").length === 0) {
+        lines.push("- (none)");
+    }
+
+    lines.push("");
+    lines.push("Project commands:");
+    for (const item of discovered.commands.filter((entry) => entry.scope === "project")) {
+        lines.push(`- ${item.path}`);
+    }
+    if (discovered.commands.filter((entry) => entry.scope === "project").length === 0) {
+        lines.push("- (none)");
+    }
+
+    lines.push("");
+    lines.push("Global commands:");
+    for (const item of discovered.commands.filter((entry) => entry.scope === "global")) {
+        lines.push(`- ${item.path}`);
+    }
+    if (discovered.commands.filter((entry) => entry.scope === "global").length === 0) {
+        lines.push("- (none)");
+    }
+
+    lines.push("");
+    lines.push("Instruction files:");
+    for (const item of discovered.instructions) {
+        lines.push(`- [${item.scope}] ${item.path}`);
+    }
+    if (discovered.instructions.length === 0) {
+        lines.push("- (none)");
+    }
+
+    if (discovered.warnings.length > 0) {
+        lines.push("");
+        lines.push("Warnings:");
+        for (const warning of discovered.warnings) {
+            lines.push(`- ${warning}`);
+        }
+    }
+
+    p.note(lines.join("\n"), "Discovered Claude assets");
+}
+
+function countScope(discovered: DiscoveredSources, scope: "project" | "global"): number {
+    const skills = discovered.skills.filter((item) => item.scope === scope).length;
+    const commands = discovered.commands.filter((item) => item.scope === scope).length;
+    const instructions = discovered.instructions.filter((item) => item.scope === scope).length;
+    return skills + commands + instructions;
+}
+
+function parseScope(value: string | undefined, fallback: MigrationScope): MigrationScope {
+    if (!value) {
+        return fallback;
+    }
+
+    if (value !== "project" && value !== "global" && value !== "both") {
+        throw new Error(`Invalid scope "${value}". Use: project | global | both`);
+    }
+
+    return value;
+}
+
+function parseMode(value: string | undefined): MigrationMode {
+    if (!value || value === "symlink") {
+        return "symlink";
+    }
+
+    if (value === "copy") {
+        return "copy";
+    }
+
+    throw new Error(`Invalid mode "${value}". Use: symlink | copy`);
+}
+
+function parseNameStyle(value: string | undefined): NameStyle {
+    if (!value || value === "prefixed") {
+        return "prefixed";
+    }
+
+    if (value === "preserve") {
+        return "preserve";
+    }
+
+    throw new Error(`Invalid name style "${value}". Use: prefixed | preserve`);
+}
+
+function parseComponents(value: string | undefined): MigrationComponent[] {
+    if (!value) {
+        return [...ALL_COMPONENTS];
+    }
+
+    const parsed = value
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean);
+
+    const invalid = parsed.filter((item) => !ALL_COMPONENTS.includes(item as MigrationComponent));
+    if (invalid.length > 0) {
+        throw new Error(`Invalid components: ${invalid.join(", ")}. Use any of: ${ALL_COMPONENTS.join(",")}`);
+    }
+
+    const unique = [...new Set(parsed)] as MigrationComponent[];
+    if (unique.length === 0) {
+        throw new Error("At least one component is required.");
+    }
+
+    return unique;
+}

--- a/src/claude/commands/migrate.ts
+++ b/src/claude/commands/migrate.ts
@@ -633,6 +633,10 @@ async function promptRenamePath(targetPath: string): Promise<string | null> {
             if (!value || !value.trim()) {
                 return "Path is required";
             }
+
+            if (existsSync(resolve(value.trim()))) {
+                return "Path already exists, choose a different name";
+            }
         },
     });
 

--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import { registerConfigCommand } from "./commands/config";
 import { registerDesktopCommand } from "./commands/desktop";
 import { registerHistoryCommand } from "./commands/history";
+import { registerMigrateCommand } from "./commands/migrate";
 import { registerResumeCommand } from "./commands/resume";
 import { registerUsageCommand } from "./commands/usage";
 
@@ -11,7 +12,7 @@ const program = new Command();
 
 program
     .name("claude")
-    .description("Claude Code tools: history, resume, desktop sync, usage, config")
+    .description("Claude Code tools: history, resume, desktop sync, usage, config, migration")
     .version("1.0.0")
     .showHelpAfterError(true);
 
@@ -20,6 +21,7 @@ registerResumeCommand(program);
 registerDesktopCommand(program);
 registerUsageCommand(program);
 registerConfigCommand(program);
+registerMigrateCommand(program);
 
 async function main(): Promise<void> {
     try {

--- a/src/claude/lib/migrate-to-codex/index.ts
+++ b/src/claude/lib/migrate-to-codex/index.ts
@@ -1,0 +1,787 @@
+import {
+    cpSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    readlinkSync,
+    rmSync,
+    symlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+
+export type MigrationScope = "project" | "global" | "both";
+export type SingleScope = "project" | "global";
+export type MigrationComponent = "skills" | "commands" | "instructions";
+export type MigrationMode = "symlink" | "copy";
+export type NameStyle = "prefixed" | "preserve";
+
+type SourceOrigin = "claude" | "plugin";
+
+export interface SkillSource {
+    path: string;
+    scope: SingleScope;
+    origin: SourceOrigin;
+    pluginName?: string;
+}
+
+export interface CommandSource {
+    path: string;
+    scope: SingleScope;
+    origin: SourceOrigin;
+    namespace: string;
+    pluginName?: string;
+}
+
+export interface InstructionSource {
+    path: string;
+    scope: SingleScope;
+    origin: "claude";
+}
+
+export interface DiscoveredSources {
+    skills: SkillSource[];
+    commands: CommandSource[];
+    instructions: InstructionSource[];
+    warnings: string[];
+}
+
+export interface MigrationPlanInput {
+    projectRoot: string;
+    sourceScope: MigrationScope;
+    targetScope: MigrationScope;
+    components: MigrationComponent[];
+    mode: MigrationMode;
+    nameStyle: NameStyle;
+}
+
+export interface PlannedOperation {
+    component: MigrationComponent;
+    mode: MigrationMode;
+    sourceScope: SingleScope;
+    targetScope: SingleScope;
+    sourcePath: string;
+    targetPath: string;
+    label: string;
+}
+
+export interface MigrationPlan {
+    operations: PlannedOperation[];
+    warnings: string[];
+}
+
+export interface ExecutePlanOptions {
+    dryRun: boolean;
+    force: boolean;
+}
+
+export interface OperationResult {
+    operation: PlannedOperation;
+    status: "created" | "updated" | "skipped" | "failed";
+    message: string;
+}
+
+interface PluginDeclaration {
+    name: string;
+    rootDir: string;
+    skills: string[];
+    commands: string[];
+    scope: SingleScope;
+}
+
+const PROJECT_CLAUDE_DIRNAME = ".claude";
+const PROJECT_CLAUDE_PLUGIN_DIRNAME = ".claude-plugin";
+const GLOBAL_CLAUDE_DIR = join(homedir(), ".claude");
+const GLOBAL_CODEX_DIR = join(homedir(), ".codex");
+
+export function discoverMigrationSources(projectRoot: string): DiscoveredSources {
+    const warnings: string[] = [];
+    const skills: SkillSource[] = [];
+    const commands: CommandSource[] = [];
+    const instructions: InstructionSource[] = [];
+
+    const seenSkills = new Set<string>();
+    const seenCommands = new Set<string>();
+    const seenInstructions = new Set<string>();
+
+    const projectClaudeDir = join(projectRoot, PROJECT_CLAUDE_DIRNAME);
+    const projectClaudeSkillsDir = join(projectClaudeDir, "skills");
+    const projectClaudeCommandsDir = join(projectClaudeDir, "commands");
+    const projectClaudeMd = join(projectRoot, "CLAUDE.md");
+
+    addSkillDirs(skills, seenSkills, collectSkillDirs(projectClaudeSkillsDir), "project", "claude");
+    addCommandFiles(
+        commands,
+        seenCommands,
+        collectMarkdownFiles(projectClaudeCommandsDir),
+        "project",
+        "claude",
+        "claude"
+    );
+    addInstruction(instructions, seenInstructions, projectClaudeMd, "project");
+
+    const plugins = discoverProjectPlugins(projectRoot, warnings);
+    for (const plugin of plugins) {
+        const skillDirs = collectSkillDirsFromPaths(plugin.rootDir, plugin.skills, warnings);
+        addSkillDirs(skills, seenSkills, skillDirs, plugin.scope, "plugin", plugin.name);
+
+        const commandFiles = collectCommandFilesFromPaths(plugin.rootDir, plugin.commands, warnings);
+        addCommandFiles(
+            commands,
+            seenCommands,
+            commandFiles,
+            plugin.scope,
+            "plugin",
+            normalizeSegment(plugin.name),
+            plugin.name
+        );
+    }
+
+    const globalSkillsDir = join(GLOBAL_CLAUDE_DIR, "skills");
+    const globalCommandsDir = join(GLOBAL_CLAUDE_DIR, "commands");
+    const globalClaudeMd = join(GLOBAL_CLAUDE_DIR, "CLAUDE.md");
+
+    addSkillDirs(skills, seenSkills, collectSkillDirs(globalSkillsDir), "global", "claude");
+    addCommandFiles(commands, seenCommands, collectMarkdownFiles(globalCommandsDir), "global", "claude", "claude");
+    addInstruction(instructions, seenInstructions, globalClaudeMd, "global");
+
+    return {
+        skills: sortByPath(skills),
+        commands: sortByPath(commands),
+        instructions: sortByPath(instructions),
+        warnings,
+    };
+}
+
+export function buildMigrationPlan(discovered: DiscoveredSources, input: MigrationPlanInput): MigrationPlan {
+    const warnings = [...discovered.warnings];
+    const operations: PlannedOperation[] = [];
+    const sourceScopes = expandScope(input.sourceScope);
+    const targetScopes = expandScope(input.targetScope);
+    const selected = new Set(input.components);
+    const seenTargets = new Set<string>();
+
+    if (selected.has("skills")) {
+        const skillSources = discovered.skills.filter((item) => sourceScopes.includes(item.scope));
+        const nameUsedByTarget = new Map<string, number>();
+
+        for (const source of skillSources) {
+            for (const targetScope of targetScopes) {
+                const targetBase =
+                    targetScope === "project"
+                        ? join(input.projectRoot, ".agents", "skills")
+                        : join(GLOBAL_CODEX_DIR, "skills");
+                const skillName = buildSkillTargetName(source, input.nameStyle, nameUsedByTarget);
+                const targetPath = join(targetBase, skillName);
+
+                if (seenTargets.has(targetPath)) {
+                    warnings.push(`Skipping duplicate skill target: ${targetPath}`);
+                    continue;
+                }
+
+                seenTargets.add(targetPath);
+                operations.push({
+                    component: "skills",
+                    mode: input.mode,
+                    sourceScope: source.scope,
+                    targetScope,
+                    sourcePath: source.path,
+                    targetPath,
+                    label: `${basename(source.path)} -> ${skillName}`,
+                });
+            }
+        }
+    }
+
+    if (selected.has("commands")) {
+        const commandSources = discovered.commands.filter((item) => sourceScopes.includes(item.scope));
+        const namespaceUsedByTarget = new Map<string, number>();
+
+        for (const source of commandSources) {
+            for (const targetScope of targetScopes) {
+                const targetBase =
+                    targetScope === "project"
+                        ? join(input.projectRoot, ".codex", "prompts")
+                        : join(GLOBAL_CODEX_DIR, "prompts");
+                const namespace = buildCommandNamespace(source, input.nameStyle, namespaceUsedByTarget);
+                const targetPath = join(targetBase, namespace, basename(source.path));
+
+                if (seenTargets.has(targetPath)) {
+                    warnings.push(`Skipping duplicate command target: ${targetPath}`);
+                    continue;
+                }
+
+                seenTargets.add(targetPath);
+                operations.push({
+                    component: "commands",
+                    mode: input.mode,
+                    sourceScope: source.scope,
+                    targetScope,
+                    sourcePath: source.path,
+                    targetPath,
+                    label: `${basename(source.path, extname(source.path))} -> /${namespace}:${basename(source.path, extname(source.path))}`,
+                });
+            }
+        }
+    }
+
+    if (selected.has("instructions")) {
+        const instructionSources = discovered.instructions.filter((item) => sourceScopes.includes(item.scope));
+
+        for (const source of instructionSources) {
+            for (const targetScope of targetScopes) {
+                const targetPath =
+                    targetScope === "project" ? join(input.projectRoot, "AGENTS.md") : join(homedir(), "AGENTS.md");
+
+                if (seenTargets.has(targetPath)) {
+                    warnings.push(`Skipping duplicate instruction target: ${targetPath}`);
+                    continue;
+                }
+
+                seenTargets.add(targetPath);
+                operations.push({
+                    component: "instructions",
+                    mode: input.mode,
+                    sourceScope: source.scope,
+                    targetScope,
+                    sourcePath: source.path,
+                    targetPath,
+                    label: `${source.path} -> ${targetPath}`,
+                });
+            }
+        }
+    }
+
+    return { operations, warnings };
+}
+
+export function executeMigrationPlan(plan: MigrationPlan, options: ExecutePlanOptions): OperationResult[] {
+    const results: OperationResult[] = [];
+
+    for (const operation of plan.operations) {
+        try {
+            if (!existsSync(operation.sourcePath)) {
+                results.push({
+                    operation,
+                    status: "skipped",
+                    message: `Source not found: ${operation.sourcePath}`,
+                });
+                continue;
+            }
+
+            const targetExists = existsSync(operation.targetPath);
+            if (targetExists && !options.force) {
+                if (operation.mode === "symlink" && isSameSymlink(operation.targetPath, operation.sourcePath)) {
+                    results.push({
+                        operation,
+                        status: "skipped",
+                        message: "Already linked",
+                    });
+                    continue;
+                }
+
+                results.push({
+                    operation,
+                    status: "skipped",
+                    message: "Target exists (use --force to overwrite)",
+                });
+                continue;
+            }
+
+            if (targetExists && options.force) {
+                if (!options.dryRun) {
+                    rmSync(operation.targetPath, { recursive: true, force: true });
+                }
+            }
+
+            if (!options.dryRun) {
+                mkdirSync(dirname(operation.targetPath), { recursive: true });
+
+                if (operation.mode === "copy") {
+                    copyPath(operation.sourcePath, operation.targetPath);
+                } else {
+                    createSymlink(operation.sourcePath, operation.targetPath, operation.targetScope === "project");
+                }
+            }
+
+            results.push({
+                operation,
+                status: targetExists ? "updated" : "created",
+                message: options.dryRun ? "Dry run" : operation.mode === "copy" ? "Copied" : "Linked",
+            });
+        } catch (error) {
+            results.push({
+                operation,
+                status: "failed",
+                message: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    return results;
+}
+
+export function summarizePlan(plan: MigrationPlan): string {
+    const componentCounts = countByComponent(plan.operations);
+    const lines: string[] = [];
+    lines.push(`Operations: ${plan.operations.length}`);
+    lines.push(`- skills: ${componentCounts.skills}`);
+    lines.push(`- commands: ${componentCounts.commands}`);
+    lines.push(`- instructions: ${componentCounts.instructions}`);
+
+    const preview = plan.operations.slice(0, 8);
+    if (preview.length > 0) {
+        lines.push("");
+        lines.push("Preview:");
+        for (const item of preview) {
+            lines.push(`- [${item.component}] ${item.label}`);
+        }
+    }
+
+    if (plan.operations.length > preview.length) {
+        lines.push(`- ... and ${plan.operations.length - preview.length} more`);
+    }
+
+    return lines.join("\n");
+}
+
+export function summarizeDiscovery(discovered: DiscoveredSources): string {
+    const lines: string[] = [];
+    lines.push(`Skills: ${discovered.skills.length}`);
+    lines.push(`Commands: ${discovered.commands.length}`);
+    lines.push(`Instruction files: ${discovered.instructions.length}`);
+
+    const projectSkills = discovered.skills.filter((item) => item.scope === "project").length;
+    const globalSkills = discovered.skills.filter((item) => item.scope === "global").length;
+    const projectCommands = discovered.commands.filter((item) => item.scope === "project").length;
+    const globalCommands = discovered.commands.filter((item) => item.scope === "global").length;
+
+    lines.push("");
+    lines.push(`Project scope: ${projectSkills} skills, ${projectCommands} commands`);
+    lines.push(`Global scope: ${globalSkills} skills, ${globalCommands} commands`);
+
+    return lines.join("\n");
+}
+
+export function summarizeExecution(results: OperationResult[]): string {
+    const created = results.filter((item) => item.status === "created").length;
+    const updated = results.filter((item) => item.status === "updated").length;
+    const skipped = results.filter((item) => item.status === "skipped").length;
+    const failed = results.filter((item) => item.status === "failed").length;
+
+    return [`Created: ${created}`, `Updated: ${updated}`, `Skipped: ${skipped}`, `Failed: ${failed}`].join("\n");
+}
+
+function addSkillDirs(
+    skills: SkillSource[],
+    seen: Set<string>,
+    paths: string[],
+    scope: SingleScope,
+    origin: SourceOrigin,
+    pluginName?: string
+): void {
+    for (const sourcePath of paths) {
+        const normalized = resolve(sourcePath);
+        const key = `${scope}:${normalized}`;
+        if (seen.has(key)) {
+            continue;
+        }
+
+        seen.add(key);
+        skills.push({
+            path: normalized,
+            scope,
+            origin,
+            pluginName,
+        });
+    }
+}
+
+function addCommandFiles(
+    commands: CommandSource[],
+    seen: Set<string>,
+    paths: string[],
+    scope: SingleScope,
+    origin: SourceOrigin,
+    namespace: string,
+    pluginName?: string
+): void {
+    for (const sourcePath of paths) {
+        const normalized = resolve(sourcePath);
+        const key = `${scope}:${namespace}:${normalized}`;
+        if (seen.has(key)) {
+            continue;
+        }
+
+        seen.add(key);
+        commands.push({
+            path: normalized,
+            scope,
+            origin,
+            namespace: normalizeSegment(namespace),
+            pluginName,
+        });
+    }
+}
+
+function addInstruction(
+    instructions: InstructionSource[],
+    seen: Set<string>,
+    sourcePath: string,
+    scope: SingleScope
+): void {
+    if (!existsSync(sourcePath)) {
+        return;
+    }
+
+    const normalized = resolve(sourcePath);
+    const key = `${scope}:${normalized}`;
+    if (seen.has(key)) {
+        return;
+    }
+
+    seen.add(key);
+    instructions.push({
+        path: normalized,
+        scope,
+        origin: "claude",
+    });
+}
+
+function discoverProjectPlugins(projectRoot: string, warnings: string[]): PluginDeclaration[] {
+    const plugins: PluginDeclaration[] = [];
+    const seen = new Set<string>();
+
+    const marketplacePath = join(projectRoot, PROJECT_CLAUDE_PLUGIN_DIRNAME, "marketplace.json");
+    if (existsSync(marketplacePath)) {
+        const marketplace = parseJsonFile(marketplacePath, warnings);
+        const pluginEntries = marketplace?.plugins;
+        if (Array.isArray(pluginEntries)) {
+            for (const pluginEntry of pluginEntries) {
+                const plugin = asObject(pluginEntry);
+                if (!plugin) {
+                    continue;
+                }
+
+                const pluginName = normalizeSegment(typeof plugin.name === "string" ? plugin.name : "plugin");
+                const sourceValue = typeof plugin.source === "string" ? plugin.source : "";
+                const pluginRoot = sourceValue ? resolve(projectRoot, sourceValue) : "";
+                if (!pluginRoot || !existsSync(pluginRoot)) {
+                    warnings.push(
+                        `Marketplace plugin root not found for ${pluginName}: ${pluginRoot || "(missing source)"}`
+                    );
+                    continue;
+                }
+
+                const key = `${pluginName}:${pluginRoot}`;
+                if (seen.has(key)) {
+                    continue;
+                }
+
+                seen.add(key);
+                plugins.push({
+                    name: pluginName,
+                    rootDir: pluginRoot,
+                    skills: toPathList(plugin.skills),
+                    commands: toPathList(plugin.commands),
+                    scope: "project",
+                });
+            }
+        }
+    }
+
+    const pluginsDir = join(projectRoot, "plugins");
+    if (existsSync(pluginsDir)) {
+        const pluginDirs = readdirSync(pluginsDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+        for (const entry of pluginDirs) {
+            const pluginRoot = join(pluginsDir, entry.name);
+            const manifestPath = join(pluginRoot, ".claude-plugin", "plugin.json");
+            if (!existsSync(manifestPath)) {
+                continue;
+            }
+
+            const manifest = parseJsonFile(manifestPath, warnings);
+            if (!manifest) {
+                continue;
+            }
+
+            const pluginName = normalizeSegment(typeof manifest.name === "string" ? manifest.name : entry.name);
+            const key = `${pluginName}:${pluginRoot}`;
+            if (seen.has(key)) {
+                continue;
+            }
+
+            seen.add(key);
+            plugins.push({
+                name: pluginName,
+                rootDir: pluginRoot,
+                skills: toPathList(manifest.skills),
+                commands: toPathList(manifest.commands),
+                scope: "project",
+            });
+        }
+    }
+
+    return plugins;
+}
+
+function collectSkillDirsFromPaths(baseDir: string, paths: string[], warnings: string[]): string[] {
+    const results: string[] = [];
+    for (const pathValue of paths) {
+        const resolvedPath = resolve(baseDir, pathValue);
+        if (!existsSync(resolvedPath)) {
+            warnings.push(`Plugin skills path not found: ${resolvedPath}`);
+            continue;
+        }
+
+        if (existsSync(join(resolvedPath, "SKILL.md"))) {
+            results.push(resolvedPath);
+            continue;
+        }
+
+        results.push(...collectSkillDirs(resolvedPath));
+    }
+
+    return uniqueStringPaths(results);
+}
+
+function collectCommandFilesFromPaths(baseDir: string, paths: string[], warnings: string[]): string[] {
+    const results: string[] = [];
+    for (const pathValue of paths) {
+        const resolvedPath = resolve(baseDir, pathValue);
+        if (!existsSync(resolvedPath)) {
+            warnings.push(`Plugin commands path not found: ${resolvedPath}`);
+            continue;
+        }
+
+        const stat = lstatSync(resolvedPath);
+        if (stat.isDirectory()) {
+            results.push(...collectMarkdownFiles(resolvedPath));
+            continue;
+        }
+
+        if (stat.isFile() && extname(resolvedPath).toLowerCase() === ".md") {
+            results.push(resolvedPath);
+        }
+    }
+
+    return uniqueStringPaths(results);
+}
+
+function collectSkillDirs(baseDir: string): string[] {
+    if (!existsSync(baseDir)) {
+        return [];
+    }
+
+    const entries = readdirSync(baseDir, { withFileTypes: true });
+    const skillDirs: string[] = [];
+    for (const entry of entries) {
+        if (!entry.isDirectory()) {
+            continue;
+        }
+
+        const candidate = join(baseDir, entry.name);
+        if (existsSync(join(candidate, "SKILL.md"))) {
+            skillDirs.push(candidate);
+        }
+    }
+
+    return uniqueStringPaths(skillDirs);
+}
+
+function collectMarkdownFiles(baseDir: string): string[] {
+    if (!existsSync(baseDir)) {
+        return [];
+    }
+
+    const files: string[] = [];
+    const walk = (currentDir: string): void => {
+        const entries = readdirSync(currentDir, { withFileTypes: true });
+        for (const entry of entries) {
+            const fullPath = join(currentDir, entry.name);
+            if (entry.isDirectory()) {
+                walk(fullPath);
+                continue;
+            }
+
+            if (entry.isFile() && extname(entry.name).toLowerCase() === ".md") {
+                files.push(fullPath);
+            }
+        }
+    };
+
+    walk(baseDir);
+    return uniqueStringPaths(files);
+}
+
+function expandScope(scope: MigrationScope): SingleScope[] {
+    if (scope === "both") {
+        return ["project", "global"];
+    }
+
+    return [scope];
+}
+
+function buildSkillTargetName(source: SkillSource, style: NameStyle, used: Map<string, number>): string {
+    const baseName = basename(source.path);
+    let candidate = baseName;
+
+    if (style === "prefixed") {
+        if (source.origin === "plugin" && source.pluginName) {
+            candidate = `${normalizeSegment(source.pluginName)}-${baseName}`;
+        } else {
+            candidate = `${source.scope}-${baseName}`;
+        }
+    }
+
+    return ensureUniqueName(candidate, used);
+}
+
+function buildCommandNamespace(source: CommandSource, style: NameStyle, used: Map<string, number>): string {
+    let namespace = source.namespace;
+
+    if (style === "prefixed") {
+        if (source.origin === "plugin" && source.pluginName) {
+            namespace = normalizeSegment(source.pluginName);
+        } else {
+            namespace = `${source.scope}-${normalizeSegment(namespace)}`;
+        }
+    }
+
+    return ensureUniqueName(namespace, used);
+}
+
+function ensureUniqueName(name: string, used: Map<string, number>): string {
+    const normalized = normalizeSegment(name);
+    const current = used.get(normalized) ?? 0;
+    if (current === 0) {
+        used.set(normalized, 1);
+        return normalized;
+    }
+
+    const next = current + 1;
+    used.set(normalized, next);
+    return `${normalized}-${next}`;
+}
+
+function countByComponent(operations: PlannedOperation[]): Record<MigrationComponent, number> {
+    return operations.reduce<Record<MigrationComponent, number>>(
+        (acc, item) => {
+            acc[item.component] += 1;
+            return acc;
+        },
+        {
+            skills: 0,
+            commands: 0,
+            instructions: 0,
+        }
+    );
+}
+
+function copyPath(sourcePath: string, targetPath: string): void {
+    const sourceStat = lstatSync(sourcePath);
+    if (sourceStat.isDirectory()) {
+        cpSync(sourcePath, targetPath, { recursive: true });
+        return;
+    }
+
+    cpSync(sourcePath, targetPath);
+}
+
+function createSymlink(sourcePath: string, targetPath: string, preferRelative: boolean): void {
+    const sourceStat = lstatSync(sourcePath);
+    const linkTarget = preferRelative ? relative(dirname(targetPath), sourcePath) : sourcePath;
+
+    if (sourceStat.isDirectory()) {
+        const type = process.platform === "win32" ? "junction" : "dir";
+        symlinkSync(linkTarget, targetPath, type);
+        return;
+    }
+
+    symlinkSync(linkTarget, targetPath);
+}
+
+function isSameSymlink(targetPath: string, sourcePath: string): boolean {
+    if (!existsSync(targetPath)) {
+        return false;
+    }
+
+    const stat = lstatSync(targetPath);
+    if (!stat.isSymbolicLink()) {
+        return false;
+    }
+
+    const current = readlinkSync(targetPath);
+    const resolvedCurrent = resolve(dirname(targetPath), current);
+    return resolvedCurrent === resolve(sourcePath);
+}
+
+function parseJsonFile(filePath: string, warnings: string[]): Record<string, unknown> | null {
+    try {
+        const content = readFileSync(filePath, "utf-8");
+        return JSON.parse(content) as Record<string, unknown>;
+    } catch (error) {
+        warnings.push(
+            `Failed to parse JSON file ${filePath}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        return null;
+    }
+}
+
+function toPathList(value: unknown): string[] {
+    if (typeof value === "string") {
+        return [value];
+    }
+
+    if (Array.isArray(value)) {
+        return value.filter((item): item is string => typeof item === "string");
+    }
+
+    return [];
+}
+
+function normalizeSegment(value: string): string {
+    const normalized = value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+/, "")
+        .replace(/-+$/, "");
+
+    if (!normalized) {
+        return "item";
+    }
+
+    return normalized;
+}
+
+function uniqueStringPaths(items: string[]): string[] {
+    const set = new Set<string>();
+    const result: string[] = [];
+
+    for (const item of items) {
+        const value = resolve(item);
+        if (set.has(value)) {
+            continue;
+        }
+
+        set.add(value);
+        result.push(item);
+    }
+
+    return result;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== "object") {
+        return null;
+    }
+
+    return value as Record<string, unknown>;
+}
+
+function sortByPath<T extends { path: string }>(items: T[]): T[] {
+    return [...items].sort((a, b) => a.path.localeCompare(b.path));
+}

--- a/src/claude/lib/migrate-to-codex/index.ts
+++ b/src/claude/lib/migrate-to-codex/index.ts
@@ -165,10 +165,10 @@ export function buildMigrationPlan(discovered: DiscoveredSources, input: Migrati
 
     if (selected.has("skills")) {
         const skillSources = discovered.skills.filter((item) => sourceScopes.includes(item.scope));
-        const nameUsedByTarget = new Map<string, number>();
 
-        for (const source of skillSources) {
-            for (const targetScope of targetScopes) {
+        for (const targetScope of targetScopes) {
+            const nameUsedByTarget = new Map<string, number>();
+            for (const source of skillSources) {
                 const targetBase =
                     targetScope === "project"
                         ? join(input.projectRoot, ".agents", "skills")
@@ -197,10 +197,10 @@ export function buildMigrationPlan(discovered: DiscoveredSources, input: Migrati
 
     if (selected.has("commands")) {
         const commandSources = discovered.commands.filter((item) => sourceScopes.includes(item.scope));
-        const namespaceUsedByTarget = new Map<string, number>();
 
-        for (const source of commandSources) {
-            for (const targetScope of targetScopes) {
+        for (const targetScope of targetScopes) {
+            const namespaceUsedByTarget = new Map<string, number>();
+            for (const source of commandSources) {
                 const targetBase =
                     targetScope === "project"
                         ? join(input.projectRoot, ".codex", "prompts")
@@ -233,7 +233,7 @@ export function buildMigrationPlan(discovered: DiscoveredSources, input: Migrati
         for (const source of instructionSources) {
             for (const targetScope of targetScopes) {
                 const targetPath =
-                    targetScope === "project" ? join(input.projectRoot, "AGENTS.md") : join(homedir(), "AGENTS.md");
+                    targetScope === "project" ? join(input.projectRoot, "AGENTS.md") : join(GLOBAL_CODEX_DIR, "AGENTS.md");
 
                 if (seenTargets.has(targetPath)) {
                     warnings.push(`Skipping duplicate instruction target: ${targetPath}`);
@@ -538,6 +538,12 @@ function collectSkillDirsFromPaths(baseDir: string, paths: string[], warnings: s
 
         if (existsSync(join(resolvedPath, "SKILL.md"))) {
             results.push(resolvedPath);
+            continue;
+        }
+
+        const stat = lstatSync(resolvedPath);
+        if (!stat.isDirectory()) {
+            warnings.push(`Plugin skills path is not a directory: ${resolvedPath}`);
             continue;
         }
 


### PR DESCRIPTION
## Summary
- add a new `tools claude migrate-to codex` command with interactive wizard and non-interactive flags
- add migration discovery/planning/execution logic for skills, commands, and CLAUDE.md -> AGENTS.md
- wire the new migrate command into the claude CLI and document usage in `src/claude/README.md`

## Validation
- bunx biome check src/claude/index.ts src/claude/commands/migrate.ts src/claude/lib/migrate-to-codex/index.ts src/claude/README.md
- bun run src/claude/index.ts migrate-to codex --help
- bun run src/claude/index.ts migrate-to codex --list --non-interactive --dry-run
- bun run src/claude/index.ts migrate-to codex --source project --target project --components skills,commands,instructions --mode symlink --non-interactive --dry-run -y


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive migration wizard to move skills, commands, and instructions to Codex with scope selection, component filters, naming options, symlink or copy modes, previews, dry-run, list/preview mode, non-interactive execution, and final confirmation.
  * Migration now provides detailed plan previews and execution summaries with per-item results.

* **Documentation**
  * Added a comprehensive README with quick-start commands, CLI options, guided examples, and wizard guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->