### PR TITLE
fix(claude-usage): preserve account order + fix plan labels

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.16",
+    "version": "1.0.19",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.16",
+            "version": "1.0.19",
             "author": {
                 "name": "GenesisTools"
             },

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.16",
+    "version": "1.0.19",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -13,7 +13,6 @@ function maskToken(token: string): string {
     return `${token.slice(0, 20)}...`;
 }
 
-
 async function generateAuthUrl(): Promise<string> {
     const spinner = p.spinner();
     spinner.start("Generating authorization URL...");

--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -1,4 +1,4 @@
-import { type ClaudeConfig, loadConfig, saveConfig } from "@app/claude/lib/config";
+import { type ClaudeConfig, determineAccountLabel, loadConfig, saveConfig } from "@app/claude/lib/config";
 import { fetchUsage } from "@app/claude/lib/usage/api";
 import { claudeOAuth, fetchOAuthProfile, getClaudeJsonAccount } from "@app/utils/claude/auth";
 import { copyToClipboard } from "@app/utils/clipboard";
@@ -13,25 +13,6 @@ function maskToken(token: string): string {
     return `${token.slice(0, 20)}...`;
 }
 
-function determineAccountLabel(profile: Awaited<ReturnType<typeof fetchOAuthProfile>>): string | undefined {
-    if (!profile) {
-        return undefined;
-    }
-
-    const tier = profile.organization.rate_limit_tier;
-
-    if (tier.includes("max")) {
-        // Extract multiplier: "max_5x" → "max 5x", "max_20x" → "max 20x"
-        const match = tier.match(/max[_\s]*(\d+x?)/i);
-        return match ? `max ${match[1]}` : "max";
-    }
-
-    if (tier.includes("pro")) {
-        return "pro";
-    }
-
-    return profile.organization.billing_type;
-}
 
 async function generateAuthUrl(): Promise<string> {
     const spinner = p.spinner();

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { type AccountConfig, loadConfig } from "@app/claude/lib/config";
+import { type AccountConfig, loadConfig, refreshAccountLabels } from "@app/claude/lib/config";
 import { type AccountUsage, fetchAllAccountsUsage } from "@app/claude/lib/usage/api";
 import type { UsageDashboardConfig } from "@app/claude/lib/usage/dashboard-config";
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
@@ -33,6 +33,9 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
     const pollingRef = useRef(false);
 
     useEffect(() => {
+        // Refresh account labels from API profiles on startup (best-effort, non-blocking)
+        refreshAccountLabels().catch(() => {});
+
         dbRef.current = new UsageHistoryDb();
         notifRef.current = new NotificationManager(config.notifications);
 
@@ -118,17 +121,18 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
             // Per-account locking: each account gets its own cache + lock
             // This ensures "tools claude usage" and "tools claude usage --filter foo"
             // share the same lock for account "foo" instead of racing.
-            const accountUsages: AccountUsage[] = [];
+            const accountEntries = Object.entries(accounts);
+            const accountUsages: (AccountUsage | null)[] = new Array(accountEntries.length).fill(null);
 
             await Promise.all(
-                Object.entries(accounts).map(async ([name, account]) => {
+                accountEntries.map(async ([name, account], index) => {
                     const cacheKey = `poll-account-${name}.json`;
 
                     // Fast path: check cache without lock
                     const cached = await storage.getCacheFile<AccountUsage>(cacheKey, `${ttlSeconds} seconds`);
 
                     if (cached) {
-                        accountUsages.push(cached);
+                        accountUsages[index] = cached;
                         return;
                     }
 
@@ -160,14 +164,14 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
                         onTimeout: () => null,
                     });
 
-                    if (result) {
-                        accountUsages.push(result);
-                    }
+                    accountUsages[index] = result;
                 })
             );
 
-            if (accountUsages.length > 0) {
-                processAccountUsages(accountUsages, new Date());
+            const resolvedUsages = accountUsages.filter((u): u is AccountUsage => u !== null);
+
+            if (resolvedUsages.length > 0) {
+                processAccountUsages(resolvedUsages, new Date());
             }
         } catch (error) {
             setResults({

--- a/src/claude/lib/config/index.ts
+++ b/src/claude/lib/config/index.ts
@@ -1,3 +1,4 @@
+import type { OAuthProfileResponse } from "@app/utils/claude/auth";
 import { Storage } from "@app/utils/storage/storage";
 
 export interface AccountConfig {
@@ -66,4 +67,60 @@ export async function loadConfig(): Promise<ClaudeConfig> {
 
 export async function saveConfig(config: ClaudeConfig): Promise<void> {
     await storage.setConfig(config);
+}
+
+export function determineAccountLabel(profile: OAuthProfileResponse | undefined): string | undefined {
+    if (!profile) {
+        return undefined;
+    }
+
+    const tier = profile.organization.rate_limit_tier;
+
+    if (tier.includes("max")) {
+        // Extract multiplier: "max_5x" → "max 5x", "max_20x" → "max 20x"
+        const match = tier.match(/max[_\s]*(\d+x?)/i);
+        // Fall back to raw tier value (e.g. "max_5") rather than just "max"
+        return match ? `max ${match[1]}` : tier.replace(/_/g, " ");
+    }
+
+    if (tier.includes("pro")) {
+        return "pro";
+    }
+
+    return profile.organization.billing_type;
+}
+
+/**
+ * Fetch profiles for all accounts and update their labels in the config.
+ * Best-effort — failures are silently ignored.
+ */
+export async function refreshAccountLabels(): Promise<void> {
+    const { fetchOAuthProfile } = await import("@app/utils/claude/auth");
+    const config = await loadConfig();
+    const entries = Object.entries(config.accounts);
+
+    if (entries.length === 0) {
+        return;
+    }
+
+    const profiles = await Promise.allSettled(
+        entries.map(([, acc]) => fetchOAuthProfile(acc.accessToken))
+    );
+
+    let changed = false;
+
+    for (let i = 0; i < entries.length; i++) {
+        const result = profiles[i];
+        const profile = result.status === "fulfilled" ? result.value : undefined;
+        const newLabel = determineAccountLabel(profile);
+
+        if (newLabel && newLabel !== entries[i][1].label) {
+            config.accounts[entries[i][0]].label = newLabel;
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        await saveConfig(config);
+    }
 }

--- a/src/claude/lib/config/index.ts
+++ b/src/claude/lib/config/index.ts
@@ -96,31 +96,33 @@ export function determineAccountLabel(profile: OAuthProfileResponse | undefined)
  */
 export async function refreshAccountLabels(): Promise<void> {
     const { fetchOAuthProfile } = await import("@app/utils/claude/auth");
-    const config = await loadConfig();
-    const entries = Object.entries(config.accounts);
 
-    if (entries.length === 0) {
-        return;
-    }
+    await withConfigLock(async () => {
+        const config = await loadConfig();
+        const entries = Object.entries(config.accounts);
 
-    const profiles = await Promise.allSettled(
-        entries.map(([, acc]) => fetchOAuthProfile(acc.accessToken))
-    );
-
-    let changed = false;
-
-    for (let i = 0; i < entries.length; i++) {
-        const result = profiles[i];
-        const profile = result.status === "fulfilled" ? result.value : undefined;
-        const newLabel = determineAccountLabel(profile);
-
-        if (newLabel && newLabel !== entries[i][1].label) {
-            config.accounts[entries[i][0]].label = newLabel;
-            changed = true;
+        if (entries.length === 0) {
+            return;
         }
-    }
 
-    if (changed) {
-        await saveConfig(config);
-    }
+        const profiles = await Promise.all(
+            entries.map(([, acc]) => fetchOAuthProfile(acc.accessToken).catch(() => undefined))
+        );
+
+        let changed = false;
+
+        for (let i = 0; i < entries.length; i++) {
+            const profile = profiles[i];
+            const newLabel = determineAccountLabel(profile);
+
+            if (newLabel && newLabel !== entries[i][1].label) {
+                config.accounts[entries[i][0]].label = newLabel;
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            await saveConfig(config);
+        }
+    });
 }


### PR DESCRIPTION
## Summary
- **Account ordering**: Fixed non-deterministic account reordering on refresh by using indexed array assignment instead of `.push()` in `Promise.all`
- **Plan labels**: Labels now correctly show tier info (e.g. "max 20x") instead of just "max" — refreshes from API profiles on startup

## Test plan
- [ ] Run `tools claude usage`, verify accounts stay in same order after "r" refresh and interval refresh
- [ ] Verify account labels show correct tier (e.g. "max 20x") after startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account labels are now refreshed automatically on startup so displayed account names stay up-to-date.

* **Refactor**
  * Improved account-label logic and reworked per-account usage polling for more consistent and reliable usage displays.

* **Chores**
  * Public plugin and marketplace manifest versions bumped to 1.0.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->