### PR TITLE
feat(timelog): update Remaining/Completed Work after logging time

### DIFF
--- a/src/azure-devops/commands/timelog/add.ts
+++ b/src/azure-devops/commands/timelog/add.ts
@@ -1,5 +1,7 @@
+import { Api } from "@app/azure-devops/api";
 import { AzureDevOpsCacheManager } from "@app/azure-devops/cache-manager";
 import { convertToMinutes, formatMinutes, getTodayDate, TimeLogApi } from "@app/azure-devops/timelog-api";
+import { updateWorkItemEffort } from "@app/azure-devops/timelog-effort";
 import { runInteractiveAddClack } from "@app/azure-devops/timelog-prompts-clack";
 import { runInteractiveAddInquirer } from "@app/azure-devops/timelog-prompts-inquirer";
 import type { AllowedTypeConfig, AzureConfigWithTimeLog, TimeLogUser } from "@app/azure-devops/types";
@@ -201,6 +203,14 @@ ${types.map((t) => `  - ${t.description}`).join("\n")}
                 }
 
                 console.log(`  Entry ID: ${ids[0]}`);
+
+                // Update Remaining/Completed Work on the work item
+                const devopsApi = new Api(config);
+                const effort = await updateWorkItemEffort(devopsApi, effectiveWorkItemId, totalMinutes);
+
+                if (effort) {
+                    console.log(`  Remaining: ${effort.remaining}h | Completed: ${effort.completed}h`);
+                }
 
                 // Evict timelog cache for affected work item
                 const cacheManager = new AzureDevOpsCacheManager();

--- a/src/azure-devops/timelog-effort.ts
+++ b/src/azure-devops/timelog-effort.ts
@@ -1,0 +1,67 @@
+import { Api } from "@app/azure-devops/api";
+import type { JsonPatchOperation } from "@app/azure-devops/types";
+import logger from "@app/logger";
+import pc from "picocolors";
+
+const REMAINING_FIELD = "Microsoft.VSTS.Scheduling.RemainingWork";
+const COMPLETED_FIELD = "Microsoft.VSTS.Scheduling.CompletedWork";
+
+interface EffortResult {
+    remaining: number;
+    completed: number;
+}
+
+/**
+ * After logging time, update the work item's Remaining Work and Completed Work fields.
+ * Remaining is decremented, Completed is incremented by the logged hours.
+ *
+ * Returns the new values, or null if the update failed (non-fatal).
+ */
+export async function updateWorkItemEffort(
+    api: Api,
+    workItemId: number,
+    loggedMinutes: number
+): Promise<EffortResult | null> {
+    try {
+        const loggedHours = loggedMinutes / 60;
+        const workItem = await api.getWorkItem(workItemId);
+        const fields = workItem.rawFields;
+
+        if (!fields) {
+            logger.debug(`[effort] Work item #${workItemId} has no rawFields, skipping effort update`);
+            return null;
+        }
+
+        const currentRemaining = fields[REMAINING_FIELD] as number | null | undefined;
+        const currentCompleted = fields[COMPLETED_FIELD] as number | null | undefined;
+
+        const newCompleted = (currentCompleted ?? 0) + loggedHours;
+        const newRemaining = Math.max(0, (currentRemaining ?? 0) - loggedHours);
+
+        const operations: JsonPatchOperation[] = [
+            {
+                op: currentRemaining != null ? "replace" : "add",
+                path: `/fields/${REMAINING_FIELD}`,
+                value: newRemaining,
+            },
+            {
+                op: currentCompleted != null ? "replace" : "add",
+                path: `/fields/${COMPLETED_FIELD}`,
+                value: newCompleted,
+            },
+        ];
+
+        await api.updateWorkItem(workItemId, operations);
+
+        logger.debug(
+            `[effort] Updated #${workItemId}: Remaining ${currentRemaining ?? 0} → ${newRemaining}, Completed ${currentCompleted ?? 0} → ${newCompleted}`
+        );
+
+        return { remaining: newRemaining, completed: newCompleted };
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[effort] Failed to update effort for #${workItemId}: ${msg}`);
+        console.warn(pc.yellow(`  ⚠ Could not update Remaining/Completed Work for #${workItemId}: ${msg}`));
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- After creating a timelog entry (via `add`, `import`, or interactive mode), the CLI now updates the work item's **Remaining Work** (decremented) and **Completed Work** (incremented) fields
- Adds `Api.updateWorkItem()` method (PATCH) and `updateWorkItemEffort()` utility
- For bulk import, minutes are aggregated per work item to avoid stale data — single fetch+update per unique work item after all entries are created
- Effort update failures are non-fatal (warning only, timelog entry is already saved)

## Test plan

- [ ] `timelog add -w <task-id> -h 0 -m 15 -t "Development"` — verify Remaining decreases by 0.25h, Completed increases by 0.25h
- [ ] `timelog import <file>` with multiple entries for same work item — verify single aggregated update
- [ ] Confirm fields in Azure DevOps web UI match
- [ ] Test with work item that has null Remaining/Completed — should initialize them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic effort updates: Work item remaining and completed hours are now automatically updated when time is logged. This enhancement applies to both individual time entry additions and bulk time log imports, eliminating the need for manual effort field updates and improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->