### PR TITLE
feat: telegram conversation memory + assistant v2

### DIFF
--- a/.claude/plans/2026-03-01-TelegramAssistantV2.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2.md
@@ -1,0 +1,108 @@
+# Telegram Conversation Memory + Assistant V2 Implementation Plan
+
+## Summary
+Build a V2 Telegram subsystem that supports full + incremental sync for users/groups/channels, range-aware query with auto-fetch caching, attachment indexing with lazy download, and an assistant workflow (auto-reply, chat assistant, suggestion drafting with pick/edit/send).
+This plan keeps existing `tools telegram listen` behavior compatible while adding new runtime modes (`daemon`, `light`, `ink`) and richer per-contact Ask/model/style configuration.
+
+## Git Start (Execute After Plan Mode)
+1. Fast-forward local `master` and branch:
+```bash
+git checkout master
+git pull --ff-only origin master
+git checkout -b feat/telegram-agent
+```
+2. Save this plan to `.claude/plans/2026-03-01-TelegramAssistantV2.md` before implementation.
+
+## Public APIs / Interfaces / Types
+- Extend Telegram config schema in `src/telegram/lib/types.ts` and migration logic in `src/telegram/lib/TelegramToolConfig.ts`.
+- Keep backward compatibility with old `askProvider/askModel/askSystemPrompt` by mapping into V2 `modes.autoReply`.
+- Add per-contact per-mode Ask config (`autoReply`, `assistant`, `suggestions`) with global defaults.
+- Add style rule array config (rich source rules, regex/time windows, cross-chat sources).
+- Add query parser interface for flags + NL helper.
+- Add attachment locator interface: `chatId + messageId + attachmentIndex`.
+- Expose Ask model-selection helpers for Telegram configure flow via `src/ask/index.lib.ts` and reuse `src/ask/providers/ModelSelector.ts`.
+
+### Proposed V2 Contact Shape (decision-complete)
+```ts
+type TelegramRuntimeMode = "daemon" | "light" | "ink";
+
+interface AskModeConfig {
+  enabled: boolean;
+  provider?: string;
+  model?: string;
+  systemPrompt?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+interface SuggestionModeConfig extends AskModeConfig {
+  count: number;
+  trigger: "manual" | "auto" | "hybrid";
+  autoDelayMs: number;
+  allowAutoSend: boolean;
+}
+
+interface StyleSourceRule {
+  id: string;
+  sourceChatId: string;
+  direction: "outgoing" | "incoming";
+  limit?: number;
+  since?: string;
+  until?: string;
+  regex?: string;
+}
+
+interface StyleProfileConfig {
+  enabled: boolean;
+  refresh: "incremental";
+  rules: StyleSourceRule[];
+  previewInWatch: boolean;
+}
+
+interface TelegramContactV2 {
+  userId: string;
+  displayName: string;
+  username?: string;
+  actions: ("say" | "ask" | "notify")[];
+  watch: { enabled: boolean; contextLength: number; runtimeMode?: TelegramRuntimeMode };
+  modes: {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+  };
+  styleProfile: StyleProfileConfig;
+}
+```
+
+## Data Model and Migration
+- Upgrade SQLite schema in `src/telegram/lib/TelegramHistoryStore.ts` using `PRAGMA user_version` migrations.
+- Add `chats` table for dialog metadata/type.
+- Extend `messages` with mutation tracking fields (`edited_date_unix`, `is_deleted`, `deleted_at_iso`, `reply_to_msg_id`).
+- Add `message_revisions` table to preserve create/edit/delete history.
+- Add `attachments` table with metadata + download status/path/hash + unique `(chat_id, message_id, attachment_index)`.
+- Add `sync_segments` table to track covered date intervals for auto-fetch gap detection.
+- Keep `sync_state` for high-watermark incremental latest sync.
+- Keep FTS + embeddings intact.
+
+## Command Surface (V2)
+- Update `src/telegram/index.ts` command registration.
+- Keep existing commands; add/extend:
+1. `tools telegram configure`
+2. `tools telegram history sync [contact] [--all] [--since] [--until] [--limit]`
+3. `tools telegram history query --from <contact> [--since] [--until] [--sender me|them|any] [--text <regex>] [--local-only] [--nl "<query>"]`
+4. `tools telegram history attachments list --from <contact> [--since] [--until] [--message-id]`
+5. `tools telegram history attachments fetch --from <contact> --message-id <id> --attachment-index <n> [--output <path>]`
+6. `tools telegram watch [contact|--all] [--runtime daemon|light|ink] [--context-length <n>]`
+7. `tools telegram listen`
+
+## Implementation Tasks
+- Implement tasks 1-12 from agreed plan.
+
+## Assumptions and Defaults
+- Default query behavior is auto-fetch-and-cache when local range is incomplete.
+- Default suggestion behavior is manual; optional delayed auto-suggest is configurable.
+- Default send behavior requires explicit user pick/edit confirmation; no auto-send by default.
+- Default style refresh is incremental background update.
+- Attachment binaries are lazy-downloaded; metadata is always indexed.
+- Deleted messages remain queryable as tombstones (`is_deleted=1`) unless explicitly filtered out.
+- TUI is split into `light` first and `ink` runtime second, but both are delivered in this feature branch.

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "boxen": "^8.0.1",
         "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
+        "chrono-node": "^2.9.0",
         "cli-html": "^5.3.0",
         "cli-table3": "^0.6.5",
         "clipboardy": "^4.0.0",
@@ -784,6 +785,8 @@
     "chroma-js": ["chroma-js@1.4.1", "", {}, "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="],
 
     "chromium-bidi": ["chromium-bidi@11.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-cM3DI+OOb89T3wO8cpPSro80Q9eKYJ7hGVXoGS3GkDPxnYSqiv+6xwpIf6XERyJ9Tdsl09hmNmY94BkgZdVekw=="],
