### PR TITLE
feat(ask): AIChat SDK — programmatic LLM chat with session management

### DIFF
--- a/.claude/plans/2026-02-25-AskLibrary.md
+++ b/.claude/plans/2026-02-25-AskLibrary.md
@@ -1,0 +1,859 @@
+# AIChat Library Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Read `.claude/plans/giggly-whistling-puppy.md` for the full API design spec — it is the source of truth for all interfaces, types, and behavior. This plan provides the step-by-step implementation tasks.
+
+**Goal:** Extract the ask tool's core into `AIChat` — a programmatic, provider-agnostic LLM chat class with session persistence, typed streaming events, and internal log capture. Fixes telegram stdout leakage by eliminating the subprocess approach.
+
+**Architecture:** `AIChat` is a facade over existing components (ChatEngine, ProviderManager, ModelSelector, DynamicPricing). It owns a `ChatSession` (JSONL-backed conversation state) and a `ChatLog` (in-memory log capture). `send()` returns a `ChatTurn` that is both `PromiseLike<ChatResponse>` and `AsyncIterable<ChatEvent>`. The existing `tools ask` CLI and telegram handler become thin wrappers around `AIChat`.
+
+**Tech Stack:** TypeScript, Bun, Vercel AI SDK (`ai` package), pino (captured), JSONL storage
+
+---
+
+## Task 1: Types
+
+**Files:**
+- Create: `src/ask/lib/types.ts`
+
+**Step 1: Write the types file**
+
+All interfaces from the design spec. Reference: `.claude/plans/giggly-whistling-puppy.md` → "Types" section.
+
+```typescript
+import type { LanguageModelUsage } from "ai";
+
+// Re-export relevant existing types
+export type { ProviderChoice, DetectedProvider, ModelInfo } from "@ask/types";
+
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug" | "trace";
+
+export interface AIChatOptions {
+    provider: string;
+    model: string;
+    systemPrompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+    tools?: Record<string, AIChatTool>;
+    logLevel?: LogLevel;
+    session?: {
+        dir?: string;
+        id?: string;
+        autoSave?: boolean;
+    };
+    resume?: string;
+}
+
+export interface AIChatTool {
+    description: string;
+    parameters: unknown; // ZodSchema or JSON schema object
+    execute: (params: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface SendOptions {
+    onChunk?: (text: string) => void;
+    override?: Partial<Omit<AIChatOptions, "session" | "resume">>;
+    addToHistory?: boolean;
+    saveThinking?: boolean;
+}
+
+export interface ChatResponse {
+    content: string;
+    thinking?: string;
+    usage?: {
+        inputTokens: number;
+        outputTokens: number;
+        totalTokens: number;
+        cachedInputTokens?: number;
+    };
+    cost?: number;
+    duration: number;
+    toolCalls?: ToolCallResult[];
+}
+
+export interface ToolCallResult {
+    name: string;
+    input: unknown;
+    output: unknown;
+    duration: number;
+}
+
+export type SessionEntry =
+    | SessionConfigEntry
+    | SessionUserEntry
+    | SessionAssistantEntry
+    | SessionSystemEntry
+    | SessionContextEntry;
+
+export interface SessionConfigEntry {
+    type: "config";
+    timestamp: string;
+    provider: string;
+    model: string;
+    systemPrompt?: string;
+}
+
+export interface SessionUserEntry {
+    type: "user";
+    content: string;
+    timestamp: string;
+    metadata?: Record<string, unknown>;
+}
+
+export interface SessionAssistantEntry {
+    type: "assistant";
+    content: string;
+    thinking?: string;
+    timestamp: string;
+    usage?: LanguageModelUsage;
+    cost?: number;
+    toolCalls?: ToolCallResult[];
+}
+
+export interface SessionSystemEntry {
+    type: "system";
+    content: string;
+    timestamp: string;
+}
+
+export interface SessionContextEntry {
+    type: "context";
+    content: string;
+    timestamp: string;
+    label?: string;
+    metadata?: Record<string, unknown>;
+}
+
+export interface AIChatSelection {
+    provider: string;
+    model: string;
+}
+
+export interface LogEntry {
+    level: LogLevel;
+    message: string;
+    timestamp: Date;
+    source?: string;
+}
+
+export interface SessionStats {
+    messageCount: number;
+    tokenCount: number;
+    cost: number;
+    duration: number;
+    startedAt: string;
+    byRole: Record<string, number>;
+}
+```
+
+**Step 2: Verify types compile**
+
+Run: `bunx tsgo --noEmit 2>&1 | rg "src/ask/lib/types"`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/ask/lib/types.ts
+git commit -m "feat(ask): add AIChat type definitions"
+```
+
+---
+
+## Task 2: ChatEvent
+
+**Files:**
+- Create: `src/ask/lib/ChatEvent.ts`
+- Create: `src/ask/lib/__tests__/ChatEvent.test.ts`
+
+**Step 1: Write the test**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { ChatEvent } from "../ChatEvent";
+
+describe("ChatEvent", () => {
+    it("creates text event with factory", () => {
+        const event = ChatEvent.text("hello");
+        expect(event.type).toBe("text");
+        expect(event.isText()).toBe(true);
+        expect(event.text).toBe("hello");
+        expect(event.isDone()).toBe(false);
+    });
+
+    it("creates done event with response", () => {
+        const response = { content: "hi", duration: 100 };
+        const event = ChatEvent.done(response as any);
+        expect(event.isDone()).toBe(true);
+        expect(event.response).toBe(response);
+        expect(event.isText()).toBe(false);
+    });
+
+    it("creates thinking event", () => {
+        const event = ChatEvent.thinking("reasoning...");
+        expect(event.isThinking()).toBe(true);
+        expect(event.text).toBe("reasoning...");
+    });
+
+    it("creates tool_call event", () => {
+        const event = ChatEvent.toolCall("searchWeb", { query: "test" });
+        expect(event.isToolCall()).toBe(true);
+        expect(event.name).toBe("searchWeb");
+        expect(event.input).toEqual({ query: "test" });
+    });
+
+    it("creates tool_result event", () => {
+        const event = ChatEvent.toolResult("searchWeb", { results: [] }, 150);
+        expect(event.isToolResult()).toBe(true);
+        expect(event.name).toBe("searchWeb");
+        expect(event.duration).toBe(150);
+    });
+
+    it("type guards narrow correctly", () => {
+        const event = ChatEvent.text("hi");
+        if (event.isText()) {
+            // TypeScript should see event.text as string (not undefined)
+            const _text: string = event.text;
+            expect(_text).toBe("hi");
+        }
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test src/ask/lib/__tests__/ChatEvent.test.ts`
+Expected: FAIL — module not found
+
+**Step 3: Implement ChatEvent**
+
+```typescript
+import type { ChatResponse } from "./types";
+
+type ChatEventType = "text" | "thinking" | "tool_call" | "tool_result" | "done";
+
+export class ChatEvent {
+    readonly type: ChatEventType;
+    readonly text?: string;
+    readonly name?: string;
+    readonly input?: unknown;
+    readonly output?: unknown;
+    readonly duration?: number;
+    readonly response?: ChatResponse;
+
+    private constructor(type: ChatEventType, data: Partial<Omit<ChatEvent, "type">>) {
+        this.type = type;
+        Object.assign(this, data);
+    }
+
+    // === Factory methods ===
+    static text(text: string): ChatEvent { return new ChatEvent("text", { text }); }
+    static thinking(text: string): ChatEvent { return new ChatEvent("thinking", { text }); }
+    static toolCall(name: string, input: unknown): ChatEvent { return new ChatEvent("tool_call", { name, input }); }
+    static toolResult(name: string, output: unknown, duration: number): ChatEvent { return new ChatEvent("tool_result", { name, output, duration }); }
+    static done(response: ChatResponse): ChatEvent { return new ChatEvent("done", { response }); }
+
+    // === Type guards ===
+    isText(): this is ChatEvent & { text: string } { return this.type === "text"; }
+    isThinking(): this is ChatEvent & { text: string } { return this.type === "thinking"; }
+    isToolCall(): this is ChatEvent & { name: string; input: unknown } { return this.type === "tool_call"; }
+    isToolResult(): this is ChatEvent & { name: string; output: unknown; duration: number } { return this.type === "tool_result"; }
+    isDone(): this is ChatEvent & { response: ChatResponse } { return this.type === "done"; }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test src/ask/lib/__tests__/ChatEvent.test.ts`
+Expected: All pass
+
+**Step 5: Commit**
+
+```bash
+git add src/ask/lib/ChatEvent.ts src/ask/lib/__tests__/ChatEvent.test.ts
+git commit -m "feat(ask): add ChatEvent class with type guards and factories"
+```
+
+---
+
+## Task 3: ChatLog
+
+**Files:**
+- Create: `src/ask/lib/ChatLog.ts`
+- Create: `src/ask/lib/__tests__/ChatLog.test.ts`
+
+**Step 1: Write the test**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { ChatLog } from "../ChatLog";
+
+describe("ChatLog", () => {
+    it("captures logs at or above configured level", () => {
+        const log = new ChatLog("warn");
+        log.capture("info", "should be ignored", "Source");
+        log.capture("warn", "visible warning", "DynamicPricing");
+        log.capture("error", "visible error", "ProviderManager");
+
+        const all = log.getAll();
+        expect(all).toHaveLength(2);
+        expect(all[0].message).toBe("visible warning");
+        expect(all[0].source).toBe("DynamicPricing");
+    });
+
+    it("getUnseen returns entries since last call", () => {
+        const log = new ChatLog("info");
+        log.capture("info", "first");
+        log.capture("info", "second");
+
+        const batch1 = log.getUnseen();
+        expect(batch1).toHaveLength(2);
+
+        log.capture("info", "third");
+        const batch2 = log.getUnseen();
+        expect(batch2).toHaveLength(1);
+        expect(batch2[0].message).toBe("third");
+    });
+
+    it("getUnseen with level filter", () => {
+        const log = new ChatLog("info");
+        log.capture("info", "info msg");
+        log.capture("warn", "warn msg");
+        log.capture("error", "error msg");
+
+        const warnings = log.getUnseen({ level: "warn" });
+        expect(warnings).toHaveLength(2); // warn + error
+    });
+
+    it("silent level captures nothing", () => {
+        const log = new ChatLog("silent");
+        log.capture("error", "should not appear");
+        expect(log.getAll()).toHaveLength(0);
+    });
+
+    it("clear resets everything", () => {
+        const log = new ChatLog("info");
+        log.capture("info", "test");
+        log.clear();
+        expect(log.getAll()).toHaveLength(0);
+        expect(log.getUnseen()).toHaveLength(0);
+    });
+
+    it("createLogger produces a pino-compatible interface", () => {
+        const log = new ChatLog("info");
+        const logger = log.createLogger("TestSource");
+        logger.info("hello from logger");
+        logger.warn("warning from logger");
+        logger.debug("should be ignored at info level");
+
+        const entries = log.getAll();
+        expect(entries).toHaveLength(2);
+        expect(entries[0].source).toBe("TestSource");
+    });
+});
+```
+
+**Step 2: Run test — verify failure**
+
+Run: `bun test src/ask/lib/__tests__/ChatLog.test.ts`
+
+**Step 3: Implement ChatLog**
+
+Create `src/ask/lib/ChatLog.ts`. Key points:
+- `LOG_LEVELS` map for numeric comparison (reuse pattern from `src/logger.ts` lines 18-25)
+- `capture(level, message, source?)` — checks level threshold, pushes to array
+- `getUnseen()` — tracks cursor index, returns slice from cursor
+- `createLogger(source)` — returns `{ info, warn, error, debug, trace }` object that calls `capture()`
+- Never writes to `process.stdout` or `process.stderr`
+
+**Step 4: Run test — verify pass**
+
+Run: `bun test src/ask/lib/__tests__/ChatLog.test.ts`
+
+**Step 5: Commit**
+
+```bash
+git add src/ask/lib/ChatLog.ts src/ask/lib/__tests__/ChatLog.test.ts
+git commit -m "feat(ask): add ChatLog — in-memory log capture with cursor-based getUnseen"
+```
+
+---
+
+## Task 4: ChatSession
+
+**Files:**
+- Create: `src/ask/lib/ChatSession.ts`
+- Create: `src/ask/lib/__tests__/ChatSession.test.ts`
+
+**Step 1: Write the test**
+
+Tests for: `add()`, `getHistory()`, `toMessages()`, `filterByRole()`, `filterByDateRange()`, `filterByContent()`, `clear()`, `getStats()`, `export()`.
+
+Key test cases:
+- `add({ role: "context" })` creates a context entry with timestamp
+- `getHistory({ last: 2 })` returns last 2 entries
+- `getHistory({ roles: ["user", "assistant"] })` filters by role
+- `toMessages()` maps context→system, skips config entries
+- `filterByRole("user")` returns new ChatSession with only user entries
+- `clear()` resets entries but keeps id
+- `getStats()` computes counts, cost, duration
+- `export("jsonl")` produces valid JSONL
+- `export("markdown")` produces readable markdown
+
+**Step 2: Run test — verify failure**
+
+**Step 3: Implement ChatSession**
+
+Create `src/ask/lib/ChatSession.ts`. Key points:
+- Constructor takes `id: string`, optional `entries: SessionEntry[]`
+- `add()` appends with auto-generated timestamp
+- `getHistory()` with `last`, `roles`, `since` filtering
+- `toMessages()` maps entries to `{ role, content }[]` — context entries become system role, config entries are skipped
+- Filter methods return `new ChatSession(this.id, filteredEntries)`
+- `getStats()` iterates entries once, caches result (invalidated on add/clear)
+- `export("jsonl")` → entries.map(JSON.stringify).join("\n")
+
+**Step 4: Run test — verify pass**
+
+**Step 5: Commit**
+
+```bash
+git add src/ask/lib/ChatSession.ts src/ask/lib/__tests__/ChatSession.test.ts
+git commit -m "feat(ask): add ChatSession — in-memory session with filtering and export"
+```
+
+---
+
+## Task 5: ChatSessionManager (JSONL persistence)
+
+**Files:**
+- Create: `src/ask/lib/ChatSessionManager.ts`
+- Create: `src/ask/lib/__tests__/ChatSessionManager.test.ts`
+
+**Step 1: Write the test**
+
+Tests for: `create()`, `save()`, `load()`, `list()`, `delete()`. Use a temp dir for file I/O.
+
+Key test cases:
+- `create()` returns ChatSession with generated UUID
+- `create("custom-id")` uses the provided ID
+- `save()` writes JSONL file, `load()` reads it back with identical entries
+- `list()` returns all sessions sorted by date
+- `delete()` removes the file
+- Loading a non-existent session throws/returns null
+
+**Step 2: Run test — verify failure**
+
+**Step 3: Implement ChatSessionManager**
+
+Create `src/ask/lib/ChatSessionManager.ts`. Key points:
+- Constructor takes `{ dir: string }`, auto-creates directory
+- `save(session)`: write `session.entries` as JSONL to `<dir>/<id>.jsonl`
+- `load(sessionId)`: read JSONL file, parse lines, return new `ChatSession(id, entries)`
+- `list()`: read directory, parse first line of each file for metadata
+- File path: `resolve(dir, `${sessionId}.jsonl`)`
+- Use `Bun.write()` for writes, `Bun.file().text()` for reads
+
+**Step 4: Run test — verify pass**
+
+**Step 5: Commit**
+
+```bash
+git add src/ask/lib/ChatSessionManager.ts src/ask/lib/__tests__/ChatSessionManager.test.ts
+git commit -m "feat(ask): add ChatSessionManager — JSONL session persistence"
+```
+
+---
+
+## Task 6: ChatTurn
+
+**Files:**
+- Create: `src/ask/lib/ChatTurn.ts`
+- Create: `src/ask/lib/__tests__/ChatTurn.test.ts`
+
+**Step 1: Write the test**
+
+Tests for: `await` resolves to ChatResponse, `for await` yields ChatEvent instances, `.response` promise, `onChunk` callback.
+
+Key test cases:
+- Construct ChatTurn with a mock async generator of ChatEvents
+- `await turn` resolves with the ChatResponse from the done event
+- `for await (const event of turn)` yields all events in order
+- `turn.response` resolves with same ChatResponse
+- With `onChunk`: callback fires for each text event
+
+**Step 2: Run test — verify failure**
+
+**Step 3: Implement ChatTurn**
+
+Create `src/ask/lib/ChatTurn.ts`. Key points:
+- Constructor takes `source: AsyncGenerator<ChatEvent>` and optional `onChunk`
+- Implements `[Symbol.asyncIterator]()` — yields from source, calls `onChunk` for text events
+- Implements `then()` (PromiseLike) — iterates internally, buffers text, resolves with ChatResponse
+- `.response` is a deferred Promise that resolves when the done event is emitted
+- Only one consumer (await or iterate) — second access replays from buffer if possible
+
+**Step 4: Run test — verify pass**
+
+**Step 5: Commit**
+
+```bash
+git add src/ask/lib/ChatTurn.ts src/ask/lib/__tests__/ChatTurn.test.ts
+git commit -m "feat(ask): add ChatTurn — dual PromiseLike + AsyncIterable response handle"
+```
+
+---
+
+## Task 7: Modify ChatEngine — Add onChunk callback
+
+**Files:**
+- Modify: `src/ask/chat/ChatEngine.ts`
+
+**Step 1: Read the current ChatEngine**
+
+Read `src/ask/chat/ChatEngine.ts` fully. Locate `sendStreamingMessage()` — find the `process.stdout.write(chunk)` calls (around lines 120-129). Also check `sendNonStreamingMessage()`.
+
+**Step 2: Add callback parameters**
+
+Add to `sendMessage()` signature:
+```typescript
+async sendMessage(
+    message: string,
+    tools?: Record<string, unknown>,
+    callbacks?: {
+        onChunk?: (chunk: string) => void;
+        onThinking?: (text: string) => void;
+    }
+): Promise<ChatResponse>
+```
+
+**Step 3: Modify streaming path**
+
+In `sendStreamingMessage()`, replace:
+```typescript
+process.stdout.write(chunk);
+```
+with:
+```typescript
+if (callbacks?.onChunk) {
+    callbacks.onChunk(chunk);
+} else {
+    process.stdout.write(chunk);
+}
+```
+
+Do the same for the trailing newline write. Also wire `onThinking` if the AI SDK provides thinking blocks.
+
+**Step 4: Verify existing CLI still works**
+
+Run: `tools ask -p openai -m gpt-4o-mini "say hello in one word"`
+Expected: Still streams output to terminal (default behavior preserved)
+
+**Step 5: Commit**
+
+```bash
+git add src/ask/chat/ChatEngine.ts
+git commit -m "feat(ask): add onChunk/onThinking callbacks to ChatEngine.sendMessage"
+```
+
+---
+
+## Task 8: AIChat — Core class
+
+**Files:**
+- Create: `src/ask/AIChat.ts`
+- Create: `src/ask/__tests__/AIChat.test.ts`
+
+This is the main task. Break into sub-steps:
+
+**Step 1: Write integration test (constructor + send)**
+
+Test that AIChat can be constructed and `send()` returns a ChatResponse. Use a real provider if API key is available, or mock ChatEngine. At minimum test:
+- Constructor resolves provider/model
+- `await chat.send("hello")` returns `{ content, duration }`
+- `chat.session.getHistory()` has user + assistant entries after send
+- `chat.log.getAll()` has no entries at logLevel "silent"
+
+**Step 2: Implement constructor**
+
+In `src/ask/AIChat.ts`:
+- Accept `AIChatOptions`
+- Create `ChatLog` with configured `logLevel`
+- Create `ChatSession` (or load via `ChatSessionManager` if `resume` is set)
+- Resolve provider/model: call `providerManager.detectProviders()` then `modelSelector.selectModelByName(provider, model)` — but pass the captured logger so no stdout
+- Create `ChatEngine` with the resolved `ChatConfig`
+- Wire `ChatSessionManager` if session config provided
+- Expose `.session`, `.log`, `.getConfig()`, `.updateConfig()`
+
+**Step 3: Implement `send()`**
+
+- Create `ChatTurn` wrapping an async generator:
+  1. Add user entry to session (if `addToHistory !== false`)
+  2. Build messages from `session.toMessages()`
+  3. Handle `override` — temporarily create new ChatEngine config if provider/model differ
+  4. Call `chatEngine.sendMessage(message, tools, { onChunk, onThinking })` where onChunk/onThinking yield ChatEvents
+  5. After completion: create `ChatResponse` from the engine response
+  6. Add assistant entry to session (if `addToHistory`)
+  7. If `autoSave`: call `session.save()`
+  8. Yield `ChatEvent.done(response)`
+- Return the `ChatTurn`
+
+**Step 4: Implement `stream()`**
+
+- Store the latest `ChatTurn` as `this._activeTurn`
+- `stream()` returns `this._activeTurn[Symbol.asyncIterator]()`
+
+**Step 5: Implement static methods**
+
+```typescript
+static async getProviders(filter?): Promise<ProviderInfo[]> {
+    await providerManager.detectProviders();
+    const providers = providerManager.getAvailableProviders();
+    // apply capability filter if provided
+    return providers;
+}
+
+static async getModels(options): Promise<ModelInfo[]> {
+    await providerManager.detectProviders();
+    return providerManager.getModelsForProvider(options.provider);
+}
+
+static async selectProviderInteractively(): Promise<ProviderInfo> {
+    return modelSelector.selectProvider();
+}
+
+static async selectModelInteractively(options?): Promise<AIChatSelection> {
+    const choice = await modelSelector.selectModel();
+    return { provider: choice.provider.name, model: choice.model.id };
+}
+```
+
+**Step 6: Implement `dispose()`**
+
+- If autoSave: `await this.session.save()`
+- Clean up ChatEngine if needed
+
+**Step 7: Run tests**
+
+Run: `bun test src/ask/__tests__/AIChat.test.ts`
+
+**Step 8: Commit**
+
+```bash
+git add src/ask/AIChat.ts src/ask/__tests__/AIChat.test.ts
+git commit -m "feat(ask): add AIChat class — programmatic LLM chat with session and log capture"
+```
+
+---
+
+## Task 9: Barrel export
+
+**Files:**
+- Create: `src/ask/index.lib.ts`
+
+**Step 1: Create barrel export**
+
+```typescript
+export { AIChat } from "./AIChat";
+export { ChatEvent } from "./lib/ChatEvent";
+export { ChatSession } from "./lib/ChatSession";
+export { ChatSessionManager } from "./lib/ChatSessionManager";
+export { ChatLog } from "./lib/ChatLog";
+export { ChatTurn } from "./lib/ChatTurn";
+export type {
+    AIChatOptions,
+    AIChatTool,
+    AIChatSelection,
+    SendOptions,
+    ChatResponse,
+    ToolCallResult,
+    SessionEntry,
+    LogEntry,
+    LogLevel,
+    SessionStats,
+} from "./lib/types";
+```
+
+**Step 2: Verify it compiles**
+
+Run: `bunx tsgo --noEmit 2>&1 | rg "src/ask/"`
+
+**Step 3: Commit**
+
+```bash
+git add src/ask/index.lib.ts
+git commit -m "feat(ask): add barrel export for AIChat library"
+```
+
+---
+
+## Task 10: Migrate telegram handler
+
+**Files:**
+- Modify: `src/telegram/lib/actions/ask.ts`
+- Modify: `src/telegram/lib/handler.ts` (or wherever contact chat state belongs)
+
+**Step 1: Read current telegram handler files**
+
+Read `src/telegram/lib/actions/ask.ts` and `src/telegram/lib/handler.ts` to understand current flow.
+
+**Step 2: Add contact chat map**
+
+In the appropriate file (handler.ts or a new module), add:
+```typescript
+import { AIChat } from "@ask/AIChat";
+const contactChats = new Map<string, AIChat>();
+```
+
+**Step 3: Replace subprocess call in ask.ts**
+
+Replace the `runTool()` call with:
+```typescript
+let chat = contactChats.get(contact.userId);
+
+if (!chat) {
+    chat = new AIChat({
+        provider: contact.askProvider,
+        model: contact.askModel,
+        systemPrompt: contact.askSystemPrompt,
+        logLevel: "silent",
+        session: {
+            id: `telegram-${contact.userId}`,
+            dir: resolve(homedir(), ".genesis-tools/telegram/ai-sessions"),
+            autoSave: true,
+        },
+    });
+    contactChats.set(contact.userId, chat);
+}
+
+chat.session.add({ role: "context", content: message.contentForLLM, label: "telegram-incoming" });
+
+const response = await chat.send(message.contentForLLM);
+await client.sendMessage(contact.userId, response.content);
+```
+
+**Step 4: Remove runTool import if no longer needed**
+
+**Step 5: Test manually**
+
+Run: `tools telegram listen`
+Send a test message to a configured contact.
+Expected: Response contains ONLY the AI response — no "Created conversations directory" or "WARN: Failed to fetch" leakage.
+
+**Step 6: Commit**
+
+```bash
+git add src/telegram/lib/actions/ask.ts src/telegram/lib/handler.ts
+git commit -m "fix(telegram): use in-process AIChat — eliminates stdout leakage in responses"
+```
+
+---
+
+## Task 11: Migrate CLI `tools ask`
+
+**Files:**
+- Modify: `src/ask/index.ts`
+
+This is a larger refactor. The existing `ASKTool` class in `index.ts` should be rewritten to use `AIChat` for both single-message and interactive modes.
+
+**Step 1: Read current index.ts**
+
+Read `src/ask/index.ts` fully. Understand both `handleSingleMessage()` and `startInteractiveChat()`.
+
+**Step 2: Refactor single-message mode**
+
+Replace `handleSingleMessage()` with:
+```typescript
+private async handleSingleMessage(argv: Args): Promise<void> {
+    const chat = new AIChat({
+        provider: argv.provider,
+        model: argv.model,
+        systemPrompt: createSystemPrompt(argv.systemPrompt),
+        temperature: parseTemperature(argv.temperature),
+        maxTokens: parseMaxTokens(argv.maxTokens),
+        logLevel: argv.raw ? "silent" : "info",
+        tools: /* existing tools setup */,
+    });
+
+    const message = argv._.join(" ");
+
+    if (argv.raw) {
+        const response = await chat.send(message);
+        process.stdout.write(response.content.endsWith("\n") ? response.content : `${response.content}\n`);
+        return;
+    }
+
+    // Streaming with UI output
+    p.log.info(`Using ${colorizeProvider(chat.getConfig().provider)}/${chat.getConfig().model}`);
+    p.log.step(pc.yellow("Thinking..."));
+
+    for await (const event of chat.send(message)) {
+        if (event.isText()) process.stdout.write(event.text);
+        if (event.isDone() && event.response.cost) {
+            console.log(await outputManager.formatCostBreakdown([/* ... */]));
+        }
+    }
+}
+```
+
+**Step 3: Refactor interactive mode**
+
+Replace `startInteractiveChat()` with:
+```typescript
+private async startInteractiveChat(argv: Args): Promise<void> {
+    const selection = await AIChat.selectModelInteractively();
+    const chat = new AIChat({
+        ...selection,
+        systemPrompt: createSystemPrompt(argv.systemPrompt),
+        temperature: parseTemperature(argv.temperature),
+        maxTokens: parseMaxTokens(argv.maxTokens),
+        session: { dir: "./conversations", autoSave: true },
+    });
+
+    // ... main loop uses chat.send() with onChunk or for-await
+}
+```
+
+**Step 4: Test single-message mode**
+
+Run: `tools ask -p openai -m gpt-4o-mini --raw "say hello"`
+Expected: Only the response text on stdout.
+
+Run: `tools ask -p openai -m gpt-4o-mini "say hello"`
+Expected: Streaming output with cost breakdown.
+
+**Step 5: Test interactive mode**
+
+Run: `tools ask`
+Expected: Model selection, then conversation loop works.
+
+**Step 6: Commit**
+
+```bash
+git add src/ask/index.ts
+git commit -m "refactor(ask): CLI uses AIChat internally — cleaner, no stdout leakage in raw mode"
+```
+
+---
+
+## Task 12: Final verification
+
+**Step 1: Run all tests**
+
+```bash
+bun test src/ask/
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit 2>&1 | rg "src/ask/"
+```
+
+**Step 3: Manual integration tests**
+
+1. `tools ask -p openai -m gpt-4o-mini --raw "hello"` — only response text
+2. `tools ask -p openai -m gpt-4o-mini "hello"` — streaming + cost
+3. `tools telegram listen` — send message, verify no log leakage
+4. Check JSONL session file exists after telegram conversation
+
+**Step 4: Final commit if any cleanup needed**

--- a/.claude/plans/future/2026-03/2026-02-26-AIChat-Tools.md
+++ b/.claude/plans/future/2026-03/2026-02-26-AIChat-Tools.md
@@ -1,0 +1,492 @@
+# AIChat Tool Calling & Engine Save/Restore
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire `AIChatTool` definitions through to the Vercel AI SDK tool-calling loop, and fix `_getEngine` to properly save/restore state on per-call overrides.
+
+**Architecture:** Convert `AIChatTool` (our interface) → AI SDK `tool()` format, pass to `ChatEngine.sendMessage()`, implement a tool-calling loop that executes tools and feeds results back to the model. For save/restore, use the existing `ChatEngine.getConfig()` to snapshot state before overrides and restore after.
+
+**Tech Stack:** Vercel AI SDK (`ai` package — `tool()`, `generateText`, `streamText`), Zod (tool parameter schemas), Bun test runner
+
+**Branch:** `feat/ai-chat-sdk`
+
+---
+
+## Context for the implementer
+
+### Current state
+
+- `AIChatTool` interface exists in `src/ask/lib/types.ts`:
+  ```typescript
+  interface AIChatTool {
+      description: string;
+      parameters: unknown; // ZodSchema or JSON schema object
+      execute: (params: Record<string, unknown>) => Promise<unknown>;
+  }
+  ```
+- `AIChat` constructor accepts `options.tools?: Record<string, AIChatTool>` but stores it without using it.
+- `ChatEngine.sendMessage()` accepts `tools?: Record<string, unknown>` but both `sendStreamingMessage` and `sendNonStreamingMessage` receive it as `_tools?` (unused).
+- The AI SDK's `generateText`/`streamText` accept a `tools` param and return `toolCalls`/`toolResults` in the response.
+- `ChatEngine.getConfig()` returns the full `ChatConfig` including `temperature`, `maxTokens`, `systemPrompt` — so save/restore IS possible despite the current TODO comment saying otherwise.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `src/ask/AIChat.ts` | Main SDK class — `send()`, `_generateEvents()`, `_getEngine()` |
+| `src/ask/chat/ChatEngine.ts` | Wraps AI SDK `generateText`/`streamText` (411 lines) |
+| `src/ask/lib/types.ts` | `AIChatTool`, `AIChatOptions`, `SendOptions`, `ChatResponse` |
+| `src/ask/lib/ChatEvent.ts` | Stream events — has `tool_call` and `tool_result` types |
+| `src/ask/lib/__tests__/` | Test directory |
+
+### AI SDK tool format
+
+```typescript
+import { tool } from "ai";
+import { z } from "zod";
+
+const tools = {
+    searchWeb: tool({
+        description: "Search the web",
+        parameters: z.object({ query: z.string() }),
+        execute: async ({ query }) => { /* ... */ },
+    }),
+};
+
+// Pass to generateText/streamText:
+const result = await generateText({ model, prompt, tools, maxSteps: 5 });
+// maxSteps enables the tool-calling loop (model calls tool → gets result → continues)
+```
+
+---
+
+## Task 1: Fix `_getEngine` save/restore (the easy TODO)
+
+**Files:**
+- Modify: `src/ask/AIChat.ts` — `_getEngine()` method (~line 255)
+
+**Step 1:** Read `src/ask/AIChat.ts` and locate `_getEngine`. Note that `ChatEngine.getConfig()` already returns the full config. The current code mutates without restoring.
+
+**Step 2:** Refactor `_getEngine` to return both the engine and a restore function. Change the method signature:
+
+```typescript
+private _getEngine(override?: SendOptions["override"]): { engine: ChatEngine; restore: () => void } {
+    if (!this._engine) {
+        throw new Error("AIChat not initialized");
+    }
+
+    if (!override) {
+        return { engine: this._engine, restore: () => {} };
+    }
+
+    // Snapshot current state
+    const savedConfig = this._engine.getConfig();
+
+    if (override.temperature !== undefined) {
+        this._engine.setTemperature(override.temperature);
+    }
+
+    if (override.maxTokens !== undefined) {
+        this._engine.setMaxTokens(override.maxTokens);
+    }
+
+    if (override.systemPrompt !== undefined) {
+        this._engine.setSystemPrompt(override.systemPrompt);
+    }
+
+    return {
+        engine: this._engine,
+        restore: () => {
+            this._engine!.setTemperature(savedConfig.temperature ?? 0.7);
+            this._engine!.setMaxTokens(savedConfig.maxTokens ?? 4096);
+            if (savedConfig.systemPrompt !== undefined) {
+                this._engine!.setSystemPrompt(savedConfig.systemPrompt);
+            }
+        },
+    };
+}
+```
+
+**Step 3:** Update the TODO comment to remove the "ChatEngine doesn't expose getters" claim.
+
+**Step 4:** Update all call sites of `_getEngine` in `_generateEvents` to use the new return shape:
+
+```typescript
+const { engine, restore } = this._getEngine(options?.override);
+try {
+    // ... use engine ...
+} finally {
+    restore();
+}
+```
+
+**Step 5:** Run type check:
+
+```bash
+bunx tsgo --noEmit | rg "AIChat"
+```
+
+**Step 6:** Commit:
+
+```bash
+git add src/ask/AIChat.ts
+git commit -m "fix(ask): save/restore engine state on per-call overrides"
+```
+
+---
+
+## Task 2: Convert `AIChatTool` → AI SDK `tool()` format
+
+**Files:**
+- Create: `src/ask/lib/toolAdapter.ts`
+- Test: `src/ask/lib/__tests__/toolAdapter.test.ts`
+
+**Step 1:** Write the failing test:
+
+```typescript
+import { describe, it, expect } from "bun:test";
+import { convertTools } from "../toolAdapter";
+import { z } from "zod";
+
+describe("convertTools", () => {
+    it("converts AIChatTool map to AI SDK tool map", () => {
+        const tools = convertTools({
+            greet: {
+                description: "Say hello",
+                parameters: z.object({ name: z.string() }),
+                execute: async ({ name }) => `Hello ${name}`,
+            },
+        });
+
+        expect(tools).toBeDefined();
+        expect(tools.greet).toBeDefined();
+        // AI SDK tools have description and parameters
+        expect(typeof tools.greet).toBe("object");
+    });
+
+    it("returns undefined for empty/undefined tools", () => {
+        expect(convertTools(undefined)).toBeUndefined();
+        expect(convertTools({})).toBeUndefined();
+    });
+});
+```
+
+**Step 2:** Run test to verify it fails:
+
+```bash
+bun test src/ask/lib/__tests__/toolAdapter.test.ts
+```
+
+Expected: FAIL — module not found.
+
+**Step 3:** Implement `toolAdapter.ts`:
+
+```typescript
+import type { AIChatTool } from "./types";
+import type { CoreTool } from "ai";
+import { tool } from "ai";
+import { z } from "zod";
+
+/**
+ * Convert AIChat tool definitions to AI SDK tool format.
+ * Returns undefined if no tools provided (AI SDK treats undefined as "no tools").
+ */
+export function convertTools(
+    tools: Record<string, AIChatTool> | undefined,
+): Record<string, CoreTool> | undefined {
+    if (!tools || Object.keys(tools).length === 0) {
+        return undefined;
+    }
+
+    const converted: Record<string, CoreTool> = {};
+
+    for (const [name, def] of Object.entries(tools)) {
+        converted[name] = tool({
+            description: def.description,
+            parameters: def.parameters instanceof z.ZodType
+                ? def.parameters
+                : z.object({}).passthrough(), // fallback for JSON schema — TODO: use jsonSchemaToZod
+            execute: async (params) => {
+                return await def.execute(params as Record<string, unknown>);
+            },
+        });
+    }
+
+    return converted;
+}
+```
+
+**Step 4:** Run test to verify it passes:
+
+```bash
+bun test src/ask/lib/__tests__/toolAdapter.test.ts
+```
+
+**Step 5:** Commit:
+
+```bash
+git add src/ask/lib/toolAdapter.ts src/ask/lib/__tests__/toolAdapter.test.ts
+git commit -m "feat(ask): add AIChatTool → AI SDK tool adapter"
+```
+
+---
+
+## Task 3: Wire tools through ChatEngine
+
+**Files:**
+- Modify: `src/ask/chat/ChatEngine.ts` — `sendStreamingMessage`, `sendNonStreamingMessage`
+
+**Step 1:** Read `ChatEngine.ts`. The `_tools` parameter is accepted but unused in both methods. The AI SDK `streamText`/`generateText` calls need the `tools` param and `maxSteps` for the tool-calling loop.
+
+**Step 2:** In `sendStreamingMessage`, change `_tools` to `tools` and pass it through:
+
+```typescript
+private async sendStreamingMessage(
+    message: string,
+    tools?: Record<string, CoreTool>,  // was: _tools?: Record<string, unknown>
+    callbacks?: { ... },
+): Promise<ChatResponse> {
+    // ...
+    const result = await streamText({
+        model: this.config.model,
+        prompt: message,
+        system: this.config.systemPrompt,
+        temperature: this.config.temperature,
+        ...(this.config.maxTokens && { maxOutputTokens: this.config.maxTokens }),
+        ...(tools && { tools, maxSteps: 10 }),
+        onFinish: async ({ usage }) => { /* ... unchanged ... */ },
+    });
+    // ...
+```
+
+**Step 3:** Same for `sendNonStreamingMessage`:
+
+```typescript
+private async sendNonStreamingMessage(
+    message: string,
+    tools?: Record<string, CoreTool>,  // was: _tools?: Record<string, unknown>
+): Promise<ChatResponse> {
+    const result = await generateText({
+        model: this.config.model,
+        prompt: message,
+        system: this.config.systemPrompt,
+        temperature: this.config.temperature,
+        ...(this.config.maxTokens && { maxOutputTokens: this.config.maxTokens }),
+        ...(tools && { tools, maxSteps: 10 }),
+    });
+```
+
+**Step 4:** Update the `sendMessage` public method signature:
+
+```typescript
+import type { CoreTool } from "ai";
+
+async sendMessage(
+    message: string,
+    tools?: Record<string, CoreTool>,  // was: Record<string, unknown>
+    callbacks?: { ... },
+): Promise<ChatResponse> {
+```
+
+**Step 5:** Run type check:
+
+```bash
+bunx tsgo --noEmit | rg "ChatEngine"
+```
+
+**Step 6:** Commit:
+
+```bash
+git add src/ask/chat/ChatEngine.ts
+git commit -m "feat(ask): pass tools to AI SDK streamText/generateText with maxSteps"
+```
+
+---
+
+## Task 4: Wire tools from AIChat → ChatEngine
+
+**Files:**
+- Modify: `src/ask/AIChat.ts` — `_generateEvents` method
+
+**Step 1:** Read `AIChat.ts`. In `_generateEvents`, the `engine.sendMessage()` call passes `undefined` for tools. Wire the converted tools through.
+
+**Step 2:** Add import and convert tools in constructor or lazily:
+
+```typescript
+import { convertTools } from "./lib/toolAdapter";
+```
+
+**Step 3:** In `_generateEvents`, replace the `undefined` tools argument:
+
+```typescript
+const aiSdkTools = convertTools(this._options.tools);
+
+const engineResponse = await engine.sendMessage(
+    message,
+    aiSdkTools,  // was: undefined
+    {
+        onChunk: (chunk: string) => { ... },
+    },
+);
+```
+
+**Step 4:** Emit `ChatEvent.toolCall` and `ChatEvent.toolResult` events for each tool call in the engine response. After the `controller.enqueue(ChatEvent.done(response))` section, check `engineResponse.toolCalls`:
+
+```typescript
+// Emit tool call events from the engine response
+if (engineResponse.toolCalls) {
+    for (const tc of engineResponse.toolCalls) {
+        controller.enqueue(ChatEvent.toolCall(tc.toolCallId, tc.args));
+        // Tool results are already handled by AI SDK maxSteps loop
+    }
+}
+```
+
+Note: With `maxSteps`, the AI SDK handles the tool call → execute → feed result → continue loop internally. The `toolCalls` in the response represent what was called. For streaming tool events, we'd need to use `streamText`'s `onToolCall` callback — that's a follow-up enhancement.
+
+**Step 5:** Update `ChatResponse` type to include tool call info from the engine:
+
+In `types.ts`, the `toolCalls` field already exists:
+```typescript
+toolCalls?: { name: string; input: unknown; output: unknown; duration: number }[];
+```
+
+Map the engine's toolCalls to this format in the response construction.
+
+**Step 6:** Run type check:
+
+```bash
+bunx tsgo --noEmit | rg "AIChat"
+```
+
+**Step 7:** Run all tests:
+
+```bash
+bun test src/ask/
+```
+
+**Step 8:** Commit:
+
+```bash
+git add src/ask/AIChat.ts
+git commit -m "feat(ask): wire AIChatTool through to ChatEngine tool-calling loop"
+```
+
+---
+
+## Task 5: Add integration test for tool calling
+
+**Files:**
+- Create: `src/ask/lib/__tests__/AIChat.tools.test.ts`
+
+**Step 1:** Write a test that verifies the full tool-calling flow. This requires mocking `ChatEngine` since we don't want real API calls:
+
+```typescript
+import { describe, it, expect, mock } from "bun:test";
+import { z } from "zod";
+import { convertTools } from "../toolAdapter";
+
+describe("AIChat tool calling", () => {
+    it("converts Zod-based tools to AI SDK format", () => {
+        const tools = convertTools({
+            getWeather: {
+                description: "Get weather for a city",
+                parameters: z.object({
+                    city: z.string().describe("City name"),
+                    unit: z.enum(["celsius", "fahrenheit"]).optional(),
+                }),
+                execute: async ({ city }) => ({ temp: 22, city, unit: "celsius" }),
+            },
+        });
+
+        expect(tools).toBeDefined();
+        expect(tools!.getWeather).toBeDefined();
+    });
+
+    it("executes tool and returns result", async () => {
+        let executed = false;
+        const tools = convertTools({
+            add: {
+                description: "Add two numbers",
+                parameters: z.object({ a: z.number(), b: z.number() }),
+                execute: async ({ a, b }) => {
+                    executed = true;
+                    return (a as number) + (b as number);
+                },
+            },
+        });
+
+        // Verify the execute function works through the adapter
+        const result = await (tools!.add as { execute: (params: unknown) => Promise<unknown> })
+            .execute({ a: 2, b: 3 });
+        expect(result).toBe(5);
+        expect(executed).toBe(true);
+    });
+});
+```
+
+**Step 2:** Run tests:
+
+```bash
+bun test src/ask/lib/__tests__/AIChat.tools.test.ts
+```
+
+**Step 3:** Commit:
+
+```bash
+git add src/ask/lib/__tests__/AIChat.tools.test.ts
+git commit -m "test(ask): add tool calling integration tests"
+```
+
+---
+
+## Task 6: Update barrel exports
+
+**Files:**
+- Modify: `src/ask/index.lib.ts`
+
+**Step 1:** Add `convertTools` to exports:
+
+```typescript
+export { convertTools } from "./lib/toolAdapter";
+```
+
+**Step 2:** Run type check:
+
+```bash
+bunx tsgo --noEmit | rg "index.lib"
+```
+
+**Step 3:** Final full test run:
+
+```bash
+bun test src/ask/
+```
+
+**Step 4:** Commit and push:
+
+```bash
+git add src/ask/index.lib.ts
+git commit -m "feat(ask): export convertTools from barrel"
+git push origin feat/ai-chat-sdk
+```
+
+---
+
+## Summary
+
+| Task | What | Priority |
+|------|------|----------|
+| 1 | Fix `_getEngine` save/restore using `getConfig()` | HIGH — bug fix |
+| 2 | `toolAdapter.ts` — convert `AIChatTool` → AI SDK `tool()` | HIGH — core feature |
+| 3 | Wire tools through `ChatEngine.sendMessage` | HIGH — core feature |
+| 4 | Wire tools from `AIChat._generateEvents` → ChatEngine | HIGH — connects everything |
+| 5 | Integration tests for tool calling | MED — verification |
+| 6 | Update barrel exports | LOW — cleanup |
+
+## Future enhancements (out of scope)
+
+- **Streaming tool events**: Use `streamText`'s `onToolCall`/`onToolResult` callbacks to emit `ChatEvent.toolCall`/`ChatEvent.toolResult` in real-time during streaming (currently only available after completion).
+- **JSON Schema → Zod**: For `AIChatTool.parameters` that are plain JSON Schema objects (not Zod), use a converter like `zod-to-json-schema` in reverse. Current fallback is `z.object({}).passthrough()`.
+- **Tool call duration tracking**: Wrap `execute` calls with timing to populate `ChatResponse.toolCalls[].duration`.
+- **maxSteps configuration**: Expose `maxSteps` as an `AIChatOptions` or `SendOptions` param instead of hardcoding 10.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+# Repo-local Codex overrides to align with Claude instructions.
+project_doc_fallback_filenames = ["CLAUDE.md"]

--- a/src/ask/AIChat.ts
+++ b/src/ask/AIChat.ts
@@ -1,0 +1,376 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { ChatEngine } from "@ask/chat/ChatEngine";
+import { ChatEvent } from "@ask/lib/ChatEvent";
+import { ChatLog } from "@ask/lib/ChatLog";
+import { ChatSession } from "@ask/lib/ChatSession";
+import { ChatSessionManager } from "@ask/lib/ChatSessionManager";
+import { ChatTurn } from "@ask/lib/ChatTurn";
+import type {
+    AIChatOptions,
+    AIChatSelection,
+    ChatResponse,
+    DetectedProvider,
+    ModelInfo,
+    SendOptions,
+} from "@ask/lib/types";
+import { modelSelector } from "@ask/providers/ModelSelector";
+import { providerManager } from "@ask/providers/ProviderManager";
+import type { ChatConfig, ProviderChoice } from "@ask/types";
+import { getLanguageModel } from "@ask/types";
+
+const DEFAULT_SESSION_DIR = resolve(homedir(), ".genesis-tools/ai-chat/sessions");
+
+export class AIChat {
+    private _options: AIChatOptions;
+    private _engine: ChatEngine | null = null;
+    private _resolvedChoice: ProviderChoice | null = null;
+    private _initPromise: Promise<void> | null = null;
+    private _activeTurn: ChatTurn | null = null;
+    private _sessionManager: ChatSessionManager | null = null;
+
+    readonly session: ChatSession;
+    readonly log: ChatLog;
+
+    constructor(options: AIChatOptions) {
+        this._options = { ...options };
+        this.log = new ChatLog(options.logLevel ?? "info");
+
+        // Set up session
+        if (options.session || options.resume) {
+            const dir = options.session?.dir ?? DEFAULT_SESSION_DIR;
+            this._sessionManager = new ChatSessionManager({ dir });
+
+            const sessionId = options.resume ?? options.session?.id ?? crypto.randomUUID();
+            this.session = this._sessionManager.create(sessionId);
+        } else {
+            this.session = new ChatSession(crypto.randomUUID());
+        }
+    }
+
+    /** Ensure provider/model are resolved and engine is created */
+    private async _ensureInitialized(): Promise<void> {
+        if (this._engine) {
+            return;
+        }
+
+        if (this._initPromise) {
+            return this._initPromise;
+        }
+
+        this._initPromise = this._initialize();
+        return this._initPromise;
+    }
+
+    private async _initialize(): Promise<void> {
+        // If resuming, load the session first
+        if (this._options.resume && this._sessionManager) {
+            try {
+                await this.session.load(this._options.resume);
+            } catch {
+                // Session doesn't exist yet — that's fine, start fresh
+                this.log.createLogger("AIChat").info(`No existing session "${this._options.resume}", starting fresh`);
+            }
+        }
+
+        // Resolve provider and model
+        const choice = await modelSelector.selectModelByName(
+            this._options.provider,
+            this._options.model,
+        );
+
+        if (!choice) {
+            throw new Error(
+                `Could not resolve provider "${this._options.provider}" / model "${this._options.model}". ` +
+                `Check that the API key is configured and the model ID is valid.`,
+            );
+        }
+
+        this._resolvedChoice = choice;
+
+        // Create ChatEngine
+        const languageModel = getLanguageModel(choice.provider.provider, choice.model.id);
+        const config: ChatConfig = {
+            model: languageModel,
+            provider: choice.provider.name,
+            modelName: choice.model.id,
+            streaming: true,
+            systemPrompt: this._options.systemPrompt,
+            temperature: this._options.temperature,
+            maxTokens: this._options.maxTokens,
+        };
+
+        this._engine = new ChatEngine(config);
+
+        // Add config entry to session
+        this.session.addConfig(
+            choice.provider.name,
+            choice.model.id,
+            this._options.systemPrompt,
+        );
+    }
+
+    /**
+     * Send a message — returns a ChatTurn that is both awaitable and streamable.
+     *
+     * @example
+     * // Buffered
+     * const response = await chat.send("Hello!");
+     *
+     * // Streaming
+     * for await (const event of chat.send("Tell me a story")) {
+     *   if (event.isText()) process.stdout.write(event.text);
+     * }
+     */
+    send(message: string, options?: SendOptions): ChatTurn {
+        const addToHistory = options?.addToHistory !== false;
+        const saveThinking = options?.saveThinking ?? false;
+
+        const source = () => this._generateEvents(message, options, addToHistory, saveThinking);
+        const turn = new ChatTurn(source, options?.onChunk);
+
+        this._activeTurn = turn;
+        return turn;
+    }
+
+    private async *_generateEvents(
+        message: string,
+        options: SendOptions | undefined,
+        addToHistory: boolean,
+        saveThinking: boolean,
+    ): AsyncGenerator<ChatEvent> {
+        await this._ensureInitialized();
+
+        const engine = this._getEngine(options?.override);
+
+        // Add user message to session
+        if (addToHistory) {
+            this.session.add({ role: "user", content: message });
+        }
+
+        // Build messages from session history
+        const messages = this.session.toMessages();
+
+        // Set up system prompt from messages
+        const systemMessages = messages.filter((m) => m.role === "system").map((m) => m.content);
+        const systemPrompt = [
+            this._options.systemPrompt,
+            ...systemMessages,
+        ].filter(Boolean).join("\n\n");
+
+        if (systemPrompt) {
+            engine.setSystemPrompt(systemPrompt);
+        }
+
+        // Track chunks for building response
+        let fullContent = "";
+        let thinkingContent = "";
+        const startTime = Date.now();
+
+        // Call ChatEngine with onChunk callback to capture streaming
+        const engineResponse = await engine.sendMessage(
+            message,
+            undefined, // tools — TODO: wire AIChatTool → AI SDK tools
+            {
+                onChunk: (chunk: string) => {
+                    // We don't use this directly — the ChatTurn handles event dispatch
+                    // But we need it to prevent ChatEngine from writing to stdout
+                    fullContent += chunk;
+                },
+            },
+        );
+
+        // Since ChatEngine buffers internally and returns the full response,
+        // we emit text events from the response content.
+        // For true streaming, we'd need to refactor ChatEngine to yield chunks.
+        // For now, emit the full content as a single text event.
+        if (engineResponse.content) {
+            yield ChatEvent.text(engineResponse.content);
+            fullContent = engineResponse.content;
+        }
+
+        // Build the ChatResponse
+        const duration = Date.now() - startTime;
+        const response: ChatResponse = {
+            content: fullContent,
+            thinking: thinkingContent || undefined,
+            usage: engineResponse.usage
+                ? {
+                      inputTokens: engineResponse.usage.inputTokens ?? 0,
+                      outputTokens: engineResponse.usage.outputTokens ?? 0,
+                      totalTokens: engineResponse.usage.totalTokens ?? 0,
+                      cachedInputTokens: engineResponse.usage.cachedInputTokens ?? undefined,
+                  }
+                : undefined,
+            cost: engineResponse.cost,
+            duration,
+        };
+
+        // Add assistant message to session
+        if (addToHistory) {
+            this.session.add({
+                role: "assistant",
+                content: fullContent,
+                thinking: saveThinking ? thinkingContent : undefined,
+                usage: engineResponse.usage
+                    ? {
+                          inputTokens: engineResponse.usage.inputTokens ?? 0,
+                          outputTokens: engineResponse.usage.outputTokens ?? 0,
+                          totalTokens: engineResponse.usage.totalTokens ?? 0,
+                          cachedInputTokens: engineResponse.usage.cachedInputTokens ?? undefined,
+                      }
+                    : undefined,
+                cost: engineResponse.cost,
+            });
+        }
+
+        // Auto-save if configured
+        if (this._options.session?.autoSave && this._sessionManager) {
+            await this.session.save();
+        }
+
+        yield ChatEvent.done(response);
+    }
+
+    /** Get a ChatEngine instance, potentially with per-call overrides */
+    private _getEngine(override?: SendOptions["override"]): ChatEngine {
+        if (!this._engine) {
+            throw new Error("AIChat not initialized");
+        }
+
+        if (!override) {
+            return this._engine;
+        }
+
+        // For provider/model overrides, we'd need a new engine
+        // For now, apply simple overrides to the existing engine
+        if (override.temperature !== undefined) {
+            this._engine.setTemperature(override.temperature);
+        }
+
+        if (override.maxTokens !== undefined) {
+            this._engine.setMaxTokens(override.maxTokens);
+        }
+
+        if (override.systemPrompt !== undefined) {
+            this._engine.setSystemPrompt(override.systemPrompt);
+        }
+
+        return this._engine;
+    }
+
+    /**
+     * Stream events from the most recent send() call.
+     */
+    stream(): AsyncIterable<ChatEvent> {
+        if (!this._activeTurn) {
+            throw new Error("No active turn — call send() first");
+        }
+
+        return this._activeTurn;
+    }
+
+    /** Update config */
+    updateConfig(options: Partial<Omit<AIChatOptions, "session" | "resume">>): void {
+        this._options = { ...this._options, ...options };
+
+        // Reset engine so it gets recreated with new config on next send()
+        if (options.provider || options.model) {
+            this._engine = null;
+            this._initPromise = null;
+            this._resolvedChoice = null;
+        }
+
+        if (this._engine) {
+            if (options.temperature !== undefined) {
+                this._engine.setTemperature(options.temperature);
+            }
+
+            if (options.maxTokens !== undefined) {
+                this._engine.setMaxTokens(options.maxTokens);
+            }
+
+            if (options.systemPrompt !== undefined) {
+                this._engine.setSystemPrompt(options.systemPrompt);
+            }
+        }
+
+        if (options.logLevel) {
+            // ChatLog doesn't support changing level after creation, so create a new one
+            // But since log is readonly, we'd need to handle this differently
+            // For now, logLevel is set at construction time only
+        }
+    }
+
+    getConfig(): Readonly<AIChatOptions> {
+        return { ...this._options };
+    }
+
+    /** Save session and release resources */
+    async dispose(): Promise<void> {
+        if (this._options.session?.autoSave && this._sessionManager) {
+            await this.session.save();
+        }
+    }
+
+    // === Static Methods ===
+
+    /**
+     * Get available providers (filtered by configured API keys)
+     */
+    static async getProviders(filter?: { capabilities?: string[] }): Promise<DetectedProvider[]> {
+        const providers = await providerManager.detectProviders();
+
+        if (!filter?.capabilities?.length) {
+            return providers;
+        }
+
+        return providers.filter((p) =>
+            p.models.some((m) =>
+                filter.capabilities!.every((cap) => m.capabilities.includes(cap)),
+            ),
+        );
+    }
+
+    /**
+     * Get models for a specific provider
+     */
+    static async getModels(options: { provider: string; capabilities?: string[] }): Promise<ModelInfo[]> {
+        await providerManager.detectProviders();
+        let models = await providerManager.getModelsForProvider(options.provider);
+
+        if (options.capabilities?.length) {
+            models = models.filter((m) =>
+                options.capabilities!.every((cap) => m.capabilities.includes(cap)),
+            );
+        }
+
+        return models;
+    }
+
+    /**
+     * Interactive provider selection (clack prompts)
+     */
+    static async selectProviderInteractively(): Promise<DetectedProvider | null> {
+        const providers = await providerManager.detectProviders();
+        return modelSelector.selectProvider(providers);
+    }
+
+    /**
+     * Interactive model selection — returns object that spreads into constructor
+     */
+    static async selectModelInteractively(_options?: {
+        providers?: DetectedProvider[];
+    }): Promise<AIChatSelection | null> {
+        const choice = await modelSelector.selectModel();
+
+        if (!choice) {
+            return null;
+        }
+
+        return {
+            provider: choice.provider.name,
+            model: choice.model.id,
+        };
+    }
+}

--- a/src/ask/docs/claude-agent-sdk/overview.md
+++ b/src/ask/docs/claude-agent-sdk/overview.md
@@ -1,0 +1,173 @@
+Title: Not Found - Claude API Docs
+
+URL Source: https://docs.anthropic.com/en/docs/agents-sdk/overview
+
+Markdown Content:
+Not Found - Claude API Docs
+===============
+
+[](https://docs.anthropic.com/docs/en/home)
+*   [Developer Guide](https://docs.anthropic.com/docs/en/intro)
+*   [API Reference](https://docs.anthropic.com/docs/en/api/overview)
+*   [MCP](https://modelcontextprotocol.io/)
+*   [Resources](https://docs.anthropic.com/docs/en/resources/overview)
+*   [Release Notes](https://docs.anthropic.com/docs/en/release-notes/overview)
+
+English[Log in](https://docs.anthropic.com/login?returnTo=%2Fdocs%2Fen%2Fagents-sdk%2Foverview)
+
+Search...
+
+⌘K
+
+First steps
+
+[Intro to Claude](https://docs.anthropic.com/docs/en/intro)[Quickstart](https://docs.anthropic.com/docs/en/get-started)
+
+Models & pricing
+
+[Models overview](https://docs.anthropic.com/docs/en/about-claude/models/overview)[Choosing a model](https://docs.anthropic.com/docs/en/about-claude/models/choosing-a-model)[What's new in Claude 4.6](https://docs.anthropic.com/docs/en/about-claude/models/whats-new-claude-4-6)[Migration guide](https://docs.anthropic.com/docs/en/about-claude/models/migration-guide)[Model deprecations](https://docs.anthropic.com/docs/en/about-claude/model-deprecations)[Pricing](https://docs.anthropic.com/docs/en/about-claude/pricing)
+
+Build with Claude
+
+[Features overview](https://docs.anthropic.com/docs/en/build-with-claude/overview)[Using the Messages API](https://docs.anthropic.com/docs/en/build-with-claude/working-with-messages)[Handling stop reasons](https://docs.anthropic.com/docs/en/build-with-claude/handling-stop-reasons)[Prompting best practices](https://docs.anthropic.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)
+
+Model capabilities
+
+[Extended thinking](https://docs.anthropic.com/docs/en/build-with-claude/extended-thinking)[Adaptive thinking](https://docs.anthropic.com/docs/en/build-with-claude/adaptive-thinking)[Effort](https://docs.anthropic.com/docs/en/build-with-claude/effort)[Fast mode (research preview)](https://docs.anthropic.com/docs/en/build-with-claude/fast-mode)[Structured outputs](https://docs.anthropic.com/docs/en/build-with-claude/structured-outputs)[Citations](https://docs.anthropic.com/docs/en/build-with-claude/citations)[Streaming Messages](https://docs.anthropic.com/docs/en/build-with-claude/streaming)[Batch processing](https://docs.anthropic.com/docs/en/build-with-claude/batch-processing)[PDF support](https://docs.anthropic.com/docs/en/build-with-claude/pdf-support)[Search results](https://docs.anthropic.com/docs/en/build-with-claude/search-results)[Multilingual support](https://docs.anthropic.com/docs/en/build-with-claude/multilingual-support)[Embeddings](https://docs.anthropic.com/docs/en/build-with-claude/embeddings)[Vision](https://docs.anthropic.com/docs/en/build-with-claude/vision)
+
+Tools
+
+[Overview](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/overview)[How to implement tool use](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/implement-tool-use)[Web search tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/web-search-tool)[Web fetch tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/web-fetch-tool)[Code execution tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/code-execution-tool)[Memory tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/memory-tool)[Bash tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/bash-tool)[Computer use tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/computer-use-tool)[Text editor tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/text-editor-tool)
+
+Tool infrastructure
+
+[Tool search](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/tool-search-tool)[Programmatic tool calling](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling)[Fine-grained tool streaming](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming)
+
+Context management
+
+[Context windows](https://docs.anthropic.com/docs/en/build-with-claude/context-windows)[Compaction](https://docs.anthropic.com/docs/en/build-with-claude/compaction)[Context editing](https://docs.anthropic.com/docs/en/build-with-claude/context-editing)[Prompt caching](https://docs.anthropic.com/docs/en/build-with-claude/prompt-caching)[Token counting](https://docs.anthropic.com/docs/en/build-with-claude/token-counting)
+
+Files & assets
+
+[Files API](https://docs.anthropic.com/docs/en/build-with-claude/files)
+
+Agent Skills
+
+[Overview](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/overview)[Quickstart](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/quickstart)[Best practices](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/best-practices)[Skills for enterprise](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/enterprise)[Using Skills with the API](https://docs.anthropic.com/docs/en/build-with-claude/skills-guide)
+
+Agent SDK
+
+[Overview](https://docs.anthropic.com/docs/en/agent-sdk/overview)[Quickstart](https://docs.anthropic.com/docs/en/agent-sdk/quickstart)[TypeScript SDK](https://docs.anthropic.com/docs/en/agent-sdk/typescript)[TypeScript V2 (preview)](https://docs.anthropic.com/docs/en/agent-sdk/typescript-v2-preview)[Python SDK](https://docs.anthropic.com/docs/en/agent-sdk/python)[Migration Guide](https://docs.anthropic.com/docs/en/agent-sdk/migration-guide)
+
+Guides
+
+MCP in the API
+
+[MCP connector](https://docs.anthropic.com/docs/en/agents-and-tools/mcp-connector)[Remote MCP servers](https://docs.anthropic.com/docs/en/agents-and-tools/remote-mcp-servers)
+
+Claude on 3rd-party platforms
+
+[Amazon Bedrock](https://docs.anthropic.com/docs/en/build-with-claude/claude-on-amazon-bedrock)[Microsoft Foundry](https://docs.anthropic.com/docs/en/build-with-claude/claude-in-microsoft-foundry)[Vertex AI](https://docs.anthropic.com/docs/en/build-with-claude/claude-on-vertex-ai)
+
+Prompt engineering
+
+[Overview](https://docs.anthropic.com/docs/en/build-with-claude/prompt-engineering/overview)[Console prompting tools](https://docs.anthropic.com/docs/en/build-with-claude/prompt-engineering/prompting-tools)
+
+Test & evaluate
+
+[Define success and build evaluations](https://docs.anthropic.com/docs/en/test-and-evaluate/develop-tests)[Using the Evaluation Tool](https://docs.anthropic.com/docs/en/test-and-evaluate/eval-tool)[Reducing latency](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-latency)
+
+Strengthen guardrails
+
+[Reduce hallucinations](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)[Increase output consistency](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/increase-consistency)[Mitigate jailbreaks](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)[Streaming refusals](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals)[Reduce prompt leak](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-prompt-leak)
+
+Administration and monitoring
+
+[Admin API overview](https://docs.anthropic.com/docs/en/build-with-claude/administration-api)[Data residency](https://docs.anthropic.com/docs/en/build-with-claude/data-residency)[Workspaces](https://docs.anthropic.com/docs/en/build-with-claude/workspaces)[Usage and Cost API](https://docs.anthropic.com/docs/en/build-with-claude/usage-cost-api)[Claude Code Analytics API](https://docs.anthropic.com/docs/en/build-with-claude/claude-code-analytics-api)[Zero Data Retention](https://docs.anthropic.com/docs/en/build-with-claude/zero-data-retention)
+
+[Console](https://docs.anthropic.com/)
+
+[Log in](https://docs.anthropic.com/login)
+
+Documentation Page
+
+Page Not Found
+--------------
+
+### The requested page could not be found.
+
+Go back
+
+[](https://docs.anthropic.com/docs)
+
+[](https://x.com/claudeai)[](https://www.linkedin.com/showcase/claude)[](https://instagram.com/claudeai)
+
+### Solutions
+
+*   [AI agents](https://claude.com/solutions/agents)
+*   [Code modernization](https://claude.com/solutions/code-modernization)
+*   [Coding](https://claude.com/solutions/coding)
+*   [Customer support](https://claude.com/solutions/customer-support)
+*   [Education](https://claude.com/solutions/education)
+*   [Financial services](https://claude.com/solutions/financial-services)
+*   [Government](https://claude.com/solutions/government)
+*   [Life sciences](https://claude.com/solutions/life-sciences)
+
+### Partners
+
+*   [Amazon Bedrock](https://claude.com/partners/amazon-bedrock)
+*   [Google Cloud's Vertex AI](https://claude.com/partners/google-cloud-vertex-ai)
+
+### Learn
+
+*   [Blog](https://claude.com/blog)
+*   [Catalog](https://claude.ai/catalog/artifacts)
+*   [Courses](https://www.anthropic.com/learn)
+*   [Use cases](https://claude.com/resources/use-cases)
+*   [Connectors](https://claude.com/partners/mcp)
+*   [Customer stories](https://claude.com/customers)
+*   [Engineering at Anthropic](https://www.anthropic.com/engineering)
+*   [Events](https://www.anthropic.com/events)
+*   [Powered by Claude](https://claude.com/partners/powered-by-claude)
+*   [Service partners](https://claude.com/partners/services)
+*   [Startups program](https://claude.com/programs/startups)
+
+### Company
+
+*   [Anthropic](https://www.anthropic.com/company)
+*   [Careers](https://www.anthropic.com/careers)
+*   [Economic Futures](https://www.anthropic.com/economic-futures)
+*   [Research](https://www.anthropic.com/research)
+*   [News](https://www.anthropic.com/news)
+*   [Responsible Scaling Policy](https://www.anthropic.com/news/announcing-our-updated-responsible-scaling-policy)
+*   [Security and compliance](https://trust.anthropic.com/)
+*   [Transparency](https://www.anthropic.com/transparency)
+
+### Learn
+
+*   [Blog](https://claude.com/blog)
+*   [Catalog](https://claude.ai/catalog/artifacts)
+*   [Courses](https://www.anthropic.com/learn)
+*   [Use cases](https://claude.com/resources/use-cases)
+*   [Connectors](https://claude.com/partners/mcp)
+*   [Customer stories](https://claude.com/customers)
+*   [Engineering at Anthropic](https://www.anthropic.com/engineering)
+*   [Events](https://www.anthropic.com/events)
+*   [Powered by Claude](https://claude.com/partners/powered-by-claude)
+*   [Service partners](https://claude.com/partners/services)
+*   [Startups program](https://claude.com/programs/startups)
+
+### Help and security
+
+*   [Availability](https://www.anthropic.com/supported-countries)
+*   [Status](https://status.claude.com/)
+*   [Support](https://support.claude.com/)
+*   [Discord](https://www.anthropic.com/discord)
+
+### Terms and policies
+
+*   [Privacy policy](https://www.anthropic.com/legal/privacy)
+*   [Responsible disclosure policy](https://www.anthropic.com/responsible-disclosure-policy)
+*   [Terms of service: Commercial](https://www.anthropic.com/legal/commercial-terms)
+*   [Terms of service: Consumer](https://www.anthropic.com/legal/consumer-terms)
+*   [Usage policy](https://www.anthropic.com/legal/aup)

--- a/src/ask/docs/claude-agent-sdk/typescript-sdk.md
+++ b/src/ask/docs/claude-agent-sdk/typescript-sdk.md
@@ -1,0 +1,173 @@
+Title: Not Found - Claude API Docs
+
+URL Source: https://docs.anthropic.com/en/docs/agents-sdk/typescript-v2-preview
+
+Markdown Content:
+Not Found - Claude API Docs
+===============
+
+[](https://docs.anthropic.com/docs/en/home)
+*   [Developer Guide](https://docs.anthropic.com/docs/en/intro)
+*   [API Reference](https://docs.anthropic.com/docs/en/api/overview)
+*   [MCP](https://modelcontextprotocol.io/)
+*   [Resources](https://docs.anthropic.com/docs/en/resources/overview)
+*   [Release Notes](https://docs.anthropic.com/docs/en/release-notes/overview)
+
+English[Log in](https://docs.anthropic.com/login?returnTo=%2Fdocs%2Fen%2Fagents-sdk%2Ftypescript-v2-preview)
+
+Search...
+
+⌘K
+
+First steps
+
+[Intro to Claude](https://docs.anthropic.com/docs/en/intro)[Quickstart](https://docs.anthropic.com/docs/en/get-started)
+
+Models & pricing
+
+[Models overview](https://docs.anthropic.com/docs/en/about-claude/models/overview)[Choosing a model](https://docs.anthropic.com/docs/en/about-claude/models/choosing-a-model)[What's new in Claude 4.6](https://docs.anthropic.com/docs/en/about-claude/models/whats-new-claude-4-6)[Migration guide](https://docs.anthropic.com/docs/en/about-claude/models/migration-guide)[Model deprecations](https://docs.anthropic.com/docs/en/about-claude/model-deprecations)[Pricing](https://docs.anthropic.com/docs/en/about-claude/pricing)
+
+Build with Claude
+
+[Features overview](https://docs.anthropic.com/docs/en/build-with-claude/overview)[Using the Messages API](https://docs.anthropic.com/docs/en/build-with-claude/working-with-messages)[Handling stop reasons](https://docs.anthropic.com/docs/en/build-with-claude/handling-stop-reasons)[Prompting best practices](https://docs.anthropic.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)
+
+Model capabilities
+
+[Extended thinking](https://docs.anthropic.com/docs/en/build-with-claude/extended-thinking)[Adaptive thinking](https://docs.anthropic.com/docs/en/build-with-claude/adaptive-thinking)[Effort](https://docs.anthropic.com/docs/en/build-with-claude/effort)[Fast mode (research preview)](https://docs.anthropic.com/docs/en/build-with-claude/fast-mode)[Structured outputs](https://docs.anthropic.com/docs/en/build-with-claude/structured-outputs)[Citations](https://docs.anthropic.com/docs/en/build-with-claude/citations)[Streaming Messages](https://docs.anthropic.com/docs/en/build-with-claude/streaming)[Batch processing](https://docs.anthropic.com/docs/en/build-with-claude/batch-processing)[PDF support](https://docs.anthropic.com/docs/en/build-with-claude/pdf-support)[Search results](https://docs.anthropic.com/docs/en/build-with-claude/search-results)[Multilingual support](https://docs.anthropic.com/docs/en/build-with-claude/multilingual-support)[Embeddings](https://docs.anthropic.com/docs/en/build-with-claude/embeddings)[Vision](https://docs.anthropic.com/docs/en/build-with-claude/vision)
+
+Tools
+
+[Overview](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/overview)[How to implement tool use](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/implement-tool-use)[Web search tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/web-search-tool)[Web fetch tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/web-fetch-tool)[Code execution tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/code-execution-tool)[Memory tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/memory-tool)[Bash tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/bash-tool)[Computer use tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/computer-use-tool)[Text editor tool](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/text-editor-tool)
+
+Tool infrastructure
+
+[Tool search](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/tool-search-tool)[Programmatic tool calling](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling)[Fine-grained tool streaming](https://docs.anthropic.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming)
+
+Context management
+
+[Context windows](https://docs.anthropic.com/docs/en/build-with-claude/context-windows)[Compaction](https://docs.anthropic.com/docs/en/build-with-claude/compaction)[Context editing](https://docs.anthropic.com/docs/en/build-with-claude/context-editing)[Prompt caching](https://docs.anthropic.com/docs/en/build-with-claude/prompt-caching)[Token counting](https://docs.anthropic.com/docs/en/build-with-claude/token-counting)
+
+Files & assets
+
+[Files API](https://docs.anthropic.com/docs/en/build-with-claude/files)
+
+Agent Skills
+
+[Overview](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/overview)[Quickstart](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/quickstart)[Best practices](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/best-practices)[Skills for enterprise](https://docs.anthropic.com/docs/en/agents-and-tools/agent-skills/enterprise)[Using Skills with the API](https://docs.anthropic.com/docs/en/build-with-claude/skills-guide)
+
+Agent SDK
+
+[Overview](https://docs.anthropic.com/docs/en/agent-sdk/overview)[Quickstart](https://docs.anthropic.com/docs/en/agent-sdk/quickstart)[TypeScript SDK](https://docs.anthropic.com/docs/en/agent-sdk/typescript)[TypeScript V2 (preview)](https://docs.anthropic.com/docs/en/agent-sdk/typescript-v2-preview)[Python SDK](https://docs.anthropic.com/docs/en/agent-sdk/python)[Migration Guide](https://docs.anthropic.com/docs/en/agent-sdk/migration-guide)
+
+Guides
+
+MCP in the API
+
+[MCP connector](https://docs.anthropic.com/docs/en/agents-and-tools/mcp-connector)[Remote MCP servers](https://docs.anthropic.com/docs/en/agents-and-tools/remote-mcp-servers)
+
+Claude on 3rd-party platforms
+
+[Amazon Bedrock](https://docs.anthropic.com/docs/en/build-with-claude/claude-on-amazon-bedrock)[Microsoft Foundry](https://docs.anthropic.com/docs/en/build-with-claude/claude-in-microsoft-foundry)[Vertex AI](https://docs.anthropic.com/docs/en/build-with-claude/claude-on-vertex-ai)
+
+Prompt engineering
+
+[Overview](https://docs.anthropic.com/docs/en/build-with-claude/prompt-engineering/overview)[Console prompting tools](https://docs.anthropic.com/docs/en/build-with-claude/prompt-engineering/prompting-tools)
+
+Test & evaluate
+
+[Define success and build evaluations](https://docs.anthropic.com/docs/en/test-and-evaluate/develop-tests)[Using the Evaluation Tool](https://docs.anthropic.com/docs/en/test-and-evaluate/eval-tool)[Reducing latency](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-latency)
+
+Strengthen guardrails
+
+[Reduce hallucinations](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)[Increase output consistency](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/increase-consistency)[Mitigate jailbreaks](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks)[Streaming refusals](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals)[Reduce prompt leak](https://docs.anthropic.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-prompt-leak)
+
+Administration and monitoring
+
+[Admin API overview](https://docs.anthropic.com/docs/en/build-with-claude/administration-api)[Data residency](https://docs.anthropic.com/docs/en/build-with-claude/data-residency)[Workspaces](https://docs.anthropic.com/docs/en/build-with-claude/workspaces)[Usage and Cost API](https://docs.anthropic.com/docs/en/build-with-claude/usage-cost-api)[Claude Code Analytics API](https://docs.anthropic.com/docs/en/build-with-claude/claude-code-analytics-api)[Zero Data Retention](https://docs.anthropic.com/docs/en/build-with-claude/zero-data-retention)
+
+[Console](https://docs.anthropic.com/)
+
+[Log in](https://docs.anthropic.com/login)
+
+Documentation Page
+
+Page Not Found
+--------------
+
+### The requested page could not be found.
+
+Go back
+
+[](https://docs.anthropic.com/docs)
+
+[](https://x.com/claudeai)[](https://www.linkedin.com/showcase/claude)[](https://instagram.com/claudeai)
+
+### Solutions
+
+*   [AI agents](https://claude.com/solutions/agents)
+*   [Code modernization](https://claude.com/solutions/code-modernization)
+*   [Coding](https://claude.com/solutions/coding)
+*   [Customer support](https://claude.com/solutions/customer-support)
+*   [Education](https://claude.com/solutions/education)
+*   [Financial services](https://claude.com/solutions/financial-services)
+*   [Government](https://claude.com/solutions/government)
+*   [Life sciences](https://claude.com/solutions/life-sciences)
+
+### Partners
+
+*   [Amazon Bedrock](https://claude.com/partners/amazon-bedrock)
+*   [Google Cloud's Vertex AI](https://claude.com/partners/google-cloud-vertex-ai)
+
+### Learn
+
+*   [Blog](https://claude.com/blog)
+*   [Catalog](https://claude.ai/catalog/artifacts)
+*   [Courses](https://www.anthropic.com/learn)
+*   [Use cases](https://claude.com/resources/use-cases)
+*   [Connectors](https://claude.com/partners/mcp)
+*   [Customer stories](https://claude.com/customers)
+*   [Engineering at Anthropic](https://www.anthropic.com/engineering)
+*   [Events](https://www.anthropic.com/events)
+*   [Powered by Claude](https://claude.com/partners/powered-by-claude)
+*   [Service partners](https://claude.com/partners/services)
+*   [Startups program](https://claude.com/programs/startups)
+
+### Company
+
+*   [Anthropic](https://www.anthropic.com/company)
+*   [Careers](https://www.anthropic.com/careers)
+*   [Economic Futures](https://www.anthropic.com/economic-futures)
+*   [Research](https://www.anthropic.com/research)
+*   [News](https://www.anthropic.com/news)
+*   [Responsible Scaling Policy](https://www.anthropic.com/news/announcing-our-updated-responsible-scaling-policy)
+*   [Security and compliance](https://trust.anthropic.com/)
+*   [Transparency](https://www.anthropic.com/transparency)
+
+### Learn
+
+*   [Blog](https://claude.com/blog)
+*   [Catalog](https://claude.ai/catalog/artifacts)
+*   [Courses](https://www.anthropic.com/learn)
+*   [Use cases](https://claude.com/resources/use-cases)
+*   [Connectors](https://claude.com/partners/mcp)
+*   [Customer stories](https://claude.com/customers)
+*   [Engineering at Anthropic](https://www.anthropic.com/engineering)
+*   [Events](https://www.anthropic.com/events)
+*   [Powered by Claude](https://claude.com/partners/powered-by-claude)
+*   [Service partners](https://claude.com/partners/services)
+*   [Startups program](https://claude.com/programs/startups)
+
+### Help and security
+
+*   [Availability](https://www.anthropic.com/supported-countries)
+*   [Status](https://status.claude.com/)
+*   [Support](https://support.claude.com/)
+*   [Discord](https://www.anthropic.com/discord)
+
+### Terms and policies
+
+*   [Privacy policy](https://www.anthropic.com/legal/privacy)
+*   [Responsible disclosure policy](https://www.anthropic.com/responsible-disclosure-policy)
+*   [Terms of service: Commercial](https://www.anthropic.com/legal/commercial-terms)
+*   [Terms of service: Consumer](https://www.anthropic.com/legal/consumer-terms)
+*   [Usage policy](https://www.anthropic.com/legal/aup)

--- a/src/ask/index.lib.ts
+++ b/src/ask/index.lib.ts
@@ -1,0 +1,18 @@
+export { AIChat } from "./AIChat";
+export { ChatEvent } from "./lib/ChatEvent";
+export { ChatSession } from "./lib/ChatSession";
+export { ChatSessionManager } from "./lib/ChatSessionManager";
+export { ChatLog } from "./lib/ChatLog";
+export { ChatTurn } from "./lib/ChatTurn";
+export type {
+    AIChatOptions,
+    AIChatTool,
+    AIChatSelection,
+    SendOptions,
+    ChatResponse,
+    ToolCallResult,
+    SessionEntry,
+    LogEntry,
+    LogLevel,
+    SessionStats,
+} from "./lib/types";

--- a/src/ask/lib/ChatEvent.ts
+++ b/src/ask/lib/ChatEvent.ts
@@ -1,0 +1,32 @@
+import type { ChatResponse } from "./types";
+
+type ChatEventType = "text" | "thinking" | "tool_call" | "tool_result" | "done";
+
+export class ChatEvent {
+    readonly type: ChatEventType;
+    readonly text?: string;
+    readonly name?: string;
+    readonly input?: unknown;
+    readonly output?: unknown;
+    readonly duration?: number;
+    readonly response?: ChatResponse;
+
+    private constructor(type: ChatEventType, data: Partial<Omit<ChatEvent, "type">>) {
+        this.type = type;
+        Object.assign(this, data);
+    }
+
+    // === Factory methods ===
+    static text(text: string): ChatEvent { return new ChatEvent("text", { text }); }
+    static thinking(text: string): ChatEvent { return new ChatEvent("thinking", { text }); }
+    static toolCall(name: string, input: unknown): ChatEvent { return new ChatEvent("tool_call", { name, input }); }
+    static toolResult(name: string, output: unknown, duration: number): ChatEvent { return new ChatEvent("tool_result", { name, output, duration }); }
+    static done(response: ChatResponse): ChatEvent { return new ChatEvent("done", { response }); }
+
+    // === Type guards ===
+    isText(): this is ChatEvent & { text: string } { return this.type === "text"; }
+    isThinking(): this is ChatEvent & { text: string } { return this.type === "thinking"; }
+    isToolCall(): this is ChatEvent & { name: string; input: unknown } { return this.type === "tool_call"; }
+    isToolResult(): this is ChatEvent & { name: string; output: unknown; duration: number } { return this.type === "tool_result"; }
+    isDone(): this is ChatEvent & { response: ChatResponse } { return this.type === "done"; }
+}

--- a/src/ask/lib/ChatLog.ts
+++ b/src/ask/lib/ChatLog.ts
@@ -1,0 +1,83 @@
+import type { LogEntry, LogLevel } from "./types";
+
+const LOG_LEVELS: Record<LogLevel, number> = {
+    trace: 10,
+    debug: 20,
+    info: 30,
+    warn: 40,
+    error: 50,
+    silent: 100,
+};
+
+export class ChatLog {
+    private entries: LogEntry[] = [];
+    private cursor = 0;
+    private readonly threshold: number;
+
+    constructor(logLevel: LogLevel = "info") {
+        this.threshold = LOG_LEVELS[logLevel];
+    }
+
+    capture(level: LogLevel, message: string, source?: string): void {
+        if (LOG_LEVELS[level] < this.threshold) {
+            return;
+        }
+
+        this.entries.push({
+            level,
+            message,
+            timestamp: new Date(),
+            source,
+        });
+    }
+
+    getUnseen(options?: { level?: LogLevel }): LogEntry[] {
+        const minLevel = options?.level ? LOG_LEVELS[options.level] : 0;
+        const unseen = this.entries.slice(this.cursor);
+        this.cursor = this.entries.length;
+
+        if (minLevel > 0) {
+            return unseen.filter((e) => LOG_LEVELS[e.level] >= minLevel);
+        }
+
+        return unseen;
+    }
+
+    getAll(options?: { level?: LogLevel; since?: Date }): LogEntry[] {
+        let result = this.entries;
+
+        if (options?.level) {
+            const minLevel = LOG_LEVELS[options.level];
+            result = result.filter((e) => LOG_LEVELS[e.level] >= minLevel);
+        }
+
+        if (options?.since) {
+            result = result.filter((e) => e.timestamp >= options.since!);
+        }
+
+        return result;
+    }
+
+    clear(): void {
+        this.entries = [];
+        this.cursor = 0;
+    }
+
+    createLogger(source: string): CapturedLogger {
+        return {
+            trace: (msg: string) => this.capture("trace", msg, source),
+            debug: (msg: string) => this.capture("debug", msg, source),
+            info: (msg: string) => this.capture("info", msg, source),
+            warn: (msg: string) => this.capture("warn", msg, source),
+            error: (msg: string) => this.capture("error", msg, source),
+        };
+    }
+}
+
+export interface CapturedLogger {
+    trace: (msg: string) => void;
+    debug: (msg: string) => void;
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+}

--- a/src/ask/lib/ChatSession.ts
+++ b/src/ask/lib/ChatSession.ts
@@ -1,0 +1,330 @@
+import type {
+    SessionEntry,
+    SessionConfigEntry,
+    SessionUserEntry,
+    SessionAssistantEntry,
+    SessionSystemEntry,
+    SessionContextEntry,
+    SessionStats,
+    ToolCallResult,
+} from "./types";
+
+export class ChatSession {
+    readonly id: string;
+    private entries: SessionEntry[] = [];
+    private _statsCache: SessionStats | null = null;
+    private _manager: ChatSessionManagerRef | null = null;
+
+    constructor(id: string, entries?: SessionEntry[]) {
+        this.id = id;
+
+        if (entries) {
+            this.entries = [...entries];
+        }
+    }
+
+    /** Set the manager reference (called by ChatSessionManager) */
+    setManager(manager: ChatSessionManagerRef): void {
+        this._manager = manager;
+    }
+
+    /** Add an entry to the session */
+    add(entry: {
+        role: "user" | "assistant" | "system" | "context";
+        content: string;
+        label?: string;
+        metadata?: Record<string, unknown>;
+        thinking?: string;
+        usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number; cachedInputTokens?: number };
+        cost?: number;
+        toolCalls?: ToolCallResult[];
+    }): void {
+        this._statsCache = null;
+        const timestamp = new Date().toISOString();
+
+        switch (entry.role) {
+            case "user":
+                this.entries.push({
+                    type: "user",
+                    content: entry.content,
+                    timestamp,
+                    metadata: entry.metadata,
+                } satisfies SessionUserEntry);
+                break;
+            case "assistant":
+                this.entries.push({
+                    type: "assistant",
+                    content: entry.content,
+                    thinking: entry.thinking,
+                    timestamp,
+                    usage: entry.usage as SessionAssistantEntry["usage"],
+                    cost: entry.cost,
+                    toolCalls: entry.toolCalls,
+                } satisfies SessionAssistantEntry);
+                break;
+            case "system":
+                this.entries.push({
+                    type: "system",
+                    content: entry.content,
+                    timestamp,
+                } satisfies SessionSystemEntry);
+                break;
+            case "context":
+                this.entries.push({
+                    type: "context",
+                    content: entry.content,
+                    timestamp,
+                    label: entry.label,
+                    metadata: entry.metadata,
+                } satisfies SessionContextEntry);
+                break;
+        }
+    }
+
+    /** Add a config entry */
+    addConfig(provider: string, model: string, systemPrompt?: string): void {
+        this._statsCache = null;
+        this.entries.push({
+            type: "config",
+            timestamp: new Date().toISOString(),
+            provider,
+            model,
+            systemPrompt,
+        } satisfies SessionConfigEntry);
+    }
+
+    /** Add a raw session entry directly */
+    addRaw(entry: SessionEntry): void {
+        this._statsCache = null;
+        this.entries.push(entry);
+    }
+
+    /** Get conversation history with optional filtering */
+    getHistory(options?: { last?: number; roles?: string[]; since?: Date }): SessionEntry[] {
+        let result = [...this.entries];
+
+        if (options?.roles) {
+            const roles = new Set(options.roles);
+            result = result.filter((e) => roles.has(e.type));
+        }
+
+        if (options?.since) {
+            const since = options.since;
+            result = result.filter((e) => new Date(e.timestamp) >= since);
+        }
+
+        if (options?.last) {
+            result = result.slice(-options.last);
+        }
+
+        return result;
+    }
+
+    /** Get all entries (raw access) */
+    getAllEntries(): SessionEntry[] {
+        return [...this.entries];
+    }
+
+    /** Convert to ChatEngine-compatible messages */
+    toMessages(): Array<{ role: "user" | "assistant" | "system"; content: string }> {
+        const messages: Array<{ role: "user" | "assistant" | "system"; content: string }> = [];
+
+        for (const entry of this.entries) {
+            switch (entry.type) {
+                case "user":
+                    messages.push({ role: "user", content: entry.content });
+                    break;
+                case "assistant":
+                    messages.push({ role: "assistant", content: entry.content });
+                    break;
+                case "system":
+                    messages.push({ role: "system", content: entry.content });
+                    break;
+                case "context":
+                    messages.push({ role: "system", content: entry.content });
+                    break;
+                case "config":
+                    // Skip config entries in messages
+                    break;
+            }
+        }
+
+        return messages;
+    }
+
+    /** Filter by role — returns new ChatSession */
+    filterByRole(...roles: string[]): ChatSession {
+        const roleSet = new Set(roles);
+        const filtered = this.entries.filter((e) => roleSet.has(e.type));
+        return new ChatSession(this.id, filtered);
+    }
+
+    /** Filter by date range — returns new ChatSession */
+    filterByDateRange(since?: Date, until?: Date): ChatSession {
+        const filtered = this.entries.filter((e) => {
+            const ts = new Date(e.timestamp);
+
+            if (since && ts < since) {
+                return false;
+            }
+
+            if (until && ts > until) {
+                return false;
+            }
+
+            return true;
+        });
+        return new ChatSession(this.id, filtered);
+    }
+
+    /** Filter by content substring — returns new ChatSession */
+    filterByContent(query: string): ChatSession {
+        const lowerQuery = query.toLowerCase();
+        const filtered = this.entries.filter((e) => {
+            if ("content" in e) {
+                return e.content.toLowerCase().includes(lowerQuery);
+            }
+            return false;
+        });
+        return new ChatSession(this.id, filtered);
+    }
+
+    /** Clear conversation history */
+    clear(): void {
+        this.entries = [];
+        this._statsCache = null;
+    }
+
+    /** Save session (delegates to manager) */
+    async save(): Promise<string> {
+        if (!this._manager) {
+            throw new Error("No session manager configured — pass session options to AIChat constructor");
+        }
+
+        await this._manager.save(this);
+        return this.id;
+    }
+
+    /** Load session (delegates to manager) */
+    async load(sessionId: string): Promise<void> {
+        if (!this._manager) {
+            throw new Error("No session manager configured");
+        }
+
+        const loaded = await this._manager.load(sessionId);
+        this.entries = loaded.getAllEntries();
+        this._statsCache = null;
+    }
+
+    /** Export in various formats */
+    async export(format: "jsonl" | "json" | "markdown" | "text"): Promise<string> {
+        switch (format) {
+            case "jsonl":
+                return this.entries.map((e) => JSON.stringify(e)).join("\n");
+            case "json":
+                return JSON.stringify(this.entries, null, 2);
+            case "markdown":
+                return this.exportMarkdown();
+            case "text":
+                return this.exportText();
+        }
+    }
+
+    /** Get session statistics */
+    getStats(): SessionStats {
+        if (this._statsCache) {
+            return this._statsCache;
+        }
+
+        const byRole: Record<string, number> = {};
+        let tokenCount = 0;
+        let cost = 0;
+        let startedAt = "";
+
+        for (const entry of this.entries) {
+            byRole[entry.type] = (byRole[entry.type] ?? 0) + 1;
+
+            if (!startedAt) {
+                startedAt = entry.timestamp;
+            }
+
+            if (entry.type === "assistant") {
+                if (entry.usage) {
+                    tokenCount += (entry.usage.inputTokens ?? 0) + (entry.usage.outputTokens ?? 0);
+                }
+
+                if (entry.cost) {
+                    cost += entry.cost;
+                }
+            }
+        }
+
+        const lastEntry = this.entries[this.entries.length - 1];
+        const duration =
+            startedAt && lastEntry
+                ? new Date(lastEntry.timestamp).getTime() - new Date(startedAt).getTime()
+                : 0;
+
+        this._statsCache = {
+            messageCount: this.entries.length,
+            tokenCount,
+            cost,
+            duration,
+            startedAt,
+            byRole,
+        };
+
+        return this._statsCache;
+    }
+
+    /** Number of entries */
+    get length(): number {
+        return this.entries.length;
+    }
+
+    private exportMarkdown(): string {
+        const lines: string[] = [`# Chat Session: ${this.id}\n`];
+
+        for (const entry of this.entries) {
+            switch (entry.type) {
+                case "config":
+                    lines.push(`> **Config:** ${entry.provider}/${entry.model}\n`);
+                    break;
+                case "user":
+                    lines.push(`**User:** ${entry.content}\n`);
+                    break;
+                case "assistant":
+                    lines.push(`**Assistant:** ${entry.content}\n`);
+                    break;
+                case "system":
+                    lines.push(`*System: ${entry.content}*\n`);
+                    break;
+                case "context":
+                    lines.push(`*Context${entry.label ? ` [${entry.label}]` : ""}: ${entry.content}*\n`);
+                    break;
+            }
+        }
+
+        return lines.join("\n");
+    }
+
+    private exportText(): string {
+        const lines: string[] = [];
+
+        for (const entry of this.entries) {
+            if (entry.type === "user") {
+                lines.push(`You: ${entry.content}`);
+            } else if (entry.type === "assistant") {
+                lines.push(`AI: ${entry.content}`);
+            }
+        }
+
+        return lines.join("\n");
+    }
+}
+
+/** Minimal interface for manager reference (avoids circular imports) */
+export interface ChatSessionManagerRef {
+    save(session: ChatSession): Promise<void>;
+    load(sessionId: string): Promise<ChatSession>;
+}

--- a/src/ask/lib/ChatSessionManager.ts
+++ b/src/ask/lib/ChatSessionManager.ts
@@ -1,0 +1,114 @@
+import { resolve } from "node:path";
+import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import { ChatSession } from "./ChatSession";
+import type { ChatSessionManagerRef } from "./ChatSession";
+import type { SessionEntry } from "./types";
+
+export class ChatSessionManager implements ChatSessionManagerRef {
+    private readonly dir: string;
+
+    constructor(options: { dir: string }) {
+        this.dir = resolve(options.dir);
+
+        if (!existsSync(this.dir)) {
+            mkdirSync(this.dir, { recursive: true });
+        }
+    }
+
+    /** Create a new empty session */
+    create(id?: string): ChatSession {
+        const sessionId = id ?? crypto.randomUUID();
+        const session = new ChatSession(sessionId);
+        session.setManager(this);
+        return session;
+    }
+
+    /** Load session from JSONL file */
+    async load(sessionId: string): Promise<ChatSession> {
+        const filePath = this.getFilePath(sessionId);
+        const file = Bun.file(filePath);
+
+        if (!(await file.exists())) {
+            throw new Error(`Session not found: ${sessionId}`);
+        }
+
+        const text = await file.text();
+        const entries: SessionEntry[] = [];
+
+        for (const line of text.split("\n")) {
+            const trimmed = line.trim();
+
+            if (!trimmed) {
+                continue;
+            }
+
+            try {
+                entries.push(JSON.parse(trimmed) as SessionEntry);
+            } catch {
+                // Skip malformed lines
+            }
+        }
+
+        const session = new ChatSession(sessionId, entries);
+        session.setManager(this);
+        return session;
+    }
+
+    /** Save session entries to JSONL file */
+    async save(session: ChatSession): Promise<void> {
+        const filePath = this.getFilePath(session.id);
+        const entries = session.getAllEntries();
+        const content = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+        await Bun.write(filePath, content);
+    }
+
+    /** List available sessions */
+    async list(): Promise<Array<{ id: string; startedAt: string; messageCount: number; lastActivity: string }>> {
+        const files = readdirSync(this.dir).filter((f) => f.endsWith(".jsonl"));
+        const sessions: Array<{ id: string; startedAt: string; messageCount: number; lastActivity: string }> = [];
+
+        for (const file of files) {
+            const id = file.replace(".jsonl", "");
+
+            try {
+                const session = await this.load(id);
+                const entries = session.getAllEntries();
+
+                if (entries.length === 0) {
+                    continue;
+                }
+
+                sessions.push({
+                    id,
+                    startedAt: entries[0].timestamp,
+                    messageCount: entries.length,
+                    lastActivity: entries[entries.length - 1].timestamp,
+                });
+            } catch {
+                // Skip unreadable files
+            }
+        }
+
+        // Sort by last activity descending
+        sessions.sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
+        return sessions;
+    }
+
+    /** Delete a session file */
+    async delete(sessionId: string): Promise<void> {
+        const filePath = this.getFilePath(sessionId);
+
+        if (existsSync(filePath)) {
+            unlinkSync(filePath);
+        }
+    }
+
+    /** Check if a session exists */
+    async exists(sessionId: string): Promise<boolean> {
+        return existsSync(this.getFilePath(sessionId));
+    }
+
+    private getFilePath(sessionId: string): string {
+        return resolve(this.dir, `${sessionId}.jsonl`);
+    }
+}

--- a/src/ask/lib/ChatSessionManager.ts
+++ b/src/ask/lib/ChatSessionManager.ts
@@ -18,6 +18,7 @@ export class ChatSessionManager implements ChatSessionManagerRef {
     /** Create a new empty session */
     create(id?: string): ChatSession {
         const sessionId = id ?? crypto.randomUUID();
+        this.validateSessionId(sessionId);
         const session = new ChatSession(sessionId);
         session.setManager(this);
         return session;
@@ -108,7 +109,14 @@ export class ChatSessionManager implements ChatSessionManagerRef {
         return existsSync(this.getFilePath(sessionId));
     }
 
+    private validateSessionId(sessionId: string): void {
+        if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+            throw new Error(`Invalid session ID "${sessionId}" — only alphanumeric, hyphens, and underscores allowed`);
+        }
+    }
+
     private getFilePath(sessionId: string): string {
+        this.validateSessionId(sessionId);
         return resolve(this.dir, `${sessionId}.jsonl`);
     }
 }

--- a/src/ask/lib/ChatTurn.ts
+++ b/src/ask/lib/ChatTurn.ts
@@ -1,0 +1,136 @@
+import { ChatEvent } from "./ChatEvent";
+import type { ChatResponse } from "./types";
+
+/**
+ * ChatTurn — returned by AIChat.send(), both awaitable and streamable.
+ *
+ * Usage:
+ *   const response = await chat.send("hello");           // buffered
+ *   for await (const event of chat.send("hello")) { }    // streaming
+ *   const turn = chat.send("hello");
+ *   const response = await turn.response;                 // deferred
+ */
+export class ChatTurn implements PromiseLike<ChatResponse>, AsyncIterable<ChatEvent> {
+    private readonly _source: () => AsyncGenerator<ChatEvent>;
+    private readonly _onChunk?: (text: string) => void;
+    private _consumed = false;
+    private _buffer: ChatEvent[] = [];
+    private _responseResolve!: (value: ChatResponse) => void;
+    private _responseReject!: (reason: unknown) => void;
+    private _drainStarted = false;
+
+    /** The final response — resolves after the stream completes */
+    readonly response: Promise<ChatResponse>;
+
+    constructor(
+        source: () => AsyncGenerator<ChatEvent>,
+        onChunk?: (text: string) => void,
+    ) {
+        this._source = source;
+        this._onChunk = onChunk;
+        this.response = new Promise<ChatResponse>((resolve, reject) => {
+            this._responseResolve = resolve;
+            this._responseReject = reject;
+        });
+    }
+
+    /** PromiseLike — await the turn to get the buffered ChatResponse */
+    then<TResult1 = ChatResponse, TResult2 = never>(
+        onfulfilled?: ((value: ChatResponse) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2> {
+        return this._drain().then(onfulfilled, onrejected);
+    }
+
+    /** AsyncIterable — iterate to get streaming ChatEvents */
+    [Symbol.asyncIterator](): AsyncIterator<ChatEvent> {
+        if (this._consumed) {
+            // Replay from buffer if already consumed
+            return this._replayFromBuffer();
+        }
+
+        this._consumed = true;
+        return this._iterateWithCallbacks();
+    }
+
+    /** Drain the stream internally, resolve with ChatResponse */
+    private async _drain(): Promise<ChatResponse> {
+        if (this._drainStarted) {
+            return this.response;
+        }
+
+        this._drainStarted = true;
+
+        try {
+            const gen = this._source();
+
+            for await (const event of gen) {
+                this._buffer.push(event);
+
+                if (event.isText() && this._onChunk) {
+                    this._onChunk(event.text);
+                }
+
+                if (event.isDone()) {
+                    this._responseResolve(event.response);
+                    return event.response;
+                }
+            }
+
+            // If no done event, create a fallback response from buffered text
+            const content = this._buffer
+                .filter((e) => e.isText())
+                .map((e) => e.text)
+                .join("");
+
+            const fallback: ChatResponse = { content, duration: 0 };
+            this._responseResolve(fallback);
+            return fallback;
+        } catch (error) {
+            this._responseReject(error);
+            throw error;
+        }
+    }
+
+    /** Iterate the source, calling onChunk and resolving response */
+    private async *_iterateWithCallbacks(): AsyncGenerator<ChatEvent> {
+        this._drainStarted = true;
+
+        try {
+            const gen = this._source();
+
+            for await (const event of gen) {
+                this._buffer.push(event);
+
+                if (event.isText() && this._onChunk) {
+                    this._onChunk(event.text);
+                }
+
+                if (event.isDone()) {
+                    this._responseResolve(event.response);
+                }
+
+                yield event;
+            }
+
+            // If no done event was emitted, resolve with fallback
+            if (!this._buffer.some((e) => e.isDone())) {
+                const content = this._buffer
+                    .filter((e) => e.isText())
+                    .map((e) => e.text)
+                    .join("");
+                this._responseResolve({ content, duration: 0 });
+            }
+        } catch (error) {
+            this._responseReject(error);
+            throw error;
+        }
+    }
+
+    /** Replay events from buffer for second consumer */
+    private async *_replayFromBuffer(): AsyncGenerator<ChatEvent> {
+        for (const event of this._buffer) {
+            yield event;
+        }
+    }
+}

--- a/src/ask/lib/ChatTurn.ts
+++ b/src/ask/lib/ChatTurn.ts
@@ -60,6 +60,7 @@ export class ChatTurn implements PromiseLike<ChatResponse>, AsyncIterable<ChatEv
         }
 
         this._drainStarted = true;
+        this._consumed = true;
 
         try {
             const gen = this._source();

--- a/src/ask/lib/__tests__/ChatEvent.test.ts
+++ b/src/ask/lib/__tests__/ChatEvent.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { ChatEvent } from "../ChatEvent";
+
+describe("ChatEvent", () => {
+    it("creates text event with factory", () => {
+        const event = ChatEvent.text("hello");
+        expect(event.type).toBe("text");
+        expect(event.isText()).toBe(true);
+        expect(event.text).toBe("hello");
+        expect(event.isDone()).toBe(false);
+    });
+
+    it("creates done event with response", () => {
+        const response = { content: "hi", duration: 100 };
+        const event = ChatEvent.done(response);
+        expect(event.isDone()).toBe(true);
+        expect(event.response).toBe(response);
+        expect(event.isText()).toBe(false);
+    });
+
+    it("creates thinking event", () => {
+        const event = ChatEvent.thinking("reasoning...");
+        expect(event.isThinking()).toBe(true);
+        expect(event.text).toBe("reasoning...");
+    });
+
+    it("creates tool_call event", () => {
+        const event = ChatEvent.toolCall("searchWeb", { query: "test" });
+        expect(event.isToolCall()).toBe(true);
+        expect(event.name).toBe("searchWeb");
+        expect(event.input).toEqual({ query: "test" });
+    });
+
+    it("creates tool_result event", () => {
+        const event = ChatEvent.toolResult("searchWeb", { results: [] }, 150);
+        expect(event.isToolResult()).toBe(true);
+        expect(event.name).toBe("searchWeb");
+        expect(event.duration).toBe(150);
+    });
+
+    it("type guards narrow correctly", () => {
+        const event = ChatEvent.text("hi");
+        if (event.isText()) {
+            const _text: string = event.text;
+            expect(_text).toBe("hi");
+        }
+    });
+});

--- a/src/ask/lib/__tests__/ChatLog.test.ts
+++ b/src/ask/lib/__tests__/ChatLog.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { ChatLog } from "../ChatLog";
+
+describe("ChatLog", () => {
+    it("captures logs at or above configured level", () => {
+        const log = new ChatLog("warn");
+        log.capture("info", "should be ignored", "Source");
+        log.capture("warn", "visible warning", "DynamicPricing");
+        log.capture("error", "visible error", "ProviderManager");
+
+        const all = log.getAll();
+        expect(all).toHaveLength(2);
+        expect(all[0].message).toBe("visible warning");
+        expect(all[0].source).toBe("DynamicPricing");
+    });
+
+    it("getUnseen returns entries since last call", () => {
+        const log = new ChatLog("info");
+        log.capture("info", "first");
+        log.capture("info", "second");
+
+        const batch1 = log.getUnseen();
+        expect(batch1).toHaveLength(2);
+
+        log.capture("info", "third");
+        const batch2 = log.getUnseen();
+        expect(batch2).toHaveLength(1);
+        expect(batch2[0].message).toBe("third");
+    });
+
+    it("getUnseen with level filter", () => {
+        const log = new ChatLog("info");
+        log.capture("info", "info msg");
+        log.capture("warn", "warn msg");
+        log.capture("error", "error msg");
+
+        const warnings = log.getUnseen({ level: "warn" });
+        expect(warnings).toHaveLength(2); // warn + error
+    });
+
+    it("silent level captures nothing", () => {
+        const log = new ChatLog("silent");
+        log.capture("error", "should not appear");
+        expect(log.getAll()).toHaveLength(0);
+    });
+
+    it("clear resets everything", () => {
+        const log = new ChatLog("info");
+        log.capture("info", "test");
+        log.clear();
+        expect(log.getAll()).toHaveLength(0);
+        expect(log.getUnseen()).toHaveLength(0);
+    });
+
+    it("createLogger produces a pino-compatible interface", () => {
+        const log = new ChatLog("info");
+        const logger = log.createLogger("TestSource");
+        logger.info("hello from logger");
+        logger.warn("warning from logger");
+        logger.debug("should be ignored at info level");
+
+        const entries = log.getAll();
+        expect(entries).toHaveLength(2);
+        expect(entries[0].source).toBe("TestSource");
+    });
+});

--- a/src/ask/lib/__tests__/ChatSession.test.ts
+++ b/src/ask/lib/__tests__/ChatSession.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { ChatSession } from "../ChatSession";
+
+describe("ChatSession", () => {
+    it("add() creates entries with timestamps", () => {
+        const session = new ChatSession("test-1");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "assistant", content: "hi there" });
+
+        const entries = session.getHistory();
+        expect(entries).toHaveLength(2);
+        expect(entries[0].type).toBe("user");
+        expect(entries[1].type).toBe("assistant");
+        expect(entries[0].timestamp).toBeTruthy();
+    });
+
+    it("add() context creates context entry with label", () => {
+        const session = new ChatSession("test-2");
+        session.add({ role: "context", content: "message from telegram", label: "telegram-incoming" });
+
+        const entries = session.getHistory();
+        expect(entries).toHaveLength(1);
+        expect(entries[0].type).toBe("context");
+        if (entries[0].type === "context") {
+            expect(entries[0].label).toBe("telegram-incoming");
+        }
+    });
+
+    it("getHistory({ last: 2 }) returns last 2 entries", () => {
+        const session = new ChatSession("test-3");
+        session.add({ role: "user", content: "first" });
+        session.add({ role: "assistant", content: "second" });
+        session.add({ role: "user", content: "third" });
+
+        const last2 = session.getHistory({ last: 2 });
+        expect(last2).toHaveLength(2);
+        if (last2[0].type === "assistant") {
+            expect(last2[0].content).toBe("second");
+        }
+    });
+
+    it("getHistory({ roles }) filters by type", () => {
+        const session = new ChatSession("test-4");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "system", content: "system msg" });
+        session.add({ role: "assistant", content: "reply" });
+
+        const chatOnly = session.getHistory({ roles: ["user", "assistant"] });
+        expect(chatOnly).toHaveLength(2);
+    });
+
+    it("toMessages() maps entries to LLM format", () => {
+        const session = new ChatSession("test-5");
+        session.addConfig("openai", "gpt-4o");
+        session.add({ role: "context", content: "background info" });
+        session.add({ role: "user", content: "question" });
+        session.add({ role: "assistant", content: "answer" });
+
+        const messages = session.toMessages();
+        expect(messages).toHaveLength(3); // config skipped
+        expect(messages[0]).toEqual({ role: "system", content: "background info" });
+        expect(messages[1]).toEqual({ role: "user", content: "question" });
+        expect(messages[2]).toEqual({ role: "assistant", content: "answer" });
+    });
+
+    it("filterByRole returns new session", () => {
+        const session = new ChatSession("test-6");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "assistant", content: "hi" });
+        session.add({ role: "system", content: "sys" });
+
+        const userOnly = session.filterByRole("user");
+        expect(userOnly.length).toBe(1);
+        expect(userOnly.id).toBe("test-6");
+        // Original unchanged
+        expect(session.length).toBe(3);
+    });
+
+    it("filterByContent searches content", () => {
+        const session = new ChatSession("test-7");
+        session.add({ role: "user", content: "what is the weather" });
+        session.add({ role: "assistant", content: "it is sunny" });
+        session.add({ role: "user", content: "tell me a joke" });
+
+        const weatherMsgs = session.filterByContent("weather");
+        expect(weatherMsgs.length).toBe(1);
+    });
+
+    it("clear resets entries but keeps id", () => {
+        const session = new ChatSession("test-8");
+        session.add({ role: "user", content: "hello" });
+        session.clear();
+        expect(session.length).toBe(0);
+        expect(session.id).toBe("test-8");
+    });
+
+    it("getStats computes correct values", () => {
+        const session = new ChatSession("test-9");
+        session.add({ role: "user", content: "hello" });
+        session.add({
+            role: "assistant",
+            content: "hi",
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            cost: 0.001,
+        });
+
+        const stats = session.getStats();
+        expect(stats.messageCount).toBe(2);
+        expect(stats.tokenCount).toBe(15);
+        expect(stats.cost).toBe(0.001);
+        expect(stats.byRole.user).toBe(1);
+        expect(stats.byRole.assistant).toBe(1);
+    });
+
+    it("export jsonl produces valid JSONL", async () => {
+        const session = new ChatSession("test-10");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "assistant", content: "hi" });
+
+        const jsonl = await session.export("jsonl");
+        const lines = jsonl.split("\n");
+        expect(lines).toHaveLength(2);
+        const parsed = JSON.parse(lines[0]);
+        expect(parsed.type).toBe("user");
+        expect(parsed.content).toBe("hello");
+    });
+
+    it("export markdown produces readable output", async () => {
+        const session = new ChatSession("test-11");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "assistant", content: "hi" });
+
+        const md = await session.export("markdown");
+        expect(md).toContain("**User:** hello");
+        expect(md).toContain("**Assistant:** hi");
+    });
+
+    it("export text produces clean dialog", async () => {
+        const session = new ChatSession("test-12");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "assistant", content: "hi" });
+
+        const text = await session.export("text");
+        expect(text).toBe("You: hello\nAI: hi");
+    });
+});

