### PR TITLE
feat(github): add commit URL support to 'tools github get'

### DIFF
--- a/src/github/commands/get.ts
+++ b/src/github/commands/get.ts
@@ -4,6 +4,7 @@ import logger from "@app/logger";
 import { copyToClipboard } from "@app/utils/clipboard";
 import { getOctokit } from "@app/utils/github/octokit";
 import { withRetry } from "@app/utils/github/rate-limit";
+import type { GitHubCommitUrl } from "@app/github/types";
 import { buildRawGitHubUrl, parseGitHubCommitUrl, parseGitHubFileUrl } from "@app/utils/github/url-parser";
 import { setGlobalVerbose, verbose } from "@app/utils/github/utils";
 import chalk from "chalk";
@@ -16,7 +17,7 @@ interface GetOptions {
     lines?: string;
     raw?: boolean;
     verbose?: boolean;
-    format?: string;
+    format?: "md" | "json";
 }
 
 interface FileContent {
@@ -125,7 +126,6 @@ export async function getCommand(input: string, options: GetOptions): Promise<vo
     const parsed = parseGitHubFileUrl(input);
 
     if (!parsed) {
-        // Try commit URL
         const commitParsed = parseGitHubCommitUrl(input);
 
         if (commitParsed) {
@@ -242,7 +242,7 @@ function formatCommitMd(commit: GetCommitData): string {
     lines.push("");
     lines.push(`    ${commit.message.replace(/\n/g, "\n    ")}`);
     lines.push("");
-    lines.push(`${commit.stats.total} changed: +${commit.stats.additions} -${commit.stats.deletions}`);
+    lines.push(`${commit.files.length} files changed: +${commit.stats.additions} -${commit.stats.deletions}`);
     lines.push("");
 
     for (const file of commit.files) {
@@ -260,7 +260,7 @@ function formatCommitMd(commit: GetCommitData): string {
 }
 
 async function handleCommitUrl(
-    parsed: { owner: string; repo: string; sha: string },
+    parsed: GitHubCommitUrl,
     options: GetOptions
 ): Promise<void> {
     const commit = await fetchCommit(parsed.owner, parsed.repo, parsed.sha);

--- a/src/github/commands/get.ts
+++ b/src/github/commands/get.ts
@@ -1,10 +1,10 @@
 // Get file content command implementation
 
+import type { GitHubCommitUrl } from "@app/github/types";
 import logger from "@app/logger";
 import { copyToClipboard } from "@app/utils/clipboard";
 import { getOctokit } from "@app/utils/github/octokit";
 import { withRetry } from "@app/utils/github/rate-limit";
-import type { GitHubCommitUrl } from "@app/github/types";
 import { buildRawGitHubUrl, parseGitHubCommitUrl, parseGitHubFileUrl } from "@app/utils/github/url-parser";
 import { setGlobalVerbose, verbose } from "@app/utils/github/utils";
 import chalk from "chalk";
@@ -206,10 +206,9 @@ interface GetCommitData {
 async function fetchCommit(owner: string, repo: string, sha: string): Promise<GetCommitData> {
     const octokit = getOctokit();
 
-    const { data } = await withRetry(
-        () => octokit.rest.repos.getCommit({ owner, repo, ref: sha }),
-        { label: `GET /repos/${owner}/${repo}/commits/${sha}` }
-    );
+    const { data } = await withRetry(() => octokit.rest.repos.getCommit({ owner, repo, ref: sha }), {
+        label: `GET /repos/${owner}/${repo}/commits/${sha}`,
+    });
 
     return {
         sha: data.sha,
@@ -259,10 +258,7 @@ function formatCommitMd(commit: GetCommitData): string {
     return lines.join("\n");
 }
 
-async function handleCommitUrl(
-    parsed: GitHubCommitUrl,
-    options: GetOptions
-): Promise<void> {
+async function handleCommitUrl(parsed: GitHubCommitUrl, options: GetOptions): Promise<void> {
     const commit = await fetchCommit(parsed.owner, parsed.repo, parsed.sha);
 
     const content = options.format === "json" ? JSON.stringify(commit, null, 2) : formatCommitMd(commit);

--- a/src/github/commands/get.ts
+++ b/src/github/commands/get.ts
@@ -4,7 +4,7 @@ import logger from "@app/logger";
 import { copyToClipboard } from "@app/utils/clipboard";
 import { getOctokit } from "@app/utils/github/octokit";
 import { withRetry } from "@app/utils/github/rate-limit";
-import { buildRawGitHubUrl, parseGitHubFileUrl } from "@app/utils/github/url-parser";
+import { buildRawGitHubUrl, parseGitHubCommitUrl, parseGitHubFileUrl } from "@app/utils/github/url-parser";
 import { setGlobalVerbose, verbose } from "@app/utils/github/utils";
 import chalk from "chalk";
 import { Command } from "commander";
@@ -16,6 +16,7 @@ interface GetOptions {
     lines?: string;
     raw?: boolean;
     verbose?: boolean;
+    format?: string;
 }
 
 interface FileContent {
@@ -122,12 +123,22 @@ export async function getCommand(input: string, options: GetOptions): Promise<vo
 
     // Parse URL
     const parsed = parseGitHubFileUrl(input);
+
     if (!parsed) {
-        console.error(chalk.red("Invalid GitHub file URL."));
+        // Try commit URL
+        const commitParsed = parseGitHubCommitUrl(input);
+
+        if (commitParsed) {
+            await handleCommitUrl(commitParsed, options);
+            return;
+        }
+
+        console.error(chalk.red("Invalid GitHub URL."));
         console.error(chalk.dim("\nSupported formats:"));
         console.error(chalk.dim("  https://github.com/owner/repo/blob/branch/path/to/file"));
         console.error(chalk.dim("  https://github.com/owner/repo/blame/tag/path/to/file"));
         console.error(chalk.dim("  https://raw.githubusercontent.com/owner/repo/ref/path"));
+        console.error(chalk.dim("  https://github.com/owner/repo/commit/SHA"));
         console.error(chalk.dim("  Any of the above with #L10 or #L10-L20 line references"));
         process.exit(1);
     }
@@ -183,6 +194,90 @@ export async function getCommand(input: string, options: GetOptions): Promise<vo
     }
 }
 
+interface GetCommitData {
+    sha: string;
+    message: string;
+    author: { name: string; date: string };
+    files: Array<{ filename: string; status: string; additions: number; deletions: number; patch?: string }>;
+    stats: { additions: number; deletions: number; total: number };
+    url: string;
+}
+
+async function fetchCommit(owner: string, repo: string, sha: string): Promise<GetCommitData> {
+    const octokit = getOctokit();
+
+    const { data } = await withRetry(
+        () => octokit.rest.repos.getCommit({ owner, repo, ref: sha }),
+        { label: `GET /repos/${owner}/${repo}/commits/${sha}` }
+    );
+
+    return {
+        sha: data.sha,
+        message: data.commit.message,
+        author: {
+            name: data.commit.author?.name ?? "unknown",
+            date: data.commit.author?.date ?? "",
+        },
+        files: (data.files ?? []).map((f) => ({
+            filename: f.filename,
+            status: f.status ?? "modified",
+            additions: f.additions,
+            deletions: f.deletions,
+            patch: f.patch,
+        })),
+        stats: {
+            additions: data.stats?.additions ?? 0,
+            deletions: data.stats?.deletions ?? 0,
+            total: data.stats?.total ?? 0,
+        },
+        url: data.html_url,
+    };
+}
+
+function formatCommitMd(commit: GetCommitData): string {
+    const lines: string[] = [];
+    lines.push(`commit ${commit.sha}`);
+    lines.push(`Author: ${commit.author.name}`);
+    lines.push(`Date:   ${commit.author.date}`);
+    lines.push("");
+    lines.push(`    ${commit.message.replace(/\n/g, "\n    ")}`);
+    lines.push("");
+    lines.push(`${commit.stats.total} changed: +${commit.stats.additions} -${commit.stats.deletions}`);
+    lines.push("");
+
+    for (const file of commit.files) {
+        lines.push(`--- a/${file.filename}`);
+        lines.push(`+++ b/${file.filename}`);
+
+        if (file.patch) {
+            lines.push(file.patch);
+        }
+
+        lines.push("");
+    }
+
+    return lines.join("\n");
+}
+
+async function handleCommitUrl(
+    parsed: { owner: string; repo: string; sha: string },
+    options: GetOptions
+): Promise<void> {
+    const commit = await fetchCommit(parsed.owner, parsed.repo, parsed.sha);
+
+    const content = options.format === "json" ? JSON.stringify(commit, null, 2) : formatCommitMd(commit);
+
+    if (options.clipboard) {
+        await copyToClipboard(content, { silent: true });
+        console.log(chalk.green(`✔ Copied commit ${commit.sha.slice(0, 7)} to clipboard`));
+    } else if (options.output) {
+        await Bun.write(options.output, content);
+        console.log(chalk.green(`✔ Written to ${options.output}`));
+    } else {
+        console.log(content);
+    }
+}
+
 export function createGetCommand(): Command {
     const cmd = new Command("get")
         .description("Get file content from a GitHub URL")
@@ -192,6 +287,7 @@ export function createGetCommand(): Command {
         .option("-o, --output <file>", "Write to file")
         .option("-c, --clipboard", "Copy to clipboard")
         .option("--raw", "Fetch via raw.githubusercontent.com (faster, less metadata)")
+        .option("-f, --format <format>", "Output format: md (default) or json")
         .option("-v, --verbose", "Enable verbose logging")
         .addHelpText(
             "after",
@@ -217,6 +313,12 @@ Examples:
 
   # Use URL with line references
   tools github get "https://github.com/owner/repo/blob/main/file.ts#L10-L20"
+
+  # Get commit diff
+  tools github get https://github.com/owner/repo/commit/abc1234
+
+  # Get commit as JSON
+  tools github get https://github.com/owner/repo/commit/abc1234 --format json
 `
         )
         .action(async (url, opts) => {

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -52,6 +52,15 @@ export interface TimelineEventRecord {
 }
 
 /**
+ * Parsed GitHub commit URL
+ */
+export interface GitHubCommitUrl {
+    owner: string;
+    repo: string;
+    sha: string;
+}
+
+/**
  * Parsed GitHub file URL
  */
 export interface GitHubFileUrl {

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -51,9 +51,6 @@ export interface TimelineEventRecord {
     data_json: string;
 }
 
-/**
- * Parsed GitHub commit URL
- */
 export interface GitHubCommitUrl {
     owner: string;
     repo: string;

--- a/src/utils/github/url-parser.ts
+++ b/src/utils/github/url-parser.ts
@@ -1,6 +1,6 @@
 // GitHub URL parsing utilities
 
-import type { GitHubFileUrl, GitHubUrl } from "@app/github/types";
+import type { GitHubCommitUrl, GitHubFileUrl, GitHubUrl } from "@app/github/types";
 import { Executor } from "@app/utils/cli";
 
 /**
@@ -246,6 +246,24 @@ export function parseGitHubFileUrl(input: string): GitHubFileUrl | null {
     }
 
     return null;
+}
+
+/**
+ * Parse a GitHub commit URL
+ * Supports: https://github.com/owner/repo/commit/SHA
+ */
+export function parseGitHubCommitUrl(input: string): GitHubCommitUrl | null {
+    const match = input.match(/github\.com\/([^/]+)\/([^/]+)\/commit\/([a-f0-9]+)/i);
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        owner: match[1],
+        repo: match[2],
+        sha: match[3],
+    };
 }
 
 /**

--- a/src/utils/github/url-parser.ts
+++ b/src/utils/github/url-parser.ts
@@ -253,7 +253,7 @@ export function parseGitHubFileUrl(input: string): GitHubFileUrl | null {
  * Supports: https://github.com/owner/repo/commit/SHA
  */
 export function parseGitHubCommitUrl(input: string): GitHubCommitUrl | null {
-    const match = input.match(/github\.com\/([^/]+)\/([^/]+)\/commit\/([a-f0-9]+)/i);
+    const match = input.match(/github\.com\/([^/]+)\/([^/]+)\/commit\/([a-f0-9]{7,40})(?=$|[?#/])/i);
 
     if (!match) {
         return null;


### PR DESCRIPTION
## Summary
- Add `GitHubCommitUrl` type and `parseGitHubCommitUrl()` function to the URL parser
- Handle commit URLs (`github.com/owner/repo/commit/SHA`) in `tools github get`
- Add `--format` option (`md` default, `json`) for commit output
- Show full commit diff with author, message, stats, and per-file patches

## Test plan
- [ ] `tools github get https://github.com/onllm-dev/onWatch/commit/0ab1009` — outputs commit diff in md format
- [ ] `tools github get https://github.com/onllm-dev/onWatch/commit/0ab1009 --format json` — outputs JSON
- [ ] `tools github get https://github.com/onllm-dev/onWatch/commit/0ab1009 -c` — copies to clipboard
- [ ] `tsgo --noEmit` passes with no type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub commit URLs in addition to file URLs
  * Introduced `--format` option to output commit data in Markdown (default) or JSON format
  * Can now fetch and display commit diffs, metadata, and per-file changes from commit URLs
  * Extended CLI help and examples with commit-related usage scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->