### PR TITLE
feat(azure-devops): download inline images from work items

### DIFF
--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -43,6 +43,7 @@ tools azure-devops timelog import <file>         # Bulk import time logs (with p
 | `--attachments-prefix <prefix>` | Only attachments starting with this name |
 | `--attachments-suffix <suffix>` | Only attachments ending with this (e.g. .har) |
 | `--output-dir <path>` | Custom directory for downloaded attachments |
+| `--images` | Download inline images from description/comments |
 
 ### Output Paths
 
@@ -57,6 +58,16 @@ Attachments are downloaded when any `--attachments-*` filter flag is provided. W
 - **Default**: Same folder as task file: `.claude/azure/tasks/<taskid>-<attachment-name>`
 - With `--task-folders`: `.claude/azure/tasks/<id>/<taskid>-<attachment-name>`
 - With `--output-dir /custom/path`: `/custom/path/<taskid>-<attachment-name>`
+
+### Inline Image Output Paths
+
+Inline images (screenshots embedded in description/comments HTML) are downloaded when `--images` is provided.
+
+- **Default**: Same folder as task file: `.claude/azure/tasks/<taskid>-<imagename>.png`
+- With `--task-folders`: `.claude/azure/tasks/<id>/<taskid>-<imagename>.png`
+- Images are referenced in the `.md` file with relative paths
+
+**Recommended**: Use `--task-folders --images` together to keep each work item's files organized in its own directory.
 
 ## Operations
 
@@ -100,14 +111,23 @@ tools azure-devops query "Active Tasks" --download-workitems --category react19
 
 When user says "analyze workitem/task X" or "analyze tasks from query Y":
 
-1. Fetch work item(s):
+1. Fetch work item(s) with images:
    ```bash
-   tools azure-devops workitem <ids> --category <cat> --task-folders
+   tools azure-devops workitem <ids> --category <cat> --task-folders --images
    ```
 
 2. Read the generated `.md` file for each work item
 
-3. Spawn **Explore agent** (Task tool with `subagent_type: "Explore"`) for each:
+3. **Read inline images** - Check if the work item directory contains image files:
+   ```bash
+   ls .claude/azure/tasks/<category>/<id>/<id>-*.{png,jpg,gif,jpeg} 2>/dev/null
+   ```
+   If images exist, use the **Read tool** to view each image file. This gives visual context for:
+   - Bug screenshots showing the issue
+   - Design mockups showing expected behavior
+   - UI comparisons (current vs expected)
+
+4. Spawn **Explore agent** (Task tool with `subagent_type: "Explore"`) for each:
 
    ```
    Analyze codebase for Azure DevOps work item:
@@ -116,6 +136,7 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
    State: {state} | Severity: {severity}
 
    **Description:** {description}
+   **Visual Context:** {describe what the inline images show, if any}
    **Comments:** {comments}
 
    Find:
@@ -173,6 +194,8 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
 | "Download .har files from task 12345" | `tools azure-devops workitem 12345 --attachments-suffix .har` |
 | "Get attachments from last hour for 12345" | Compute datetime 1h ago, then `tools azure-devops workitem 12345 --attachments-from "2026-02-12T10:00:00"` |
 | "Download all attachments for task 12345" | `tools azure-devops workitem 12345 --attachments-from 2000-01-01` |
+| "Get task 261575 with screenshots" | `tools azure-devops workitem 261575 --task-folders --images` |
+| "Analyze bug with images" | Fetch with `--images` → Read images → Explore agent with visual context |
 
 ## Creating Work Items
 

--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -118,9 +118,9 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
 
 2. Read the generated `.md` file for each work item
 
-3. **Read inline images** - Check if the work item directory contains image files:
+3. **Read inline images** - Check for image files next to the work item's `.md` file:
    ```bash