+
+    "chrono-node": ["chrono-node@2.9.0", "", {}, "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "boxen": "^8.0.1",
         "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
+        "chrono-node": "^2.9.0",
         "cli-html": "^5.3.0",
         "cli-table3": "^0.6.5",
         "clipboardy": "^4.0.0",

--- a/src/ask/AIChat.ts
+++ b/src/ask/AIChat.ts
@@ -161,6 +161,7 @@ export class AIChat {
         let fullContent = "";
         let thinkingContent = "";
         const startTime = Date.now();
+        const toolsForTurn = options?.override?.tools ?? this._options.tools;
 
         // Bridge push-based onChunk to pull-based async generator via ReadableStream
         const stream = new ReadableStream<ChatEvent>({
@@ -168,7 +169,7 @@ export class AIChat {
                 try {
                     const engineResponse = await engine.sendMessage(
                         message,
-                        undefined, // tools — TODO: wire AIChatTool → AI SDK tools
+                        toolsForTurn,
                         {
                             onChunk: (chunk: string) => {
                                 controller.enqueue(ChatEvent.text(chunk));

--- a/src/ask/AIChat.ts
+++ b/src/ask/AIChat.ts
@@ -167,20 +167,16 @@ export class AIChat {
         const stream = new ReadableStream<ChatEvent>({
             start: async (controller) => {
                 try {
-                    const engineResponse = await engine.sendMessage(
-                        message,
-                        toolsForTurn,
-                        {
-                            onChunk: (chunk: string) => {
-                                controller.enqueue(ChatEvent.text(chunk));
-                                fullContent += chunk;
-                            },
-                            onThinking: (text: string) => {
-                                controller.enqueue(ChatEvent.thinking(text));
-                                thinkingContent += text;
-                            },
-                        }
-                    );
+                    const engineResponse = await engine.sendMessage(message, toolsForTurn, {
+                        onChunk: (chunk: string) => {
+                            controller.enqueue(ChatEvent.text(chunk));
+                            fullContent += chunk;
+                        },
+                        onThinking: (text: string) => {
+                            controller.enqueue(ChatEvent.thinking(text));
+                            thinkingContent += text;
+                        },
+                    });
 
                     const duration = Date.now() - startTime;
                     const response: ChatResponse = {

--- a/src/ask/chat/ChatEngine.ts
+++ b/src/ask/chat/ChatEngine.ts
@@ -71,7 +71,7 @@ export class ChatEngine {
 
     private async sendStreamingMessage(
         message: string,
-        _tools?: Record<string, unknown>,
+        tools?: Record<string, unknown>,
         callbacks?: {
             onChunk?: (chunk: string) => void;
             onThinking?: (text: string) => void;
@@ -87,6 +87,7 @@ export class ChatEngine {
             system: this.config.systemPrompt,
             temperature: this.config.temperature,
             ...(this.config.maxTokens && { maxOutputTokens: this.config.maxTokens }),
+            ...(tools ? { tools: tools as never } : {}),
             onFinish: async ({ usage }) => {
                 // This is called when the stream completes - usage is available HERE
                 logger.debug(
@@ -225,13 +226,14 @@ export class ChatEngine {
         };
     }
 
-    private async sendNonStreamingMessage(message: string, _tools?: Record<string, unknown>): Promise<ChatResponse> {
+    private async sendNonStreamingMessage(message: string, tools?: Record<string, unknown>): Promise<ChatResponse> {
         const result = await generateText({
             model: this.config.model,
             prompt: message, // Use prompt instead of messages array
             system: this.config.systemPrompt,
             temperature: this.config.temperature,
             ...(this.config.maxTokens && { maxOutputTokens: this.config.maxTokens }),
+            ...(tools ? { tools: tools as never } : {}),
         });
 
         // DEBUG: Log the full result object structure

--- a/src/ask/index.lib.ts
+++ b/src/ask/index.lib.ts
@@ -16,3 +16,4 @@ export type {
     SessionStats,
     ToolCallResult,
 } from "./lib/types";
+export { modelSelector } from "./providers/ModelSelector";

--- a/src/telegram/commands/configure.ts
+++ b/src/telegram/commands/configure.ts
@@ -1,20 +1,68 @@
+import { modelSelector } from "@ask/providers/ModelSelector";
+import type { ProviderChoice } from "@ask/types";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 import type { Api } from "telegram";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
-import type { ActionType, ContactConfig, TelegramConfigData } from "../lib/types";
-import { DEFAULTS } from "../lib/types";
+import type {
+    ActionType,
+    AskModeConfig,
+    ContactConfig,
+    SuggestionModeConfig,
+    TelegramConfigData,
+    TelegramDialogType,
+} from "../lib/types";
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULTS,
+    TELEGRAM_CONFIG_VERSION,
+} from "../lib/types";
+
+interface DialogOption {
+    id: string;
+    label: string;
+    hint?: string;
+    dialogType: TelegramDialogType;
+}
 
 function isUser(entity: unknown): entity is Api.User {
-    return (
-        entity !== null &&
-        entity !== undefined &&
-        typeof entity === "object" &&
-        "className" in entity &&
-        (entity as { className: string }).className === "User"
-    );
+    if (entity === null || entity === undefined || typeof entity !== "object") {
+        return false;
+    }
+
+    if (!("className" in entity)) {
+        return false;
+    }
+
+    return (entity as { className: string }).className === "User";
+}
+
+function isChat(entity: unknown): entity is Api.Chat {
+    if (entity === null || entity === undefined || typeof entity !== "object") {
+        return false;
+    }
+
+    if (!("className" in entity)) {
+        return false;
+    }
+
+    return (entity as { className: string }).className === "Chat";
+}
+
+function isChannel(entity: unknown): entity is Api.Channel {
+    if (entity === null || entity === undefined || typeof entity !== "object") {
+        return false;
+    }
+
+    if (!("className" in entity)) {
+        return false;
+    }
+
+    return (entity as { className: string }).className === "Channel";
 }
 
 async function promptCredentials(
@@ -25,8 +73,8 @@ async function promptCredentials(
     const apiId = await p.text({
         message: "API ID:",
         initialValue: String(existing?.apiId ?? DEFAULTS.apiId),
-        validate: (v) => {
-            if (!v || !/^\d+$/.test(v)) {
+        validate: (value) => {
+            if (!value || !/^\d+$/.test(value)) {
                 return "Must be a number";
             }
         },
@@ -39,8 +87,8 @@ async function promptCredentials(
     const apiHash = await p.text({
         message: "API Hash:",
         initialValue: existing?.apiHash ?? DEFAULTS.apiHash,
-        validate: (v) => {
-            if (!v || !/^[a-f0-9]{32}$/.test(v)) {
+        validate: (value) => {
+            if (!value || !/^[a-f0-9]{32}$/.test(value)) {
                 return "Must be 32 hex chars";
             }
         },
@@ -86,15 +134,15 @@ async function runAuthFlow(client: TGClient): Promise<boolean> {
                 return code as string;
             },
             password: async () => {
-                const pass = await p.password({
+                const password = await p.password({
                     message: "2FA password (if enabled):",
                 });
 
-                if (p.isCancel(pass)) {
+                if (p.isCancel(password)) {
                     throw new Error("Cancelled");
                 }
 
-                return pass as string;
+                return password as string;
             },
         });
 
@@ -106,40 +154,69 @@ async function runAuthFlow(client: TGClient): Promise<boolean> {
     }
 }
 
-interface ContactOption {
-    userId: string;
-    label: string;
-    hint: string;
-    user: Api.User;
-}
-
-async function fetchContacts(client: TGClient): Promise<ContactOption[]> {
+async function fetchDialogs(client: TGClient): Promise<DialogOption[]> {
     const spinner = p.spinner();
-    spinner.start("Fetching your recent chats...");
+    spinner.start("Fetching your recent dialogs...");
 
-    const dialogs = await client.getDialogs(100);
+    const dialogs = await client.getDialogs(200);
+    const options: DialogOption[] = [];
 
-    const userDialogs = dialogs.filter((d) => d.isUser && isUser(d.entity) && !d.entity.bot && !d.entity.self);
+    for (const dialog of dialogs) {
+        const entity = dialog.entity;
 
-    spinner.stop(`Found ${userDialogs.length} contacts`);
+        if (!entity) {
+            continue;
+        }
 
-    return userDialogs
-        .filter((d): d is typeof d & { entity: Api.User } => isUser(d.entity))
-        .map((d) => {
-            const user = d.entity;
-            const label = `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.id.toString();
-            const hint = user.username ? `@${user.username}` : user.phone ? `+${user.phone}` : "";
-            return { userId: user.id.toString(), label, hint, user };
-        });
+        if (isUser(entity)) {
+            if (entity.bot || entity.self) {
+                continue;
+            }
+
+            const label = `${entity.firstName || ""} ${entity.lastName || ""}`.trim() || entity.id.toString();
+            options.push({
+                id: entity.id.toString(),
+                label,
+                hint: entity.username ? `@${entity.username}` : entity.phone ? `+${entity.phone}` : undefined,
+                dialogType: "user",
+            });
+            continue;
+        }
+
+        if (isChat(entity)) {
+            options.push({
+                id: entity.id.toString(),
+                label: entity.title,
+                hint: "group",
+                dialogType: "group",
+            });
+            continue;
+        }
+
+        if (isChannel(entity)) {
+            options.push({
+                id: entity.id.toString(),
+                label: entity.title,
+                hint: entity.username ? `@${entity.username}` : "channel",
+                dialogType: "channel",
+            });
+        }
+    }
+
+    spinner.stop(`Found ${options.length} dialogs`);
+    return options;
 }
 
-async function selectContacts(options: ContactOption[], existingContacts: ContactConfig[]): Promise<string[] | null> {
-    const existingIds = new Set(existingContacts.map((c) => c.userId));
-
+async function selectDialogs(options: DialogOption[], existingContacts: ContactConfig[]): Promise<string[] | null> {
+    const existingIds = new Set(existingContacts.map((contact) => contact.userId));
     const selected = await p.multiselect({
-        message: "Select contacts to watch:",
-        options: options.map((o) => ({ value: o.userId, label: o.label, hint: o.hint })),
-        initialValues: [...existingIds].filter((id) => options.some((o) => o.userId === id)),
+        message: "Select dialogs to watch:",
+        options: options.map((option) => ({
+            value: option.id,
+            label: option.label,
+            hint: option.hint,
+        })),
+        initialValues: [...existingIds].filter((id) => options.some((option) => option.id === id)),
         required: false,
     });
 
@@ -150,15 +227,208 @@ async function selectContacts(options: ContactOption[], existingContacts: Contac
     return selected as string[];
 }
 
-async function configureContactActions(opt: ContactOption, existing?: ContactConfig): Promise<ContactConfig | null> {
-    p.log.step(pc.bold(opt.label));
+async function chooseProviderModel(existingProvider?: string, existingModel?: string): Promise<ProviderChoice | null> {
+    if (existingProvider && existingModel) {
+        const exact = await modelSelector.selectModelByName(existingProvider, existingModel);
+
+        if (exact) {
+            const reuse = await p.confirm({
+                message: `Reuse ${existingProvider}/${existingModel}?`,
+                initialValue: true,
+            });
+
+            if (!p.isCancel(reuse) && reuse) {
+                return exact;
+            }
+        }
+    }
+
+    return modelSelector.selectModel();
+}
+
+async function promptAskModeConfig(
+    label: string,
+    defaults: AskModeConfig,
+    existing: AskModeConfig | undefined,
+    initialEnabled: boolean
+): Promise<AskModeConfig | null> {
+    const enabled = await p.confirm({
+        message: `Enable ${label}?`,
+        initialValue: existing?.enabled ?? initialEnabled,
+    });
+
+    if (p.isCancel(enabled)) {
+        return null;
+    }
+
+    const result: AskModeConfig = {
+        ...defaults,
+        ...existing,
+        enabled,
+    };
+
+    if (!enabled) {
+        return result;
+    }
+
+    const choice = await chooseProviderModel(result.provider, result.model);
+
+    if (!choice) {
+        return null;
+    }
+
+    result.provider = choice.provider.name;
+    result.model = choice.model.id;
+
+    const systemPrompt = await p.text({
+        message: `${label} system prompt:`,
+        initialValue: result.systemPrompt ?? DEFAULTS.askSystemPrompt,
+    });
+
+    if (p.isCancel(systemPrompt)) {
+        return null;
+    }
+
+    result.systemPrompt = systemPrompt as string;
+
+    const temperatureInput = await p.text({
+        message: `${label} temperature:`,
+        initialValue: String(result.temperature ?? DEFAULTS.askTemperature),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (Number.isNaN(parsed) || parsed < 0 || parsed > 2) {
+                return "Use number between 0 and 2";
+            }
+        },
+    });
+
+    if (p.isCancel(temperatureInput)) {
+        return null;
+    }
+
+    result.temperature = Number(temperatureInput);
+
+    const maxTokensInput = await p.text({
+        message: `${label} max tokens:`,
+        initialValue: String(result.maxTokens ?? DEFAULTS.askMaxTokens),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed <= 0) {
+                return "Use positive integer";
+            }
+        },
+    });
+
+    if (p.isCancel(maxTokensInput)) {
+        return null;
+    }
+
+    result.maxTokens = Number(maxTokensInput);
+
+    return result;
+}
+
+async function promptSuggestionModeConfig(
+    existing: SuggestionModeConfig | undefined
+): Promise<SuggestionModeConfig | null> {
+    const base = await promptAskModeConfig(
+        "Suggestion mode",
+        DEFAULT_MODE_CONFIG.suggestions,
+        existing,
+        DEFAULT_MODE_CONFIG.suggestions.enabled
+    );
+
+    if (!base) {
+        return null;
+    }
+
+    const result: SuggestionModeConfig = {
+        ...DEFAULT_MODE_CONFIG.suggestions,
+        ...existing,
+        ...base,
+    };
+
+    if (!result.enabled) {
+        return result;
+    }
+
+    const countInput = await p.text({
+        message: "How many suggestions (1-5)?",
+        initialValue: String(result.count),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed < 1 || parsed > 5) {
+                return "Enter integer from 1 to 5";
+            }
+        },
+    });
+
+    if (p.isCancel(countInput)) {
+        return null;
+    }
+
+    result.count = Number(countInput);
+
+    const trigger = await p.select({
+        message: "Suggestion trigger mode:",
+        options: [
+            { value: "manual" as const, label: "Manual only (/suggest)" },
+            { value: "auto" as const, label: "Auto on every incoming message" },
+            { value: "hybrid" as const, label: "Manual + auto with debounce" },
+        ],
+        initialValue: result.trigger,
+    });
+
+    if (p.isCancel(trigger)) {
+        return null;
+    }
+
+    result.trigger = trigger;
+
+    const delayInput = await p.text({
+        message: "Auto suggestion debounce delay (ms):",
+        initialValue: String(result.autoDelayMs),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed < 0) {
+                return "Enter non-negative integer";
+            }
+        },
+    });
+
+    if (p.isCancel(delayInput)) {
+        return null;
+    }
+
+    result.autoDelayMs = Number(delayInput);
+
+    const allowAutoSend = await p.confirm({
+        message: "Allow automatic sending of top suggestion?",
+        initialValue: result.allowAutoSend,
+    });
+
+    if (p.isCancel(allowAutoSend)) {
+        return null;
+    }
+
+    result.allowAutoSend = allowAutoSend;
+
+    return result;
+}
+
+async function configureContact(option: DialogOption, existing?: ContactConfig): Promise<ContactConfig | null> {
+    p.log.step(pc.bold(option.label));
 
     const actions = await p.multiselect({
-        message: `Actions for ${opt.label}:`,
+        message: `Actions for ${option.label}:`,
         options: [
-            { value: "say" as const, label: "Say aloud", hint: "macOS TTS with language detection" },
-            { value: "ask" as const, label: "Auto-reply", hint: "LLM generates reply via tools ask" },
-            { value: "notify" as const, label: "Notification", hint: "macOS notification" },
+            { value: "say" as const, label: "Say aloud", hint: "macOS TTS" },
+            { value: "ask" as const, label: "Auto-reply", hint: "AI response" },
+            { value: "notify" as const, label: "Notification", hint: "Desktop notification" },
         ],
         initialValues: existing?.actions ?? ["notify"],
         required: true,
@@ -168,56 +438,86 @@ async function configureContactActions(opt: ContactOption, existing?: ContactCon
         return null;
     }
 
-    const typedActions = actions as ActionType[];
-    let askSystemPrompt: string | undefined;
-    let askProvider: string | undefined;
-    let askModel: string | undefined;
+    const contextLengthInput = await p.text({
+        message: "Watch context length (messages):",
+        initialValue: String(existing?.watch?.contextLength ?? DEFAULT_WATCH_CONFIG.contextLength),
+        validate: (value) => {
+            const parsed = Number(value);
 
-    if (typedActions.includes("ask")) {
-        const prompt = await p.text({
-            message: `System prompt for auto-replies to ${opt.label}:`,
-            initialValue: existing?.askSystemPrompt || DEFAULTS.askSystemPrompt,
-        });
+            if (!Number.isInteger(parsed) || parsed < 1) {
+                return "Enter a positive integer";
+            }
+        },
+    });
 
-        if (p.isCancel(prompt)) {
-            return null;
-        }
+    if (p.isCancel(contextLengthInput)) {
+        return null;
+    }
 
-        askSystemPrompt = prompt as string;
+    const runtimeMode = await p.select({
+        message: "Preferred runtime:",
+        options: [
+            { value: "daemon" as const, label: "daemon" },
+            { value: "light" as const, label: "light" },
+            { value: "ink" as const, label: "ink" },
+        ],
+        initialValue: existing?.watch?.runtimeMode ?? DEFAULT_WATCH_CONFIG.runtimeMode,
+    });
 
-        const provider = await p.text({
-            message: "LLM provider:",
-            initialValue: existing?.askProvider || DEFAULTS.askProvider,
-        });
+    if (p.isCancel(runtimeMode)) {
+        return null;
+    }
 
-        if (p.isCancel(provider)) {
-            return null;
-        }
+    const autoReply = await promptAskModeConfig(
+        "Auto reply",
+        DEFAULT_MODE_CONFIG.autoReply,
+        existing?.modes?.autoReply,
+        (actions as ActionType[]).includes("ask")
+    );
 
-        askProvider = provider as string;
+    if (!autoReply) {
+        return null;
+    }
 
-        const model = await p.text({
-            message: "LLM model:",
-            initialValue: existing?.askModel || DEFAULTS.askModel,
-        });
+    const assistantMode = await promptAskModeConfig(
+        "Assistant mode",
+        DEFAULT_MODE_CONFIG.assistant,
+        existing?.modes?.assistant,
+        true
+    );
 
-        if (p.isCancel(model)) {
-            return null;
-        }
+    if (!assistantMode) {
+        return null;
+    }
 
-        askModel = model as string;
+    const suggestionMode = await promptSuggestionModeConfig(existing?.modes?.suggestions);
+
+    if (!suggestionMode) {
+        return null;
     }
 
     return {
-        userId: opt.userId,
-        displayName: opt.label,
-        username: opt.user.username ?? undefined,
-        actions: typedActions,
-        askSystemPrompt,
-        askProvider,
-        askModel,
+        userId: option.id,
+        displayName: option.label,
+        username: undefined,
+        dialogType: option.dialogType,
+        actions: actions as ActionType[],
+        modes: {
+            autoReply,
+            assistant: assistantMode,
+            suggestions: suggestionMode,
+        },
+        watch: {
+            enabled: true,
+            contextLength: Number(contextLengthInput),
+            runtimeMode,
+        },
+        styleProfile: existing?.styleProfile ?? { ...DEFAULT_STYLE_PROFILE },
         replyDelayMin: existing?.replyDelayMin ?? DEFAULTS.replyDelayMin,
         replyDelayMax: existing?.replyDelayMax ?? DEFAULTS.replyDelayMax,
+        askProvider: autoReply.provider,
+        askModel: autoReply.model,
+        askSystemPrompt: autoReply.systemPrompt,
     };
 }
 
@@ -243,7 +543,7 @@ export function registerConfigureCommand(program: Command): void {
                     spinner.stop("Session valid");
                     const me = await client.getMe();
                     p.log.success(
-                        `Logged in as ${pc.bold(me.firstName || "")} ` + `${me.username ? `(@${me.username})` : ""}`
+                        `Logged in as ${pc.bold(me.firstName || "")} ${me.username ? `(@${me.username})` : ""}`
                     );
                 } else {
                     spinner.stop("Session expired — re-authentication needed");
@@ -256,15 +556,15 @@ export function registerConfigureCommand(program: Command): void {
             let effectiveApiHash = toolConfig.getApiHash();
 
             if (!client) {
-                const creds = await promptCredentials(existing);
+                const credentials = await promptCredentials(existing);
 
-                if (!creds) {
+                if (!credentials) {
                     return;
                 }
 
-                effectiveApiId = creds.apiId;
-                effectiveApiHash = creds.apiHash;
-                client = new TGClient(creds.apiId, creds.apiHash);
+                effectiveApiId = credentials.apiId;
+                effectiveApiHash = credentials.apiHash;
+                client = new TGClient(credentials.apiId, credentials.apiHash);
 
                 const ok = await runAuthFlow(client);
 
@@ -276,12 +576,12 @@ export function registerConfigureCommand(program: Command): void {
 
             const me = await client.getMe();
             const session = client.getSessionString();
+            const dialogOptions = await fetchDialogs(client);
 
-            const contactOptions = await fetchContacts(client);
-
-            if (contactOptions.length === 0) {
-                p.log.warn("No contacts found in recent chats.");
+            if (dialogOptions.length === 0) {
+                p.log.warn("No dialogs found in recent chats.");
                 await toolConfig.save({
+                    version: TELEGRAM_CONFIG_VERSION,
                     apiId: effectiveApiId,
                     apiHash: effectiveApiHash,
                     session,
@@ -290,15 +590,16 @@ export function registerConfigureCommand(program: Command): void {
                         username: me.username ?? undefined,
                         phone: me.phone ?? undefined,
                     },
+                    defaults: existing?.defaults,
                     contacts: [],
                     configuredAt: new Date().toISOString(),
                 });
                 await client.disconnect();
-                p.outro("Configuration saved (no contacts to watch).");
+                p.outro("Configuration saved (no dialogs to watch).");
                 return;
             }
 
-            const selectedIds = await selectContacts(contactOptions, existing?.contacts ?? []);
+            const selectedIds = await selectDialogs(dialogOptions, existing?.contacts ?? []);
 
             if (!selectedIds) {
                 await client.disconnect();
@@ -307,25 +608,26 @@ export function registerConfigureCommand(program: Command): void {
 
             const contacts: ContactConfig[] = [];
 
-            for (const userId of selectedIds) {
-                const opt = contactOptions.find((o) => o.userId === userId);
+            for (const id of selectedIds) {
+                const option = dialogOptions.find((candidate) => candidate.id === id);
 
-                if (!opt) {
+                if (!option) {
                     continue;
                 }
 
-                const existingContact = existing?.contacts.find((c) => c.userId === userId);
-                const contact = await configureContactActions(opt, existingContact);
+                const existingContact = existing?.contacts.find((contact) => contact.userId === id);
+                const configured = await configureContact(option, existingContact);
 
-                if (!contact) {
+                if (!configured) {
                     await client.disconnect();
                     return;
                 }
 
-                contacts.push(contact);
+                contacts.push(configured);
             }
 
             await toolConfig.save({
+                version: TELEGRAM_CONFIG_VERSION,
                 apiId: effectiveApiId,
                 apiHash: effectiveApiHash,
                 session,
@@ -334,13 +636,17 @@ export function registerConfigureCommand(program: Command): void {
                     username: me.username ?? undefined,
                     phone: me.phone ?? undefined,
                 },
+                defaults: existing?.defaults ?? {
+                    autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+                    assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+                    suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+                },
                 contacts,
                 configuredAt: new Date().toISOString(),
             });
 
             await client.disconnect();
-
             p.log.success(`Saved ${contacts.length} contact(s)`);
-            p.outro("Run: tools telegram listen");
+            p.outro("Run: tools telegram watch --all");
         });
 }

--- a/src/telegram/commands/contacts.ts
+++ b/src/telegram/commands/contacts.ts
@@ -27,7 +27,11 @@ export function registerContactsCommand(program: Command): void {
                 p.log.info(
                     `${pc.bold(c.displayName)} ${c.username ? pc.dim(`@${c.username}`) : ""}\n` +
                         `  Actions: [${c.actions.join(", ")}]` +
-                        (c.askSystemPrompt ? `\n  Prompt: "${c.askSystemPrompt}"` : "")
+                        `\n  Type: ${c.dialogType ?? "user"}` +
+                        `\n  Runtime: ${c.watch?.runtimeMode ?? "daemon"} (ctx ${c.watch?.contextLength ?? 30})` +
+                        (c.modes?.autoReply?.model
+                            ? `\n  Auto-reply: ${c.modes.autoReply.provider}/${c.modes.autoReply.model}`
+                            : "")
                 );
             }
 

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -6,16 +6,19 @@ import { formatTable } from "@app/utils/table";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
-import { downloadContact, embedMessages } from "../lib/download";
+import { attachmentDownloader } from "../lib/AttachmentDownloader";
+import { conversationSyncService } from "../lib/ConversationSyncService";
+import { embedMessages } from "../lib/download";
 import { type ExportFormat, formatMessages, VALID_EXPORT_FORMATS } from "../lib/export";
+import { queryParser } from "../lib/QueryParser";
+import { styleProfileEngine } from "../lib/StyleProfileEngine";
 import { displayResults } from "../lib/search";
+import { TelegramContact } from "../lib/TelegramContact";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
-import type { ContactConfig, SearchResult } from "../lib/types";
+import type { ContactConfig, QueryRequest, SearchResult } from "../lib/types";
 import { EMBEDDING_LANGUAGES } from "../lib/types";
-
-// ── Helpers ───────────────────────────────────────────────────────────
 
 async function ensureClient(config: TelegramToolConfig): Promise<TGClient | null> {
     if (!config.hasValidSession()) {
@@ -37,159 +40,162 @@ async function ensureClient(config: TelegramToolConfig): Promise<TGClient | null
 function resolveContact(contacts: ContactConfig[], nameOrId: string): ContactConfig | undefined {
     const lower = nameOrId.toLowerCase();
 
-    return contacts.find(
-        (c) =>
-            c.userId === nameOrId ||
-            c.displayName.toLowerCase() === lower ||
-            c.username?.toLowerCase() === lower ||
-            c.username?.toLowerCase() === lower.replace(/^@/, "")
-    );
+    return contacts.find((contact) => {
+        if (contact.userId === nameOrId) {
+            return true;
+        }
+
+        if (contact.displayName.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower.replace(/^@/, "")) {
+            return true;
+        }
+
+        return false;
+    });
 }
 
-// ── Download Command ──────────────────────────────────────────────────
+async function pickContacts(contacts: ContactConfig[]): Promise<ContactConfig[] | null> {
+    const selected = await p.select({
+        message: "Which contact?",
+        options: [
+            ...contacts.map((contact) => ({
+                value: contact.userId,
+                label: contact.displayName,
+                hint: contact.username ? `@${contact.username}` : contact.dialogType,
+            })),
+            { value: "__all__", label: "All configured contacts" },
+        ],
+    });
 
-function registerDownloadCommand(history: Command): void {
+    if (p.isCancel(selected)) {
+        return null;
+    }
+
+    if (selected === "__all__") {
+        return contacts;
+    }
+
+    const match = contacts.find((contact) => contact.userId === selected);
+
+    if (!match) {
+        return null;
+    }
+
+    return [match];
+}
+
+function registerSyncCommand(history: Command): void {
+    const runSync = async (
+        contactName: string | undefined,
+        opts: {
+            since?: string;
+            until?: string;
+            limit?: number;
+            all?: boolean;
+        },
+        title: string
+    ) => {
+        p.intro(pc.bgMagenta(pc.white(` ${title} `)));
+
+        const config = new TelegramToolConfig();
+        const data = await config.load();
+
+        if (!data) {
+            p.log.error("Not configured. Run: tools telegram configure");
+            return;
+        }
+
+        if (data.contacts.length === 0) {
+            p.log.warn("No contacts configured. Run: tools telegram configure");
+            return;
+        }
+
+        let targetContacts: ContactConfig[] = [];
+
+        if (opts.all) {
+            targetContacts = data.contacts;
+        } else if (contactName) {
+            const match = resolveContact(data.contacts, contactName);
+
+            if (!match) {
+                p.log.error(`Contact "${contactName}" not found.`);
+                return;
+            }
+
+            targetContacts = [match];
+        } else {
+            const picked = await pickContacts(data.contacts);
+
+            if (!picked) {
+                return;
+            }
+
+            targetContacts = picked;
+        }
+
+        const client = await ensureClient(config);
+
+        if (!client) {
+            return;
+        }
+
+        const store = new TelegramHistoryStore();
+        store.open();
+
+        try {
+            const since = opts.since ? parseDate(opts.since) : undefined;
+            const until = opts.until ? parseDate(opts.until) : undefined;
+
+            for (const contact of targetContacts) {
+                p.log.step(pc.bold(contact.displayName));
+
+                if (since && until) {
+                    await conversationSyncService.ensureRange(client, store, contact.userId, since, until, {
+                        limit: opts.limit,
+                    });
+                } else {
+                    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+                        since,
+                        until,
+                        limit: opts.limit,
+                    });
+                }
+            }
+        } finally {
+            store.close();
+            await client.disconnect();
+        }
+
+        p.outro("Sync complete.");
+    };
+
     history
-        .command("download [contact]")
-        .description("Download conversation history to local SQLite database")
+        .command("sync [contact]")
+        .description("Sync conversation history to local SQLite storage")
         .option("--since <date>", "Start date (YYYY-MM-DD)")
         .option("--until <date>", "End date (YYYY-MM-DD)")
-        .option("--limit <n>", "Max messages to download", parseInt)
-        .option("--all", "Download all configured contacts")
-        .action(
-            async (
-                contactName: string | undefined,
-                opts: {
-                    since?: string;
-                    until?: string;
-                    limit?: number;
-                    all?: boolean;
-                }
-            ) => {
-                p.intro(pc.bgMagenta(pc.white(" telegram history download ")));
+        .option("--limit <n>", "Max messages to sync", (value) => Number.parseInt(value, 10))
+        .option("--all", "Sync all configured contacts")
+        .action(async (contactName: string | undefined, opts) => runSync(contactName, opts, "telegram history sync"));
 
-                const config = new TelegramToolConfig();
-                const data = await config.load();
-
-                if (!data) {
-                    p.log.error("Not configured. Run: tools telegram configure");
-                    return;
-                }
-
-                const contacts = data.contacts;
-
-                if (contacts.length === 0) {
-                    p.log.warn("No contacts configured. Run: tools telegram configure");
-                    return;
-                }
-
-                let targetContacts: ContactConfig[];
-
-                if (opts.all) {
-                    targetContacts = contacts;
-                } else if (contactName) {
-                    const found = resolveContact(contacts, contactName);
-
-                    if (!found) {
-                        p.log.error(
-                            `Contact "${contactName}" not found. Available: ${contacts.map((c) => c.displayName).join(", ")}`
-                        );
-                        return;
-                    }
-
-                    targetContacts = [found];
-                } else {
-                    const selected = await p.select({
-                        message: "Which contact to download?",
-                        options: [
-                            ...contacts.map((c) => ({
-                                value: c.userId,
-                                label: c.displayName,
-                                hint: c.username ? `@${c.username}` : undefined,
-                            })),
-                            { value: "__all__", label: "All contacts" },
-                        ],
-                    });
-
-                    if (p.isCancel(selected)) {
-                        return;
-                    }
-
-                    if (selected === "__all__") {
-                        targetContacts = contacts;
-                    } else {
-                        const found = contacts.find((c) => c.userId === selected);
-
-                        if (!found) {
-                            return;
-                        }
-
-                        targetContacts = [found];
-                    }
-                }
-
-                const spinner = p.spinner();
-                spinner.start("Connecting to Telegram...");
-
-                const client = await ensureClient(config);
-
-                if (!client) {
-                    spinner.stop("Connection failed");
-                    return;
-                }
-
-                spinner.stop("Connected");
-
-                const store = new TelegramHistoryStore();
-                store.open();
-
-                const since = opts.since ? parseDate(opts.since) : undefined;
-                const until = opts.until ? parseDate(opts.until) : undefined;
-
-                try {
-                    for (const contact of targetContacts) {
-                        await downloadContact(client, store, contact, {
-                            since,
-                            until,
-                            limit: opts.limit,
-                        });
-                    }
-
-                    const shouldEmbed = await p.confirm({
-                        message: "Generate semantic embeddings for new messages?",
-                        initialValue: true,
-                    });
-
-                    if (!p.isCancel(shouldEmbed) && shouldEmbed) {
-                        for (const contact of targetContacts) {
-                            const embedSpinner = p.spinner();
-                            embedSpinner.start(`Embedding ${contact.displayName}...`);
-
-                            const { embedded, skipped, unsupportedLangs } = await embedMessages(store, contact.userId);
-
-                            embedSpinner.stop(`${pc.green(String(embedded))} embeddings generated, ${skipped} skipped`);
-
-                            if (unsupportedLangs.size > 0) {
-                                const langs = [...unsupportedLangs].join(", ");
-                                p.log.warn(
-                                    `Some messages were in unsupported languages (${langs}). ` +
-                                        `Semantic search only works for: ${[...EMBEDDING_LANGUAGES].join(", ")}. ` +
-                                        `Keyword search still works for all languages.`
-                                );
-                            }
-                        }
-                    }
-                } finally {
-                    store.close();
-                    await client.disconnect();
-                }
-
-                p.outro("Download complete.");
-            }
+    history
+        .command("download [contact]")
+        .description("Alias for sync")
+        .option("--since <date>", "Start date (YYYY-MM-DD)")
+        .option("--until <date>", "End date (YYYY-MM-DD)")
+        .option("--limit <n>", "Max messages to sync", (value) => Number.parseInt(value, 10))
+        .option("--all", "Sync all configured contacts")
+        .action(async (contactName: string | undefined, opts) =>
+            runSync(contactName, opts, "telegram history download")
         );
 }
-
-// ── Embed Command ─────────────────────────────────────────────────────
 
 function registerEmbedCommand(history: Command): void {
     history
@@ -207,9 +213,7 @@ function registerEmbedCommand(history: Command): void {
                 return;
             }
 
-            const contacts = data.contacts;
-
-            if (contacts.length === 0) {
+            if (data.contacts.length === 0) {
                 p.log.warn("No contacts configured.");
                 return;
             }
@@ -217,45 +221,24 @@ function registerEmbedCommand(history: Command): void {
             let targetContacts: ContactConfig[];
 
             if (opts.all) {
-                targetContacts = contacts;
+                targetContacts = data.contacts;
             } else if (contactName) {
-                const found = resolveContact(contacts, contactName);
+                const found = resolveContact(data.contacts, contactName);
 
                 if (!found) {
-                    p.log.error(
-                        `Contact "${contactName}" not found. Available: ${contacts.map((c) => c.displayName).join(", ")}`
-                    );
+                    p.log.error(`Contact "${contactName}" not found.`);
                     return;
                 }
 
                 targetContacts = [found];
             } else {
-                const selected = await p.select({
-                    message: "Which contact to embed?",
-                    options: [
-                        ...contacts.map((c) => ({
-                            value: c.userId,
-                            label: c.displayName,
-                        })),
-                        { value: "__all__", label: "All contacts" },
-                    ],
-                });
+                const selected = await pickContacts(data.contacts);
 
-                if (p.isCancel(selected)) {
+                if (!selected) {
                     return;
                 }
 
-                if (selected === "__all__") {
-                    targetContacts = contacts;
-                } else {
-                    const found = contacts.find((c) => c.userId === selected);
-
-                    if (!found) {
-                        return;
-                    }
-
-                    targetContacts = [found];
-                }
+                targetContacts = selected;
             }
 
             const store = new TelegramHistoryStore();
@@ -264,12 +247,10 @@ function registerEmbedCommand(history: Command): void {
             try {
                 for (const contact of targetContacts) {
                     p.log.step(pc.bold(contact.displayName));
-
                     const spinner = p.spinner();
                     spinner.start("Generating embeddings...");
 
                     const { embedded, skipped, unsupportedLangs } = await embedMessages(store, contact.userId);
-
                     const total = store.getEmbeddedCount(contact.userId);
 
                     spinner.stop(
@@ -279,9 +260,7 @@ function registerEmbedCommand(history: Command): void {
                     if (unsupportedLangs.size > 0) {
                         const langs = [...unsupportedLangs].join(", ");
                         p.log.warn(
-                            `Some messages were in unsupported languages (${langs}). ` +
-                                `Semantic search only works for: ${[...EMBEDDING_LANGUAGES].join(", ")}. ` +
-                                `Keyword search still works for all languages.`
+                            `Unsupported semantic languages encountered (${langs}). Supported: ${[...EMBEDDING_LANGUAGES].join(", ")}`
                         );
                     }
                 }
@@ -293,7 +272,280 @@ function registerEmbedCommand(history: Command): void {
         });
 }
 
-// ── Search Command ────────────────────────────────────────────────────
+function registerQueryCommand(history: Command): void {
+    history
+        .command("query")
+        .description("Query messages by date/sender/text with optional auto-fetch")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .option("--since <date>", "Start date (YYYY-MM-DD)")
+        .option("--until <date>", "End date (YYYY-MM-DD)")
+        .option("--sender <kind>", "me|them|any", "any")
+        .option("--text <regex>", "Regex filter")
+        .option("--limit <n>", "Maximum rows", (value) => Number.parseInt(value, 10))
+        .option("--local-only", "Only query local DB")
+        .option("--nl <query>", "Natural language helper query")
+        .action(
+            async (opts: {
+                from: string;
+                since?: string;
+                until?: string;
+                sender: "me" | "them" | "any";
+                text?: string;
+                localOnly?: boolean;
+                nl?: string;
+                limit?: number;
+            }) => {
+                p.intro(pc.bgMagenta(pc.white(" telegram history query ")));
+
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    return;
+                }
+
+                const parsed = queryParser.parseFromFlags({
+                    from: opts.from,
+                    since: opts.since,
+                    until: opts.until,
+                    sender: opts.sender,
+                    text: opts.text,
+                    localOnly: opts.localOnly,
+                    nl: opts.nl,
+                    limit: opts.limit,
+                } satisfies QueryRequest);
+                const contact = resolveContact(data.contacts, parsed.from);
+
+                if (!contact) {
+                    p.log.error(`Contact "${parsed.from}" not found.`);
+                    return;
+                }
+
+                const since = parsed.since ? parseDate(parsed.since) : undefined;
+                const until = parsed.until ? parseDate(parsed.until) : undefined;
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                try {
+                    if (!parsed.localOnly && since && until) {
+                        const client = await ensureClient(config);
+
+                        if (client) {
+                            try {
+                                await conversationSyncService.ensureRange(client, store, contact.userId, since, until, {
+                                    limit: opts.limit,
+                                });
+                            } finally {
+                                await client.disconnect();
+                            }
+                        }
+                    }
+
+                    const rows = store.queryMessages(contact.userId, {
+                        since,
+                        until,
+                        sender: parsed.sender,
+                        textRegex: parsed.text,
+                        limit: parsed.limit,
+                    });
+
+                    if (rows.length === 0) {
+                        p.log.warn("No messages found.");
+                        return;
+                    }
+
+                    for (const row of rows) {
+                        const who = row.is_outgoing ? pc.blue("You") : pc.cyan(contact.displayName);
+                        const text = row.is_deleted ? pc.dim("[deleted]") : (row.text ?? row.media_desc ?? "(empty)");
+                        const stamp = new Date(row.date_unix * 1000).toISOString();
+                        p.log.info(`${pc.dim(stamp)} ${who}: ${text}`);
+                    }
+
+                    p.outro(`${rows.length} message(s)`);
+                } finally {
+                    store.close();
+                }
+            }
+        );
+}
+
+function registerAttachmentsCommand(history: Command): void {
+    const attachments = history.command("attachments").description("Attachment index and downloads");
+
+    attachments
+        .command("list")
+        .description("List indexed attachments")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .option("--since <date>", "Start date (YYYY-MM-DD)")
+        .option("--until <date>", "End date (YYYY-MM-DD)")
+        .option("--message-id <id>", "Specific message id", (value) => Number.parseInt(value, 10))
+        .option("--limit <n>", "Maximum rows", (value) => Number.parseInt(value, 10))
+        .action(async (opts: { from: string; since?: string; until?: string; messageId?: number; limit?: number }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
+            }
+
+            const contact = resolveContact(data.contacts, opts.from);
+
+            if (!contact) {
+                p.log.error(`Contact "${opts.from}" not found.`);
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const rows = store.listAttachments(contact.userId, {
+                    since: opts.since ? parseDate(opts.since) : undefined,
+                    until: opts.until ? parseDate(opts.until) : undefined,
+                    messageId: opts.messageId,
+                    limit: opts.limit,
+                });
+
+                if (rows.length === 0) {
+                    p.log.warn("No attachments found.");
+                    return;
+                }
+
+                const tableRows = rows.map((row) => [
+                    String(row.message_id),
+                    String(row.attachment_index),
+                    row.kind,
+                    row.file_name ?? "—",
+                    row.mime_type ?? "—",
+                    row.is_downloaded ? "yes" : "no",
+                ]);
+
+                console.log(
+                    formatTable(tableRows, ["Message ID", "Index", "Kind", "File", "MIME", "Downloaded"], {
+                        alignRight: [0, 1],
+                    })
+                );
+            } finally {
+                store.close();
+            }
+        });
+
+    attachments
+        .command("fetch")
+        .description("Download one attachment by locator")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .requiredOption("--message-id <id>", "Message id", (value) => Number.parseInt(value, 10))
+        .requiredOption("--attachment-index <n>", "Attachment index", (value) => Number.parseInt(value, 10))
+        .option("--output <path>", "Output path")
+        .action(async (opts: { from: string; messageId: number; attachmentIndex: number; output?: string }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
+            }
+
+            const contact = resolveContact(data.contacts, opts.from);
+
+            if (!contact) {
+                p.log.error(`Contact "${opts.from}" not found.`);
+                return;
+            }
+
+            const client = await ensureClient(config);
+
+            if (!client) {
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const result = await attachmentDownloader.downloadByLocator(
+                    client,
+                    store,
+                    {
+                        chatId: contact.userId,
+                        messageId: opts.messageId,
+                        attachmentIndex: opts.attachmentIndex,
+                    },
+                    {
+                        outputPath: opts.output ? resolve(opts.output) : undefined,
+                    }
+                );
+
+                p.log.success(`Downloaded ${result.bytes} bytes to ${result.outputPath}`);
+            } finally {
+                store.close();
+                await client.disconnect();
+            }
+        });
+}
+
+function registerStyleCommand(history: Command): void {
+    const style = history.command("style").description("Style profile utilities");
+
+    style
+        .command("derive")
+        .description("Derive writing style prompt from style profile rules")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .action(async (opts: { from: string }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
+            }
+
+            const contactConfig = resolveContact(data.contacts, opts.from);
+
+            if (!contactConfig) {
+                p.log.error(`Contact "${opts.from}" not found.`);
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const contact = TelegramContact.fromConfig(contactConfig);
+                const derived = await styleProfileEngine.deriveStylePrompt(contact, store);
+
+                if (!derived) {
+                    p.log.warn("No style profile rules or no matching messages.");
+                    return;
+                }
+
+                contactConfig.styleProfile = {
+                    ...contactConfig.styleProfile,
+                    enabled: true,
+                    refresh: "incremental",
+                    rules: contactConfig.styleProfile?.rules ?? [],
+                    previewInWatch: contactConfig.styleProfile?.previewInWatch ?? false,
+                    derivedPrompt: derived.prompt,
+                    derivedAt: derived.generatedAt,
+                };
+
+                await config.save({
+                    ...data,
+                    contacts: data.contacts.map((contact) =>
+                        contact.userId === contactConfig.userId ? contactConfig : contact
+                    ),
+                    configuredAt: new Date().toISOString(),
+                });
+
+                p.log.success(`Derived style prompt from ${derived.sampleCount} sample messages.`);
+                p.log.info(derived.prompt);
+            } finally {
+                store.close();
+            }
+        });
+}
 
 function registerSearchCommand(history: Command): void {
     history
@@ -303,7 +555,7 @@ function registerSearchCommand(history: Command): void {
         .option("--until <date>", "End date (YYYY-MM-DD)")
         .option("--semantic", "Use semantic (vector) search instead of keyword")
         .option("--hybrid", "Use hybrid search (keyword + semantic combined)")
-        .option("--limit <n>", "Max results (default: 20)", parseInt)
+        .option("--limit <n>", "Max results (default: 20)", (value) => Number.parseInt(value, 10))
         .action(
             async (
                 contactName: string,
@@ -329,9 +581,7 @@ function registerSearchCommand(history: Command): void {
                 const contact = resolveContact(data.contacts, contactName);
 
                 if (!contact) {
-                    p.log.error(
-                        `Contact "${contactName}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
+                    p.log.error(`Contact "${contactName}" not found.`);
                     return;
                 }
 
@@ -356,15 +606,6 @@ function registerSearchCommand(history: Command): void {
                         try {
                             const langResult = await detectLanguage(query);
                             const lang = EMBEDDING_LANGUAGES.has(langResult.language) ? langResult.language : "en";
-
-                            if (!EMBEDDING_LANGUAGES.has(langResult.language)) {
-                                p.log.warn(
-                                    `Query language "${langResult.language}" is not supported for semantic search. ` +
-                                        `Supported: ${[...EMBEDDING_LANGUAGES].join(", ")}. ` +
-                                        `Results may be less accurate. Use keyword search for best results with this language.`
-                                );
-                            }
-
                             const embedResult = await embedText(query, lang, "sentence");
                             queryEmbedding = new Float32Array(embedResult.vector);
                             spinner.stop("Query embedded");
@@ -372,9 +613,7 @@ function registerSearchCommand(history: Command): void {
                             spinner.stop("Embedding failed — falling back to keyword search");
                             p.log.warn(`Could not embed query: ${err}`);
                             results = store.search(contact.userId, query, searchOpts);
-
                             displayResults(results, contact.displayName);
-                            store.close();
                             return;
                         }
 
@@ -388,16 +627,13 @@ function registerSearchCommand(history: Command): void {
                     }
 
                     displayResults(results, contact.displayName);
+                    p.outro(`${results.length} result(s) found.`);
                 } finally {
                     store.close();
                 }
-
-                p.outro(`${results?.length ?? 0} result(s) found.`);
             }
         );
 }
-
-// ── Export Command ────────────────────────────────────────────────────
 
 function registerExportCommand(history: Command): void {
     history
@@ -433,19 +669,18 @@ function registerExportCommand(history: Command): void {
                 const contact = resolveContact(data.contacts, contactName);
 
                 if (!contact) {
-                    p.log.error(
-                        `Contact "${contactName}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
+                    p.log.error(`Contact "${contactName}" not found.`);
                     return;
                 }
 
                 const store = new TelegramHistoryStore();
                 store.open();
 
-                const since = opts.since ? parseDate(opts.since) : undefined;
-                const until = opts.until ? parseDate(opts.until) : undefined;
-
-                const messages = store.getByDateRange(contact.userId, since, until);
+                const messages = store.getByDateRange(
+                    contact.userId,
+                    opts.since ? parseDate(opts.since) : undefined,
+                    opts.until ? parseDate(opts.until) : undefined
+                );
                 store.close();
 
                 if (messages.length === 0) {
@@ -465,8 +700,6 @@ function registerExportCommand(history: Command): void {
             }
         );
 }
-
-// ── Stats Command ─────────────────────────────────────────────────────
 
 function registerStatsCommand(history: Command): void {
     history
@@ -491,9 +724,7 @@ function registerStatsCommand(history: Command): void {
                     const contact = resolveContact(data.contacts, contactName);
 
                     if (!contact) {
-                        p.log.error(
-                            `Contact "${contactName}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                        );
+                        p.log.error(`Contact "${contactName}" not found.`);
                         return;
                     }
 
@@ -501,47 +732,44 @@ function registerStatsCommand(history: Command): void {
 
                     if (stats.length === 0) {
                         p.log.warn(
-                            `No messages downloaded for ${contact.displayName}. Run: tools telegram history download`
+                            `No messages downloaded for ${contact.displayName}. Run: tools telegram history sync`
                         );
                         return;
                     }
 
-                    const s = stats[0];
+                    const stat = stats[0];
                     p.log.info(
                         `${pc.bold(contact.displayName)}\n` +
-                            `  Total messages:    ${formatNumber(s.totalMessages)}\n` +
-                            `  Sent:              ${formatNumber(s.outgoingMessages)}\n` +
-                            `  Received:          ${formatNumber(s.incomingMessages)}\n` +
-                            `  Embedded:          ${formatNumber(s.embeddedMessages)}\n` +
-                            `  First message:     ${s.firstMessageDate ?? "—"}\n` +
-                            `  Last message:      ${s.lastMessageDate ?? "—"}`
+                            `  Total messages:    ${formatNumber(stat.totalMessages)}\n` +
+                            `  Sent:              ${formatNumber(stat.outgoingMessages)}\n` +
+                            `  Received:          ${formatNumber(stat.incomingMessages)}\n` +
+                            `  Embedded:          ${formatNumber(stat.embeddedMessages)}\n` +
+                            `  First message:     ${stat.firstMessageDate ?? "—"}\n` +
+                            `  Last message:      ${stat.lastMessageDate ?? "—"}`
                     );
                 } else {
                     const allStats = store.getStats();
 
                     if (allStats.length === 0) {
-                        p.log.warn("No messages downloaded yet. Run: tools telegram history download");
+                        p.log.warn("No messages downloaded yet. Run: tools telegram history sync");
                         return;
                     }
 
                     const contactMap = new Map<string, string>();
 
-                    for (const c of data.contacts) {
-                        contactMap.set(c.userId, c.displayName);
+                    for (const contact of data.contacts) {
+                        contactMap.set(contact.userId, contact.displayName);
                     }
 
-                    const rows = allStats.map((s) => [
-                        contactMap.get(s.chatId) ?? s.chatId,
-                        formatNumber(s.totalMessages),
-                        formatNumber(s.incomingMessages),
-                        formatNumber(s.outgoingMessages),
-                        formatNumber(s.embeddedMessages),
-                        s.firstMessageDate?.slice(0, 10) ?? "—",
-                        s.lastMessageDate?.slice(0, 10) ?? "—",
+                    const rows = allStats.map((stat) => [
+                        contactMap.get(stat.chatId) ?? stat.chatId,
+                        formatNumber(stat.totalMessages),
+                        formatNumber(stat.incomingMessages),
+                        formatNumber(stat.outgoingMessages),
+                        formatNumber(stat.embeddedMessages),
+                        stat.firstMessageDate?.slice(0, 10) ?? "—",
+                        stat.lastMessageDate?.slice(0, 10) ?? "—",
                     ]);
-
-                    const totalMessages = allStats.reduce((sum, s) => sum + s.totalMessages, 0);
-                    const totalEmbedded = allStats.reduce((sum, s) => sum + s.embeddedMessages, 0);
 
                     console.log();
                     console.log(
@@ -550,11 +778,6 @@ function registerStatsCommand(history: Command): void {
                         })
                     );
                     console.log();
-
-                    p.log.info(
-                        `${pc.bold("Summary")}: ${formatNumber(totalMessages)} messages across ${allStats.length} contact(s), ` +
-                            `${formatNumber(totalEmbedded)} embedded`
-                    );
                 }
             } finally {
                 store.close();
@@ -564,13 +787,14 @@ function registerStatsCommand(history: Command): void {
         });
 }
 
-// ── Registration ──────────────────────────────────────────────────────
-
 export function registerHistoryCommand(program: Command): void {
-    const history = program.command("history").description("Download, search, and export conversation history");
+    const history = program.command("history").description("Download, query, and export conversation history");
 
-    registerDownloadCommand(history);
+    registerSyncCommand(history);
     registerEmbedCommand(history);
+    registerQueryCommand(history);
+    registerAttachmentsCommand(history);
+    registerStyleCommand(history);
     registerSearchCommand(history);
     registerExportCommand(history);
     registerStatsCommand(history);

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -328,14 +328,27 @@ function registerQueryCommand(history: Command): void {
                 store.open();
 
                 try {
-                    if (!parsed.localOnly && since && until) {
+                    if (!parsed.localOnly) {
                         const client = await ensureClient(config);
 
                         if (client) {
                             try {
-                                await conversationSyncService.ensureRange(client, store, contact.userId, since, until, {
-                                    limit: opts.limit,
-                                });
+                                if (since || until) {
+                                    await conversationSyncService.ensureRange(
+                                        client,
+                                        store,
+                                        contact.userId,
+                                        since ?? new Date(0),
+                                        until ?? new Date(),
+                                        {
+                                            limit: opts.limit,
+                                        }
+                                    );
+                                } else {
+                                    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+                                        limit: opts.limit,
+                                    });
+                                }
                             } finally {
                                 await client.disconnect();
                             }

--- a/src/telegram/commands/watch.ts
+++ b/src/telegram/commands/watch.ts
@@ -1,0 +1,180 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { conversationSyncService } from "../lib/ConversationSyncService";
+import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
+import { TelegramToolConfig } from "../lib/TelegramToolConfig";
+import { TGClient } from "../lib/TGClient";
+import type { ContactConfig, TelegramRuntimeMode } from "../lib/types";
+import { runWatchInkApp } from "../runtime/ink/WatchInkApp";
+import { runWatchRuntime } from "../runtime/light/WatchRuntime";
+
+function resolveContact(contacts: ContactConfig[], nameOrId: string): ContactConfig | undefined {
+    const lower = nameOrId.toLowerCase();
+
+    return contacts.find((contact) => {
+        if (contact.userId === nameOrId) {
+            return true;
+        }
+
+        if (contact.displayName.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower.replace(/^@/, "")) {
+            return true;
+        }
+
+        return false;
+    });
+}
+
+export function registerWatchCommand(program: Command): void {
+    program
+        .command("watch [contact]")
+        .description("Watch configured Telegram dialogs in daemon/light/ink mode")
+        .option("--all", "Watch all configured contacts")
+        .option("--runtime <mode>", "daemon|light|ink")
+        .option("--context-length <n>", "Override context length", (value) => Number.parseInt(value, 10))
+        .action(
+            async (
+                contactName: string | undefined,
+                opts: {
+                    all?: boolean;
+                    runtime?: TelegramRuntimeMode;
+                    contextLength?: number;
+                }
+            ) => {
+                p.intro(pc.bgMagenta(pc.white(" telegram watch ")));
+
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data?.session) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    process.exit(1);
+                }
+
+                if (data.contacts.length === 0) {
+                    p.log.warn("No contacts configured. Run: tools telegram configure");
+                    process.exit(1);
+                }
+
+                let targetContacts: ContactConfig[] = [];
+
+                if (opts.all) {
+                    targetContacts = data.contacts;
+                } else if (contactName) {
+                    const found = resolveContact(data.contacts, contactName);
+
+                    if (!found) {
+                        p.log.error(`Contact "${contactName}" not found.`);
+                        process.exit(1);
+                    }
+
+                    targetContacts = [found];
+                } else {
+                    const selected = await p.select({
+                        message: "Which contact to watch?",
+                        options: [
+                            ...data.contacts.map((contact) => ({
+                                value: contact.userId,
+                                label: contact.displayName,
+                                hint: contact.username ? `@${contact.username}` : contact.dialogType,
+                            })),
+                            { value: "__all__", label: "All contacts" },
+                        ],
+                    });
+
+                    if (p.isCancel(selected)) {
+                        return;
+                    }
+
+                    if (selected === "__all__") {
+                        targetContacts = data.contacts;
+                    } else {
+                        const found = data.contacts.find((contact) => contact.userId === selected);
+
+                        if (!found) {
+                            return;
+                        }
+
+                        targetContacts = [found];
+                    }
+                }
+
+                const spinner = p.spinner();
+                spinner.start("Connecting to Telegram...");
+
+                const client = TGClient.fromConfig(config);
+                const authorized = await client.connect();
+
+                if (!authorized) {
+                    spinner.stop("Session expired");
+                    p.log.error("Session expired. Run: tools telegram configure");
+                    process.exit(1);
+                }
+
+                const me = await client.getMe();
+                const myName = me.firstName || "Me";
+                spinner.stop(`Connected as ${myName}`);
+
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                for (const contact of targetContacts) {
+                    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+                        limit: 200,
+                    });
+                }
+
+                const runtimeMode: TelegramRuntimeMode =
+                    opts.runtime ?? targetContacts[0]?.watch?.runtimeMode ?? "daemon";
+
+                const shutdown = async () => {
+                    store.close();
+
+                    try {
+                        await client.disconnect();
+                    } catch {
+                        // ignore disconnect errors
+                    }
+                };
+
+                process.on("SIGINT", async () => {
+                    await shutdown();
+                    process.exit(0);
+                });
+
+                process.on("SIGTERM", async () => {
+                    await shutdown();
+                    process.exit(0);
+                });
+
+                if (runtimeMode === "ink") {
+                    await runWatchInkApp({
+                        contacts: targetContacts,
+                        myName,
+                        client,
+                        store,
+                        contextLength: opts.contextLength,
+                    });
+                } else {
+                    await runWatchRuntime({
+                        contacts: targetContacts,
+                        myName,
+                        client,
+                        store,
+                        contextLength: opts.contextLength,
+                        daemon: runtimeMode === "daemon",
+                    });
+                }
+
+                await shutdown();
+            }
+        );
+}

--- a/src/telegram/index.ts
+++ b/src/telegram/index.ts
@@ -4,6 +4,7 @@ import { registerConfigureCommand } from "./commands/configure";
 import { registerContactsCommand } from "./commands/contacts";
 import { registerHistoryCommand } from "./commands/history";
 import { registerListenCommand } from "./commands/listen";
+import { registerWatchCommand } from "./commands/watch";
 
 handleReadmeFlag(import.meta.url);
 
@@ -15,6 +16,7 @@ program
     .showHelpAfterError(true);
 
 registerConfigureCommand(program);
+registerWatchCommand(program);
 registerListenCommand(program);
 registerContactsCommand(program);
 registerHistoryCommand(program);

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -1,7 +1,12 @@
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { AIChat } from "@ask/AIChat";
+import type { AIChatTool } from "@ask/lib/types";
+import { createAssistantTools } from "./AssistantTools";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { AskModeConfig } from "./types";
+
+const MAX_HISTORY_CONTEXT_CHARS = 90_000;
 
 export interface AssistantRequest {
     sessionId: string;
@@ -9,6 +14,10 @@ export interface AssistantRequest {
     incomingText: string;
     conversationHistory?: string;
     stylePrompt?: string;
+    rawStyleSamples?: string[];
+    store?: TelegramHistoryStore;
+    chatId?: string;
+    includeFullDbHistory?: boolean;
 }
 
 export class AssistantEngine {
@@ -45,24 +54,75 @@ export class AssistantEngine {
         return chat;
     }
 
-    async ask(request: AssistantRequest): Promise<string> {
-        const chat = this.getChat(request.sessionId, request.mode);
+    private buildTools(store: TelegramHistoryStore | undefined, chatId: string | undefined): Record<string, AIChatTool> {
+        if (!store || !chatId) {
+            return {};
+        }
+
+        return createAssistantTools(store, chatId);
+    }
+
+    private buildFullHistoryContext(store: TelegramHistoryStore, chatId: string): string {
+        const rows = store.queryMessages(chatId, {
+            sender: "any",
+        });
+        const lines = rows.map((row) => {
+            const who = row.is_outgoing ? "me" : "them";
+            const text = row.text ?? row.media_desc ?? "";
+            return `${row.date_iso} ${who}: ${text}`;
+        });
+
+        const all = lines.join("\n");
+
+        if (all.length <= MAX_HISTORY_CONTEXT_CHARS) {
+            return all;
+        }
+
+        return all.slice(all.length - MAX_HISTORY_CONTEXT_CHARS);
+    }
+
+    private buildPrompt(request: AssistantRequest): string {
+        const sections: string[] = [];
 
         if (request.stylePrompt) {
-            chat.session.add({
-                role: "system",
-                content: `[Style profile]\n${request.stylePrompt}`,
-            });
+            sections.push(`[Style summary]\n${request.stylePrompt}`);
+        }
+
+        if (request.rawStyleSamples && request.rawStyleSamples.length > 0) {
+            sections.push(`[Raw style samples]\n${request.rawStyleSamples.join("\n")}`);
         }
 
         if (request.conversationHistory) {
-            chat.session.add({
-                role: "system",
-                content: `[Recent conversation]\n${request.conversationHistory}`,
+            sections.push(`[Recent conversation]\n${request.conversationHistory}`);
+        }
+
+        if (request.includeFullDbHistory && request.store && request.chatId) {
+            sections.push(
+                "[Full DB history snapshot]\n" +
+                    this.buildFullHistoryContext(request.store, request.chatId) +
+                    "\n\n[Note] If you need specific ranges/filters, use available tools (query_messages/search_messages/list_attachments/get_stats/get_suggestion_feedback)."
+            );
+        }
+
+        sections.push(`[User request]\n${request.incomingText}`);
+
+        return sections.join("\n\n");
+    }
+
+    async ask(request: AssistantRequest): Promise<string> {
+        const chat = this.getChat(request.sessionId, request.mode);
+        const tools = this.buildTools(request.store, request.chatId);
+        const toolCount = Object.keys(tools).length;
+
+        if (toolCount > 0) {
+            chat.updateConfig({
+                tools,
             });
         }
 
-        const response = await chat.send(request.incomingText);
+        const response = await chat.send(this.buildPrompt(request), {
+            addToHistory: false,
+        });
 
         return response.content;
     }

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -54,7 +54,10 @@ export class AssistantEngine {
         return chat;
     }
 
-    private buildTools(store: TelegramHistoryStore | undefined, chatId: string | undefined): Record<string, AIChatTool> {
+    private buildTools(
+        store: TelegramHistoryStore | undefined,
+        chatId: string | undefined
+    ): Record<string, AIChatTool> {
         if (!store || !chatId) {
             return {};
         }

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -1,0 +1,77 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { AIChat } from "@ask/AIChat";
+import type { AskModeConfig } from "./types";
+
+export interface AssistantRequest {
+    sessionId: string;
+    mode: AskModeConfig;
+    incomingText: string;
+    conversationHistory?: string;
+    stylePrompt?: string;
+}
+
+export class AssistantEngine {
+    private sessions = new Map<string, AIChat>();
+
+    private getCacheKey(sessionId: string, mode: AskModeConfig): string {
+        return `${sessionId}:${mode.provider ?? "default"}:${mode.model ?? "default"}`;
+    }
+
+    private getChat(sessionId: string, mode: AskModeConfig): AIChat {
+        const key = this.getCacheKey(sessionId, mode);
+        const existing = this.sessions.get(key);
+
+        if (existing) {
+            return existing;
+        }
+
+        const chat = new AIChat({
+            provider: mode.provider ?? "openai",
+            model: mode.model ?? "gpt-4o-mini",
+            systemPrompt: mode.systemPrompt,
+            temperature: mode.temperature,
+            maxTokens: mode.maxTokens,
+            logLevel: "silent",
+            session: {
+                id: key,
+                dir: resolve(homedir(), ".genesis-tools/telegram/ai-sessions"),
+                autoSave: true,
+            },
+        });
+
+        this.sessions.set(key, chat);
+
+        return chat;
+    }
+
+    async ask(request: AssistantRequest): Promise<string> {
+        const chat = this.getChat(request.sessionId, request.mode);
+
+        if (request.stylePrompt) {
+            chat.session.add({
+                role: "system",
+                content: `[Style profile]\n${request.stylePrompt}`,
+            });
+        }
+
+        if (request.conversationHistory) {
+            chat.session.add({
+                role: "system",
+                content: `[Recent conversation]\n${request.conversationHistory}`,
+            });
+        }
+
+        const response = await chat.send(request.incomingText);
+
+        return response.content;
+    }
+
+    async disposeAll(): Promise<void> {
+        const disposals = [...this.sessions.values()].map((chat) => chat.dispose());
+        await Promise.all(disposals);
+        this.sessions.clear();
+    }
+}
+
+export const assistantEngine = new AssistantEngine();

--- a/src/telegram/lib/AssistantTools.ts
+++ b/src/telegram/lib/AssistantTools.ts
@@ -1,0 +1,150 @@
+import type { AIChatTool } from "@ask/lib/types";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+
+function asString(value: unknown): string | undefined {
+    if (typeof value === "string" && value.length > 0) {
+        return value;
+    }
+
+    return undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return undefined;
+}
+
+function parseOptionalDate(value: unknown): Date | undefined {
+    const text = asString(value);
+
+    if (!text) {
+        return undefined;
+    }
+
+    const date = new Date(text);
+
+    if (Number.isNaN(date.getTime())) {
+        return undefined;
+    }
+
+    return date;
+}
+
+export function createAssistantTools(store: TelegramHistoryStore, chatId: string): Record<string, AIChatTool> {
+    return {
+        query_messages: {
+            description:
+                "Query conversation messages from local DB for this chat by optional date/sender/text filters.",
+            parameters: {
+                since: { type: "string", description: "Optional ISO date or YYYY-MM-DD start date", optional: true },
+                until: { type: "string", description: "Optional ISO date or YYYY-MM-DD end date", optional: true },
+                sender: {
+                    type: "string",
+                    description: "me|them|any (default any)",
+                    optional: true,
+                },
+                textRegex: { type: "string", description: "Optional regex filter", optional: true },
+                limit: { type: "number", description: "Optional max rows", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                const senderRaw = asString(params.sender);
+                const sender = senderRaw === "me" || senderRaw === "them" || senderRaw === "any" ? senderRaw : "any";
+
+                const rows = store.queryMessages(chatId, {
+                    since: parseOptionalDate(params.since),
+                    until: parseOptionalDate(params.until),
+                    sender,
+                    textRegex: asString(params.textRegex),
+                    limit: asNumber(params.limit),
+                });
+
+                return rows.map((row) => ({
+                    id: row.id,
+                    date: row.date_iso,
+                    sender: row.is_outgoing ? "me" : "them",
+                    text: row.text,
+                    media: row.media_desc,
+                    deleted: row.is_deleted === 1,
+                }));
+            },
+        },
+        search_messages: {
+            description: "FTS keyword search in this chat's local DB index.",
+            parameters: {
+                query: { type: "string", description: "Search query text" },
+                limit: { type: "number", description: "Optional result count", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                const query = asString(params.query);
+
+                if (!query) {
+                    return [];
+                }
+
+                const results = store.search(chatId, query, {
+                    limit: asNumber(params.limit),
+                });
+
+                return results.map((result) => ({
+                    id: result.message.id,
+                    date: result.message.date_iso,
+                    sender: result.message.is_outgoing ? "me" : "them",
+                    text: result.message.text,
+                    media: result.message.media_desc,
+                }));
+            },
+        },
+        list_attachments: {
+            description: "List indexed attachment locators for this chat.",
+            parameters: {
+                limit: { type: "number", description: "Optional max rows", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                const rows = store.listAttachments(chatId, { limit: asNumber(params.limit) });
+
+                return rows.map((row) => ({
+                    locator: `${row.chat_id}:${row.message_id}:${row.attachment_index}`,
+                    messageId: row.message_id,
+                    attachmentIndex: row.attachment_index,
+                    kind: row.kind,
+                    fileName: row.file_name,
+                    mimeType: row.mime_type,
+                    downloaded: row.is_downloaded === 1,
+                }));
+            },
+        },
+        get_stats: {
+            description: "Return message and embedding stats for this chat.",
+            parameters: {},
+            execute: async () => {
+                const stats = store.getStats(chatId)[0];
+
+                if (!stats) {
+                    return null;
+                }
+
+                return stats;
+            },
+        },
+        get_suggestion_feedback: {
+            description: "Return recent suggestion feedback (suggested text vs edited sent text).",
+            parameters: {
+                limit: { type: "number", description: "Optional max rows", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                return store.getSuggestionFeedback(chatId, asNumber(params.limit) ?? 20);
+            },
+        },
+    };
+}

--- a/src/telegram/lib/AttachmentDownloader.ts
+++ b/src/telegram/lib/AttachmentDownloader.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { TGClient } from "./TGClient";
+import type { AttachmentLocator } from "./types";
+
+const DEFAULT_ATTACHMENTS_DIR = join(homedir(), ".genesis-tools", "telegram", "attachments");
+
+export interface DownloadAttachmentOptions {
+    outputPath?: string;
+}
+
+export interface DownloadAttachmentResult {
+    outputPath: string;
+    bytes: number;
+}
+
+export class AttachmentDownloader {
+    async downloadByLocator(
+        client: TGClient,
+        store: TelegramHistoryStore,
+        locator: AttachmentLocator,
+        options: DownloadAttachmentOptions = {}
+    ): Promise<DownloadAttachmentResult> {
+        const attachment = store.getAttachment(locator);
+
+        if (!attachment) {
+            throw new Error(
+                `Attachment not found for ${locator.chatId}:${locator.messageId}:${locator.attachmentIndex}`
+            );
+        }
+
+        const message = await client.getMessageById(locator.chatId, locator.messageId);
+
+        if (!message || !message.media) {
+            throw new Error(`Telegram message ${locator.messageId} has no downloadable media`);
+        }
+
+        const baseName = attachment.file_name ?? `${locator.messageId}-${locator.attachmentIndex}`;
+        const fallbackPath = join(DEFAULT_ATTACHMENTS_DIR, locator.chatId, baseName);
+        const outputPath = options.outputPath ?? fallbackPath;
+        const outputDir = dirname(outputPath);
+
+        if (!existsSync(outputDir)) {
+            mkdirSync(outputDir, { recursive: true });
+        }
+
+        const downloaded = await client.downloadMedia(message, {
+            outputFile: outputPath,
+        });
+
+        if (downloaded === undefined) {
+            throw new Error("Telegram client returned no data while downloading media");
+        }
+
+        if (Buffer.isBuffer(downloaded)) {
+            store.markAttachmentDownloaded(locator, outputPath, downloaded);
+
+            return {
+                outputPath,
+                bytes: downloaded.byteLength,
+            };
+        }
+
+        const fileBytes = readFileSync(downloaded);
+        store.markAttachmentDownloaded(locator, downloaded, fileBytes);
+
+        return {
+            outputPath: downloaded,
+            bytes: fileBytes.byteLength,
+        };
+    }
+}
+
+export const attachmentDownloader = new AttachmentDownloader();

--- a/src/telegram/lib/AttachmentDownloader.ts
+++ b/src/telegram/lib/AttachmentDownloader.ts
@@ -5,7 +5,7 @@ import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { TGClient } from "./TGClient";
 import type { AttachmentLocator } from "./types";
 
-const DEFAULT_ATTACHMENTS_DIR = join(homedir(), ".genesis-tools", "telegram", "attachments");
+const DEFAULT_CHATS_DIR = join(homedir(), ".genesis-tools", "telegram", "chats");
 
 export interface DownloadAttachmentOptions {
     outputPath?: string;
@@ -37,8 +37,16 @@ export class AttachmentDownloader {
             throw new Error(`Telegram message ${locator.messageId} has no downloadable media`);
         }
 
-        const baseName = attachment.file_name ?? `${locator.messageId}-${locator.attachmentIndex}`;
-        const fallbackPath = join(DEFAULT_ATTACHMENTS_DIR, locator.chatId, baseName);
+        const safeFileName = (attachment.file_name ?? `${locator.messageId}-${locator.attachmentIndex}`).replace(
+            /[\\/:*?"<>|]/g,
+            "_"
+        );
+        const fallbackPath = join(
+            DEFAULT_CHATS_DIR,
+            locator.chatId,
+            "attachments",
+            `${locator.messageId}-${locator.attachmentIndex}-${safeFileName}`
+        );
         const outputPath = options.outputPath ?? fallbackPath;
         const outputDir = dirname(outputPath);
 

--- a/src/telegram/lib/AttachmentIndexer.ts
+++ b/src/telegram/lib/AttachmentIndexer.ts
@@ -1,0 +1,20 @@
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { SerializedMessage } from "./TelegramMessage";
+
+export class AttachmentIndexer {
+    indexSerializedMessage(store: TelegramHistoryStore, chatId: string, message: SerializedMessage): void {
+        if (!message.attachments || message.attachments.length === 0) {
+            return;
+        }
+
+        store.upsertAttachments(chatId, message.id, message.attachments);
+    }
+
+    indexBatch(store: TelegramHistoryStore, chatId: string, messages: SerializedMessage[]): void {
+        for (const message of messages) {
+            this.indexSerializedMessage(store, chatId, message);
+        }
+    }
+}
+
+export const attachmentIndexer = new AttachmentIndexer();

--- a/src/telegram/lib/ConversationSyncService.ts
+++ b/src/telegram/lib/ConversationSyncService.ts
@@ -1,0 +1,181 @@
+import { formatNumber } from "@app/utils/format";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { syncRangePlanner } from "./SyncRangePlanner";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import { TelegramMessage } from "./TelegramMessage";
+import type { TGClient } from "./TGClient";
+
+export interface SyncOptions {
+    since?: Date;
+    until?: Date;
+    limit?: number;
+}
+
+export interface SyncResult {
+    downloaded: number;
+    inserted: number;
+    updated: number;
+    highestId: number;
+}
+
+interface SyncRangeOptions {
+    since?: Date;
+    until?: Date;
+    limit?: number;
+    minId?: number;
+    source: "query" | "full" | "incremental";
+}
+
+export class ConversationSyncService {
+    async syncIncremental(
+        client: TGClient,
+        store: TelegramHistoryStore,
+        chatId: string,
+        options: SyncOptions = {}
+    ): Promise<SyncResult> {
+        const lastSyncedId = store.getLastSyncedId(chatId);
+        const plan = syncRangePlanner.planIncremental(lastSyncedId);
+
+        return this.syncRange(client, store, chatId, {
+            since: options.since ?? plan.since,
+            until: options.until ?? plan.until,
+            limit: options.limit,
+            minId: lastSyncedId ?? undefined,
+            source: plan.source,
+        });
+    }
+
+    async ensureRange(
+        client: TGClient,
+        store: TelegramHistoryStore,
+        chatId: string,
+        since: Date,
+        until: Date,
+        options: { limit?: number } = {}
+    ): Promise<SyncResult[]> {
+        const ranges = syncRangePlanner.planQueryBackfill(store, chatId, since, until);
+        const results: SyncResult[] = [];
+
+        for (const range of ranges) {
+            const result = await this.syncRange(client, store, chatId, {
+                since: range.since,
+                until: range.until,
+                source: "query",
+                limit: options.limit,
+            });
+            results.push(result);
+        }
+
+        return results;
+    }
+
+    async syncRange(
+        client: TGClient,
+        store: TelegramHistoryStore,
+        chatId: string,
+        options: SyncRangeOptions
+    ): Promise<SyncResult> {
+        const iterOptions: {
+            limit?: number;
+            offsetDate?: number;
+            minId?: number;
+        } = {};
+
+        if (options.limit !== undefined) {
+            iterOptions.limit = options.limit;
+        }
+
+        if (options.until) {
+            iterOptions.offsetDate = Math.floor(options.until.getTime() / 1000);
+        }
+
+        if (options.minId !== undefined) {
+            iterOptions.minId = options.minId;
+        }
+
+        const spinner = p.spinner();
+        spinner.start(`Syncing ${chatId} (${options.source})...`);
+
+        let downloaded = 0;
+        let inserted = 0;
+        let updated = 0;
+        let highestId = options.minId ?? 0;
+        let rangeMin: number | null = null;
+        let rangeMax: number | null = null;
+
+        for await (const apiMessage of client.getMessages(chatId, iterOptions)) {
+            const message = new TelegramMessage(apiMessage);
+
+            if (options.since && message.date < options.since) {
+                continue;
+            }
+
+            if (options.until && message.date > options.until) {
+                continue;
+            }
+
+            const serialized = message.toJSON();
+            const revisionType = serialized.editedDateUnix ? "edit" : "create";
+            const upsertResult = store.upsertMessageWithRevision(chatId, serialized, revisionType);
+
+            downloaded++;
+
+            if (upsertResult.inserted) {
+                inserted++;
+            }
+
+            if (upsertResult.updated) {
+                updated++;
+            }
+
+            if (message.id > highestId) {
+                highestId = message.id;
+            }
+
+            if (rangeMin === null || serialized.dateUnix < rangeMin) {
+                rangeMin = serialized.dateUnix;
+            }
+
+            if (rangeMax === null || serialized.dateUnix > rangeMax) {
+                rangeMax = serialized.dateUnix;
+            }
+
+            if (downloaded % 100 === 0) {
+                spinner.message(
+                    `Downloaded ${formatNumber(downloaded)} messages (${inserted} new, ${updated} updated)`
+                );
+            }
+        }
+
+        if (highestId > 0) {
+            store.setLastSyncedId(chatId, highestId);
+        }
+
+        if (rangeMin !== null && rangeMax !== null) {
+            store.insertSyncSegment(chatId, rangeMin, rangeMax, options.source);
+        }
+
+        if (rangeMin === null && options.since && options.until) {
+            store.insertSyncSegment(
+                chatId,
+                Math.floor(options.since.getTime() / 1000),
+                Math.floor(options.until.getTime() / 1000),
+                options.source
+            );
+        }
+
+        spinner.stop(
+            `${pc.green(formatNumber(downloaded))} downloaded, ${pc.green(String(inserted))} new, ${pc.yellow(String(updated))} updated`
+        );
+
+        return {
+            downloaded,
+            inserted,
+            updated,
+            highestId,
+        };
+    }
+}
+
+export const conversationSyncService = new ConversationSyncService();

--- a/src/telegram/lib/QueryParser.ts
+++ b/src/telegram/lib/QueryParser.ts
@@ -1,0 +1,90 @@
+import type { QueryRequest } from "./types";
+
+const DATE_PATTERN = /(\d{4}-\d{2}-\d{2})/g;
+
+export class QueryParser {
+    parseFromFlags(request: QueryRequest): QueryRequest {
+        const parsed = { ...request };
+
+        if (request.nl) {
+            const extracted = this.parseNaturalLanguage(request.nl);
+
+            if (!parsed.from && extracted.from) {
+                parsed.from = extracted.from;
+            }
+
+            if (!parsed.since && extracted.since) {
+                parsed.since = extracted.since;
+            }
+
+            if (!parsed.until && extracted.until) {
+                parsed.until = extracted.until;
+            }
+
+            if (!parsed.sender && extracted.sender) {
+                parsed.sender = extracted.sender;
+            }
+
+            if (!parsed.text && extracted.text) {
+                parsed.text = extracted.text;
+            }
+        }
+
+        if (!parsed.sender) {
+            parsed.sender = "any";
+        }
+
+        return parsed;
+    }
+
+    parseNaturalLanguage(input: string): Partial<QueryRequest> {
+        const normalized = input.trim();
+        const result: Partial<QueryRequest> = {};
+
+        const fromMatch = normalized.match(/messages\s+from\s+(.+?)(?:\s+since|\s+until|\s+text|\s+matching|$)/i);
+
+        if (fromMatch) {
+            result.from = fromMatch[1].trim();
+        }
+
+        const sinceMatch = normalized.match(/since\s+(\d{4}-\d{2}-\d{2})/i);
+
+        if (sinceMatch) {
+            result.since = sinceMatch[1];
+        }
+
+        const untilMatch = normalized.match(/until\s+(\d{4}-\d{2}-\d{2})/i);
+
+        if (untilMatch) {
+            result.until = untilMatch[1];
+        }
+
+        const dates = [...normalized.matchAll(DATE_PATTERN)].map((match) => match[1]);
+
+        if (!result.since && dates.length > 0) {
+            result.since = dates[0];
+        }
+
+        if (!result.until && dates.length > 1) {
+            result.until = dates[1];
+        }
+
+        if (/\bfrom\s+me\b/i.test(normalized) || /\bmy messages\b/i.test(normalized)) {
+            result.sender = "me";
+        }
+
+        if (/\bfrom\s+(her|him|them)\b/i.test(normalized) || /\btheir messages\b/i.test(normalized)) {
+            result.sender = "them";
+        }
+
+        const textMatch = normalized.match(/matching\s+"([^"]+)"/i) ?? normalized.match(/text\s+"([^"]+)"/i);
+
+        if (textMatch) {
+            result.text = textMatch[1];
+        }
+
+        return result;
+    }
+}
+
+export const queryParser = new QueryParser();

--- a/src/telegram/lib/QueryParser.ts
+++ b/src/telegram/lib/QueryParser.ts
@@ -1,13 +1,45 @@
+import * as chrono from "chrono-node";
 import type { QueryRequest } from "./types";
 
-const DATE_PATTERN = /(\d{4}-\d{2}-\d{2})/g;
+const ISO_DATE_PATTERN = /(\d{4}-\d{2}-\d{2})/g;
+
+function toIsoDate(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
+function parseDatePhrase(phrase: string, referenceDate: Date): string | undefined {
+    const parsed = chrono.parseDate(phrase.trim(), referenceDate);
+
+    if (!parsed) {
+        return undefined;
+    }
+
+    return toIsoDate(parsed);
+}
 
 export class QueryParser {
     parseFromFlags(request: QueryRequest): QueryRequest {
         const parsed = { ...request };
+        const now = new Date();
+
+        if (parsed.since) {
+            const normalizedSince = parseDatePhrase(parsed.since, now);
+
+            if (normalizedSince) {
+                parsed.since = normalizedSince;
+            }
+        }
+
+        if (parsed.until) {
+            const normalizedUntil = parseDatePhrase(parsed.until, now);
+
+            if (normalizedUntil) {
+                parsed.until = normalizedUntil;
+            }
+        }
 
         if (request.nl) {
-            const extracted = this.parseNaturalLanguage(request.nl);
+            const extracted = this.parseNaturalLanguage(request.nl, now);
 
             if (!parsed.from && extracted.from) {
                 parsed.from = extracted.from;
@@ -37,7 +69,7 @@ export class QueryParser {
         return parsed;
     }
 
-    parseNaturalLanguage(input: string): Partial<QueryRequest> {
+    parseNaturalLanguage(input: string, referenceDate: Date = new Date()): Partial<QueryRequest> {
         const normalized = input.trim();
         const result: Partial<QueryRequest> = {};
 
@@ -47,26 +79,51 @@ export class QueryParser {
             result.from = fromMatch[1].trim();
         }
 
-        const sinceMatch = normalized.match(/since\s+(\d{4}-\d{2}-\d{2})/i);
+        const sincePhraseMatch = normalized.match(/since\s+(.+?)(?:\s+until|\s+text|\s+matching|$)/i);
+        const untilPhraseMatch = normalized.match(/until\s+(.+?)(?:\s+since|\s+text|\s+matching|$)/i);
 
-        if (sinceMatch) {
-            result.since = sinceMatch[1];
+        if (sincePhraseMatch) {
+            const parsed = parseDatePhrase(sincePhraseMatch[1], referenceDate);
+
+            if (parsed) {
+                result.since = parsed;
+            }
         }
 
-        const untilMatch = normalized.match(/until\s+(\d{4}-\d{2}-\d{2})/i);
+        if (untilPhraseMatch) {
+            const parsed = parseDatePhrase(untilPhraseMatch[1], referenceDate);
 
-        if (untilMatch) {
-            result.until = untilMatch[1];
+            if (parsed) {
+                result.until = parsed;
+            }
         }
 
-        const dates = [...normalized.matchAll(DATE_PATTERN)].map((match) => match[1]);
+        if (!result.since || !result.until) {
+            const chronoResults = chrono.parse(normalized, referenceDate, { forwardDate: false });
 
-        if (!result.since && dates.length > 0) {
-            result.since = dates[0];
+            for (const chronoResult of chronoResults) {
+                if (!result.since && chronoResult.start) {
+                    result.since = toIsoDate(chronoResult.start.date());
+                }
+
+                if (!result.until) {
+                    if (chronoResult.end) {
+                        result.until = toIsoDate(chronoResult.end.date());
+                    } else if (chronoResult.start) {
+                        result.until = toIsoDate(chronoResult.start.date());
+                    }
+                }
+            }
         }
 
-        if (!result.until && dates.length > 1) {
-            result.until = dates[1];
+        const isoDates = [...normalized.matchAll(ISO_DATE_PATTERN)].map((match) => match[1]);
+
+        if (!result.since && isoDates.length > 0) {
+            result.since = isoDates[0];
+        }
+
+        if (!result.until && isoDates.length > 1) {
+            result.until = isoDates[1];
         }
 
         if (/\bfrom\s+me\b/i.test(normalized) || /\bmy messages\b/i.test(normalized)) {

--- a/src/telegram/lib/StyleProfileEngine.ts
+++ b/src/telegram/lib/StyleProfileEngine.ts
@@ -1,0 +1,53 @@
+import { assistantEngine } from "./AssistantEngine";
+import { styleRuleResolver } from "./StyleRuleResolver";
+import type { TelegramContact } from "./TelegramContact";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import { DEFAULT_MODE_CONFIG } from "./types";
+
+export interface DerivedStyleResult {
+    prompt: string;
+    sampleCount: number;
+    generatedAt: string;
+}
+
+export class StyleProfileEngine {
+    async deriveStylePrompt(contact: TelegramContact, store: TelegramHistoryStore): Promise<DerivedStyleResult | null> {
+        const styleConfig = contact.config.styleProfile;
+
+        if (!styleConfig || !styleConfig.enabled || styleConfig.rules.length === 0) {
+            return null;
+        }
+
+        const lines = styleRuleResolver.resolveRules(store, styleConfig.rules).slice(-500);
+
+        if (lines.length === 0) {
+            return null;
+        }
+
+        const mode = contact.assistantMode.provider
+            ? contact.assistantMode
+            : {
+                  ...DEFAULT_MODE_CONFIG.assistant,
+              };
+
+        const content =
+            "You are deriving a style profile for one user's outbound Telegram writing. " +
+            "Output a concise system prompt that captures tone, pacing, sentence length, greeting habits, and conflict de-escalation style. " +
+            "Return only the final system prompt.\n\n" +
+            `Samples:\n${lines.join("\n")}`;
+
+        const prompt = await assistantEngine.ask({
+            sessionId: `style-${contact.userId}`,
+            mode,
+            incomingText: content,
+        });
+
+        return {
+            prompt: prompt.trim(),
+            sampleCount: lines.length,
+            generatedAt: new Date().toISOString(),
+        };
+    }
+}
+
+export const styleProfileEngine = new StyleProfileEngine();

--- a/src/telegram/lib/StyleRuleResolver.ts
+++ b/src/telegram/lib/StyleRuleResolver.ts
@@ -1,0 +1,45 @@
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { StyleSourceRule } from "./types";
+
+export class StyleRuleResolver {
+    resolveRule(store: TelegramHistoryStore, rule: StyleSourceRule): string[] {
+        const since = rule.since ? new Date(rule.since) : undefined;
+        const until = rule.until ? new Date(rule.until) : undefined;
+        const sender = rule.direction === "outgoing" ? "me" : "them";
+
+        let lines = store
+            .queryMessages(rule.sourceChatId, {
+                since,
+                until,
+                sender,
+                limit: rule.limit,
+            })
+            .map((row) => row.text ?? row.media_desc ?? "")
+            .map((line) => line.trim())
+            .filter(Boolean);
+
+        if (rule.regex) {
+            try {
+                const regex = new RegExp(rule.regex, "i");
+                lines = lines.filter((line) => regex.test(line));
+            } catch {
+                // ignore invalid regex in rule
+            }
+        }
+
+        return lines;
+    }
+
+    resolveRules(store: TelegramHistoryStore, rules: StyleSourceRule[]): string[] {
+        const output: string[] = [];
+
+        for (const rule of rules) {
+            const ruleLines = this.resolveRule(store, rule);
+            output.push(...ruleLines);
+        }
+
+        return output;
+    }
+}
+
+export const styleRuleResolver = new StyleRuleResolver();

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -1,0 +1,38 @@
+import { assistantEngine } from "./AssistantEngine";
+import type { SuggestionModeConfig } from "./types";
+
+export interface SuggestionRequest {
+    sessionId: string;
+    mode: SuggestionModeConfig;
+    incomingText: string;
+    conversationHistory?: string;
+    stylePrompt?: string;
+}
+
+export class SuggestionEngine {
+    async generateSuggestions(request: SuggestionRequest): Promise<string[]> {
+        const desired = Math.max(1, Math.min(request.mode.count, 5));
+        const prompt =
+            `Generate ${desired} possible message replies. ` +
+            "Return each option on a new line without numbering. Keep each line under 220 characters." +
+            `\n\nLatest incoming message:\n${request.incomingText}`;
+
+        const response = await assistantEngine.ask({
+            sessionId: `${request.sessionId}:suggestions`,
+            mode: request.mode,
+            conversationHistory: request.conversationHistory,
+            stylePrompt: request.stylePrompt,
+            incomingText: prompt,
+        });
+
+        const lines = response
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line) => line.replace(/^[-*\d.)\s]+/, ""));
+
+        return lines.slice(0, desired);
+    }
+}
+
+export const suggestionEngine = new SuggestionEngine();

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -1,28 +1,58 @@
 import { assistantEngine } from "./AssistantEngine";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { SuggestionModeConfig } from "./types";
 
 export interface SuggestionRequest {
     sessionId: string;
     mode: SuggestionModeConfig;
     incomingText: string;
+    incomingMessageId?: number;
     conversationHistory?: string;
     stylePrompt?: string;
+    rawStyleSamples?: string[];
+    store?: TelegramHistoryStore;
+    chatId?: string;
+}
+
+function buildFeedbackExamples(store: TelegramHistoryStore | undefined, chatId: string | undefined): string {
+    if (!store || !chatId) {
+        return "";
+    }
+
+    const rows = store.getSuggestionFeedback(chatId, 25);
+
+    if (rows.length === 0) {
+        return "";
+    }
+
+    const lines = rows.map((row) => {
+        const editedSuffix = row.was_edited ? ` | edited="${row.edited_text ?? ""}"` : "";
+        return `suggested="${row.suggestion_text}" | sent="${row.sent_text}"${editedSuffix}`;
+    });
+
+    return `\n\n[Suggestion edit feedback]\n${lines.join("\n")}`;
 }
 
 export class SuggestionEngine {
     async generateSuggestions(request: SuggestionRequest): Promise<string[]> {
         const desired = Math.max(1, Math.min(request.mode.count, 5));
+        const feedbackExamples = buildFeedbackExamples(request.store, request.chatId);
         const prompt =
             `Generate ${desired} possible message replies. ` +
             "Return each option on a new line without numbering. Keep each line under 220 characters." +
-            `\n\nLatest incoming message:\n${request.incomingText}`;
+            `\n\nLatest incoming message:\n${request.incomingText}` +
+            feedbackExamples;
 
         const response = await assistantEngine.ask({
             sessionId: `${request.sessionId}:suggestions`,
             mode: request.mode,
             conversationHistory: request.conversationHistory,
             stylePrompt: request.stylePrompt,
+            rawStyleSamples: request.rawStyleSamples,
             incomingText: prompt,
+            store: request.store,
+            chatId: request.chatId,
+            includeFullDbHistory: true,
         });
 
         const lines = response

--- a/src/telegram/lib/SyncRangePlanner.ts
+++ b/src/telegram/lib/SyncRangePlanner.ts
@@ -1,0 +1,37 @@
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+
+export interface PlannedSyncRange {
+    since: Date;
+    until: Date;
+    source: "query" | "full" | "incremental";
+}
+
+export class SyncRangePlanner {
+    planQueryBackfill(store: TelegramHistoryStore, chatId: string, since: Date, until: Date): PlannedSyncRange[] {
+        const missing = store.getMissingSegments(chatId, since, until);
+
+        return missing.map((range) => ({
+            since: new Date(range.sinceUnix * 1000),
+            until: new Date(range.untilUnix * 1000),
+            source: "query" as const,
+        }));
+    }
+
+    planIncremental(lastSyncedId: number | null): PlannedSyncRange {
+        if (lastSyncedId === null) {
+            return {
+                since: new Date(0),
+                until: new Date(),
+                source: "full",
+            };
+        }
+
+        return {
+            since: new Date(0),
+            until: new Date(),
+            source: "incremental",
+        };
+    }
+}
+
+export const syncRangePlanner = new SyncRangePlanner();

--- a/src/telegram/lib/TelegramContact.ts
+++ b/src/telegram/lib/TelegramContact.ts
@@ -1,6 +1,6 @@
 import type { Api } from "telegram";
-import type { ActionType, ContactConfig } from "./types";
-import { DEFAULTS } from "./types";
+import type { ActionType, AskModeConfig, ContactConfig, SuggestionModeConfig, TelegramRuntimeMode } from "./types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
 
 export class TelegramContact {
     constructor(
@@ -15,19 +15,53 @@ export class TelegramContact {
     }
 
     get hasAskAction(): boolean {
-        return this.config.actions.includes("ask");
+        return this.actions.includes("ask") || this.autoReplyMode.enabled;
+    }
+
+    get watchEnabled(): boolean {
+        return this.config.watch?.enabled ?? DEFAULT_WATCH_CONFIG.enabled;
+    }
+
+    get contextLength(): number {
+        return this.config.watch?.contextLength ?? DEFAULT_WATCH_CONFIG.contextLength;
+    }
+
+    get runtimeMode(): TelegramRuntimeMode {
+        return this.config.watch?.runtimeMode ?? DEFAULT_WATCH_CONFIG.runtimeMode ?? "daemon";
+    }
+
+    get autoReplyMode(): AskModeConfig {
+        return {
+            ...DEFAULT_MODE_CONFIG.autoReply,
+            ...this.config.modes?.autoReply,
+            enabled: this.config.modes?.autoReply?.enabled ?? this.actions.includes("ask"),
+        };
+    }
+
+    get assistantMode(): AskModeConfig {
+        return {
+            ...DEFAULT_MODE_CONFIG.assistant,
+            ...this.config.modes?.assistant,
+        };
+    }
+
+    get suggestionMode(): SuggestionModeConfig {
+        return {
+            ...DEFAULT_MODE_CONFIG.suggestions,
+            ...this.config.modes?.suggestions,
+        };
     }
 
     get askSystemPrompt(): string {
-        return this.config.askSystemPrompt ?? DEFAULTS.askSystemPrompt;
+        return this.autoReplyMode.systemPrompt ?? DEFAULTS.askSystemPrompt;
     }
 
     get askProvider(): string {
-        return this.config.askProvider ?? DEFAULTS.askProvider;
+        return this.autoReplyMode.provider ?? DEFAULTS.askProvider;
     }
 
     get askModel(): string {
-        return this.config.askModel ?? DEFAULTS.askModel;
+        return this.autoReplyMode.model ?? DEFAULTS.askModel;
     }
 
     get replyDelayMin(): number {

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -1,13 +1,35 @@
 import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import logger from "@app/logger";
 import { cosineDistance } from "@app/utils/math";
-import type { SerializedMessage } from "./TelegramMessage";
-import type { ChatStats, MessageRow, SearchOptions, SearchResult, SyncStateRow } from "./types";
+import type { AttachmentDescriptor, SerializedMessage } from "./TelegramMessage";
+import type {
+    AttachmentLocator,
+    AttachmentRow,
+    ChatRow,
+    ChatStats,
+    MessageRow,
+    MissingRange,
+    QueryMessagesOptions,
+    SearchOptions,
+    SearchResult,
+    SyncSegmentRow,
+    SyncStateRow,
+} from "./types";
 
 const DB_PATH = join(homedir(), ".genesis-tools", "telegram", "history.db");
+
+interface UpsertMessageResult {
+    inserted: boolean;
+    updated: boolean;
+}
+
+interface MessageRowWithEmbedding extends MessageRow {
+    embedding: Buffer;
+}
 
 export class TelegramHistoryStore {
     private db: Database | null = null;
@@ -49,116 +71,596 @@ export class TelegramHistoryStore {
 
     private initSchema(): void {
         const db = this.getDb();
+        const row = db.query("PRAGMA user_version").get() as { user_version: number };
+        let version = row.user_version;
+
+        if (version < 1) {
+            this.createBaseSchemaV1();
+            db.run("PRAGMA user_version = 1");
+            version = 1;
+        }
+
+        if (version < 2) {
+            this.migrateToV2();
+            db.run("PRAGMA user_version = 2");
+            version = 2;
+        }
+
+        if (version >= 2) {
+            this.ensureV2Schema();
+        }
+
+        this.ensureFtsTable();
+        this.ensureFtsTriggers();
+    }
+
+    private ensureFtsTable(): void {
+        const db = this.getDb();
 
         db.run(`
-			CREATE TABLE IF NOT EXISTS messages (
-				id INTEGER NOT NULL,
-				chat_id TEXT NOT NULL,
-				sender_id TEXT,
-				text TEXT,
-				media_desc TEXT,
-				is_outgoing INTEGER NOT NULL,
-				date_unix INTEGER NOT NULL,
-				date_iso TEXT NOT NULL,
-				PRIMARY KEY (chat_id, id)
-			)
-		`);
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                text,
+                content=messages,
+                content_rowid=rowid,
+                tokenize='unicode61'
+            )
+        `);
+    }
+
+    private createBaseSchemaV1(): void {
+        const db = this.getDb();
 
         db.run(`
-			CREATE INDEX IF NOT EXISTS idx_messages_chat_date
-				ON messages(chat_id, date_unix)
-		`);
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER NOT NULL,
+                chat_id TEXT NOT NULL,
+                sender_id TEXT,
+                text TEXT,
+                media_desc TEXT,
+                is_outgoing INTEGER NOT NULL,
+                date_unix INTEGER NOT NULL,
+                date_iso TEXT NOT NULL,
+                PRIMARY KEY (chat_id, id)
+            )
+        `);
 
         db.run(`
-			CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-				text,
-				content=messages,
-				content_rowid=rowid,
-				tokenize='unicode61'
-			)
-		`);
+            CREATE INDEX IF NOT EXISTS idx_messages_chat_date
+            ON messages(chat_id, date_unix)
+        `);
 
         db.run(`
-			CREATE TABLE IF NOT EXISTS sync_state (
-				chat_id TEXT PRIMARY KEY,
-				last_synced_id INTEGER NOT NULL,
-				last_synced_at TEXT NOT NULL
-			)
-		`);
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                text,
+                content=messages,
+                content_rowid=rowid,
+                tokenize='unicode61'
+            )
+        `);
 
-        // Embeddings stored as BLOBs (bun:sqlite doesn't support sqlite-vec extensions)
         db.run(`
-			CREATE TABLE IF NOT EXISTS embeddings (
-				message_rowid INTEGER PRIMARY KEY,
-				embedding BLOB NOT NULL
-			)
-		`);
+            CREATE TABLE IF NOT EXISTS sync_state (
+                chat_id TEXT PRIMARY KEY,
+                last_synced_id INTEGER NOT NULL,
+                last_synced_at TEXT NOT NULL
+            )
+        `);
 
-        // FTS5 external content triggers
+        db.run(`
+            CREATE TABLE IF NOT EXISTS embeddings (
+                message_rowid INTEGER PRIMARY KEY,
+                embedding BLOB NOT NULL
+            )
+        `);
+    }
+
+    private migrateToV2(): void {
+        const db = this.getDb();
+
+        if (!this.hasColumn("messages", "edited_date_unix")) {
+            db.run("ALTER TABLE messages ADD COLUMN edited_date_unix INTEGER");
+        }
+
+        if (!this.hasColumn("messages", "is_deleted")) {
+            db.run("ALTER TABLE messages ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0");
+        }
+
+        if (!this.hasColumn("messages", "deleted_at_iso")) {
+            db.run("ALTER TABLE messages ADD COLUMN deleted_at_iso TEXT");
+        }
+
+        if (!this.hasColumn("messages", "reply_to_msg_id")) {
+            db.run("ALTER TABLE messages ADD COLUMN reply_to_msg_id INTEGER");
+        }
+
+        this.ensureV2Schema();
+    }
+
+    private ensureV2Schema(): void {
+        const db = this.getDb();
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS chats (
+                chat_id TEXT PRIMARY KEY,
+                chat_type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                username TEXT,
+                last_seen_at_iso TEXT NOT NULL
+            )
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS message_revisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                revision_type TEXT NOT NULL,
+                text TEXT,
+                media_desc TEXT,
+                date_iso TEXT NOT NULL,
+                date_unix INTEGER NOT NULL,
+                UNIQUE(chat_id, message_id, revision_type, date_unix)
+            )
+        `);
+
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_message_revisions_chat_msg
+            ON message_revisions(chat_id, message_id, date_unix)
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS attachments (
+                chat_id TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                attachment_index INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                mime_type TEXT,
+                file_name TEXT,
+                file_size INTEGER,
+                telegram_file_id TEXT,
+                thumb_count INTEGER NOT NULL DEFAULT 0,
+                is_downloaded INTEGER NOT NULL DEFAULT 0,
+                local_path TEXT,
+                sha256 TEXT,
+                created_at_iso TEXT NOT NULL,
+                updated_at_iso TEXT NOT NULL,
+                PRIMARY KEY (chat_id, message_id, attachment_index)
+            )
+        `);
+
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_attachments_chat_message
+            ON attachments(chat_id, message_id)
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS sync_segments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id TEXT NOT NULL,
+                start_unix INTEGER NOT NULL,
+                end_unix INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                created_at_iso TEXT NOT NULL
+            )
+        `);
+
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_sync_segments_chat_range
+            ON sync_segments(chat_id, start_unix, end_unix)
+        `);
+    }
+
+    private ensureFtsTriggers(): void {
+        const db = this.getDb();
+
         try {
             db.run(`
-				CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
-					INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
-				END
-			`);
+                CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+                END
+            `);
         } catch {
             // trigger already exists
         }
 
         try {
             db.run(`
-				CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
-					INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
-				END
-			`);
+                CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                END
+            `);
         } catch {
             // trigger already exists
         }
 
         try {
             db.run(`
-				CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
-					INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
-					INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
-				END
-			`);
+                CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+                END
+            `);
         } catch {
             // trigger already exists
         }
     }
 
-    // ── Insert ────────────────────────────────────────────────────────
+    private hasColumn(table: string, column: string): boolean {
+        const db = this.getDb();
+        const rows = db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+
+        return rows.some((row) => row.name === column);
+    }
+
+    private toMessageRow(row: Record<string, unknown>): MessageRow {
+        return {
+            id: Number(row.id),
+            chat_id: String(row.chat_id),
+            sender_id: row.sender_id === null ? null : String(row.sender_id),
+            text: row.text === null ? null : String(row.text),
+            media_desc: row.media_desc === null ? null : String(row.media_desc),
+            is_outgoing: Number(row.is_outgoing),
+            date_unix: Number(row.date_unix),
+            date_iso: String(row.date_iso),
+            edited_date_unix: row.edited_date_unix === null ? null : Number(row.edited_date_unix),
+            is_deleted: Number(row.is_deleted ?? 0),
+            deleted_at_iso: row.deleted_at_iso === null ? null : String(row.deleted_at_iso),
+            reply_to_msg_id: row.reply_to_msg_id === null ? null : Number(row.reply_to_msg_id),
+        };
+    }
+
+    // ── Chat Metadata ────────────────────────────────────────────────
+
+    upsertChat(chat: Omit<ChatRow, "last_seen_at_iso">): void {
+        const db = this.getDb();
+
+        db.run(
+            `
+            INSERT INTO chats (chat_id, chat_type, title, username, last_seen_at_iso)
+            VALUES (?, ?, ?, ?, datetime('now'))
+            ON CONFLICT(chat_id) DO UPDATE SET
+                chat_type = excluded.chat_type,
+                title = excluded.title,
+                username = excluded.username,
+                last_seen_at_iso = excluded.last_seen_at_iso
+            `,
+            [chat.chat_id, chat.chat_type, chat.title, chat.username ?? null]
+        );
+    }
+
+    // ── Insert / Upsert ──────────────────────────────────────────────
 
     insertMessages(chatId: string, messages: SerializedMessage[]): number {
-        const db = this.getDb();
         let inserted = 0;
 
-        const insertStmt = db.prepare(`
-			INSERT OR IGNORE INTO messages (id, chat_id, sender_id, text, media_desc, is_outgoing, date_unix, date_iso)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-		`);
+        for (const msg of messages) {
+            const result = this.upsertMessageWithRevision(chatId, msg, "create");
 
-        const insertMany = db.transaction(() => {
-            for (const msg of messages) {
-                const result = insertStmt.run(
-                    msg.id,
-                    chatId,
-                    msg.senderId ?? null,
-                    msg.text || null,
-                    msg.mediaDescription ?? null,
-                    msg.isOutgoing ? 1 : 0,
-                    msg.dateUnix,
-                    msg.date
-                );
-
-                if (result.changes > 0) {
-                    inserted++;
-                }
+            if (result.inserted) {
+                inserted++;
             }
-        });
+        }
 
-        insertMany();
         return inserted;
+    }
+
+    upsertMessageWithRevision(
+        chatId: string,
+        message: SerializedMessage,
+        revisionType: "create" | "edit" = "create"
+    ): UpsertMessageResult {
+        const db = this.getDb();
+        const existing = db
+            .query(
+                `
+                SELECT text, media_desc, edited_date_unix, is_deleted, reply_to_msg_id
+                FROM messages
+                WHERE chat_id = ? AND id = ?
+                `
+            )
+            .get(chatId, message.id) as {
+            text: string | null;
+            media_desc: string | null;
+            edited_date_unix: number | null;
+            is_deleted: number;
+            reply_to_msg_id: number | null;
+        } | null;
+
+        if (!existing) {
+            db.run(
+                `
+                INSERT INTO messages (
+                    id,
+                    chat_id,
+                    sender_id,
+                    text,
+                    media_desc,
+                    is_outgoing,
+                    date_unix,
+                    date_iso,
+                    edited_date_unix,
+                    is_deleted,
+                    deleted_at_iso,
+                    reply_to_msg_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)
+                `,
+                [
+                    message.id,
+                    chatId,
+                    message.senderId ?? null,
+                    message.text || null,
+                    message.mediaDescription ?? null,
+                    message.isOutgoing ? 1 : 0,
+                    message.dateUnix,
+                    message.date,
+                    message.editedDateUnix ?? null,
+                    message.replyToMsgId ?? null,
+                ]
+            );
+
+            this.insertMessageRevision(
+                chatId,
+                message.id,
+                revisionType,
+                message.text,
+                message.mediaDescription,
+                message.dateUnix
+            );
+
+            if (message.attachments && message.attachments.length > 0) {
+                this.upsertAttachments(chatId, message.id, message.attachments);
+            }
+
+            return { inserted: true, updated: false };
+        }
+
+        const normalizedText = message.text || null;
+        const normalizedMedia = message.mediaDescription ?? null;
+        const normalizedEdited = message.editedDateUnix ?? null;
+        const normalizedReplyTo = message.replyToMsgId ?? null;
+
+        const changed =
+            existing.text !== normalizedText ||
+            existing.media_desc !== normalizedMedia ||
+            existing.edited_date_unix !== normalizedEdited ||
+            existing.reply_to_msg_id !== normalizedReplyTo ||
+            existing.is_deleted !== 0;
+
+        if (!changed) {
+            if (message.attachments && message.attachments.length > 0) {
+                this.upsertAttachments(chatId, message.id, message.attachments);
+            }
+
+            return { inserted: false, updated: false };
+        }
+
+        db.run(
+            `
+            UPDATE messages
+            SET
+                sender_id = ?,
+                text = ?,
+                media_desc = ?,
+                is_outgoing = ?,
+                date_unix = ?,
+                date_iso = ?,
+                edited_date_unix = ?,
+                is_deleted = 0,
+                deleted_at_iso = NULL,
+                reply_to_msg_id = ?
+            WHERE chat_id = ? AND id = ?
+            `,
+            [
+                message.senderId ?? null,
+                normalizedText,
+                normalizedMedia,
+                message.isOutgoing ? 1 : 0,
+                message.dateUnix,
+                message.date,
+                normalizedEdited,
+                normalizedReplyTo,
+                chatId,
+                message.id,
+            ]
+        );
+
+        this.insertMessageRevision(
+            chatId,
+            message.id,
+            "edit",
+            message.text,
+            message.mediaDescription,
+            message.dateUnix
+        );
+
+        if (message.attachments && message.attachments.length > 0) {
+            this.upsertAttachments(chatId, message.id, message.attachments);
+        }
+
+        return { inserted: false, updated: true };
+    }
+
+    markMessageDeleted(chatId: string, messageId: number, deletedAtUnix: number = Math.floor(Date.now() / 1000)): void {
+        const db = this.getDb();
+        const existing = db.query("SELECT id FROM messages WHERE chat_id = ? AND id = ?").get(chatId, messageId) as {
+            id: number;
+        } | null;
+
+        if (!existing) {
+            return;
+        }
+
+        const deletedIso = new Date(deletedAtUnix * 1000).toISOString();
+
+        db.run(
+            `
+            UPDATE messages
+            SET is_deleted = 1,
+                deleted_at_iso = ?
+            WHERE chat_id = ? AND id = ?
+            `,
+            [deletedIso, chatId, messageId]
+        );
+
+        this.insertMessageRevision(chatId, messageId, "delete", null, null, deletedAtUnix);
+    }
+
+    private insertMessageRevision(
+        chatId: string,
+        messageId: number,
+        revisionType: "create" | "edit" | "delete",
+        text: string | null | undefined,
+        mediaDescription: string | null | undefined,
+        dateUnix: number
+    ): void {
+        const db = this.getDb();
+        const dateIso = new Date(dateUnix * 1000).toISOString();
+
+        db.run(
+            `
+            INSERT OR IGNORE INTO message_revisions (
+                chat_id,
+                message_id,
+                revision_type,
+                text,
+                media_desc,
+                date_iso,
+                date_unix
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            `,
+            [chatId, messageId, revisionType, text ?? null, mediaDescription ?? null, dateIso, dateUnix]
+        );
+    }
+
+    upsertAttachments(chatId: string, messageId: number, attachments: AttachmentDescriptor[]): void {
+        const db = this.getDb();
+        const now = new Date().toISOString();
+
+        for (const attachment of attachments) {
+            db.run(
+                `
+                INSERT INTO attachments (
+                    chat_id,
+                    message_id,
+                    attachment_index,
+                    kind,
+                    mime_type,
+                    file_name,
+                    file_size,
+                    telegram_file_id,
+                    thumb_count,
+                    is_downloaded,
+                    local_path,
+                    sha256,
+                    created_at_iso,
+                    updated_at_iso
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, ?, ?)
+                ON CONFLICT(chat_id, message_id, attachment_index) DO UPDATE SET
+                    kind = excluded.kind,
+                    mime_type = excluded.mime_type,
+                    file_name = excluded.file_name,
+                    file_size = excluded.file_size,
+                    telegram_file_id = excluded.telegram_file_id,
+                    thumb_count = excluded.thumb_count,
+                    updated_at_iso = excluded.updated_at_iso
+                `,
+                [
+                    chatId,
+                    messageId,
+                    attachment.index,
+                    attachment.kind,
+                    attachment.mimeType ?? null,
+                    attachment.fileName ?? null,
+                    attachment.fileSize ?? null,
+                    attachment.telegramFileId ?? null,
+                    attachment.thumbCount,
+                    now,
+                    now,
+                ]
+            );
+        }
+    }
+
+    markAttachmentDownloaded(locator: AttachmentLocator, localPath: string, content: Buffer): void {
+        const db = this.getDb();
+        const now = new Date().toISOString();
+        const hash = createHash("sha256").update(content).digest("hex");
+
+        db.run(
+            `
+            UPDATE attachments
+            SET is_downloaded = 1,
+                local_path = ?,
+                sha256 = ?,
+                updated_at_iso = ?
+            WHERE chat_id = ? AND message_id = ? AND attachment_index = ?
+            `,
+            [localPath, hash, now, locator.chatId, locator.messageId, locator.attachmentIndex]
+        );
+    }
+
+    listAttachments(
+        chatId: string,
+        options: {
+            since?: Date;
+            until?: Date;
+            messageId?: number;
+            limit?: number;
+        } = {}
+    ): AttachmentRow[] {
+        const db = this.getDb();
+        const params: Array<number | string> = [chatId];
+        let where = "WHERE a.chat_id = ?";
+
+        if (options.messageId !== undefined) {
+            where += " AND a.message_id = ?";
+            params.push(options.messageId);
+        }
+
+        if (options.since) {
+            where += " AND m.date_unix >= ?";
+            params.push(Math.floor(options.since.getTime() / 1000));
+        }
+
+        if (options.until) {
+            where += " AND m.date_unix <= ?";
+            params.push(Math.floor(options.until.getTime() / 1000));
+        }
+
+        const limit = options.limit ?? 200;
+        params.push(limit);
+
+        return db
+            .query(
+                `
+                SELECT a.*
+                FROM attachments a
+                JOIN messages m
+                ON m.chat_id = a.chat_id AND m.id = a.message_id
+                ${where}
+                ORDER BY m.date_unix DESC, a.attachment_index ASC
+                LIMIT ?
+                `
+            )
+            .all(...params) as AttachmentRow[];
+    }
+
+    getAttachment(locator: AttachmentLocator): AttachmentRow | null {
+        const db = this.getDb();
+
+        return (
+            (db
+                .query(
+                    `
+                SELECT *
+                FROM attachments
+                WHERE chat_id = ?
+                    AND message_id = ?
+                    AND attachment_index = ?
+                `
+                )
+                .get(locator.chatId, locator.messageId, locator.attachmentIndex) as AttachmentRow | null) ?? null
+        );
     }
 
     // ── Embeddings ────────────────────────────────────────────────────
@@ -167,18 +669,22 @@ export class TelegramHistoryStore {
         const db = this.getDb();
 
         return db
-            .query(`
-			SELECT m.*
-			FROM messages m
-			LEFT JOIN embeddings e ON e.message_rowid = m.rowid
-			WHERE m.chat_id = ?
-				AND m.text IS NOT NULL
-				AND m.text != ''
-				AND e.message_rowid IS NULL
-			ORDER BY m.date_unix ASC
-			LIMIT ?
-		`)
-            .all(chatId, limit) as MessageRow[];
+            .query(
+                `
+                SELECT m.*
+                FROM messages m
+                LEFT JOIN embeddings e ON e.message_rowid = m.rowid
+                WHERE m.chat_id = ?
+                    AND m.text IS NOT NULL
+                    AND m.text != ''
+                    AND m.is_deleted = 0
+                    AND e.message_rowid IS NULL
+                ORDER BY m.date_unix ASC
+                LIMIT ?
+                `
+            )
+            .all(chatId, limit)
+            .map((row) => this.toMessageRow(row as Record<string, unknown>));
     }
 
     insertEmbedding(chatId: string, messageId: number, embedding: Float32Array): void {
@@ -202,12 +708,14 @@ export class TelegramHistoryStore {
         const db = this.getDb();
 
         const row = db
-            .query(`
-			SELECT COUNT(*) AS cnt
-			FROM embeddings e
-			JOIN messages m ON m.rowid = e.message_rowid
-			WHERE m.chat_id = ?
-		`)
+            .query(
+                `
+                SELECT COUNT(*) AS cnt
+                FROM embeddings e
+                JOIN messages m ON m.rowid = e.message_rowid
+                WHERE m.chat_id = ?
+                `
+            )
             .get(chatId) as { cnt: number };
 
         return row.cnt;
@@ -218,7 +726,6 @@ export class TelegramHistoryStore {
     search(chatId: string, query: string, options: SearchOptions = {}): SearchResult[] {
         const db = this.getDb();
 
-        // FTS5 query — wrap each word in quotes for safe matching
         const ftsQuery = query
             .replace(/['"]/g, "")
             .split(/\s+/)
@@ -231,9 +738,8 @@ export class TelegramHistoryStore {
         }
 
         const limit = options.limit ?? 20;
-
         let dateFilter = "";
-        const params: (string | number)[] = [ftsQuery, chatId];
+        const params: Array<number | string> = [ftsQuery, chatId];
 
         if (options.since) {
             dateFilter += " AND m.date_unix >= ?";
@@ -248,30 +754,22 @@ export class TelegramHistoryStore {
         params.push(limit);
 
         const sql = `
-			SELECT m.*, fts.rank
-			FROM messages_fts fts
-			JOIN messages m ON m.rowid = fts.rowid
-			WHERE messages_fts MATCH ?
-				AND m.chat_id = ?
-				${dateFilter}
-			ORDER BY fts.rank
-			LIMIT ?
-		`;
+            SELECT m.*, fts.rank
+            FROM messages_fts fts
+            JOIN messages m ON m.rowid = fts.rowid
+            WHERE messages_fts MATCH ?
+                AND m.chat_id = ?
+                AND m.is_deleted = 0
+                ${dateFilter}
+            ORDER BY fts.rank
+            LIMIT ?
+        `;
 
-        const rows = db.query(sql).all(...params) as Array<MessageRow & { rank: number }>;
+        const rows = db.query(sql).all(...params) as Array<Record<string, unknown> & { rank: number }>;
 
         return rows.map((row) => ({
-            message: {
-                id: row.id,
-                chat_id: row.chat_id,
-                sender_id: row.sender_id,
-                text: row.text,
-                media_desc: row.media_desc,
-                is_outgoing: row.is_outgoing,
-                date_unix: row.date_unix,
-                date_iso: row.date_iso,
-            },
-            rank: row.rank,
+            message: this.toMessageRow(row),
+            rank: Number(row.rank),
         }));
     }
 
@@ -280,7 +778,7 @@ export class TelegramHistoryStore {
         const limit = options.limit ?? 20;
 
         let dateFilter = "";
-        const params: (string | number)[] = [chatId];
+        const params: Array<number | string> = [chatId];
 
         if (options.since) {
             dateFilter += " AND m.date_unix >= ?";
@@ -292,18 +790,16 @@ export class TelegramHistoryStore {
             params.push(Math.floor(options.until.getTime() / 1000));
         }
 
-        // Fetch all embedded messages for this chat (with date filter)
         const sql = `
-			SELECT m.*, e.embedding
-			FROM embeddings e
-			JOIN messages m ON m.rowid = e.message_rowid
-			WHERE m.chat_id = ?
-				${dateFilter}
-		`;
+            SELECT m.*, e.embedding
+            FROM embeddings e
+            JOIN messages m ON m.rowid = e.message_rowid
+            WHERE m.chat_id = ?
+                AND m.is_deleted = 0
+                ${dateFilter}
+        `;
 
-        const rows = db.query(sql).all(...params) as Array<MessageRow & { embedding: Buffer }>;
-
-        // Brute-force cosine similarity in TypeScript
+        const rows = db.query(sql).all(...params) as MessageRowWithEmbedding[];
         const scored: Array<{ message: MessageRow; distance: number }> = [];
 
         for (const row of rows) {
@@ -315,16 +811,7 @@ export class TelegramHistoryStore {
             const distance = cosineDistance(queryEmbedding, storedVec);
 
             scored.push({
-                message: {
-                    id: row.id,
-                    chat_id: row.chat_id,
-                    sender_id: row.sender_id,
-                    text: row.text,
-                    media_desc: row.media_desc,
-                    is_outgoing: row.is_outgoing,
-                    date_unix: row.date_unix,
-                    date_iso: row.date_iso,
-                },
+                message: this.toMessageRow(row as unknown as Record<string, unknown>),
                 distance,
             });
         }
@@ -345,32 +832,30 @@ export class TelegramHistoryStore {
     ): SearchResult[] {
         const ftsResults = this.search(chatId, query, { ...options, limit: 100 });
         const vecResults = this.semanticSearch(chatId, queryEmbedding, { ...options, limit: 100 });
-
-        // Reciprocal Rank Fusion (k=60)
         const K = 60;
         const scores = new Map<number, { score: number; row: MessageRow }>();
 
         for (let i = 0; i < ftsResults.length; i++) {
-            const r = ftsResults[i];
+            const result = ftsResults[i];
             const rrfScore = 1.0 / (K + i + 1);
-            const existing = scores.get(r.message.id);
+            const existing = scores.get(result.message.id);
 
             if (existing) {
                 existing.score += rrfScore;
             } else {
-                scores.set(r.message.id, { score: rrfScore, row: r.message });
+                scores.set(result.message.id, { score: rrfScore, row: result.message });
             }
         }
 
         for (let i = 0; i < vecResults.length; i++) {
-            const r = vecResults[i];
+            const result = vecResults[i];
             const rrfScore = 1.0 / (K + i + 1);
-            const existing = scores.get(r.message.id);
+            const existing = scores.get(result.message.id);
 
             if (existing) {
                 existing.score += rrfScore;
             } else {
-                scores.set(r.message.id, { score: rrfScore, row: r.message });
+                scores.set(result.message.id, { score: rrfScore, row: result.message });
             }
         }
 
@@ -385,37 +870,154 @@ export class TelegramHistoryStore {
             }));
     }
 
-    // ── Date Range Queries ────────────────────────────────────────────
+    // ── Date/Query ────────────────────────────────────────────────────
 
     getByDateRange(chatId: string, since?: Date, until?: Date, limit?: number): MessageRow[] {
+        return this.queryMessages(chatId, {
+            since,
+            until,
+            sender: "any",
+            limit,
+        });
+    }
+
+    queryMessages(chatId: string, options: QueryMessagesOptions = {}): MessageRow[] {
         const db = this.getDb();
-        const params: (string | number)[] = [chatId];
-        let dateFilter = "";
+        const params: Array<number | string> = [chatId];
+        const where: string[] = ["chat_id = ?"];
 
-        if (since) {
-            dateFilter += " AND date_unix >= ?";
-            params.push(Math.floor(since.getTime() / 1000));
+        if (options.since) {
+            where.push("date_unix >= ?");
+            params.push(Math.floor(options.since.getTime() / 1000));
         }
 
-        if (until) {
-            dateFilter += " AND date_unix <= ?";
-            params.push(Math.floor(until.getTime() / 1000));
+        if (options.until) {
+            where.push("date_unix <= ?");
+            params.push(Math.floor(options.until.getTime() / 1000));
         }
 
-        const limitClause = limit ? " LIMIT ?" : "";
-
-        if (limit) {
-            params.push(limit);
+        if (options.sender === "me") {
+            where.push("is_outgoing = 1");
         }
+
+        if (options.sender === "them") {
+            where.push("is_outgoing = 0");
+        }
+
+        let limitClause = "";
+
+        if (options.limit !== undefined) {
+            limitClause = "LIMIT ?";
+            params.push(options.limit);
+        }
+
+        const rows = db
+            .query(
+                `
+                SELECT *
+                FROM messages
+                WHERE ${where.join(" AND ")}
+                ORDER BY date_unix ASC
+                ${limitClause}
+                `
+            )
+            .all(...params)
+            .map((row) => this.toMessageRow(row as Record<string, unknown>));
+
+        if (!options.textRegex) {
+            return rows;
+        }
+
+        try {
+            const regex = new RegExp(options.textRegex, "i");
+            return rows.filter((row) => {
+                const text = row.text ?? row.media_desc ?? "";
+                return regex.test(text);
+            });
+        } catch {
+            return rows;
+        }
+    }
+
+    // ── Sync Coverage ────────────────────────────────────────────────
+
+    insertSyncSegment(
+        chatId: string,
+        sinceUnix: number,
+        untilUnix: number,
+        source: "full" | "incremental" | "query"
+    ): void {
+        const db = this.getDb();
+        const start = Math.min(sinceUnix, untilUnix);
+        const end = Math.max(sinceUnix, untilUnix);
+
+        db.run(
+            `
+            INSERT INTO sync_segments (chat_id, start_unix, end_unix, source, created_at_iso)
+            VALUES (?, ?, ?, ?, datetime('now'))
+            `,
+            [chatId, start, end, source]
+        );
+    }
+
+    getSyncSegments(chatId: string): SyncSegmentRow[] {
+        const db = this.getDb();
 
         return db
-            .query(`
-			SELECT * FROM messages
-			WHERE chat_id = ? ${dateFilter}
-			ORDER BY date_unix ASC
-			${limitClause}
-		`)
-            .all(...params) as MessageRow[];
+            .query(
+                `
+                SELECT *
+                FROM sync_segments
+                WHERE chat_id = ?
+                ORDER BY start_unix ASC, end_unix ASC
+                `
+            )
+            .all(chatId) as SyncSegmentRow[];
+    }
+
+    getMissingSegments(chatId: string, since: Date, until: Date): MissingRange[] {
+        const targetStart = Math.floor(since.getTime() / 1000);
+        const targetEnd = Math.floor(until.getTime() / 1000);
+        const segments = this.getSyncSegments(chatId)
+            .filter((segment) => segment.end_unix >= targetStart && segment.start_unix <= targetEnd)
+            .sort((a, b) => a.start_unix - b.start_unix);
+
+        if (segments.length === 0) {
+            return [{ sinceUnix: targetStart, untilUnix: targetEnd }];
+        }
+
+        const gaps: MissingRange[] = [];
+        let cursor = targetStart;
+
+        for (const segment of segments) {
+            if (segment.start_unix > cursor) {
+                gaps.push({
+                    sinceUnix: cursor,
+                    untilUnix: Math.min(segment.start_unix - 1, targetEnd),
+                });
+            }
+
+            cursor = Math.max(cursor, segment.end_unix + 1);
+
+            if (cursor > targetEnd) {
+                break;
+            }
+        }
+
+        if (cursor <= targetEnd) {
+            gaps.push({ sinceUnix: cursor, untilUnix: targetEnd });
+        }
+
+        return gaps;
+    }
+
+    findChatsByMessageId(messageId: number): string[] {
+        const db = this.getDb();
+        const rows = db.query("SELECT DISTINCT chat_id FROM messages WHERE id = ?").all(messageId) as Array<{
+            chat_id: string;
+        }>;
+
+        return rows.map((row) => row.chat_id);
     }
 
     // ── Sync State ────────────────────────────────────────────────────
@@ -434,12 +1036,12 @@ export class TelegramHistoryStore {
 
         db.run(
             `
-			INSERT INTO sync_state (chat_id, last_synced_id, last_synced_at)
-			VALUES (?, ?, datetime('now'))
-			ON CONFLICT(chat_id) DO UPDATE SET
-				last_synced_id = excluded.last_synced_id,
-				last_synced_at = excluded.last_synced_at
-		`,
+            INSERT INTO sync_state (chat_id, last_synced_id, last_synced_at)
+            VALUES (?, ?, datetime('now'))
+            ON CONFLICT(chat_id) DO UPDATE SET
+                last_synced_id = excluded.last_synced_id,
+                last_synced_at = excluded.last_synced_at
+            `,
             [chatId, messageId]
         );
     }
@@ -451,18 +1053,20 @@ export class TelegramHistoryStore {
 
         if (chatId) {
             const row = db
-                .query(`
-				SELECT
-					chat_id,
-					COUNT(*) AS total_messages,
-					SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
-					SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
-					MIN(date_iso) AS first_message_date,
-					MAX(date_iso) AS last_message_date
-				FROM messages
-				WHERE chat_id = ?
-				GROUP BY chat_id
-			`)
+                .query(
+                    `
+                    SELECT
+                        chat_id,
+                        COUNT(*) AS total_messages,
+                        SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
+                        SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
+                        MIN(date_iso) AS first_message_date,
+                        MAX(date_iso) AS last_message_date
+                    FROM messages
+                    WHERE chat_id = ?
+                    GROUP BY chat_id
+                    `
+                )
                 .get(chatId) as {
                 chat_id: string;
                 total_messages: number;
@@ -492,18 +1096,20 @@ export class TelegramHistoryStore {
         }
 
         const rows = db
-            .query(`
-			SELECT
-				chat_id,
-				COUNT(*) AS total_messages,
-				SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
-				SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
-				MIN(date_iso) AS first_message_date,
-				MAX(date_iso) AS last_message_date
-			FROM messages
-			GROUP BY chat_id
-			ORDER BY total_messages DESC
-		`)
+            .query(
+                `
+                SELECT
+                    chat_id,
+                    COUNT(*) AS total_messages,
+                    SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
+                    SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
+                    MIN(date_iso) AS first_message_date,
+                    MAX(date_iso) AS last_message_date
+                FROM messages
+                GROUP BY chat_id
+                ORDER BY total_messages DESC
+                `
+            )
             .all() as Array<{
             chat_id: string;
             total_messages: number;
@@ -527,6 +1133,7 @@ export class TelegramHistoryStore {
     getTotalMessageCount(): number {
         const db = this.getDb();
         const row = db.query("SELECT COUNT(*) AS cnt FROM messages").get() as { cnt: number };
+
         return row.cnt;
     }
 }

--- a/src/telegram/lib/TelegramToolConfig.ts
+++ b/src/telegram/lib/TelegramToolConfig.ts
@@ -1,20 +1,128 @@
 import { chmodSync } from "node:fs";
 import { Storage } from "@app/utils/storage/storage";
-import type { ContactConfig, TelegramConfigData } from "./types";
-import { DEFAULTS } from "./types";
+import type {
+    ContactConfig,
+    ContactModesConfig,
+    TelegramConfigData,
+    TelegramDefaultsConfig,
+    WatchConfig,
+} from "./types";
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULTS,
+    TELEGRAM_CONFIG_VERSION,
+} from "./types";
+
+function cloneModesConfig(): ContactModesConfig {
+    return {
+        autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+        assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+        suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+    };
+}
+
+function cloneWatchConfig(): WatchConfig {
+    return { ...DEFAULT_WATCH_CONFIG };
+}
+
+function normalizeModes(contact: ContactConfig): ContactModesConfig {
+    const modes = cloneModesConfig();
+
+    if (contact.modes) {
+        modes.autoReply = { ...modes.autoReply, ...contact.modes.autoReply };
+        modes.assistant = { ...modes.assistant, ...contact.modes.assistant };
+        modes.suggestions = { ...modes.suggestions, ...contact.modes.suggestions };
+    }
+
+    if (contact.askProvider) {
+        modes.autoReply.provider = contact.askProvider;
+    }
+
+    if (contact.askModel) {
+        modes.autoReply.model = contact.askModel;
+    }
+
+    if (contact.askSystemPrompt) {
+        modes.autoReply.systemPrompt = contact.askSystemPrompt;
+    }
+
+    modes.autoReply.enabled = contact.actions.includes("ask") || modes.autoReply.enabled;
+
+    return modes;
+}
+
+function normalizeContact(contact: ContactConfig): ContactConfig {
+    const watch = contact.watch ? { ...cloneWatchConfig(), ...contact.watch } : cloneWatchConfig();
+    const modes = normalizeModes(contact);
+    const styleProfile = { ...DEFAULT_STYLE_PROFILE, ...contact.styleProfile };
+
+    return {
+        ...contact,
+        dialogType: contact.dialogType ?? "user",
+        replyDelayMin: contact.replyDelayMin ?? DEFAULTS.replyDelayMin,
+        replyDelayMax: contact.replyDelayMax ?? DEFAULTS.replyDelayMax,
+        watch,
+        modes,
+        styleProfile,
+    };
+}
+
+function normalizeDefaults(defaults: TelegramDefaultsConfig | undefined): TelegramDefaultsConfig {
+    if (!defaults) {
+        return {
+            autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+            assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+            suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+        };
+    }
+
+    return {
+        autoReply: { ...DEFAULT_MODE_CONFIG.autoReply, ...defaults.autoReply },
+        assistant: { ...DEFAULT_MODE_CONFIG.assistant, ...defaults.assistant },
+        suggestions: { ...DEFAULT_MODE_CONFIG.suggestions, ...defaults.suggestions },
+    };
+}
+
+function normalizeConfig(config: TelegramConfigData): TelegramConfigData {
+    const contacts = config.contacts.map((contact) => normalizeContact(contact));
+
+    return {
+        ...config,
+        version: TELEGRAM_CONFIG_VERSION,
+        defaults: normalizeDefaults(config.defaults),
+        contacts,
+    };
+}
 
 export class TelegramToolConfig {
     private storage = new Storage("telegram");
     private data: TelegramConfigData | null = null;
 
     async load(): Promise<TelegramConfigData | null> {
-        this.data = await this.storage.getConfig<TelegramConfigData>();
-        return this.data;
+        const raw = await this.storage.getConfig<TelegramConfigData>();
+
+        if (!raw) {
+            this.data = null;
+            return null;
+        }
+
+        const normalized = normalizeConfig(raw);
+        this.data = normalized;
+
+        if (raw.version !== normalized.version || JSON.stringify(raw) !== JSON.stringify(normalized)) {
+            await this.storage.setConfig(normalized);
+            this.protect();
+        }
+
+        return normalized;
     }
 
     async save(config: TelegramConfigData): Promise<void> {
-        await this.storage.setConfig(config);
-        this.data = config;
+        const normalized = normalizeConfig(config);
+        await this.storage.setConfig(normalized);
+        this.data = normalized;
         this.protect();
     }
 
@@ -42,6 +150,10 @@ export class TelegramToolConfig {
 
     getContacts(): ContactConfig[] {
         return this.data?.contacts ?? [];
+    }
+
+    getDefaults(): TelegramDefaultsConfig {
+        return normalizeDefaults(this.data?.defaults);
     }
 
     hasValidSession(): boolean {

--- a/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
+++ b/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { AttachmentIndexer } from "../AttachmentIndexer";
+
+describe("AttachmentIndexer", () => {
+    it("indexes message attachments into store", () => {
+        const indexer = new AttachmentIndexer();
+        const fakeStore = {
+            upsertAttachments: () => {},
+        };
+        const spy = spyOn(fakeStore, "upsertAttachments");
+
+        indexer.indexSerializedMessage(
+            fakeStore as unknown as Parameters<AttachmentIndexer["indexSerializedMessage"]>[0],
+            "chat-1",
+            {
+                id: 10,
+                senderId: "u1",
+                text: "",
+                mediaDescription: "a photo",
+                isOutgoing: false,
+                date: new Date().toISOString(),
+                dateUnix: Math.floor(Date.now() / 1000),
+                attachments: [
+                    {
+                        index: 0,
+                        kind: "photo",
+                        thumbCount: 1,
+                    },
+                ],
+            }
+        );
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith("chat-1", 10, [
+            {
+                index: 0,
+                kind: "photo",
+                thumbCount: 1,
+            },
+        ]);
+    });
+});

--- a/src/telegram/lib/__tests__/QueryParser.test.ts
+++ b/src/telegram/lib/__tests__/QueryParser.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { QueryParser } from "../QueryParser";
+
+describe("QueryParser", () => {
+    it("parses natural language fields", () => {
+        const parser = new QueryParser();
+        const parsed = parser.parseNaturalLanguage('messages from Alice since 2025-01-01 until 2025-01-31 text "calm"');
+
+        expect(parsed.from).toBe("Alice");
+        expect(parsed.since).toBe("2025-01-01");
+        expect(parsed.until).toBe("2025-01-31");
+        expect(parsed.text).toBe("calm");
+    });
+
+    it("merges NL values into flag query", () => {
+        const parser = new QueryParser();
+        const result = parser.parseFromFlags({
+            from: "bob",
+            nl: "since 2025-02-01 until 2025-02-28",
+        });
+
+        expect(result.from).toBe("bob");
+        expect(result.since).toBe("2025-02-01");
+        expect(result.until).toBe("2025-02-28");
+        expect(result.sender).toBe("any");
+    });
+});

--- a/src/telegram/lib/__tests__/QueryParser.test.ts
+++ b/src/telegram/lib/__tests__/QueryParser.test.ts
@@ -24,4 +24,14 @@ describe("QueryParser", () => {
         expect(result.until).toBe("2025-02-28");
         expect(result.sender).toBe("any");
     });
+
+    it("supports natural-language date phrases", () => {
+        const parser = new QueryParser();
+        const reference = new Date("2026-03-01T12:00:00.000Z");
+        const parsed = parser.parseNaturalLanguage("messages from Alice since last week until yesterday", reference);
+
+        expect(parsed.from).toBe("Alice");
+        expect(parsed.since).toBeTruthy();
+        expect(parsed.until).toBeTruthy();
+    });
 });

--- a/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+++ b/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { StyleProfileEngine } from "../StyleProfileEngine";
+import { TelegramContact } from "../TelegramContact";
+
+describe("StyleProfileEngine", () => {
+    it("returns null when style profile is disabled", async () => {
+        const engine = new StyleProfileEngine();
+        const contact = TelegramContact.fromConfig({
+            userId: "1",
+            displayName: "Alice",
+            actions: ["notify"],
+            replyDelayMin: 1000,
+            replyDelayMax: 2000,
+            styleProfile: {
+                enabled: false,
+                refresh: "incremental",
+                rules: [],
+                previewInWatch: false,
+            },
+        });
+        const fakeStore = {
+            queryMessages: () => [],
+        };
+
+        const result = await engine.deriveStylePrompt(
+            contact,
+            fakeStore as unknown as Parameters<StyleProfileEngine["deriveStylePrompt"]>[1]
+        );
+
+        expect(result).toBeNull();
+    });
+});

--- a/src/telegram/lib/__tests__/SuggestionEngine.test.ts
+++ b/src/telegram/lib/__tests__/SuggestionEngine.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { assistantEngine } from "../AssistantEngine";
+import { SuggestionEngine } from "../SuggestionEngine";
+
+describe("SuggestionEngine", () => {
+    it("extracts and trims suggestion lines", async () => {
+        const engine = new SuggestionEngine();
+        const askSpy = spyOn(assistantEngine, "ask").mockResolvedValue(
+            "1. First option\n- Second option\nThird option"
+        );
+
+        const options = await engine.generateSuggestions({
+            sessionId: "s1",
+            mode: {
+                enabled: true,
+                provider: "openai",
+                model: "gpt-4o-mini",
+                count: 3,
+                trigger: "manual",
+                autoDelayMs: 0,
+                allowAutoSend: false,
+            },
+            incomingText: "How are you?",
+        });
+
+        expect(askSpy).toHaveBeenCalledTimes(1);
+        expect(options).toEqual(["First option", "Second option", "Third option"]);
+    });
+});

--- a/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+++ b/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { SyncRangePlanner } from "../SyncRangePlanner";
+
+describe("SyncRangePlanner", () => {
+    it("maps missing unix ranges into Date ranges", () => {
+        const planner = new SyncRangePlanner();
+        const fakeStore = {
+            getMissingSegments: () => [
+                { sinceUnix: 1_700_000_000, untilUnix: 1_700_000_100 },
+                { sinceUnix: 1_700_000_200, untilUnix: 1_700_000_300 },
+            ],
+        };
+
+        const ranges = planner.planQueryBackfill(
+            fakeStore as unknown as Parameters<SyncRangePlanner["planQueryBackfill"]>[0],
+            "chat-1",
+            new Date("2024-01-01T00:00:00.000Z"),
+            new Date("2024-02-01T00:00:00.000Z")
+        );
+
+        expect(ranges).toHaveLength(2);
+        expect(ranges[0].source).toBe("query");
+        expect(ranges[0].since.toISOString()).toBe("2023-11-14T22:13:20.000Z");
+        expect(ranges[1].until.toISOString()).toBe("2023-11-14T22:18:20.000Z");
+    });
+});

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
@@ -1,0 +1,84 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+describe("TelegramHistoryStore migration", () => {
+    it("migrates v1 schema to v2 and supports new methods", () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "telegram-store-"));
+        const dbPath = join(tempDir, "history.db");
+
+        try {
+            const db = new Database(dbPath);
+            db.run(`
+                CREATE TABLE messages (
+                    id INTEGER NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    sender_id TEXT,
+                    text TEXT,
+                    media_desc TEXT,
+                    is_outgoing INTEGER NOT NULL,
+                    date_unix INTEGER NOT NULL,
+                    date_iso TEXT NOT NULL,
+                    PRIMARY KEY (chat_id, id)
+                )
+            `);
+            db.run(`
+                CREATE TABLE sync_state (
+                    chat_id TEXT PRIMARY KEY,
+                    last_synced_id INTEGER NOT NULL,
+                    last_synced_at TEXT NOT NULL
+                )
+            `);
+            db.run(`
+                CREATE TABLE embeddings (
+                    message_rowid INTEGER PRIMARY KEY,
+                    embedding BLOB NOT NULL
+                )
+            `);
+            db.run("PRAGMA user_version = 1");
+            db.close();
+
+            const store = new TelegramHistoryStore();
+            store.open(dbPath);
+
+            const inserted = store.insertMessages("chat-1", [
+                {
+                    id: 1,
+                    senderId: "u1",
+                    text: "hello",
+                    mediaDescription: undefined,
+                    isOutgoing: false,
+                    date: "2025-01-01T00:00:00.000Z",
+                    dateUnix: 1_735_689_600,
+                    attachments: [],
+                },
+            ]);
+
+            expect(inserted).toBe(1);
+
+            const rows = store.queryMessages("chat-1", {
+                sender: "any",
+            });
+            expect(rows).toHaveLength(1);
+            expect(rows[0].is_deleted).toBe(0);
+
+            store.markMessageDeleted("chat-1", 1, 1_735_689_700);
+            const deletedRows = store.queryMessages("chat-1", {});
+            expect(deletedRows[0].is_deleted).toBe(1);
+
+            store.insertSyncSegment("chat-1", 100, 200, "query");
+            const gaps = store.getMissingSegments("chat-1", new Date(90 * 1000), new Date(220 * 1000));
+            expect(gaps).toEqual([
+                { sinceUnix: 90, untilUnix: 99 },
+                { sinceUnix: 201, untilUnix: 220 },
+            ]);
+
+            store.close();
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/telegram/lib/download.ts
+++ b/src/telegram/lib/download.ts
@@ -1,12 +1,10 @@
 import logger from "@app/logger";
-import { formatNumber } from "@app/utils/format";
 import { detectLanguage, embedText } from "@app/utils/macos/nlp";
 import type { EmbedResult } from "@app/utils/macos/types";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { conversationSyncService } from "./ConversationSyncService";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { SerializedMessage } from "./TelegramMessage";
-import { TelegramMessage } from "./TelegramMessage";
 import type { TGClient } from "./TGClient";
 import type { ContactConfig } from "./types";
 import { EMBEDDING_LANGUAGES } from "./types";
@@ -22,117 +20,32 @@ export async function downloadContact(
     const spinner = p.spinner();
     spinner.start("Counting messages...");
 
-    let totalEstimate: number;
+    let totalEstimate = 0;
 
     try {
         totalEstimate = await client.getMessageCount(contact.userId);
     } catch {
-        spinner.stop("Could not count messages");
-        totalEstimate = 0;
+        // ignore counting failures
     }
 
-    const lastSyncedId = store.getLastSyncedId(contact.userId);
-    const isIncremental = lastSyncedId !== null && !options.since;
+    spinner.stop(`Found ${totalEstimate.toLocaleString()} total messages`);
 
-    if (isIncremental) {
-        spinner.stop(`Found ${formatNumber(totalEstimate)} total messages (incremental sync from #${lastSyncedId})`);
-    } else {
-        spinner.stop(`Found ${formatNumber(totalEstimate)} total messages`);
+    if (options.since || options.until) {
+        const since = options.since ?? new Date(0);
+        const until = options.until ?? new Date();
+
+        await conversationSyncService.syncRange(client, store, contact.userId, {
+            since,
+            until,
+            limit: options.limit,
+            source: "query",
+        });
+        return;
     }
 
-    const iterOptions: {
-        limit?: number;
-        offsetDate?: number;
-        minId?: number;
-    } = {};
-
-    if (options.limit) {
-        iterOptions.limit = options.limit;
-    }
-
-    if (options.until) {
-        iterOptions.offsetDate = Math.floor(options.until.getTime() / 1000);
-    }
-
-    if (isIncremental && lastSyncedId !== null) {
-        iterOptions.minId = lastSyncedId;
-    }
-
-    const progressSpinner = p.spinner();
-    progressSpinner.start("Downloading messages...");
-
-    const batch: SerializedMessage[] = [];
-    let downloaded = 0;
-    let inserted = 0;
-    let highestId = lastSyncedId ?? 0;
-    let retryCount = 0;
-    const BATCH_SIZE = 100;
-    const MAX_RETRIES = 5;
-
-    try {
-        for await (const apiMessage of client.getMessages(contact.userId, iterOptions)) {
-            const msg = new TelegramMessage(apiMessage);
-
-            if (options.since && msg.date < options.since) {
-                continue;
-            }
-
-            if (options.until && msg.date > options.until) {
-                continue;
-            }
-
-            batch.push(msg.toJSON());
-            downloaded++;
-
-            if (msg.id > highestId) {
-                highestId = msg.id;
-            }
-
-            if (batch.length >= BATCH_SIZE) {
-                const batchInserted = store.insertMessages(contact.userId, batch);
-                inserted += batchInserted;
-                batch.length = 0;
-                retryCount = 0;
-
-                progressSpinner.message(
-                    `Downloaded ${formatNumber(downloaded)} messages (${formatNumber(inserted)} new)`
-                );
-            }
-        }
-    } catch (err) {
-        const errorStr = String(err);
-
-        if (errorStr.includes("FLOOD_WAIT") || errorStr.includes("FloodWait")) {
-            const waitMatch = errorStr.match(/(\d+)/);
-            const waitSeconds = waitMatch ? parseInt(waitMatch[1], 10) : 30;
-            retryCount++;
-
-            if (retryCount <= MAX_RETRIES) {
-                const backoff = waitSeconds * 2 ** (retryCount - 1);
-                progressSpinner.message(`Rate limited — waiting ${backoff}s (retry ${retryCount}/${MAX_RETRIES})`);
-                await Bun.sleep(backoff * 1000);
-            } else {
-                progressSpinner.stop(`Rate limited after ${MAX_RETRIES} retries`);
-                p.log.warn("Stopped due to persistent rate limiting. Run again later to resume.");
-            }
-        } else {
-            progressSpinner.stop("Error during download");
-            p.log.error(`Download error: ${errorStr}`);
-        }
-    }
-
-    if (batch.length > 0) {
-        const batchInserted = store.insertMessages(contact.userId, batch);
-        inserted += batchInserted;
-    }
-
-    if (highestId > 0) {
-        store.setLastSyncedId(contact.userId, highestId);
-    }
-
-    progressSpinner.stop(
-        `${pc.green(formatNumber(downloaded))} downloaded, ${pc.green(formatNumber(inserted))} new messages stored`
-    );
+    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+        limit: options.limit,
+    });
 }
 
 export async function embedMessages(

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -174,20 +174,26 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
                     if (result.action === "ask" && result.reply && context) {
                         context.append(options.myName, result.reply);
 
-                        options.store.upsertMessageWithRevision(
-                            targetChatId,
-                            {
-                                id: result.sentMessageId ?? Date.now(),
-                                senderId: undefined,
-                                text: result.reply,
-                                mediaDescription: undefined,
-                                isOutgoing: true,
-                                date: new Date().toISOString(),
-                                dateUnix: Math.floor(Date.now() / 1000),
-                                attachments: [],
-                            },
-                            "create"
-                        );
+                        if (result.sentMessageId) {
+                            options.store.upsertMessageWithRevision(
+                                targetChatId,
+                                {
+                                    id: result.sentMessageId,
+                                    senderId: undefined,
+                                    text: result.reply,
+                                    mediaDescription: undefined,
+                                    isOutgoing: true,
+                                    date: new Date().toISOString(),
+                                    dateUnix: Math.floor(Date.now() / 1000),
+                                    attachments: [],
+                                },
+                                "create"
+                            );
+                        } else {
+                            logger.warn(
+                                `Auto-reply message id missing for ${targetChatId}; skipping outgoing persistence.`
+                            );
+                        }
                     }
                 } else {
                     logger.warn(`  ${pc.red(`[${result.action}]`)} FAILED: ${result.error}`);

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -1,6 +1,8 @@
 import logger from "@app/logger";
 import pc from "picocolors";
-import type { NewMessageEvent } from "telegram/events";
+import type { DeletedMessageEvent } from "telegram/events/DeletedMessage";
+import type { EditedMessageEvent } from "telegram/events/EditedMessage";
+import type { NewMessageEvent } from "telegram/events/NewMessage";
 import { executeActions } from "./actions";
 import { TelegramContact } from "./TelegramContact";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
@@ -31,23 +33,22 @@ function trackMessage(id: number): boolean {
     return true;
 }
 
-/**
- * Per-contact conversation context buffer.
- * Stores formatted "Name: message" lines for LLM context.
- */
 class ConversationContext {
     private lines: string[] = [];
+    private maxLines: number;
 
-    constructor(initialLines?: string[]) {
+    constructor(maxLines: number, initialLines?: string[]) {
+        this.maxLines = maxLines;
+
         if (initialLines) {
-            this.lines = initialLines.slice(-DEFAULTS.maxContextMessages);
+            this.lines = initialLines.slice(-maxLines);
         }
     }
 
     append(name: string, content: string): void {
         this.lines.push(`${name}: ${content}`);
 
-        while (this.lines.length > DEFAULTS.maxContextMessages) {
+        while (this.lines.length > this.maxLines) {
             this.lines.shift();
         }
     }
@@ -59,6 +60,48 @@ class ConversationContext {
     get isEmpty(): boolean {
         return this.lines.length === 0;
     }
+}
+
+function resolveTargetChatId(message: TelegramMessage): string | undefined {
+    if (message.chatId) {
+        return message.chatId;
+    }
+
+    if (message.senderId) {
+        return message.senderId;
+    }
+
+    return undefined;
+}
+
+function resolveDeletedEventChatId(event: DeletedMessageEvent): string | undefined {
+    const peer = event.peer;
+
+    if (!peer) {
+        return undefined;
+    }
+
+    if (typeof peer === "string") {
+        return peer;
+    }
+
+    if (typeof peer !== "object" || peer === null) {
+        return undefined;
+    }
+
+    if ("channelId" in peer && peer.channelId) {
+        return String(peer.channelId);
+    }
+
+    if ("chatId" in peer && peer.chatId) {
+        return String(peer.chatId);
+    }
+
+    if ("userId" in peer && peer.userId) {
+        return String(peer.userId);
+    }
+
+    return undefined;
 }
 
 export interface HandlerOptions {
@@ -77,84 +120,77 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
         contactMap.set(config.userId, contact);
 
         const initial = options.initialHistory?.get(config.userId);
-        contexts.set(config.userId, new ConversationContext(initial));
+        contexts.set(config.userId, new ConversationContext(contact.contextLength, initial));
     }
 
     client.onNewMessage(async (event: NewMessageEvent) => {
         try {
-            const msg = new TelegramMessage(event.message);
+            const message = new TelegramMessage(event.message);
 
-            if (!msg.isPrivate || msg.isOutgoing) {
+            if (message.isOutgoing) {
                 return;
             }
 
-            const senderId = msg.senderId;
+            const targetChatId = resolveTargetChatId(message);
 
-            if (!senderId) {
+            if (!targetChatId) {
                 return;
             }
 
-            const contact = contactMap.get(senderId);
+            const contact = contactMap.get(targetChatId);
 
             if (!contact) {
                 return;
             }
 
-            if (!trackMessage(msg.id)) {
+            if (!trackMessage(message.id)) {
                 return;
             }
 
-            if (!msg.hasText && !msg.hasMedia) {
+            if (!message.hasText && !message.hasMedia) {
                 return;
             }
 
-            // Persist incoming message to history store
-            try {
-                options.store.insertMessages(senderId, [msg.toJSON()]);
-            } catch (err) {
-                logger.debug(`Failed to persist message: ${err}`);
+            options.store.upsertMessageWithRevision(targetChatId, message.toJSON(), "create");
+
+            const context = contexts.get(targetChatId);
+
+            if (context) {
+                context.append(contact.displayName, message.contentForLLM);
             }
 
-            // Append incoming message to conversation context
-            const ctx = contexts.get(senderId);
+            logger.info(`${pc.bold(pc.cyan(contact.displayName))}: ${message.preview}`);
 
-            if (ctx) {
-                ctx.append(contact.displayName, msg.contentForLLM);
-            }
+            const history = context && !context.isEmpty ? context.toString() : undefined;
+            const results = await executeActions(contact, message, client, history);
 
-            logger.info(`${pc.bold(pc.cyan(contact.displayName))}: ${msg.preview}`);
+            for (const result of results) {
+                if (result.success) {
+                    const extra = result.reply
+                        ? ` "${result.reply.slice(0, 60)}${result.reply.length > 60 ? "..." : ""}"`
+                        : "";
+                    logger.info(`  ${pc.green(`[${result.action}]`)} OK${pc.dim(extra)}`);
 
-            const history = ctx && !ctx.isEmpty ? ctx.toString() : undefined;
-            const results = await executeActions(contact, msg, client, history);
+                    if (result.action === "ask" && result.reply && context) {
+                        context.append(options.myName, result.reply);
 
-            for (const r of results) {
-                if (r.success) {
-                    const extra = r.reply ? ` "${r.reply.slice(0, 60)}${r.reply.length > 60 ? "..." : ""}"` : "";
-                    logger.info(`  ${pc.green(`[${r.action}]`)} OK${pc.dim(extra)}`);
-
-                    // Append our reply to the conversation context
-                    if (r.action === "ask" && r.reply && ctx) {
-                        ctx.append(options.myName, r.reply);
-
-                        // Persist outgoing reply to history store
-                        try {
-                            options.store.insertMessages(senderId, [
-                                {
-                                    id: Date.now(),
-                                    senderId: undefined,
-                                    text: r.reply,
-                                    mediaDescription: undefined,
-                                    isOutgoing: true,
-                                    date: new Date().toISOString(),
-                                    dateUnix: Math.floor(Date.now() / 1000),
-                                },
-                            ]);
-                        } catch (err) {
-                            logger.debug(`Failed to persist reply: ${err}`);
-                        }
+                        options.store.upsertMessageWithRevision(
+                            targetChatId,
+                            {
+                                id: result.sentMessageId ?? Date.now(),
+                                senderId: undefined,
+                                text: result.reply,
+                                mediaDescription: undefined,
+                                isOutgoing: true,
+                                date: new Date().toISOString(),
+                                dateUnix: Math.floor(Date.now() / 1000),
+                                attachments: [],
+                            },
+                            "create"
+                        );
                     }
                 } else {
-                    logger.warn(`  ${pc.red(`[${r.action}]`)} FAILED: ${r.error}`);
+                    logger.warn(`  ${pc.red(`[${result.action}]`)} FAILED: ${result.error}`);
                 }
             }
         } catch (err) {
@@ -162,6 +198,43 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
         }
     });
 
-    const names = options.contacts.map((c) => pc.cyan(c.displayName)).join(", ");
+    client.onEditedMessage(async (event: EditedMessageEvent) => {
+        try {
+            const message = new TelegramMessage(event.message);
+            const targetChatId = resolveTargetChatId(message);
+
+            if (!targetChatId || !contactMap.has(targetChatId)) {
+                return;
+            }
+
+            options.store.upsertMessageWithRevision(targetChatId, message.toJSON(), "edit");
+            logger.info(`${pc.yellow("Edited")} ${pc.cyan(targetChatId)} #${message.id}`);
+        } catch (err) {
+            logger.warn(`Edit event handling failed: ${err}`);
+        }
+    });
+
+    client.onDeletedMessage(async (event: DeletedMessageEvent) => {
+        try {
+            const eventChatId = resolveDeletedEventChatId(event);
+
+            for (const messageId of event.deletedIds) {
+                const candidateChats = eventChatId ? [eventChatId] : options.store.findChatsByMessageId(messageId);
+
+                for (const chatId of candidateChats) {
+                    if (!contactMap.has(chatId)) {
+                        continue;
+                    }
+
+                    options.store.markMessageDeleted(chatId, messageId);
+                    logger.info(`${pc.red("Deleted")} ${pc.cyan(chatId)} #${messageId}`);
+                }
+            }
+        } catch (err) {
+            logger.warn(`Delete event handling failed: ${err}`);
+        }
+    });
+
+    const names = options.contacts.map((contact) => pc.cyan(contact.displayName)).join(", ");
     logger.info(`Listening for messages from ${options.contacts.length} contact(s): ${names}`);
 }

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -220,6 +220,17 @@ export interface AttachmentRow {
     updated_at_iso: string;
 }
 
+export interface SuggestionFeedbackRow {
+    id: number;
+    chat_id: string;
+    incoming_message_id: number | null;
+    suggestion_text: string;
+    edited_text: string | null;
+    sent_text: string;
+    was_edited: number;
+    created_at_iso: string;
+}
+
 export interface SyncStateRow {
     chat_id: string;
     last_synced_id: number;

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -1,22 +1,91 @@
 export type ActionType = "say" | "ask" | "notify";
 
+export type TelegramRuntimeMode = "daemon" | "light" | "ink";
+export type TelegramDialogType = "user" | "group" | "channel";
+export type SuggestionTrigger = "manual" | "auto" | "hybrid";
+export type StyleRefreshMode = "incremental";
+
+export interface AskModeConfig {
+    enabled: boolean;
+    provider?: string;
+    model?: string;
+    systemPrompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+}
+
+export interface SuggestionModeConfig extends AskModeConfig {
+    count: number;
+    trigger: SuggestionTrigger;
+    autoDelayMs: number;
+    allowAutoSend: boolean;
+}
+
+export interface StyleSourceRule {
+    id: string;
+    sourceChatId: string;
+    direction: "outgoing" | "incoming";
+    limit?: number;
+    since?: string;
+    until?: string;
+    regex?: string;
+}
+
+export interface StyleProfileConfig {
+    enabled: boolean;
+    refresh: StyleRefreshMode;
+    rules: StyleSourceRule[];
+    previewInWatch: boolean;
+    derivedPrompt?: string;
+    derivedAt?: string;
+}
+
+export interface WatchConfig {
+    enabled: boolean;
+    contextLength: number;
+    runtimeMode?: TelegramRuntimeMode;
+}
+
+export interface ContactModesConfig {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+}
+
 export interface ContactConfig {
     userId: string;
     displayName: string;
     username?: string;
+    dialogType?: TelegramDialogType;
     actions: ActionType[];
+
+    // V2 config
+    watch?: WatchConfig;
+    modes?: ContactModesConfig;
+    styleProfile?: StyleProfileConfig;
+
+    // V1 compatibility (auto-migrated to modes.autoReply)
     askSystemPrompt?: string;
     askProvider?: string;
     askModel?: string;
+
     replyDelayMin: number;
     replyDelayMax: number;
 }
 
+export interface TelegramDefaultsConfig {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+}
+
 export interface TelegramConfigData {
+    version?: number;
     apiId: number;
     apiHash: string;
     session: string;
     me?: { firstName: string; username?: string; phone?: string };
+    defaults?: TelegramDefaultsConfig;
     contacts: ContactConfig[];
     configuredAt: string;
 }
@@ -25,6 +94,7 @@ export interface ActionResult {
     action: ActionType;
     success: boolean;
     reply?: string;
+    sentMessageId?: number;
     duration: number;
     error?: unknown;
 }
@@ -49,11 +119,63 @@ export const DEFAULTS = {
     askTimeoutMs: 60_000,
     askProvider: "openai",
     askModel: "gpt-4o-mini",
+    askTemperature: 0.7,
+    askMaxTokens: 512,
     maxContextMessages: 30,
     historyFetchLimit: 100,
+    watchContextLength: 30,
+    watchRuntimeMode: "daemon" as TelegramRuntimeMode,
+    suggestionCount: 3,
+    suggestionAutoDelayMs: 5000,
 } as const;
 
-// ── History Types (Phase 2) ─────────────────────────────────────────
+export const TELEGRAM_CONFIG_VERSION = 2;
+
+export const DEFAULT_MODE_CONFIG: ContactModesConfig = {
+    autoReply: {
+        enabled: false,
+        provider: DEFAULTS.askProvider,
+        model: DEFAULTS.askModel,
+        systemPrompt: DEFAULTS.askSystemPrompt,
+        temperature: DEFAULTS.askTemperature,
+        maxTokens: DEFAULTS.askMaxTokens,
+    },
+    assistant: {
+        enabled: true,
+        provider: DEFAULTS.askProvider,
+        model: DEFAULTS.askModel,
+        systemPrompt: DEFAULTS.askSystemPrompt,
+        temperature: DEFAULTS.askTemperature,
+        maxTokens: DEFAULTS.askMaxTokens,
+    },
+    suggestions: {
+        enabled: true,
+        provider: DEFAULTS.askProvider,
+        model: DEFAULTS.askModel,
+        systemPrompt: DEFAULTS.askSystemPrompt,
+        temperature: DEFAULTS.askTemperature,
+        maxTokens: DEFAULTS.askMaxTokens,
+        count: DEFAULTS.suggestionCount,
+        trigger: "manual",
+        autoDelayMs: DEFAULTS.suggestionAutoDelayMs,
+        allowAutoSend: false,
+    },
+};
+
+export const DEFAULT_STYLE_PROFILE: StyleProfileConfig = {
+    enabled: false,
+    refresh: "incremental",
+    rules: [],
+    previewInWatch: false,
+};
+
+export const DEFAULT_WATCH_CONFIG: WatchConfig = {
+    enabled: true,
+    contextLength: DEFAULTS.watchContextLength,
+    runtimeMode: DEFAULTS.watchRuntimeMode,
+};
+
+// ── History Types (V2) ──────────────────────────────────────────────
 
 export interface MessageRow {
     id: number;
@@ -64,6 +186,38 @@ export interface MessageRow {
     is_outgoing: number;
     date_unix: number;
     date_iso: string;
+    edited_date_unix: number | null;
+    is_deleted: number;
+    deleted_at_iso: string | null;
+    reply_to_msg_id: number | null;
+}
+
+export interface MessageRevisionRow {
+    id: number;
+    chat_id: string;
+    message_id: number;
+    revision_type: "create" | "edit" | "delete";
+    text: string | null;
+    media_desc: string | null;
+    date_iso: string;
+    date_unix: number;
+}
+
+export interface AttachmentRow {
+    chat_id: string;
+    message_id: number;
+    attachment_index: number;
+    kind: string;
+    mime_type: string | null;
+    file_name: string | null;
+    file_size: number | null;
+    telegram_file_id: string | null;
+    thumb_count: number;
+    is_downloaded: number;
+    local_path: string | null;
+    sha256: string | null;
+    created_at_iso: string;
+    updated_at_iso: string;
 }
 
 export interface SyncStateRow {
@@ -72,9 +226,34 @@ export interface SyncStateRow {
     last_synced_at: string;
 }
 
+export interface SyncSegmentRow {
+    id: number;
+    chat_id: string;
+    start_unix: number;
+    end_unix: number;
+    source: "full" | "incremental" | "query";
+    created_at_iso: string;
+}
+
+export interface ChatRow {
+    chat_id: string;
+    chat_type: TelegramDialogType;
+    title: string;
+    username: string | null;
+    last_seen_at_iso: string;
+}
+
 export interface SearchOptions {
     since?: Date;
     until?: Date;
+    limit?: number;
+}
+
+export interface QueryMessagesOptions {
+    since?: Date;
+    until?: Date;
+    sender?: "me" | "them" | "any";
+    textRegex?: string;
     limit?: number;
 }
 
@@ -94,6 +273,28 @@ export interface ChatStats {
     firstMessageDate: string | null;
     lastMessageDate: string | null;
     embeddedMessages: number;
+}
+
+export interface AttachmentLocator {
+    chatId: string;
+    messageId: number;
+    attachmentIndex: number;
+}
+
+export interface MissingRange {
+    sinceUnix: number;
+    untilUnix: number;
+}
+
+export interface QueryRequest {
+    from: string;
+    since?: string;
+    until?: string;
+    sender?: "me" | "them" | "any";
+    text?: string;
+    localOnly?: boolean;
+    nl?: string;
+    limit?: number;
 }
 
 /** Languages supported by macOS NLEmbedding */

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -1,8 +1,119 @@
-import logger from "@app/logger";
+import { useTerminalSize } from "@app/utils/ink/hooks/use-terminal-size";
+import { Box, render, Text, useApp, useInput } from "ink";
+import TextInput from "ink-text-input";
+import { useEffect, useState } from "react";
 import type { WatchRuntimeOptions } from "../light/WatchRuntime";
-import { runWatchRuntime } from "../light/WatchRuntime";
+import { WatchSession } from "../shared/WatchSession";
+
+interface WatchInkRootProps {
+    session: WatchSession;
+}
+
+function WatchInkRoot({ session }: WatchInkRootProps) {
+    useTerminalSize({ clearOnResize: true });
+    const { exit } = useApp();
+    const [input, setInput] = useState("");
+    const [feedback, setFeedback] = useState("");
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    useEffect(() => {
+        const unsubscribe = session.subscribe(() => {
+            setRefreshKey((value) => value + 1);
+        });
+
+        return () => {
+            unsubscribe();
+        };
+    }, [session]);
+
+    const view = session.getViewModel();
+
+    useInput((value, key) => {
+        if (key.ctrl && value === "c") {
+            exit();
+            return;
+        }
+
+        if (key.tab) {
+            session.cycleActiveChat(key.shift ? -1 : 1);
+        }
+    });
+
+    const submitInput = (value: string) => {
+        void (async () => {
+            const result = await session.handleInput(value);
+            setInput("");
+
+            if (result.output) {
+                setFeedback(result.output);
+            }
+
+            if (result.exit) {
+                exit();
+            }
+        })();
+    };
+
+    return (
+        <Box flexDirection="column" key={refreshKey}>
+            <Text>
+                Telegram Watch (Ink) | Tab/Shift+Tab switch chat | Enter sends | /help commands | Mode:{" "}
+                {view.carefulMode ? "careful" : "normal"}
+            </Text>
+
+            <Box marginTop={1} flexDirection="row" flexWrap="wrap">
+                {view.contacts.map((contact) => (
+                    <Box key={contact.id} marginRight={2}>
+                        <Text color={contact.isActive ? "cyan" : "white"}>
+                            {contact.isActive ? ">" : " "} {contact.name}
+                            {contact.unreadCount > 0 ? ` (${contact.unreadCount})` : ""}
+                        </Text>
+                    </Box>
+                ))}
+            </Box>
+
+            <Box marginTop={1} flexDirection="column">
+                {view.messages.slice(-25).map((message) => (
+                    <Text key={`${message.id}-${message.timestampIso}`}>
+                        {message.direction === "out" ? "You" : "Them"}: {message.text}
+                    </Text>
+                ))}
+            </Box>
+
+            {view.pendingSuggestions.length > 0 ? (
+                <Box marginTop={1} flexDirection="column">
+                    <Text color="yellow">Pending suggestions:</Text>
+                    {view.pendingSuggestions.map((suggestion, index) => (
+                        <Text key={`${index + 1}-${suggestion}`}>  {index + 1}. {suggestion}</Text>
+                    ))}
+                </Box>
+            ) : null}
+
+            {feedback ? (
+                <Box marginTop={1}>
+                    <Text color="green">{feedback}</Text>
+                </Box>
+            ) : null}
+
+            <Box marginTop={1}>
+                <Text color="cyan">Input: </Text>
+                <TextInput value={input} onChange={setInput} onSubmit={submitInput} />
+            </Box>
+        </Box>
+    );
+}
 
 export async function runWatchInkApp(options: WatchRuntimeOptions): Promise<void> {
-    logger.info("Ink runtime is experimental. Falling back to light runtime for this session.");
-    await runWatchRuntime({ ...options, daemon: false });
+    const session = new WatchSession({
+        contacts: options.contacts,
+        myName: options.myName,
+        client: options.client,
+        store: options.store,
+        contextLengthOverride: options.contextLength,
+    });
+
+    await session.startListeners();
+
+    const app = render(<WatchInkRoot session={session} />);
+    await app.waitUntilExit();
 }

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -1,0 +1,8 @@
+import logger from "@app/logger";
+import type { WatchRuntimeOptions } from "../light/WatchRuntime";
+import { runWatchRuntime } from "../light/WatchRuntime";
+
+export async function runWatchInkApp(options: WatchRuntimeOptions): Promise<void> {
+    logger.info("Ink runtime is experimental. Falling back to light runtime for this session.");
+    await runWatchRuntime({ ...options, daemon: false });
+}

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -84,7 +84,10 @@ function WatchInkRoot({ session }: WatchInkRootProps) {
                 <Box marginTop={1} flexDirection="column">
                     <Text color="yellow">Pending suggestions:</Text>
                     {view.pendingSuggestions.map((suggestion, index) => (
-                        <Text key={`${index + 1}-${suggestion}`}>  {index + 1}. {suggestion}</Text>
+                        <Text key={`${index + 1}-${suggestion}`}>
+                            {" "}
+                            {index + 1}. {suggestion}
+                        </Text>
                     ))}
                 </Box>
             ) : null}

--- a/src/telegram/runtime/light/WatchRuntime.ts
+++ b/src/telegram/runtime/light/WatchRuntime.ts
@@ -1,0 +1,61 @@
+import logger from "@app/logger";
+import { registerHandler } from "../../lib/handler";
+import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
+import type { TGClient } from "../../lib/TGClient";
+import type { ContactConfig } from "../../lib/types";
+import { WatchSession } from "../shared/WatchSession";
+
+export interface WatchRuntimeOptions {
+    contacts: ContactConfig[];
+    myName: string;
+    client: TGClient;
+    store: TelegramHistoryStore;
+    contextLength?: number;
+    daemon?: boolean;
+}
+
+export async function runWatchRuntime(options: WatchRuntimeOptions): Promise<void> {
+    if (options.daemon) {
+        const initialHistory = new Map<string, string[]>();
+
+        for (const contact of options.contacts) {
+            const contextLength = options.contextLength ?? contact.watch?.contextLength ?? 30;
+            const rows = options.store.getByDateRange(contact.userId, undefined, undefined, contextLength);
+            const lines = rows
+                .map((row) => {
+                    const content = row.text || row.media_desc;
+
+                    if (!content) {
+                        return undefined;
+                    }
+
+                    const name = row.is_outgoing ? options.myName : contact.displayName;
+                    return `${name}: ${content}`;
+                })
+                .filter((line): line is string => line !== undefined);
+
+            initialHistory.set(contact.userId, lines);
+        }
+
+        registerHandler(options.client, {
+            contacts: options.contacts,
+            myName: options.myName,
+            initialHistory,
+            store: options.store,
+        });
+
+        logger.info("Daemon watch started. Press Ctrl+C to stop.");
+        await new Promise(() => {});
+    }
+
+    const session = new WatchSession({
+        contacts: options.contacts,
+        myName: options.myName,
+        client: options.client,
+        store: options.store,
+        contextLengthOverride: options.contextLength,
+    });
+
+    await session.startListeners();
+    await session.runLightPromptLoop();
+}

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -223,6 +223,16 @@ export class WatchSession {
         return state.historyLines.join("\n");
     }
 
+    private refreshStyleSamples(state: ContactState): void {
+        const styleProfile = state.contact.config.styleProfile;
+
+        if (!styleProfile || !styleProfile.enabled) {
+            return;
+        }
+
+        state.rawStyleSamples = styleProfileEngine.getRawStyleSamples(state.contact, this.options.store, 120);
+    }
+
     private findState(target: string): ContactState | null {
         const lower = target.toLowerCase();
 
@@ -307,6 +317,7 @@ export class WatchSession {
             text,
             timestampIso,
         });
+        this.refreshStyleSamples(state);
 
         logger.info(`${pc.green("You")} → ${pc.cyan(state.contact.displayName)}: ${text}`);
         this.notifyViewUpdate();
@@ -419,6 +430,7 @@ export class WatchSession {
                     text: content,
                     timestampIso: new Date(message.date.getTime()).toISOString(),
                 });
+                this.refreshStyleSamples(state);
             }
 
             if (state.contact.userId !== this.activeChatId) {

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -1,8 +1,8 @@
 import { stdin as input, stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import logger from "@app/logger";
-import * as p from "@clack/prompts";
 import { modelSelector } from "@ask/providers/ModelSelector";
+import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { assistantEngine } from "../../lib/AssistantEngine";
 import { attachmentDownloader } from "../../lib/AttachmentDownloader";
@@ -79,7 +79,12 @@ export class WatchSession {
         for (const config of options.contacts) {
             const contact = TelegramContact.fromConfig(config);
             const contextLength = options.contextLengthOverride ?? contact.contextLength;
-            const rows = this.options.store.getByDateRange(contact.userId, undefined, undefined, Math.max(contextLength, 200));
+            const rows = this.options.store.getByDateRange(
+                contact.userId,
+                undefined,
+                undefined,
+                Math.max(contextLength, 200)
+            );
             const historyLines = rows
                 .map((row) => {
                     const content = row.text ?? row.media_desc ?? "";
@@ -261,7 +266,11 @@ export class WatchSession {
         };
     }
 
-    private async sendText(state: ContactState, text: string, feedback?: { suggestionText: string; incomingMessageId?: number }): Promise<void> {
+    private async sendText(
+        state: ContactState,
+        text: string,
+        feedback?: { suggestionText: string; incomingMessageId?: number }
+    ): Promise<void> {
         const sent = await this.options.client.sendMessage(state.contact.userId, text);
         const timestampUnix = sent.date ? sent.date : Math.floor(Date.now() / 1000);
         const timestampIso = new Date(timestampUnix * 1000).toISOString();
@@ -524,7 +533,10 @@ export class WatchSession {
                 return { output: `No suggestion at index ${index}` };
             }
 
-            const inlineEditedText = args.slice(target.consumed + 1).join(" ").trim();
+            const inlineEditedText = args
+                .slice(target.consumed + 1)
+                .join(" ")
+                .trim();
             let sendText = inlineEditedText;
 
             if (!sendText) {
@@ -616,7 +628,8 @@ export class WatchSession {
             const messageIdRaw = args[target.consumed];
             const attachmentIndexRaw = args[target.consumed + 1];
             const messageId = messageIdRaw ? Number(messageIdRaw) : Number.NaN;
-            const attachmentIndex = attachmentIndexRaw && /^\d+$/.test(attachmentIndexRaw) ? Number(attachmentIndexRaw) : 0;
+            const attachmentIndex =
+                attachmentIndexRaw && /^\d+$/.test(attachmentIndexRaw) ? Number(attachmentIndexRaw) : 0;
 
             if (!Number.isInteger(messageId) || messageId <= 0) {
                 return { output: "Usage: /attachment [contact] <messageId> [attachmentIndex] [outputPath]" };
@@ -681,7 +694,9 @@ export class WatchSession {
 
             mode.provider = choice.provider.name;
             mode.model = choice.model.id;
-            return { output: `Updated ${target.state.contact.displayName} ${modeArg} -> ${mode.provider}/${mode.model}` };
+            return {
+                output: `Updated ${target.state.contact.displayName} ${modeArg} -> ${mode.provider}/${mode.model}`,
+            };
         }
 
         if (command === "/style" && args[0] === "derive") {

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -1,9 +1,11 @@
 import { stdin as input, stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import logger from "@app/logger";
+import * as p from "@clack/prompts";
 import { modelSelector } from "@ask/providers/ModelSelector";
 import pc from "picocolors";
 import { assistantEngine } from "../../lib/AssistantEngine";
+import { attachmentDownloader } from "../../lib/AttachmentDownloader";
 import { styleProfileEngine } from "../../lib/StyleProfileEngine";
 import { suggestionEngine } from "../../lib/SuggestionEngine";
 import { TelegramContact } from "../../lib/TelegramContact";
@@ -12,11 +14,23 @@ import { TelegramMessage } from "../../lib/TelegramMessage";
 import type { TGClient } from "../../lib/TGClient";
 import type { ContactConfig } from "../../lib/types";
 
+interface FeedEntry {
+    id: number;
+    direction: "in" | "out";
+    text: string;
+    timestampIso: string;
+}
+
 interface ContactState {
     contact: TelegramContact;
     historyLines: string[];
+    messageFeed: FeedEntry[];
     lastIncoming?: string;
+    lastIncomingMessageId?: number;
+    pendingIncomingMessageId?: number;
     pendingSuggestions: string[];
+    rawStyleSamples: string[];
+    unreadCount: number;
 }
 
 export interface WatchSessionOptions {
@@ -27,33 +41,339 @@ export interface WatchSessionOptions {
     contextLengthOverride?: number;
 }
 
+export interface WatchViewModel {
+    carefulMode: boolean;
+    activeChatId: string;
+    contacts: Array<{
+        id: string;
+        name: string;
+        unreadCount: number;
+        isActive: boolean;
+    }>;
+    messages: FeedEntry[];
+    pendingSuggestions: string[];
+}
+
+interface HandleResult {
+    output?: string;
+    exit?: boolean;
+}
+
+const MAX_FEED_MESSAGES = 500;
+
 export class WatchSession {
     private states = new Map<string, ContactState>();
+    private activeChatId: string;
+    private carefulMode = false;
+    private shouldExit = false;
+    private listeners = new Set<() => void>();
+    private suggestionTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
     constructor(private options: WatchSessionOptions) {
+        if (options.contacts.length === 0) {
+            throw new Error("WatchSession requires at least one contact.");
+        }
+
+        this.activeChatId = options.contacts[0].userId;
+
         for (const config of options.contacts) {
             const contact = TelegramContact.fromConfig(config);
             const contextLength = options.contextLengthOverride ?? contact.contextLength;
-            const rows = this.options.store.getByDateRange(contact.userId, undefined, undefined, contextLength);
+            const rows = this.options.store.getByDateRange(contact.userId, undefined, undefined, Math.max(contextLength, 200));
             const historyLines = rows
                 .map((row) => {
-                    const name = row.is_outgoing ? this.options.myName : contact.displayName;
                     const content = row.text ?? row.media_desc ?? "";
 
                     if (!content) {
                         return undefined;
                     }
 
+                    const name = row.is_outgoing ? this.options.myName : contact.displayName;
                     return `${name}: ${content}`;
                 })
                 .filter((line): line is string => line !== undefined);
+            const messageFeed: FeedEntry[] = rows
+                .map((row) => {
+                    const text = row.text ?? row.media_desc ?? "";
+
+                    if (!text) {
+                        return undefined;
+                    }
+
+                    return {
+                        id: row.id,
+                        direction: row.is_outgoing ? "out" : "in",
+                        text,
+                        timestampIso: row.date_iso,
+                    } satisfies FeedEntry;
+                })
+                .filter((entry): entry is FeedEntry => entry !== undefined);
+            const rawStyleSamples = styleProfileEngine.getRawStyleSamples(contact, this.options.store, 120);
 
             this.states.set(contact.userId, {
                 contact,
                 historyLines,
+                messageFeed,
                 pendingSuggestions: [],
+                unreadCount: 0,
+                rawStyleSamples,
             });
         }
+    }
+
+    subscribe(listener: () => void): () => void {
+        this.listeners.add(listener);
+
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    getViewModel(): WatchViewModel {
+        const active = this.getRequiredState(this.activeChatId);
+
+        return {
+            carefulMode: this.carefulMode,
+            activeChatId: this.activeChatId,
+            contacts: [...this.states.values()].map((state) => ({
+                id: state.contact.userId,
+                name: state.contact.displayName,
+                unreadCount: state.unreadCount,
+                isActive: state.contact.userId === this.activeChatId,
+            })),
+            messages: active.messageFeed.slice(-200),
+            pendingSuggestions: active.pendingSuggestions,
+        };
+    }
+
+    private notifyViewUpdate(): void {
+        for (const listener of this.listeners) {
+            listener();
+        }
+    }
+
+    private getRequiredState(chatId: string): ContactState {
+        const state = this.states.get(chatId);
+
+        if (!state) {
+            throw new Error(`Unknown chat id: ${chatId}`);
+        }
+
+        return state;
+    }
+
+    getActiveState(): ContactState {
+        return this.getRequiredState(this.activeChatId);
+    }
+
+    setActiveChat(chatId: string): void {
+        const state = this.states.get(chatId);
+
+        if (!state) {
+            return;
+        }
+
+        this.activeChatId = chatId;
+        state.unreadCount = 0;
+        this.notifyViewUpdate();
+    }
+
+    cycleActiveChat(direction: 1 | -1 = 1): void {
+        const ids = [...this.states.keys()];
+
+        if (ids.length <= 1) {
+            return;
+        }
+
+        const index = ids.findIndex((id) => id === this.activeChatId);
+
+        if (index === -1) {
+            this.activeChatId = ids[0];
+            this.notifyViewUpdate();
+            return;
+        }
+
+        const next = (index + direction + ids.length) % ids.length;
+        this.setActiveChat(ids[next]);
+    }
+
+    private pushHistory(state: ContactState, line: string): void {
+        const maxLength = this.options.contextLengthOverride ?? state.contact.contextLength;
+        state.historyLines.push(line);
+
+        while (state.historyLines.length > maxLength) {
+            state.historyLines.shift();
+        }
+    }
+
+    private pushFeed(state: ContactState, entry: FeedEntry): void {
+        state.messageFeed.push(entry);
+
+        while (state.messageFeed.length > MAX_FEED_MESSAGES) {
+            state.messageFeed.shift();
+        }
+    }
+
+    private getHistoryText(state: ContactState): string {
+        return state.historyLines.join("\n");
+    }
+
+    private findState(target: string): ContactState | null {
+        const lower = target.toLowerCase();
+
+        for (const state of this.states.values()) {
+            if (state.contact.userId === target) {
+                return state;
+            }
+
+            if (state.contact.displayName.toLowerCase() === lower) {
+                return state;
+            }
+
+            if (state.contact.username?.toLowerCase() === lower) {
+                return state;
+            }
+        }
+
+        return null;
+    }
+
+    private parseStateFromArgs(args: string[]): { state: ContactState; consumed: number } | null {
+        if (args.length === 0) {
+            return {
+                state: this.getActiveState(),
+                consumed: 0,
+            };
+        }
+
+        const contactCandidate = this.findState(args[0]);
+
+        if (contactCandidate) {
+            return {
+                state: contactCandidate,
+                consumed: 1,
+            };
+        }
+
+        return {
+            state: this.getActiveState(),
+            consumed: 0,
+        };
+    }
+
+    private async sendText(state: ContactState, text: string, feedback?: { suggestionText: string; incomingMessageId?: number }): Promise<void> {
+        const sent = await this.options.client.sendMessage(state.contact.userId, text);
+        const timestampUnix = sent.date ? sent.date : Math.floor(Date.now() / 1000);
+        const timestampIso = new Date(timestampUnix * 1000).toISOString();
+
+        this.options.store.upsertMessageWithRevision(
+            state.contact.userId,
+            {
+                id: sent.id,
+                senderId: undefined,
+                text,
+                mediaDescription: undefined,
+                isOutgoing: true,
+                date: timestampIso,
+                dateUnix: timestampUnix,
+                attachments: [],
+            },
+            "create"
+        );
+
+        if (feedback) {
+            this.options.store.recordSuggestionFeedback({
+                chatId: state.contact.userId,
+                incomingMessageId: feedback.incomingMessageId,
+                suggestionText: feedback.suggestionText,
+                sentText: text,
+                editedText: feedback.suggestionText === text ? undefined : text,
+            });
+        }
+
+        this.pushHistory(state, `${this.options.myName}: ${text}`);
+        this.pushFeed(state, {
+            id: sent.id,
+            direction: "out",
+            text,
+            timestampIso,
+        });
+
+        logger.info(`${pc.green("You")} → ${pc.cyan(state.contact.displayName)}: ${text}`);
+        this.notifyViewUpdate();
+    }
+
+    private async generateSuggestionsForState(state: ContactState): Promise<string[]> {
+        if (!state.lastIncoming) {
+            return [];
+        }
+
+        if (state.rawStyleSamples.length === 0) {
+            state.rawStyleSamples = styleProfileEngine.getRawStyleSamples(state.contact, this.options.store, 120);
+        }
+
+        const suggestions = await suggestionEngine.generateSuggestions({
+            sessionId: `watch-${state.contact.userId}`,
+            mode: state.contact.suggestionMode,
+            incomingText: state.lastIncoming,
+            incomingMessageId: state.lastIncomingMessageId,
+            conversationHistory: this.getHistoryText(state),
+            stylePrompt: state.contact.config.styleProfile?.derivedPrompt,
+            rawStyleSamples: state.rawStyleSamples,
+            store: this.options.store,
+            chatId: state.contact.userId,
+        });
+
+        state.pendingSuggestions = suggestions;
+        state.pendingIncomingMessageId = state.lastIncomingMessageId;
+        this.notifyViewUpdate();
+
+        if (state.contact.suggestionMode.allowAutoSend && suggestions.length > 0) {
+            await this.sendText(state, suggestions[0], {
+                suggestionText: suggestions[0],
+                incomingMessageId: state.pendingIncomingMessageId,
+            });
+            state.pendingSuggestions = [];
+            state.pendingIncomingMessageId = undefined;
+            this.notifyViewUpdate();
+        }
+
+        return suggestions;
+    }
+
+    private printSuggestions(state: ContactState): void {
+        if (state.pendingSuggestions.length === 0) {
+            logger.info(`[suggest:${state.contact.displayName}] no options generated`);
+            return;
+        }
+
+        logger.info(pc.yellow(`Suggestions for ${state.contact.displayName}:`));
+
+        for (let i = 0; i < state.pendingSuggestions.length; i++) {
+            logger.info(`  ${i + 1}. ${state.pendingSuggestions[i]}`);
+        }
+    }
+
+    private scheduleAutoSuggestion(state: ContactState): void {
+        const existing = this.suggestionTimers.get(state.contact.userId);
+
+        if (existing) {
+            clearTimeout(existing);
+        }
+
+        const delayMs = state.contact.suggestionMode.autoDelayMs;
+        const timer = setTimeout(async () => {
+            try {
+                await this.generateSuggestionsForState(state);
+                this.printSuggestions(state);
+            } catch (err) {
+                logger.warn(`Auto suggestion failed: ${err}`);
+            } finally {
+                this.suggestionTimers.delete(state.contact.userId);
+            }
+        }, delayMs);
+
+        this.suggestionTimers.set(state.contact.userId, timer);
     }
 
     async startListeners(): Promise<void> {
@@ -83,9 +403,21 @@ export class WatchSession {
             if (content) {
                 this.pushHistory(state, `${state.contact.displayName}: ${content}`);
                 state.lastIncoming = content;
+                state.lastIncomingMessageId = message.id;
+                this.pushFeed(state, {
+                    id: message.id,
+                    direction: "in",
+                    text: content,
+                    timestampIso: new Date(message.date.getTime()).toISOString(),
+                });
+            }
+
+            if (state.contact.userId !== this.activeChatId) {
+                state.unreadCount += 1;
             }
 
             logger.info(`${pc.bold(pc.cyan(state.contact.displayName))}: ${message.preview}`);
+            this.notifyViewUpdate();
 
             const suggestionMode = state.contact.suggestionMode;
 
@@ -94,267 +426,279 @@ export class WatchSession {
             }
 
             if (suggestionMode.trigger === "auto" || suggestionMode.trigger === "hybrid") {
-                if (suggestionMode.autoDelayMs > 0) {
-                    await Bun.sleep(suggestionMode.autoDelayMs);
-                }
-
-                const suggestions = await this.generateSuggestionsForState(state);
-                this.printSuggestions(state.contact.displayName, suggestions);
+                this.scheduleAutoSuggestion(state);
             }
         });
     }
 
-    private pushHistory(state: ContactState, line: string): void {
-        const maxLength = this.options.contextLengthOverride ?? state.contact.contextLength;
-        state.historyLines.push(line);
-
-        while (state.historyLines.length > maxLength) {
-            state.historyLines.shift();
-        }
-    }
-
-    private getHistoryText(state: ContactState): string {
-        return state.historyLines.join("\n");
-    }
-
-    private findState(target: string): ContactState | null {
-        const lower = target.toLowerCase();
-
-        for (const state of this.states.values()) {
-            if (state.contact.userId === target) {
-                return state;
-            }
-
-            if (state.contact.displayName.toLowerCase() === lower) {
-                return state;
-            }
-
-            if (state.contact.username?.toLowerCase() === lower) {
-                return state;
-            }
-        }
-
-        return null;
-    }
-
-    private async generateSuggestionsForState(state: ContactState): Promise<string[]> {
-        if (!state.lastIncoming) {
-            return [];
-        }
-
-        const suggestions = await suggestionEngine.generateSuggestions({
-            sessionId: `watch-${state.contact.userId}`,
-            mode: state.contact.suggestionMode,
-            incomingText: state.lastIncoming,
-            conversationHistory: this.getHistoryText(state),
-            stylePrompt: state.contact.config.styleProfile?.derivedPrompt,
-        });
-
-        state.pendingSuggestions = suggestions;
-        return suggestions;
-    }
-
-    private printSuggestions(contactLabel: string, suggestions: string[]): void {
-        if (suggestions.length === 0) {
-            logger.info(`[suggest:${contactLabel}] no options generated`);
-            return;
-        }
-
-        logger.info(pc.yellow(`Suggestions for ${contactLabel}:`));
-
-        for (let i = 0; i < suggestions.length; i++) {
-            logger.info(`  ${i + 1}. ${suggestions[i]}`);
-        }
-    }
-
-    async runLightPromptLoop(): Promise<void> {
-        const rl = createInterface({ input, output });
-
-        logger.info(
-            "Watch commands: /suggest <contact>, /send <contact> <text>, /ask <contact> <question>, /model <contact> <mode>, /style derive <contact>, /quit"
-        );
-
-        try {
-            while (true) {
-                const line = (await rl.question(pc.dim("watch> "))).trim();
-
-                if (!line) {
-                    continue;
-                }
-
-                if (line === "/quit" || line === "/exit") {
-                    break;
-                }
-
-                await this.executeCommand(line);
-            }
-        } finally {
-            rl.close();
-        }
-    }
-
-    private async executeCommand(line: string): Promise<void> {
+    private async handleCommand(line: string): Promise<HandleResult> {
         const parts = line.split(" ").filter(Boolean);
         const command = parts[0];
+        const args = parts.slice(1);
 
-        if (command === "/suggest") {
-            const contactArg = parts[1];
+        if (command === "/quit" || command === "/exit") {
+            this.shouldExit = true;
+            return { exit: true };
+        }
 
-            if (!contactArg) {
-                logger.warn("Usage: /suggest <contact>");
-                return;
+        if (command === "/help") {
+            const active = this.getActiveState();
+            return {
+                output:
+                    "Commands:\n" +
+                    "/chat <contact> | /next | /prev\n" +
+                    "/suggest [contact]\n" +
+                    "/pick [contact] <index> [edited text]\n" +
+                    "/send [contact] <text>\n" +
+                    "/ask [contact] <question>\n" +
+                    "/attachment [contact] <messageId> [attachmentIndex] [outputPath]\n" +
+                    "/model [contact] <autoReply|assistant|suggestions>\n" +
+                    "/style derive [contact]\n" +
+                    "/careful (toggle plain-text sending)\n" +
+                    `/active: ${active.contact.displayName}`,
+            };
+        }
+
+        if (command === "/careful") {
+            this.carefulMode = !this.carefulMode;
+            this.notifyViewUpdate();
+            return {
+                output: `Careful mode ${this.carefulMode ? "enabled" : "disabled"}`,
+            };
+        }
+
+        if (command === "/chat") {
+            if (args.length === 0) {
+                return { output: "Usage: /chat <contact>" };
             }
 
-            const state = this.findState(contactArg);
+            const state = this.findState(args[0]);
 
             if (!state) {
-                logger.warn(`Unknown contact: ${contactArg}`);
-                return;
+                return { output: `Unknown contact: ${args[0]}` };
             }
 
-            const suggestions = await this.generateSuggestionsForState(state);
-            this.printSuggestions(state.contact.displayName, suggestions);
-            return;
+            this.setActiveChat(state.contact.userId);
+            return { output: `Active chat: ${state.contact.displayName}` };
+        }
+
+        if (command === "/next") {
+            this.cycleActiveChat(1);
+            return { output: `Active chat: ${this.getActiveState().contact.displayName}` };
+        }
+
+        if (command === "/prev") {
+            this.cycleActiveChat(-1);
+            return { output: `Active chat: ${this.getActiveState().contact.displayName}` };
+        }
+
+        if (command === "/suggest") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            await this.generateSuggestionsForState(target.state);
+            this.printSuggestions(target.state);
+            return { output: `Generated suggestions for ${target.state.contact.displayName}` };
+        }
+
+        if (command === "/pick") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const indexRaw = args[target.consumed];
+            const index = indexRaw ? Number(indexRaw) : Number.NaN;
+
+            if (!Number.isInteger(index) || index < 1) {
+                return { output: "Usage: /pick [contact] <index> [edited text]" };
+            }
+
+            const suggestion = target.state.pendingSuggestions[index - 1];
+
+            if (!suggestion) {
+                return { output: `No suggestion at index ${index}` };
+            }
+
+            const inlineEditedText = args.slice(target.consumed + 1).join(" ").trim();
+            let sendText = inlineEditedText;
+
+            if (!sendText) {
+                const promptValue = await p.text({
+                    message: `Edit suggestion ${index} before send (empty = keep as-is):`,
+                    initialValue: suggestion,
+                });
+
+                if (p.isCancel(promptValue)) {
+                    return { output: "Suggestion send cancelled." };
+                }
+
+                const textValue = (promptValue as string).trim();
+                sendText = textValue.length > 0 ? textValue : suggestion;
+            }
+
+            await this.sendText(target.state, sendText, {
+                suggestionText: suggestion,
+                incomingMessageId: target.state.pendingIncomingMessageId,
+            });
+
+            target.state.pendingSuggestions = [];
+            target.state.pendingIncomingMessageId = undefined;
+            this.notifyViewUpdate();
+            return { output: `Sent suggestion ${index} to ${target.state.contact.displayName}` };
         }
 
         if (command === "/send") {
-            const contactArg = parts[1];
+            const target = this.parseStateFromArgs(args);
 
-            if (!contactArg) {
-                logger.warn("Usage: /send <contact> <text>");
-                return;
+            if (!target) {
+                return { output: "Unable to resolve contact." };
             }
 
-            const state = this.findState(contactArg);
-
-            if (!state) {
-                logger.warn(`Unknown contact: ${contactArg}`);
-                return;
-            }
-
-            const text = parts.slice(2).join(" ");
+            const text = args.slice(target.consumed).join(" ").trim();
 
             if (!text) {
-                logger.warn("Message text is required.");
-                return;
+                return { output: "Usage: /send [contact] <text>" };
             }
 
-            const sent = await this.options.client.sendMessage(state.contact.userId, text);
-            const nowUnix = Math.floor(Date.now() / 1000);
-
-            this.options.store.upsertMessageWithRevision(
-                state.contact.userId,
-                {
-                    id: sent.id,
-                    senderId: undefined,
-                    text,
-                    mediaDescription: undefined,
-                    isOutgoing: true,
-                    date: new Date(nowUnix * 1000).toISOString(),
-                    dateUnix: nowUnix,
-                    attachments: [],
-                },
-                "create"
-            );
-
-            this.pushHistory(state, `${this.options.myName}: ${text}`);
-            logger.info(`Sent to ${state.contact.displayName}`);
-            return;
+            await this.sendText(target.state, text);
+            return { output: `Sent to ${target.state.contact.displayName}` };
         }
 
         if (command === "/ask") {
-            const contactArg = parts[1];
+            const target = this.parseStateFromArgs(args);
 
-            if (!contactArg) {
-                logger.warn("Usage: /ask <contact> <question>");
-                return;
+            if (!target) {
+                return { output: "Unable to resolve contact." };
             }
 
-            const state = this.findState(contactArg);
-
-            if (!state) {
-                logger.warn(`Unknown contact: ${contactArg}`);
-                return;
-            }
-
-            const question = parts.slice(2).join(" ");
+            const question = args.slice(target.consumed).join(" ").trim();
 
             if (!question) {
-                logger.warn("Question is required.");
-                return;
+                return { output: "Usage: /ask [contact] <question>" };
+            }
+
+            if (target.state.rawStyleSamples.length === 0) {
+                target.state.rawStyleSamples = styleProfileEngine.getRawStyleSamples(
+                    target.state.contact,
+                    this.options.store,
+                    120
+                );
             }
 
             const answer = await assistantEngine.ask({
-                sessionId: `watch-assistant-${state.contact.userId}`,
-                mode: state.contact.assistantMode,
+                sessionId: `watch-assistant-${target.state.contact.userId}`,
+                mode: target.state.contact.assistantMode,
                 incomingText: question,
-                conversationHistory: this.getHistoryText(state),
-                stylePrompt: state.contact.config.styleProfile?.derivedPrompt,
+                conversationHistory: this.getHistoryText(target.state),
+                stylePrompt: target.state.contact.config.styleProfile?.derivedPrompt,
+                rawStyleSamples: target.state.rawStyleSamples,
+                store: this.options.store,
+                chatId: target.state.contact.userId,
+                includeFullDbHistory: true,
             });
 
             logger.info(pc.green(answer));
-            return;
+            return { output: answer };
+        }
+
+        if (command === "/attachment") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const messageIdRaw = args[target.consumed];
+            const attachmentIndexRaw = args[target.consumed + 1];
+            const messageId = messageIdRaw ? Number(messageIdRaw) : Number.NaN;
+            const attachmentIndex = attachmentIndexRaw && /^\d+$/.test(attachmentIndexRaw) ? Number(attachmentIndexRaw) : 0;
+
+            if (!Number.isInteger(messageId) || messageId <= 0) {
+                return { output: "Usage: /attachment [contact] <messageId> [attachmentIndex] [outputPath]" };
+            }
+
+            let outputPath = args
+                .slice(target.consumed + (attachmentIndexRaw && /^\d+$/.test(attachmentIndexRaw) ? 2 : 1))
+                .join(" ")
+                .trim();
+
+            if (!outputPath) {
+                const inputPath = await p.text({
+                    message: "Output path (leave empty for default chats/<id>/attachments path):",
+                    initialValue: "",
+                });
+
+                if (!p.isCancel(inputPath)) {
+                    outputPath = (inputPath as string).trim();
+                }
+            }
+
+            const result = await attachmentDownloader.downloadByLocator(
+                this.options.client,
+                this.options.store,
+                {
+                    chatId: target.state.contact.userId,
+                    messageId,
+                    attachmentIndex,
+                },
+                {
+                    outputPath: outputPath || undefined,
+                }
+            );
+
+            return { output: `Attachment saved: ${result.outputPath} (${result.bytes} bytes)` };
         }
 
         if (command === "/model") {
-            const contactArg = parts[1];
-            const modeArg = parts[2] as "autoReply" | "assistant" | "suggestions" | undefined;
+            const target = this.parseStateFromArgs(args);
 
-            if (!contactArg || !modeArg) {
-                logger.warn("Usage: /model <contact> <autoReply|assistant|suggestions>");
-                return;
+            if (!target) {
+                return { output: "Unable to resolve contact." };
             }
 
-            const state = this.findState(contactArg);
+            const modeArg = args[target.consumed] as "autoReply" | "assistant" | "suggestions" | undefined;
 
-            if (!state) {
-                logger.warn(`Unknown contact: ${contactArg}`);
-                return;
+            if (!modeArg || !["autoReply", "assistant", "suggestions"].includes(modeArg)) {
+                return { output: "Usage: /model [contact] <autoReply|assistant|suggestions>" };
             }
 
-            const mode = state.contact.config.modes?.[modeArg];
+            const mode = target.state.contact.config.modes?.[modeArg];
 
             if (!mode) {
-                logger.warn(`Mode ${modeArg} missing in contact configuration.`);
-                return;
+                return { output: `Mode ${modeArg} missing in contact config.` };
             }
 
             const choice = await modelSelector.selectModel();
 
             if (!choice) {
-                return;
+                return { output: "Model selection cancelled." };
             }
 
             mode.provider = choice.provider.name;
             mode.model = choice.model.id;
-            logger.info(`Updated ${state.contact.displayName} ${modeArg} model to ${mode.provider}/${mode.model}`);
-            return;
+            return { output: `Updated ${target.state.contact.displayName} ${modeArg} -> ${mode.provider}/${mode.model}` };
         }
 
-        if (command === "/style" && parts[1] === "derive") {
-            const contactArg = parts[2];
+        if (command === "/style" && args[0] === "derive") {
+            const target = this.parseStateFromArgs(args.slice(1));
 
-            if (!contactArg) {
-                logger.warn("Usage: /style derive <contact>");
-                return;
+            if (!target) {
+                return { output: "Usage: /style derive [contact]" };
             }
 
-            const state = this.findState(contactArg);
-
-            if (!state) {
-                logger.warn(`Unknown contact: ${contactArg}`);
-                return;
-            }
-
-            const result = await styleProfileEngine.deriveStylePrompt(state.contact, this.options.store);
+            const result = await styleProfileEngine.deriveStylePrompt(target.state.contact, this.options.store);
 
             if (!result) {
-                logger.warn("No style profile generated (rules missing or no matching messages).");
-                return;
+                return { output: "No style profile generated (rules missing or no matching messages)." };
             }
 
-            if (!state.contact.config.styleProfile) {
-                state.contact.config.styleProfile = {
+            if (!target.state.contact.config.styleProfile) {
+                target.state.contact.config.styleProfile = {
                     enabled: true,
                     refresh: "incremental",
                     rules: [],
@@ -362,13 +706,59 @@ export class WatchSession {
                 };
             }
 
-            state.contact.config.styleProfile.derivedPrompt = result.prompt;
-            state.contact.config.styleProfile.derivedAt = result.generatedAt;
-            logger.info(`Derived style profile (${result.sampleCount} samples).`);
-            logger.info(result.prompt);
-            return;
+            target.state.contact.config.styleProfile.derivedPrompt = result.prompt;
+            target.state.contact.config.styleProfile.derivedAt = result.generatedAt;
+            target.state.rawStyleSamples = result.rawSamples;
+            return { output: `Derived style profile from ${result.sampleCount} samples.` };
         }
 
-        logger.warn("Unknown command.");
+        return { output: "Unknown command. Use /help." };
+    }
+
+    async handleInput(line: string): Promise<HandleResult> {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            return {};
+        }
+
+        if (trimmed.startsWith("/")) {
+            return this.handleCommand(trimmed);
+        }
+
+        if (this.carefulMode) {
+            return { output: "Careful mode is on. Use /send to send messages." };
+        }
+
+        const active = this.getActiveState();
+        await this.sendText(active, trimmed);
+        return { output: `Sent to ${active.contact.displayName}` };
+    }
+
+    async runLightPromptLoop(): Promise<void> {
+        const rl = createInterface({ input, output });
+
+        logger.info(
+            "Live watch mode. Plain text sends to active chat. Use /help for commands. /careful toggles explicit /send-only mode."
+        );
+
+        try {
+            while (!this.shouldExit) {
+                const active = this.getActiveState();
+                const prompt = `${pc.dim("watch")}(${pc.cyan(active.contact.displayName)}${this.carefulMode ? pc.yellow(":careful") : ""})> `;
+                const line = await rl.question(prompt);
+                const result = await this.handleInput(line);
+
+                if (result.output) {
+                    logger.info(result.output);
+                }
+
+                if (result.exit) {
+                    break;
+                }
+            }
+        } finally {
+            rl.close();
+        }
     }
 }

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -1,0 +1,374 @@
+import { stdin as input, stdout as output } from "node:process";
+import { createInterface } from "node:readline/promises";
+import logger from "@app/logger";
+import { modelSelector } from "@ask/providers/ModelSelector";
+import pc from "picocolors";
+import { assistantEngine } from "../../lib/AssistantEngine";
+import { styleProfileEngine } from "../../lib/StyleProfileEngine";
+import { suggestionEngine } from "../../lib/SuggestionEngine";
+import { TelegramContact } from "../../lib/TelegramContact";
+import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
+import { TelegramMessage } from "../../lib/TelegramMessage";
+import type { TGClient } from "../../lib/TGClient";
+import type { ContactConfig } from "../../lib/types";
+
+interface ContactState {
+    contact: TelegramContact;
+    historyLines: string[];
+    lastIncoming?: string;
+    pendingSuggestions: string[];
+}
+
+export interface WatchSessionOptions {
+    contacts: ContactConfig[];
+    myName: string;
+    client: TGClient;
+    store: TelegramHistoryStore;
+    contextLengthOverride?: number;
+}
+
+export class WatchSession {
+    private states = new Map<string, ContactState>();
+
+    constructor(private options: WatchSessionOptions) {
+        for (const config of options.contacts) {
+            const contact = TelegramContact.fromConfig(config);
+            const contextLength = options.contextLengthOverride ?? contact.contextLength;
+            const rows = this.options.store.getByDateRange(contact.userId, undefined, undefined, contextLength);
+            const historyLines = rows
+                .map((row) => {
+                    const name = row.is_outgoing ? this.options.myName : contact.displayName;
+                    const content = row.text ?? row.media_desc ?? "";
+
+                    if (!content) {
+                        return undefined;
+                    }
+
+                    return `${name}: ${content}`;
+                })
+                .filter((line): line is string => line !== undefined);
+
+            this.states.set(contact.userId, {
+                contact,
+                historyLines,
+                pendingSuggestions: [],
+            });
+        }
+    }
+
+    async startListeners(): Promise<void> {
+        this.options.client.onNewMessage(async (event) => {
+            const message = new TelegramMessage(event.message);
+
+            if (message.isOutgoing) {
+                return;
+            }
+
+            const targetId = message.chatId ?? message.senderId;
+
+            if (!targetId) {
+                return;
+            }
+
+            const state = this.states.get(targetId);
+
+            if (!state) {
+                return;
+            }
+
+            const serialized = message.toJSON();
+            this.options.store.upsertMessageWithRevision(targetId, serialized, "create");
+            const content = message.contentForLLM;
+
+            if (content) {
+                this.pushHistory(state, `${state.contact.displayName}: ${content}`);
+                state.lastIncoming = content;
+            }
+
+            logger.info(`${pc.bold(pc.cyan(state.contact.displayName))}: ${message.preview}`);
+
+            const suggestionMode = state.contact.suggestionMode;
+
+            if (!suggestionMode.enabled) {
+                return;
+            }
+
+            if (suggestionMode.trigger === "auto" || suggestionMode.trigger === "hybrid") {
+                if (suggestionMode.autoDelayMs > 0) {
+                    await Bun.sleep(suggestionMode.autoDelayMs);
+                }
+
+                const suggestions = await this.generateSuggestionsForState(state);
+                this.printSuggestions(state.contact.displayName, suggestions);
+            }
+        });
+    }
+
+    private pushHistory(state: ContactState, line: string): void {
+        const maxLength = this.options.contextLengthOverride ?? state.contact.contextLength;
+        state.historyLines.push(line);
+
+        while (state.historyLines.length > maxLength) {
+            state.historyLines.shift();
+        }
+    }
+
+    private getHistoryText(state: ContactState): string {
+        return state.historyLines.join("\n");
+    }
+
+    private findState(target: string): ContactState | null {
+        const lower = target.toLowerCase();
+
+        for (const state of this.states.values()) {
+            if (state.contact.userId === target) {
+                return state;
+            }
+
+            if (state.contact.displayName.toLowerCase() === lower) {
+                return state;
+            }
+
+            if (state.contact.username?.toLowerCase() === lower) {
+                return state;
+            }
+        }
+
+        return null;
+    }
+
+    private async generateSuggestionsForState(state: ContactState): Promise<string[]> {
+        if (!state.lastIncoming) {
+            return [];
+        }
+
+        const suggestions = await suggestionEngine.generateSuggestions({
+            sessionId: `watch-${state.contact.userId}`,
+            mode: state.contact.suggestionMode,
+            incomingText: state.lastIncoming,
+            conversationHistory: this.getHistoryText(state),
+            stylePrompt: state.contact.config.styleProfile?.derivedPrompt,
+        });
+
+        state.pendingSuggestions = suggestions;
+        return suggestions;
+    }
+
+    private printSuggestions(contactLabel: string, suggestions: string[]): void {
+        if (suggestions.length === 0) {
+            logger.info(`[suggest:${contactLabel}] no options generated`);
+            return;
+        }
+
+        logger.info(pc.yellow(`Suggestions for ${contactLabel}:`));
+
+        for (let i = 0; i < suggestions.length; i++) {
+            logger.info(`  ${i + 1}. ${suggestions[i]}`);
+        }
+    }
+
+    async runLightPromptLoop(): Promise<void> {
+        const rl = createInterface({ input, output });
+
+        logger.info(
+            "Watch commands: /suggest <contact>, /send <contact> <text>, /ask <contact> <question>, /model <contact> <mode>, /style derive <contact>, /quit"
+        );
+
+        try {
+            while (true) {
+                const line = (await rl.question(pc.dim("watch> "))).trim();
+
+                if (!line) {
+                    continue;
+                }
+
+                if (line === "/quit" || line === "/exit") {
+                    break;
+                }
+
+                await this.executeCommand(line);
+            }
+        } finally {
+            rl.close();
+        }
+    }
+
+    private async executeCommand(line: string): Promise<void> {
+        const parts = line.split(" ").filter(Boolean);
+        const command = parts[0];
+
+        if (command === "/suggest") {
+            const contactArg = parts[1];
+
+            if (!contactArg) {
+                logger.warn("Usage: /suggest <contact>");
+                return;
+            }
+
+            const state = this.findState(contactArg);
+
+            if (!state) {
+                logger.warn(`Unknown contact: ${contactArg}`);
+                return;
+            }
+
+            const suggestions = await this.generateSuggestionsForState(state);
+            this.printSuggestions(state.contact.displayName, suggestions);
+            return;
+        }
+
+        if (command === "/send") {
+            const contactArg = parts[1];
+
+            if (!contactArg) {
+                logger.warn("Usage: /send <contact> <text>");
+                return;
+            }
+
+            const state = this.findState(contactArg);
+
+            if (!state) {
+                logger.warn(`Unknown contact: ${contactArg}`);
+                return;
+            }
+
+            const text = parts.slice(2).join(" ");
+
+            if (!text) {
+                logger.warn("Message text is required.");
+                return;
+            }
+
+            const sent = await this.options.client.sendMessage(state.contact.userId, text);
+            const nowUnix = Math.floor(Date.now() / 1000);
+
+            this.options.store.upsertMessageWithRevision(
+                state.contact.userId,
+                {
+                    id: sent.id,
+                    senderId: undefined,
+                    text,
+                    mediaDescription: undefined,
+                    isOutgoing: true,
+                    date: new Date(nowUnix * 1000).toISOString(),
+                    dateUnix: nowUnix,
+                    attachments: [],
+                },
+                "create"
+            );
+
+            this.pushHistory(state, `${this.options.myName}: ${text}`);
+            logger.info(`Sent to ${state.contact.displayName}`);
+            return;
+        }
+
+        if (command === "/ask") {
+            const contactArg = parts[1];
+
+            if (!contactArg) {
+                logger.warn("Usage: /ask <contact> <question>");
+                return;
+            }
+
+            const state = this.findState(contactArg);
+
+            if (!state) {
+                logger.warn(`Unknown contact: ${contactArg}`);
+                return;
+            }
+
+            const question = parts.slice(2).join(" ");
+
+            if (!question) {
+                logger.warn("Question is required.");
+                return;
+            }
+
+            const answer = await assistantEngine.ask({
+                sessionId: `watch-assistant-${state.contact.userId}`,
+                mode: state.contact.assistantMode,
+                incomingText: question,
+                conversationHistory: this.getHistoryText(state),
+                stylePrompt: state.contact.config.styleProfile?.derivedPrompt,
+            });
+
+            logger.info(pc.green(answer));
+            return;
+        }
+
+        if (command === "/model") {
+            const contactArg = parts[1];
+            const modeArg = parts[2] as "autoReply" | "assistant" | "suggestions" | undefined;
+
+            if (!contactArg || !modeArg) {
+                logger.warn("Usage: /model <contact> <autoReply|assistant|suggestions>");
+                return;
+            }
+
+            const state = this.findState(contactArg);
+
+            if (!state) {
+                logger.warn(`Unknown contact: ${contactArg}`);
+                return;
+            }
+
+            const mode = state.contact.config.modes?.[modeArg];
+
+            if (!mode) {
+                logger.warn(`Mode ${modeArg} missing in contact configuration.`);
+                return;
+            }
+
+            const choice = await modelSelector.selectModel();
+
+            if (!choice) {
+                return;
+            }
+
+            mode.provider = choice.provider.name;
+            mode.model = choice.model.id;
+            logger.info(`Updated ${state.contact.displayName} ${modeArg} model to ${mode.provider}/${mode.model}`);
+            return;
+        }
+
+        if (command === "/style" && parts[1] === "derive") {
+            const contactArg = parts[2];
+
+            if (!contactArg) {
+                logger.warn("Usage: /style derive <contact>");
+                return;
+            }
+
+            const state = this.findState(contactArg);
+
+            if (!state) {
+                logger.warn(`Unknown contact: ${contactArg}`);
+                return;
+            }
+
+            const result = await styleProfileEngine.deriveStylePrompt(state.contact, this.options.store);
+
+            if (!result) {
+                logger.warn("No style profile generated (rules missing or no matching messages).");
+                return;
+            }
+
+            if (!state.contact.config.styleProfile) {
+                state.contact.config.styleProfile = {
+                    enabled: true,
+                    refresh: "incremental",
+                    rules: [],
+                    previewInWatch: false,
+                };
+            }
+
+            state.contact.config.styleProfile.derivedPrompt = result.prompt;
+            state.contact.config.styleProfile.derivedAt = result.generatedAt;
+            logger.info(`Derived style profile (${result.sampleCount} samples).`);
+            logger.info(result.prompt);
+            return;
+        }
+
+        logger.warn("Unknown command.");
+    }
+}


### PR DESCRIPTION
## Summary
- complete Telegram V2 conversation memory stack (full/incremental/range sync, segment-aware query auto-fetch, attachment index + lazy download)
- add assistant/suggestion/watch runtime split with live light + Ink experiences, inline slash command flows, and per-mode provider/model configs
- add style profile pipeline (rules + derive) with hybrid style summary + raw samples and suggestion edit feedback loop
- add edit/delete ingestion, outgoing message ID correctness, natural-language query dates, and compatibility alias paths for existing listen/download usage

## Validation
- bun test src/telegram
- tsgo --noEmit
- biome check src/telegram src/ask

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `watch` command for monitoring Telegram conversations in daemon, light, and ink runtime modes.
  * Introduced reply suggestion generation based on conversation history and writing style.
  * Added automatic style profile derivation from user's outbound messages.
  * Enhanced per-contact configuration for auto-reply, assistant, and suggestion behaviors.
  * Added attachment indexing and download support for messages.

* **Refactor**
  * Replaced legacy `download` command with improved `sync` for history management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->