### PR TITLE
feat: telegram conversation memory + assistant v2

### DIFF
--- a/.claude/plans/2026-03-01-TelegramAssistantV2.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2.md
@@ -1,0 +1,108 @@
+# Telegram Conversation Memory + Assistant V2 Implementation Plan
+
+## Summary
+Build a V2 Telegram subsystem that supports full + incremental sync for users/groups/channels, range-aware query with auto-fetch caching, attachment indexing with lazy download, and an assistant workflow (auto-reply, chat assistant, suggestion drafting with pick/edit/send).
+This plan keeps existing `tools telegram listen` behavior compatible while adding new runtime modes (`daemon`, `light`, `ink`) and richer per-contact Ask/model/style configuration.
+
+## Git Start (Execute After Plan Mode)
+1. Fast-forward local `master` and branch:
+```bash
+git checkout master
+git pull --ff-only origin master
+git checkout -b feat/telegram-agent
+```
+2. Save this plan to `.claude/plans/2026-03-01-TelegramAssistantV2.md` before implementation.
+
+## Public APIs / Interfaces / Types
+- Extend Telegram config schema in `src/telegram/lib/types.ts` and migration logic in `src/telegram/lib/TelegramToolConfig.ts`.
+- Keep backward compatibility with old `askProvider/askModel/askSystemPrompt` by mapping into V2 `modes.autoReply`.
+- Add per-contact per-mode Ask config (`autoReply`, `assistant`, `suggestions`) with global defaults.
+- Add style rule array config (rich source rules, regex/time windows, cross-chat sources).
+- Add query parser interface for flags + NL helper.
+- Add attachment locator interface: `chatId + messageId + attachmentIndex`.
+- Expose Ask model-selection helpers for Telegram configure flow via `src/ask/index.lib.ts` and reuse `src/ask/providers/ModelSelector.ts`.
+
+### Proposed V2 Contact Shape (decision-complete)
+```ts
+type TelegramRuntimeMode = "daemon" | "light" | "ink";
+
+interface AskModeConfig {
+  enabled: boolean;
+  provider?: string;
+  model?: string;
+  systemPrompt?: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+interface SuggestionModeConfig extends AskModeConfig {
+  count: number;
+  trigger: "manual" | "auto" | "hybrid";
+  autoDelayMs: number;
+  allowAutoSend: boolean;
+}
+
+interface StyleSourceRule {
+  id: string;
+  sourceChatId: string;
+  direction: "outgoing" | "incoming";
+  limit?: number;
+  since?: string;
+  until?: string;
+  regex?: string;
+}
+
+interface StyleProfileConfig {
+  enabled: boolean;
+  refresh: "incremental";
+  rules: StyleSourceRule[];
+  previewInWatch: boolean;
+}
+
+interface TelegramContactV2 {
+  userId: string;
+  displayName: string;
+  username?: string;
+  actions: ("say" | "ask" | "notify")[];
+  watch: { enabled: boolean; contextLength: number; runtimeMode?: TelegramRuntimeMode };
+  modes: {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+  };
+  styleProfile: StyleProfileConfig;
+}
+```
+
+## Data Model and Migration
+- Upgrade SQLite schema in `src/telegram/lib/TelegramHistoryStore.ts` using `PRAGMA user_version` migrations.
+- Add `chats` table for dialog metadata/type.
+- Extend `messages` with mutation tracking fields (`edited_date_unix`, `is_deleted`, `deleted_at_iso`, `reply_to_msg_id`).
+- Add `message_revisions` table to preserve create/edit/delete history.
+- Add `attachments` table with metadata + download status/path/hash + unique `(chat_id, message_id, attachment_index)`.
+- Add `sync_segments` table to track covered date intervals for auto-fetch gap detection.
+- Keep `sync_state` for high-watermark incremental latest sync.
+- Keep FTS + embeddings intact.
+
+## Command Surface (V2)
+- Update `src/telegram/index.ts` command registration.
+- Keep existing commands; add/extend:
+1. `tools telegram configure`
+2. `tools telegram history sync [contact] [--all] [--since] [--until] [--limit]`
+3. `tools telegram history query --from <contact> [--since] [--until] [--sender me|them|any] [--text <regex>] [--local-only] [--nl "<query>"]`
+4. `tools telegram history attachments list --from <contact> [--since] [--until] [--message-id]`
+5. `tools telegram history attachments fetch --from <contact> --message-id <id> --attachment-index <n> [--output <path>]`
+6. `tools telegram watch [contact|--all] [--runtime daemon|light|ink] [--context-length <n>]`
+7. `tools telegram listen`
+
+## Implementation Tasks
+- Implement tasks 1-12 from agreed plan.
+
+## Assumptions and Defaults
+- Default query behavior is auto-fetch-and-cache when local range is incomplete.
+- Default suggestion behavior is manual; optional delayed auto-suggest is configurable.
+- Default send behavior requires explicit user pick/edit confirmation; no auto-send by default.
+- Default style refresh is incremental background update.
+- Attachment binaries are lazy-downloaded; metadata is always indexed.
+- Deleted messages remain queryable as tombstones (`is_deleted=1`) unless explicitly filtered out.
+- TUI is split into `light` first and `ink` runtime second, but both are delivered in this feature branch.

