### PR TITLE
fix(ask): use .chat() for OpenAI v5+ and enable file logging

### DIFF
--- a/src/ask/index.ts
+++ b/src/ask/index.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
 
-import logger from "@app/logger";
+import logger, { configureLogger } from "@app/logger";
 import { input } from "@app/utils/prompts/clack";
 import { handleReadmeFlag } from "@app/utils/readme";
+
+configureLogger({ logToFile: true });
 import { AIChat } from "@ask/AIChat";
 import { transcriptionManager } from "@ask/audio/TranscriptionManager";
 import { ChatEngine } from "@ask/chat/ChatEngine";

--- a/src/ask/index.ts
+++ b/src/ask/index.ts
@@ -3,8 +3,6 @@
 import logger, { configureLogger } from "@app/logger";
 import { input } from "@app/utils/prompts/clack";
 import { handleReadmeFlag } from "@app/utils/readme";
-
-configureLogger({ logToFile: true });
 import { AIChat } from "@ask/AIChat";
 import { transcriptionManager } from "@ask/audio/TranscriptionManager";
 import { ChatEngine } from "@ask/chat/ChatEngine";
@@ -42,6 +40,8 @@ import {
     validateOptions,
 } from "@ask/utils/cli";
 import { colorizeProvider, generateSessionId } from "@ask/utils/helpers";
+
+configureLogger({ logToFile: true });
 
 // Initialize conversation manager
 const convManager = conversationManager;

--- a/src/ask/types/provider.ts
+++ b/src/ask/types/provider.ts
@@ -3,7 +3,13 @@ import type { LanguageModel } from "ai";
 import type { ModelInfo } from "./chat";
 
 // Helper function to get language model from ProviderV2
+// For OpenAI providers (v5+), prefer .chat() over .languageModel() which defaults to
+// the Responses API — that silently returns empty on errors instead of throwing.
 export function getLanguageModel(provider: ProviderV2, modelId: string): LanguageModel {
+    if ("chat" in provider && typeof provider.chat === "function") {
+        return (provider.chat as (id: string) => LanguageModel)(modelId);
+    }
+
     return provider.languageModel(modelId);
 }
 

--- a/src/ask/types/provider.ts
+++ b/src/ask/types/provider.ts
@@ -2,9 +2,8 @@ import type { ProviderV2 } from "@ai-sdk/provider";
 import type { LanguageModel } from "ai";
 import type { ModelInfo } from "./chat";
 
-// Helper function to get language model from ProviderV2
-// For OpenAI providers (v5+), prefer .chat() over .languageModel() which defaults to
-// the Responses API — that silently returns empty on errors instead of throwing.
+// For OpenAI providers (v5+), prefer .chat() over .languageModel() for better
+// compatibility — .languageModel() defaults to the Responses API endpoint.
 export function getLanguageModel(provider: ProviderV2, modelId: string): LanguageModel {
     if ("chat" in provider && typeof provider.chat === "function") {
         return (provider.chat as (id: string) => LanguageModel)(modelId);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -248,6 +248,7 @@ export const configureLogger = (config: LoggerConfig): void => {
     globalConfig = { ...globalConfig, ...config };
     const logToFile = globalConfig.logToFile ?? false;
     logger = createLogger({ logToFile, minimalLevels: true });
+    // consoleLog participates in file logging to capture full session output
     consoleLog = createLogger({ logToFile, minimalLevels: true });
 };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -63,6 +63,7 @@ export interface LoggerConfig {
     includeTimestamp?: boolean;
     timestampFormat?: string;
     sync?: boolean;
+    logToFile?: boolean;
 }
 
 // Global config
@@ -245,8 +246,9 @@ let consoleLog = createLogger({ logToFile: false, minimalLevels: true });
  */
 export const configureLogger = (config: LoggerConfig): void => {
     globalConfig = { ...globalConfig, ...config };
-    logger = createLogger({ logToFile: false, minimalLevels: true });
-    consoleLog = createLogger({ logToFile: false, minimalLevels: true });
+    const logToFile = globalConfig.logToFile ?? false;
+    logger = createLogger({ logToFile, minimalLevels: true });
+    consoleLog = createLogger({ logToFile, minimalLevels: true });
 };
 
 export { consoleLog };


### PR DESCRIPTION
## Summary
- Prefer `provider.chat()` over `.languageModel()` for OpenAI providers — the Responses API (default in v5+) silently returns empty on errors instead of throwing
- Add `logToFile` config option to logger and enable it for the ask tool so debug output goes to disk

## Test plan
- [ ] Verify ask tool works with OpenAI provider (no empty responses)
- [ ] Check logs appear in `/logs/` directory when using ask tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable file logging: diagnostic logs can now be written to disk and are activated during startup for improved troubleshooting.
  * Improved model selection: the system now prefers newer chat-capable model endpoints when available, with automatic fallback to legacy language-model endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->