### PR TITLE
feat(living-docs): add parallel dispatch docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.12",
+            "version": "1.0.13",
             "author": {
                 "name": "GenesisTools"
             },

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"


### PR DESCRIPTION
## Summary
- Add documentation for using living-docs as a `subagent_type` for parallel Task dispatch
- Cover prompt requirements, examples, and anti-patterns
- Bump plugin version to 1.0.13

## Test plan
- [ ] Verify SKILL.md renders correctly on GitHub
- [ ] Confirm parallel dispatch section is accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for Parallel Dispatch functionality, describing how to dispatch work across subagents for bootstrapping, bulk validation, and multi-source analysis, including best practices and implementation guidance.

* **Chores**
  * Version updated to 1.0.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->