### PR TITLE
feat(watchman): add --temporary flag to auto-unwatch on exit

### DIFF
--- a/src/watchman/README.md
+++ b/src/watchman/README.md
@@ -44,6 +44,7 @@ tools watchman ./relative/path
 | Option | Alias | Description | Default |
 |--------|-------|-------------|---------|
 | `--current` | `-c` | Use current working directory | `false` |
+| `--temporary` | `-t` | Remove watch when tool exits | `false` |
 | `--help-full` | `-?` | Show detailed help message | - |
 | `[directory]` | - | Path to directory to watch (positional) | interactive |
 
@@ -74,6 +75,17 @@ tools watchman /Users/me/projects/myapp
 # Relative path
 tools watchman ../other-project
 ```
+
+### Temporary Watch (auto-cleanup)
+```bash
+# Watch a directory temporarily — unwatch on Ctrl+C
+tools watchman -t /path/to/project
+
+# Combine with current directory shorthand
+tools watchman -t -c
+```
+
+> **Note:** If the directory was already in Watchman's watch list before the tool started, `--temporary` will **not** unwatch it on exit to avoid disrupting pre-existing watches.
 
 ---
 

--- a/src/watchman/index.ts
+++ b/src/watchman/index.ts
@@ -33,10 +33,11 @@ const client = new watchman.Client();
 // Parse command line arguments using Commander
 const program = new Command()
     .option("-c, --current", "Use current working directory")
+    .option("-t, --temporary", "Remove watch when tool exits (won't unwatch pre-existing watches)")
     .option("-?, --help-full", "Show detailed help message")
     .parse();
 
-const options = program.opts<{ current?: boolean; helpFull?: boolean }>();
+const options = program.opts<{ current?: boolean; temporary?: boolean; helpFull?: boolean }>();
 
 if (options.helpFull) {
     console.log(`
@@ -49,6 +50,7 @@ Arguments:
 
 Options:
   -c, --current      Use current working directory
+  -t, --temporary    Remove watch when tool exits
   -?, --help-full    Show this detailed help message
 
 If no directory is provided, you'll be prompted to select from:
@@ -60,21 +62,31 @@ Examples:
   tools watchman .                  # Watch current directory
   tools watchman /path/to/project   # Watch specific directory
   tools watchman -c                 # Watch current directory (no prompt)
