### PR TITLE
fix(tools): replace @inquirer/prompts with clack searchSelect to avoid signal-exit crash

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,6 @@ if git diff --cached --name-only --diff-filter=d | grep -q '^src/claude-history-
 fi
 
 echo "▶ tsgo --noEmit..."
-tsgo --noEmit
+bunx tsgo --noEmit
 
 echo "✔ pre-commit passed"

--- a/install.sh
+++ b/install.sh
@@ -83,9 +83,10 @@ echo ""
 echo "🎉 Setup complete."
 
 if [ "$SHELL_CONFIG_CHANGED" = true ]; then
+    echo "   Please restart your terminal or run:"
     case "$SHELL" in
-        */zsh)  echo "   Sourcing ~/.zshrc..."; source "$HOME/.zshrc" ;;
-        */bash) echo "   Sourcing ~/.bashrc..."; source "$HOME/.bashrc" ;;
-        *)      echo "   Please restart your terminal or source your shell config for the changes to take effect." ;;
+        */zsh)  echo "     source ~/.zshrc" ;;
+        */bash) echo "     source ~/.bashrc" ;;
+        *)      echo "     source your shell config" ;;
     esac
 fi

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,8 @@ CURRENT_DIR="$(pwd)"
 TOOLS_LINE="export GENESIS_TOOLS_PATH=\"$CURRENT_DIR\""
 EXPORT_LINE="export PATH=\"\$GENESIS_TOOLS_PATH:\$PATH\""
 
+SHELL_CONFIG_CHANGED=false
+
 # Function to add the export line to a shell config file
 add_to_shell_config() {
     local shell_config_file="$1"
@@ -50,11 +52,13 @@ add_to_shell_config() {
             echo "$TOOLS_LINE" >> "$shell_config_file"
             echo "$EXPORT_LINE" >> "$shell_config_file"
             echo "📝 Added $CURRENT_DIR to PATH in $shell_config_file"
+            SHELL_CONFIG_CHANGED=true
         fi
     else
         # Create the file and add the export line if the file does not exist
         echo "$EXPORT_LINE" > "$shell_config_file"
         echo "➕ Created $shell_config_file and added $CURRENT_DIR to PATH"
+        SHELL_CONFIG_CHANGED=true
     fi
 }
 
@@ -64,4 +68,16 @@ add_to_shell_config "$HOME/.zshrc"
 # Add to .bashrc
 add_to_shell_config "$HOME/.bashrc"
 
-echo "🎉 Setup complete. Please restart your terminal or run 'source ~/.zshrc' and/or 'source ~/.bashrc' for the changes to take effect."
+# Make tools available for the rest of the script
+export PATH="$CURRENT_DIR:$PATH"
+
+# Run update (plugin setup, changelog, etc.)
+echo "🔄 Running tools update..."
+tools update
+
+echo ""
+echo "🎉 Setup complete."
+
+if [ "$SHELL_CONFIG_CHANGED" = true ]; then
+    echo "   Please restart your terminal or run 'source ~/.zshrc' and/or 'source ~/.bashrc' for the changes to take effect."
+fi

--- a/install.sh
+++ b/install.sh
@@ -55,8 +55,9 @@ add_to_shell_config() {
             SHELL_CONFIG_CHANGED=true
         fi
     else
-        # Create the file and add the export line if the file does not exist
-        echo "$EXPORT_LINE" > "$shell_config_file"
+        # Create the file and add both lines
+        echo "$TOOLS_LINE" > "$shell_config_file"
+        echo "$EXPORT_LINE" >> "$shell_config_file"
         echo "➕ Created $shell_config_file and added $CURRENT_DIR to PATH"
         SHELL_CONFIG_CHANGED=true
     fi
@@ -73,7 +74,10 @@ export PATH="$CURRENT_DIR:$PATH"
 
 # Run update (plugin setup, changelog, etc.)
 echo "🔄 Running tools update..."
-tools update
+if ! tools update; then
+    echo "❌ tools update failed"
+    exit 1
+fi
 
 echo ""
 echo "🎉 Setup complete."

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ add_to_shell_config() {
 
     if [ -f "$shell_config_file" ]; then
         # Check if the line already exists in the file
-        if grep -q "export PATH=\"$CURRENT_DIR:\$PATH" "$shell_config_file" && grep -q "$CURRENT_DIR" "$shell_config_file"; then
+        if grep -q "GENESIS_TOOLS_PATH" "$shell_config_file"; then
             echo "✅ $CURRENT_DIR is already in PATH in $shell_config_file"
         else
             # Append the export line if not found

--- a/install.sh
+++ b/install.sh
@@ -79,5 +79,9 @@ echo ""
 echo "🎉 Setup complete."
 
 if [ "$SHELL_CONFIG_CHANGED" = true ]; then
-    echo "   Please restart your terminal or run 'source ~/.zshrc' and/or 'source ~/.bashrc' for the changes to take effect."
+    case "$SHELL" in
+        */zsh)  echo "   Sourcing ~/.zshrc..."; source "$HOME/.zshrc" ;;
+        */bash) echo "   Sourcing ~/.bashrc..."; source "$HOME/.bashrc" ;;
+        *)      echo "   Please restart your terminal or source your shell config for the changes to take effect." ;;
+    esac
 fi