-   ls .claude/azure/tasks/<category>/<id>/<id>-*.{png,jpg,gif,jpeg} 2>/dev/null
+   ls $(dirname <path-to-workitem.md>)/<id>-*.{png,jpg,gif,jpeg} 2>/dev/null
    ```
    If images exist, use the **Read tool** to view each image file. This gives visual context for:
    - Bug screenshots showing the issue
@@ -149,7 +149,7 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
    Return: files found, current implementation, recommended approach, considerations, complexity (Low/Medium/High)
    ```
 
-4. Write `.analysis.md` next to the work item file:
+5. Write `.analysis.md` next to the work item file:
    - Work item: `.claude/azure/tasks/261575-Title.md`
    - Analysis: `.claude/azure/tasks/261575-Title.analysis.md`
 

--- a/src/azure-devops/commands/query.ts
+++ b/src/azure-devops/commands/query.ts
@@ -188,7 +188,9 @@ export type WorkItemHandler = (
     category?: string,
     taskFolders?: boolean,
     queryMetadata?: Map<number, QueryItemMetadata>,
-    fetchOptions?: { comments?: boolean; updates?: boolean }
+    fetchOptions?: { comments?: boolean; updates?: boolean },
+    attachmentFilter?: undefined,
+    downloadImages?: boolean
 ) => Promise<void>;
 
 let workItemHandler: WorkItemHandler | null = null;