+  tools watchman -t .               # Watch CWD, unwatch on exit
 `);
     process.exit(0);
 }
 
+async function getWatchedRoots(): Promise<string[]> {
+    return new Promise((resolve) => {
+        // biome-ignore lint/suspicious/noExplicitAny: fb-watchman Client lacks command() in types
+        (client as any).command(["watch-list"], (err: unknown, resp: WatchmanResponse) => {
+            if (err || !resp?.roots) {
+                return resolve([]);
+            }
+            resolve(resp.roots);
+        });
+    });
+}
+
 async function getDirOfInterest(): Promise<string> {
-    // If -c or --current is passed, use process.cwd()
     if (options.current) {
         return process.cwd();
     }
 
-    // If a positional argument is provided, try to resolve it
     const args = program.args;
     const arg = args[0];
     if (arg) {
-        // Resolve relative paths to absolute
         const resolved = path.isAbsolute(arg) ? arg : path.resolve(process.cwd(), arg);
         try {
             const stats = fs.statSync(resolved);
@@ -92,18 +104,7 @@ async function getDirOfInterest(): Promise<string> {
         }
     }
 
-    // No valid argument, show interactive selection
-    // Get watched directories from watchman
-    const watchedDirs: string[] = await new Promise((resolve) => {
-        // biome-ignore lint/suspicious/noExplicitAny: fb-watchman Client lacks command() in types
-        (client as any).command(["watch-list"], (err: unknown, resp: WatchmanResponse) => {
-            if (err || !resp || !resp.roots) {
-                client.end(); // Close client on error
-                return resolve([]);
-            }
-            resolve(resp.roots);
-        });
-    });
+    const watchedDirs = await getWatchedRoots();
 
     const allChoices = [
         ...watchedDirs.map((dir) => ({
@@ -200,14 +201,15 @@ function makeSubscription(
     });
 }
 
-async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
+async function watchWithRetry(dirOfInterest: string, maxRetries = 15): Promise<watchman.Client> {
     let attempt = 0;
     let lastError: unknown = null;
-    let succeeded = false;
+    let succeededClient: watchman.Client | null = null;
+
     while (attempt < maxRetries) {
-        const client = new (require("fb-watchman").Client)();
-        await new Promise((resolve) => {
-            client.capabilityCheck(
+        const retryClient = new watchman.Client();
+        await new Promise<void>((resolve) => {
+            retryClient.capabilityCheck(
                 { optional: [], required: ["relative_root"] },
                 (capabilityError: unknown, _capabilityResp: unknown) => {
                     if (capabilityError) {
@@ -216,12 +218,12 @@ async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
                         );
                         lastError = capabilityError;
                         attempt++;
-                        client.end();
+                        retryClient.end();
                         setTimeout(resolve, 1000);
                         return;
                     }
                     // biome-ignore lint/suspicious/noExplicitAny: fb-watchman Client lacks command() in types
-                    (client as any).command(
+                    (retryClient as any).command(
                         ["watch-project", dirOfInterest],
                         (watchError: unknown, watchResp: WatchmanResponse) => {
                             if (watchError) {
@@ -230,10 +232,11 @@ async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
                                 );
                                 lastError = watchError;
                                 attempt++;
-                                client.end();
+                                retryClient.end();
                                 setTimeout(resolve, 1000);
                                 return;
                             }
+
                             if ("warning" in watchResp && watchResp.warning) {
                                 logger.warn(`Warning: ${watchResp.warning}`);
                             }
@@ -242,7 +245,7 @@ async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
                                 logger.error("watch-project response missing watch root");
                                 lastError = new Error("watch-project response missing watch root");
                                 attempt++;
-                                client.end();
+                                retryClient.end();
                                 setTimeout(resolve, 1000);
                                 return;
                             }
@@ -250,24 +253,67 @@ async function watchWithRetry(dirOfInterest: string, maxRetries = 15) {
                             logger.info(
                                 `Watch established on ${watchResp.watch} relative_path: ${watchResp.relative_path}`
                             );
-                            makeSubscription(client, watchResp.watch, watchResp.relative_path);
-                            succeeded = true;
-                            resolve(undefined);
+                            makeSubscription(retryClient, watchResp.watch, watchResp.relative_path);
+                            succeededClient = retryClient;
+                            resolve();
                         }
                     );
                 }
             );
         });
-        if (succeeded) {
-            return;
+
+        if (succeededClient) {
+            return succeededClient;
         }
     }
+
     logger.error(`Failed to establish watch after ${maxRetries} attempts. Exiting. ${lastError}`);
     process.exit(1);
+}
+
+function setupCleanup(activeClient: watchman.Client, dirOfInterest: string): void {
+    let cleaned = false;
+
+    const cleanup = () => {
+        if (cleaned) {
+            return;
+        }
+        cleaned = true;
+
+        logger.info(`Temporary mode: removing watch for ${dirOfInterest}...`);
+        // biome-ignore lint/suspicious/noExplicitAny: fb-watchman Client lacks command() in types
+        (activeClient as any).command(["watch-del", dirOfInterest], (err: unknown) => {
+            if (err) {
+                logger.error(`Failed to remove watch: ${err}`);
+            } else {
+                logger.info(`Watch removed for ${dirOfInterest}`);
+            }
+
+            activeClient.end();
+            process.exit(0);
+        });
+    };
+
+    process.on("SIGINT", cleanup);
+    process.on("SIGTERM", cleanup);
 }
 
 (async () => {
     const dirOfInterest = await getDirOfInterest();
     logger.info(`Directory of interest: ${dirOfInterest}`);
-    await watchWithRetry(dirOfInterest);
+
+    const preExistingRoots = await getWatchedRoots();
+    const wasAlreadyWatched = preExistingRoots.some(
+        (root) => dirOfInterest === root || dirOfInterest.startsWith(root + "/")
+    );
+
+    if (options.temporary && wasAlreadyWatched) {
+        logger.info("Directory already watched by Watchman — will NOT unwatch on exit");
+    }
+
+    const activeClient = await watchWithRetry(dirOfInterest);
+
+    if (options.temporary && !wasAlreadyWatched) {
+        setupCleanup(activeClient, dirOfInterest);
+    }
 })();

--- a/src/watchman/index.ts
+++ b/src/watchman/index.ts
@@ -290,7 +290,7 @@ function setupCleanup(activeClient: watchman.Client, dirOfInterest: string): voi
             }
 
             activeClient.end();
-            process.exit(0);
+            process.exit(err ? 1 : 0);
         });
     };
 

--- a/src/watchman/index.ts
+++ b/src/watchman/index.ts
@@ -68,13 +68,13 @@ Examples:
 }
 
 async function getWatchedRoots(): Promise<string[]> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         // biome-ignore lint/suspicious/noExplicitAny: fb-watchman Client lacks command() in types
         (client as any).command(["watch-list"], (err: unknown, resp: WatchmanResponse) => {
-            if (err || !resp?.roots) {
-                return resolve([]);
+            if (err) {
+                return reject(new Error(`Failed to get watch list from Watchman: ${err}`));
             }
-            resolve(resp.roots);
+            resolve(resp?.roots ?? []);
         });
     });
 }


### PR DESCRIPTION
## Summary
- Adds `-t` / `--temporary` flag that calls `watch-del` on SIGINT/SIGTERM so the directory doesn't persist in Watchman's watch list after the tool exits
- Extracts `getWatchedRoots()` helper (refactored from inline `watch-list` call in `getDirOfInterest`)
- Returns the active client from `watchWithRetry` so the cleanup handler can use it
- Safety: if the directory was already watched before the tool started, `--temporary` does **not** unwatch it

## Test plan
- [ ] `tools watchman -t /tmp/test-dir` — verify watch is removed on Ctrl+C (`watchman watch-list` should not include `/tmp/test-dir`)
- [ ] `tools watchman -t .` on an already-watched directory — verify it logs "will NOT unwatch on exit" and the watch persists after exit
- [ ] `tools watchman .` (without `-t`) — verify existing behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--temporary` (`-t`) option to automatically remove watches when the tool exits.
  * Improved watch establishment with retry logic for more reliable connections.
  * Automatic cleanup on application exit (SIGINT/SIGTERM) for temporary watches.
  * Logs clarify when a directory was already being watched and thus won’t be unwatched on exit.

* **Documentation**
  * Added examples and guidance for temporary watch mode and pre-existing watch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->