### PR TITLE
feat(daemon): general-purpose background task scheduler

### DIFF
--- a/src/daemon/commands/config.ts
+++ b/src/daemon/commands/config.ts
@@ -1,0 +1,81 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { loadConfig, removeTask, setTaskEnabled, upsertTask } from "../lib/config";
+import { formatInterval } from "../lib/interval";
+import { runTaskEditor } from "../interactive/task-editor";
+
+export function registerConfigCommand(program: Command): void {
+    const config = program.command("config").description("Manage daemon tasks");
+
+    config
+        .command("list")
+        .description("List all configured tasks")
+        .action(async () => {
+            const cfg = await loadConfig();
+
+            if (cfg.tasks.length === 0) {
+                p.log.info("No tasks configured.");
+                return;
+            }
+
+            for (const task of cfg.tasks) {
+                const state = task.enabled ? pc.green("enabled") : pc.dim("disabled");
+                const retries = task.retries > 0 ? pc.dim(` retries:${task.retries}`) : "";
+                p.log.step(
+                    `${pc.bold(task.name)} [${state}] ${pc.dim(formatInterval(task.every))}${retries}\n  ${pc.cyan(task.command)}${task.description ? `\n  ${pc.dim(task.description)}` : ""}`
+                );
+            }
+        });
+
+    config
+        .command("add")
+        .description("Add a new task interactively")
+        .action(async () => {
+            const task = await runTaskEditor();
+
+            if (!task) {
+                return;
+            }
+
+            await upsertTask(task);
+            p.log.success(`Task "${task.name}" created`);
+        });
+
+    config
+        .command("remove <name>")
+        .description("Remove a task")
+        .action(async (name: string) => {
+            const removed = await removeTask(name);
+
+            if (removed) {
+                p.log.success(`Task "${name}" removed`);
+            } else {
+                p.log.warn(`Task "${name}" not found`);
+            }
+        });
+
+    config
+        .command("enable <name>")
+        .description("Enable a task")
+        .action(async (name: string) => {
+            try {
+                await setTaskEnabled(name, true);
+                p.log.success(`Task "${name}" enabled`);
+            } catch (err) {
+                p.log.error(err instanceof Error ? err.message : String(err));
+            }
+        });
+
+    config
+        .command("disable <name>")
+        .description("Disable a task")
+        .action(async (name: string) => {
+            try {
+                await setTaskEnabled(name, false);
+                p.log.success(`Task "${name}" disabled`);
+            } catch (err) {
+                p.log.error(err instanceof Error ? err.message : String(err));
+            }
+        });
+}

--- a/src/daemon/commands/config.ts
+++ b/src/daemon/commands/config.ts
@@ -1,9 +1,9 @@
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
+import { runTaskEditor } from "../interactive/task-editor";
 import { loadConfig, removeTask, setTaskEnabled, upsertTask } from "../lib/config";
 import { formatInterval } from "../lib/interval";
