### PR TITLE
fix(telegram): resolve entity lookup failures + docs(macos) updates

### DIFF
--- a/docs/typescript-sdks/apple/github-repos-index.md
+++ b/docs/typescript-sdks/apple/github-repos-index.md
@@ -1,0 +1,164 @@
+# macOS TypeScript/Node.js SDK — GitHub Repos Index
+
+> Last updated: 2026-03-10
+> 49 repos sorted by GitHub stars (descending)
+
+A comprehensive index of GitHub repos providing TypeScript/JavaScript SDKs, bindings, or bridges for macOS native libraries and Apple frameworks.
+
+---
+
+## Tier 1: Frameworks & General-Purpose Bridges (1000+ stars)
+
+| # | Repo | Stars | Last Active | Description | macOS APIs |
+|---|------|------:|------------|-------------|------------|
+| 1 | [NativeScript/NativeScript](https://github.com/NativeScript/NativeScript) | 25,469 | 2026-03 | Write native apps with TypeScript — full ObjC/Swift runtime bridge | All Apple frameworks |
+| 2 | [napi-rs/napi-rs](https://github.com/napi-rs/napi-rs) | 7,569 | 2026-03 | Build compiled Node.js addons in Rust via Node-API | Any native library (FFI) |
+| 3 | [mikaelbr/node-notifier](https://github.com/mikaelbr/node-notifier) | 5,837 | 2026-03 | Send native notifications (cross-platform) | NSUserNotification |
+| 4 | [node-ffi/node-ffi](https://github.com/node-ffi/node-ffi) | 4,317 | 2026-03 | Node.js Foreign Function Interface | Any C-compatible library |
+| 5 | [supermemoryai/apple-mcp](https://github.com/supermemoryai/apple-mcp) | 2,999 | 2025-08 | MCP tools for 8 Apple apps (Notes, Mail, Calendar, etc.) | OSA / AppleScript |
+| 6 | [TooTallNate/NodObjC](https://github.com/TooTallNate/NodObjC) | 1,421 | 2020-08 | ObjC bridge via BridgeSupport + FFI (legacy) | Full ObjC runtime |
+| 7 | [atom/node-keytar](https://github.com/atom/node-keytar) | 1,420 | 2022-12 | Native password module | Security / Keychain |
+| 8 | [node-ffi-napi/node-ffi-napi](https://github.com/node-ffi-napi/node-ffi-napi) | 1,096 | 2026-03 | Modern FFI via N-API (fork of node-ffi) | Any C-compatible library |
+| 9 | [sindresorhus/wallpaper](https://github.com/sindresorhus/wallpaper) | 1,087 | 2024-07 | Desktop wallpaper management (cross-platform) | NSWorkspace / AppKit |
+
+---
+
+## Tier 2: Notable Projects (100–999 stars)
+
+| # | Repo | Stars | Last Active | Description | macOS APIs |
+|---|------|------:|------------|-------------|------------|
+| 10 | [sindresorhus/active-win](https://github.com/sindresorhus/active-win) | 895 | 2026-03 | Active window metadata (title, bounds, owner) | Accessibility API (AXUIElement) |
+| 11 | [steipete/macos-automator-mcp](https://github.com/steipete/macos-automator-mcp) | 707 | 2026-03 | MCP + 200 pre-built AppleScript/JXA scripts | OSA / AppleScript / JXA |
+| 12 | [sindresorhus/macos-wallpaper](https://github.com/sindresorhus/macos-wallpaper) | 696 | 2025-10 | macOS wallpaper (Swift CLI) | AppKit / NSWorkspace |
+| 13 | [sindresorhus/dark-mode](https://github.com/sindresorhus/dark-mode) | 679 | 2025-09 | Control macOS dark mode | NSUserDefaults / AppKit |
+| 14 | [TooTallNate/plist.js](https://github.com/TooTallNate/plist.js) | 598 | 2026-03 | Plist parser/builder for Node.js and browsers | CoreFoundation plist format |
+| 15 | [kabiroberai/node-swift](https://github.com/kabiroberai/node-swift) | 571 | 2025-07 | Write Node modules in Swift (NodeSwift bridge) | Any Swift/Apple framework |
+| 16 | [coreybutler/node-mac](https://github.com/coreybutler/node-mac) | 541 | 2024-05 | Node utilities: processes, daemons, event logs | launchd, syslog |
+| 17 | [sindresorhus/clipboard-cli](https://github.com/sindresorhus/clipboard-cli) | 506 | 2026-02 | System clipboard access | NSPasteboard / AppKit |
+| 18 | [JXA-userland/JXA](https://github.com/JXA-userland/JXA) | 482 | 2026-03 | JXA TypeScript ecosystem (types, runner, sdef-to-dts) | OSA / JXA / AppleScript |
+| 19 | [sindresorhus/macos-trash](https://github.com/sindresorhus/macos-trash) | 422 | 2026-02 | Move files to Trash | NSFileManager / Foundation |
+| 20 | [TooTallNate/node-applescript](https://github.com/TooTallNate/node-applescript) | 388 | 2020-06 | Execute AppleScript from Node.js | OSA / AppleScript |
+| 21 | [Koromix/koffi](https://github.com/Koromix/koffi) | 366 | 2026-01 | Fast C FFI for Node.js | Any C-compatible library |
+| 22 | [joshrutkowski/applescript-mcp](https://github.com/joshrutkowski/applescript-mcp) | 358 | 2025-04 | Structured AppleScript MCP server | OSA / AppleScript |
+| 23 | [zhangyuang/node-ffi-rs](https://github.com/zhangyuang/node-ffi-rs) | 332 | 2025-12 | FFI via Rust + NAPI | Any C-compatible library |
+| 24 | [wtfaremyinitials/jxa](https://github.com/wtfaremyinitials/jxa) | 306 | 2019-04 | Access macOS JXA APIs in Node | OSA / JXA |
+| 25 | [sindresorhus/fix-path](https://github.com/sindresorhus/fix-path) | 295 | 2026-02 | Fix $PATH when run from GUI app | Shell / launchd |
+| 26 | [CharlieHess/node-mac-notifier](https://github.com/CharlieHess/node-mac-notifier) | 283 | 2020-11 | Native macOS notifications from Node.js | NSUserNotificationCenter |
+| 27 | [codebytere/node-mac-permissions](https://github.com/codebytere/node-mac-permissions) | 237 | 2026-03 | Manage system permissions (camera, mic, screen, etc.) | TCC / Privacy framework |
+| 28 | [nodekit-io/nodekit](https://github.com/nodekit-io/nodekit) | 232 | 2017-02 | Embedded Node engine with Swift/ObjC bridge | JavaScriptCore, AppKit, UIKit |
+| 29 | [sindresorhus/do-not-disturb](https://github.com/sindresorhus/do-not-disturb) | 224 | 2022-01 | Control macOS Do Not Disturb | Notification Center |
+| 30 | [sindresorhus/run-applescript](https://github.com/sindresorhus/run-applescript) | 172 | 2025-09 | Run AppleScript with typed result | OSA / AppleScript |
+| 31 | [sindresorhus/run-jxa](https://github.com/sindresorhus/run-jxa) | 152 | 2025-09 | Run JXA with generics + AbortSignal | OSA / JXA |
+| 32 | [Meridius-Labs/apple-on-device-ai](https://github.com/Meridius-Labs/apple-on-device-ai) | 148 | 2025-08 | Apple Foundation Model bindings (Vercel AI SDK) | Apple Intelligence |
+| 33 | [lukaskollmer/objc](https://github.com/lukaskollmer/objc) | 104 | 2026-01 | Experimental ObjC bridge for Node.js | Full ObjC runtime |
+
+---
+
+## Tier 3: Smaller but Relevant (10–99 stars)
+
+| # | Repo | Stars | Last Active | Description | macOS APIs |
+|---|------|------:|------------|-------------|------------|
+| 34 | [codebytere/node-mac-contacts](https://github.com/codebytere/node-mac-contacts) | 83 | 2026-02 | CRUD for contacts | CNContactStore / Contacts |
+| 35 | [johnelm/node-jxa](https://github.com/johnelm/node-jxa) | 81 | 2020-08 | Use Node modules in JXA scripts | OSA / JXA |
+| 36 | [wtfaremyinitials/osa2](https://github.com/wtfaremyinitials/osa2) | 72 | 2018-03 | OSA bridge for Node.js | OSA / AppleScript / JXA |
+| 37 | [sindresorhus/macos-release](https://github.com/sindresorhus/macos-release) | 67 | 2025-06 | Get macOS name/version from Darwin version | System version APIs |
+| 38 | [mikaelbr/node-osascript](https://github.com/mikaelbr/node-osascript) | 60 | 2015-11 | Streaming OSA interface | OSA / AppleScript / JXA |
+| 39 | [codebytere/node-mac-swift-addon](https://github.com/codebytere/node-mac-swift-addon) | 59 | 2022-12 | PoC Node.js addon written in Swift | Any Swift framework |
+| 40 | [fardog/node-osx-audio](https://github.com/fardog/node-osx-audio) | 52 | 2016-05 | Mac audio I/O as Node streams | CoreAudio |
+| 41 | [abruneau/apple-notes-jxa](https://github.com/abruneau/apple-notes-jxa) | 52 | 2017-11 | Read/edit/manage Apple Notes via JXA | Notes.app / JXA |
+| 42 | [caroso1222/node-reminders](https://github.com/caroso1222/node-reminders) | 46 | 2023-01 | macOS Reminders wrapper | Reminders.app / EventKit via JXA |
+| 43 | [Tatsh/jxa-lib](https://github.com/Tatsh/jxa-lib) | 39 | 2026-03 | General library for JXA | OSA / JXA |
+| 44 | [stephancasas/jxa-ui-explorer](https://github.com/stephancasas/jxa-ui-explorer) | 39 | 2024-04 | Discover JXA UI elements easily | Accessibility API via JXA |
+| 45 | [Morglod/bun-ffi-gen](https://github.com/Morglod/bun-ffi-gen) | 34 | 2024-09 | FFI bindings generator for Bun (from C headers) | Any C-compatible library |
+| 46 | [codebytere/node-mac-auth](https://github.com/codebytere/node-mac-auth) | 29 | 2024-06 | Touch ID / biometric auth | LocalAuthentication |
+| 47 | [aslanon/node-mac-recorder](https://github.com/aslanon/node-mac-recorder) | 24 | 2026-02 | Screen recording from Node.js | ScreenCaptureKit / CoreGraphics |
+| 48 | [codebytere/node-mac-userdefaults](https://github.com/codebytere/node-mac-userdefaults) | 17 | 2026-01 | Interface to user defaults database | NSUserDefaults / Foundation |
+| 49 | [codebytere/node-mac-displays](https://github.com/codebytere/node-mac-displays) | 14 | 2021-11 | Enumerate display information | CoreGraphics display APIs |
+
+---
+
+## Not on GitHub (npm-only / in this repo)
+
+| Package | Description | Source |
+|---------|-------------|--------|
+| `@nativescript/macos-node-api` | Engine-agnostic full Apple SDK access with auto-generated TS types | See [macos-node-api.md](./macos-node-api.md) |
+| `darwinkit` (0xMassi) | Swift CLI: NLP + Vision via JSON-RPC subprocess | See [darwinkit.md](./darwinkit.md) |
+| `@cherrystudio/mac-system-ocr` | Vision OCR native addon | See [typescript-sdks.md](./typescript-sdks.md) |
+| `eventkit-node` | EventKit CRUD (Calendar & Reminders) | See [typescript-sdks.md](./typescript-sdks.md) |
+| `@appkit/apple-contacts` | Pure TS contacts via SQLite (read-only) | See [typescript-sdks.md](./typescript-sdks.md) |
+
+---
+
+## Category Index
+
+### General FFI / Bridge Frameworks
+Call any native library from TypeScript:
+- `napi-rs/napi-rs` (7.6k) — Rust → Node addon
+- `node-ffi/node-ffi` (4.3k) — Generic FFI (legacy)
+- `node-ffi-napi/node-ffi-napi` (1.1k) — Modern FFI (N-API)
+- `Koromix/koffi` (366) — Fast C FFI
+- `zhangyuang/node-ffi-rs` (332) — Rust-based FFI
+- `Morglod/bun-ffi-gen` (34) — Bun FFI generator
+
+### Objective-C / Swift Bridges
+Full runtime access to Apple frameworks:
+- `NativeScript/NativeScript` (25.5k) — Full ObjC/Swift runtime
+- `@nativescript/macos-node-api` — Engine-agnostic full SDK (see [macos-node-api.md](./macos-node-api.md))
+- `TooTallNate/NodObjC` (1.4k) — ObjC bridge (legacy)
+- `kabiroberai/node-swift` (571) — Swift → Node modules
+- `lukaskollmer/objc` (104) — Experimental ObjC bridge
+- `codebytere/node-mac-swift-addon` (59) — PoC Swift addon
+
+### AppleScript / JXA
+macOS automation layer:
+- `steipete/macos-automator-mcp` (707) — MCP + 200 scripts (see [macos-automator-mcp.md](./macos-automator-mcp.md))
+- `JXA-userland/JXA` (482) — Full JXA TS ecosystem (see [jxa-userland.md](./jxa-userland.md))
+- `TooTallNate/node-applescript` (388) — Execute AppleScript
+- `joshrutkowski/applescript-mcp` (358) — Structured MCP
+- `wtfaremyinitials/jxa` (306) — JXA in Node
+- `sindresorhus/run-applescript` (172) — Typed AppleScript
+- `sindresorhus/run-jxa` (152) — Typed JXA with generics
+- `johnelm/node-jxa` (81) — Node modules in JXA
+- `wtfaremyinitials/osa2` (72) — OSA bridge
+- `mikaelbr/node-osascript` (60) — Streaming OSA
+
+### MCP Servers (AI Integration)
+Pre-built MCP tools for Apple apps:
+- `supermemoryai/apple-mcp` (3.0k) — 8 Apple apps (see [apple-mcp.md](./apple-mcp.md))
+- `steipete/macos-automator-mcp` (707) — 200 automation scripts
+- `joshrutkowski/applescript-mcp` (358) — Modular categories
+
+### Specific macOS API Wrappers
+
+**Notifications:**
+- `mikaelbr/node-notifier` (5.8k), `CharlieHess/node-mac-notifier` (283)
+
+**Permissions / Privacy:**
+- `codebytere/node-mac-permissions` (237)
+
+**Keychain / Auth:**
+- `atom/node-keytar` (1.4k), `codebytere/node-mac-auth` (29)
+
+**Window / Display:**
+- `sindresorhus/active-win` (895), `codebytere/node-mac-displays` (14)
+
+**Desktop / Appearance:**
+- `sindresorhus/wallpaper` (1.1k), `sindresorhus/macos-wallpaper` (696), `sindresorhus/dark-mode` (679), `sindresorhus/do-not-disturb` (224)
+
+**Filesystem / System:**
+- `TooTallNate/plist.js` (598), `coreybutler/node-mac` (541), `sindresorhus/macos-trash` (422), `sindresorhus/fix-path` (295), `sindresorhus/macos-release` (67), `codebytere/node-mac-userdefaults` (17)
+
+**Contacts:**
+- `codebytere/node-mac-contacts` (83)
+
+**Audio:**
+- `fardog/node-osx-audio` (52)
+
+**Screen Recording:**
+- `aslanon/node-mac-recorder` (24)
+
+**AI / ML:**
+- `Meridius-Labs/apple-on-device-ai` (148)
+
+**Apple App Automation (JXA):**
+- `abruneau/apple-notes-jxa` (52), `caroso1222/node-reminders` (46), `Tatsh/jxa-lib` (39), `stephancasas/jxa-ui-explorer` (39)

--- a/docs/typescript-sdks/apple/macos-node-api.md
+++ b/docs/typescript-sdks/apple/macos-node-api.md
@@ -1,0 +1,458 @@
+# @nativescript/macos-node-api — Comprehensive Reference
+
+> **Repository:** [NativeScript/runtime-node-api](https://github.com/NativeScript/runtime-node-api) (42 stars)
+> **npm:** `@nativescript/macos-node-api` (v0.4.0 published, repo at 0.1.4)
+> **License:** MIT
+> **Language breakdown:** C 47%, Assembly 11%, C++ 10%, Shell 10%, TeX 9%
+> **Contributors:** DjDeveloperr, Nathan Walker, Jamie Birch (shirakaba)
+
+An embeddable, engine-agnostic NativeScript runtime based on **Node-API** and **libffi**. Gives Node.js and Deno **full access to every Objective-C macOS API** — AppKit, Vision, NaturalLanguage, Metal, SpriteKit, CoreML, and 50+ more frameworks — with auto-generated TypeScript type definitions.
+
+---
+
+## Table of Contents
+
+1. [Architecture](#architecture)
+2. [Installation](#installation)
+3. [Core API Surface](#core-api-surface)
+4. [Available Frameworks (56)](#available-frameworks-56)
+5. [Code Examples](#code-examples)
+6. [TypeScript Type Generation](#typescript-type-generation)
+7. [Performance](#performance)
+8. [Compatibility](#compatibility)
+9. [Known Limitations](#known-limitations)
+10. [Comparison with Alternatives](#comparison-with-alternatives)
+11. [Related Projects](#related-projects)
+
+---
+
+## Architecture
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────┐
+│ TypeScript / JavaScript                              │
+│   import '@nativescript/macos-node-api'              │
+│   objc.import('Vision')                             │
+│   VNRecognizeTextRequest.alloc().init()             │
+├─────────────────────────────────────────────────────┤
+│ Node-API (engine-agnostic)                          │
+│   process.dlopen() → NativeScript.node              │
+├─────────────────────────────────────────────────────┤
+│ NativeScript Runtime (C/C++)                        │
+│   Binary metadata (.nsmd) → lazy binding creation   │
+│   libffi for dynamic Objective-C calls              │
+│   Objective-C runtime (class_addMethod, etc.)       │
+├─────────────────────────────────────────────────────┤
+│ Apple Frameworks                                    │
+│   AppKit, Vision, Metal, CoreML, Foundation, ...    │
+└─────────────────────────────────────────────────────┘
+```
+
+1. **Metadata Generator** — A clang-based tool (`MetadataGenerator`) reads all public Objective-C headers from Apple SDK frameworks using clang's `RecursiveASTVisitor`. Produces:
+   - Binary metadata files (`.nsmd`) per architecture (arm64, x86_64)
+   - TypeScript type definitions (`.d.ts`) per framework
+
+2. **Native Runtime Library** — A C/C++ shared library (`NativeScript.node`) built with CMake that:
+   - Loads binary metadata as a memory-mapped mach-o section (`__DATA __TNSMetadata`)
+   - Uses **libffi** for dynamic function calls into Objective-C
+   - Exposes all discovered APIs as JavaScript objects via **Node-API**
+   - Handles memory management, type marshalling, and ObjC runtime integration
+
+3. **Engine Independence** — Works with any JS engine implementing Node-API:
+   - **Node.js** (V8)
+   - **Deno** (V8)
+   - **Hermes** (React Native)
+   - **QuickJS**
+   - **JavaScriptCore**
+
+4. **Lazy Binding** — Bindings are created on first access, not at startup. Only frameworks you `objc.import()` get loaded.
+
+---
+
+## Installation
+
+### For Node.js
+
+```bash
+npm install @nativescript/macos-node-api
+# or
+bun add @nativescript/macos-node-api
+```
+
+### For Deno
+
+```json
+// deno.json
+{
+  "imports": {
+    "@nativescript/macos-node-api": "npm:@nativescript/macos-node-api@^0.1.0"
+  }
+}
+```
+
+### TypeScript Configuration
+
+```json
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+### Building from Source
+
+```bash
+git clone https://github.com/NativeScript/runtime-node-api.git
+cd runtime-node-api
+npm install
+
+# 1. Build metadata generator (downloads LLVM, uses cmake)
+deno task build-metagen
+
+# 2. Generate metadata + TypeScript types for macOS
+deno task metagen macos
+# Outputs: metadata/metadata.macos.{arm64,x86_64}.nsmd
+#          packages/macos/types/*.d.ts
+
+# 3. Build runtime
+deno task build macos
+# Outputs: packages/macos/dist/macos/NativeScript.node
+```
+
+---
+
+## Core API Surface
+
+### `objc` Namespace
+
+```typescript
+namespace objc {
+  function import(framework: string): void;         // Load a framework dynamically
+  function registerClass(cls: Function): void;       // Alternative to NativeClass
+  function registerBlock(encoding: string, fn: T): T; // Register an ObjC block
+  function autoreleasepool(fn: () => T): T;          // Autorelease pool scope
+  function getArrayBuffer(ptr: Pointer, size: number): ArrayBuffer;
+}
+```
+
+### `NativeClass(cls)`
+
+Registers a JavaScript class with the Objective-C runtime:
+
+```typescript
+function NativeClass(cls: Function): void;
+```
+
+### `interop` Namespace
+
+```typescript
+namespace interop {
+  // Primitive types for FFI
+  const types: {
+    void, bool, int8, uint8, int16, uint16, int32, uint32,
+    int64, uint64, float, double, UTF8CString, unichar,
+    id, protocol, class, SEL, pointer
+  };
+
+  class Pointer implements PointerObject {
+    constructor(address: number);
+    add(offset: number): Pointer;
+    subtract(offset: number): Pointer;
+    toNumber(): number;
+  }
+
+  class Reference<T> implements PointerObject {
+    value: T;
+    constructor(value: T);
+    constructor(type: Type, value: T);
+    constructor(type: Type, pointer: Pointer);
+  }
+
+  function addMethod(constructor, method): void;   // Add method after registration
+  function addProtocol(constructor, protocol): void;
+  function adopt(ptr: Pointer): Pointer;           // Take ownership
+  function free(ptr: Pointer): void;
+  function sizeof(obj: unknown): number;
+  function alloc(size: number): Pointer;
+  function handleof(obj: unknown): Pointer;
+  function bufferFromData(data: NativeObject): ArrayBuffer;
+}
+```
+
+### Static Class Properties for ObjC Integration
+
+```typescript
+class MyClass extends NSObject {
+  // Declare which ObjC protocols this class implements
+  static ObjCProtocols = [NSApplicationDelegate, NSWindowDelegate];
+
+  // Expose methods with explicit type encodings
+  static ObjCExposedMethods = {
+    myMethod: { returns: interop.types.void, params: [NSNotification] }
+  };
+
+  // Register with ObjC runtime (must be in static initializer)
+  static { NativeClass(this); }
+}
+```
+
+---
+
+## Available Frameworks (56)
+
+All frameworks have auto-generated `.d.ts` files in `packages/macos/types/`:
+
+| Category | Frameworks |
+|----------|-----------|
+| **UI/AppKit** | AppKit, WebKit, GLKit |
+| **Graphics/Rendering** | CoreGraphics, CoreImage, Metal, MetalKit, MetalPerformanceShaders, OpenGL, QuartzCore, SceneKit, SpriteKit, ModelIO |
+| **Media** | AVFoundation, AVFAudio, AudioToolbox, CoreAudio, CoreAudioTypes, CoreMedia, CoreVideo, CoreMIDI, MediaToolbox, ImageIO |
+| **ML/AI** | CoreML, MLCompute, NaturalLanguage, GameplayKit |
+| **Data/Storage** | CoreData, CoreFoundation, Foundation, CloudKit, CoreSpotlight, DiskArbitration, UniformTypeIdentifiers |
+| **Location/Motion** | CoreLocation, CoreMotion, MapKit |
+| **Contacts/Calendar** | Contacts, AddressBook, EventKit |
+| **System** | IOKit, IOSurface, Security, CoreServices, CoreText, CoreHaptics, ScreenCaptureKit |
+| **Gaming** | SpriteKit, SceneKit, GameController, GameKit, GameplayKit |
+| **Communication** | CoreBluetooth, Intents, UserNotifications |
+| **Other** | JavaScriptCore, Symbols |
+
+**Foundation and AppKit are loaded automatically.** Others need `objc.import()`:
+
+```typescript
+objc.import("Metal");
+objc.import("NaturalLanguage");
+objc.import("CoreML");
+objc.import("ScreenCaptureKit");
+```
+
+**Missing from auto-generated types** (may still work via `objc.import()` if they have ObjC headers):
+Vision, ARKit, RealityKit, StoreKit, HealthKit, HomeKit, NetworkExtension, CryptoKit, PassKit, Photos, PhotosUI, PDFKit, Virtualization.
+
+---
+
+## Code Examples
+
+### Basic Foundation Usage
+
+```typescript
+import "@nativescript/macos-node-api";
+
+console.log(NSProcessInfo.processInfo.operatingSystemVersionString);
+console.log(NSDate.date());
+
+const arr = NSMutableArray.arrayWithCapacity(1);
+arr.insertObjectAtIndex(NSObject.new(), 0);
+
+const dict = NSMutableDictionary.dictionary();
+dict.setObjectForKey(NSObject.new(), "key");
+for (const key of dict) { console.log(key); }
+
+// Pointer operations
+const ptr = new interop.Pointer(1);
+const ref = new interop.Reference(interop.types.int32, 1);
+ref.value = 42;
+```
+
+### AppKit Window Application
+
+```typescript
+import "@nativescript/macos-node-api";
+objc.import("AppKit");
+
+class AppDelegate extends NSObject {
+  static ObjCProtocols = [NSApplicationDelegate];
+  static { NativeClass(this); }
+
+  applicationDidFinishLaunching(_notification: NSNotification) {
+    const window = NSWindow.alloc().initWithContentRectStyleMaskBackingDefer(
+      { origin: { x: 0, y: 0 }, size: { width: 500, height: 500 } },
+      NSWindowStyleMask.Titled | NSWindowStyleMask.Closable | NSWindowStyleMask.Resizable,
+      2, false
+    );
+    window.title = "Hello from Node.js";
+    window.makeKeyAndOrderFront(NSApp);
+  }
+}
+
+const NSApp = NSApplication.sharedApplication;
+NSApp.setActivationPolicy(NSApplicationActivationPolicy.Regular);
+NSApp.delegate = AppDelegate.new();
+NSApplicationMain(0, null);
+```
+
+### Vision OCR
+
+```typescript
+import "@nativescript/macos-node-api";
+objc.import("Vision");
+
+const request = VNRecognizeTextRequest.alloc().init();
+request.recognitionLevel = VNRequestTextRecognitionLevel.Accurate;
+
+const handler = VNImageRequestHandler.alloc().initWithURLOptions(
+  NSURL.fileURLWithPath("/tmp/image.png"),
+  null,
+);
+handler.performRequestsError([request], null);
+
+const results = request.results as VNRecognizedTextObservation[];
+for (const obs of results) {
+  console.log(obs.topCandidates(1)[0].string);
+}
+```
+
+### MLCompute (GPU Machine Learning)
+
+```typescript
+import "@nativescript/macos-node-api";
+objc.import("MLCompute");
+
+const shape = [1, 28, 28, 1];
+const tInput = MLCTensor.tensorWithShapeDataType(shape, MLCDataType.Float32);
+const tWeights = MLCTensor.tensorWithShapeRandomInitializerTypeDataType(
+  [1, 784, 128, 1], MLCRandomInitializerType.GlorotUniform, MLCDataType.Float32
+);
+const graph = MLCGraph.new();
+const device = MLCDevice.gpuDevice();
+const inference = MLCInferenceGraph.graphWithGraphObjects([graph]);
+inference.addInputs({ input: tInput });
+inference.compileWithOptionsDevice(MLCGraphCompilationOptions.DebugLayers, device);
+inference.executeWithInputsDataBatchSizeOptionsCompletionHandler(
+  { input: dataInput }, 1, MLCExecutionOptions.Synchronous, (output, error, time) => {
+    console.log(output, error, time);
+  }
+);
+```
+
+### CADisplayLink Animation Driver
+
+```typescript
+import "@nativescript/macos-node-api";
+objc.import("AppKit");
+
+class AnimDriver extends NSObject {
+  static ObjCExposedMethods = {
+    tick: { returns: interop.types.void, params: [] },
+  };
+  static { NativeClass(this); }
+
+  tick() { /* called every frame */ }
+
+  start() {
+    const displayLink = NSScreen.mainScreen.displayLinkWithTargetSelector(this, "tick");
+    displayLink.addToRunLoopForMode(NSRunLoop.currentRunLoop, NSDefaultRunLoopMode);
+    displayLink.preferredFrameRateRange = { minimum: 90, maximum: 120, preferred: 120 };
+  }
+}
+```
+
+### Dynamic Method Addition (Post-Registration)
+
+```typescript
+// Add a method to a class AFTER it's been registered:
+interop.addMethod(
+  AppDelegate,
+  function applicationDidFinishLaunching(_notification: NSNotification) {
+    // 'this' refers to the ObjC instance
+    console.log("App launched!");
+  },
+);
+```
+
+---
+
+## TypeScript Type Generation
+
+The type generation pipeline:
+
+1. **Build metadata generator** (`deno task build-metagen`):
+   - Downloads LLVM
+   - Compiles C++ metadata generator with CMake
+   - Binary: `metadata/build/Release/MetadataGenerator`
+
+2. **Run generation** (`deno task metagen macos`):
+   - Scans all Apple SDK headers via clang's HeaderSearch + RecursiveASTVisitor
+   - For each declaration (class, protocol, enum, struct, function, constant) → Meta instance
+   - Serializes to binary `.nsmd` files (per architecture: arm64, x86_64)
+   - Generates TypeScript `.d.ts` files per framework
+
+3. **Result**: ~56 `.d.ts` files with full type coverage, giving autocomplete and type-checking.
+
+---
+
+## Performance
+
+- **libffi** provides dynamic function calling with minimal overhead
+- Metadata loaded as memory-mapped mach-o section — no deserialization
+- Bindings lazily created on first access
+- Node-API layer adds minimal overhead vs direct V8/JSC calls
+- Competitive with or faster than the old V8-direct NativeScript runtime
+- No JIT-specific optimizations — performance depends on JS engine
+
+---
+
+## Compatibility
+
+| Dimension | Support |
+|-----------|---------|
+| **macOS versions** | 10.15+ (based on SDK availability) |
+| **Architectures** | arm64 (Apple Silicon) and x86_64 (Intel) |
+| **Node.js** | Supported (primary target, uses `process.dlopen`) |
+| **Deno** | Supported (native, with bundled app support) |
+| **Bun** | Untested / uncertain (depends on Node-API compat) |
+| **React Native** | Integration in progress (via Node-API / Hermes) |
+| **iOS** | Separate package: `@nativescript/ios-node-api` |
+| **Package format** | ESM (`"type": "module"`) |
+
+---
+
+## Known Limitations
+
+| Limitation | Details |
+|------------|---------|
+| **Objective-C only** | No direct Swift API access. Swift APIs with `@objc` bridging work. Pure Swift APIs (SwiftUI, Swift Concurrency) don't. |
+| **No Swift-only APIs** | Many post-2020 Apple APIs are Swift-only (SwiftUI, SwiftData, WidgetKit). Use `node-swift` for those. |
+| **Event loop integration** | When using `NSApplicationMain`, special handling needed to keep Node.js event loop alive. |
+| **Missing framework types** | Vision, ARKit, RealityKit, Photos, PDFKit etc. may work but lack auto-generated `.d.ts`. |
+| **Pre-1.0** | npm shows v0.4.0 but repo says 0.1.4. API may change. |
+| **Build complexity** | Building from source requires LLVM, cmake, and deno. Pre-built npm package includes compiled `.node` addon. |
+| **No Bun guarantee** | Loader uses `process.dlopen()` which is Node.js-specific. |
+
+---
+
+## Comparison with Alternatives
+
+| Feature | @nativescript/macos-node-api | NodObjC | node-swift | ffi-napi | lukaskollmer/objc |
+|---------|---------------------------|---------|------------|----------|-------------------|
+| **Approach** | Auto-generated from SDK headers | Manual ObjC runtime + BridgeSupport | Swift → Node module | Generic FFI | Manual ObjC runtime + ffi-napi |
+| **Type Safety** | Full auto-generated TS types | None | Manual (you write Swift) | None | Partial |
+| **API Coverage** | 56+ frameworks automatically | Manual per-API | Per-module | Manual per-API | Manual per-API |
+| **Maintenance** | Active (2024–2025) | Dead (2014) | Active (2025) | Community maintained | Unmaintained (2022) |
+| **Engine Support** | Node, Deno, Hermes, QuickJS, JSC | Node only | Node only | Node only | Node only |
+| **Class Subclassing** | Native (`static { NativeClass(this) }`) | Limited | N/A (Swift side) | N/A | Limited |
+| **Protocol Support** | Full (`static ObjCProtocols`) | Manual | N/A | N/A | Manual |
+| **Swift-only APIs** | No | No | Yes | No | No |
+| **Performance** | Near-native via libffi | Overhead from runtime lookups | Native Swift | High overhead | Overhead from ffi-napi |
+
+**Key advantage:** Auto-generated bindings for the entire macOS SDK with full TypeScript types. All alternatives require manual, per-API bridging.
+
+**When to use node-swift instead:** When you need Swift-only APIs (SwiftUI, SwiftData, WidgetKit, Apple Foundation Models).
+
+---
+
+## Related Projects
+
+- **`@nativescript/ios-node-api`** — iOS sibling package
+- **`@nativescript/objc-node-api`** — Shared ObjC runtime type definitions
+- **[NSBall](https://github.com/DjDeveloperr/NSBall)** — Full example app (bouncing ball with AppKit + SpriteKit)
+- **[nativescript-macos-solid](https://github.com/ammarahm-ed/nativescript-macos-solid)** — SolidJS integration for macOS native apps
+- **[NativeScript/napi-android](https://github.com/NativeScript/napi-android)** — Android runtime using same Node-API approach

--- a/docs/typescript-sdks/apple/typescript-sdks-automation.md
+++ b/docs/typescript-sdks/apple/typescript-sdks-automation.md
@@ -1,6 +1,6 @@
 # TypeScript SDKs for macOS Native App Automation
 
-> Last updated: 2026-02-16
+> Last updated: 2026-03-10
 
 ## Overview
 

--- a/docs/typescript-sdks/apple/typescript-sdks.md
+++ b/docs/typescript-sdks/apple/typescript-sdks.md
@@ -1,6 +1,18 @@
 # TypeScript / Node.js SDKs for Apple Frameworks
 
+> Last updated: 2026-03-10
+
 A curated list of GitHub repos and npm packages that bridge TypeScript/Node.js to Apple's native macOS/iOS SDKs — Vision, NaturalLanguage, EventKit, Contacts, LocalAuthentication, and more.
+
+**See also:**
+- **[github-repos-index.md](./github-repos-index.md)** — Full index of 49 repos sorted by stars, categorized
+- **[macos-node-api.md](./macos-node-api.md)** — Comprehensive docs for `@nativescript/macos-node-api` (full Apple SDK access)
+- **[darwinkit.md](./darwinkit.md)** — Complete reference for DarwinKit (NLP + Vision via JSON-RPC)
+- **[typescript-sdks-automation.md](./typescript-sdks-automation.md)** — AppleScript/JXA automation SDKs
+- **[typescript-sdks-native-bridge.md](./typescript-sdks-native-bridge.md)** — Native bridge details
+- **[jxa-userland.md](./jxa-userland.md)** — Deep dive into @jxa/* packages
+- **[apple-mcp.md](./apple-mcp.md)** — apple-mcp codebase exploration
+- **[macos-automator-mcp.md](./macos-automator-mcp.md)** — macos-automator-mcp exploration
 
 ---
 
@@ -12,6 +24,7 @@ A curated list of GitHub repos and npm packages that bridge TypeScript/Node.js t
 - [Contacts Framework](#contacts-framework)
 - [LocalAuthentication (Touch ID / Face ID)](#localauthentication-touch-id--face-id)
 - [Full Apple SDK Access (Runtimes & Bridges)](#full-apple-sdk-access-runtimes--bridges)
+- [Desktop / System Utilities](#desktop--system-utilities)
 - [React Native Bridges (iOS / visionOS)](#react-native-bridges)
 - [Generic FFI](#generic-ffi)
 - [Quick Comparison](#quick-comparison)
@@ -526,6 +539,67 @@ $.framework('Vision');
 
 ---
 
+## Desktop / System Utilities
+
+Focused modules wrapping specific macOS APIs — mostly by [sindresorhus](https://github.com/sindresorhus) and [codebytere](https://github.com/codebytere) (Electron core team).
+
+### Window & Display
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`active-win`](https://github.com/sindresorhus/active-win) | 895 | Get active window metadata (title, bounds, owner) | Accessibility API (AXUIElement) |
+| [`node-mac-displays`](https://github.com/codebytere/node-mac-displays) | 14 | Enumerate display information | CoreGraphics display APIs |
+
+### Desktop & Appearance
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`wallpaper`](https://github.com/sindresorhus/wallpaper) | 1,087 | Manage desktop wallpaper (cross-platform) | NSWorkspace / AppKit |
+| [`macos-wallpaper`](https://github.com/sindresorhus/macos-wallpaper) | 696 | macOS-specific wallpaper (Swift CLI) | AppKit |
+| [`dark-mode`](https://github.com/sindresorhus/dark-mode) | 679 | Control dark mode from CLI | NSUserDefaults / AppKit |
+| [`do-not-disturb`](https://github.com/sindresorhus/do-not-disturb) | 224 | Control DND | Notification Center |
+
+### Notifications
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`node-notifier`](https://github.com/mikaelbr/node-notifier) | 5,837 | Send native notifications (cross-platform) | NSUserNotification |
+| [`node-mac-notifier`](https://github.com/CharlieHess/node-mac-notifier) | 283 | macOS-native notifications | NSUserNotificationCenter |
+
+### Security & Permissions
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`node-keytar`](https://github.com/atom/node-keytar) | 1,420 | Native password module | Security / Keychain |
+| [`node-mac-permissions`](https://github.com/codebytere/node-mac-permissions) | 237 | Manage system permissions (camera, mic, screen) | TCC / Privacy framework |
+
+### Filesystem & System
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`plist.js`](https://github.com/TooTallNate/plist.js) | 598 | Plist parser/builder | CoreFoundation plist |
+| [`node-mac`](https://github.com/coreybutler/node-mac) | 541 | Processes, daemons, event logs | launchd, syslog |
+| [`clipboard-cli`](https://github.com/sindresorhus/clipboard-cli) | 506 | System clipboard access | NSPasteboard |
+| [`macos-trash`](https://github.com/sindresorhus/macos-trash) | 422 | Move files to Trash | NSFileManager |
+| [`fix-path`](https://github.com/sindresorhus/fix-path) | 295 | Fix $PATH in GUI apps | Shell / launchd |
+| [`macos-release`](https://github.com/sindresorhus/macos-release) | 67 | Get macOS name/version | System version |
+| [`node-mac-userdefaults`](https://github.com/codebytere/node-mac-userdefaults) | 17 | NSUserDefaults interface | Foundation |
+
+### Media & Screen
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`node-osx-audio`](https://github.com/fardog/node-osx-audio) | 52 | Audio I/O as Node streams | CoreAudio |
+| [`node-mac-recorder`](https://github.com/aslanon/node-mac-recorder) | 24 | Screen recording | ScreenCaptureKit |
+
+### AI / ML
+
+| Package | Stars | Description | macOS API |
+|---------|------:|-------------|-----------|
+| [`apple-on-device-ai`](https://github.com/Meridius-Labs/apple-on-device-ai) | 148 | Apple Foundation Model bindings (Vercel AI SDK) | Apple Intelligence |
+
+---
+
 ## React Native Bridges
 
 ### `react-native-vision` (iOS — VisionKit + CoreML)
@@ -596,9 +670,16 @@ const CoreFoundation = ffi.Library('/System/Library/Frameworks/CoreFoundation.fr
 | `@nativescript/macos-node-api` | **All macOS APIs** | Runtime + TS types | ✅ | ❌ |
 | `node-swift` | Any Swift API | Swift → Node module | ✅ | ❌ |
 | `ffi-napi` | Any C-level API | FFI | ✅ | ❌ |
+| `active-win` | Accessibility (AXUIElement) | Native addon | ✅ | ❌ |
+| `node-mac-permissions` | TCC / Privacy | Native addon | ✅ | ❌ |
+| `node-keytar` | Security / Keychain | Native addon | ❌ Archived | ❌ |
+| `node-mac-recorder` | ScreenCaptureKit | Native addon | ✅ | ❌ |
+| `apple-on-device-ai` | Apple Intelligence | Node module | ✅ | ✅ |
 | `react-native-vision` | VisionKit + CoreML | React Native | ⚠️ Alpha | ❌ |
 | `react-native-visionos` | visionOS SDK | React Native | ✅ | ❌ |
 | `NodObjC` | All ObjC APIs | Dynamic bridge | ❌ Unmaintained | ❌ |
+
+For the full list of 49 repos with stars and categories, see **[github-repos-index.md](./github-repos-index.md)**.
 
 ### Decision Guide
 
@@ -611,7 +692,13 @@ const CoreFoundation = ffi.Library('/System/Library/Frameworks/CoreFoundation.fr
 | Read+write Contacts | `node-mac-contacts` |
 | Read-only Contacts, no native build | `@appkit/apple-contacts` |
 | Touch ID / biometric auth | `node-mac-auth` |
-| Access **any** Apple framework in TypeScript | `@nativescript/macos-node-api` |
+| Access **any** Apple framework in TypeScript | [`@nativescript/macos-node-api`](./macos-node-api.md) |
 | Use Swift-only APIs (WidgetKit, SwiftData, etc.) | `node-swift` |
+| Active window info | `active-win` |
+| System permissions (camera, mic, screen) | `node-mac-permissions` |
+| Keychain / password storage | `node-keytar` |
+| Desktop wallpaper, dark mode, DND | `wallpaper` / `dark-mode` / `do-not-disturb` |
+| Screen recording | `node-mac-recorder` |
+| Apple on-device AI / Foundation Models | `apple-on-device-ai` |
 | React Native iOS ML / Vision | `react-native-vision` |
 | Build native visionOS app in React | `react-native-visionos` |

--- a/src/claude/lib/history/search.ts
+++ b/src/claude/lib/history/search.ts
@@ -603,10 +603,7 @@ async function processFileForCommit(
  * Fast commit hash search: uses git log + SQLite cache + raw text scanning
  * to avoid parsing all JSONL files.
  */
-async function searchCommitHashFast(
-    hashPrefix: string,
-    filters: SearchFilters
-): Promise<SearchResult[]> {
+async function searchCommitHashFast(hashPrefix: string, filters: SearchFilters): Promise<SearchResult[]> {
     const hashLower = hashPrefix.toLowerCase();
 
     // Step 1: Resolve full hash + date via git log
@@ -655,7 +652,9 @@ async function searchCommitHashFast(
         });
 
         candidateFiles = candidates.map((s) => s.filePath);
-        logger.debug(`Commit search: narrowed to ${candidateFiles.length} files from cache (±2 days of ${commitInfo.date.toISOString()})`);
+        logger.debug(
+            `Commit search: narrowed to ${candidateFiles.length} files from cache (±2 days of ${commitInfo.date.toISOString()})`
+        );
     } else {
         // No git info — fall back to all files (but still use raw text filter)
         candidateFiles = await findConversationFiles(filters);

--- a/src/telegram/commands/listen.ts
+++ b/src/telegram/commands/listen.ts
@@ -97,7 +97,11 @@ export function registerListenCommand(program: Command): void {
 
             // Fetch dialogs to populate gramjs entity cache — required for
             // resolving userIds when sending messages / fetching history.
-            await client.getDialogs(100);
+            try {
+                await client.getDialogs(100);
+            } catch (err) {
+                logger.warn(`Failed to prefetch dialogs (entity cache may be incomplete): ${err}`);
+            }
 
             spinner.stop(`Connected as ${myName}`);
 

--- a/src/telegram/commands/listen.ts
+++ b/src/telegram/commands/listen.ts
@@ -94,6 +94,11 @@ export function registerListenCommand(program: Command): void {
 
             const me = await client.getMe();
             const myName = me.firstName || "Me";
+
+            // Fetch dialogs to populate gramjs entity cache — required for
+            // resolving userIds when sending messages / fetching history.
+            await client.getDialogs(100);
+
             spinner.stop(`Connected as ${myName}`);
 
             const store = new TelegramHistoryStore();

--- a/src/telegram/index.ts
+++ b/src/telegram/index.ts
@@ -1,3 +1,4 @@
+import { configureLogger } from "@app/logger";
 import { handleReadmeFlag } from "@app/utils/readme";
 import { Command } from "commander";
 import { registerConfigureCommand } from "./commands/configure";
@@ -7,6 +8,7 @@ import { registerListenCommand } from "./commands/listen";
 import { registerWatchCommand } from "./commands/watch";
 
 handleReadmeFlag(import.meta.url);
+configureLogger({ logToFile: true });
 
 const program = new Command();
 program

--- a/src/telegram/lib/TGClient.ts
+++ b/src/telegram/lib/TGClient.ts
@@ -57,11 +57,13 @@ export class TGClient {
         return this.client.getDialogs({ limit });
     }
 
+    private static readonly ENTITY_NOT_FOUND = "Could not find the input entity";
+
     async sendMessage(userId: string, text: string, username?: string): Promise<Api.Message> {
         try {
             return await this.client.sendMessage(userId, { message: text });
         } catch (err) {
-            if (username && String(err).includes("Could not find the input entity")) {
+            if (username && String(err).includes(TGClient.ENTITY_NOT_FOUND)) {
                 return this.client.sendMessage(username, { message: text });
             }
 
@@ -75,7 +77,7 @@ export class TGClient {
         try {
             peer = await this.client.getInputEntity(userId);
         } catch (err) {
-            if (username && String(err).includes("Could not find the input entity")) {
+            if (username && String(err).includes(TGClient.ENTITY_NOT_FOUND)) {
                 peer = await this.client.getInputEntity(username);
             } else {
                 throw err;
@@ -90,7 +92,7 @@ export class TGClient {
         );
     }
 
-    startTypingLoop(userId: string): { stop: () => void } {
+    startTypingLoop(userId: string, username?: string): { stop: () => void } {
         let stopped = false;
 
         const tick = async () => {
@@ -99,7 +101,7 @@ export class TGClient {
             }
 
             try {
-                await this.sendTyping(userId);
+                await this.sendTyping(userId, username);
             } catch {
                 // ignore typing errors
             }

--- a/src/telegram/lib/TGClient.ts
+++ b/src/telegram/lib/TGClient.ts
@@ -57,12 +57,30 @@ export class TGClient {
         return this.client.getDialogs({ limit });
     }
 
-    async sendMessage(userId: string, text: string): Promise<Api.Message> {
-        return this.client.sendMessage(userId, { message: text });
+    async sendMessage(userId: string, text: string, username?: string): Promise<Api.Message> {
+        try {
+            return await this.client.sendMessage(userId, { message: text });
+        } catch (err) {
+            if (username && String(err).includes("Could not find the input entity")) {
+                return this.client.sendMessage(username, { message: text });
+            }
+
+            throw err;
+        }
     }
 
-    async sendTyping(userId: string): Promise<void> {
-        const peer = await this.client.getInputEntity(userId);
+    async sendTyping(userId: string, username?: string): Promise<void> {
+        let peer: Api.TypeInputPeer;
+
+        try {
+            peer = await this.client.getInputEntity(userId);
+        } catch (err) {
+            if (username && String(err).includes("Could not find the input entity")) {
+                peer = await this.client.getInputEntity(username);
+            } else {
+                throw err;
+            }
+        }
 
         await this.client.invoke(
             new Api.messages.SetTyping({

--- a/src/telegram/lib/actions/ask.ts
+++ b/src/telegram/lib/actions/ask.ts
@@ -9,7 +9,7 @@ const contactChats = new Map<string, AIChat>();
 
 export const handleAsk: ActionHandler = async (message, contact, client, conversationHistory) => {
     const start = performance.now();
-    const typing = client.startTypingLoop(contact.userId);
+    const typing = client.startTypingLoop(contact.userId, contact.username);
 
     try {
         // Get or create AIChat instance — cache key includes config so changes are detected

--- a/src/telegram/lib/actions/ask.ts
+++ b/src/telegram/lib/actions/ask.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { resolve } from "node:path";
+import logger from "@app/logger";
 import { AIChat } from "@ask/AIChat";
 import type { ActionHandler } from "../types";
 
@@ -44,11 +45,25 @@ export const handleAsk: ActionHandler = async (message, contact, client, convers
             chat.session.add({ role: "system", content: `[Recent conversation]\n${conversationHistory}` });
         }
 
+        logger.debug(
+            `[ask] Sending to ${contact.askProvider}/${contact.askModel}: "${message.contentForLLM.slice(0, 100)}"`
+        );
+
         const response = await chat.send(message.contentForLLM);
 
         typing.stop();
 
+        logger.debug(
+            `[ask] Response: content=${response.content.length} chars, cost=${response.cost}, usage=${JSON.stringify(response.usage)}`
+        );
+
         if (!response.content) {
+            logger.warn(
+                `[ask] Empty LLM response for ${contact.askProvider}/${contact.askModel}. ` +
+                    `Input: "${message.contentForLLM.slice(0, 200)}". ` +
+                    `Usage: ${JSON.stringify(response.usage)}. Cost: ${response.cost}`
+            );
+
             return {
                 action: "ask",
                 success: false,
@@ -59,7 +74,7 @@ export const handleAsk: ActionHandler = async (message, contact, client, convers
 
         await Bun.sleep(contact.randomDelay);
 
-        const sentMessage = await client.sendMessage(contact.userId, response.content);
+        const sentMessage = await client.sendMessage(contact.userId, response.content, contact.username);
 
         return {
             action: "ask",

--- a/src/telegram/lib/handler.ts
+++ b/src/telegram/lib/handler.ts
@@ -158,7 +158,7 @@ export function registerHandler(client: TGClient, options: HandlerOptions): void
 
             for (const r of results) {
                 if (r.success) {
-                    const extra = r.reply ? ` "${r.reply.slice(0, 60)}${r.reply.length > 60 ? "..." : ""}"` : "";
+                    const extra = r.reply ? ` "${r.reply}"` : "";
                     logger.info(`  ${pc.green(`[${r.action}]`)} OK${pc.dim(extra)}`);
 
                     if (r.action === "ask" && r.reply && ctx) {

--- a/src/telegram/lib/types.ts
+++ b/src/telegram/lib/types.ts
@@ -50,7 +50,7 @@ export const DEFAULTS = {
     typingIntervalMs: 4000,
     askTimeoutMs: 60_000,
     askProvider: "openai",
-    askModel: "gpt-4o-mini",
+    askModel: "gpt-5-chat-latest",
     maxContextMessages: 30,
     historyFetchLimit: 100,
 } as const;

--- a/src/utils/macos/darwinkit.ts
+++ b/src/utils/macos/darwinkit.ts
@@ -58,7 +58,9 @@ export class DarwinKitClient {
 
         // If we already tried and failed, don't retry
         if (existsSync(DarwinKitClient.UNAVAILABLE_MARKER)) {
-            throw new Error("darwinkit is not available (install failed previously, remove ~/.genesis-tools/.darwinkit-unavailable to retry)");
+            throw new Error(
+                "darwinkit is not available (install failed previously, remove ~/.genesis-tools/.darwinkit-unavailable to retry)"
+            );
         }
 
         logger.info("DarwinKitClient: darwinkit not found, installing...");

--- a/src/utils/macos/darwinkit.ts
+++ b/src/utils/macos/darwinkit.ts
@@ -1,5 +1,6 @@
 // src/utils/macos/darwinkit.ts
 
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import logger from "@app/logger";
 import type { CapabilitiesResult, DarwinKitConfig, JsonRpcRequest, JsonRpcResponse } from "./types";
 
@@ -34,10 +35,25 @@ export class DarwinKitClient {
         return this.startPromise;
     }
 
+    private static readonly UNAVAILABLE_MARKER = `${process.env.HOME}/.genesis-tools/.darwinkit-unavailable`;
+
     private async _ensureInstalled(): Promise<void> {
+        // Check known install path first
+        const knownPath = `${process.env.HOME}/.local/bin/darwinkit`;
+        if (Bun.spawnSync(["test", "-x", knownPath]).exitCode === 0) {
+            this.config.binaryPath = knownPath;
+            return;
+        }
+
+        // Check PATH
         const which = Bun.spawnSync(["which", this.config.binaryPath]);
         if (which.exitCode === 0) {
             return;
+        }
+
+        // If we already tried and failed, don't retry
+        if (existsSync(DarwinKitClient.UNAVAILABLE_MARKER)) {
+            throw new Error("darwinkit is not available (install failed previously, remove ~/.genesis-tools/.darwinkit-unavailable to retry)");
         }
 
         logger.info("DarwinKitClient: darwinkit not found, installing...");
@@ -49,13 +65,17 @@ export class DarwinKitClient {
 
         // Try direct binary download first (no sudo needed)
         const download = Bun.spawnSync(
-            ["bash", "-c", `mkdir -p "${installDir}" && curl -fsSL "${downloadUrl}" | tar xz -C "${installDir}"`],
+            [
+                "bash",
+                "-c",
+                `set -o pipefail && mkdir -p "${installDir}" && curl -fsSL "${downloadUrl}" | tar xz -C "${installDir}"`,
+            ],
             { stdio: ["ignore", "pipe", "pipe"] }
         );
 
-        if (download.exitCode === 0) {
-            logger.info(`DarwinKitClient: installed to ${installDir}/darwinkit`);
-            this.config.binaryPath = `${installDir}/darwinkit`;
+        if (download.exitCode === 0 && Bun.spawnSync(["test", "-x", knownPath]).exitCode === 0) {
+            logger.info(`DarwinKitClient: installed to ${knownPath}`);
+            this.config.binaryPath = knownPath;
             return;
         }
 
@@ -75,10 +95,16 @@ export class DarwinKitClient {
             }
         }
 
+        // Mark as unavailable so we don't retry on every process start
+        try {
+            mkdirSync(`${process.env.HOME}/.genesis-tools`, { recursive: true });
+            writeFileSync(DarwinKitClient.UNAVAILABLE_MARKER, new Date().toISOString());
+        } catch {
+            // ignore — worst case we retry next time
+        }
+
         throw new Error(
-            "Failed to install darwinkit. Install manually:\n" +
-                `  curl -fsSL ${downloadUrl} | tar xz\n` +
-                '  mv darwinkit ~/.local/bin/ && export PATH="$HOME/.local/bin:$PATH"'
+            "Failed to install darwinkit (won't retry — remove ~/.genesis-tools/.darwinkit-unavailable to try again)"
         );
     }
 

--- a/src/utils/macos/darwinkit.ts
+++ b/src/utils/macos/darwinkit.ts
@@ -1,6 +1,8 @@
 // src/utils/macos/darwinkit.ts
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import logger from "@app/logger";
 import type { CapabilitiesResult, DarwinKitConfig, JsonRpcRequest, JsonRpcResponse } from "./types";
 
@@ -31,15 +33,18 @@ export class DarwinKitClient {
         if (this.startPromise) {
             return this.startPromise;
         }
-        this.startPromise = this._doStart();
+        this.startPromise = this._doStart().catch((err) => {
+            this.startPromise = null;
+            throw err;
+        });
         return this.startPromise;
     }
 
-    private static readonly UNAVAILABLE_MARKER = `${process.env.HOME}/.genesis-tools/.darwinkit-unavailable`;
+    private static readonly UNAVAILABLE_MARKER = resolve(homedir(), ".genesis-tools", ".darwinkit-unavailable");
 
     private async _ensureInstalled(): Promise<void> {
         // Check known install path first
-        const knownPath = `${process.env.HOME}/.local/bin/darwinkit`;
+        const knownPath = resolve(homedir(), ".local", "bin", "darwinkit");
         if (Bun.spawnSync(["test", "-x", knownPath]).exitCode === 0) {
             this.config.binaryPath = knownPath;
             return;
@@ -61,7 +66,7 @@ export class DarwinKitClient {
 
         const downloadUrl =
             "https://github.com/0xMassi/darwinkit/releases/latest/download/darwinkit-macos-universal.tar.gz";
-        const installDir = `${process.env.HOME}/.local/bin`;
+        const installDir = resolve(homedir(), ".local", "bin");
 
         // Try direct binary download first (no sudo needed)
         const download = Bun.spawnSync(
@@ -97,7 +102,7 @@ export class DarwinKitClient {
 
         // Mark as unavailable so we don't retry on every process start
         try {
-            mkdirSync(`${process.env.HOME}/.genesis-tools`, { recursive: true });
+            mkdirSync(resolve(homedir(), ".genesis-tools"), { recursive: true });
             writeFileSync(DarwinKitClient.UNAVAILABLE_MARKER, new Date().toISOString());
         } catch {
             // ignore — worst case we retry next time


### PR DESCRIPTION
## Summary
- **fix(telegram)**: Prefetch dialogs to populate gramjs entity cache; fall back to username when userId entity lookup fails for sendMessage/sendTyping; add debug/warn logging for empty LLM responses; enable file logging; update default model to gpt-5-chat-latest
- **docs(macos)**: Add github-repos-index.md (49 repos) and macos-node-api.md reference; update typescript-sdks.md with desktop/system utilities section
- **fix(darwinkit)**: Harden install — check known path first, cache unavailability marker, use `set -o pipefail`

## Test plan
- [ ] Verify telegram listen connects and can send messages to contacts
- [ ] Verify entity fallback to username works when userId lookup fails
- [ ] Check log files in `/logs/` for debug output
- [ ] Verify darwinkit installs correctly on fresh setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GitHub repositories index for macOS TypeScript/Node.js SDKs.
  * Added macOS node API package documentation with installation guides and code examples.
  * Expanded TypeScript SDK documentation with Desktop/System Utilities section.

* **New Features**
  * Enhanced Telegram messaging with fallback username resolution for improved reliability.
  * Added debug logging for AI chat requests and response metrics.

* **Bug Fixes**
  * Improved macOS development tools installation with failure recovery and retry prevention.

* **Chores**
  * Updated default AI model for Telegram integration.
  * Improved log message formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->