--- a/src/claude/lib/history/search.ts
+++ b/src/claude/lib/history/search.ts
@@ -603,10 +603,7 @@ async function processFileForCommit(
  * Fast commit hash search: uses git log + SQLite cache + raw text scanning
  * to avoid parsing all JSONL files.
  */
-async function searchCommitHashFast(
-    hashPrefix: string,
-    filters: SearchFilters
-): Promise<SearchResult[]> {
+async function searchCommitHashFast(hashPrefix: string, filters: SearchFilters): Promise<SearchResult[]> {
     const hashLower = hashPrefix.toLowerCase();
 
     // Step 1: Resolve full hash + date via git log
@@ -655,7 +652,9 @@ async function searchCommitHashFast(
         });
 
         candidateFiles = candidates.map((s) => s.filePath);
-        logger.debug(`Commit search: narrowed to ${candidateFiles.length} files from cache (±2 days of ${commitInfo.date.toISOString()})`);
+        logger.debug(
+            `Commit search: narrowed to ${candidateFiles.length} files from cache (±2 days of ${commitInfo.date.toISOString()})`
+        );
     } else {
         // No git info — fall back to all files (but still use raw text filter)
         candidateFiles = await findConversationFiles(filters);

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { discoverTools } from "@app/tools/lib/discovery";
 import * as p from "@clack/prompts";
@@ -25,17 +25,25 @@ const program = new Command()
             process.exit(1);
         }
 
-        // 2. Clean install dependencies (rm node_modules to avoid stale nested deps)
-        console.log(pc.dim("\n  Installing dependencies (clean)..."));
-        const nodeModulesPath = join(genesisPath, "node_modules");
-        Bun.spawnSync(["rm", "-rf", nodeModulesPath], { stdio: ["inherit", "inherit", "inherit"] });
+        // 2. Install dependencies (clean retry if first attempt fails)
+        console.log(pc.dim("\n  Installing dependencies..."));
         const install = Bun.spawnSync(["bun", "install"], {
             cwd: genesisPath,
             stdio: ["inherit", "inherit", "inherit"],
         });
+
         if (install.exitCode !== 0) {
-            console.error(pc.red("  Failed to bun install"));
-            process.exit(1);
+            console.log(pc.yellow("  Install failed, retrying with clean node_modules..."));
+            rmSync(join(genesisPath, "node_modules"), { recursive: true, force: true });
+            const retry = Bun.spawnSync(["bun", "install"], {
+                cwd: genesisPath,
+                stdio: ["inherit", "inherit", "inherit"],
+            });
+
+            if (retry.exitCode !== 0) {
+                console.error(pc.red("  Failed to install dependencies"));
+                process.exit(1);
+            }
         }
 
         // 3. Claude Code plugin management

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -25,8 +25,10 @@ const program = new Command()
             process.exit(1);
         }
 