@@ -213,6 +215,7 @@ interface QueryOptions {
     downloadWorkitems?: boolean;
     category?: string;
     taskFolders?: boolean;
+    images?: boolean;
 }
 
 /**
@@ -225,7 +228,8 @@ export async function handleQuery(
     filters?: QueryFilters,
     downloadWorkitems?: boolean,
     category?: string,
-    taskFolders?: boolean
+    taskFolders?: boolean,
+    downloadImages?: boolean
 ): Promise<void> {
     silentMode = format === "json"; // Suppress progress messages for JSON output
     logger.debug(`[query] Starting with input: ${input}, force=${forceRefresh}`);
@@ -361,7 +365,7 @@ export async function handleQuery(
         // Pass queryMetadata for smart comparison (ignores forceRefresh when metadata available)
         await workItemHandler(ids, format, false, effectiveCategory, effectiveTaskFolders, queryMetadata, {
             comments: true,
-        });
+        }, undefined, downloadImages);
     }
 }
 
@@ -383,6 +387,7 @@ export function registerQueryCommand(program: Command): void {
         .option("--download-workitems", "Download all work items to tasks/")
         .option("--category <name>", "Save to tasks/<category>/")
         .option("--task-folders", "Save in tasks/<id>/ subfolder")
+        .option("--images", "Download inline images from description and comments")
         .action(async (input: string, options: QueryOptions) => {
             // Parse filters from options
             const filters: QueryFilters = {};
@@ -419,7 +424,8 @@ export function registerQueryCommand(program: Command): void {
                 filters,
                 options.downloadWorkitems,
                 options.category,
-                options.taskFolders
+                options.taskFolders,
+                options.images
             );
         });
 }

--- a/src/azure-devops/commands/query.ts
+++ b/src/azure-devops/commands/query.ts
@@ -7,6 +7,7 @@
 import { Api } from "@app/azure-devops/api";
 import { CACHE_TTL, formatJSON, loadGlobalCache, saveGlobalCache, storage } from "@app/azure-devops/cache";
 import type {
+    AttachmentFilter,
     AzureConfig,
     ChangeInfo,
     OutputFormat,
@@ -189,7 +190,7 @@ export type WorkItemHandler = (
     taskFolders?: boolean,
     queryMetadata?: Map<number, QueryItemMetadata>,
     fetchOptions?: { comments?: boolean; updates?: boolean },
-    attachmentFilter?: undefined,
+    attachmentFilter?: AttachmentFilter,
     downloadImages?: boolean
 ) => Promise<void>;
 
@@ -363,9 +364,19 @@ export async function handleQuery(
         );
         const ids = items.map((item) => item.id).join(",");
         // Pass queryMetadata for smart comparison (ignores forceRefresh when metadata available)
-        await workItemHandler(ids, format, false, effectiveCategory, effectiveTaskFolders, queryMetadata, {
-            comments: true,
-        }, undefined, downloadImages);
+        await workItemHandler(
+            ids,
+            format,
+            false,
+            effectiveCategory,
+            effectiveTaskFolders,
+            queryMetadata,
+            {
+                comments: true,
+            },
+            undefined,
+            downloadImages
+        );
     }
 }
 

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -375,7 +375,7 @@ export async function handleWorkItem(
 
             const imageRefs = [
                 ...extractInlineImageUrls(item.description ?? "", id),
-                ...item.comments.flatMap((c) => extractInlineImageUrls(c.text, id)),
+                ...(item.comments ?? []).flatMap((c) => extractInlineImageUrls(c.text, id)),
             ];
 
             if (imageRefs.length === 0) {
@@ -505,7 +505,13 @@ export async function handleWorkItem(
         switch (format) {
             case "ai":
                 console.log(
-                    formatWorkItemAI(item, taskPath, cacheTime, attachmentsMap.get(item.id), inlineImageMaps.get(item.id))
+                    formatWorkItemAI(
+                        item,
+                        taskPath,
+                        cacheTime,
+                        attachmentsMap.get(item.id),
+                        inlineImageMaps.get(item.id)
+                    )
                 );
                 break;
             case "md":

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -6,10 +6,11 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { Api } from "@app/azure-devops/api";
 import { formatJSON, loadWorkItemCache, saveWorkItemCache, WORKITEM_FRESHNESS_MINUTES } from "@app/azure-devops/cache";
 import { downloadAttachments } from "@app/azure-devops/commands/attachments";
+import { downloadInlineImages, extractInlineImageUrls, rewriteImageUrls } from "@app/azure-devops/inline-images";
 import type {
     AttachmentFilter,
     AttachmentInfo,
@@ -50,7 +51,8 @@ function formatWorkItemAI(
     item: WorkItemFull,
     taskPath: string,
     cacheTime?: Date,
-    downloadedAttachments?: AttachmentInfo[]
+    downloadedAttachments?: AttachmentInfo[],
+    inlineImages?: Map<string, string>
 ): string {
     const lines: string[] = [];
 
@@ -140,10 +142,19 @@ function formatWorkItemAI(
         }
     }
 
+    if (inlineImages && inlineImages.size > 0) {
+        const taskDir = dirname(taskPath);
+        lines.push("");
+        lines.push(`## Inline Images (${inlineImages.size} downloaded)`);
+        for (const [, localFile] of inlineImages) {
+            lines.push(`- ${localFile} → ${join(taskDir, localFile)}`);
+        }
+    }
+
     return lines.join("\n");
 }
 
-function generateWorkItemMarkdown(item: WorkItemFull): string {
+function generateWorkItemMarkdown(item: WorkItemFull, imageMap?: Map<string, string>): string {
     const lines: string[] = [];
 
     lines.push(`# #${item.id}: ${item.title}`);
@@ -166,7 +177,8 @@ function generateWorkItemMarkdown(item: WorkItemFull): string {
         lines.push("");
         lines.push("## Description");
         lines.push("");
-        lines.push(htmlToMarkdown(item.description));
+        const descHtml = imageMap ? rewriteImageUrls(item.description, imageMap) : item.description;
+        lines.push(htmlToMarkdown(descHtml));
     }
 
     if (item.relations && item.relations.length > 0) {
@@ -204,7 +216,8 @@ function generateWorkItemMarkdown(item: WorkItemFull): string {
         for (const comment of item.comments) {
             lines.push(`### ${comment.author} - ${new Date(comment.date).toLocaleString()}`);
             lines.push("");
-            lines.push(htmlToMarkdown(comment.text));
+            const commentHtml = imageMap ? rewriteImageUrls(comment.text, imageMap) : comment.text;
+            lines.push(htmlToMarkdown(commentHtml));
             lines.push("");
         }
     }
@@ -232,7 +245,8 @@ export async function handleWorkItem(
     taskFoldersArg?: boolean,
     queryMetadata?: Map<number, QueryItemMetadata>,
     fetchOptions?: { comments?: boolean; updates?: boolean },
-    attachmentFilter?: AttachmentFilter
+    attachmentFilter?: AttachmentFilter,
+    downloadImages?: boolean
 ): Promise<void> {
     silentMode = format === "json";
     logger.debug(
@@ -347,6 +361,39 @@ export async function handleWorkItem(
         }
     }
 
+    // Phase 2.6: Download inline images if requested
+    const inlineImageMaps = new Map<number, Map<string, string>>();
+    if (downloadImages) {
+        const allItems = new Map<number, WorkItemFull>([...cachedResults, ...fetchedItems]);
+
+        for (const [id, item] of allItems) {
+            const settings = settingsMap.get(id);
+
+            if (!settings) {
+                continue;
+            }
+
+            const imageRefs = [
+                ...extractInlineImageUrls(item.description ?? "", id),
+                ...item.comments.flatMap((c) => extractInlineImageUrls(c.text, id)),
+            ];
+
+            if (imageRefs.length === 0) {
+                continue;
+            }
+
+            const outputDir = dirname(getTaskFilePath(id, item.title, "md", settings.category, settings.taskFolder));
+
+            if (!existsSync(outputDir)) {
+                mkdirSync(outputDir, { recursive: true });
+            }
+
+            log(`   Downloading ${imageRefs.length} inline image(s) for #${id}...`);
+            const urlMap = await downloadInlineImages(api, imageRefs, outputDir);
+            inlineImageMaps.set(id, urlMap);
+        }
+    }
+
     // Phase 3: Save fetched items to disk + update cache
     for (const [id, item] of fetchedItems) {
         const existingJsonPath = existingFilePaths.get(id) ?? null;
@@ -380,8 +427,9 @@ export async function handleWorkItem(
 
         logger.debug(`[workitem] #${id} saving JSON: ${jsonPath}`);
         writeFileSync(jsonPath, JSON.stringify(item, null, 2));
+        const imageMap = inlineImageMaps.get(id);
         logger.debug(`[workitem] #${id} saving MD: ${mdPath}`);
-        writeFileSync(mdPath, generateWorkItemMarkdown(item));
+        writeFileSync(mdPath, generateWorkItemMarkdown(item, imageMap));
 
         logger.debug(`[workitem] #${id} updating workitem cache`);
         const now = new Date().toISOString();
@@ -405,6 +453,22 @@ export async function handleWorkItem(
             comments: commentsFetched ? item.comments : existingCache?.comments,
         };
         await saveWorkItemCache(id, cacheData);
+    }
+
+    // Phase 3.5: Handle cached items that need image download + markdown regeneration
+    if (downloadImages) {
+        for (const [id, item] of cachedResults) {
+            const imageMap = inlineImageMaps.get(id);
+
+            if (!imageMap || imageMap.size === 0) {
+                continue;
+            }
+
+            const settings = settingsMap.get(id)!;
+            const mdPath = getTaskFilePath(id, item.title, "md", settings.category, settings.taskFolder);
+            writeFileSync(mdPath, generateWorkItemMarkdown(item, imageMap));
+            log(`   Regenerated markdown for #${id} with ${imageMap.size} inline image(s)`);
+        }
     }
 
     // Build results in original ID order
@@ -440,7 +504,9 @@ export async function handleWorkItem(
 
         switch (format) {
             case "ai":
-                console.log(formatWorkItemAI(item, taskPath, cacheTime, attachmentsMap.get(item.id)));
+                console.log(
+                    formatWorkItemAI(item, taskPath, cacheTime, attachmentsMap.get(item.id), inlineImageMaps.get(item.id))
+                );
                 break;
             case "md":
                 console.log(
@@ -473,6 +539,7 @@ export function registerWorkitemCommand(program: Command): void {
         .option("--attachments-prefix <prefix>", "Only attachments starting with this name")
         .option("--attachments-suffix <suffix>", "Only attachments ending with this (e.g. .har)")
         .option("--output-dir <path>", "Custom directory for downloaded attachments")
+        .option("--images", "Download inline images from description and comments")
         .action(
             async (
                 input: string,
@@ -486,6 +553,7 @@ export function registerWorkitemCommand(program: Command): void {
                     attachmentsPrefix?: string;
                     attachmentsSuffix?: string;
                     outputDir?: string;
+                    images?: boolean;
                 }
             ) => {
                 const hasAttachmentFilter =
@@ -524,7 +592,8 @@ export function registerWorkitemCommand(program: Command): void {
                     options.taskFolders,
                     undefined,
                     undefined,
-                    attachmentFilter
+                    attachmentFilter,
+                    options.images
                 );
             }
         );

--- a/src/azure-devops/inline-images.ts
+++ b/src/azure-devops/inline-images.ts
@@ -3,7 +3,7 @@
  */
 
 import { existsSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { Api } from "@app/azure-devops/api";
 import logger from "@app/logger";
 import { concurrentMap } from "@app/utils/async";
@@ -47,7 +47,7 @@ export function extractInlineImageUrls(html: string, workItemId: number): Inline
 
         const attachmentId = attachmentMatch[1];
         const fileName = extractFileName(url, attachmentId);
-        const localFileName = `${workItemId}-${fileName}`;
+        const localFileName = `${workItemId}-${attachmentId.slice(0, 8)}-${fileName}`;
 
         images.push({ originalUrl: url, attachmentId, fileName, localFileName });
     }