--- a/src/ask/lib/__tests__/ChatSessionManager.test.ts
+++ b/src/ask/lib/__tests__/ChatSessionManager.test.ts
@@ -93,4 +93,15 @@ describe("ChatSessionManager", () => {
     it("exists() returns false for non-existent session", async () => {
         expect(await manager.exists("ghost")).toBe(false);
     });
+
+    it("rejects session IDs with path traversal characters", () => {
+        expect(() => manager.create("../etc/passwd")).toThrow("Invalid session ID");
+        expect(() => manager.create("foo/bar")).toThrow("Invalid session ID");
+        expect(() => manager.create("foo bar")).toThrow("Invalid session ID");
+    });
+
+    it("accepts valid session IDs with hyphens and underscores", () => {
+        const session = manager.create("my-session_123");
+        expect(session.id).toBe("my-session_123");
+    });
 });

--- a/src/ask/lib/__tests__/ChatSessionManager.test.ts
+++ b/src/ask/lib/__tests__/ChatSessionManager.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ChatSessionManager } from "../ChatSessionManager";
+
+describe("ChatSessionManager", () => {
+    let tempDir: string;
+    let manager: ChatSessionManager;
+
+    beforeEach(() => {
+        tempDir = mkdtempSync(join(tmpdir(), "ai-chat-test-"));
+        manager = new ChatSessionManager({ dir: tempDir });
+    });
+
+    afterEach(() => {
+        rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("create() returns a session with generated UUID", () => {
+        const session = manager.create();
+        expect(session.id).toBeTruthy();
+        expect(session.id.length).toBeGreaterThan(10); // UUID format
+        expect(session.length).toBe(0);
+    });
+
+    it("create(id) uses provided ID", () => {
+        const session = manager.create("my-session");
+        expect(session.id).toBe("my-session");
+    });
+
+    it("save and load roundtrip preserves entries", async () => {
+        const session = manager.create("roundtrip-test");
+        session.add({ role: "user", content: "hello" });
+        session.add({ role: "assistant", content: "hi there!" });
+        await manager.save(session);
+
+        const loaded = await manager.load("roundtrip-test");
+        expect(loaded.length).toBe(2);
+        const entries = loaded.getAllEntries();
+        expect(entries[0].type).toBe("user");
+
+        if (entries[0].type === "user") {
+            expect(entries[0].content).toBe("hello");
+        }
+
+        if (entries[1].type === "assistant") {
+            expect(entries[1].content).toBe("hi there!");
+        }
+    });
+
+    it("session.save() works through manager reference", async () => {
+        const session = manager.create("delegate-test");
+        session.add({ role: "user", content: "test" });
+        await session.save(); // should delegate to manager
+
+        const loaded = await manager.load("delegate-test");
+        expect(loaded.length).toBe(1);
+    });
+
+    it("load non-existent session throws", async () => {
+        expect(manager.load("non-existent")).rejects.toThrow("Session not found");
+    });
+
+    it("list() returns sessions sorted by last activity", async () => {
+        const s1 = manager.create("session-a");
+        s1.add({ role: "user", content: "first" });
+        await manager.save(s1);
+
+        // Small delay to ensure different timestamps
+        await new Promise((r) => setTimeout(r, 10));
+
+        const s2 = manager.create("session-b");
+        s2.add({ role: "user", content: "second" });
+        await manager.save(s2);
+
+        const list = await manager.list();
+        expect(list).toHaveLength(2);
+        expect(list[0].id).toBe("session-b"); // most recent first
+        expect(list[1].id).toBe("session-a");
+    });
+
+    it("delete() removes the session file", async () => {
+        const session = manager.create("delete-me");
+        session.add({ role: "user", content: "temp" });
+        await manager.save(session);
+
+        expect(await manager.exists("delete-me")).toBe(true);
+        await manager.delete("delete-me");
+        expect(await manager.exists("delete-me")).toBe(false);
+    });
+
+    it("exists() returns false for non-existent session", async () => {
+        expect(await manager.exists("ghost")).toBe(false);
+    });
+});

--- a/src/ask/lib/__tests__/ChatTurn.test.ts
+++ b/src/ask/lib/__tests__/ChatTurn.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "bun:test";
+import { ChatEvent } from "../ChatEvent";
+import { ChatTurn } from "../ChatTurn";
+import type { ChatResponse } from "../types";
+
+function createMockSource(events: ChatEvent[]): () => AsyncGenerator<ChatEvent> {
+    return async function* () {
+        for (const event of events) {
+            yield event;
+        }
+    };
+}
+
+describe("ChatTurn", () => {
+    const mockResponse: ChatResponse = {
+        content: "Hello there!",
+        duration: 150,
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        cost: 0.001,
+    };
+
+    const mockEvents = [
+        ChatEvent.text("Hello "),
+        ChatEvent.text("there!"),
+        ChatEvent.done(mockResponse),
+    ];
+
+    it("await resolves with ChatResponse", async () => {
+        const turn = new ChatTurn(createMockSource(mockEvents));
+        const response = await turn;
+        expect(response.content).toBe("Hello there!");
+        expect(response.duration).toBe(150);
+        expect(response.cost).toBe(0.001);
+    });
+
+    it("for-await yields ChatEvent instances", async () => {
+        const turn = new ChatTurn(createMockSource(mockEvents));
+        const collected: ChatEvent[] = [];
+
+        for await (const event of turn) {
+            collected.push(event);
+        }
+
+        expect(collected).toHaveLength(3);
+        expect(collected[0].isText()).toBe(true);
+        expect(collected[0].text).toBe("Hello ");
+        expect(collected[1].text).toBe("there!");
+        expect(collected[2].isDone()).toBe(true);
+    });
+
+    it(".response resolves after stream completes", async () => {
+        const turn = new ChatTurn(createMockSource(mockEvents));
+
+        // Consume the stream
+        for await (const _ of turn) { /* drain */ }
+
+        const response = await turn.response;
+        expect(response.content).toBe("Hello there!");
+    });
+
+    it("onChunk fires for each text event", async () => {
+        const chunks: string[] = [];
+        const turn = new ChatTurn(createMockSource(mockEvents), (text) => chunks.push(text));
+
+        await turn; // drain via await
+
+        expect(chunks).toEqual(["Hello ", "there!"]);
+    });
+
+    it("onChunk fires during for-await iteration too", async () => {
+        const chunks: string[] = [];
+        const turn = new ChatTurn(createMockSource(mockEvents), (text) => chunks.push(text));
+
+        for await (const _ of turn) { /* drain */ }
+
+        expect(chunks).toEqual(["Hello ", "there!"]);
+    });
+
+    it("second iteration replays from buffer", async () => {
+        const turn = new ChatTurn(createMockSource(mockEvents));
+
+        // First iteration
+        const first: ChatEvent[] = [];
+        for await (const event of turn) {
+            first.push(event);
+        }
+
+        // Second iteration (replays buffer)
+        const second: ChatEvent[] = [];
+        for await (const event of turn) {
+            second.push(event);
+        }
+
+        expect(first).toHaveLength(3);
+        expect(second).toHaveLength(3);
+        expect(second[0].text).toBe("Hello ");
+    });
+
+    it("handles events with thinking and tool calls", async () => {
+        const events = [
+            ChatEvent.thinking("Let me think..."),
+            ChatEvent.toolCall("search", { query: "test" }),
+            ChatEvent.toolResult("search", { results: [] }, 100),
+            ChatEvent.text("Based on my search: "),
+            ChatEvent.text("nothing found."),
+            ChatEvent.done({ content: "Based on my search: nothing found.", duration: 300 }),
+        ];
+
+        const turn = new ChatTurn(createMockSource(events));
+        const collected: ChatEvent[] = [];
+
+        for await (const event of turn) {
+            collected.push(event);
+        }
+
+        expect(collected).toHaveLength(6);
+        expect(collected[0].isThinking()).toBe(true);
+        expect(collected[1].isToolCall()).toBe(true);
+        expect(collected[2].isToolResult()).toBe(true);
+        expect(collected[3].isText()).toBe(true);
+    });
+
+    it("fallback response when no done event", async () => {
+        const events = [
+            ChatEvent.text("partial "),
+            ChatEvent.text("response"),
+        ];
+
+        const turn = new ChatTurn(createMockSource(events));
+        const response = await turn;
+
+        expect(response.content).toBe("partial response");
+        expect(response.duration).toBe(0);
+    });
+});

--- a/src/ask/lib/types.ts
+++ b/src/ask/lib/types.ts
@@ -1,0 +1,123 @@
+import type { LanguageModelUsage } from "ai";
+
+// Re-export relevant existing types
+export type { ProviderChoice, DetectedProvider, ModelInfo } from "@ask/types";
+
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug" | "trace";
+
+export interface AIChatOptions {
+    provider: string;
+    model: string;
+    systemPrompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+    tools?: Record<string, AIChatTool>;
+    logLevel?: LogLevel;
+    session?: {
+        dir?: string;
+        id?: string;
+        autoSave?: boolean;
+    };
+    resume?: string;
+}
+
+export interface AIChatTool {
+    description: string;
+    parameters: unknown; // ZodSchema or JSON schema object
+    execute: (params: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface SendOptions {
+    onChunk?: (text: string) => void;
+    override?: Partial<Omit<AIChatOptions, "session" | "resume">>;
+    addToHistory?: boolean;
+    saveThinking?: boolean;
+}
+
+export interface ChatResponse {
+    content: string;
+    thinking?: string;
+    usage?: {
+        inputTokens: number;
+        outputTokens: number;
+        totalTokens: number;
+        cachedInputTokens?: number;
+    };
+    cost?: number;
+    duration: number;
+    toolCalls?: ToolCallResult[];
+}
+
+export interface ToolCallResult {
+    name: string;
+    input: unknown;
+    output: unknown;
+    duration: number;
+}
+
+export type SessionEntry =
+    | SessionConfigEntry
+    | SessionUserEntry
+    | SessionAssistantEntry
+    | SessionSystemEntry
+    | SessionContextEntry;
+
+export interface SessionConfigEntry {
+    type: "config";
+    timestamp: string;
+    provider: string;
+    model: string;
+    systemPrompt?: string;
+}
+
+export interface SessionUserEntry {
+    type: "user";
+    content: string;
+    timestamp: string;
+    metadata?: Record<string, unknown>;
+}
+
+export interface SessionAssistantEntry {
+    type: "assistant";
+    content: string;
+    thinking?: string;
+    timestamp: string;
+    usage?: LanguageModelUsage;
+    cost?: number;
+    toolCalls?: ToolCallResult[];
+}
+
+export interface SessionSystemEntry {
+    type: "system";
+    content: string;
+    timestamp: string;
+}
+
+export interface SessionContextEntry {
+    type: "context";
+    content: string;
+    timestamp: string;
+    label?: string;
+    metadata?: Record<string, unknown>;
+}
+
+export interface AIChatSelection {
+    provider: string;
+    model: string;
+}
+
+export interface LogEntry {
+    level: LogLevel;
+    message: string;
+    timestamp: Date;
+    source?: string;
+}
+
+export interface SessionStats {
+    messageCount: number;
+    tokenCount: number;
+    cost: number;
+    duration: number;
+    startedAt: string;
+    byRole: Record<string, number>;
+}

--- a/src/telegram/lib/actions/ask.ts
+++ b/src/telegram/lib/actions/ask.ts
@@ -1,14 +1,35 @@
-import { runTool } from "@app/utils/cli/tools";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { AIChat } from "@ask/AIChat";
 import type { ActionHandler } from "../types";
-import { DEFAULTS } from "../types";
+
+/** Cache of AIChat instances per contact */
+const contactChats = new Map<string, AIChat>();
 
 export const handleAsk: ActionHandler = async (message, contact, client, conversationHistory) => {
     const start = performance.now();
     const typing = client.startTypingLoop(contact.userId);
 
     try {
-        const systemPrompt = contact.askSystemPrompt;
+        // Get or create AIChat instance for this contact
+        let chat = contactChats.get(contact.userId);
 
+        if (!chat) {
+            chat = new AIChat({
+                provider: contact.askProvider,
+                model: contact.askModel,
+                systemPrompt: contact.askSystemPrompt,
+                logLevel: "silent",
+                session: {
+                    id: `telegram-${contact.userId}`,
+                    dir: resolve(homedir(), ".genesis-tools/telegram/ai-sessions"),
+                    autoSave: true,
+                },
+            });
+            contactChats.set(contact.userId, chat);
+        }
+
+        // Build prompt with conversation history context
         let promptText: string;
 
         if (conversationHistory) {
@@ -19,42 +40,27 @@ export const handleAsk: ActionHandler = async (message, contact, client, convers
             promptText = message.contentForLLM;
         }
 
-        const result = await runTool(
-            [
-                "ask",
-                "-p",
-                contact.askProvider,
-                "-m",
-                contact.askModel,
-                "--system-prompt",
-                systemPrompt,
-                "--no-streaming",
-                "--raw",
-                "--",
-                promptText,
-            ],
-            { timeout: DEFAULTS.askTimeoutMs }
-        );
+        const response = await chat.send(promptText);
 
         typing.stop();
 
-        if (!result.success || !result.stdout) {
+        if (!response.content) {
             return {
                 action: "ask",
                 success: false,
                 duration: performance.now() - start,
-                error: result.stderr || "Empty LLM response",
+                error: "Empty LLM response",
             };
         }
 
         await Bun.sleep(contact.randomDelay);
 
-        await client.sendMessage(contact.userId, result.stdout);
+        await client.sendMessage(contact.userId, response.content);
 
         return {
             action: "ask",
             success: true,
-            reply: result.stdout,
+            reply: response.content,
             duration: performance.now() - start,
         };
     } catch (err) {


### PR DESCRIPTION
## Summary

- Extracts the ask tool's core into `AIChat` — a programmatic, provider-agnostic LLM chat class
- **Fixes telegram stdout leakage** by replacing subprocess `runTool()` with in-process `AIChat({ logLevel: "silent" })`
- CLI single-message mode refactored to use AIChat (eliminates `process.stdout.write` monkey-patch hack)

## New Components

| File | Purpose |
|------|---------|
| `src/ask/AIChat.ts` | Main class — constructor, `send()`, `stream()`, static discovery methods |
| `src/ask/lib/types.ts` | All AIChat interfaces (`AIChatOptions`, `SendOptions`, `ChatResponse`, `SessionEntry`, etc.) |
| `src/ask/lib/ChatEvent.ts` | Single event class with type guards (`.isText()`, `.isDone()`, etc.) and factories |
| `src/ask/lib/ChatTurn.ts` | Dual `PromiseLike<ChatResponse>` + `AsyncIterable<ChatEvent>` — await or stream |
| `src/ask/lib/ChatLog.ts` | In-memory log capture with cursor-based `getUnseen()` — never writes to stdout |
| `src/ask/lib/ChatSession.ts` | Session data class with `add()`, `getHistory()`, `toMessages()`, filtering, export |
| `src/ask/lib/ChatSessionManager.ts` | JSONL persistence — `create()`, `save()`, `load()`, `list()`, `delete()` |
| `src/ask/index.lib.ts` | Barrel export for programmatic use |

## Usage

```typescript
// Programmatic (telegram, scripts)
const chat = new AIChat({ provider: "openai", model: "gpt-4o-mini", logLevel: "silent" });
const response = await chat.send("Hello!");

// Streaming
for await (const event of chat.send("Tell me a story")) {
  if (event.isText()) process.stdout.write(event.text);
  if (event.isDone()) console.log(`Cost: $${event.response.cost}`);
}

// With session persistence
const chat = new AIChat({
  provider: "anthropic", model: "claude-sonnet-4-6",
  session: { id: "my-session", autoSave: true },
});
```

## Test plan

- [x] 40 unit tests pass across 5 test files (ChatEvent, ChatLog, ChatSession, ChatSessionManager, ChatTurn)
- [x] Type-check passes with no new errors
- [ ] Manual: `tools ask -p openai -m gpt-4o-mini --raw "hello"` — only response on stdout
- [ ] Manual: `tools telegram listen` — verify no log leakage in responses