### PR TITLE
feat: telegram conversation memory + assistant v2

### DIFF
--- a/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-AIEngines.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-AIEngines.md
@@ -1,0 +1,1349 @@
+# Phase 5: AI Engines — Assistant, Suggestions, Style Profiles
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build three AI engine modules: (1) Chat Assistant with full DB tool access, (2) Suggestion Engine with pick/edit/send and edit tracking feedback loop, (3) Style Profile Engine with hybrid summary+examples. Wire all three into the Watch TUI's slash commands.
+
+**Architecture:** Each engine is a standalone class that takes the store, client, and contact config. They use `AIChat` from `src/ask/index.lib.ts` for LLM calls. The assistant gets AI SDK tools for DB queries. Suggestions use the style profile + correction history for context. All engines are injected into `WatchSession` and invoked by slash command routing.
+
+**Tech Stack:** AI SDK (`ai` package) tool definitions, `AIChat` from src/ask, bun:sqlite
+
+**Prerequisites:** Phase 1 (data), Phase 3 (config V2), Phase 4 (Watch TUI)
+
+---
+
+## Task 1: Assistant Engine with Tool Use
+
+**Files:**
+- Create: `src/telegram/lib/AssistantEngine.ts`
+- Test: `src/telegram/lib/__tests__/AssistantEngine.test.ts`
+
+**Context:** The assistant can answer questions about the conversation using the full message DB. It has these tools:
+- `search_messages` — search by text, date range, sender
+- `get_message_count` — count messages matching filters
+- `get_conversation_summary` — summarize messages in a date range
+- `get_attachments` — list attachments for a message or date range
+- `get_style_analysis` — analyze writing patterns
+- `search_across_chats` — search multiple chats
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/AssistantEngine.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { AssistantEngine } from "../AssistantEngine";
+
+describe("AssistantEngine", () => {
+    it("builds correct tool definitions", () => {
+        const tools = AssistantEngine.getToolDefinitions();
+
+        expect(tools).toHaveProperty("search_messages");
+        expect(tools).toHaveProperty("get_message_count");
+        expect(tools).toHaveProperty("get_conversation_summary");
+        expect(tools).toHaveProperty("get_attachments");
+        expect(tools).toHaveProperty("get_style_analysis");
+        expect(tools).toHaveProperty("search_across_chats");
+    });
+
+    it("search_messages tool has correct parameters", () => {
+        const tools = AssistantEngine.getToolDefinitions();
+        const searchTool = tools.search_messages;
+
+        expect(searchTool.parameters).toBeDefined();
+        // Should have: query, since, until, sender, limit
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/AssistantEngine.test.ts
+```
+
+**Step 3: Implement AssistantEngine**
+
+```typescript
+import { AIChat } from "@app/ask/index.lib";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { TelegramContactV2, AskModeConfig } from "./types";
+import { parseDate } from "./DateParser";
+import { DEFAULTS } from "./types";
+import { z } from "zod";
+import { tool } from "ai";
+
+export class AssistantEngine {
+    private chat: AIChat | null = null;
+
+    constructor(
+        private store: TelegramHistoryStore,
+        private contact: TelegramContactV2,
+        private myName: string,
+    ) {}
+
+    private getConfig(): AskModeConfig {
+        return this.contact.modes.assistant;
+    }
+
+    private ensureChat(): AIChat {
+        if (!this.chat) {
+            const config = this.getConfig();
+            this.chat = new AIChat({
+                provider: config.provider ?? DEFAULTS.askProvider,
+                model: config.model ?? DEFAULTS.askModel,
+                systemPrompt: this.buildSystemPrompt(config),
+                temperature: config.temperature ?? 0.7,
+                tools: this.buildTools(),
+                session: {
+                    id: `telegram-assistant-${this.contact.userId}`,
+                    dir: `${process.env.HOME}/.genesis-tools/telegram/ai-sessions`,
+                    autoSave: true,
+                },
+            });
+        }
+        return this.chat;
+    }
+
+    private buildSystemPrompt(config: AskModeConfig): string {
+        const base = config.systemPrompt ?? [
+            `You are a helpful assistant analyzing a Telegram conversation between "${this.myName}" and "${this.contact.displayName}".`,
+            "You have access to tools that let you search the full message history.",
+            "Use the tools to find relevant messages before answering questions.",
+            "Be concise but thorough. Reference specific messages when relevant.",
+        ].join("\n");
+
+        return base;
+    }
+
+    private buildTools() {
+        const store = this.store;
+        const contactId = this.contact.userId;
+
+        return {
+            search_messages: tool({
+                description: "Search messages in the conversation by text content, date range, or sender",
+                parameters: z.object({
+                    query: z.string().optional().describe("Text to search for"),
+                    since: z.string().optional().describe("Start date (ISO or natural language like 'last week')"),
+                    until: z.string().optional().describe("End date (ISO or natural language)"),
+                    sender: z.enum(["me", "them", "any"]).optional().describe("Filter by sender"),
+                    limit: z.number().optional().default(20).describe("Max results"),
+                }),
+                execute: async ({ query, since, until, sender, limit }) => {
+                    const results = store.queryMessages(contactId, {
+                        textPattern: query,
+                        since: since ? parseDate(since) ?? undefined : undefined,
+                        until: until ? parseDate(until) ?? undefined : undefined,
+                        sender: sender ?? "any",
+                        limit: limit ?? 20,
+                    });
+
+                    return results.map((r) => ({
+                        id: r.id,
+                        date: r.date_iso,
+                        sender: r.is_outgoing ? "me" : "them",
+                        text: r.text ?? "[media]",
+                    }));
+                },
+            }),
+
+            get_message_count: tool({
+                description: "Count messages matching filters",
+                parameters: z.object({
+                    since: z.string().optional(),
+                    until: z.string().optional(),
+                    sender: z.enum(["me", "them", "any"]).optional(),
+                }),
+                execute: async ({ since, until, sender }) => {
+                    const results = store.queryMessages(contactId, {
+                        since: since ? parseDate(since) ?? undefined : undefined,
+                        until: until ? parseDate(until) ?? undefined : undefined,
+                        sender: sender ?? "any",
+                    });
+                    return { count: results.length };
+                },
+            }),
+
+            get_conversation_summary: tool({
+                description: "Get a summary of messages in a date range. Returns messages for you to summarize.",
+                parameters: z.object({
+                    since: z.string().describe("Start date"),
+                    until: z.string().optional().describe("End date (defaults to now)"),
+                    limit: z.number().optional().default(50),
+                }),
+                execute: async ({ since, until, limit }) => {
+                    const results = store.queryMessages(contactId, {
+                        since: parseDate(since) ?? undefined,
+                        until: until ? parseDate(until) ?? undefined : undefined,
+                        limit: limit ?? 50,
+                    });
+
+                    return results.map((r) => ({
+                        date: r.date_iso,
+                        sender: r.is_outgoing ? "me" : "them",
+                        text: r.text ?? "[media]",
+                    }));
+                },
+            }),
+
+            get_attachments: tool({
+                description: "List attachments (photos, videos, documents) in messages",
+                parameters: z.object({
+                    messageId: z.number().optional().describe("Specific message ID"),
+                    since: z.string().optional(),
+                    until: z.string().optional(),
+                }),
+                execute: async ({ messageId, since, until }) => {
+                    if (messageId) {
+                        return store.getAttachments(contactId, messageId);
+                    }
+                    return store.listAttachments(contactId, {
+                        since: since ? parseDate(since) ?? undefined : undefined,
+                        until: until ? parseDate(until) ?? undefined : undefined,
+                    });
+                },
+            }),
+
+            get_style_analysis: tool({
+                description: "Analyze writing style patterns for a sender (message length, emoji usage, common phrases)",
+                parameters: z.object({
+                    sender: z.enum(["me", "them"]).describe("Whose style to analyze"),
+                    limit: z.number().optional().default(200).describe("Number of messages to analyze"),
+                }),
+                execute: async ({ sender, limit }) => {
+                    const messages = store.queryMessages(contactId, {
+                        sender,
+                        limit: limit ?? 200,
+                    });
+
+                    const texts = messages.map((m) => m.text ?? "").filter(Boolean);
+                    const avgLength = texts.reduce((sum, t) => sum + t.length, 0) / (texts.length || 1);
+                    const emojiCount = texts.reduce((sum, t) => sum + (t.match(/[\p{Emoji}]/gu) ?? []).length, 0);
+                    const avgWords = texts.reduce((sum, t) => sum + t.split(/\s+/).length, 0) / (texts.length || 1);
+
+                    return {
+                        totalMessages: texts.length,
+                        avgCharLength: Math.round(avgLength),
+                        avgWordCount: Math.round(avgWords),
+                        totalEmojis: emojiCount,
+                        emojisPerMessage: (emojiCount / (texts.length || 1)).toFixed(2),
+                        sampleMessages: texts.slice(-10),
+                    };
+                },
+            }),
+
+            search_across_chats: tool({
+                description: "Search for text across ALL synced chats, not just the current one",
+                parameters: z.object({
+                    query: z.string().describe("Text to search for"),
+                    limit: z.number().optional().default(20),
+                }),
+                execute: async ({ query, limit }) => {
+                    // Get all chats
+                    const chats = store.listChats();
+                    const allResults: Array<{ chatId: string; chatTitle: string; date: string; sender: string; text: string }> = [];
+
+                    for (const chat of chats) {
+                        const results = store.queryMessages(chat.chat_id, {
+                            textPattern: query,
+                            limit: 5, // Limit per chat
+                        });
+
+                        for (const r of results) {
+                            allResults.push({
+                                chatId: chat.chat_id,
+                                chatTitle: chat.title,
+                                date: r.date_iso,
+                                sender: r.is_outgoing ? "me" : chat.title,
+                                text: r.text ?? "[media]",
+                            });
+                        }
+                    }
+
+                    return allResults.slice(0, limit ?? 20);
+                },
+            }),
+        };
+    }
+
+    /** Ask the assistant a question */
+    async ask(question: string): Promise<string> {
+        const chat = this.ensureChat();
+        const response = await chat.send(question);
+        return response.content;
+    }
+
+    /** Static: get tool definitions for testing */
+    static getToolDefinitions() {
+        // Return tool schemas without store binding (for testing)
+        return {
+            search_messages: { parameters: { query: "string", since: "string", until: "string", sender: "string", limit: "number" } },
+            get_message_count: { parameters: { since: "string", until: "string", sender: "string" } },
+            get_conversation_summary: { parameters: { since: "string", until: "string", limit: "number" } },
+            get_attachments: { parameters: { messageId: "number", since: "string", until: "string" } },
+            get_style_analysis: { parameters: { sender: "string", limit: "number" } },
+            search_across_chats: { parameters: { query: "string", limit: "number" } },
+        };
+    }
+
+    /** Reset chat session (e.g. when switching models) */
+    resetSession(): void {
+        this.chat = null;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/AssistantEngine.test.ts
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/AssistantEngine.ts src/telegram/lib/__tests__/AssistantEngine.test.ts
+git commit -m "feat(telegram): AssistantEngine with full DB tool access via AI SDK"
+```
+
+---
+
+## Task 2: Style Profile Engine
+
+**Files:**
+- Create: `src/telegram/lib/StyleProfileEngine.ts`
+- Create: `src/telegram/lib/StyleRuleResolver.ts`
+- Test: `src/telegram/lib/__tests__/StyleProfileEngine.test.ts`
+
+**Context:** Builds a style prompt from the user's messages using the hybrid approach: generate a style summary + include representative examples. Sources are configurable via `StyleSourceRule[]`.
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/StyleProfileEngine.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { StyleProfileEngine } from "../StyleProfileEngine";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-style-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("StyleProfileEngine", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+
+        // Seed outgoing messages with varied style
+        const messages = [
+            { id: 1, senderId: "me", text: "hey whats up", isOutgoing: true, date: "2024-01-10T10:00:00Z", dateUnix: 1704880800 },
+            { id: 2, senderId: "me", text: "lol yea that was crazy 😂", isOutgoing: true, date: "2024-01-10T10:01:00Z", dateUnix: 1704880860 },
+            { id: 3, senderId: "me", text: "nah im good thanks tho", isOutgoing: true, date: "2024-01-10T10:02:00Z", dateUnix: 1704880920 },
+            { id: 4, senderId: "me", text: "wanna grab coffee tmrw?", isOutgoing: true, date: "2024-01-10T10:03:00Z", dateUnix: 1704880980 },
+            { id: 5, senderId: "me", text: "k cool see ya", isOutgoing: true, date: "2024-01-10T10:04:00Z", dateUnix: 1704881040 },
+        ];
+
+        for (const msg of messages) {
+            store.insertMessages("chat1", [{ ...msg, mediaDescription: undefined }]);
+        }
+    });
+
+    afterEach(() => {
+        store.close();
+        if (existsSync(dbPath)) unlinkSync(dbPath);
+    });
+
+    it("generates a style summary from messages", () => {
+        const engine = new StyleProfileEngine(store);
+        const summary = engine.analyzeStyle("chat1", "me", 100);
+
+        expect(summary.totalMessages).toBe(5);
+        expect(summary.avgLength).toBeGreaterThan(0);
+        expect(summary.traits).toBeInstanceOf(Array);
+        expect(summary.traits.length).toBeGreaterThan(0);
+    });
+
+    it("builds a hybrid style prompt", () => {
+        const engine = new StyleProfileEngine(store);
+        const prompt = engine.buildStylePrompt("chat1", {
+            rules: [
+                { id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 },
+            ],
+            exampleCount: 5,
+        });
+
+        expect(prompt).toContain("Style Summary");
+        expect(prompt).toContain("Example Messages");
+        // Should contain actual messages
+        expect(prompt).toContain("hey whats up");
+    });
+
+    it("respects rule filters", () => {
+        const engine = new StyleProfileEngine(store);
+
+        // Add incoming messages
+        store.insertMessages("chat1", [
+            { id: 10, senderId: "other", text: "How are you?", mediaDescription: undefined, isOutgoing: false, date: "2024-01-10T10:05:00Z", dateUnix: 1704881100 },
+        ]);
+
+        const prompt = engine.buildStylePrompt("chat1", {
+            rules: [
+                { id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 },
+            ],
+            exampleCount: 5,
+        });
+
+        // Should not contain incoming messages
+        expect(prompt).not.toContain("How are you?");
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+```
+
+**Step 3: Implement StyleRuleResolver**
+
+Create `src/telegram/lib/StyleRuleResolver.ts`:
+
+```typescript
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { StyleSourceRule, MessageRowV2 } from "./types";
+import { parseDate } from "./DateParser";
+
+export class StyleRuleResolver {
+    constructor(private store: TelegramHistoryStore) {}
+
+    resolveMessages(rules: StyleSourceRule[]): MessageRowV2[] {
+        const allMessages: MessageRowV2[] = [];
+
+        for (const rule of rules) {
+            const sender = rule.direction === "outgoing" ? "me" : "them";
+            const messages = this.store.queryMessages(rule.sourceChatId, {
+                sender,
+                since: rule.since ? parseDate(rule.since) ?? undefined : undefined,
+                until: rule.until ? parseDate(rule.until) ?? undefined : undefined,
+                limit: rule.limit ?? 500,
+            });
+
+            let filtered = messages;
+
+            // Apply regex filter if present
+            if (rule.regex) {
+                const re = new RegExp(rule.regex, "i");
+                filtered = filtered.filter((m) => m.text && re.test(m.text));
+            }
+
+            allMessages.push(...filtered);
+        }
+
+        // Deduplicate by id+chat_id
+        const seen = new Set<string>();
+        return allMessages.filter((m) => {
+            const key = `${m.chat_id}:${m.id}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+    }
+}
+```
+
+**Step 4: Implement StyleProfileEngine**
+
+Create `src/telegram/lib/StyleProfileEngine.ts`:
+
+```typescript
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { StyleSourceRule, MessageRowV2 } from "./types";
+import { StyleRuleResolver } from "./StyleRuleResolver";
+
+interface StyleAnalysis {
+    totalMessages: number;
+    avgLength: number;
+    avgWords: number;
+    usesEmojis: boolean;
+    emojiFrequency: number;
+    usesSlang: boolean;
+    traits: string[];
+    commonPatterns: string[];
+}
+
+interface StylePromptOptions {
+    rules: StyleSourceRule[];
+    exampleCount?: number;
+}
+
+export class StyleProfileEngine {
+    private ruleResolver: StyleRuleResolver;
+
+    constructor(private store: TelegramHistoryStore) {
+        this.ruleResolver = new StyleRuleResolver(store);
+    }
+
+    analyzeStyle(chatId: string, sender: "me" | "them", limit = 500): StyleAnalysis {
+        const messages = this.store.queryMessages(chatId, { sender, limit });
+        const texts = messages.map((m) => m.text ?? "").filter(Boolean);
+
+        if (texts.length === 0) {
+            return {
+                totalMessages: 0, avgLength: 0, avgWords: 0,
+                usesEmojis: false, emojiFrequency: 0, usesSlang: false,
+                traits: ["No messages to analyze"], commonPatterns: [],
+            };
+        }
+
+        const avgLength = texts.reduce((s, t) => s + t.length, 0) / texts.length;
+        const avgWords = texts.reduce((s, t) => s + t.split(/\s+/).length, 0) / texts.length;
+        const emojiCount = texts.reduce((s, t) => s + (t.match(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu) ?? []).length, 0);
+        const emojiFreq = emojiCount / texts.length;
+
+        // Detect traits
+        const traits: string[] = [];
+
+        // Length traits
+        if (avgWords < 5) traits.push("Very short messages (1-4 words)");
+        else if (avgWords < 10) traits.push("Short messages (5-9 words)");
+        else if (avgWords < 20) traits.push("Medium-length messages");
+        else traits.push("Long, detailed messages");
+
+        // Emoji usage
+        if (emojiFreq > 1) traits.push("Heavy emoji user");
+        else if (emojiFreq > 0.3) traits.push("Moderate emoji user");
+        else if (emojiFreq > 0) traits.push("Occasional emoji user");
+        else traits.push("Rarely or never uses emojis");
+
+        // Capitalization
+        const lowercaseRatio = texts.filter((t) => t === t.toLowerCase()).length / texts.length;
+        if (lowercaseRatio > 0.8) traits.push("Mostly lowercase");
+        else if (lowercaseRatio < 0.3) traits.push("Uses proper capitalization");
+
+        // Punctuation
+        const noPuncRatio = texts.filter((t) => !/[.!?]$/.test(t.trim())).length / texts.length;
+        if (noPuncRatio > 0.7) traits.push("Often omits ending punctuation");
+
+        // Slang/abbreviations detection
+        const slangPatterns = /\b(lol|lmao|nah|yea|wanna|gonna|kinda|idk|imo|tbh|rn|tmrw|btw|omg|brb|ttyl)\b/i;
+        const slangCount = texts.filter((t) => slangPatterns.test(t)).length;
+        const usesSlang = slangCount / texts.length > 0.1;
+        if (usesSlang) traits.push("Uses informal slang/abbreviations");
+
+        // Detect common starting patterns
+        const starters = new Map<string, number>();
+        for (const t of texts) {
+            const firstWord = t.split(/\s+/)[0]?.toLowerCase();
+            if (firstWord) {
+                starters.set(firstWord, (starters.get(firstWord) ?? 0) + 1);
+            }
+        }
+        const commonPatterns = [...starters.entries()]
+            .filter(([, count]) => count > texts.length * 0.05)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+            .map(([word, count]) => `"${word}..." (${count} times)`);
+
+        return {
+            totalMessages: texts.length,
+            avgLength: Math.round(avgLength),
+            avgWords: Math.round(avgWords * 10) / 10,
+            usesEmojis: emojiFreq > 0,
+            emojiFrequency: Math.round(emojiFreq * 100) / 100,
+            usesSlang,
+            traits,
+            commonPatterns,
+        };
+    }
+
+    buildStylePrompt(chatId: string, options: StylePromptOptions): string {
+        const messages = this.ruleResolver.resolveMessages(options.rules);
+        const texts = messages.map((m) => m.text ?? "").filter(Boolean);
+
+        if (texts.length === 0) {
+            return "No messages available for style analysis.";
+        }
+
+        // Generate style summary
+        const analysis = this.analyzeStyleFromTexts(texts);
+
+        // Select representative examples
+        const exampleCount = options.exampleCount ?? 15;
+        const examples = this.selectRepresentativeExamples(texts, exampleCount);
+
+        const sections: string[] = [];
+
+        // Style Summary section
+        sections.push("## Style Summary");
+        sections.push(`Analyzed ${texts.length} messages.`);
+        sections.push("");
+        sections.push("Characteristics:");
+        for (const trait of analysis.traits) {
+            sections.push(`- ${trait}`);
+        }
+        if (analysis.commonPatterns.length > 0) {
+            sections.push("");
+            sections.push("Common patterns:");
+            for (const pattern of analysis.commonPatterns) {
+                sections.push(`- ${pattern}`);
+            }
+        }
+
+        // Example Messages section
+        sections.push("");
+        sections.push("## Example Messages");
+        sections.push("These are real messages showing the typical style:");
+        sections.push("");
+        for (const ex of examples) {
+            sections.push(`> ${ex}`);
+        }
+
+        return sections.join("\n");
+    }
+
+    private analyzeStyleFromTexts(texts: string[]): StyleAnalysis {
+        const avgLength = texts.reduce((s, t) => s + t.length, 0) / texts.length;
+        const avgWords = texts.reduce((s, t) => s + t.split(/\s+/).length, 0) / texts.length;
+        const emojiCount = texts.reduce((s, t) => s + (t.match(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu) ?? []).length, 0);
+        const emojiFreq = emojiCount / texts.length;
+
+        const traits: string[] = [];
+        if (avgWords < 5) traits.push("Very short messages (1-4 words)");
+        else if (avgWords < 10) traits.push("Short messages (5-9 words)");
+        else traits.push("Longer messages");
+
+        if (emojiFreq > 0.5) traits.push("Frequent emoji use");
+        else if (emojiFreq === 0) traits.push("No emojis");
+
+        const lowercaseRatio = texts.filter((t) => t === t.toLowerCase()).length / texts.length;
+        if (lowercaseRatio > 0.7) traits.push("Lowercase style");
+
+        const slangPatterns = /\b(lol|lmao|nah|yea|wanna|gonna|idk|tbh|rn|tmrw|btw|omg)\b/i;
+        if (texts.filter((t) => slangPatterns.test(t)).length / texts.length > 0.1) {
+            traits.push("Uses slang/abbreviations");
+        }
+
+        const starters = new Map<string, number>();
+        for (const t of texts) {
+            const w = t.split(/\s+/)[0]?.toLowerCase();
+            if (w) starters.set(w, (starters.get(w) ?? 0) + 1);
+        }
+        const commonPatterns = [...starters.entries()]
+            .filter(([, c]) => c > texts.length * 0.05)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+            .map(([w, c]) => `"${w}..." (${c}x)`);
+
+        return {
+            totalMessages: texts.length, avgLength: Math.round(avgLength),
+            avgWords: Math.round(avgWords * 10) / 10,
+            usesEmojis: emojiFreq > 0, emojiFrequency: emojiFreq,
+            usesSlang: traits.includes("Uses slang/abbreviations"),
+            traits, commonPatterns,
+        };
+    }
+
+    private selectRepresentativeExamples(texts: string[], count: number): string[] {
+        if (texts.length <= count) return texts;
+
+        // Select evenly spaced examples to represent the full range
+        const step = Math.floor(texts.length / count);
+        const examples: string[] = [];
+
+        for (let i = 0; i < texts.length && examples.length < count; i += step) {
+            const t = texts[i];
+            if (t.length > 0 && t.length < 200) { // Skip very long messages
+                examples.push(t);
+            }
+        }
+
+        return examples;
+    }
+}
+```
+
+**Step 5: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/telegram/lib/StyleProfileEngine.ts src/telegram/lib/StyleRuleResolver.ts src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+git commit -m "feat(telegram): StyleProfileEngine with hybrid summary+examples approach"
+```
+
+---
+
+## Task 3: Suggestion Engine
+
+**Files:**
+- Create: `src/telegram/lib/SuggestionEngine.ts`
+- Test: `src/telegram/lib/__tests__/SuggestionEngine.test.ts`
+
+**Context:** Generates 3-5 reply suggestions based on conversation context, style profile, and correction history. The user picks/edits one and it's sent. Edit diffs are tracked.
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/SuggestionEngine.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { SuggestionEngine } from "../SuggestionEngine";
+
+describe("SuggestionEngine", () => {
+    it("builds suggestion system prompt with style and corrections", () => {
+        const prompt = SuggestionEngine.buildSuggestionPrompt({
+            contactName: "Alice",
+            myName: "Martin",
+            stylePrompt: "Short messages, lowercase, uses emoji",
+            recentCorrections: [
+                { suggested: "Hey, how are you?", sent: "hey wyd" },
+            ],
+            count: 3,
+        });
+
+        expect(prompt).toContain("Alice");
+        expect(prompt).toContain("3");
+        expect(prompt).toContain("lowercase");
+        // Should include correction example
+        expect(prompt).toContain("hey wyd");
+    });
+
+    it("parseSuggestions extracts numbered list", () => {
+        const raw = `Here are 3 suggestions:
+
+1. hey whats up
+2. yo how was your day
+3. lol yea that sounds fun`;
+
+        const suggestions = SuggestionEngine.parseSuggestions(raw);
+        expect(suggestions.length).toBe(3);
+        expect(suggestions[0]).toBe("hey whats up");
+        expect(suggestions[2]).toBe("lol yea that sounds fun");
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/SuggestionEngine.test.ts
+```
+
+**Step 3: Implement SuggestionEngine**
+
+```typescript
+import { AIChat } from "@app/ask/index.lib";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { TelegramContactV2, SuggestionModeConfig, MessageRowV2 } from "./types";
+import { StyleProfileEngine } from "./StyleProfileEngine";
+import { DEFAULTS } from "./types";
+
+interface SuggestionPromptInput {
+    contactName: string;
+    myName: string;
+    stylePrompt?: string;
+    recentCorrections?: Array<{ suggested: string; sent: string }>;
+    count: number;
+}
+
+export class SuggestionEngine {
+    private chat: AIChat | null = null;
+    private styleEngine: StyleProfileEngine;
+    private autoTriggerTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(
+        private store: TelegramHistoryStore,
+        private contact: TelegramContactV2,
+        private myName: string,
+    ) {
+        this.styleEngine = new StyleProfileEngine(store);
+    }
+
+    private getConfig(): SuggestionModeConfig {
+        return this.contact.modes.suggestions;
+    }
+
+    /** Generate reply suggestions */
+    async suggest(
+        recentMessages: Array<{ sender: string; text: string }>,
+        customPrompt?: string,
+    ): Promise<string[]> {
+        const config = this.getConfig();
+        const count = config.count ?? 3;
+
+        // Build style prompt if style profile is enabled
+        let stylePrompt: string | undefined;
+        if (this.contact.styleProfile?.enabled && this.contact.styleProfile.rules.length > 0) {
+            stylePrompt = this.styleEngine.buildStylePrompt(this.contact.userId, {
+                rules: this.contact.styleProfile.rules,
+                exampleCount: 15,
+            });
+        }
+
+        // Get recent corrections for feedback loop
+        const corrections = this.store.getRecentSuggestionEdits(this.contact.userId, 10)
+            .filter((e) => e.suggested_text !== e.sent_text) // Only include actual edits
+            .map((e) => ({ suggested: e.suggested_text, sent: e.sent_text }));
+
+        const systemPrompt = SuggestionEngine.buildSuggestionPrompt({
+            contactName: this.contact.displayName,
+            myName: this.myName,
+            stylePrompt,
+            recentCorrections: corrections,
+            count,
+        });
+
+        // Build conversation context
+        const context = recentMessages
+            .map((m) => `${m.sender}: ${m.text}`)
+            .join("\n");
+
+        const userMessage = customPrompt
+            ? `${customPrompt}\n\nRecent conversation:\n${context}`
+            : `Generate ${count} reply suggestions for this conversation:\n\n${context}`;
+
+        const chat = new AIChat({
+            provider: config.provider ?? DEFAULTS.askProvider,
+            model: config.model ?? DEFAULTS.askModel,
+            systemPrompt,
+            temperature: config.temperature ?? 0.8, // Higher temp for variety
+        });
+
+        const response = await chat.send(userMessage);
+        return SuggestionEngine.parseSuggestions(response.content);
+    }
+
+    /** Track what was suggested vs. what was actually sent */
+    trackEdit(suggestedText: string, editedText: string, sentText: string, messageId: number | null): void {
+        const config = this.getConfig();
+        this.store.insertSuggestionEdit({
+            chatId: this.contact.userId,
+            messageId,
+            suggestedText,
+            editedText,
+            sentText,
+            provider: config.provider ?? DEFAULTS.askProvider,
+            model: config.model ?? DEFAULTS.askModel,
+        });
+    }
+
+    /** Schedule auto-suggestion after delay (for hybrid trigger mode) */
+    scheduleAutoSuggest(
+        recentMessages: Array<{ sender: string; text: string }>,
+        onSuggestions: (suggestions: string[]) => void,
+    ): void {
+        const config = this.getConfig();
+
+        if (config.trigger === "manual") return;
+
+        // Clear existing timer (debounce)
+        if (this.autoTriggerTimer) {
+            clearTimeout(this.autoTriggerTimer);
+        }
+
+        this.autoTriggerTimer = setTimeout(async () => {
+            try {
+                const suggestions = await this.suggest(recentMessages);
+                onSuggestions(suggestions);
+            } catch {
+                // Silently fail for auto-suggest
+            }
+        }, config.autoDelayMs ?? 5000);
+    }
+
+    cancelAutoSuggest(): void {
+        if (this.autoTriggerTimer) {
+            clearTimeout(this.autoTriggerTimer);
+            this.autoTriggerTimer = null;
+        }
+    }
+
+    static buildSuggestionPrompt(input: SuggestionPromptInput): string {
+        const sections: string[] = [];
+
+        sections.push(`You are helping ${input.myName} craft replies to ${input.contactName} on Telegram.`);
+        sections.push(`Generate exactly ${input.count} distinct reply options.`);
+        sections.push("Each reply should feel natural and match the conversation tone.");
+        sections.push("Output ONLY a numbered list (1. 2. 3. etc.) with no other text.");
+
+        if (input.stylePrompt) {
+            sections.push("");
+            sections.push("## Writing Style to Match");
+            sections.push(input.stylePrompt);
+        }
+
+        if (input.recentCorrections && input.recentCorrections.length > 0) {
+            sections.push("");
+            sections.push("## Style Corrections (learn from these)");
+            sections.push("When I was suggested these, I changed them before sending:");
+            for (const c of input.recentCorrections.slice(0, 5)) {
+                sections.push(`- Suggested: "${c.suggested}" → Actually sent: "${c.sent}"`);
+            }
+            sections.push("Adjust your suggestions to match what I actually prefer to send.");
+        }
+
+        return sections.join("\n");
+    }
+
+    static parseSuggestions(raw: string): string[] {
+        const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
+        const suggestions: string[] = [];
+
+        for (const line of lines) {
+            // Match numbered list items: "1. text", "1) text", "1: text"
+            const match = line.match(/^\d+[.):\-]\s*(.+)/);
+            if (match) {
+                suggestions.push(match[1].trim());
+            }
+        }
+
+        return suggestions;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/SuggestionEngine.test.ts
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/SuggestionEngine.ts src/telegram/lib/__tests__/SuggestionEngine.test.ts
+git commit -m "feat(telegram): SuggestionEngine with style matching and edit tracking"
+```
+
+---
+
+## Task 4: Wire AI Engines into WatchSession
+
+**Files:**
+- Modify: `src/telegram/runtime/shared/WatchSession.ts`
+
+**Context:** Replace the placeholder slash command handlers with real engine calls.
+
+**Step 1: Add engine instances to WatchSession**
+
+Add to constructor/fields:
+
+```typescript
+import { AssistantEngine } from "../../lib/AssistantEngine";
+import { SuggestionEngine } from "../../lib/SuggestionEngine";
+import { StyleProfileEngine } from "../../lib/StyleProfileEngine";
+
+// In constructor:
+private assistantEngine: AssistantEngine;
+private suggestionEngine: SuggestionEngine;
+private styleEngine: StyleProfileEngine;
+
+// In constructor body:
+this.assistantEngine = new AssistantEngine(store, contact, myName);
+this.suggestionEngine = new SuggestionEngine(store, contact, myName);
+this.styleEngine = new StyleProfileEngine(store);
+```
+
+**Step 2: Update switchContact to recreate engines**
+
+```typescript
+async switchContact(contact: TelegramContactV2): Promise<void> {
+    this._currentContact = contact;
+    this.messages = [];
+    this.clearUnread(contact.userId);
+    this.assistantEngine = new AssistantEngine(this.store, contact, this.myName);
+    this.suggestionEngine = new SuggestionEngine(this.store, contact, this.myName);
+    await this.loadHistory();
+}
+```
+
+**Step 3: Replace placeholder slash commands with real implementations**
+
+In `handleSlashCommand()`:
+
+```typescript
+case "ask": {
+    if (!args) {
+        return { handled: true, output: "Usage: /ask <question>" };
+    }
+    try {
+        const answer = await this.assistantEngine.ask(args);
+        return { handled: true, output: answer };
+    } catch (err) {
+        return { handled: true, output: `Assistant error: ${err instanceof Error ? err.message : String(err)}` };
+    }
+}
+
+case "suggest": {
+    try {
+        const recentMsgs = this.messages.slice(-10).map((m) => ({
+            sender: m.senderName,
+            text: m.text,
+        }));
+        const customPrompt = args || undefined;
+        const suggestions = await this.suggestionEngine.suggest(recentMsgs, customPrompt);
+
+        // Store suggestions for later pick/send
+        this._pendingSuggestions = suggestions;
+
+        const formatted = suggestions.map((s, i) => `  ${i + 1}. ${s}`).join("\n");
+        return {
+            handled: true,
+            output: `Suggestions:\n${formatted}\n\nUse /pick <number> to select, or /pick <number> <edited text> to edit and send.`,
+        };
+    } catch (err) {
+        return { handled: true, output: `Suggestion error: ${err instanceof Error ? err.message : String(err)}` };
+    }
+}
+
+case "pick": {
+    if (!this._pendingSuggestions || this._pendingSuggestions.length === 0) {
+        return { handled: true, output: "No pending suggestions. Use /suggest first." };
+    }
+
+    const parts = args.split(/\s+/);
+    const index = Number.parseInt(parts[0], 10) - 1;
+
+    if (Number.isNaN(index) || index < 0 || index >= this._pendingSuggestions.length) {
+        return { handled: true, output: `Invalid choice. Pick 1-${this._pendingSuggestions.length}` };
+    }
+
+    const original = this._pendingSuggestions[index];
+    const edited = parts.length > 1 ? parts.slice(1).join(" ") : original;
+
+    // Send the message
+    const sent = await this.client.sendMessage(this._currentContact.userId, edited);
+
+    // Persist
+    this.store.insertMessages(this._currentContact.userId, [{
+        id: sent.id,
+        senderId: undefined,
+        text: edited,
+        mediaDescription: undefined,
+        isOutgoing: true,
+        date: new Date().toISOString(),
+        dateUnix: Math.floor(Date.now() / 1000),
+    }]);
+
+    this.messages.push({
+        id: sent.id,
+        text: edited,
+        isOutgoing: true,
+        senderName: this.myName,
+        date: new Date(),
+    });
+
+    // Track the edit
+    this.suggestionEngine.trackEdit(original, edited, edited, sent.id);
+
+    this._pendingSuggestions = null;
+    this.notify();
+
+    return { handled: true, output: `Sent: "${edited}"` };
+}
+
+case "style": {
+    try {
+        const analysis = this.styleEngine.analyzeStyle(
+            this._currentContact.userId, "me", 200
+        );
+        const lines = [
+            `Style analysis (${analysis.totalMessages} messages):`,
+            ...analysis.traits.map((t) => `  - ${t}`),
+        ];
+        if (analysis.commonPatterns.length > 0) {
+            lines.push("Common starters:");
+            lines.push(...analysis.commonPatterns.map((p) => `  - ${p}`));
+        }
+        return { handled: true, output: lines.join("\n") };
+    } catch (err) {
+        return { handled: true, output: `Style error: ${err instanceof Error ? err.message : String(err)}` };
+    }
+}
+```
+
+Add the field:
+
+```typescript
+private _pendingSuggestions: string[] | null = null;
+```
+
+**Step 4: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/runtime/shared/WatchSession.ts
+git commit -m "feat(telegram): wire AI engines into watch slash commands"
+```
+
+---
+
+## Task 5: Auto-Suggest Trigger in Watch Mode
+
+**Files:**
+- Modify: `src/telegram/runtime/shared/WatchSession.ts`
+
+**Context:** When a new incoming message arrives and the contact's suggestion trigger is "auto" or "hybrid", schedule auto-suggestions after the configured delay.
+
+**Step 1: Update addIncoming to trigger auto-suggest**
+
+In `addIncoming()`:
+
+```typescript
+addIncoming(msg: TelegramMessage): void {
+    this.messages.push({
+        id: msg.id,
+        text: msg.text,
+        isOutgoing: false,
+        senderName: this._currentContact.displayName,
+        date: msg.date,
+        mediaDesc: msg.mediaDescription,
+    });
+
+    // Auto-suggest if configured
+    const triggerMode = this._currentContact.modes.suggestions.trigger;
+    if (triggerMode === "auto" || triggerMode === "hybrid") {
+        const recentMsgs = this.messages.slice(-10).map((m) => ({
+            sender: m.senderName,
+            text: m.text,
+        }));
+
+        this.suggestionEngine.scheduleAutoSuggest(recentMsgs, (suggestions) => {
+            this._pendingSuggestions = suggestions;
+            this._autoSuggestCallback?.(suggestions);
+            this.notify();
+        });
+    }
+
+    this.notify();
+}
+```
+
+Add callback field:
+
+```typescript
+private _autoSuggestCallback: ((suggestions: string[]) => void) | null = null;
+
+onAutoSuggest(callback: (suggestions: string[]) => void): void {
+    this._autoSuggestCallback = callback;
+}
+```
+
+**Step 2: Wire auto-suggest display in WatchInkApp**
+
+In `WatchInkApp.tsx`, in the `useEffect` for session subscription:
+
+```tsx
+useEffect(() => {
+    session.onAutoSuggest((suggestions) => {
+        setSystemLines(suggestions.map((s, i) => ({
+            text: `  ${i + 1}. ${s}`,
+            type: "suggestion" as const,
+        })));
+        // Auto-clear after 30s
+        setTimeout(() => setSystemLines([]), 30000);
+    });
+}, [session]);
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/runtime/shared/WatchSession.ts src/telegram/runtime/ink/WatchInkApp.tsx
+git commit -m "feat(telegram): auto-suggest trigger with configurable delay"
+```
+
+---
+
+## Task 6: Model Switching in Watch Mode
+
+**Files:**
+- Modify: `src/telegram/runtime/shared/WatchSession.ts`
+
+**Context:** The `/model` slash command should let users switch AI model for the current mode. Since we're in Ink TUI, we can't use @clack/prompts (they conflict with Ink). Instead, display available models and let the user type `/model <provider>/<model>`.
+
+**Step 1: Implement /model command**
+
+In `handleSlashCommand()`:
+
+```typescript
+case "model": {
+    if (!args) {
+        const current = this._currentContact.modes.assistant;
+        return {
+            handled: true,
+            output: [
+                "Current models:",
+                `  Assistant: ${current.provider ?? "default"}/${current.model ?? "default"}`,
+                `  Suggestions: ${this._currentContact.modes.suggestions.provider ?? "default"}/${this._currentContact.modes.suggestions.model ?? "default"}`,
+                "",
+                "Usage: /model assistant <provider>/<model>",
+                "       /model suggestions <provider>/<model>",
+            ].join("\n"),
+        };
+    }
+
+    const modelParts = args.split(/\s+/);
+    const mode = modelParts[0] as "assistant" | "suggestions" | "autoReply";
+    const modelSpec = modelParts[1];
+
+    if (!modelSpec || !modelSpec.includes("/")) {
+        return { handled: true, output: "Usage: /model <mode> <provider>/<model>" };
+    }
+
+    const [provider, ...modelParts2] = modelSpec.split("/");
+    const model = modelParts2.join("/");
+
+    if (mode === "assistant" || mode === "suggestions" || mode === "autoReply") {
+        this._currentContact = {
+            ...this._currentContact,
+            modes: {
+                ...this._currentContact.modes,
+                [mode]: { ...this._currentContact.modes[mode], provider, model },
+            },
+        };
+
+        // Reset engine sessions so they pick up new model
+        if (mode === "assistant") this.assistantEngine.resetSession();
+
+        return { handled: true, output: `${mode} model set to ${provider}/${model}` };
+    }
+
+    return { handled: true, output: `Unknown mode: ${mode}. Use assistant, suggestions, or autoReply` };
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/telegram/runtime/shared/WatchSession.ts
+git commit -m "feat(telegram): /model command for runtime AI model switching"
+```
+
+---
+
+## Task 7: Phase 5 Full Verification
+
+**Step 1: Run all tests**
+
+```bash
+bun test src/telegram/
+```
+
+Expected: all pass
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+bunx tsgo --noEmit | rg "src/ask"
+```
+
+**Step 3: Lint**
+
+```bash
+bunx biome check src/telegram src/ask
+```
+
+**Step 4: Manual end-to-end test**
+
+```bash
+# 1. Configure a contact with V2 settings
+tools telegram configure
+
+# 2. Sync history
+tools telegram history sync <contact>
+
+# 3. Query with natural language dates
+tools telegram history query --from <contact> --since "last week"
+
+# 4. Launch watch mode
+tools telegram watch <contact>
+
+# 5. In watch mode:
+#    - Type a message → sends
+#    - /ask "what were we talking about yesterday?" → assistant searches DB
+#    - /suggest → generates 3 suggestions
+#    - /pick 1 → sends suggestion 1
+#    - /pick 2 this is my edit → sends edited version
+#    - /style → shows style analysis
+#    - /model assistant anthropic/claude-sonnet-4-20250514 → switches model
+#    - /careful → toggles careful mode
+#    - Tab → shows contact list
+#    - /quit → exits
+
+# 6. Verify existing listen still works
+tools telegram listen
+```
+
+**Step 5: Commit any final fixes**
+
+```bash
+git add src/telegram/ src/ask/
+git commit -m "fix(telegram): Phase 5 verification fixes"
+```
+
+---
+
+## Summary of Phase 5 Deliverables
+
+| Component | File | Status |
+|-----------|------|--------|
+| AssistantEngine with AI tools | `src/telegram/lib/AssistantEngine.ts` | Task 1 |
+| StyleProfileEngine (hybrid) | `src/telegram/lib/StyleProfileEngine.ts` | Task 2 |
+| StyleRuleResolver | `src/telegram/lib/StyleRuleResolver.ts` | Task 2 |
+| SuggestionEngine | `src/telegram/lib/SuggestionEngine.ts` | Task 3 |
+| AI engines wired into WatchSession | `src/telegram/runtime/shared/WatchSession.ts` | Task 4 |
+| Auto-suggest trigger | `WatchSession.ts`, `WatchInkApp.tsx` | Task 5 |
+| /model runtime switching | `WatchSession.ts` | Task 6 |
+
+---
+
+## Full Feature Checklist (All Phases)
+
+| Feature | Phase | Implemented In |
+|---------|-------|----------------|
+| Download conversations incrementally | 1, 2 | ConversationSyncService |
+| Save to SQLite DB | 1 | TelegramHistoryStore migration |
+| Query "messages from X since Y until Z" | 1, 2 | queryMessages + history query command |
+| Auto-fetch missing ranges | 2 | ConversationSyncService.queryWithAutoFetch |
+| Natural language date parsing | 1 | DateParser (chrono-node) |
+| Attachment indexing | 1, 2 | AttachmentIndexer + store methods |
+| Lazy attachment download | 2 | AttachmentDownloader |
+| Group/channel support | 3 | Configure command + ChatRow |
+| Per-contact per-mode model selection | 3 | V2 config + ModelSelector |
+| Watch live conversation | 4 | Ink WatchInkApp |
+| Configurable context length | 3, 4 | WatchConfig.contextLength |
+| /ask inline assistant | 5 | AssistantEngine |
+| Full DB history access with tools | 5 | AssistantEngine AI tools |
+| /suggest message suggestions (3-5) | 5 | SuggestionEngine |
+| Pick/edit/send flow | 5 | /pick command |
+| Style profile (hybrid summary+examples) | 5 | StyleProfileEngine |
+| Configurable style rules | 3 | StyleSourceRule[] config |
+| Suggestion edit tracking | 1, 5 | suggestion_edits table + SuggestionEngine.trackEdit |
+| Auto-feed corrections into suggestions | 5 | SuggestionEngine.buildSuggestionPrompt |
+| Edit/delete event tracking | 1, 2 | message_revisions + handler edit/delete |
+| /careful mode | 4 | WatchSession input mode |
+| /model runtime switching | 5 | /model command |
+| Contact list with unread badges | 4 | ContactList + WatchSession unread tracking |
+| Backward compatible with V1 config | 3 | migrateConfigV1toV2 |
+| Backward compatible listen command | 4 | listen.ts unchanged |

--- a/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-ConfigV2.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-ConfigV2.md
@@ -1,0 +1,769 @@
+# Phase 3: Config V2 & Model Selection
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Redesign the contact configuration schema to support per-contact per-mode AI settings (autoReply, assistant, suggestions), style profiles, watch config, and group/channel support. Provide backward compatibility with V1 configs. Integrate Ask's interactive provider/model selection into Telegram's configure flow.
+
+**Architecture:** New `TelegramContactV2` type with nested mode configs. V1→V2 migration normalizer runs on config load. `configure.ts` updated with richer interactive flows. Ask's `ModelSelector` reused for provider/model picking.
+
+**Tech Stack:** @clack/prompts, Commander, AI SDK providers
+
+**Prerequisites:** Phase 1 complete (schema), Phase 2 complete (sync)
+
+---
+
+## Task 1: Define V2 Config Types
+
+**Files:**
+- Modify: `src/telegram/lib/types.ts`
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/configV2.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import type {
+    TelegramContactV2,
+    AskModeConfig,
+    SuggestionModeConfig,
+    StyleProfileConfig,
+    StyleSourceRule,
+    WatchConfig,
+    ContactModesConfig,
+    TelegramConfigDataV2,
+} from "../types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_WATCH_CONFIG, DEFAULT_STYLE_PROFILE } from "../types";
+
+describe("V2 Config types", () => {
+    it("default mode config has correct shape", () => {
+        expect(DEFAULT_MODE_CONFIG.autoReply.enabled).toBe(false);
+        expect(DEFAULT_MODE_CONFIG.assistant.enabled).toBe(true);
+        expect(DEFAULT_MODE_CONFIG.suggestions.enabled).toBe(true);
+        expect(DEFAULT_MODE_CONFIG.suggestions.count).toBe(3);
+        expect(DEFAULT_MODE_CONFIG.suggestions.trigger).toBe("manual");
+    });
+
+    it("default watch config has correct shape", () => {
+        expect(DEFAULT_WATCH_CONFIG.enabled).toBe(true);
+        expect(DEFAULT_WATCH_CONFIG.contextLength).toBe(30);
+        expect(DEFAULT_WATCH_CONFIG.runtimeMode).toBe("ink");
+    });
+
+    it("default style profile is disabled", () => {
+        expect(DEFAULT_STYLE_PROFILE.enabled).toBe(false);
+        expect(DEFAULT_STYLE_PROFILE.rules).toEqual([]);
+    });
+
+    it("TelegramContactV2 can be constructed", () => {
+        const contact: TelegramContactV2 = {
+            userId: "123",
+            displayName: "Alice",
+            username: "alice",
+            chatType: "user",
+            actions: ["ask", "notify"],
+            watch: DEFAULT_WATCH_CONFIG,
+            modes: DEFAULT_MODE_CONFIG,
+            styleProfile: DEFAULT_STYLE_PROFILE,
+            replyDelayMin: 2000,
+            replyDelayMax: 5000,
+        };
+        expect(contact.displayName).toBe("Alice");
+        expect(contact.modes.suggestions.count).toBe(3);
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/configV2.test.ts
+```
+
+**Step 3: Add V2 config types to types.ts**
+
+Add to `src/telegram/lib/types.ts`:
+
+```typescript
+// --- V2 Config Types ---
+
+export type TelegramRuntimeMode = "daemon" | "light" | "ink";
+
+export interface AskModeConfig {
+    enabled: boolean;
+    provider?: string;
+    model?: string;
+    systemPrompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+}
+
+export interface SuggestionModeConfig extends AskModeConfig {
+    count: number; // 3-5, default 3
+    trigger: "manual" | "auto" | "hybrid";
+    autoDelayMs: number; // burst debounce, default 5000
+    allowAutoSend: boolean; // default false
+}
+
+export interface StyleSourceRule {
+    id: string;
+    sourceChatId: string;
+    direction: "outgoing" | "incoming";
+    limit?: number;
+    since?: string; // ISO
+    until?: string; // ISO
+    regex?: string;
+}
+
+export interface StyleProfileConfig {
+    enabled: boolean;
+    refresh: "incremental";
+    rules: StyleSourceRule[];
+    previewInWatch: boolean;
+}
+
+export interface WatchConfig {
+    enabled: boolean;
+    contextLength: number;
+    runtimeMode: TelegramRuntimeMode;
+}
+
+export interface ContactModesConfig {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+}
+
+export interface TelegramContactV2 {
+    userId: string;
+    displayName: string;
+    username?: string;
+    chatType: ChatType;
+    actions: ActionType[];
+    watch: WatchConfig;
+    modes: ContactModesConfig;
+    styleProfile: StyleProfileConfig;
+    replyDelayMin: number;
+    replyDelayMax: number;
+}
+
+export interface TelegramConfigDataV2 {
+    version: 2;
+    apiId: number;
+    apiHash: string;
+    session: string;
+    me?: {
+        firstName: string;
+        username?: string;
+        phone?: string;
+    };
+    contacts: TelegramContactV2[];
+    globalDefaults: {
+        modes: ContactModesConfig;
+        watch: WatchConfig;
+        styleProfile: StyleProfileConfig;
+    };
+    configuredAt: string;
+}
+
+// --- Defaults ---
+
+export const DEFAULT_MODE_CONFIG: ContactModesConfig = {
+    autoReply: {
+        enabled: false,
+        provider: undefined,
+        model: undefined,
+        systemPrompt: undefined,
+    },
+    assistant: {
+        enabled: true,
+        provider: undefined,
+        model: undefined,
+        systemPrompt: undefined,
+    },
+    suggestions: {
+        enabled: true,
+        provider: undefined,
+        model: undefined,
+        systemPrompt: undefined,
+        count: 3,
+        trigger: "manual",
+        autoDelayMs: 5000,
+        allowAutoSend: false,
+    },
+};
+
+export const DEFAULT_WATCH_CONFIG: WatchConfig = {
+    enabled: true,
+    contextLength: 30,
+    runtimeMode: "ink",
+};
+
+export const DEFAULT_STYLE_PROFILE: StyleProfileConfig = {
+    enabled: false,
+    refresh: "incremental",
+    rules: [],
+    previewInWatch: false,
+};
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/configV2.test.ts
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/types.ts src/telegram/lib/__tests__/configV2.test.ts
+git commit -m "feat(telegram): V2 config type definitions with defaults"
+```
+
+---
+
+## Task 2: V1 → V2 Config Migration
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramToolConfig.ts`
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/configMigration.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { migrateContactV1toV2, migrateConfigV1toV2 } from "../TelegramToolConfig";
+import type { ContactConfig, TelegramConfigData } from "../types";
+
+describe("V1 → V2 config migration", () => {
+    it("migrates a V1 contact with ask config into V2 modes", () => {
+        const v1: ContactConfig = {
+            userId: "123",
+            displayName: "Alice",
+            username: "alice",
+            actions: ["ask", "notify"],
+            askSystemPrompt: "Be helpful",
+            askProvider: "openai",
+            askModel: "gpt-4o",
+            replyDelayMin: 2000,
+            replyDelayMax: 5000,
+        };
+
+        const v2 = migrateContactV1toV2(v1);
+
+        expect(v2.userId).toBe("123");
+        expect(v2.displayName).toBe("Alice");
+        expect(v2.chatType).toBe("user");
+        expect(v2.actions).toEqual(["ask", "notify"]);
+
+        // V1 ask fields should map to autoReply mode
+        expect(v2.modes.autoReply.enabled).toBe(true); // because "ask" is in actions
+        expect(v2.modes.autoReply.provider).toBe("openai");
+        expect(v2.modes.autoReply.model).toBe("gpt-4o");
+        expect(v2.modes.autoReply.systemPrompt).toBe("Be helpful");
+
+        // Other modes get defaults
+        expect(v2.modes.assistant.enabled).toBe(true);
+        expect(v2.modes.suggestions.enabled).toBe(true);
+        expect(v2.modes.suggestions.count).toBe(3);
+    });
+
+    it("migrates a V1 contact without ask config", () => {
+        const v1: ContactConfig = {
+            userId: "456",
+            displayName: "Bob",
+            actions: ["notify"],
+            replyDelayMin: 2000,
+            replyDelayMax: 5000,
+        };
+
+        const v2 = migrateContactV1toV2(v1);
+
+        expect(v2.modes.autoReply.enabled).toBe(false);
+        expect(v2.modes.autoReply.provider).toBeUndefined();
+    });
+
+    it("migrates full V1 config to V2", () => {
+        const v1: TelegramConfigData = {
+            apiId: 12345,
+            apiHash: "abc",
+            session: "session",
+            contacts: [
+                { userId: "1", displayName: "A", actions: ["ask"], replyDelayMin: 2000, replyDelayMax: 5000 },
+            ],
+            configuredAt: "2024-01-01",
+        };
+
+        const v2 = migrateConfigV1toV2(v1);
+
+        expect(v2.version).toBe(2);
+        expect(v2.contacts.length).toBe(1);
+        expect(v2.contacts[0].modes).toBeDefined();
+        expect(v2.globalDefaults).toBeDefined();
+    });
+
+    it("passes through V2 config unchanged", () => {
+        const v2Config = {
+            version: 2,
+            apiId: 12345,
+            apiHash: "abc",
+            session: "session",
+            contacts: [],
+            globalDefaults: {
+                modes: { autoReply: { enabled: false }, assistant: { enabled: true }, suggestions: { enabled: true, count: 3, trigger: "manual", autoDelayMs: 5000, allowAutoSend: false } },
+                watch: { enabled: true, contextLength: 30, runtimeMode: "ink" },
+                styleProfile: { enabled: false, refresh: "incremental", rules: [], previewInWatch: false },
+            },
+            configuredAt: "2024-01-01",
+        };
+
+        // Should not throw or modify
+        const result = migrateConfigV1toV2(v2Config as any);
+        expect(result.version).toBe(2);
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/configMigration.test.ts
+```
+
+**Step 3: Implement migration functions**
+
+Add to `src/telegram/lib/TelegramToolConfig.ts`:
+
+```typescript
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    type ContactConfig,
+    type TelegramConfigData,
+    type TelegramContactV2,
+    type TelegramConfigDataV2,
+} from "./types";
+
+export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
+    const hasAsk = v1.actions.includes("ask");
+
+    return {
+        userId: v1.userId,
+        displayName: v1.displayName,
+        username: v1.username,
+        chatType: "user",
+        actions: v1.actions,
+        watch: { ...DEFAULT_WATCH_CONFIG },
+        modes: {
+            autoReply: {
+                enabled: hasAsk,
+                provider: v1.askProvider,
+                model: v1.askModel,
+                systemPrompt: v1.askSystemPrompt,
+            },
+            assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+            suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+        },
+        styleProfile: { ...DEFAULT_STYLE_PROFILE },
+        replyDelayMin: v1.replyDelayMin,
+        replyDelayMax: v1.replyDelayMax,
+    };
+}
+
+export function migrateConfigV1toV2(config: TelegramConfigData | TelegramConfigDataV2): TelegramConfigDataV2 {
+    // Already V2
+    if ("version" in config && config.version === 2) {
+        return config as TelegramConfigDataV2;
+    }
+
+    const v1 = config as TelegramConfigData;
+    return {
+        version: 2,
+        apiId: v1.apiId,
+        apiHash: v1.apiHash,
+        session: v1.session,
+        me: v1.me,
+        contacts: v1.contacts.map(migrateContactV1toV2),
+        globalDefaults: {
+            modes: { ...DEFAULT_MODE_CONFIG },
+            watch: { ...DEFAULT_WATCH_CONFIG },
+            styleProfile: { ...DEFAULT_STYLE_PROFILE },
+        },
+        configuredAt: v1.configuredAt,
+    };
+}
+```
+
+Update the `load()` method in `TelegramToolConfig` to auto-migrate:
+
+```typescript
+async load(): Promise<TelegramConfigDataV2 | null> {
+    const raw = await this.storage.load();
+    if (!raw) return null;
+    this.data = migrateConfigV1toV2(raw);
+    return this.data;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/configMigration.test.ts
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/TelegramToolConfig.ts src/telegram/lib/__tests__/configMigration.test.ts
+git commit -m "feat(telegram): V1→V2 config migration with backward compatibility"
+```
+
+---
+
+## Task 3: Export Ask's Model Selection for Reuse
+
+**Files:**
+- Modify: `src/ask/index.lib.ts`
+
+**Context:** `ModelSelector` in `src/ask/providers/ModelSelector.ts` has the interactive `selectModel()` flow. We need to export it (and `ProviderManager`) so Telegram's configure command can reuse them.
+
+**Step 1: Add exports to index.lib.ts**
+
+Add these exports to `src/ask/index.lib.ts`:
+
+```typescript
+export { ModelSelector } from "./providers/ModelSelector";
+export { ProviderManager } from "./providers/ProviderManager";
+export type { DetectedProvider, ModelInfo, ProviderChoice } from "./types";
+```
+
+**Step 2: Verify exports compile**
+
+```bash
+bunx tsgo --noEmit | rg "src/ask"
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/ask/index.lib.ts
+git commit -m "feat(ask): export ModelSelector and ProviderManager for cross-tool reuse"
+```
+
+---
+
+## Task 4: Update Configure Command — Group/Channel Support + Model Selection
+
+**Files:**
+- Modify: `src/telegram/commands/configure.ts`
+
+**Context:** The current configure command only discovers user dialogs. We need to:
+1. Also discover groups and channels
+2. Use Ask's `ModelSelector` for per-mode provider/model selection
+3. Support V2 contact shape with watch/modes/style config
+
+**Step 1: Update dialog discovery to include groups/channels**
+
+In `src/telegram/commands/configure.ts`, find the dialog filtering logic (around where `client.getDialogs()` is called). Change the filter to include groups and channels:
+
+```typescript
+const dialogs = await client.getDialogs(200);
+
+// Separate by type
+const userDialogs = dialogs.filter((d) => d.isUser && !d.entity?.bot && d.entity?.id !== me.id);
+const groupDialogs = dialogs.filter((d) => d.isGroup);
+const channelDialogs = dialogs.filter((d) => d.isChannel);
+
+// Build choices with type labels
+const choices = [
+    ...userDialogs.map((d) => ({
+        value: { dialog: d, type: "user" as const },
+        label: `👤 ${d.title}${d.entity?.username ? ` (@${d.entity.username})` : ""}`,
+    })),
+    ...groupDialogs.map((d) => ({
+        value: { dialog: d, type: "group" as const },
+        label: `👥 ${d.title}`,
+    })),
+    ...channelDialogs.map((d) => ({
+        value: { dialog: d, type: "channel" as const },
+        label: `📢 ${d.title}${d.entity?.username ? ` (@${d.entity.username})` : ""}`,
+    })),
+];
+```
+
+**Step 2: Add per-mode model selection**
+
+After contact selection, for each contact, add mode configuration:
+
+```typescript
+import { ModelSelector, ProviderManager } from "@app/ask/index.lib";
+
+// For each selected contact:
+const modeChoices = await p.multiselect({
+    message: `Which AI modes for ${contact.displayName}?`,
+    options: [
+        { value: "autoReply", label: "Auto-Reply", hint: "Automatically respond to messages" },
+        { value: "assistant", label: "Chat Assistant", hint: "Ask questions about the conversation" },
+        { value: "suggestions", label: "Message Suggestions", hint: "Get suggested replies to pick/edit/send" },
+    ],
+});
+
+if (p.isCancel(modeChoices)) continue;
+
+const modes = { ...DEFAULT_MODE_CONFIG };
+const providerManager = new ProviderManager();
+const providers = await providerManager.detectProviders();
+const modelSelector = new ModelSelector(providers);
+
+for (const mode of modeChoices as string[]) {
+    const configureModel = await p.confirm({
+        message: `Configure custom model for ${mode}?`,
+        initialValue: false,
+    });
+
+    if (configureModel && !p.isCancel(configureModel)) {
+        const choice = await modelSelector.selectModel();
+        if (choice) {
+            modes[mode as keyof typeof modes] = {
+                ...modes[mode as keyof typeof modes],
+                enabled: true,
+                provider: choice.provider.name,
+                model: choice.model.id,
+            };
+        }
+    } else {
+        modes[mode as keyof typeof modes] = {
+            ...modes[mode as keyof typeof modes],
+            enabled: true,
+        };
+    }
+}
+```
+
+**Step 3: Add watch config**
+
+```typescript
+const contextLength = await p.text({
+    message: `Context window size (number of recent messages)?`,
+    initialValue: "30",
+    validate: (v) => {
+        const n = Number.parseInt(v, 10);
+        if (Number.isNaN(n) || n < 1 || n > 500) return "Must be 1-500";
+    },
+});
+
+const watchConfig: WatchConfig = {
+    enabled: true,
+    contextLength: Number.parseInt(contextLength as string, 10),
+    runtimeMode: "ink",
+};
+```
+
+**Step 4: Assemble V2 contact and save**
+
+```typescript
+const v2Contact: TelegramContactV2 = {
+    userId: String(dialog.entity.id),
+    displayName: dialog.title,
+    username: dialog.entity?.username,
+    chatType: type, // "user" | "group" | "channel"
+    actions: selectedActions,
+    watch: watchConfig,
+    modes,
+    styleProfile: { ...DEFAULT_STYLE_PROFILE },
+    replyDelayMin: DEFAULTS.replyDelayMin,
+    replyDelayMax: DEFAULTS.replyDelayMax,
+};
+```
+
+**Step 5: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/commands/configure.ts
+git commit -m "feat(telegram): V2 configure with groups/channels and per-mode model selection"
+```
+
+---
+
+## Task 5: Update TelegramContact Wrapper for V2
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramContact.ts`
+
+**Context:** The `TelegramContact` class wraps `ContactConfig`. It needs to also work with `TelegramContactV2`, accessing modes and watch config.
+
+**Step 1: Update TelegramContact**
+
+```typescript
+import type { TelegramContactV2, AskModeConfig, SuggestionModeConfig, WatchConfig, StyleProfileConfig, ContactModesConfig } from "./types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_WATCH_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULTS } from "./types";
+
+export class TelegramContact {
+    readonly userId: string;
+    readonly displayName: string;
+    readonly username: string | undefined;
+    readonly config: TelegramContactV2;
+
+    constructor(config: TelegramContactV2) {
+        this.userId = config.userId;
+        this.displayName = config.displayName;
+        this.username = config.username;
+        this.config = config;
+    }
+
+    get actions() { return this.config.actions; }
+    get chatType() { return this.config.chatType; }
+    get hasAskAction() { return this.config.actions.includes("ask"); }
+
+    // Mode accessors
+    get modes(): ContactModesConfig { return this.config.modes ?? DEFAULT_MODE_CONFIG; }
+    get autoReply(): AskModeConfig { return this.modes.autoReply; }
+    get assistant(): AskModeConfig { return this.modes.assistant; }
+    get suggestions(): SuggestionModeConfig { return this.modes.suggestions as SuggestionModeConfig; }
+
+    // Watch config
+    get watch(): WatchConfig { return this.config.watch ?? DEFAULT_WATCH_CONFIG; }
+    get contextLength(): number { return this.watch.contextLength; }
+
+    // Style profile
+    get styleProfile(): StyleProfileConfig { return this.config.styleProfile ?? DEFAULT_STYLE_PROFILE; }
+
+    // Backward compat — resolve provider/model from mode or defaults
+    get askProvider(): string {
+        return this.autoReply.provider ?? DEFAULTS.askProvider;
+    }
+    get askModel(): string {
+        return this.autoReply.model ?? DEFAULTS.askModel;
+    }
+    get askSystemPrompt(): string {
+        return this.autoReply.systemPrompt ?? DEFAULTS.askSystemPrompt;
+    }
+
+    get replyDelayMin(): number { return this.config.replyDelayMin ?? DEFAULTS.replyDelayMin; }
+    get replyDelayMax(): number { return this.config.replyDelayMax ?? DEFAULTS.replyDelayMax; }
+    get randomDelay(): number {
+        return this.replyDelayMin + Math.random() * (this.replyDelayMax - this.replyDelayMin);
+    }
+
+    static fromConfig(config: TelegramContactV2): TelegramContact {
+        return new TelegramContact(config);
+    }
+}
+```
+
+**Step 2: Update all callers**
+
+Search for `TelegramContact.fromUser` and `TelegramContact.fromConfig` and `new TelegramContact` across `src/telegram/` to ensure they pass V2 configs. The `handler.ts` and `listen.ts` build `TelegramContact` from `ContactConfig` — after migration, they receive `TelegramContactV2`.
+
+**Step 3: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/lib/TelegramContact.ts src/telegram/lib/handler.ts src/telegram/commands/listen.ts
+git commit -m "refactor(telegram): TelegramContact uses V2 config shape"
+```
+
+---
+
+## Task 6: Update handler.ts and listen.ts for V2 Config
+
+**Files:**
+- Modify: `src/telegram/lib/handler.ts`
+- Modify: `src/telegram/commands/listen.ts`
+
+**Context:** These files currently use `ContactConfig`. After V2, they need to use `TelegramContactV2` from the migrated config.
+
+**Step 1: Update listen.ts**
+
+In `listen.ts`, change the config load to use the migrated V2 config:
+
+```typescript
+const config = new TelegramToolConfig();
+const data = await config.load(); // Now returns TelegramConfigDataV2
+```
+
+Since `data.contacts` is now `TelegramContactV2[]`, all downstream code (handler, actions) receives V2 contacts.
+
+**Step 2: Update handler.ts**
+
+The `registerHandler` function takes `contacts: ContactConfig[]`. Change to `contacts: TelegramContactV2[]`:
+
+```typescript
+interface HandlerOptions {
+    contacts: TelegramContactV2[];
+    myName: string;
+    initialHistory?: Map<string, string[]>;
+    store: TelegramHistoryStore;
+}
+```
+
+**Step 3: Type check all changes flow through**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+Fix any remaining type errors from the ContactConfig → TelegramContactV2 transition.
+
+**Step 4: Commit**
+
+```bash
+git add src/telegram/
+git commit -m "refactor(telegram): all handlers use V2 config types"
+```
+
+---
+
+## Task 7: Phase 3 Verification
+
+**Step 1: Run all tests**
+
+```bash
+bun test src/telegram/
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+bunx tsgo --noEmit | rg "src/ask"
+```
+
+**Step 3: Lint**
+
+```bash
+bunx biome check src/telegram src/ask
+```
+
+**Step 4: Test V1 config migration manually**
+
+If you have an existing V1 config at `~/.genesis-tools/telegram/config.json`, back it up and verify:
+
+```bash
+cp ~/.genesis-tools/telegram/config.json ~/.genesis-tools/telegram/config.json.v1.bak
+tools telegram contacts
+# Should load and display contacts normally (auto-migrated)
+```
+
+**Step 5: Commit fixes**
+
+```bash
+git add src/telegram/ src/ask/
+git commit -m "fix(telegram): Phase 3 verification fixes"
+```
+
+---
+
+## Summary of Phase 3 Deliverables
+
+| Component | File | Status |
+|-----------|------|--------|
+| V2 config types + defaults | `src/telegram/lib/types.ts` | Task 1 |
+| V1→V2 migration functions | `src/telegram/lib/TelegramToolConfig.ts` | Task 2 |
+| Ask ModelSelector export | `src/ask/index.lib.ts` | Task 3 |
+| Configure with groups/channels + model picker | `src/telegram/commands/configure.ts` | Task 4 |
+| TelegramContact V2 wrapper | `src/telegram/lib/TelegramContact.ts` | Task 5 |
+| handler/listen V2 integration | `src/telegram/lib/handler.ts`, `listen.ts` | Task 6 |

--- a/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-DataFoundation.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-DataFoundation.md
@@ -1,0 +1,1520 @@
+# Phase 1: Data Foundation
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the SQLite schema to support full conversation memory — revision tracking, attachment metadata, sync coverage segments, and rich query primitives.
+
+**Architecture:** Versioned schema migrations via `PRAGMA user_version`. All new tables and columns added in a single migration function. Query primitives built as methods on `TelegramHistoryStore`.
+
+**Tech Stack:** bun:sqlite, chrono-node (natural language dates)
+
+---
+
+## Task 1: Install Natural Language Date Parser
+
+**Files:**
+- Modify: `package.json`
+
+**Step 1: Install chrono-node**
+
+```bash
+bun add chrono-node
+```
+
+chrono-node is a natural language date parser that handles "yesterday", "last week", "3 days ago", "since January", etc. Zero config, works in Node/Bun.
+
+**Step 2: Verify installation**
+
+```bash
+bunx tsgo --noEmit | rg "chrono"
+```
+
+Expected: no errors (or no output)
+
+**Step 3: Commit**
+
+```bash
+git add package.json bun.lock
+git commit -m "feat(telegram): add chrono-node for natural language date parsing"
+```
+
+---
+
+## Task 2: Define New Type Definitions for Schema V2
+
+**Files:**
+- Modify: `src/telegram/lib/types.ts`
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/types.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import type {
+    AttachmentRow,
+    ChatRow,
+    MessageRevisionRow,
+    SyncSegmentRow,
+    MessageRowV2,
+} from "../types";
+
+describe("V2 type definitions", () => {
+    it("MessageRowV2 extends MessageRow with new fields", () => {
+        const msg: MessageRowV2 = {
+            id: 1,
+            chat_id: "123",
+            sender_id: "456",
+            text: "hello",
+            media_desc: null,
+            is_outgoing: 0,
+            date_unix: 1700000000,
+            date_iso: "2023-11-14T00:00:00Z",
+            edited_date_unix: null,
+            is_deleted: 0,
+            deleted_at_iso: null,
+            reply_to_msg_id: null,
+        };
+        expect(msg.is_deleted).toBe(0);
+    });
+
+    it("ChatRow has required fields", () => {
+        const chat: ChatRow = {
+            chat_id: "123",
+            chat_type: "user",
+            title: "John Doe",
+            username: "johndoe",
+            last_synced_at: "2023-11-14T00:00:00Z",
+        };
+        expect(chat.chat_type).toBe("user");
+    });
+
+    it("AttachmentRow has required fields", () => {
+        const att: AttachmentRow = {
+            chat_id: "123",
+            message_id: 1,
+            attachment_index: 0,
+            kind: "photo",
+            mime_type: "image/jpeg",
+            file_name: null,
+            file_size: 1024,
+            telegram_file_id: "abc123",
+            is_downloaded: 0,
+            local_path: null,
+            sha256: null,
+        };
+        expect(att.is_downloaded).toBe(0);
+    });
+
+    it("MessageRevisionRow tracks edits", () => {
+        const rev: MessageRevisionRow = {
+            id: 1,
+            chat_id: "123",
+            message_id: 1,
+            revision_type: "edit",
+            old_text: "hello",
+            new_text: "hello!",
+            revised_at_unix: 1700000100,
+            revised_at_iso: "2023-11-14T00:01:40Z",
+        };
+        expect(rev.revision_type).toBe("edit");
+    });
+
+    it("SyncSegmentRow tracks coverage", () => {
+        const seg: SyncSegmentRow = {
+            id: 1,
+            chat_id: "123",
+            from_date_unix: 1700000000,
+            to_date_unix: 1700086400,
+            from_msg_id: 1,
+            to_msg_id: 100,
+            synced_at: "2023-11-14T00:00:00Z",
+        };
+        expect(seg.from_msg_id).toBe(1);
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/types.test.ts
+```
+
+Expected: FAIL — types don't exist yet
+
+**Step 3: Add V2 type definitions to types.ts**
+
+Add these types to `src/telegram/lib/types.ts` (after the existing `MessageRow` interface):
+
+```typescript
+export interface MessageRowV2 extends MessageRow {
+    edited_date_unix: number | null;
+    is_deleted: number; // 0 or 1
+    deleted_at_iso: string | null;
+    reply_to_msg_id: number | null;
+}
+
+export type ChatType = "user" | "group" | "channel";
+
+export interface ChatRow {
+    chat_id: string;
+    chat_type: ChatType;
+    title: string;
+    username: string | null;
+    last_synced_at: string | null;
+}
+
+export interface AttachmentRow {
+    chat_id: string;
+    message_id: number;
+    attachment_index: number;
+    kind: string; // "photo" | "video" | "audio" | "voice" | "sticker" | "document" | "animation"
+    mime_type: string | null;
+    file_name: string | null;
+    file_size: number | null;
+    telegram_file_id: string | null;
+    is_downloaded: number; // 0 or 1
+    local_path: string | null;
+    sha256: string | null;
+}
+
+export interface MessageRevisionRow {
+    id: number;
+    chat_id: string;
+    message_id: number;
+    revision_type: "create" | "edit" | "delete";
+    old_text: string | null;
+    new_text: string | null;
+    revised_at_unix: number;
+    revised_at_iso: string;
+}
+
+export interface SyncSegmentRow {
+    id: number;
+    chat_id: string;
+    from_date_unix: number;
+    to_date_unix: number;
+    from_msg_id: number;
+    to_msg_id: number;
+    synced_at: string;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/types.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/types.ts src/telegram/lib/__tests__/types.test.ts
+git commit -m "feat(telegram): add V2 schema type definitions"
+```
+
+---
+
+## Task 3: Schema Migration System
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+**Context:** The current store calls `initSchema()` which uses `CREATE TABLE IF NOT EXISTS`. We need versioned migrations using `PRAGMA user_version` so we can add columns and tables incrementally.
+
+**Step 1: Write migration test**
+
+Create `src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore migrations", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+    });
+
+    afterEach(() => {
+        store.close();
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("creates all V2 tables on fresh database", () => {
+        store.open(dbPath);
+        const db = (store as any).db;
+
+        // Check chats table exists
+        const chats = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='chats'").get();
+        expect(chats).toBeTruthy();
+
+        // Check message_revisions table exists
+        const revisions = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='message_revisions'").get();
+        expect(revisions).toBeTruthy();
+
+        // Check attachments table exists
+        const attachments = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='attachments'").get();
+        expect(attachments).toBeTruthy();
+
+        // Check sync_segments table exists
+        const segments = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_segments'").get();
+        expect(segments).toBeTruthy();
+
+        // Check user_version is set
+        const version = db.query("PRAGMA user_version").get() as { user_version: number };
+        expect(version.user_version).toBe(2);
+    });
+
+    it("migrates V0 (fresh) to V2 with new message columns", () => {
+        store.open(dbPath);
+        const db = (store as any).db;
+
+        // Check new columns exist on messages table
+        const cols = db.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
+        const colNames = cols.map((c) => c.name);
+
+        expect(colNames).toContain("edited_date_unix");
+        expect(colNames).toContain("is_deleted");
+        expect(colNames).toContain("deleted_at_iso");
+        expect(colNames).toContain("reply_to_msg_id");
+    });
+
+    it("migrates existing V1 database to V2", () => {
+        // Simulate V1: open and create old schema manually
+        const Database = require("bun:sqlite").default;
+        const db = new Database(dbPath);
+        db.run("PRAGMA journal_mode = WAL");
+        db.run(`CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER NOT NULL,
+            chat_id TEXT NOT NULL,
+            sender_id TEXT,
+            text TEXT,
+            media_desc TEXT,
+            is_outgoing INTEGER NOT NULL,
+            date_unix INTEGER NOT NULL,
+            date_iso TEXT NOT NULL,
+            PRIMARY KEY (chat_id, id)
+        )`);
+        db.run(`CREATE TABLE IF NOT EXISTS sync_state (
+            chat_id TEXT PRIMARY KEY,
+            last_synced_id INTEGER NOT NULL,
+            last_synced_at TEXT NOT NULL
+        )`);
+        // V1 has user_version = 0 (default)
+        db.close();
+
+        // Now open with V2 store — migration should run
+        store.open(dbPath);
+        const storeDb = (store as any).db;
+
+        const version = storeDb.query("PRAGMA user_version").get() as { user_version: number };
+        expect(version.user_version).toBe(2);
+
+        const cols = storeDb.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
+        const colNames = cols.map((c) => c.name);
+        expect(colNames).toContain("is_deleted");
+    });
+
+    it("idempotent: opening V2 database doesn't re-migrate", () => {
+        store.open(dbPath);
+        store.close();
+
+        // Re-open — should not throw
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+
+        const db = (store as any).db;
+        const version = db.query("PRAGMA user_version").get() as { user_version: number };
+        expect(version.user_version).toBe(2);
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+```
+
+Expected: FAIL — migration logic doesn't exist yet
+
+**Step 3: Implement versioned migration in TelegramHistoryStore.ts**
+
+Replace the `initSchema()` method (currently called in `open()`) with a versioned migration system. The key changes to `src/telegram/lib/TelegramHistoryStore.ts`:
+
+In the `open()` method, after setting pragmas, replace the `initSchema()` call with `this.migrate()`.
+
+Add private method `migrate()`:
+
+```typescript
+private migrate(): void {
+    const db = this.db!;
+    const { user_version: currentVersion } = db.query("PRAGMA user_version").get() as { user_version: number };
+
+    if (currentVersion < 1) {
+        // V0 → V1: Original schema (messages, sync_state, FTS, embeddings)
+        db.run(`CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER NOT NULL,
+            chat_id TEXT NOT NULL,
+            sender_id TEXT,
+            text TEXT,
+            media_desc TEXT,
+            is_outgoing INTEGER NOT NULL,
+            date_unix INTEGER NOT NULL,
+            date_iso TEXT NOT NULL,
+            PRIMARY KEY (chat_id, id)
+        )`);
+        db.run(`CREATE INDEX IF NOT EXISTS idx_messages_chat_date ON messages(chat_id, date_unix)`);
+        db.run(`CREATE TABLE IF NOT EXISTS sync_state (
+            chat_id TEXT PRIMARY KEY,
+            last_synced_id INTEGER NOT NULL,
+            last_synced_at TEXT NOT NULL
+        )`);
+        db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+            text, content=messages, content_rowid=rowid, tokenize='unicode61'
+        )`);
+        // FTS triggers
+        db.run(`CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+            INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+        END`);
+        db.run(`CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+            INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+        END`);
+        db.run(`CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+            INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+            INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+        END`);
+        db.run(`CREATE TABLE IF NOT EXISTS embeddings (
+            message_rowid INTEGER PRIMARY KEY,
+            embedding BLOB NOT NULL
+        )`);
+    }
+
+    if (currentVersion < 2) {
+        // V1 → V2: Add new columns to messages, new tables
+        // New columns on messages (use try/catch for idempotency — ALTER TABLE IF NOT EXISTS not supported)
+        const existingCols = new Set(
+            (db.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>).map((c) => c.name)
+        );
+
+        if (!existingCols.has("edited_date_unix")) {
+            db.run("ALTER TABLE messages ADD COLUMN edited_date_unix INTEGER");
+        }
+        if (!existingCols.has("is_deleted")) {
+            db.run("ALTER TABLE messages ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0");
+        }
+        if (!existingCols.has("deleted_at_iso")) {
+            db.run("ALTER TABLE messages ADD COLUMN deleted_at_iso TEXT");
+        }
+        if (!existingCols.has("reply_to_msg_id")) {
+            db.run("ALTER TABLE messages ADD COLUMN reply_to_msg_id INTEGER");
+        }
+
+        // Chats table
+        db.run(`CREATE TABLE IF NOT EXISTS chats (
+            chat_id TEXT PRIMARY KEY,
+            chat_type TEXT NOT NULL DEFAULT 'user',
+            title TEXT NOT NULL,
+            username TEXT,
+            last_synced_at TEXT
+        )`);
+
+        // Message revisions (edit/delete history)
+        db.run(`CREATE TABLE IF NOT EXISTS message_revisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            revision_type TEXT NOT NULL,
+            old_text TEXT,
+            new_text TEXT,
+            revised_at_unix INTEGER NOT NULL,
+            revised_at_iso TEXT NOT NULL
+        )`);
+        db.run(`CREATE INDEX IF NOT EXISTS idx_revisions_chat_msg ON message_revisions(chat_id, message_id)`);
+
+        // Attachments
+        db.run(`CREATE TABLE IF NOT EXISTS attachments (
+            chat_id TEXT NOT NULL,
+            message_id INTEGER NOT NULL,
+            attachment_index INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            mime_type TEXT,
+            file_name TEXT,
+            file_size INTEGER,
+            telegram_file_id TEXT,
+            is_downloaded INTEGER NOT NULL DEFAULT 0,
+            local_path TEXT,
+            sha256 TEXT,
+            PRIMARY KEY (chat_id, message_id, attachment_index)
+        )`);
+
+        // Sync segments (date coverage tracking)
+        db.run(`CREATE TABLE IF NOT EXISTS sync_segments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id TEXT NOT NULL,
+            from_date_unix INTEGER NOT NULL,
+            to_date_unix INTEGER NOT NULL,
+            from_msg_id INTEGER NOT NULL,
+            to_msg_id INTEGER NOT NULL,
+            synced_at TEXT NOT NULL
+        )`);
+        db.run(`CREATE INDEX IF NOT EXISTS idx_sync_segments_chat ON sync_segments(chat_id, from_date_unix)`);
+    }
+
+    db.run(`PRAGMA user_version = 2`);
+}
+```
+
+Also remove the old `initSchema()` method and update `open()` to call `this.migrate()` instead of `this.initSchema()`.
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Run full type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+Expected: no errors
+
+**Step 6: Commit**
+
+```bash
+git add src/telegram/lib/TelegramHistoryStore.ts src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+git commit -m "feat(telegram): versioned schema migration with V2 tables"
+```
+
+---
+
+## Task 4: Query Primitives — queryMessages()
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+**Step 1: Write query test**
+
+Create `src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-query-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore.queryMessages", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+
+        // Seed test data
+        store.insertMessages("chat1", [
+            { id: 1, senderId: "user1", text: "hello from them", mediaDescription: undefined, isOutgoing: false, date: "2024-01-10T10:00:00Z", dateUnix: 1704880800 },
+            { id: 2, senderId: "me", text: "hello back", mediaDescription: undefined, isOutgoing: true, date: "2024-01-10T10:01:00Z", dateUnix: 1704880860 },
+            { id: 3, senderId: "user1", text: "how are you?", mediaDescription: undefined, isOutgoing: false, date: "2024-01-11T10:00:00Z", dateUnix: 1704967200 },
+            { id: 4, senderId: "me", text: "I am good thanks", mediaDescription: undefined, isOutgoing: true, date: "2024-01-12T10:00:00Z", dateUnix: 1705053600 },
+            { id: 5, senderId: "user1", text: "great to hear!", mediaDescription: undefined, isOutgoing: false, date: "2024-01-13T10:00:00Z", dateUnix: 1705140000 },
+        ]);
+    });
+
+    afterEach(() => {
+        store.close();
+        if (existsSync(dbPath)) unlinkSync(dbPath);
+    });
+
+    it("returns all messages for a chat", () => {
+        const results = store.queryMessages("chat1", {});
+        expect(results.length).toBe(5);
+    });
+
+    it("filters by sender=outgoing", () => {
+        const results = store.queryMessages("chat1", { sender: "me" });
+        expect(results.length).toBe(2);
+        expect(results.every((r) => r.is_outgoing === 1)).toBe(true);
+    });
+
+    it("filters by sender=incoming", () => {
+        const results = store.queryMessages("chat1", { sender: "them" });
+        expect(results.length).toBe(3);
+        expect(results.every((r) => r.is_outgoing === 0)).toBe(true);
+    });
+
+    it("filters by date range", () => {
+        const results = store.queryMessages("chat1", {
+            since: new Date("2024-01-11T00:00:00Z"),
+            until: new Date("2024-01-12T23:59:59Z"),
+        });
+        expect(results.length).toBe(2); // messages 3 and 4
+    });
+
+    it("filters by text regex", () => {
+        const results = store.queryMessages("chat1", { textPattern: "hello" });
+        expect(results.length).toBe(2); // messages 1 and 2
+    });
+
+    it("combines filters", () => {
+        const results = store.queryMessages("chat1", {
+            sender: "me",
+            since: new Date("2024-01-10T00:00:00Z"),
+            until: new Date("2024-01-11T00:00:00Z"),
+        });
+        expect(results.length).toBe(1); // only message 2
+    });
+
+    it("respects limit", () => {
+        const results = store.queryMessages("chat1", { limit: 2 });
+        expect(results.length).toBe(2);
+    });
+
+    it("excludes deleted messages by default", () => {
+        // Mark message 3 as deleted
+        store.markMessageDeleted("chat1", 3);
+        const results = store.queryMessages("chat1", {});
+        expect(results.length).toBe(4);
+    });
+
+    it("includes deleted messages when requested", () => {
+        store.markMessageDeleted("chat1", 3);
+        const results = store.queryMessages("chat1", { includeDeleted: true });
+        expect(results.length).toBe(5);
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts
+```
+
+Expected: FAIL — `queryMessages` and `markMessageDeleted` don't exist
+
+**Step 3: Implement queryMessages and markMessageDeleted on TelegramHistoryStore**
+
+Add to `src/telegram/lib/TelegramHistoryStore.ts`:
+
+```typescript
+interface QueryOptions {
+    sender?: "me" | "them" | "any";
+    since?: Date;
+    until?: Date;
+    textPattern?: string;
+    limit?: number;
+    includeDeleted?: boolean;
+}
+
+queryMessages(chatId: string, options: QueryOptions): MessageRowV2[] {
+    const db = this.db!;
+    const conditions: string[] = ["chat_id = ?"];
+    const params: (string | number)[] = [chatId];
+
+    if (!options.includeDeleted) {
+        conditions.push("is_deleted = 0");
+    }
+
+    if (options.sender === "me") {
+        conditions.push("is_outgoing = 1");
+    } else if (options.sender === "them") {
+        conditions.push("is_outgoing = 0");
+    }
+
+    if (options.since) {
+        conditions.push("date_unix >= ?");
+        params.push(Math.floor(options.since.getTime() / 1000));
+    }
+
+    if (options.until) {
+        conditions.push("date_unix <= ?");
+        params.push(Math.floor(options.until.getTime() / 1000));
+    }
+
+    if (options.textPattern) {
+        conditions.push("text LIKE ?");
+        params.push(`%${options.textPattern}%`);
+    }
+
+    let sql = `SELECT * FROM messages WHERE ${conditions.join(" AND ")} ORDER BY date_unix ASC`;
+
+    if (options.limit) {
+        sql += ` LIMIT ?`;
+        params.push(options.limit);
+    }
+
+    return db.query(sql).all(...params) as MessageRowV2[];
+}
+
+markMessageDeleted(chatId: string, messageId: number): void {
+    const db = this.db!;
+    const now = new Date();
+
+    // Get current text before marking deleted
+    const current = db.query("SELECT text FROM messages WHERE chat_id = ? AND id = ?").get(chatId, messageId) as { text: string | null } | null;
+
+    db.run(
+        "UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?",
+        now.toISOString(), chatId, messageId
+    );
+
+    // Record revision
+    db.run(
+        `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
+         VALUES (?, ?, 'delete', ?, NULL, ?, ?)`,
+        chatId, messageId, current?.text ?? null, Math.floor(now.getTime() / 1000), now.toISOString()
+    );
+}
+```
+
+Also export `QueryOptions` from types.ts.
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/TelegramHistoryStore.ts src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts src/telegram/lib/types.ts
+git commit -m "feat(telegram): add queryMessages with filters and markMessageDeleted"
+```
+
+---
+
+## Task 5: Upsert With Revision Tracking
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+**Step 1: Write the test**
+
+Add to `src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts` (or create a new file `TelegramHistoryStore.revisions.test.ts`):
+
+```typescript
+describe("TelegramHistoryStore.upsertMessageWithRevision", () => {
+    it("inserts new message and records create revision", () => {
+        store.upsertMessageWithRevision("chat1", {
+            id: 100, senderId: "user1", text: "new msg", mediaDescription: undefined,
+            isOutgoing: false, date: "2024-02-01T10:00:00Z", dateUnix: 1706781600,
+        });
+
+        const msgs = store.queryMessages("chat1", {});
+        const msg = msgs.find((m) => m.id === 100);
+        expect(msg).toBeTruthy();
+        expect(msg!.text).toBe("new msg");
+
+        const revisions = store.getRevisions("chat1", 100);
+        expect(revisions.length).toBe(1);
+        expect(revisions[0].revision_type).toBe("create");
+    });
+
+    it("updates existing message text and records edit revision", () => {
+        // Insert original
+        store.upsertMessageWithRevision("chat1", {
+            id: 101, senderId: "user1", text: "original", mediaDescription: undefined,
+            isOutgoing: false, date: "2024-02-01T10:00:00Z", dateUnix: 1706781600,
+        });
+
+        // Edit
+        store.upsertMessageWithRevision("chat1", {
+            id: 101, senderId: "user1", text: "edited!", mediaDescription: undefined,
+            isOutgoing: false, date: "2024-02-01T10:00:00Z", dateUnix: 1706781600,
+            editedDateUnix: 1706781700,
+        });
+
+        const msgs = store.queryMessages("chat1", {});
+        const msg = msgs.find((m) => m.id === 101);
+        expect(msg!.text).toBe("edited!");
+        expect(msg!.edited_date_unix).toBe(1706781700);
+
+        const revisions = store.getRevisions("chat1", 101);
+        expect(revisions.length).toBe(2);
+        expect(revisions[1].revision_type).toBe("edit");
+        expect(revisions[1].old_text).toBe("original");
+        expect(revisions[1].new_text).toBe("edited!");
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.revisions.test.ts
+```
+
+**Step 3: Implement upsertMessageWithRevision and getRevisions**
+
+Add to `TelegramHistoryStore.ts`:
+
+```typescript
+interface UpsertMessage {
+    id: number;
+    senderId: string | undefined;
+    text: string;
+    mediaDescription: string | undefined;
+    isOutgoing: boolean;
+    date: string;
+    dateUnix: number;
+    editedDateUnix?: number;
+    replyToMsgId?: number;
+}
+
+upsertMessageWithRevision(chatId: string, msg: UpsertMessage): void {
+    const db = this.db!;
+    const now = new Date();
+
+    const existing = db.query(
+        "SELECT text FROM messages WHERE chat_id = ? AND id = ?"
+    ).get(chatId, msg.id) as { text: string | null } | null;
+
+    if (existing) {
+        // Update — record edit revision if text changed
+        if (existing.text !== msg.text) {
+            db.run(
+                `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
+                 VALUES (?, ?, 'edit', ?, ?, ?, ?)`,
+                chatId, msg.id, existing.text, msg.text,
+                msg.editedDateUnix ?? Math.floor(now.getTime() / 1000), now.toISOString()
+            );
+        }
+
+        db.run(
+            `UPDATE messages SET text = ?, media_desc = ?, edited_date_unix = ?, reply_to_msg_id = ? WHERE chat_id = ? AND id = ?`,
+            msg.text, msg.mediaDescription ?? null, msg.editedDateUnix ?? null, msg.replyToMsgId ?? null,
+            chatId, msg.id
+        );
+    } else {
+        // Insert new
+        db.run(
+            `INSERT INTO messages (id, chat_id, sender_id, text, media_desc, is_outgoing, date_unix, date_iso, reply_to_msg_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            msg.id, chatId, msg.senderId ?? null, msg.text, msg.mediaDescription ?? null,
+            msg.isOutgoing ? 1 : 0, msg.dateUnix, msg.date, msg.replyToMsgId ?? null
+        );
+
+        // Record create revision
+        db.run(
+            `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
+             VALUES (?, ?, 'create', NULL, ?, ?, ?)`,
+            chatId, msg.id, msg.text, msg.dateUnix, msg.date
+        );
+    }
+}
+
+getRevisions(chatId: string, messageId: number): MessageRevisionRow[] {
+    const db = this.db!;
+    return db.query(
+        "SELECT * FROM message_revisions WHERE chat_id = ? AND message_id = ? ORDER BY revised_at_unix ASC"
+    ).all(chatId, messageId) as MessageRevisionRow[];
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.revisions.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/TelegramHistoryStore.ts src/telegram/lib/__tests__/TelegramHistoryStore.revisions.test.ts
+git commit -m "feat(telegram): upsert with revision tracking for edit history"
+```
+
+---
+
+## Task 6: Attachment Metadata Methods
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/TelegramHistoryStore.attachments.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-att-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore attachments", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+    });
+
+    afterEach(() => {
+        store.close();
+        if (existsSync(dbPath)) unlinkSync(dbPath);
+    });
+
+    it("upserts attachment metadata", () => {
+        store.upsertAttachment({
+            chat_id: "chat1",
+            message_id: 1,
+            attachment_index: 0,
+            kind: "photo",
+            mime_type: "image/jpeg",
+            file_name: null,
+            file_size: 1024,
+            telegram_file_id: "abc123",
+        });
+
+        const atts = store.getAttachments("chat1", 1);
+        expect(atts.length).toBe(1);
+        expect(atts[0].kind).toBe("photo");
+        expect(atts[0].is_downloaded).toBe(0);
+    });
+
+    it("lists attachments for a chat", () => {
+        store.upsertAttachment({ chat_id: "chat1", message_id: 1, attachment_index: 0, kind: "photo", mime_type: "image/jpeg", file_name: null, file_size: 1024, telegram_file_id: "a" });
+        store.upsertAttachment({ chat_id: "chat1", message_id: 2, attachment_index: 0, kind: "video", mime_type: "video/mp4", file_name: "vid.mp4", file_size: 5000, telegram_file_id: "b" });
+        store.upsertAttachment({ chat_id: "chat1", message_id: 2, attachment_index: 1, kind: "document", mime_type: "application/pdf", file_name: "doc.pdf", file_size: 2000, telegram_file_id: "c" });
+
+        const all = store.listAttachments("chat1");
+        expect(all.length).toBe(3);
+
+        const forMsg2 = store.getAttachments("chat1", 2);
+        expect(forMsg2.length).toBe(2);
+    });
+
+    it("marks attachment as downloaded", () => {
+        store.upsertAttachment({ chat_id: "chat1", message_id: 1, attachment_index: 0, kind: "photo", mime_type: "image/jpeg", file_name: null, file_size: 1024, telegram_file_id: "a" });
+
+        store.markAttachmentDownloaded("chat1", 1, 0, "/path/to/file.jpg", "sha256hash");
+
+        const atts = store.getAttachments("chat1", 1);
+        expect(atts[0].is_downloaded).toBe(1);
+        expect(atts[0].local_path).toBe("/path/to/file.jpg");
+        expect(atts[0].sha256).toBe("sha256hash");
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.attachments.test.ts
+```
+
+**Step 3: Implement attachment methods**
+
+Add to `TelegramHistoryStore.ts`:
+
+```typescript
+interface UpsertAttachmentInput {
+    chat_id: string;
+    message_id: number;
+    attachment_index: number;
+    kind: string;
+    mime_type: string | null;
+    file_name: string | null;
+    file_size: number | null;
+    telegram_file_id: string | null;
+}
+
+upsertAttachment(input: UpsertAttachmentInput): void {
+    const db = this.db!;
+    db.run(
+        `INSERT OR REPLACE INTO attachments (chat_id, message_id, attachment_index, kind, mime_type, file_name, file_size, telegram_file_id, is_downloaded, local_path, sha256)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE((SELECT is_downloaded FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?), 0),
+                 (SELECT local_path FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?),
+                 (SELECT sha256 FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?))`,
+        input.chat_id, input.message_id, input.attachment_index, input.kind, input.mime_type, input.file_name, input.file_size, input.telegram_file_id,
+        input.chat_id, input.message_id, input.attachment_index,
+        input.chat_id, input.message_id, input.attachment_index,
+        input.chat_id, input.message_id, input.attachment_index
+    );
+}
+
+getAttachments(chatId: string, messageId: number): AttachmentRow[] {
+    const db = this.db!;
+    return db.query(
+        "SELECT * FROM attachments WHERE chat_id = ? AND message_id = ? ORDER BY attachment_index ASC"
+    ).all(chatId, messageId) as AttachmentRow[];
+}
+
+listAttachments(chatId: string, options?: { since?: Date; until?: Date; kind?: string }): AttachmentRow[] {
+    const db = this.db!;
+    const conditions = ["a.chat_id = ?"];
+    const params: (string | number)[] = [chatId];
+
+    if (options?.kind) {
+        conditions.push("a.kind = ?");
+        params.push(options.kind);
+    }
+
+    // Join with messages for date filtering
+    let sql = `SELECT a.* FROM attachments a`;
+
+    if (options?.since || options?.until) {
+        sql += ` JOIN messages m ON a.chat_id = m.chat_id AND a.message_id = m.id`;
+        if (options.since) {
+            conditions.push("m.date_unix >= ?");
+            params.push(Math.floor(options.since.getTime() / 1000));
+        }
+        if (options.until) {
+            conditions.push("m.date_unix <= ?");
+            params.push(Math.floor(options.until.getTime() / 1000));
+        }
+    }
+
+    sql += ` WHERE ${conditions.join(" AND ")} ORDER BY a.message_id ASC, a.attachment_index ASC`;
+
+    return db.query(sql).all(...params) as AttachmentRow[];
+}
+
+markAttachmentDownloaded(chatId: string, messageId: number, attachmentIndex: number, localPath: string, sha256: string): void {
+    const db = this.db!;
+    db.run(
+        "UPDATE attachments SET is_downloaded = 1, local_path = ?, sha256 = ? WHERE chat_id = ? AND message_id = ? AND attachment_index = ?",
+        localPath, sha256, chatId, messageId, attachmentIndex
+    );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/TelegramHistoryStore.attachments.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/TelegramHistoryStore.ts src/telegram/lib/__tests__/TelegramHistoryStore.attachments.test.ts
+git commit -m "feat(telegram): attachment metadata storage and query methods"
+```
+
+---
+
+## Task 7: Sync Segment Tracking
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/SyncSegments.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-seg-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("Sync segment tracking", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+    });
+
+    afterEach(() => {
+        store.close();
+        if (existsSync(dbPath)) unlinkSync(dbPath);
+    });
+
+    it("inserts a sync segment", () => {
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700000000,
+            toDateUnix: 1700086400,
+            fromMsgId: 1,
+            toMsgId: 100,
+        });
+
+        const segments = store.getSyncSegments("chat1");
+        expect(segments.length).toBe(1);
+        expect(segments[0].from_msg_id).toBe(1);
+        expect(segments[0].to_msg_id).toBe(100);
+    });
+
+    it("detects missing segments (gap in coverage)", () => {
+        // We have coverage for day 1 and day 3, but not day 2
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700000000, // Nov 14 00:00
+            toDateUnix: 1700086400,   // Nov 15 00:00
+            fromMsgId: 1, toMsgId: 50,
+        });
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700172800, // Nov 16 00:00
+            toDateUnix: 1700259200,   // Nov 17 00:00
+            fromMsgId: 100, toMsgId: 150,
+        });
+
+        // Query for full range Nov 14 - Nov 17
+        const gaps = store.getMissingSegments("chat1", 1700000000, 1700259200);
+        expect(gaps.length).toBe(1);
+        expect(gaps[0].fromDateUnix).toBe(1700086400); // gap starts Nov 15
+        expect(gaps[0].toDateUnix).toBe(1700172800);   // gap ends Nov 16
+    });
+
+    it("returns empty when fully covered", () => {
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700000000,
+            toDateUnix: 1700259200,
+            fromMsgId: 1, toMsgId: 150,
+        });
+
+        const gaps = store.getMissingSegments("chat1", 1700000000, 1700259200);
+        expect(gaps.length).toBe(0);
+    });
+
+    it("returns full range when no segments exist", () => {
+        const gaps = store.getMissingSegments("chat1", 1700000000, 1700259200);
+        expect(gaps.length).toBe(1);
+        expect(gaps[0].fromDateUnix).toBe(1700000000);
+        expect(gaps[0].toDateUnix).toBe(1700259200);
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/SyncSegments.test.ts
+```
+
+**Step 3: Implement sync segment methods**
+
+Add to `TelegramHistoryStore.ts`:
+
+```typescript
+interface InsertSegmentInput {
+    fromDateUnix: number;
+    toDateUnix: number;
+    fromMsgId: number;
+    toMsgId: number;
+}
+
+interface DateRange {
+    fromDateUnix: number;
+    toDateUnix: number;
+}
+
+insertSyncSegment(chatId: string, input: InsertSegmentInput): void {
+    const db = this.db!;
+    db.run(
+        `INSERT INTO sync_segments (chat_id, from_date_unix, to_date_unix, from_msg_id, to_msg_id, synced_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        chatId, input.fromDateUnix, input.toDateUnix, input.fromMsgId, input.toMsgId, new Date().toISOString()
+    );
+}
+
+getSyncSegments(chatId: string): SyncSegmentRow[] {
+    const db = this.db!;
+    return db.query(
+        "SELECT * FROM sync_segments WHERE chat_id = ? ORDER BY from_date_unix ASC"
+    ).all(chatId) as SyncSegmentRow[];
+}
+
+getMissingSegments(chatId: string, fromDateUnix: number, toDateUnix: number): DateRange[] {
+    const segments = this.getSyncSegments(chatId);
+    const gaps: DateRange[] = [];
+
+    // Sort segments by start date
+    const sorted = segments
+        .filter((s) => s.to_date_unix > fromDateUnix && s.from_date_unix < toDateUnix)
+        .sort((a, b) => a.from_date_unix - b.from_date_unix);
+
+    if (sorted.length === 0) {
+        return [{ fromDateUnix, toDateUnix }];
+    }
+
+    // Check gap before first segment
+    if (sorted[0].from_date_unix > fromDateUnix) {
+        gaps.push({ fromDateUnix, toDateUnix: sorted[0].from_date_unix });
+    }
+
+    // Check gaps between segments
+    for (let i = 0; i < sorted.length - 1; i++) {
+        const currentEnd = sorted[i].to_date_unix;
+        const nextStart = sorted[i + 1].from_date_unix;
+        if (nextStart > currentEnd) {
+            gaps.push({ fromDateUnix: currentEnd, toDateUnix: nextStart });
+        }
+    }
+
+    // Check gap after last segment
+    const lastEnd = sorted[sorted.length - 1].to_date_unix;
+    if (lastEnd < toDateUnix) {
+        gaps.push({ fromDateUnix: lastEnd, toDateUnix });
+    }
+
+    return gaps;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/SyncSegments.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/TelegramHistoryStore.ts src/telegram/lib/__tests__/SyncSegments.test.ts
+git commit -m "feat(telegram): sync segment tracking with gap detection"
+```
+
+---
+
+## Task 8: Chat Table Methods
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+**Step 1: Write the test**
+
+Add a small test for chat upsert:
+
+```typescript
+describe("TelegramHistoryStore chats", () => {
+    it("upserts chat metadata", () => {
+        store.upsertChat({ chat_id: "123", chat_type: "user", title: "John", username: "john" });
+        const chat = store.getChat("123");
+        expect(chat).toBeTruthy();
+        expect(chat!.title).toBe("John");
+        expect(chat!.chat_type).toBe("user");
+    });
+
+    it("lists chats by type", () => {
+        store.upsertChat({ chat_id: "1", chat_type: "user", title: "Alice", username: null });
+        store.upsertChat({ chat_id: "2", chat_type: "group", title: "Dev Team", username: null });
+        store.upsertChat({ chat_id: "3", chat_type: "channel", title: "News", username: "news" });
+
+        const users = store.listChats("user");
+        expect(users.length).toBe(1);
+
+        const all = store.listChats();
+        expect(all.length).toBe(3);
+    });
+});
+```
+
+**Step 2: Implement**
+
+```typescript
+upsertChat(input: { chat_id: string; chat_type: string; title: string; username: string | null }): void {
+    const db = this.db!;
+    db.run(
+        `INSERT INTO chats (chat_id, chat_type, title, username) VALUES (?, ?, ?, ?)
+         ON CONFLICT(chat_id) DO UPDATE SET chat_type = excluded.chat_type, title = excluded.title, username = excluded.username`,
+        input.chat_id, input.chat_type, input.title, input.username
+    );
+}
+
+getChat(chatId: string): ChatRow | null {
+    const db = this.db!;
+    return (db.query("SELECT * FROM chats WHERE chat_id = ?").get(chatId) as ChatRow) ?? null;
+}
+
+listChats(type?: string): ChatRow[] {
+    const db = this.db!;
+    if (type) {
+        return db.query("SELECT * FROM chats WHERE chat_type = ? ORDER BY title").all(type) as ChatRow[];
+    }
+    return db.query("SELECT * FROM chats ORDER BY chat_type, title").all() as ChatRow[];
+}
+```
+
+**Step 3: Run tests, commit**
+
+```bash
+bun test src/telegram/lib/__tests__/
+git add src/telegram/lib/TelegramHistoryStore.ts src/telegram/lib/__tests__/
+git commit -m "feat(telegram): chat metadata storage (user/group/channel)"
+```
+
+---
+
+## Task 9: Natural Language Date Parser Utility
+
+**Files:**
+- Create: `src/telegram/lib/DateParser.ts`
+
+**Step 1: Write the test**
+
+Create `src/telegram/lib/__tests__/DateParser.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { parseDate, parseDateRange } from "../DateParser";
+
+describe("DateParser", () => {
+    it("parses ISO dates", () => {
+        const d = parseDate("2024-01-15");
+        expect(d).toBeInstanceOf(Date);
+        expect(d!.getFullYear()).toBe(2024);
+    });
+
+    it("parses natural language 'yesterday'", () => {
+        const d = parseDate("yesterday");
+        expect(d).toBeInstanceOf(Date);
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        expect(d!.toDateString()).toBe(yesterday.toDateString());
+    });
+
+    it("parses '3 days ago'", () => {
+        const d = parseDate("3 days ago");
+        expect(d).toBeInstanceOf(Date);
+    });
+
+    it("parses 'last week'", () => {
+        const d = parseDate("last week");
+        expect(d).toBeInstanceOf(Date);
+    });
+
+    it("returns null for unparseable input", () => {
+        const d = parseDate("not a date at all xyz");
+        expect(d).toBeNull();
+    });
+
+    it("parseDateRange handles 'since X until Y'", () => {
+        const range = parseDateRange({ since: "2024-01-01", until: "2024-01-31" });
+        expect(range.since).toBeInstanceOf(Date);
+        expect(range.until).toBeInstanceOf(Date);
+        expect(range.since!.getMonth()).toBe(0); // January
+    });
+
+    it("parseDateRange handles natural language", () => {
+        const range = parseDateRange({ since: "last week" });
+        expect(range.since).toBeInstanceOf(Date);
+        expect(range.until).toBeUndefined();
+    });
+});
+```
+
+**Step 2: Implement DateParser.ts**
+
+```typescript
+import * as chrono from "chrono-node";
+
+export function parseDate(input: string): Date | null {
+    if (!input) {
+        return null;
+    }
+
+    // Try ISO first
+    const isoDate = new Date(input);
+    if (!Number.isNaN(isoDate.getTime()) && /^\d{4}-\d{2}-\d{2}/.test(input)) {
+        return isoDate;
+    }
+
+    // Try chrono natural language
+    const results = chrono.parse(input);
+    if (results.length > 0) {
+        return results[0].start.date();
+    }
+
+    return null;
+}
+
+export function parseDateRange(input: { since?: string; until?: string }): {
+    since?: Date;
+    until?: Date;
+} {
+    return {
+        since: input.since ? parseDate(input.since) ?? undefined : undefined,
+        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+    };
+}
+```
+
+**Step 3: Run test**
+
+```bash
+bun test src/telegram/lib/__tests__/DateParser.test.ts
+```
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/telegram/lib/DateParser.ts src/telegram/lib/__tests__/DateParser.test.ts
+git commit -m "feat(telegram): natural language date parsing with chrono-node"
+```
+
+---
+
+## Task 10: Suggestion Tracking Table
+
+**Files:**
+- Modify: `src/telegram/lib/TelegramHistoryStore.ts`
+
+This table stores AI suggestion vs. user edit pairs for the feedback loop (Phase 5).
+
+**Step 1: Add to migration (in the V2 block)**
+
+Add to the `currentVersion < 2` migration block:
+
+```sql
+CREATE TABLE IF NOT EXISTS suggestion_edits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id TEXT NOT NULL,
+    message_id INTEGER,
+    suggested_text TEXT NOT NULL,
+    edited_text TEXT NOT NULL,
+    sent_text TEXT NOT NULL,
+    provider TEXT,
+    model TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_suggestion_edits_chat ON suggestion_edits(chat_id);
+```
+
+**Step 2: Add store methods**
+
+```typescript
+insertSuggestionEdit(input: {
+    chatId: string;
+    messageId: number | null;
+    suggestedText: string;
+    editedText: string;
+    sentText: string;
+    provider: string | null;
+    model: string | null;
+}): void {
+    const db = this.db!;
+    db.run(
+        `INSERT INTO suggestion_edits (chat_id, message_id, suggested_text, edited_text, sent_text, provider, model, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        input.chatId, input.messageId, input.suggestedText, input.editedText, input.sentText,
+        input.provider, input.model, new Date().toISOString()
+    );
+}
+
+getRecentSuggestionEdits(chatId: string, limit = 10): Array<{
+    suggested_text: string;
+    edited_text: string;
+    sent_text: string;
+    created_at: string;
+}> {
+    const db = this.db!;
+    return db.query(
+        `SELECT suggested_text, edited_text, sent_text, created_at
+         FROM suggestion_edits WHERE chat_id = ? ORDER BY created_at DESC LIMIT ?`
+    ).all(chatId, limit) as any[];
+}
+```
+
+**Step 3: Test, commit**
+
+```bash
+bun test src/telegram/lib/__tests__/
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/lib/TelegramHistoryStore.ts
+git commit -m "feat(telegram): suggestion edit tracking table for feedback loop"
+```
+
+---
+
+## Task 11: Final Phase 1 Verification
+
+**Step 1: Run all telegram tests**
+
+```bash
+bun test src/telegram/
+```
+
+Expected: all pass
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+Expected: no errors
+
+**Step 3: Lint**
+
+```bash
+bunx biome check src/telegram
+```
+
+Fix any issues.
+
+**Step 4: Commit any fixes**
+
+```bash
+git add src/telegram/
+git commit -m "fix(telegram): lint and type fixes for Phase 1"
+```
+
+---
+
+## Summary of Phase 1 Deliverables
+
+| Component | Status |
+|-----------|--------|
+| chrono-node installed | Task 1 |
+| V2 type definitions (MessageRowV2, ChatRow, AttachmentRow, etc.) | Task 2 |
+| Versioned schema migration (PRAGMA user_version) | Task 3 |
+| queryMessages() with sender/date/text/deleted filters | Task 4 |
+| upsertMessageWithRevision() + getRevisions() | Task 5 |
+| Attachment metadata CRUD | Task 6 |
+| Sync segment tracking + gap detection | Task 7 |
+| Chat metadata (user/group/channel) | Task 8 |
+| Natural language date parser | Task 9 |
+| Suggestion edit tracking table | Task 10 |

--- a/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-SyncAndAttachments.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-SyncAndAttachments.md
@@ -1,0 +1,1198 @@
+# Phase 2: Sync Engine & Attachments
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a range-aware sync engine that tracks coverage segments, auto-fetches missing ranges on query, indexes attachment metadata during sync, and supports lazy on-demand attachment downloading. Also wire edit/delete event ingestion and fix sending to return real message IDs.
+
+**Architecture:** `ConversationSyncService` orchestrates sync. `SyncRangePlanner` computes missing date ranges from sync_segments. `AttachmentIndexer` extracts metadata from Telegram API message objects during sync. `AttachmentDownloader` lazily downloads on demand. All built on Phase 1's schema.
+
+**Tech Stack:** telegram (MTProto API), bun:sqlite, crypto (for sha256)
+
+**Prerequisites:** Phase 1 complete (schema migration, query primitives, sync segments, attachment table)
+
+---
+
+## Task 1: SyncRangePlanner
+
+**Files:**
+- Create: `src/telegram/lib/SyncRangePlanner.ts`
+- Test: `src/telegram/lib/__tests__/SyncRangePlanner.test.ts`
+
+**Step 1: Write the test**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { SyncRangePlanner } from "../SyncRangePlanner";
+
+describe("SyncRangePlanner", () => {
+    it("returns full range when no segments exist", () => {
+        const plan = SyncRangePlanner.plan([], 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0]).toEqual({ from: 1700000000, to: 1700259200 });
+    });
+
+    it("returns empty when fully covered", () => {
+        const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700259200 }];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(0);
+    });
+
+    it("finds gap between two segments", () => {
+        const segments = [
+            { from_date_unix: 1700000000, to_date_unix: 1700086400 },
+            { from_date_unix: 1700172800, to_date_unix: 1700259200 },
+        ];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0]).toEqual({ from: 1700086400, to: 1700172800 });
+    });
+
+    it("finds gap before first segment", () => {
+        const segments = [{ from_date_unix: 1700086400, to_date_unix: 1700259200 }];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0].from).toBe(1700000000);
+    });
+
+    it("finds gap after last segment", () => {
+        const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700086400 }];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0].from).toBe(1700086400);
+    });
+
+    it("handles overlapping segments", () => {
+        const segments = [
+            { from_date_unix: 1700000000, to_date_unix: 1700100000 },
+            { from_date_unix: 1700050000, to_date_unix: 1700259200 },
+        ];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(0); // fully covered by overlap
+    });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+bun test src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+```
+
+**Step 3: Implement SyncRangePlanner**
+
+```typescript
+interface SegmentInput {
+    from_date_unix: number;
+    to_date_unix: number;
+}
+
+interface SyncRange {
+    from: number;
+    to: number;
+}
+
+export class SyncRangePlanner {
+    static plan(segments: SegmentInput[], queryFrom: number, queryTo: number): SyncRange[] {
+        if (segments.length === 0) {
+            return [{ from: queryFrom, to: queryTo }];
+        }
+
+        // Sort and merge overlapping segments
+        const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
+        const merged: SyncRange[] = [];
+
+        let current = { from: sorted[0].from_date_unix, to: sorted[0].to_date_unix };
+        for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i].from_date_unix <= current.to) {
+                current.to = Math.max(current.to, sorted[i].to_date_unix);
+            } else {
+                merged.push(current);
+                current = { from: sorted[i].from_date_unix, to: sorted[i].to_date_unix };
+            }
+        }
+        merged.push(current);
+
+        // Find gaps within query range
+        const gaps: SyncRange[] = [];
+        const clipped = merged.filter((s) => s.to > queryFrom && s.from < queryTo);
+
+        if (clipped.length === 0) {
+            return [{ from: queryFrom, to: queryTo }];
+        }
+
+        // Gap before first
+        if (clipped[0].from > queryFrom) {
+            gaps.push({ from: queryFrom, to: clipped[0].from });
+        }
+
+        // Gaps between
+        for (let i = 0; i < clipped.length - 1; i++) {
+            if (clipped[i + 1].from > clipped[i].to) {
+                gaps.push({ from: clipped[i].to, to: clipped[i + 1].from });
+            }
+        }
+
+        // Gap after last
+        if (clipped[clipped.length - 1].to < queryTo) {
+            gaps.push({ from: clipped[clipped.length - 1].to, to: queryTo });
+        }
+
+        return gaps;
+    }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+bun test src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/telegram/lib/SyncRangePlanner.ts src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+git commit -m "feat(telegram): SyncRangePlanner with gap detection and overlap merging"
+```
+
+---
+
+## Task 2: AttachmentIndexer
+
+**Files:**
+- Create: `src/telegram/lib/AttachmentIndexer.ts`
+- Test: `src/telegram/lib/__tests__/AttachmentIndexer.test.ts`
+
+**Context:** During sync, each Telegram API message may have media. We need to extract attachment metadata (kind, mime, filename, size, file_id) and call `store.upsertAttachment()`. This module normalizes the various Telegram media types into our schema.
+
+**Step 1: Write the test**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { AttachmentIndexer } from "../AttachmentIndexer";
+
+describe("AttachmentIndexer", () => {
+    it("extracts photo attachment", () => {
+        const fakeMessage = {
+            id: 1,
+            media: {
+                className: "MessageMediaPhoto",
+                photo: {
+                    id: { value: BigInt(12345) },
+                    sizes: [{ type: "x", w: 800, h: 600, size: 50000 }],
+                    mimeType: "image/jpeg",
+                },
+            },
+        };
+
+        const attachments = AttachmentIndexer.extract("chat1", fakeMessage as any);
+        expect(attachments.length).toBe(1);
+        expect(attachments[0].kind).toBe("photo");
+        expect(attachments[0].attachment_index).toBe(0);
+    });
+
+    it("extracts document attachment with filename", () => {
+        const fakeMessage = {
+            id: 2,
+            media: {
+                className: "MessageMediaDocument",
+                document: {
+                    id: { value: BigInt(67890) },
+                    mimeType: "application/pdf",
+                    size: BigInt(1024),
+                    attributes: [
+                        { className: "DocumentAttributeFilename", fileName: "report.pdf" },
+                    ],
+                },
+            },
+        };
+
+        const attachments = AttachmentIndexer.extract("chat1", fakeMessage as any);
+        expect(attachments.length).toBe(1);
+        expect(attachments[0].kind).toBe("document");
+        expect(attachments[0].file_name).toBe("report.pdf");
+        expect(attachments[0].mime_type).toBe("application/pdf");
+    });
+
+    it("returns empty for text-only message", () => {
+        const fakeMessage = { id: 3, media: null };
+        const attachments = AttachmentIndexer.extract("chat1", fakeMessage as any);
+        expect(attachments.length).toBe(0);
+    });
+
+    it("classifies sticker correctly", () => {
+        const fakeMessage = {
+            id: 4,
+            media: {
+                className: "MessageMediaDocument",
+                document: {
+                    id: { value: BigInt(11111) },
+                    mimeType: "image/webp",
+                    size: BigInt(5000),
+                    attributes: [{ className: "DocumentAttributeSticker" }],
+                },
+            },
+        };
+
+        const attachments = AttachmentIndexer.extract("chat1", fakeMessage as any);
+        expect(attachments[0].kind).toBe("sticker");
+    });
+
+    it("classifies voice message correctly", () => {
+        const fakeMessage = {
+            id: 5,
+            media: {
+                className: "MessageMediaDocument",
+                document: {
+                    id: { value: BigInt(22222) },
+                    mimeType: "audio/ogg",
+                    size: BigInt(8000),
+                    attributes: [{ className: "DocumentAttributeAudio", voice: true }],
+                },
+            },
+        };
+
+        const attachments = AttachmentIndexer.extract("chat1", fakeMessage as any);
+        expect(attachments[0].kind).toBe("voice");
+    });
+});
+```
+
+**Step 2: Implement AttachmentIndexer**
+
+```typescript
+import type { UpsertAttachmentInput } from "./types"; // we'll add this type alias
+
+export class AttachmentIndexer {
+    static extract(chatId: string, message: any): UpsertAttachmentInput[] {
+        if (!message.media) {
+            return [];
+        }
+
+        const results: UpsertAttachmentInput[] = [];
+        const media = message.media;
+        const msgId = message.id;
+
+        switch (media.className) {
+            case "MessageMediaPhoto": {
+                const photo = media.photo;
+                if (!photo) break;
+                const largestSize = photo.sizes?.at(-1);
+                results.push({
+                    chat_id: chatId,
+                    message_id: msgId,
+                    attachment_index: 0,
+                    kind: "photo",
+                    mime_type: "image/jpeg",
+                    file_name: null,
+                    file_size: largestSize?.size ?? null,
+                    telegram_file_id: photo.id ? String(photo.id.value ?? photo.id) : null,
+                });
+                break;
+            }
+
+            case "MessageMediaDocument": {
+                const doc = media.document;
+                if (!doc) break;
+
+                const kind = this.classifyDocument(doc.attributes ?? []);
+                const fileName = this.extractFileName(doc.attributes ?? []);
+
+                results.push({
+                    chat_id: chatId,
+                    message_id: msgId,
+                    attachment_index: 0,
+                    kind,
+                    mime_type: doc.mimeType ?? null,
+                    file_name: fileName,
+                    file_size: doc.size ? Number(doc.size) : null,
+                    telegram_file_id: doc.id ? String(doc.id.value ?? doc.id) : null,
+                });
+                break;
+            }
+
+            // Geo, contact, poll etc. — no downloadable attachment
+            default:
+                break;
+        }
+
+        return results;
+    }
+
+    private static classifyDocument(attributes: any[]): string {
+        for (const attr of attributes) {
+            switch (attr.className) {
+                case "DocumentAttributeSticker":
+                    return "sticker";
+                case "DocumentAttributeAudio":
+                    return attr.voice ? "voice" : "audio";
+                case "DocumentAttributeVideo":
+                    return attr.roundMessage ? "video_note" : "video";
+                case "DocumentAttributeAnimated":
+                    return "animation";
+            }
+        }
+        return "document";
+    }
+
+    private static extractFileName(attributes: any[]): string | null {
+        for (const attr of attributes) {
+            if (attr.className === "DocumentAttributeFilename") {
+                return attr.fileName ?? null;
+            }
+        }
+        return null;
+    }
+}
+```
+
+**Step 3: Run test, commit**
+
+```bash
+bun test src/telegram/lib/__tests__/AttachmentIndexer.test.ts
+git add src/telegram/lib/AttachmentIndexer.ts src/telegram/lib/__tests__/AttachmentIndexer.test.ts
+git commit -m "feat(telegram): attachment metadata extraction from Telegram API messages"
+```
+
+---
+
+## Task 3: AttachmentDownloader
+
+**Files:**
+- Create: `src/telegram/lib/AttachmentDownloader.ts`
+
+**Context:** Downloads a specific attachment by message ID + attachment index. Uses `client.raw.downloadMedia()` from the telegram MTProto library. Saves to `~/.genesis-tools/telegram/chats/<chat_id>/attachments/`. Computes SHA-256 and updates the DB.
+
+**Step 1: Implement AttachmentDownloader**
+
+```typescript
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { mkdirSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import type { TGClient } from "./TGClient";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+
+const ATTACHMENTS_BASE = resolve(homedir(), ".genesis-tools/telegram/chats");
+
+export class AttachmentDownloader {
+    constructor(
+        private client: TGClient,
+        private store: TelegramHistoryStore,
+    ) {}
+
+    async download(
+        chatId: string,
+        messageId: number,
+        attachmentIndex: number,
+        outputPath?: string,
+    ): Promise<{ path: string; size: number; sha256: string }> {
+        // Get attachment record
+        const attachments = this.store.getAttachments(chatId, messageId);
+        const attachment = attachments.find((a) => a.attachment_index === attachmentIndex);
+
+        if (!attachment) {
+            throw new Error(`Attachment not found: chat=${chatId} msg=${messageId} idx=${attachmentIndex}`);
+        }
+
+        if (attachment.is_downloaded && attachment.local_path && existsSync(attachment.local_path)) {
+            return {
+                path: attachment.local_path,
+                size: attachment.file_size ?? 0,
+                sha256: attachment.sha256 ?? "",
+            };
+        }
+
+        // Fetch the message from Telegram to get the media object
+        const messages = [];
+        for await (const msg of this.client.getMessages(chatId, { minId: messageId - 1, maxId: messageId + 1, limit: 1 })) {
+            if (msg.id === messageId) {
+                messages.push(msg);
+            }
+        }
+
+        if (messages.length === 0 || !messages[0].media) {
+            throw new Error(`Message ${messageId} not found or has no media`);
+        }
+
+        // Determine output path
+        const dir = outputPath
+            ? resolve(outputPath, "..")
+            : resolve(ATTACHMENTS_BASE, chatId, "attachments");
+
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+
+        const ext = this.guessExtension(attachment.mime_type, attachment.file_name);
+        const fileName = outputPath
+            ? resolve(outputPath)
+            : resolve(dir, `${messageId}-${attachmentIndex}${ext}`);
+
+        // Download using telegram client
+        const buffer = await this.client.raw.downloadMedia(messages[0].media, {}) as Buffer;
+
+        if (!buffer) {
+            throw new Error("Download returned empty buffer");
+        }
+
+        // Write file
+        await Bun.write(fileName, buffer);
+
+        // Compute SHA-256
+        const hash = createHash("sha256").update(buffer).digest("hex");
+
+        // Update DB
+        this.store.markAttachmentDownloaded(chatId, messageId, attachmentIndex, fileName, hash);
+
+        return { path: fileName, size: buffer.length, sha256: hash };
+    }
+
+    private guessExtension(mimeType: string | null, fileName: string | null): string {
+        if (fileName) {
+            const dot = fileName.lastIndexOf(".");
+            if (dot !== -1) {
+                return fileName.slice(dot);
+            }
+        }
+
+        const mimeMap: Record<string, string> = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
+            "image/gif": ".gif",
+            "video/mp4": ".mp4",
+            "audio/ogg": ".ogg",
+            "audio/mpeg": ".mp3",
+            "application/pdf": ".pdf",
+        };
+
+        return mimeMap[mimeType ?? ""] ?? "";
+    }
+}
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/lib/AttachmentDownloader.ts
+git commit -m "feat(telegram): lazy attachment downloader with SHA-256 verification"
+```
+
+---
+
+## Task 4: ConversationSyncService
+
+**Files:**
+- Create: `src/telegram/lib/ConversationSyncService.ts`
+
+**Context:** This is the main sync orchestrator. It replaces the direct download logic in `download.ts`. It handles:
+1. **Latest incremental** — uses `sync_state.last_synced_id` (high-watermark)
+2. **Range backfill** — uses `SyncRangePlanner` to find gaps, fetches missing ranges
+3. **Attachment indexing** — calls `AttachmentIndexer.extract()` during sync
+4. **Segment recording** — inserts sync_segments after each batch
+
+**Step 1: Implement ConversationSyncService**
+
+```typescript
+import type { TGClient } from "./TGClient";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import { TelegramMessage } from "./TelegramMessage";
+import { SyncRangePlanner } from "./SyncRangePlanner";
+import { AttachmentIndexer } from "./AttachmentIndexer";
+
+const BATCH_SIZE = 100;
+const MAX_RETRIES = 5;
+
+interface SyncOptions {
+    since?: Date;
+    until?: Date;
+    limit?: number;
+    onProgress?: (synced: number, total: number | null) => void;
+}
+
+interface SyncResult {
+    synced: number;
+    attachmentsIndexed: number;
+    segments: number;
+}
+
+export class ConversationSyncService {
+    constructor(
+        private client: TGClient,
+        private store: TelegramHistoryStore,
+    ) {}
+
+    /**
+     * Full incremental sync — fetches all new messages since last sync.
+     * Uses high-watermark (last_synced_id).
+     */
+    async syncLatest(chatId: string, options?: SyncOptions): Promise<SyncResult> {
+        const lastSyncedId = this.store.getLastSyncedId(chatId);
+        let synced = 0;
+        let attachmentsIndexed = 0;
+        let highestId = lastSyncedId ?? 0;
+        let lowestDateUnix = Infinity;
+        let highestDateUnix = 0;
+        let lowestMsgId = Infinity;
+
+        const iterOptions: Record<string, unknown> = {};
+        if (lastSyncedId) {
+            iterOptions.minId = lastSyncedId;
+        }
+        if (options?.limit) {
+            iterOptions.limit = options.limit;
+        }
+
+        const batch: Array<ReturnType<TelegramMessage["toJSON"]>> = [];
+
+        for await (const rawMsg of this.client.getMessages(chatId, iterOptions)) {
+            const msg = new TelegramMessage(rawMsg);
+            const serialized = msg.toJSON();
+            batch.push(serialized);
+
+            // Index attachments
+            const atts = AttachmentIndexer.extract(chatId, rawMsg);
+            for (const att of atts) {
+                this.store.upsertAttachment(att);
+                attachmentsIndexed++;
+            }
+
+            // Track bounds
+            if (rawMsg.id > highestId) highestId = rawMsg.id;
+            if (rawMsg.id < lowestMsgId) lowestMsgId = rawMsg.id;
+            if (serialized.dateUnix < lowestDateUnix) lowestDateUnix = serialized.dateUnix;
+            if (serialized.dateUnix > highestDateUnix) highestDateUnix = serialized.dateUnix;
+
+            if (batch.length >= BATCH_SIZE) {
+                synced += this.store.insertMessages(chatId, batch);
+                batch.length = 0;
+                options?.onProgress?.(synced, null);
+            }
+        }
+
+        if (batch.length > 0) {
+            synced += this.store.insertMessages(chatId, batch);
+        }
+
+        // Update sync state
+        if (highestId > 0) {
+            this.store.setLastSyncedId(chatId, highestId);
+        }
+
+        // Record segment
+        let segmentsRecorded = 0;
+        if (synced > 0 && lowestDateUnix < Infinity) {
+            this.store.insertSyncSegment(chatId, {
+                fromDateUnix: lowestDateUnix,
+                toDateUnix: highestDateUnix,
+                fromMsgId: lowestMsgId,
+                toMsgId: highestId,
+            });
+            segmentsRecorded = 1;
+        }
+
+        return { synced, attachmentsIndexed, segments: segmentsRecorded };
+    }
+
+    /**
+     * Range-aware sync — fetches missing date ranges using SyncRangePlanner.
+     * Used by query auto-fetch.
+     */
+    async syncRange(chatId: string, since: Date, until: Date, options?: SyncOptions): Promise<SyncResult> {
+        const sinceUnix = Math.floor(since.getTime() / 1000);
+        const untilUnix = Math.floor(until.getTime() / 1000);
+
+        const segments = this.store.getSyncSegments(chatId);
+        const gaps = SyncRangePlanner.plan(
+            segments.map((s) => ({ from_date_unix: s.from_date_unix, to_date_unix: s.to_date_unix })),
+            sinceUnix,
+            untilUnix,
+        );
+
+        if (gaps.length === 0) {
+            return { synced: 0, attachmentsIndexed: 0, segments: 0 };
+        }
+
+        let totalSynced = 0;
+        let totalAttachments = 0;
+        let totalSegments = 0;
+
+        for (const gap of gaps) {
+            const result = await this.syncDateRange(chatId, gap.from, gap.to, options);
+            totalSynced += result.synced;
+            totalAttachments += result.attachmentsIndexed;
+            totalSegments += result.segments;
+        }
+
+        return { synced: totalSynced, attachmentsIndexed: totalAttachments, segments: totalSegments };
+    }
+
+    private async syncDateRange(
+        chatId: string,
+        fromUnix: number,
+        toUnix: number,
+        options?: SyncOptions,
+    ): Promise<SyncResult> {
+        let synced = 0;
+        let attachmentsIndexed = 0;
+        let highestId = 0;
+        let lowestMsgId = Infinity;
+
+        const batch: Array<ReturnType<TelegramMessage["toJSON"]>> = [];
+        let retries = 0;
+
+        const iterOptions = {
+            offsetDate: toUnix,
+            limit: options?.limit,
+        };
+
+        try {
+            for await (const rawMsg of this.client.getMessages(chatId, iterOptions)) {
+                const msg = new TelegramMessage(rawMsg);
+                const dateUnix = Math.floor(msg.date.getTime() / 1000);
+
+                // Stop if we've gone past the range
+                if (dateUnix < fromUnix) break;
+
+                const serialized = msg.toJSON();
+                batch.push(serialized);
+
+                // Index attachments
+                const atts = AttachmentIndexer.extract(chatId, rawMsg);
+                for (const att of atts) {
+                    this.store.upsertAttachment(att);
+                    attachmentsIndexed++;
+                }
+
+                if (rawMsg.id > highestId) highestId = rawMsg.id;
+                if (rawMsg.id < lowestMsgId) lowestMsgId = rawMsg.id;
+
+                if (batch.length >= BATCH_SIZE) {
+                    synced += this.store.insertMessages(chatId, batch);
+                    batch.length = 0;
+                }
+            }
+        } catch (err: unknown) {
+            // Handle FLOOD_WAIT
+            if (err instanceof Error && err.message.includes("FLOOD_WAIT")) {
+                const match = err.message.match(/FLOOD_WAIT_(\d+)/);
+                const waitSeconds = match ? Number.parseInt(match[1], 10) : 30;
+                if (retries < MAX_RETRIES) {
+                    retries++;
+                    await Bun.sleep(waitSeconds * 1000 * 2 ** (retries - 1));
+                    return this.syncDateRange(chatId, fromUnix, toUnix, options);
+                }
+            }
+            throw err;
+        }
+
+        if (batch.length > 0) {
+            synced += this.store.insertMessages(chatId, batch);
+        }
+
+        // Record segment
+        if (synced > 0) {
+            this.store.insertSyncSegment(chatId, {
+                fromDateUnix: fromUnix,
+                toDateUnix: toUnix,
+                fromMsgId: lowestMsgId,
+                toMsgId: highestId,
+            });
+        }
+
+        return { synced, attachmentsIndexed, segments: synced > 0 ? 1 : 0 };
+    }
+
+    /**
+     * Auto-fetch for queries: checks coverage, fetches gaps, returns local results.
+     */
+    async queryWithAutoFetch(
+        chatId: string,
+        options: {
+            sender?: "me" | "them" | "any";
+            since?: Date;
+            until?: Date;
+            textPattern?: string;
+            limit?: number;
+            localOnly?: boolean;
+        },
+    ) {
+        // If not local-only, ensure coverage
+        if (!options.localOnly && (options.since || options.until)) {
+            const since = options.since ?? new Date(0);
+            const until = options.until ?? new Date();
+            await this.syncRange(chatId, since, until);
+        }
+
+        return this.store.queryMessages(chatId, {
+            sender: options.sender,
+            since: options.since,
+            until: options.until,
+            textPattern: options.textPattern,
+            limit: options.limit,
+        });
+    }
+}
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/lib/ConversationSyncService.ts
+git commit -m "feat(telegram): ConversationSyncService with range-aware auto-fetch"
+```
+
+---
+
+## Task 5: Wire Edit/Delete Events into TGClient
+
+**Files:**
+- Modify: `src/telegram/lib/TGClient.ts`
+
+**Context:** Currently TGClient only has `onNewMessage`. We need `onEditedMessage` and `onDeletedMessage` event handlers.
+
+**Step 1: Add event handlers to TGClient**
+
+Add to `src/telegram/lib/TGClient.ts`:
+
+```typescript
+import { EditedMessage, DeletedMessage } from "telegram/events";
+
+onEditedMessage(handler: (event: any) => Promise<void>): void {
+    this.client.addEventHandler(handler, new EditedMessage({}));
+}
+
+onDeletedMessage(handler: (event: any) => Promise<void>): void {
+    this.client.addEventHandler(handler, new DeletedMessage({}));
+}
+```
+
+**Note:** Check exact import paths from `telegram` package. The `EditedMessage` event class may be at `telegram/events/EditedMessage` — verify with:
+
+```bash
+bunx tsgo --noEmit | rg "EditedMessage"
+```
+
+If the imports don't exist in grammy/telegram, use the raw event handler approach:
+
+```typescript
+onEditedMessage(handler: (event: any) => Promise<void>): void {
+    this.client.addEventHandler(
+        async (update: any) => {
+            if (update.className === "UpdateEditMessage" || update.className === "UpdateEditChannelMessage") {
+                await handler(update);
+            }
+        }
+    );
+}
+```
+
+**Step 2: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/lib/TGClient.ts
+git commit -m "feat(telegram): add edit/delete message event handlers to TGClient"
+```
+
+---
+
+## Task 6: Wire Edit/Delete Handling into handler.ts
+
+**Files:**
+- Modify: `src/telegram/lib/handler.ts`
+
+**Context:** When an edited message arrives, we should call `store.upsertMessageWithRevision()`. When a deleted message arrives, call `store.markMessageDeleted()`.
+
+**Step 1: Add edit/delete handlers to registerHandler()**
+
+In `src/telegram/lib/handler.ts`, inside `registerHandler()`, after the existing `client.onNewMessage()` registration:
+
+```typescript
+// Handle edited messages
+client.onEditedMessage(async (event) => {
+    try {
+        const message = event.message;
+        if (!message) return;
+
+        const msg = new TelegramMessage(message);
+        const chatId = msg.senderId ?? String(message.peerId?.userId ?? message.peerId?.chatId ?? message.peerId?.channelId);
+        if (!chatId) return;
+
+        store.upsertMessageWithRevision(chatId, {
+            id: msg.id,
+            senderId: msg.senderId,
+            text: msg.text,
+            mediaDescription: msg.mediaDescription,
+            isOutgoing: msg.isOutgoing,
+            date: msg.date.toISOString(),
+            dateUnix: Math.floor(msg.date.getTime() / 1000),
+            editedDateUnix: message.editDate ?? Math.floor(Date.now() / 1000),
+        });
+    } catch (err) {
+        logger.error({ err }, "Error handling edited message");
+    }
+});
+
+// Handle deleted messages
+client.onDeletedMessage(async (event) => {
+    try {
+        const deletedIds: number[] = event.deletedIds ?? [];
+        // We don't know the chat_id from delete events in MTProto,
+        // so we search all chats for each deleted ID
+        for (const msgId of deletedIds) {
+            // Try to find which chat this message belongs to
+            const row = store.findMessageById(msgId);
+            if (row) {
+                store.markMessageDeleted(row.chat_id, msgId);
+            }
+        }
+    } catch (err) {
+        logger.error({ err }, "Error handling deleted message");
+    }
+});
+```
+
+**Step 2: Add findMessageById to TelegramHistoryStore**
+
+```typescript
+findMessageById(messageId: number): { chat_id: string } | null {
+    const db = this.db!;
+    return (db.query("SELECT chat_id FROM messages WHERE id = ? LIMIT 1").get(messageId) as { chat_id: string }) ?? null;
+}
+```
+
+**Step 3: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/lib/handler.ts src/telegram/lib/TelegramHistoryStore.ts
+git commit -m "feat(telegram): wire edit/delete events into handler with revision tracking"
+```
+
+---
+
+## Task 7: Fix sendMessage to Return Real Message IDs
+
+**Files:**
+- Modify: `src/telegram/lib/TGClient.ts`
+
+**Context:** Currently `sendMessage` returns `void`. We need it to return the Telegram `Api.Message` so we can persist the real message ID.
+
+**Step 1: Update sendMessage signature and implementation**
+
+In `src/telegram/lib/TGClient.ts`:
+
+```typescript
+// Before:
+async sendMessage(userId: string, text: string): Promise<void> {
+    await this.client.sendMessage(userId, { message: text });
+}
+
+// After:
+async sendMessage(userId: string, text: string): Promise<Api.Message> {
+    const result = await this.client.sendMessage(userId, { message: text });
+    return result;
+}
+```
+
+**Step 2: Update handler.ts to persist outgoing messages with real IDs**
+
+In `handler.ts`, where the ask action result is handled, after `client.sendMessage()`:
+
+```typescript
+// In the ask action success handler:
+const sentMessage = await client.sendMessage(contact.userId, response.content);
+store.insertMessages(contact.userId, [{
+    id: sentMessage.id,
+    senderId: myId,
+    text: response.content,
+    mediaDescription: undefined,
+    isOutgoing: true,
+    date: new Date().toISOString(),
+    dateUnix: Math.floor(Date.now() / 1000),
+}]);
+```
+
+**Step 3: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/lib/TGClient.ts src/telegram/lib/handler.ts
+git commit -m "fix(telegram): sendMessage returns Api.Message for real ID persistence"
+```
+
+---
+
+## Task 8: Update download.ts to Use ConversationSyncService
+
+**Files:**
+- Modify: `src/telegram/lib/download.ts`
+
+**Context:** The existing `downloadContact()` function has its own sync logic. Refactor it to delegate to `ConversationSyncService` while keeping the same external interface.
+
+**Step 1: Refactor downloadContact**
+
+```typescript
+import { ConversationSyncService } from "./ConversationSyncService";
+
+export async function downloadContact(
+    client: TGClient,
+    store: TelegramHistoryStore,
+    contact: ContactConfig,
+    options: { since?: Date; until?: Date; limit?: number } = {},
+): Promise<number> {
+    const syncService = new ConversationSyncService(client, store);
+
+    if (options.since || options.until) {
+        // Range sync
+        const since = options.since ?? new Date(0);
+        const until = options.until ?? new Date();
+        const result = await syncService.syncRange(contact.userId, since, until, { limit: options.limit });
+        return result.synced;
+    }
+
+    // Incremental latest sync
+    const result = await syncService.syncLatest(contact.userId, { limit: options.limit });
+    return result.synced;
+}
+```
+
+Keep `embedMessages()` unchanged.
+
+**Step 2: Type check, run existing functionality**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/lib/download.ts
+git commit -m "refactor(telegram): delegate download to ConversationSyncService"
+```
+
+---
+
+## Task 9: Update History Command with Query Subcommand
+
+**Files:**
+- Modify: `src/telegram/commands/history.ts`
+
+**Context:** Add `history query` subcommand that uses `ConversationSyncService.queryWithAutoFetch()` and `DateParser` for natural language dates.
+
+**Step 1: Add query subcommand**
+
+Add to the history command registration in `src/telegram/commands/history.ts`:
+
+```typescript
+import { parseDate } from "../lib/DateParser";
+import { ConversationSyncService } from "../lib/ConversationSyncService";
+
+history
+    .command("query")
+    .description("Query messages with filters, auto-fetching missing ranges")
+    .requiredOption("--from <contact>", "Contact name or ID")
+    .option("--since <date>", "Start date (natural language or YYYY-MM-DD)")
+    .option("--until <date>", "End date (natural language or YYYY-MM-DD)")
+    .option("--sender <who>", "Filter by sender: me, them, any", "any")
+    .option("--text <pattern>", "Text pattern to search")
+    .option("--local-only", "Don't fetch from Telegram, only search local DB")
+    .option("--limit <n>", "Max results", parseInt)
+    .action(async (opts) => {
+        const config = new TelegramToolConfig();
+        const data = await config.load();
+        if (!data) { console.error("Not configured"); process.exit(1); }
+
+        const contact = data.contacts.find(
+            (c) => c.displayName.toLowerCase() === opts.from.toLowerCase()
+                || c.userId === opts.from
+                || c.username?.toLowerCase() === opts.from.toLowerCase()
+        );
+        if (!contact) { console.error(`Contact not found: ${opts.from}`); process.exit(1); }
+
+        const since = opts.since ? parseDate(opts.since) ?? undefined : undefined;
+        const until = opts.until ? parseDate(opts.until) ?? undefined : undefined;
+
+        const client = TGClient.fromConfig(config);
+        await client.connect();
+        const store = new TelegramHistoryStore();
+        store.open();
+
+        const syncService = new ConversationSyncService(client, store);
+        const results = await syncService.queryWithAutoFetch(contact.userId, {
+            sender: opts.sender as "me" | "them" | "any",
+            since,
+            until,
+            textPattern: opts.text,
+            limit: opts.limit,
+            localOnly: opts.localOnly,
+        });
+
+        // Display results
+        for (const msg of results) {
+            const direction = msg.is_outgoing ? "→" : "←";
+            const date = new Date(msg.date_unix * 1000).toLocaleString();
+            const text = msg.text ?? "[media]";
+            console.log(`${date} ${direction} ${text}`);
+        }
+
+        console.log(`\n${results.length} message(s) found`);
+
+        store.close();
+        await client.disconnect();
+    });
+```
+
+**Step 2: Add attachment list/fetch subcommands**
+
+```typescript
+const attachments = history.command("attachments").description("Manage message attachments");
+
+attachments
+    .command("list")
+    .description("List attachment metadata for a contact")
+    .requiredOption("--from <contact>", "Contact name or ID")
+    .option("--since <date>", "Start date")
+    .option("--until <date>", "End date")
+    .option("--message-id <id>", "Specific message ID", parseInt)
+    .action(async (opts) => {
+        const store = new TelegramHistoryStore();
+        store.open();
+
+        const contact = await resolveContact(opts.from);
+        if (!contact) { process.exit(1); }
+
+        if (opts.messageId) {
+            const atts = store.getAttachments(contact.userId, opts.messageId);
+            for (const att of atts) {
+                const dl = att.is_downloaded ? "✓" : "✗";
+                console.log(`  [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""} ${att.file_size ? `(${att.file_size}b)` : ""}`);
+            }
+        } else {
+            const since = opts.since ? parseDate(opts.since) ?? undefined : undefined;
+            const until = opts.until ? parseDate(opts.until) ?? undefined : undefined;
+            const atts = store.listAttachments(contact.userId, { since, until });
+            for (const att of atts) {
+                const dl = att.is_downloaded ? "✓" : "✗";
+                console.log(`msg:${att.message_id} [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""}`);
+            }
+            console.log(`\n${atts.length} attachment(s)`);
+        }
+
+        store.close();
+    });
+
+attachments
+    .command("fetch")
+    .description("Download a specific attachment")
+    .requiredOption("--from <contact>", "Contact name or ID")
+    .requiredOption("--message-id <id>", "Message ID", parseInt)
+    .option("--attachment-index <n>", "Attachment index (default 0)", parseInt, 0)
+    .option("--output <path>", "Output file path")
+    .action(async (opts) => {
+        const config = new TelegramToolConfig();
+        const data = await config.load();
+        if (!data) { process.exit(1); }
+
+        const contact = data.contacts.find(
+            (c) => c.displayName.toLowerCase() === opts.from.toLowerCase() || c.userId === opts.from
+        );
+        if (!contact) { process.exit(1); }
+
+        const client = TGClient.fromConfig(config);
+        await client.connect();
+        const store = new TelegramHistoryStore();
+        store.open();
+
+        const downloader = new AttachmentDownloader(client, store);
+        const result = await downloader.download(contact.userId, opts.messageId, opts.attachmentIndex, opts.output);
+
+        console.log(`Downloaded to: ${result.path}`);
+        console.log(`Size: ${result.size} bytes`);
+        console.log(`SHA-256: ${result.sha256}`);
+
+        store.close();
+        await client.disconnect();
+    });
+```
+
+**Step 3: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/commands/history.ts
+git commit -m "feat(telegram): query and attachment CLI subcommands with auto-fetch"
+```
+
+---
+
+## Task 10: Phase 2 Verification
+
+**Step 1: Run all tests**
+
+```bash
+bun test src/telegram/
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 3: Lint**
+
+```bash
+bunx biome check src/telegram
+```
+
+**Step 4: Manual smoke test**
+
+```bash
+# Sync a contact
+tools telegram history sync <contact_name>
+
+# Query with natural language dates
+tools telegram history query --from <contact> --since "last week"
+
+# List attachments
+tools telegram history attachments list --from <contact>
+```
+
+**Step 5: Commit any fixes**
+
+```bash
+git add src/telegram/
+git commit -m "fix(telegram): Phase 2 lint and type fixes"
+```
+
+---
+
+## Summary of Phase 2 Deliverables
+
+| Component | File | Status |
+|-----------|------|--------|
+| SyncRangePlanner | `src/telegram/lib/SyncRangePlanner.ts` | Task 1 |
+| AttachmentIndexer | `src/telegram/lib/AttachmentIndexer.ts` | Task 2 |
+| AttachmentDownloader | `src/telegram/lib/AttachmentDownloader.ts` | Task 3 |
+| ConversationSyncService | `src/telegram/lib/ConversationSyncService.ts` | Task 4 |
+| Edit/delete events on TGClient | `src/telegram/lib/TGClient.ts` | Task 5 |
+| Edit/delete handling in handler | `src/telegram/lib/handler.ts` | Task 6 |
+| sendMessage returns real IDs | `src/telegram/lib/TGClient.ts` | Task 7 |
+| download.ts delegates to SyncService | `src/telegram/lib/download.ts` | Task 8 |
+| history query + attachments commands | `src/telegram/commands/history.ts` | Task 9 |

--- a/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-WatchTUI.md
+++ b/.claude/plans/2026-03-01-TelegramAssistantV2-Claude-WatchTUI.md
@@ -1,0 +1,927 @@
+# Phase 4: Watch TUI (Ink Live Chat)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build an interactive live chat terminal UI using Ink (React for terminals). Users watch a conversation in real-time, send messages by typing, and use slash commands (/ask, /suggest, /model, /attachment, /style, /careful, /quit) for AI features. Single contact view with a chat list to quickly switch contacts.
+
+**Architecture:** Ink app with React components. `WatchSession` manages shared state (messages, contact, client, store). The TUI renders a message list + input bar. Slash commands are parsed in the input handler and dispatched to the appropriate engine (AI engines come in Phase 5, but the command routing is built here).
+
+**Tech Stack:** Ink 6, React 19, @clack/prompts (for pre-TUI setup), Commander
+
+**Prerequisites:** Phase 2 (sync), Phase 3 (V2 config) complete
+
+**Existing Ink patterns to follow:** `src/claude/commands/usage/app.tsx`, `src/utils/ink/components/`, `src/utils/ink/hooks/`
+
+---
+
+## Task 1: WatchSession — Shared State Manager
+
+**Files:**
+- Create: `src/telegram/runtime/shared/WatchSession.ts`
+
+**Context:** WatchSession holds the current contact, message buffer, client, store, and provides methods for sending messages, loading history, and handling slash commands. It's framework-agnostic (not React-specific) so both light and ink runtimes can use it.
+
+**Step 1: Implement WatchSession**
+
+```typescript
+import type { TGClient } from "../../lib/TGClient";
+import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
+import type { TelegramContactV2, MessageRowV2 } from "../../lib/types";
+import { TelegramMessage } from "../../lib/TelegramMessage";
+import { ConversationSyncService } from "../../lib/ConversationSyncService";
+
+export interface WatchMessage {
+    id: number;
+    text: string;
+    isOutgoing: boolean;
+    senderName: string;
+    date: Date;
+    mediaDesc?: string;
+}
+
+export type InputMode = "chat" | "careful";
+
+export class WatchSession {
+    private messages: WatchMessage[] = [];
+    private listeners: Array<() => void> = [];
+    private _inputMode: InputMode = "chat";
+    private _currentContact: TelegramContactV2;
+    private syncService: ConversationSyncService;
+
+    constructor(
+        private client: TGClient,
+        private store: TelegramHistoryStore,
+        private myName: string,
+        contact: TelegramContactV2,
+        private allContacts: TelegramContactV2[],
+    ) {
+        this._currentContact = contact;
+        this.syncService = new ConversationSyncService(client, store);
+    }
+
+    get currentContact(): TelegramContactV2 { return this._currentContact; }
+    get inputMode(): InputMode { return this._inputMode; }
+    get contextLength(): number { return this._currentContact.watch?.contextLength ?? 30; }
+
+    /** Load recent messages from DB */
+    async loadHistory(): Promise<void> {
+        const rows = this.store.queryMessages(this._currentContact.userId, {
+            limit: this.contextLength,
+        });
+
+        this.messages = rows.map((r) => ({
+            id: r.id,
+            text: r.text ?? "",
+            isOutgoing: r.is_outgoing === 1,
+            senderName: r.is_outgoing === 1 ? this.myName : this._currentContact.displayName,
+            date: new Date(r.date_unix * 1000),
+            mediaDesc: r.media_desc ?? undefined,
+        }));
+
+        this.notify();
+    }
+
+    /** Subscribe to state changes */
+    subscribe(listener: () => void): () => void {
+        this.listeners.push(listener);
+        return () => {
+            this.listeners = this.listeners.filter((l) => l !== listener);
+        };
+    }
+
+    private notify() {
+        for (const l of this.listeners) l();
+    }
+
+    /** Get messages for rendering */
+    getMessages(): WatchMessage[] {
+        return this.messages.slice(-this.contextLength);
+    }
+
+    /** Get all configured contacts for chat list */
+    getContacts(): TelegramContactV2[] {
+        return this.allContacts;
+    }
+
+    /** Add incoming message (from event handler) */
+    addIncoming(msg: TelegramMessage): void {
+        this.messages.push({
+            id: msg.id,
+            text: msg.text,
+            isOutgoing: false,
+            senderName: this._currentContact.displayName,
+            date: msg.date,
+            mediaDesc: msg.mediaDescription,
+        });
+        this.notify();
+    }
+
+    /** Send a message */
+    async sendMessage(text: string): Promise<void> {
+        const sent = await this.client.sendMessage(this._currentContact.userId, text);
+        this.store.insertMessages(this._currentContact.userId, [{
+            id: sent.id,
+            senderId: undefined, // self
+            text,
+            mediaDescription: undefined,
+            isOutgoing: true,
+            date: new Date().toISOString(),
+            dateUnix: Math.floor(Date.now() / 1000),
+        }]);
+
+        this.messages.push({
+            id: sent.id,
+            text,
+            isOutgoing: true,
+            senderName: this.myName,
+            date: new Date(),
+        });
+        this.notify();
+    }
+
+    /** Switch to a different contact */
+    async switchContact(contact: TelegramContactV2): Promise<void> {
+        this._currentContact = contact;
+        this.messages = [];
+        await this.loadHistory();
+    }
+
+    /** Toggle input mode */
+    toggleCarefulMode(): void {
+        this._inputMode = this._inputMode === "chat" ? "careful" : "chat";
+        this.notify();
+    }
+
+    /** Parse and route slash commands. Returns true if handled. */
+    async handleSlashCommand(input: string): Promise<{ handled: boolean; output?: string }> {
+        const trimmed = input.trim();
+        if (!trimmed.startsWith("/")) {
+            return { handled: false };
+        }
+
+        const parts = trimmed.slice(1).split(/\s+/);
+        const cmd = parts[0].toLowerCase();
+        const args = parts.slice(1).join(" ");
+
+        switch (cmd) {
+            case "careful":
+                this.toggleCarefulMode();
+                return { handled: true, output: `Input mode: ${this._inputMode}` };
+
+            case "send":
+                if (this._inputMode === "careful" && args) {
+                    await this.sendMessage(args);
+                    return { handled: true };
+                }
+                return { handled: true, output: "Usage: /send <message>" };
+
+            case "quit":
+            case "exit":
+                return { handled: true, output: "__EXIT__" };
+
+            case "ask":
+                // Placeholder — AI engine hooks in Phase 5
+                return { handled: true, output: `[assistant] ${args}` };
+
+            case "suggest":
+                // Placeholder — Suggestion engine hooks in Phase 5
+                return { handled: true, output: "[suggestions loading...]" };
+
+            case "model":
+                // Placeholder — model switching hooks in Phase 5
+                return { handled: true, output: "[model selector]" };
+
+            case "style":
+                // Placeholder — style derivation hooks in Phase 5
+                return { handled: true, output: "[style profile]" };
+
+            case "attachment": {
+                const msgId = Number.parseInt(args, 10);
+                if (Number.isNaN(msgId)) {
+                    return { handled: true, output: "Usage: /attachment <message_id>" };
+                }
+                const atts = this.store.getAttachments(this._currentContact.userId, msgId);
+                if (atts.length === 0) {
+                    return { handled: true, output: "No attachments for this message" };
+                }
+                const list = atts.map((a) =>
+                    `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "✓" : "✗"}`
+                ).join("\n");
+                return { handled: true, output: `Attachments:\n${list}` };
+            }
+
+            case "help":
+                return {
+                    handled: true,
+                    output: [
+                        "Commands:",
+                        "  /ask <question>     Ask assistant about the conversation",
+                        "  /suggest            Generate reply suggestions",
+                        "  /send <text>        Send message (required in /careful mode)",
+                        "  /careful            Toggle careful mode (require /send)",
+                        "  /model              Switch AI model",
+                        "  /style              Derive/preview style profile",
+                        "  /attachment <id>    List/download attachments",
+                        "  /contacts           Switch to contact list",
+                        "  /quit               Exit watch mode",
+                    ].join("\n"),
+                };
+
+            default:
+                return { handled: true, output: `Unknown command: /${cmd}. Type /help for available commands.` };
+        }
+    }
+}
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/runtime/shared/WatchSession.ts
+git commit -m "feat(telegram): WatchSession state manager with slash command routing"
+```
+
+---
+
+## Task 2: Ink Components — Message List
+
+**Files:**
+- Create: `src/telegram/runtime/ink/components/MessageList.tsx`
+
+**Step 1: Implement MessageList**
+
+```tsx
+import React from "react";
+import { Box, Text } from "ink";
+import type { WatchMessage } from "../../shared/WatchSession";
+
+interface MessageListProps {
+    messages: WatchMessage[];
+    contactName: string;
+}
+
+export function MessageList({ messages, contactName }: MessageListProps) {
+    if (messages.length === 0) {
+        return (
+            <Box flexDirection="column" padding={1}>
+                <Text dimColor>No messages yet. Start typing to send a message.</Text>
+            </Box>
+        );
+    }
+
+    return (
+        <Box flexDirection="column">
+            {messages.map((msg) => (
+                <MessageBubble key={msg.id} message={msg} />
+            ))}
+        </Box>
+    );
+}
+
+function MessageBubble({ message }: { message: WatchMessage }) {
+    const time = formatTime(message.date);
+    const prefix = message.isOutgoing ? "→" : "←";
+    const nameColor = message.isOutgoing ? "cyan" : "green";
+
+    return (
+        <Box>
+            <Text dimColor>{time} </Text>
+            <Text color={nameColor}>{prefix} {message.senderName}: </Text>
+            <Text>{message.text}</Text>
+            {message.mediaDesc && <Text dimColor> [{message.mediaDesc}]</Text>}
+        </Box>
+    );
+}
+
+function formatTime(date: Date): string {
+    return date.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+    });
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/telegram/runtime/ink/components/MessageList.tsx
+git commit -m "feat(telegram): Ink MessageList component"
+```
+
+---
+
+## Task 3: Ink Components — Input Bar
+
+**Files:**
+- Create: `src/telegram/runtime/ink/components/InputBar.tsx`
+
+**Step 1: Implement InputBar**
+
+```tsx
+import React, { useState } from "react";
+import { Box, Text } from "ink";
+import TextInput from "ink-text-input";
+import type { InputMode } from "../../shared/WatchSession";
+
+interface InputBarProps {
+    mode: InputMode;
+    contactName: string;
+    onSubmit: (text: string) => void;
+}
+
+export function InputBar({ mode, contactName, onSubmit }: InputBarProps) {
+    const [value, setValue] = useState("");
+
+    const handleSubmit = (text: string) => {
+        if (!text.trim()) return;
+        onSubmit(text.trim());
+        setValue("");
+    };
+
+    const modeIndicator = mode === "careful" ? " [CAREFUL]" : "";
+    const prompt = `${contactName}${modeIndicator} > `;
+
+    return (
+        <Box borderStyle="single" borderColor="gray" paddingLeft={1}>
+            <Text color={mode === "careful" ? "yellow" : "blue"}>{prompt}</Text>
+            <TextInput
+                value={value}
+                onChange={setValue}
+                onSubmit={handleSubmit}
+                placeholder={mode === "careful" ? "Use /send <msg> to send..." : "Type a message or /help..."}
+            />
+        </Box>
+    );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/telegram/runtime/ink/components/InputBar.tsx
+git commit -m "feat(telegram): Ink InputBar component with mode indicator"
+```
+
+---
+
+## Task 4: Ink Components — Status Bar and Contact List
+
+**Files:**
+- Create: `src/telegram/runtime/ink/components/StatusBar.tsx`
+- Create: `src/telegram/runtime/ink/components/ContactList.tsx`
+
+**Step 1: Implement StatusBar**
+
+```tsx
+import React from "react";
+import { Box, Text } from "ink";
+import type { TelegramContactV2 } from "../../../lib/types";
+
+interface StatusBarProps {
+    contact: TelegramContactV2;
+    messageCount: number;
+    inputMode: string;
+    systemMessage?: string;
+}
+
+export function StatusBar({ contact, messageCount, inputMode, systemMessage }: StatusBarProps) {
+    const typeEmoji = contact.chatType === "group" ? "👥" : contact.chatType === "channel" ? "📢" : "👤";
+
+    return (
+        <Box borderStyle="single" borderColor="blue" justifyContent="space-between" paddingLeft={1} paddingRight={1}>
+            <Text color="blue" bold>
+                {typeEmoji} {contact.displayName}
+                {contact.username ? ` (@${contact.username})` : ""}
+            </Text>
+            <Box gap={2}>
+                {systemMessage && <Text color="yellow">{systemMessage}</Text>}
+                <Text dimColor>{messageCount} msgs</Text>
+                <Text dimColor>mode: {inputMode}</Text>
+                <Text dimColor>Tab: contacts</Text>
+            </Box>
+        </Box>
+    );
+}
+```
+
+**Step 2: Implement ContactList**
+
+```tsx
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { TelegramContactV2 } from "../../../lib/types";
+
+interface ContactListProps {
+    contacts: TelegramContactV2[];
+    currentContactId: string;
+    onSelect: (contact: TelegramContactV2) => void;
+    onBack: () => void;
+}
+
+export function ContactList({ contacts, currentContactId, onSelect, onBack }: ContactListProps) {
+    const items = contacts.map((c) => {
+        const typeIcon = c.chatType === "group" ? "👥" : c.chatType === "channel" ? "📢" : "👤";
+        const current = c.userId === currentContactId ? " ◀" : "";
+        return {
+            label: `${typeIcon} ${c.displayName}${current}`,
+            value: c.userId,
+        };
+    });
+
+    const handleSelect = (item: { value: string }) => {
+        const contact = contacts.find((c) => c.userId === item.value);
+        if (contact) {
+            onSelect(contact);
+        }
+    };
+
+    return (
+        <Box flexDirection="column" padding={1}>
+            <Text bold color="blue">Select a contact (Esc to go back):</Text>
+            <Box marginTop={1}>
+                <SelectInput items={items} onSelect={handleSelect} />
+            </Box>
+        </Box>
+    );
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/runtime/ink/components/StatusBar.tsx src/telegram/runtime/ink/components/ContactList.tsx
+git commit -m "feat(telegram): Ink StatusBar and ContactList components"
+```
+
+---
+
+## Task 5: Ink Components — System Output
+
+**Files:**
+- Create: `src/telegram/runtime/ink/components/SystemOutput.tsx`
+
+**Context:** Shows system messages (command output, AI responses, suggestions, errors) in a distinct area between messages and input.
+
+**Step 1: Implement SystemOutput**
+
+```tsx
+import React from "react";
+import { Box, Text } from "ink";
+
+interface SystemOutputProps {
+    lines: Array<{ text: string; type: "info" | "error" | "suggestion" | "assistant" }>;
+}
+
+export function SystemOutput({ lines }: SystemOutputProps) {
+    if (lines.length === 0) return null;
+
+    const colorMap = {
+        info: "gray" as const,
+        error: "red" as const,
+        suggestion: "magenta" as const,
+        assistant: "cyan" as const,
+    };
+
+    return (
+        <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingLeft={1} marginTop={1} marginBottom={1}>
+            {lines.map((line, i) => (
+                <Text key={i} color={colorMap[line.type]}>
+                    {line.text}
+                </Text>
+            ))}
+        </Box>
+    );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/telegram/runtime/ink/components/SystemOutput.tsx
+git commit -m "feat(telegram): Ink SystemOutput component for command/AI feedback"
+```
+
+---
+
+## Task 6: Main Ink App — WatchInkApp
+
+**Files:**
+- Create: `src/telegram/runtime/ink/WatchInkApp.tsx`
+
+**Context:** This is the top-level Ink app that composes all components, manages state via WatchSession, handles keyboard events, and routes input.
+
+**Step 1: Implement WatchInkApp**
+
+```tsx
+import React, { useState, useEffect, useCallback } from "react";
+import { Box, useApp, useInput } from "ink";
+import { MessageList } from "./components/MessageList";
+import { InputBar } from "./components/InputBar";
+import { StatusBar } from "./components/StatusBar";
+import { ContactList } from "./components/ContactList";
+import { SystemOutput } from "./components/SystemOutput";
+import type { WatchSession, WatchMessage } from "../shared/WatchSession";
+import type { TelegramContactV2 } from "../../lib/types";
+
+type View = "chat" | "contacts";
+
+interface SystemLine {
+    text: string;
+    type: "info" | "error" | "suggestion" | "assistant";
+}
+
+interface WatchInkAppProps {
+    session: WatchSession;
+}
+
+export function WatchInkApp({ session }: WatchInkAppProps) {
+    const { exit } = useApp();
+    const [messages, setMessages] = useState<WatchMessage[]>(session.getMessages());
+    const [view, setView] = useState<View>("chat");
+    const [systemLines, setSystemLines] = useState<SystemLine[]>([]);
+
+    // Subscribe to session changes
+    useEffect(() => {
+        const unsub = session.subscribe(() => {
+            setMessages([...session.getMessages()]);
+        });
+        return unsub;
+    }, [session]);
+
+    // Handle Tab key for switching views
+    useInput((input, key) => {
+        if (key.tab) {
+            setView((v) => (v === "chat" ? "contacts" : "chat"));
+        }
+    });
+
+    const clearSystemLines = useCallback(() => {
+        setTimeout(() => setSystemLines([]), 10000); // auto-clear after 10s
+    }, []);
+
+    const handleSubmit = useCallback(async (text: string) => {
+        // Clear previous system output
+        setSystemLines([]);
+
+        // Check for slash command
+        if (text.startsWith("/")) {
+            const result = await session.handleSlashCommand(text);
+
+            if (result.output === "__EXIT__") {
+                exit();
+                return;
+            }
+
+            if (result.handled && result.output) {
+                setSystemLines([{ text: result.output, type: "info" }]);
+                clearSystemLines();
+            }
+            return;
+        }
+
+        // Regular message
+        if (session.inputMode === "careful") {
+            setSystemLines([{ text: "Careful mode: use /send <message> to send", type: "info" }]);
+            clearSystemLines();
+            return;
+        }
+
+        try {
+            await session.sendMessage(text);
+        } catch (err) {
+            setSystemLines([{
+                text: `Failed to send: ${err instanceof Error ? err.message : String(err)}`,
+                type: "error",
+            }]);
+        }
+    }, [session, exit, clearSystemLines]);
+
+    const handleContactSelect = useCallback(async (contact: TelegramContactV2) => {
+        await session.switchContact(contact);
+        setView("chat");
+    }, [session]);
+
+    if (view === "contacts") {
+        return (
+            <ContactList
+                contacts={session.getContacts()}
+                currentContactId={session.currentContact.userId}
+                onSelect={handleContactSelect}
+                onBack={() => setView("chat")}
+            />
+        );
+    }
+
+    return (
+        <Box flexDirection="column" height="100%">
+            <StatusBar
+                contact={session.currentContact}
+                messageCount={messages.length}
+                inputMode={session.inputMode}
+            />
+            <Box flexDirection="column" flexGrow={1}>
+                <MessageList
+                    messages={messages}
+                    contactName={session.currentContact.displayName}
+                />
+            </Box>
+            <SystemOutput lines={systemLines} />
+            <InputBar
+                mode={session.inputMode}
+                contactName={session.currentContact.displayName}
+                onSubmit={handleSubmit}
+            />
+        </Box>
+    );
+}
+```
+
+**Step 2: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/runtime/ink/WatchInkApp.tsx
+git commit -m "feat(telegram): WatchInkApp main Ink application"
+```
+
+---
+
+## Task 7: Watch Command
+
+**Files:**
+- Create: `src/telegram/commands/watch.ts`
+- Modify: `src/telegram/index.ts`
+
+**Step 1: Implement watch command**
+
+```typescript
+import { Command } from "commander";
+import * as p from "@clack/prompts";
+import { render } from "ink";
+import React from "react";
+import { TelegramToolConfig } from "../lib/TelegramToolConfig";
+import { TGClient } from "../lib/TGClient";
+import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
+import { WatchSession } from "../runtime/shared/WatchSession";
+import { WatchInkApp } from "../runtime/ink/WatchInkApp";
+import { TelegramMessage } from "../lib/TelegramMessage";
+import { ConversationSyncService } from "../lib/ConversationSyncService";
+
+export function registerWatchCommand(program: Command) {
+    program
+        .command("watch [contact]")
+        .description("Watch a conversation in real-time with AI assistant features")
+        .option("--context-length <n>", "Number of recent messages to show", parseInt)
+        .action(async (contactArg, opts) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data?.session) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                process.exit(1);
+            }
+
+            const client = TGClient.fromConfig(config);
+            const connected = await client.connect();
+
+            if (!connected) {
+                p.log.error("Failed to connect. Re-run: tools telegram configure");
+                process.exit(1);
+            }
+
+            const me = await client.getMe();
+            const myName = [me.firstName, me.lastName].filter(Boolean).join(" ");
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            // Resolve contact
+            let contact = contactArg
+                ? data.contacts.find(
+                    (c) => c.displayName.toLowerCase() === contactArg.toLowerCase()
+                        || c.userId === contactArg
+                        || c.username?.toLowerCase() === contactArg.toLowerCase()
+                )
+                : undefined;
+
+            if (!contact) {
+                // Interactive contact selection
+                const choices = data.contacts.map((c) => {
+                    const icon = c.chatType === "group" ? "👥" : c.chatType === "channel" ? "📢" : "👤";
+                    return { value: c.userId, label: `${icon} ${c.displayName}` };
+                });
+
+                const selected = await p.select({
+                    message: "Which conversation to watch?",
+                    options: choices,
+                });
+
+                if (p.isCancel(selected)) process.exit(0);
+                contact = data.contacts.find((c) => c.userId === selected);
+            }
+
+            if (!contact) {
+                p.log.error("Contact not found");
+                process.exit(1);
+            }
+
+            // Override context length if provided
+            if (opts.contextLength) {
+                contact = { ...contact, watch: { ...contact.watch, contextLength: opts.contextLength } };
+            }
+
+            // Sync latest messages before starting
+            const spinner = p.spinner();
+            spinner.start("Syncing latest messages...");
+            const syncService = new ConversationSyncService(client, store);
+            const syncResult = await syncService.syncLatest(contact.userId);
+            spinner.stop(`Synced ${syncResult.synced} new messages`);
+
+            // Create session
+            const session = new WatchSession(client, store, myName, contact, data.contacts);
+            await session.loadHistory();
+
+            // Register incoming message handler for this contact
+            client.onNewMessage(async (event) => {
+                const msg = new TelegramMessage(event.message);
+                const senderId = msg.senderId;
+
+                if (senderId === contact!.userId || String(event.message?.peerId?.chatId) === contact!.userId) {
+                    // Persist
+                    store.insertMessages(contact!.userId, [msg.toJSON()]);
+                    // Push to session
+                    session.addIncoming(msg);
+                }
+            });
+
+            // Render Ink app
+            p.log.info(`Watching ${contact.displayName}. Tab to switch contacts, /help for commands.`);
+            const { waitUntilExit } = render(
+                React.createElement(WatchInkApp, { session }),
+            );
+
+            await waitUntilExit();
+
+            // Cleanup
+            store.close();
+            await client.disconnect();
+        });
+}
+```
+
+**Step 2: Register in index.ts**
+
+Add to `src/telegram/index.ts`:
+
+```typescript
+import { registerWatchCommand } from "./commands/watch";
+registerWatchCommand(program);
+```
+
+**Step 3: Update listen.ts as compatibility alias**
+
+At the end of `registerListenCommand` in `listen.ts`, add a note that `listen` is now a backward-compatible alias. No functional changes needed — `listen` continues to work as the daemon-style handler.
+
+**Step 4: Type check and commit**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+git add src/telegram/commands/watch.ts src/telegram/index.ts
+git commit -m "feat(telegram): watch command with Ink live chat TUI"
+```
+
+---
+
+## Task 8: Wire Incoming Messages to Watch Session (Event Bridge)
+
+**Files:**
+- Modify: `src/telegram/runtime/ink/WatchInkApp.tsx`
+
+**Context:** The watch command registers `client.onNewMessage` above, but we also need to handle messages from OTHER contacts (to show unread badges in the contact list) and handle group messages where `peerId` may be the group ID.
+
+**Step 1: Add unread tracking to WatchSession**
+
+Add to `src/telegram/runtime/shared/WatchSession.ts`:
+
+```typescript
+private unreadCounts = new Map<string, number>();
+
+incrementUnread(contactId: string): void {
+    const current = this.unreadCounts.get(contactId) ?? 0;
+    this.unreadCounts.set(contactId, current + 1);
+    this.notify();
+}
+
+getUnreadCount(contactId: string): number {
+    return this.unreadCounts.get(contactId) ?? 0;
+}
+
+clearUnread(contactId: string): void {
+    this.unreadCounts.delete(contactId);
+}
+```
+
+Update `switchContact` to clear unreads:
+
+```typescript
+async switchContact(contact: TelegramContactV2): Promise<void> {
+    this._currentContact = contact;
+    this.messages = [];
+    this.clearUnread(contact.userId);
+    await this.loadHistory();
+}
+```
+
+**Step 2: Update ContactList to show unread badges**
+
+In `ContactList.tsx`:
+
+```tsx
+interface ContactListProps {
+    contacts: TelegramContactV2[];
+    currentContactId: string;
+    unreadCounts: Map<string, number>;
+    onSelect: (contact: TelegramContactV2) => void;
+    onBack: () => void;
+}
+
+// In the items mapping:
+const unread = unreadCounts.get(c.userId) ?? 0;
+const badge = unread > 0 ? ` (${unread})` : "";
+return {
+    label: `${typeIcon} ${c.displayName}${badge}${current}`,
+    value: c.userId,
+};
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/telegram/runtime/shared/WatchSession.ts src/telegram/runtime/ink/components/ContactList.tsx
+git commit -m "feat(telegram): unread message tracking in watch session"
+```
+
+---
+
+## Task 9: Phase 4 Verification
+
+**Step 1: Type check**
+
+```bash
+bunx tsgo --noEmit | rg "src/telegram"
+```
+
+**Step 2: Lint**
+
+```bash
+bunx biome check src/telegram
+```
+
+**Step 3: Manual smoke test**
+
+```bash
+# Launch watch mode
+tools telegram watch
+
+# Should show contact selector → pick a contact → see message history
+# Type a message → it should send
+# Type /help → see command list
+# Type /careful → toggle careful mode
+# Tab → switch to contact list
+```
+
+**Step 4: Commit fixes**
+
+```bash
+git add src/telegram/
+git commit -m "fix(telegram): Phase 4 verification fixes"
+```
+
+---
+
+## Summary of Phase 4 Deliverables
+
+| Component | File | Status |
+|-----------|------|--------|
+| WatchSession state manager | `src/telegram/runtime/shared/WatchSession.ts` | Task 1 |
+| MessageList component | `src/telegram/runtime/ink/components/MessageList.tsx` | Task 2 |
+| InputBar component | `src/telegram/runtime/ink/components/InputBar.tsx` | Task 3 |
+| StatusBar component | `src/telegram/runtime/ink/components/StatusBar.tsx` | Task 4 |
+| ContactList component | `src/telegram/runtime/ink/components/ContactList.tsx` | Task 4 |
+| SystemOutput component | `src/telegram/runtime/ink/components/SystemOutput.tsx` | Task 5 |
+| WatchInkApp main app | `src/telegram/runtime/ink/WatchInkApp.tsx` | Task 6 |
+| watch command | `src/telegram/commands/watch.ts` | Task 7 |
+| Unread tracking | `WatchSession.ts`, `ContactList.tsx` | Task 8 |

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "boxen": "^8.0.1",
         "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
+        "chrono-node": "^2.9.0",
         "cli-html": "^5.3.0",
         "cli-table3": "^0.6.5",
         "clipboardy": "^4.0.0",
@@ -840,6 +841,8 @@
     "chroma-js": ["chroma-js@1.4.1", "", {}, "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="],
 
     "chromium-bidi": ["chromium-bidi@11.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-cM3DI+OOb89T3wO8cpPSro80Q9eKYJ7hGVXoGS3GkDPxnYSqiv+6xwpIf6XERyJ9Tdsl09hmNmY94BkgZdVekw=="],
+
+    "chrono-node": ["chrono-node@2.9.0", "", {}, "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "boxen": "^8.0.1",
         "chalk": "^5.6.0",
         "chokidar": "^4.0.3",
+        "chrono-node": "^2.9.0",
         "cli-html": "^5.3.0",
         "cli-table3": "^0.6.5",
         "clipboardy": "^4.0.0",

--- a/src/ask/index.lib.ts
+++ b/src/ask/index.lib.ts
@@ -4,8 +4,6 @@ export { ChatLog } from "./lib/ChatLog";
 export { ChatSession } from "./lib/ChatSession";
 export { ChatSessionManager } from "./lib/ChatSessionManager";
 export { ChatTurn } from "./lib/ChatTurn";
-export { ModelSelector } from "./providers/ModelSelector";
-export { ProviderManager } from "./providers/ProviderManager";
 export type {
     AIChatOptions,
     AIChatSelection,
@@ -18,4 +16,6 @@ export type {
     SessionStats,
     ToolCallResult,
 } from "./lib/types";
+export { ModelSelector } from "./providers/ModelSelector";
+export { ProviderManager } from "./providers/ProviderManager";
 export type { DetectedProvider, ModelInfo, ProviderChoice } from "./types";

--- a/src/ask/index.lib.ts
+++ b/src/ask/index.lib.ts
@@ -4,6 +4,8 @@ export { ChatLog } from "./lib/ChatLog";
 export { ChatSession } from "./lib/ChatSession";
 export { ChatSessionManager } from "./lib/ChatSessionManager";
 export { ChatTurn } from "./lib/ChatTurn";
+export { ModelSelector } from "./providers/ModelSelector";
+export { ProviderManager } from "./providers/ProviderManager";
 export type {
     AIChatOptions,
     AIChatSelection,
@@ -16,3 +18,4 @@ export type {
     SessionStats,
     ToolCallResult,
 } from "./lib/types";
+export type { DetectedProvider, ModelInfo, ProviderChoice } from "./types";

--- a/src/telegram/commands/configure.ts
+++ b/src/telegram/commands/configure.ts
@@ -14,12 +14,7 @@ import type {
     TelegramContactV2,
     WatchConfig,
 } from "../lib/types";
-import {
-    DEFAULT_MODE_CONFIG,
-    DEFAULT_STYLE_PROFILE,
-    DEFAULT_WATCH_CONFIG,
-    DEFAULTS,
-} from "../lib/types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "../lib/types";
 
 function isUser(entity: unknown): entity is Api.User {
     return (
@@ -181,10 +176,7 @@ async function fetchDialogOptions(client: TGClient): Promise<DialogOption[]> {
     return options;
 }
 
-async function selectDialogs(
-    options: DialogOption[],
-    existingContacts: TelegramContactV2[]
-): Promise<string[] | null> {
+async function selectDialogs(options: DialogOption[], existingContacts: TelegramContactV2[]): Promise<string[] | null> {
     const existingIds = new Set(existingContacts.map((c) => c.userId));
 
     const selected = await p.multiselect({
@@ -210,7 +202,11 @@ async function configureContactModes(
         options: [
             { value: "autoReply" as const, label: "Auto-Reply", hint: "Automatically respond to messages" },
             { value: "assistant" as const, label: "Chat Assistant", hint: "Ask questions about the conversation" },
-            { value: "suggestions" as const, label: "Message Suggestions", hint: "Get suggested replies to pick/edit/send" },
+            {
+                value: "suggestions" as const,
+                label: "Message Suggestions",
+                hint: "Get suggested replies to pick/edit/send",
+            },
         ],
         initialValues: getExistingEnabledModes(existing),
         required: false,

--- a/src/telegram/commands/configure.ts
+++ b/src/telegram/commands/configure.ts
@@ -1,11 +1,25 @@
+import { ModelSelector } from "@app/ask/index.lib";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 import type { Api } from "telegram";
+import type { Dialog } from "telegram/tl/custom/dialog";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
-import type { ActionType, ContactConfig, TelegramConfigData } from "../lib/types";
-import { DEFAULTS } from "../lib/types";
+import type {
+    ActionType,
+    ChatType,
+    ContactModesConfig,
+    TelegramConfigDataV2,
+    TelegramContactV2,
+    WatchConfig,
+} from "../lib/types";
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULTS,
+} from "../lib/types";
 
 function isUser(entity: unknown): entity is Api.User {
     return (
@@ -18,7 +32,7 @@ function isUser(entity: unknown): entity is Api.User {
 }
 
 async function promptCredentials(
-    existing: TelegramConfigData | null
+    existing: TelegramConfigDataV2 | null
 ): Promise<{ apiId: number; apiHash: string } | null> {
     p.note("Telegram API credentials are pre-filled.\nGet your own at https://my.telegram.org/apps", "API Credentials");
 
@@ -106,40 +120,77 @@ async function runAuthFlow(client: TGClient): Promise<boolean> {
     }
 }
 
-interface ContactOption {
-    userId: string;
+interface DialogOption {
+    dialog: Dialog;
+    chatType: ChatType;
+    entityId: string;
     label: string;
     hint: string;
-    user: Api.User;
 }
 
-async function fetchContacts(client: TGClient): Promise<ContactOption[]> {
+function classifyDialog(d: Dialog): { chatType: ChatType; entityId: string } | null {
+    if (!d.entity) {
+        return null;
+    }
+
+    if (d.isUser && isUser(d.entity) && !d.entity.bot && !d.entity.self) {
+        return { chatType: "user", entityId: d.entity.id.toString() };
+    }
+
+    if (d.isGroup && d.entity.id) {
+        return { chatType: "group", entityId: d.entity.id.toString() };
+    }
+
+    if (d.isChannel && d.entity.id) {
+        return { chatType: "channel", entityId: d.entity.id.toString() };
+    }
+
+    return null;
+}
+
+async function fetchDialogOptions(client: TGClient): Promise<DialogOption[]> {
     const spinner = p.spinner();
     spinner.start("Fetching your recent chats...");
 
-    const dialogs = await client.getDialogs(100);
+    const dialogs = await client.getDialogs(200);
+    const options: DialogOption[] = [];
 
-    const userDialogs = dialogs.filter((d) => d.isUser && isUser(d.entity) && !d.entity.bot && !d.entity.self);
+    for (const d of dialogs) {
+        const classified = classifyDialog(d);
 
-    spinner.stop(`Found ${userDialogs.length} contacts`);
+        if (!classified) {
+            continue;
+        }
 
-    return userDialogs
-        .filter((d): d is typeof d & { entity: Api.User } => isUser(d.entity))
-        .map((d) => {
-            const user = d.entity;
-            const label = `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.id.toString();
-            const hint = user.username ? `@${user.username}` : user.phone ? `+${user.phone}` : "";
-            return { userId: user.id.toString(), label, hint, user };
+        const entity = d.entity as { username?: string; phone?: string; id: { toString(): string } };
+        const username = "username" in entity ? entity.username : undefined;
+        const typePrefix = classified.chatType === "user" ? "U" : classified.chatType === "group" ? "G" : "C";
+        const label = `[${typePrefix}] ${d.title || classified.entityId}`;
+        const hint = username ? `@${username}` : "";
+
+        options.push({
+            dialog: d,
+            chatType: classified.chatType,
+            entityId: classified.entityId,
+            label,
+            hint,
         });
+    }
+
+    spinner.stop(`Found ${options.length} chats`);
+    return options;
 }
 
-async function selectContacts(options: ContactOption[], existingContacts: ContactConfig[]): Promise<string[] | null> {
+async function selectDialogs(
+    options: DialogOption[],
+    existingContacts: TelegramContactV2[]
+): Promise<string[] | null> {
     const existingIds = new Set(existingContacts.map((c) => c.userId));
 
     const selected = await p.multiselect({
-        message: "Select contacts to watch:",
-        options: options.map((o) => ({ value: o.userId, label: o.label, hint: o.hint })),
-        initialValues: [...existingIds].filter((id) => options.some((o) => o.userId === id)),
+        message: "Select chats to watch:",
+        options: options.map((o) => ({ value: o.entityId, label: o.label, hint: o.hint })),
+        initialValues: [...existingIds].filter((id) => options.some((o) => o.entityId === id)),
         required: false,
     });
 
@@ -150,7 +201,107 @@ async function selectContacts(options: ContactOption[], existingContacts: Contac
     return selected as string[];
 }
 
-async function configureContactActions(opt: ContactOption, existing?: ContactConfig): Promise<ContactConfig | null> {
+async function configureContactModes(
+    displayName: string,
+    existing?: TelegramContactV2
+): Promise<ContactModesConfig | null> {
+    const modeChoices = await p.multiselect({
+        message: `Which AI modes for ${displayName}?`,
+        options: [
+            { value: "autoReply" as const, label: "Auto-Reply", hint: "Automatically respond to messages" },
+            { value: "assistant" as const, label: "Chat Assistant", hint: "Ask questions about the conversation" },
+            { value: "suggestions" as const, label: "Message Suggestions", hint: "Get suggested replies to pick/edit/send" },
+        ],
+        initialValues: getExistingEnabledModes(existing),
+        required: false,
+    });
+
+    if (p.isCancel(modeChoices)) {
+        return null;
+    }
+
+    const selectedModes = modeChoices as string[];
+    const modes: ContactModesConfig = {
+        autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+        assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+        suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+    };
+
+    const modelSelector = new ModelSelector();
+
+    for (const mode of selectedModes) {
+        const configureModel = await p.confirm({
+            message: `Configure custom model for ${mode}?`,
+            initialValue: false,
+        });
+
+        if (configureModel && !p.isCancel(configureModel)) {
+            const choice = await modelSelector.selectModel();
+
+            if (choice) {
+                if (mode === "autoReply") {
+                    modes.autoReply = {
+                        ...modes.autoReply,
+                        enabled: true,
+                        provider: choice.provider.name,
+                        model: choice.model.id,
+                    };
+                } else if (mode === "assistant") {
+                    modes.assistant = {
+                        ...modes.assistant,
+                        enabled: true,
+                        provider: choice.provider.name,
+                        model: choice.model.id,
+                    };
+                } else if (mode === "suggestions") {
+                    modes.suggestions = {
+                        ...modes.suggestions,
+                        enabled: true,
+                        provider: choice.provider.name,
+                        model: choice.model.id,
+                    };
+                }
+            }
+        } else if (!p.isCancel(configureModel)) {
+            if (mode === "autoReply") {
+                modes.autoReply = { ...modes.autoReply, enabled: true };
+            } else if (mode === "assistant") {
+                modes.assistant = { ...modes.assistant, enabled: true };
+            } else if (mode === "suggestions") {
+                modes.suggestions = { ...modes.suggestions, enabled: true };
+            }
+        }
+    }
+
+    return modes;
+}
+
+function getExistingEnabledModes(existing?: TelegramContactV2): string[] {
+    if (!existing?.modes) {
+        return ["assistant", "suggestions"];
+    }
+
+    const enabled: string[] = [];
+
+    if (existing.modes.autoReply.enabled) {
+        enabled.push("autoReply");
+    }
+
+    if (existing.modes.assistant.enabled) {
+        enabled.push("assistant");
+    }
+
+    if (existing.modes.suggestions.enabled) {
+        enabled.push("suggestions");
+    }
+
+    return enabled;
+}
+
+async function configureContactActions(
+    opt: DialogOption,
+    existing?: TelegramContactV2
+): Promise<TelegramContactV2 | null> {
     p.log.step(pc.bold(opt.label));
 
     const actions = await p.multiselect({
@@ -169,56 +320,84 @@ async function configureContactActions(opt: ContactOption, existing?: ContactCon
     }
 
     const typedActions = actions as ActionType[];
-    let askSystemPrompt: string | undefined;
-    let askProvider: string | undefined;
-    let askModel: string | undefined;
+
+    let systemPrompt: string | undefined;
 
     if (typedActions.includes("ask")) {
         const prompt = await p.text({
             message: `System prompt for auto-replies to ${opt.label}:`,
-            initialValue: existing?.askSystemPrompt || DEFAULTS.askSystemPrompt,
+            initialValue: existing?.modes?.autoReply?.systemPrompt || DEFAULTS.askSystemPrompt,
         });
 
         if (p.isCancel(prompt)) {
             return null;
         }
 
-        askSystemPrompt = prompt as string;
-
-        const provider = await p.text({
-            message: "LLM provider:",
-            initialValue: existing?.askProvider || DEFAULTS.askProvider,
-        });
-
-        if (p.isCancel(provider)) {
-            return null;
-        }
-
-        askProvider = provider as string;
-
-        const model = await p.text({
-            message: "LLM model:",
-            initialValue: existing?.askModel || DEFAULTS.askModel,
-        });
-
-        if (p.isCancel(model)) {
-            return null;
-        }
-
-        askModel = model as string;
+        systemPrompt = prompt as string;
     }
 
+    const modes = await configureContactModes(opt.label, existing);
+
+    if (!modes) {
+        return null;
+    }
+
+    if (systemPrompt && modes.autoReply.enabled) {
+        modes.autoReply.systemPrompt = systemPrompt;
+    }
+
+    const contextLength = await p.text({
+        message: "Context window size (number of recent messages)?",
+        initialValue: String(existing?.watch?.contextLength ?? 30),
+        validate: (v) => {
+            if (!v) {
+                return "Required";
+            }
+
+            const n = Number.parseInt(v, 10);
+
+            if (Number.isNaN(n) || n < 1 || n > 500) {
+                return "Must be 1-500";
+            }
+        },
+    });
+
+    if (p.isCancel(contextLength)) {
+        return null;
+    }
+
+    const watchConfig: WatchConfig = {
+        enabled: true,
+        contextLength: Number.parseInt(contextLength as string, 10),
+        runtimeMode: existing?.watch?.runtimeMode ?? "ink",
+    };
+
     return {
-        userId: opt.userId,
-        displayName: opt.label,
-        username: opt.user.username ?? undefined,
+        userId: opt.entityId,
+        displayName: opt.dialog.title || opt.entityId,
+        username: getEntityUsername(opt.dialog),
+        chatType: opt.chatType,
         actions: typedActions,
-        askSystemPrompt,
-        askProvider,
-        askModel,
+        watch: watchConfig,
+        modes,
+        styleProfile: existing?.styleProfile ?? { ...DEFAULT_STYLE_PROFILE },
         replyDelayMin: existing?.replyDelayMin ?? DEFAULTS.replyDelayMin,
         replyDelayMax: existing?.replyDelayMax ?? DEFAULTS.replyDelayMax,
     };
+}
+
+function getEntityUsername(dialog: Dialog): string | undefined {
+    const entity = dialog.entity;
+
+    if (!entity) {
+        return undefined;
+    }
+
+    if ("username" in entity && typeof entity.username === "string") {
+        return entity.username;
+    }
+
+    return undefined;
 }
 
 export function registerConfigureCommand(program: Command): void {
@@ -246,7 +425,7 @@ export function registerConfigureCommand(program: Command): void {
                         `Logged in as ${pc.bold(me.firstName || "")} ` + `${me.username ? `(@${me.username})` : ""}`
                     );
                 } else {
-                    spinner.stop("Session expired — re-authentication needed");
+                    spinner.stop("Session expired -- re-authentication needed");
                     await client.disconnect();
                     client = null;
                 }
@@ -277,11 +456,12 @@ export function registerConfigureCommand(program: Command): void {
             const me = await client.getMe();
             const session = client.getSessionString();
 
-            const contactOptions = await fetchContacts(client);
+            const dialogOptions = await fetchDialogOptions(client);
 
-            if (contactOptions.length === 0) {
-                p.log.warn("No contacts found in recent chats.");
-                await toolConfig.save({
+            if (dialogOptions.length === 0) {
+                p.log.warn("No chats found.");
+                const emptyConfig: TelegramConfigDataV2 = {
+                    version: 2,
                     apiId: effectiveApiId,
                     apiHash: effectiveApiHash,
                     session,
@@ -291,30 +471,36 @@ export function registerConfigureCommand(program: Command): void {
                         phone: me.phone ?? undefined,
                     },
                     contacts: [],
+                    globalDefaults: {
+                        modes: { ...DEFAULT_MODE_CONFIG },
+                        watch: { ...DEFAULT_WATCH_CONFIG },
+                        styleProfile: { ...DEFAULT_STYLE_PROFILE },
+                    },
                     configuredAt: new Date().toISOString(),
-                });
+                };
+                await toolConfig.save(emptyConfig);
                 await client.disconnect();
                 p.outro("Configuration saved (no contacts to watch).");
                 return;
             }
 
-            const selectedIds = await selectContacts(contactOptions, existing?.contacts ?? []);
+            const selectedIds = await selectDialogs(dialogOptions, existing?.contacts ?? []);
 
             if (!selectedIds) {
                 await client.disconnect();
                 return;
             }
 
-            const contacts: ContactConfig[] = [];
+            const contacts: TelegramContactV2[] = [];
 
-            for (const userId of selectedIds) {
-                const opt = contactOptions.find((o) => o.userId === userId);
+            for (const entityId of selectedIds) {
+                const opt = dialogOptions.find((o) => o.entityId === entityId);
 
                 if (!opt) {
                     continue;
                 }
 
-                const existingContact = existing?.contacts.find((c) => c.userId === userId);
+                const existingContact = existing?.contacts.find((c) => c.userId === entityId);
                 const contact = await configureContactActions(opt, existingContact);
 
                 if (!contact) {
@@ -325,7 +511,8 @@ export function registerConfigureCommand(program: Command): void {
                 contacts.push(contact);
             }
 
-            await toolConfig.save({
+            const configToSave: TelegramConfigDataV2 = {
+                version: 2,
                 apiId: effectiveApiId,
                 apiHash: effectiveApiHash,
                 session,
@@ -335,9 +522,15 @@ export function registerConfigureCommand(program: Command): void {
                     phone: me.phone ?? undefined,
                 },
                 contacts,
+                globalDefaults: existing?.globalDefaults ?? {
+                    modes: { ...DEFAULT_MODE_CONFIG },
+                    watch: { ...DEFAULT_WATCH_CONFIG },
+                    styleProfile: { ...DEFAULT_STYLE_PROFILE },
+                },
                 configuredAt: new Date().toISOString(),
-            });
+            };
 
+            await toolConfig.save(configToSave);
             await client.disconnect();
 
             p.log.success(`Saved ${contacts.length} contact(s)`);

--- a/src/telegram/commands/configure.ts
+++ b/src/telegram/commands/configure.ts
@@ -119,25 +119,29 @@ interface DialogOption {
     dialog: Dialog;
     chatType: ChatType;
     entityId: string;
+    dialogKey: string;
     label: string;
     hint: string;
 }
 
-function classifyDialog(d: Dialog): { chatType: ChatType; entityId: string } | null {
+function classifyDialog(d: Dialog): { chatType: ChatType; entityId: string; dialogKey: string } | null {
     if (!d.entity) {
         return null;
     }
 
     if (d.isUser && isUser(d.entity) && !d.entity.bot && !d.entity.self) {
-        return { chatType: "user", entityId: d.entity.id.toString() };
+        const entityId = d.entity.id.toString();
+        return { chatType: "user", entityId, dialogKey: `user:${entityId}` };
     }
 
     if (d.isGroup && d.entity.id) {
-        return { chatType: "group", entityId: d.entity.id.toString() };
+        const entityId = d.entity.id.toString();
+        return { chatType: "group", entityId, dialogKey: `group:${entityId}` };
     }
 
     if (d.isChannel && d.entity.id) {
-        return { chatType: "channel", entityId: d.entity.id.toString() };
+        const entityId = d.entity.id.toString();
+        return { chatType: "channel", entityId, dialogKey: `channel:${entityId}` };
     }
 
     return null;
@@ -167,6 +171,7 @@ async function fetchDialogOptions(client: TGClient): Promise<DialogOption[]> {
             dialog: d,
             chatType: classified.chatType,
             entityId: classified.entityId,
+            dialogKey: classified.dialogKey,
             label,
             hint,
         });
@@ -177,12 +182,12 @@ async function fetchDialogOptions(client: TGClient): Promise<DialogOption[]> {
 }
 
 async function selectDialogs(options: DialogOption[], existingContacts: TelegramContactV2[]): Promise<string[] | null> {
-    const existingIds = new Set(existingContacts.map((c) => c.userId));
+    const existingDialogKeys = new Set(existingContacts.map((c) => `${c.chatType}:${c.userId}`));
 
     const selected = await p.multiselect({
         message: "Select chats to watch:",
-        options: options.map((o) => ({ value: o.entityId, label: o.label, hint: o.hint })),
-        initialValues: [...existingIds].filter((id) => options.some((o) => o.entityId === id)),
+        options: options.map((o) => ({ value: o.dialogKey, label: o.label, hint: o.hint })),
+        initialValues: options.filter((o) => existingDialogKeys.has(o.dialogKey)).map((o) => o.dialogKey),
         required: false,
     });
 
@@ -231,40 +236,41 @@ async function configureContactModes(
             initialValue: false,
         });
 
-        if (configureModel && !p.isCancel(configureModel)) {
+        if (p.isCancel(configureModel)) {
+            return null;
+        }
+
+        if (mode === "autoReply") {
+            modes.autoReply = { ...modes.autoReply, enabled: true };
+        } else if (mode === "assistant") {
+            modes.assistant = { ...modes.assistant, enabled: true };
+        } else if (mode === "suggestions") {
+            modes.suggestions = { ...modes.suggestions, enabled: true };
+        }
+
+        if (configureModel) {
             const choice = await modelSelector.selectModel();
 
-            if (choice) {
+            if (choice && !p.isCancel(choice)) {
                 if (mode === "autoReply") {
                     modes.autoReply = {
                         ...modes.autoReply,
-                        enabled: true,
                         provider: choice.provider.name,
                         model: choice.model.id,
                     };
                 } else if (mode === "assistant") {
                     modes.assistant = {
                         ...modes.assistant,
-                        enabled: true,
                         provider: choice.provider.name,
                         model: choice.model.id,
                     };
                 } else if (mode === "suggestions") {
                     modes.suggestions = {
                         ...modes.suggestions,
-                        enabled: true,
                         provider: choice.provider.name,
                         model: choice.model.id,
                     };
                 }
-            }
-        } else if (!p.isCancel(configureModel)) {
-            if (mode === "autoReply") {
-                modes.autoReply = { ...modes.autoReply, enabled: true };
-            } else if (mode === "assistant") {
-                modes.assistant = { ...modes.assistant, enabled: true };
-            } else if (mode === "suggestions") {
-                modes.suggestions = { ...modes.suggestions, enabled: true };
             }
         }
     }
@@ -489,14 +495,14 @@ export function registerConfigureCommand(program: Command): void {
 
             const contacts: TelegramContactV2[] = [];
 
-            for (const entityId of selectedIds) {
-                const opt = dialogOptions.find((o) => o.entityId === entityId);
+            for (const dialogKey of selectedIds) {
+                const opt = dialogOptions.find((o) => o.dialogKey === dialogKey);
 
                 if (!opt) {
                     continue;
                 }
 
-                const existingContact = existing?.contacts.find((c) => c.userId === entityId);
+                const existingContact = existing?.contacts.find((c) => `${c.chatType}:${c.userId}` === dialogKey);
                 const contact = await configureContactActions(opt, existingContact);
 
                 if (!contact) {

--- a/src/telegram/commands/configure.ts
+++ b/src/telegram/commands/configure.ts
@@ -150,35 +150,38 @@ function classifyDialog(d: Dialog): { chatType: ChatType; entityId: string; dial
 async function fetchDialogOptions(client: TGClient): Promise<DialogOption[]> {
     const spinner = p.spinner();
     spinner.start("Fetching your recent chats...");
-
-    const dialogs = await client.getDialogs(200);
     const options: DialogOption[] = [];
 
-    for (const d of dialogs) {
-        const classified = classifyDialog(d);
+    try {
+        const dialogs = await client.getDialogs(200);
 
-        if (!classified) {
-            continue;
+        for (const d of dialogs) {
+            const classified = classifyDialog(d);
+
+            if (!classified) {
+                continue;
+            }
+
+            const entity = d.entity as { username?: string; phone?: string; id: { toString(): string } };
+            const username = "username" in entity ? entity.username : undefined;
+            const typePrefix = classified.chatType === "user" ? "U" : classified.chatType === "group" ? "G" : "C";
+            const label = `[${typePrefix}] ${d.title || classified.entityId}`;
+            const hint = username ? `@${username}` : "";
+
+            options.push({
+                dialog: d,
+                chatType: classified.chatType,
+                entityId: classified.entityId,
+                dialogKey: classified.dialogKey,
+                label,
+                hint,
+            });
         }
 
-        const entity = d.entity as { username?: string; phone?: string; id: { toString(): string } };
-        const username = "username" in entity ? entity.username : undefined;
-        const typePrefix = classified.chatType === "user" ? "U" : classified.chatType === "group" ? "G" : "C";
-        const label = `[${typePrefix}] ${d.title || classified.entityId}`;
-        const hint = username ? `@${username}` : "";
-
-        options.push({
-            dialog: d,
-            chatType: classified.chatType,
-            entityId: classified.entityId,
-            dialogKey: classified.dialogKey,
-            label,
-            hint,
-        });
+        return options;
+    } finally {
+        spinner.stop(`Found ${options.length} chats`);
     }
-
-    spinner.stop(`Found ${options.length} chats`);
-    return options;
 }
 
 async function selectDialogs(options: DialogOption[], existingContacts: TelegramContactV2[]): Promise<string[] | null> {

--- a/src/telegram/commands/contacts.ts
+++ b/src/telegram/commands/contacts.ts
@@ -24,10 +24,11 @@ export function registerContactsCommand(program: Command): void {
             p.intro(pc.bgMagenta(pc.white(" telegram contacts ")));
 
             for (const c of data.contacts) {
+                const autoReplyPrompt = c.modes?.autoReply?.systemPrompt;
                 p.log.info(
                     `${pc.bold(c.displayName)} ${c.username ? pc.dim(`@${c.username}`) : ""}\n` +
-                        `  Actions: [${c.actions.join(", ")}]` +
-                        (c.askSystemPrompt ? `\n  Prompt: "${c.askSystemPrompt}"` : "")
+                        `  Type: ${c.chatType} | Actions: [${c.actions.join(", ")}]` +
+                        (autoReplyPrompt ? `\n  Prompt: "${autoReplyPrompt}"` : "")
                 );
             }
 

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -612,10 +612,11 @@ function registerQueryCommand(history: Command): void {
 
                 const store = new TelegramHistoryStore();
                 store.open();
+                let client: TGClient | null = null;
 
                 try {
                     if (!opts.localOnly) {
-                        const client = await ensureClient(config);
+                        client = await ensureClient(config);
 
                         if (!client) {
                             return;
@@ -639,7 +640,6 @@ function registerQueryCommand(history: Command): void {
                         }
 
                         console.log(`\n${results.length} message(s) found`);
-                        await client.disconnect();
                     } else {
                         const results = store.queryMessages(contact.userId, {
                             sender: opts.sender as "me" | "them" | "any",
@@ -660,6 +660,10 @@ function registerQueryCommand(history: Command): void {
                     }
                 } finally {
                     store.close();
+
+                    if (client) {
+                        await client.disconnect();
+                    }
                 }
             }
         );

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -6,6 +6,9 @@ import { formatTable } from "@app/utils/table";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
+import { AttachmentDownloader } from "../lib/AttachmentDownloader";
+import { ConversationSyncService } from "../lib/ConversationSyncService";
+import { parseDate as parseDateNatural } from "../lib/DateParser";
 import { downloadContact, embedMessages } from "../lib/download";
 import { type ExportFormat, formatMessages, VALID_EXPORT_FORMATS } from "../lib/export";
 import { displayResults } from "../lib/search";
@@ -564,6 +567,233 @@ function registerStatsCommand(history: Command): void {
         });
 }
 
+// ── Query Command ─────────────────────────────────────────────────────
+
+function registerQueryCommand(history: Command): void {
+    history
+        .command("query")
+        .description("Query messages with filters, auto-fetching missing ranges")
+        .requiredOption("--from <contact>", "Contact name or ID")
+        .option("--since <date>", "Start date (natural language or YYYY-MM-DD)")
+        .option("--until <date>", "End date (natural language or YYYY-MM-DD)")
+        .option("--sender <who>", "Filter by sender: me, them, any", "any")
+        .option("--text <pattern>", "Text pattern to search")
+        .option("--local-only", "Don't fetch from Telegram, only search local DB")
+        .option("--limit <n>", "Max results", parseInt)
+        .action(
+            async (opts: {
+                from: string;
+                since?: string;
+                until?: string;
+                sender: string;
+                text?: string;
+                localOnly?: boolean;
+                limit?: number;
+            }) => {
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    return;
+                }
+
+                const contact = resolveContact(data.contacts, opts.from);
+
+                if (!contact) {
+                    p.log.error(
+                        `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
+                    );
+                    return;
+                }
+
+                const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
+                const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
+
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                try {
+                    if (!opts.localOnly) {
+                        const client = await ensureClient(config);
+
+                        if (!client) {
+                            return;
+                        }
+
+                        const syncService = new ConversationSyncService(client, store);
+                        const results = await syncService.queryWithAutoFetch(contact.userId, {
+                            sender: opts.sender as "me" | "them" | "any",
+                            since,
+                            until,
+                            textPattern: opts.text,
+                            limit: opts.limit,
+                            localOnly: opts.localOnly,
+                        });
+
+                        for (const msg of results) {
+                            const direction = msg.is_outgoing ? "\u2192" : "\u2190";
+                            const date = new Date(msg.date_unix * 1000).toLocaleString();
+                            const text = msg.text ?? "[media]";
+                            console.log(`${date} ${direction} ${text}`);
+                        }
+
+                        console.log(`\n${results.length} message(s) found`);
+                        await client.disconnect();
+                    } else {
+                        const results = store.queryMessages(contact.userId, {
+                            sender: opts.sender as "me" | "them" | "any",
+                            since,
+                            until,
+                            textPattern: opts.text,
+                            limit: opts.limit,
+                        });
+
+                        for (const msg of results) {
+                            const direction = msg.is_outgoing ? "\u2192" : "\u2190";
+                            const date = new Date(msg.date_unix * 1000).toLocaleString();
+                            const text = msg.text ?? "[media]";
+                            console.log(`${date} ${direction} ${text}`);
+                        }
+
+                        console.log(`\n${results.length} message(s) found`);
+                    }
+                } finally {
+                    store.close();
+                }
+            }
+        );
+}
+
+// ── Attachments Commands ──────────────────────────────────────────────
+
+function registerAttachmentsCommand(history: Command): void {
+    const attachments = history.command("attachments").description("Manage message attachments");
+
+    attachments
+        .command("list")
+        .description("List attachment metadata for a contact")
+        .requiredOption("--from <contact>", "Contact name or ID")
+        .option("--since <date>", "Start date")
+        .option("--until <date>", "End date")
+        .option("--message-id <id>", "Specific message ID", parseInt)
+        .action(
+            async (opts: {
+                from: string;
+                since?: string;
+                until?: string;
+                messageId?: number;
+            }) => {
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    return;
+                }
+
+                const contact = resolveContact(data.contacts, opts.from);
+
+                if (!contact) {
+                    p.log.error(
+                        `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
+                    );
+                    return;
+                }
+
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                try {
+                    if (opts.messageId) {
+                        const atts = store.getAttachments(contact.userId, opts.messageId);
+
+                        for (const att of atts) {
+                            const dl = att.is_downloaded ? "dl" : "--";
+                            console.log(
+                                `  [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""} ${att.file_size ? `(${att.file_size}b)` : ""}`
+                            );
+                        }
+                    } else {
+                        const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
+                        const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
+                        const atts = store.listAttachments(contact.userId, { since, until });
+
+                        for (const att of atts) {
+                            const dl = att.is_downloaded ? "dl" : "--";
+                            console.log(
+                                `msg:${att.message_id} [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""}`
+                            );
+                        }
+
+                        console.log(`\n${atts.length} attachment(s)`);
+                    }
+                } finally {
+                    store.close();
+                }
+            }
+        );
+
+    attachments
+        .command("fetch")
+        .description("Download a specific attachment")
+        .requiredOption("--from <contact>", "Contact name or ID")
+        .requiredOption("--message-id <id>", "Message ID", parseInt)
+        .option("--attachment-index <n>", "Attachment index (default 0)", parseInt, 0)
+        .option("--output <path>", "Output file path")
+        .action(
+            async (opts: {
+                from: string;
+                messageId: number;
+                attachmentIndex: number;
+                output?: string;
+            }) => {
+                const config = new TelegramToolConfig();
+                const data = await config.load();
+
+                if (!data) {
+                    p.log.error("Not configured. Run: tools telegram configure");
+                    return;
+                }
+
+                const contact = resolveContact(data.contacts, opts.from);
+
+                if (!contact) {
+                    p.log.error(
+                        `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
+                    );
+                    return;
+                }
+
+                const client = await ensureClient(config);
+
+                if (!client) {
+                    return;
+                }
+
+                const store = new TelegramHistoryStore();
+                store.open();
+
+                try {
+                    const downloader = new AttachmentDownloader(client, store);
+                    const result = await downloader.download(
+                        contact.userId,
+                        opts.messageId,
+                        opts.attachmentIndex,
+                        opts.output
+                    );
+
+                    console.log(`Downloaded to: ${result.path}`);
+                    console.log(`Size: ${result.size} bytes`);
+                    console.log(`SHA-256: ${result.sha256}`);
+                } finally {
+                    store.close();
+                    await client.disconnect();
+                }
+            }
+        );
+}
+
 // ── Registration ──────────────────────────────────────────────────────
 
 export function registerHistoryCommand(program: Command): void {
@@ -574,4 +804,6 @@ export function registerHistoryCommand(program: Command): void {
     registerSearchCommand(history);
     registerExportCommand(history);
     registerStatsCommand(history);
+    registerQueryCommand(history);
+    registerAttachmentsCommand(history);
 }

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -610,6 +610,16 @@ function registerQueryCommand(history: Command): void {
                 const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
                 const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
 
+                if (opts.since && !since) {
+                    p.log.error(`Invalid --since date: "${opts.since}"`);
+                    return;
+                }
+
+                if (opts.until && !until) {
+                    p.log.error(`Invalid --until date: "${opts.until}"`);
+                    return;
+                }
+
                 const store = new TelegramHistoryStore();
                 store.open();
                 let client: TGClient | null = null;

--- a/src/telegram/commands/history.ts
+++ b/src/telegram/commands/history.ts
@@ -677,62 +677,55 @@ function registerAttachmentsCommand(history: Command): void {
         .option("--since <date>", "Start date")
         .option("--until <date>", "End date")
         .option("--message-id <id>", "Specific message ID", parseInt)
-        .action(
-            async (opts: {
-                from: string;
-                since?: string;
-                until?: string;
-                messageId?: number;
-            }) => {
-                const config = new TelegramToolConfig();
-                const data = await config.load();
+        .action(async (opts: { from: string; since?: string; until?: string; messageId?: number }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
 
-                if (!data) {
-                    p.log.error("Not configured. Run: tools telegram configure");
-                    return;
-                }
-
-                const contact = resolveContact(data.contacts, opts.from);
-
-                if (!contact) {
-                    p.log.error(
-                        `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
-                    return;
-                }
-
-                const store = new TelegramHistoryStore();
-                store.open();
-
-                try {
-                    if (opts.messageId) {
-                        const atts = store.getAttachments(contact.userId, opts.messageId);
-
-                        for (const att of atts) {
-                            const dl = att.is_downloaded ? "dl" : "--";
-                            console.log(
-                                `  [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""} ${att.file_size ? `(${att.file_size}b)` : ""}`
-                            );
-                        }
-                    } else {
-                        const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
-                        const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
-                        const atts = store.listAttachments(contact.userId, { since, until });
-
-                        for (const att of atts) {
-                            const dl = att.is_downloaded ? "dl" : "--";
-                            console.log(
-                                `msg:${att.message_id} [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""}`
-                            );
-                        }
-
-                        console.log(`\n${atts.length} attachment(s)`);
-                    }
-                } finally {
-                    store.close();
-                }
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
             }
-        );
+
+            const contact = resolveContact(data.contacts, opts.from);
+
+            if (!contact) {
+                p.log.error(
+                    `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
+                );
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                if (opts.messageId) {
+                    const atts = store.getAttachments(contact.userId, opts.messageId);
+
+                    for (const att of atts) {
+                        const dl = att.is_downloaded ? "dl" : "--";
+                        console.log(
+                            `  [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""} ${att.file_size ? `(${att.file_size}b)` : ""}`
+                        );
+                    }
+                } else {
+                    const since = opts.since ? (parseDateNatural(opts.since) ?? undefined) : undefined;
+                    const until = opts.until ? (parseDateNatural(opts.until) ?? undefined) : undefined;
+                    const atts = store.listAttachments(contact.userId, { since, until });
+
+                    for (const att of atts) {
+                        const dl = att.is_downloaded ? "dl" : "--";
+                        console.log(
+                            `msg:${att.message_id} [${dl}] ${att.kind} idx=${att.attachment_index} ${att.file_name ?? ""}`
+                        );
+                    }
+
+                    console.log(`\n${atts.length} attachment(s)`);
+                }
+            } finally {
+                store.close();
+            }
+        });
 
     attachments
         .command("fetch")
@@ -741,57 +734,50 @@ function registerAttachmentsCommand(history: Command): void {
         .requiredOption("--message-id <id>", "Message ID", parseInt)
         .option("--attachment-index <n>", "Attachment index (default 0)", parseInt, 0)
         .option("--output <path>", "Output file path")
-        .action(
-            async (opts: {
-                from: string;
-                messageId: number;
-                attachmentIndex: number;
-                output?: string;
-            }) => {
-                const config = new TelegramToolConfig();
-                const data = await config.load();
+        .action(async (opts: { from: string; messageId: number; attachmentIndex: number; output?: string }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
 
-                if (!data) {
-                    p.log.error("Not configured. Run: tools telegram configure");
-                    return;
-                }
-
-                const contact = resolveContact(data.contacts, opts.from);
-
-                if (!contact) {
-                    p.log.error(
-                        `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
-                    );
-                    return;
-                }
-
-                const client = await ensureClient(config);
-
-                if (!client) {
-                    return;
-                }
-
-                const store = new TelegramHistoryStore();
-                store.open();
-
-                try {
-                    const downloader = new AttachmentDownloader(client, store);
-                    const result = await downloader.download(
-                        contact.userId,
-                        opts.messageId,
-                        opts.attachmentIndex,
-                        opts.output
-                    );
-
-                    console.log(`Downloaded to: ${result.path}`);
-                    console.log(`Size: ${result.size} bytes`);
-                    console.log(`SHA-256: ${result.sha256}`);
-                } finally {
-                    store.close();
-                    await client.disconnect();
-                }
+            if (!data) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                return;
             }
-        );
+
+            const contact = resolveContact(data.contacts, opts.from);
+
+            if (!contact) {
+                p.log.error(
+                    `Contact "${opts.from}" not found. Available: ${data.contacts.map((c) => c.displayName).join(", ")}`
+                );
+                return;
+            }
+
+            const client = await ensureClient(config);
+
+            if (!client) {
+                return;
+            }
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            try {
+                const downloader = new AttachmentDownloader(client, store);
+                const result = await downloader.download(
+                    contact.userId,
+                    opts.messageId,
+                    opts.attachmentIndex,
+                    opts.output
+                );
+
+                console.log(`Downloaded to: ${result.path}`);
+                console.log(`Size: ${result.size} bytes`);
+                console.log(`SHA-256: ${result.sha256}`);
+            } finally {
+                store.close();
+                await client.disconnect();
+            }
+        });
 }
 
 // ── Registration ──────────────────────────────────────────────────────

--- a/src/telegram/commands/listen.ts
+++ b/src/telegram/commands/listen.ts
@@ -7,13 +7,13 @@ import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramMessage } from "../lib/TelegramMessage";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
 import { TGClient } from "../lib/TGClient";
-import type { ContactConfig } from "../lib/types";
+import type { TelegramContactV2 } from "../lib/types";
 import { DEFAULTS } from "../lib/types";
 
 async function syncAndLoadHistory(
     client: TGClient,
     store: TelegramHistoryStore,
-    contacts: ContactConfig[],
+    contacts: TelegramContactV2[],
     myName: string
 ): Promise<Map<string, string[]>> {
     const historyMap = new Map<string, string[]>();

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -48,96 +48,98 @@ export function registerWatchCommand(program: Command): void {
             const store = new TelegramHistoryStore();
             store.open();
 
-            let contact = contactArg
-                ? data.contacts.find(
-                      (c) =>
-                          c.displayName.toLowerCase() === contactArg.toLowerCase() ||
-                          c.userId === contactArg ||
-                          c.username?.toLowerCase() === contactArg.toLowerCase()
-                  )
-                : undefined;
-
-            if (!contact) {
-                const choices = data.contacts.map((c) => {
-                    const icon = c.chatType === "group" ? "[group]" : c.chatType === "channel" ? "[channel]" : "[user]";
-                    return { value: c.userId, label: `${icon} ${c.displayName}` };
-                });
-
-                const selected = await p.select({
-                    message: "Which conversation to watch?",
-                    options: choices,
-                });
-
-                if (p.isCancel(selected)) {
-                    process.exit(0);
-                }
-
-                contact = data.contacts.find((c) => c.userId === selected);
-            }
-
-            if (!contact) {
-                p.log.error("Contact not found");
-                process.exit(1);
-            }
-
-            if (opts.contextLength) {
-                contact = {
-                    ...contact,
-                    watch: { ...contact.watch, contextLength: opts.contextLength },
-                };
-            }
-
-            const syncSpinner = p.spinner();
-            syncSpinner.start("Syncing latest messages...");
-            const syncService = new ConversationSyncService(client, store);
-            const syncResult = await syncService.syncLatest(contact.userId);
-            syncSpinner.stop(`Synced ${syncResult.synced} new messages`);
-
-            const session = new WatchSession(client, store, myName, contact, data.contacts);
-            await session.loadHistory();
-
-            const activeContact = contact;
-
-            client.onNewMessage(async (event) => {
-                const msg = new TelegramMessage(event.message);
-                const senderId = msg.senderId;
-                const peer = event.message?.peerId;
-                const peerId = peer
-                    ? String(
-                          "userId" in peer
-                              ? peer.userId
-                              : "chatId" in peer
-                                ? peer.chatId
-                                : "channelId" in peer
-                                  ? peer.channelId
-                                  : ""
+            try {
+                let contact = contactArg
+                    ? data.contacts.find(
+                          (c) =>
+                              c.displayName.toLowerCase() === contactArg.toLowerCase() ||
+                              c.userId === contactArg ||
+                              c.username?.toLowerCase() === contactArg.toLowerCase()
                       )
-                    : "";
+                    : undefined;
 
-                if (senderId === activeContact.userId || peerId === activeContact.userId) {
-                    store.insertMessages(activeContact.userId, [msg.toJSON()]);
-                    session.addIncoming(msg);
-                } else {
-                    const matchedContact = data.contacts.find((c) => c.userId === senderId || c.userId === peerId);
+                if (!contact) {
+                    const choices = data.contacts.map((c) => {
+                        const icon =
+                            c.chatType === "group" ? "[group]" : c.chatType === "channel" ? "[channel]" : "[user]";
+                        return { value: c.userId, label: `${icon} ${c.displayName}` };
+                    });
 
-                    if (matchedContact) {
-                        store.insertMessages(matchedContact.userId, [msg.toJSON()]);
-                        session.incrementUnread(matchedContact.userId);
+                    const selected = await p.select({
+                        message: "Which conversation to watch?",
+                        options: choices,
+                    });
+
+                    if (p.isCancel(selected)) {
+                        return;
                     }
+
+                    contact = data.contacts.find((c) => c.userId === selected);
                 }
-            });
 
-            p.log.info(`Watching ${activeContact.displayName}. Tab to switch contacts, /help for commands.`);
+                if (!contact) {
+                    p.log.error("Contact not found");
+                    return;
+                }
 
-            // Clack prompts permanently damage process.stdin (readline internals).
-            // Create a fresh TTY stream on fd 0 so Ink gets clean input.
-            const freshStdin = new ReadStream(0);
+                if (opts.contextLength) {
+                    contact = {
+                        ...contact,
+                        watch: { ...contact.watch, contextLength: opts.contextLength },
+                    };
+                }
 
-            const { waitUntilExit } = render(<WatchInkApp session={session} />, { stdin: freshStdin });
+                const syncSpinner = p.spinner();
+                syncSpinner.start("Syncing latest messages...");
+                const syncService = new ConversationSyncService(client, store);
+                const syncResult = await syncService.syncLatest(contact.userId);
+                syncSpinner.stop(`Synced ${syncResult.synced} new messages`);
 
-            await waitUntilExit();
+                const session = new WatchSession(client, store, myName, contact, data.contacts);
+                await session.loadHistory();
 
-            store.close();
-            await client.disconnect();
+                client.onNewMessage(async (event) => {
+                    const msg = new TelegramMessage(event.message);
+                    const senderId = msg.senderId;
+                    const peer = event.message?.peerId;
+                    const peerId = peer
+                        ? String(
+                              "userId" in peer
+                                  ? peer.userId
+                                  : "chatId" in peer
+                                    ? peer.chatId
+                                    : "channelId" in peer
+                                      ? peer.channelId
+                                      : ""
+                          )
+                        : "";
+                    const currentContactId = session.currentContact.userId;
+
+                    if (senderId === currentContactId || peerId === currentContactId) {
+                        store.insertMessages(currentContactId, [msg.toJSON()]);
+                        session.addIncoming(msg);
+                    } else {
+                        const matchedContact = data.contacts.find((c) => c.userId === senderId || c.userId === peerId);
+
+                        if (matchedContact) {
+                            store.insertMessages(matchedContact.userId, [msg.toJSON()]);
+                            session.incrementUnread(matchedContact.userId);
+                        }
+                    }
+                });
+
+                p.log.info(`Watching ${contact.displayName}. Tab to switch contacts, /help for commands.`);
+
+                // Clack prompts permanently damage process.stdin (readline internals).
+                // Create a fresh TTY stream on fd 0 so Ink gets clean input.
+                const freshStdin = new ReadStream(0);
+
+                const { waitUntilExit } = render(<WatchInkApp session={session} />, { stdin: freshStdin });
+
+                await waitUntilExit();
+            } finally {
+                store.close();
+                await client.disconnect();
+            }
         });
 }

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -1,6 +1,7 @@
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { render } from "ink";
+import { ReadStream } from "tty";
 import { ConversationSyncService } from "../lib/ConversationSyncService";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramMessage } from "../lib/TelegramMessage";
@@ -128,10 +129,11 @@ export function registerWatchCommand(program: Command): void {
 
             p.log.info(`Watching ${activeContact.displayName}. Tab to switch contacts, /help for commands.`);
 
-            // Clack prompts leave stdin paused after readline.close(); resume so Ink can read input
-            process.stdin.resume();
+            // Clack prompts permanently damage process.stdin (readline internals).
+            // Create a fresh TTY stream on fd 0 so Ink gets clean input.
+            const freshStdin = new ReadStream(0);
 
-            const { waitUntilExit } = render(<WatchInkApp session={session} />);
+            const { waitUntilExit } = render(<WatchInkApp session={session} />, { stdin: freshStdin });
 
             await waitUntilExit();
 

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -1,0 +1,140 @@
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import { render } from "ink";
+import { TGClient } from "../lib/TGClient";
+import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
+import { TelegramMessage } from "../lib/TelegramMessage";
+import { TelegramToolConfig } from "../lib/TelegramToolConfig";
+import { ConversationSyncService } from "../lib/ConversationSyncService";
+import { WatchInkApp } from "../runtime/ink/WatchInkApp";
+import { WatchSession } from "../runtime/shared/WatchSession";
+
+export function registerWatchCommand(program: Command): void {
+    program
+        .command("watch [contact]")
+        .description("Watch a conversation in real-time with AI assistant features")
+        .option("--context-length <n>", "Number of recent messages to show", Number.parseInt)
+        .action(async (contactArg: string | undefined, opts: { contextLength?: number }) => {
+            const config = new TelegramToolConfig();
+            const data = await config.load();
+
+            if (!data?.session) {
+                p.log.error("Not configured. Run: tools telegram configure");
+                process.exit(1);
+            }
+
+            if (data.contacts.length === 0) {
+                p.log.warn("No contacts configured. Run: tools telegram configure");
+                process.exit(1);
+            }
+
+            const connectSpinner = p.spinner();
+            connectSpinner.start("Connecting to Telegram...");
+
+            const client = TGClient.fromConfig(config);
+            const connected = await client.connect();
+
+            if (!connected) {
+                connectSpinner.stop("Session expired");
+                p.log.error("Failed to connect. Re-run: tools telegram configure");
+                process.exit(1);
+            }
+
+            const me = await client.getMe();
+            const myName = [me.firstName, me.lastName].filter(Boolean).join(" ");
+            connectSpinner.stop(`Connected as ${myName}`);
+
+            const store = new TelegramHistoryStore();
+            store.open();
+
+            let contact = contactArg
+                ? data.contacts.find(
+                      (c) =>
+                          c.displayName.toLowerCase() === contactArg.toLowerCase() ||
+                          c.userId === contactArg ||
+                          c.username?.toLowerCase() === contactArg.toLowerCase(),
+                  )
+                : undefined;
+
+            if (!contact) {
+                const choices = data.contacts.map((c) => {
+                    const icon =
+                        c.chatType === "group" ? "[group]" : c.chatType === "channel" ? "[channel]" : "[user]";
+                    return { value: c.userId, label: `${icon} ${c.displayName}` };
+                });
+
+                const selected = await p.select({
+                    message: "Which conversation to watch?",
+                    options: choices,
+                });
+
+                if (p.isCancel(selected)) {
+                    process.exit(0);
+                }
+
+                contact = data.contacts.find((c) => c.userId === selected);
+            }
+
+            if (!contact) {
+                p.log.error("Contact not found");
+                process.exit(1);
+            }
+
+            if (opts.contextLength) {
+                contact = {
+                    ...contact,
+                    watch: { ...contact.watch, contextLength: opts.contextLength },
+                };
+            }
+
+            const syncSpinner = p.spinner();
+            syncSpinner.start("Syncing latest messages...");
+            const syncService = new ConversationSyncService(client, store);
+            const syncResult = await syncService.syncLatest(contact.userId);
+            syncSpinner.stop(`Synced ${syncResult.synced} new messages`);
+
+            const session = new WatchSession(client, store, myName, contact, data.contacts);
+            await session.loadHistory();
+
+            const activeContact = contact;
+
+            client.onNewMessage(async (event) => {
+                const msg = new TelegramMessage(event.message);
+                const senderId = msg.senderId;
+                const peer = event.message?.peerId;
+                const peerId = peer
+                    ? String(
+                          "userId" in peer
+                              ? peer.userId
+                              : "chatId" in peer
+                                ? peer.chatId
+                                : "channelId" in peer
+                                  ? peer.channelId
+                                  : "",
+                      )
+                    : "";
+
+                if (senderId === activeContact.userId || peerId === activeContact.userId) {
+                    store.insertMessages(activeContact.userId, [msg.toJSON()]);
+                    session.addIncoming(msg);
+                } else {
+                    const matchedContact = data.contacts.find(
+                        (c) => c.userId === senderId || c.userId === peerId,
+                    );
+
+                    if (matchedContact) {
+                        store.insertMessages(matchedContact.userId, [msg.toJSON()]);
+                        session.incrementUnread(matchedContact.userId);
+                    }
+                }
+            });
+
+            p.log.info(`Watching ${activeContact.displayName}. Tab to switch contacts, /help for commands.`);
+            const { waitUntilExit } = render(<WatchInkApp session={session} />);
+
+            await waitUntilExit();
+
+            store.close();
+            await client.disconnect();
+        });
+}

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -1,11 +1,11 @@
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { render } from "ink";
-import { TGClient } from "../lib/TGClient";
+import { ConversationSyncService } from "../lib/ConversationSyncService";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramMessage } from "../lib/TelegramMessage";
 import { TelegramToolConfig } from "../lib/TelegramToolConfig";
-import { ConversationSyncService } from "../lib/ConversationSyncService";
+import { TGClient } from "../lib/TGClient";
 import { WatchInkApp } from "../runtime/ink/WatchInkApp";
 import { WatchSession } from "../runtime/shared/WatchSession";
 
@@ -52,14 +52,13 @@ export function registerWatchCommand(program: Command): void {
                       (c) =>
                           c.displayName.toLowerCase() === contactArg.toLowerCase() ||
                           c.userId === contactArg ||
-                          c.username?.toLowerCase() === contactArg.toLowerCase(),
+                          c.username?.toLowerCase() === contactArg.toLowerCase()
                   )
                 : undefined;
 
             if (!contact) {
                 const choices = data.contacts.map((c) => {
-                    const icon =
-                        c.chatType === "group" ? "[group]" : c.chatType === "channel" ? "[channel]" : "[user]";
+                    const icon = c.chatType === "group" ? "[group]" : c.chatType === "channel" ? "[channel]" : "[user]";
                     return { value: c.userId, label: `${icon} ${c.displayName}` };
                 });
 
@@ -110,7 +109,7 @@ export function registerWatchCommand(program: Command): void {
                                 ? peer.chatId
                                 : "channelId" in peer
                                   ? peer.channelId
-                                  : "",
+                                  : ""
                       )
                     : "";
 
@@ -118,9 +117,7 @@ export function registerWatchCommand(program: Command): void {
                     store.insertMessages(activeContact.userId, [msg.toJSON()]);
                     session.addIncoming(msg);
                 } else {
-                    const matchedContact = data.contacts.find(
-                        (c) => c.userId === senderId || c.userId === peerId,
-                    );
+                    const matchedContact = data.contacts.find((c) => c.userId === senderId || c.userId === peerId);
 
                     if (matchedContact) {
                         store.insertMessages(matchedContact.userId, [msg.toJSON()]);

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -1,7 +1,7 @@
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { render } from "ink";
-import { ReadStream } from "tty";
+import { ReadStream } from "node:tty";
 import { ConversationSyncService } from "../lib/ConversationSyncService";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramMessage } from "../lib/TelegramMessage";

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -127,6 +127,10 @@ export function registerWatchCommand(program: Command): void {
             });
 
             p.log.info(`Watching ${activeContact.displayName}. Tab to switch contacts, /help for commands.`);
+
+            // Clack prompts leave stdin paused after readline.close(); resume so Ink can read input
+            process.stdin.resume();
+
             const { waitUntilExit } = render(<WatchInkApp session={session} />);
 
             await waitUntilExit();

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -2,6 +2,7 @@ import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { render } from "ink";
 import { ReadStream } from "node:tty";
+import type { NewMessageEvent } from "telegram/events";
 import { ConversationSyncService } from "../lib/ConversationSyncService";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";
 import { TelegramMessage } from "../lib/TelegramMessage";
@@ -47,6 +48,10 @@ export function registerWatchCommand(program: Command): void {
 
             const store = new TelegramHistoryStore();
             store.open();
+            const syncService = new ConversationSyncService(client, store);
+            const bufferedEvents: NewMessageEvent[] = [];
+            let session: WatchSession | null = null;
+            let sessionReady = false;
 
             try {
                 let contact = contactArg
@@ -89,15 +94,6 @@ export function registerWatchCommand(program: Command): void {
                     };
                 }
 
-                const syncSpinner = p.spinner();
-                syncSpinner.start("Syncing latest messages...");
-                const syncService = new ConversationSyncService(client, store);
-                const syncResult = await syncService.syncLatest(contact.userId);
-                syncSpinner.stop(`Synced ${syncResult.synced} new messages`);
-
-                const session = new WatchSession(client, store, myName, contact, data.contacts);
-                await session.loadHistory();
-
                 client.onNewMessage(async (event) => {
                     const msg = new TelegramMessage(event.message);
                     const senderId = msg.senderId;
@@ -113,6 +109,11 @@ export function registerWatchCommand(program: Command): void {
                                       : ""
                           )
                         : "";
+                    if (!session || !sessionReady) {
+                        bufferedEvents.push(event);
+                        return;
+                    }
+
                     const currentContactId = session.currentContact.userId;
 
                     if (senderId === currentContactId || peerId === currentContactId) {
@@ -127,6 +128,51 @@ export function registerWatchCommand(program: Command): void {
                         }
                     }
                 });
+
+                const syncSpinner = p.spinner();
+                syncSpinner.start("Syncing latest messages...");
+                const syncResult = await syncService.syncLatest(contact.userId);
+                syncSpinner.stop(`Synced ${syncResult.synced} new messages`);
+
+                session = new WatchSession(client, store, myName, contact, data.contacts);
+                await session.loadHistory();
+                sessionReady = true;
+
+                if (bufferedEvents.length > 0) {
+                    for (const event of bufferedEvents) {
+                        const msg = new TelegramMessage(event.message);
+                        const senderId = msg.senderId;
+                        const peer = event.message?.peerId;
+                        const peerId = peer
+                            ? String(
+                                  "userId" in peer
+                                      ? peer.userId
+                                      : "chatId" in peer
+                                        ? peer.chatId
+                                        : "channelId" in peer
+                                          ? peer.channelId
+                                          : ""
+                              )
+                            : "";
+                        const currentContactId = session.currentContact.userId;
+
+                        if (senderId === currentContactId || peerId === currentContactId) {
+                            store.insertMessages(currentContactId, [msg.toJSON()]);
+                            session.addIncoming(msg);
+                        } else {
+                            const matchedContact = data.contacts.find(
+                                (c) => c.userId === senderId || c.userId === peerId
+                            );
+
+                            if (matchedContact) {
+                                store.insertMessages(matchedContact.userId, [msg.toJSON()]);
+                                session.incrementUnread(matchedContact.userId);
+                            }
+                        }
+                    }
+
+                    bufferedEvents.length = 0;
+                }
 
                 p.log.info(`Watching ${contact.displayName}. Tab to switch contacts, /help for commands.`);
 

--- a/src/telegram/commands/watch.tsx
+++ b/src/telegram/commands/watch.tsx
@@ -1,7 +1,7 @@
+import { ReadStream } from "node:tty";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { render } from "ink";
-import { ReadStream } from "node:tty";
 import type { NewMessageEvent } from "telegram/events";
 import { ConversationSyncService } from "../lib/ConversationSyncService";
 import { TelegramHistoryStore } from "../lib/TelegramHistoryStore";

--- a/src/telegram/index.ts
+++ b/src/telegram/index.ts
@@ -4,6 +4,7 @@ import { registerConfigureCommand } from "./commands/configure";
 import { registerContactsCommand } from "./commands/contacts";
 import { registerHistoryCommand } from "./commands/history";
 import { registerListenCommand } from "./commands/listen";
+import { registerWatchCommand } from "./commands/watch";
 
 handleReadmeFlag(import.meta.url);
 
@@ -18,6 +19,7 @@ registerConfigureCommand(program);
 registerListenCommand(program);
 registerContactsCommand(program);
 registerHistoryCommand(program);
+registerWatchCommand(program);
 
 program.parseAsync().catch((err) => {
     console.error(err);

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -1,6 +1,6 @@
-import { AIChat } from "@app/ask/index.lib";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
+import { AIChat } from "@app/ask/index.lib";
 import { z } from "zod";
 import { parseDate } from "./DateParser";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -1,0 +1,239 @@
+import { AIChat } from "@app/ask/index.lib";
+import { z } from "zod";
+import { parseDate } from "./DateParser";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import { DEFAULTS } from "./types";
+import type { AskModeConfig, TelegramContactV2 } from "./types";
+
+const searchMessagesSchema = z.object({
+    query: z.string().optional().describe("Text to search for"),
+    since: z.string().optional().describe("Start date (ISO or natural language like 'last week')"),
+    until: z.string().optional().describe("End date (ISO or natural language)"),
+    sender: z.enum(["me", "them", "any"]).optional().describe("Filter by sender"),
+    limit: z.number().optional().describe("Max results (default 20)"),
+});
+
+const messageCountSchema = z.object({
+    since: z.string().optional(),
+    until: z.string().optional(),
+    sender: z.enum(["me", "them", "any"]).optional(),
+});
+
+const conversationSummarySchema = z.object({
+    since: z.string().describe("Start date"),
+    until: z.string().optional().describe("End date (defaults to now)"),
+    limit: z.number().optional().describe("Max results (default 50)"),
+});
+
+const attachmentsSchema = z.object({
+    messageId: z.number().optional().describe("Specific message ID"),
+    since: z.string().optional(),
+    until: z.string().optional(),
+});
+
+const styleAnalysisSchema = z.object({
+    sender: z.enum(["me", "them"]).describe("Whose style to analyze"),
+    limit: z.number().optional().describe("Number of messages to analyze (default 200)"),
+});
+
+const searchAcrossChatsSchema = z.object({
+    query: z.string().describe("Text to search for"),
+    limit: z.number().optional().describe("Max results (default 20)"),
+});
+
+type SearchMessagesInput = z.infer<typeof searchMessagesSchema>;
+type MessageCountInput = z.infer<typeof messageCountSchema>;
+type ConversationSummaryInput = z.infer<typeof conversationSummarySchema>;
+type AttachmentsInput = z.infer<typeof attachmentsSchema>;
+type StyleAnalysisInput = z.infer<typeof styleAnalysisSchema>;
+type SearchAcrossChatsInput = z.infer<typeof searchAcrossChatsSchema>;
+
+export class AssistantEngine {
+    private chat: AIChat | null = null;
+
+    constructor(
+        private store: TelegramHistoryStore,
+        private contact: TelegramContactV2,
+        private myName: string,
+    ) {}
+
+    private getConfig(): AskModeConfig {
+        return this.contact.modes.assistant;
+    }
+
+    private ensureChat(): AIChat {
+        if (!this.chat) {
+            const config = this.getConfig();
+            this.chat = new AIChat({
+                provider: config.provider ?? DEFAULTS.askProvider,
+                model: config.model ?? DEFAULTS.askModel,
+                systemPrompt: this.buildSystemPrompt(config),
+                temperature: config.temperature ?? 0.7,
+                session: {
+                    id: `telegram-assistant-${this.contact.userId}`,
+                    dir: `${process.env.HOME}/.genesis-tools/telegram/ai-sessions`,
+                    autoSave: true,
+                },
+            });
+        }
+
+        return this.chat;
+    }
+
+    private buildSystemPrompt(config: AskModeConfig): string {
+        return config.systemPrompt ?? [
+            `You are a helpful assistant analyzing a Telegram conversation between "${this.myName}" and "${this.contact.displayName}".`,
+            "You have access to tools that let you search the full message history.",
+            "Use the tools to find relevant messages before answering questions.",
+            "Be concise but thorough. Reference specific messages when relevant.",
+        ].join("\n");
+    }
+
+    buildTools() {
+        const store = this.store;
+        const contactId = this.contact.userId;
+
+        return {
+            search_messages: {
+                description: "Search messages in the conversation by text content, date range, or sender",
+                parameters: searchMessagesSchema,
+                execute: async (input: SearchMessagesInput) => {
+                    const results = store.queryMessages(contactId, {
+                        textPattern: input.query,
+                        since: input.since ? parseDate(input.since) ?? undefined : undefined,
+                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        sender: input.sender ?? "any",
+                        limit: input.limit ?? 20,
+                    });
+
+                    return results.map((r) => ({
+                        id: r.id,
+                        date: r.date_iso,
+                        sender: r.is_outgoing ? "me" : "them",
+                        text: r.text ?? "[media]",
+                    }));
+                },
+            },
+
+            get_message_count: {
+                description: "Count messages matching filters",
+                parameters: messageCountSchema,
+                execute: async (input: MessageCountInput) => {
+                    const results = store.queryMessages(contactId, {
+                        since: input.since ? parseDate(input.since) ?? undefined : undefined,
+                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        sender: input.sender ?? "any",
+                    });
+                    return { count: results.length };
+                },
+            },
+
+            get_conversation_summary: {
+                description: "Get a summary of messages in a date range. Returns messages for you to summarize.",
+                parameters: conversationSummarySchema,
+                execute: async (input: ConversationSummaryInput) => {
+                    const results = store.queryMessages(contactId, {
+                        since: parseDate(input.since) ?? undefined,
+                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        limit: input.limit ?? 50,
+                    });
+
+                    return results.map((r) => ({
+                        date: r.date_iso,
+                        sender: r.is_outgoing ? "me" : "them",
+                        text: r.text ?? "[media]",
+                    }));
+                },
+            },
+
+            get_attachments: {
+                description: "List attachments (photos, videos, documents) in messages",
+                parameters: attachmentsSchema,
+                execute: async (input: AttachmentsInput) => {
+                    if (input.messageId) {
+                        return store.getAttachments(contactId, input.messageId);
+                    }
+
+                    return store.listAttachments(contactId, {
+                        since: input.since ? parseDate(input.since) ?? undefined : undefined,
+                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                    });
+                },
+            },
+
+            get_style_analysis: {
+                description: "Analyze writing style patterns for a sender (message length, emoji usage, common phrases)",
+                parameters: styleAnalysisSchema,
+                execute: async (input: StyleAnalysisInput) => {
+                    const messages = store.queryMessages(contactId, {
+                        sender: input.sender,
+                        limit: input.limit ?? 200,
+                    });
+
+                    const texts = messages.map((m) => m.text ?? "").filter(Boolean);
+                    const avgLength = texts.reduce((sum, t) => sum + t.length, 0) / (texts.length || 1);
+                    const emojiCount = texts.reduce((sum, t) => sum + (t.match(/[\p{Emoji}]/gu) ?? []).length, 0);
+                    const avgWords = texts.reduce((sum, t) => sum + t.split(/\s+/).length, 0) / (texts.length || 1);
+
+                    return {
+                        totalMessages: texts.length,
+                        avgCharLength: Math.round(avgLength),
+                        avgWordCount: Math.round(avgWords),
+                        totalEmojis: emojiCount,
+                        emojisPerMessage: (emojiCount / (texts.length || 1)).toFixed(2),
+                        sampleMessages: texts.slice(-10),
+                    };
+                },
+            },
+
+            search_across_chats: {
+                description: "Search for text across ALL synced chats, not just the current one",
+                parameters: searchAcrossChatsSchema,
+                execute: async (input: SearchAcrossChatsInput) => {
+                    const chats = store.listChats();
+                    const allResults: Array<{ chatId: string; chatTitle: string; date: string; sender: string; text: string }> = [];
+
+                    for (const chat of chats) {
+                        const results = store.queryMessages(chat.chat_id, {
+                            textPattern: input.query,
+                            limit: 5,
+                        });
+
+                        for (const r of results) {
+                            allResults.push({
+                                chatId: chat.chat_id,
+                                chatTitle: chat.title,
+                                date: r.date_iso,
+                                sender: r.is_outgoing ? "me" : chat.title,
+                                text: r.text ?? "[media]",
+                            });
+                        }
+                    }
+
+                    return allResults.slice(0, input.limit ?? 20);
+                },
+            },
+        };
+    }
+
+    async ask(question: string): Promise<string> {
+        const chat = this.ensureChat();
+        const response = await chat.send(question);
+        return response.content;
+    }
+
+    static getToolDefinitions() {
+        return {
+            search_messages: { parameters: { query: "string", since: "string", until: "string", sender: "string", limit: "number" } },
+            get_message_count: { parameters: { since: "string", until: "string", sender: "string" } },
+            get_conversation_summary: { parameters: { since: "string", until: "string", limit: "number" } },
+            get_attachments: { parameters: { messageId: "number", since: "string", until: "string" } },
+            get_style_analysis: { parameters: { sender: "string", limit: "number" } },
+            search_across_chats: { parameters: { query: "string", limit: "number" } },
+        };
+    }
+
+    resetSession(): void {
+        this.chat = null;
+    }
+}

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -122,12 +122,12 @@ export class AssistantEngine {
                 description: "Count messages matching filters",
                 parameters: messageCountSchema,
                 execute: async (input: MessageCountInput) => {
-                    const results = store.queryMessages(contactId, {
+                    const count = store.countMessages(contactId, {
                         since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
                         until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
                         sender: input.sender ?? "any",
                     });
-                    return { count: results.length };
+                    return { count };
                 },
             },
 

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -2,8 +2,8 @@ import { AIChat } from "@app/ask/index.lib";
 import { z } from "zod";
 import { parseDate } from "./DateParser";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import { DEFAULTS } from "./types";
 import type { AskModeConfig, TelegramContactV2 } from "./types";
+import { DEFAULTS } from "./types";
 
 const searchMessagesSchema = z.object({
     query: z.string().optional().describe("Text to search for"),
@@ -54,7 +54,7 @@ export class AssistantEngine {
     constructor(
         private store: TelegramHistoryStore,
         private contact: TelegramContactV2,
-        private myName: string,
+        private myName: string
     ) {}
 
     private getConfig(): AskModeConfig {
@@ -81,12 +81,15 @@ export class AssistantEngine {
     }
 
     private buildSystemPrompt(config: AskModeConfig): string {
-        return config.systemPrompt ?? [
-            `You are a helpful assistant analyzing a Telegram conversation between "${this.myName}" and "${this.contact.displayName}".`,
-            "You have access to tools that let you search the full message history.",
-            "Use the tools to find relevant messages before answering questions.",
-            "Be concise but thorough. Reference specific messages when relevant.",
-        ].join("\n");
+        return (
+            config.systemPrompt ??
+            [
+                `You are a helpful assistant analyzing a Telegram conversation between "${this.myName}" and "${this.contact.displayName}".`,
+                "You have access to tools that let you search the full message history.",
+                "Use the tools to find relevant messages before answering questions.",
+                "Be concise but thorough. Reference specific messages when relevant.",
+            ].join("\n")
+        );
     }
 
     buildTools() {
@@ -100,8 +103,8 @@ export class AssistantEngine {
                 execute: async (input: SearchMessagesInput) => {
                     const results = store.queryMessages(contactId, {
                         textPattern: input.query,
-                        since: input.since ? parseDate(input.since) ?? undefined : undefined,
-                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
+                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
                         sender: input.sender ?? "any",
                         limit: input.limit ?? 20,
                     });
@@ -120,8 +123,8 @@ export class AssistantEngine {
                 parameters: messageCountSchema,
                 execute: async (input: MessageCountInput) => {
                     const results = store.queryMessages(contactId, {
-                        since: input.since ? parseDate(input.since) ?? undefined : undefined,
-                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
+                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
                         sender: input.sender ?? "any",
                     });
                     return { count: results.length };
@@ -134,7 +137,7 @@ export class AssistantEngine {
                 execute: async (input: ConversationSummaryInput) => {
                     const results = store.queryMessages(contactId, {
                         since: parseDate(input.since) ?? undefined,
-                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
                         limit: input.limit ?? 50,
                     });
 
@@ -155,14 +158,15 @@ export class AssistantEngine {
                     }
 
                     return store.listAttachments(contactId, {
-                        since: input.since ? parseDate(input.since) ?? undefined : undefined,
-                        until: input.until ? parseDate(input.until) ?? undefined : undefined,
+                        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
+                        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
                     });
                 },
             },
 
             get_style_analysis: {
-                description: "Analyze writing style patterns for a sender (message length, emoji usage, common phrases)",
+                description:
+                    "Analyze writing style patterns for a sender (message length, emoji usage, common phrases)",
                 parameters: styleAnalysisSchema,
                 execute: async (input: StyleAnalysisInput) => {
                     const messages = store.queryMessages(contactId, {
@@ -191,7 +195,13 @@ export class AssistantEngine {
                 parameters: searchAcrossChatsSchema,
                 execute: async (input: SearchAcrossChatsInput) => {
                     const chats = store.listChats();
-                    const allResults: Array<{ chatId: string; chatTitle: string; date: string; sender: string; text: string }> = [];
+                    const allResults: Array<{
+                        chatId: string;
+                        chatTitle: string;
+                        date: string;
+                        sender: string;
+                        text: string;
+                    }> = [];
 
                     for (const chat of chats) {
                         const results = store.queryMessages(chat.chat_id, {
@@ -224,7 +234,9 @@ export class AssistantEngine {
 
     static getToolDefinitions() {
         return {
-            search_messages: { parameters: { query: "string", since: "string", until: "string", sender: "string", limit: "number" } },
+            search_messages: {
+                parameters: { query: "string", since: "string", until: "string", sender: "string", limit: "number" },
+            },
             get_message_count: { parameters: { since: "string", until: "string", sender: "string" } },
             get_conversation_summary: { parameters: { since: "string", until: "string", limit: "number" } },
             get_attachments: { parameters: { messageId: "number", since: "string", until: "string" } },

--- a/src/telegram/lib/AssistantEngine.ts
+++ b/src/telegram/lib/AssistantEngine.ts
@@ -1,4 +1,6 @@
 import { AIChat } from "@app/ask/index.lib";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import { z } from "zod";
 import { parseDate } from "./DateParser";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
@@ -71,7 +73,7 @@ export class AssistantEngine {
                 temperature: config.temperature ?? 0.7,
                 session: {
                     id: `telegram-assistant-${this.contact.userId}`,
-                    dir: `${process.env.HOME}/.genesis-tools/telegram/ai-sessions`,
+                    dir: resolve(homedir(), ".genesis-tools", "telegram", "ai-sessions"),
                     autoSave: true,
                 },
             });

--- a/src/telegram/lib/AttachmentDownloader.ts
+++ b/src/telegram/lib/AttachmentDownloader.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { TGClient } from "./TGClient";
 
@@ -34,23 +34,24 @@ export class AttachmentDownloader {
             };
         }
 
-        const messages: import("telegram").Api.Message[] = [];
+        let targetMessage: import("telegram").Api.Message | null = null;
 
         for await (const msg of this.client.getMessages(chatId, {
             minId: messageId - 1,
             maxId: messageId + 1,
-            limit: 1,
+            limit: 3,
         })) {
             if (msg.id === messageId) {
-                messages.push(msg);
+                targetMessage = msg;
+                break;
             }
         }
 
-        if (messages.length === 0 || !messages[0].media) {
+        if (!targetMessage?.media) {
             throw new Error(`Message ${messageId} not found or has no media`);
         }
 
-        const dir = outputPath ? resolve(outputPath, "..") : resolve(ATTACHMENTS_BASE, chatId, "attachments");
+        const dir = outputPath ? resolve(dirname(outputPath)) : resolve(ATTACHMENTS_BASE, chatId, "attachments");
 
         if (!existsSync(dir)) {
             mkdirSync(dir, { recursive: true });
@@ -59,7 +60,7 @@ export class AttachmentDownloader {
         const ext = this.guessExtension(attachment.mime_type, attachment.file_name);
         const fileName = outputPath ? resolve(outputPath) : resolve(dir, `${messageId}-${attachmentIndex}${ext}`);
 
-        const buffer = (await this.client.raw.downloadMedia(messages[0].media, {})) as Buffer;
+        const buffer = (await this.client.raw.downloadMedia(targetMessage.media, {})) as Buffer;
 
         if (!buffer) {
             throw new Error("Download returned empty buffer");

--- a/src/telegram/lib/AttachmentDownloader.ts
+++ b/src/telegram/lib/AttachmentDownloader.ts
@@ -2,22 +2,22 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import type { TGClient } from "./TGClient";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { TGClient } from "./TGClient";
 
 const ATTACHMENTS_BASE = resolve(homedir(), ".genesis-tools/telegram/chats");
 
 export class AttachmentDownloader {
     constructor(
         private client: TGClient,
-        private store: TelegramHistoryStore,
+        private store: TelegramHistoryStore
     ) {}
 
     async download(
         chatId: string,
         messageId: number,
         attachmentIndex: number,
-        outputPath?: string,
+        outputPath?: string
     ): Promise<{ path: string; size: number; sha256: string }> {
         const attachments = this.store.getAttachments(chatId, messageId);
         const attachment = attachments.find((a) => a.attachment_index === attachmentIndex);

--- a/src/telegram/lib/AttachmentDownloader.ts
+++ b/src/telegram/lib/AttachmentDownloader.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import type { TGClient } from "./TGClient";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+
+const ATTACHMENTS_BASE = resolve(homedir(), ".genesis-tools/telegram/chats");
+
+export class AttachmentDownloader {
+    constructor(
+        private client: TGClient,
+        private store: TelegramHistoryStore,
+    ) {}
+
+    async download(
+        chatId: string,
+        messageId: number,
+        attachmentIndex: number,
+        outputPath?: string,
+    ): Promise<{ path: string; size: number; sha256: string }> {
+        const attachments = this.store.getAttachments(chatId, messageId);
+        const attachment = attachments.find((a) => a.attachment_index === attachmentIndex);
+
+        if (!attachment) {
+            throw new Error(`Attachment not found: chat=${chatId} msg=${messageId} idx=${attachmentIndex}`);
+        }
+
+        if (attachment.is_downloaded && attachment.local_path && existsSync(attachment.local_path)) {
+            return {
+                path: attachment.local_path,
+                size: attachment.file_size ?? 0,
+                sha256: attachment.sha256 ?? "",
+            };
+        }
+
+        const messages: import("telegram").Api.Message[] = [];
+
+        for await (const msg of this.client.getMessages(chatId, {
+            minId: messageId - 1,
+            maxId: messageId + 1,
+            limit: 1,
+        })) {
+            if (msg.id === messageId) {
+                messages.push(msg);
+            }
+        }
+
+        if (messages.length === 0 || !messages[0].media) {
+            throw new Error(`Message ${messageId} not found or has no media`);
+        }
+
+        const dir = outputPath ? resolve(outputPath, "..") : resolve(ATTACHMENTS_BASE, chatId, "attachments");
+
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+
+        const ext = this.guessExtension(attachment.mime_type, attachment.file_name);
+        const fileName = outputPath ? resolve(outputPath) : resolve(dir, `${messageId}-${attachmentIndex}${ext}`);
+
+        const buffer = (await this.client.raw.downloadMedia(messages[0].media, {})) as Buffer;
+
+        if (!buffer) {
+            throw new Error("Download returned empty buffer");
+        }
+
+        await Bun.write(fileName, buffer);
+
+        const hash = createHash("sha256").update(buffer).digest("hex");
+
+        this.store.markAttachmentDownloaded(chatId, messageId, attachmentIndex, fileName, hash);
+
+        return { path: fileName, size: buffer.length, sha256: hash };
+    }
+
+    private guessExtension(mimeType: string | null, fileName: string | null): string {
+        if (fileName) {
+            const dot = fileName.lastIndexOf(".");
+
+            if (dot !== -1) {
+                return fileName.slice(dot);
+            }
+        }
+
+        const mimeMap: Record<string, string> = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
+            "image/gif": ".gif",
+            "video/mp4": ".mp4",
+            "audio/ogg": ".ogg",
+            "audio/mpeg": ".mp3",
+            "application/pdf": ".pdf",
+        };
+
+        return mimeMap[mimeType ?? ""] ?? "";
+    }
+}

--- a/src/telegram/lib/AttachmentIndexer.ts
+++ b/src/telegram/lib/AttachmentIndexer.ts
@@ -57,7 +57,7 @@ export class AttachmentIndexer {
                     kind,
                     mime_type: fullDoc.mimeType ?? null,
                     file_name: fileName,
-                    file_size: fullDoc.size ? Number(fullDoc.size) : null,
+                    file_size: fullDoc.size != null ? Number(fullDoc.size) : null,
                     telegram_file_id: fullDoc.id ? String(fullDoc.id) : null,
                 });
                 break;

--- a/src/telegram/lib/AttachmentIndexer.ts
+++ b/src/telegram/lib/AttachmentIndexer.ts
@@ -2,98 +2,98 @@ import type { Api } from "telegram";
 import type { UpsertAttachmentInput } from "./types";
 
 export class AttachmentIndexer {
-	static extract(chatId: string, message: Api.Message): UpsertAttachmentInput[] {
-		if (!message.media) {
-			return [];
-		}
+    static extract(chatId: string, message: Api.Message): UpsertAttachmentInput[] {
+        if (!message.media) {
+            return [];
+        }
 
-		const results: UpsertAttachmentInput[] = [];
-		const media = message.media;
-		const msgId = message.id;
+        const results: UpsertAttachmentInput[] = [];
+        const media = message.media;
+        const msgId = message.id;
 
-		switch (media.className) {
-			case "MessageMediaPhoto": {
-				const photoMedia = media as Api.MessageMediaPhoto;
-				const photo = photoMedia.photo;
+        switch (media.className) {
+            case "MessageMediaPhoto": {
+                const photoMedia = media as Api.MessageMediaPhoto;
+                const photo = photoMedia.photo;
 
-				if (!photo || photo.className === "PhotoEmpty") {
-					break;
-				}
+                if (!photo || photo.className === "PhotoEmpty") {
+                    break;
+                }
 
-				const fullPhoto = photo as Api.Photo;
-				const largestSize = fullPhoto.sizes?.at(-1);
-				const fileSize = largestSize && "size" in largestSize ? (largestSize as Api.PhotoSize).size : null;
+                const fullPhoto = photo as Api.Photo;
+                const largestSize = fullPhoto.sizes?.at(-1);
+                const fileSize = largestSize && "size" in largestSize ? (largestSize as Api.PhotoSize).size : null;
 
-				results.push({
-					chat_id: chatId,
-					message_id: msgId,
-					attachment_index: 0,
-					kind: "photo",
-					mime_type: "image/jpeg",
-					file_name: null,
-					file_size: fileSize ?? null,
-					telegram_file_id: fullPhoto.id ? String(fullPhoto.id) : null,
-				});
-				break;
-			}
+                results.push({
+                    chat_id: chatId,
+                    message_id: msgId,
+                    attachment_index: 0,
+                    kind: "photo",
+                    mime_type: "image/jpeg",
+                    file_name: null,
+                    file_size: fileSize ?? null,
+                    telegram_file_id: fullPhoto.id ? String(fullPhoto.id) : null,
+                });
+                break;
+            }
 
-			case "MessageMediaDocument": {
-				const docMedia = media as Api.MessageMediaDocument;
-				const doc = docMedia.document;
+            case "MessageMediaDocument": {
+                const docMedia = media as Api.MessageMediaDocument;
+                const doc = docMedia.document;
 
-				if (!doc || doc.className === "DocumentEmpty") {
-					break;
-				}
+                if (!doc || doc.className === "DocumentEmpty") {
+                    break;
+                }
 
-				const fullDoc = doc as Api.Document;
-				const attributes = fullDoc.attributes ?? [];
-				const kind = this.classifyDocument(attributes);
-				const fileName = this.extractFileName(attributes);
+                const fullDoc = doc as Api.Document;
+                const attributes = fullDoc.attributes ?? [];
+                const kind = AttachmentIndexer.classifyDocument(attributes);
+                const fileName = AttachmentIndexer.extractFileName(attributes);
 
-				results.push({
-					chat_id: chatId,
-					message_id: msgId,
-					attachment_index: 0,
-					kind,
-					mime_type: fullDoc.mimeType ?? null,
-					file_name: fileName,
-					file_size: fullDoc.size ? Number(fullDoc.size) : null,
-					telegram_file_id: fullDoc.id ? String(fullDoc.id) : null,
-				});
-				break;
-			}
+                results.push({
+                    chat_id: chatId,
+                    message_id: msgId,
+                    attachment_index: 0,
+                    kind,
+                    mime_type: fullDoc.mimeType ?? null,
+                    file_name: fileName,
+                    file_size: fullDoc.size ? Number(fullDoc.size) : null,
+                    telegram_file_id: fullDoc.id ? String(fullDoc.id) : null,
+                });
+                break;
+            }
 
-			default:
-				break;
-		}
+            default:
+                break;
+        }
 
-		return results;
-	}
+        return results;
+    }
 
-	private static classifyDocument(attributes: Api.TypeDocumentAttribute[]): string {
-		for (const attr of attributes) {
-			switch (attr.className) {
-				case "DocumentAttributeSticker":
-					return "sticker";
-				case "DocumentAttributeAudio":
-					return (attr as Api.DocumentAttributeAudio).voice ? "voice" : "audio";
-				case "DocumentAttributeVideo":
-					return (attr as Api.DocumentAttributeVideo).roundMessage ? "video_note" : "video";
-				case "DocumentAttributeAnimated":
-					return "animation";
-			}
-		}
+    private static classifyDocument(attributes: Api.TypeDocumentAttribute[]): string {
+        for (const attr of attributes) {
+            switch (attr.className) {
+                case "DocumentAttributeSticker":
+                    return "sticker";
+                case "DocumentAttributeAudio":
+                    return (attr as Api.DocumentAttributeAudio).voice ? "voice" : "audio";
+                case "DocumentAttributeVideo":
+                    return (attr as Api.DocumentAttributeVideo).roundMessage ? "video_note" : "video";
+                case "DocumentAttributeAnimated":
+                    return "animation";
+            }
+        }
 
-		return "document";
-	}
+        return "document";
+    }
 
-	private static extractFileName(attributes: Api.TypeDocumentAttribute[]): string | null {
-		for (const attr of attributes) {
-			if (attr.className === "DocumentAttributeFilename") {
-				return (attr as Api.DocumentAttributeFilename).fileName ?? null;
-			}
-		}
+    private static extractFileName(attributes: Api.TypeDocumentAttribute[]): string | null {
+        for (const attr of attributes) {
+            if (attr.className === "DocumentAttributeFilename") {
+                return (attr as Api.DocumentAttributeFilename).fileName ?? null;
+            }
+        }
 
-		return null;
-	}
+        return null;
+    }
 }

--- a/src/telegram/lib/AttachmentIndexer.ts
+++ b/src/telegram/lib/AttachmentIndexer.ts
@@ -1,0 +1,99 @@
+import type { Api } from "telegram";
+import type { UpsertAttachmentInput } from "./types";
+
+export class AttachmentIndexer {
+	static extract(chatId: string, message: Api.Message): UpsertAttachmentInput[] {
+		if (!message.media) {
+			return [];
+		}
+
+		const results: UpsertAttachmentInput[] = [];
+		const media = message.media;
+		const msgId = message.id;
+
+		switch (media.className) {
+			case "MessageMediaPhoto": {
+				const photoMedia = media as Api.MessageMediaPhoto;
+				const photo = photoMedia.photo;
+
+				if (!photo || photo.className === "PhotoEmpty") {
+					break;
+				}
+
+				const fullPhoto = photo as Api.Photo;
+				const largestSize = fullPhoto.sizes?.at(-1);
+				const fileSize = largestSize && "size" in largestSize ? (largestSize as Api.PhotoSize).size : null;
+
+				results.push({
+					chat_id: chatId,
+					message_id: msgId,
+					attachment_index: 0,
+					kind: "photo",
+					mime_type: "image/jpeg",
+					file_name: null,
+					file_size: fileSize ?? null,
+					telegram_file_id: fullPhoto.id ? String(fullPhoto.id) : null,
+				});
+				break;
+			}
+
+			case "MessageMediaDocument": {
+				const docMedia = media as Api.MessageMediaDocument;
+				const doc = docMedia.document;
+
+				if (!doc || doc.className === "DocumentEmpty") {
+					break;
+				}
+
+				const fullDoc = doc as Api.Document;
+				const attributes = fullDoc.attributes ?? [];
+				const kind = this.classifyDocument(attributes);
+				const fileName = this.extractFileName(attributes);
+
+				results.push({
+					chat_id: chatId,
+					message_id: msgId,
+					attachment_index: 0,
+					kind,
+					mime_type: fullDoc.mimeType ?? null,
+					file_name: fileName,
+					file_size: fullDoc.size ? Number(fullDoc.size) : null,
+					telegram_file_id: fullDoc.id ? String(fullDoc.id) : null,
+				});
+				break;
+			}
+
+			default:
+				break;
+		}
+
+		return results;
+	}
+
+	private static classifyDocument(attributes: Api.TypeDocumentAttribute[]): string {
+		for (const attr of attributes) {
+			switch (attr.className) {
+				case "DocumentAttributeSticker":
+					return "sticker";
+				case "DocumentAttributeAudio":
+					return (attr as Api.DocumentAttributeAudio).voice ? "voice" : "audio";
+				case "DocumentAttributeVideo":
+					return (attr as Api.DocumentAttributeVideo).roundMessage ? "video_note" : "video";
+				case "DocumentAttributeAnimated":
+					return "animation";
+			}
+		}
+
+		return "document";
+	}
+
+	private static extractFileName(attributes: Api.TypeDocumentAttribute[]): string | null {
+		for (const attr of attributes) {
+			if (attr.className === "DocumentAttributeFilename") {
+				return (attr as Api.DocumentAttributeFilename).fileName ?? null;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/telegram/lib/ConversationSyncService.ts
+++ b/src/telegram/lib/ConversationSyncService.ts
@@ -164,13 +164,13 @@ export class ConversationSyncService {
         chatId: string,
         fromUnix: number,
         toUnix: number,
-        options?: SyncOptions
+        options?: SyncOptions,
+        retryAttempt = 0
     ): Promise<SyncResult> {
         let synced = 0;
         let attachmentsIndexed = 0;
         let highestId = 0;
         let lowestMsgId = Infinity;
-        let retries = 0;
 
         const batch: SerializedMessage[] = [];
 
@@ -214,10 +214,9 @@ export class ConversationSyncService {
                 const match = err.message.match(/FLOOD_WAIT_(\d+)/);
                 const waitSeconds = match ? Number.parseInt(match[1], 10) : 30;
 
-                if (retries < MAX_RETRIES) {
-                    retries++;
-                    await Bun.sleep(waitSeconds * 1000 * 2 ** (retries - 1));
-                    return this.syncDateRange(chatId, fromUnix, toUnix, options);
+                if (retryAttempt < MAX_RETRIES) {
+                    await Bun.sleep(waitSeconds * 1000 * 2 ** retryAttempt);
+                    return this.syncDateRange(chatId, fromUnix, toUnix, options, retryAttempt + 1);
                 }
             }
 
@@ -228,7 +227,9 @@ export class ConversationSyncService {
             synced += this.store.insertMessages(chatId, batch);
         }
 
-        if (synced > 0) {
+        const isLimitedRangeFetch = typeof iterOptions.limit === "number";
+
+        if (synced > 0 && !isLimitedRangeFetch) {
             this.store.insertSyncSegment(chatId, {
                 fromDateUnix: fromUnix,
                 toDateUnix: toUnix,
@@ -237,7 +238,7 @@ export class ConversationSyncService {
             });
         }
 
-        return { synced, attachmentsIndexed, segments: synced > 0 ? 1 : 0 };
+        return { synced, attachmentsIndexed, segments: synced > 0 && !isLimitedRangeFetch ? 1 : 0 };
     }
 
     private indexAttachments(chatId: string, rawMsg: Api.Message): number {

--- a/src/telegram/lib/ConversationSyncService.ts
+++ b/src/telegram/lib/ConversationSyncService.ts
@@ -1,10 +1,10 @@
 import type { Api } from "telegram";
 import { AttachmentIndexer } from "./AttachmentIndexer";
 import { SyncRangePlanner } from "./SyncRangePlanner";
-import type { TGClient } from "./TGClient";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { SerializedMessage } from "./TelegramMessage";
 import { TelegramMessage } from "./TelegramMessage";
+import type { TGClient } from "./TGClient";
 
 const BATCH_SIZE = 100;
 const MAX_RETRIES = 5;
@@ -14,7 +14,7 @@ interface SyncOptions {
     onProgress?: (synced: number, total: number | null) => void;
 }
 
-interface SyncResult {
+export interface SyncResult {
     synced: number;
     attachmentsIndexed: number;
     segments: number;
@@ -23,7 +23,7 @@ interface SyncResult {
 export class ConversationSyncService {
     constructor(
         private client: TGClient,
-        private store: TelegramHistoryStore,
+        private store: TelegramHistoryStore
     ) {}
 
     async syncLatest(chatId: string, options?: SyncOptions): Promise<SyncResult> {
@@ -108,7 +108,7 @@ export class ConversationSyncService {
         const gaps = SyncRangePlanner.plan(
             segments.map((s) => ({ from_date_unix: s.from_date_unix, to_date_unix: s.to_date_unix })),
             sinceUnix,
-            untilUnix,
+            untilUnix
         );
 
         if (gaps.length === 0) {
@@ -138,7 +138,7 @@ export class ConversationSyncService {
             textPattern?: string;
             limit?: number;
             localOnly?: boolean;
-        },
+        }
     ) {
         if (!options.localOnly && (options.since || options.until)) {
             const since = options.since ?? new Date(0);
@@ -159,7 +159,7 @@ export class ConversationSyncService {
         chatId: string,
         fromUnix: number,
         toUnix: number,
-        options?: SyncOptions,
+        options?: SyncOptions
     ): Promise<SyncResult> {
         let synced = 0;
         let attachmentsIndexed = 0;

--- a/src/telegram/lib/ConversationSyncService.ts
+++ b/src/telegram/lib/ConversationSyncService.ts
@@ -1,0 +1,249 @@
+import type { Api } from "telegram";
+import { AttachmentIndexer } from "./AttachmentIndexer";
+import { SyncRangePlanner } from "./SyncRangePlanner";
+import type { TGClient } from "./TGClient";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { SerializedMessage } from "./TelegramMessage";
+import { TelegramMessage } from "./TelegramMessage";
+
+const BATCH_SIZE = 100;
+const MAX_RETRIES = 5;
+
+interface SyncOptions {
+    limit?: number;
+    onProgress?: (synced: number, total: number | null) => void;
+}
+
+interface SyncResult {
+    synced: number;
+    attachmentsIndexed: number;
+    segments: number;
+}
+
+export class ConversationSyncService {
+    constructor(
+        private client: TGClient,
+        private store: TelegramHistoryStore,
+    ) {}
+
+    async syncLatest(chatId: string, options?: SyncOptions): Promise<SyncResult> {
+        const lastSyncedId = this.store.getLastSyncedId(chatId);
+        let synced = 0;
+        let attachmentsIndexed = 0;
+        let highestId = lastSyncedId ?? 0;
+        let lowestDateUnix = Infinity;
+        let highestDateUnix = 0;
+        let lowestMsgId = Infinity;
+
+        const iterOptions: { minId?: number; limit?: number } = {};
+
+        if (lastSyncedId) {
+            iterOptions.minId = lastSyncedId;
+        }
+
+        if (options?.limit) {
+            iterOptions.limit = options.limit;
+        }
+
+        const batch: SerializedMessage[] = [];
+
+        for await (const rawMsg of this.client.getMessages(chatId, iterOptions)) {
+            const msg = new TelegramMessage(rawMsg);
+            const serialized = msg.toJSON();
+            batch.push(serialized);
+
+            attachmentsIndexed += this.indexAttachments(chatId, rawMsg);
+
+            if (rawMsg.id > highestId) {
+                highestId = rawMsg.id;
+            }
+
+            if (rawMsg.id < lowestMsgId) {
+                lowestMsgId = rawMsg.id;
+            }
+
+            if (serialized.dateUnix < lowestDateUnix) {
+                lowestDateUnix = serialized.dateUnix;
+            }
+
+            if (serialized.dateUnix > highestDateUnix) {
+                highestDateUnix = serialized.dateUnix;
+            }
+
+            if (batch.length >= BATCH_SIZE) {
+                synced += this.store.insertMessages(chatId, batch);
+                batch.length = 0;
+                options?.onProgress?.(synced, null);
+            }
+        }
+
+        if (batch.length > 0) {
+            synced += this.store.insertMessages(chatId, batch);
+        }
+
+        if (highestId > 0) {
+            this.store.setLastSyncedId(chatId, highestId);
+        }
+
+        let segmentsRecorded = 0;
+
+        if (synced > 0 && lowestDateUnix < Infinity) {
+            this.store.insertSyncSegment(chatId, {
+                fromDateUnix: lowestDateUnix,
+                toDateUnix: highestDateUnix,
+                fromMsgId: lowestMsgId,
+                toMsgId: highestId,
+            });
+            segmentsRecorded = 1;
+        }
+
+        return { synced, attachmentsIndexed, segments: segmentsRecorded };
+    }
+
+    async syncRange(chatId: string, since: Date, until: Date, options?: SyncOptions): Promise<SyncResult> {
+        const sinceUnix = Math.floor(since.getTime() / 1000);
+        const untilUnix = Math.floor(until.getTime() / 1000);
+
+        const segments = this.store.getSyncSegments(chatId);
+        const gaps = SyncRangePlanner.plan(
+            segments.map((s) => ({ from_date_unix: s.from_date_unix, to_date_unix: s.to_date_unix })),
+            sinceUnix,
+            untilUnix,
+        );
+
+        if (gaps.length === 0) {
+            return { synced: 0, attachmentsIndexed: 0, segments: 0 };
+        }
+
+        let totalSynced = 0;
+        let totalAttachments = 0;
+        let totalSegments = 0;
+
+        for (const gap of gaps) {
+            const result = await this.syncDateRange(chatId, gap.from, gap.to, options);
+            totalSynced += result.synced;
+            totalAttachments += result.attachmentsIndexed;
+            totalSegments += result.segments;
+        }
+
+        return { synced: totalSynced, attachmentsIndexed: totalAttachments, segments: totalSegments };
+    }
+
+    async queryWithAutoFetch(
+        chatId: string,
+        options: {
+            sender?: "me" | "them" | "any";
+            since?: Date;
+            until?: Date;
+            textPattern?: string;
+            limit?: number;
+            localOnly?: boolean;
+        },
+    ) {
+        if (!options.localOnly && (options.since || options.until)) {
+            const since = options.since ?? new Date(0);
+            const until = options.until ?? new Date();
+            await this.syncRange(chatId, since, until);
+        }
+
+        return this.store.queryMessages(chatId, {
+            sender: options.sender,
+            since: options.since,
+            until: options.until,
+            textPattern: options.textPattern,
+            limit: options.limit,
+        });
+    }
+
+    private async syncDateRange(
+        chatId: string,
+        fromUnix: number,
+        toUnix: number,
+        options?: SyncOptions,
+    ): Promise<SyncResult> {
+        let synced = 0;
+        let attachmentsIndexed = 0;
+        let highestId = 0;
+        let lowestMsgId = Infinity;
+        let retries = 0;
+
+        const batch: SerializedMessage[] = [];
+
+        const iterOptions: { offsetDate?: number; limit?: number } = {
+            offsetDate: toUnix,
+        };
+
+        if (options?.limit) {
+            iterOptions.limit = options.limit;
+        }
+
+        try {
+            for await (const rawMsg of this.client.getMessages(chatId, iterOptions)) {
+                const msg = new TelegramMessage(rawMsg);
+                const dateUnix = Math.floor(msg.date.getTime() / 1000);
+
+                if (dateUnix < fromUnix) {
+                    break;
+                }
+
+                const serialized = msg.toJSON();
+                batch.push(serialized);
+
+                attachmentsIndexed += this.indexAttachments(chatId, rawMsg);
+
+                if (rawMsg.id > highestId) {
+                    highestId = rawMsg.id;
+                }
+
+                if (rawMsg.id < lowestMsgId) {
+                    lowestMsgId = rawMsg.id;
+                }
+
+                if (batch.length >= BATCH_SIZE) {
+                    synced += this.store.insertMessages(chatId, batch);
+                    batch.length = 0;
+                }
+            }
+        } catch (err: unknown) {
+            if (err instanceof Error && err.message.includes("FLOOD_WAIT")) {
+                const match = err.message.match(/FLOOD_WAIT_(\d+)/);
+                const waitSeconds = match ? Number.parseInt(match[1], 10) : 30;
+
+                if (retries < MAX_RETRIES) {
+                    retries++;
+                    await Bun.sleep(waitSeconds * 1000 * 2 ** (retries - 1));
+                    return this.syncDateRange(chatId, fromUnix, toUnix, options);
+                }
+            }
+
+            throw err;
+        }
+
+        if (batch.length > 0) {
+            synced += this.store.insertMessages(chatId, batch);
+        }
+
+        if (synced > 0) {
+            this.store.insertSyncSegment(chatId, {
+                fromDateUnix: fromUnix,
+                toDateUnix: toUnix,
+                fromMsgId: lowestMsgId,
+                toMsgId: highestId,
+            });
+        }
+
+        return { synced, attachmentsIndexed, segments: synced > 0 ? 1 : 0 };
+    }
+
+    private indexAttachments(chatId: string, rawMsg: Api.Message): number {
+        const atts = AttachmentIndexer.extract(chatId, rawMsg);
+        let count = 0;
+
+        for (const att of atts) {
+            this.store.upsertAttachment(att);
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/src/telegram/lib/ConversationSyncService.ts
+++ b/src/telegram/lib/ConversationSyncService.ts
@@ -7,6 +7,7 @@ import { TelegramMessage } from "./TelegramMessage";
 import type { TGClient } from "./TGClient";
 
 const BATCH_SIZE = 100;
+const INITIAL_SYNC_LIMIT = 100;
 const MAX_RETRIES = 5;
 
 interface SyncOptions {
@@ -39,6 +40,10 @@ export class ConversationSyncService {
 
         if (lastSyncedId) {
             iterOptions.minId = lastSyncedId;
+        } else {
+            // First sync — only fetch the most recent messages, not the entire history.
+            // Use syncRange() to backfill older messages on demand.
+            iterOptions.limit = options?.limit ?? INITIAL_SYNC_LIMIT;
         }
 
         if (options?.limit) {

--- a/src/telegram/lib/DateParser.ts
+++ b/src/telegram/lib/DateParser.ts
@@ -5,15 +5,17 @@ export function parseDate(input: string): Date | null {
         return null;
     }
 
-    if (/^\d{4}-\d{2}-\d{2}/.test(input)) {
-        const isoDate = new Date(input);
+    const trimmed = input.trim();
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        const isoDate = new Date(trimmed);
 
         if (!Number.isNaN(isoDate.getTime())) {
             return isoDate;
         }
     }
 
-    const results = chrono.parse(input);
+    const results = chrono.parse(trimmed);
 
     if (results.length > 0) {
         return results[0].start.date();

--- a/src/telegram/lib/DateParser.ts
+++ b/src/telegram/lib/DateParser.ts
@@ -1,0 +1,33 @@
+import * as chrono from "chrono-node";
+
+export function parseDate(input: string): Date | null {
+    if (!input) {
+        return null;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}/.test(input)) {
+        const isoDate = new Date(input);
+
+        if (!Number.isNaN(isoDate.getTime())) {
+            return isoDate;
+        }
+    }
+
+    const results = chrono.parse(input);
+
+    if (results.length > 0) {
+        return results[0].start.date();
+    }
+
+    return null;
+}
+
+export function parseDateRange(input: { since?: string; until?: string }): {
+    since?: Date;
+    until?: Date;
+} {
+    return {
+        since: input.since ? (parseDate(input.since) ?? undefined) : undefined,
+        until: input.until ? (parseDate(input.until) ?? undefined) : undefined,
+    };
+}

--- a/src/telegram/lib/StyleProfileEngine.ts
+++ b/src/telegram/lib/StyleProfileEngine.ts
@@ -45,7 +45,7 @@ export class StyleProfileEngine {
         return this.analyzeStyleFromTexts(texts);
     }
 
-    buildStylePrompt(_chatId: string, options: StylePromptOptions): string {
+    buildStylePrompt(options: StylePromptOptions): string {
         const messages = this.ruleResolver.resolveMessages(options.rules);
         const texts = messages.map((m) => m.text ?? "").filter(Boolean);
 
@@ -171,11 +171,15 @@ export class StyleProfileEngine {
     }
 
     private selectRepresentativeExamples(texts: string[], count: number): string[] {
+        if (count <= 0) {
+            return [];
+        }
+
         if (texts.length <= count) {
             return texts;
         }
 
-        const step = Math.floor(texts.length / count);
+        const step = Math.max(1, Math.floor(texts.length / count));
         const examples: string[] = [];
 
         for (let i = 0; i < texts.length && examples.length < count; i += step) {

--- a/src/telegram/lib/StyleProfileEngine.ts
+++ b/src/telegram/lib/StyleProfileEngine.ts
@@ -45,7 +45,7 @@ export class StyleProfileEngine {
         return this.analyzeStyleFromTexts(texts);
     }
 
-    buildStylePrompt(chatId: string, options: StylePromptOptions): string {
+    buildStylePrompt(_chatId: string, options: StylePromptOptions): string {
         const messages = this.ruleResolver.resolveMessages(options.rules);
         const texts = messages.map((m) => m.text ?? "").filter(Boolean);
 
@@ -94,7 +94,7 @@ export class StyleProfileEngine {
         const avgWords = texts.reduce((s, t) => s + t.split(/\s+/).length, 0) / texts.length;
         const emojiCount = texts.reduce(
             (s, t) => s + (t.match(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu) ?? []).length,
-            0,
+            0
         );
         const emojiFreq = emojiCount / texts.length;
 

--- a/src/telegram/lib/StyleProfileEngine.ts
+++ b/src/telegram/lib/StyleProfileEngine.ts
@@ -1,0 +1,191 @@
+import { StyleRuleResolver } from "./StyleRuleResolver";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { StyleSourceRule } from "./types";
+
+interface StyleAnalysis {
+    totalMessages: number;
+    avgLength: number;
+    avgWords: number;
+    usesEmojis: boolean;
+    emojiFrequency: number;
+    usesSlang: boolean;
+    traits: string[];
+    commonPatterns: string[];
+}
+
+interface StylePromptOptions {
+    rules: StyleSourceRule[];
+    exampleCount?: number;
+}
+
+export class StyleProfileEngine {
+    private ruleResolver: StyleRuleResolver;
+
+    constructor(private store: TelegramHistoryStore) {
+        this.ruleResolver = new StyleRuleResolver(store);
+    }
+
+    analyzeStyle(chatId: string, sender: "me" | "them", limit = 500): StyleAnalysis {
+        const messages = this.store.queryMessages(chatId, { sender, limit });
+        const texts = messages.map((m) => m.text ?? "").filter(Boolean);
+
+        if (texts.length === 0) {
+            return {
+                totalMessages: 0,
+                avgLength: 0,
+                avgWords: 0,
+                usesEmojis: false,
+                emojiFrequency: 0,
+                usesSlang: false,
+                traits: ["No messages to analyze"],
+                commonPatterns: [],
+            };
+        }
+
+        return this.analyzeStyleFromTexts(texts);
+    }
+
+    buildStylePrompt(chatId: string, options: StylePromptOptions): string {
+        const messages = this.ruleResolver.resolveMessages(options.rules);
+        const texts = messages.map((m) => m.text ?? "").filter(Boolean);
+
+        if (texts.length === 0) {
+            return "No messages available for style analysis.";
+        }
+
+        const analysis = this.analyzeStyleFromTexts(texts);
+        const exampleCount = options.exampleCount ?? 15;
+        const examples = this.selectRepresentativeExamples(texts, exampleCount);
+
+        const sections: string[] = [];
+
+        sections.push("## Style Summary");
+        sections.push(`Analyzed ${texts.length} messages.`);
+        sections.push("");
+        sections.push("Characteristics:");
+
+        for (const trait of analysis.traits) {
+            sections.push(`- ${trait}`);
+        }
+
+        if (analysis.commonPatterns.length > 0) {
+            sections.push("");
+            sections.push("Common patterns:");
+
+            for (const pattern of analysis.commonPatterns) {
+                sections.push(`- ${pattern}`);
+            }
+        }
+
+        sections.push("");
+        sections.push("## Example Messages");
+        sections.push("These are real messages showing the typical style:");
+        sections.push("");
+
+        for (const ex of examples) {
+            sections.push(`> ${ex}`);
+        }
+
+        return sections.join("\n");
+    }
+
+    private analyzeStyleFromTexts(texts: string[]): StyleAnalysis {
+        const avgLength = texts.reduce((s, t) => s + t.length, 0) / texts.length;
+        const avgWords = texts.reduce((s, t) => s + t.split(/\s+/).length, 0) / texts.length;
+        const emojiCount = texts.reduce(
+            (s, t) => s + (t.match(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu) ?? []).length,
+            0,
+        );
+        const emojiFreq = emojiCount / texts.length;
+
+        const traits: string[] = [];
+
+        if (avgWords < 5) {
+            traits.push("Very short messages (1-4 words)");
+        } else if (avgWords < 10) {
+            traits.push("Short messages (5-9 words)");
+        } else if (avgWords < 20) {
+            traits.push("Medium-length messages");
+        } else {
+            traits.push("Long, detailed messages");
+        }
+
+        if (emojiFreq > 1) {
+            traits.push("Heavy emoji user");
+        } else if (emojiFreq > 0.3) {
+            traits.push("Moderate emoji user");
+        } else if (emojiFreq > 0) {
+            traits.push("Occasional emoji user");
+        } else {
+            traits.push("Rarely or never uses emojis");
+        }
+
+        const lowercaseRatio = texts.filter((t) => t === t.toLowerCase()).length / texts.length;
+
+        if (lowercaseRatio > 0.8) {
+            traits.push("Mostly lowercase");
+        } else if (lowercaseRatio < 0.3) {
+            traits.push("Uses proper capitalization");
+        }
+
+        const noPuncRatio = texts.filter((t) => !/[.!?]$/.test(t.trim())).length / texts.length;
+
+        if (noPuncRatio > 0.7) {
+            traits.push("Often omits ending punctuation");
+        }
+
+        const slangPatterns = /\b(lol|lmao|nah|yea|wanna|gonna|kinda|idk|imo|tbh|rn|tmrw|btw|omg|brb|ttyl)\b/i;
+        const slangCount = texts.filter((t) => slangPatterns.test(t)).length;
+        const usesSlang = slangCount / texts.length > 0.1;
+
+        if (usesSlang) {
+            traits.push("Uses informal slang/abbreviations");
+        }
+
+        const starters = new Map<string, number>();
+
+        for (const t of texts) {
+            const firstWord = t.split(/\s+/)[0]?.toLowerCase();
+
+            if (firstWord) {
+                starters.set(firstWord, (starters.get(firstWord) ?? 0) + 1);
+            }
+        }
+
+        const commonPatterns = [...starters.entries()]
+            .filter(([, count]) => count > texts.length * 0.05)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5)
+            .map(([word, count]) => `"${word}..." (${count} times)`);
+
+        return {
+            totalMessages: texts.length,
+            avgLength: Math.round(avgLength),
+            avgWords: Math.round(avgWords * 10) / 10,
+            usesEmojis: emojiFreq > 0,
+            emojiFrequency: Math.round(emojiFreq * 100) / 100,
+            usesSlang,
+            traits,
+            commonPatterns,
+        };
+    }
+
+    private selectRepresentativeExamples(texts: string[], count: number): string[] {
+        if (texts.length <= count) {
+            return texts;
+        }
+
+        const step = Math.floor(texts.length / count);
+        const examples: string[] = [];
+
+        for (let i = 0; i < texts.length && examples.length < count; i += step) {
+            const t = texts[i];
+
+            if (t.length > 0 && t.length < 200) {
+                examples.push(t);
+            }
+        }
+
+        return examples;
+    }
+}

--- a/src/telegram/lib/StyleRuleResolver.ts
+++ b/src/telegram/lib/StyleRuleResolver.ts
@@ -1,0 +1,42 @@
+import { parseDate } from "./DateParser";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import type { MessageRowV2, StyleSourceRule } from "./types";
+
+export class StyleRuleResolver {
+    constructor(private store: TelegramHistoryStore) {}
+
+    resolveMessages(rules: StyleSourceRule[]): MessageRowV2[] {
+        const allMessages: MessageRowV2[] = [];
+
+        for (const rule of rules) {
+            const sender = rule.direction === "outgoing" ? "me" : "them";
+            const messages = this.store.queryMessages(rule.sourceChatId, {
+                sender,
+                since: rule.since ? parseDate(rule.since) ?? undefined : undefined,
+                until: rule.until ? parseDate(rule.until) ?? undefined : undefined,
+                limit: rule.limit ?? 500,
+            });
+
+            let filtered = messages;
+
+            if (rule.regex) {
+                const re = new RegExp(rule.regex, "i");
+                filtered = filtered.filter((m) => m.text && re.test(m.text));
+            }
+
+            allMessages.push(...filtered);
+        }
+
+        const seen = new Set<string>();
+        return allMessages.filter((m) => {
+            const key = `${m.chat_id}:${m.id}`;
+
+            if (seen.has(key)) {
+                return false;
+            }
+
+            seen.add(key);
+            return true;
+        });
+    }
+}

--- a/src/telegram/lib/StyleRuleResolver.ts
+++ b/src/telegram/lib/StyleRuleResolver.ts
@@ -12,8 +12,8 @@ export class StyleRuleResolver {
             const sender = rule.direction === "outgoing" ? "me" : "them";
             const messages = this.store.queryMessages(rule.sourceChatId, {
                 sender,
-                since: rule.since ? parseDate(rule.since) ?? undefined : undefined,
-                until: rule.until ? parseDate(rule.until) ?? undefined : undefined,
+                since: rule.since ? (parseDate(rule.since) ?? undefined) : undefined,
+                until: rule.until ? (parseDate(rule.until) ?? undefined) : undefined,
                 limit: rule.limit ?? 500,
             });
 

--- a/src/telegram/lib/StyleRuleResolver.ts
+++ b/src/telegram/lib/StyleRuleResolver.ts
@@ -1,6 +1,13 @@
+import logger from "@app/logger";
 import { parseDate } from "./DateParser";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import type { MessageRowV2, StyleSourceRule } from "./types";
+
+const MAX_REGEX_LENGTH = 200;
+
+function hasObviousCatastrophicPattern(pattern: string): boolean {
+    return /(\([^)]*[+*][^)]*\))[+*]/.test(pattern) || /(\.\*){2,}/.test(pattern);
+}
 
 export class StyleRuleResolver {
     constructor(private store: TelegramHistoryStore) {}
@@ -20,8 +27,29 @@ export class StyleRuleResolver {
             let filtered = messages;
 
             if (rule.regex) {
-                const re = new RegExp(rule.regex, "i");
-                filtered = filtered.filter((m) => m.text && re.test(m.text));
+                const pattern = rule.regex.trim();
+
+                if (!pattern || pattern.length > MAX_REGEX_LENGTH || hasObviousCatastrophicPattern(pattern)) {
+                    logger.warn({ ruleId: rule.id, pattern }, "Skipping unsafe style regex");
+                } else {
+                    try {
+                        const re = new RegExp(pattern, "i");
+                        filtered = filtered.filter((m) => {
+                            if (!m.text) {
+                                return false;
+                            }
+
+                            try {
+                                return re.test(m.text);
+                            } catch (err) {
+                                logger.warn({ err, ruleId: rule.id, pattern }, "Regex test failed; skipping rule");
+                                return false;
+                            }
+                        });
+                    } catch (err) {
+                        logger.warn({ err, ruleId: rule.id, pattern }, "Invalid style regex; skipping rule");
+                    }
+                }
             }
 
             allMessages.push(...filtered);

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -40,7 +40,7 @@ export class SuggestionEngine {
         let stylePrompt: string | undefined;
 
         if (this.contact.styleProfile?.enabled && this.contact.styleProfile.rules.length > 0) {
-            stylePrompt = this.styleEngine.buildStylePrompt(this.contact.userId, {
+            stylePrompt = this.styleEngine.buildStylePrompt({
                 rules: this.contact.styleProfile.rules,
                 exampleCount: 15,
             });

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -30,6 +30,11 @@ export class SuggestionEngine {
 
     async suggest(recentMessages: Array<{ sender: string; text: string }>, customPrompt?: string): Promise<string[]> {
         const config = this.getConfig();
+
+        if (!config.enabled) {
+            return [];
+        }
+
         const count = config.count ?? 3;
 
         let stylePrompt: string | undefined;
@@ -90,7 +95,7 @@ export class SuggestionEngine {
     ): void {
         const config = this.getConfig();
 
-        if (config.trigger === "manual") {
+        if (!config.enabled || config.trigger === "manual") {
             return;
         }
 

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -1,8 +1,8 @@
 import { AIChat } from "@app/ask/index.lib";
 import { StyleProfileEngine } from "./StyleProfileEngine";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import { DEFAULTS } from "./types";
 import type { SuggestionModeConfig, TelegramContactV2 } from "./types";
+import { DEFAULTS } from "./types";
 
 interface SuggestionPromptInput {
     contactName: string;
@@ -19,7 +19,7 @@ export class SuggestionEngine {
     constructor(
         private store: TelegramHistoryStore,
         private contact: TelegramContactV2,
-        private myName: string,
+        private myName: string
     ) {
         this.styleEngine = new StyleProfileEngine(store);
     }
@@ -28,10 +28,7 @@ export class SuggestionEngine {
         return this.contact.modes.suggestions;
     }
 
-    async suggest(
-        recentMessages: Array<{ sender: string; text: string }>,
-        customPrompt?: string,
-    ): Promise<string[]> {
+    async suggest(recentMessages: Array<{ sender: string; text: string }>, customPrompt?: string): Promise<string[]> {
         const config = this.getConfig();
         const count = config.count ?? 3;
 
@@ -89,7 +86,7 @@ export class SuggestionEngine {
 
     scheduleAutoSuggest(
         recentMessages: Array<{ sender: string; text: string }>,
-        onSuggestions: (suggestions: string[]) => void,
+        onSuggestions: (suggestions: string[]) => void
     ): void {
         const config = this.getConfig();
 
@@ -155,7 +152,7 @@ export class SuggestionEngine {
         const suggestions: string[] = [];
 
         for (const line of lines) {
-            const match = line.match(/^\d+[.):\-]\s*(.+)/);
+            const match = line.match(/^\d+[.):-]\s*(.+)/);
 
             if (match) {
                 suggestions.push(match[1].trim());

--- a/src/telegram/lib/SuggestionEngine.ts
+++ b/src/telegram/lib/SuggestionEngine.ts
@@ -1,0 +1,167 @@
+import { AIChat } from "@app/ask/index.lib";
+import { StyleProfileEngine } from "./StyleProfileEngine";
+import type { TelegramHistoryStore } from "./TelegramHistoryStore";
+import { DEFAULTS } from "./types";
+import type { SuggestionModeConfig, TelegramContactV2 } from "./types";
+
+interface SuggestionPromptInput {
+    contactName: string;
+    myName: string;
+    stylePrompt?: string;
+    recentCorrections?: Array<{ suggested: string; sent: string }>;
+    count: number;
+}
+
+export class SuggestionEngine {
+    private styleEngine: StyleProfileEngine;
+    private autoTriggerTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(
+        private store: TelegramHistoryStore,
+        private contact: TelegramContactV2,
+        private myName: string,
+    ) {
+        this.styleEngine = new StyleProfileEngine(store);
+    }
+
+    private getConfig(): SuggestionModeConfig {
+        return this.contact.modes.suggestions;
+    }
+
+    async suggest(
+        recentMessages: Array<{ sender: string; text: string }>,
+        customPrompt?: string,
+    ): Promise<string[]> {
+        const config = this.getConfig();
+        const count = config.count ?? 3;
+
+        let stylePrompt: string | undefined;
+
+        if (this.contact.styleProfile?.enabled && this.contact.styleProfile.rules.length > 0) {
+            stylePrompt = this.styleEngine.buildStylePrompt(this.contact.userId, {
+                rules: this.contact.styleProfile.rules,
+                exampleCount: 15,
+            });
+        }
+
+        const corrections = this.store
+            .getRecentSuggestionEdits(this.contact.userId, 10)
+            .filter((e) => e.suggested_text !== e.sent_text)
+            .map((e) => ({ suggested: e.suggested_text, sent: e.sent_text }));
+
+        const systemPrompt = SuggestionEngine.buildSuggestionPrompt({
+            contactName: this.contact.displayName,
+            myName: this.myName,
+            stylePrompt,
+            recentCorrections: corrections,
+            count,
+        });
+
+        const context = recentMessages.map((m) => `${m.sender}: ${m.text}`).join("\n");
+
+        const userMessage = customPrompt
+            ? `${customPrompt}\n\nRecent conversation:\n${context}`
+            : `Generate ${count} reply suggestions for this conversation:\n\n${context}`;
+
+        const chat = new AIChat({
+            provider: config.provider ?? DEFAULTS.askProvider,
+            model: config.model ?? DEFAULTS.askModel,
+            systemPrompt,
+            temperature: config.temperature ?? 0.8,
+        });
+
+        const response = await chat.send(userMessage);
+        return SuggestionEngine.parseSuggestions(response.content);
+    }
+
+    trackEdit(suggestedText: string, editedText: string, sentText: string, messageId: number | null): void {
+        const config = this.getConfig();
+        this.store.insertSuggestionEdit({
+            chatId: this.contact.userId,
+            messageId,
+            suggestedText,
+            editedText,
+            sentText,
+            provider: config.provider ?? DEFAULTS.askProvider,
+            model: config.model ?? DEFAULTS.askModel,
+        });
+    }
+
+    scheduleAutoSuggest(
+        recentMessages: Array<{ sender: string; text: string }>,
+        onSuggestions: (suggestions: string[]) => void,
+    ): void {
+        const config = this.getConfig();
+
+        if (config.trigger === "manual") {
+            return;
+        }
+
+        if (this.autoTriggerTimer) {
+            clearTimeout(this.autoTriggerTimer);
+        }
+
+        this.autoTriggerTimer = setTimeout(async () => {
+            try {
+                const suggestions = await this.suggest(recentMessages);
+                onSuggestions(suggestions);
+            } catch {
+                // Silently fail for auto-suggest
+            }
+        }, config.autoDelayMs ?? 5000);
+    }
+
+    cancelAutoSuggest(): void {
+        if (this.autoTriggerTimer) {
+            clearTimeout(this.autoTriggerTimer);
+            this.autoTriggerTimer = null;
+        }
+    }
+
+    static buildSuggestionPrompt(input: SuggestionPromptInput): string {
+        const sections: string[] = [];
+
+        sections.push(`You are helping ${input.myName} craft replies to ${input.contactName} on Telegram.`);
+        sections.push(`Generate exactly ${input.count} distinct reply options.`);
+        sections.push("Each reply should feel natural and match the conversation tone.");
+        sections.push("Output ONLY a numbered list (1. 2. 3. etc.) with no other text.");
+
+        if (input.stylePrompt) {
+            sections.push("");
+            sections.push("## Writing Style to Match");
+            sections.push(input.stylePrompt);
+        }
+
+        if (input.recentCorrections && input.recentCorrections.length > 0) {
+            sections.push("");
+            sections.push("## Style Corrections (learn from these)");
+            sections.push("When I was suggested these, I changed them before sending:");
+
+            for (const c of input.recentCorrections.slice(0, 5)) {
+                sections.push(`- Suggested: "${c.suggested}" → Actually sent: "${c.sent}"`);
+            }
+
+            sections.push("Adjust your suggestions to match what I actually prefer to send.");
+        }
+
+        return sections.join("\n");
+    }
+
+    static parseSuggestions(raw: string): string[] {
+        const lines = raw
+            .split("\n")
+            .map((l) => l.trim())
+            .filter(Boolean);
+        const suggestions: string[] = [];
+
+        for (const line of lines) {
+            const match = line.match(/^\d+[.):\-]\s*(.+)/);
+
+            if (match) {
+                suggestions.push(match[1].trim());
+            }
+        }
+
+        return suggestions;
+    }
+}

--- a/src/telegram/lib/SyncRangePlanner.ts
+++ b/src/telegram/lib/SyncRangePlanner.ts
@@ -1,0 +1,56 @@
+interface SegmentInput {
+	from_date_unix: number;
+	to_date_unix: number;
+}
+
+interface SyncRange {
+	from: number;
+	to: number;
+}
+
+export class SyncRangePlanner {
+	static plan(segments: SegmentInput[], queryFrom: number, queryTo: number): SyncRange[] {
+		if (segments.length === 0) {
+			return [{ from: queryFrom, to: queryTo }];
+		}
+
+		const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
+		const merged: SyncRange[] = [];
+
+		let current = { from: sorted[0].from_date_unix, to: sorted[0].to_date_unix };
+
+		for (let i = 1; i < sorted.length; i++) {
+			if (sorted[i].from_date_unix <= current.to) {
+				current.to = Math.max(current.to, sorted[i].to_date_unix);
+			} else {
+				merged.push(current);
+				current = { from: sorted[i].from_date_unix, to: sorted[i].to_date_unix };
+			}
+		}
+
+		merged.push(current);
+
+		const gaps: SyncRange[] = [];
+		const clipped = merged.filter((s) => s.to > queryFrom && s.from < queryTo);
+
+		if (clipped.length === 0) {
+			return [{ from: queryFrom, to: queryTo }];
+		}
+
+		if (clipped[0].from > queryFrom) {
+			gaps.push({ from: queryFrom, to: clipped[0].from });
+		}
+
+		for (let i = 0; i < clipped.length - 1; i++) {
+			if (clipped[i + 1].from > clipped[i].to) {
+				gaps.push({ from: clipped[i].to, to: clipped[i + 1].from });
+			}
+		}
+
+		if (clipped[clipped.length - 1].to < queryTo) {
+			gaps.push({ from: clipped[clipped.length - 1].to, to: queryTo });
+		}
+
+		return gaps;
+	}
+}

--- a/src/telegram/lib/SyncRangePlanner.ts
+++ b/src/telegram/lib/SyncRangePlanner.ts
@@ -10,6 +10,10 @@ interface SyncRange {
 
 export class SyncRangePlanner {
     static plan(segments: SegmentInput[], queryFrom: number, queryTo: number): SyncRange[] {
+        if (queryFrom > queryTo) {
+            throw new RangeError("queryFrom must be <= queryTo");
+        }
+
         if (segments.length === 0) {
             return [{ from: queryFrom, to: queryTo }];
         }

--- a/src/telegram/lib/SyncRangePlanner.ts
+++ b/src/telegram/lib/SyncRangePlanner.ts
@@ -1,56 +1,56 @@
 interface SegmentInput {
-	from_date_unix: number;
-	to_date_unix: number;
+    from_date_unix: number;
+    to_date_unix: number;
 }
 
 interface SyncRange {
-	from: number;
-	to: number;
+    from: number;
+    to: number;
 }
 
 export class SyncRangePlanner {
-	static plan(segments: SegmentInput[], queryFrom: number, queryTo: number): SyncRange[] {
-		if (segments.length === 0) {
-			return [{ from: queryFrom, to: queryTo }];
-		}
+    static plan(segments: SegmentInput[], queryFrom: number, queryTo: number): SyncRange[] {
+        if (segments.length === 0) {
+            return [{ from: queryFrom, to: queryTo }];
+        }
 
-		const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
-		const merged: SyncRange[] = [];
+        const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
+        const merged: SyncRange[] = [];
 
-		let current = { from: sorted[0].from_date_unix, to: sorted[0].to_date_unix };
+        let current = { from: sorted[0].from_date_unix, to: sorted[0].to_date_unix };
 
-		for (let i = 1; i < sorted.length; i++) {
-			if (sorted[i].from_date_unix <= current.to) {
-				current.to = Math.max(current.to, sorted[i].to_date_unix);
-			} else {
-				merged.push(current);
-				current = { from: sorted[i].from_date_unix, to: sorted[i].to_date_unix };
-			}
-		}
+        for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i].from_date_unix <= current.to) {
+                current.to = Math.max(current.to, sorted[i].to_date_unix);
+            } else {
+                merged.push(current);
+                current = { from: sorted[i].from_date_unix, to: sorted[i].to_date_unix };
+            }
+        }
 
-		merged.push(current);
+        merged.push(current);
 
-		const gaps: SyncRange[] = [];
-		const clipped = merged.filter((s) => s.to > queryFrom && s.from < queryTo);
+        const gaps: SyncRange[] = [];
+        const clipped = merged.filter((s) => s.to > queryFrom && s.from < queryTo);
 
-		if (clipped.length === 0) {
-			return [{ from: queryFrom, to: queryTo }];
-		}
+        if (clipped.length === 0) {
+            return [{ from: queryFrom, to: queryTo }];
+        }
 
-		if (clipped[0].from > queryFrom) {
-			gaps.push({ from: queryFrom, to: clipped[0].from });
-		}
+        if (clipped[0].from > queryFrom) {
+            gaps.push({ from: queryFrom, to: clipped[0].from });
+        }
 
-		for (let i = 0; i < clipped.length - 1; i++) {
-			if (clipped[i + 1].from > clipped[i].to) {
-				gaps.push({ from: clipped[i].to, to: clipped[i + 1].from });
-			}
-		}
+        for (let i = 0; i < clipped.length - 1; i++) {
+            if (clipped[i + 1].from > clipped[i].to) {
+                gaps.push({ from: clipped[i].to, to: clipped[i + 1].from });
+            }
+        }
 
-		if (clipped[clipped.length - 1].to < queryTo) {
-			gaps.push({ from: clipped[clipped.length - 1].to, to: queryTo });
-		}
+        if (clipped[clipped.length - 1].to < queryTo) {
+            gaps.push({ from: clipped[clipped.length - 1].to, to: queryTo });
+        }
 
-		return gaps;
-	}
+        return gaps;
+    }
 }

--- a/src/telegram/lib/TGClient.ts
+++ b/src/telegram/lib/TGClient.ts
@@ -1,5 +1,7 @@
 import bigInt from "big-integer";
 import { Api, TelegramClient } from "telegram";
+import { DeletedMessage, type DeletedMessageEvent } from "telegram/events/DeletedMessage";
+import { EditedMessage, type EditedMessageEvent } from "telegram/events/EditedMessage";
 import { NewMessage, type NewMessageEvent } from "telegram/events";
 import { StringSession } from "telegram/sessions";
 import type { Dialog } from "telegram/tl/custom/dialog";
@@ -55,8 +57,8 @@ export class TGClient {
         return this.client.getDialogs({ limit });
     }
 
-    async sendMessage(userId: string, text: string): Promise<void> {
-        await this.client.sendMessage(userId, { message: text });
+    async sendMessage(userId: string, text: string): Promise<Api.Message> {
+        return this.client.sendMessage(userId, { message: text });
     }
 
     async sendTyping(userId: string): Promise<void> {
@@ -98,6 +100,14 @@ export class TGClient {
 
     onNewMessage(handler: (event: NewMessageEvent) => Promise<void>): void {
         this.client.addEventHandler(handler, new NewMessage({}));
+    }
+
+    onEditedMessage(handler: (event: EditedMessageEvent) => Promise<void>): void {
+        this.client.addEventHandler(handler, new EditedMessage({}));
+    }
+
+    onDeletedMessage(handler: (event: DeletedMessageEvent) => Promise<void>): void {
+        this.client.addEventHandler(handler, new DeletedMessage({}));
     }
 
     get raw(): TelegramClient {

--- a/src/telegram/lib/TGClient.ts
+++ b/src/telegram/lib/TGClient.ts
@@ -1,8 +1,8 @@
 import bigInt from "big-integer";
 import { Api, TelegramClient } from "telegram";
+import { NewMessage, type NewMessageEvent } from "telegram/events";
 import { DeletedMessage, type DeletedMessageEvent } from "telegram/events/DeletedMessage";
 import { EditedMessage, type EditedMessageEvent } from "telegram/events/EditedMessage";
-import { NewMessage, type NewMessageEvent } from "telegram/events";
 import { StringSession } from "telegram/sessions";
 import type { Dialog } from "telegram/tl/custom/dialog";
 import type { TelegramToolConfig } from "./TelegramToolConfig";

--- a/src/telegram/lib/TelegramContact.ts
+++ b/src/telegram/lib/TelegramContact.ts
@@ -1,33 +1,77 @@
-import type { Api } from "telegram";
-import type { ActionType, ContactConfig } from "./types";
-import { DEFAULTS } from "./types";
+import type {
+    ActionType,
+    AskModeConfig,
+    ContactModesConfig,
+    StyleProfileConfig,
+    SuggestionModeConfig,
+    TelegramContactV2,
+    WatchConfig,
+} from "./types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
 
 export class TelegramContact {
-    constructor(
-        public readonly userId: string,
-        public readonly displayName: string,
-        public readonly username: string | undefined,
-        public readonly config: ContactConfig
-    ) {}
+    readonly userId: string;
+    readonly displayName: string;
+    readonly username: string | undefined;
+    readonly config: TelegramContactV2;
+
+    constructor(config: TelegramContactV2) {
+        this.userId = config.userId;
+        this.displayName = config.displayName;
+        this.username = config.username;
+        this.config = config;
+    }
 
     get actions(): ActionType[] {
         return this.config.actions;
+    }
+
+    get chatType() {
+        return this.config.chatType;
     }
 
     get hasAskAction(): boolean {
         return this.config.actions.includes("ask");
     }
 
-    get askSystemPrompt(): string {
-        return this.config.askSystemPrompt ?? DEFAULTS.askSystemPrompt;
+    get modes(): ContactModesConfig {
+        return this.config.modes ?? DEFAULT_MODE_CONFIG;
+    }
+
+    get autoReply(): AskModeConfig {
+        return this.modes.autoReply;
+    }
+
+    get assistant(): AskModeConfig {
+        return this.modes.assistant;
+    }
+
+    get suggestions(): SuggestionModeConfig {
+        return this.modes.suggestions;
+    }
+
+    get watch(): WatchConfig {
+        return this.config.watch ?? DEFAULT_WATCH_CONFIG;
+    }
+
+    get contextLength(): number {
+        return this.watch.contextLength;
+    }
+
+    get styleProfile(): StyleProfileConfig {
+        return this.config.styleProfile ?? DEFAULT_STYLE_PROFILE;
     }
 
     get askProvider(): string {
-        return this.config.askProvider ?? DEFAULTS.askProvider;
+        return this.autoReply.provider ?? DEFAULTS.askProvider;
     }
 
     get askModel(): string {
-        return this.config.askModel ?? DEFAULTS.askModel;
+        return this.autoReply.model ?? DEFAULTS.askModel;
+    }
+
+    get askSystemPrompt(): string {
+        return this.autoReply.systemPrompt ?? DEFAULTS.askSystemPrompt;
     }
 
     get replyDelayMin(): number {
@@ -42,18 +86,7 @@ export class TelegramContact {
         return this.replyDelayMin + Math.random() * (this.replyDelayMax - this.replyDelayMin);
     }
 
-    static fromUser(user: Api.User, config: ContactConfig): TelegramContact {
-        const displayName = `${user.firstName || ""} ${user.lastName || ""}`.trim();
-
-        return new TelegramContact(
-            user.id.toString(),
-            displayName || config.displayName,
-            user.username ?? undefined,
-            config
-        );
-    }
-
-    static fromConfig(config: ContactConfig): TelegramContact {
-        return new TelegramContact(config.userId, config.displayName, config.username, config);
+    static fromConfig(config: TelegramContactV2): TelegramContact {
+        return new TelegramContact(config);
     }
 }

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -557,14 +557,22 @@ export class TelegramHistoryStore {
             params.push(`%${options.textPattern}%`);
         }
 
-        let sql = `SELECT * FROM messages WHERE ${conditions.join(" AND ")} ORDER BY date_unix ASC`;
+        const order = options.limit ? "DESC" : "ASC";
+        let sql = `SELECT * FROM messages WHERE ${conditions.join(" AND ")} ORDER BY date_unix ${order}`;
 
         if (options.limit) {
             sql += " LIMIT ?";
             params.push(options.limit);
         }
 
-        return db.query(sql).all(...params) as MessageRowV2[];
+        const rows = db.query(sql).all(...params) as MessageRowV2[];
+
+        // DESC + LIMIT gives us the *last* N rows; reverse back to chronological for display
+        if (options.limit) {
+            rows.reverse();
+        }
+
+        return rows;
     }
 
     findMessageById(messageId: number): { chat_id: string } | null {

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -567,6 +567,15 @@ export class TelegramHistoryStore {
         return db.query(sql).all(...params) as MessageRowV2[];
     }
 
+    findMessageById(messageId: number): { chat_id: string } | null {
+        const db = this.getDb();
+        return (
+            (db.query("SELECT chat_id FROM messages WHERE id = ? LIMIT 1").get(messageId) as {
+                chat_id: string;
+            }) ?? null
+        );
+    }
+
     markMessageDeleted(chatId: string, messageId: number): void {
         const db = this.getDb();
         const now = new Date();

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -605,7 +605,9 @@ export class TelegramHistoryStore {
             params.push(`%${options.textPattern}%`);
         }
 
-        const row = db.query(`SELECT COUNT(*) AS count FROM messages WHERE ${conditions.join(" AND ")}`).get(...params) as {
+        const row = db
+            .query(`SELECT COUNT(*) AS count FROM messages WHERE ${conditions.join(" AND ")}`)
+            .get(...params) as {
             count: number;
         };
         return row.count;
@@ -616,13 +618,17 @@ export class TelegramHistoryStore {
 
         if (chatId) {
             return (
-                (db.query("SELECT chat_id FROM messages WHERE chat_id = ? AND id = ? LIMIT 1").get(chatId, messageId) as {
+                (db
+                    .query("SELECT chat_id FROM messages WHERE chat_id = ? AND id = ? LIMIT 1")
+                    .get(chatId, messageId) as {
                     chat_id: string;
                 }) ?? null
             );
         }
 
-        const rows = db.query("SELECT chat_id FROM messages WHERE id = ? GROUP BY chat_id LIMIT 2").all(messageId) as Array<{
+        const rows = db
+            .query("SELECT chat_id FROM messages WHERE id = ? GROUP BY chat_id LIMIT 2")
+            .all(messageId) as Array<{
             chat_id: string;
         }>;
         return rows.length === 1 ? rows[0] : null;
@@ -636,11 +642,10 @@ export class TelegramHistoryStore {
             text: string | null;
         } | null;
 
-        const updateResult = db.run("UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?", [
-            now.toISOString(),
-            chatId,
-            messageId,
-        ]);
+        const updateResult = db.run(
+            "UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?",
+            [now.toISOString(), chatId, messageId]
+        );
 
         if (updateResult.changes === 0) {
             return;
@@ -817,20 +822,30 @@ export class TelegramHistoryStore {
         );
     }
 
-    getSyncSegments(chatId: string): SyncSegmentRow[] {
+    getSyncSegments(chatId: string, fromDateUnix?: number, toDateUnix?: number): SyncSegmentRow[] {
         const db = this.getDb();
-        return db
-            .query("SELECT * FROM sync_segments WHERE chat_id = ? ORDER BY from_date_unix ASC")
-            .all(chatId) as SyncSegmentRow[];
+        let sql = "SELECT * FROM sync_segments WHERE chat_id = ?";
+        const params: Array<string | number> = [chatId];
+
+        if (fromDateUnix !== undefined) {
+            sql += " AND to_date_unix > ?";
+            params.push(fromDateUnix);
+        }
+
+        if (toDateUnix !== undefined) {
+            sql += " AND from_date_unix < ?";
+            params.push(toDateUnix);
+        }
+
+        sql += " ORDER BY from_date_unix ASC";
+
+        return db.query(sql).all(...params) as SyncSegmentRow[];
     }
 
     getMissingSegments(chatId: string, fromDateUnix: number, toDateUnix: number): DateRange[] {
-        const segments = this.getSyncSegments(chatId);
+        const segments = this.getSyncSegments(chatId, fromDateUnix, toDateUnix);
         const gaps: DateRange[] = [];
-
-        const sorted = segments
-            .filter((s) => s.to_date_unix > fromDateUnix && s.from_date_unix < toDateUnix)
-            .sort((a, b) => a.from_date_unix - b.from_date_unix);
+        const sorted = [...segments].sort((a, b) => a.from_date_unix - b.from_date_unix);
 
         const merged: Array<{ from: number; to: number }> = [];
 

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -575,13 +575,57 @@ export class TelegramHistoryStore {
         return rows;
     }
 
-    findMessageById(messageId: number): { chat_id: string } | null {
+    countMessages(chatId: string, options: QueryOptions): number {
         const db = this.getDb();
-        return (
-            (db.query("SELECT chat_id FROM messages WHERE id = ? LIMIT 1").get(messageId) as {
-                chat_id: string;
-            }) ?? null
-        );
+        const conditions: string[] = ["chat_id = ?"];
+        const params: (string | number)[] = [chatId];
+
+        if (!options.includeDeleted) {
+            conditions.push("is_deleted = 0");
+        }
+
+        if (options.sender === "me") {
+            conditions.push("is_outgoing = 1");
+        } else if (options.sender === "them") {
+            conditions.push("is_outgoing = 0");
+        }
+
+        if (options.since) {
+            conditions.push("date_unix >= ?");
+            params.push(Math.floor(options.since.getTime() / 1000));
+        }
+
+        if (options.until) {
+            conditions.push("date_unix <= ?");
+            params.push(Math.floor(options.until.getTime() / 1000));
+        }
+
+        if (options.textPattern) {
+            conditions.push("text LIKE ?");
+            params.push(`%${options.textPattern}%`);
+        }
+
+        const row = db.query(`SELECT COUNT(*) AS count FROM messages WHERE ${conditions.join(" AND ")}`).get(...params) as {
+            count: number;
+        };
+        return row.count;
+    }
+
+    findMessageById(messageId: number, chatId?: string): { chat_id: string } | null {
+        const db = this.getDb();
+
+        if (chatId) {
+            return (
+                (db.query("SELECT chat_id FROM messages WHERE chat_id = ? AND id = ? LIMIT 1").get(chatId, messageId) as {
+                    chat_id: string;
+                }) ?? null
+            );
+        }
+
+        const rows = db.query("SELECT chat_id FROM messages WHERE id = ? GROUP BY chat_id LIMIT 2").all(messageId) as Array<{
+            chat_id: string;
+        }>;
+        return rows.length === 1 ? rows[0] : null;
     }
 
     markMessageDeleted(chatId: string, messageId: number): void {
@@ -592,11 +636,15 @@ export class TelegramHistoryStore {
             text: string | null;
         } | null;
 
-        db.run("UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?", [
+        const updateResult = db.run("UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?", [
             now.toISOString(),
             chatId,
             messageId,
         ]);
+
+        if (updateResult.changes === 0) {
+            return;
+        }
 
         db.run(
             `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
@@ -784,24 +832,34 @@ export class TelegramHistoryStore {
             .filter((s) => s.to_date_unix > fromDateUnix && s.from_date_unix < toDateUnix)
             .sort((a, b) => a.from_date_unix - b.from_date_unix);
 
-        if (sorted.length === 0) {
+        const merged: Array<{ from: number; to: number }> = [];
+
+        for (const s of sorted) {
+            if (merged.length === 0 || s.from_date_unix > merged[merged.length - 1].to) {
+                merged.push({ from: s.from_date_unix, to: s.to_date_unix });
+            } else {
+                merged[merged.length - 1].to = Math.max(merged[merged.length - 1].to, s.to_date_unix);
+            }
+        }
+
+        if (merged.length === 0) {
             return [{ fromDateUnix, toDateUnix }];
         }
 
-        if (sorted[0].from_date_unix > fromDateUnix) {
-            gaps.push({ fromDateUnix, toDateUnix: sorted[0].from_date_unix });
+        if (merged[0].from > fromDateUnix) {
+            gaps.push({ fromDateUnix, toDateUnix: merged[0].from });
         }
 
-        for (let i = 0; i < sorted.length - 1; i++) {
-            const currentEnd = sorted[i].to_date_unix;
-            const nextStart = sorted[i + 1].from_date_unix;
+        for (let i = 0; i < merged.length - 1; i++) {
+            const currentEnd = merged[i].to;
+            const nextStart = merged[i + 1].from;
 
             if (nextStart > currentEnd) {
                 gaps.push({ fromDateUnix: currentEnd, toDateUnix: nextStart });
             }
         }
 
-        const lastEnd = sorted[sorted.length - 1].to_date_unix;
+        const lastEnd = merged[merged.length - 1].to;
 
         if (lastEnd < toDateUnix) {
             gaps.push({ fromDateUnix: lastEnd, toDateUnix });

--- a/src/telegram/lib/TelegramHistoryStore.ts
+++ b/src/telegram/lib/TelegramHistoryStore.ts
@@ -5,7 +5,25 @@ import { dirname, join } from "node:path";
 import logger from "@app/logger";
 import { cosineDistance } from "@app/utils/math";
 import type { SerializedMessage } from "./TelegramMessage";
-import type { ChatStats, MessageRow, SearchOptions, SearchResult, SyncStateRow } from "./types";
+import type {
+    AttachmentRow,
+    ChatRow,
+    ChatStats,
+    DateRange,
+    InsertSegmentInput,
+    MessageRevisionRow,
+    MessageRow,
+    MessageRowV2,
+    QueryOptions,
+    SearchOptions,
+    SearchResult,
+    SuggestionEditInput,
+    SuggestionEditRow,
+    SyncSegmentRow,
+    SyncStateRow,
+    UpsertAttachmentInput,
+    UpsertMessageInput,
+} from "./types";
 
 const DB_PATH = join(homedir(), ".genesis-tools", "telegram", "history.db");
 
@@ -27,7 +45,7 @@ export class TelegramHistoryStore {
         this.db.run("PRAGMA journal_mode = WAL");
         this.db.run("PRAGMA foreign_keys = ON");
 
-        this.initSchema();
+        this.migrate();
         logger.debug("TelegramHistoryStore opened");
     }
 
@@ -47,84 +65,147 @@ export class TelegramHistoryStore {
         return this.db;
     }
 
-    private initSchema(): void {
+    private migrate(): void {
         const db = this.getDb();
+        const { user_version: currentVersion } = db.query("PRAGMA user_version").get() as {
+            user_version: number;
+        };
 
-        db.run(`
-			CREATE TABLE IF NOT EXISTS messages (
-				id INTEGER NOT NULL,
-				chat_id TEXT NOT NULL,
-				sender_id TEXT,
-				text TEXT,
-				media_desc TEXT,
-				is_outgoing INTEGER NOT NULL,
-				date_unix INTEGER NOT NULL,
-				date_iso TEXT NOT NULL,
-				PRIMARY KEY (chat_id, id)
-			)
-		`);
+        if (currentVersion < 1) {
+            db.run(`CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER NOT NULL,
+                chat_id TEXT NOT NULL,
+                sender_id TEXT,
+                text TEXT,
+                media_desc TEXT,
+                is_outgoing INTEGER NOT NULL,
+                date_unix INTEGER NOT NULL,
+                date_iso TEXT NOT NULL,
+                PRIMARY KEY (chat_id, id)
+            )`);
+            db.run(`CREATE INDEX IF NOT EXISTS idx_messages_chat_date ON messages(chat_id, date_unix)`);
+            db.run(`CREATE TABLE IF NOT EXISTS sync_state (
+                chat_id TEXT PRIMARY KEY,
+                last_synced_id INTEGER NOT NULL,
+                last_synced_at TEXT NOT NULL
+            )`);
+            db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+                text, content=messages, content_rowid=rowid, tokenize='unicode61'
+            )`);
 
-        db.run(`
-			CREATE INDEX IF NOT EXISTS idx_messages_chat_date
-				ON messages(chat_id, date_unix)
-		`);
+            try {
+                db.run(`CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+                END`);
+            } catch {
+                // trigger already exists
+            }
 
-        db.run(`
-			CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-				text,
-				content=messages,
-				content_rowid=rowid,
-				tokenize='unicode61'
-			)
-		`);
+            try {
+                db.run(`CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                END`);
+            } catch {
+                // trigger already exists
+            }
 
-        db.run(`
-			CREATE TABLE IF NOT EXISTS sync_state (
-				chat_id TEXT PRIMARY KEY,
-				last_synced_id INTEGER NOT NULL,
-				last_synced_at TEXT NOT NULL
-			)
-		`);
+            try {
+                db.run(`CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+                    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                    INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+                END`);
+            } catch {
+                // trigger already exists
+            }
 
-        // Embeddings stored as BLOBs (bun:sqlite doesn't support sqlite-vec extensions)
-        db.run(`
-			CREATE TABLE IF NOT EXISTS embeddings (
-				message_rowid INTEGER PRIMARY KEY,
-				embedding BLOB NOT NULL
-			)
-		`);
-
-        // FTS5 external content triggers
-        try {
-            db.run(`
-				CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
-					INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
-				END
-			`);
-        } catch {
-            // trigger already exists
+            db.run(`CREATE TABLE IF NOT EXISTS embeddings (
+                message_rowid INTEGER PRIMARY KEY,
+                embedding BLOB NOT NULL
+            )`);
         }
 
-        try {
-            db.run(`
-				CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
-					INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
-				END
-			`);
-        } catch {
-            // trigger already exists
+        if (currentVersion < 2) {
+            const existingCols = new Set(
+                (db.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>).map((c) => c.name)
+            );
+
+            if (!existingCols.has("edited_date_unix")) {
+                db.run("ALTER TABLE messages ADD COLUMN edited_date_unix INTEGER");
+            }
+
+            if (!existingCols.has("is_deleted")) {
+                db.run("ALTER TABLE messages ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0");
+            }
+
+            if (!existingCols.has("deleted_at_iso")) {
+                db.run("ALTER TABLE messages ADD COLUMN deleted_at_iso TEXT");
+            }
+
+            if (!existingCols.has("reply_to_msg_id")) {
+                db.run("ALTER TABLE messages ADD COLUMN reply_to_msg_id INTEGER");
+            }
+
+            db.run(`CREATE TABLE IF NOT EXISTS chats (
+                chat_id TEXT PRIMARY KEY,
+                chat_type TEXT NOT NULL DEFAULT 'user',
+                title TEXT NOT NULL,
+                username TEXT,
+                last_synced_at TEXT
+            )`);
+
+            db.run(`CREATE TABLE IF NOT EXISTS message_revisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                revision_type TEXT NOT NULL,
+                old_text TEXT,
+                new_text TEXT,
+                revised_at_unix INTEGER NOT NULL,
+                revised_at_iso TEXT NOT NULL
+            )`);
+            db.run(`CREATE INDEX IF NOT EXISTS idx_revisions_chat_msg ON message_revisions(chat_id, message_id)`);
+
+            db.run(`CREATE TABLE IF NOT EXISTS attachments (
+                chat_id TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                attachment_index INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                mime_type TEXT,
+                file_name TEXT,
+                file_size INTEGER,
+                telegram_file_id TEXT,
+                is_downloaded INTEGER NOT NULL DEFAULT 0,
+                local_path TEXT,
+                sha256 TEXT,
+                PRIMARY KEY (chat_id, message_id, attachment_index)
+            )`);
+
+            db.run(`CREATE TABLE IF NOT EXISTS sync_segments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id TEXT NOT NULL,
+                from_date_unix INTEGER NOT NULL,
+                to_date_unix INTEGER NOT NULL,
+                from_msg_id INTEGER NOT NULL,
+                to_msg_id INTEGER NOT NULL,
+                synced_at TEXT NOT NULL
+            )`);
+            db.run(`CREATE INDEX IF NOT EXISTS idx_sync_segments_chat ON sync_segments(chat_id, from_date_unix)`);
+
+            db.run(`CREATE TABLE IF NOT EXISTS suggestion_edits (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id TEXT NOT NULL,
+                message_id INTEGER,
+                suggested_text TEXT NOT NULL,
+                edited_text TEXT NOT NULL,
+                sent_text TEXT NOT NULL,
+                provider TEXT,
+                model TEXT,
+                created_at TEXT NOT NULL
+            )`);
+            db.run(`CREATE INDEX IF NOT EXISTS idx_suggestion_edits_chat ON suggestion_edits(chat_id)`);
         }
 
-        try {
-            db.run(`
-				CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
-					INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
-					INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
-				END
-			`);
-        } catch {
-            // trigger already exists
-        }
+        db.run("PRAGMA user_version = 2");
     }
 
     // ── Insert ────────────────────────────────────────────────────────
@@ -442,6 +523,330 @@ export class TelegramHistoryStore {
 		`,
             [chatId, messageId]
         );
+    }
+
+    // ── Query Primitives (V2) ────────────────────────────────────────
+
+    queryMessages(chatId: string, options: QueryOptions): MessageRowV2[] {
+        const db = this.getDb();
+        const conditions: string[] = ["chat_id = ?"];
+        const params: (string | number)[] = [chatId];
+
+        if (!options.includeDeleted) {
+            conditions.push("is_deleted = 0");
+        }
+
+        if (options.sender === "me") {
+            conditions.push("is_outgoing = 1");
+        } else if (options.sender === "them") {
+            conditions.push("is_outgoing = 0");
+        }
+
+        if (options.since) {
+            conditions.push("date_unix >= ?");
+            params.push(Math.floor(options.since.getTime() / 1000));
+        }
+
+        if (options.until) {
+            conditions.push("date_unix <= ?");
+            params.push(Math.floor(options.until.getTime() / 1000));
+        }
+
+        if (options.textPattern) {
+            conditions.push("text LIKE ?");
+            params.push(`%${options.textPattern}%`);
+        }
+
+        let sql = `SELECT * FROM messages WHERE ${conditions.join(" AND ")} ORDER BY date_unix ASC`;
+
+        if (options.limit) {
+            sql += " LIMIT ?";
+            params.push(options.limit);
+        }
+
+        return db.query(sql).all(...params) as MessageRowV2[];
+    }
+
+    markMessageDeleted(chatId: string, messageId: number): void {
+        const db = this.getDb();
+        const now = new Date();
+
+        const current = db.query("SELECT text FROM messages WHERE chat_id = ? AND id = ?").get(chatId, messageId) as {
+            text: string | null;
+        } | null;
+
+        db.run("UPDATE messages SET is_deleted = 1, deleted_at_iso = ? WHERE chat_id = ? AND id = ?", [
+            now.toISOString(),
+            chatId,
+            messageId,
+        ]);
+
+        db.run(
+            `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
+             VALUES (?, ?, 'delete', ?, NULL, ?, ?)`,
+            [chatId, messageId, current?.text ?? null, Math.floor(now.getTime() / 1000), now.toISOString()]
+        );
+    }
+
+    // ── Upsert With Revision Tracking ────────────────────────────────
+
+    upsertMessageWithRevision(chatId: string, msg: UpsertMessageInput): void {
+        const db = this.getDb();
+        const now = new Date();
+
+        const existing = db.query("SELECT text FROM messages WHERE chat_id = ? AND id = ?").get(chatId, msg.id) as {
+            text: string | null;
+        } | null;
+
+        if (existing) {
+            if (existing.text !== msg.text) {
+                db.run(
+                    `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
+                     VALUES (?, ?, 'edit', ?, ?, ?, ?)`,
+                    [
+                        chatId,
+                        msg.id,
+                        existing.text,
+                        msg.text,
+                        msg.editedDateUnix ?? Math.floor(now.getTime() / 1000),
+                        now.toISOString(),
+                    ]
+                );
+            }
+
+            db.run(
+                `UPDATE messages SET text = ?, media_desc = ?, edited_date_unix = ?, reply_to_msg_id = ? WHERE chat_id = ? AND id = ?`,
+                [
+                    msg.text,
+                    msg.mediaDescription ?? null,
+                    msg.editedDateUnix ?? null,
+                    msg.replyToMsgId ?? null,
+                    chatId,
+                    msg.id,
+                ]
+            );
+        } else {
+            db.run(
+                `INSERT INTO messages (id, chat_id, sender_id, text, media_desc, is_outgoing, date_unix, date_iso, reply_to_msg_id)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                [
+                    msg.id,
+                    chatId,
+                    msg.senderId ?? null,
+                    msg.text,
+                    msg.mediaDescription ?? null,
+                    msg.isOutgoing ? 1 : 0,
+                    msg.dateUnix,
+                    msg.date,
+                    msg.replyToMsgId ?? null,
+                ]
+            );
+
+            db.run(
+                `INSERT INTO message_revisions (chat_id, message_id, revision_type, old_text, new_text, revised_at_unix, revised_at_iso)
+                 VALUES (?, ?, 'create', NULL, ?, ?, ?)`,
+                [chatId, msg.id, msg.text, msg.dateUnix, msg.date]
+            );
+        }
+    }
+
+    getRevisions(chatId: string, messageId: number): MessageRevisionRow[] {
+        const db = this.getDb();
+        return db
+            .query("SELECT * FROM message_revisions WHERE chat_id = ? AND message_id = ? ORDER BY revised_at_unix ASC")
+            .all(chatId, messageId) as MessageRevisionRow[];
+    }
+
+    // ── Attachments ──────────────────────────────────────────────────
+
+    upsertAttachment(input: UpsertAttachmentInput): void {
+        const db = this.getDb();
+        db.run(
+            `INSERT OR REPLACE INTO attachments (chat_id, message_id, attachment_index, kind, mime_type, file_name, file_size, telegram_file_id, is_downloaded, local_path, sha256)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?,
+                     COALESCE((SELECT is_downloaded FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?), 0),
+                     (SELECT local_path FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?),
+                     (SELECT sha256 FROM attachments WHERE chat_id = ? AND message_id = ? AND attachment_index = ?))`,
+            [
+                input.chat_id,
+                input.message_id,
+                input.attachment_index,
+                input.kind,
+                input.mime_type,
+                input.file_name,
+                input.file_size,
+                input.telegram_file_id,
+                input.chat_id,
+                input.message_id,
+                input.attachment_index,
+                input.chat_id,
+                input.message_id,
+                input.attachment_index,
+                input.chat_id,
+                input.message_id,
+                input.attachment_index,
+            ]
+        );
+    }
+
+    getAttachments(chatId: string, messageId: number): AttachmentRow[] {
+        const db = this.getDb();
+        return db
+            .query("SELECT * FROM attachments WHERE chat_id = ? AND message_id = ? ORDER BY attachment_index ASC")
+            .all(chatId, messageId) as AttachmentRow[];
+    }
+
+    listAttachments(chatId: string, options?: { since?: Date; until?: Date; kind?: string }): AttachmentRow[] {
+        const db = this.getDb();
+        const conditions = ["a.chat_id = ?"];
+        const params: (string | number)[] = [chatId];
+
+        if (options?.kind) {
+            conditions.push("a.kind = ?");
+            params.push(options.kind);
+        }
+
+        let sql = "SELECT a.* FROM attachments a";
+
+        if (options?.since || options?.until) {
+            sql += " JOIN messages m ON a.chat_id = m.chat_id AND a.message_id = m.id";
+
+            if (options.since) {
+                conditions.push("m.date_unix >= ?");
+                params.push(Math.floor(options.since.getTime() / 1000));
+            }
+
+            if (options.until) {
+                conditions.push("m.date_unix <= ?");
+                params.push(Math.floor(options.until.getTime() / 1000));
+            }
+        }
+
+        sql += ` WHERE ${conditions.join(" AND ")} ORDER BY a.message_id ASC, a.attachment_index ASC`;
+
+        return db.query(sql).all(...params) as AttachmentRow[];
+    }
+
+    markAttachmentDownloaded(
+        chatId: string,
+        messageId: number,
+        attachmentIndex: number,
+        localPath: string,
+        sha256: string
+    ): void {
+        const db = this.getDb();
+        db.run(
+            "UPDATE attachments SET is_downloaded = 1, local_path = ?, sha256 = ? WHERE chat_id = ? AND message_id = ? AND attachment_index = ?",
+            [localPath, sha256, chatId, messageId, attachmentIndex]
+        );
+    }
+
+    // ── Sync Segments ────────────────────────────────────────────────
+
+    insertSyncSegment(chatId: string, input: InsertSegmentInput): void {
+        const db = this.getDb();
+        db.run(
+            `INSERT INTO sync_segments (chat_id, from_date_unix, to_date_unix, from_msg_id, to_msg_id, synced_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+            [chatId, input.fromDateUnix, input.toDateUnix, input.fromMsgId, input.toMsgId, new Date().toISOString()]
+        );
+    }
+
+    getSyncSegments(chatId: string): SyncSegmentRow[] {
+        const db = this.getDb();
+        return db
+            .query("SELECT * FROM sync_segments WHERE chat_id = ? ORDER BY from_date_unix ASC")
+            .all(chatId) as SyncSegmentRow[];
+    }
+
+    getMissingSegments(chatId: string, fromDateUnix: number, toDateUnix: number): DateRange[] {
+        const segments = this.getSyncSegments(chatId);
+        const gaps: DateRange[] = [];
+
+        const sorted = segments
+            .filter((s) => s.to_date_unix > fromDateUnix && s.from_date_unix < toDateUnix)
+            .sort((a, b) => a.from_date_unix - b.from_date_unix);
+
+        if (sorted.length === 0) {
+            return [{ fromDateUnix, toDateUnix }];
+        }
+
+        if (sorted[0].from_date_unix > fromDateUnix) {
+            gaps.push({ fromDateUnix, toDateUnix: sorted[0].from_date_unix });
+        }
+
+        for (let i = 0; i < sorted.length - 1; i++) {
+            const currentEnd = sorted[i].to_date_unix;
+            const nextStart = sorted[i + 1].from_date_unix;
+
+            if (nextStart > currentEnd) {
+                gaps.push({ fromDateUnix: currentEnd, toDateUnix: nextStart });
+            }
+        }
+
+        const lastEnd = sorted[sorted.length - 1].to_date_unix;
+
+        if (lastEnd < toDateUnix) {
+            gaps.push({ fromDateUnix: lastEnd, toDateUnix });
+        }
+
+        return gaps;
+    }
+
+    // ── Chat Metadata ────────────────────────────────────────────────
+
+    upsertChat(input: { chat_id: string; chat_type: string; title: string; username: string | null }): void {
+        const db = this.getDb();
+        db.run(
+            `INSERT INTO chats (chat_id, chat_type, title, username) VALUES (?, ?, ?, ?)
+             ON CONFLICT(chat_id) DO UPDATE SET chat_type = excluded.chat_type, title = excluded.title, username = excluded.username`,
+            [input.chat_id, input.chat_type, input.title, input.username]
+        );
+    }
+
+    getChat(chatId: string): ChatRow | null {
+        const db = this.getDb();
+        return (db.query("SELECT * FROM chats WHERE chat_id = ?").get(chatId) as ChatRow) ?? null;
+    }
+
+    listChats(type?: string): ChatRow[] {
+        const db = this.getDb();
+
+        if (type) {
+            return db.query("SELECT * FROM chats WHERE chat_type = ? ORDER BY title").all(type) as ChatRow[];
+        }
+
+        return db.query("SELECT * FROM chats ORDER BY chat_type, title").all() as ChatRow[];
+    }
+
+    // ── Suggestion Edits ─────────────────────────────────────────────
+
+    insertSuggestionEdit(input: SuggestionEditInput): void {
+        const db = this.getDb();
+        db.run(
+            `INSERT INTO suggestion_edits (chat_id, message_id, suggested_text, edited_text, sent_text, provider, model, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+                input.chatId,
+                input.messageId,
+                input.suggestedText,
+                input.editedText,
+                input.sentText,
+                input.provider,
+                input.model,
+                new Date().toISOString(),
+            ]
+        );
+    }
+
+    getRecentSuggestionEdits(chatId: string, limit = 10): SuggestionEditRow[] {
+        const db = this.getDb();
+        return db
+            .query(
+                `SELECT suggested_text, edited_text, sent_text, created_at
+                 FROM suggestion_edits WHERE chat_id = ? ORDER BY created_at DESC LIMIT ?`
+            )
+            .all(chatId, limit) as SuggestionEditRow[];
     }
 
     // ── Stats ─────────────────────────────────────────────────────────

--- a/src/telegram/lib/TelegramToolConfig.ts
+++ b/src/telegram/lib/TelegramToolConfig.ts
@@ -1,17 +1,7 @@
 import { chmodSync } from "node:fs";
 import { Storage } from "@app/utils/storage/storage";
-import type {
-    ContactConfig,
-    TelegramConfigData,
-    TelegramConfigDataV2,
-    TelegramContactV2,
-} from "./types";
-import {
-    DEFAULT_MODE_CONFIG,
-    DEFAULT_STYLE_PROFILE,
-    DEFAULT_WATCH_CONFIG,
-    DEFAULTS,
-} from "./types";
+import type { ContactConfig, TelegramConfigData, TelegramConfigDataV2, TelegramContactV2 } from "./types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
 
 export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
     const hasAsk = v1.actions.includes("ask");

--- a/src/telegram/lib/TelegramToolConfig.ts
+++ b/src/telegram/lib/TelegramToolConfig.ts
@@ -1,18 +1,82 @@
 import { chmodSync } from "node:fs";
 import { Storage } from "@app/utils/storage/storage";
-import type { ContactConfig, TelegramConfigData } from "./types";
-import { DEFAULTS } from "./types";
+import type {
+    ContactConfig,
+    TelegramConfigData,
+    TelegramConfigDataV2,
+    TelegramContactV2,
+} from "./types";
+import {
+    DEFAULT_MODE_CONFIG,
+    DEFAULT_STYLE_PROFILE,
+    DEFAULT_WATCH_CONFIG,
+    DEFAULTS,
+} from "./types";
+
+export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
+    const hasAsk = v1.actions.includes("ask");
+
+    return {
+        userId: v1.userId,
+        displayName: v1.displayName,
+        username: v1.username,
+        chatType: "user",
+        actions: v1.actions,
+        watch: { ...DEFAULT_WATCH_CONFIG },
+        modes: {
+            autoReply: {
+                enabled: hasAsk,
+                provider: v1.askProvider,
+                model: v1.askModel,
+                systemPrompt: v1.askSystemPrompt,
+            },
+            assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+            suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+        },
+        styleProfile: { ...DEFAULT_STYLE_PROFILE },
+        replyDelayMin: v1.replyDelayMin,
+        replyDelayMax: v1.replyDelayMax,
+    };
+}
+
+export function migrateConfigV1toV2(config: TelegramConfigData | TelegramConfigDataV2): TelegramConfigDataV2 {
+    if ("version" in config && config.version === 2) {
+        return config as TelegramConfigDataV2;
+    }
+
+    const v1 = config as TelegramConfigData;
+    return {
+        version: 2,
+        apiId: v1.apiId,
+        apiHash: v1.apiHash,
+        session: v1.session,
+        me: v1.me,
+        contacts: v1.contacts.map(migrateContactV1toV2),
+        globalDefaults: {
+            modes: { ...DEFAULT_MODE_CONFIG },
+            watch: { ...DEFAULT_WATCH_CONFIG },
+            styleProfile: { ...DEFAULT_STYLE_PROFILE },
+        },
+        configuredAt: v1.configuredAt,
+    };
+}
 
 export class TelegramToolConfig {
     private storage = new Storage("telegram");
-    private data: TelegramConfigData | null = null;
+    private data: TelegramConfigDataV2 | null = null;
 
-    async load(): Promise<TelegramConfigData | null> {
-        this.data = await this.storage.getConfig<TelegramConfigData>();
+    async load(): Promise<TelegramConfigDataV2 | null> {
+        const raw = await this.storage.getConfig<TelegramConfigData | TelegramConfigDataV2>();
+
+        if (!raw) {
+            return null;
+        }
+
+        this.data = migrateConfigV1toV2(raw);
         return this.data;
     }
 
-    async save(config: TelegramConfigData): Promise<void> {
+    async save(config: TelegramConfigDataV2): Promise<void> {
         await this.storage.setConfig(config);
         this.data = config;
         this.protect();
@@ -40,7 +104,7 @@ export class TelegramToolConfig {
         return this.data?.session ?? "";
     }
 
-    getContacts(): ContactConfig[] {
+    getContacts(): TelegramContactV2[] {
         return this.data?.contacts ?? [];
     }
 
@@ -52,7 +116,7 @@ export class TelegramToolConfig {
         try {
             chmodSync(this.storage.getConfigPath(), 0o600);
         } catch {
-            // ignore — file may not exist yet
+            // ignore -- file may not exist yet
         }
     }
 }

--- a/src/telegram/lib/TelegramToolConfig.ts
+++ b/src/telegram/lib/TelegramToolConfig.ts
@@ -3,6 +3,22 @@ import { Storage } from "@app/utils/storage/storage";
 import type { ContactConfig, TelegramConfigData, TelegramConfigDataV2, TelegramContactV2 } from "./types";
 import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG, DEFAULTS } from "./types";
 
+function cloneDefaults() {
+    return {
+        modes: {
+            autoReply: { ...DEFAULT_MODE_CONFIG.autoReply },
+            assistant: { ...DEFAULT_MODE_CONFIG.assistant },
+            suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
+        },
+        watch: { ...DEFAULT_WATCH_CONFIG },
+        styleProfile: {
+            enabled: DEFAULT_STYLE_PROFILE.enabled,
+            source: DEFAULT_STYLE_PROFILE.source,
+            rules: DEFAULT_STYLE_PROFILE.rules.map((rule) => ({ ...rule })),
+        },
+    };
+}
+
 export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
     const hasAsk = v1.actions.includes("ask");
 
@@ -23,7 +39,11 @@ export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
             assistant: { ...DEFAULT_MODE_CONFIG.assistant },
             suggestions: { ...DEFAULT_MODE_CONFIG.suggestions },
         },
-        styleProfile: { ...DEFAULT_STYLE_PROFILE },
+        styleProfile: {
+            enabled: DEFAULT_STYLE_PROFILE.enabled,
+            source: DEFAULT_STYLE_PROFILE.source,
+            rules: DEFAULT_STYLE_PROFILE.rules.map((rule) => ({ ...rule })),
+        },
         replyDelayMin: v1.replyDelayMin,
         replyDelayMax: v1.replyDelayMax,
     };
@@ -42,11 +62,7 @@ export function migrateConfigV1toV2(config: TelegramConfigData | TelegramConfigD
         session: v1.session,
         me: v1.me,
         contacts: v1.contacts.map(migrateContactV1toV2),
-        globalDefaults: {
-            modes: { ...DEFAULT_MODE_CONFIG },
-            watch: { ...DEFAULT_WATCH_CONFIG },
-            styleProfile: { ...DEFAULT_STYLE_PROFILE },
-        },
+        globalDefaults: cloneDefaults(),
         configuredAt: v1.configuredAt,
     };
 }

--- a/src/telegram/lib/TelegramToolConfig.ts
+++ b/src/telegram/lib/TelegramToolConfig.ts
@@ -13,7 +13,8 @@ function cloneDefaults() {
         watch: { ...DEFAULT_WATCH_CONFIG },
         styleProfile: {
             enabled: DEFAULT_STYLE_PROFILE.enabled,
-            source: DEFAULT_STYLE_PROFILE.source,
+            refresh: DEFAULT_STYLE_PROFILE.refresh,
+            previewInWatch: DEFAULT_STYLE_PROFILE.previewInWatch,
             rules: DEFAULT_STYLE_PROFILE.rules.map((rule) => ({ ...rule })),
         },
     };
@@ -41,7 +42,8 @@ export function migrateContactV1toV2(v1: ContactConfig): TelegramContactV2 {
         },
         styleProfile: {
             enabled: DEFAULT_STYLE_PROFILE.enabled,
-            source: DEFAULT_STYLE_PROFILE.source,
+            refresh: DEFAULT_STYLE_PROFILE.refresh,
+            previewInWatch: DEFAULT_STYLE_PROFILE.previewInWatch,
             rules: DEFAULT_STYLE_PROFILE.rules.map((rule) => ({ ...rule })),
         },
         replyDelayMin: v1.replyDelayMin,

--- a/src/telegram/lib/__tests__/AssistantEngine.test.ts
+++ b/src/telegram/lib/__tests__/AssistantEngine.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { AssistantEngine } from "../AssistantEngine";
+
+describe("AssistantEngine", () => {
+    it("builds correct tool definitions", () => {
+        const tools = AssistantEngine.getToolDefinitions();
+
+        expect(tools).toHaveProperty("search_messages");
+        expect(tools).toHaveProperty("get_message_count");
+        expect(tools).toHaveProperty("get_conversation_summary");
+        expect(tools).toHaveProperty("get_attachments");
+        expect(tools).toHaveProperty("get_style_analysis");
+        expect(tools).toHaveProperty("search_across_chats");
+    });
+
+    it("search_messages tool has correct parameters", () => {
+        const tools = AssistantEngine.getToolDefinitions();
+        const searchTool = tools.search_messages;
+
+        expect(searchTool.parameters).toBeDefined();
+    });
+});

--- a/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
+++ b/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import type { Api } from "telegram";
+import { AttachmentIndexer } from "../AttachmentIndexer";
+
+function fakeMessage(overrides: Record<string, unknown>): Api.Message {
+	return { id: 0, media: null, ...overrides } as unknown as Api.Message;
+}
+
+describe("AttachmentIndexer", () => {
+	it("extracts photo attachment", () => {
+		const msg = fakeMessage({
+			id: 1,
+			media: {
+				className: "MessageMediaPhoto",
+				photo: {
+					className: "Photo",
+					id: BigInt(12345),
+					sizes: [{ className: "PhotoSize", type: "x", w: 800, h: 600, size: 50000 }],
+					mimeType: "image/jpeg",
+				},
+			},
+		});
+
+		const attachments = AttachmentIndexer.extract("chat1", msg);
+		expect(attachments.length).toBe(1);
+		expect(attachments[0].kind).toBe("photo");
+		expect(attachments[0].attachment_index).toBe(0);
+	});
+
+	it("extracts document attachment with filename", () => {
+		const msg = fakeMessage({
+			id: 2,
+			media: {
+				className: "MessageMediaDocument",
+				document: {
+					className: "Document",
+					id: BigInt(67890),
+					mimeType: "application/pdf",
+					size: BigInt(1024),
+					attributes: [
+						{ className: "DocumentAttributeFilename", fileName: "report.pdf" },
+					],
+				},
+			},
+		});
+
+		const attachments = AttachmentIndexer.extract("chat1", msg);
+		expect(attachments.length).toBe(1);
+		expect(attachments[0].kind).toBe("document");
+		expect(attachments[0].file_name).toBe("report.pdf");
+		expect(attachments[0].mime_type).toBe("application/pdf");
+	});
+
+	it("returns empty for text-only message", () => {
+		const msg = fakeMessage({ id: 3, media: null });
+		const attachments = AttachmentIndexer.extract("chat1", msg);
+		expect(attachments.length).toBe(0);
+	});
+
+	it("classifies sticker correctly", () => {
+		const msg = fakeMessage({
+			id: 4,
+			media: {
+				className: "MessageMediaDocument",
+				document: {
+					className: "Document",
+					id: BigInt(11111),
+					mimeType: "image/webp",
+					size: BigInt(5000),
+					attributes: [{ className: "DocumentAttributeSticker" }],
+				},
+			},
+		});
+
+		const attachments = AttachmentIndexer.extract("chat1", msg);
+		expect(attachments[0].kind).toBe("sticker");
+	});
+
+	it("classifies voice message correctly", () => {
+		const msg = fakeMessage({
+			id: 5,
+			media: {
+				className: "MessageMediaDocument",
+				document: {
+					className: "Document",
+					id: BigInt(22222),
+					mimeType: "audio/ogg",
+					size: BigInt(8000),
+					attributes: [{ className: "DocumentAttributeAudio", voice: true }],
+				},
+			},
+		});
+
+		const attachments = AttachmentIndexer.extract("chat1", msg);
+		expect(attachments[0].kind).toBe("voice");
+	});
+});

--- a/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
+++ b/src/telegram/lib/__tests__/AttachmentIndexer.test.ts
@@ -3,95 +3,93 @@ import type { Api } from "telegram";
 import { AttachmentIndexer } from "../AttachmentIndexer";
 
 function fakeMessage(overrides: Record<string, unknown>): Api.Message {
-	return { id: 0, media: null, ...overrides } as unknown as Api.Message;
+    return { id: 0, media: null, ...overrides } as unknown as Api.Message;
 }
 
 describe("AttachmentIndexer", () => {
-	it("extracts photo attachment", () => {
-		const msg = fakeMessage({
-			id: 1,
-			media: {
-				className: "MessageMediaPhoto",
-				photo: {
-					className: "Photo",
-					id: BigInt(12345),
-					sizes: [{ className: "PhotoSize", type: "x", w: 800, h: 600, size: 50000 }],
-					mimeType: "image/jpeg",
-				},
-			},
-		});
+    it("extracts photo attachment", () => {
+        const msg = fakeMessage({
+            id: 1,
+            media: {
+                className: "MessageMediaPhoto",
+                photo: {
+                    className: "Photo",
+                    id: BigInt(12345),
+                    sizes: [{ className: "PhotoSize", type: "x", w: 800, h: 600, size: 50000 }],
+                    mimeType: "image/jpeg",
+                },
+            },
+        });
 
-		const attachments = AttachmentIndexer.extract("chat1", msg);
-		expect(attachments.length).toBe(1);
-		expect(attachments[0].kind).toBe("photo");
-		expect(attachments[0].attachment_index).toBe(0);
-	});
+        const attachments = AttachmentIndexer.extract("chat1", msg);
+        expect(attachments.length).toBe(1);
+        expect(attachments[0].kind).toBe("photo");
+        expect(attachments[0].attachment_index).toBe(0);
+    });
 
-	it("extracts document attachment with filename", () => {
-		const msg = fakeMessage({
-			id: 2,
-			media: {
-				className: "MessageMediaDocument",
-				document: {
-					className: "Document",
-					id: BigInt(67890),
-					mimeType: "application/pdf",
-					size: BigInt(1024),
-					attributes: [
-						{ className: "DocumentAttributeFilename", fileName: "report.pdf" },
-					],
-				},
-			},
-		});
+    it("extracts document attachment with filename", () => {
+        const msg = fakeMessage({
+            id: 2,
+            media: {
+                className: "MessageMediaDocument",
+                document: {
+                    className: "Document",
+                    id: BigInt(67890),
+                    mimeType: "application/pdf",
+                    size: BigInt(1024),
+                    attributes: [{ className: "DocumentAttributeFilename", fileName: "report.pdf" }],
+                },
+            },
+        });
 
-		const attachments = AttachmentIndexer.extract("chat1", msg);
-		expect(attachments.length).toBe(1);
-		expect(attachments[0].kind).toBe("document");
-		expect(attachments[0].file_name).toBe("report.pdf");
-		expect(attachments[0].mime_type).toBe("application/pdf");
-	});
+        const attachments = AttachmentIndexer.extract("chat1", msg);
+        expect(attachments.length).toBe(1);
+        expect(attachments[0].kind).toBe("document");
+        expect(attachments[0].file_name).toBe("report.pdf");
+        expect(attachments[0].mime_type).toBe("application/pdf");
+    });
 
-	it("returns empty for text-only message", () => {
-		const msg = fakeMessage({ id: 3, media: null });
-		const attachments = AttachmentIndexer.extract("chat1", msg);
-		expect(attachments.length).toBe(0);
-	});
+    it("returns empty for text-only message", () => {
+        const msg = fakeMessage({ id: 3, media: null });
+        const attachments = AttachmentIndexer.extract("chat1", msg);
+        expect(attachments.length).toBe(0);
+    });
 
-	it("classifies sticker correctly", () => {
-		const msg = fakeMessage({
-			id: 4,
-			media: {
-				className: "MessageMediaDocument",
-				document: {
-					className: "Document",
-					id: BigInt(11111),
-					mimeType: "image/webp",
-					size: BigInt(5000),
-					attributes: [{ className: "DocumentAttributeSticker" }],
-				},
-			},
-		});
+    it("classifies sticker correctly", () => {
+        const msg = fakeMessage({
+            id: 4,
+            media: {
+                className: "MessageMediaDocument",
+                document: {
+                    className: "Document",
+                    id: BigInt(11111),
+                    mimeType: "image/webp",
+                    size: BigInt(5000),
+                    attributes: [{ className: "DocumentAttributeSticker" }],
+                },
+            },
+        });
 
-		const attachments = AttachmentIndexer.extract("chat1", msg);
-		expect(attachments[0].kind).toBe("sticker");
-	});
+        const attachments = AttachmentIndexer.extract("chat1", msg);
+        expect(attachments[0].kind).toBe("sticker");
+    });
 
-	it("classifies voice message correctly", () => {
-		const msg = fakeMessage({
-			id: 5,
-			media: {
-				className: "MessageMediaDocument",
-				document: {
-					className: "Document",
-					id: BigInt(22222),
-					mimeType: "audio/ogg",
-					size: BigInt(8000),
-					attributes: [{ className: "DocumentAttributeAudio", voice: true }],
-				},
-			},
-		});
+    it("classifies voice message correctly", () => {
+        const msg = fakeMessage({
+            id: 5,
+            media: {
+                className: "MessageMediaDocument",
+                document: {
+                    className: "Document",
+                    id: BigInt(22222),
+                    mimeType: "audio/ogg",
+                    size: BigInt(8000),
+                    attributes: [{ className: "DocumentAttributeAudio", voice: true }],
+                },
+            },
+        });
 
-		const attachments = AttachmentIndexer.extract("chat1", msg);
-		expect(attachments[0].kind).toBe("voice");
-	});
+        const attachments = AttachmentIndexer.extract("chat1", msg);
+        expect(attachments[0].kind).toBe("voice");
+    });
 });

--- a/src/telegram/lib/__tests__/DateParser.test.ts
+++ b/src/telegram/lib/__tests__/DateParser.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { parseDate, parseDateRange } from "../DateParser";
+
+describe("DateParser", () => {
+    it("parses ISO dates", () => {
+        const d = parseDate("2024-01-15");
+        expect(d).toBeInstanceOf(Date);
+        expect(d!.getFullYear()).toBe(2024);
+    });
+
+    it("parses natural language 'yesterday'", () => {
+        const d = parseDate("yesterday");
+        expect(d).toBeInstanceOf(Date);
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        expect(d!.toDateString()).toBe(yesterday.toDateString());
+    });
+
+    it("parses '3 days ago'", () => {
+        const d = parseDate("3 days ago");
+        expect(d).toBeInstanceOf(Date);
+    });
+
+    it("parses 'last week'", () => {
+        const d = parseDate("last week");
+        expect(d).toBeInstanceOf(Date);
+    });
+
+    it("returns null for unparseable input", () => {
+        const d = parseDate("not a date at all xyz");
+        expect(d).toBeNull();
+    });
+
+    it("parseDateRange handles 'since X until Y'", () => {
+        const range = parseDateRange({ since: "2024-01-01", until: "2024-01-31" });
+        expect(range.since).toBeInstanceOf(Date);
+        expect(range.until).toBeInstanceOf(Date);
+        expect(range.since!.getMonth()).toBe(0);
+    });
+
+    it("parseDateRange handles natural language", () => {
+        const range = parseDateRange({ since: "last week" });
+        expect(range.since).toBeInstanceOf(Date);
+        expect(range.until).toBeUndefined();
+    });
+});

--- a/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+++ b/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
@@ -19,11 +19,46 @@ describe("StyleProfileEngine", () => {
         store.open(dbPath);
 
         const messages = [
-            { id: 1, senderId: "me", text: "hey whats up", isOutgoing: true, date: "2024-01-10T10:00:00Z", dateUnix: 1704880800 },
-            { id: 2, senderId: "me", text: "lol yea that was crazy", isOutgoing: true, date: "2024-01-10T10:01:00Z", dateUnix: 1704880860 },
-            { id: 3, senderId: "me", text: "nah im good thanks tho", isOutgoing: true, date: "2024-01-10T10:02:00Z", dateUnix: 1704880920 },
-            { id: 4, senderId: "me", text: "wanna grab coffee tmrw?", isOutgoing: true, date: "2024-01-10T10:03:00Z", dateUnix: 1704880980 },
-            { id: 5, senderId: "me", text: "k cool see ya", isOutgoing: true, date: "2024-01-10T10:04:00Z", dateUnix: 1704881040 },
+            {
+                id: 1,
+                senderId: "me",
+                text: "hey whats up",
+                isOutgoing: true,
+                date: "2024-01-10T10:00:00Z",
+                dateUnix: 1704880800,
+            },
+            {
+                id: 2,
+                senderId: "me",
+                text: "lol yea that was crazy",
+                isOutgoing: true,
+                date: "2024-01-10T10:01:00Z",
+                dateUnix: 1704880860,
+            },
+            {
+                id: 3,
+                senderId: "me",
+                text: "nah im good thanks tho",
+                isOutgoing: true,
+                date: "2024-01-10T10:02:00Z",
+                dateUnix: 1704880920,
+            },
+            {
+                id: 4,
+                senderId: "me",
+                text: "wanna grab coffee tmrw?",
+                isOutgoing: true,
+                date: "2024-01-10T10:03:00Z",
+                dateUnix: 1704880980,
+            },
+            {
+                id: 5,
+                senderId: "me",
+                text: "k cool see ya",
+                isOutgoing: true,
+                date: "2024-01-10T10:04:00Z",
+                dateUnix: 1704881040,
+            },
         ];
 
         for (const msg of messages) {
@@ -52,9 +87,7 @@ describe("StyleProfileEngine", () => {
     it("builds a hybrid style prompt", () => {
         const engine = new StyleProfileEngine(store);
         const prompt = engine.buildStylePrompt("chat1", {
-            rules: [
-                { id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 },
-            ],
+            rules: [{ id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 }],
             exampleCount: 5,
         });
 
@@ -67,13 +100,19 @@ describe("StyleProfileEngine", () => {
         const engine = new StyleProfileEngine(store);
 
         store.insertMessages("chat1", [
-            { id: 10, senderId: "other", text: "How are you?", mediaDescription: undefined, isOutgoing: false, date: "2024-01-10T10:05:00Z", dateUnix: 1704881100 },
+            {
+                id: 10,
+                senderId: "other",
+                text: "How are you?",
+                mediaDescription: undefined,
+                isOutgoing: false,
+                date: "2024-01-10T10:05:00Z",
+                dateUnix: 1704881100,
+            },
         ]);
 
         const prompt = engine.buildStylePrompt("chat1", {
-            rules: [
-                { id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 },
-            ],
+            rules: [{ id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 }],
             exampleCount: 5,
         });
 

--- a/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+++ b/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
@@ -86,7 +86,7 @@ describe("StyleProfileEngine", () => {
 
     it("builds a hybrid style prompt", () => {
         const engine = new StyleProfileEngine(store);
-        const prompt = engine.buildStylePrompt("chat1", {
+        const prompt = engine.buildStylePrompt({
             rules: [{ id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 }],
             exampleCount: 5,
         });
@@ -111,7 +111,7 @@ describe("StyleProfileEngine", () => {
             },
         ]);
 
-        const prompt = engine.buildStylePrompt("chat1", {
+        const prompt = engine.buildStylePrompt({
             rules: [{ id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 }],
             exampleCount: 5,
         });

--- a/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
+++ b/src/telegram/lib/__tests__/StyleProfileEngine.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StyleProfileEngine } from "../StyleProfileEngine";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-style-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("StyleProfileEngine", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+
+        const messages = [
+            { id: 1, senderId: "me", text: "hey whats up", isOutgoing: true, date: "2024-01-10T10:00:00Z", dateUnix: 1704880800 },
+            { id: 2, senderId: "me", text: "lol yea that was crazy", isOutgoing: true, date: "2024-01-10T10:01:00Z", dateUnix: 1704880860 },
+            { id: 3, senderId: "me", text: "nah im good thanks tho", isOutgoing: true, date: "2024-01-10T10:02:00Z", dateUnix: 1704880920 },
+            { id: 4, senderId: "me", text: "wanna grab coffee tmrw?", isOutgoing: true, date: "2024-01-10T10:03:00Z", dateUnix: 1704880980 },
+            { id: 5, senderId: "me", text: "k cool see ya", isOutgoing: true, date: "2024-01-10T10:04:00Z", dateUnix: 1704881040 },
+        ];
+
+        for (const msg of messages) {
+            store.insertMessages("chat1", [{ ...msg, mediaDescription: undefined }]);
+        }
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("generates a style summary from messages", () => {
+        const engine = new StyleProfileEngine(store);
+        const summary = engine.analyzeStyle("chat1", "me", 100);
+
+        expect(summary.totalMessages).toBe(5);
+        expect(summary.avgLength).toBeGreaterThan(0);
+        expect(summary.traits).toBeInstanceOf(Array);
+        expect(summary.traits.length).toBeGreaterThan(0);
+    });
+
+    it("builds a hybrid style prompt", () => {
+        const engine = new StyleProfileEngine(store);
+        const prompt = engine.buildStylePrompt("chat1", {
+            rules: [
+                { id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 },
+            ],
+            exampleCount: 5,
+        });
+
+        expect(prompt).toContain("Style Summary");
+        expect(prompt).toContain("Example Messages");
+        expect(prompt).toContain("hey whats up");
+    });
+
+    it("respects rule filters", () => {
+        const engine = new StyleProfileEngine(store);
+
+        store.insertMessages("chat1", [
+            { id: 10, senderId: "other", text: "How are you?", mediaDescription: undefined, isOutgoing: false, date: "2024-01-10T10:05:00Z", dateUnix: 1704881100 },
+        ]);
+
+        const prompt = engine.buildStylePrompt("chat1", {
+            rules: [
+                { id: "r1", sourceChatId: "chat1", direction: "outgoing", limit: 100 },
+            ],
+            exampleCount: 5,
+        });
+
+        expect(prompt).not.toContain("How are you?");
+    });
+});

--- a/src/telegram/lib/__tests__/SuggestionEngine.test.ts
+++ b/src/telegram/lib/__tests__/SuggestionEngine.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { SuggestionEngine } from "../SuggestionEngine";
+
+describe("SuggestionEngine", () => {
+    it("builds suggestion system prompt with style and corrections", () => {
+        const prompt = SuggestionEngine.buildSuggestionPrompt({
+            contactName: "Alice",
+            myName: "Martin",
+            stylePrompt: "Short messages, lowercase, uses emoji",
+            recentCorrections: [{ suggested: "Hey, how are you?", sent: "hey wyd" }],
+            count: 3,
+        });
+
+        expect(prompt).toContain("Alice");
+        expect(prompt).toContain("3");
+        expect(prompt).toContain("lowercase");
+        expect(prompt).toContain("hey wyd");
+    });
+
+    it("parseSuggestions extracts numbered list", () => {
+        const raw = `Here are 3 suggestions:
+
+1. hey whats up
+2. yo how was your day
+3. lol yea that sounds fun`;
+
+        const suggestions = SuggestionEngine.parseSuggestions(raw);
+        expect(suggestions.length).toBe(3);
+        expect(suggestions[0]).toBe("hey whats up");
+        expect(suggestions[2]).toBe("lol yea that sounds fun");
+    });
+});

--- a/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+++ b/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { SyncRangePlanner } from "../SyncRangePlanner";
+
+describe("SyncRangePlanner", () => {
+	it("returns full range when no segments exist", () => {
+		const plan = SyncRangePlanner.plan([], 1700000000, 1700259200);
+		expect(plan.length).toBe(1);
+		expect(plan[0]).toEqual({ from: 1700000000, to: 1700259200 });
+	});
+
+	it("returns empty when fully covered", () => {
+		const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700259200 }];
+		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+		expect(plan.length).toBe(0);
+	});
+
+	it("finds gap between two segments", () => {
+		const segments = [
+			{ from_date_unix: 1700000000, to_date_unix: 1700086400 },
+			{ from_date_unix: 1700172800, to_date_unix: 1700259200 },
+		];
+		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+		expect(plan.length).toBe(1);
+		expect(plan[0]).toEqual({ from: 1700086400, to: 1700172800 });
+	});
+
+	it("finds gap before first segment", () => {
+		const segments = [{ from_date_unix: 1700086400, to_date_unix: 1700259200 }];
+		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+		expect(plan.length).toBe(1);
+		expect(plan[0].from).toBe(1700000000);
+	});
+
+	it("finds gap after last segment", () => {
+		const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700086400 }];
+		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+		expect(plan.length).toBe(1);
+		expect(plan[0].from).toBe(1700086400);
+	});
+
+	it("handles overlapping segments", () => {
+		const segments = [
+			{ from_date_unix: 1700000000, to_date_unix: 1700100000 },
+			{ from_date_unix: 1700050000, to_date_unix: 1700259200 },
+		];
+		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+		expect(plan.length).toBe(0);
+	});
+});

--- a/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
+++ b/src/telegram/lib/__tests__/SyncRangePlanner.test.ts
@@ -2,48 +2,48 @@ import { describe, expect, it } from "bun:test";
 import { SyncRangePlanner } from "../SyncRangePlanner";
 
 describe("SyncRangePlanner", () => {
-	it("returns full range when no segments exist", () => {
-		const plan = SyncRangePlanner.plan([], 1700000000, 1700259200);
-		expect(plan.length).toBe(1);
-		expect(plan[0]).toEqual({ from: 1700000000, to: 1700259200 });
-	});
+    it("returns full range when no segments exist", () => {
+        const plan = SyncRangePlanner.plan([], 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0]).toEqual({ from: 1700000000, to: 1700259200 });
+    });
 
-	it("returns empty when fully covered", () => {
-		const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700259200 }];
-		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-		expect(plan.length).toBe(0);
-	});
+    it("returns empty when fully covered", () => {
+        const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700259200 }];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(0);
+    });
 
-	it("finds gap between two segments", () => {
-		const segments = [
-			{ from_date_unix: 1700000000, to_date_unix: 1700086400 },
-			{ from_date_unix: 1700172800, to_date_unix: 1700259200 },
-		];
-		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-		expect(plan.length).toBe(1);
-		expect(plan[0]).toEqual({ from: 1700086400, to: 1700172800 });
-	});
+    it("finds gap between two segments", () => {
+        const segments = [
+            { from_date_unix: 1700000000, to_date_unix: 1700086400 },
+            { from_date_unix: 1700172800, to_date_unix: 1700259200 },
+        ];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0]).toEqual({ from: 1700086400, to: 1700172800 });
+    });
 
-	it("finds gap before first segment", () => {
-		const segments = [{ from_date_unix: 1700086400, to_date_unix: 1700259200 }];
-		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-		expect(plan.length).toBe(1);
-		expect(plan[0].from).toBe(1700000000);
-	});
+    it("finds gap before first segment", () => {
+        const segments = [{ from_date_unix: 1700086400, to_date_unix: 1700259200 }];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0].from).toBe(1700000000);
+    });
 
-	it("finds gap after last segment", () => {
-		const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700086400 }];
-		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-		expect(plan.length).toBe(1);
-		expect(plan[0].from).toBe(1700086400);
-	});
+    it("finds gap after last segment", () => {
+        const segments = [{ from_date_unix: 1700000000, to_date_unix: 1700086400 }];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(1);
+        expect(plan[0].from).toBe(1700086400);
+    });
 
-	it("handles overlapping segments", () => {
-		const segments = [
-			{ from_date_unix: 1700000000, to_date_unix: 1700100000 },
-			{ from_date_unix: 1700050000, to_date_unix: 1700259200 },
-		];
-		const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
-		expect(plan.length).toBe(0);
-	});
+    it("handles overlapping segments", () => {
+        const segments = [
+            { from_date_unix: 1700000000, to_date_unix: 1700100000 },
+            { from_date_unix: 1700050000, to_date_unix: 1700259200 },
+        ];
+        const plan = SyncRangePlanner.plan(segments, 1700000000, 1700259200);
+        expect(plan.length).toBe(0);
+    });
 });

--- a/src/telegram/lib/__tests__/SyncSegments.test.ts
+++ b/src/telegram/lib/__tests__/SyncSegments.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-seg-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("Sync segment tracking", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("inserts a sync segment", () => {
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700000000,
+            toDateUnix: 1700086400,
+            fromMsgId: 1,
+            toMsgId: 100,
+        });
+
+        const segments = store.getSyncSegments("chat1");
+        expect(segments.length).toBe(1);
+        expect(segments[0].from_msg_id).toBe(1);
+        expect(segments[0].to_msg_id).toBe(100);
+    });
+
+    it("detects missing segments (gap in coverage)", () => {
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700000000,
+            toDateUnix: 1700086400,
+            fromMsgId: 1,
+            toMsgId: 50,
+        });
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700172800,
+            toDateUnix: 1700259200,
+            fromMsgId: 100,
+            toMsgId: 150,
+        });
+
+        const gaps = store.getMissingSegments("chat1", 1700000000, 1700259200);
+        expect(gaps.length).toBe(1);
+        expect(gaps[0].fromDateUnix).toBe(1700086400);
+        expect(gaps[0].toDateUnix).toBe(1700172800);
+    });
+
+    it("returns empty when fully covered", () => {
+        store.insertSyncSegment("chat1", {
+            fromDateUnix: 1700000000,
+            toDateUnix: 1700259200,
+            fromMsgId: 1,
+            toMsgId: 150,
+        });
+
+        const gaps = store.getMissingSegments("chat1", 1700000000, 1700259200);
+        expect(gaps.length).toBe(0);
+    });
+
+    it("returns full range when no segments exist", () => {
+        const gaps = store.getMissingSegments("chat1", 1700000000, 1700259200);
+        expect(gaps.length).toBe(1);
+        expect(gaps[0].fromDateUnix).toBe(1700000000);
+        expect(gaps[0].toDateUnix).toBe(1700259200);
+    });
+});

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.attachments.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.attachments.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-att-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore attachments", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("upserts attachment metadata", () => {
+        store.upsertAttachment({
+            chat_id: "chat1",
+            message_id: 1,
+            attachment_index: 0,
+            kind: "photo",
+            mime_type: "image/jpeg",
+            file_name: null,
+            file_size: 1024,
+            telegram_file_id: "abc123",
+        });
+
+        const atts = store.getAttachments("chat1", 1);
+        expect(atts.length).toBe(1);
+        expect(atts[0].kind).toBe("photo");
+        expect(atts[0].is_downloaded).toBe(0);
+    });
+
+    it("lists attachments for a chat", () => {
+        store.upsertAttachment({
+            chat_id: "chat1",
+            message_id: 1,
+            attachment_index: 0,
+            kind: "photo",
+            mime_type: "image/jpeg",
+            file_name: null,
+            file_size: 1024,
+            telegram_file_id: "a",
+        });
+        store.upsertAttachment({
+            chat_id: "chat1",
+            message_id: 2,
+            attachment_index: 0,
+            kind: "video",
+            mime_type: "video/mp4",
+            file_name: "vid.mp4",
+            file_size: 5000,
+            telegram_file_id: "b",
+        });
+        store.upsertAttachment({
+            chat_id: "chat1",
+            message_id: 2,
+            attachment_index: 1,
+            kind: "document",
+            mime_type: "application/pdf",
+            file_name: "doc.pdf",
+            file_size: 2000,
+            telegram_file_id: "c",
+        });
+
+        const all = store.listAttachments("chat1");
+        expect(all.length).toBe(3);
+
+        const forMsg2 = store.getAttachments("chat1", 2);
+        expect(forMsg2.length).toBe(2);
+    });
+
+    it("marks attachment as downloaded", () => {
+        store.upsertAttachment({
+            chat_id: "chat1",
+            message_id: 1,
+            attachment_index: 0,
+            kind: "photo",
+            mime_type: "image/jpeg",
+            file_name: null,
+            file_size: 1024,
+            telegram_file_id: "a",
+        });
+
+        store.markAttachmentDownloaded("chat1", 1, 0, "/path/to/file.jpg", "sha256hash");
+
+        const atts = store.getAttachments("chat1", 1);
+        expect(atts[0].is_downloaded).toBe(1);
+        expect(atts[0].local_path).toBe("/path/to/file.jpg");
+        expect(atts[0].sha256).toBe("sha256hash");
+    });
+});

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.chats.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.chats.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-chat-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore chats", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("upserts chat metadata", () => {
+        store.upsertChat({ chat_id: "123", chat_type: "user", title: "John", username: "john" });
+        const chat = store.getChat("123");
+        expect(chat).toBeTruthy();
+        expect(chat!.title).toBe("John");
+        expect(chat!.chat_type).toBe("user");
+    });
+
+    it("lists chats by type", () => {
+        store.upsertChat({ chat_id: "1", chat_type: "user", title: "Alice", username: null });
+        store.upsertChat({ chat_id: "2", chat_type: "group", title: "Dev Team", username: null });
+        store.upsertChat({
+            chat_id: "3",
+            chat_type: "channel",
+            title: "News",
+            username: "news",
+        });
+
+        const users = store.listChats("user");
+        expect(users.length).toBe(1);
+
+        const all = store.listChats();
+        expect(all.length).toBe(3);
+    });
+});

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
@@ -1,0 +1,107 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore migrations", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("creates all V2 tables on fresh database", () => {
+        store.open(dbPath);
+        const db = (store as unknown as { db: Database }).db;
+
+        const chats = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='chats'").get();
+        expect(chats).toBeTruthy();
+
+        const revisions = db
+            .query("SELECT name FROM sqlite_master WHERE type='table' AND name='message_revisions'")
+            .get();
+        expect(revisions).toBeTruthy();
+
+        const attachments = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='attachments'").get();
+        expect(attachments).toBeTruthy();
+
+        const segments = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_segments'").get();
+        expect(segments).toBeTruthy();
+
+        const version = db.query("PRAGMA user_version").get() as { user_version: number };
+        expect(version.user_version).toBe(2);
+    });
+
+    it("migrates V0 (fresh) to V2 with new message columns", () => {
+        store.open(dbPath);
+        const db = (store as unknown as { db: Database }).db;
+
+        const cols = db.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
+        const colNames = cols.map((c) => c.name);
+
+        expect(colNames).toContain("edited_date_unix");
+        expect(colNames).toContain("is_deleted");
+        expect(colNames).toContain("deleted_at_iso");
+        expect(colNames).toContain("reply_to_msg_id");
+    });
+
+    it("migrates existing V1 database to V2", () => {
+        const db = new Database(dbPath);
+        db.run("PRAGMA journal_mode = WAL");
+        db.run(`CREATE TABLE IF NOT EXISTS messages (
+			id INTEGER NOT NULL,
+			chat_id TEXT NOT NULL,
+			sender_id TEXT,
+			text TEXT,
+			media_desc TEXT,
+			is_outgoing INTEGER NOT NULL,
+			date_unix INTEGER NOT NULL,
+			date_iso TEXT NOT NULL,
+			PRIMARY KEY (chat_id, id)
+		)`);
+        db.run(`CREATE TABLE IF NOT EXISTS sync_state (
+			chat_id TEXT PRIMARY KEY,
+			last_synced_id INTEGER NOT NULL,
+			last_synced_at TEXT NOT NULL
+		)`);
+        db.close();
+
+        store.open(dbPath);
+        const storeDb = (store as unknown as { db: Database }).db;
+
+        const version = storeDb.query("PRAGMA user_version").get() as { user_version: number };
+        expect(version.user_version).toBe(2);
+
+        const cols = storeDb.query("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
+        const colNames = cols.map((c) => c.name);
+        expect(colNames).toContain("is_deleted");
+    });
+
+    it("idempotent: opening V2 database doesn't re-migrate", () => {
+        store.open(dbPath);
+        store.close();
+
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+
+        const db = (store as unknown as { db: Database }).db;
+        const version = db.query("PRAGMA user_version").get() as { user_version: number };
+        expect(version.user_version).toBe(2);
+    });
+});

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.migration.test.ts
@@ -80,6 +80,7 @@ describe("TelegramHistoryStore migrations", () => {
 			last_synced_id INTEGER NOT NULL,
 			last_synced_at TEXT NOT NULL
 		)`);
+        db.run("PRAGMA user_version = 1");
         db.close();
 
         store.open(dbPath);

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.query.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-query-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore.queryMessages", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+
+        store.insertMessages("chat1", [
+            {
+                id: 1,
+                senderId: "user1",
+                text: "hello from them",
+                mediaDescription: undefined,
+                isOutgoing: false,
+                date: "2024-01-10T10:00:00Z",
+                dateUnix: 1704880800,
+            },
+            {
+                id: 2,
+                senderId: "me",
+                text: "hello back",
+                mediaDescription: undefined,
+                isOutgoing: true,
+                date: "2024-01-10T10:01:00Z",
+                dateUnix: 1704880860,
+            },
+            {
+                id: 3,
+                senderId: "user1",
+                text: "how are you?",
+                mediaDescription: undefined,
+                isOutgoing: false,
+                date: "2024-01-11T10:00:00Z",
+                dateUnix: 1704967200,
+            },
+            {
+                id: 4,
+                senderId: "me",
+                text: "I am good thanks",
+                mediaDescription: undefined,
+                isOutgoing: true,
+                date: "2024-01-12T10:00:00Z",
+                dateUnix: 1705053600,
+            },
+            {
+                id: 5,
+                senderId: "user1",
+                text: "great to hear!",
+                mediaDescription: undefined,
+                isOutgoing: false,
+                date: "2024-01-13T10:00:00Z",
+                dateUnix: 1705140000,
+            },
+        ]);
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("returns all messages for a chat", () => {
+        const results = store.queryMessages("chat1", {});
+        expect(results.length).toBe(5);
+    });
+
+    it("filters by sender=outgoing", () => {
+        const results = store.queryMessages("chat1", { sender: "me" });
+        expect(results.length).toBe(2);
+        expect(results.every((r) => r.is_outgoing === 1)).toBe(true);
+    });
+
+    it("filters by sender=incoming", () => {
+        const results = store.queryMessages("chat1", { sender: "them" });
+        expect(results.length).toBe(3);
+        expect(results.every((r) => r.is_outgoing === 0)).toBe(true);
+    });
+
+    it("filters by date range", () => {
+        const results = store.queryMessages("chat1", {
+            since: new Date("2024-01-11T00:00:00Z"),
+            until: new Date("2024-01-12T23:59:59Z"),
+        });
+        expect(results.length).toBe(2);
+    });
+
+    it("filters by text regex", () => {
+        const results = store.queryMessages("chat1", { textPattern: "hello" });
+        expect(results.length).toBe(2);
+    });
+
+    it("combines filters", () => {
+        const results = store.queryMessages("chat1", {
+            sender: "me",
+            since: new Date("2024-01-10T00:00:00Z"),
+            until: new Date("2024-01-11T00:00:00Z"),
+        });
+        expect(results.length).toBe(1);
+    });
+
+    it("respects limit", () => {
+        const results = store.queryMessages("chat1", { limit: 2 });
+        expect(results.length).toBe(2);
+    });
+
+    it("excludes deleted messages by default", () => {
+        store.markMessageDeleted("chat1", 3);
+        const results = store.queryMessages("chat1", {});
+        expect(results.length).toBe(4);
+    });
+
+    it("includes deleted messages when requested", () => {
+        store.markMessageDeleted("chat1", 3);
+        const results = store.queryMessages("chat1", { includeDeleted: true });
+        expect(results.length).toBe(5);
+    });
+});

--- a/src/telegram/lib/__tests__/TelegramHistoryStore.revisions.test.ts
+++ b/src/telegram/lib/__tests__/TelegramHistoryStore.revisions.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramHistoryStore } from "../TelegramHistoryStore";
+
+function tmpDbPath() {
+    return join(tmpdir(), `telegram-rev-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+describe("TelegramHistoryStore.upsertMessageWithRevision", () => {
+    let store: TelegramHistoryStore;
+    let dbPath: string;
+
+    beforeEach(() => {
+        dbPath = tmpDbPath();
+        store = new TelegramHistoryStore();
+        store.open(dbPath);
+    });
+
+    afterEach(() => {
+        store.close();
+
+        if (existsSync(dbPath)) {
+            unlinkSync(dbPath);
+        }
+    });
+
+    it("inserts new message and records create revision", () => {
+        store.upsertMessageWithRevision("chat1", {
+            id: 100,
+            senderId: "user1",
+            text: "new msg",
+            mediaDescription: undefined,
+            isOutgoing: false,
+            date: "2024-02-01T10:00:00Z",
+            dateUnix: 1706781600,
+        });
+
+        const msgs = store.queryMessages("chat1", {});
+        const msg = msgs.find((m) => m.id === 100);
+        expect(msg).toBeTruthy();
+        expect(msg!.text).toBe("new msg");
+
+        const revisions = store.getRevisions("chat1", 100);
+        expect(revisions.length).toBe(1);
+        expect(revisions[0].revision_type).toBe("create");
+    });
+
+    it("updates existing message text and records edit revision", () => {
+        store.upsertMessageWithRevision("chat1", {
+            id: 101,
+            senderId: "user1",
+            text: "original",
+            mediaDescription: undefined,
+            isOutgoing: false,
+            date: "2024-02-01T10:00:00Z",
+            dateUnix: 1706781600,
+        });
+
+        store.upsertMessageWithRevision("chat1", {
+            id: 101,
+            senderId: "user1",
+            text: "edited!",
+            mediaDescription: undefined,
+            isOutgoing: false,
+            date: "2024-02-01T10:00:00Z",
+            dateUnix: 1706781600,
+            editedDateUnix: 1706781700,
+        });
+
+        const msgs = store.queryMessages("chat1", {});
+        const msg = msgs.find((m) => m.id === 101);
+        expect(msg!.text).toBe("edited!");
+        expect(msg!.edited_date_unix).toBe(1706781700);
+
+        const revisions = store.getRevisions("chat1", 101);
+        expect(revisions.length).toBe(2);
+        expect(revisions[1].revision_type).toBe("edit");
+        expect(revisions[1].old_text).toBe("original");
+        expect(revisions[1].new_text).toBe("edited!");
+    });
+});

--- a/src/telegram/lib/__tests__/configMigration.test.ts
+++ b/src/telegram/lib/__tests__/configMigration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { migrateContactV1toV2, migrateConfigV1toV2 } from "../TelegramToolConfig";
+import { migrateConfigV1toV2, migrateContactV1toV2 } from "../TelegramToolConfig";
 import type { ContactConfig, TelegramConfigData, TelegramConfigDataV2 } from "../types";
 
 describe("V1 -> V2 config migration", () => {
@@ -53,9 +53,7 @@ describe("V1 -> V2 config migration", () => {
             apiId: 12345,
             apiHash: "abc",
             session: "session",
-            contacts: [
-                { userId: "1", displayName: "A", actions: ["ask"], replyDelayMin: 2000, replyDelayMax: 5000 },
-            ],
+            contacts: [{ userId: "1", displayName: "A", actions: ["ask"], replyDelayMin: 2000, replyDelayMax: 5000 }],
             configuredAt: "2024-01-01",
         };
 
@@ -78,7 +76,13 @@ describe("V1 -> V2 config migration", () => {
                 modes: {
                     autoReply: { enabled: false },
                     assistant: { enabled: true },
-                    suggestions: { enabled: true, count: 3, trigger: "manual", autoDelayMs: 5000, allowAutoSend: false },
+                    suggestions: {
+                        enabled: true,
+                        count: 3,
+                        trigger: "manual",
+                        autoDelayMs: 5000,
+                        allowAutoSend: false,
+                    },
                 },
                 watch: { enabled: true, contextLength: 30, runtimeMode: "ink" },
                 styleProfile: { enabled: false, refresh: "incremental", rules: [], previewInWatch: false },

--- a/src/telegram/lib/__tests__/configMigration.test.ts
+++ b/src/telegram/lib/__tests__/configMigration.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { migrateContactV1toV2, migrateConfigV1toV2 } from "../TelegramToolConfig";
+import type { ContactConfig, TelegramConfigData, TelegramConfigDataV2 } from "../types";
+
+describe("V1 -> V2 config migration", () => {
+    it("migrates a V1 contact with ask config into V2 modes", () => {
+        const v1: ContactConfig = {
+            userId: "123",
+            displayName: "Alice",
+            username: "alice",
+            actions: ["ask", "notify"],
+            askSystemPrompt: "Be helpful",
+            askProvider: "openai",
+            askModel: "gpt-4o",
+            replyDelayMin: 2000,
+            replyDelayMax: 5000,
+        };
+
+        const v2 = migrateContactV1toV2(v1);
+
+        expect(v2.userId).toBe("123");
+        expect(v2.displayName).toBe("Alice");
+        expect(v2.chatType).toBe("user");
+        expect(v2.actions).toEqual(["ask", "notify"]);
+
+        expect(v2.modes.autoReply.enabled).toBe(true);
+        expect(v2.modes.autoReply.provider).toBe("openai");
+        expect(v2.modes.autoReply.model).toBe("gpt-4o");
+        expect(v2.modes.autoReply.systemPrompt).toBe("Be helpful");
+
+        expect(v2.modes.assistant.enabled).toBe(true);
+        expect(v2.modes.suggestions.enabled).toBe(true);
+        expect(v2.modes.suggestions.count).toBe(3);
+    });
+
+    it("migrates a V1 contact without ask config", () => {
+        const v1: ContactConfig = {
+            userId: "456",
+            displayName: "Bob",
+            actions: ["notify"],
+            replyDelayMin: 2000,
+            replyDelayMax: 5000,
+        };
+
+        const v2 = migrateContactV1toV2(v1);
+
+        expect(v2.modes.autoReply.enabled).toBe(false);
+        expect(v2.modes.autoReply.provider).toBeUndefined();
+    });
+
+    it("migrates full V1 config to V2", () => {
+        const v1: TelegramConfigData = {
+            apiId: 12345,
+            apiHash: "abc",
+            session: "session",
+            contacts: [
+                { userId: "1", displayName: "A", actions: ["ask"], replyDelayMin: 2000, replyDelayMax: 5000 },
+            ],
+            configuredAt: "2024-01-01",
+        };
+
+        const v2 = migrateConfigV1toV2(v1);
+
+        expect(v2.version).toBe(2);
+        expect(v2.contacts.length).toBe(1);
+        expect(v2.contacts[0].modes).toBeDefined();
+        expect(v2.globalDefaults).toBeDefined();
+    });
+
+    it("passes through V2 config unchanged", () => {
+        const v2Config: TelegramConfigDataV2 = {
+            version: 2,
+            apiId: 12345,
+            apiHash: "abc",
+            session: "session",
+            contacts: [],
+            globalDefaults: {
+                modes: {
+                    autoReply: { enabled: false },
+                    assistant: { enabled: true },
+                    suggestions: { enabled: true, count: 3, trigger: "manual", autoDelayMs: 5000, allowAutoSend: false },
+                },
+                watch: { enabled: true, contextLength: 30, runtimeMode: "ink" },
+                styleProfile: { enabled: false, refresh: "incremental", rules: [], previewInWatch: false },
+            },
+            configuredAt: "2024-01-01",
+        };
+
+        const result = migrateConfigV1toV2(v2Config);
+        expect(result.version).toBe(2);
+    });
+});

--- a/src/telegram/lib/__tests__/configV2.test.ts
+++ b/src/telegram/lib/__tests__/configV2.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import type { TelegramContactV2 } from "../types";
+import { DEFAULT_MODE_CONFIG, DEFAULT_STYLE_PROFILE, DEFAULT_WATCH_CONFIG } from "../types";
+
+describe("V2 Config types", () => {
+    it("default mode config has correct shape", () => {
+        expect(DEFAULT_MODE_CONFIG.autoReply.enabled).toBe(false);
+        expect(DEFAULT_MODE_CONFIG.assistant.enabled).toBe(true);
+        expect(DEFAULT_MODE_CONFIG.suggestions.enabled).toBe(true);
+        expect(DEFAULT_MODE_CONFIG.suggestions.count).toBe(3);
+        expect(DEFAULT_MODE_CONFIG.suggestions.trigger).toBe("manual");
+    });
+
+    it("default watch config has correct shape", () => {
+        expect(DEFAULT_WATCH_CONFIG.enabled).toBe(true);
+        expect(DEFAULT_WATCH_CONFIG.contextLength).toBe(30);
+        expect(DEFAULT_WATCH_CONFIG.runtimeMode).toBe("ink");
+    });
+
+    it("default style profile is disabled", () => {
+        expect(DEFAULT_STYLE_PROFILE.enabled).toBe(false);
+        expect(DEFAULT_STYLE_PROFILE.rules).toEqual([]);
+    });
+
+    it("TelegramContactV2 can be constructed", () => {
+        const contact: TelegramContactV2 = {
+            userId: "123",
+            displayName: "Alice",
+            username: "alice",
+            chatType: "user",
+            actions: ["ask", "notify"],
+            watch: DEFAULT_WATCH_CONFIG,
+            modes: DEFAULT_MODE_CONFIG,
+            styleProfile: DEFAULT_STYLE_PROFILE,
+            replyDelayMin: 2000,
+            replyDelayMax: 5000,
+        };
+        expect(contact.displayName).toBe("Alice");
+        expect(contact.modes.suggestions.count).toBe(3);
+    });
+});

--- a/src/telegram/lib/__tests__/types.test.ts
+++ b/src/telegram/lib/__tests__/types.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import type { AttachmentRow, ChatRow, MessageRevisionRow, MessageRowV2, SyncSegmentRow } from "../types";
+
+describe("V2 type definitions", () => {
+    it("MessageRowV2 extends MessageRow with new fields", () => {
+        const msg: MessageRowV2 = {
+            id: 1,
+            chat_id: "123",
+            sender_id: "456",
+            text: "hello",
+            media_desc: null,
+            is_outgoing: 0,
+            date_unix: 1700000000,
+            date_iso: "2023-11-14T00:00:00Z",
+            edited_date_unix: null,
+            is_deleted: 0,
+            deleted_at_iso: null,
+            reply_to_msg_id: null,
+        };
+        expect(msg.is_deleted).toBe(0);
+    });
+
+    it("ChatRow has required fields", () => {
+        const chat: ChatRow = {
+            chat_id: "123",
+            chat_type: "user",
+            title: "John Doe",
+            username: "johndoe",
+            last_synced_at: "2023-11-14T00:00:00Z",
+        };
+        expect(chat.chat_type).toBe("user");
+    });
+
+    it("AttachmentRow has required fields", () => {
+        const att: AttachmentRow = {
+            chat_id: "123",
+            message_id: 1,
+            attachment_index: 0,
+            kind: "photo",
+            mime_type: "image/jpeg",
+            file_name: null,
+            file_size: 1024,
+            telegram_file_id: "abc123",
+            is_downloaded: 0,
+            local_path: null,
+            sha256: null,
+        };
+        expect(att.is_downloaded).toBe(0);
+    });
+
+    it("MessageRevisionRow tracks edits", () => {
+        const rev: MessageRevisionRow = {
+            id: 1,
+            chat_id: "123",
+            message_id: 1,
+            revision_type: "edit",
+            old_text: "hello",
+            new_text: "hello!",
+            revised_at_unix: 1700000100,
+            revised_at_iso: "2023-11-14T00:01:40Z",
+        };
+        expect(rev.revision_type).toBe("edit");
+    });
+
+    it("SyncSegmentRow tracks coverage", () => {
+        const seg: SyncSegmentRow = {
+            id: 1,
+            chat_id: "123",
+            from_date_unix: 1700000000,
+            to_date_unix: 1700086400,
+            from_msg_id: 1,
+            to_msg_id: 100,
+            synced_at: "2023-11-14T00:00:00Z",
+        };
+        expect(seg.from_msg_id).toBe(1);
+    });
+});

--- a/src/telegram/lib/actions/ask.ts
+++ b/src/telegram/lib/actions/ask.ts
@@ -59,12 +59,13 @@ export const handleAsk: ActionHandler = async (message, contact, client, convers
 
         await Bun.sleep(contact.randomDelay);
 
-        await client.sendMessage(contact.userId, response.content);
+        const sentMessage = await client.sendMessage(contact.userId, response.content);
 
         return {
             action: "ask",
             success: true,
             reply: response.content,
+            replyMessageId: sentMessage.id,
             duration: performance.now() - start,
         };
     } catch (err) {

--- a/src/telegram/lib/download.ts
+++ b/src/telegram/lib/download.ts
@@ -4,9 +4,8 @@ import { detectLanguage, embedText } from "@app/utils/macos/nlp";
 import type { EmbedResult } from "@app/utils/macos/types";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { ConversationSyncService, type SyncResult } from "./ConversationSyncService";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
-import type { SerializedMessage } from "./TelegramMessage";
-import { TelegramMessage } from "./TelegramMessage";
 import type { TGClient } from "./TGClient";
 import type { ContactConfig } from "./types";
 import { EMBEDDING_LANGUAGES } from "./types";
@@ -40,99 +39,42 @@ export async function downloadContact(
         spinner.stop(`Found ${formatNumber(totalEstimate)} total messages`);
     }
 
-    const iterOptions: {
-        limit?: number;
-        offsetDate?: number;
-        minId?: number;
-    } = {};
-
-    if (options.limit) {
-        iterOptions.limit = options.limit;
-    }
-
-    if (options.until) {
-        iterOptions.offsetDate = Math.floor(options.until.getTime() / 1000);
-    }
-
-    if (isIncremental && lastSyncedId !== null) {
-        iterOptions.minId = lastSyncedId;
-    }
-
     const progressSpinner = p.spinner();
-    progressSpinner.start("Downloading messages...");
+    progressSpinner.start("Syncing messages...");
 
-    const batch: SerializedMessage[] = [];
-    let downloaded = 0;
-    let inserted = 0;
-    let highestId = lastSyncedId ?? 0;
-    let retryCount = 0;
-    const BATCH_SIZE = 100;
-    const MAX_RETRIES = 5;
+    const syncService = new ConversationSyncService(client, store);
 
     try {
-        for await (const apiMessage of client.getMessages(contact.userId, iterOptions)) {
-            const msg = new TelegramMessage(apiMessage);
+        let result: SyncResult;
 
-            if (options.since && msg.date < options.since) {
-                continue;
-            }
-
-            if (options.until && msg.date > options.until) {
-                continue;
-            }
-
-            batch.push(msg.toJSON());
-            downloaded++;
-
-            if (msg.id > highestId) {
-                highestId = msg.id;
-            }
-
-            if (batch.length >= BATCH_SIZE) {
-                const batchInserted = store.insertMessages(contact.userId, batch);
-                inserted += batchInserted;
-                batch.length = 0;
-                retryCount = 0;
-
-                progressSpinner.message(
-                    `Downloaded ${formatNumber(downloaded)} messages (${formatNumber(inserted)} new)`
-                );
-            }
-        }
-    } catch (err) {
-        const errorStr = String(err);
-
-        if (errorStr.includes("FLOOD_WAIT") || errorStr.includes("FloodWait")) {
-            const waitMatch = errorStr.match(/(\d+)/);
-            const waitSeconds = waitMatch ? parseInt(waitMatch[1], 10) : 30;
-            retryCount++;
-
-            if (retryCount <= MAX_RETRIES) {
-                const backoff = waitSeconds * 2 ** (retryCount - 1);
-                progressSpinner.message(`Rate limited — waiting ${backoff}s (retry ${retryCount}/${MAX_RETRIES})`);
-                await Bun.sleep(backoff * 1000);
-            } else {
-                progressSpinner.stop(`Rate limited after ${MAX_RETRIES} retries`);
-                p.log.warn("Stopped due to persistent rate limiting. Run again later to resume.");
-            }
+        if (options.since || options.until) {
+            const since = options.since ?? new Date(0);
+            const until = options.until ?? new Date();
+            result = await syncService.syncRange(contact.userId, since, until, {
+                limit: options.limit,
+                onProgress: (synced) => {
+                    progressSpinner.message(`Synced ${formatNumber(synced)} messages`);
+                },
+            });
         } else {
-            progressSpinner.stop("Error during download");
-            p.log.error(`Download error: ${errorStr}`);
+            result = await syncService.syncLatest(contact.userId, {
+                limit: options.limit,
+                onProgress: (synced) => {
+                    progressSpinner.message(`Synced ${formatNumber(synced)} messages`);
+                },
+            });
         }
-    }
 
-    if (batch.length > 0) {
-        const batchInserted = store.insertMessages(contact.userId, batch);
-        inserted += batchInserted;
+        progressSpinner.stop(
+            `${pc.green(formatNumber(result.synced))} new messages stored` +
+                (result.attachmentsIndexed > 0
+                    ? `, ${formatNumber(result.attachmentsIndexed)} attachments indexed`
+                    : "")
+        );
+    } catch (err) {
+        progressSpinner.stop("Error during sync");
+        p.log.error(`Sync error: ${String(err)}`);
     }
-
-    if (highestId > 0) {
-        store.setLastSyncedId(contact.userId, highestId);
-    }
-
-    progressSpinner.stop(
-        `${pc.green(formatNumber(downloaded))} downloaded, ${pc.green(formatNumber(inserted))} new messages stored`
-    );
 }
 
 export async function embedMessages(

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -8,7 +8,7 @@ import { TelegramContact } from "./TelegramContact";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
 import { TelegramMessage } from "./TelegramMessage";
 import type { TGClient } from "./TGClient";
-import type { ContactConfig } from "./types";
+import type { TelegramContactV2 } from "./types";
 import { DEFAULTS } from "./types";
 
 const processedIds = new Set<number>();
@@ -64,7 +64,7 @@ class ConversationContext {
 }
 
 export interface HandlerOptions {
-    contacts: ContactConfig[];
+    contacts: TelegramContactV2[];
     myName: string;
     initialHistory?: Map<string, string[]>;
     store: TelegramHistoryStore;

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -1,6 +1,8 @@
 import logger from "@app/logger";
 import pc from "picocolors";
 import type { NewMessageEvent } from "telegram/events";
+import type { DeletedMessageEvent } from "telegram/events/DeletedMessage";
+import type { EditedMessageEvent } from "telegram/events/EditedMessage";
 import { executeActions } from "./actions";
 import { TelegramContact } from "./TelegramContact";
 import type { TelegramHistoryStore } from "./TelegramHistoryStore";
@@ -132,15 +134,13 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
                     const extra = r.reply ? ` "${r.reply.slice(0, 60)}${r.reply.length > 60 ? "..." : ""}"` : "";
                     logger.info(`  ${pc.green(`[${r.action}]`)} OK${pc.dim(extra)}`);
 
-                    // Append our reply to the conversation context
                     if (r.action === "ask" && r.reply && ctx) {
                         ctx.append(options.myName, r.reply);
 
-                        // Persist outgoing reply to history store
                         try {
                             options.store.insertMessages(senderId, [
                                 {
-                                    id: Date.now(),
+                                    id: r.replyMessageId ?? Date.now(),
                                     senderId: undefined,
                                     text: r.reply,
                                     mediaDescription: undefined,
@@ -159,6 +159,63 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
             }
         } catch (err) {
             logger.error(`Handler error: ${err}`);
+        }
+    });
+
+    client.onEditedMessage(async (event: EditedMessageEvent) => {
+        try {
+            const message = event.message;
+
+            if (!message) {
+                return;
+            }
+
+            const msg = new TelegramMessage(message);
+            const chatId =
+                msg.senderId ??
+                String(
+                    message.peerId &&
+                        ("userId" in message.peerId
+                            ? message.peerId.userId
+                            : "chatId" in message.peerId
+                              ? message.peerId.chatId
+                              : "channelId" in message.peerId
+                                ? message.peerId.channelId
+                                : null)
+                );
+
+            if (!chatId) {
+                return;
+            }
+
+            options.store.upsertMessageWithRevision(chatId, {
+                id: msg.id,
+                senderId: msg.senderId,
+                text: msg.text,
+                mediaDescription: msg.mediaDescription,
+                isOutgoing: msg.isOutgoing,
+                date: msg.date.toISOString(),
+                dateUnix: Math.floor(msg.date.getTime() / 1000),
+                editedDateUnix: message.editDate ?? Math.floor(Date.now() / 1000),
+            });
+        } catch (err) {
+            logger.error({ err }, "Error handling edited message");
+        }
+    });
+
+    client.onDeletedMessage(async (event: DeletedMessageEvent) => {
+        try {
+            const deletedIds: number[] = event.deletedIds ?? [];
+
+            for (const msgId of deletedIds) {
+                const row = options.store.findMessageById(msgId);
+
+                if (row) {
+                    options.store.markMessageDeleted(row.chat_id, msgId);
+                }
+            }
+        } catch (err) {
+            logger.error({ err }, "Error handling deleted message");
         }
     });
 

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -70,6 +70,32 @@ export interface HandlerOptions {
     store: TelegramHistoryStore;
 }
 
+function extractPeerId(
+    peer?: {
+        userId?: unknown;
+        chatId?: unknown;
+        channelId?: unknown;
+    } | null
+): string | null {
+    if (!peer) {
+        return null;
+    }
+
+    if ("userId" in peer && peer.userId !== undefined && peer.userId !== null) {
+        return String(peer.userId);
+    }
+
+    if ("chatId" in peer && peer.chatId !== undefined && peer.chatId !== null) {
+        return String(peer.chatId);
+    }
+
+    if ("channelId" in peer && peer.channelId !== undefined && peer.channelId !== null) {
+        return String(peer.channelId);
+    }
+
+    return null;
+}
+
 export function registerHandler(client: TGClient, options: HandlerOptions): void {
     const contactMap = new Map<string, TelegramContact>();
     const contexts = new Map<string, ConversationContext>();
@@ -171,18 +197,7 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
             }
 
             const msg = new TelegramMessage(message);
-            const chatId =
-                msg.senderId ??
-                String(
-                    message.peerId &&
-                        ("userId" in message.peerId
-                            ? message.peerId.userId
-                            : "chatId" in message.peerId
-                              ? message.peerId.chatId
-                              : "channelId" in message.peerId
-                                ? message.peerId.channelId
-                                : null)
-                );
+            const chatId = extractPeerId(message.peerId);
 
             if (!chatId) {
                 return;
@@ -206,9 +221,10 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
     client.onDeletedMessage(async (event: DeletedMessageEvent) => {
         try {
             const deletedIds: number[] = event.deletedIds ?? [];
+            const peerChatId = extractPeerId((event.peer as { userId?: unknown; chatId?: unknown; channelId?: unknown } | null) ?? null);
 
             for (const msgId of deletedIds) {
-                const row = options.store.findMessageById(msgId);
+                const row = options.store.findMessageById(msgId, peerChatId ?? undefined);
 
                 if (row) {
                     options.store.markMessageDeleted(row.chat_id, msgId);

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -13,6 +13,7 @@ import { DEFAULTS } from "./types";
 
 const processedIds = new Set<number>();
 const processedOrder: number[] = [];
+let localReplyFallbackId = -1;
 
 function trackMessage(id: number): boolean {
     if (processedIds.has(id)) {
@@ -166,7 +167,7 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
                         try {
                             options.store.insertMessages(senderId, [
                                 {
-                                    id: r.replyMessageId ?? Date.now(),
+                                    id: r.replyMessageId ?? localReplyFallbackId--,
                                     senderId: undefined,
                                     text: r.reply,
                                     mediaDescription: undefined,
@@ -221,7 +222,9 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
     client.onDeletedMessage(async (event: DeletedMessageEvent) => {
         try {
             const deletedIds: number[] = event.deletedIds ?? [];
-            const peerChatId = extractPeerId((event.peer as { userId?: unknown; chatId?: unknown; channelId?: unknown } | null) ?? null);
+            const peerChatId = extractPeerId(
+                (event.peer as { userId?: unknown; chatId?: unknown; channelId?: unknown } | null) ?? null
+            );
 
             for (const msgId of deletedIds) {
                 const row = options.store.findMessageById(msgId, peerChatId ?? undefined);

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -214,3 +214,122 @@ export interface SuggestionEditRow {
     sent_text: string;
     created_at: string;
 }
+
+// ── V2 Config Types ──────────────────────────────────────────────────
+
+export type TelegramRuntimeMode = "daemon" | "light" | "ink";
+
+export interface AskModeConfig {
+    enabled: boolean;
+    provider?: string;
+    model?: string;
+    systemPrompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+}
+
+export interface SuggestionModeConfig extends AskModeConfig {
+    count: number;
+    trigger: "manual" | "auto" | "hybrid";
+    autoDelayMs: number;
+    allowAutoSend: boolean;
+}
+
+export interface StyleSourceRule {
+    id: string;
+    sourceChatId: string;
+    direction: "outgoing" | "incoming";
+    limit?: number;
+    since?: string;
+    until?: string;
+    regex?: string;
+}
+
+export interface StyleProfileConfig {
+    enabled: boolean;
+    refresh: "incremental";
+    rules: StyleSourceRule[];
+    previewInWatch: boolean;
+}
+
+export interface WatchConfig {
+    enabled: boolean;
+    contextLength: number;
+    runtimeMode: TelegramRuntimeMode;
+}
+
+export interface ContactModesConfig {
+    autoReply: AskModeConfig;
+    assistant: AskModeConfig;
+    suggestions: SuggestionModeConfig;
+}
+
+export interface TelegramContactV2 {
+    userId: string;
+    displayName: string;
+    username?: string;
+    chatType: ChatType;
+    actions: ActionType[];
+    watch: WatchConfig;
+    modes: ContactModesConfig;
+    styleProfile: StyleProfileConfig;
+    replyDelayMin: number;
+    replyDelayMax: number;
+}
+
+export interface TelegramConfigDataV2 {
+    version: 2;
+    apiId: number;
+    apiHash: string;
+    session: string;
+    me?: {
+        firstName: string;
+        username?: string;
+        phone?: string;
+    };
+    contacts: TelegramContactV2[];
+    globalDefaults: {
+        modes: ContactModesConfig;
+        watch: WatchConfig;
+        styleProfile: StyleProfileConfig;
+    };
+    configuredAt: string;
+}
+
+export const DEFAULT_MODE_CONFIG: ContactModesConfig = {
+    autoReply: {
+        enabled: false,
+        provider: undefined,
+        model: undefined,
+        systemPrompt: undefined,
+    },
+    assistant: {
+        enabled: true,
+        provider: undefined,
+        model: undefined,
+        systemPrompt: undefined,
+    },
+    suggestions: {
+        enabled: true,
+        provider: undefined,
+        model: undefined,
+        systemPrompt: undefined,
+        count: 3,
+        trigger: "manual",
+        autoDelayMs: 5000,
+        allowAutoSend: false,
+    },
+};
+
+export const DEFAULT_WATCH_CONFIG: WatchConfig = {
+    enabled: true,
+    contextLength: 30,
+    runtimeMode: "ink",
+};
+
+export const DEFAULT_STYLE_PROFILE: StyleProfileConfig = {
+    enabled: false,
+    refresh: "incremental",
+    rules: [],
+    previewInWatch: false,
+};

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -25,6 +25,7 @@ export interface ActionResult {
     action: ActionType;
     success: boolean;
     reply?: string;
+    replyMessageId?: number;
     duration: number;
     error?: unknown;
 }

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -25,6 +25,7 @@ export interface ActionResult {
     action: ActionType;
     success: boolean;
     reply?: string;
+    /** Telegram ID of the sent outgoing message produced by the action. */
     replyMessageId?: number;
     duration: number;
     error?: unknown;

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -98,3 +98,118 @@ export interface ChatStats {
 
 /** Languages supported by macOS NLEmbedding */
 export const EMBEDDING_LANGUAGES = new Set(["en", "es", "fr", "de", "it", "pt", "zh"]);
+
+// ── V2 Schema Types ─────────────────────────────────────────────────
+
+export interface MessageRowV2 extends MessageRow {
+    edited_date_unix: number | null;
+    is_deleted: number; // 0 or 1
+    deleted_at_iso: string | null;
+    reply_to_msg_id: number | null;
+}
+
+export type ChatType = "user" | "group" | "channel";
+
+export interface ChatRow {
+    chat_id: string;
+    chat_type: ChatType;
+    title: string;
+    username: string | null;
+    last_synced_at: string | null;
+}
+
+export interface AttachmentRow {
+    chat_id: string;
+    message_id: number;
+    attachment_index: number;
+    kind: string;
+    mime_type: string | null;
+    file_name: string | null;
+    file_size: number | null;
+    telegram_file_id: string | null;
+    is_downloaded: number; // 0 or 1
+    local_path: string | null;
+    sha256: string | null;
+}
+
+export interface MessageRevisionRow {
+    id: number;
+    chat_id: string;
+    message_id: number;
+    revision_type: "create" | "edit" | "delete";
+    old_text: string | null;
+    new_text: string | null;
+    revised_at_unix: number;
+    revised_at_iso: string;
+}
+
+export interface SyncSegmentRow {
+    id: number;
+    chat_id: string;
+    from_date_unix: number;
+    to_date_unix: number;
+    from_msg_id: number;
+    to_msg_id: number;
+    synced_at: string;
+}
+
+export interface QueryOptions {
+    sender?: "me" | "them" | "any";
+    since?: Date;
+    until?: Date;
+    textPattern?: string;
+    limit?: number;
+    includeDeleted?: boolean;
+}
+
+export interface UpsertMessageInput {
+    id: number;
+    senderId: string | undefined;
+    text: string;
+    mediaDescription: string | undefined;
+    isOutgoing: boolean;
+    date: string;
+    dateUnix: number;
+    editedDateUnix?: number;
+    replyToMsgId?: number;
+}
+
+export interface UpsertAttachmentInput {
+    chat_id: string;
+    message_id: number;
+    attachment_index: number;
+    kind: string;
+    mime_type: string | null;
+    file_name: string | null;
+    file_size: number | null;
+    telegram_file_id: string | null;
+}
+
+export interface InsertSegmentInput {
+    fromDateUnix: number;
+    toDateUnix: number;
+    fromMsgId: number;
+    toMsgId: number;
+}
+
+export interface DateRange {
+    fromDateUnix: number;
+    toDateUnix: number;
+}
+
+export interface SuggestionEditInput {
+    chatId: string;
+    messageId: number | null;
+    suggestedText: string;
+    editedText: string;
+    sentText: string;
+    provider: string | null;
+    model: string | null;
+}
+
+export interface SuggestionEditRow {
+    suggested_text: string;
+    edited_text: string;
+    sent_text: string;
+    created_at: string;
+}

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -1,5 +1,5 @@
 import { Box, useApp, useInput } from "ink";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { TelegramContactV2 } from "../../lib/types";
 import type { WatchMessage, WatchSession } from "../shared/WatchSession";
 import { ContactList } from "./components/ContactList";
@@ -19,6 +19,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
     const [messages, setMessages] = useState<WatchMessage[]>(session.getMessages());
     const [view, setView] = useState<View>("chat");
     const [systemLines, setSystemLines] = useState<SystemLine[]>([]);
+    const autoSuggestTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         const unsub = session.subscribe(() => {
@@ -26,16 +27,28 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
         });
 
         session.onAutoSuggest((suggestions) => {
+            if (autoSuggestTimeoutRef.current) {
+                clearTimeout(autoSuggestTimeoutRef.current);
+            }
+
             setSystemLines(
                 suggestions.map((s, i) => ({
                     text: `  ${i + 1}. ${s}`,
                     type: "suggestion" as const,
                 }))
             );
-            setTimeout(() => setSystemLines([]), 30000);
+            autoSuggestTimeoutRef.current = setTimeout(() => setSystemLines([]), 30000);
         });
 
-        return unsub;
+        return () => {
+            unsub();
+            session.onAutoSuggest(null);
+
+            if (autoSuggestTimeoutRef.current) {
+                clearTimeout(autoSuggestTimeoutRef.current);
+                autoSuggestTimeoutRef.current = null;
+            }
+        };
     }, [session]);
 
     useInput((_input, key) => {

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -6,7 +6,7 @@ import { ContactList } from "./components/ContactList";
 import { InputBar } from "./components/InputBar";
 import { MessageList } from "./components/MessageList";
 import { StatusBar } from "./components/StatusBar";
-import { SystemOutput, type SystemLine } from "./components/SystemOutput";
+import { type SystemLine, SystemOutput } from "./components/SystemOutput";
 
 type View = "chat" | "contacts";
 
@@ -24,6 +24,17 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
         const unsub = session.subscribe(() => {
             setMessages([...session.getMessages()]);
         });
+
+        session.onAutoSuggest((suggestions) => {
+            setSystemLines(
+                suggestions.map((s, i) => ({
+                    text: `  ${i + 1}. ${s}`,
+                    type: "suggestion" as const,
+                })),
+            );
+            setTimeout(() => setSystemLines([]), 30000);
+        });
+
         return unsub;
     }, [session]);
 
@@ -74,7 +85,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
                 ]);
             }
         },
-        [session, exit, clearSystemLines],
+        [session, exit, clearSystemLines]
     );
 
     const handleContactSelect = useCallback(
@@ -82,7 +93,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
             await session.switchContact(contact);
             setView("chat");
         },
-        [session],
+        [session]
     );
 
     if (view === "contacts") {
@@ -99,11 +110,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
 
     return (
         <Box flexDirection="column" height="100%">
-            <StatusBar
-                contact={session.currentContact}
-                messageCount={messages.length}
-                inputMode={session.inputMode}
-            />
+            <StatusBar contact={session.currentContact} messageCount={messages.length} inputMode={session.inputMode} />
             <Box flexDirection="column" flexGrow={1}>
                 <MessageList messages={messages} contactName={session.currentContact.displayName} />
             </Box>

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -44,10 +44,6 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
         }
     });
 
-    const clearSystemLines = useCallback(() => {
-        setTimeout(() => setSystemLines([]), 10000);
-    }, []);
-
     const handleSubmit = useCallback(
         async (text: string) => {
             setSystemLines([]);
@@ -62,7 +58,6 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
 
                 if (result.handled && result.output) {
                     setSystemLines([{ text: result.output, type: "info" }]);
-                    clearSystemLines();
                 }
 
                 return;
@@ -70,7 +65,6 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
 
             if (session.inputMode === "careful") {
                 setSystemLines([{ text: "Careful mode: use /send <message> to send", type: "info" }]);
-                clearSystemLines();
                 return;
             }
 
@@ -85,7 +79,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
                 ]);
             }
         },
-        [session, exit, clearSystemLines]
+        [session, exit]
     );
 
     const handleContactSelect = useCallback(

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -1,0 +1,118 @@
+import { Box, useApp, useInput } from "ink";
+import { useCallback, useEffect, useState } from "react";
+import type { TelegramContactV2 } from "../../lib/types";
+import type { WatchMessage, WatchSession } from "../shared/WatchSession";
+import { ContactList } from "./components/ContactList";
+import { InputBar } from "./components/InputBar";
+import { MessageList } from "./components/MessageList";
+import { StatusBar } from "./components/StatusBar";
+import { SystemOutput, type SystemLine } from "./components/SystemOutput";
+
+type View = "chat" | "contacts";
+
+interface WatchInkAppProps {
+    session: WatchSession;
+}
+
+export function WatchInkApp({ session }: WatchInkAppProps) {
+    const { exit } = useApp();
+    const [messages, setMessages] = useState<WatchMessage[]>(session.getMessages());
+    const [view, setView] = useState<View>("chat");
+    const [systemLines, setSystemLines] = useState<SystemLine[]>([]);
+
+    useEffect(() => {
+        const unsub = session.subscribe(() => {
+            setMessages([...session.getMessages()]);
+        });
+        return unsub;
+    }, [session]);
+
+    useInput((_input, key) => {
+        if (key.tab) {
+            setView((v) => (v === "chat" ? "contacts" : "chat"));
+        }
+    });
+
+    const clearSystemLines = useCallback(() => {
+        setTimeout(() => setSystemLines([]), 10000);
+    }, []);
+
+    const handleSubmit = useCallback(
+        async (text: string) => {
+            setSystemLines([]);
+
+            if (text.startsWith("/")) {
+                const result = await session.handleSlashCommand(text);
+
+                if (result.output === "__EXIT__") {
+                    exit();
+                    return;
+                }
+
+                if (result.handled && result.output) {
+                    setSystemLines([{ text: result.output, type: "info" }]);
+                    clearSystemLines();
+                }
+
+                return;
+            }
+
+            if (session.inputMode === "careful") {
+                setSystemLines([{ text: "Careful mode: use /send <message> to send", type: "info" }]);
+                clearSystemLines();
+                return;
+            }
+
+            try {
+                await session.sendMessage(text);
+            } catch (err) {
+                setSystemLines([
+                    {
+                        text: `Failed to send: ${err instanceof Error ? err.message : String(err)}`,
+                        type: "error",
+                    },
+                ]);
+            }
+        },
+        [session, exit, clearSystemLines],
+    );
+
+    const handleContactSelect = useCallback(
+        async (contact: TelegramContactV2) => {
+            await session.switchContact(contact);
+            setView("chat");
+        },
+        [session],
+    );
+
+    if (view === "contacts") {
+        return (
+            <ContactList
+                contacts={session.getContacts()}
+                currentContactId={session.currentContact.userId}
+                unreadCounts={session.getUnreadCounts()}
+                onSelect={handleContactSelect}
+                onBack={() => setView("chat")}
+            />
+        );
+    }
+
+    return (
+        <Box flexDirection="column" height="100%">
+            <StatusBar
+                contact={session.currentContact}
+                messageCount={messages.length}
+                inputMode={session.inputMode}
+            />
+            <Box flexDirection="column" flexGrow={1}>
+                <MessageList messages={messages} contactName={session.currentContact.displayName} />
+            </Box>
+            <SystemOutput lines={systemLines} />
+            <InputBar
+                mode={session.inputMode}
+                contactName={session.currentContact.displayName}
+                onSubmit={handleSubmit}
+            />
+        </Box>
+    );
+}

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -30,7 +30,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
                 suggestions.map((s, i) => ({
                     text: `  ${i + 1}. ${s}`,
                     type: "suggestion" as const,
-                })),
+                }))
             );
             setTimeout(() => setSystemLines([]), 30000);
         });

--- a/src/telegram/runtime/ink/WatchInkApp.tsx
+++ b/src/telegram/runtime/ink/WatchInkApp.tsx
@@ -56,6 +56,11 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
                     return;
                 }
 
+                if (result.output === "__CONTACTS__") {
+                    setView("contacts");
+                    return;
+                }
+
                 if (result.handled && result.output) {
                     setSystemLines([{ text: result.output, type: "info" }]);
                 }
@@ -106,7 +111,7 @@ export function WatchInkApp({ session }: WatchInkAppProps) {
         <Box flexDirection="column" height="100%">
             <StatusBar contact={session.currentContact} messageCount={messages.length} inputMode={session.inputMode} />
             <Box flexDirection="column" flexGrow={1}>
-                <MessageList messages={messages} contactName={session.currentContact.displayName} />
+                <MessageList messages={messages} />
             </Box>
             <SystemOutput lines={systemLines} />
             <InputBar

--- a/src/telegram/runtime/ink/components/ContactList.tsx
+++ b/src/telegram/runtime/ink/components/ContactList.tsx
@@ -1,5 +1,4 @@
-import { Box, Text } from "ink";
-import { useInput } from "ink";
+import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import type { TelegramContactV2 } from "../../../lib/types";
 

--- a/src/telegram/runtime/ink/components/ContactList.tsx
+++ b/src/telegram/runtime/ink/components/ContactList.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from "ink";
+import { useInput } from "ink";
 import SelectInput from "ink-select-input";
 import type { TelegramContactV2 } from "../../../lib/types";
 
@@ -22,7 +23,13 @@ function chatTypeIcon(chatType: string): string {
     return "[user]";
 }
 
-export function ContactList({ contacts, currentContactId, unreadCounts, onSelect }: ContactListProps) {
+export function ContactList({ contacts, currentContactId, unreadCounts, onSelect, onBack }: ContactListProps) {
+    useInput((_input, key) => {
+        if (key.tab) {
+            onBack();
+        }
+    });
+
     const items = contacts.map((c) => {
         const icon = chatTypeIcon(c.chatType);
         const current = c.userId === currentContactId ? " <" : "";

--- a/src/telegram/runtime/ink/components/ContactList.tsx
+++ b/src/telegram/runtime/ink/components/ContactList.tsx
@@ -1,0 +1,55 @@
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { TelegramContactV2 } from "../../../lib/types";
+
+interface ContactListProps {
+    contacts: TelegramContactV2[];
+    currentContactId: string;
+    unreadCounts: Map<string, number>;
+    onSelect: (contact: TelegramContactV2) => void;
+    onBack: () => void;
+}
+
+function chatTypeIcon(chatType: string): string {
+    if (chatType === "group") {
+        return "[group]";
+    }
+
+    if (chatType === "channel") {
+        return "[channel]";
+    }
+
+    return "[user]";
+}
+
+export function ContactList({ contacts, currentContactId, unreadCounts, onSelect }: ContactListProps) {
+    const items = contacts.map((c) => {
+        const icon = chatTypeIcon(c.chatType);
+        const current = c.userId === currentContactId ? " <" : "";
+        const unread = unreadCounts.get(c.userId) ?? 0;
+        const badge = unread > 0 ? ` (${unread})` : "";
+        return {
+            label: `${icon} ${c.displayName}${badge}${current}`,
+            value: c.userId,
+        };
+    });
+
+    const handleSelect = (item: { value: string }) => {
+        const contact = contacts.find((c) => c.userId === item.value);
+
+        if (contact) {
+            onSelect(contact);
+        }
+    };
+
+    return (
+        <Box flexDirection="column" padding={1}>
+            <Text bold color="blue">
+                Select a contact (Tab to go back):
+            </Text>
+            <Box marginTop={1}>
+                <SelectInput items={items} onSelect={handleSelect} />
+            </Box>
+        </Box>
+    );
+}

--- a/src/telegram/runtime/ink/components/InputBar.tsx
+++ b/src/telegram/runtime/ink/components/InputBar.tsx
@@ -1,0 +1,38 @@
+import { Box, Text } from "ink";
+import TextInput from "ink-text-input";
+import { useState } from "react";
+import type { InputMode } from "../../shared/WatchSession";
+
+interface InputBarProps {
+    mode: InputMode;
+    contactName: string;
+    onSubmit: (text: string) => void;
+}
+
+export function InputBar({ mode, contactName, onSubmit }: InputBarProps) {
+    const [value, setValue] = useState("");
+
+    const handleSubmit = (text: string) => {
+        if (!text.trim()) {
+            return;
+        }
+
+        onSubmit(text.trim());
+        setValue("");
+    };
+
+    const modeIndicator = mode === "careful" ? " [CAREFUL]" : "";
+    const prompt = `${contactName}${modeIndicator} > `;
+
+    return (
+        <Box borderStyle="single" borderColor="gray" paddingLeft={1}>
+            <Text color={mode === "careful" ? "yellow" : "blue"}>{prompt}</Text>
+            <TextInput
+                value={value}
+                onChange={setValue}
+                onSubmit={handleSubmit}
+                placeholder={mode === "careful" ? "Use /send <msg> to send..." : "Type a message or /help..."}
+            />
+        </Box>
+    );
+}

--- a/src/telegram/runtime/ink/components/MessageList.tsx
+++ b/src/telegram/runtime/ink/components/MessageList.tsx
@@ -3,7 +3,6 @@ import type { WatchMessage } from "../../shared/WatchSession";
 
 interface MessageListProps {
     messages: WatchMessage[];
-    contactName: string;
 }
 
 export function MessageList({ messages }: MessageListProps) {

--- a/src/telegram/runtime/ink/components/MessageList.tsx
+++ b/src/telegram/runtime/ink/components/MessageList.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "ink";
+import type { WatchMessage } from "../../shared/WatchSession";
+
+interface MessageListProps {
+    messages: WatchMessage[];
+    contactName: string;
+}
+
+export function MessageList({ messages }: MessageListProps) {
+    if (messages.length === 0) {
+        return (
+            <Box flexDirection="column" padding={1}>
+                <Text dimColor>No messages yet. Start typing to send a message.</Text>
+            </Box>
+        );
+    }
+
+    return (
+        <Box flexDirection="column">
+            {messages.map((msg) => (
+                <MessageBubble key={msg.id} message={msg} />
+            ))}
+        </Box>
+    );
+}
+
+function MessageBubble({ message }: { message: WatchMessage }) {
+    const time = formatTime(message.date);
+    const prefix = message.isOutgoing ? ">" : "<";
+    const nameColor = message.isOutgoing ? "cyan" : "green";
+
+    return (
+        <Box>
+            <Text dimColor>{time} </Text>
+            <Text color={nameColor}>
+                {prefix} {message.senderName}:{" "}
+            </Text>
+            <Text>{message.text}</Text>
+            {message.mediaDesc && <Text dimColor> [{message.mediaDesc}]</Text>}
+        </Box>
+    );
+}
+
+function formatTime(date: Date): string {
+    return date.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+    });
+}

--- a/src/telegram/runtime/ink/components/MessageList.tsx
+++ b/src/telegram/runtime/ink/components/MessageList.tsx
@@ -41,9 +41,7 @@ function MessageBubble({ message }: { message: WatchMessage }) {
 }
 
 function formatTime(date: Date): string {
-    return date.toLocaleTimeString("en-US", {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-    });
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${hours}:${minutes}`;
 }

--- a/src/telegram/runtime/ink/components/StatusBar.tsx
+++ b/src/telegram/runtime/ink/components/StatusBar.tsx
@@ -1,0 +1,46 @@
+import { Box, Text } from "ink";
+import type { TelegramContactV2 } from "../../../lib/types";
+
+interface StatusBarProps {
+    contact: TelegramContactV2;
+    messageCount: number;
+    inputMode: string;
+    systemMessage?: string;
+}
+
+function chatTypeIcon(chatType: string): string {
+    if (chatType === "group") {
+        return "[group]";
+    }
+
+    if (chatType === "channel") {
+        return "[channel]";
+    }
+
+    return "[user]";
+}
+
+export function StatusBar({ contact, messageCount, inputMode, systemMessage }: StatusBarProps) {
+    const icon = chatTypeIcon(contact.chatType);
+
+    return (
+        <Box
+            borderStyle="single"
+            borderColor="blue"
+            justifyContent="space-between"
+            paddingLeft={1}
+            paddingRight={1}
+        >
+            <Text color="blue" bold>
+                {icon} {contact.displayName}
+                {contact.username ? ` (@${contact.username})` : ""}
+            </Text>
+            <Box gap={2}>
+                {systemMessage && <Text color="yellow">{systemMessage}</Text>}
+                <Text dimColor>{messageCount} msgs</Text>
+                <Text dimColor>mode: {inputMode}</Text>
+                <Text dimColor>Tab: contacts</Text>
+            </Box>
+        </Box>
+    );
+}

--- a/src/telegram/runtime/ink/components/StatusBar.tsx
+++ b/src/telegram/runtime/ink/components/StatusBar.tsx
@@ -24,13 +24,7 @@ export function StatusBar({ contact, messageCount, inputMode, systemMessage }: S
     const icon = chatTypeIcon(contact.chatType);
 
     return (
-        <Box
-            borderStyle="single"
-            borderColor="blue"
-            justifyContent="space-between"
-            paddingLeft={1}
-            paddingRight={1}
-        >
+        <Box borderStyle="single" borderColor="blue" justifyContent="space-between" paddingLeft={1} paddingRight={1}>
             <Text color="blue" bold>
                 {icon} {contact.displayName}
                 {contact.username ? ` (@${contact.username})` : ""}

--- a/src/telegram/runtime/ink/components/SystemOutput.tsx
+++ b/src/telegram/runtime/ink/components/SystemOutput.tsx
@@ -22,7 +22,14 @@ export function SystemOutput({ lines }: SystemOutputProps) {
     }
 
     return (
-        <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingLeft={1} marginTop={1} marginBottom={1}>
+        <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor="gray"
+            paddingLeft={1}
+            marginTop={1}
+            marginBottom={1}
+        >
             {lines.map((line, i) => (
                 <Text key={`sys-${i}-${line.type}`} color={colorMap[line.type]}>
                     {line.text}

--- a/src/telegram/runtime/ink/components/SystemOutput.tsx
+++ b/src/telegram/runtime/ink/components/SystemOutput.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from "ink";
+
+export interface SystemLine {
+    text: string;
+    type: "info" | "error" | "suggestion" | "assistant";
+}
+
+interface SystemOutputProps {
+    lines: SystemLine[];
+}
+
+const colorMap = {
+    info: "gray",
+    error: "red",
+    suggestion: "magenta",
+    assistant: "cyan",
+} as const;
+
+export function SystemOutput({ lines }: SystemOutputProps) {
+    if (lines.length === 0) {
+        return null;
+    }
+
+    return (
+        <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingLeft={1} marginTop={1} marginBottom={1}>
+            {lines.map((line, i) => (
+                <Text key={`sys-${i}-${line.type}`} color={colorMap[line.type]}>
+                    {line.text}
+                </Text>
+            ))}
+        </Box>
+    );
+}

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -35,7 +35,7 @@ export class WatchSession {
         private store: TelegramHistoryStore,
         private myName: string,
         contact: TelegramContactV2,
-        private allContacts: TelegramContactV2[],
+        private allContacts: TelegramContactV2[]
     ) {
         this._currentContact = contact;
         this.assistantEngine = new AssistantEngine(store, contact, myName);
@@ -241,7 +241,7 @@ export class WatchSession {
                 const list = atts
                     .map(
                         (a) =>
-                            `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "downloaded" : "not downloaded"}`,
+                            `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "downloaded" : "not downloaded"}`
                     )
                     .join("\n");
                 return { handled: true, output: `Attachments:\n${list}` };

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -1,0 +1,232 @@
+import type { TGClient } from "../../lib/TGClient";
+import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
+import type { TelegramMessage } from "../../lib/TelegramMessage";
+import type { TelegramContactV2 } from "../../lib/types";
+
+export interface WatchMessage {
+    id: number;
+    text: string;
+    isOutgoing: boolean;
+    senderName: string;
+    date: Date;
+    mediaDesc?: string;
+}
+
+export type InputMode = "chat" | "careful";
+
+export class WatchSession {
+    private messages: WatchMessage[] = [];
+    private listeners: Array<() => void> = [];
+    private _inputMode: InputMode = "chat";
+    private _currentContact: TelegramContactV2;
+    private unreadCounts = new Map<string, number>();
+
+    constructor(
+        private client: TGClient,
+        private store: TelegramHistoryStore,
+        private myName: string,
+        contact: TelegramContactV2,
+        private allContacts: TelegramContactV2[]
+    ) {
+        this._currentContact = contact;
+    }
+
+    get currentContact(): TelegramContactV2 {
+        return this._currentContact;
+    }
+
+    get inputMode(): InputMode {
+        return this._inputMode;
+    }
+
+    get contextLength(): number {
+        return this._currentContact.watch?.contextLength ?? 30;
+    }
+
+    async loadHistory(): Promise<void> {
+        const rows = this.store.queryMessages(this._currentContact.userId, {
+            limit: this.contextLength,
+        });
+
+        this.messages = rows.map((r) => ({
+            id: r.id,
+            text: r.text ?? "",
+            isOutgoing: r.is_outgoing === 1,
+            senderName: r.is_outgoing === 1 ? this.myName : this._currentContact.displayName,
+            date: new Date(r.date_unix * 1000),
+            mediaDesc: r.media_desc ?? undefined,
+        }));
+
+        this.notify();
+    }
+
+    subscribe(listener: () => void): () => void {
+        this.listeners.push(listener);
+        return () => {
+            this.listeners = this.listeners.filter((l) => l !== listener);
+        };
+    }
+
+    private notify() {
+        for (const l of this.listeners) {
+            l();
+        }
+    }
+
+    getMessages(): WatchMessage[] {
+        return this.messages.slice(-this.contextLength);
+    }
+
+    getContacts(): TelegramContactV2[] {
+        return this.allContacts;
+    }
+
+    addIncoming(msg: TelegramMessage): void {
+        this.messages.push({
+            id: msg.id,
+            text: msg.text,
+            isOutgoing: false,
+            senderName: this._currentContact.displayName,
+            date: msg.date,
+            mediaDesc: msg.mediaDescription,
+        });
+        this.notify();
+    }
+
+    async sendMessage(text: string): Promise<void> {
+        const sent = await this.client.sendMessage(this._currentContact.userId, text);
+        this.store.insertMessages(this._currentContact.userId, [
+            {
+                id: sent.id,
+                senderId: undefined,
+                text,
+                mediaDescription: undefined,
+                isOutgoing: true,
+                date: new Date().toISOString(),
+                dateUnix: Math.floor(Date.now() / 1000),
+            },
+        ]);
+
+        this.messages.push({
+            id: sent.id,
+            text,
+            isOutgoing: true,
+            senderName: this.myName,
+            date: new Date(),
+        });
+        this.notify();
+    }
+
+    async switchContact(contact: TelegramContactV2): Promise<void> {
+        this._currentContact = contact;
+        this.messages = [];
+        this.clearUnread(contact.userId);
+        await this.loadHistory();
+    }
+
+    toggleCarefulMode(): void {
+        this._inputMode = this._inputMode === "chat" ? "careful" : "chat";
+        this.notify();
+    }
+
+    incrementUnread(contactId: string): void {
+        const current = this.unreadCounts.get(contactId) ?? 0;
+        this.unreadCounts.set(contactId, current + 1);
+        this.notify();
+    }
+
+    getUnreadCount(contactId: string): number {
+        return this.unreadCounts.get(contactId) ?? 0;
+    }
+
+    clearUnread(contactId: string): void {
+        this.unreadCounts.delete(contactId);
+    }
+
+    getUnreadCounts(): Map<string, number> {
+        return this.unreadCounts;
+    }
+
+    async handleSlashCommand(input: string): Promise<{ handled: boolean; output?: string }> {
+        const trimmed = input.trim();
+
+        if (!trimmed.startsWith("/")) {
+            return { handled: false };
+        }
+
+        const parts = trimmed.slice(1).split(/\s+/);
+        const cmd = parts[0].toLowerCase();
+        const args = parts.slice(1).join(" ");
+
+        switch (cmd) {
+            case "careful":
+                this.toggleCarefulMode();
+                return { handled: true, output: `Input mode: ${this._inputMode}` };
+
+            case "send":
+                if (this._inputMode === "careful" && args) {
+                    await this.sendMessage(args);
+                    return { handled: true };
+                }
+                return { handled: true, output: "Usage: /send <message>" };
+
+            case "quit":
+            case "exit":
+                return { handled: true, output: "__EXIT__" };
+
+            case "ask":
+                return { handled: true, output: `[assistant] ${args}` };
+
+            case "suggest":
+                return { handled: true, output: "[suggestions loading...]" };
+
+            case "model":
+                return { handled: true, output: "[model selector]" };
+
+            case "style":
+                return { handled: true, output: "[style profile]" };
+
+            case "attachment": {
+                const msgId = Number.parseInt(args, 10);
+
+                if (Number.isNaN(msgId)) {
+                    return { handled: true, output: "Usage: /attachment <message_id>" };
+                }
+
+                const atts = this.store.getAttachments(this._currentContact.userId, msgId);
+
+                if (atts.length === 0) {
+                    return { handled: true, output: "No attachments for this message" };
+                }
+
+                const list = atts
+                    .map(
+                        (a) =>
+                            `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "downloaded" : "not downloaded"}`
+                    )
+                    .join("\n");
+                return { handled: true, output: `Attachments:\n${list}` };
+            }
+
+            case "help":
+                return {
+                    handled: true,
+                    output: [
+                        "Commands:",
+                        "  /ask <question>     Ask assistant about the conversation",
+                        "  /suggest            Generate reply suggestions",
+                        "  /send <text>        Send message (required in /careful mode)",
+                        "  /careful            Toggle careful mode (require /send)",
+                        "  /model              Switch AI model",
+                        "  /style              Derive/preview style profile",
+                        "  /attachment <id>    List/download attachments",
+                        "  /contacts           Switch to contact list",
+                        "  /quit               Exit watch mode",
+                    ].join("\n"),
+                };
+
+            default:
+                return { handled: true, output: `Unknown command: /${cmd}. Type /help for available commands.` };
+        }
+    }
+}

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -121,7 +121,7 @@ export class WatchSession {
         this.notify();
     }
 
-    onAutoSuggest(callback: (suggestions: string[]) => void): void {
+    onAutoSuggest(callback: ((suggestions: string[]) => void) | null): void {
         this._autoSuggestCallback = callback;
     }
 

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -150,6 +150,7 @@ export class WatchSession {
     }
 
     async switchContact(contact: TelegramContactV2): Promise<void> {
+        this.suggestionEngine.cancelAutoSuggest();
         this._currentContact = contact;
         this.messages = [];
         this._pendingSuggestions = null;
@@ -264,6 +265,9 @@ export class WatchSession {
                         "  /quit               Exit watch mode",
                     ].join("\n"),
                 };
+
+            case "contacts":
+                return { handled: true, output: "__CONTACTS__" };
 
             default:
                 return { handled: true, output: `Unknown command: /${cmd}. Type /help for available commands.` };
@@ -403,6 +407,9 @@ export class WatchSession {
                     [mode]: { ...this._currentContact.modes[mode], provider, model },
                 },
             };
+
+            this.assistantEngine = new AssistantEngine(this.store, this._currentContact, this.myName);
+            this.suggestionEngine = new SuggestionEngine(this.store, this._currentContact, this.myName);
 
             if (mode === "assistant") {
                 this.assistantEngine.resetSession();

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -1,6 +1,9 @@
-import type { TGClient } from "../../lib/TGClient";
+import { AssistantEngine } from "../../lib/AssistantEngine";
+import { StyleProfileEngine } from "../../lib/StyleProfileEngine";
+import { SuggestionEngine } from "../../lib/SuggestionEngine";
 import type { TelegramHistoryStore } from "../../lib/TelegramHistoryStore";
 import type { TelegramMessage } from "../../lib/TelegramMessage";
+import type { TGClient } from "../../lib/TGClient";
 import type { TelegramContactV2 } from "../../lib/types";
 
 export interface WatchMessage {
@@ -20,15 +23,24 @@ export class WatchSession {
     private _inputMode: InputMode = "chat";
     private _currentContact: TelegramContactV2;
     private unreadCounts = new Map<string, number>();
+    private _pendingSuggestions: string[] | null = null;
+    private _autoSuggestCallback: ((suggestions: string[]) => void) | null = null;
+
+    private assistantEngine: AssistantEngine;
+    private suggestionEngine: SuggestionEngine;
+    private styleEngine: StyleProfileEngine;
 
     constructor(
         private client: TGClient,
         private store: TelegramHistoryStore,
         private myName: string,
         contact: TelegramContactV2,
-        private allContacts: TelegramContactV2[]
+        private allContacts: TelegramContactV2[],
     ) {
         this._currentContact = contact;
+        this.assistantEngine = new AssistantEngine(store, contact, myName);
+        this.suggestionEngine = new SuggestionEngine(store, contact, myName);
+        this.styleEngine = new StyleProfileEngine(store);
     }
 
     get currentContact(): TelegramContactV2 {
@@ -90,7 +102,27 @@ export class WatchSession {
             date: msg.date,
             mediaDesc: msg.mediaDescription,
         });
+
+        const triggerMode = this._currentContact.modes.suggestions.trigger;
+
+        if (triggerMode === "auto" || triggerMode === "hybrid") {
+            const recentMsgs = this.messages.slice(-10).map((m) => ({
+                sender: m.senderName,
+                text: m.text,
+            }));
+
+            this.suggestionEngine.scheduleAutoSuggest(recentMsgs, (suggestions) => {
+                this._pendingSuggestions = suggestions;
+                this._autoSuggestCallback?.(suggestions);
+                this.notify();
+            });
+        }
+
         this.notify();
+    }
+
+    onAutoSuggest(callback: (suggestions: string[]) => void): void {
+        this._autoSuggestCallback = callback;
     }
 
     async sendMessage(text: string): Promise<void> {
@@ -120,7 +152,10 @@ export class WatchSession {
     async switchContact(contact: TelegramContactV2): Promise<void> {
         this._currentContact = contact;
         this.messages = [];
+        this._pendingSuggestions = null;
         this.clearUnread(contact.userId);
+        this.assistantEngine = new AssistantEngine(this.store, contact, this.myName);
+        this.suggestionEngine = new SuggestionEngine(this.store, contact, this.myName);
         await this.loadHistory();
     }
 
@@ -168,6 +203,7 @@ export class WatchSession {
                     await this.sendMessage(args);
                     return { handled: true };
                 }
+
                 return { handled: true, output: "Usage: /send <message>" };
 
             case "quit":
@@ -175,16 +211,19 @@ export class WatchSession {
                 return { handled: true, output: "__EXIT__" };
 
             case "ask":
-                return { handled: true, output: `[assistant] ${args}` };
+                return this.handleAsk(args);
 
             case "suggest":
-                return { handled: true, output: "[suggestions loading...]" };
+                return this.handleSuggest(args);
 
-            case "model":
-                return { handled: true, output: "[model selector]" };
+            case "pick":
+                return this.handlePick(args);
 
             case "style":
-                return { handled: true, output: "[style profile]" };
+                return this.handleStyle();
+
+            case "model":
+                return this.handleModel(args);
 
             case "attachment": {
                 const msgId = Number.parseInt(args, 10);
@@ -202,7 +241,7 @@ export class WatchSession {
                 const list = atts
                     .map(
                         (a) =>
-                            `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "downloaded" : "not downloaded"}`
+                            `  [${a.attachment_index}] ${a.kind} ${a.file_name ?? ""} ${a.is_downloaded ? "downloaded" : "not downloaded"}`,
                     )
                     .join("\n");
                 return { handled: true, output: `Attachments:\n${list}` };
@@ -214,7 +253,8 @@ export class WatchSession {
                     output: [
                         "Commands:",
                         "  /ask <question>     Ask assistant about the conversation",
-                        "  /suggest            Generate reply suggestions",
+                        "  /suggest [prompt]   Generate reply suggestions",
+                        "  /pick <n> [edit]    Pick/edit a suggestion and send",
                         "  /send <text>        Send message (required in /careful mode)",
                         "  /careful            Toggle careful mode (require /send)",
                         "  /model              Switch AI model",
@@ -228,5 +268,149 @@ export class WatchSession {
             default:
                 return { handled: true, output: `Unknown command: /${cmd}. Type /help for available commands.` };
         }
+    }
+
+    private async handleAsk(args: string): Promise<{ handled: boolean; output?: string }> {
+        if (!args) {
+            return { handled: true, output: "Usage: /ask <question>" };
+        }
+
+        try {
+            const answer = await this.assistantEngine.ask(args);
+            return { handled: true, output: answer };
+        } catch (err) {
+            return { handled: true, output: `Assistant error: ${err instanceof Error ? err.message : String(err)}` };
+        }
+    }
+
+    private async handleSuggest(args: string): Promise<{ handled: boolean; output?: string }> {
+        try {
+            const recentMsgs = this.messages.slice(-10).map((m) => ({
+                sender: m.senderName,
+                text: m.text,
+            }));
+            const customPrompt = args || undefined;
+            const suggestions = await this.suggestionEngine.suggest(recentMsgs, customPrompt);
+
+            this._pendingSuggestions = suggestions;
+
+            const formatted = suggestions.map((s, i) => `  ${i + 1}. ${s}`).join("\n");
+            return {
+                handled: true,
+                output: `Suggestions:\n${formatted}\n\nUse /pick <number> to select, or /pick <number> <edited text> to edit and send.`,
+            };
+        } catch (err) {
+            return { handled: true, output: `Suggestion error: ${err instanceof Error ? err.message : String(err)}` };
+        }
+    }
+
+    private async handlePick(args: string): Promise<{ handled: boolean; output?: string }> {
+        if (!this._pendingSuggestions || this._pendingSuggestions.length === 0) {
+            return { handled: true, output: "No pending suggestions. Use /suggest first." };
+        }
+
+        const pickParts = args.split(/\s+/);
+        const index = Number.parseInt(pickParts[0], 10) - 1;
+
+        if (Number.isNaN(index) || index < 0 || index >= this._pendingSuggestions.length) {
+            return { handled: true, output: `Invalid choice. Pick 1-${this._pendingSuggestions.length}` };
+        }
+
+        const original = this._pendingSuggestions[index];
+        const edited = pickParts.length > 1 ? pickParts.slice(1).join(" ") : original;
+
+        const sent = await this.client.sendMessage(this._currentContact.userId, edited);
+
+        this.store.insertMessages(this._currentContact.userId, [
+            {
+                id: sent.id,
+                senderId: undefined,
+                text: edited,
+                mediaDescription: undefined,
+                isOutgoing: true,
+                date: new Date().toISOString(),
+                dateUnix: Math.floor(Date.now() / 1000),
+            },
+        ]);
+
+        this.messages.push({
+            id: sent.id,
+            text: edited,
+            isOutgoing: true,
+            senderName: this.myName,
+            date: new Date(),
+        });
+
+        this.suggestionEngine.trackEdit(original, edited, edited, sent.id);
+
+        this._pendingSuggestions = null;
+        this.notify();
+
+        return { handled: true, output: `Sent: "${edited}"` };
+    }
+
+    private handleStyle(): { handled: boolean; output?: string } {
+        try {
+            const analysis = this.styleEngine.analyzeStyle(this._currentContact.userId, "me", 200);
+            const lines = [
+                `Style analysis (${analysis.totalMessages} messages):`,
+                ...analysis.traits.map((t) => `  - ${t}`),
+            ];
+
+            if (analysis.commonPatterns.length > 0) {
+                lines.push("Common starters:");
+                lines.push(...analysis.commonPatterns.map((p) => `  - ${p}`));
+            }
+
+            return { handled: true, output: lines.join("\n") };
+        } catch (err) {
+            return { handled: true, output: `Style error: ${err instanceof Error ? err.message : String(err)}` };
+        }
+    }
+
+    private handleModel(args: string): { handled: boolean; output?: string } {
+        if (!args) {
+            const current = this._currentContact.modes.assistant;
+            return {
+                handled: true,
+                output: [
+                    "Current models:",
+                    `  Assistant: ${current.provider ?? "default"}/${current.model ?? "default"}`,
+                    `  Suggestions: ${this._currentContact.modes.suggestions.provider ?? "default"}/${this._currentContact.modes.suggestions.model ?? "default"}`,
+                    "",
+                    "Usage: /model assistant <provider>/<model>",
+                    "       /model suggestions <provider>/<model>",
+                ].join("\n"),
+            };
+        }
+
+        const modelParts = args.split(/\s+/);
+        const mode = modelParts[0];
+        const modelSpec = modelParts[1];
+
+        if (!modelSpec || !modelSpec.includes("/")) {
+            return { handled: true, output: "Usage: /model <mode> <provider>/<model>" };
+        }
+
+        const [provider, ...modelNameParts] = modelSpec.split("/");
+        const model = modelNameParts.join("/");
+
+        if (mode === "assistant" || mode === "suggestions" || mode === "autoReply") {
+            this._currentContact = {
+                ...this._currentContact,
+                modes: {
+                    ...this._currentContact.modes,
+                    [mode]: { ...this._currentContact.modes[mode], provider, model },
+                },
+            };
+
+            if (mode === "assistant") {
+                this.assistantEngine.resetSession();
+            }
+
+            return { handled: true, output: `${mode} model set to ${provider}/${model}` };
+        }
+
+        return { handled: true, output: `Unknown mode: ${mode}. Use assistant, suggestions, or autoReply` };
     }
 }


### PR DESCRIPTION
## Summary

Complete rewrite of the Telegram assistant with V2 architecture:

- **Data Foundation**: V2 schema with natural language date parsing (chrono-node), sync range planner with gap detection, lazy attachment downloader with SHA-256 verification
- **Sync & Attachments**: ConversationSyncService with range-aware auto-fetch, edit/delete event handlers, attachment metadata extraction, query and attachment CLI subcommands
- **Config V2**: Per-contact mode/model selection, groups/channels support, V1→V2 migration with backward compatibility, ModelSelector/ProviderManager reuse from ask tool
- **Watch TUI**: Ink-based live chat interface with MessageList, InputBar, StatusBar, ContactList, SystemOutput components, slash command routing via WatchSession
- **AI Engines**: AssistantEngine with full DB tool access, StyleProfileEngine with hybrid summary+examples, SuggestionEngine with style matching and edit tracking

54 files changed, ~10K lines added across 34 commits.

## Test plan
- [ ] Run `tools telegram configure` — verify V1→V2 migration works
- [ ] Run `tools telegram query` — verify conversation search
- [ ] Run `tools telegram watch` — verify Ink TUI renders and slash commands work
- [ ] Verify AI engines respond correctly with `/assist`, `/suggest`, `/style`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a live chat interface for Telegram with real-time message viewing and sending.
  * Introduced AI-powered assistant to answer questions about chat history.
  * Implemented reply suggestions based on conversation style and history.
  * Added attachment management with lazy downloading and metadata tracking.
  * Extended history queries with natural language date parsing and filtering.
  * Introduced per-contact configuration for AI models and watch preferences.

* **Chores**
  * Migrated Telegram configuration from V1 to V2 with backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->