-        // 2. Bun install
-        console.log(pc.dim("\n  Installing dependencies..."));
+        // 2. Clean install dependencies (rm node_modules to avoid stale nested deps)
+        console.log(pc.dim("\n  Installing dependencies (clean)..."));
+        const nodeModulesPath = join(genesisPath, "node_modules");
+        Bun.spawnSync(["rm", "-rf", nodeModulesPath], { stdio: ["inherit", "inherit", "inherit"] });
         const install = Bun.spawnSync(["bun", "install"], {
             cwd: genesisPath,
             stdio: ["inherit", "inherit", "inherit"],

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -16,31 +16,31 @@ const program = new Command()
 
         // 1. Git pull
         console.log(pc.dim("  Pulling latest changes..."));
-        const pull = Bun.spawnSync(["git", "pull"], {
+        const pull = Bun.spawn(["git", "pull"], {
             cwd: genesisPath,
             stdio: ["inherit", "inherit", "inherit"],
         });
-        if (pull.exitCode !== 0) {
+        if ((await pull.exited) !== 0) {
             console.error(pc.red("  Failed to git pull"));
             process.exit(1);
         }
 
         // 2. Install dependencies (clean retry if first attempt fails)
         console.log(pc.dim("\n  Installing dependencies..."));
-        const install = Bun.spawnSync(["bun", "install"], {
+        const install = Bun.spawn(["bun", "install"], {
             cwd: genesisPath,
             stdio: ["inherit", "inherit", "inherit"],
         });
 
-        if (install.exitCode !== 0) {
+        if ((await install.exited) !== 0) {
             console.log(pc.yellow("  Install failed, retrying with clean node_modules..."));
             rmSync(join(genesisPath, "node_modules"), { recursive: true, force: true });
-            const retry = Bun.spawnSync(["bun", "install"], {
+            const retry = Bun.spawn(["bun", "install"], {
                 cwd: genesisPath,
                 stdio: ["inherit", "inherit", "inherit"],
             });
 
-            if (retry.exitCode !== 0) {
+            if ((await retry.exited) !== 0) {
                 console.error(pc.red("  Failed to install dependencies"));
                 process.exit(1);
             }
@@ -61,41 +61,41 @@ const program = new Command()
         if (runClaudeUpdates) {
             if (inClaudeCode) {
                 console.log(pc.dim("\n  Adding marketplace (if needed)..."));
-                Bun.spawnSync(["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"], {
+                await Bun.spawn(["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"], {
                     stdio: ["inherit", "inherit", "inherit"],
-                });
+                }).exited;
 
                 console.log(pc.dim("\n  Installing plugin (if needed)..."));
-                const pluginInstall = Bun.spawnSync(["claude", "plugin", "install", "genesis-tools@genesis-tools"], {
+                const pluginInstallCode = await Bun.spawn(["claude", "plugin", "install", "genesis-tools@genesis-tools"], {
                     stdio: ["inherit", "inherit", "inherit"],
-                });
-                if (pluginInstall.exitCode !== 0) {
+                }).exited;
+                if (pluginInstallCode !== 0) {
                     console.log(pc.yellow("  Plugin install had issues (may already be installed)"));
                 }
 
                 console.log(pc.dim("\n  Updating Claude Code plugin..."));
-                const pluginUpdate = Bun.spawnSync(["claude", "plugin", "update", "genesis-tools@genesis-tools"], {
+                const pluginUpdateCode = await Bun.spawn(["claude", "plugin", "update", "genesis-tools@genesis-tools"], {
                     stdio: ["inherit", "inherit", "inherit"],
-                });
-                if (pluginUpdate.exitCode !== 0) {
+                }).exited;
+                if (pluginUpdateCode !== 0) {
                     console.log(pc.yellow("  Plugin update had issues"));
                 }
             } else {
                 console.log(pc.dim("\n  Updating Claude Code marketplace..."));
-                Bun.spawnSync(["claude", "plugin", "marketplace", "update"], {
+                await Bun.spawn(["claude", "plugin", "marketplace", "update"], {
                     stdio: ["inherit", "inherit", "inherit"],
-                });
+                }).exited;
 
                 console.log(pc.dim("\n  Adding marketplace..."));
-                Bun.spawnSync(["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"], {
+                await Bun.spawn(["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"], {
                     stdio: ["inherit", "inherit", "inherit"],
-                });
+                }).exited;
 
                 console.log(pc.dim("\n  Installing plugin..."));
-                const pluginInstall = Bun.spawnSync(["claude", "plugin", "install", "genesis-tools@genesis-tools"], {
+                const pluginInstallCode = await Bun.spawn(["claude", "plugin", "install", "genesis-tools@genesis-tools"], {
                     stdio: ["inherit", "inherit", "inherit"],
-                });
-                if (pluginInstall.exitCode !== 0) {
+                }).exited;
+                if (pluginInstallCode !== 0) {
                     console.log(pc.yellow("  Plugin install had issues"));
                 }
             }

--- a/src/update/index.ts
+++ b/src/update/index.ts
@@ -61,22 +61,31 @@ const program = new Command()
         if (runClaudeUpdates) {
             if (inClaudeCode) {
                 console.log(pc.dim("\n  Adding marketplace (if needed)..."));
-                await Bun.spawn(["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"], {
-                    stdio: ["inherit", "inherit", "inherit"],
-                }).exited;
+                await Bun.spawn(
+                    ["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"],
+                    {
+                        stdio: ["inherit", "inherit", "inherit"],
+                    }
+                ).exited;
 
                 console.log(pc.dim("\n  Installing plugin (if needed)..."));
-                const pluginInstallCode = await Bun.spawn(["claude", "plugin", "install", "genesis-tools@genesis-tools"], {
-                    stdio: ["inherit", "inherit", "inherit"],
-                }).exited;
+                const pluginInstallCode = await Bun.spawn(
+                    ["claude", "plugin", "install", "genesis-tools@genesis-tools"],
+                    {
+                        stdio: ["inherit", "inherit", "inherit"],
+                    }
+                ).exited;
                 if (pluginInstallCode !== 0) {
                     console.log(pc.yellow("  Plugin install had issues (may already be installed)"));
                 }
 
                 console.log(pc.dim("\n  Updating Claude Code plugin..."));
-                const pluginUpdateCode = await Bun.spawn(["claude", "plugin", "update", "genesis-tools@genesis-tools"], {
-                    stdio: ["inherit", "inherit", "inherit"],
-                }).exited;
+                const pluginUpdateCode = await Bun.spawn(
+                    ["claude", "plugin", "update", "genesis-tools@genesis-tools"],
+                    {
+                        stdio: ["inherit", "inherit", "inherit"],
+                    }
+                ).exited;
                 if (pluginUpdateCode !== 0) {
                     console.log(pc.yellow("  Plugin update had issues"));
                 }
@@ -87,14 +96,20 @@ const program = new Command()
                 }).exited;
 
                 console.log(pc.dim("\n  Adding marketplace..."));
-                await Bun.spawn(["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"], {
-                    stdio: ["inherit", "inherit", "inherit"],
-                }).exited;
+                await Bun.spawn(
+                    ["claude", "plugin", "marketplace", "add", "https://github.com/genesiscz/GenesisTools"],
+                    {
+                        stdio: ["inherit", "inherit", "inherit"],
+                    }
+                ).exited;
 
                 console.log(pc.dim("\n  Installing plugin..."));
-                const pluginInstallCode = await Bun.spawn(["claude", "plugin", "install", "genesis-tools@genesis-tools"], {
-                    stdio: ["inherit", "inherit", "inherit"],
-                }).exited;
+                const pluginInstallCode = await Bun.spawn(
+                    ["claude", "plugin", "install", "genesis-tools@genesis-tools"],
+                    {
+                        stdio: ["inherit", "inherit", "inherit"],
+                    }
+                ).exited;
                 if (pluginInstallCode !== 0) {
                     console.log(pc.yellow("  Plugin install had issues"));
                 }

--- a/tools
+++ b/tools
@@ -1,7 +1,5 @@
 #!/usr/bin/env bun
 
-import { search } from "@inquirer/prompts";
-import { ExitPromptError } from "@inquirer/core";
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
@@ -85,6 +83,7 @@ async function executeTool(scriptId, scriptArgs) {
         }
 
         if (!targetScript) {
+            const { searchSelect, searchSelectCancelSymbol } = await import("@app/utils/prompts/clack/search-select");
             const chalk = (await import("chalk")).default;
             // Fuzzy match: find tools that contain the input or share segments
             const availableTools = await getAvailableTools(srcDir);
@@ -105,28 +104,18 @@ async function executeTool(scriptId, scriptArgs) {
                 process.exit(1);
             }
 
-            // Launch interactive selector pre-filtered with matches
             console.log(`\n  ${chalk.yellow("No exact match for")} ${chalk.bold(scriptId)}${chalk.yellow(". Did you mean?")}\n`);
 
-            try {
-                const tool = await search({
-                    message: "Select a tool:",
-                    source: async (term) => {
-                        const filtered = matches.filter(t =>
-                            t.toLowerCase().includes((term || "").toLowerCase())
-                        );
-                        return filtered.map(t => ({ value: t, name: t }));
-                    },
-                });
+            const tool = await searchSelect({
+                message: "Select a tool:",
+                items: matches.map(t => ({ value: t, label: t })),
+            });
 
-                // Re-execute with the selected tool
-                await executeTool(tool, scriptArgs);
-            } catch (error) {
-                if (error instanceof ExitPromptError) {
-                    process.exit(0);
-                }
-                throw error;
+            if (tool === searchSelectCancelSymbol) {
+                process.exit(0);
             }
+
+            await executeTool(tool as string, scriptArgs);
             return;
         }
     }


### PR DESCRIPTION
## Summary
- Replaced top-level `@inquirer/prompts` / `@inquirer/core` imports in the `tools` entry point with a lazy-loaded `searchSelect` from `@app/utils/prompts/clack/search-select`
- `@inquirer/core` depends on `signal-exit@^4`, but the top-level `signal-exit` is v3 — when Bun's `node_modules` gets stale (missing nested v4 copies), **every** `tools` command crashes with `SyntaxError: Export named 'onExit' not found`
- The clack-based `searchSelect` has no `signal-exit` dependency and is only loaded when fuzzy-matching is actually needed
- `tools update` now does a clean install (`rm -rf node_modules` before `bun install`) to prevent stale nested deps

## Test plan
- [ ] Run `tools update --help` — should print help without errors
- [ ] Delete `node_modules/execa/node_modules/signal-exit/` and run `tools update --help` — should still work
- [ ] Run `tools nonexistent-tool` — should show fuzzy match selector using clack UI
- [ ] Run `tools update` — should do clean install and update successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retry package installation automatically: on initial failure the app cleans stale packages and retries, exiting only if the retry also fails.
  * Improved tool selection flow: switched to a new interactive selector with explicit cancel handling for a smoother selection experience.
  * Made update/pull/plugin operations use asynchronous execution with clearer exit-code checks and consolidated error handling.

* **Chores**
  * Updated pre-commit checks command.
  * Enhanced installer: tracks shell config changes, updates PATH handling, runs post-update steps, and shows conditional restart/sourcing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->