@@ -71,15 +71,17 @@ function extractFileName(url: string, attachmentId: string): string {
     return `image-${attachmentId.slice(0, 8)}.png`;
 }
 
-/** Sanitize filename for filesystem */
+/** Sanitize filename for filesystem — strips path components and dangerous characters */
 function sanitizeFileName(name: string): string {
+    const base = basename(name);
     // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control char removal
-    return name.replace(/[<>:"|?*\x00-\x1f]/g, "_");
+    const safe = base.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_").replace(/^\.+/, "_");
+    return safe || "image.png";
 }
 
 /**
  * Download inline images to the output directory.
- * Skips already-existing files with matching content.
+ * Skips already-existing non-empty files (does not verify content).
  * Returns map of originalUrl -> localFileName for URL rewriting.
  */
 export async function downloadInlineImages(

--- a/src/azure-devops/inline-images.ts
+++ b/src/azure-devops/inline-images.ts
@@ -1,0 +1,144 @@
+/**
+ * Azure DevOps CLI - Inline image extraction and download from work item HTML
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { Api } from "@app/azure-devops/api";
+import logger from "@app/logger";
+import { concurrentMap } from "@app/utils/async";
+
+/** Parsed inline image reference from HTML */
+export interface InlineImageRef {
+    originalUrl: string;
+    attachmentId: string;
+    fileName: string;
+    localFileName: string;
+}
+
+const ATTACHMENT_URL_PATTERN = /\/_apis\/wit\/attachments\/([a-f0-9-]+)/i;
+const IMG_SRC_PATTERN = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi;
+
+/**
+ * Extract Azure DevOps attachment image URLs from HTML content.
+ * Returns deduplicated list of image references.
+ */
+export function extractInlineImageUrls(html: string, workItemId: number): InlineImageRef[] {
+    if (!html) {
+        return [];
+    }
+
+    const seen = new Set<string>();
+    const images: InlineImageRef[] = [];
+
+    for (const match of html.matchAll(IMG_SRC_PATTERN)) {
+        const url = match[1];
+
+        if (seen.has(url)) {
+            continue;
+        }
+
+        seen.add(url);
+        const attachmentMatch = url.match(ATTACHMENT_URL_PATTERN);
+
+        if (!attachmentMatch) {
+            continue;
+        }
+
+        const attachmentId = attachmentMatch[1];
+        const fileName = extractFileName(url, attachmentId);
+        const localFileName = `${workItemId}-${fileName}`;
+
+        images.push({ originalUrl: url, attachmentId, fileName, localFileName });
+    }
+
+    return images;
+}
+
+/** Extract filename from URL query params or generate from UUID */
+function extractFileName(url: string, attachmentId: string): string {
+    try {
+        const parsed = new URL(url);
+        const fileName = parsed.searchParams.get("fileName");
+
+        if (fileName) {
+            return sanitizeFileName(fileName);
+        }
+    } catch {
+        // Invalid URL, fall through
+    }
+
+    return `image-${attachmentId.slice(0, 8)}.png`;
+}
+
+/** Sanitize filename for filesystem */
+function sanitizeFileName(name: string): string {
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control char removal
+    return name.replace(/[<>:"|?*\x00-\x1f]/g, "_");
+}
+
+/**
+ * Download inline images to the output directory.
+ * Skips already-existing files with matching content.
+ * Returns map of originalUrl -> localFileName for URL rewriting.
+ */
+export async function downloadInlineImages(
+    api: Api,
+    images: InlineImageRef[],
+    outputDir: string
+): Promise<Map<string, string>> {
+    if (images.length === 0) {
+        return new Map();
+    }
+
+    const urlMap = new Map<string, string>();
+
+    await concurrentMap({
+        items: images,
+        fn: async (img) => {
+            const targetPath = join(outputDir, img.localFileName);
+
+            if (existsSync(targetPath)) {
+                const stat = statSync(targetPath);
+
+                if (stat.size > 0) {
+                    logger.debug(`[inline-images] Skipping ${img.localFileName} (already exists)`);
+                    urlMap.set(img.originalUrl, img.localFileName);
+                    return;
+                }
+            }
+
+            try {
+                const buffer = await api.fetchBinary(img.originalUrl, img.localFileName);
+                await Bun.write(targetPath, buffer);
+                logger.debug(`[inline-images] Downloaded ${img.localFileName} (${buffer.byteLength} bytes)`);
+                urlMap.set(img.originalUrl, img.localFileName);
+            } catch (error) {
+                logger.warn(`[inline-images] Failed to download ${img.localFileName}: ${error}`);
+            }
+        },
+        onError: (img, error) => {
+            logger.warn(`[inline-images] Error downloading ${img.localFileName}: ${error}`);
+        },
+    });
+
+    return urlMap;
+}
+
+/**
+ * Rewrite image URLs in HTML to use local filenames.
+ * Used before HTML-to-Markdown conversion so generated markdown references local files.
+ */
+export function rewriteImageUrls(html: string, urlMap: Map<string, string>): string {
+    if (!html || urlMap.size === 0) {
+        return html;
+    }
+
+    let result = html;
+
+    for (const [originalUrl, localFileName] of urlMap) {
+        result = result.replaceAll(originalUrl, localFileName);
+    }
+
+    return result;
+}


### PR DESCRIPTION
## Summary
- Adds `--images` flag to `workitem` and `query` commands that downloads inline images (screenshots embedded in HTML descriptions/comments) from Azure DevOps
- Images saved as `<wid>-<filename>.png` alongside work item files, markdown rewritten to reference local paths
- Updates azure-devops skill to instruct Claude to Read images for visual context during analysis

## Test plan
- [ ] Run `tools azure-devops workitem 272325 --task-folders --images --category login --force` and verify images downloaded
- [ ] Check `.md` file references local image filenames, not remote URLs
- [ ] Check `.json` file still has original Azure DevOps URLs
- [ ] Run without `--images` and verify no images downloaded (backward compat)
- [ ] Run same command twice — second run should skip existing images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --images flag to download inline images from work item descriptions and comments; images are saved locally and markdown is updated.
  * Image support available for both query and individual work item commands.
  * Analysis output now surfaces a Visual Context field when images are included.

* **Documentation**
  * Added guidance on inline image output paths, examples with screenshots, and updated Analyze Work Items flow to document image handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->