### PR TITLE
feat(claude-usage): 429 bypass via token refresh + poll coordination

### DIFF
--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -17,13 +17,19 @@ function determineAccountLabel(profile: Awaited<ReturnType<typeof fetchOAuthProf
     if (!profile) {
         return undefined;
     }
+
     const tier = profile.organization.rate_limit_tier;
+
     if (tier.includes("max")) {
-        return "max";
+        // Extract multiplier: "max_5x" → "max 5x", "max_20x" → "max 20x"
+        const match = tier.match(/max[_\s]*(\d+x?)/i);
+        return match ? `max ${match[1]}` : "max";
     }
+
     if (tier.includes("pro")) {
         return "pro";
     }
+
     return profile.organization.billing_type;
 }
 

--- a/src/claude/commands/usage/app.tsx
+++ b/src/claude/commands/usage/app.tsx
@@ -43,7 +43,7 @@ function Dashboard({ config, accountFilter }: DashboardProps) {
     const { activeTab, tabs, activeIndex } = useTabNavigation(config.defaultTab);
 
     const [pollInterval, setPollInterval] = useState<PollInterval>(
-        (POLL_INTERVALS.includes(config.refreshInterval as PollInterval) ? config.refreshInterval : 10) as PollInterval
+        (POLL_INTERVALS.includes(config.refreshInterval as PollInterval) ? config.refreshInterval : 60) as PollInterval
     );
 
     const [paused, setPaused] = useState(false);

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -1,10 +1,10 @@
+import { join } from "node:path";
 import { type AccountConfig, loadConfig } from "@app/claude/lib/config";
 import { type AccountUsage, fetchAllAccountsUsage } from "@app/claude/lib/usage/api";
 import type { UsageDashboardConfig } from "@app/claude/lib/usage/dashboard-config";
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { NotificationManager } from "@app/claude/lib/usage/notification-manager";
 import { Storage } from "@app/utils/storage/storage";
-import { join } from "node:path";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PollResult } from "../types";
 

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -4,6 +4,7 @@ import type { UsageDashboardConfig } from "@app/claude/lib/usage/dashboard-confi
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { NotificationManager } from "@app/claude/lib/usage/notification-manager";
 import { Storage } from "@app/utils/storage/storage";
+import { join } from "node:path";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PollResult } from "../types";
 
