### PR TITLE
fix(migrate): overhaul migrate-to-codex scope, namespacing and plugin handling

### DIFF
--- a/src/claude/commands/migrate.ts
+++ b/src/claude/commands/migrate.ts
@@ -427,7 +427,8 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of projectSkills) {
-            lines.push(`- ${item.path}`);
+            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
+            lines.push(`- ${item.path}${tag}`);
         }
     }
 
@@ -438,7 +439,8 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of globalSkills) {
-            lines.push(`- ${item.path}`);
+            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
+            lines.push(`- ${item.path}${tag}`);
         }
     }
 
@@ -449,7 +451,8 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of projectCommands) {
-            lines.push(`- ${item.path}`);
+            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
+            lines.push(`- ${item.path}${tag}`);
         }
     }
 
@@ -460,7 +463,8 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of globalCommands) {
-            lines.push(`- ${item.path}`);
+            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
+            lines.push(`- ${item.path}${tag}`);
         }
     }
 

--- a/src/claude/commands/migrate.ts
+++ b/src/claude/commands/migrate.ts
@@ -416,6 +416,11 @@ async function runWizard(
     return null;
 }
 
+function formatDiscoveredItem(item: { path: string; origin: string; pluginName?: string }): string {
+    const tag = item.origin === "plugin" && item.pluginName ? ` [plugin: ${item.pluginName}]` : "";
+    return `- ${item.path}${tag}`;
+}
+
 function renderDiscoveryList(discovered: DiscoveredSources): void {
     const lines: string[] = [];
     lines.push(summarizeDiscovery(discovered));
@@ -427,8 +432,7 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of projectSkills) {
-            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
-            lines.push(`- ${item.path}${tag}`);
+            lines.push(formatDiscoveredItem(item));
         }
     }
 
@@ -439,8 +443,7 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of globalSkills) {
-            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
-            lines.push(`- ${item.path}${tag}`);
+            lines.push(formatDiscoveredItem(item));
         }
     }
 
@@ -451,8 +454,7 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of projectCommands) {
-            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
-            lines.push(`- ${item.path}${tag}`);
+            lines.push(formatDiscoveredItem(item));
         }
     }
 
@@ -463,8 +465,7 @@ function renderDiscoveryList(discovered: DiscoveredSources): void {
         lines.push("- (none)");
     } else {
         for (const item of globalCommands) {
-            const tag = item.origin === "plugin" ? ` [plugin: ${item.pluginName}]` : "";
-            lines.push(`- ${item.path}${tag}`);
+            lines.push(formatDiscoveredItem(item));
         }
     }
 


### PR DESCRIPTION
## Summary

- **Namespace collision**: Commands from the same plugin now share one namespace folder instead of getting `genesis-tools`, `genesis-tools-2`, `genesis-tools-3`
- **Plugin directory symlinks**: Plugin skills and commands are symlinked as whole directories (`genesis-tools/`) instead of individual entries
- **Scope matching**: Project-scoped sources skip global targets and vice versa; global CLAUDE.md no longer lands in project AGENTS.md
- **Out-of-repo guard**: Project-scope targets skip sources outside the repo (prevents git "illegal operation on directory")
- **Skip symlinked sources**: Already-symlinked entries in `.claude/skills/` and `.claude/commands/` are skipped during discovery
- **Full preview**: Plan preview shows all operations instead of truncating at 8
- **Plugin tags**: `--list` output now shows `[plugin: name]` on discovered assets

## Test plan

- [ ] Run `tools claude migrate-to codex --list` and verify plugin assets show `[plugin: genesis-tools]`
- [ ] Run migration with `--source both --target global` — verify plugin skills/commands are single directory symlinks
- [ ] Run migration twice — verify idempotent (all "Already linked")
- [ ] Run with `--source both --target project` — verify out-of-repo sources are skipped
- [ ] Verify no `project-claude` or `genesis-tools-2/3` folders created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Plugin source tags now display in discovery lists, clearly indicating where each skill and command originates
* Enhanced plugin directory handling with improved symlink detection and management
* Better organization of project and global scoped resources with improved collision handling for duplicate names
* Optimized discovery process with enhanced namespace management for plugin-aware resource organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->