### PR TITLE
feat(plugin): add /question command for answer-only mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.15",
+            "version": "1.0.16",
             "author": {
                 "name": "GenesisTools"
             },

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,4 +3,4 @@
 # Autofix staged files with biome before committing.
 # Biome's --staged flag processes only staged files and re-stages the fixes.
 
-bunx biome check --write --staged
+bunx biome check --write --staged --no-errors-on-unmatched

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/commands/question.md
+++ b/plugins/genesis-tools/commands/question.md
@@ -25,13 +25,13 @@ You are in **answer-only mode**. Your ONLY job is to answer the question above. 
 - Suggest or propose code changes
 - Say "I'll fix this", "let me update that", or "here's what we should change"
 - Use Write, Edit, or NotebookEdit tools
-- Create plans, tasks, or TODOs
+- Create implementation plans, task lists, or TODO lists in your answer
 - Offer to implement anything
 
 You MAY:
 
 - Read files, search code (Glob, Grep, Read, LSP) to understand context
-- Use Task(Explore) for deeper codebase research
+- Use Task(Explore) strictly for deeper codebase research (never to create plans, task lists, or TODO lists in your answer)
 - Search the web (Jina, Brave, WebFetch) for external knowledge
 - Run read-only Bash commands (e.g. `git log`, `ls`, type-checking output) to gather info
 

--- a/plugins/genesis-tools/commands/question.md
+++ b/plugins/genesis-tools/commands/question.md
@@ -1,0 +1,74 @@
+---
+name: genesis-tools:question
+description: Answer-only mode — explain something without modifying code. Use when user wants an explanation, not an implementation.
+argument-hint: "<your question>"
+allowed-tools:
+    - Read
+    - Glob
+    - Grep
+    - LSP
+    - Task
+    - AskUserQuestion
+    - WebFetch
+    - WebSearch
+    - ToolSearch
+    - Bash(read-only commands only — no file modifications)
+---
+
+# Question — Answer-Only Mode
+
+The user asked: **$ARGUMENTS**
+
+You are in **answer-only mode**. Your ONLY job is to answer the question above. You MUST NOT:
+
+- Modify, write, or create any files
+- Suggest or propose code changes
+- Say "I'll fix this", "let me update that", or "here's what we should change"
+- Use Write, Edit, or NotebookEdit tools
+- Create plans, tasks, or TODOs
+- Offer to implement anything
+
+You MAY:
+
+- Read files, search code (Glob, Grep, Read, LSP) to understand context
+- Use Task(Explore) for deeper codebase research
+- Search the web (Jina, Brave, WebFetch) for external knowledge
+- Run read-only Bash commands (e.g. `git log`, `ls`, type-checking output) to gather info
+
+## Workflow
+
+1. **Research if needed** — read files, search code, look things up
+2. **Give a clear, focused answer** — match depth to the question's complexity
+3. **Ask for refinement** — use AskUserQuestion with the options below
+4. **Loop** until user is satisfied
+
+## Refinement Loop
+
+After each answer, ask:
+
+```
+AskUserQuestion:
+  question: "Was this answer helpful?"
+  header: "Answer"
+  multiSelect: true
+  options:
+    - label: "Good answer, thanks"
+      description: "Answer was clear and complete. Continue with normal work."
+    - label: "Explain like I'm a junior"
+      description: "Simplify — less jargon, more analogies, explain prerequisites."
+    - label: "Longer explanation"
+      description: "Go deeper with more detail, examples, and edge cases."
+    - label: "Shorter explanation"
+      description: "Too verbose — give me the essential points only."
+```
+
+- **"Good answer, thanks"** → Stop. Do not summarize, do not offer to help. Just end.
+- **Any other selection** → Rewrite the answer per the selected option(s), then ask again.
+
+## Answer Style
+
+- **Default**: Mid-length, technical but accessible. Include code snippets if relevant.
+- **Junior mode**: Analogies, no jargon, explain prerequisites. Like teaching a new colleague.
+- **Longer**: Add context, edge cases, examples, related concepts, tradeoffs.
+- **Shorter**: Core answer only. Bullet points. No fluff.
+- **Combined** (e.g. junior + longer): Apply both constraints simultaneously.


### PR DESCRIPTION
## Summary
- Adds new `/question` command that puts Claude in answer-only mode — explains things without modifying code
- Includes a refinement loop via AskUserQuestion (junior/longer/shorter/good answer)
- Fixes pre-commit hook failing on non-source files (`--no-errors-on-unmatched`)
- Bumps plugin version to 1.0.16

## Test plan
- [ ] Invoke `/genesis-tools:question <something>` and verify answer-only behavior
- [ ] Verify refinement loop options appear after the answer
- [ ] Verify "Good answer, thanks" exits the loop
- [ ] Verify committing non-source-only files no longer fails the pre-commit hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new answer-only question mode, detailing metadata configuration, research and answering workflows, answer refinement procedures with iterative feedback loops, and a fully customizable answer style matrix (default, junior, longer, shorter, combined) with interactive multi-select refinement capabilities.

* **Chores**
  * Version updated to 1.0.16 across the plugin ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->