-import { runTaskEditor } from "../interactive/task-editor";
 
 export function registerConfigCommand(program: Command): void {
     const config = program.command("config").description("Manage daemon tasks");

--- a/src/daemon/commands/install.ts
+++ b/src/daemon/commands/install.ts
@@ -1,0 +1,32 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import { getDaemonStatus, installLaunchd, uninstallLaunchd } from "../lib/launchd";
+
+export function registerInstallCommand(program: Command): void {
+    program
+        .command("install")
+        .description("Install macOS launchd plist (auto-start on login)")
+        .action(async () => {
+            try {
+                await installLaunchd();
+                p.log.success("Daemon installed via launchd (starts on login)");
+            } catch (err) {
+                p.log.error(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        });
+
+    program
+        .command("uninstall")
+        .description("Remove macOS launchd plist")
+        .action(async () => {
+            const status = await getDaemonStatus();
+
+            if (!status.installed) {
+                p.log.info("Daemon is not installed.");
+                return;
+            }
+
+            await uninstallLaunchd();
+            p.log.success("Daemon uninstalled from launchd");
+        });
+}

--- a/src/daemon/commands/logs.ts
+++ b/src/daemon/commands/logs.ts
@@ -2,10 +2,10 @@ import { existsSync } from "node:fs";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
+import { runLogViewer } from "../interactive/log-viewer";
 import { getLogsBaseDir } from "../lib/config";
 import { DAEMON_STDERR_LOG, DAEMON_STDOUT_LOG } from "../lib/launchd";
 import { listRunsForTask, parseLogFile } from "../lib/log-reader";
-import { runLogViewer } from "../interactive/log-viewer";
 
 export function registerLogsCommand(program: Command): void {
     program

--- a/src/daemon/commands/logs.ts
+++ b/src/daemon/commands/logs.ts
@@ -1,0 +1,109 @@
+import { existsSync } from "node:fs";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { getLogsBaseDir } from "../lib/config";
+import { DAEMON_STDERR_LOG, DAEMON_STDOUT_LOG } from "../lib/launchd";
+import { listRunsForTask, parseLogFile } from "../lib/log-reader";
+import { runLogViewer } from "../interactive/log-viewer";
+
+export function registerLogsCommand(program: Command): void {
+    program
+        .command("logs")
+        .description("View task logs")
+        .option("-t, --task <name>", "Show logs for a specific task")
+        .option("--tail", "Tail daemon stdout/stderr logs")
+        .action(async (opts: { task?: string; tail?: boolean }) => {
+            if (opts.tail) {
+                tailDaemonLogs();
+                return;
+            }
+
+            if (opts.task) {
+                showTaskLogs(opts.task);
+                return;
+            }
+
+            await runLogViewer();
+        });
+}
+
+function showTaskLogs(taskName: string): void {
+    const logsBaseDir = getLogsBaseDir();
+    const runs = listRunsForTask(logsBaseDir, taskName);
+
+    if (runs.length === 0) {
+        p.log.info(`No logs found for task "${taskName}".`);
+        return;
+    }
+
+    const latest = runs[0];
+    const entries = parseLogFile(latest.logFile);
+
+    for (const entry of entries) {
+        switch (entry.type) {
+            case "meta":
+                p.log.info(
+                    `${pc.bold(entry.taskName)}  cmd: ${pc.cyan(entry.command)}  attempt: ${entry.attempt}  run: ${entry.runId}`
+                );
+                break;
+            case "stdout":
+                console.log(entry.data);
+                break;
+            case "stderr":
+                console.log(pc.yellow(entry.data));
+                break;
+            case "exit": {
+                const color = entry.code === 0 ? pc.green : pc.red;
+                console.log(color(`[exit ${entry.code ?? "killed"} in ${formatDuration(entry.duration_ms)}]`));
+                break;
+            }
+        }
+    }
+}
+
+function tailDaemonLogs(): void {
+    const files: string[] = [];
+
+    if (existsSync(DAEMON_STDOUT_LOG)) {
+        files.push(DAEMON_STDOUT_LOG);
+    }
+
+    if (existsSync(DAEMON_STDERR_LOG)) {
+        files.push(DAEMON_STDERR_LOG);
+    }
+
+    if (files.length === 0) {
+        p.log.warn("No daemon logs found. Is the daemon installed?");
+        return;
+    }
+
+    p.log.info(`Tailing: ${pc.dim(files.join(", "))}`);
+    p.log.info(pc.dim("Press Ctrl+C to stop"));
+
+    const proc = Bun.spawn(["tail", "-f", ...files], {
+        stdio: ["ignore", "inherit", "inherit"],
+    });
+
+    const cleanup = () => {
+        proc.kill();
+        process.exit(0);
+    };
+
+    process.on("SIGINT", cleanup);
+    process.on("SIGTERM", cleanup);
+
+    proc.exited.then(() => process.exit(0));
+}
+
+function formatDuration(ms: number): string {
+    if (ms < 1000) {
+        return `${ms}ms`;
+    }
+
+    if (ms < 60_000) {
+        return `${(ms / 1000).toFixed(1)}s`;
+    }
+
+    return `${(ms / 60_000).toFixed(1)}m`;
+}

--- a/src/daemon/commands/start.ts
+++ b/src/daemon/commands/start.ts
@@ -1,0 +1,20 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import { getDaemonPid, startDaemon } from "../daemon";
+
+export function registerStartCommand(program: Command): void {
+    program
+        .command("start")
+        .description("Run the daemon in foreground")
+        .action(async () => {
+            const existing = getDaemonPid();
+
+            if (existing) {
+                p.log.info(`Daemon already running (PID ${existing})`);
+                return;
+            }
+
+            p.log.info("Starting daemon in foreground... (Ctrl+C to stop)");
+            await startDaemon();
+        });
+}

--- a/src/daemon/commands/start.ts
+++ b/src/daemon/commands/start.ts
@@ -1,6 +1,8 @@
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
+import pc from "picocolors";
 import { getDaemonPid, startDaemon } from "../daemon";
+import { getDaemonStatus } from "../lib/launchd";
 
 export function registerStartCommand(program: Command): void {
     program
@@ -11,6 +13,15 @@ export function registerStartCommand(program: Command): void {
 
             if (existing) {
                 p.log.info(`Daemon already running (PID ${existing})`);
+                return;
+            }
+
+            const status = await getDaemonStatus();
+
+            if (status.running) {
+                p.log.warn(
+                    `Daemon is already running via launchd (PID ${status.pid}). Use ${pc.cyan("tools daemon uninstall")} first to avoid duplicate execution.`
+                );
                 return;
             }
 

--- a/src/daemon/commands/status.ts
+++ b/src/daemon/commands/status.ts
@@ -1,0 +1,44 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { loadConfig } from "../lib/config";
+import { formatInterval } from "../lib/interval";
+import { getDaemonStatus } from "../lib/launchd";
+import { getDaemonPid } from "../daemon";
+
+export function registerStatusCommand(program: Command): void {
+    program
+        .command("status")
+        .description("Show daemon and task status")
+        .action(async () => {
+            const status = await getDaemonStatus();
+            const fgPid = getDaemonPid();
+
+            if (status.running) {
+                p.log.success(`Daemon running (launchd, PID ${status.pid})`);
+            } else if (fgPid) {
+                p.log.success(`Daemon running (foreground, PID ${fgPid})`);
+            } else if (status.installed) {
+                p.log.warn("Daemon installed but not running");
+            } else {
+                p.log.info("Daemon not running. Run: tools daemon install");
+            }
+
+            const config = await loadConfig();
+
+            if (config.tasks.length === 0) {
+                p.log.info("No tasks configured.");
+                return;
+            }
+
+            console.log("");
+
+            for (const task of config.tasks) {
+                const state = task.enabled ? pc.green("enabled") : pc.dim("disabled");
+                const retries = task.retries > 0 ? pc.dim(` retries:${task.retries}`) : "";
+                p.log.step(
+                    `${pc.bold(task.name)} [${state}] ${pc.dim(formatInterval(task.every))}${retries}\n  ${pc.cyan(task.command)}`
+                );
+            }
+        });
+}

--- a/src/daemon/commands/status.ts
+++ b/src/daemon/commands/status.ts
@@ -1,10 +1,10 @@
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
+import { getDaemonPid } from "../daemon";
 import { loadConfig } from "../lib/config";
 import { formatInterval } from "../lib/interval";
 import { getDaemonStatus } from "../lib/launchd";
-import { getDaemonPid } from "../daemon";
 
 export function registerStatusCommand(program: Command): void {
     program

--- a/src/daemon/commands/stop.ts
+++ b/src/daemon/commands/stop.ts
@@ -1,0 +1,42 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { getDaemonPid } from "../daemon";
+import { getDaemonStatus, uninstallLaunchd } from "../lib/launchd";
+
+export function registerStopCommand(program: Command): void {
+    program
+        .command("stop")
+        .description("Stop the running daemon")
+        .action(async () => {
+            const pid = getDaemonPid();
+
+            if (!pid) {
+                p.log.info("Daemon is not running.");
+                return;
+            }
+
+            const status = await getDaemonStatus();
+
+            if (status.installed && status.running) {
+                p.log.warn(
+                    `Daemon is managed by launchd (KeepAlive). Use ${pc.cyan("tools daemon uninstall")} to fully stop it.`
+                );
+
+                const confirm = await p.confirm({
+                    message: "Uninstall from launchd and stop?",
+                });
+
+                if (p.isCancel(confirm) || !confirm) {
+                    return;
+                }
+
+                await uninstallLaunchd();
+                p.log.success("Daemon uninstalled from launchd and stopped");
+                return;
+            }
+
+            process.kill(pid, "SIGTERM");
+            p.log.success(`Sent SIGTERM to daemon (PID ${pid})`);
+        });
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { createLogger } from "@app/logger";
+import { getLogsBaseDir, getPidFile } from "./lib/config";
+import { runSchedulerLoop } from "./lib/scheduler";
+
+const log = createLogger({ logToFile: false });
+
+export async function startDaemon(): Promise<void> {
+    const pidFile = getPidFile();
+    writeFileSync(pidFile, String(process.pid));
+    log.info({ pid: process.pid }, "Daemon starting");
+
+    const cleanup = () => {
+        if (existsSync(pidFile)) {
+            unlinkSync(pidFile);
+        }
+
+        log.info("Daemon stopped");
+    };
+
+    process.once("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
+
+    try {
+        await runSchedulerLoop(getLogsBaseDir());
+    } catch (err) {
+        log.error({ err }, "Daemon crashed");
+    } finally {
+        process.off("SIGTERM", cleanup);
+        process.off("SIGINT", cleanup);
+        cleanup();
+    }
+}
+
+export function getDaemonPid(): number | null {
+    const pidFile = getPidFile();
+
+    if (!existsSync(pidFile)) {
+        return null;
+    }
+
+    try {
+        const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+
+        try {
+            process.kill(pid, 0);
+            return pid;
+        } catch {
+            return null;
+        }
+    } catch {
+        return null;
+    }
+}
+
+if (import.meta.main) {
+    startDaemon();
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env bun
 
+import { handleReadmeFlag } from "@app/utils/readme";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
-import { handleReadmeFlag } from "@app/utils/readme";
-import { ensureStorage } from "./lib/config";
-import { registerStartCommand } from "./commands/start";
-import { registerStopCommand } from "./commands/stop";
-import { registerStatusCommand } from "./commands/status";
-import { registerInstallCommand } from "./commands/install";
 import { registerConfigCommand } from "./commands/config";
+import { registerInstallCommand } from "./commands/install";
 import { registerLogsCommand } from "./commands/logs";
+import { registerStartCommand } from "./commands/start";
+import { registerStatusCommand } from "./commands/status";
+import { registerStopCommand } from "./commands/stop";
 import { runInteractiveMenu } from "./interactive/menu";
+import { ensureStorage } from "./lib/config";
 
 handleReadmeFlag(import.meta.url);
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+import * as p from "@clack/prompts";
+import { Command } from "commander";
+import pc from "picocolors";
+import { handleReadmeFlag } from "@app/utils/readme";
+import { ensureStorage } from "./lib/config";
+import { registerStartCommand } from "./commands/start";
+import { registerStopCommand } from "./commands/stop";
+import { registerStatusCommand } from "./commands/status";
+import { registerInstallCommand } from "./commands/install";
+import { registerConfigCommand } from "./commands/config";
+import { registerLogsCommand } from "./commands/logs";
+import { runInteractiveMenu } from "./interactive/menu";
+
+handleReadmeFlag(import.meta.url);
+
+const program = new Command();
+
+program
+    .name("daemon")
+    .description("General-purpose background task scheduler daemon")
+    .version("1.0.0")
+    .showHelpAfterError(true);
+
+registerStartCommand(program);
+registerStopCommand(program);
+registerStatusCommand(program);
+registerInstallCommand(program);
+registerConfigCommand(program);
+registerLogsCommand(program);
+
+async function main(): Promise<void> {
+    await ensureStorage();
+
+    if (process.argv.length <= 2) {
+        p.intro(pc.bgCyan(pc.white(" daemon ")));
+        await runInteractiveMenu();
+        return;
+    }
+
+    try {
+        await program.parseAsync(process.argv);
+    } catch (error) {
+        p.log.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+    }
+}
+
+main().catch((err) => {
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+});

--- a/src/daemon/interactive/log-viewer.ts
+++ b/src/daemon/interactive/log-viewer.ts
@@ -16,10 +16,7 @@ export async function runLogViewer(): Promise<void> {
 
         const taskName = await p.select({
             message: "Select task",
-            options: [
-                ...tasks.map((t) => ({ value: t, label: t })),
-                { value: "back", label: pc.dim("← Back") },
-            ],
+            options: [...tasks.map((t) => ({ value: t, label: t })), { value: "back", label: pc.dim("← Back") }],
         });
 
         if (p.isCancel(taskName) || taskName === "back") {
@@ -86,11 +83,7 @@ function showLogContent(logFile: string): void {
                 break;
             case "exit": {
                 const color = entry.code === 0 ? pc.green : pc.red;
-                console.log(
-                    color(
-                        `\n[exit ${entry.code ?? "killed"} in ${formatDuration(entry.duration_ms)}]`
-                    )
-                );
+                console.log(color(`\n[exit ${entry.code ?? "killed"} in ${formatDuration(entry.duration_ms)}]`));
                 break;
             }
         }
@@ -106,8 +99,7 @@ function formatRunLabel(
     attempt: number
 ): string {
     const date = startedAt.replace("T", " ").slice(0, 19);
-    const code =
-        exitCode === null ? pc.dim("?") : exitCode === 0 ? pc.green("0") : pc.red(String(exitCode));
+    const code = exitCode === null ? pc.dim("?") : exitCode === 0 ? pc.green("0") : pc.red(String(exitCode));
     const dur = durationMs !== null ? formatDuration(durationMs) : "?";
     const att = attempt > 1 ? pc.dim(` attempt:${attempt}`) : "";
 

--- a/src/daemon/interactive/log-viewer.ts
+++ b/src/daemon/interactive/log-viewer.ts
@@ -1,0 +1,127 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { getLogsBaseDir } from "../lib/config";
+import { listRunsForTask, listTasksWithLogs, parseLogFile } from "../lib/log-reader";
+
+export async function runLogViewer(): Promise<void> {
+    const logsBaseDir = getLogsBaseDir();
+
+    while (true) {
+        const tasks = listTasksWithLogs(logsBaseDir);
+
+        if (tasks.length === 0) {
+            p.log.info("No task logs found yet.");
+            return;
+        }
+
+        const taskName = await p.select({
+            message: "Select task",
+            options: [
+                ...tasks.map((t) => ({ value: t, label: t })),
+                { value: "back", label: pc.dim("← Back") },
+            ],
+        });
+
+        if (p.isCancel(taskName) || taskName === "back") {
+            break;
+        }
+
+        await showTaskRuns(taskName);
+    }
+}
+
+async function showTaskRuns(taskName: string): Promise<void> {
+    const logsBaseDir = getLogsBaseDir();
+
+    while (true) {
+        const runs = listRunsForTask(logsBaseDir, taskName);
+
+        if (runs.length === 0) {
+            p.log.info(`No runs found for "${taskName}".`);
+            return;
+        }
+
+        const selected = await p.select({
+            message: `Runs for ${pc.bold(taskName)}`,
+            options: [
+                ...runs.slice(0, 50).map((r) => ({
+                    value: r.logFile,
+                    label: formatRunLabel(r.startedAt, r.exitCode, r.duration_ms, r.attempt),
+                })),
+                { value: "back", label: pc.dim("← Back") },
+            ],
+        });
+
+        if (p.isCancel(selected) || selected === "back") {
+            break;
+        }
+
+        showLogContent(selected);
+
+        const cont = await p.confirm({ message: "View another run?" });
+
+        if (p.isCancel(cont) || !cont) {
+            break;
+        }
+    }
+}
+
+function showLogContent(logFile: string): void {
+    const entries = parseLogFile(logFile);
+
+    console.log("");
+
+    for (const entry of entries) {
+        switch (entry.type) {
+            case "meta":
+                p.log.info(
+                    `${pc.bold(entry.taskName)}  cmd: ${pc.cyan(entry.command)}  attempt: ${entry.attempt}  run: ${entry.runId}`
+                );
+                break;
+            case "stdout":
+                console.log(entry.data);
+                break;
+            case "stderr":
+                console.log(pc.yellow(entry.data));
+                break;
+            case "exit": {
+                const color = entry.code === 0 ? pc.green : pc.red;
+                console.log(
+                    color(
+                        `\n[exit ${entry.code ?? "killed"} in ${formatDuration(entry.duration_ms)}]`
+                    )
+                );
+                break;
+            }
+        }
+    }
+
+    console.log("");
+}
+
+function formatRunLabel(
+    startedAt: string,
+    exitCode: number | null,
+    durationMs: number | null,
+    attempt: number
+): string {
+    const date = startedAt.replace("T", " ").slice(0, 19);
+    const code =
+        exitCode === null ? pc.dim("?") : exitCode === 0 ? pc.green("0") : pc.red(String(exitCode));
+    const dur = durationMs !== null ? formatDuration(durationMs) : "?";
+    const att = attempt > 1 ? pc.dim(` attempt:${attempt}`) : "";
+
+    return `${pc.dim(date)}  exit:${code}  ${pc.dim(dur)}${att}`;
+}
+
+function formatDuration(ms: number): string {
+    if (ms < 1000) {
+        return `${ms}ms`;
+    }
+
+    if (ms < 60_000) {
+        return `${(ms / 1000).toFixed(1)}s`;
+    }
+
+    return `${(ms / 60_000).toFixed(1)}m`;
+}

--- a/src/daemon/interactive/menu.ts
+++ b/src/daemon/interactive/menu.ts
@@ -1,0 +1,272 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { loadConfig, removeTask, setTaskEnabled, upsertTask } from "../lib/config";
+import { formatInterval } from "../lib/interval";
+import { getDaemonStatus, installLaunchd, uninstallLaunchd } from "../lib/launchd";
+import { getDaemonPid, startDaemon } from "../daemon";
+import { runLogViewer } from "./log-viewer";
+import { runTaskEditor } from "./task-editor";
+
+export async function runInteractiveMenu(): Promise<void> {
+    while (true) {
+        const action = await p.select({
+            message: "What would you like to do?",
+            options: [
+                { value: "status", label: "Status", hint: "daemon & task status" },
+                { value: "tasks", label: "Tasks", hint: "manage background tasks" },
+                { value: "logs", label: "Logs", hint: "view task run logs" },
+                { value: "start", label: "Start", hint: "run daemon in foreground" },
+                { value: "stop", label: "Stop", hint: "stop running daemon" },
+                { value: "launchd", label: "Launchd", hint: "install/uninstall auto-start" },
+                { value: "quit", label: "Quit" },
+            ],
+        });
+
+        if (p.isCancel(action) || action === "quit") {
+            p.outro(pc.dim("Bye!"));
+            break;
+        }
+
+        switch (action) {
+            case "status":
+                await showStatus();
+                break;
+            case "tasks":
+                await tasksSubmenu();
+                break;
+            case "logs":
+                await runLogViewer();
+                break;
+            case "start":
+                await handleStart();
+                break;
+            case "stop":
+                handleStop();
+                break;
+            case "launchd":
+                await launchdSubmenu();
+                break;
+        }
+
+        console.log("");
+    }
+}
+
+async function showStatus(): Promise<void> {
+    const status = await getDaemonStatus();
+    const fgPid = getDaemonPid();
+    const config = await loadConfig();
+
+    if (status.running) {
+        p.log.success(`Daemon running ${pc.dim(`(launchd, PID ${status.pid})`)}`);
+    } else if (fgPid) {
+        p.log.success(`Daemon running ${pc.dim(`(foreground, PID ${fgPid})`)}`);
+    } else if (status.installed) {
+        p.log.warn("Daemon installed but not running");
+    } else {
+        p.log.info("Daemon not running");
+    }
+
+    const enabled = config.tasks.filter((t) => t.enabled);
+    const disabled = config.tasks.filter((t) => !t.enabled);
+    p.log.info(
+        `Tasks: ${pc.green(String(enabled.length))} enabled, ${pc.dim(String(disabled.length))} disabled`
+    );
+
+    if (enabled.length > 0) {
+        for (const task of enabled) {
+            p.log.step(
+                `  ${pc.bold(task.name)} — ${pc.dim(formatInterval(task.every))} — ${pc.cyan(truncate(task.command, 40))}`
+            );
+        }
+    }
+}
+
+async function tasksSubmenu(): Promise<void> {
+    while (true) {
+        const action = await p.select({
+            message: "Task management",
+            options: [
+                { value: "list", label: "List tasks" },
+                { value: "add", label: "Add task" },
+                { value: "toggle", label: "Enable/Disable" },
+                { value: "delete", label: "Delete task" },
+                { value: "back", label: pc.dim("← Back") },
+            ],
+        });
+
+        if (p.isCancel(action) || action === "back") {
+            break;
+        }
+
+        switch (action) {
+            case "list":
+                await listTasks();
+                break;
+            case "add":
+                await addTask();
+                break;
+            case "toggle":
+                await toggleTask();
+                break;
+            case "delete":
+                await deleteTask();
+                break;
+        }
+    }
+}
+
+async function listTasks(): Promise<void> {
+    const config = await loadConfig();
+
+    if (config.tasks.length === 0) {
+        p.log.info("No tasks configured.");
+        return;
+    }
+
+    for (const task of config.tasks) {
+        const status = task.enabled ? pc.green("enabled") : pc.dim("disabled");
+        const retries = task.retries > 0 ? pc.dim(` retries:${task.retries}`) : "";
+        p.log.step(
+            `${pc.bold(task.name)} [${status}] ${pc.dim(formatInterval(task.every))}${retries}\n  ${pc.cyan(task.command)}${task.description ? `\n  ${pc.dim(task.description)}` : ""}`
+        );
+    }
+}
+
+async function addTask(): Promise<void> {
+    const task = await runTaskEditor();
+
+    if (!task) {
+        return;
+    }
+
+    await upsertTask(task);
+    p.log.success(`Task "${task.name}" created`);
+}
+
+async function toggleTask(): Promise<void> {
+    const config = await loadConfig();
+
+    if (config.tasks.length === 0) {
+        p.log.info("No tasks to toggle.");
+        return;
+    }
+
+    const taskName = await p.select({
+        message: "Select task",
+        options: [
+            ...config.tasks.map((t) => ({
+                value: t.name,
+                label: `${t.name} — ${t.enabled ? pc.green("enabled") : pc.dim("disabled")}`,
+            })),
+            { value: "back", label: pc.dim("← Back") },
+        ],
+    });
+
+    if (p.isCancel(taskName) || taskName === "back") {
+        return;
+    }
+
+    const task = config.tasks.find((t) => t.name === taskName);
+
+    if (!task) {
+        p.log.warn(`Task "${taskName}" no longer exists.`);
+        return;
+    }
+
+    const newState = !task.enabled;
+    await setTaskEnabled(taskName, newState);
+    p.log.success(`Task "${taskName}" ${newState ? "enabled" : "disabled"}`);
+}
+
+async function deleteTask(): Promise<void> {
+    const config = await loadConfig();
+
+    if (config.tasks.length === 0) {
+        p.log.info("No tasks to delete.");
+        return;
+    }
+
+    const taskName = await p.select({
+        message: "Select task to delete",
+        options: [
+            ...config.tasks.map((t) => ({ value: t.name, label: t.name })),
+            { value: "back", label: pc.dim("← Back") },
+        ],
+    });
+
+    if (p.isCancel(taskName) || taskName === "back") {
+        return;
+    }
+
+    const confirmed = await p.confirm({ message: `Delete task "${taskName}"?` });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+        return;
+    }
+
+    await removeTask(taskName);
+    p.log.success(`Task "${taskName}" deleted`);
+}
+
+async function handleStart(): Promise<void> {
+    const existing = getDaemonPid();
+
+    if (existing) {
+        p.log.info(`Daemon already running (PID ${existing})`);
+        return;
+    }
+
+    p.log.info("Starting daemon in foreground... (Ctrl+C to stop)");
+    await startDaemon();
+}
+
+function handleStop(): void {
+    const pid = getDaemonPid();
+
+    if (!pid) {
+        p.log.info("Daemon is not running.");
+        return;
+    }
+
+    process.kill(pid, "SIGTERM");
+    p.log.success(`Sent SIGTERM to daemon (PID ${pid})`);
+}
+
+async function launchdSubmenu(): Promise<void> {
+    const status = await getDaemonStatus();
+
+    const action = await p.select({
+        message: `Launchd ${status.installed ? pc.green("(installed)") : pc.dim("(not installed)")}`,
+        options: [
+            ...(status.installed
+                ? [{ value: "uninstall" as const, label: "Uninstall", hint: "remove auto-start" }]
+                : [{ value: "install" as const, label: "Install", hint: "auto-start on login" }]),
+            { value: "back" as const, label: pc.dim("← Back") },
+        ],
+    });
+
+    if (p.isCancel(action) || action === "back") {
+        return;
+    }
+
+    if (action === "install") {
+        try {
+            await installLaunchd();
+            p.log.success("Daemon installed via launchd (starts on login)");
+        } catch (err) {
+            p.log.error(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    } else {
+        await uninstallLaunchd();
+        p.log.success("Daemon uninstalled from launchd");
+    }
+}
+
+function truncate(s: string, max: number): string {
+    if (s.length <= max) {
+        return s;
+    }
+
+    return s.slice(0, max - 1) + "…";
+}

--- a/src/daemon/interactive/menu.ts
+++ b/src/daemon/interactive/menu.ts
@@ -215,6 +215,15 @@ async function handleStart(): Promise<void> {
         return;
     }
 
+    const status = await getDaemonStatus();
+
+    if (status.running) {
+        p.log.warn(
+            `Daemon is already running via launchd (PID ${status.pid}). Use ${pc.cyan("tools daemon uninstall")} first to avoid duplicate execution.`
+        );
+        return;
+    }
+
     p.log.info("Starting daemon in foreground... (Ctrl+C to stop)");
     await startDaemon();
 }

--- a/src/daemon/interactive/menu.ts
+++ b/src/daemon/interactive/menu.ts
@@ -1,9 +1,9 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { getDaemonPid, startDaemon } from "../daemon";
 import { loadConfig, removeTask, setTaskEnabled, upsertTask } from "../lib/config";
 import { formatInterval } from "../lib/interval";
 import { getDaemonStatus, installLaunchd, uninstallLaunchd } from "../lib/launchd";
-import { getDaemonPid, startDaemon } from "../daemon";
 import { runLogViewer } from "./log-viewer";
 import { runTaskEditor } from "./task-editor";
 
@@ -69,9 +69,7 @@ async function showStatus(): Promise<void> {
 
     const enabled = config.tasks.filter((t) => t.enabled);
     const disabled = config.tasks.filter((t) => !t.enabled);
-    p.log.info(
-        `Tasks: ${pc.green(String(enabled.length))} enabled, ${pc.dim(String(disabled.length))} disabled`
-    );
+    p.log.info(`Tasks: ${pc.green(String(enabled.length))} enabled, ${pc.dim(String(disabled.length))} disabled`);
 
     if (enabled.length > 0) {
         for (const task of enabled) {
@@ -268,5 +266,5 @@ function truncate(s: string, max: number): string {
         return s;
     }
 
-    return s.slice(0, max - 1) + "…";
+    return `${s.slice(0, max - 1)}…`;
 }

--- a/src/daemon/interactive/task-editor.ts
+++ b/src/daemon/interactive/task-editor.ts
@@ -1,0 +1,112 @@
+import * as p from "@clack/prompts";
+import { getTask } from "../lib/config";
+import { parseInterval } from "../lib/interval";
+import type { DaemonTask } from "../lib/types";
+
+export async function runTaskEditor(initial?: Partial<DaemonTask>): Promise<DaemonTask | null> {
+    const name = await p.text({
+        message: "Task name",
+        placeholder: "my-task",
+        initialValue: initial?.name,
+        validate(value = "") {
+            if (!value.trim()) {
+                return "Name is required";
+            }
+
+            if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+                return "Only letters, numbers, hyphens, and underscores";
+            }
+        },
+    });
+
+    if (p.isCancel(name)) {
+        return null;
+    }
+
+    if (!initial?.name) {
+        const existing = await getTask(name);
+
+        if (existing) {
+            p.log.warn(`Task "${name}" already exists`);
+            return null;
+        }
+    }
+
+    const command = await p.text({
+        message: "Shell command",
+        placeholder: "echo hello",
+        initialValue: initial?.command,
+        validate(value = "") {
+            if (!value.trim()) {
+                return "Command is required";
+            }
+        },
+    });
+
+    if (p.isCancel(command)) {
+        return null;
+    }
+
+    const every = await p.text({
+        message: "Run interval",
+        placeholder: "every 5 minutes",
+        initialValue: initial?.every,
+        validate(value = "") {
+            if (!value.trim()) {
+                return "Interval is required";
+            }
+
+            try {
+                parseInterval(value);
+            } catch (err) {
+                return err instanceof Error ? err.message : String(err);
+            }
+        },
+    });
+
+    if (p.isCancel(every)) {
+        return null;
+    }
+
+    const retries = await p.select({
+        message: "Retries on failure",
+        initialValue: String(initial?.retries ?? 3),
+        options: [
+            { value: "0", label: "0 — no retries" },
+            { value: "1", label: "1 retry" },
+            { value: "3", label: "3 retries (default)" },
+            { value: "5", label: "5 retries" },
+        ],
+    });
+
+    if (p.isCancel(retries)) {
+        return null;
+    }
+
+    const description = await p.text({
+        message: "Description (optional)",
+        placeholder: "What does this task do?",
+        initialValue: initial?.description ?? "",
+    });
+
+    if (p.isCancel(description)) {
+        return null;
+    }
+
+    const confirmed = await p.confirm({
+        message: `Create task "${name}"?`,
+    });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+        return null;
+    }
+
+    return {
+        name,
+        command,
+        every,
+        retries: parseInt(retries, 10),
+        enabled: initial?.enabled ?? true,
+        description: description || undefined,
+    };
+}

--- a/src/daemon/lib/config.ts
+++ b/src/daemon/lib/config.ts
@@ -1,0 +1,81 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Storage } from "@app/utils/storage/storage";
+import type { DaemonConfig, DaemonTask } from "./types";
+
+const storage = new Storage("daemon");
+
+const BASE_DIR = join(homedir(), ".genesis-tools", "daemon");
+const LOGS_DIR = join(BASE_DIR, "logs");
+const PID_FILE = join(BASE_DIR, "daemon.pid");
+
+export function getLogsBaseDir(): string {
+    return LOGS_DIR;
+}
+
+export function getPidFile(): string {
+    return PID_FILE;
+}
+
+export async function ensureStorage(): Promise<void> {
+    await storage.ensureDirs();
+    mkdirSync(LOGS_DIR, { recursive: true });
+}
+
+export async function loadConfig(): Promise<DaemonConfig> {
+    const config = await storage.getConfig<DaemonConfig>();
+
+    if (!config || !Array.isArray(config.tasks)) {
+        return { tasks: [] };
+    }
+
+    return config;
+}
+
+export async function saveConfig(config: DaemonConfig): Promise<void> {
+    await storage.setConfig(config);
+}
+
+export async function getTask(name: string): Promise<DaemonTask | undefined> {
+    const config = await loadConfig();
+    return config.tasks.find((t) => t.name === name);
+}
+
+export async function upsertTask(task: DaemonTask): Promise<void> {
+    const config = await loadConfig();
+    const idx = config.tasks.findIndex((t) => t.name === task.name);
+
+    if (idx >= 0) {
+        config.tasks[idx] = task;
+    } else {
+        config.tasks.push(task);
+    }
+
+    await saveConfig(config);
+}
+
+export async function removeTask(name: string): Promise<boolean> {
+    const config = await loadConfig();
+    const before = config.tasks.length;
+    config.tasks = config.tasks.filter((t) => t.name !== name);
+
+    if (config.tasks.length === before) {
+        return false;
+    }
+
+    await saveConfig(config);
+    return true;
+}
+
+export async function setTaskEnabled(name: string, enabled: boolean): Promise<void> {
+    const config = await loadConfig();
+    const task = config.tasks.find((t) => t.name === name);
+
+    if (!task) {
+        throw new Error(`Task "${name}" not found`);
+    }
+
+    task.enabled = enabled;
+    await saveConfig(config);
+}

--- a/src/daemon/lib/interval.ts
+++ b/src/daemon/lib/interval.ts
@@ -1,0 +1,88 @@
+export interface ParsedInterval {
+    intervalMs: number;
+    atHour?: number;
+    atMinute?: number;
+    isTimeOfDay: boolean;
+}
+
+const INTERVAL_PATTERN = /^every\s+(\d+)\s+(second|minute|hour|day|week)s?$/i;
+const DAILY_AT_PATTERN = /^every\s+day\s+at\s+(\d{1,2}):(\d{2})$/i;
+
+const MULTIPLIERS: Record<string, number> = {
+    second: 1_000,
+    minute: 60_000,
+    hour: 3_600_000,
+    day: 86_400_000,
+    week: 604_800_000,
+};
+
+export function parseInterval(interval: string): ParsedInterval {
+    const dailyMatch = interval.match(DAILY_AT_PATTERN);
+
+    if (dailyMatch) {
+        const hour = parseInt(dailyMatch[1], 10);
+        const minute = parseInt(dailyMatch[2], 10);
+
+        if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+            throw new Error(`Invalid time: "${interval}" — hour 0-23, minute 0-59`);
+        }
+
+        return { intervalMs: 86_400_000, atHour: hour, atMinute: minute, isTimeOfDay: true };
+    }
+
+    const match = interval.match(INTERVAL_PATTERN);
+
+    if (!match) {
+        throw new Error(
+            `Invalid interval: "${interval}". Expected "every N minutes", "every day at HH:MM", etc.`
+        );
+    }
+
+    const value = parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+
+    return { intervalMs: value * MULTIPLIERS[unit], isTimeOfDay: false };
+}
+
+export function computeNextRunAt(parsed: ParsedInterval, from: Date = new Date()): Date {
+    if (parsed.isTimeOfDay && parsed.atHour !== undefined && parsed.atMinute !== undefined) {
+        const next = new Date(from);
+        next.setHours(parsed.atHour, parsed.atMinute, 0, 0);
+
+        if (next <= from) {
+            next.setDate(next.getDate() + 1);
+        }
+
+        return next;
+    }
+
+    return new Date(from.getTime() + parsed.intervalMs);
+}
+
+export function formatInterval(every: string): string {
+    try {
+        const parsed = parseInterval(every);
+
+        if (parsed.isTimeOfDay) {
+            return `daily at ${String(parsed.atHour).padStart(2, "0")}:${String(parsed.atMinute).padStart(2, "0")}`;
+        }
+
+        const seconds = parsed.intervalMs / 1000;
+
+        if (seconds < 60) {
+            return `every ${seconds}s`;
+        }
+
+        if (seconds < 3600) {
+            return `every ${seconds / 60}m`;
+        }
+
+        if (seconds < 86400) {
+            return `every ${seconds / 3600}h`;
+        }
+
+        return `every ${seconds / 86400}d`;
+    } catch {
+        return every;
+    }
+}

--- a/src/daemon/lib/interval.ts
+++ b/src/daemon/lib/interval.ts
@@ -37,6 +37,11 @@ export function parseInterval(interval: string): ParsedInterval {
     }
 
     const value = parseInt(match[1], 10);
+
+    if (value <= 0) {
+        throw new Error(`Invalid interval: "${interval}". Value must be greater than 0.`);
+    }
+
     const unit = match[2].toLowerCase();
 
     return { intervalMs: value * MULTIPLIERS[unit], isTimeOfDay: false };

--- a/src/daemon/lib/interval.ts
+++ b/src/daemon/lib/interval.ts
@@ -33,9 +33,7 @@ export function parseInterval(interval: string): ParsedInterval {
     const match = interval.match(INTERVAL_PATTERN);
 
     if (!match) {
-        throw new Error(
-            `Invalid interval: "${interval}". Expected "every N minutes", "every day at HH:MM", etc.`
-        );
+        throw new Error(`Invalid interval: "${interval}". Expected "every N minutes", "every day at HH:MM", etc.`);
     }
 
     const value = parseInt(match[1], 10);

--- a/src/daemon/lib/launchd.ts
+++ b/src/daemon/lib/launchd.ts
@@ -73,8 +73,18 @@ export async function getDaemonStatus(): Promise<{
         return { installed: true, running: false, pid: null };
     }
 
-    const pidMatch = stdout.match(/^(\d+)/m);
-    const pid = pidMatch ? parseInt(pidMatch[1], 10) : null;
+    let pid: number | null = null;
+    const tablePidMatch = stdout.match(/^\s*(\d+)\b/m);
+
+    if (tablePidMatch?.[1]) {
+        pid = parseInt(tablePidMatch[1], 10);
+    } else {
+        const dictPidMatch = stdout.match(/"PID"\s*=\s*(\d+);?/);
+
+        if (dictPidMatch?.[1]) {
+            pid = parseInt(dictPidMatch[1], 10);
+        }
+    }
 
     return { installed, running: pid != null && pid > 0, pid };
 }

--- a/src/daemon/lib/launchd.ts
+++ b/src/daemon/lib/launchd.ts
@@ -39,10 +39,7 @@ export async function installLaunchd(): Promise<void> {
     mkdirSync(join(homedir(), ".genesis-tools", "daemon", "logs"), { recursive: true });
     await Bun.write(PLIST_PATH, generatePlist());
     const proc = Bun.spawn(["launchctl", "load", PLIST_PATH], { stdio: ["ignore", "pipe", "pipe"] });
-    const [exitCode, stderr] = await Promise.all([
-        proc.exited,
-        new Response(proc.stderr).text(),
-    ]);
+    const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
 
     if (exitCode !== 0) {
         throw new Error(`launchctl load failed: ${stderr}`);

--- a/src/daemon/lib/launchd.ts
+++ b/src/daemon/lib/launchd.ts
@@ -1,0 +1,83 @@
+import { existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const PLIST_PATH = join(homedir(), "Library", "LaunchAgents", "com.genesis-tools.daemon.plist");
+const LABEL = "com.genesis-tools.daemon";
+
+export const DAEMON_LOG_DIR = join(homedir(), ".genesis-tools", "daemon", "logs");
+export const DAEMON_STDOUT_LOG = join(DAEMON_LOG_DIR, "daemon-stdout.log");
+export const DAEMON_STDERR_LOG = join(DAEMON_LOG_DIR, "daemon-stderr.log");
+
+export function generatePlist(): string {
+    const home = homedir();
+    const daemonScript = resolve(import.meta.dir, "../daemon.ts");
+    const logDir = join(home, ".genesis-tools", "daemon", "logs");
+    const bunPath = Bun.which("bun") ?? "/usr/local/bin/bun";
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array><string>${bunPath}</string><string>run</string><string>${daemonScript}</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${logDir}/daemon-stdout.log</string>
+  <key>StandardErrorPath</key><string>${logDir}/daemon-stderr.log</string>
+  <key>EnvironmentVariables</key>
+  <dict><key>HOME</key><string>${home}</string><key>PATH</key><string>/usr/local/bin:/usr/bin:/bin:${dirname(bunPath)}</string></dict>
+  <key>WorkingDirectory</key><string>${home}</string>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>`;
+}
+
+export async function installLaunchd(): Promise<void> {
+    mkdirSync(join(homedir(), ".genesis-tools", "daemon", "logs"), { recursive: true });
+    await Bun.write(PLIST_PATH, generatePlist());
+    const proc = Bun.spawn(["launchctl", "load", PLIST_PATH], { stdio: ["ignore", "pipe", "pipe"] });
+    const [exitCode, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stderr).text(),
+    ]);
+
+    if (exitCode !== 0) {
+        throw new Error(`launchctl load failed: ${stderr}`);
+    }
+}
+
+export async function uninstallLaunchd(): Promise<void> {
+    if (existsSync(PLIST_PATH)) {
+        await Bun.spawn(["launchctl", "unload", PLIST_PATH], {
+            stdio: ["ignore", "pipe", "pipe"],
+        }).exited;
+        unlinkSync(PLIST_PATH);
+    }
+}
+
+export async function getDaemonStatus(): Promise<{
+    installed: boolean;
+    running: boolean;
+    pid: number | null;
+}> {
+    const installed = existsSync(PLIST_PATH);
+
+    if (!installed) {
+        return { installed: false, running: false, pid: null };
+    }
+
+    const proc = Bun.spawn(["launchctl", "list", LABEL], { stdio: ["ignore", "pipe", "pipe"] });
+    const stdout = await new Response(proc.stdout).text();
+
+    if ((await proc.exited) !== 0) {
+        return { installed: true, running: false, pid: null };
+    }
+
+    const pidMatch = stdout.match(/^(\d+)/m);
+    const pid = pidMatch ? parseInt(pidMatch[1], 10) : null;
+
+    return { installed, running: pid != null && pid > 0, pid };
+}

--- a/src/daemon/lib/log-reader.ts
+++ b/src/daemon/lib/log-reader.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { LogEntry, RunSummary } from "./types";
 

--- a/src/daemon/lib/log-reader.ts
+++ b/src/daemon/lib/log-reader.ts
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { LogEntry, RunSummary } from "./types";
+
+const VALID_LOG_TYPES = new Set<string>(["meta", "stdout", "stderr", "exit"]);
+
+export function listTasksWithLogs(logsBaseDir: string): string[] {
+    if (!existsSync(logsBaseDir)) {
+        return [];
+    }
+
+    return readdirSync(logsBaseDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith("daemon-"))
+        .map((d) => d.name)
+        .sort();
+}
+
+export function listRunsForTask(logsBaseDir: string, taskName: string): RunSummary[] {
+    const taskDir = join(logsBaseDir, taskName);
+
+    if (!existsSync(taskDir)) {
+        return [];
+    }
+
+    const files = readdirSync(taskDir)
+        .filter((f) => f.endsWith(".jsonl"))
+        .sort()
+        .reverse();
+
+    const summaries: RunSummary[] = [];
+
+    for (const file of files) {
+        const logFile = join(taskDir, file);
+
+        try {
+            const content = readFileSync(logFile, "utf-8").trim();
+            const lines = content.split("\n");
+
+            if (lines.length === 0) {
+                continue;
+            }
+
+            const meta = JSON.parse(lines[0]) as Record<string, unknown>;
+
+            if (meta.type !== "meta" || typeof meta.runId !== "string" || typeof meta.startedAt !== "string") {
+                continue;
+            }
+
+            let exitCode: number | null = null;
+            let duration_ms: number | null = null;
+
+            if (lines.length > 1) {
+                try {
+                    const last = JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+
+                    if (last.type === "exit") {
+                        exitCode = typeof last.code === "number" ? last.code : null;
+                        duration_ms = typeof last.duration_ms === "number" ? last.duration_ms : null;
+                    }
+                } catch {
+                    // incomplete log
+                }
+            }
+
+            summaries.push({
+                taskName,
+                runId: meta.runId,
+                logFile,
+                startedAt: meta.startedAt,
+                exitCode,
+                duration_ms,
+                attempt: typeof meta.attempt === "number" ? meta.attempt : 1,
+            });
+        } catch {
+            // skip malformed log files
+        }
+    }
+
+    return summaries;
+}
+
+export function parseLogFile(logFile: string): LogEntry[] {
+    if (!existsSync(logFile)) {
+        return [];
+    }
+
+    const content = readFileSync(logFile, "utf-8").trim();
+
+    if (!content) {
+        return [];
+    }
+
+    const entries: LogEntry[] = [];
+
+    for (const line of content.split("\n")) {
+        if (!line.trim()) {
+            continue;
+        }
+
+        try {
+            const parsed = JSON.parse(line) as Record<string, unknown>;
+
+            if (typeof parsed.type === "string" && VALID_LOG_TYPES.has(parsed.type)) {
+                entries.push(parsed as unknown as LogEntry);
+            }
+        } catch {
+            // skip malformed lines
+        }
+    }
+
+    return entries;
+}

--- a/src/daemon/lib/register.ts
+++ b/src/daemon/lib/register.ts
@@ -12,7 +12,14 @@ export interface RegisterTaskOptions {
     overwrite?: boolean;
 }
 
+function validateTaskName(name: string): void {
+    if (!name || /[/\\]|\.\./.test(name)) {
+        throw new Error(`Invalid task name "${name}". Must not contain "/", "\\", or "..".`);
+    }
+}
+
 export async function registerTask(opts: RegisterTaskOptions): Promise<boolean> {
+    validateTaskName(opts.name);
     parseInterval(opts.every);
     await ensureStorage();
 

--- a/src/daemon/lib/register.ts
+++ b/src/daemon/lib/register.ts
@@ -1,0 +1,47 @@
+import { ensureStorage, getTask, removeTask, upsertTask } from "./config";
+import { parseInterval } from "./interval";
+import type { DaemonTask } from "./types";
+
+export interface RegisterTaskOptions {
+    name: string;
+    command: string;
+    every: string;
+    retries?: number;
+    enabled?: boolean;
+    description?: string;
+    overwrite?: boolean;
+}
+
+export async function registerTask(opts: RegisterTaskOptions): Promise<boolean> {
+    parseInterval(opts.every);
+    await ensureStorage();
+
+    const existing = await getTask(opts.name);
+
+    if (existing && !opts.overwrite) {
+        return false;
+    }
+
+    const task: DaemonTask = {
+        name: opts.name,
+        command: opts.command,
+        every: opts.every,
+        retries: opts.retries ?? 3,
+        enabled: opts.enabled ?? true,
+        description: opts.description,
+    };
+
+    await upsertTask(task);
+    return true;
+}
+
+export async function unregisterTask(name: string): Promise<boolean> {
+    await ensureStorage();
+    return removeTask(name);
+}
+
+export async function isTaskRegistered(name: string): Promise<boolean> {
+    await ensureStorage();
+    const task = await getTask(name);
+    return task !== undefined;
+}

--- a/src/daemon/lib/runner.ts
+++ b/src/daemon/lib/runner.ts
@@ -7,7 +7,7 @@ function safeTimestamp(): string {
 }
 
 function appendJsonl(path: string, data: Record<string, unknown>): void {
-    appendFileSync(path, JSON.stringify(data) + "\n");
+    appendFileSync(path, `${JSON.stringify(data)}\n`);
 }
 
 async function streamLines(
@@ -46,11 +46,7 @@ async function streamLines(
     }
 }
 
-export async function runTask(
-    task: DaemonTask,
-    attempt: number,
-    logsBaseDir: string
-): Promise<RunResult> {
+export async function runTask(task: DaemonTask, attempt: number, logsBaseDir: string): Promise<RunResult> {
     const runId = crypto.randomUUID().slice(0, 8);
     const taskLogDir = join(logsBaseDir, task.name);
     mkdirSync(taskLogDir, { recursive: true });

--- a/src/daemon/lib/runner.ts
+++ b/src/daemon/lib/runner.ts
@@ -1,0 +1,91 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { DaemonTask, RunResult } from "./types";
+
+function safeTimestamp(): string {
+    return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+}
+
+function appendJsonl(path: string, data: Record<string, unknown>): void {
+    appendFileSync(path, JSON.stringify(data) + "\n");
+}
+
+async function streamLines(
+    stream: ReadableStream<Uint8Array>,
+    type: "stdout" | "stderr",
+    logPath: string
+): Promise<void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let partial = "";
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+
+            if (done) {
+                if (partial) {
+                    appendJsonl(logPath, { type, ts: new Date().toISOString(), data: partial });
+                }
+
+                break;
+            }
+
+            partial += decoder.decode(value, { stream: true });
+            const lines = partial.split("\n");
+            partial = lines.pop() ?? "";
+
+            for (const line of lines) {
+                if (line) {
+                    appendJsonl(logPath, { type, ts: new Date().toISOString(), data: line });
+                }
+            }
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+export async function runTask(
+    task: DaemonTask,
+    attempt: number,
+    logsBaseDir: string
+): Promise<RunResult> {
+    const runId = crypto.randomUUID().slice(0, 8);
+    const taskLogDir = join(logsBaseDir, task.name);
+    mkdirSync(taskLogDir, { recursive: true });
+
+    const logFile = join(taskLogDir, `${safeTimestamp()}-${runId}.jsonl`);
+    const startedAt = new Date().toISOString();
+    const startMs = Date.now();
+
+    appendJsonl(logFile, {
+        type: "meta",
+        taskName: task.name,
+        command: task.command,
+        runId,
+        attempt,
+        startedAt,
+    });
+
+    const proc = Bun.spawn(["sh", "-c", task.command], {
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+    });
+
+    const stdoutDone = streamLines(proc.stdout, "stdout", logFile);
+    const stderrDone = streamLines(proc.stderr, "stderr", logFile);
+
+    const [exitCode] = await Promise.all([proc.exited, stdoutDone, stderrDone]);
+    const duration_ms = Date.now() - startMs;
+
+    appendJsonl(logFile, {
+        type: "exit",
+        ts: new Date().toISOString(),
+        code: exitCode,
+        duration_ms,
+    });
+
+    return { exitCode, duration_ms, logFile };
+}

--- a/src/daemon/lib/scheduler.ts
+++ b/src/daemon/lib/scheduler.ts
@@ -111,13 +111,10 @@ async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void>
             return;
         }
 
-        log.warn(
-            { task: task.name, exitCode: result.exitCode, attempt, maxAttempts },
-            "Task failed"
-        );
+        log.warn({ task: task.name, exitCode: result.exitCode, attempt, maxAttempts }, "Task failed");
 
         if (attempt < maxAttempts) {
-            const backoffMs = Math.min(Math.pow(2, attempt) * 1000, 60_000);
+            const backoffMs = Math.min(2 ** attempt * 1000, 60_000);
             log.info({ task: task.name, backoffMs }, "Retrying after backoff");
             await Bun.sleep(backoffMs);
         }
@@ -131,10 +128,7 @@ async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void>
     });
 }
 
-async function initializeTaskStates(
-    taskStates: Map<string, TaskState>,
-    logsBaseDir: string
-): Promise<void> {
+async function initializeTaskStates(taskStates: Map<string, TaskState>, logsBaseDir: string): Promise<void> {
     const config = await loadConfig();
 
     for (const task of config.tasks) {

--- a/src/daemon/lib/scheduler.ts
+++ b/src/daemon/lib/scheduler.ts
@@ -1,0 +1,216 @@
+import { createLogger } from "@app/logger";
+import { sendNotification } from "@app/utils/macos/notifications";
+import { loadConfig } from "./config";
+import { computeNextRunAt, parseInterval } from "./interval";
+import { listRunsForTask } from "./log-reader";
+import { runTask } from "./runner";
+import type { DaemonTask, TaskState } from "./types";
+
+const log = createLogger({ logToFile: false });
+
+export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
+    let running = true;
+    const activeRuns = new Set<string>();
+    const taskStates = new Map<string, TaskState>();
+
+    const shutdown = () => {
+        running = false;
+    };
+
+    process.once("SIGTERM", shutdown);
+    process.once("SIGINT", shutdown);
+
+    log.info("Daemon scheduler started");
+
+    await initializeTaskStates(taskStates, logsBaseDir);
+
+    while (running) {
+        const config = await loadConfig();
+        const now = new Date();
+
+        syncTaskStates(taskStates, config.tasks);
+
+        for (const task of config.tasks) {
+            if (!task.enabled) {
+                continue;
+            }
+
+            if (activeRuns.has(task.name)) {
+                continue;
+            }
+
+            const state = taskStates.get(task.name);
+
+            if (!state || now < state.nextRunAt) {
+                continue;
+            }
+
+            activeRuns.add(task.name);
+            state.running = true;
+
+            executeTask(task, logsBaseDir)
+                .catch((err) => log.error({ err, task: task.name }, "Task execution error"))
+                .finally(() => {
+                    activeRuns.delete(task.name);
+                    const s = taskStates.get(task.name);
+
+                    if (s) {
+                        s.running = false;
+                        const parsed = parseInterval(task.every);
+                        s.nextRunAt = computeNextRunAt(parsed);
+                    }
+                });
+        }
+
+        const sleepMs = getNextWakeupMs(taskStates, config.tasks);
+        log.debug({ sleepMs, activeTasks: activeRuns.size }, "Sleeping");
+        await Bun.sleep(sleepMs);
+    }
+
+    if (activeRuns.size > 0) {
+        log.info({ activeCount: activeRuns.size }, "Waiting for active runs to finish...");
+        const deadline = Date.now() + 30_000;
+
+        while (activeRuns.size > 0 && Date.now() < deadline) {
+            await Bun.sleep(500);
+        }
+
+        if (activeRuns.size > 0) {
+            log.warn({ remaining: [...activeRuns] }, "Timed out waiting for active runs");
+        }
+    }
+
+    log.info("Daemon scheduler stopped");
+}
+
+async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void> {
+    const maxAttempts = task.retries + 1;
+
+    sendNotification({
+        title: "Daemon",
+        subtitle: task.name,
+        message: "Task started",
+        sound: "Tink",
+    });
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        log.info({ task: task.name, attempt, maxAttempts }, "Running task");
+
+        const result = await runTask(task, attempt, logsBaseDir);
+
+        if (result.exitCode === 0) {
+            log.info({ task: task.name, duration: result.duration_ms }, "Task completed");
+
+            sendNotification({
+                title: "Daemon",
+                subtitle: task.name,
+                message: `Completed in ${formatDurationShort(result.duration_ms)}`,
+                sound: "Tink",
+            });
+
+            return;
+        }
+
+        log.warn(
+            { task: task.name, exitCode: result.exitCode, attempt, maxAttempts },
+            "Task failed"
+        );
+
+        if (attempt < maxAttempts) {
+            const backoffMs = Math.min(Math.pow(2, attempt) * 1000, 60_000);
+            log.info({ task: task.name, backoffMs }, "Retrying after backoff");
+            await Bun.sleep(backoffMs);
+        }
+    }
+
+    sendNotification({
+        title: "Daemon",
+        subtitle: task.name,
+        message: `Failed after ${maxAttempts} attempt${maxAttempts > 1 ? "s" : ""}, retries exhausted`,
+        sound: "Basso",
+    });
+}
+
+async function initializeTaskStates(
+    taskStates: Map<string, TaskState>,
+    logsBaseDir: string
+): Promise<void> {
+    const config = await loadConfig();
+
+    for (const task of config.tasks) {
+        const parsed = parseInterval(task.every);
+        const runs = listRunsForTask(logsBaseDir, task.name);
+        let nextRunAt: Date;
+
+        if (runs.length > 0) {
+            const lastRun = new Date(runs[0].startedAt);
+            nextRunAt = computeNextRunAt(parsed, lastRun);
+
+            if (nextRunAt < new Date()) {
+                nextRunAt = new Date();
+            }
+        } else {
+            nextRunAt = new Date();
+        }
+
+        taskStates.set(task.name, { nextRunAt, attemptCount: 0, running: false });
+        log.debug({ task: task.name, nextRunAt: nextRunAt.toISOString() }, "Initialized task state");
+    }
+}
+
+function syncTaskStates(taskStates: Map<string, TaskState>, tasks: DaemonTask[]): void {
+    const taskNames = new Set(tasks.map((t) => t.name));
+
+    for (const name of taskStates.keys()) {
+        if (!taskNames.has(name)) {
+            taskStates.delete(name);
+        }
+    }
+
+    for (const task of tasks) {
+        if (!taskStates.has(task.name)) {
+            taskStates.set(task.name, {
+                nextRunAt: new Date(),
+                attemptCount: 0,
+                running: false,
+            });
+        }
+    }
+}
+
+function getNextWakeupMs(taskStates: Map<string, TaskState>, tasks: DaemonTask[]): number {
+    const now = Date.now();
+    let earliest = 60_000;
+
+    for (const task of tasks) {
+        if (!task.enabled) {
+            continue;
+        }
+
+        const state = taskStates.get(task.name);
+
+        if (!state || state.running) {
+            continue;
+        }
+
+        const ms = state.nextRunAt.getTime() - now;
+
+        if (ms < earliest) {
+            earliest = ms;
+        }
+    }
+
+    return Math.min(Math.max(earliest, 1000), 60_000);
+}
+
+function formatDurationShort(ms: number): string {
+    if (ms < 1000) {
+        return `${ms}ms`;
+    }
+
+    if (ms < 60_000) {
+        return `${(ms / 1000).toFixed(1)}s`;
+    }
+
+    return `${(ms / 60_000).toFixed(1)}m`;
+}

--- a/src/daemon/lib/types.ts
+++ b/src/daemon/lib/types.ts
@@ -1,0 +1,58 @@
+export interface DaemonTask {
+    name: string;
+    command: string;
+    every: string;
+    retries: number;
+    enabled: boolean;
+    description?: string;
+}
+
+export interface DaemonConfig {
+    tasks: DaemonTask[];
+}
+
+export interface LogMeta {
+    type: "meta";
+    taskName: string;
+    command: string;
+    runId: string;
+    attempt: number;
+    startedAt: string;
+}
+
+export interface LogLine {
+    type: "stdout" | "stderr";
+    ts: string;
+    data: string;
+}
+
+export interface LogExit {
+    type: "exit";
+    ts: string;
+    code: number | null;
+    duration_ms: number;
+}
+
+export type LogEntry = LogMeta | LogLine | LogExit;
+
+export interface TaskState {
+    nextRunAt: Date;
+    attemptCount: number;
+    running: boolean;
+}
+
+export interface RunResult {
+    exitCode: number | null;
+    duration_ms: number;
+    logFile: string;
+}
+
+export interface RunSummary {
+    taskName: string;
+    runId: string;
+    logFile: string;
+    startedAt: string;
+    exitCode: number | null;
+    duration_ms: number | null;
+    attempt: number;
+}


### PR DESCRIPTION
## Summary

- New standalone tool at `src/daemon/` — a general-purpose background task scheduler daemon
- Manages shell-command tasks with interval scheduling (`every N minutes`, `every day at HH:MM`), retry on crash with exponential backoff, and JSONL log capture
- Interactive clack-based UI (`tools daemon`) with back-navigation: status, task management, 3-level log viewer
- macOS launchd integration for auto-start on login (`tools daemon install`)
- macOS notifications on task start/success/failure
- Public registration API (`src/daemon/lib/register.ts`) so other tools can programmatically register background tasks

## Test plan

- [ ] `tools daemon --help` shows all subcommands
- [ ] `tools daemon` launches interactive menu with back-navigation at every level
- [ ] `tools daemon config add` creates a task interactively
- [ ] `tools daemon config list` shows configured tasks
- [ ] `tools daemon start` runs scheduler in foreground, executes tasks on interval
- [ ] JSONL logs written to `~/.genesis-tools/daemon/logs/<task>/` with meta/stdout/stderr/exit entries
- [ ] Retry logic: task with `exit 1` and retries=2 attempts 3 times with backoff
- [ ] `tools daemon install` creates launchd plist, `tools daemon uninstall` removes it
- [ ] `tools daemon stop` detects launchd-managed daemon and offers uninstall
- [ ] Registration API: `registerTask()`/`unregisterTask()` works from external imports