--- a/src/ask/AIChat.ts
+++ b/src/ask/AIChat.ts
@@ -161,25 +161,22 @@ export class AIChat {
         let fullContent = "";
         let thinkingContent = "";
         const startTime = Date.now();
+        const toolsForTurn = options?.override?.tools ?? this._options.tools;
 
         // Bridge push-based onChunk to pull-based async generator via ReadableStream
         const stream = new ReadableStream<ChatEvent>({
             start: async (controller) => {
                 try {
-                    const engineResponse = await engine.sendMessage(
-                        message,
-                        undefined, // tools — TODO: wire AIChatTool → AI SDK tools
-                        {
-                            onChunk: (chunk: string) => {
-                                controller.enqueue(ChatEvent.text(chunk));
-                                fullContent += chunk;
-                            },
-                            onThinking: (text: string) => {
-                                controller.enqueue(ChatEvent.thinking(text));
-                                thinkingContent += text;
-                            },
-                        }
-                    );
+                    const engineResponse = await engine.sendMessage(message, toolsForTurn, {
+                        onChunk: (chunk: string) => {
+                            controller.enqueue(ChatEvent.text(chunk));
+                            fullContent += chunk;
+                        },
+                        onThinking: (text: string) => {
+                            controller.enqueue(ChatEvent.thinking(text));
+                            thinkingContent += text;
+                        },
+                    });
 
                     const duration = Date.now() - startTime;
                     const response: ChatResponse = {

--- a/src/ask/chat/ChatEngine.ts
+++ b/src/ask/chat/ChatEngine.ts
@@ -71,7 +71,7 @@ export class ChatEngine {
 
     private async sendStreamingMessage(
         message: string,
-        _tools?: Record<string, unknown>,
+        tools?: Record<string, unknown>,
         callbacks?: {
             onChunk?: (chunk: string) => void;
             onThinking?: (text: string) => void;
@@ -87,6 +87,7 @@ export class ChatEngine {
             system: this.config.systemPrompt,
             temperature: this.config.temperature,
             ...(this.config.maxTokens && { maxOutputTokens: this.config.maxTokens }),
+            ...(tools ? { tools: tools as never } : {}),
             onFinish: async ({ usage }) => {
                 // This is called when the stream completes - usage is available HERE
                 logger.debug(
@@ -225,13 +226,14 @@ export class ChatEngine {
         };
     }
 
-    private async sendNonStreamingMessage(message: string, _tools?: Record<string, unknown>): Promise<ChatResponse> {
+    private async sendNonStreamingMessage(message: string, tools?: Record<string, unknown>): Promise<ChatResponse> {
         const result = await generateText({
             model: this.config.model,
             prompt: message, // Use prompt instead of messages array
             system: this.config.systemPrompt,
             temperature: this.config.temperature,
             ...(this.config.maxTokens && { maxOutputTokens: this.config.maxTokens }),
+            ...(tools ? { tools: tools as never } : {}),
         });
 
         // DEBUG: Log the full result object structure

--- a/src/ask/index.lib.ts
+++ b/src/ask/index.lib.ts
@@ -16,6 +16,4 @@ export type {
     SessionStats,
     ToolCallResult,
 } from "./lib/types";
-export { ModelSelector } from "./providers/ModelSelector";
-export { ProviderManager } from "./providers/ProviderManager";
-export type { DetectedProvider, ModelInfo, ProviderChoice } from "./types";
+export { modelSelector } from "./providers/ModelSelector";

--- a/src/telegram/commands/configure.ts
+++ b/src/telegram/commands/configure.ts
@@ -1,41 +1,82 @@
-import { ModelSelector } from "@app/ask/index.lib";
+import { modelSelector } from "@ask/providers/ModelSelector";
+import type { ProviderChoice } from "@ask/types";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 import type { Api } from "telegram";
-import type { Dialog } from "telegram/tl/custom/dialog";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
 import type {
     ActionType,
-    ChatType,
-    ContactModesConfig,
-    TelegramConfigDataV2,
-    TelegramContactV2,
-    WatchConfig,
+    AskModeConfig,
+    ContactConfig,
+    StyleProfileConfig,
+    StyleSourceRule,
+    SuggestionModeConfig,
+    TelegramConfigData,
+    TelegramDialogType,
 } from "../lib/types";
-import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "../lib/types";
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULTS,
+    TELEGRAM_CONFIG_VERSION,
+} from "../lib/types";
+
+interface DialogOption {
+    id: string;
+    label: string;
+    hint?: string;
+    dialogType: TelegramDialogType;
+}
 
 function isUser(entity: unknown): entity is Api.User {
-    return (
-        entity !== null &&
-        entity !== undefined &&
-        typeof entity === "object" &&
-        "className" in entity &&
-        (entity as { className: string }).className === "User"
-    );
+    if (entity === null || entity === undefined || typeof entity !== "object") {
+        return false;
+    }
+
+    if (!("className" in entity)) {
+        return false;
+    }
+
+    return (entity as { className: string }).className === "User";
+}
+
+function isChat(entity: unknown): entity is Api.Chat {
+    if (entity === null || entity === undefined || typeof entity !== "object") {
+        return false;
+    }
+
+    if (!("className" in entity)) {
+        return false;
+    }
+
+    return (entity as { className: string }).className === "Chat";
+}
+
+function isChannel(entity: unknown): entity is Api.Channel {
+    if (entity === null || entity === undefined || typeof entity !== "object") {
+        return false;
+    }
+
+    if (!("className" in entity)) {
+        return false;
+    }
+
+    return (entity as { className: string }).className === "Channel";
 }
 
 async function promptCredentials(
-    existing: TelegramConfigDataV2 | null
+    existing: TelegramConfigData | null
 ): Promise<{ apiId: number; apiHash: string } | null> {
     p.note("Telegram API credentials are pre-filled.\nGet your own at https://my.telegram.org/apps", "API Credentials");
 
     const apiId = await p.text({
         message: "API ID:",
         initialValue: String(existing?.apiId ?? DEFAULTS.apiId),
-        validate: (v) => {
-            if (!v || !/^\d+$/.test(v)) {
+        validate: (value) => {
+            if (!value || !/^\d+$/.test(value)) {
                 return "Must be a number";
             }
         },
@@ -48,8 +89,8 @@ async function promptCredentials(
     const apiHash = await p.text({
         message: "API Hash:",
         initialValue: existing?.apiHash ?? DEFAULTS.apiHash,
-        validate: (v) => {
-            if (!v || !/^[a-f0-9]{32}$/.test(v)) {
+        validate: (value) => {
+            if (!value || !/^[a-f0-9]{32}$/.test(value)) {
                 return "Must be 32 hex chars";
             }
         },
@@ -95,15 +136,15 @@ async function runAuthFlow(client: TGClient): Promise<boolean> {
                 return code as string;
             },
             password: async () => {
-                const pass = await p.password({
+                const password = await p.password({
                     message: "2FA password (if enabled):",
                 });
 
-                if (p.isCancel(pass)) {
+                if (p.isCancel(password)) {
                     throw new Error("Cancelled");
                 }
 
-                return pass as string;
+                return password as string;
             },
         });
 
@@ -115,82 +156,69 @@ async function runAuthFlow(client: TGClient): Promise<boolean> {
     }
 }
 
-interface DialogOption {
-    dialog: Dialog;
-    chatType: ChatType;
-    entityId: string;
-    dialogKey: string;
-    label: string;
-    hint: string;
-}
-
-function classifyDialog(d: Dialog): { chatType: ChatType; entityId: string; dialogKey: string } | null {
-    if (!d.entity) {
-        return null;
-    }
-
-    if (d.isUser && isUser(d.entity) && !d.entity.bot && !d.entity.self) {
-        const entityId = d.entity.id.toString();
-        return { chatType: "user", entityId, dialogKey: `user:${entityId}` };
-    }
-
-    if (d.isGroup && d.entity.id) {
-        const entityId = d.entity.id.toString();
-        return { chatType: "group", entityId, dialogKey: `group:${entityId}` };
-    }
-
-    if (d.isChannel && d.entity.id) {
-        const entityId = d.entity.id.toString();
-        return { chatType: "channel", entityId, dialogKey: `channel:${entityId}` };
-    }
-
-    return null;
-}
-
-async function fetchDialogOptions(client: TGClient): Promise<DialogOption[]> {
+async function fetchDialogs(client: TGClient): Promise<DialogOption[]> {
     const spinner = p.spinner();
-    spinner.start("Fetching your recent chats...");
+    spinner.start("Fetching your recent dialogs...");
+
+    const dialogs = await client.getDialogs(200);
     const options: DialogOption[] = [];
 
-    try {
-        const dialogs = await client.getDialogs(200);
+    for (const dialog of dialogs) {
+        const entity = dialog.entity;
 
-        for (const d of dialogs) {
-            const classified = classifyDialog(d);
+        if (!entity) {
+            continue;
+        }
 
-            if (!classified) {
+        if (isUser(entity)) {
+            if (entity.bot || entity.self) {
                 continue;
             }
 
-            const entity = d.entity as { username?: string; phone?: string; id: { toString(): string } };
-            const username = "username" in entity ? entity.username : undefined;
-            const typePrefix = classified.chatType === "user" ? "U" : classified.chatType === "group" ? "G" : "C";
-            const label = `[${typePrefix}] ${d.title || classified.entityId}`;
-            const hint = username ? `@${username}` : "";
-
+            const label = `${entity.firstName || ""} ${entity.lastName || ""}`.trim() || entity.id.toString();
             options.push({
-                dialog: d,
-                chatType: classified.chatType,
-                entityId: classified.entityId,
-                dialogKey: classified.dialogKey,
+                id: entity.id.toString(),
                 label,
-                hint,
+                hint: entity.username ? `@${entity.username}` : entity.phone ? `+${entity.phone}` : undefined,
+                dialogType: "user",
             });
+            continue;
         }
 
-        return options;
-    } finally {
-        spinner.stop(`Found ${options.length} chats`);
+        if (isChat(entity)) {
+            options.push({
+                id: entity.id.toString(),
+                label: entity.title,
+                hint: "group",
+                dialogType: "group",
+            });
+            continue;
+        }
+
+        if (isChannel(entity)) {
+            options.push({
+                id: entity.id.toString(),
+                label: entity.title,
+                hint: entity.username ? `@${entity.username}` : "channel",
+                dialogType: "channel",
+            });
+        }
     }
+
+    spinner.stop(`Found ${options.length} dialogs`);
+    return options;
 }
 
-async function selectDialogs(options: DialogOption[], existingContacts: TelegramContactV2[]): Promise<string[] | null> {
-    const existingDialogKeys = new Set(existingContacts.map((c) => `${c.chatType}:${c.userId}`));
-
+async function selectDialogs(options: DialogOption[], existingContacts: ContactConfig[]): Promise<string[] | null> {
+    const existingIds = new Set(existingContacts.map((contact) => contact.userId));
     const selected = await p.multiselect({
-        message: "Select chats to watch:",
-        options: options.map((o) => ({ value: o.dialogKey, label: o.label, hint: o.hint })),
-        initialValues: options.filter((o) => existingDialogKeys.has(o.dialogKey)).map((o) => o.dialogKey),
+        message: "Select dialogs to watch:",
+        options: options.map((option) => ({
+            value: option.id,
+            label: option.label,
+            hint: option.hint,
+        })),
+        initialValues: [...existingIds].filter((id) => options.some((option) => option.id === id)),
         required: false,
     });
 
@@ -201,120 +229,427 @@ async function selectDialogs(options: DialogOption[], existingContacts: Telegram
     return selected as string[];
 }
 
-async function configureContactModes(
-    displayName: string,
-    existing?: TelegramContactV2
-): Promise<ContactModesConfig | null> {
-    const modeChoices = await p.multiselect({
-        message: `Which AI modes for ${displayName}?`,
-        options: [
-            { value: "autoReply" as const, label: "Auto-Reply", hint: "Automatically respond to messages" },
-            { value: "assistant" as const, label: "Chat Assistant", hint: "Ask questions about the conversation" },
-            {
-                value: "suggestions" as const,
-                label: "Message Suggestions",
-                hint: "Get suggested replies to pick/edit/send",
-            },
-        ],
-        initialValues: getExistingEnabledModes(existing),
-        required: false,
-    });
+async function chooseProviderModel(existingProvider?: string, existingModel?: string): Promise<ProviderChoice | null> {
+    if (existingProvider && existingModel) {
+        const exact = await modelSelector.selectModelByName(existingProvider, existingModel);
 
-    if (p.isCancel(modeChoices)) {
-        return null;
-    }
+        if (exact) {
+            const reuse = await p.confirm({
+                message: `Reuse ${existingProvider}/${existingModel}?`,
+                initialValue: true,
+            });
 
-    const selectedModes = modeChoices as string[];
-    const modes: ContactModesConfig = {
-        autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
-        assistant: { ...DEFAULT_MODE_CONFIG.assistant },
-        suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
-    };
-
-    const modelSelector = new ModelSelector();
-
-    for (const mode of selectedModes) {
-        const configureModel = await p.confirm({
-            message: `Configure custom model for ${mode}?`,
-            initialValue: false,
-        });
-
-        if (p.isCancel(configureModel)) {
-            return null;
-        }
-
-        if (mode === "autoReply") {
-            modes.autoReply = { ...modes.autoReply, enabled: true };
-        } else if (mode === "assistant") {
-            modes.assistant = { ...modes.assistant, enabled: true };
-        } else if (mode === "suggestions") {
-            modes.suggestions = { ...modes.suggestions, enabled: true };
-        }
-
-        if (configureModel) {
-            const choice = await modelSelector.selectModel();
-
-            if (choice && !p.isCancel(choice)) {
-                if (mode === "autoReply") {
-                    modes.autoReply = {
-                        ...modes.autoReply,
-                        provider: choice.provider.name,
-                        model: choice.model.id,
-                    };
-                } else if (mode === "assistant") {
-                    modes.assistant = {
-                        ...modes.assistant,
-                        provider: choice.provider.name,
-                        model: choice.model.id,
-                    };
-                } else if (mode === "suggestions") {
-                    modes.suggestions = {
-                        ...modes.suggestions,
-                        provider: choice.provider.name,
-                        model: choice.model.id,
-                    };
-                }
+            if (!p.isCancel(reuse) && reuse) {
+                return exact;
             }
         }
     }
 
-    return modes;
+    return modelSelector.selectModel();
 }
 
-function getExistingEnabledModes(existing?: TelegramContactV2): string[] {
-    if (!existing?.modes) {
-        return ["assistant", "suggestions"];
+async function promptAskModeConfig(
+    label: string,
+    defaults: AskModeConfig,
+    existing: AskModeConfig | undefined,
+    initialEnabled: boolean
+): Promise<AskModeConfig | null> {
+    const enabled = await p.confirm({
+        message: `Enable ${label}?`,
+        initialValue: existing?.enabled ?? initialEnabled,
+    });
+
+    if (p.isCancel(enabled)) {
+        return null;
     }
 
-    const enabled: string[] = [];
+    const result: AskModeConfig = {
+        ...defaults,
+        ...existing,
+        enabled,
+    };
 
-    if (existing.modes.autoReply.enabled) {
-        enabled.push("autoReply");
+    if (!enabled) {
+        return result;
     }
 
-    if (existing.modes.assistant.enabled) {
-        enabled.push("assistant");
+    const choice = await chooseProviderModel(result.provider, result.model);
+
+    if (!choice) {
+        return null;
     }
 
-    if (existing.modes.suggestions.enabled) {
-        enabled.push("suggestions");
+    result.provider = choice.provider.name;
+    result.model = choice.model.id;
+
+    const systemPrompt = await p.text({
+        message: `${label} system prompt:`,
+        initialValue: result.systemPrompt ?? DEFAULTS.askSystemPrompt,
+    });
+
+    if (p.isCancel(systemPrompt)) {
+        return null;
     }
 
-    return enabled;
+    result.systemPrompt = systemPrompt as string;
+
+    const temperatureInput = await p.text({
+        message: `${label} temperature:`,
+        initialValue: String(result.temperature ?? DEFAULTS.askTemperature),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (Number.isNaN(parsed) || parsed < 0 || parsed > 2) {
+                return "Use number between 0 and 2";
+            }
+        },
+    });
+
+    if (p.isCancel(temperatureInput)) {
+        return null;
+    }
+
+    result.temperature = Number(temperatureInput);
+
+    const maxTokensInput = await p.text({
+        message: `${label} max tokens:`,
+        initialValue: String(result.maxTokens ?? DEFAULTS.askMaxTokens),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed <= 0) {
+                return "Use positive integer";
+            }
+        },
+    });
+
+    if (p.isCancel(maxTokensInput)) {
+        return null;
+    }
+
+    result.maxTokens = Number(maxTokensInput);
+
+    return result;
 }
 
-async function configureContactActions(
-    opt: DialogOption,
-    existing?: TelegramContactV2
-): Promise<TelegramContactV2 | null> {
-    p.log.step(pc.bold(opt.label));
+async function promptSuggestionModeConfig(
+    existing: SuggestionModeConfig | undefined
+): Promise<SuggestionModeConfig | null> {
+    const base = await promptAskModeConfig(
+        "Suggestion mode",
+        DEFAULT_MODE_CONFIG.suggestions,
+        existing,
+        DEFAULT_MODE_CONFIG.suggestions.enabled
+    );
+
+    if (!base) {
+        return null;
+    }
+
+    const result: SuggestionModeConfig = {
+        ...DEFAULT_MODE_CONFIG.suggestions,
+        ...existing,
+        ...base,
+    };
+
+    if (!result.enabled) {
+        return result;
+    }
+
+    const countInput = await p.text({
+        message: "How many suggestions (1-5)?",
+        initialValue: String(result.count),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed < 1 || parsed > 5) {
+                return "Enter integer from 1 to 5";
+            }
+        },
+    });
+
+    if (p.isCancel(countInput)) {
+        return null;
+    }
+
+    result.count = Number(countInput);
+
+    const trigger = await p.select({
+        message: "Suggestion trigger mode:",
+        options: [
+            { value: "manual" as const, label: "Manual only (/suggest)" },
+            { value: "auto" as const, label: "Auto on every incoming message" },
+            { value: "hybrid" as const, label: "Manual + auto with debounce" },
+        ],
+        initialValue: result.trigger,
+    });
+
+    if (p.isCancel(trigger)) {
+        return null;
+    }
+
+    result.trigger = trigger;
+
+    const delayInput = await p.text({
+        message: "Auto suggestion debounce delay (ms):",
+        initialValue: String(result.autoDelayMs),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed < 0) {
+                return "Enter non-negative integer";
+            }
+        },
+    });
+
+    if (p.isCancel(delayInput)) {
+        return null;
+    }
+
+    result.autoDelayMs = Number(delayInput);
+
+    const allowAutoSend = await p.confirm({
+        message: "Allow automatic sending of top suggestion?",
+        initialValue: result.allowAutoSend,
+    });
+
+    if (p.isCancel(allowAutoSend)) {
+        return null;
+    }
+
+    result.allowAutoSend = allowAutoSend;
+
+    return result;
+}
+
+function parseOptionalIsoDateInput(raw: string): string | undefined {
+    const value = raw.trim();
+
+    if (!value) {
+        return undefined;
+    }
+
+    const parsed = new Date(value);
+
+    if (Number.isNaN(parsed.getTime())) {
+        return undefined;
+    }
+
+    return parsed.toISOString();
+}
+
+function buildDefaultStyleRule(dialogId: string): StyleSourceRule {
+    return {
+        id: "self-outgoing-500",
+        sourceChatId: dialogId,
+        direction: "outgoing",
+        limit: 500,
+    };
+}
+
+async function promptStyleProfileConfig(
+    currentDialog: DialogOption,
+    allDialogs: DialogOption[],
+    existing: StyleProfileConfig | undefined
+): Promise<StyleProfileConfig | null> {
+    const enabled = await p.confirm({
+        message: "Enable style profile?",
+        initialValue: existing?.enabled ?? false,
+    });
+
+    if (p.isCancel(enabled)) {
+        return null;
+    }
+
+    const base: StyleProfileConfig = {
+        ...DEFAULT_STYLE_PROFILE,
+        ...existing,
+        enabled,
+    };
+
+    if (!enabled) {
+        return {
+            ...base,
+            rules: existing?.rules ?? [],
+        };
+    }
+
+    const previewInWatch = await p.confirm({
+        message: "Preview derived style prompt in watch mode?",
+        initialValue: base.previewInWatch,
+    });
+
+    if (p.isCancel(previewInWatch)) {
+        return null;
+    }
+
+    const seedRules = existing?.rules.length ? existing.rules : [buildDefaultStyleRule(currentDialog.id)];
+    const ruleCountInput = await p.text({
+        message: "How many style rules?",
+        initialValue: String(seedRules.length),
+        validate: (value) => {
+            const parsed = Number(value);
+
+            if (!Number.isInteger(parsed) || parsed < 1 || parsed > 10) {
+                return "Enter integer from 1 to 10";
+            }
+        },
+    });
+
+    if (p.isCancel(ruleCountInput)) {
+        return null;
+    }
+
+    const desiredRuleCount = Number(ruleCountInput);
+    const rules: StyleSourceRule[] = [];
+
+    for (let i = 0; i < desiredRuleCount; i++) {
+        const seed = seedRules[i] ?? buildDefaultStyleRule(currentDialog.id);
+        const sourceChatId = await p.select({
+            message: `Rule ${i + 1}: source chat`,
+            options: allDialogs.map((dialog) => ({
+                value: dialog.id,
+                label: dialog.label,
+                hint: dialog.hint ?? dialog.dialogType,
+            })),
+            initialValue: seed.sourceChatId,
+        });
+
+        if (p.isCancel(sourceChatId)) {
+            return null;
+        }
+
+        const direction = await p.select({
+            message: `Rule ${i + 1}: direction`,
+            options: [
+                { value: "outgoing" as const, label: "outgoing (my messages)" },
+                { value: "incoming" as const, label: "incoming (their messages)" },
+            ],
+            initialValue: seed.direction,
+        });
+
+        if (p.isCancel(direction)) {
+            return null;
+        }
+
+        const limitInput = await p.text({
+            message: `Rule ${i + 1}: max messages (empty = unlimited)`,
+            initialValue: seed.limit !== undefined ? String(seed.limit) : "",
+            validate: (value) => {
+                const trimmed = (value ?? "").trim();
+
+                if (!trimmed) {
+                    return;
+                }
+
+                const parsed = Number(trimmed);
+
+                if (!Number.isInteger(parsed) || parsed < 1) {
+                    return "Enter a positive integer or leave empty";
+                }
+            },
+        });
+
+        if (p.isCancel(limitInput)) {
+            return null;
+        }
+
+        const sinceInput = await p.text({
+            message: `Rule ${i + 1}: since (optional, e.g. 2025-01-01)`,
+            initialValue: seed.since ?? "",
+            validate: (value) => {
+                const trimmed = (value ?? "").trim();
+
+                if (!trimmed) {
+                    return;
+                }
+
+                if (!parseOptionalIsoDateInput(trimmed)) {
+                    return "Use a valid date/time or leave empty";
+                }
+            },
+        });
+
+        if (p.isCancel(sinceInput)) {
+            return null;
+        }
+
+        const untilInput = await p.text({
+            message: `Rule ${i + 1}: until (optional, e.g. 2025-12-31)`,
+            initialValue: seed.until ?? "",
+            validate: (value) => {
+                const trimmed = (value ?? "").trim();
+
+                if (!trimmed) {
+                    return;
+                }
+
+                if (!parseOptionalIsoDateInput(trimmed)) {
+                    return "Use a valid date/time or leave empty";
+                }
+            },
+        });
+
+        if (p.isCancel(untilInput)) {
+            return null;
+        }
+
+        const regexInput = await p.text({
+            message: `Rule ${i + 1}: regex filter (optional)`,
+            initialValue: seed.regex ?? "",
+            validate: (value) => {
+                const trimmed = (value ?? "").trim();
+
+                if (!trimmed) {
+                    return;
+                }
+
+                try {
+                    new RegExp(trimmed);
+                } catch {
+                    return "Invalid regex";
+                }
+            },
+        });
+
+        if (p.isCancel(regexInput)) {
+            return null;
+        }
+
+        const limitValue = (limitInput as string).trim();
+
+        rules.push({
+            id: seed.id || `rule-${i + 1}`,
+            sourceChatId: sourceChatId as string,
+            direction,
+            limit: limitValue ? Number(limitValue) : undefined,
+            since: parseOptionalIsoDateInput(sinceInput as string),
+            until: parseOptionalIsoDateInput(untilInput as string),
+            regex: (regexInput as string).trim() || undefined,
+        });
+    }
+
+    return {
+        ...base,
+        enabled: true,
+        previewInWatch,
+        rules,
+    };
+}
+
+async function configureContact(
+    option: DialogOption,
+    dialogOptions: DialogOption[],
+    existing?: ContactConfig
+): Promise<ContactConfig | null> {
+    p.log.step(pc.bold(option.label));
 
     const actions = await p.multiselect({
-        message: `Actions for ${opt.label}:`,
+        message: `Actions for ${option.label}:`,
         options: [
-            { value: "say" as const, label: "Say aloud", hint: "macOS TTS with language detection" },
-            { value: "ask" as const, label: "Auto-reply", hint: "LLM generates reply via tools ask" },
-            { value: "notify" as const, label: "Notification", hint: "macOS notification" },
+            { value: "say" as const, label: "Say aloud", hint: "macOS TTS" },
+            { value: "ask" as const, label: "Auto-reply", hint: "AI response" },
+            { value: "notify" as const, label: "Notification", hint: "Desktop notification" },
         ],
         initialValues: existing?.actions ?? ["notify"],
         required: true,
@@ -324,85 +659,93 @@ async function configureContactActions(
         return null;
     }
 
-    const typedActions = actions as ActionType[];
+    const contextLengthInput = await p.text({
+        message: "Watch context length (messages):",
+        initialValue: String(existing?.watch?.contextLength ?? DEFAULT_WATCH_CONFIG.contextLength),
+        validate: (value) => {
+            const parsed = Number(value);
 
-    let systemPrompt: string | undefined;
-
-    if (typedActions.includes("ask")) {
-        const prompt = await p.text({
-            message: `System prompt for auto-replies to ${opt.label}:`,
-            initialValue: existing?.modes?.autoReply?.systemPrompt || DEFAULTS.askSystemPrompt,
-        });
-
-        if (p.isCancel(prompt)) {
-            return null;
-        }
-
-        systemPrompt = prompt as string;
-    }
-
-    const modes = await configureContactModes(opt.label, existing);
-
-    if (!modes) {
-        return null;
-    }
-
-    if (systemPrompt && modes.autoReply.enabled) {
-        modes.autoReply.systemPrompt = systemPrompt;
-    }
-
-    const contextLength = await p.text({
-        message: "Context window size (number of recent messages)?",
-        initialValue: String(existing?.watch?.contextLength ?? 30),
-        validate: (v) => {
-            if (!v) {
-                return "Required";
-            }
-
-            const n = Number.parseInt(v, 10);
-
-            if (Number.isNaN(n) || n < 1 || n > 500) {
-                return "Must be 1-500";
+            if (!Number.isInteger(parsed) || parsed < 1) {
+                return "Enter a positive integer";
             }
         },
     });
 
-    if (p.isCancel(contextLength)) {
+    if (p.isCancel(contextLengthInput)) {
         return null;
     }
 
-    const watchConfig: WatchConfig = {
-        enabled: true,
-        contextLength: Number.parseInt(contextLength as string, 10),
-        runtimeMode: existing?.watch?.runtimeMode ?? "ink",
-    };
+    const runtimeMode = await p.select({
+        message: "Preferred runtime:",
+        options: [
+            { value: "daemon" as const, label: "daemon" },
+            { value: "light" as const, label: "light" },
+            { value: "ink" as const, label: "ink" },
+        ],
+        initialValue: existing?.watch?.runtimeMode ?? DEFAULT_WATCH_CONFIG.runtimeMode,
+    });
+
+    if (p.isCancel(runtimeMode)) {
+        return null;
+    }
+
+    const autoReply = await promptAskModeConfig(
+        "Auto reply",
+        DEFAULT_MODE_CONFIG.autoReply,
+        existing?.modes?.autoReply,
+        (actions as ActionType[]).includes("ask")
+    );
+
+    if (!autoReply) {
+        return null;
+    }
+
+    const assistantMode = await promptAskModeConfig(
+        "Assistant mode",
+        DEFAULT_MODE_CONFIG.assistant,
+        existing?.modes?.assistant,
+        true
+    );
+
+    if (!assistantMode) {
+        return null;
+    }
+
+    const suggestionMode = await promptSuggestionModeConfig(existing?.modes?.suggestions);
+
+    if (!suggestionMode) {
+        return null;
+    }
+
+    const styleProfile = await promptStyleProfileConfig(option, dialogOptions, existing?.styleProfile);
+
+    if (!styleProfile) {
+        return null;
+    }
 
     return {
-        userId: opt.entityId,
-        displayName: opt.dialog.title || opt.entityId,
-        username: getEntityUsername(opt.dialog),
-        chatType: opt.chatType,
-        actions: typedActions,
-        watch: watchConfig,
-        modes,
-        styleProfile: existing?.styleProfile ?? { ...DEFAULT_STYLE_PROFILE },
+        userId: option.id,
+        displayName: option.label,
+        username: undefined,
+        dialogType: option.dialogType,
+        actions: actions as ActionType[],
+        modes: {
+            autoReply,
+            assistant: assistantMode,
+            suggestions: suggestionMode,
+        },
+        watch: {
+            enabled: true,
+            contextLength: Number(contextLengthInput),
+            runtimeMode,
+        },
+        styleProfile,
         replyDelayMin: existing?.replyDelayMin ?? DEFAULTS.replyDelayMin,
         replyDelayMax: existing?.replyDelayMax ?? DEFAULTS.replyDelayMax,
+        askProvider: autoReply.provider,
+        askModel: autoReply.model,
+        askSystemPrompt: autoReply.systemPrompt,
     };
-}
-
-function getEntityUsername(dialog: Dialog): string | undefined {
-    const entity = dialog.entity;
-
-    if (!entity) {
-        return undefined;
-    }
-
-    if ("username" in entity && typeof entity.username === "string") {
-        return entity.username;
-    }
-
-    return undefined;
 }
 
 export function registerConfigureCommand(program: Command): void {
@@ -427,10 +770,10 @@ export function registerConfigureCommand(program: Command): void {
                     spinner.stop("Session valid");
                     const me = await client.getMe();
                     p.log.success(
-                        `Logged in as ${pc.bold(me.firstName || "")} ` + `${me.username ? `(@${me.username})` : ""}`
+                        `Logged in as ${pc.bold(me.firstName || "")} ${me.username ? `(@${me.username})` : ""}`
                     );
                 } else {
-                    spinner.stop("Session expired -- re-authentication needed");
+                    spinner.stop("Session expired — re-authentication needed");
                     await client.disconnect();
                     client = null;
                 }
@@ -440,15 +783,15 @@ export function registerConfigureCommand(program: Command): void {
             let effectiveApiHash = toolConfig.getApiHash();
 
             if (!client) {
-                const creds = await promptCredentials(existing);
+                const credentials = await promptCredentials(existing);
 
-                if (!creds) {
+                if (!credentials) {
                     return;
                 }
 
-                effectiveApiId = creds.apiId;
-                effectiveApiHash = creds.apiHash;
-                client = new TGClient(creds.apiId, creds.apiHash);
+                effectiveApiId = credentials.apiId;
+                effectiveApiHash = credentials.apiHash;
+                client = new TGClient(credentials.apiId, credentials.apiHash);
 
                 const ok = await runAuthFlow(client);
 
@@ -460,13 +803,12 @@ export function registerConfigureCommand(program: Command): void {
 
             const me = await client.getMe();
             const session = client.getSessionString();
-
-            const dialogOptions = await fetchDialogOptions(client);
+            const dialogOptions = await fetchDialogs(client);
 
             if (dialogOptions.length === 0) {
-                p.log.warn("No chats found.");
-                const emptyConfig: TelegramConfigDataV2 = {
-                    version: 2,
+                p.log.warn("No dialogs found in recent chats.");
+                await toolConfig.save({
+                    version: TELEGRAM_CONFIG_VERSION,
                     apiId: effectiveApiId,
                     apiHash: effectiveApiHash,
                     session,
@@ -475,17 +817,12 @@ export function registerConfigureCommand(program: Command): void {
                         username: me.username ?? undefined,
                         phone: me.phone ?? undefined,
                     },
+                    defaults: existing?.defaults,
                     contacts: [],
-                    globalDefaults: {
-                        modes: { ...DEFAULT_MODE_CONFIG },
-                        watch: { ...DEFAULT_WATCH_CONFIG },
-                        styleProfile: { ...DEFAULT_STYLE_PROFILE },
-                    },
                     configuredAt: new Date().toISOString(),
-                };
-                await toolConfig.save(emptyConfig);
+                });
                 await client.disconnect();
-                p.outro("Configuration saved (no contacts to watch).");
+                p.outro("Configuration saved (no dialogs to watch).");
                 return;
             }
 
@@ -496,28 +833,28 @@ export function registerConfigureCommand(program: Command): void {
                 return;
             }
 
-            const contacts: TelegramContactV2[] = [];
+            const contacts: ContactConfig[] = [];
 
-            for (const dialogKey of selectedIds) {
-                const opt = dialogOptions.find((o) => o.dialogKey === dialogKey);
+            for (const id of selectedIds) {
+                const option = dialogOptions.find((candidate) => candidate.id === id);
 
-                if (!opt) {
+                if (!option) {
                     continue;
                 }
 
-                const existingContact = existing?.contacts.find((c) => `${c.chatType}:${c.userId}` === dialogKey);
-                const contact = await configureContactActions(opt, existingContact);
+                const existingContact = existing?.contacts.find((contact) => contact.userId === id);
+                const configured = await configureContact(option, dialogOptions, existingContact);
 
-                if (!contact) {
+                if (!configured) {
                     await client.disconnect();
                     return;
                 }
 
-                contacts.push(contact);
+                contacts.push(configured);
             }
 
-            const configToSave: TelegramConfigDataV2 = {
-                version: 2,
+            await toolConfig.save({
+                version: TELEGRAM_CONFIG_VERSION,
                 apiId: effectiveApiId,
                 apiHash: effectiveApiHash,
                 session,
@@ -526,19 +863,17 @@ export function registerConfigureCommand(program: Command): void {
                     username: me.username ?? undefined,
                     phone: me.phone ?? undefined,
                 },
-                contacts,
-                globalDefaults: existing?.globalDefaults ?? {
-                    modes: { ...DEFAULT_MODE_CONFIG },
-                    watch: { ...DEFAULT_WATCH_CONFIG },
-                    styleProfile: { ...DEFAULT_STYLE_PROFILE },
+                defaults: existing?.defaults ?? {
+                    autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+                    assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+                    suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
                 },
+                contacts,
                 configuredAt: new Date().toISOString(),
-            };
+            });
 
-            await toolConfig.save(configToSave);
             await client.disconnect();
-
             p.log.success(`Saved ${contacts.length} contact(s)`);
-            p.outro("Run: tools telegram listen");
+            p.outro("Run: tools telegram watch --all");
         });
 }

--- a/src/telegram/commands/contacts.ts
+++ b/src/telegram/commands/contacts.ts
@@ -24,11 +24,14 @@ export function registerContactsCommand(program: Command): void {
             p.intro(pc.bgMagenta(pc.white(" telegram contacts ")));
 
             for (const c of data.contacts) {
-                const autoReplyPrompt = c.modes?.autoReply?.systemPrompt;
                 p.log.info(
                     `${pc.bold(c.displayName)} ${c.username ? pc.dim(`@${c.username}`) : ""}\n` +
-                        `  Type: ${c.chatType} | Actions: [${c.actions.join(", ")}]` +
-                        (autoReplyPrompt ? `\n  Prompt: "${autoReplyPrompt}"` : "")
+                        `  Actions: [${c.actions.join(", ")}]` +
+                        `\n  Type: ${c.dialogType ?? "user"}` +
+                        `\n  Runtime: ${c.watch?.runtimeMode ?? "daemon"} (ctx ${c.watch?.contextLength ?? 30})` +
+                        (c.modes?.autoReply?.model
+                            ? `\n  Auto-reply: ${c.modes.autoReply.provider}/${c.modes.autoReply.model}`
+                            : "")
                 );
             }
 

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -6,19 +6,19 @@ import { formatTable } from "@app/utils/table";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
-import { AttachmentDownloader } from "../lib/AttachmentDownloader";
-import { ConversationSyncService } from "../lib/ConversationSyncService";
-import { parseDate as parseDateNatural } from "../lib/DateParser";
-import { downloadContact, embedMessages } from "../lib/download";
+import { attachmentDownloader } from "../lib/AttachmentDownloader";
+import { conversationSyncService } from "../lib/ConversationSyncService";
+import { embedMessages } from "../lib/download";
 import { type ExportFormat, formatMessages, VALID_EXPORT_FORMATS } from "../lib/export";
+import { queryParser } from "../lib/QueryParser";
+import { styleProfileEngine } from "../lib/StyleProfileEngine";
 import { displayResults } from "../lib/search";
+import { TelegramContact } from "../lib/TelegramContact";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
-import type { ContactConfig, SearchResult } from "../lib/types";
+import type { ContactConfig, QueryRequest, SearchResult } from "../lib/types";
 import { EMBEDDING_LANGUAGES } from "../lib/types";
-
-// ── Helpers ───────────────────────────────────────────────────────────
 
 async function ensureClient(config: TelegramToolConfig): Promise<TGClient | null> {
     if (!config.hasValidSession()) {
@@ -40,159 +40,162 @@ async function ensureClient(config: TelegramToolConfig): Promise<TGClient | null
 function resolveContact(contacts: ContactConfig[], nameOrId: string): ContactConfig | undefined {
     const lower = nameOrId.toLowerCase();
 
-    return contacts.find(
-        (c) =>
-            c.userId === nameOrId ||
-            c.displayName.toLowerCase() === lower ||
-            c.username?.toLowerCase() === lower ||
-            c.username?.toLowerCase() === lower.replace(/^@/, "")
-    );
+    return contacts.find((contact) => {
+        if (contact.userId === nameOrId) {
+            return true;
+        }
+
+        if (contact.displayName.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower.replace(/^@/, "")) {
+            return true;
+        }
+
+        return false;
+    });
 }
 
-// ── Download Command ──────────────────────────────────────────────────
+async function pickContacts(contacts: ContactConfig[]): Promise<ContactConfig[] | null> {
+    const selected = await p.select({
+        message: "Which contact?",
+        options: [
+            ...contacts.map((contact) => ({
+                value: contact.userId,
+                label: contact.displayName,
+                hint: contact.username ? `@${contact.username}` : contact.dialogType,
+            })),
+            { value: "__all__", label: "All configured contacts" },
+        ],
+    });
 
-function registerDownloadCommand(history: Command): void {
+    if (p.isCancel(selected)) {
+        return null;
+    }
+
+    if (selected === "__all__") {
+        return contacts;
+    }
+
+    const match = contacts.find((contact) => contact.userId === selected);
+
+    if (!match) {
+        return null;
+    }
+
+    return [match];
+}
+
+function registerSyncCommand(history: Command): void {
+    const runSync = async (
+        contactName: string | undefined,
+        opts: {
+            since?: string;
+            until?: string;
+            limit?: number;
+            all?: boolean;
+        },
+        title: string
+    ) => {
+        p.intro(pc.bgMagenta(pc.white(` ${title} `)));
+
+        const config = new TelegramToolConfig();
+        const data = await config.load();
+
+        if (!data) {
+            p.log.error("Not configured. Run: tools telegram configure");
+            return;
+        }
+
+        if (data.contacts.length === 0) {
+            p.log.warn("No contacts configured. Run: tools telegram configure");
+            return;
+        }
+
+        let targetContacts: ContactConfig[] = [];
+
+        if (opts.all) {
+            targetContacts = data.contacts;
+        } else if (contactName) {
+            const match = resolveContact(data.contacts, contactName);
+
+            if (!match) {
+                p.log.error(`Contact "${contactName}" not found.`);
+                return;
+            }
+
+            targetContacts = [match];
+        } else {
+            const picked = await pickContacts(data.contacts);
+
+            if (!picked) {
+                return;
+            }
+
+            targetContacts = picked;
+        }
+
+        const client = await ensureClient(config);
+
+        if (!client) {
+            return;
+        }
+
+        const store = new TelegramHistoryStore();
+        store.open();
+
+        try {
+            const since = opts.since ? parseDate(opts.since) : undefined;
+            const until = opts.until ? parseDate(opts.until) : undefined;
+
+            for (const contact of targetContacts) {
+                p.log.step(pc.bold(contact.displayName));
+
+                if (since && until) {
+                    await conversationSyncService.ensureRange(client, store, contact.userId, since, until, {
+                        limit: opts.limit,
+                    });
+                } else {
+                    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+                        since,
+                        until,
+                        limit: opts.limit,
+                    });
+                }
+            }
+        } finally {
+            store.close();
+            await client.disconnect();
+        }
+
+        p.outro("Sync complete.");
+    };
+
     history
-        .command("download [contact]")
-        .description("Download conversation history to local SQLite database")
+        .command("sync [contact]")
+        .description("Sync conversation history to local SQLite storage")
         .option("--since <date>", "Start date (YYYY-MM-DD)")
         .option("--until <date>", "End date (YYYY-MM-DD)")
-        .option("--limit <n>", "Max messages to download", parseInt)
-        .option("--all", "Download all configured contacts")
-        .action(
-            async (
-                contactName: string | undefined,
-                opts: {
-                    since?: string;
-                    until?: string;
-                    limit?: number;
-                    all?: boolean;
-                }
-            ) => {
-                p.intro(pc.bgMagenta(pc.white(" telegram history download ")));
+        .option("--limit <n>", "Max messages to sync", (value) => Number.parseInt(value, 10))
+        .option("--all", "Sync all configured contacts")
+        .action(async (contactName: string | undefined, opts) => runSync(contactName, opts, "telegram history sync"));
 
-                const config = new TelegramToolConfig();
-                const data = await config.load();
-
-                if (!data) {
-                    p.log.error("Not configured. Run: tools telegram configure");
-                    return;
-                }
-
-                const contacts = data.contacts;
-
-                if (contacts.length === 0) {
-                    p.log.warn("No contacts configured. Run: tools telegram configure");
-                    return;
-                }
-
-                let targetContacts: ContactConfig[];
-
-                if (opts.all) {
-                    targetContacts = contacts;
-                } else if (contactName) {
-                    const found = resolveContact(contacts, contactName);
-
-                    if (!found) {
-                        p.log.error(
-                            `Contact "${contactName}" not found. Available: ${contacts.map((c) => c.displayName).join(", ")}`
-                        );
-                        return;
-                    }
-
-                    targetContacts = [found];
-                } else {
-                    const selected = await p.select({
-                        message: "Which contact to download?",
-                        options: [
-                            ...contacts.map((c) => ({
-                                value: c.userId,
-                                label: c.displayName,
-                                hint: c.username ? `@${c.username}` : undefined,
-                            })),
-                            { value: "__all__", label: "All contacts" },
-                        ],
-                    });
-
-                    if (p.isCancel(selected)) {
-                        return;
-                    }
-
-                    if (selected === "__all__") {
-                        targetContacts = contacts;
-                    } else {
-                        const found = contacts.find((c) => c.userId === selected);
-
-                        if (!found) {
-                            return;
-                        }
-
-                        targetContacts = [found];
-                    }
-                }
-
-                const spinner = p.spinner();
-                spinner.start("Connecting to Telegram...");
-
-                const client = await ensureClient(config);
-
-                if (!client) {
-                    spinner.stop("Connection failed");
-                    return;
-                }
-
-                spinner.stop("Connected");
-
-                const store = new TelegramHistoryStore();
-                store.open();
-
-                const since = opts.since ? parseDate(opts.since) : undefined;
-                const until = opts.until ? parseDate(opts.until) : undefined;
-
-                try {
-                    for (const contact of targetContacts) {
-                        await downloadContact(client, store, contact, {
-                            since,
-                            until,
-                            limit: opts.limit,
-                        });
-                    }
-
-                    const shouldEmbed = await p.confirm({
-                        message: "Generate semantic embeddings for new messages?",
-                        initialValue: true,
-                    });
-
-                    if (!p.isCancel(shouldEmbed) && shouldEmbed) {
-                        for (const contact of targetContacts) {
-                            const embedSpinner = p.spinner();
-                            embedSpinner.start(`Embedding ${contact.displayName}...`);
-
-                            const { embedded, skipped, unsupportedLangs } = await embedMessages(store, contact.userId);
-
-                            embedSpinner.stop(`${pc.green(String(embedded))} embeddings generated, ${skipped} skipped`);
-
-                            if (unsupportedLangs.size > 0) {
-                                const langs = [...unsupportedLangs].join(", ");
-                                p.log.warn(
-                                    `Some messages were in unsupported languages (${langs}). ` +
-                                        `Semantic search only works for: ${[...EMBEDDING_LANGUAGES].join(", ")}. ` +
-                                        `Keyword search still works for all languages.`
-                                );
-                            }
-                        }
-                    }
-                } finally {
-                    store.close();
-                    await client.disconnect();
-                }
-
-                p.outro("Download complete.");
-            }
+    history
+        .command("download [contact]")
+        .description("Alias for sync")
+        .option("--since <date>", "Start date (YYYY-MM-DD)")
+        .option("--until <date>", "End date (YYYY-MM-DD)")
+        .option("--limit <n>", "Max messages to sync", (value) => Number.parseInt(value, 10))
+        .option("--all", "Sync all configured contacts")
+        .action(async (contactName: string | undefined, opts) =>
+            runSync(contactName, opts, "telegram history download")
         );
 }
-
-// ── Embed Command ─────────────────────────────────────────────────────
 
 function registerEmbedCommand(history: Command): void {
     history
@@ -210,9 +213,7 @@ function registerEmbedCommand(history: Command): void {
                 return;
             }
 
-            const contacts = data.contacts;
-
-            if (contacts.length === 0) {
+            if (data.contacts.length === 0) {
                 p.log.warn("No contacts configured.");
                 return;
             }
@@ -220,45 +221,24 @@ function registerEmbedCommand(history: Command): void {
             let targetContacts: ContactConfig[];
 
             if (opts.all) {
-                targetContacts = contacts;
+                targetContacts = data.contacts;
             } else if (contactName) {
-                const found = resolveContact(contacts, contactName);
+                const found = resolveContact(data.contacts, contactName);
 
                 if (!found) {
-                    p.log.error(
-                        `Contact "${contactName}" not found. Available: ${contacts.map((c) => c.displayName).join(", ")}`
-                    );
+                    p.log.error(`Contact "${contactName}" not found.`);
                     return;
                 }
 
                 targetContacts = [found];
             } else {
-                const selected = await p.select({
-                    message: "Which contact to embed?",
-                    options: [
-                        ...contacts.map((c) => ({
-                            value: c.userId,
-                            label: c.displayName,
-                        })),
-                        { value: "__all__", label: "All contacts" },
-                    ],
-                });
+                const selected = await pickContacts(data.contacts);
 
-                if (p.isCancel(selected)) {
+                if (!selected) {
                     return;
                 }
 
-                if (selected === "__all__") {
-                    targetContacts = contacts;
-                } else {
-                    const found = contacts.find((c) => c.userId === selected);
-
-                    if (!found) {
-                        return;
-                    }
-
-                    targetContacts = [found];
-                }
+                targetContacts = selected;
             }
 
             const store = new TelegramHistoryStore();
@@ -267,12 +247,10 @@ function registerEmbedCommand(history: Command): void {
             try {
                 for (const contact of targetContacts) {
                     p.log.step(pc.bold(contact.displayName));
-
                     const spinner = p.spinner();
                     spinner.start("Generating embeddings...");
 
                     const { embedded, skipped, unsupportedLangs } = await embedMessages(store, contact.userId);
-
                     const total = store.getEmbeddedCount(contact.userId);
 
                     spinner.stop(
@@ -282,9 +260,7 @@ function registerEmbedCommand(history: Command): void {
                     if (unsupportedLangs.size > 0) {
                         const langs = [...unsupportedLangs].join(", ");
                         p.log.warn(
-                            `Some messages were in unsupported languages (${langs}). ` +
-                                `Semantic search only works for: ${[...EMBEDDING_LANGUAGES].join(", ")}. ` +
-                                `Keyword search still works for all languages.`
+                            `Unsupported semantic languages encountered (${langs}). Supported: ${[...EMBEDDING_LANGUAGES].join(", ")}`
                         );
                     }
                 }
@@ -296,7 +272,293 @@ function registerEmbedCommand(history: Command): void {
         });
 }
 
-// ── Search Command ────────────────────────────────────────────────────
+function registerQueryCommand(history: Command): void {
+    history
+        .command("query")
+        .description("Query messages by date/sender/text with optional auto-fetch")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .option("--since <date>", "Start date (YYYY-MM-DD)")
+        .option("--until <date>", "End date (YYYY-MM-DD)")
+        .option("--sender <kind>", "me|them|any", "any")
+        .option("--text <regex>", "Regex filter")
+        .option("--limit <n>", "Maximum rows", (value) => Number.parseInt(value, 10))
+        .option("--local-only", "Only query local DB")
+        .option("--nl <query>", "Natural language helper query")
+        .action(
+            async (opts: {
+                from: string;
+                since?: string;
+                until?: string;
+                sender: "me" | "them" | "any";
+                text?: string;
+                localOnly?: boolean;
+                nl?: string;
+                limit?: number;
+            }) => {
+                p.intro(pc.bgMagenta(pc.white(" telegram history query ")));
+
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    return;
+                }
+
+                const parsed = queryParser.parseFromFlags({
+                    from: opts.from,
+                    since: opts.since,
+                    until: opts.until,
+                    sender: opts.sender,
+                    text: opts.text,
+                    localOnly: opts.localOnly,
+                    nl: opts.nl,
+                    limit: opts.limit,
+                } satisfies QueryRequest);
+                const contact = resolveContact(data.contacts, parsed.from);
+
+                if (!contact) {
+                    p.log.error(`Contact "${parsed.from}" not found.`);
+                    return;
+                }
+
+                const since = parsed.since ? parseDate(parsed.since) : undefined;
+                const until = parsed.until ? parseDate(parsed.until) : undefined;
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                try {
+                    if (!parsed.localOnly) {
+                        const client = await ensureClient(config);
+
+                        if (client) {
+                            try {
+                                if (since || until) {
+                                    await conversationSyncService.ensureRange(
+                                        client,
+                                        store,
+                                        contact.userId,
+                                        since ?? new Date(0),
+                                        until ?? new Date(),
+                                        {
+                                            limit: opts.limit,
+                                        }
+                                    );
+                                } else {
+                                    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+                                        limit: opts.limit,
+                                    });
+                                }
+                            } finally {
+                                await client.disconnect();
+                            }
+                        }
+                    }
+
+                    const rows = store.queryMessages(contact.userId, {
+                        since,
+                        until,
+                        sender: parsed.sender,
+                        textRegex: parsed.text,
+                        limit: parsed.limit,
+                    });
+
+                    if (rows.length === 0) {
+                        p.log.warn("No messages found.");
+                        return;
+                    }
+
+                    for (const row of rows) {
+                        const who = row.is_outgoing ? pc.blue("You") : pc.cyan(contact.displayName);
+                        const text = row.is_deleted ? pc.dim("[deleted]") : (row.text ?? row.media_desc ?? "(empty)");
+                        const stamp = new Date(row.date_unix * 1000).toISOString();
+                        p.log.info(`${pc.dim(stamp)} ${who}: ${text}`);
+                    }
+
+                    p.outro(`${rows.length} message(s)`);
+                } finally {
+                    store.close();
+                }
+            }
+        );
+}
+
+function registerAttachmentsCommand(history: Command): void {
+    const attachments = history.command("attachments").description("Attachment index and downloads");
+
+    attachments
+        .command("list")
+        .description("List indexed attachments")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .option("--since <date>", "Start date (YYYY-MM-DD)")
+        .option("--until <date>", "End date (YYYY-MM-DD)")
+        .option("--message-id <id>", "Specific message id", (value) => Number.parseInt(value, 10))
+        .option("--limit <n>", "Maximum rows", (value) => Number.parseInt(value, 10))
+        .action(async (opts: { from: string; since?: string; until?: string; messageId?: number; limit?: number }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
+            }
+
+            const contact = resolveContact(data.contacts, opts.from);
+
+            if (!contact) {
+                p.log.error(`Contact "${opts.from}" not found.`);
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const rows = store.listAttachments(contact.userId, {
+                    since: opts.since ? parseDate(opts.since) : undefined,
+                    until: opts.until ? parseDate(opts.until) : undefined,
+                    messageId: opts.messageId,
+                    limit: opts.limit,
+                });
+
+                if (rows.length === 0) {
+                    p.log.warn("No attachments found.");
+                    return;
+                }
+
+                const tableRows = rows.map((row) => [
+                    String(row.message_id),
+                    String(row.attachment_index),
+                    row.kind,
+                    row.file_name ?? "—",
+                    row.mime_type ?? "—",
+                    row.is_downloaded ? "yes" : "no",
+                ]);
+
+                console.log(
+                    formatTable(tableRows, ["Message ID", "Index", "Kind", "File", "MIME", "Downloaded"], {
+                        alignRight: [0, 1],
+                    })
+                );
+            } finally {
+                store.close();
+            }
+        });
+
+    attachments
+        .command("fetch")
+        .description("Download one attachment by locator")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .requiredOption("--message-id <id>", "Message id", (value) => Number.parseInt(value, 10))
+        .requiredOption("--attachment-index <n>", "Attachment index", (value) => Number.parseInt(value, 10))
+        .option("--output <path>", "Output path")
+        .action(async (opts: { from: string; messageId: number; attachmentIndex: number; output?: string }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
+            }
+
+            const contact = resolveContact(data.contacts, opts.from);
+
+            if (!contact) {
+                p.log.error(`Contact "${opts.from}" not found.`);
+                return;
+            }
+
+            const client = await ensureClient(config);
+
+            if (!client) {
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const result = await attachmentDownloader.downloadByLocator(
+                    client,
+                    store,
+                    {
+                        chatId: contact.userId,
+                        messageId: opts.messageId,
+                        attachmentIndex: opts.attachmentIndex,
+                    },
+                    {
+                        outputPath: opts.output ? resolve(opts.output) : undefined,
+                    }
+                );
+
+                p.log.success(`Downloaded ${result.bytes} bytes to ${result.outputPath}`);
+            } finally {
+                store.close();
+                await client.disconnect();
+            }
+        });
+}
+
+function registerStyleCommand(history: Command): void {
+    const style = history.command("style").description("Style profile utilities");
+
+    style
+        .command("derive")
+        .description("Derive writing style prompt from style profile rules")
+        .requiredOption("--from <contact>", "Contact display name, username, or id")
+        .action(async (opts: { from: string }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
+            }
+
+            const contactConfig = resolveContact(data.contacts, opts.from);
+
+            if (!contactConfig) {
+                p.log.error(`Contact "${opts.from}" not found.`);
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const contact = TelegramContact.fromConfig(contactConfig);
+                const derived = await styleProfileEngine.deriveStylePrompt(contact, store);
+
+                if (!derived) {
+                    p.log.warn("No style profile rules or no matching messages.");
+                    return;
+                }
+
+                contactConfig.styleProfile = {
+                    ...contactConfig.styleProfile,
+                    enabled: true,
+                    refresh: "incremental",
+                    rules: contactConfig.styleProfile?.rules ?? [],
+                    previewInWatch: contactConfig.styleProfile?.previewInWatch ?? false,
+                    derivedPrompt: derived.prompt,
+                    derivedAt: derived.generatedAt,
+                };
+
+                await config.save({
+                    ...data,
+                    contacts: data.contacts.map((contact) =>
+                        contact.userId === contactConfig.userId ? contactConfig : contact
+                    ),
+                    configuredAt: new Date().toISOString(),
+                });
+
+                p.log.success(`Derived style prompt from ${derived.sampleCount} sample messages.`);
+                p.log.info(derived.prompt);
+            } finally {
+                store.close();
+            }
+        });
+}
 
 function registerSearchCommand(history: Command): void {
     history
@@ -306,7 +568,7 @@ function registerSearchCommand(history: Command): void {
         .option("--until <date>", "End date (YYYY-MM-DD)")
         .option("--semantic", "Use semantic (vector) search instead of keyword")
         .option("--hybrid", "Use hybrid search (keyword + semantic combined)")
-        .option("--limit <n>", "Max results (default: 20)", parseInt)
+        .option("--limit <n>", "Max results (default: 20)", (value) => Number.parseInt(value, 10))
         .action(
             async (
                 contactName: string,
@@ -332,9 +594,7 @@ function registerSearchCommand(history: Command): void {
                 const contact = resolveContact(data.contacts, contactName);
 
                 if (!contact) {
-                    p.log.error(
-                        `Contact "${contactName}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
+                    p.log.error(`Contact "${contactName}" not found.`);
                     return;
                 }
 
@@ -359,15 +619,6 @@ function registerSearchCommand(history: Command): void {
                         try {
                             const langResult = await detectLanguage(query);
                             const lang = EMBEDDING_LANGUAGES.has(langResult.language) ? langResult.language : "en";
-
-                            if (!EMBEDDING_LANGUAGES.has(langResult.language)) {
-                                p.log.warn(
-                                    `Query language "${langResult.language}" is not supported for semantic search. ` +
-                                        `Supported: ${[...EMBEDDING_LANGUAGES].join(", ")}. ` +
-                                        `Results may be less accurate. Use keyword search for best results with this language.`
-                                );
-                            }
-
                             const embedResult = await embedText(query, lang, "sentence");
                             queryEmbedding = new Float32Array(embedResult.vector);
                             spinner.stop("Query embedded");
@@ -375,9 +626,7 @@ function registerSearchCommand(history: Command): void {
                             spinner.stop("Embedding failed — falling back to keyword search");
                             p.log.warn(`Could not embed query: ${err}`);
                             results = store.search(contact.userId, query, searchOpts);
-
                             displayResults(results, contact.displayName);
-                            store.close();
                             return;
                         }
 
@@ -391,16 +640,13 @@ function registerSearchCommand(history: Command): void {
                     }
 
                     displayResults(results, contact.displayName);
+                    p.outro(`${results.length} result(s) found.`);
                 } finally {
                     store.close();
                 }
-
-                p.outro(`${results?.length ?? 0} result(s) found.`);
             }
         );
 }
-
-// ── Export Command ────────────────────────────────────────────────────
 
 function registerExportCommand(history: Command): void {
     history
@@ -436,19 +682,18 @@ function registerExportCommand(history: Command): void {
                 const contact = resolveContact(data.contacts, contactName);
 
                 if (!contact) {
-                    p.log.error(
-                        `Contact "${contactName}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
+                    p.log.error(`Contact "${contactName}" not found.`);
                     return;
                 }
 
                 const store = new TelegramHistoryStore();
                 store.open();
 
-                const since = opts.since ? parseDate(opts.since) : undefined;
-                const until = opts.until ? parseDate(opts.until) : undefined;
-
-                const messages = store.getByDateRange(contact.userId, since, until);
+                const messages = store.getByDateRange(
+                    contact.userId,
+                    opts.since ? parseDate(opts.since) : undefined,
+                    opts.until ? parseDate(opts.until) : undefined
+                );
                 store.close();
 
                 if (messages.length === 0) {
@@ -468,8 +713,6 @@ function registerExportCommand(history: Command): void {
             }
         );
 }
-
-// ── Stats Command ─────────────────────────────────────────────────────
 
 function registerStatsCommand(history: Command): void {
     history
@@ -494,9 +737,7 @@ function registerStatsCommand(history: Command): void {
                     const contact = resolveContact(data.contacts, contactName);
 
                     if (!contact) {
-                        p.log.error(
-                            `Contact "${contactName}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                        );
+                        p.log.error(`Contact "${contactName}" not found.`);
                         return;
                     }
 
@@ -504,47 +745,44 @@ function registerStatsCommand(history: Command): void {
 
                     if (stats.length === 0) {
                         p.log.warn(
-                            `No messages downloaded for ${contact.displayName}. Run: tools telegram history download`
+                            `No messages downloaded for ${contact.displayName}. Run: tools telegram history sync`
                         );
                         return;
                     }
 
-                    const s = stats[0];
+                    const stat = stats[0];
                     p.log.info(
                         `${pc.bold(contact.displayName)}\n` +
-                            `  Total messages:    ${formatNumber(s.totalMessages)}\n` +
-                            `  Sent:              ${formatNumber(s.outgoingMessages)}\n` +
-                            `  Received:          ${formatNumber(s.incomingMessages)}\n` +
-                            `  Embedded:          ${formatNumber(s.embeddedMessages)}\n` +
-                            `  First message:     ${s.firstMessageDate ?? "—"}\n` +
-                            `  Last message:      ${s.lastMessageDate ?? "—"}`
+                            `  Total messages:    ${formatNumber(stat.totalMessages)}\n` +
+                            `  Sent:              ${formatNumber(stat.outgoingMessages)}\n` +
+                            `  Received:          ${formatNumber(stat.incomingMessages)}\n` +
+                            `  Embedded:          ${formatNumber(stat.embeddedMessages)}\n` +
+                            `  First message:     ${stat.firstMessageDate ?? "—"}\n` +
+                            `  Last message:      ${stat.lastMessageDate ?? "—"}`
                     );
                 } else {
                     const allStats = store.getStats();
 
                     if (allStats.length === 0) {
-                        p.log.warn("No messages downloaded yet. Run: tools telegram history download");
+                        p.log.warn("No messages downloaded yet. Run: tools telegram history sync");
                         return;
                     }
 
                     const contactMap = new Map<string, string>();
 
-                    for (const c of data.contacts) {
-                        contactMap.set(c.userId, c.displayName);
+                    for (const contact of data.contacts) {
+                        contactMap.set(contact.userId, contact.displayName);
                     }
 
-                    const rows = allStats.map((s) => [
-                        contactMap.get(s.chatId) ?? s.chatId,
-                        formatNumber(s.totalMessages),
-                        formatNumber(s.incomingMessages),
-                        formatNumber(s.outgoingMessages),
-                        formatNumber(s.embeddedMessages),
-                        s.firstMessageDate?.slice(0, 10) ?? "—",
-                        s.lastMessageDate?.slice(0, 10) ?? "—",
+                    const rows = allStats.map((stat) => [
+                        contactMap.get(stat.chatId) ?? stat.chatId,
+                        formatNumber(stat.totalMessages),
+                        formatNumber(stat.incomingMessages),
+                        formatNumber(stat.outgoingMessages),
+                        formatNumber(stat.embeddedMessages),
+                        stat.firstMessageDate?.slice(0, 10) ?? "—",
+                        stat.lastMessageDate?.slice(0, 10) ?? "—",
                     ]);
-
-                    const totalMessages = allStats.reduce((sum, s) => sum + s.totalMessages, 0);
-                    const totalEmbedded = allStats.reduce((sum, s) => sum + s.embeddedMessages, 0);
 
                     console.log();
                     console.log(
@@ -553,11 +791,6 @@ function registerStatsCommand(history: Command): void {
                         })
                     );
                     console.log();
-
-                    p.log.info(
-                        `${pc.bold("Summary")}: ${formatNumber(totalMessages)} messages across ${allStats.length} contact(s), ` +
-                            `${formatNumber(totalEmbedded)} embedded`
-                    );
                 }
             } finally {
                 store.close();
@@ -567,243 +800,15 @@ function registerStatsCommand(history: Command): void {
         });
 }
 
-// ── Query Command ─────────────────────────────────────────────────────
-
-function registerQueryCommand(history: Command): void {
-    history
-        .command("query")
-        .description("Query messages with filters, auto-fetching missing ranges")
-        .requiredOption("--from <contact>", "Contact name or ID")
-        .option("--since <date>", "Start date (natural language or YYYY-MM-DD)")
-        .option("--until <date>", "End date (natural language or YYYY-MM-DD)")
-        .option("--sender <who>", "Filter by sender: me, them, any", "any")
-        .option("--text <pattern>", "Text pattern to search")
-        .option("--local-only", "Don't fetch from Telegram, only search local DB")
-        .option("--limit <n>", "Max results", parseInt)
-        .action(
-            async (opts: {
-                from: string;
-                since?: string;
-                until?: string;
-                sender: string;
-                text?: string;
-                localOnly?: boolean;
-                limit?: number;
-            }) => {
-                const config = new TelegramToolConfig();
-                const data = await config.load();
-
-                if (!data) {
-                    p.log.error("Not configured. Run: tools telegram configure");
-                    return;
-                }
-
-                const contact = resolveContact(data.contacts, opts.from);
-
-                if (!contact) {
-                    p.log.error(
-                        `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
-                    return;
-                }
-
-                const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
-                const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
-
-                if (opts.since && !since) {
-                    p.log.error(`Invalid --since date: "${opts.since}"`);
-                    return;
-                }
-
-                if (opts.until && !until) {
-                    p.log.error(`Invalid --until date: "${opts.until}"`);
-                    return;
-                }
-
-                const store = new TelegramHistoryStore();
-                store.open();
-                let client: TGClient | null = null;
-
-                try {
-                    if (!opts.localOnly) {
-                        client = await ensureClient(config);
-
-                        if (!client) {
-                            return;
-                        }
-
-                        const syncService = new ConversationSyncService(client, store);
-                        const results = await syncService.queryWithAutoFetch(contact.userId, {
-                            sender: opts.sender as "me" | "them" | "any",
-                            since,
-                            until,
-                            textPattern: opts.text,
-                            limit: opts.limit,
-                            localOnly: opts.localOnly,
-                        });
-
-                        for (const msg of results) {
-                            const direction = msg.is_outgoing ? "\u2192" : "\u2190";
-                            const date = new Date(msg.date_unix * 1000).toLocaleString();
-                            const text = msg.text ?? "[media]";
-                            console.log(`${date} ${direction} ${text}`);
-                        }
-
-                        console.log(`\n${results.length} message(s) found`);
-                    } else {
-                        const results = store.queryMessages(contact.userId, {
-                            sender: opts.sender as "me" | "them" | "any",
-                            since,
-                            until,
-                            textPattern: opts.text,
-                            limit: opts.limit,
-                        });
-
-                        for (const msg of results) {
-                            const direction = msg.is_outgoing ? "\u2192" : "\u2190";
-                            const date = new Date(msg.date_unix * 1000).toLocaleString();
-                            const text = msg.text ?? "[media]";
-                            console.log(`${date} ${direction} ${text}`);
-                        }
-
-                        console.log(`\n${results.length} message(s) found`);
-                    }
-                } finally {
-                    store.close();
-
-                    if (client) {
-                        await client.disconnect();
-                    }
-                }
-            }
-        );
-}
-
-// ── Attachments Commands ──────────────────────────────────────────────
-
-function registerAttachmentsCommand(history: Command): void {
-    const attachments = history.command("attachments").description("Manage message attachments");
-
-    attachments
-        .command("list")
-        .description("List attachment metadata for a contact")
-        .requiredOption("--from <contact>", "Contact name or ID")
-        .option("--since <date>", "Start date")
-        .option("--until <date>", "End date")
-        .option("--message-id <id>", "Specific message ID", parseInt)
-        .action(async (opts: { from: string; since?: string; until?: string; messageId?: number }) => {
-            const config = new TelegramToolConfig();
-            const data = await config.load();
-
-            if (!data) {
-                p.log.error("Not configured. Run: tools telegram configure");
-                return;
-            }
-
-            const contact = resolveContact(data.contacts, opts.from);
-
-            if (!contact) {
-                p.log.error(
-                    `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                );
-                return;
-            }
-
-            const store = new TelegramHistoryStore();
-            store.open();
-
-            try {
-                if (opts.messageId) {
-                    const atts = store.getAttachments(contact.userId, opts.messageId);
-
-                    for (const att of atts) {
-                        const dl = att.is_downloaded ? "dl" : "--";
-                        console.log(
-                            `  [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""} ${att.file_size ? `(${att.file_size}b)` : ""}`
-                        );
-                    }
-                } else {
-                    const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
-                    const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
-                    const atts = store.listAttachments(contact.userId, { since, until });
-
-                    for (const att of atts) {
-                        const dl = att.is_downloaded ? "dl" : "--";
-                        console.log(
-                            `msg:${att.message_id} [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""}`
-                        );
-                    }
-
-                    console.log(`\n${atts.length} attachment(s)`);
-                }
-            } finally {
-                store.close();
-            }
-        });
-
-    attachments
-        .command("fetch")
-        .description("Download a specific attachment")
-        .requiredOption("--from <contact>", "Contact name or ID")
-        .requiredOption("--message-id <id>", "Message ID", parseInt)
-        .option("--attachment-index <n>", "Attachment index (default 0)", parseInt, 0)
-        .option("--output <path>", "Output file path")
-        .action(async (opts: { from: string; messageId: number; attachmentIndex: number; output?: string }) => {
-            const config = new TelegramToolConfig();
-            const data = await config.load();
-
-            if (!data) {
-                p.log.error("Not configured. Run: tools telegram configure");
-                return;
-            }
-
-            const contact = resolveContact(data.contacts, opts.from);
-
-            if (!contact) {
-                p.log.error(
-                    `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                );
-                return;
-            }
-
-            const client = await ensureClient(config);
-
-            if (!client) {
-                return;
-            }
-
-            const store = new TelegramHistoryStore();
-            store.open();
-
-            try {
-                const downloader = new AttachmentDownloader(client, store);
-                const result = await downloader.download(
-                    contact.userId,
-                    opts.messageId,
-                    opts.attachmentIndex,
-                    opts.output
-                );
-
-                console.log(`Downloaded to: ${result.path}`);
-                console.log(`Size: ${result.size} bytes`);
-                console.log(`SHA-256: ${result.sha256}`);
-            } finally {
-                store.close();
-                await client.disconnect();
-            }
-        });
-}
-
-// ── Registration ──────────────────────────────────────────────────────
-
 export function registerHistoryCommand(program: Command): void {
-    const history = program.command("history").description("Download, search, and export conversation history");
+    const history = program.command("history").description("Download, query, and export conversation history");
 
-    registerDownloadCommand(history);
+    registerSyncCommand(history);
     registerEmbedCommand(history);
+    registerQueryCommand(history);
+    registerAttachmentsCommand(history);
+    registerStyleCommand(history);
     registerSearchCommand(history);
     registerExportCommand(history);
     registerStatsCommand(history);
-    registerQueryCommand(history);
-    registerAttachmentsCommand(history);
 }

--- a/src/telegram/commands/listen.ts
+++ b/src/telegram/commands/listen.ts
@@ -1,71 +1,15 @@
-import logger from "@app/logger";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
-import pc from "picocolors";
-import { registerHandler } from "../lib/handler";
+import { conversationSyncService } from "../lib/ConversationSyncService";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
-import { TelegramMessage } from "../lib/TelegramMessage";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
-import type { TelegramContactV2 } from "../lib/types";
-import { DEFAULTS } from "../lib/types";
-
-async function syncAndLoadHistory(
-    client: TGClient,
-    store: TelegramHistoryStore,
-    contacts: TelegramContactV2[],
-    myName: string
-): Promise<Map<string, string[]>> {
-    const historyMap = new Map<string, string[]>();
-
-    for (const contact of contacts) {
-        try {
-            // Fetch recent messages from Telegram API and persist to DB
-            const fetched = [];
-
-            for await (const rawMsg of client.getMessages(contact.userId, { limit: DEFAULTS.historyFetchLimit })) {
-                fetched.push(new TelegramMessage(rawMsg));
-            }
-
-            if (fetched.length > 0) {
-                const serialized = fetched.map((m) => m.toJSON());
-                const inserted = store.insertMessages(contact.userId, serialized);
-
-                if (inserted > 0) {
-                    logger.info(`  ${pc.cyan(contact.displayName)}: ${inserted} new messages stored`);
-                }
-            }
-
-            // Read back from DB for context (chronological order, last N)
-            const messages = store.getByDateRange(contact.userId).slice(-DEFAULTS.historyFetchLimit);
-            const lines: string[] = [];
-
-            for (const msg of messages) {
-                const content = msg.text || msg.media_desc;
-
-                if (!content) {
-                    continue;
-                }
-
-                const name = msg.is_outgoing ? myName : contact.displayName;
-                lines.push(`${name}: ${content}`);
-            }
-
-            historyMap.set(contact.userId, lines);
-            logger.info(`  ${pc.cyan(contact.displayName)}: ${lines.length} messages loaded for context`);
-        } catch (err) {
-            logger.warn(`  ${pc.cyan(contact.displayName)}: failed to sync history: ${err}`);
-            historyMap.set(contact.userId, []);
-        }
-    }
-
-    return historyMap;
-}
+import { runWatchRuntime } from "../runtime/light/WatchRuntime";
 
 export function registerListenCommand(program: Command): void {
     program
         .command("listen")
-        .description("Start listening for messages from configured contacts")
+        .description("Backward-compatible alias for watch daemon mode")
         .action(async () => {
             const config = new TelegramToolConfig();
             const data = await config.load();
@@ -80,46 +24,24 @@ export function registerListenCommand(program: Command): void {
                 process.exit(1);
             }
 
-            const spinner = p.spinner();
-            spinner.start("Connecting to Telegram...");
-
             const client = TGClient.fromConfig(config);
             const authorized = await client.connect();
 
             if (!authorized) {
-                spinner.stop("Session expired");
                 p.log.error("Session expired. Run: tools telegram configure");
                 process.exit(1);
             }
 
             const me = await client.getMe();
             const myName = me.firstName || "Me";
-            spinner.stop(`Connected as ${myName}`);
-
             const store = new TelegramHistoryStore();
             store.open();
 
-            const historySpinner = p.spinner();
-            historySpinner.start("Syncing conversation history...");
-
-            const initialHistory = await syncAndLoadHistory(client, store, data.contacts, myName);
-
-            historySpinner.stop("Conversation history synced");
-
-            for (const c of data.contacts) {
-                logger.info(`Watching: ${pc.cyan(c.displayName)} → [${c.actions.map((a) => pc.yellow(a)).join(", ")}]`);
+            for (const contact of data.contacts) {
+                await conversationSyncService.syncIncremental(client, store, contact.userId, { limit: 200 });
             }
 
-            registerHandler(client, {
-                contacts: data.contacts,
-                myName,
-                initialHistory,
-                store,
-            });
-            logger.info(`Press ${pc.dim("Ctrl+C")} to stop.`);
-
             const shutdown = async () => {
-                logger.info("Shutting down...");
                 store.close();
 
                 try {
@@ -134,6 +56,12 @@ export function registerListenCommand(program: Command): void {
             process.on("SIGINT", shutdown);
             process.on("SIGTERM", shutdown);
 
-            await new Promise(() => {});
+            await runWatchRuntime({
+                contacts: data.contacts,
+                myName,
+                client,
+                store,
+                daemon: true,
+            });
         });
 }

--- a/src/telegram/commands/watch.ts
+++ b/src/telegram/commands/watch.ts
@@ -1,0 +1,180 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { conversationSyncService } from "../lib/ConversationSyncService";
+import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
+import { TelegramToolConfig } from "../lib/TelegramToolConfig";
+import { TGClient } from "../lib/TGClient";
+import type { ContactConfig, TelegramRuntimeMode } from "../lib/types";
+import { runWatchInkApp } from "../runtime/ink/WatchInkApp";
+import { runWatchRuntime } from "../runtime/light/WatchRuntime";
+
+function resolveContact(contacts: ContactConfig[], nameOrId: string): ContactConfig | undefined {
+    const lower = nameOrId.toLowerCase();
+
+    return contacts.find((contact) => {
+        if (contact.userId === nameOrId) {
+            return true;
+        }
+
+        if (contact.displayName.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower) {
+            return true;
+        }
+
+        if (contact.username?.toLowerCase() === lower.replace(/^@/, "")) {
+            return true;
+        }
+
+        return false;
+    });
+}
+
+export function registerWatchCommand(program: Command): void {
+    program
+        .command("watch [contact]")
+        .description("Watch configured Telegram dialogs in daemon/light/ink mode")
+        .option("--all", "Watch all configured contacts")
+        .option("--runtime <mode>", "daemon|light|ink")
+        .option("--context-length <n>", "Override context length", (value) => Number.parseInt(value, 10))
+        .action(
+            async (
+                contactName: string | undefined,
+                opts: {
+                    all?: boolean;
+                    runtime?: TelegramRuntimeMode;
+                    contextLength?: number;
+                }
+            ) => {
+                p.intro(pc.bgMagenta(pc.white(" telegram watch ")));
+
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data?.session) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    process.exit(1);
+                }
+
+                if (data.contacts.length === 0) {
+                    p.log.warn("No contacts configured. Run: tools telegram configure");
+                    process.exit(1);
+                }
+
+                let targetContacts: ContactConfig[] = [];
+
+                if (opts.all) {
+                    targetContacts = data.contacts;
+                } else if (contactName) {
+                    const found = resolveContact(data.contacts, contactName);
+
+                    if (!found) {
+                        p.log.error(`Contact "${contactName}" not found.`);
+                        process.exit(1);
+                    }
+
+                    targetContacts = [found];
+                } else {
+                    const selected = await p.select({
+                        message: "Which contact to watch?",
+                        options: [
+                            ...data.contacts.map((contact) => ({
+                                value: contact.userId,
+                                label: contact.displayName,
+                                hint: contact.username ? `@${contact.username}` : contact.dialogType,
+                            })),
+                            { value: "__all__", label: "All contacts" },
+                        ],
+                    });
+
+                    if (p.isCancel(selected)) {
+                        return;
+                    }
+
+                    if (selected === "__all__") {
+                        targetContacts = data.contacts;
+                    } else {
+                        const found = data.contacts.find((contact) => contact.userId === selected);
+
+                        if (!found) {
+                            return;
+                        }
+
+                        targetContacts = [found];
+                    }
+                }
+
+                const spinner = p.spinner();
+                spinner.start("Connecting to Telegram...");
+
+                const client = TGClient.fromConfig(config);
+                const authorized = await client.connect();
+
+                if (!authorized) {
+                    spinner.stop("Session expired");
+                    p.log.error("Session expired. Run: tools telegram configure");
+                    process.exit(1);
+                }
+
+                const me = await client.getMe();
+                const myName = me.firstName || "Me";
+                spinner.stop(`Connected as ${myName}`);
+
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                for (const contact of targetContacts) {
+                    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+                        limit: 200,
+                    });
+                }
+
+                const runtimeMode: TelegramRuntimeMode =
+                    opts.runtime ?? targetContacts[0]?.watch?.runtimeMode ?? "daemon";
+
+                const shutdown = async () => {
+                    store.close();
+
+                    try {
+                        await client.disconnect();
+                    } catch {
+                        // ignore disconnect errors
+                    }
+                };
+
+                process.on("SIGINT", async () => {
+                    await shutdown();
+                    process.exit(0);
+                });
+
+                process.on("SIGTERM", async () => {
+                    await shutdown();
+                    process.exit(0);
+                });
+
+                if (runtimeMode === "ink") {
+                    await runWatchInkApp({
+                        contacts: targetContacts,
+                        myName,
+                        client,
+                        store,
+                        contextLength: opts.contextLength,
+                    });
+                } else {
+                    await runWatchRuntime({
+                        contacts: targetContacts,
+                        myName,
+                        client,
+                        store,
+                        contextLength: opts.contextLength,
+                        daemon: runtimeMode === "daemon",
+                    });
+                }
+
+                await shutdown();
+            }
+        );
+}

--- a/src/telegram/index.ts
+++ b/src/telegram/index.ts
@@ -16,6 +16,7 @@ program
     .showHelpAfterError(true);
 
 registerConfigureCommand(program);
+registerWatchCommand(program);
 registerListenCommand(program);
 registerContactsCommand(program);
 registerHistoryCommand(program);

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -1,253 +1,140 @@
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import { AIChat } from "@app/ask/index.lib";
-import { z } from "zod";
-import { parseDate } from "./DateParser";
+import { AIChat } from "@ask/AIChat";
+import type { AIChatTool } from "@ask/lib/types";
+import { createAssistantTools } from "./AssistantTools";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { AskModeConfig, TelegramContactV2 } from "./types";
-import { DEFAULTS } from "./types";
+import type { AskModeConfig } from "./types";
 
-const searchMessagesSchema = z.object({
-    query: z.string().optional().describe("Text to search for"),
-    since: z.string().optional().describe("Start date (ISO or natural language like 'last week')"),
-    until: z.string().optional().describe("End date (ISO or natural language)"),
-    sender: z.enum(["me", "them", "any"]).optional().describe("Filter by sender"),
-    limit: z.number().optional().describe("Max results (default 20)"),
-});
+const MAX_HISTORY_CONTEXT_CHARS = 90_000;
 
-const messageCountSchema = z.object({
-    since: z.string().optional(),
-    until: z.string().optional(),
-    sender: z.enum(["me", "them", "any"]).optional(),
-});
-
-const conversationSummarySchema = z.object({
-    since: z.string().describe("Start date"),
-    until: z.string().optional().describe("End date (defaults to now)"),
-    limit: z.number().optional().describe("Max results (default 50)"),
-});
-
-const attachmentsSchema = z.object({
-    messageId: z.number().optional().describe("Specific message ID"),
-    since: z.string().optional(),
-    until: z.string().optional(),
-});
-
-const styleAnalysisSchema = z.object({
-    sender: z.enum(["me", "them"]).describe("Whose style to analyze"),
-    limit: z.number().optional().describe("Number of messages to analyze (default 200)"),
-});
-
-const searchAcrossChatsSchema = z.object({
-    query: z.string().describe("Text to search for"),
-    limit: z.number().optional().describe("Max results (default 20)"),
-});
-
-type SearchMessagesInput = z.infer<typeof searchMessagesSchema>;
-type MessageCountInput = z.infer<typeof messageCountSchema>;
-type ConversationSummaryInput = z.infer<typeof conversationSummarySchema>;
-type AttachmentsInput = z.infer<typeof attachmentsSchema>;
-type StyleAnalysisInput = z.infer<typeof styleAnalysisSchema>;
-type SearchAcrossChatsInput = z.infer<typeof searchAcrossChatsSchema>;
+export interface AssistantRequest {
+    sessionId: string;
+    mode: AskModeConfig;
+    incomingText: string;
+    conversationHistory?: string;
+    stylePrompt?: string;
+    rawStyleSamples?: string[];
+    store?: TelegramHistoryStore;
+    chatId?: string;
+    includeFullDbHistory?: boolean;
+}
 
 export class AssistantEngine {
-    private chat: AIChat | null = null;
+    private sessions = new Map<string, AIChat>();
 
-    constructor(
-        private store: TelegramHistoryStore,
-        private contact: TelegramContactV2,
-        private myName: string
-    ) {}
-
-    private getConfig(): AskModeConfig {
-        return this.contact.modes.assistant;
+    private getCacheKey(sessionId: string, mode: AskModeConfig): string {
+        return `${sessionId}:${mode.provider ?? "default"}:${mode.model ?? "default"}`;
     }
 
-    private ensureChat(): AIChat {
-        if (!this.chat) {
-            const config = this.getConfig();
-            this.chat = new AIChat({
-                provider: config.provider ?? DEFAULTS.askProvider,
-                model: config.model ?? DEFAULTS.askModel,
-                systemPrompt: this.buildSystemPrompt(config),
-                temperature: config.temperature ?? 0.7,
-                session: {
-                    id: `telegram-assistant-${this.contact.userId}`,
-                    dir: resolve(homedir(), ".genesis-tools", "telegram", "ai-sessions"),
-                    autoSave: true,
-                },
+    private getChat(sessionId: string, mode: AskModeConfig): AIChat {
+        const key = this.getCacheKey(sessionId, mode);
+        const existing = this.sessions.get(key);
+
+        if (existing) {
+            return existing;
+        }
+
+        const chat = new AIChat({
+            provider: mode.provider ?? "openai",
+            model: mode.model ?? "gpt-4o-mini",
+            systemPrompt: mode.systemPrompt,
+            temperature: mode.temperature,
+            maxTokens: mode.maxTokens,
+            logLevel: "silent",
+            session: {
+                id: key,
+                dir: resolve(homedir(), ".genesis-tools/telegram/ai-sessions"),
+                autoSave: true,
+            },
+        });
+
+        this.sessions.set(key, chat);
+
+        return chat;
+    }
+
+    private buildTools(
+        store: TelegramHistoryStore | undefined,
+        chatId: string | undefined
+    ): Record<string, AIChatTool> {
+        if (!store || !chatId) {
+            return {};
+        }
+
+        return createAssistantTools(store, chatId);
+    }
+
+    private buildFullHistoryContext(store: TelegramHistoryStore, chatId: string): string {
+        const rows = store.queryMessages(chatId, {
+            sender: "any",
+        });
+        const lines = rows.map((row) => {
+            const who = row.is_outgoing ? "me" : "them";
+            const text = row.text ?? row.media_desc ?? "";
+            return `${row.date_iso} ${who}: ${text}`;
+        });
+
+        const all = lines.join("\n");
+
+        if (all.length <= MAX_HISTORY_CONTEXT_CHARS) {
+            return all;
+        }
+
+        return all.slice(all.length - MAX_HISTORY_CONTEXT_CHARS);
+    }
+
+    private buildPrompt(request: AssistantRequest): string {
+        const sections: string[] = [];
+
+        if (request.stylePrompt) {
+            sections.push(`[Style summary]\n${request.stylePrompt}`);
+        }
+
+        if (request.rawStyleSamples && request.rawStyleSamples.length > 0) {
+            sections.push(`[Raw style samples]\n${request.rawStyleSamples.join("\n")}`);
+        }
+
+        if (request.conversationHistory) {
+            sections.push(`[Recent conversation]\n${request.conversationHistory}`);
+        }
+
+        if (request.includeFullDbHistory && request.store && request.chatId) {
+            sections.push(
+                "[Full DB history snapshot]\n" +
+                    this.buildFullHistoryContext(request.store, request.chatId) +
+                    "\n\n[Note] If you need specific ranges/filters, use available tools (query_messages/search_messages/list_attachments/get_stats/get_suggestion_feedback)."
+            );
+        }
+
+        sections.push(`[User request]\n${request.incomingText}`);
+
+        return sections.join("\n\n");
+    }
+
+    async ask(request: AssistantRequest): Promise<string> {
+        const chat = this.getChat(request.sessionId, request.mode);
+        const tools = this.buildTools(request.store, request.chatId);
+        const toolCount = Object.keys(tools).length;
+
+        if (toolCount > 0) {
+            chat.updateConfig({
+                tools,
             });
         }
 
-        return this.chat;
-    }
+        const response = await chat.send(this.buildPrompt(request), {
+            addToHistory: false,
+        });
 
-    private buildSystemPrompt(config: AskModeConfig): string {
-        return (
-            config.systemPrompt ??
-            [
-                `You are a helpful assistant analyzing a Telegram conversation between "${this.myName}" and "${this.contact.displayName}".`,
-                "You have access to tools that let you search the full message history.",
-                "Use the tools to find relevant messages before answering questions.",
-                "Be concise but thorough. Reference specific messages when relevant.",
-            ].join("\n")
-        );
-    }
-
-    buildTools() {
-        const store = this.store;
-        const contactId = this.contact.userId;
-
-        return {
-            search_messages: {
-                description: "Search messages in the conversation by text content, date range, or sender",
-                parameters: searchMessagesSchema,
-                execute: async (input: SearchMessagesInput) => {
-                    const results = store.queryMessages(contactId, {
-                        textPattern: input.query,
-                        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
-                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
-                        sender: input.sender ?? "any",
-                        limit: input.limit ?? 20,
-                    });
-
-                    return results.map((r) => ({
-                        id: r.id,
-                        date: r.date_iso,
-                        sender: r.is_outgoing ? "me" : "them",
-                        text: r.text ?? "[media]",
-                    }));
-                },
-            },
-
-            get_message_count: {
-                description: "Count messages matching filters",
-                parameters: messageCountSchema,
-                execute: async (input: MessageCountInput) => {
-                    const count = store.countMessages(contactId, {
-                        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
-                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
-                        sender: input.sender ?? "any",
-                    });
-                    return { count };
-                },
-            },
-
-            get_conversation_summary: {
-                description: "Get a summary of messages in a date range. Returns messages for you to summarize.",
-                parameters: conversationSummarySchema,
-                execute: async (input: ConversationSummaryInput) => {
-                    const results = store.queryMessages(contactId, {
-                        since: parseDate(input.since) ?? undefined,
-                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
-                        limit: input.limit ?? 50,
-                    });
-
-                    return results.map((r) => ({
-                        date: r.date_iso,
-                        sender: r.is_outgoing ? "me" : "them",
-                        text: r.text ?? "[media]",
-                    }));
-                },
-            },
-
-            get_attachments: {
-                description: "List attachments (photos, videos, documents) in messages",
-                parameters: attachmentsSchema,
-                execute: async (input: AttachmentsInput) => {
-                    if (input.messageId) {
-                        return store.getAttachments(contactId, input.messageId);
-                    }
-
-                    return store.listAttachments(contactId, {
-                        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
-                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
-                    });
-                },
-            },
-
-            get_style_analysis: {
-                description:
-                    "Analyze writing style patterns for a sender (message length, emoji usage, common phrases)",
-                parameters: styleAnalysisSchema,
-                execute: async (input: StyleAnalysisInput) => {
-                    const messages = store.queryMessages(contactId, {
-                        sender: input.sender,
-                        limit: input.limit ?? 200,
-                    });
-
-                    const texts = messages.map((m) => m.text ?? "").filter(Boolean);
-                    const avgLength = texts.reduce((sum, t) => sum + t.length, 0) / (texts.length || 1);
-                    const emojiCount = texts.reduce((sum, t) => sum + (t.match(/[\p{Emoji}]/gu) ?? []).length, 0);
-                    const avgWords = texts.reduce((sum, t) => sum + t.split(/\s+/).length, 0) / (texts.length || 1);
-
-                    return {
-                        totalMessages: texts.length,
-                        avgCharLength: Math.round(avgLength),
-                        avgWordCount: Math.round(avgWords),
-                        totalEmojis: emojiCount,
-                        emojisPerMessage: (emojiCount / (texts.length || 1)).toFixed(2),
-                        sampleMessages: texts.slice(-10),
-                    };
-                },
-            },
-
-            search_across_chats: {
-                description: "Search for text across ALL synced chats, not just the current one",
-                parameters: searchAcrossChatsSchema,
-                execute: async (input: SearchAcrossChatsInput) => {
-                    const chats = store.listChats();
-                    const allResults: Array<{
-                        chatId: string;
-                        chatTitle: string;
-                        date: string;
-                        sender: string;
-                        text: string;
-                    }> = [];
-
-                    for (const chat of chats) {
-                        const results = store.queryMessages(chat.chat_id, {
-                            textPattern: input.query,
-                            limit: 5,
-                        });
-
-                        for (const r of results) {
-                            allResults.push({
-                                chatId: chat.chat_id,
-                                chatTitle: chat.title,
-                                date: r.date_iso,
-                                sender: r.is_outgoing ? "me" : chat.title,
-                                text: r.text ?? "[media]",
-                            });
-                        }
-                    }
-
-                    return allResults.slice(0, input.limit ?? 20);
-                },
-            },
-        };
-    }
-
-    async ask(question: string): Promise<string> {
-        const chat = this.ensureChat();
-        const response = await chat.send(question);
         return response.content;
     }
 
-    static getToolDefinitions() {
-        return {
-            search_messages: {
-                parameters: { query: "string", since: "string", until: "string", sender: "string", limit: "number" },
-            },
-            get_message_count: { parameters: { since: "string", until: "string", sender: "string" } },
-            get_conversation_summary: { parameters: { since: "string", until: "string", limit: "number" } },
-            get_attachments: { parameters: { messageId: "number", since: "string", until: "string" } },
-            get_style_analysis: { parameters: { sender: "string", limit: "number" } },
-            search_across_chats: { parameters: { query: "string", limit: "number" } },
-        };
-    }
-
-    resetSession(): void {
-        this.chat = null;
+    async disposeAll(): Promise<void> {
+        const disposals = [...this.sessions.values()].map((chat) => chat.dispose());
+        await Promise.all(disposals);
+        this.sessions.clear();
     }
 }
+
+export const assistantEngine = new AssistantEngine();

--- a/src/telegram/lib/AssistantTools.ts
+++ b/src/telegram/lib/AssistantTools.ts
@@ -1,0 +1,150 @@
+import type { AIChatTool } from "@ask/lib/types";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+
+function asString(value: unknown): string | undefined {
+    if (typeof value === "string" && value.length > 0) {
+        return value;
+    }
+
+    return undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return undefined;
+}
+
+function parseOptionalDate(value: unknown): Date | undefined {
+    const text = asString(value);
+
+    if (!text) {
+        return undefined;
+    }
+
+    const date = new Date(text);
+
+    if (Number.isNaN(date.getTime())) {
+        return undefined;
+    }
+
+    return date;
+}
+
+export function createAssistantTools(store: TelegramHistoryStore, chatId: string): Record<string, AIChatTool> {
+    return {
+        query_messages: {
+            description:
+                "Query conversation messages from local DB for this chat by optional date/sender/text filters.",
+            parameters: {
+                since: { type: "string", description: "Optional ISO date or YYYY-MM-DD start date", optional: true },
+                until: { type: "string", description: "Optional ISO date or YYYY-MM-DD end date", optional: true },
+                sender: {
+                    type: "string",
+                    description: "me|them|any (default any)",
+                    optional: true,
+                },
+                textRegex: { type: "string", description: "Optional regex filter", optional: true },
+                limit: { type: "number", description: "Optional max rows", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                const senderRaw = asString(params.sender);
+                const sender = senderRaw === "me" || senderRaw === "them" || senderRaw === "any" ? senderRaw : "any";
+
+                const rows = store.queryMessages(chatId, {
+                    since: parseOptionalDate(params.since),
+                    until: parseOptionalDate(params.until),
+                    sender,
+                    textRegex: asString(params.textRegex),
+                    limit: asNumber(params.limit),
+                });
+
+                return rows.map((row) => ({
+                    id: row.id,
+                    date: row.date_iso,
+                    sender: row.is_outgoing ? "me" : "them",
+                    text: row.text,
+                    media: row.media_desc,
+                    deleted: row.is_deleted === 1,
+                }));
+            },
+        },
+        search_messages: {
+            description: "FTS keyword search in this chat's local DB index.",
+            parameters: {
+                query: { type: "string", description: "Search query text" },
+                limit: { type: "number", description: "Optional result count", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                const query = asString(params.query);
+
+                if (!query) {
+                    return [];
+                }
+
+                const results = store.search(chatId, query, {
+                    limit: asNumber(params.limit),
+                });
+
+                return results.map((result) => ({
+                    id: result.message.id,
+                    date: result.message.date_iso,
+                    sender: result.message.is_outgoing ? "me" : "them",
+                    text: result.message.text,
+                    media: result.message.media_desc,
+                }));
+            },
+        },
+        list_attachments: {
+            description: "List indexed attachment locators for this chat.",
+            parameters: {
+                limit: { type: "number", description: "Optional max rows", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                const rows = store.listAttachments(chatId, { limit: asNumber(params.limit) });
+
+                return rows.map((row) => ({
+                    locator: `${row.chat_id}:${row.message_id}:${row.attachment_index}`,
+                    messageId: row.message_id,
+                    attachmentIndex: row.attachment_index,
+                    kind: row.kind,
+                    fileName: row.file_name,
+                    mimeType: row.mime_type,
+                    downloaded: row.is_downloaded === 1,
+                }));
+            },
+        },
+        get_stats: {
+            description: "Return message and embedding stats for this chat.",
+            parameters: {},
+            execute: async () => {
+                const stats = store.getStats(chatId)[0];
+
+                if (!stats) {
+                    return null;
+                }
+
+                return stats;
+            },
+        },
+        get_suggestion_feedback: {
+            description: "Return recent suggestion feedback (suggested text vs edited sent text).",
+            parameters: {
+                limit: { type: "number", description: "Optional max rows", optional: true },
+            },
+            execute: async (params: Record<string, unknown>) => {
+                return store.getSuggestionFeedback(chatId, asNumber(params.limit) ?? 20);
+            },
+        },
+    };
+}

--- a/src/telegram/lib/AttachmentDownloader.ts
+++ b/src/telegram/lib/AttachmentDownloader.ts
@@ -1,100 +1,84 @@
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { TGClient } from "./TGClient";
+import type { AttachmentLocator } from "./types";
 
-const ATTACHMENTS_BASE = resolve(homedir(), ".genesis-tools/telegram/chats");
+const DEFAULT_CHATS_DIR = join(homedir(), ".genesis-tools", "telegram", "chats");
+
+export interface DownloadAttachmentOptions {
+    outputPath?: string;
+}
+
+export interface DownloadAttachmentResult {
+    outputPath: string;
+    bytes: number;
+}
 
 export class AttachmentDownloader {
-    constructor(
-        private client: TGClient,
-        private store: TelegramHistoryStore
-    ) {}
-
-    async download(
-        chatId: string,
-        messageId: number,
-        attachmentIndex: number,
-        outputPath?: string
-    ): Promise<{ path: string; size: number; sha256: string }> {
-        const attachments = this.store.getAttachments(chatId, messageId);
-        const attachment = attachments.find((a) => a.attachment_index === attachmentIndex);
+    async downloadByLocator(
+        client: TGClient,
+        store: TelegramHistoryStore,
+        locator: AttachmentLocator,
+        options: DownloadAttachmentOptions = {}
+    ): Promise<DownloadAttachmentResult> {
+        const attachment = store.getAttachment(locator);
 
         if (!attachment) {
-            throw new Error(`Attachment not found: chat=${chatId} msg=${messageId} idx=${attachmentIndex}`);
+            throw new Error(
+                `Attachment not found for ${locator.chatId}:${locator.messageId}:${locator.attachmentIndex}`
+            );
         }
 
-        if (attachment.is_downloaded && attachment.local_path && existsSync(attachment.local_path)) {
+        const message = await client.getMessageById(locator.chatId, locator.messageId);
+
+        if (!message || !message.media) {
+            throw new Error(`Telegram message ${locator.messageId} has no downloadable media`);
+        }
+
+        const safeFileName = (attachment.file_name ?? `${locator.messageId}-${locator.attachmentIndex}`).replace(
+            /[\\/:*?"<>|]/g,
+            "_"
+        );
+        const fallbackPath = join(
+            DEFAULT_CHATS_DIR,
+            locator.chatId,
+            "attachments",
+            `${locator.messageId}-${locator.attachmentIndex}-${safeFileName}`
+        );
+        const outputPath = options.outputPath ?? fallbackPath;
+        const outputDir = dirname(outputPath);
+
+        if (!existsSync(outputDir)) {
+            mkdirSync(outputDir, { recursive: true });
+        }
+
+        const downloaded = await client.downloadMedia(message, {
+            outputFile: outputPath,
+        });
+
+        if (downloaded === undefined) {
+            throw new Error("Telegram client returned no data while downloading media");
+        }
+
+        if (Buffer.isBuffer(downloaded)) {
+            store.markAttachmentDownloaded(locator, outputPath, downloaded);
+
             return {
-                path: attachment.local_path,
-                size: attachment.file_size ?? 0,
-                sha256: attachment.sha256 ?? "",
+                outputPath,
+                bytes: downloaded.byteLength,
             };
         }
 
-        let targetMessage: import("telegram").Api.Message | null = null;
+        const fileBytes = readFileSync(downloaded);
+        store.markAttachmentDownloaded(locator, downloaded, fileBytes);
 
-        for await (const msg of this.client.getMessages(chatId, {
-            minId: messageId - 1,
-            maxId: messageId + 1,
-            limit: 3,
-        })) {
-            if (msg.id === messageId) {
-                targetMessage = msg;
-                break;
-            }
-        }
-
-        if (!targetMessage?.media) {
-            throw new Error(`Message ${messageId} not found or has no media`);
-        }
-
-        const dir = outputPath ? resolve(dirname(outputPath)) : resolve(ATTACHMENTS_BASE, chatId, "attachments");
-
-        if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true });
-        }
-
-        const ext = this.guessExtension(attachment.mime_type, attachment.file_name);
-        const fileName = outputPath ? resolve(outputPath) : resolve(dir, `${messageId}-${attachmentIndex}${ext}`);
-
-        const buffer = (await this.client.raw.downloadMedia(targetMessage.media, {})) as Buffer;
-
-        if (!buffer) {
-            throw new Error("Download returned empty buffer");
-        }
-
-        await Bun.write(fileName, buffer);
-
-        const hash = createHash("sha256").update(buffer).digest("hex");
-
-        this.store.markAttachmentDownloaded(chatId, messageId, attachmentIndex, fileName, hash);
-
-        return { path: fileName, size: buffer.length, sha256: hash };
-    }
-
-    private guessExtension(mimeType: string | null, fileName: string | null): string {
-        if (fileName) {
-            const dot = fileName.lastIndexOf(".");
-
-            if (dot !== -1) {
-                return fileName.slice(dot);
-            }
-        }
-
-        const mimeMap: Record<string, string> = {
-            "image/jpeg": ".jpg",
-            "image/png": ".png",
-            "image/webp": ".webp",
-            "image/gif": ".gif",
-            "video/mp4": ".mp4",
-            "audio/ogg": ".ogg",
-            "audio/mpeg": ".mp3",
-            "application/pdf": ".pdf",
+        return {
+            outputPath: downloaded,
+            bytes: fileBytes.byteLength,
         };
-
-        return mimeMap[mimeType ?? ""] ?? "";
     }
 }
+
+export const attachmentDownloader = new AttachmentDownloader();

--- a/src/telegram/lib/AttachmentIndexer.ts
+++ b/src/telegram/lib/AttachmentIndexer.ts
@@ -1,99 +1,20 @@
-import type { Api } from "telegram";
-import type { UpsertAttachmentInput } from "./types";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { SerializedMessage } from "./TelegramMessage";
 
 export class AttachmentIndexer {
-    static extract(chatId: string, message: Api.Message): UpsertAttachmentInput[] {
-        if (!message.media) {
-            return [];
+    indexSerializedMessage(store: TelegramHistoryStore, chatId: string, message: SerializedMessage): void {
+        if (!message.attachments || message.attachments.length === 0) {
+            return;
         }
 
-        const results: UpsertAttachmentInput[] = [];
-        const media = message.media;
-        const msgId = message.id;
-
-        switch (media.className) {
-            case "MessageMediaPhoto": {
-                const photoMedia = media as Api.MessageMediaPhoto;
-                const photo = photoMedia.photo;
-
-                if (!photo || photo.className === "PhotoEmpty") {
-                    break;
-                }
-
-                const fullPhoto = photo as Api.Photo;
-                const largestSize = fullPhoto.sizes?.at(-1);
-                const fileSize = largestSize && "size" in largestSize ? (largestSize as Api.PhotoSize).size : null;
-
-                results.push({
-                    chat_id: chatId,
-                    message_id: msgId,
-                    attachment_index: 0,
-                    kind: "photo",
-                    mime_type: "image/jpeg",
-                    file_name: null,
-                    file_size: fileSize ?? null,
-                    telegram_file_id: fullPhoto.id ? String(fullPhoto.id) : null,
-                });
-                break;
-            }
-
-            case "MessageMediaDocument": {
-                const docMedia = media as Api.MessageMediaDocument;
-                const doc = docMedia.document;
-
-                if (!doc || doc.className === "DocumentEmpty") {
-                    break;
-                }
-
-                const fullDoc = doc as Api.Document;
-                const attributes = fullDoc.attributes ?? [];
-                const kind = AttachmentIndexer.classifyDocument(attributes);
-                const fileName = AttachmentIndexer.extractFileName(attributes);
-
-                results.push({
-                    chat_id: chatId,
-                    message_id: msgId,
-                    attachment_index: 0,
-                    kind,
-                    mime_type: fullDoc.mimeType ?? null,
-                    file_name: fileName,
-                    file_size: fullDoc.size != null ? Number(fullDoc.size) : null,
-                    telegram_file_id: fullDoc.id ? String(fullDoc.id) : null,
-                });
-                break;
-            }
-
-            default:
-                break;
-        }
-
-        return results;
+        store.upsertAttachments(chatId, message.id, message.attachments);
     }
 
-    private static classifyDocument(attributes: Api.TypeDocumentAttribute[]): string {
-        for (const attr of attributes) {
-            switch (attr.className) {
-                case "DocumentAttributeSticker":
-                    return "sticker";
-                case "DocumentAttributeAudio":
-                    return (attr as Api.DocumentAttributeAudio).voice ? "voice" : "audio";
-                case "DocumentAttributeVideo":
-                    return (attr as Api.DocumentAttributeVideo).roundMessage ? "video_note" : "video";
-                case "DocumentAttributeAnimated":
-                    return "animation";
-            }
+    indexBatch(store: TelegramHistoryStore, chatId: string, messages: SerializedMessage[]): void {
+        for (const message of messages) {
+            this.indexSerializedMessage(store, chatId, message);
         }
-
-        return "document";
-    }
-
-    private static extractFileName(attributes: Api.TypeDocumentAttribute[]): string | null {
-        for (const attr of attributes) {
-            if (attr.className === "DocumentAttributeFilename") {
-                return (attr as Api.DocumentAttributeFilename).fileName ?? null;
-            }
-        }
-
-        return null;
     }
 }
+
+export const attachmentIndexer = new AttachmentIndexer();

--- a/src/telegram/lib/ConversationSyncService.ts
+++ b/src/telegram/lib/ConversationSyncService.ts
@@ -1,255 +1,181 @@
-import type { Api } from "telegram";
-import { AttachmentIndexer } from "./AttachmentIndexer";
-import { SyncRangePlanner } from "./SyncRangePlanner";
+import { formatNumber } from "@app/utils/format";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { syncRangePlanner } from "./SyncRangePlanner";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { SerializedMessage } from "./TelegramMessage";
 import { TelegramMessage } from "./TelegramMessage";
 import type { TGClient } from "./TGClient";
 
-const BATCH_SIZE = 100;
-const INITIAL_SYNC_LIMIT = 100;
-const MAX_RETRIES = 5;
-
-interface SyncOptions {
+export interface SyncOptions {
+    since?: Date;
+    until?: Date;
     limit?: number;
-    onProgress?: (synced: number, total: number | null) => void;
 }
 
 export interface SyncResult {
-    synced: number;
-    attachmentsIndexed: number;
-    segments: number;
+    downloaded: number;
+    inserted: number;
+    updated: number;
+    highestId: number;
+}
+
+interface SyncRangeOptions {
+    since?: Date;
+    until?: Date;
+    limit?: number;
+    minId?: number;
+    source: "query" | "full" | "incremental";
 }
 
 export class ConversationSyncService {
-    constructor(
-        private client: TGClient,
-        private store: TelegramHistoryStore
-    ) {}
-
-    async syncLatest(chatId: string, options?: SyncOptions): Promise<SyncResult> {
-        const lastSyncedId = this.store.getLastSyncedId(chatId);
-        let synced = 0;
-        let attachmentsIndexed = 0;
-        let highestId = lastSyncedId ?? 0;
-        let lowestDateUnix = Infinity;
-        let highestDateUnix = 0;
-        let lowestMsgId = Infinity;
-
-        const iterOptions: { minId?: number; limit?: number } = {};
-
-        if (lastSyncedId) {
-            iterOptions.minId = lastSyncedId;
-        } else {
-            // First sync — only fetch the most recent messages, not the entire history.
-            // Use syncRange() to backfill older messages on demand.
-            iterOptions.limit = options?.limit ?? INITIAL_SYNC_LIMIT;
-        }
-
-        if (options?.limit) {
-            iterOptions.limit = options.limit;
-        }
-
-        const batch: SerializedMessage[] = [];
-
-        for await (const rawMsg of this.client.getMessages(chatId, iterOptions)) {
-            const msg = new TelegramMessage(rawMsg);
-            const serialized = msg.toJSON();
-            batch.push(serialized);
-
-            attachmentsIndexed += this.indexAttachments(chatId, rawMsg);
-
-            if (rawMsg.id > highestId) {
-                highestId = rawMsg.id;
-            }
-
-            if (rawMsg.id < lowestMsgId) {
-                lowestMsgId = rawMsg.id;
-            }
-
-            if (serialized.dateUnix < lowestDateUnix) {
-                lowestDateUnix = serialized.dateUnix;
-            }
-
-            if (serialized.dateUnix > highestDateUnix) {
-                highestDateUnix = serialized.dateUnix;
-            }
-
-            if (batch.length >= BATCH_SIZE) {
-                synced += this.store.insertMessages(chatId, batch);
-                batch.length = 0;
-                options?.onProgress?.(synced, null);
-            }
-        }
-
-        if (batch.length > 0) {
-            synced += this.store.insertMessages(chatId, batch);
-        }
-
-        if (highestId > 0) {
-            this.store.setLastSyncedId(chatId, highestId);
-        }
-
-        let segmentsRecorded = 0;
-
-        if (synced > 0 && lowestDateUnix < Infinity) {
-            this.store.insertSyncSegment(chatId, {
-                fromDateUnix: lowestDateUnix,
-                toDateUnix: highestDateUnix,
-                fromMsgId: lowestMsgId,
-                toMsgId: highestId,
-            });
-            segmentsRecorded = 1;
-        }
-
-        return { synced, attachmentsIndexed, segments: segmentsRecorded };
-    }
-
-    async syncRange(chatId: string, since: Date, until: Date, options?: SyncOptions): Promise<SyncResult> {
-        const sinceUnix = Math.floor(since.getTime() / 1000);
-        const untilUnix = Math.floor(until.getTime() / 1000);
-
-        const segments = this.store.getSyncSegments(chatId);
-        const gaps = SyncRangePlanner.plan(
-            segments.map((s) => ({ from_date_unix: s.from_date_unix, to_date_unix: s.to_date_unix })),
-            sinceUnix,
-            untilUnix
-        );
-
-        if (gaps.length === 0) {
-            return { synced: 0, attachmentsIndexed: 0, segments: 0 };
-        }
-
-        let totalSynced = 0;
-        let totalAttachments = 0;
-        let totalSegments = 0;
-
-        for (const gap of gaps) {
-            const result = await this.syncDateRange(chatId, gap.from, gap.to, options);
-            totalSynced += result.synced;
-            totalAttachments += result.attachmentsIndexed;
-            totalSegments += result.segments;
-        }
-
-        return { synced: totalSynced, attachmentsIndexed: totalAttachments, segments: totalSegments };
-    }
-
-    async queryWithAutoFetch(
+    async syncIncremental(
+        client: TGClient,
+        store: TelegramHistoryStore,
         chatId: string,
-        options: {
-            sender?: "me" | "them" | "any";
-            since?: Date;
-            until?: Date;
-            textPattern?: string;
-            limit?: number;
-            localOnly?: boolean;
-        }
-    ) {
-        if (!options.localOnly && (options.since || options.until)) {
-            const since = options.since ?? new Date(0);
-            const until = options.until ?? new Date();
-            await this.syncRange(chatId, since, until);
-        }
+        options: SyncOptions = {}
+    ): Promise<SyncResult> {
+        const lastSyncedId = store.getLastSyncedId(chatId);
+        const plan = syncRangePlanner.planIncremental(lastSyncedId);
 
-        return this.store.queryMessages(chatId, {
-            sender: options.sender,
-            since: options.since,
-            until: options.until,
-            textPattern: options.textPattern,
+        return this.syncRange(client, store, chatId, {
+            since: options.since ?? plan.since,
+            until: options.until ?? plan.until,
             limit: options.limit,
+            minId: lastSyncedId ?? undefined,
+            source: plan.source,
         });
     }
 
-    private async syncDateRange(
+    async ensureRange(
+        client: TGClient,
+        store: TelegramHistoryStore,
         chatId: string,
-        fromUnix: number,
-        toUnix: number,
-        options?: SyncOptions,
-        retryAttempt = 0
+        since: Date,
+        until: Date,
+        options: { limit?: number } = {}
+    ): Promise<SyncResult[]> {
+        const ranges = syncRangePlanner.planQueryBackfill(store, chatId, since, until);
+        const results: SyncResult[] = [];
+
+        for (const range of ranges) {
+            const result = await this.syncRange(client, store, chatId, {
+                since: range.since,
+                until: range.until,
+                source: "query",
+                limit: options.limit,
+            });
+            results.push(result);
+        }
+
+        return results;
+    }
+
+    async syncRange(
+        client: TGClient,
+        store: TelegramHistoryStore,
+        chatId: string,
+        options: SyncRangeOptions
     ): Promise<SyncResult> {
-        let synced = 0;
-        let attachmentsIndexed = 0;
-        let highestId = 0;
-        let lowestMsgId = Infinity;
+        const iterOptions: {
+            limit?: number;
+            offsetDate?: number;
+            minId?: number;
+        } = {};
 
-        const batch: SerializedMessage[] = [];
-
-        const iterOptions: { offsetDate?: number; limit?: number } = {
-            offsetDate: toUnix,
-        };
-
-        if (options?.limit) {
+        if (options.limit !== undefined) {
             iterOptions.limit = options.limit;
         }
 
-        try {
-            for await (const rawMsg of this.client.getMessages(chatId, iterOptions)) {
-                const msg = new TelegramMessage(rawMsg);
-                const dateUnix = Math.floor(msg.date.getTime() / 1000);
+        if (options.until) {
+            iterOptions.offsetDate = Math.floor(options.until.getTime() / 1000);
+        }
 
-                if (dateUnix < fromUnix) {
-                    break;
-                }
+        if (options.minId !== undefined) {
+            iterOptions.minId = options.minId;
+        }
 
-                const serialized = msg.toJSON();
-                batch.push(serialized);
+        const spinner = p.spinner();
+        spinner.start(`Syncing ${chatId} (${options.source})...`);
 
-                attachmentsIndexed += this.indexAttachments(chatId, rawMsg);
+        let downloaded = 0;
+        let inserted = 0;
+        let updated = 0;
+        let highestId = options.minId ?? 0;
+        let rangeMin: number | null = null;
+        let rangeMax: number | null = null;
 
-                if (rawMsg.id > highestId) {
-                    highestId = rawMsg.id;
-                }
+        for await (const apiMessage of client.getMessages(chatId, iterOptions)) {
+            const message = new TelegramMessage(apiMessage);
 
-                if (rawMsg.id < lowestMsgId) {
-                    lowestMsgId = rawMsg.id;
-                }
-
-                if (batch.length >= BATCH_SIZE) {
-                    synced += this.store.insertMessages(chatId, batch);
-                    batch.length = 0;
-                }
-            }
-        } catch (err: unknown) {
-            if (err instanceof Error && err.message.includes("FLOOD_WAIT")) {
-                const match = err.message.match(/FLOOD_WAIT_(\d+)/);
-                const waitSeconds = match ? Number.parseInt(match[1], 10) : 30;
-
-                if (retryAttempt < MAX_RETRIES) {
-                    await Bun.sleep(waitSeconds * 1000 * 2 ** retryAttempt);
-                    return this.syncDateRange(chatId, fromUnix, toUnix, options, retryAttempt + 1);
-                }
+            if (options.since && message.date < options.since) {
+                continue;
             }
 
-            throw err;
+            if (options.until && message.date > options.until) {
+                continue;
+            }
+
+            const serialized = message.toJSON();
+            const revisionType = serialized.editedDateUnix ? "edit" : "create";
+            const upsertResult = store.upsertMessageWithRevision(chatId, serialized, revisionType);
+
+            downloaded++;
+
+            if (upsertResult.inserted) {
+                inserted++;
+            }
+
+            if (upsertResult.updated) {
+                updated++;
+            }
+
+            if (message.id > highestId) {
+                highestId = message.id;
+            }
+
+            if (rangeMin === null || serialized.dateUnix < rangeMin) {
+                rangeMin = serialized.dateUnix;
+            }
+
+            if (rangeMax === null || serialized.dateUnix > rangeMax) {
+                rangeMax = serialized.dateUnix;
+            }
+
+            if (downloaded % 100 === 0) {
+                spinner.message(
+                    `Downloaded ${formatNumber(downloaded)} messages (${inserted} new, ${updated} updated)`
+                );
+            }
         }
 
-        if (batch.length > 0) {
-            synced += this.store.insertMessages(chatId, batch);
+        if (highestId > 0) {
+            store.setLastSyncedId(chatId, highestId);
         }
 
-        const isLimitedRangeFetch = typeof iterOptions.limit === "number";
-
-        if (synced > 0 && !isLimitedRangeFetch) {
-            this.store.insertSyncSegment(chatId, {
-                fromDateUnix: fromUnix,
-                toDateUnix: toUnix,
-                fromMsgId: lowestMsgId,
-                toMsgId: highestId,
-            });
+        if (rangeMin !== null && rangeMax !== null) {
+            store.insertSyncSegment(chatId, rangeMin, rangeMax, options.source);
         }
 
-        return { synced, attachmentsIndexed, segments: synced > 0 && !isLimitedRangeFetch ? 1 : 0 };
-    }
-
-    private indexAttachments(chatId: string, rawMsg: Api.Message): number {
-        const atts = AttachmentIndexer.extract(chatId, rawMsg);
-        let count = 0;
-
-        for (const att of atts) {
-            this.store.upsertAttachment(att);
-            count++;
+        if (rangeMin === null && options.since && options.until) {
+            store.insertSyncSegment(
+                chatId,
+                Math.floor(options.since.getTime() / 1000),
+                Math.floor(options.until.getTime() / 1000),
+                options.source
+            );
         }
 
-        return count;
+        spinner.stop(
+            `${pc.green(formatNumber(downloaded))} downloaded, ${pc.green(String(inserted))} new, ${pc.yellow(String(updated))} updated`
+        );
+
+        return {
+            downloaded,
+            inserted,
+            updated,
+            highestId,
+        };
     }
 }
+
+export const conversationSyncService = new ConversationSyncService();

--- a/src/telegram/lib/QueryParser.ts
+++ b/src/telegram/lib/QueryParser.ts
@@ -1,0 +1,147 @@
+import * as chrono from "chrono-node";
+import type { QueryRequest } from "./types";
+
+const ISO_DATE_PATTERN = /(\d{4}-\d{2}-\d{2})/g;
+
+function toIsoDate(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
+function parseDatePhrase(phrase: string, referenceDate: Date): string | undefined {
+    const parsed = chrono.parseDate(phrase.trim(), referenceDate);
+
+    if (!parsed) {
+        return undefined;
+    }
+
+    return toIsoDate(parsed);
+}
+
+export class QueryParser {
+    parseFromFlags(request: QueryRequest): QueryRequest {
+        const parsed = { ...request };
+        const now = new Date();
+
+        if (parsed.since) {
+            const normalizedSince = parseDatePhrase(parsed.since, now);
+
+            if (normalizedSince) {
+                parsed.since = normalizedSince;
+            }
+        }
+
+        if (parsed.until) {
+            const normalizedUntil = parseDatePhrase(parsed.until, now);
+
+            if (normalizedUntil) {
+                parsed.until = normalizedUntil;
+            }
+        }
+
+        if (request.nl) {
+            const extracted = this.parseNaturalLanguage(request.nl, now);
+
+            if (!parsed.from && extracted.from) {
+                parsed.from = extracted.from;
+            }
+
+            if (!parsed.since && extracted.since) {
+                parsed.since = extracted.since;
+            }
+
+            if (!parsed.until && extracted.until) {
+                parsed.until = extracted.until;
+            }
+
+            if (!parsed.sender && extracted.sender) {
+                parsed.sender = extracted.sender;
+            }
+
+            if (!parsed.text && extracted.text) {
+                parsed.text = extracted.text;
+            }
+        }
+
+        if (!parsed.sender) {
+            parsed.sender = "any";
+        }
+
+        return parsed;
+    }
+
+    parseNaturalLanguage(input: string, referenceDate: Date = new Date()): Partial<QueryRequest> {
+        const normalized = input.trim();
+        const result: Partial<QueryRequest> = {};
+
+        const fromMatch = normalized.match(/messages\s+from\s+(.+?)(?:\s+since|\s+until|\s+text|\s+matching|$)/i);
+
+        if (fromMatch) {
+            result.from = fromMatch[1].trim();
+        }
+
+        const sincePhraseMatch = normalized.match(/since\s+(.+?)(?:\s+until|\s+text|\s+matching|$)/i);
+        const untilPhraseMatch = normalized.match(/until\s+(.+?)(?:\s+since|\s+text|\s+matching|$)/i);
+
+        if (sincePhraseMatch) {
+            const parsed = parseDatePhrase(sincePhraseMatch[1], referenceDate);
+
+            if (parsed) {
+                result.since = parsed;
+            }
+        }
+
+        if (untilPhraseMatch) {
+            const parsed = parseDatePhrase(untilPhraseMatch[1], referenceDate);
+
+            if (parsed) {
+                result.until = parsed;
+            }
+        }
+
+        if (!result.since || !result.until) {
+            const chronoResults = chrono.parse(normalized, referenceDate, { forwardDate: false });
+
+            for (const chronoResult of chronoResults) {
+                if (!result.since && chronoResult.start) {
+                    result.since = toIsoDate(chronoResult.start.date());
+                }
+
+                if (!result.until) {
+                    if (chronoResult.end) {
+                        result.until = toIsoDate(chronoResult.end.date());
+                    } else if (chronoResult.start) {
+                        result.until = toIsoDate(chronoResult.start.date());
+                    }
+                }
+            }
+        }
+
+        const isoDates = [...normalized.matchAll(ISO_DATE_PATTERN)].map((match) => match[1]);
+
+        if (!result.since && isoDates.length > 0) {
+            result.since = isoDates[0];
+        }
+
+        if (!result.until && isoDates.length > 1) {
+            result.until = isoDates[1];
+        }
+
+        if (/\bfrom\s+me\b/i.test(normalized) || /\bmy messages\b/i.test(normalized)) {
+            result.sender = "me";
+        }
+
+        if (/\bfrom\s+(her|him|them)\b/i.test(normalized) || /\btheir messages\b/i.test(normalized)) {
+            result.sender = "them";
+        }
+
+        const textMatch = normalized.match(/matching\s+"([^"]+)"/i) ?? normalized.match(/text\s+"([^"]+)"/i);
+
+        if (textMatch) {
+            result.text = textMatch[1];
+        }
+
+        return result;
+    }
+}
+
+export const queryParser = new QueryParser();

--- a/src/telegram/lib/StyleProfileEngine.ts
+++ b/src/telegram/lib/StyleProfileEngine.ts
@@ -1,195 +1,59 @@
-import { StyleRuleResolver } from "./StyleRuleResolver";
+import { assistantEngine } from "./AssistantEngine";
+import { styleRuleResolver } from "./StyleRuleResolver";
+import type { TelegramContact } from "./TelegramContact";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { StyleSourceRule } from "./types";
+import { DEFAULT_MODE_CONFIG } from "./types";
 
-interface StyleAnalysis {
-    totalMessages: number;
-    avgLength: number;
-    avgWords: number;
-    usesEmojis: boolean;
-    emojiFrequency: number;
-    usesSlang: boolean;
-    traits: string[];
-    commonPatterns: string[];
-}
-
-interface StylePromptOptions {
-    rules: StyleSourceRule[];
-    exampleCount?: number;
+export interface DerivedStyleResult {
+    prompt: string;
+    sampleCount: number;
+    generatedAt: string;
+    rawSamples: string[];
 }
 
 export class StyleProfileEngine {
-    private ruleResolver: StyleRuleResolver;
+    getRawStyleSamples(contact: TelegramContact, store: TelegramHistoryStore, limit = 200): string[] {
+        const styleConfig = contact.config.styleProfile;
 
-    constructor(private store: TelegramHistoryStore) {
-        this.ruleResolver = new StyleRuleResolver(store);
-    }
-
-    analyzeStyle(chatId: string, sender: "me" | "them", limit = 500): StyleAnalysis {
-        const messages = this.store.queryMessages(chatId, { sender, limit });
-        const texts = messages.map((m) => m.text ?? "").filter(Boolean);
-
-        if (texts.length === 0) {
-            return {
-                totalMessages: 0,
-                avgLength: 0,
-                avgWords: 0,
-                usesEmojis: false,
-                emojiFrequency: 0,
-                usesSlang: false,
-                traits: ["No messages to analyze"],
-                commonPatterns: [],
-            };
-        }
-
-        return this.analyzeStyleFromTexts(texts);
-    }
-
-    buildStylePrompt(options: StylePromptOptions): string {
-        const messages = this.ruleResolver.resolveMessages(options.rules);
-        const texts = messages.map((m) => m.text ?? "").filter(Boolean);
-
-        if (texts.length === 0) {
-            return "No messages available for style analysis.";
-        }
-
-        const analysis = this.analyzeStyleFromTexts(texts);
-        const exampleCount = options.exampleCount ?? 15;
-        const examples = this.selectRepresentativeExamples(texts, exampleCount);
-
-        const sections: string[] = [];
-
-        sections.push("## Style Summary");
-        sections.push(`Analyzed ${texts.length} messages.`);
-        sections.push("");
-        sections.push("Characteristics:");
-
-        for (const trait of analysis.traits) {
-            sections.push(`- ${trait}`);
-        }
-
-        if (analysis.commonPatterns.length > 0) {
-            sections.push("");
-            sections.push("Common patterns:");
-
-            for (const pattern of analysis.commonPatterns) {
-                sections.push(`- ${pattern}`);
-            }
-        }
-
-        sections.push("");
-        sections.push("## Example Messages");
-        sections.push("These are real messages showing the typical style:");
-        sections.push("");
-
-        for (const ex of examples) {
-            sections.push(`> ${ex}`);
-        }
-
-        return sections.join("\n");
-    }
-
-    private analyzeStyleFromTexts(texts: string[]): StyleAnalysis {
-        const avgLength = texts.reduce((s, t) => s + t.length, 0) / texts.length;
-        const avgWords = texts.reduce((s, t) => s + t.split(/\s+/).length, 0) / texts.length;
-        const emojiCount = texts.reduce(
-            (s, t) => s + (t.match(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu) ?? []).length,
-            0
-        );
-        const emojiFreq = emojiCount / texts.length;
-
-        const traits: string[] = [];
-
-        if (avgWords < 5) {
-            traits.push("Very short messages (1-4 words)");
-        } else if (avgWords < 10) {
-            traits.push("Short messages (5-9 words)");
-        } else if (avgWords < 20) {
-            traits.push("Medium-length messages");
-        } else {
-            traits.push("Long, detailed messages");
-        }
-
-        if (emojiFreq > 1) {
-            traits.push("Heavy emoji user");
-        } else if (emojiFreq > 0.3) {
-            traits.push("Moderate emoji user");
-        } else if (emojiFreq > 0) {
-            traits.push("Occasional emoji user");
-        } else {
-            traits.push("Rarely or never uses emojis");
-        }
-
-        const lowercaseRatio = texts.filter((t) => t === t.toLowerCase()).length / texts.length;
-
-        if (lowercaseRatio > 0.8) {
-            traits.push("Mostly lowercase");
-        } else if (lowercaseRatio < 0.3) {
-            traits.push("Uses proper capitalization");
-        }
-
-        const noPuncRatio = texts.filter((t) => !/[.!?]$/.test(t.trim())).length / texts.length;
-
-        if (noPuncRatio > 0.7) {
-            traits.push("Often omits ending punctuation");
-        }
-
-        const slangPatterns = /\b(lol|lmao|nah|yea|wanna|gonna|kinda|idk|imo|tbh|rn|tmrw|btw|omg|brb|ttyl)\b/i;
-        const slangCount = texts.filter((t) => slangPatterns.test(t)).length;
-        const usesSlang = slangCount / texts.length > 0.1;
-
-        if (usesSlang) {
-            traits.push("Uses informal slang/abbreviations");
-        }
-
-        const starters = new Map<string, number>();
-
-        for (const t of texts) {
-            const firstWord = t.split(/\s+/)[0]?.toLowerCase();
-
-            if (firstWord) {
-                starters.set(firstWord, (starters.get(firstWord) ?? 0) + 1);
-            }
-        }
-
-        const commonPatterns = [...starters.entries()]
-            .filter(([, count]) => count > texts.length * 0.05)
-            .sort((a, b) => b[1] - a[1])
-            .slice(0, 5)
-            .map(([word, count]) => `"${word}..." (${count} times)`);
-
-        return {
-            totalMessages: texts.length,
-            avgLength: Math.round(avgLength),
-            avgWords: Math.round(avgWords * 10) / 10,
-            usesEmojis: emojiFreq > 0,
-            emojiFrequency: Math.round(emojiFreq * 100) / 100,
-            usesSlang,
-            traits,
-            commonPatterns,
-        };
-    }
-
-    private selectRepresentativeExamples(texts: string[], count: number): string[] {
-        if (count <= 0) {
+        if (!styleConfig || !styleConfig.enabled || styleConfig.rules.length === 0) {
             return [];
         }
 
-        if (texts.length <= count) {
-            return texts;
+        return styleRuleResolver.resolveRules(store, styleConfig.rules).slice(-limit);
+    }
+
+    async deriveStylePrompt(contact: TelegramContact, store: TelegramHistoryStore): Promise<DerivedStyleResult | null> {
+        const rawSamples = this.getRawStyleSamples(contact, store, 500);
+
+        if (rawSamples.length === 0) {
+            return null;
         }
 
-        const step = Math.max(1, Math.floor(texts.length / count));
-        const examples: string[] = [];
+        const mode = contact.assistantMode.provider
+            ? contact.assistantMode
+            : {
+                  ...DEFAULT_MODE_CONFIG.assistant,
+              };
 
-        for (let i = 0; i < texts.length && examples.length < count; i += step) {
-            const t = texts[i];
+        const content =
+            "You are deriving a style profile for one user's outbound Telegram writing. " +
+            "Output a concise system prompt that captures tone, pacing, sentence length, greeting habits, and conflict de-escalation style. " +
+            "Return only the final system prompt.\n\n" +
+            `Samples:\n${rawSamples.join("\n")}`;
 
-            if (t.length > 0 && t.length < 200) {
-                examples.push(t);
-            }
-        }
+        const prompt = await assistantEngine.ask({
+            sessionId: `style-${contact.userId}`,
+            mode,
+            incomingText: content,
+        });
 
-        return examples;
+        return {
+            prompt: prompt.trim(),
+            sampleCount: rawSamples.length,
+            generatedAt: new Date().toISOString(),
+            rawSamples: rawSamples.slice(-120),
+        };
     }
 }
+
+export const styleProfileEngine = new StyleProfileEngine();

--- a/src/telegram/lib/StyleRuleResolver.ts
+++ b/src/telegram/lib/StyleRuleResolver.ts
@@ -1,70 +1,45 @@
-import logger from "@app/logger";
-import { parseDate } from "./DateParser";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { MessageRowV2, StyleSourceRule } from "./types";
-
-const MAX_REGEX_LENGTH = 200;
-
-function hasObviousCatastrophicPattern(pattern: string): boolean {
-    return /(\([^)]*[+*][^)]*\))[+*]/.test(pattern) || /(\.\*){2,}/.test(pattern);
-}
+import type { StyleSourceRule } from "./types";
 
 export class StyleRuleResolver {
-    constructor(private store: TelegramHistoryStore) {}
+    resolveRule(store: TelegramHistoryStore, rule: StyleSourceRule): string[] {
+        const since = rule.since ? new Date(rule.since) : undefined;
+        const until = rule.until ? new Date(rule.until) : undefined;
+        const sender = rule.direction === "outgoing" ? "me" : "them";
 
-    resolveMessages(rules: StyleSourceRule[]): MessageRowV2[] {
-        const allMessages: MessageRowV2[] = [];
-
-        for (const rule of rules) {
-            const sender = rule.direction === "outgoing" ? "me" : "them";
-            const messages = this.store.queryMessages(rule.sourceChatId, {
+        let lines = store
+            .queryMessages(rule.sourceChatId, {
+                since,
+                until,
                 sender,
-                since: rule.since ? (parseDate(rule.since) ?? undefined) : undefined,
-                until: rule.until ? (parseDate(rule.until) ?? undefined) : undefined,
-                limit: rule.limit ?? 500,
-            });
+                limit: rule.limit,
+            })
+            .map((row) => row.text ?? row.media_desc ?? "")
+            .map((line) => line.trim())
+            .filter(Boolean);
 
-            let filtered = messages;
-
-            if (rule.regex) {
-                const pattern = rule.regex.trim();
-
-                if (!pattern || pattern.length > MAX_REGEX_LENGTH || hasObviousCatastrophicPattern(pattern)) {
-                    logger.warn({ ruleId: rule.id, pattern }, "Skipping unsafe style regex");
-                } else {
-                    try {
-                        const re = new RegExp(pattern, "i");
-                        filtered = filtered.filter((m) => {
-                            if (!m.text) {
-                                return false;
-                            }
-
-                            try {
-                                return re.test(m.text);
-                            } catch (err) {
-                                logger.warn({ err, ruleId: rule.id, pattern }, "Regex test failed; skipping rule");
-                                return false;
-                            }
-                        });
-                    } catch (err) {
-                        logger.warn({ err, ruleId: rule.id, pattern }, "Invalid style regex; skipping rule");
-                    }
-                }
+        if (rule.regex) {
+            try {
+                const regex = new RegExp(rule.regex, "i");
+                lines = lines.filter((line) => regex.test(line));
+            } catch {
+                // ignore invalid regex in rule
             }
-
-            allMessages.push(...filtered);
         }
 
-        const seen = new Set<string>();
-        return allMessages.filter((m) => {
-            const key = `${m.chat_id}:${m.id}`;
+        return lines;
+    }
 
-            if (seen.has(key)) {
-                return false;
-            }
+    resolveRules(store: TelegramHistoryStore, rules: StyleSourceRule[]): string[] {
+        const output: string[] = [];
 
-            seen.add(key);
-            return true;
-        });
+        for (const rule of rules) {
+            const ruleLines = this.resolveRule(store, rule);
+            output.push(...ruleLines);
+        }
+
+        return output;
     }
 }
+
+export const styleRuleResolver = new StyleRuleResolver();

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -1,169 +1,68 @@
-import { AIChat } from "@app/ask/index.lib";
-import { StyleProfileEngine } from "./StyleProfileEngine";
+import { assistantEngine } from "./AssistantEngine";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { SuggestionModeConfig, TelegramContactV2 } from "./types";
-import { DEFAULTS } from "./types";
+import type { SuggestionModeConfig } from "./types";
 
-interface SuggestionPromptInput {
-    contactName: string;
-    myName: string;
+export interface SuggestionRequest {
+    sessionId: string;
+    mode: SuggestionModeConfig;
+    incomingText: string;
+    incomingMessageId?: number;
+    conversationHistory?: string;
     stylePrompt?: string;
-    recentCorrections?: Array<{ suggested: string; sent: string }>;
-    count: number;
+    rawStyleSamples?: string[];
+    store?: TelegramHistoryStore;
+    chatId?: string;
+}
+
+function buildFeedbackExamples(store: TelegramHistoryStore | undefined, chatId: string | undefined): string {
+    if (!store || !chatId) {
+        return "";
+    }
+
+    const rows = store.getSuggestionFeedback(chatId, 25);
+
+    if (rows.length === 0) {
+        return "";
+    }
+
+    const lines = rows.map((row) => {
+        const editedSuffix = row.was_edited ? ` | edited="${row.edited_text ?? ""}"` : "";
+        return `suggested="${row.suggestion_text}" | sent="${row.sent_text}"${editedSuffix}`;
+    });
+
+    return `\n\n[Suggestion edit feedback]\n${lines.join("\n")}`;
 }
 
 export class SuggestionEngine {
-    private styleEngine: StyleProfileEngine;
-    private autoTriggerTimer: ReturnType<typeof setTimeout> | null = null;
+    async generateSuggestions(request: SuggestionRequest): Promise<string[]> {
+        const desired = Math.max(1, Math.min(request.mode.count, 5));
+        const feedbackExamples = buildFeedbackExamples(request.store, request.chatId);
+        const prompt =
+            `Generate ${desired} possible message replies. ` +
+            "Return each option on a new line without numbering. Keep each line under 220 characters." +
+            `\n\nLatest incoming message:\n${request.incomingText}` +
+            feedbackExamples;
 
-    constructor(
-        private store: TelegramHistoryStore,
-        private contact: TelegramContactV2,
-        private myName: string
-    ) {
-        this.styleEngine = new StyleProfileEngine(store);
-    }
-
-    private getConfig(): SuggestionModeConfig {
-        return this.contact.modes.suggestions;
-    }
-
-    async suggest(recentMessages: Array<{ sender: string; text: string }>, customPrompt?: string): Promise<string[]> {
-        const config = this.getConfig();
-
-        if (!config.enabled) {
-            return [];
-        }
-
-        const count = config.count ?? 3;
-
-        let stylePrompt: string | undefined;
-
-        if (this.contact.styleProfile?.enabled && this.contact.styleProfile.rules.length > 0) {
-            stylePrompt = this.styleEngine.buildStylePrompt({
-                rules: this.contact.styleProfile.rules,
-                exampleCount: 15,
-            });
-        }
-
-        const corrections = this.store
-            .getRecentSuggestionEdits(this.contact.userId, 10)
-            .filter((e) => e.suggested_text !== e.sent_text)
-            .map((e) => ({ suggested: e.suggested_text, sent: e.sent_text }));
-
-        const systemPrompt = SuggestionEngine.buildSuggestionPrompt({
-            contactName: this.contact.displayName,
-            myName: this.myName,
-            stylePrompt,
-            recentCorrections: corrections,
-            count,
+        const response = await assistantEngine.ask({
+            sessionId: `${request.sessionId}:suggestions`,
+            mode: request.mode,
+            conversationHistory: request.conversationHistory,
+            stylePrompt: request.stylePrompt,
+            rawStyleSamples: request.rawStyleSamples,
+            incomingText: prompt,
+            store: request.store,
+            chatId: request.chatId,
+            includeFullDbHistory: true,
         });
 
-        const context = recentMessages.map((m) => `${m.sender}: ${m.text}`).join("\n");
-
-        const userMessage = customPrompt
-            ? `${customPrompt}\n\nRecent conversation:\n${context}`
-            : `Generate ${count} reply suggestions for this conversation:\n\n${context}`;
-
-        const chat = new AIChat({
-            provider: config.provider ?? DEFAULTS.askProvider,
-            model: config.model ?? DEFAULTS.askModel,
-            systemPrompt,
-            temperature: config.temperature ?? 0.8,
-        });
-
-        const response = await chat.send(userMessage);
-        return SuggestionEngine.parseSuggestions(response.content);
-    }
-
-    trackEdit(suggestedText: string, editedText: string, sentText: string, messageId: number | null): void {
-        const config = this.getConfig();
-        this.store.insertSuggestionEdit({
-            chatId: this.contact.userId,
-            messageId,
-            suggestedText,
-            editedText,
-            sentText,
-            provider: config.provider ?? DEFAULTS.askProvider,
-            model: config.model ?? DEFAULTS.askModel,
-        });
-    }
-
-    scheduleAutoSuggest(
-        recentMessages: Array<{ sender: string; text: string }>,
-        onSuggestions: (suggestions: string[]) => void
-    ): void {
-        const config = this.getConfig();
-
-        if (!config.enabled || config.trigger === "manual") {
-            return;
-        }
-
-        if (this.autoTriggerTimer) {
-            clearTimeout(this.autoTriggerTimer);
-        }
-
-        this.autoTriggerTimer = setTimeout(async () => {
-            try {
-                const suggestions = await this.suggest(recentMessages);
-                onSuggestions(suggestions);
-            } catch {
-                // Silently fail for auto-suggest
-            }
-        }, config.autoDelayMs ?? 5000);
-    }
-
-    cancelAutoSuggest(): void {
-        if (this.autoTriggerTimer) {
-            clearTimeout(this.autoTriggerTimer);
-            this.autoTriggerTimer = null;
-        }
-    }
-
-    static buildSuggestionPrompt(input: SuggestionPromptInput): string {
-        const sections: string[] = [];
-
-        sections.push(`You are helping ${input.myName} craft replies to ${input.contactName} on Telegram.`);
-        sections.push(`Generate exactly ${input.count} distinct reply options.`);
-        sections.push("Each reply should feel natural and match the conversation tone.");
-        sections.push("Output ONLY a numbered list (1. 2. 3. etc.) with no other text.");
-
-        if (input.stylePrompt) {
-            sections.push("");
-            sections.push("## Writing Style to Match");
-            sections.push(input.stylePrompt);
-        }
-
-        if (input.recentCorrections && input.recentCorrections.length > 0) {
-            sections.push("");
-            sections.push("## Style Corrections (learn from these)");
-            sections.push("When I was suggested these, I changed them before sending:");
-
-            for (const c of input.recentCorrections.slice(0, 5)) {
-                sections.push(`- Suggested: "${c.suggested}" → Actually sent: "${c.sent}"`);
-            }
-
-            sections.push("Adjust your suggestions to match what I actually prefer to send.");
-        }
-
-        return sections.join("\n");
-    }
-
-    static parseSuggestions(raw: string): string[] {
-        const lines = raw
+        const lines = response
             .split("\n")
-            .map((l) => l.trim())
-            .filter(Boolean);
-        const suggestions: string[] = [];
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line) => line.replace(/^[-*\d.)\s]+/, ""));
 
-        for (const line of lines) {
-            const match = line.match(/^\d+[.):-]\s*(.+)/);
-
-            if (match) {
-                suggestions.push(match[1].trim());
-            }
-        }
-
-        return suggestions;
+        return lines.slice(0, desired);
     }
 }
+
+export const suggestionEngine = new SuggestionEngine();

--- a/src/telegram/lib/SyncRangePlanner.ts
+++ b/src/telegram/lib/SyncRangePlanner.ts
@@ -1,60 +1,37 @@
-interface SegmentInput {
-    from_date_unix: number;
-    to_date_unix: number;
-}
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 
-interface SyncRange {
-    from: number;
-    to: number;
+export interface PlannedSyncRange {
+    since: Date;
+    until: Date;
+    source: "query" | "full" | "incremental";
 }
 
 export class SyncRangePlanner {
-    static plan(segments: SegmentInput[], queryFrom: number, queryTo: number): SyncRange[] {
-        if (queryFrom > queryTo) {
-            throw new RangeError("queryFrom must be <= queryTo");
+    planQueryBackfill(store: TelegramHistoryStore, chatId: string, since: Date, until: Date): PlannedSyncRange[] {
+        const missing = store.getMissingSegments(chatId, since, until);
+
+        return missing.map((range) => ({
+            since: new Date(range.sinceUnix * 1000),
+            until: new Date(range.untilUnix * 1000),
+            source: "query" as const,
+        }));
+    }
+
+    planIncremental(lastSyncedId: number | null): PlannedSyncRange {
+        if (lastSyncedId === null) {
+            return {
+                since: new Date(0),
+                until: new Date(),
+                source: "full",
+            };
         }
 
-        if (segments.length === 0) {
-            return [{ from: queryFrom, to: queryTo }];
-        }
-
-        const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
-        const merged: SyncRange[] = [];
-
-        let current = { from: sorted[0].from_date_unix, to: sorted[0].to_date_unix };
-
-        for (let i = 1; i < sorted.length; i++) {
-            if (sorted[i].from_date_unix <= current.to) {
-                current.to = Math.max(current.to, sorted[i].to_date_unix);
-            } else {
-                merged.push(current);
-                current = { from: sorted[i].from_date_unix, to: sorted[i].to_date_unix };
-            }
-        }
-
-        merged.push(current);
-
-        const gaps: SyncRange[] = [];
-        const clipped = merged.filter((s) => s.to > queryFrom && s.from < queryTo);
-
-        if (clipped.length === 0) {
-            return [{ from: queryFrom, to: queryTo }];
-        }
-
-        if (clipped[0].from > queryFrom) {
-            gaps.push({ from: queryFrom, to: clipped[0].from });
-        }
-
-        for (let i = 0; i < clipped.length - 1; i++) {
-            if (clipped[i + 1].from > clipped[i].to) {
-                gaps.push({ from: clipped[i].to, to: clipped[i + 1].from });
-            }
-        }
-
-        if (clipped[clipped.length - 1].to < queryTo) {
-            gaps.push({ from: clipped[clipped.length - 1].to, to: queryTo });
-        }
-
-        return gaps;
+        return {
+            since: new Date(0),
+            until: new Date(),
+            source: "incremental",
+        };
     }
 }
+
+export const syncRangePlanner = new SyncRangePlanner();

--- a/src/telegram/lib/TGClient.ts
+++ b/src/telegram/lib/TGClient.ts
@@ -1,8 +1,8 @@
 import bigInt from "big-integer";
 import { Api, TelegramClient } from "telegram";
-import { NewMessage, type NewMessageEvent } from "telegram/events";
 import { DeletedMessage, type DeletedMessageEvent } from "telegram/events/DeletedMessage";
 import { EditedMessage, type EditedMessageEvent } from "telegram/events/EditedMessage";
+import { NewMessage, type NewMessageEvent } from "telegram/events/NewMessage";
 import { StringSession } from "telegram/sessions";
 import type { Dialog } from "telegram/tl/custom/dialog";
 import type { TelegramToolConfig } from "./TelegramToolConfig";
@@ -12,6 +12,11 @@ export interface AuthCallbacks {
     phoneNumber: () => Promise<string>;
     phoneCode: () => Promise<string>;
     password: () => Promise<string>;
+}
+
+export interface DownloadMediaOptions {
+    outputFile?: string;
+    thumb?: number | Api.TypePhotoSize;
 }
 
 export class TGClient {
@@ -58,7 +63,7 @@ export class TGClient {
     }
 
     async sendMessage(userId: string, text: string): Promise<Api.Message> {
-        return this.client.sendMessage(userId, { message: text });
+        return (await this.client.sendMessage(userId, { message: text })) as Api.Message;
     }
 
     async sendTyping(userId: string): Promise<void> {
@@ -110,30 +115,51 @@ export class TGClient {
         this.client.addEventHandler(handler, new DeletedMessage({}));
     }
 
+    async downloadMedia(
+        messageOrMedia: Api.Message | Api.TypeMessageMedia,
+        options: DownloadMediaOptions = {}
+    ): Promise<string | Buffer | undefined> {
+        return this.client.downloadMedia(messageOrMedia, {
+            outputFile: options.outputFile,
+            thumb: options.thumb,
+        });
+    }
+
     get raw(): TelegramClient {
         return this.client;
     }
 
-    // ── History methods (Phase 2 preparation) ──────────────────────────
+    // ── History methods ──────────────────────────────────────────────
 
     async *getMessages(
-        userId: string,
-        options: { limit?: number; offsetDate?: number; minId?: number; maxId?: number } = {}
+        chatId: string,
+        options: {
+            limit?: number;
+            offsetDate?: number;
+            minId?: number;
+            maxId?: number;
+            reverse?: boolean;
+        } = {}
     ): AsyncGenerator<Api.Message> {
-        for await (const message of this.client.iterMessages(userId, {
+        for await (const message of this.client.iterMessages(chatId, {
             limit: options.limit,
             offsetDate: options.offsetDate,
             minId: options.minId,
             maxId: options.maxId,
+            reverse: options.reverse,
         })) {
+            if (message.className !== "Message") {
+                continue;
+            }
+
             yield message;
         }
     }
 
-    async getMessageCount(userId: string): Promise<number> {
+    async getMessageCount(chatId: string): Promise<number> {
         const result = await this.client.invoke(
             new Api.messages.Search({
-                peer: await this.client.getInputEntity(userId),
+                peer: await this.client.getInputEntity(chatId),
                 q: "",
                 filter: new Api.InputMessagesFilterEmpty(),
                 minDate: 0,
@@ -152,5 +178,19 @@ export class TGClient {
         }
 
         return 0;
+    }
+
+    async getMessageById(chatId: string, messageId: number): Promise<Api.Message | null> {
+        for await (const message of this.getMessages(chatId, {
+            minId: Math.max(0, messageId - 1),
+            maxId: messageId + 1,
+            limit: 10,
+        })) {
+            if (message.id === messageId) {
+                return message;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/telegram/lib/TelegramContact.ts
+++ b/src/telegram/lib/TelegramContact.ts
@@ -1,77 +1,67 @@
-import type {
-    ActionType,
-    AskModeConfig,
-    ContactModesConfig,
-    StyleProfileConfig,
-    SuggestionModeConfig,
-    TelegramContactV2,
-    WatchConfig,
-} from "./types";
-import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
+import type { Api } from "telegram";
+import type { ActionType, AskModeConfig, ContactConfig, SuggestionModeConfig, TelegramRuntimeMode } from "./types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
 
 export class TelegramContact {
-    readonly userId: string;
-    readonly displayName: string;
-    readonly username: string | undefined;
-    readonly config: TelegramContactV2;
-
-    constructor(config: TelegramContactV2) {
-        this.userId = config.userId;
-        this.displayName = config.displayName;
-        this.username = config.username;
-        this.config = config;
-    }
+    constructor(
+        public readonly userId: string,
+        public readonly displayName: string,
+        public readonly username: string | undefined,
+        public readonly config: ContactConfig
+    ) {}
 
     get actions(): ActionType[] {
         return this.config.actions;
     }
 
-    get chatType() {
-        return this.config.chatType;
-    }
-
     get hasAskAction(): boolean {
-        return this.config.actions.includes("ask");
+        return this.actions.includes("ask") || this.autoReplyMode.enabled;
     }
 
-    get modes(): ContactModesConfig {
-        return this.config.modes ?? DEFAULT_MODE_CONFIG;
-    }
-
-    get autoReply(): AskModeConfig {
-        return this.modes.autoReply;
-    }
-
-    get assistant(): AskModeConfig {
-        return this.modes.assistant;
-    }
-
-    get suggestions(): SuggestionModeConfig {
-        return this.modes.suggestions;
-    }
-
-    get watch(): WatchConfig {
-        return this.config.watch ?? DEFAULT_WATCH_CONFIG;
+    get watchEnabled(): boolean {
+        return this.config.watch?.enabled ?? DEFAULT_WATCH_CONFIG.enabled;
     }
 
     get contextLength(): number {
-        return this.watch.contextLength;
+        return this.config.watch?.contextLength ?? DEFAULT_WATCH_CONFIG.contextLength;
     }
 
-    get styleProfile(): StyleProfileConfig {
-        return this.config.styleProfile ?? DEFAULT_STYLE_PROFILE;
+    get runtimeMode(): TelegramRuntimeMode {
+        return this.config.watch?.runtimeMode ?? DEFAULT_WATCH_CONFIG.runtimeMode ?? "daemon";
     }
 
-    get askProvider(): string {
-        return this.autoReply.provider ?? DEFAULTS.askProvider;
+    get autoReplyMode(): AskModeConfig {
+        return {
+            ...DEFAULT_MODE_CONFIG.autoReply,
+            ...this.config.modes?.autoReply,
+            enabled: this.config.modes?.autoReply?.enabled ?? this.actions.includes("ask"),
+        };
     }
 
-    get askModel(): string {
-        return this.autoReply.model ?? DEFAULTS.askModel;
+    get assistantMode(): AskModeConfig {
+        return {
+            ...DEFAULT_MODE_CONFIG.assistant,
+            ...this.config.modes?.assistant,
+        };
+    }
+
+    get suggestionMode(): SuggestionModeConfig {
+        return {
+            ...DEFAULT_MODE_CONFIG.suggestions,
+            ...this.config.modes?.suggestions,
+        };
     }
 
     get askSystemPrompt(): string {
-        return this.autoReply.systemPrompt ?? DEFAULTS.askSystemPrompt;
+        return this.autoReplyMode.systemPrompt ?? DEFAULTS.askSystemPrompt;
+    }
+
+    get askProvider(): string {
+        return this.autoReplyMode.provider ?? DEFAULTS.askProvider;
+    }
+
+    get askModel(): string {
+        return this.autoReplyMode.model ?? DEFAULTS.askModel;
     }
 
     get replyDelayMin(): number {
@@ -86,7 +76,18 @@ export class TelegramContact {
         return this.replyDelayMin + Math.random() * (this.replyDelayMax - this.replyDelayMin);
     }
 
-    static fromConfig(config: TelegramContactV2): TelegramContact {
-        return new TelegramContact(config);
+    static fromUser(user: Api.User, config: ContactConfig): TelegramContact {
+        const displayName = `${user.firstName || ""} ${user.lastName || ""}`.trim();
+
+        return new TelegramContact(
+            user.id.toString(),
+            displayName || config.displayName,
+            user.username ?? undefined,
+            config
+        );
+    }
+
+    static fromConfig(config: ContactConfig): TelegramContact {
+        return new TelegramContact(config.userId, config.displayName, config.username, config);
     }
 }

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -1,31 +1,36 @@
 import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import logger from "@app/logger";
 import { cosineDistance } from "@app/utils/math";
-import type { SerializedMessage } from "./TelegramMessage";
+import type { AttachmentDescriptor, SerializedMessage } from "./TelegramMessage";
 import type {
+    AttachmentLocator,
     AttachmentRow,
     ChatRow,
     ChatStats,
-    DateRange,
-    InsertSegmentInput,
-    MessageRevisionRow,
     MessageRow,
-    MessageRowV2,
-    QueryOptions,
+    MissingRange,
+    QueryMessagesOptions,
     SearchOptions,
     SearchResult,
-    SuggestionEditInput,
-    SuggestionEditRow,
+    SuggestionFeedbackRow,
     SyncSegmentRow,
     SyncStateRow,
-    UpsertAttachmentInput,
-    UpsertMessageInput,
 } from "./types";
 
 const DB_PATH = join(homedir(), ".genesis-tools", "telegram", "history.db");
+
+interface UpsertMessageResult {
+    inserted: boolean;
+    updated: boolean;
+}
+
+interface MessageRowWithEmbedding extends MessageRow {
+    embedding: Buffer;
+}
 
 export class TelegramHistoryStore {
     private db: Database | null = null;
@@ -45,7 +50,7 @@ export class TelegramHistoryStore {
         this.db.run("PRAGMA journal_mode = WAL");
         this.db.run("PRAGMA foreign_keys = ON");
 
-        this.migrate();
+        this.initSchema();
         logger.debug("TelegramHistoryStore opened");
     }
 
@@ -65,14 +70,49 @@ export class TelegramHistoryStore {
         return this.db;
     }
 
-    private migrate(): void {
+    private initSchema(): void {
         const db = this.getDb();
-        const { user_version: currentVersion } = db.query("PRAGMA user_version").get() as {
-            user_version: number;
-        };
+        const row = db.query("PRAGMA user_version").get() as { user_version: number };
+        let version = row.user_version;
 
-        if (currentVersion < 1) {
-            db.run(`CREATE TABLE IF NOT EXISTS messages (
+        if (version < 1) {
+            this.createBaseSchemaV1();
+            db.run("PRAGMA user_version = 1");
+            version = 1;
+        }
+
+        if (version < 2) {
+            this.migrateToV2();
+            db.run("PRAGMA user_version = 2");
+            version = 2;
+        }
+
+        if (version >= 2) {
+            this.ensureV2Schema();
+        }
+
+        this.ensureFtsTable();
+        this.ensureFtsTriggers();
+    }
+
+    private ensureFtsTable(): void {
+        const db = this.getDb();
+
+        db.run(`
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                text,
+                content=messages,
+                content_rowid=rowid,
+                tokenize='unicode61'
+            )
+        `);
+    }
+
+    private createBaseSchemaV1(): void {
+        const db = this.getDb();
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS messages (
                 id INTEGER NOT NULL,
                 chat_id TEXT NOT NULL,
                 sender_id TEXT,
@@ -82,90 +122,95 @@ export class TelegramHistoryStore {
                 date_unix INTEGER NOT NULL,
                 date_iso TEXT NOT NULL,
                 PRIMARY KEY (chat_id, id)
-            )`);
-            db.run(`CREATE INDEX IF NOT EXISTS idx_messages_chat_date ON messages(chat_id, date_unix)`);
-            db.run(`CREATE TABLE IF NOT EXISTS sync_state (
+            )
+        `);
+
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_messages_chat_date
+            ON messages(chat_id, date_unix)
+        `);
+
+        db.run(`
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                text,
+                content=messages,
+                content_rowid=rowid,
+                tokenize='unicode61'
+            )
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS sync_state (
                 chat_id TEXT PRIMARY KEY,
                 last_synced_id INTEGER NOT NULL,
                 last_synced_at TEXT NOT NULL
-            )`);
-            db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-                text, content=messages, content_rowid=rowid, tokenize='unicode61'
-            )`);
+            )
+        `);
 
-            try {
-                db.run(`CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
-                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
-                END`);
-            } catch {
-                // trigger already exists
-            }
-
-            try {
-                db.run(`CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
-                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
-                END`);
-            } catch {
-                // trigger already exists
-            }
-
-            try {
-                db.run(`CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
-                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
-                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
-                END`);
-            } catch {
-                // trigger already exists
-            }
-
-            db.run(`CREATE TABLE IF NOT EXISTS embeddings (
+        db.run(`
+            CREATE TABLE IF NOT EXISTS embeddings (
                 message_rowid INTEGER PRIMARY KEY,
                 embedding BLOB NOT NULL
-            )`);
+            )
+        `);
+    }
+
+    private migrateToV2(): void {
+        const db = this.getDb();
+
+        if (!this.hasColumn("messages", "edited_date_unix")) {
+            db.run("ALTER TABLE messages ADD COLUMN edited_date_unix INTEGER");
         }
 
-        if (currentVersion < 2) {
-            const existingCols = new Set(
-                (db.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>).map((c) => c.name)
-            );
+        if (!this.hasColumn("messages", "is_deleted")) {
+            db.run("ALTER TABLE messages ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0");
+        }
 
-            if (!existingCols.has("edited_date_unix")) {
-                db.run("ALTER TABLE messages ADD COLUMN edited_date_unix INTEGER");
-            }
+        if (!this.hasColumn("messages", "deleted_at_iso")) {
+            db.run("ALTER TABLE messages ADD COLUMN deleted_at_iso TEXT");
+        }
 
-            if (!existingCols.has("is_deleted")) {
-                db.run("ALTER TABLE messages ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0");
-            }
+        if (!this.hasColumn("messages", "reply_to_msg_id")) {
+            db.run("ALTER TABLE messages ADD COLUMN reply_to_msg_id INTEGER");
+        }
 
-            if (!existingCols.has("deleted_at_iso")) {
-                db.run("ALTER TABLE messages ADD COLUMN deleted_at_iso TEXT");
-            }
+        this.ensureV2Schema();
+    }
 
-            if (!existingCols.has("reply_to_msg_id")) {
-                db.run("ALTER TABLE messages ADD COLUMN reply_to_msg_id INTEGER");
-            }
+    private ensureV2Schema(): void {
+        const db = this.getDb();
 
-            db.run(`CREATE TABLE IF NOT EXISTS chats (
+        db.run(`
+            CREATE TABLE IF NOT EXISTS chats (
                 chat_id TEXT PRIMARY KEY,
-                chat_type TEXT NOT NULL DEFAULT 'user',
+                chat_type TEXT NOT NULL,
                 title TEXT NOT NULL,
                 username TEXT,
-                last_synced_at TEXT
-            )`);
+                last_seen_at_iso TEXT NOT NULL
+            )
+        `);
 
-            db.run(`CREATE TABLE IF NOT EXISTS message_revisions (
+        db.run(`
+            CREATE TABLE IF NOT EXISTS message_revisions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 chat_id TEXT NOT NULL,
                 message_id INTEGER NOT NULL,
                 revision_type TEXT NOT NULL,
-                old_text TEXT,
-                new_text TEXT,
-                revised_at_unix INTEGER NOT NULL,
-                revised_at_iso TEXT NOT NULL
-            )`);
-            db.run(`CREATE INDEX IF NOT EXISTS idx_revisions_chat_msg ON message_revisions(chat_id, message_id)`);
+                text TEXT,
+                media_desc TEXT,
+                date_iso TEXT NOT NULL,
+                date_unix INTEGER NOT NULL,
+                UNIQUE(chat_id, message_id, revision_type, date_unix)
+            )
+        `);
 
-            db.run(`CREATE TABLE IF NOT EXISTS attachments (
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_message_revisions_chat_msg
+            ON message_revisions(chat_id, message_id, date_unix)
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS attachments (
                 chat_id TEXT NOT NULL,
                 message_id INTEGER NOT NULL,
                 attachment_index INTEGER NOT NULL,
@@ -174,72 +219,516 @@ export class TelegramHistoryStore {
                 file_name TEXT,
                 file_size INTEGER,
                 telegram_file_id TEXT,
+                thumb_count INTEGER NOT NULL DEFAULT 0,
                 is_downloaded INTEGER NOT NULL DEFAULT 0,
                 local_path TEXT,
                 sha256 TEXT,
+                created_at_iso TEXT NOT NULL,
+                updated_at_iso TEXT NOT NULL,
                 PRIMARY KEY (chat_id, message_id, attachment_index)
-            )`);
+            )
+        `);
 
-            db.run(`CREATE TABLE IF NOT EXISTS sync_segments (
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_attachments_chat_message
+            ON attachments(chat_id, message_id)
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS sync_segments (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 chat_id TEXT NOT NULL,
-                from_date_unix INTEGER NOT NULL,
-                to_date_unix INTEGER NOT NULL,
-                from_msg_id INTEGER NOT NULL,
-                to_msg_id INTEGER NOT NULL,
-                synced_at TEXT NOT NULL
-            )`);
-            db.run(`CREATE INDEX IF NOT EXISTS idx_sync_segments_chat ON sync_segments(chat_id, from_date_unix)`);
+                start_unix INTEGER NOT NULL,
+                end_unix INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                created_at_iso TEXT NOT NULL
+            )
+        `);
 
-            db.run(`CREATE TABLE IF NOT EXISTS suggestion_edits (
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_sync_segments_chat_range
+            ON sync_segments(chat_id, start_unix, end_unix)
+        `);
+
+        db.run(`
+            CREATE TABLE IF NOT EXISTS suggestion_feedback (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 chat_id TEXT NOT NULL,
-                message_id INTEGER,
-                suggested_text TEXT NOT NULL,
-                edited_text TEXT NOT NULL,
+                incoming_message_id INTEGER,
+                suggestion_text TEXT NOT NULL,
+                edited_text TEXT,
                 sent_text TEXT NOT NULL,
-                provider TEXT,
-                model TEXT,
-                created_at TEXT NOT NULL
-            )`);
-            db.run(`CREATE INDEX IF NOT EXISTS idx_suggestion_edits_chat ON suggestion_edits(chat_id)`);
-        }
+                was_edited INTEGER NOT NULL DEFAULT 0,
+                created_at_iso TEXT NOT NULL
+            )
+        `);
 
-        db.run("PRAGMA user_version = 2");
+        db.run(`
+            CREATE INDEX IF NOT EXISTS idx_suggestion_feedback_chat_time
+            ON suggestion_feedback(chat_id, created_at_iso DESC)
+        `);
     }
 
-    // ── Insert ────────────────────────────────────────────────────────
+    private ensureFtsTriggers(): void {
+        const db = this.getDb();
+
+        try {
+            db.run(`
+                CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+                END
+            `);
+        } catch {
+            // trigger already exists
+        }
+
+        try {
+            db.run(`
+                CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                END
+            `);
+        } catch {
+            // trigger already exists
+        }
+
+        try {
+            db.run(`
+                CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+                END
+            `);
+        } catch {
+            // trigger already exists
+        }
+    }
+
+    private hasColumn(table: string, column: string): boolean {
+        const db = this.getDb();
+        const rows = db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+
+        return rows.some((row) => row.name === column);
+    }
+
+    private toMessageRow(row: Record<string, unknown>): MessageRow {
+        return {
+            id: Number(row.id),
+            chat_id: String(row.chat_id),
+            sender_id: row.sender_id === null ? null : String(row.sender_id),
+            text: row.text === null ? null : String(row.text),
+            media_desc: row.media_desc === null ? null : String(row.media_desc),
+            is_outgoing: Number(row.is_outgoing),
+            date_unix: Number(row.date_unix),
+            date_iso: String(row.date_iso),
+            edited_date_unix: row.edited_date_unix === null ? null : Number(row.edited_date_unix),
+            is_deleted: Number(row.is_deleted ?? 0),
+            deleted_at_iso: row.deleted_at_iso === null ? null : String(row.deleted_at_iso),
+            reply_to_msg_id: row.reply_to_msg_id === null ? null : Number(row.reply_to_msg_id),
+        };
+    }
+
+    // ── Chat Metadata ────────────────────────────────────────────────
+
+    upsertChat(chat: Omit<ChatRow, "last_seen_at_iso">): void {
+        const db = this.getDb();
+
+        db.run(
+            `
+            INSERT INTO chats (chat_id, chat_type, title, username, last_seen_at_iso)
+            VALUES (?, ?, ?, ?, datetime('now'))
+            ON CONFLICT(chat_id) DO UPDATE SET
+                chat_type = excluded.chat_type,
+                title = excluded.title,
+                username = excluded.username,
+                last_seen_at_iso = excluded.last_seen_at_iso
+            `,
+            [chat.chat_id, chat.chat_type, chat.title, chat.username ?? null]
+        );
+    }
+
+    // ── Insert / Upsert ──────────────────────────────────────────────
 
     insertMessages(chatId: string, messages: SerializedMessage[]): number {
-        const db = this.getDb();
         let inserted = 0;
 
-        const insertStmt = db.prepare(`
-			INSERT OR IGNORE INTO messages (id, chat_id, sender_id, text, media_desc, is_outgoing, date_unix, date_iso)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-		`);
+        for (const msg of messages) {
+            const result = this.upsertMessageWithRevision(chatId, msg, "create");
 
-        const insertMany = db.transaction(() => {
-            for (const msg of messages) {
-                const result = insertStmt.run(
-                    msg.id,
-                    chatId,
-                    msg.senderId ?? null,
-                    msg.text || null,
-                    msg.mediaDescription ?? null,
-                    msg.isOutgoing ? 1 : 0,
-                    msg.dateUnix,
-                    msg.date
-                );
-
-                if (result.changes > 0) {
-                    inserted++;
-                }
+            if (result.inserted) {
+                inserted++;
             }
-        });
+        }
 
-        insertMany();
         return inserted;
+    }
+
+    upsertMessageWithRevision(
+        chatId: string,
+        message: SerializedMessage,
+        revisionType: "create" | "edit" = "create"
+    ): UpsertMessageResult {
+        const db = this.getDb();
+        const existing = db
+            .query(
+                `
+                SELECT text, media_desc, edited_date_unix, is_deleted, reply_to_msg_id
+                FROM messages
+                WHERE chat_id = ? AND id = ?
+                `
+            )
+            .get(chatId, message.id) as {
+            text: string | null;
+            media_desc: string | null;
+            edited_date_unix: number | null;
+            is_deleted: number;
+            reply_to_msg_id: number | null;
+        } | null;
+
+        if (!existing) {
+            db.run(
+                `
+                INSERT INTO messages (
+                    id,
+                    chat_id,
+                    sender_id,
+                    text,
+                    media_desc,
+                    is_outgoing,
+                    date_unix,
+                    date_iso,
+                    edited_date_unix,
+                    is_deleted,
+                    deleted_at_iso,
+                    reply_to_msg_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)
+                `,
+                [
+                    message.id,
+                    chatId,
+                    message.senderId ?? null,
+                    message.text || null,
+                    message.mediaDescription ?? null,
+                    message.isOutgoing ? 1 : 0,
+                    message.dateUnix,
+                    message.date,
+                    message.editedDateUnix ?? null,
+                    message.replyToMsgId ?? null,
+                ]
+            );
+
+            this.insertMessageRevision(
+                chatId,
+                message.id,
+                revisionType,
+                message.text,
+                message.mediaDescription,
+                message.dateUnix
+            );
+
+            if (message.attachments && message.attachments.length > 0) {
+                this.upsertAttachments(chatId, message.id, message.attachments);
+            }
+
+            return { inserted: true, updated: false };
+        }
+
+        const normalizedText = message.text || null;
+        const normalizedMedia = message.mediaDescription ?? null;
+        const normalizedEdited = message.editedDateUnix ?? null;
+        const normalizedReplyTo = message.replyToMsgId ?? null;
+
+        const changed =
+            existing.text !== normalizedText ||
+            existing.media_desc !== normalizedMedia ||
+            existing.edited_date_unix !== normalizedEdited ||
+            existing.reply_to_msg_id !== normalizedReplyTo ||
+            existing.is_deleted !== 0;
+
+        if (!changed) {
+            if (message.attachments && message.attachments.length > 0) {
+                this.upsertAttachments(chatId, message.id, message.attachments);
+            }
+
+            return { inserted: false, updated: false };
+        }
+
+        db.run(
+            `
+            UPDATE messages
+            SET
+                sender_id = ?,
+                text = ?,
+                media_desc = ?,
+                is_outgoing = ?,
+                date_unix = ?,
+                date_iso = ?,
+                edited_date_unix = ?,
+                is_deleted = 0,
+                deleted_at_iso = NULL,
+                reply_to_msg_id = ?
+            WHERE chat_id = ? AND id = ?
+            `,
+            [
+                message.senderId ?? null,
+                normalizedText,
+                normalizedMedia,
+                message.isOutgoing ? 1 : 0,
+                message.dateUnix,
+                message.date,
+                normalizedEdited,
+                normalizedReplyTo,
+                chatId,
+                message.id,
+            ]
+        );
+
+        this.insertMessageRevision(
+            chatId,
+            message.id,
+            "edit",
+            message.text,
+            message.mediaDescription,
+            message.dateUnix
+        );
+
+        if (message.attachments && message.attachments.length > 0) {
+            this.upsertAttachments(chatId, message.id, message.attachments);
+        }
+
+        return { inserted: false, updated: true };
+    }
+
+    markMessageDeleted(chatId: string, messageId: number, deletedAtUnix: number = Math.floor(Date.now() / 1000)): void {
+        const db = this.getDb();
+        const existing = db.query("SELECT id FROM messages WHERE chat_id = ? AND id = ?").get(chatId, messageId) as {
+            id: number;
+        } | null;
+
+        if (!existing) {
+            return;
+        }
+
+        const deletedIso = new Date(deletedAtUnix * 1000).toISOString();
+
+        db.run(
+            `
+            UPDATE messages
+            SET is_deleted = 1,
+                deleted_at_iso = ?
+            WHERE chat_id = ? AND id = ?
+            `,
+            [deletedIso, chatId, messageId]
+        );
+
+        this.insertMessageRevision(chatId, messageId, "delete", null, null, deletedAtUnix);
+    }
+
+    private insertMessageRevision(
+        chatId: string,
+        messageId: number,
+        revisionType: "create" | "edit" | "delete",
+        text: string | null | undefined,
+        mediaDescription: string | null | undefined,
+        dateUnix: number
+    ): void {
+        const db = this.getDb();
+        const dateIso = new Date(dateUnix * 1000).toISOString();
+
+        db.run(
+            `
+            INSERT OR IGNORE INTO message_revisions (
+                chat_id,
+                message_id,
+                revision_type,
+                text,
+                media_desc,
+                date_iso,
+                date_unix
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            `,
+            [chatId, messageId, revisionType, text ?? null, mediaDescription ?? null, dateIso, dateUnix]
+        );
+    }
+
+    upsertAttachments(chatId: string, messageId: number, attachments: AttachmentDescriptor[]): void {
+        const db = this.getDb();
+        const now = new Date().toISOString();
+
+        for (const attachment of attachments) {
+            db.run(
+                `
+                INSERT INTO attachments (
+                    chat_id,
+                    message_id,
+                    attachment_index,
+                    kind,
+                    mime_type,
+                    file_name,
+                    file_size,
+                    telegram_file_id,
+                    thumb_count,
+                    is_downloaded,
+                    local_path,
+                    sha256,
+                    created_at_iso,
+                    updated_at_iso
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, ?, ?)
+                ON CONFLICT(chat_id, message_id, attachment_index) DO UPDATE SET
+                    kind = excluded.kind,
+                    mime_type = excluded.mime_type,
+                    file_name = excluded.file_name,
+                    file_size = excluded.file_size,
+                    telegram_file_id = excluded.telegram_file_id,
+                    thumb_count = excluded.thumb_count,
+                    updated_at_iso = excluded.updated_at_iso
+                `,
+                [
+                    chatId,
+                    messageId,
+                    attachment.index,
+                    attachment.kind,
+                    attachment.mimeType ?? null,
+                    attachment.fileName ?? null,
+                    attachment.fileSize ?? null,
+                    attachment.telegramFileId ?? null,
+                    attachment.thumbCount,
+                    now,
+                    now,
+                ]
+            );
+        }
+    }
+
+    markAttachmentDownloaded(locator: AttachmentLocator, localPath: string, content: Buffer): void {
+        const db = this.getDb();
+        const now = new Date().toISOString();
+        const hash = createHash("sha256").update(content).digest("hex");
+
+        db.run(
+            `
+            UPDATE attachments
+            SET is_downloaded = 1,
+                local_path = ?,
+                sha256 = ?,
+                updated_at_iso = ?
+            WHERE chat_id = ? AND message_id = ? AND attachment_index = ?
+            `,
+            [localPath, hash, now, locator.chatId, locator.messageId, locator.attachmentIndex]
+        );
+    }
+
+    listAttachments(
+        chatId: string,
+        options: {
+            since?: Date;
+            until?: Date;
+            messageId?: number;
+            limit?: number;
+        } = {}
+    ): AttachmentRow[] {
+        const db = this.getDb();
+        const params: Array<number | string> = [chatId];
+        let where = "WHERE a.chat_id = ?";
+
+        if (options.messageId !== undefined) {
+            where += " AND a.message_id = ?";
+            params.push(options.messageId);
+        }
+
+        if (options.since) {
+            where += " AND m.date_unix >= ?";
+            params.push(Math.floor(options.since.getTime() / 1000));
+        }
+
+        if (options.until) {
+            where += " AND m.date_unix <= ?";
+            params.push(Math.floor(options.until.getTime() / 1000));
+        }
+
+        const limit = options.limit ?? 200;
+        params.push(limit);
+
+        return db
+            .query(
+                `
+                SELECT a.*
+                FROM attachments a
+                JOIN messages m
+                ON m.chat_id = a.chat_id AND m.id = a.message_id
+                ${where}
+                ORDER BY m.date_unix DESC, a.attachment_index ASC
+                LIMIT ?
+                `
+            )
+            .all(...params) as AttachmentRow[];
+    }
+
+    getAttachment(locator: AttachmentLocator): AttachmentRow | null {
+        const db = this.getDb();
+
+        return (
+            (db
+                .query(
+                    `
+                SELECT *
+                FROM attachments
+                WHERE chat_id = ?
+                    AND message_id = ?
+                    AND attachment_index = ?
+                `
+                )
+                .get(locator.chatId, locator.messageId, locator.attachmentIndex) as AttachmentRow | null) ?? null
+        );
+    }
+
+    recordSuggestionFeedback(options: {
+        chatId: string;
+        incomingMessageId?: number;
+        suggestionText: string;
+        sentText: string;
+        editedText?: string;
+    }): void {
+        const db = this.getDb();
+        const wasEdited = options.editedText !== undefined && options.editedText !== options.suggestionText;
+
+        db.run(
+            `
+            INSERT INTO suggestion_feedback (
+                chat_id,
+                incoming_message_id,
+                suggestion_text,
+                edited_text,
+                sent_text,
+                was_edited,
+                created_at_iso
+            ) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+            `,
+            [
+                options.chatId,
+                options.incomingMessageId ?? null,
+                options.suggestionText,
+                options.editedText ?? null,
+                options.sentText,
+                wasEdited ? 1 : 0,
+            ]
+        );
+    }
+
+    getSuggestionFeedback(chatId: string, limit = 40): SuggestionFeedbackRow[] {
+        const db = this.getDb();
+
+        return db
+            .query(
+                `
+                SELECT *
+                FROM suggestion_feedback
+                WHERE chat_id = ?
+                ORDER BY created_at_iso DESC
+                LIMIT ?
+                `
+            )
+            .all(chatId, limit) as SuggestionFeedbackRow[];
     }
 
     // ── Embeddings ────────────────────────────────────────────────────
@@ -248,18 +737,22 @@ export class TelegramHistoryStore {
         const db = this.getDb();
 
         return db
-            .query(`
-			SELECT m.*
-			FROM messages m
-			LEFT JOIN embeddings e ON e.message_rowid = m.rowid
-			WHERE m.chat_id = ?
-				AND m.text IS NOT NULL
-				AND m.text != ''
-				AND e.message_rowid IS NULL
-			ORDER BY m.date_unix ASC
-			LIMIT ?
-		`)
-            .all(chatId, limit) as MessageRow[];
+            .query(
+                `
+                SELECT m.*
+                FROM messages m
+                LEFT JOIN embeddings e ON e.message_rowid = m.rowid
+                WHERE m.chat_id = ?
+                    AND m.text IS NOT NULL
+                    AND m.text != ''
+                    AND m.is_deleted = 0
+                    AND e.message_rowid IS NULL
+                ORDER BY m.date_unix ASC
+                LIMIT ?
+                `
+            )
+            .all(chatId, limit)
+            .map((row) => this.toMessageRow(row as Record<string, unknown>));
     }
 
     insertEmbedding(chatId: string, messageId: number, embedding: Float32Array): void {
@@ -283,12 +776,14 @@ export class TelegramHistoryStore {
         const db = this.getDb();
 
         const row = db
-            .query(`
-			SELECT COUNT(*) AS cnt
-			FROM embeddings e
-			JOIN messages m ON m.rowid = e.message_rowid
-			WHERE m.chat_id = ?
-		`)
+            .query(
+                `
+                SELECT COUNT(*) AS cnt
+                FROM embeddings e
+                JOIN messages m ON m.rowid = e.message_rowid
+                WHERE m.chat_id = ?
+                `
+            )
             .get(chatId) as { cnt: number };
 
         return row.cnt;
@@ -299,7 +794,6 @@ export class TelegramHistoryStore {
     search(chatId: string, query: string, options: SearchOptions = {}): SearchResult[] {
         const db = this.getDb();
 
-        // FTS5 query — wrap each word in quotes for safe matching
         const ftsQuery = query
             .replace(/['"]/g, "")
             .split(/\s+/)
@@ -312,9 +806,8 @@ export class TelegramHistoryStore {
         }
 
         const limit = options.limit ?? 20;
-
         let dateFilter = "";
-        const params: (string | number)[] = [ftsQuery, chatId];
+        const params: Array<number | string> = [ftsQuery, chatId];
 
         if (options.since) {
             dateFilter += " AND m.date_unix >= ?";
@@ -329,30 +822,22 @@ export class TelegramHistoryStore {
         params.push(limit);
 
         const sql = `
-			SELECT m.*, fts.rank
-			FROM messages_fts fts
-			JOIN messages m ON m.rowid = fts.rowid
-			WHERE messages_fts MATCH ?
-				AND m.chat_id = ?
-				${dateFilter}
-			ORDER BY fts.rank
-			LIMIT ?
-		`;
+            SELECT m.*, fts.rank
+            FROM messages_fts fts
+            JOIN messages m ON m.rowid = fts.rowid
+            WHERE messages_fts MATCH ?
+                AND m.chat_id = ?
+                AND m.is_deleted = 0
+                ${dateFilter}
+            ORDER BY fts.rank
+            LIMIT ?
+        `;
 
-        const rows = db.query(sql).all(...params) as Array<MessageRow & { rank: number }>;
+        const rows = db.query(sql).all(...params) as Array<Record<string, unknown> & { rank: number }>;
 
         return rows.map((row) => ({
-            message: {
-                id: row.id,
-                chat_id: row.chat_id,
-                sender_id: row.sender_id,
-                text: row.text,
-                media_desc: row.media_desc,
-                is_outgoing: row.is_outgoing,
-                date_unix: row.date_unix,
-                date_iso: row.date_iso,
-            },
-            rank: row.rank,
+            message: this.toMessageRow(row),
+            rank: Number(row.rank),
         }));
     }
 
@@ -361,7 +846,7 @@ export class TelegramHistoryStore {
         const limit = options.limit ?? 20;
 
         let dateFilter = "";
-        const params: (string | number)[] = [chatId];
+        const params: Array<number | string> = [chatId];
 
         if (options.since) {
             dateFilter += " AND m.date_unix >= ?";
@@ -373,18 +858,16 @@ export class TelegramHistoryStore {
             params.push(Math.floor(options.until.getTime() / 1000));
         }
 
-        // Fetch all embedded messages for this chat (with date filter)
         const sql = `
-			SELECT m.*, e.embedding
-			FROM embeddings e
-			JOIN messages m ON m.rowid = e.message_rowid
-			WHERE m.chat_id = ?
-				${dateFilter}
-		`;
+            SELECT m.*, e.embedding
+            FROM embeddings e
+            JOIN messages m ON m.rowid = e.message_rowid
+            WHERE m.chat_id = ?
+                AND m.is_deleted = 0
+                ${dateFilter}
+        `;
 
-        const rows = db.query(sql).all(...params) as Array<MessageRow & { embedding: Buffer }>;
-
-        // Brute-force cosine similarity in TypeScript
+        const rows = db.query(sql).all(...params) as MessageRowWithEmbedding[];
         const scored: Array<{ message: MessageRow; distance: number }> = [];
 
         for (const row of rows) {
@@ -396,16 +879,7 @@ export class TelegramHistoryStore {
             const distance = cosineDistance(queryEmbedding, storedVec);
 
             scored.push({
-                message: {
-                    id: row.id,
-                    chat_id: row.chat_id,
-                    sender_id: row.sender_id,
-                    text: row.text,
-                    media_desc: row.media_desc,
-                    is_outgoing: row.is_outgoing,
-                    date_unix: row.date_unix,
-                    date_iso: row.date_iso,
-                },
+                message: this.toMessageRow(row as unknown as Record<string, unknown>),
                 distance,
             });
         }
@@ -426,32 +900,30 @@ export class TelegramHistoryStore {
     ): SearchResult[] {
         const ftsResults = this.search(chatId, query, { ...options, limit: 100 });
         const vecResults = this.semanticSearch(chatId, queryEmbedding, { ...options, limit: 100 });
-
-        // Reciprocal Rank Fusion (k=60)
         const K = 60;
         const scores = new Map<number, { score: number; row: MessageRow }>();
 
         for (let i = 0; i < ftsResults.length; i++) {
-            const r = ftsResults[i];
+            const result = ftsResults[i];
             const rrfScore = 1.0 / (K + i + 1);
-            const existing = scores.get(r.message.id);
+            const existing = scores.get(result.message.id);
 
             if (existing) {
                 existing.score += rrfScore;
             } else {
-                scores.set(r.message.id, { score: rrfScore, row: r.message });
+                scores.set(result.message.id, { score: rrfScore, row: result.message });
             }
         }
 
         for (let i = 0; i < vecResults.length; i++) {
-            const r = vecResults[i];
+            const result = vecResults[i];
             const rrfScore = 1.0 / (K + i + 1);
-            const existing = scores.get(r.message.id);
+            const existing = scores.get(result.message.id);
 
             if (existing) {
                 existing.score += rrfScore;
             } else {
-                scores.set(r.message.id, { score: rrfScore, row: r.message });
+                scores.set(result.message.id, { score: rrfScore, row: result.message });
             }
         }
 
@@ -466,37 +938,154 @@ export class TelegramHistoryStore {
             }));
     }
 
-    // ── Date Range Queries ────────────────────────────────────────────
+    // ── Date/Query ────────────────────────────────────────────────────
 
     getByDateRange(chatId: string, since?: Date, until?: Date, limit?: number): MessageRow[] {
+        return this.queryMessages(chatId, {
+            since,
+            until,
+            sender: "any",
+            limit,
+        });
+    }
+
+    queryMessages(chatId: string, options: QueryMessagesOptions = {}): MessageRow[] {
         const db = this.getDb();
-        const params: (string | number)[] = [chatId];
-        let dateFilter = "";
+        const params: Array<number | string> = [chatId];
+        const where: string[] = ["chat_id = ?"];
 
-        if (since) {
-            dateFilter += " AND date_unix >= ?";
-            params.push(Math.floor(since.getTime() / 1000));
+        if (options.since) {
+            where.push("date_unix >= ?");
+            params.push(Math.floor(options.since.getTime() / 1000));
         }
 
-        if (until) {
-            dateFilter += " AND date_unix <= ?";
-            params.push(Math.floor(until.getTime() / 1000));
+        if (options.until) {
+            where.push("date_unix <= ?");
+            params.push(Math.floor(options.until.getTime() / 1000));
         }
 
-        const limitClause = limit ? " LIMIT ?" : "";
-
-        if (limit) {
-            params.push(limit);
+        if (options.sender === "me") {
+            where.push("is_outgoing = 1");
         }
+
+        if (options.sender === "them") {
+            where.push("is_outgoing = 0");
+        }
+
+        let limitClause = "";
+
+        if (options.limit !== undefined) {
+            limitClause = "LIMIT ?";
+            params.push(options.limit);
+        }
+
+        const rows = db
+            .query(
+                `
+                SELECT *
+                FROM messages
+                WHERE ${where.join(" AND ")}
+                ORDER BY date_unix ASC
+                ${limitClause}
+                `
+            )
+            .all(...params)
+            .map((row) => this.toMessageRow(row as Record<string, unknown>));
+
+        if (!options.textRegex) {
+            return rows;
+        }
+
+        try {
+            const regex = new RegExp(options.textRegex, "i");
+            return rows.filter((row) => {
+                const text = row.text ?? row.media_desc ?? "";
+                return regex.test(text);
+            });
+        } catch {
+            return rows;
+        }
+    }
+
+    // ── Sync Coverage ────────────────────────────────────────────────
+
+    insertSyncSegment(
+        chatId: string,
+        sinceUnix: number,
+        untilUnix: number,
+        source: "full" | "incremental" | "query"
+    ): void {
+        const db = this.getDb();
+        const start = Math.min(sinceUnix, untilUnix);
+        const end = Math.max(sinceUnix, untilUnix);
+
+        db.run(
+            `
+            INSERT INTO sync_segments (chat_id, start_unix, end_unix, source, created_at_iso)
+            VALUES (?, ?, ?, ?, datetime('now'))
+            `,
+            [chatId, start, end, source]
+        );
+    }
+
+    getSyncSegments(chatId: string): SyncSegmentRow[] {
+        const db = this.getDb();
 
         return db
-            .query(`
-			SELECT * FROM messages
-			WHERE chat_id = ? ${dateFilter}
-			ORDER BY date_unix ASC
-			${limitClause}
-		`)
-            .all(...params) as MessageRow[];
+            .query(
+                `
+                SELECT *
+                FROM sync_segments
+                WHERE chat_id = ?
+                ORDER BY start_unix ASC, end_unix ASC
+                `
+            )
+            .all(chatId) as SyncSegmentRow[];
+    }
+
+    getMissingSegments(chatId: string, since: Date, until: Date): MissingRange[] {
+        const targetStart = Math.floor(since.getTime() / 1000);
+        const targetEnd = Math.floor(until.getTime() / 1000);
+        const segments = this.getSyncSegments(chatId)
+            .filter((segment) => segment.end_unix >= targetStart && segment.start_unix <= targetEnd)
+            .sort((a, b) => a.start_unix - b.start_unix);
+
+        if (segments.length === 0) {
+            return [{ sinceUnix: targetStart, untilUnix: targetEnd }];
+        }
+
+        const gaps: MissingRange[] = [];
+        let cursor = targetStart;
+
+        for (const segment of segments) {
+            if (segment.start_unix > cursor) {
+                gaps.push({
+                    sinceUnix: cursor,
+                    untilUnix: Math.min(segment.start_unix - 1, targetEnd),
+                });
+            }
+
+            cursor = Math.max(cursor, segment.end_unix + 1);
+
+            if (cursor > targetEnd) {
+                break;
+            }
+        }
+
+        if (cursor <= targetEnd) {
+            gaps.push({ sinceUnix: cursor, untilUnix: targetEnd });
+        }
+
+        return gaps;
+    }
+
+    findChatsByMessageId(messageId: number): string[] {
+        const db = this.getDb();
+        const rows = db.query("SELECT DISTINCT chat_id FROM messages WHERE id = ?").all(messageId) as Array<{
+            chat_id: string;
+        }>;
+
+        return rows.map((row) => row.chat_id);
     }
 
     // ── Sync State ────────────────────────────────────────────────────
@@ -515,428 +1104,14 @@ export class TelegramHistoryStore {
 
         db.run(
             `
-			INSERT INTO sync_state (chat_id, last_synced_id, last_synced_at)
-			VALUES (?, ?, datetime('now'))
-			ON CONFLICT(chat_id) DO UPDATE SET
-				last_synced_id = excluded.last_synced_id,
-				last_synced_at = excluded.last_synced_at
-		`,
+            INSERT INTO sync_state (chat_id, last_synced_id, last_synced_at)
+            VALUES (?, ?, datetime('now'))
+            ON CONFLICT(chat_id) DO UPDATE SET
+                last_synced_id = excluded.last_synced_id,
+                last_synced_at = excluded.last_synced_at
+            `,
             [chatId, messageId]
         );
-    }
-
-    // ── Query Primitives (V2) ────────────────────────────────────────
-
-    queryMessages(chatId: string, options: QueryOptions): MessageRowV2[] {
-        const db = this.getDb();
-        const conditions: string[] = ["chat_id = ?"];
-        const params: (string | number)[] = [chatId];
-
-        if (!options.includeDeleted) {
-            conditions.push("is_deleted = 0");
-        }
-
-        if (options.sender === "me") {
-            conditions.push("is_outgoing = 1");
-        } else if (options.sender === "them") {
-            conditions.push("is_outgoing = 0");
-        }
-
-        if (options.since) {
-            conditions.push("date_unix >= ?");
-            params.push(Math.floor(options.since.getTime() / 1000));
-        }
-
-        if (options.until) {
-            conditions.push("date_unix <= ?");
-            params.push(Math.floor(options.until.getTime() / 1000));
-        }
-
-        if (options.textPattern) {
-            conditions.push("text LIKE ?");
-            params.push(`%${options.textPattern}%`);
-        }
-
-        const order = options.limit ? "DESC" : "ASC";
-        let sql = `SELECT * FROM messages WHERE ${conditions.join(" AND ")} ORDER BY date_unix ${order}`;
-
-        if (options.limit) {
-            sql += " LIMIT ?";
-            params.push(options.limit);
-        }
-
-        const rows = db.query(sql).all(...params) as MessageRowV2[];
-
-        // DESC + LIMIT gives us the *last* N rows; reverse back to chronological for display
-        if (options.limit) {
-            rows.reverse();
-        }
-
-        return rows;
-    }
-
-    countMessages(chatId: string, options: QueryOptions): number {
-        const db = this.getDb();
-        const conditions: string[] = ["chat_id = ?"];
-        const params: (string | number)[] = [chatId];
-
-        if (!options.includeDeleted) {
-            conditions.push("is_deleted = 0");
-        }
-
-        if (options.sender === "me") {
-            conditions.push("is_outgoing = 1");
-        } else if (options.sender === "them") {
-            conditions.push("is_outgoing = 0");
-        }
-
-        if (options.since) {
-            conditions.push("date_unix >= ?");
-            params.push(Math.floor(options.since.getTime() / 1000));
-        }
-
-        if (options.until) {
-            conditions.push("date_unix <= ?");
-            params.push(Math.floor(options.until.getTime() / 1000));
-        }
-
-        if (options.textPattern) {
-            conditions.push("text LIKE ?");
-            params.push(`%${options.textPattern}%`);
-        }
-
-        const row = db
-            .query(`SELECT COUNT(*) AS count FROM messages WHERE ${conditions.join(" AND ")}`)
-            .get(...params) as {
-            count: number;
-        };
-        return row.count;
-    }
-
-    findMessageById(messageId: number, chatId?: string): { chat_id: string } | null {
-        const db = this.getDb();
-
-        if (chatId) {
-            return (
-                (db
-                    .query("SELECT chat_id FROM messages WHERE chat_id = ? AND id = ? LIMIT 1")
-                    .get(chatId, messageId) as {
-                    chat_id: string;
-                }) ?? null
-            );
-        }
-
-        const rows = db
-            .query("SELECT chat_id FROM messages WHERE id = ? GROUP BY chat_id LIMIT 2")
-            .all(messageId) as Array<{
-            chat_id: string;
-        }>;
-        return rows.length === 1 ? rows[0] : null;
-    }
-
-    markMessageDeleted(chatId: string, messageId: number): void {
-        const db = this.getDb();
-        const now = new Date();
-
-        const current = db.query("SELECT text FROM messages WHERE chat_id = ? AND id = ?").get(chatId, messageId) as {
-            text: string | null;
-        } | null;
-
-        const updateResult = db.run(
-            "UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?",
-            [now.toISOString(), chatId, messageId]
-        );
-
-        if (updateResult.changes === 0) {
-            return;
-        }
-
-        db.run(
-            `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
-             VALUES (?, ?, 'delete', ?, NULL, ?, ?)`,
-            [chatId, messageId, current?.text ?? null, Math.floor(now.getTime() / 1000), now.toISOString()]
-        );
-    }
-
-    // ── Upsert With Revision Tracking ────────────────────────────────
-
-    upsertMessageWithRevision(chatId: string, msg: UpsertMessageInput): void {
-        const db = this.getDb();
-        const now = new Date();
-
-        const existing = db.query("SELECT text FROM messages WHERE chat_id = ? AND id = ?").get(chatId, msg.id) as {
-            text: string | null;
-        } | null;
-
-        if (existing) {
-            if (existing.text !== msg.text) {
-                db.run(
-                    `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
-                     VALUES (?, ?, 'edit', ?, ?, ?, ?)`,
-                    [
-                        chatId,
-                        msg.id,
-                        existing.text,
-                        msg.text,
-                        msg.editedDateUnix ?? Math.floor(now.getTime() / 1000),
-                        now.toISOString(),
-                    ]
-                );
-            }
-
-            db.run(
-                `UPDATE messages SET text = ?, media_desc = ?, edited_date_unix = ?, reply_to_msg_id = ? WHERE chat_id = ? AND id = ?`,
-                [
-                    msg.text,
-                    msg.mediaDescription ?? null,
-                    msg.editedDateUnix ?? null,
-                    msg.replyToMsgId ?? null,
-                    chatId,
-                    msg.id,
-                ]
-            );
-        } else {
-            db.run(
-                `INSERT INTO messages (id, chat_id, sender_id, text, media_desc, is_outgoing, date_unix, date_iso, reply_to_msg_id)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-                [
-                    msg.id,
-                    chatId,
-                    msg.senderId ?? null,
-                    msg.text,
-                    msg.mediaDescription ?? null,
-                    msg.isOutgoing ? 1 : 0,
-                    msg.dateUnix,
-                    msg.date,
-                    msg.replyToMsgId ?? null,
-                ]
-            );
-
-            db.run(
-                `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
-                 VALUES (?, ?, 'create', NULL, ?, ?, ?)`,
-                [chatId, msg.id, msg.text, msg.dateUnix, msg.date]
-            );
-        }
-    }
-
-    getRevisions(chatId: string, messageId: number): MessageRevisionRow[] {
-        const db = this.getDb();
-        return db
-            .query("SELECT * FROM message_revisions WHERE chat_id = ? AND message_id = ? ORDER BY revised_at_unix ASC")
-            .all(chatId, messageId) as MessageRevisionRow[];
-    }
-
-    // ── Attachments ──────────────────────────────────────────────────
-
-    upsertAttachment(input: UpsertAttachmentInput): void {
-        const db = this.getDb();
-        db.run(
-            `INSERT OR REPLACE INTO attachments (chat_id, message_id, attachment_index, kind, mime_type, file_name, file_size, telegram_file_id, is_downloaded, local_path, sha256)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?,
-                     COALESCE((SELECT is_downloaded FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?), 0),
-                     (SELECT local_path FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?),
-                     (SELECT sha256 FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?))`,
-            [
-                input.chat_id,
-                input.message_id,
-                input.attachment_index,
-                input.kind,
-                input.mime_type,
-                input.file_name,
-                input.file_size,
-                input.telegram_file_id,
-                input.chat_id,
-                input.message_id,
-                input.attachment_index,
-                input.chat_id,
-                input.message_id,
-                input.attachment_index,
-                input.chat_id,
-                input.message_id,
-                input.attachment_index,
-            ]
-        );
-    }
-
-    getAttachments(chatId: string, messageId: number): AttachmentRow[] {
-        const db = this.getDb();
-        return db
-            .query("SELECT * FROM attachments WHERE chat_id = ? AND message_id = ? ORDER BY attachment_index ASC")
-            .all(chatId, messageId) as AttachmentRow[];
-    }
-
-    listAttachments(chatId: string, options?: { since?: Date; until?: Date; kind?: string }): AttachmentRow[] {
-        const db = this.getDb();
-        const conditions = ["a.chat_id = ?"];
-        const params: (string | number)[] = [chatId];
-
-        if (options?.kind) {
-            conditions.push("a.kind = ?");
-            params.push(options.kind);
-        }
-
-        let sql = "SELECT a.* FROM attachments a";
-
-        if (options?.since || options?.until) {
-            sql += " JOIN messages m ON a.chat_id = m.chat_id AND a.message_id = m.id";
-
-            if (options.since) {
-                conditions.push("m.date_unix >= ?");
-                params.push(Math.floor(options.since.getTime() / 1000));
-            }
-
-            if (options.until) {
-                conditions.push("m.date_unix <= ?");
-                params.push(Math.floor(options.until.getTime() / 1000));
-            }
-        }
-
-        sql += ` WHERE ${conditions.join(" AND ")} ORDER BY a.message_id ASC, a.attachment_index ASC`;
-
-        return db.query(sql).all(...params) as AttachmentRow[];
-    }
-
-    markAttachmentDownloaded(
-        chatId: string,
-        messageId: number,
-        attachmentIndex: number,
-        localPath: string,
-        sha256: string
-    ): void {
-        const db = this.getDb();
-        db.run(
-            "UPDATE attachments SET is_downloaded = 1, local_path = ?, sha256 = ? WHERE chat_id = ? AND message_id = ? AND attachment_index = ?",
-            [localPath, sha256, chatId, messageId, attachmentIndex]
-        );
-    }
-
-    // ── Sync Segments ────────────────────────────────────────────────
-
-    insertSyncSegment(chatId: string, input: InsertSegmentInput): void {
-        const db = this.getDb();
-        db.run(
-            `INSERT INTO sync_segments (chat_id, from_date_unix, to_date_unix, from_msg_id, to_msg_id, synced_at)
-             VALUES (?, ?, ?, ?, ?, ?)`,
-            [chatId, input.fromDateUnix, input.toDateUnix, input.fromMsgId, input.toMsgId, new Date().toISOString()]
-        );
-    }
-
-    getSyncSegments(chatId: string, fromDateUnix?: number, toDateUnix?: number): SyncSegmentRow[] {
-        const db = this.getDb();
-        let sql = "SELECT * FROM sync_segments WHERE chat_id = ?";
-        const params: Array<string | number> = [chatId];
-
-        if (fromDateUnix !== undefined) {
-            sql += " AND to_date_unix > ?";
-            params.push(fromDateUnix);
-        }
-
-        if (toDateUnix !== undefined) {
-            sql += " AND from_date_unix < ?";
-            params.push(toDateUnix);
-        }
-
-        sql += " ORDER BY from_date_unix ASC";
-
-        return db.query(sql).all(...params) as SyncSegmentRow[];
-    }
-
-    getMissingSegments(chatId: string, fromDateUnix: number, toDateUnix: number): DateRange[] {
-        const segments = this.getSyncSegments(chatId, fromDateUnix, toDateUnix);
-        const gaps: DateRange[] = [];
-        const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
-
-        const merged: Array<{ from: number; to: number }> = [];
-
-        for (const s of sorted) {
-            if (merged.length === 0 || s.from_date_unix > merged[merged.length - 1].to) {
-                merged.push({ from: s.from_date_unix, to: s.to_date_unix });
-            } else {
-                merged[merged.length - 1].to = Math.max(merged[merged.length - 1].to, s.to_date_unix);
-            }
-        }
-
-        if (merged.length === 0) {
-            return [{ fromDateUnix, toDateUnix }];
-        }
-
-        if (merged[0].from > fromDateUnix) {
-            gaps.push({ fromDateUnix, toDateUnix: merged[0].from });
-        }
-
-        for (let i = 0; i < merged.length - 1; i++) {
-            const currentEnd = merged[i].to;
-            const nextStart = merged[i + 1].from;
-
-            if (nextStart > currentEnd) {
-                gaps.push({ fromDateUnix: currentEnd, toDateUnix: nextStart });
-            }
-        }
-
-        const lastEnd = merged[merged.length - 1].to;
-
-        if (lastEnd < toDateUnix) {
-            gaps.push({ fromDateUnix: lastEnd, toDateUnix });
-        }
-
-        return gaps;
-    }
-
-    // ── Chat Metadata ────────────────────────────────────────────────
-
-    upsertChat(input: { chat_id: string; chat_type: string; title: string; username: string | null }): void {
-        const db = this.getDb();
-        db.run(
-            `INSERT INTO chats (chat_id, chat_type, title, username) VALUES (?, ?, ?, ?)
-             ON CONFLICT(chat_id) DO UPDATE SET chat_type = excluded.chat_type, title = excluded.title, username = excluded.username`,
-            [input.chat_id, input.chat_type, input.title, input.username]
-        );
-    }
-
-    getChat(chatId: string): ChatRow | null {
-        const db = this.getDb();
-        return (db.query("SELECT * FROM chats WHERE chat_id = ?").get(chatId) as ChatRow) ?? null;
-    }
-
-    listChats(type?: string): ChatRow[] {
-        const db = this.getDb();
-
-        if (type) {
-            return db.query("SELECT * FROM chats WHERE chat_type = ? ORDER BY title").all(type) as ChatRow[];
-        }
-
-        return db.query("SELECT * FROM chats ORDER BY chat_type, title").all() as ChatRow[];
-    }
-
-    // ── Suggestion Edits ─────────────────────────────────────────────
-
-    insertSuggestionEdit(input: SuggestionEditInput): void {
-        const db = this.getDb();
-        db.run(
-            `INSERT INTO suggestion_edits (chat_id, message_id, suggested_text, edited_text, sent_text, provider, model, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-            [
-                input.chatId,
-                input.messageId,
-                input.suggestedText,
-                input.editedText,
-                input.sentText,
-                input.provider,
-                input.model,
-                new Date().toISOString(),
-            ]
-        );
-    }
-
-    getRecentSuggestionEdits(chatId: string, limit = 10): SuggestionEditRow[] {
-        const db = this.getDb();
-        return db
-            .query(
-                `SELECT suggested_text, edited_text, sent_text, created_at
-                 FROM suggestion_edits WHERE chat_id = ? ORDER BY created_at DESC LIMIT ?`
-            )
-            .all(chatId, limit) as SuggestionEditRow[];
     }
 
     // ── Stats ─────────────────────────────────────────────────────────
@@ -946,18 +1121,20 @@ export class TelegramHistoryStore {
 
         if (chatId) {
             const row = db
-                .query(`
-				SELECT
-					chat_id,
-					COUNT(*) AS total_messages,
-					SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
-					SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
-					MIN(date_iso) AS first_message_date,
-					MAX(date_iso) AS last_message_date
-				FROM messages
-				WHERE chat_id = ?
-				GROUP BY chat_id
-			`)
+                .query(
+                    `
+                    SELECT
+                        chat_id,
+                        COUNT(*) AS total_messages,
+                        SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
+                        SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
+                        MIN(date_iso) AS first_message_date,
+                        MAX(date_iso) AS last_message_date
+                    FROM messages
+                    WHERE chat_id = ?
+                    GROUP BY chat_id
+                    `
+                )
                 .get(chatId) as {
                 chat_id: string;
                 total_messages: number;
@@ -987,18 +1164,20 @@ export class TelegramHistoryStore {
         }
 
         const rows = db
-            .query(`
-			SELECT
-				chat_id,
-				COUNT(*) AS total_messages,
-				SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
-				SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
-				MIN(date_iso) AS first_message_date,
-				MAX(date_iso) AS last_message_date
-			FROM messages
-			GROUP BY chat_id
-			ORDER BY total_messages DESC
-		`)
+            .query(
+                `
+                SELECT
+                    chat_id,
+                    COUNT(*) AS total_messages,
+                    SUM(CASE WHEN is_outgoing = 1 THEN 1 ELSE 0 END) AS outgoing_messages,
+                    SUM(CASE WHEN is_outgoing = 0 THEN 1 ELSE 0 END) AS incoming_messages,
+                    MIN(date_iso) AS first_message_date,
+                    MAX(date_iso) AS last_message_date
+                FROM messages
+                GROUP BY chat_id
+                ORDER BY total_messages DESC
+                `
+            )
             .all() as Array<{
             chat_id: string;
             total_messages: number;
@@ -1022,6 +1201,7 @@ export class TelegramHistoryStore {
     getTotalMessageCount(): number {
         const db = this.getDb();
         const row = db.query("SELECT COUNT(*) AS cnt FROM messages").get() as { cnt: number };
+
         return row.cnt;
     }
 }

--- a/src/telegram/lib/TelegramToolConfig.ts
+++ b/src/telegram/lib/TelegramToolConfig.ts
@@ -1,92 +1,128 @@
 import { chmodSync } from "node:fs";
 import { Storage } from "@app/utils/storage/storage";
-import type { ContactConfig, TelegramConfigData, TelegramConfigDataV2, TelegramContactV2 } from "./types";
-import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
+import type {
+    ContactConfig,
+    ContactModesConfig,
+    TelegramConfigData,
+    TelegramDefaultsConfig,
+    WatchConfig,
+} from "./types";
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULTS,
+    TELEGRAM_CONFIG_VERSION,
+} from "./types";
 
-function cloneDefaults() {
+function cloneModesConfig(): ContactModesConfig {
     return {
-        modes: {
+        autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+        assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+        suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+    };
+}
+
+function cloneWatchConfig(): WatchConfig {
+    return { ...DEFAULT_WATCH_CONFIG };
+}
+
+function normalizeModes(contact: ContactConfig): ContactModesConfig {
+    const modes = cloneModesConfig();
+
+    if (contact.modes) {
+        modes.autoReply = { ...modes.autoReply, ...contact.modes.autoReply };
+        modes.assistant = { ...modes.assistant, ...contact.modes.assistant };
+        modes.suggestions = { ...modes.suggestions, ...contact.modes.suggestions };
+    }
+
+    if (contact.askProvider) {
+        modes.autoReply.provider = contact.askProvider;
+    }
+
+    if (contact.askModel) {
+        modes.autoReply.model = contact.askModel;
+    }
+
+    if (contact.askSystemPrompt) {
+        modes.autoReply.systemPrompt = contact.askSystemPrompt;
+    }
+
+    modes.autoReply.enabled = contact.actions.includes("ask") || modes.autoReply.enabled;
+
+    return modes;
+}
+
+function normalizeContact(contact: ContactConfig): ContactConfig {
+    const watch = contact.watch ? { ...cloneWatchConfig(), ...contact.watch } : cloneWatchConfig();
+    const modes = normalizeModes(contact);
+    const styleProfile = { ...DEFAULT_STYLE_PROFILE, ...contact.styleProfile };
+
+    return {
+        ...contact,
+        dialogType: contact.dialogType ?? "user",
+        replyDelayMin: contact.replyDelayMin ?? DEFAULTS.replyDelayMin,
+        replyDelayMax: contact.replyDelayMax ?? DEFAULTS.replyDelayMax,
+        watch,
+        modes,
+        styleProfile,
+    };
+}
+
+function normalizeDefaults(defaults: TelegramDefaultsConfig | undefined): TelegramDefaultsConfig {
+    if (!defaults) {
+        return {
             autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
             assistant: { ...DEFAULT_MODE_CONFIG.assistant },
             suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
-        },
-        watch: { ...DEFAULT_WATCH_CONFIG },
-        styleProfile: {
-            enabled: DEFAULT_STYLE_PROFILE.enabled,
-            refresh: DEFAULT_STYLE_PROFILE.refresh,
-            previewInWatch: DEFAULT_STYLE_PROFILE.previewInWatch,
-            rules: DEFAULT_STYLE_PROFILE.rules.map((rule) => ({ ...rule })),
-        },
-    };
-}
-
-export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
-    const hasAsk = v1.actions.includes("ask");
-
-    return {
-        userId: v1.userId,
-        displayName: v1.displayName,
-        username: v1.username,
-        chatType: "user",
-        actions: v1.actions,
-        watch: { ...DEFAULT_WATCH_CONFIG },
-        modes: {
-            autoReply: {
-                enabled: hasAsk,
-                provider: v1.askProvider,
-                model: v1.askModel,
-                systemPrompt: v1.askSystemPrompt,
-            },
-            assistant: { ...DEFAULT_MODE_CONFIG.assistant },
-            suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
-        },
-        styleProfile: {
-            enabled: DEFAULT_STYLE_PROFILE.enabled,
-            refresh: DEFAULT_STYLE_PROFILE.refresh,
-            previewInWatch: DEFAULT_STYLE_PROFILE.previewInWatch,
-            rules: DEFAULT_STYLE_PROFILE.rules.map((rule) => ({ ...rule })),
-        },
-        replyDelayMin: v1.replyDelayMin,
-        replyDelayMax: v1.replyDelayMax,
-    };
-}
-
-export function migrateConfigV1toV2(config: TelegramConfigData | TelegramConfigDataV2): TelegramConfigDataV2 {
-    if ("version" in config && config.version === 2) {
-        return config as TelegramConfigDataV2;
+        };
     }
 
-    const v1 = config as TelegramConfigData;
     return {
-        version: 2,
-        apiId: v1.apiId,
-        apiHash: v1.apiHash,
-        session: v1.session,
-        me: v1.me,
-        contacts: v1.contacts.map(migrateContactV1toV2),
-        globalDefaults: cloneDefaults(),
-        configuredAt: v1.configuredAt,
+        autoReply: { ...DEFAULT_MODE_CONFIG.autoReply, ...defaults.autoReply },
+        assistant: { ...DEFAULT_MODE_CONFIG.assistant, ...defaults.assistant },
+        suggestions: { ...DEFAULT_MODE_CONFIG.suggestions, ...defaults.suggestions },
+    };
+}
+
+function normalizeConfig(config: TelegramConfigData): TelegramConfigData {
+    const contacts = config.contacts.map((contact) => normalizeContact(contact));
+
+    return {
+        ...config,
+        version: TELEGRAM_CONFIG_VERSION,
+        defaults: normalizeDefaults(config.defaults),
+        contacts,
     };
 }
 
 export class TelegramToolConfig {
     private storage = new Storage("telegram");
-    private data: TelegramConfigDataV2 | null = null;
+    private data: TelegramConfigData | null = null;
 
-    async load(): Promise<TelegramConfigDataV2 | null> {
-        const raw = await this.storage.getConfig<TelegramConfigData | TelegramConfigDataV2>();
+    async load(): Promise<TelegramConfigData | null> {
+        const raw = await this.storage.getConfig<TelegramConfigData>();
 
         if (!raw) {
+            this.data = null;
             return null;
         }
 
-        this.data = migrateConfigV1toV2(raw);
-        return this.data;
+        const normalized = normalizeConfig(raw);
+        this.data = normalized;
+
+        if (raw.version !== normalized.version || JSON.stringify(raw) !== JSON.stringify(normalized)) {
+            await this.storage.setConfig(normalized);
+            this.protect();
+        }
+
+        return normalized;
     }
 
-    async save(config: TelegramConfigDataV2): Promise<void> {
-        await this.storage.setConfig(config);
-        this.data = config;
+    async save(config: TelegramConfigData): Promise<void> {
+        const normalized = normalizeConfig(config);
+        await this.storage.setConfig(normalized);
+        this.data = normalized;
         this.protect();
     }
 
@@ -112,8 +148,12 @@ export class TelegramToolConfig {
         return this.data?.session ?? "";
     }
 
-    getContacts(): TelegramContactV2[] {
+    getContacts(): ContactConfig[] {
         return this.data?.contacts ?? [];
+    }
+
+    getDefaults(): TelegramDefaultsConfig {
+        return normalizeDefaults(this.data?.defaults);
     }
 
     hasValidSession(): boolean {
@@ -124,7 +164,7 @@ export class TelegramToolConfig {
         try {
             chmodSync(this.storage.getConfigPath(), 0o600);
         } catch {
-            // ignore -- file may not exist yet
+            // ignore — file may not exist yet
         }
     }
 }

--- a/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
+++ b/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
@@ -1,95 +1,42 @@
-import { describe, expect, it } from "bun:test";
-import type { Api } from "telegram";
+import { describe, expect, it, spyOn } from "bun:test";
 import { AttachmentIndexer } from "../AttachmentIndexer";
 
-function fakeMessage(overrides: Record<string, unknown>): Api.Message {
-    return { id: 0, media: null, ...overrides } as unknown as Api.Message;
-}
-
 describe("AttachmentIndexer", () => {
-    it("extracts photo attachment", () => {
-        const msg = fakeMessage({
-            id: 1,
-            media: {
-                className: "MessageMediaPhoto",
-                photo: {
-                    className: "Photo",
-                    id: BigInt(12345),
-                    sizes: [{ className: "PhotoSize", type: "x", w: 800, h: 600, size: 50000 }],
-                    mimeType: "image/jpeg",
-                },
+    it("indexes message attachments into store", () => {
+        const indexer = new AttachmentIndexer();
+        const fakeStore = {
+            upsertAttachments: () => {},
+        };
+        const spy = spyOn(fakeStore, "upsertAttachments");
+
+        indexer.indexSerializedMessage(
+            fakeStore as unknown as Parameters<AttachmentIndexer["indexSerializedMessage"]>[0],
+            "chat-1",
+            {
+                id: 10,
+                senderId: "u1",
+                text: "",
+                mediaDescription: "a photo",
+                isOutgoing: false,
+                date: new Date().toISOString(),
+                dateUnix: Math.floor(Date.now() / 1000),
+                attachments: [
+                    {
+                        index: 0,
+                        kind: "photo",
+                        thumbCount: 1,
+                    },
+                ],
+            }
+        );
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith("chat-1", 10, [
+            {
+                index: 0,
+                kind: "photo",
+                thumbCount: 1,
             },
-        });
-
-        const attachments = AttachmentIndexer.extract("chat1", msg);
-        expect(attachments.length).toBe(1);
-        expect(attachments[0].kind).toBe("photo");
-        expect(attachments[0].attachment_index).toBe(0);
-    });
-
-    it("extracts document attachment with filename", () => {
-        const msg = fakeMessage({
-            id: 2,
-            media: {
-                className: "MessageMediaDocument",
-                document: {
-                    className: "Document",
-                    id: BigInt(67890),
-                    mimeType: "application/pdf",
-                    size: BigInt(1024),
-                    attributes: [{ className: "DocumentAttributeFilename", fileName: "report.pdf" }],
-                },
-            },
-        });
-
-        const attachments = AttachmentIndexer.extract("chat1", msg);
-        expect(attachments.length).toBe(1);
-        expect(attachments[0].kind).toBe("document");
-        expect(attachments[0].file_name).toBe("report.pdf");
-        expect(attachments[0].mime_type).toBe("application/pdf");
-    });
-
-    it("returns empty for text-only message", () => {
-        const msg = fakeMessage({ id: 3, media: null });
-        const attachments = AttachmentIndexer.extract("chat1", msg);
-        expect(attachments.length).toBe(0);
-    });
-
-    it("classifies sticker correctly", () => {
-        const msg = fakeMessage({
-            id: 4,
-            media: {
-                className: "MessageMediaDocument",
-                document: {
-                    className: "Document",
-                    id: BigInt(11111),
-                    mimeType: "image/webp",
-                    size: BigInt(5000),
-                    attributes: [{ className: "DocumentAttributeSticker" }],
-                },
-            },
-        });
-
-        const attachments = AttachmentIndexer.extract("chat1", msg);
-        expect(attachments[0].kind).toBe("sticker");
-    });
-
-    it("classifies voice message correctly", () => {
-        const msg = fakeMessage({
-            id: 5,
-            media: {
-                className: "MessageMediaDocument",
-                document: {
-                    className: "Document",
-                    id: BigInt(22222),
-                    mimeType: "audio/ogg",
-                    size: BigInt(8000),
-                    attributes: [{ className: "DocumentAttributeAudio", voice: true }],
-                },
-            },
-        });
-
-        const attachments = AttachmentIndexer.extract("chat1", msg);
-        expect(attachments[0].kind).toBe("voice");
+        ]);
     });
 });

--- a/src/telegram/lib/__tests__/QueryParser.test.ts
+++ b/src/telegram/lib/__tests__/QueryParser.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { QueryParser } from "../QueryParser";
+
+describe("QueryParser", () => {
+    it("parses natural language fields", () => {
+        const parser = new QueryParser();
+        const parsed = parser.parseNaturalLanguage('messages from Alice since 2025-01-01 until 2025-01-31 text "calm"');
+
+        expect(parsed.from).toBe("Alice");
+        expect(parsed.since).toBe("2025-01-01");
+        expect(parsed.until).toBe("2025-01-31");
+        expect(parsed.text).toBe("calm");
+    });
+
+    it("merges NL values into flag query", () => {
+        const parser = new QueryParser();
+        const result = parser.parseFromFlags({
+            from: "bob",
+            nl: "since 2025-02-01 until 2025-02-28",
+        });
+
+        expect(result.from).toBe("bob");
+        expect(result.since).toBe("2025-02-01");
+        expect(result.until).toBe("2025-02-28");
+        expect(result.sender).toBe("any");
+    });
+
+    it("supports natural-language date phrases", () => {
+        const parser = new QueryParser();
+        const reference = new Date("2026-03-01T12:00:00.000Z");
+        const parsed = parser.parseNaturalLanguage("messages from Alice since last week until yesterday", reference);
+
+        expect(parsed.from).toBe("Alice");
+        expect(parsed.since).toBeTruthy();
+        expect(parsed.until).toBeTruthy();
+    });
+});

--- a/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+++ b/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
@@ -1,121 +1,32 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { StyleProfileEngine } from "../StyleProfileEngine";
-import { TelegramHistoryStore } from "../TelegramHistoryStore";
-
-function tmpDbPath() {
-    return join(tmpdir(), `telegram-style-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
-}
+import { TelegramContact } from "../TelegramContact";
 
 describe("StyleProfileEngine", () => {
-    let store: TelegramHistoryStore;
-    let dbPath: string;
-
-    beforeEach(() => {
-        dbPath = tmpDbPath();
-        store = new TelegramHistoryStore();
-        store.open(dbPath);
-
-        const messages = [
-            {
-                id: 1,
-                senderId: "me",
-                text: "hey whats up",
-                isOutgoing: true,
-                date: "2024-01-10T10:00:00Z",
-                dateUnix: 1704880800,
+    it("returns null when style profile is disabled", async () => {
+        const engine = new StyleProfileEngine();
+        const contact = TelegramContact.fromConfig({
+            userId: "1",
+            displayName: "Alice",
+            actions: ["notify"],
+            replyDelayMin: 1000,
+            replyDelayMax: 2000,
+            styleProfile: {
+                enabled: false,
+                refresh: "incremental",
+                rules: [],
+                previewInWatch: false,
             },
-            {
-                id: 2,
-                senderId: "me",
-                text: "lol yea that was crazy",
-                isOutgoing: true,
-                date: "2024-01-10T10:01:00Z",
-                dateUnix: 1704880860,
-            },
-            {
-                id: 3,
-                senderId: "me",
-                text: "nah im good thanks tho",
-                isOutgoing: true,
-                date: "2024-01-10T10:02:00Z",
-                dateUnix: 1704880920,
-            },
-            {
-                id: 4,
-                senderId: "me",
-                text: "wanna grab coffee tmrw?",
-                isOutgoing: true,
-                date: "2024-01-10T10:03:00Z",
-                dateUnix: 1704880980,
-            },
-            {
-                id: 5,
-                senderId: "me",
-                text: "k cool see ya",
-                isOutgoing: true,
-                date: "2024-01-10T10:04:00Z",
-                dateUnix: 1704881040,
-            },
-        ];
-
-        for (const msg of messages) {
-            store.insertMessages("chat1", [{ ...msg, mediaDescription: undefined }]);
-        }
-    });
-
-    afterEach(() => {
-        store.close();
-
-        if (existsSync(dbPath)) {
-            unlinkSync(dbPath);
-        }
-    });
-
-    it("generates a style summary from messages", () => {
-        const engine = new StyleProfileEngine(store);
-        const summary = engine.analyzeStyle("chat1", "me", 100);
-
-        expect(summary.totalMessages).toBe(5);
-        expect(summary.avgLength).toBeGreaterThan(0);
-        expect(summary.traits).toBeInstanceOf(Array);
-        expect(summary.traits.length).toBeGreaterThan(0);
-    });
-
-    it("builds a hybrid style prompt", () => {
-        const engine = new StyleProfileEngine(store);
-        const prompt = engine.buildStylePrompt({
-            rules: [{ id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 }],
-            exampleCount: 5,
         });
+        const fakeStore = {
+            queryMessages: () => [],
+        };
 
-        expect(prompt).toContain("Style Summary");
-        expect(prompt).toContain("Example Messages");
-        expect(prompt).toContain("hey whats up");
-    });
+        const result = await engine.deriveStylePrompt(
+            contact,
+            fakeStore as unknown as Parameters<StyleProfileEngine["deriveStylePrompt"]>[1]
+        );
 
-    it("respects rule filters", () => {
-        const engine = new StyleProfileEngine(store);
-
-        store.insertMessages("chat1", [
-            {
-                id: 10,
-                senderId: "other",
-                text: "How are you?",
-                mediaDescription: undefined,
-                isOutgoing: false,
-                date: "2024-01-10T10:05:00Z",
-                dateUnix: 1704881100,
-            },
-        ]);
-
-        const prompt = engine.buildStylePrompt({
-            rules: [{ id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 }],
-            exampleCount: 5,
-        });
-
-        expect(prompt).not.toContain("How are you?");
+        expect(result).toBeNull();
     });
 });

--- a/src/telegram/lib/__tests__/SuggestionEngine.test.ts
+++ b/src/telegram/lib/__tests__/SuggestionEngine.test.ts
@@ -1,32 +1,29 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
+import { assistantEngine } from "../AssistantEngine";
 import { SuggestionEngine } from "../SuggestionEngine";
 
 describe("SuggestionEngine", () => {
-    it("builds suggestion system prompt with style and corrections", () => {
-        const prompt = SuggestionEngine.buildSuggestionPrompt({
-            contactName: "Alice",
-            myName: "Martin",
-            stylePrompt: "Short messages, lowercase, uses emoji",
-            recentCorrections: [{ suggested: "Hey, how are you?", sent: "hey wyd" }],
-            count: 3,
+    it("extracts and trims suggestion lines", async () => {
+        const engine = new SuggestionEngine();
+        const askSpy = spyOn(assistantEngine, "ask").mockResolvedValue(
+            "1. First option\n- Second option\nThird option"
+        );
+
+        const options = await engine.generateSuggestions({
+            sessionId: "s1",
+            mode: {
+                enabled: true,
+                provider: "openai",
+                model: "gpt-4o-mini",
+                count: 3,
+                trigger: "manual",
+                autoDelayMs: 0,
+                allowAutoSend: false,
+            },
+            incomingText: "How are you?",
         });
 
-        expect(prompt).toContain("Alice");
-        expect(prompt).toContain("3");
-        expect(prompt).toContain("lowercase");
-        expect(prompt).toContain("hey wyd");
-    });
-
-    it("parseSuggestions extracts numbered list", () => {
-        const raw = `Here are 3 suggestions:
-
-1. hey whats up
-2. yo how was your day
-3. lol yea that sounds fun`;
-
-        const suggestions = SuggestionEngine.parseSuggestions(raw);
-        expect(suggestions.length).toBe(3);
-        expect(suggestions[0]).toBe("hey whats up");
-        expect(suggestions[2]).toBe("lol yea that sounds fun");
+        expect(askSpy).toHaveBeenCalledTimes(1);
+        expect(options).toEqual(["First option", "Second option", "Third option"]);
     });
 });

--- a/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+++ b/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
@@ -2,48 +2,25 @@ import { describe, expect, it } from "bun:test";
 import { SyncRangePlanner } from "../SyncRangePlanner";
 
 describe("SyncRangePlanner", () => {
-    it("returns full range when no segments exist", () => {
-        const plan = SyncRangePlanner.plan([], 1700000000, 1700259200);
-        expect(plan.length).toBe(1);
-        expect(plan[0]).toEqual({ from: 1700000000, to: 1700259200 });
-    });
+    it("maps missing unix ranges into Date ranges", () => {
+        const planner = new SyncRangePlanner();
+        const fakeStore = {
+            getMissingSegments: () => [
+                { sinceUnix: 1_700_000_000, untilUnix: 1_700_000_100 },
+                { sinceUnix: 1_700_000_200, untilUnix: 1_700_000_300 },
+            ],
+        };
 
-    it("returns empty when fully covered", () => {
-        const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700259200 }];
-        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-        expect(plan.length).toBe(0);
-    });
+        const ranges = planner.planQueryBackfill(
+            fakeStore as unknown as Parameters<SyncRangePlanner["planQueryBackfill"]>[0],
+            "chat-1",
+            new Date("2024-01-01T00:00:00.000Z"),
+            new Date("2024-02-01T00:00:00.000Z")
+        );
 
-    it("finds gap between two segments", () => {
-        const segments = [
-            { from_date_unix: 1700000000, to_date_unix: 1700086400 },
-            { from_date_unix: 1700172800, to_date_unix: 1700259200 },
-        ];
-        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-        expect(plan.length).toBe(1);
-        expect(plan[0]).toEqual({ from: 1700086400, to: 1700172800 });
-    });
-
-    it("finds gap before first segment", () => {
-        const segments = [{ from_date_unix: 1700086400, to_date_unix: 1700259200 }];
-        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-        expect(plan.length).toBe(1);
-        expect(plan[0].from).toBe(1700000000);
-    });
-
-    it("finds gap after last segment", () => {
-        const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700086400 }];
-        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-        expect(plan.length).toBe(1);
-        expect(plan[0].from).toBe(1700086400);
-    });
-
-    it("handles overlapping segments", () => {
-        const segments = [
-            { from_date_unix: 1700000000, to_date_unix: 1700100000 },
-            { from_date_unix: 1700050000, to_date_unix: 1700259200 },
-        ];
-        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-        expect(plan.length).toBe(0);
+        expect(ranges).toHaveLength(2);
+        expect(ranges[0].source).toBe("query");
+        expect(ranges[0].since.toISOString()).toBe("2023-11-14T22:13:20.000Z");
+        expect(ranges[1].until.toISOString()).toBe("2023-11-14T22:18:20.000Z");
     });
 });

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
@@ -1,108 +1,84 @@
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, unlinkSync } from "node:fs";
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TelegramHistoryStore } from "../TelegramHistoryStore";
 
-function tmpDbPath() {
-    return join(tmpdir(), `telegram-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
-}
+describe("TelegramHistoryStore migration", () => {
+    it("migrates v1 schema to v2 and supports new methods", () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "telegram-store-"));
+        const dbPath = join(tempDir, "history.db");
 
-describe("TelegramHistoryStore migrations", () => {
-    let store: TelegramHistoryStore;
-    let dbPath: string;
+        try {
+            const db = new Database(dbPath);
+            db.run(`
+                CREATE TABLE messages (
+                    id INTEGER NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    sender_id TEXT,
+                    text TEXT,
+                    media_desc TEXT,
+                    is_outgoing INTEGER NOT NULL,
+                    date_unix INTEGER NOT NULL,
+                    date_iso TEXT NOT NULL,
+                    PRIMARY KEY (chat_id, id)
+                )
+            `);
+            db.run(`
+                CREATE TABLE sync_state (
+                    chat_id TEXT PRIMARY KEY,
+                    last_synced_id INTEGER NOT NULL,
+                    last_synced_at TEXT NOT NULL
+                )
+            `);
+            db.run(`
+                CREATE TABLE embeddings (
+                    message_rowid INTEGER PRIMARY KEY,
+                    embedding BLOB NOT NULL
+                )
+            `);
+            db.run("PRAGMA user_version = 1");
+            db.close();
 
-    beforeEach(() => {
-        dbPath = tmpDbPath();
-        store = new TelegramHistoryStore();
-    });
+            const store = new TelegramHistoryStore();
+            store.open(dbPath);
 
-    afterEach(() => {
-        store.close();
+            const inserted = store.insertMessages("chat-1", [
+                {
+                    id: 1,
+                    senderId: "u1",
+                    text: "hello",
+                    mediaDescription: undefined,
+                    isOutgoing: false,
+                    date: "2025-01-01T00:00:00.000Z",
+                    dateUnix: 1_735_689_600,
+                    attachments: [],
+                },
+            ]);
 
-        if (existsSync(dbPath)) {
-            unlinkSync(dbPath);
+            expect(inserted).toBe(1);
+
+            const rows = store.queryMessages("chat-1", {
+                sender: "any",
+            });
+            expect(rows).toHaveLength(1);
+            expect(rows[0].is_deleted).toBe(0);
+
+            store.markMessageDeleted("chat-1", 1, 1_735_689_700);
+            const deletedRows = store.queryMessages("chat-1", {});
+            expect(deletedRows[0].is_deleted).toBe(1);
+
+            store.insertSyncSegment("chat-1", 100, 200, "query");
+            const gaps = store.getMissingSegments("chat-1", new Date(90 * 1000), new Date(220 * 1000));
+            expect(gaps).toEqual([
+                { sinceUnix: 90, untilUnix: 99 },
+                { sinceUnix: 201, untilUnix: 220 },
+            ]);
+
+            store.close();
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
         }
-    });
-
-    it("creates all V2 tables on fresh database", () => {
-        store.open(dbPath);
-        const db = (store as unknown as { db: Database }).db;
-
-        const chats = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='chats'").get();
-        expect(chats).toBeTruthy();
-
-        const revisions = db
-            .query("SELECT name FROM sqlite_master WHERE type='table' AND name='message_revisions'")
-            .get();
-        expect(revisions).toBeTruthy();
-
-        const attachments = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='attachments'").get();
-        expect(attachments).toBeTruthy();
-
-        const segments = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_segments'").get();
-        expect(segments).toBeTruthy();
-
-        const version = db.query("PRAGMA user_version").get() as { user_version: number };
-        expect(version.user_version).toBe(2);
-    });
-
-    it("migrates V0 (fresh) to V2 with new message columns", () => {
-        store.open(dbPath);
-        const db = (store as unknown as { db: Database }).db;
-
-        const cols = db.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
-        const colNames = cols.map((c) => c.name);
-
-        expect(colNames).toContain("edited_date_unix");
-        expect(colNames).toContain("is_deleted");
-        expect(colNames).toContain("deleted_at_iso");
-        expect(colNames).toContain("reply_to_msg_id");
-    });
-
-    it("migrates existing V1 database to V2", () => {
-        const db = new Database(dbPath);
-        db.run("PRAGMA journal_mode = WAL");
-        db.run(`CREATE TABLE IF NOT EXISTS messages (
-			id INTEGER NOT NULL,
-			chat_id TEXT NOT NULL,
-			sender_id TEXT,
-			text TEXT,
-			media_desc TEXT,
-			is_outgoing INTEGER NOT NULL,
-			date_unix INTEGER NOT NULL,
-			date_iso TEXT NOT NULL,
-			PRIMARY KEY (chat_id, id)
-		)`);
-        db.run(`CREATE TABLE IF NOT EXISTS sync_state (
-			chat_id TEXT PRIMARY KEY,
-			last_synced_id INTEGER NOT NULL,
-			last_synced_at TEXT NOT NULL
-		)`);
-        db.run("PRAGMA user_version = 1");
-        db.close();
-
-        store.open(dbPath);
-        const storeDb = (store as unknown as { db: Database }).db;
-
-        const version = storeDb.query("PRAGMA user_version").get() as { user_version: number };
-        expect(version.user_version).toBe(2);
-
-        const cols = storeDb.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
-        const colNames = cols.map((c) => c.name);
-        expect(colNames).toContain("is_deleted");
-    });
-
-    it("idempotent: opening V2 database doesn't re-migrate", () => {
-        store.open(dbPath);
-        store.close();
-
-        store = new TelegramHistoryStore();
-        store.open(dbPath);
-
-        const db = (store as unknown as { db: Database }).db;
-        const version = db.query("PRAGMA user_version").get() as { user_version: number };
-        expect(version.user_version).toBe(2);
     });
 });

--- a/src/telegram/lib/actions/ask.ts
+++ b/src/telegram/lib/actions/ask.ts
@@ -1,54 +1,34 @@
-import { homedir } from "node:os";
-import { resolve } from "node:path";
-import { AIChat } from "@ask/AIChat";
+import { assistantEngine } from "../AssistantEngine";
 import type { ActionHandler } from "../types";
-
-/** Cache of AIChat instances per contact */
-const contactChats = new Map<string, AIChat>();
 
 export const handleAsk: ActionHandler = async (message, contact, client, conversationHistory) => {
     const start = performance.now();
     const typing = client.startTypingLoop(contact.userId);
 
     try {
-        // Get or create AIChat instance — cache key includes config so changes are detected
-        const cacheKey = `${contact.userId}:${contact.askProvider}:${contact.askModel}`;
-        let chat = contactChats.get(cacheKey);
+        const mode = contact.autoReplyMode;
 
-        if (!chat) {
-            // Clean up old instance for this user if config changed
-            for (const [key, oldChat] of contactChats) {
-                if (key.startsWith(`${contact.userId}:`)) {
-                    oldChat.dispose();
-                    contactChats.delete(key);
-                }
-            }
+        if (!mode.enabled) {
+            typing.stop();
 
-            chat = new AIChat({
-                provider: contact.askProvider,
-                model: contact.askModel,
-                systemPrompt: contact.askSystemPrompt,
-                logLevel: "silent",
-                session: {
-                    id: `telegram-${contact.userId}`,
-                    dir: resolve(homedir(), ".genesis-tools/telegram/ai-sessions"),
-                    autoSave: true,
-                },
-            });
-            contactChats.set(cacheKey, chat);
+            return {
+                action: "ask",
+                success: true,
+                duration: performance.now() - start,
+            };
         }
 
-        // Add conversation history as context if available, then send only the new message.
-        // Using addToHistory: false for the context to avoid duplicating history in the session.
-        if (conversationHistory) {
-            chat.session.add({ role: "system", content: `[Recent conversation]\n${conversationHistory}` });
-        }
-
-        const response = await chat.send(message.contentForLLM);
+        const response = await assistantEngine.ask({
+            sessionId: `telegram-${contact.userId}-autoreply`,
+            mode,
+            incomingText: message.contentForLLM,
+            conversationHistory,
+            stylePrompt: contact.config.styleProfile?.derivedPrompt,
+        });
 
         typing.stop();
 
-        if (!response.content) {
+        if (!response) {
             return {
                 action: "ask",
                 success: false,
@@ -59,13 +39,13 @@ export const handleAsk: ActionHandler = async (message, contact, client, convers
 
         await Bun.sleep(contact.randomDelay);
 
-        const sentMessage = await client.sendMessage(contact.userId, response.content);
+        const sent = await client.sendMessage(contact.userId, response);
 
         return {
             action: "ask",
             success: true,
-            reply: response.content,
-            replyMessageId: sentMessage.id,
+            reply: response,
+            sentMessageId: sent.id,
             duration: performance.now() - start,
         };
     } catch (err) {

--- a/src/telegram/lib/download.ts
+++ b/src/telegram/lib/download.ts
@@ -1,10 +1,9 @@
 import logger from "@app/logger";
-import { formatNumber } from "@app/utils/format";
 import { detectLanguage, embedText } from "@app/utils/macos/nlp";
 import type { EmbedResult } from "@app/utils/macos/types";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { ConversationSyncService, type SyncResult } from "./ConversationSyncService";
+import { conversationSyncService } from "./ConversationSyncService";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { TGClient } from "./TGClient";
 import type { ContactConfig } from "./types";
@@ -21,60 +20,32 @@ export async function downloadContact(
     const spinner = p.spinner();
     spinner.start("Counting messages...");
 
-    let totalEstimate: number;
+    let totalEstimate = 0;
 
     try {
         totalEstimate = await client.getMessageCount(contact.userId);
     } catch {
-        spinner.stop("Could not count messages");
-        totalEstimate = 0;
+        // ignore counting failures
     }
 
-    const lastSyncedId = store.getLastSyncedId(contact.userId);
-    const isIncremental = lastSyncedId !== null && !options.since;
+    spinner.stop(`Found ${totalEstimate.toLocaleString()} total messages`);
 
-    if (isIncremental) {
-        spinner.stop(`Found ${formatNumber(totalEstimate)} total messages (incremental sync from #${lastSyncedId})`);
-    } else {
-        spinner.stop(`Found ${formatNumber(totalEstimate)} total messages`);
+    if (options.since || options.until) {
+        const since = options.since ?? new Date(0);
+        const until = options.until ?? new Date();
+
+        await conversationSyncService.syncRange(client, store, contact.userId, {
+            since,
+            until,
+            limit: options.limit,
+            source: "query",
+        });
+        return;
     }
 
-    const progressSpinner = p.spinner();
-    progressSpinner.start("Syncing messages...");
-
-    const syncService = new ConversationSyncService(client, store);
-
-    try {
-        let result: SyncResult;
-
-        if (options.since || options.until) {
-            const since = options.since ?? new Date(0);
-            const until = options.until ?? new Date();
-            result = await syncService.syncRange(contact.userId, since, until, {
-                limit: options.limit,
-                onProgress: (synced) => {
-                    progressSpinner.message(`Synced ${formatNumber(synced)} messages`);
-                },
-            });
-        } else {
-            result = await syncService.syncLatest(contact.userId, {
-                limit: options.limit,
-                onProgress: (synced) => {
-                    progressSpinner.message(`Synced ${formatNumber(synced)} messages`);
-                },
-            });
-        }
-
-        progressSpinner.stop(
-            `${pc.green(formatNumber(result.synced))} new messages stored` +
-                (result.attachmentsIndexed > 0
-                    ? `, ${formatNumber(result.attachmentsIndexed)} attachments indexed`
-                    : "")
-        );
-    } catch (err) {
-        progressSpinner.stop("Error during sync");
-        p.log.error(`Sync error: ${String(err)}`);
-    }
+    await conversationSyncService.syncIncremental(client, store, contact.userId, {
+        limit: options.limit,
+    });
 }
 
 export async function embedMessages(

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -1,19 +1,18 @@
 import logger from "@app/logger";
 import pc from "picocolors";
-import type { NewMessageEvent } from "telegram/events";
 import type { DeletedMessageEvent } from "telegram/events/DeletedMessage";
 import type { EditedMessageEvent } from "telegram/events/EditedMessage";
+import type { NewMessageEvent } from "telegram/events/NewMessage";
 import { executeActions } from "./actions";
 import { TelegramContact } from "./TelegramContact";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import { TelegramMessage } from "./TelegramMessage";
 import type { TGClient } from "./TGClient";
-import type { TelegramContactV2 } from "./types";
+import type { ContactConfig } from "./types";
 import { DEFAULTS } from "./types";
 
 const processedIds = new Set<number>();
 const processedOrder: number[] = [];
-let localReplyFallbackId = -1;
 
 function trackMessage(id: number): boolean {
     if (processedIds.has(id)) {
@@ -34,23 +33,22 @@ function trackMessage(id: number): boolean {
     return true;
 }
 
-/**
- * Per-contact conversation context buffer.
- * Stores formatted "Name: message" lines for LLM context.
- */
 class ConversationContext {
     private lines: string[] = [];
+    private maxLines: number;
 
-    constructor(initialLines?: string[]) {
+    constructor(maxLines: number, initialLines?: string[]) {
+        this.maxLines = maxLines;
+
         if (initialLines) {
-            this.lines = initialLines.slice(-DEFAULTS.maxContextMessages);
+            this.lines = initialLines.slice(-maxLines);
         }
     }
 
     append(name: string, content: string): void {
         this.lines.push(`${name}: ${content}`);
 
-        while (this.lines.length > DEFAULTS.maxContextMessages) {
+        while (this.lines.length > this.maxLines) {
             this.lines.shift();
         }
     }
@@ -64,37 +62,53 @@ class ConversationContext {
     }
 }
 
-export interface HandlerOptions {
-    contacts: TelegramContactV2[];
-    myName: string;
-    initialHistory?: Map<string, string[]>;
-    store: TelegramHistoryStore;
+function resolveTargetChatId(message: TelegramMessage): string | undefined {
+    if (message.chatId) {
+        return message.chatId;
+    }
+
+    if (message.senderId) {
+        return message.senderId;
+    }
+
+    return undefined;
 }
 
-function extractPeerId(
-    peer?: {
-        userId?: unknown;
-        chatId?: unknown;
-        channelId?: unknown;
-    } | null
-): string | null {
+function resolveDeletedEventChatId(event: DeletedMessageEvent): string | undefined {
+    const peer = event.peer;
+
     if (!peer) {
-        return null;
+        return undefined;
     }
 
-    if ("userId" in peer && peer.userId !== undefined && peer.userId !== null) {
-        return String(peer.userId);
+    if (typeof peer === "string") {
+        return peer;
     }
 
-    if ("chatId" in peer && peer.chatId !== undefined && peer.chatId !== null) {
-        return String(peer.chatId);
+    if (typeof peer !== "object" || peer === null) {
+        return undefined;
     }
 
-    if ("channelId" in peer && peer.channelId !== undefined && peer.channelId !== null) {
+    if ("channelId" in peer && peer.channelId) {
         return String(peer.channelId);
     }
 
-    return null;
+    if ("chatId" in peer && peer.chatId) {
+        return String(peer.chatId);
+    }
+
+    if ("userId" in peer && peer.userId) {
+        return String(peer.userId);
+    }
+
+    return undefined;
+}
+
+export interface HandlerOptions {
+    contacts: ContactConfig[];
+    myName: string;
+    initialHistory?: Map<string, string[]>;
+    store: TelegramHistoryStore;
 }
 
 export function registerHandler(client: TGClient, options: HandlerOptions): void {
@@ -106,82 +120,83 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
         contactMap.set(config.userId, contact);
 
         const initial = options.initialHistory?.get(config.userId);
-        contexts.set(config.userId, new ConversationContext(initial));
+        contexts.set(config.userId, new ConversationContext(contact.contextLength, initial));
     }
 
     client.onNewMessage(async (event: NewMessageEvent) => {
         try {
-            const msg = new TelegramMessage(event.message);
+            const message = new TelegramMessage(event.message);
 
-            if (!msg.isPrivate || msg.isOutgoing) {
+            if (message.isOutgoing) {
                 return;
             }
 
-            const senderId = msg.senderId;
+            const targetChatId = resolveTargetChatId(message);
 
-            if (!senderId) {
+            if (!targetChatId) {
                 return;
             }
 
-            const contact = contactMap.get(senderId);
+            const contact = contactMap.get(targetChatId);
 
             if (!contact) {
                 return;
             }
 
-            if (!trackMessage(msg.id)) {
+            if (!trackMessage(message.id)) {
                 return;
             }
 
-            if (!msg.hasText && !msg.hasMedia) {
+            if (!message.hasText && !message.hasMedia) {
                 return;
             }
 
-            // Persist incoming message to history store
-            try {
-                options.store.insertMessages(senderId, [msg.toJSON()]);
-            } catch (err) {
-                logger.debug(`Failed to persist message: ${err}`);
+            options.store.upsertMessageWithRevision(targetChatId, message.toJSON(), "create");
+
+            const context = contexts.get(targetChatId);
+
+            if (context) {
+                context.append(contact.displayName, message.contentForLLM);
             }
 
-            // Append incoming message to conversation context
-            const ctx = contexts.get(senderId);
+            logger.info(`${pc.bold(pc.cyan(contact.displayName))}: ${message.preview}`);
 
-            if (ctx) {
-                ctx.append(contact.displayName, msg.contentForLLM);
-            }
+            const history = context && !context.isEmpty ? context.toString() : undefined;
+            const results = await executeActions(contact, message, client, history);
 
-            logger.info(`${pc.bold(pc.cyan(contact.displayName))}: ${msg.preview}`);
+            for (const result of results) {
+                if (result.success) {
+                    const extra = result.reply
+                        ? ` "${result.reply.slice(0, 60)}${result.reply.length > 60 ? "..." : ""}"`
+                        : "";
+                    logger.info(`  ${pc.green(`[${result.action}]`)} OK${pc.dim(extra)}`);
 
-            const history = ctx && !ctx.isEmpty ? ctx.toString() : undefined;
-            const results = await executeActions(contact, msg, client, history);
+                    if (result.action === "ask" && result.reply && context) {
+                        context.append(options.myName, result.reply);
 
-            for (const r of results) {
-                if (r.success) {
-                    const extra = r.reply ? ` "${r.reply.slice(0, 60)}${r.reply.length > 60 ? "..." : ""}"` : "";
-                    logger.info(`  ${pc.green(`[${r.action}]`)} OK${pc.dim(extra)}`);
-
-                    if (r.action === "ask" && r.reply && ctx) {
-                        ctx.append(options.myName, r.reply);
-
-                        try {
-                            options.store.insertMessages(senderId, [
+                        if (result.sentMessageId) {
+                            options.store.upsertMessageWithRevision(
+                                targetChatId,
                                 {
-                                    id: r.replyMessageId ?? localReplyFallbackId--,
+                                    id: result.sentMessageId,
                                     senderId: undefined,
-                                    text: r.reply,
+                                    text: result.reply,
                                     mediaDescription: undefined,
                                     isOutgoing: true,
                                     date: new Date().toISOString(),
                                     dateUnix: Math.floor(Date.now() / 1000),
+                                    attachments: [],
                                 },
-                            ]);
-                        } catch (err) {
-                            logger.debug(`Failed to persist reply: ${err}`);
+                                "create"
+                            );
+                        } else {
+                            logger.warn(
+                                `Auto-reply message id missing for ${targetChatId}; skipping outgoing persistence.`
+                            );
                         }
                     }
                 } else {
-                    logger.warn(`  ${pc.red(`[${r.action}]`)} FAILED: ${r.error}`);
+                    logger.warn(`  ${pc.red(`[${result.action}]`)} FAILED: ${result.error}`);
                 }
             }
         } catch (err) {
@@ -191,53 +206,41 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
 
     client.onEditedMessage(async (event: EditedMessageEvent) => {
         try {
-            const message = event.message;
+            const message = new TelegramMessage(event.message);
+            const targetChatId = resolveTargetChatId(message);
 
-            if (!message) {
+            if (!targetChatId || !contactMap.has(targetChatId)) {
                 return;
             }
 
-            const msg = new TelegramMessage(message);
-            const chatId = extractPeerId(message.peerId);
-
-            if (!chatId) {
-                return;
-            }
-
-            options.store.upsertMessageWithRevision(chatId, {
-                id: msg.id,
-                senderId: msg.senderId,
-                text: msg.text,
-                mediaDescription: msg.mediaDescription,
-                isOutgoing: msg.isOutgoing,
-                date: msg.date.toISOString(),
-                dateUnix: Math.floor(msg.date.getTime() / 1000),
-                editedDateUnix: message.editDate ?? Math.floor(Date.now() / 1000),
-            });
+            options.store.upsertMessageWithRevision(targetChatId, message.toJSON(), "edit");
+            logger.info(`${pc.yellow("Edited")} ${pc.cyan(targetChatId)} #${message.id}`);
         } catch (err) {
-            logger.error({ err }, "Error handling edited message");
+            logger.warn(`Edit event handling failed: ${err}`);
         }
     });
 
     client.onDeletedMessage(async (event: DeletedMessageEvent) => {
         try {
-            const deletedIds: number[] = event.deletedIds ?? [];
-            const peerChatId = extractPeerId(
-                (event.peer as { userId?: unknown; chatId?: unknown; channelId?: unknown } | null) ?? null
-            );
+            const eventChatId = resolveDeletedEventChatId(event);
 
-            for (const msgId of deletedIds) {
-                const row = options.store.findMessageById(msgId, peerChatId ?? undefined);
+            for (const messageId of event.deletedIds) {
+                const candidateChats = eventChatId ? [eventChatId] : options.store.findChatsByMessageId(messageId);
 
-                if (row) {
-                    options.store.markMessageDeleted(row.chat_id, msgId);
+                for (const chatId of candidateChats) {
+                    if (!contactMap.has(chatId)) {
+                        continue;
+                    }
+
+                    options.store.markMessageDeleted(chatId, messageId);
+                    logger.info(`${pc.red("Deleted")} ${pc.cyan(chatId)} #${messageId}`);
                 }
             }
         } catch (err) {
-            logger.error({ err }, "Error handling deleted message");
+            logger.warn(`Delete event handling failed: ${err}`);
         }
     });
 
-    const names = options.contacts.map((c) => pc.cyan(c.displayName)).join(", ");
+    const names = options.contacts.map((contact) => pc.cyan(contact.displayName)).join(", ");
     logger.info(`Listening for messages from ${options.contacts.length} contact(s): ${names}`);
 }

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -1,22 +1,91 @@
 export type ActionType = "say" | "ask" | "notify";
 
+export type TelegramRuntimeMode = "daemon" | "light" | "ink";
+export type TelegramDialogType = "user" | "group" | "channel";
+export type SuggestionTrigger = "manual" | "auto" | "hybrid";
+export type StyleRefreshMode = "incremental";
+
+export interface AskModeConfig {
+    enabled: boolean;
+    provider?: string;
+    model?: string;
+    systemPrompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+}
+
+export interface SuggestionModeConfig extends AskModeConfig {
+    count: number;
+    trigger: SuggestionTrigger;
+    autoDelayMs: number;
+    allowAutoSend: boolean;
+}
+
+export interface StyleSourceRule {
+    id: string;
+    sourceChatId: string;
+    direction: "outgoing" | "incoming";
+    limit?: number;
+    since?: string;
+    until?: string;
+    regex?: string;
+}
+
+export interface StyleProfileConfig {
+    enabled: boolean;
+    refresh: StyleRefreshMode;
+    rules: StyleSourceRule[];
+    previewInWatch: boolean;
+    derivedPrompt?: string;
+    derivedAt?: string;
+}
+
+export interface WatchConfig {
+    enabled: boolean;
+    contextLength: number;
+    runtimeMode?: TelegramRuntimeMode;
+}
+
+export interface ContactModesConfig {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+}
+
 export interface ContactConfig {
     userId: string;
     displayName: string;
     username?: string;
+    dialogType?: TelegramDialogType;
     actions: ActionType[];
+
+    // V2 config
+    watch?: WatchConfig;
+    modes?: ContactModesConfig;
+    styleProfile?: StyleProfileConfig;
+
+    // V1 compatibility (auto-migrated to modes.autoReply)
     askSystemPrompt?: string;
     askProvider?: string;
     askModel?: string;
+
     replyDelayMin: number;
     replyDelayMax: number;
 }
 
+export interface TelegramDefaultsConfig {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+}
+
 export interface TelegramConfigData {
+    version?: number;
     apiId: number;
     apiHash: string;
     session: string;
     me?: { firstName: string; username?: string; phone?: string };
+    defaults?: TelegramDefaultsConfig;
     contacts: ContactConfig[];
     configuredAt: string;
 }
@@ -25,8 +94,7 @@ export interface ActionResult {
     action: ActionType;
     success: boolean;
     reply?: string;
-    /** Telegram ID of the sent outgoing message produced by the action. */
-    replyMessageId?: number;
+    sentMessageId?: number;
     duration: number;
     error?: unknown;
 }
@@ -51,11 +119,63 @@ export const DEFAULTS = {
     askTimeoutMs: 60_000,
     askProvider: "openai",
     askModel: "gpt-4o-mini",
+    askTemperature: 0.7,
+    askMaxTokens: 512,
     maxContextMessages: 30,
     historyFetchLimit: 100,
+    watchContextLength: 30,
+    watchRuntimeMode: "daemon" as TelegramRuntimeMode,
+    suggestionCount: 3,
+    suggestionAutoDelayMs: 5000,
 } as const;
 
-// ── History Types (Phase 2) ─────────────────────────────────────────
+export const TELEGRAM_CONFIG_VERSION = 2;
+
+export const DEFAULT_MODE_CONFIG: ContactModesConfig = {
+    autoReply: {
+        enabled: false,
+        provider: DEFAULTS.askProvider,
+        model: DEFAULTS.askModel,
+        systemPrompt: DEFAULTS.askSystemPrompt,
+        temperature: DEFAULTS.askTemperature,
+        maxTokens: DEFAULTS.askMaxTokens,
+    },
+    assistant: {
+        enabled: true,
+        provider: DEFAULTS.askProvider,
+        model: DEFAULTS.askModel,
+        systemPrompt: DEFAULTS.askSystemPrompt,
+        temperature: DEFAULTS.askTemperature,
+        maxTokens: DEFAULTS.askMaxTokens,
+    },
+    suggestions: {
+        enabled: true,
+        provider: DEFAULTS.askProvider,
+        model: DEFAULTS.askModel,
+        systemPrompt: DEFAULTS.askSystemPrompt,
+        temperature: DEFAULTS.askTemperature,
+        maxTokens: DEFAULTS.askMaxTokens,
+        count: DEFAULTS.suggestionCount,
+        trigger: "manual",
+        autoDelayMs: DEFAULTS.suggestionAutoDelayMs,
+        allowAutoSend: false,
+    },
+};
+
+export const DEFAULT_STYLE_PROFILE: StyleProfileConfig = {
+    enabled: false,
+    refresh: "incremental",
+    rules: [],
+    previewInWatch: false,
+};
+
+export const DEFAULT_WATCH_CONFIG: WatchConfig = {
+    enabled: true,
+    contextLength: DEFAULTS.watchContextLength,
+    runtimeMode: DEFAULTS.watchRuntimeMode,
+};
+
+// ── History Types (V2) ──────────────────────────────────────────────
 
 export interface MessageRow {
     id: number;
@@ -66,6 +186,49 @@ export interface MessageRow {
     is_outgoing: number;
     date_unix: number;
     date_iso: string;
+    edited_date_unix: number | null;
+    is_deleted: number;
+    deleted_at_iso: string | null;
+    reply_to_msg_id: number | null;
+}
+
+export interface MessageRevisionRow {
+    id: number;
+    chat_id: string;
+    message_id: number;
+    revision_type: "create" | "edit" | "delete";
+    text: string | null;
+    media_desc: string | null;
+    date_iso: string;
+    date_unix: number;
+}
+
+export interface AttachmentRow {
+    chat_id: string;
+    message_id: number;
+    attachment_index: number;
+    kind: string;
+    mime_type: string | null;
+    file_name: string | null;
+    file_size: number | null;
+    telegram_file_id: string | null;
+    thumb_count: number;
+    is_downloaded: number;
+    local_path: string | null;
+    sha256: string | null;
+    created_at_iso: string;
+    updated_at_iso: string;
+}
+
+export interface SuggestionFeedbackRow {
+    id: number;
+    chat_id: string;
+    incoming_message_id: number | null;
+    suggestion_text: string;
+    edited_text: string | null;
+    sent_text: string;
+    was_edited: number;
+    created_at_iso: string;
 }
 
 export interface SyncStateRow {
@@ -74,9 +237,34 @@ export interface SyncStateRow {
     last_synced_at: string;
 }
 
+export interface SyncSegmentRow {
+    id: number;
+    chat_id: string;
+    start_unix: number;
+    end_unix: number;
+    source: "full" | "incremental" | "query";
+    created_at_iso: string;
+}
+
+export interface ChatRow {
+    chat_id: string;
+    chat_type: TelegramDialogType;
+    title: string;
+    username: string | null;
+    last_seen_at_iso: string;
+}
+
 export interface SearchOptions {
     since?: Date;
     until?: Date;
+    limit?: number;
+}
+
+export interface QueryMessagesOptions {
+    since?: Date;
+    until?: Date;
+    sender?: "me" | "them" | "any";
+    textRegex?: string;
     limit?: number;
 }
 
@@ -98,239 +286,27 @@ export interface ChatStats {
     embeddedMessages: number;
 }
 
-/** Languages supported by macOS NLEmbedding */
-export const EMBEDDING_LANGUAGES = new Set(["en", "es", "fr", "de", "it", "pt", "zh"]);
-
-// ── V2 Schema Types ─────────────────────────────────────────────────
-
-export interface MessageRowV2 extends MessageRow {
-    edited_date_unix: number | null;
-    is_deleted: number; // 0 or 1
-    deleted_at_iso: string | null;
-    reply_to_msg_id: number | null;
-}
-
-export type ChatType = "user" | "group" | "channel";
-
-export interface ChatRow {
-    chat_id: string;
-    chat_type: ChatType;
-    title: string;
-    username: string | null;
-    last_synced_at: string | null;
-}
-
-export interface AttachmentRow {
-    chat_id: string;
-    message_id: number;
-    attachment_index: number;
-    kind: string;
-    mime_type: string | null;
-    file_name: string | null;
-    file_size: number | null;
-    telegram_file_id: string | null;
-    is_downloaded: number; // 0 or 1
-    local_path: string | null;
-    sha256: string | null;
-}
-
-export interface MessageRevisionRow {
-    id: number;
-    chat_id: string;
-    message_id: number;
-    revision_type: "create" | "edit" | "delete";
-    old_text: string | null;
-    new_text: string | null;
-    revised_at_unix: number;
-    revised_at_iso: string;
-}
-
-export interface SyncSegmentRow {
-    id: number;
-    chat_id: string;
-    from_date_unix: number;
-    to_date_unix: number;
-    from_msg_id: number;
-    to_msg_id: number;
-    synced_at: string;
-}
-
-export interface QueryOptions {
-    sender?: "me" | "them" | "any";
-    since?: Date;
-    until?: Date;
-    textPattern?: string;
-    limit?: number;
-    includeDeleted?: boolean;
-}
-
-export interface UpsertMessageInput {
-    id: number;
-    senderId: string | undefined;
-    text: string;
-    mediaDescription: string | undefined;
-    isOutgoing: boolean;
-    date: string;
-    dateUnix: number;
-    editedDateUnix?: number;
-    replyToMsgId?: number;
-}
-
-export interface UpsertAttachmentInput {
-    chat_id: string;
-    message_id: number;
-    attachment_index: number;
-    kind: string;
-    mime_type: string | null;
-    file_name: string | null;
-    file_size: number | null;
-    telegram_file_id: string | null;
-}
-
-export interface InsertSegmentInput {
-    fromDateUnix: number;
-    toDateUnix: number;
-    fromMsgId: number;
-    toMsgId: number;
-}
-
-export interface DateRange {
-    fromDateUnix: number;
-    toDateUnix: number;
-}
-
-export interface SuggestionEditInput {
+export interface AttachmentLocator {
     chatId: string;
-    messageId: number | null;
-    suggestedText: string;
-    editedText: string;
-    sentText: string;
-    provider: string | null;
-    model: string | null;
+    messageId: number;
+    attachmentIndex: number;
 }
 
-export interface SuggestionEditRow {
-    suggested_text: string;
-    edited_text: string;
-    sent_text: string;
-    created_at: string;
+export interface MissingRange {
+    sinceUnix: number;
+    untilUnix: number;
 }
 
-// ── V2 Config Types ──────────────────────────────────────────────────
-
-export type TelegramRuntimeMode = "daemon" | "light" | "ink";
-
-export interface AskModeConfig {
-    enabled: boolean;
-    provider?: string;
-    model?: string;
-    systemPrompt?: string;
-    temperature?: number;
-    maxTokens?: number;
-}
-
-export interface SuggestionModeConfig extends AskModeConfig {
-    count: number;
-    trigger: "manual" | "auto" | "hybrid";
-    autoDelayMs: number;
-    allowAutoSend: boolean;
-}
-
-export interface StyleSourceRule {
-    id: string;
-    sourceChatId: string;
-    direction: "outgoing" | "incoming";
-    limit?: number;
+export interface QueryRequest {
+    from: string;
     since?: string;
     until?: string;
-    regex?: string;
+    sender?: "me" | "them" | "any";
+    text?: string;
+    localOnly?: boolean;
+    nl?: string;
+    limit?: number;
 }
 
-export interface StyleProfileConfig {
-    enabled: boolean;
-    refresh: "incremental";
-    rules: StyleSourceRule[];
-    previewInWatch: boolean;
-}
-
-export interface WatchConfig {
-    enabled: boolean;
-    contextLength: number;
-    runtimeMode: TelegramRuntimeMode;
-}
-
-export interface ContactModesConfig {
-    autoReply: AskModeConfig;
-    assistant: AskModeConfig;
-    suggestions: SuggestionModeConfig;
-}
-
-export interface TelegramContactV2 {
-    userId: string;
-    displayName: string;
-    username?: string;
-    chatType: ChatType;
-    actions: ActionType[];
-    watch: WatchConfig;
-    modes: ContactModesConfig;
-    styleProfile: StyleProfileConfig;
-    replyDelayMin: number;
-    replyDelayMax: number;
-}
-
-export interface TelegramConfigDataV2 {
-    version: 2;
-    apiId: number;
-    apiHash: string;
-    session: string;
-    me?: {
-        firstName: string;
-        username?: string;
-        phone?: string;
-    };
-    contacts: TelegramContactV2[];
-    globalDefaults: {
-        modes: ContactModesConfig;
-        watch: WatchConfig;
-        styleProfile: StyleProfileConfig;
-    };
-    configuredAt: string;
-}
-
-export const DEFAULT_MODE_CONFIG: ContactModesConfig = {
-    autoReply: {
-        enabled: false,
-        provider: undefined,
-        model: undefined,
-        systemPrompt: undefined,
-    },
-    assistant: {
-        enabled: true,
-        provider: undefined,
-        model: undefined,
-        systemPrompt: undefined,
-    },
-    suggestions: {
-        enabled: true,
-        provider: undefined,
-        model: undefined,
-        systemPrompt: undefined,
-        count: 3,
-        trigger: "manual",
-        autoDelayMs: 5000,
-        allowAutoSend: false,
-    },
-};
-
-export const DEFAULT_WATCH_CONFIG: WatchConfig = {
-    enabled: true,
-    contextLength: 30,
-    runtimeMode: "ink",
-};
-
-export const DEFAULT_STYLE_PROFILE: StyleProfileConfig = {
-    enabled: false,
-    refresh: "incremental",
-    rules: [],
-    previewInWatch: false,
-};
+/** Languages supported by macOS NLEmbedding */
+export const EMBEDDING_LANGUAGES = new Set(["en", "es", "fr", "de", "it", "pt", "zh"]);

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -1,137 +1,122 @@
-import { Box, useApp, useInput } from "ink";
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { TelegramContactV2 } from "../../lib/types";
-import type { WatchMessage, WatchSession } from "../shared/WatchSession";
-import { ContactList } from "./components/ContactList";
-import { InputBar } from "./components/InputBar";
-import { MessageList } from "./components/MessageList";
-import { StatusBar } from "./components/StatusBar";
-import { type SystemLine, SystemOutput } from "./components/SystemOutput";
+import { useTerminalSize } from "@app/utils/ink/hooks/use-terminal-size";
+import { Box, render, Text, useApp, useInput } from "ink";
+import TextInput from "ink-text-input";
+import { useEffect, useState } from "react";
+import type { WatchRuntimeOptions } from "../light/WatchRuntime";
+import { WatchSession } from "../shared/WatchSession";
 
-type View = "chat" | "contacts";
-
-interface WatchInkAppProps {
+interface WatchInkRootProps {
     session: WatchSession;
 }
 
-export function WatchInkApp({ session }: WatchInkAppProps) {
+function WatchInkRoot({ session }: WatchInkRootProps) {
+    useTerminalSize({ clearOnResize: true });
     const { exit } = useApp();
-    const [messages, setMessages] = useState<WatchMessage[]>(session.getMessages());
-    const [view, setView] = useState<View>("chat");
-    const [systemLines, setSystemLines] = useState<SystemLine[]>([]);
-    const autoSuggestTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [input, setInput] = useState("");
+    const [feedback, setFeedback] = useState("");
+    const [refreshKey, setRefreshKey] = useState(0);
 
     useEffect(() => {
-        const unsub = session.subscribe(() => {
-            setMessages([...session.getMessages()]);
-        });
-
-        session.onAutoSuggest((suggestions) => {
-            if (autoSuggestTimeoutRef.current) {
-                clearTimeout(autoSuggestTimeoutRef.current);
-            }
-
-            setSystemLines(
-                suggestions.map((s, i) => ({
-                    text: `  ${i + 1}. ${s}`,
-                    type: "suggestion" as const,
-                }))
-            );
-            autoSuggestTimeoutRef.current = setTimeout(() => setSystemLines([]), 30000);
+        const unsubscribe = session.subscribe(() => {
+            setRefreshKey((value) => value + 1);
         });
 
         return () => {
-            unsub();
-            session.onAutoSuggest(null);
-
-            if (autoSuggestTimeoutRef.current) {
-                clearTimeout(autoSuggestTimeoutRef.current);
-                autoSuggestTimeoutRef.current = null;
-            }
+            unsubscribe();
         };
     }, [session]);
 
-    useInput((_input, key) => {
+    const view = session.getViewModel();
+
+    useInput((value, key) => {
+        if (key.ctrl && value === "c") {
+            exit();
+            return;
+        }
+
         if (key.tab) {
-            setView((v) => (v === "chat" ? "contacts" : "chat"));
+            session.cycleActiveChat(key.shift ? -1 : 1);
         }
     });
 
-    const handleSubmit = useCallback(
-        async (text: string) => {
-            setSystemLines([]);
+    const submitInput = (value: string) => {
+        void (async () => {
+            const result = await session.handleInput(value);
+            setInput("");
 
-            if (text.startsWith("/")) {
-                const result = await session.handleSlashCommand(text);
-
-                if (result.output === "__EXIT__") {
-                    exit();
-                    return;
-                }
-
-                if (result.output === "__CONTACTS__") {
-                    setView("contacts");
-                    return;
-                }
-
-                if (result.handled && result.output) {
-                    setSystemLines([{ text: result.output, type: "info" }]);
-                }
-
-                return;
+            if (result.output) {
+                setFeedback(result.output);
             }
 
-            if (session.inputMode === "careful") {
-                setSystemLines([{ text: "Careful mode: use /send <message> to send", type: "info" }]);
-                return;
+            if (result.exit) {
+                exit();
             }
-
-            try {
-                await session.sendMessage(text);
-            } catch (err) {
-                setSystemLines([
-                    {
-                        text: `Failed to send: ${err instanceof Error ? err.message : String(err)}`,
-                        type: "error",
-                    },
-                ]);
-            }
-        },
-        [session, exit]
-    );
-
-    const handleContactSelect = useCallback(
-        async (contact: TelegramContactV2) => {
-            await session.switchContact(contact);
-            setView("chat");
-        },
-        [session]
-    );
-
-    if (view === "contacts") {
-        return (
-            <ContactList
-                contacts={session.getContacts()}
-                currentContactId={session.currentContact.userId}
-                unreadCounts={session.getUnreadCounts()}
-                onSelect={handleContactSelect}
-                onBack={() => setView("chat")}
-            />
-        );
-    }
+        })();
+    };
 
     return (
-        <Box flexDirection="column" height="100%">
-            <StatusBar contact={session.currentContact} messageCount={messages.length} inputMode={session.inputMode} />
-            <Box flexDirection="column" flexGrow={1}>
-                <MessageList messages={messages} />
+        <Box flexDirection="column" key={refreshKey}>
+            <Text>
+                Telegram Watch (Ink) | Tab/Shift+Tab switch chat | Enter sends | /help commands | Mode:{" "}
+                {view.carefulMode ? "careful" : "normal"}
+            </Text>
+
+            <Box marginTop={1} flexDirection="row" flexWrap="wrap">
+                {view.contacts.map((contact) => (
+                    <Box key={contact.id} marginRight={2}>
+                        <Text color={contact.isActive ? "cyan" : "white"}>
+                            {contact.isActive ? ">" : " "} {contact.name}
+                            {contact.unreadCount > 0 ? ` (${contact.unreadCount})` : ""}
+                        </Text>
+                    </Box>
+                ))}
             </Box>
-            <SystemOutput lines={systemLines} />
-            <InputBar
-                mode={session.inputMode}
-                contactName={session.currentContact.displayName}
-                onSubmit={handleSubmit}
-            />
+
+            <Box marginTop={1} flexDirection="column">
+                {view.messages.slice(-25).map((message) => (
+                    <Text key={`${message.id}-${message.timestampIso}`}>
+                        {message.direction === "out" ? "You" : "Them"}: {message.text}
+                    </Text>
+                ))}
+            </Box>
+
+            {view.pendingSuggestions.length > 0 ? (
+                <Box marginTop={1} flexDirection="column">
+                    <Text color="yellow">Pending suggestions:</Text>
+                    {view.pendingSuggestions.map((suggestion, index) => (
+                        <Text key={`${index + 1}-${suggestion}`}>
+                            {" "}
+                            {index + 1}. {suggestion}
+                        </Text>
+                    ))}
+                </Box>
+            ) : null}
+
+            {feedback ? (
+                <Box marginTop={1}>
+                    <Text color="green">{feedback}</Text>
+                </Box>
+            ) : null}
+
+            <Box marginTop={1}>
+                <Text color="cyan">Input: </Text>
+                <TextInput value={input} onChange={setInput} onSubmit={submitInput} />
+            </Box>
         </Box>
     );
+}
+
+export async function runWatchInkApp(options: WatchRuntimeOptions): Promise<void> {
+    const session = new WatchSession({
+        contacts: options.contacts,
+        myName: options.myName,
+        client: options.client,
+        store: options.store,
+        contextLengthOverride: options.contextLength,
+    });
+
+    await session.startListeners();
+
+    const app = render(<WatchInkRoot session={session} />);
+    await app.waitUntilExit();
 }

--- a/src/telegram/runtime/light/WatchRuntime.ts
+++ b/src/telegram/runtime/light/WatchRuntime.ts
@@ -1,0 +1,61 @@
+import logger from "@app/logger";
+import { registerHandler } from "../../lib/handler";
+import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
+import type { TGClient } from "../../lib/TGClient";
+import type { ContactConfig } from "../../lib/types";
+import { WatchSession } from "../shared/WatchSession";
+
+export interface WatchRuntimeOptions {
+    contacts: ContactConfig[];
+    myName: string;
+    client: TGClient;
+    store: TelegramHistoryStore;
+    contextLength?: number;
+    daemon?: boolean;
+}
+
+export async function runWatchRuntime(options: WatchRuntimeOptions): Promise<void> {
+    if (options.daemon) {
+        const initialHistory = new Map<string, string[]>();
+
+        for (const contact of options.contacts) {
+            const contextLength = options.contextLength ?? contact.watch?.contextLength ?? 30;
+            const rows = options.store.getByDateRange(contact.userId, undefined, undefined, contextLength);
+            const lines = rows
+                .map((row) => {
+                    const content = row.text || row.media_desc;
+
+                    if (!content) {
+                        return undefined;
+                    }
+
+                    const name = row.is_outgoing ? options.myName : contact.displayName;
+                    return `${name}: ${content}`;
+                })
+                .filter((line): line is string => line !== undefined);
+
+            initialHistory.set(contact.userId, lines);
+        }
+
+        registerHandler(options.client, {
+            contacts: options.contacts,
+            myName: options.myName,
+            initialHistory,
+            store: options.store,
+        });
+
+        logger.info("Daemon watch started. Press Ctrl+C to stop.");
+        await new Promise(() => {});
+    }
+
+    const session = new WatchSession({
+        contacts: options.contacts,
+        myName: options.myName,
+        client: options.client,
+        store: options.store,
+        contextLengthOverride: options.contextLength,
+    });
+
+    await session.startListeners();
+    await session.runLightPromptLoop();
+}

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -1,423 +1,791 @@
-import { AssistantEngine } from "../../lib/AssistantEngine";
-import { StyleProfileEngine } from "../../lib/StyleProfileEngine";
-import { SuggestionEngine } from "../../lib/SuggestionEngine";
+import { stdin as input, stdout as output } from "node:process";
+import { createInterface } from "node:readline/promises";
+import logger from "@app/logger";
+import { modelSelector } from "@ask/providers/ModelSelector";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { assistantEngine } from "../../lib/AssistantEngine";
+import { attachmentDownloader } from "../../lib/AttachmentDownloader";
+import { styleProfileEngine } from "../../lib/StyleProfileEngine";
+import { suggestionEngine } from "../../lib/SuggestionEngine";
+import { TelegramContact } from "../../lib/TelegramContact";
 import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
-import type { TelegramMessage } from "../../lib/TelegramMessage";
+import { TelegramMessage } from "../../lib/TelegramMessage";
 import type { TGClient } from "../../lib/TGClient";
-import type { TelegramContactV2 } from "../../lib/types";
+import type { ContactConfig } from "../../lib/types";
 
-export interface WatchMessage {
+interface FeedEntry {
     id: number;
+    direction: "in" | "out";
     text: string;
-    isOutgoing: boolean;
-    senderName: string;
-    date: Date;
-    mediaDesc?: string;
+    timestampIso: string;
 }
 
-export type InputMode = "chat" | "careful";
+interface ContactState {
+    contact: TelegramContact;
+    historyLines: string[];
+    messageFeed: FeedEntry[];
+    lastIncoming?: string;
+    lastIncomingMessageId?: number;
+    pendingIncomingMessageId?: number;
+    pendingSuggestions: string[];
+    rawStyleSamples: string[];
+    unreadCount: number;
+}
+
+export interface WatchSessionOptions {
+    contacts: ContactConfig[];
+    myName: string;
+    client: TGClient;
+    store: TelegramHistoryStore;
+    contextLengthOverride?: number;
+}
+
+export interface WatchViewModel {
+    carefulMode: boolean;
+    activeChatId: string;
+    contacts: Array<{
+        id: string;
+        name: string;
+        unreadCount: number;
+        isActive: boolean;
+    }>;
+    messages: FeedEntry[];
+    pendingSuggestions: string[];
+}
+
+interface HandleResult {
+    output?: string;
+    exit?: boolean;
+}
+
+const MAX_FEED_MESSAGES = 500;
 
 export class WatchSession {
-    private messages: WatchMessage[] = [];
-    private listeners: Array<() => void> = [];
-    private _inputMode: InputMode = "chat";
-    private _currentContact: TelegramContactV2;
-    private unreadCounts = new Map<string, number>();
-    private _pendingSuggestions: string[] | null = null;
-    private _autoSuggestCallback: ((suggestions: string[]) => void) | null = null;
+    private states = new Map<string, ContactState>();
+    private activeChatId: string;
+    private carefulMode = false;
+    private shouldExit = false;
+    private listeners = new Set<() => void>();
+    private suggestionTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-    private assistantEngine: AssistantEngine;
-    private suggestionEngine: SuggestionEngine;
-    private styleEngine: StyleProfileEngine;
+    constructor(private options: WatchSessionOptions) {
+        if (options.contacts.length === 0) {
+            throw new Error("WatchSession requires at least one contact.");
+        }
 
-    constructor(
-        private client: TGClient,
-        private store: TelegramHistoryStore,
-        private myName: string,
-        contact: TelegramContactV2,
-        private allContacts: TelegramContactV2[]
-    ) {
-        this._currentContact = contact;
-        this.assistantEngine = new AssistantEngine(store, contact, myName);
-        this.suggestionEngine = new SuggestionEngine(store, contact, myName);
-        this.styleEngine = new StyleProfileEngine(store);
-    }
+        this.activeChatId = options.contacts[0].userId;
 
-    get currentContact(): TelegramContactV2 {
-        return this._currentContact;
-    }
+        for (const config of options.contacts) {
+            const contact = TelegramContact.fromConfig(config);
+            const contextLength = options.contextLengthOverride ?? contact.contextLength;
+            const rows = this.options.store.getByDateRange(
+                contact.userId,
+                undefined,
+                undefined,
+                Math.max(contextLength, 200)
+            );
+            const historyLines = rows
+                .map((row) => {
+                    const content = row.text ?? row.media_desc ?? "";
 
-    get inputMode(): InputMode {
-        return this._inputMode;
-    }
+                    if (!content) {
+                        return undefined;
+                    }
 
-    get contextLength(): number {
-        return this._currentContact.watch?.contextLength ?? 30;
-    }
+                    const name = row.is_outgoing ? this.options.myName : contact.displayName;
+                    return `${name}: ${content}`;
+                })
+                .filter((line): line is string => line !== undefined);
+            const messageFeed: FeedEntry[] = rows
+                .map((row) => {
+                    const text = row.text ?? row.media_desc ?? "";
 
-    async loadHistory(): Promise<void> {
-        const rows = this.store.queryMessages(this._currentContact.userId, {
-            limit: this.contextLength,
-        });
+                    if (!text) {
+                        return undefined;
+                    }
 
-        this.messages = rows.map((r) => ({
-            id: r.id,
-            text: r.text ?? "",
-            isOutgoing: r.is_outgoing === 1,
-            senderName: r.is_outgoing === 1 ? this.myName : this._currentContact.displayName,
-            date: new Date(r.date_unix * 1000),
-            mediaDesc: r.media_desc ?? undefined,
-        }));
+                    return {
+                        id: row.id,
+                        direction: row.is_outgoing ? "out" : "in",
+                        text,
+                        timestampIso: row.date_iso,
+                    } satisfies FeedEntry;
+                })
+                .filter((entry): entry is FeedEntry => entry !== undefined);
+            const rawStyleSamples = styleProfileEngine.getRawStyleSamples(contact, this.options.store, 120);
 
-        this.notify();
+            this.states.set(contact.userId, {
+                contact,
+                historyLines,
+                messageFeed,
+                pendingSuggestions: [],
+                unreadCount: 0,
+                rawStyleSamples,
+            });
+        }
     }
 
     subscribe(listener: () => void): () => void {
-        this.listeners.push(listener);
+        this.listeners.add(listener);
+
         return () => {
-            this.listeners = this.listeners.filter((l) => l !== listener);
+            this.listeners.delete(listener);
         };
     }
 
-    private notify() {
-        for (const l of this.listeners) {
-            l();
+    getViewModel(): WatchViewModel {
+        const active = this.getRequiredState(this.activeChatId);
+
+        return {
+            carefulMode: this.carefulMode,
+            activeChatId: this.activeChatId,
+            contacts: [...this.states.values()].map((state) => ({
+                id: state.contact.userId,
+                name: state.contact.displayName,
+                unreadCount: state.unreadCount,
+                isActive: state.contact.userId === this.activeChatId,
+            })),
+            messages: active.messageFeed.slice(-200),
+            pendingSuggestions: active.pendingSuggestions,
+        };
+    }
+
+    private notifyViewUpdate(): void {
+        for (const listener of this.listeners) {
+            listener();
         }
     }
 
-    getMessages(): WatchMessage[] {
-        return this.messages.slice(-this.contextLength);
-    }
+    private getRequiredState(chatId: string): ContactState {
+        const state = this.states.get(chatId);
 
-    getContacts(): TelegramContactV2[] {
-        return this.allContacts;
-    }
-
-    addIncoming(msg: TelegramMessage): void {
-        this.messages.push({
-            id: msg.id,
-            text: msg.text,
-            isOutgoing: false,
-            senderName: this._currentContact.displayName,
-            date: msg.date,
-            mediaDesc: msg.mediaDescription,
-        });
-
-        const triggerMode = this._currentContact.modes.suggestions.trigger;
-
-        if (triggerMode === "auto" || triggerMode === "hybrid") {
-            const recentMsgs = this.messages.slice(-10).map((m) => ({
-                sender: m.senderName,
-                text: m.text,
-            }));
-
-            this.suggestionEngine.scheduleAutoSuggest(recentMsgs, (suggestions) => {
-                this._pendingSuggestions = suggestions;
-                this._autoSuggestCallback?.(suggestions);
-                this.notify();
-            });
+        if (!state) {
+            throw new Error(`Unknown chat id: ${chatId}`);
         }
 
-        this.notify();
+        return state;
     }
 
-    onAutoSuggest(callback: ((suggestions: string[]) => void) | null): void {
-        this._autoSuggestCallback = callback;
+    getActiveState(): ContactState {
+        return this.getRequiredState(this.activeChatId);
     }
 
-    async sendMessage(text: string): Promise<void> {
-        const sent = await this.client.sendMessage(this._currentContact.userId, text);
-        this.store.insertMessages(this._currentContact.userId, [
+    setActiveChat(chatId: string): void {
+        const state = this.states.get(chatId);
+
+        if (!state) {
+            return;
+        }
+
+        this.activeChatId = chatId;
+        state.unreadCount = 0;
+        this.notifyViewUpdate();
+    }
+
+    cycleActiveChat(direction: 1 | -1 = 1): void {
+        const ids = [...this.states.keys()];
+
+        if (ids.length <= 1) {
+            return;
+        }
+
+        const index = ids.findIndex((id) => id === this.activeChatId);
+
+        if (index === -1) {
+            this.activeChatId = ids[0];
+            this.notifyViewUpdate();
+            return;
+        }
+
+        const next = (index + direction + ids.length) % ids.length;
+        this.setActiveChat(ids[next]);
+    }
+
+    private pushHistory(state: ContactState, line: string): void {
+        const maxLength = this.options.contextLengthOverride ?? state.contact.contextLength;
+        state.historyLines.push(line);
+
+        while (state.historyLines.length > maxLength) {
+            state.historyLines.shift();
+        }
+    }
+
+    private pushFeed(state: ContactState, entry: FeedEntry): void {
+        state.messageFeed.push(entry);
+
+        while (state.messageFeed.length > MAX_FEED_MESSAGES) {
+            state.messageFeed.shift();
+        }
+    }
+
+    private getHistoryText(state: ContactState): string {
+        return state.historyLines.join("\n");
+    }
+
+    private refreshStyleSamples(state: ContactState): void {
+        const styleProfile = state.contact.config.styleProfile;
+
+        if (!styleProfile || !styleProfile.enabled) {
+            return;
+        }
+
+        state.rawStyleSamples = styleProfileEngine.getRawStyleSamples(state.contact, this.options.store, 120);
+    }
+
+    private findState(target: string): ContactState | null {
+        const lower = target.toLowerCase();
+
+        for (const state of this.states.values()) {
+            if (state.contact.userId === target) {
+                return state;
+            }
+
+            if (state.contact.displayName.toLowerCase() === lower) {
+                return state;
+            }
+
+            if (state.contact.username?.toLowerCase() === lower) {
+                return state;
+            }
+        }
+
+        return null;
+    }
+
+    private parseStateFromArgs(args: string[]): { state: ContactState; consumed: number } | null {
+        if (args.length === 0) {
+            return {
+                state: this.getActiveState(),
+                consumed: 0,
+            };
+        }
+
+        const contactCandidate = this.findState(args[0]);
+
+        if (contactCandidate) {
+            return {
+                state: contactCandidate,
+                consumed: 1,
+            };
+        }
+
+        return {
+            state: this.getActiveState(),
+            consumed: 0,
+        };
+    }
+
+    private async sendText(
+        state: ContactState,
+        text: string,
+        feedback?: { suggestionText: string; incomingMessageId?: number }
+    ): Promise<void> {
+        const sent = await this.options.client.sendMessage(state.contact.userId, text);
+        const timestampUnix = sent.date ? sent.date : Math.floor(Date.now() / 1000);
+        const timestampIso = new Date(timestampUnix * 1000).toISOString();
+
+        this.options.store.upsertMessageWithRevision(
+            state.contact.userId,
             {
                 id: sent.id,
                 senderId: undefined,
                 text,
                 mediaDescription: undefined,
                 isOutgoing: true,
-                date: new Date().toISOString(),
-                dateUnix: Math.floor(Date.now() / 1000),
+                date: timestampIso,
+                dateUnix: timestampUnix,
+                attachments: [],
             },
-        ]);
+            "create"
+        );
 
-        this.messages.push({
+        if (feedback) {
+            this.options.store.recordSuggestionFeedback({
+                chatId: state.contact.userId,
+                incomingMessageId: feedback.incomingMessageId,
+                suggestionText: feedback.suggestionText,
+                sentText: text,
+                editedText: feedback.suggestionText === text ? undefined : text,
+            });
+        }
+
+        this.pushHistory(state, `${this.options.myName}: ${text}`);
+        this.pushFeed(state, {
             id: sent.id,
+            direction: "out",
             text,
-            isOutgoing: true,
-            senderName: this.myName,
-            date: new Date(),
+            timestampIso,
         });
-        this.notify();
+        this.refreshStyleSamples(state);
+
+        logger.info(`${pc.green("You")} → ${pc.cyan(state.contact.displayName)}: ${text}`);
+        this.notifyViewUpdate();
     }
 
-    async switchContact(contact: TelegramContactV2): Promise<void> {
-        this.suggestionEngine.cancelAutoSuggest();
-        this._currentContact = contact;
-        this.messages = [];
-        this._pendingSuggestions = null;
-        this.clearUnread(contact.userId);
-        this.assistantEngine = new AssistantEngine(this.store, contact, this.myName);
-        this.suggestionEngine = new SuggestionEngine(this.store, contact, this.myName);
-        await this.loadHistory();
-    }
-
-    toggleCarefulMode(): void {
-        this._inputMode = this._inputMode === "chat" ? "careful" : "chat";
-        this.notify();
-    }
-
-    incrementUnread(contactId: string): void {
-        const current = this.unreadCounts.get(contactId) ?? 0;
-        this.unreadCounts.set(contactId, current + 1);
-        this.notify();
-    }
-
-    getUnreadCount(contactId: string): number {
-        return this.unreadCounts.get(contactId) ?? 0;
-    }
-
-    clearUnread(contactId: string): void {
-        this.unreadCounts.delete(contactId);
-    }
-
-    getUnreadCounts(): Map<string, number> {
-        return this.unreadCounts;
-    }
-
-    async handleSlashCommand(input: string): Promise<{ handled: boolean; output?: string }> {
-        const trimmed = input.trim();
-
-        if (!trimmed.startsWith("/")) {
-            return { handled: false };
+    private async generateSuggestionsForState(state: ContactState): Promise<string[]> {
+        if (!state.lastIncoming) {
+            return [];
         }
 
-        const parts = trimmed.slice(1).split(/\s+/);
-        const cmd = parts[0].toLowerCase();
-        const args = parts.slice(1).join(" ");
-
-        switch (cmd) {
-            case "careful":
-                this.toggleCarefulMode();
-                return { handled: true, output: `Input mode: ${this._inputMode}` };
-
-            case "send":
-                if (this._inputMode === "careful" && args) {
-                    await this.sendMessage(args);
-                    return { handled: true };
-                }
-
-                return { handled: true, output: "Usage: /send <message>" };
-
-            case "quit":
-            case "exit":
-                return { handled: true, output: "__EXIT__" };
-
-            case "ask":
-                return this.handleAsk(args);
-
-            case "suggest":
-                return this.handleSuggest(args);
-
-            case "pick":
-                return this.handlePick(args);
-
-            case "style":
-                return this.handleStyle();
-
-            case "model":
-                return this.handleModel(args);
-
-            case "attachment": {
-                const msgId = Number.parseInt(args, 10);
-
-                if (Number.isNaN(msgId)) {
-                    return { handled: true, output: "Usage: /attachment <message_id>" };
-                }
-
-                const atts = this.store.getAttachments(this._currentContact.userId, msgId);
-
-                if (atts.length === 0) {
-                    return { handled: true, output: "No attachments for this message" };
-                }
-
-                const list = atts
-                    .map(
-                        (a) =>
-                            `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "downloaded" : "not downloaded"}`
-                    )
-                    .join("\n");
-                return { handled: true, output: `Attachments:\n${list}` };
-            }
-
-            case "help":
-                return {
-                    handled: true,
-                    output: [
-                        "Commands:",
-                        "  /ask <question>     Ask assistant about the conversation",
-                        "  /suggest [prompt]   Generate reply suggestions",
-                        "  /pick <n> [edit]    Pick/edit a suggestion and send",
-                        "  /send <text>        Send message (required in /careful mode)",
-                        "  /careful            Toggle careful mode (require /send)",
-                        "  /model              Switch AI model",
-                        "  /style              Derive/preview style profile",
-                        "  /attachment <id>    List/download attachments",
-                        "  /contacts           Switch to contact list",
-                        "  /quit               Exit watch mode",
-                    ].join("\n"),
-                };
-
-            case "contacts":
-                return { handled: true, output: "__CONTACTS__" };
-
-            default:
-                return { handled: true, output: `Unknown command: /${cmd}. Type /help for available commands.` };
-        }
-    }
-
-    private async handleAsk(args: string): Promise<{ handled: boolean; output?: string }> {
-        if (!args) {
-            return { handled: true, output: "Usage: /ask <question>" };
+        if (state.rawStyleSamples.length === 0) {
+            state.rawStyleSamples = styleProfileEngine.getRawStyleSamples(state.contact, this.options.store, 120);
         }
 
-        try {
-            const answer = await this.assistantEngine.ask(args);
-            return { handled: true, output: answer };
-        } catch (err) {
-            return { handled: true, output: `Assistant error: ${err instanceof Error ? err.message : String(err)}` };
-        }
-    }
-
-    private async handleSuggest(args: string): Promise<{ handled: boolean; output?: string }> {
-        try {
-            const recentMsgs = this.messages.slice(-10).map((m) => ({
-                sender: m.senderName,
-                text: m.text,
-            }));
-            const customPrompt = args || undefined;
-            const suggestions = await this.suggestionEngine.suggest(recentMsgs, customPrompt);
-
-            this._pendingSuggestions = suggestions;
-
-            const formatted = suggestions.map((s, i) => `  ${i + 1}. ${s}`).join("\n");
-            return {
-                handled: true,
-                output: `Suggestions:\n${formatted}\n\nUse /pick <number> to select, or /pick <number> <edited text> to edit and send.`,
-            };
-        } catch (err) {
-            return { handled: true, output: `Suggestion error: ${err instanceof Error ? err.message : String(err)}` };
-        }
-    }
-
-    private async handlePick(args: string): Promise<{ handled: boolean; output?: string }> {
-        if (!this._pendingSuggestions || this._pendingSuggestions.length === 0) {
-            return { handled: true, output: "No pending suggestions. Use /suggest first." };
-        }
-
-        const pickParts = args.split(/\s+/);
-        const index = Number.parseInt(pickParts[0], 10) - 1;
-
-        if (Number.isNaN(index) || index < 0 || index >= this._pendingSuggestions.length) {
-            return { handled: true, output: `Invalid choice. Pick 1-${this._pendingSuggestions.length}` };
-        }
-
-        const original = this._pendingSuggestions[index];
-        const edited = pickParts.length > 1 ? pickParts.slice(1).join(" ") : original;
-
-        const sent = await this.client.sendMessage(this._currentContact.userId, edited);
-
-        this.store.insertMessages(this._currentContact.userId, [
-            {
-                id: sent.id,
-                senderId: undefined,
-                text: edited,
-                mediaDescription: undefined,
-                isOutgoing: true,
-                date: new Date().toISOString(),
-                dateUnix: Math.floor(Date.now() / 1000),
-            },
-        ]);
-
-        this.messages.push({
-            id: sent.id,
-            text: edited,
-            isOutgoing: true,
-            senderName: this.myName,
-            date: new Date(),
+        const suggestions = await suggestionEngine.generateSuggestions({
+            sessionId: `watch-${state.contact.userId}`,
+            mode: state.contact.suggestionMode,
+            incomingText: state.lastIncoming,
+            incomingMessageId: state.lastIncomingMessageId,
+            conversationHistory: this.getHistoryText(state),
+            stylePrompt: state.contact.config.styleProfile?.derivedPrompt,
+            rawStyleSamples: state.rawStyleSamples,
+            store: this.options.store,
+            chatId: state.contact.userId,
         });
 
-        this.suggestionEngine.trackEdit(original, edited, edited, sent.id);
+        state.pendingSuggestions = suggestions;
+        state.pendingIncomingMessageId = state.lastIncomingMessageId;
+        this.notifyViewUpdate();
 
-        this._pendingSuggestions = null;
-        this.notify();
+        if (state.contact.suggestionMode.allowAutoSend && suggestions.length > 0) {
+            await this.sendText(state, suggestions[0], {
+                suggestionText: suggestions[0],
+                incomingMessageId: state.pendingIncomingMessageId,
+            });
+            state.pendingSuggestions = [];
+            state.pendingIncomingMessageId = undefined;
+            this.notifyViewUpdate();
+        }
 
-        return { handled: true, output: `Sent: "${edited}"` };
+        return suggestions;
     }
 
-    private handleStyle(): { handled: boolean; output?: string } {
-        try {
-            const analysis = this.styleEngine.analyzeStyle(this._currentContact.userId, "me", 200);
-            const lines = [
-                `Style analysis (${analysis.totalMessages} messages):`,
-                ...analysis.traits.map((t) => `  - ${t}`),
-            ];
+    private printSuggestions(state: ContactState): void {
+        if (state.pendingSuggestions.length === 0) {
+            logger.info(`[suggest:${state.contact.displayName}] no options generated`);
+            return;
+        }
 
-            if (analysis.commonPatterns.length > 0) {
-                lines.push("Common starters:");
-                lines.push(...analysis.commonPatterns.map((p) => `  - ${p}`));
-            }
+        logger.info(pc.yellow(`Suggestions for ${state.contact.displayName}:`));
 
-            return { handled: true, output: lines.join("\n") };
-        } catch (err) {
-            return { handled: true, output: `Style error: ${err instanceof Error ? err.message : String(err)}` };
+        for (let i = 0; i < state.pendingSuggestions.length; i++) {
+            logger.info(`  ${i + 1}. ${state.pendingSuggestions[i]}`);
         }
     }
 
-    private handleModel(args: string): { handled: boolean; output?: string } {
-        if (!args) {
-            const current = this._currentContact.modes.assistant;
+    private scheduleAutoSuggestion(state: ContactState): void {
+        const existing = this.suggestionTimers.get(state.contact.userId);
+
+        if (existing) {
+            clearTimeout(existing);
+        }
+
+        const delayMs = state.contact.suggestionMode.autoDelayMs;
+        const timer = setTimeout(async () => {
+            try {
+                await this.generateSuggestionsForState(state);
+                this.printSuggestions(state);
+            } catch (err) {
+                logger.warn(`Auto suggestion failed: ${err}`);
+            } finally {
+                this.suggestionTimers.delete(state.contact.userId);
+            }
+        }, delayMs);
+
+        this.suggestionTimers.set(state.contact.userId, timer);
+    }
+
+    async startListeners(): Promise<void> {
+        this.options.client.onNewMessage(async (event) => {
+            const message = new TelegramMessage(event.message);
+
+            if (message.isOutgoing) {
+                return;
+            }
+
+            const targetId = message.chatId ?? message.senderId;
+
+            if (!targetId) {
+                return;
+            }
+
+            const state = this.states.get(targetId);
+
+            if (!state) {
+                return;
+            }
+
+            const serialized = message.toJSON();
+            this.options.store.upsertMessageWithRevision(targetId, serialized, "create");
+            const content = message.contentForLLM;
+
+            if (content) {
+                this.pushHistory(state, `${state.contact.displayName}: ${content}`);
+                state.lastIncoming = content;
+                state.lastIncomingMessageId = message.id;
+                this.pushFeed(state, {
+                    id: message.id,
+                    direction: "in",
+                    text: content,
+                    timestampIso: new Date(message.date.getTime()).toISOString(),
+                });
+                this.refreshStyleSamples(state);
+            }
+
+            if (state.contact.userId !== this.activeChatId) {
+                state.unreadCount += 1;
+            }
+
+            logger.info(`${pc.bold(pc.cyan(state.contact.displayName))}: ${message.preview}`);
+            this.notifyViewUpdate();
+
+            const suggestionMode = state.contact.suggestionMode;
+
+            if (!suggestionMode.enabled) {
+                return;
+            }
+
+            if (suggestionMode.trigger === "auto" || suggestionMode.trigger === "hybrid") {
+                this.scheduleAutoSuggestion(state);
+            }
+        });
+    }
+
+    private async handleCommand(line: string): Promise<HandleResult> {
+        const parts = line.split(" ").filter(Boolean);
+        const command = parts[0];
+        const args = parts.slice(1);
+
+        if (command === "/quit" || command === "/exit") {
+            this.shouldExit = true;
+            return { exit: true };
+        }
+
+        if (command === "/help") {
+            const active = this.getActiveState();
             return {
-                handled: true,
-                output: [
-                    "Current models:",
-                    `  Assistant: ${current.provider ?? "default"}/${current.model ?? "default"}`,
-                    `  Suggestions: ${this._currentContact.modes.suggestions.provider ?? "default"}/${this._currentContact.modes.suggestions.model ?? "default"}`,
-                    "",
-                    "Usage: /model assistant <provider>/<model>",
-                    "       /model suggestions <provider>/<model>",
-                ].join("\n"),
+                output:
+                    "Commands:\n" +
+                    "/chat <contact> | /next | /prev\n" +
+                    "/suggest [contact]\n" +
+                    "/pick [contact] <index> [edited text]\n" +
+                    "/send [contact] <text>\n" +
+                    "/ask [contact] <question>\n" +
+                    "/attachment [contact] <messageId> [attachmentIndex] [outputPath]\n" +
+                    "/model [contact] <autoReply|assistant|suggestions>\n" +
+                    "/style derive [contact]\n" +
+                    "/careful (toggle plain-text sending)\n" +
+                    `/active: ${active.contact.displayName}`,
             };
         }
 
-        const modelParts = args.split(/\s+/);
-        const mode = modelParts[0];
-        const modelSpec = modelParts[1];
-
-        if (!modelSpec || !modelSpec.includes("/")) {
-            return { handled: true, output: "Usage: /model <mode> <provider>/<model>" };
+        if (command === "/careful") {
+            this.carefulMode = !this.carefulMode;
+            this.notifyViewUpdate();
+            return {
+                output: `Careful mode ${this.carefulMode ? "enabled" : "disabled"}`,
+            };
         }
 
-        const [provider, ...modelNameParts] = modelSpec.split("/");
-        const model = modelNameParts.join("/");
+        if (command === "/chat") {
+            if (args.length === 0) {
+                return { output: "Usage: /chat <contact>" };
+            }
 
-        if (mode === "assistant" || mode === "suggestions" || mode === "autoReply") {
-            this._currentContact = {
-                ...this._currentContact,
-                modes: {
-                    ...this._currentContact.modes,
-                    [mode]: { ...this._currentContact.modes[mode], provider, model },
+            const state = this.findState(args[0]);
+
+            if (!state) {
+                return { output: `Unknown contact: ${args[0]}` };
+            }
+
+            this.setActiveChat(state.contact.userId);
+            return { output: `Active chat: ${state.contact.displayName}` };
+        }
+
+        if (command === "/next") {
+            this.cycleActiveChat(1);
+            return { output: `Active chat: ${this.getActiveState().contact.displayName}` };
+        }
+
+        if (command === "/prev") {
+            this.cycleActiveChat(-1);
+            return { output: `Active chat: ${this.getActiveState().contact.displayName}` };
+        }
+
+        if (command === "/suggest") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            await this.generateSuggestionsForState(target.state);
+            this.printSuggestions(target.state);
+            return { output: `Generated suggestions for ${target.state.contact.displayName}` };
+        }
+
+        if (command === "/pick") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const indexRaw = args[target.consumed];
+            const index = indexRaw ? Number(indexRaw) : Number.NaN;
+
+            if (!Number.isInteger(index) || index < 1) {
+                return { output: "Usage: /pick [contact] <index> [edited text]" };
+            }
+
+            const suggestion = target.state.pendingSuggestions[index - 1];
+
+            if (!suggestion) {
+                return { output: `No suggestion at index ${index}` };
+            }
+
+            const inlineEditedText = args
+                .slice(target.consumed + 1)
+                .join(" ")
+                .trim();
+            let sendText = inlineEditedText;
+
+            if (!sendText) {
+                const promptValue = await p.text({
+                    message: `Edit suggestion ${index} before send (empty = keep as-is):`,
+                    initialValue: suggestion,
+                });
+
+                if (p.isCancel(promptValue)) {
+                    return { output: "Suggestion send cancelled." };
+                }
+
+                const textValue = (promptValue as string).trim();
+                sendText = textValue.length > 0 ? textValue : suggestion;
+            }
+
+            await this.sendText(target.state, sendText, {
+                suggestionText: suggestion,
+                incomingMessageId: target.state.pendingIncomingMessageId,
+            });
+
+            target.state.pendingSuggestions = [];
+            target.state.pendingIncomingMessageId = undefined;
+            this.notifyViewUpdate();
+            return { output: `Sent suggestion ${index} to ${target.state.contact.displayName}` };
+        }
+
+        if (command === "/send") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const text = args.slice(target.consumed).join(" ").trim();
+
+            if (!text) {
+                return { output: "Usage: /send [contact] <text>" };
+            }
+
+            await this.sendText(target.state, text);
+            return { output: `Sent to ${target.state.contact.displayName}` };
+        }
+
+        if (command === "/ask") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const question = args.slice(target.consumed).join(" ").trim();
+
+            if (!question) {
+                return { output: "Usage: /ask [contact] <question>" };
+            }
+
+            if (target.state.rawStyleSamples.length === 0) {
+                target.state.rawStyleSamples = styleProfileEngine.getRawStyleSamples(
+                    target.state.contact,
+                    this.options.store,
+                    120
+                );
+            }
+
+            const answer = await assistantEngine.ask({
+                sessionId: `watch-assistant-${target.state.contact.userId}`,
+                mode: target.state.contact.assistantMode,
+                incomingText: question,
+                conversationHistory: this.getHistoryText(target.state),
+                stylePrompt: target.state.contact.config.styleProfile?.derivedPrompt,
+                rawStyleSamples: target.state.rawStyleSamples,
+                store: this.options.store,
+                chatId: target.state.contact.userId,
+                includeFullDbHistory: true,
+            });
+
+            logger.info(pc.green(answer));
+            return { output: answer };
+        }
+
+        if (command === "/attachment") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const messageIdRaw = args[target.consumed];
+            const attachmentIndexRaw = args[target.consumed + 1];
+            const messageId = messageIdRaw ? Number(messageIdRaw) : Number.NaN;
+            const attachmentIndex =
+                attachmentIndexRaw && /^\d+$/.test(attachmentIndexRaw) ? Number(attachmentIndexRaw) : 0;
+
+            if (!Number.isInteger(messageId) || messageId <= 0) {
+                return { output: "Usage: /attachment [contact] <messageId> [attachmentIndex] [outputPath]" };
+            }
+
+            let outputPath = args
+                .slice(target.consumed + (attachmentIndexRaw && /^\d+$/.test(attachmentIndexRaw) ? 2 : 1))
+                .join(" ")
+                .trim();
+
+            if (!outputPath) {
+                const inputPath = await p.text({
+                    message: "Output path (leave empty for default chats/<id>/attachments path):",
+                    initialValue: "",
+                });
+
+                if (!p.isCancel(inputPath)) {
+                    outputPath = (inputPath as string).trim();
+                }
+            }
+
+            const result = await attachmentDownloader.downloadByLocator(
+                this.options.client,
+                this.options.store,
+                {
+                    chatId: target.state.contact.userId,
+                    messageId,
+                    attachmentIndex,
                 },
-            };
+                {
+                    outputPath: outputPath || undefined,
+                }
+            );
 
-            this.assistantEngine = new AssistantEngine(this.store, this._currentContact, this.myName);
-            this.suggestionEngine = new SuggestionEngine(this.store, this._currentContact, this.myName);
-
-            if (mode === "assistant") {
-                this.assistantEngine.resetSession();
-            }
-
-            return { handled: true, output: `${mode} model set to ${provider}/${model}` };
+            return { output: `Attachment saved: ${result.outputPath} (${result.bytes} bytes)` };
         }
 
-        return { handled: true, output: `Unknown mode: ${mode}. Use assistant, suggestions, or autoReply` };
+        if (command === "/model") {
+            const target = this.parseStateFromArgs(args);
+
+            if (!target) {
+                return { output: "Unable to resolve contact." };
+            }
+
+            const modeArg = args[target.consumed] as "autoReply" | "assistant" | "suggestions" | undefined;
+
+            if (!modeArg || !["autoReply", "assistant", "suggestions"].includes(modeArg)) {
+                return { output: "Usage: /model [contact] <autoReply|assistant|suggestions>" };
+            }
+
+            const mode = target.state.contact.config.modes?.[modeArg];
+
+            if (!mode) {
+                return { output: `Mode ${modeArg} missing in contact config.` };
+            }
+
+            const choice = await modelSelector.selectModel();
+
+            if (!choice) {
+                return { output: "Model selection cancelled." };
+            }
+
+            mode.provider = choice.provider.name;
+            mode.model = choice.model.id;
+            return {
+                output: `Updated ${target.state.contact.displayName} ${modeArg} -> ${mode.provider}/${mode.model}`,
+            };
+        }
+
+        if (command === "/style" && args[0] === "derive") {
+            const target = this.parseStateFromArgs(args.slice(1));
+
+            if (!target) {
+                return { output: "Usage: /style derive [contact]" };
+            }
+
+            const result = await styleProfileEngine.deriveStylePrompt(target.state.contact, this.options.store);
+
+            if (!result) {
+                return { output: "No style profile generated (rules missing or no matching messages)." };
+            }
+
+            if (!target.state.contact.config.styleProfile) {
+                target.state.contact.config.styleProfile = {
+                    enabled: true,
+                    refresh: "incremental",
+                    rules: [],
+                    previewInWatch: false,
+                };
+            }
+
+            target.state.contact.config.styleProfile.derivedPrompt = result.prompt;
+            target.state.contact.config.styleProfile.derivedAt = result.generatedAt;
+            target.state.rawStyleSamples = result.rawSamples;
+            return { output: `Derived style profile from ${result.sampleCount} samples.` };
+        }
+
+        return { output: "Unknown command. Use /help." };
+    }
+
+    async handleInput(line: string): Promise<HandleResult> {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            return {};
+        }
+
+        if (trimmed.startsWith("/")) {
+            return this.handleCommand(trimmed);
+        }
+
+        if (this.carefulMode) {
+            return { output: "Careful mode is on. Use /send to send messages." };
+        }
+
+        const active = this.getActiveState();
+        await this.sendText(active, trimmed);
+        return { output: `Sent to ${active.contact.displayName}` };
+    }
+
+    async runLightPromptLoop(): Promise<void> {
+        const rl = createInterface({ input, output });
+
+        logger.info(
+            "Live watch mode. Plain text sends to active chat. Use /help for commands. /careful toggles explicit /send-only mode."
+        );
+
+        try {
+            while (!this.shouldExit) {
+                const active = this.getActiveState();
+                const prompt = `${pc.dim("watch")}(${pc.cyan(active.contact.displayName)}${this.carefulMode ? pc.yellow(":careful") : ""})> `;
+                const line = await rl.question(prompt);
+                const result = await this.handleInput(line);
+
+                if (result.output) {
+                    logger.info(result.output);
+                }
+
+                if (result.exit) {
+                    break;
+                }
+            }
+        } finally {
+            rl.close();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- complete Telegram V2 conversation memory stack (full/incremental/range sync, segment-aware query auto-fetch, attachment index + lazy download)
- add assistant/suggestion/watch runtime split with live light + Ink experiences, inline slash command flows, and per-mode provider/model configs
- add style profile pipeline (rules + derive) with hybrid style summary + raw samples and suggestion edit feedback loop
- add edit/delete ingestion, outgoing message ID correctness, natural-language query dates, and compatibility alias paths for existing listen/download usage

## Validation
- bun test src/telegram
- tsgo --noEmit
- biome check src/telegram src/ask

Supersedes #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `watch` command with three runtime modes: daemon (background monitoring), light (interactive prompts), and ink (rich UI).
  * Introduced per-dialog configuration for auto-reply, suggestions, and style profiles with provider/model selection.
  * Added attachment management: list, download, and lazy loading with metadata indexing.
  * Added query and search: natural language parsing, semantic search via embeddings, and hybrid search.
  * Added style derivation: automatically generate conversation styles from message history.
  * Added suggestion engine: auto-generate reply options with user feedback tracking.
  * Expanded history: incremental synchronization, revision tracking, and sync segments for efficient backfill.

* **Documentation**
  * Added V2 implementation plan detailing new subsystems and feature scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->