@@ -106,54 +107,71 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
         setPollingLabel(names.length > 0 ? names.join(", ") : "...");
 
         try {
-            // Cache key per account filter so filtered views don't share results with full views
             const cacheKey = `poll-results-${accountFilter ?? "all"}.json`;
-            // TTL: use pollInterval minus a small buffer so cache expires just before the next poll
             const ttlSeconds = Math.max(3, pollIntervalSeconds - 2);
+
+            // Check cache first WITHOUT lock (fast path — avoids lock contention when cache is fresh)
             const cached = await storage.getCacheFile<PollCache>(cacheKey, `${ttlSeconds} seconds`);
 
             if (cached) {
-                // Fresh data already fetched by another instance — reuse it
                 processAccountUsages(cached.accounts, new Date(cached.timestamp));
                 return;
             }
 
-            // Always reload config — tokens may have been refreshed by daemon or another process
-            const cfg = await loadConfig();
-            let accounts = cfg.accounts;
+            // Cache is stale — acquire lock and poll (or wait for another process that's already polling)
+            const cacheFilePath = join(storage.getCacheDir(), cacheKey);
+            const result = await storage.withFileLock({
+                file: cacheFilePath,
+                fn: async (): Promise<PollCache | null> => {
+                    // Re-check cache inside lock — another process may have just written it
+                    const freshCached = await storage.getCacheFile<PollCache>(cacheKey, `${ttlSeconds} seconds`);
 
-            if (accountFilter) {
-                accounts = accounts[accountFilter] ? { [accountFilter]: accounts[accountFilter] } : {};
+                    if (freshCached) {
+                        return freshCached;
+                    }
+
+                    // We're the winner — fetch fresh data
+                    const cfg = await loadConfig();
+                    let accounts = cfg.accounts;
+
+                    if (accountFilter) {
+                        accounts = accounts[accountFilter] ? { [accountFilter]: accounts[accountFilter] } : {};
+                    }
+
+                    accountsRef.current = accounts;
+                    setPollingLabel(Object.keys(accountsRef.current).join(", ") || "...");
+
+                    const controller = new AbortController();
+                    const timeout = setTimeout(() => controller.abort(), 3000);
+                    let accountUsages: AccountUsage[];
+
+                    try {
+                        accountUsages = await fetchAllAccountsUsage(accountsRef.current, controller.signal);
+                    } finally {
+                        clearTimeout(timeout);
+                    }
+
+                    const now = new Date();
+                    const pollCache: PollCache = { timestamp: now.toISOString(), accounts: accountUsages };
+
+                    try {
+                        await storage.putCacheFile<PollCache>(cacheKey, pollCache, `${pollIntervalSeconds} seconds`);
+                    } catch {
+                        // Cache write is best-effort
+                    }
+
+                    return pollCache;
+                },
+                timeout: 10_000,
+                onTimeout: () => {
+                    // Lock timed out — return null, we'll try again next interval
+                    return null;
+                },
+            });
+
+            if (result) {
+                processAccountUsages(result.accounts, new Date(result.timestamp));
             }
-
-            accountsRef.current = accounts;
-
-            setPollingLabel(Object.keys(accountsRef.current).join(", ") || "...");
-
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 3000);
-            let accountUsages: AccountUsage[];
-
-            try {
-                accountUsages = await fetchAllAccountsUsage(accountsRef.current, controller.signal);
-            } finally {
-                clearTimeout(timeout);
-            }
-
-            const now = new Date();
-
-            // Persist for other instances to reuse within the same interval (best-effort)
-            try {
-                await storage.putCacheFile<PollCache>(
-                    cacheKey,
-                    { timestamp: now.toISOString(), accounts: accountUsages },
-                    `${pollIntervalSeconds} seconds`
-                );
-            } catch {
-                // Cache is an optimization; continue with fresh results
-            }
-
-            processAccountUsages(accountUsages, now);
         } catch (error) {
             setResults({
                 accounts: [],

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -142,7 +142,7 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
                     setPollingLabel(Object.keys(accountsRef.current).join(", ") || "...");
 
                     const controller = new AbortController();
-                    const timeout = setTimeout(() => controller.abort(), 3000);
+                    const timeout = setTimeout(() => controller.abort(), 10_000);
                     let accountUsages: AccountUsage[];
 
                     try {

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -15,11 +15,6 @@ interface PollerOptions {
     pollIntervalSeconds: number;
 }
 
-interface PollCache {
-    timestamp: string;
-    accounts: AccountUsage[];
-}
-
 // Shared across all instances of the tool process — storage is per-user on disk
 const storage = new Storage("claude-usage");
 
@@ -103,74 +98,79 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
         }
 
         pollingRef.current = true;
-        const names = Object.keys(accountsRef.current);
-        setPollingLabel(names.length > 0 ? names.join(", ") : "...");
+        setPollingLabel("...");
 
         try {
-            const cacheKey = `poll-results-${accountFilter ?? "all"}.json`;
             const ttlSeconds = Math.max(3, pollIntervalSeconds - 2);
 
-            // Check cache first WITHOUT lock (fast path — avoids lock contention when cache is fresh)
-            const cached = await storage.getCacheFile<PollCache>(cacheKey, `${ttlSeconds} seconds`);
+            // Resolve which accounts to poll
+            const cfg = await loadConfig();
+            let accounts = cfg.accounts;
 
-            if (cached) {
-                processAccountUsages(cached.accounts, new Date(cached.timestamp));
-                return;
+            if (accountFilter) {
+                accounts = accounts[accountFilter] ? { [accountFilter]: accounts[accountFilter] } : {};
             }
 
-            // Cache is stale — acquire lock and poll (or wait for another process that's already polling)
-            const cacheFilePath = join(storage.getCacheDir(), cacheKey);
-            const result = await storage.withFileLock({
-                file: cacheFilePath,
-                fn: async (): Promise<PollCache | null> => {
-                    // Re-check cache inside lock — another process may have just written it
-                    const freshCached = await storage.getCacheFile<PollCache>(cacheKey, `${ttlSeconds} seconds`);
+            accountsRef.current = accounts;
+            const accountNames = Object.keys(accounts);
+            setPollingLabel(accountNames.join(", ") || "...");
 
-                    if (freshCached) {
-                        return freshCached;
+            // Per-account locking: each account gets its own cache + lock
+            // This ensures "tools claude usage" and "tools claude usage --filter foo"
+            // share the same lock for account "foo" instead of racing.
+            const accountUsages: AccountUsage[] = [];
+
+            await Promise.all(
+                Object.entries(accounts).map(async ([name, account]) => {
+                    const cacheKey = `poll-account-${name}.json`;
+
+                    // Fast path: check cache without lock
+                    const cached = await storage.getCacheFile<AccountUsage>(cacheKey, `${ttlSeconds} seconds`);
+
+                    if (cached) {
+                        accountUsages.push(cached);
+                        return;
                     }
 
-                    // We're the winner — fetch fresh data
-                    const cfg = await loadConfig();
-                    let accounts = cfg.accounts;
+                    // Cache stale — acquire per-account lock
+                    const cacheFilePath = join(storage.getCacheDir(), cacheKey);
+                    const result = await storage.withFileLock({
+                        file: cacheFilePath,
+                        fn: async (): Promise<AccountUsage | null> => {
+                            const freshCached = await storage.getCacheFile<AccountUsage>(
+                                cacheKey,
+                                `${ttlSeconds} seconds`
+                            );
 
-                    if (accountFilter) {
-                        accounts = accounts[accountFilter] ? { [accountFilter]: accounts[accountFilter] } : {};
+                            if (freshCached) {
+                                return freshCached;
+                            }
+
+                            const [usage] = await fetchAllAccountsUsage(
+                                { [name]: account },
+                                new AbortController().signal
+                            );
+
+                            try {
+                                await storage.putCacheFile(cacheKey, usage, `${pollIntervalSeconds} seconds`);
+                            } catch {
+                                // Cache write is best-effort
+                            }
+
+                            return usage;
+                        },
+                        timeout: 10_000,
+                        onTimeout: () => null,
+                    });
+
+                    if (result) {
+                        accountUsages.push(result);
                     }
+                })
+            );
 
-                    accountsRef.current = accounts;
-                    setPollingLabel(Object.keys(accountsRef.current).join(", ") || "...");
-
-                    const controller = new AbortController();
-                    const timeout = setTimeout(() => controller.abort(), 10_000);
-                    let accountUsages: AccountUsage[];
-
-                    try {
-                        accountUsages = await fetchAllAccountsUsage(accountsRef.current, controller.signal);
-                    } finally {
-                        clearTimeout(timeout);
-                    }
-
-                    const now = new Date();
-                    const pollCache: PollCache = { timestamp: now.toISOString(), accounts: accountUsages };
-
-                    try {
-                        await storage.putCacheFile<PollCache>(cacheKey, pollCache, `${pollIntervalSeconds} seconds`);
-                    } catch {
-                        // Cache write is best-effort
-                    }
-
-                    return pollCache;
-                },
-                timeout: 10_000,
-                onTimeout: () => {
-                    // Lock timed out — return null, we'll try again next interval
-                    return null;
-                },
-            });
-
-            if (result) {
-                processAccountUsages(result.accounts, new Date(result.timestamp));
+            if (accountUsages.length > 0) {
+                processAccountUsages(accountUsages, new Date());
             }
         } catch (error) {
             setResults({

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -146,10 +146,7 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
                                 return freshCached;
                             }
 
-                            const [usage] = await fetchAllAccountsUsage(
-                                { [name]: account },
-                                new AbortController().signal
-                            );
+                            const [usage] = await fetchAllAccountsUsage({ [name]: account });
 
                             try {
                                 await storage.putCacheFile(cacheKey, usage, `${pollIntervalSeconds} seconds`);

--- a/src/claude/commands/usage/index.tsx
+++ b/src/claude/commands/usage/index.tsx
@@ -6,13 +6,15 @@ export function registerUsageCommand(program: Command): void {
     program
         .command("usage")
         .description("Show Claude API usage dashboard (interactive TUI)")
-        .argument("[account]", "Specific account name")
+        .option("-f, --filter <account>", "Filter to a specific account name")
         .option("--token <token>", "Use a specific OAuth access token")
         .option("--no-tui", "Use legacy plain text output")
         .option("--json", "Output as JSON")
         .option("--watch", "Watch mode (legacy)")
         .option("--interval <seconds>", "Poll interval override")
-        .action(async (accountArg: string | undefined, opts: Record<string, string | boolean | undefined>) => {
+        .action(async (opts: Record<string, string | boolean | undefined>) => {
+            const accountFilter = typeof opts.filter === "string" ? opts.filter : undefined;
+
             if (opts.tui === false || opts.json || opts.token || opts.watch) {
                 const { loadConfig } = await import("@app/claude/lib/config");
                 const { fetchAllAccountsUsage, fetchUsage } = await import("@app/claude/lib/usage/api");
@@ -34,13 +36,13 @@ export function registerUsageCommand(program: Command): void {
                 const config = await loadConfig();
                 let accounts = config.accounts;
 
-                if (accountArg) {
-                    if (!accounts[accountArg]) {
-                        console.error(`Unknown account: ${accountArg}`);
+                if (accountFilter) {
+                    if (!accounts[accountFilter]) {
+                        console.error(`Unknown account: ${accountFilter}`);
                         process.exit(1);
                     }
 
-                    accounts = { [accountArg]: accounts[accountArg] };
+                    accounts = { [accountFilter]: accounts[accountFilter] };
                 }
 
                 if (opts.watch) {
@@ -60,7 +62,7 @@ export function registerUsageCommand(program: Command): void {
                 return;
             }
 
-            const { waitUntilExit } = render(<App accountFilter={accountArg} />);
+            const { waitUntilExit } = render(<App accountFilter={accountFilter} />);
             await waitUntilExit();
         });
 }

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -68,20 +68,9 @@ async function ensureValidToken(
     account: AccountConfig,
     options?: { forceRefresh?: boolean }
 ): Promise<{ accessToken: string; refreshed: boolean }> {
-    if (!options?.forceRefresh) {
-        // No refresh token? Can't auto-refresh
-        if (!account.refreshToken) {
-            return { accessToken: account.accessToken, refreshed: false };
-        }
+    const tokenIsValid = account.expiresAt && account.expiresAt > Date.now() + EXPIRY_BUFFER_MS;
 
-        // Token still valid? No refresh needed
-        if (account.expiresAt && account.expiresAt > Date.now() + EXPIRY_BUFFER_MS) {
-            return { accessToken: account.accessToken, refreshed: false };
-        }
-    }
-
-    // Need refresh but no refresh token available
-    if (!account.refreshToken) {
+    if (!account.refreshToken || (!options?.forceRefresh && tokenIsValid)) {
         return { accessToken: account.accessToken, refreshed: false };
     }
 
@@ -91,12 +80,16 @@ async function ensureValidToken(
         const freshConfig = await loadConfig();
         const diskAccount = freshConfig.accounts[accountName];
 
-        // Another process already refreshed — use their tokens (check before missing refreshToken)
+        // Another process already refreshed — use their tokens if:
+        // - Token is time-valid AND we're not force-refreshing, OR
+        // - Token is different from ours (another process refreshed for 429 too)
         if (diskAccount?.expiresAt && diskAccount.expiresAt > Date.now() + EXPIRY_BUFFER_MS) {
-            account.accessToken = diskAccount.accessToken;
-            account.refreshToken = diskAccount.refreshToken;
-            account.expiresAt = diskAccount.expiresAt;
-            return { accessToken: diskAccount.accessToken, refreshed: true };
+            if (!options?.forceRefresh || diskAccount.accessToken !== account.accessToken) {
+                account.accessToken = diskAccount.accessToken;
+                account.refreshToken = diskAccount.refreshToken;
+                account.expiresAt = diskAccount.expiresAt;
+                return { accessToken: diskAccount.accessToken, refreshed: true };
+            }
         }
 
         if (!diskAccount?.refreshToken) {

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -145,8 +145,28 @@ export async function fetchAllAccountsUsage(
     const results = await Promise.allSettled(
         entries.map(async ([name, account]) => {
             const { accessToken } = await ensureValidToken(name, account);
-            const usage = await fetchUsage(accessToken, signal);
-            return { accountName: name, label: account.label, usage } satisfies AccountUsage;
+
+            try {
+                const usage = await fetchUsage(accessToken, signal);
+                return { accountName: name, label: account.label, usage } satisfies AccountUsage;
+            } catch (err) {
+                if (!(err instanceof RateLimitError)) {
+                    throw err;
+                }
+
+                // 429 — force-refresh token to get fresh rate limit window
+                const { accessToken: freshToken, refreshed } = await ensureValidToken(name, account, {
+                    forceRefresh: true,
+                });
+
+                if (!refreshed) {
+                    throw err; // No refresh token available, can't bypass
+                }
+
+                // Retry once with new token
+                const usage = await fetchUsage(freshToken, signal);
+                return { accountName: name, label: account.label, usage } satisfies AccountUsage;
+            }
         })
     );
 

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -65,15 +65,23 @@ export async function fetchUsage(accessToken: string, signal?: AbortSignal): Pro
  */
 async function ensureValidToken(
     accountName: string,
-    account: AccountConfig
+    account: AccountConfig,
+    options?: { forceRefresh?: boolean }
 ): Promise<{ accessToken: string; refreshed: boolean }> {
-    // No refresh token? Can't auto-refresh
-    if (!account.refreshToken) {
-        return { accessToken: account.accessToken, refreshed: false };
+    if (!options?.forceRefresh) {
+        // No refresh token? Can't auto-refresh
+        if (!account.refreshToken) {
+            return { accessToken: account.accessToken, refreshed: false };
+        }
+
+        // Token still valid? No refresh needed
+        if (account.expiresAt && account.expiresAt > Date.now() + EXPIRY_BUFFER_MS) {
+            return { accessToken: account.accessToken, refreshed: false };
+        }
     }
 
-    // Token still valid? No refresh needed
-    if (account.expiresAt && account.expiresAt > Date.now() + EXPIRY_BUFFER_MS) {
+    // Need refresh but no refresh token available
+    if (!account.refreshToken) {
         return { accessToken: account.accessToken, refreshed: false };
     }
 

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -4,6 +4,13 @@ import { refreshOAuthToken } from "@app/utils/claude/auth";
 
 export type { AccountInfo, KeychainCredentials } from "@app/utils/claude/auth";
 
+export class RateLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "RateLimitError";
+    }
+}
+
 // Refresh tokens 5 minutes before expiry to avoid edge cases
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
@@ -39,6 +46,11 @@ export async function fetchUsage(accessToken: string, signal?: AbortSignal): Pro
         },
         signal,
     });
+    if (res.status === 429) {
+        const body = await res.text().catch(() => "");
+        throw new RateLimitError(`Usage API 429: ${body.slice(0, 200)}`);
+    }
+
     if (!res.ok) {
         const body = await res.text().catch(() => "");
         throw new Error(`Usage API ${res.status}: ${body.slice(0, 200)}`);

--- a/src/claude/lib/usage/dashboard-config.ts
+++ b/src/claude/lib/usage/dashboard-config.ts
@@ -22,7 +22,7 @@ export interface UsageDashboardConfig {
 }
 
 const DEFAULTS: UsageDashboardConfig = {
-    refreshInterval: 15,
+    refreshInterval: 60,
     prominentBuckets: ["five_hour", "seven_day", "seven_day_sonnet"],
     hiddenBuckets: [],
     hiddenAccounts: [],


### PR DESCRIPTION
## Summary
- Detect 429 rate limits with a distinct `RateLimitError` class and automatically retry with a force-refreshed OAuth token (rate limits are per-access-token)
- Wrap the poll cycle in a file lock so multiple `tools claude usage` processes coordinate — one polls, others wait and reuse cached results
- Increase default poll interval from 15s to 60s to reduce 429 risk
- Extract "max 5x"/"max 20x" from `rate_limit_tier` instead of showing just "max" in account labels

## Test plan
- [ ] `tools claude usage` starts at 60s interval (check status bar)
- [ ] Switch to 5s with `i` key, wait for 429 — should see token refresh + successful retry
- [ ] Open two `tools claude usage` instances — only one polls at a time
- [ ] `tools claude login <account>` — label shows "max 5x" or "max 20x"
- [ ] `tsgo --noEmit` passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic token refresh with a one-time retry on rate-limit responses.
  * Per-account caching and parallel polling for faster, more resilient usage updates.
  * Usage command now supports a filter option to target a specific account.

* **Bug Fixes**
  * Improved formatting for "max" premium tier labels (e.g., "max 5x").

* **Performance**
  * Increased default polling/refresh intervals to reduce API load and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->