### PR TITLE
feat(debugging-master): delete-session, multi-tail, interactive picker

### DIFF
--- a/src/debugging-master/commands/delete-session.ts
+++ b/src/debugging-master/commands/delete-session.ts
@@ -1,0 +1,81 @@
+import { SessionManager } from "@app/debugging-master/core/session-manager";
+import { parseVariadic } from "@app/utils/cli/variadic";
+import { confirm } from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+export function registerDeleteSessionCommand(program: Command): void {
+    program
+        .command("delete-session")
+        .description("Delete debugging sessions")
+        .argument("[names...]", "Session names to delete (comma-separated)")
+        .option("--inactive", "Delete sessions inactive for >24h")
+        .option("--all", "Delete all sessions")
+        .option("--force", "Skip confirmation (for non-TTY)")
+        .action(async (rawNames: string[], opts: { inactive?: boolean; all?: boolean; force?: boolean }) => {
+            const sm = new SessionManager();
+            let toDelete: string[] = [];
+
+            if (opts.all) {
+                toDelete = await sm.listSessionNames();
+
+                if (toDelete.length === 0) {
+                    console.log(pc.dim("No sessions to delete."));
+                    return;
+                }
+            } else if (opts.inactive) {
+                const inactive = await sm.getInactiveSessions();
+                toDelete = inactive.map((s) => s.name);
+
+                if (toDelete.length === 0) {
+                    console.log(pc.dim("No inactive sessions found."));
+                    return;
+                }
+            } else {
+                toDelete = parseVariadic(rawNames);
+
+                if (toDelete.length === 0) {
+                    console.error(pc.red("No session names provided. Use positional args, --inactive, or --all."));
+                    process.exit(1);
+                }
+            }
+
+            console.log(pc.bold(`Sessions to delete (${toDelete.length}):`));
+            for (const name of toDelete) {
+                console.log(`  ${name}`);
+            }
+            console.log("");
+
+            if (process.stdout.isTTY && !opts.force) {
+                const confirmed = await confirm({
+                    message: `Delete ${toDelete.length} session(s)?`,
+                });
+
+                if (typeof confirmed === "symbol" || !confirmed) {
+                    console.log(pc.dim("Cancelled."));
+                    return;
+                }
+            } else if (!opts.force) {
+                console.error(pc.red("Non-TTY environment. Use --force to skip confirmation."));
+                process.exit(1);
+            }
+
+            let deleted = 0;
+            let notFound = 0;
+
+            for (const name of toDelete) {
+                const result = await sm.deleteSession(name);
+
+                if (result) {
+                    deleted++;
+                    console.log(pc.green(`  Deleted: ${name}`));
+                } else {
+                    notFound++;
+                    console.log(pc.yellow(`  Not found: ${name}`));
+                }
+            }
+
+            console.log("");
+            console.log(pc.bold(`Done: ${deleted} deleted${notFound > 0 ? `, ${notFound} not found` : ""}`));
+        });
+}

--- a/src/debugging-master/commands/tail.ts
+++ b/src/debugging-master/commands/tail.ts
@@ -1,10 +1,19 @@
-import { readFileSync, statSync, watch } from "node:fs";
+import { type FSWatcher, readFileSync, statSync, watch } from "node:fs";
 import { formatEntryLine } from "@app/debugging-master/core/formatter";
 import { filterByLevel, indexEntries } from "@app/debugging-master/core/log-parser";
 import { SessionManager } from "@app/debugging-master/core/session-manager";
 import type { IndexedLogEntry, LogEntry } from "@app/debugging-master/types";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
+import pc from "picocolors";
+
+interface SessionTailState {
+    name: string;
+    filePath: string;
+    offset: number;
+    entryIndex: number;
+    currentFile: string;
+}
 
 export function registerTailCommand(program: Command): void {
     program
@@ -15,98 +24,148 @@ export function registerTailCommand(program: Command): void {
         .action(async (opts) => {
             const globalOpts = program.opts();
             const sm = new SessionManager();
-            const sessionName = await sm.resolveSession(globalOpts.session);
-            const filePath = await sm.getSessionPath(sessionName);
+            const sessionNames = await sm.resolveSessionInteractive(globalOpts.session);
             const pretty = globalOpts.pretty ?? process.stdout.isTTY ?? false;
             const levels = opts.level?.split(",").map((l: string) => l.trim());
             const lastCount = parseInt(opts.n, 10);
+            const multiSession = sessionNames.length > 1;
 
-            const raw = await sm.readEntries(sessionName);
-            let existing = indexEntries(raw);
-            if (levels) {
-                existing = filterByLevel(existing, levels);
+            const allEntries: Array<IndexedLogEntry & { session: string }> = [];
+
+            for (const sessionName of sessionNames) {
+                const raw = await sm.readEntries(sessionName);
+                let existing = indexEntries(raw);
+
+                if (levels) {
+                    existing = filterByLevel(existing, levels);
+                }
+
+                for (const entry of existing) {
+                    allEntries.push({ ...entry, session: sessionName });
+                }
             }
-            const tail = existing.slice(-lastCount);
 
-            console.log(`Tailing session: ${sessionName} (${raw.length} entries, showing last ${tail.length})`);
+            allEntries.sort((a, b) => a.ts - b.ts);
+            const tail = allEntries.slice(-lastCount);
+
+            if (multiSession) {
+                console.log(
+                    `Tailing ${sessionNames.length} sessions: ${sessionNames.join(", ")} (showing last ${tail.length})`
+                );
+            } else {
+                const raw = await sm.readEntries(sessionNames[0]);
+                console.log(`Tailing session: ${sessionNames[0]} (${raw.length} entries, showing last ${tail.length})`);
+            }
+
             console.log("");
 
-            let currentFile = "";
+            const currentFiles: Record<string, string> = {};
+
             for (const entry of tail) {
+                const prefix = multiSession ? pc.dim(`[${entry.session}] `) : "";
                 const file = entry.file ?? "unknown";
-                if (file !== currentFile) {
-                    currentFile = file;
-                    console.log(`File: ${file}`);
+
+                if (file !== (currentFiles[entry.session] ?? "")) {
+                    currentFiles[entry.session] = file;
+                    console.log(`${prefix}File: ${file}`);
                 }
-                console.log(formatEntryLine(entry, pretty));
+
+                console.log(`${prefix}${formatEntryLine(entry, pretty)}`);
             }
 
             console.log("");
             console.log("--- Watching for new entries (Ctrl+C to stop) ---");
 
-            let offset = 0;
-            try {
-                offset = statSync(filePath).size;
-            } catch {
-                // File might not exist yet
+            const states: SessionTailState[] = [];
+
+            for (const sessionName of sessionNames) {
+                const filePath = await sm.getSessionPath(sessionName);
+                const raw = await sm.readEntries(sessionName);
+                let offset = 0;
+
+                try {
+                    offset = statSync(filePath).size;
+                } catch {
+                    // File might not exist yet
+                }
+
+                states.push({
+                    name: sessionName,
+                    filePath,
+                    offset,
+                    entryIndex: raw.length,
+                    currentFile: currentFiles[sessionName] ?? "",
+                });
             }
 
-            let entryIndex = raw.length;
+            const watchers: FSWatcher[] = [];
 
-            const processNewData = () => {
-                try {
-                    const currentSize = statSync(filePath).size;
-                    if (currentSize < offset) {
-                        offset = 0;
-                    }
-                    if (currentSize <= offset) {
-                        return;
-                    }
+            for (const state of states) {
+                const processNewData = () => {
+                    try {
+                        const currentSize = statSync(state.filePath).size;
 
-                    const buffer = readFileSync(filePath);
-                    const newBytes = buffer.subarray(offset, currentSize);
-                    offset = currentSize;
-
-                    const text = new TextDecoder().decode(newBytes);
-                    const lines = text.split("\n").filter(Boolean);
-
-                    for (const line of lines) {
-                        entryIndex++;
-                        try {
-                            const entry = SafeJSON.parse(line, { strict: true }) as LogEntry;
-                            const indexed: IndexedLogEntry = { ...entry, index: entryIndex };
-
-                            if (levels && !levels.includes(entry.level) && entry.level !== "raw") {
-                                continue;
-                            }
-
-                            const file = indexed.file ?? "unknown";
-                            if (file !== currentFile) {
-                                currentFile = file;
-                                console.log(`File: ${file}`);
-                            }
-                            console.log(formatEntryLine(indexed, pretty));
-                        } catch {
-                            const fallback: IndexedLogEntry = {
-                                level: "raw",
-                                msg: line,
-                                ts: Date.now(),
-                                index: entryIndex,
-                            };
-                            console.log(formatEntryLine(fallback, pretty));
+                        if (currentSize < state.offset) {
+                            state.offset = 0;
                         }
-                    }
-                } catch {
-                    // Ignore read errors during watch
-                }
-            };
 
-            const watcher = watch(filePath, () => {
-                processNewData();
-            });
+                        if (currentSize <= state.offset) {
+                            return;
+                        }
+
+                        const buffer = readFileSync(state.filePath);
+                        const newBytes = buffer.subarray(state.offset, currentSize);
+                        state.offset = currentSize;
+
+                        const text = new TextDecoder().decode(newBytes);
+                        const lines = text.split("\n").filter(Boolean);
+                        const prefix = multiSession ? pc.dim(`[${state.name}] `) : "";
+
+                        for (const line of lines) {
+                            state.entryIndex++;
+
+                            try {
+                                const entry = SafeJSON.parse(line, { strict: true }) as LogEntry;
+                                const indexed: IndexedLogEntry = { ...entry, index: state.entryIndex };
+
+                                if (levels && !levels.includes(entry.level) && entry.level !== "raw") {
+                                    continue;
+                                }
+
+                                const file = indexed.file ?? "unknown";
+
+                                if (file !== state.currentFile) {
+                                    state.currentFile = file;
+                                    console.log(`${prefix}File: ${file}`);
+                                }
+
+                                console.log(`${prefix}${formatEntryLine(indexed, pretty)}`);
+                            } catch {
+                                const fallback: IndexedLogEntry = {
+                                    level: "raw",
+                                    msg: line,
+                                    ts: Date.now(),
+                                    index: state.entryIndex,
+                                };
+                                console.log(`${prefix}${formatEntryLine(fallback, pretty)}`);
+                            }
+                        }
+                    } catch {
+                        // Ignore read errors during watch
+                    }
+                };
+
+                const watcher = watch(state.filePath, () => {
+                    processNewData();
+                });
+                watchers.push(watcher);
+            }
 
             process.on("SIGINT", () => {
-                watcher.close();
+                for (const watcher of watchers) {
+                    watcher.close();
+                }
+
                 console.log("\nStopped tailing.");
                 process.exit(0);
             });

--- a/src/debugging-master/commands/tail.ts
+++ b/src/debugging-master/commands/tail.ts
@@ -30,10 +30,15 @@ export function registerTailCommand(program: Command): void {
             const lastCount = parseInt(opts.n, 10);
             const multiSession = sessionNames.length > 1;
 
-            const allEntries: Array<IndexedLogEntry & { session: string }> = [];
+            const entriesBySession = new Map<string, LogEntry[]>();
 
             for (const sessionName of sessionNames) {
-                const raw = await sm.readEntries(sessionName);
+                entriesBySession.set(sessionName, await sm.readEntries(sessionName));
+            }
+
+            const allEntries: Array<IndexedLogEntry & { session: string }> = [];
+
+            for (const [sessionName, raw] of entriesBySession) {
                 let existing = indexEntries(raw);
 
                 if (levels) {
@@ -53,7 +58,7 @@ export function registerTailCommand(program: Command): void {
                     `Tailing ${sessionNames.length} sessions: ${sessionNames.join(", ")} (showing last ${tail.length})`
                 );
             } else {
-                const raw = await sm.readEntries(sessionNames[0]);
+                const raw = entriesBySession.get(sessionNames[0])!;
                 console.log(`Tailing session: ${sessionNames[0]} (${raw.length} entries, showing last ${tail.length})`);
             }
 
@@ -80,7 +85,7 @@ export function registerTailCommand(program: Command): void {
 
             for (const sessionName of sessionNames) {
                 const filePath = await sm.getSessionPath(sessionName);
-                const raw = await sm.readEntries(sessionName);
+                const raw = entriesBySession.get(sessionName)!;
                 let offset = 0;
 
                 try {

--- a/src/debugging-master/core/session-manager.test.ts
+++ b/src/debugging-master/core/session-manager.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DebugMasterConfig } from "@app/debugging-master/types";
+import { SafeJSON } from "@app/utils/json";
+import { ConfigManager } from "./config-manager";
+import { ACTIVE_THRESHOLD_MS, SessionManager } from "./session-manager";
+
+function createTestSessionManager(sessionsDir: string): SessionManager {
+    const configManager = new ConfigManager();
+
+    // Override getSessionsDir to return our temp directory
+    configManager.getSessionsDir = () => sessionsDir;
+
+    // Stub config persistence methods to avoid touching real config
+    let recentSession: string | null = null;
+    const config: DebugMasterConfig = { projects: {} };
+
+    configManager.setRecentSession = async (name: string) => {
+        recentSession = name;
+        config.recentSession = name;
+    };
+
+    configManager.getRecentSession = async () => recentSession;
+
+    configManager.load = async () => config;
+
+    configManager.save = async () => {};
+
+    return new SessionManager(configManager);
+}
+
+describe("SessionManager", () => {
+    let tempDir: string;
+    let sm: SessionManager;
+
+    beforeEach(() => {
+        tempDir = mkdtempSync(join(tmpdir(), "dbg-master-test-"));
+        sm = createTestSessionManager(tempDir);
+    });
+
+    afterEach(() => {
+        if (existsSync(tempDir)) {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    describe("ACTIVE_THRESHOLD_MS", () => {
+        it("is 2 hours", () => {
+            expect(ACTIVE_THRESHOLD_MS).toBe(2 * 60 * 60 * 1000);
+        });
+    });
+
+    describe("createSession", () => {
+        it("creates both .jsonl and .meta.json files", async () => {
+            await sm.createSession("test-session", "/tmp/project");
+
+            const files = readdirSync(tempDir);
+            expect(files).toContain("test-session.jsonl");
+            expect(files).toContain("test-session.meta.json");
+        });
+
+        it("writes valid meta JSON with expected fields", async () => {
+            const before = Date.now();
+            await sm.createSession("my-session", "/home/user/project");
+            const after = Date.now();
+
+            const meta = await sm.getSessionMeta("my-session");
+            expect(meta).not.toBeNull();
+            expect(meta!.name).toBe("my-session");
+            expect(meta!.projectPath).toBe("/home/user/project");
+            expect(meta!.createdAt).toBeGreaterThanOrEqual(before);
+            expect(meta!.createdAt).toBeLessThanOrEqual(after);
+            expect(meta!.lastActivityAt).toBeGreaterThanOrEqual(before);
+            expect(meta!.lastActivityAt).toBeLessThanOrEqual(after);
+        });
+
+        it("creates an empty .jsonl file", async () => {
+            await sm.createSession("empty-session", "/tmp/project");
+            const jsonlPath = join(tempDir, "empty-session.jsonl");
+            const content = await Bun.file(jsonlPath).text();
+            expect(content).toBe("");
+        });
+
+        it("throws if session already exists", async () => {
+            await sm.createSession("dup", "/tmp/project");
+            expect(sm.createSession("dup", "/tmp/project")).rejects.toThrow("already exists");
+        });
+    });
+
+    describe("listSessionNames", () => {
+        it("returns empty array when no sessions exist", async () => {
+            const names = await sm.listSessionNames();
+            expect(names).toEqual([]);
+        });
+
+        it("returns created session names", async () => {
+            await sm.createSession("alpha", "/tmp/a");
+            await sm.createSession("beta", "/tmp/b");
+
+            const names = await sm.listSessionNames();
+            expect(names).toContain("alpha");
+            expect(names).toContain("beta");
+            expect(names.length).toBe(2);
+        });
+
+        it("does not include meta files in the list", async () => {
+            await sm.createSession("sess", "/tmp/p");
+            const names = await sm.listSessionNames();
+            for (const name of names) {
+                expect(name).not.toContain(".meta");
+            }
+        });
+    });
+
+    describe("deleteSession", () => {
+        it("removes both .jsonl and .meta.json and returns true", async () => {
+            await sm.createSession("to-delete", "/tmp/project");
+
+            const result = await sm.deleteSession("to-delete");
+            expect(result).toBe(true);
+
+            expect(existsSync(join(tempDir, "to-delete.jsonl"))).toBe(false);
+            expect(existsSync(join(tempDir, "to-delete.meta.json"))).toBe(false);
+        });
+
+        it("returns false for non-existent session", async () => {
+            const result = await sm.deleteSession("does-not-exist");
+            expect(result).toBe(false);
+        });
+
+        it("removes session from listSessionNames after deletion", async () => {
+            await sm.createSession("ephemeral", "/tmp/project");
+            expect(await sm.listSessionNames()).toContain("ephemeral");
+
+            await sm.deleteSession("ephemeral");
+            expect(await sm.listSessionNames()).not.toContain("ephemeral");
+        });
+    });
+
+    describe("getInactiveSessions", () => {
+        it("returns sessions older than threshold", async () => {
+            await sm.createSession("old-session", "/tmp/project");
+
+            // Manually set lastActivityAt to 48 hours ago
+            const metaPath = join(tempDir, "old-session.meta.json");
+            const meta = await Bun.file(metaPath).json();
+            meta.lastActivityAt = Date.now() - 48 * 60 * 60 * 1000;
+            await Bun.write(metaPath, SafeJSON.stringify(meta, null, "\t"));
+
+            const inactive = await sm.getInactiveSessions();
+            expect(inactive.length).toBe(1);
+            expect(inactive[0].name).toBe("old-session");
+        });
+
+        it("does not return recently active sessions", async () => {
+            await sm.createSession("fresh-session", "/tmp/project");
+
+            const inactive = await sm.getInactiveSessions();
+            expect(inactive.length).toBe(0);
+        });
+
+        it("respects custom threshold", async () => {
+            await sm.createSession("mid-session", "/tmp/project");
+
+            // Set lastActivityAt to 5 minutes ago
+            const metaPath = join(tempDir, "mid-session.meta.json");
+            const meta = await Bun.file(metaPath).json();
+            meta.lastActivityAt = Date.now() - 5 * 60 * 1000;
+            await Bun.write(metaPath, SafeJSON.stringify(meta, null, "\t"));
+
+            // With 1-minute threshold, session should be inactive
+            const inactive = await sm.getInactiveSessions(60 * 1000);
+            expect(inactive.length).toBe(1);
+
+            // With 10-minute threshold, session should still be active
+            const stillActive = await sm.getInactiveSessions(10 * 60 * 1000);
+            expect(stillActive.length).toBe(0);
+        });
+    });
+
+    describe("getActiveSessions", () => {
+        it("returns sessions within the active threshold", async () => {
+            await sm.createSession("active-sess", "/tmp/project");
+
+            const active = await sm.getActiveSessions();
+            expect(active.length).toBe(1);
+            expect(active[0].name).toBe("active-sess");
+        });
+
+        it("does not return sessions outside the active threshold", async () => {
+            await sm.createSession("stale-sess", "/tmp/project");
+
+            // Set lastActivityAt to 3 hours ago (beyond ACTIVE_THRESHOLD_MS of 2h)
+            const metaPath = join(tempDir, "stale-sess.meta.json");
+            const meta = await Bun.file(metaPath).json();
+            meta.lastActivityAt = Date.now() - 3 * 60 * 60 * 1000;
+            await Bun.write(metaPath, SafeJSON.stringify(meta, null, "\t"));
+
+            const active = await sm.getActiveSessions();
+            expect(active.length).toBe(0);
+        });
+
+        it("returns empty array when no sessions exist", async () => {
+            const active = await sm.getActiveSessions();
+            expect(active).toEqual([]);
+        });
+    });
+});

--- a/src/debugging-master/core/session-manager.ts
+++ b/src/debugging-master/core/session-manager.ts
@@ -1,12 +1,15 @@
-import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { LogEntry, SessionMeta } from "@app/debugging-master/types";
 import { suggestCommand } from "@app/utils/cli/executor";
+import { parseVariadic } from "@app/utils/cli/variadic";
+import { formatRelativeTime } from "@app/utils/format";
 import { SafeJSON } from "@app/utils/json";
 import { fuzzyFind } from "@app/utils/string";
+import { formatTable } from "@app/utils/table";
 import { ConfigManager } from "./config-manager";
 
-export const ACTIVE_THRESHOLD_MS = 60 * 60 * 1000;
+export const ACTIVE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 const TOOL_NAME = "tools debugging-master";
 
 export class SessionManager {
@@ -183,5 +186,144 @@ export class SessionManager {
     async getSessionPath(name: string): Promise<string> {
         const dir = await this.getSessionsDir();
         return join(dir, `${name}.jsonl`);
+    }
+
+    async deleteSession(name: string): Promise<boolean> {
+        const dir = await this.getSessionsDir();
+        const jsonlPath = join(dir, `${name}.jsonl`);
+        const metaPath = join(dir, `${name}.meta.json`);
+
+        if (!existsSync(jsonlPath) && !existsSync(metaPath)) {
+            return false;
+        }
+
+        if (existsSync(jsonlPath)) {
+            unlinkSync(jsonlPath);
+        }
+
+        if (existsSync(metaPath)) {
+            unlinkSync(metaPath);
+        }
+
+        const recent = await this.config.getRecentSession();
+
+        if (recent === name) {
+            const cfg = await this.config.load();
+            delete cfg.recentSession;
+            await this.config.save();
+        }
+
+        return true;
+    }
+
+    async getInactiveSessions(thresholdMs: number = 24 * 60 * 60 * 1000): Promise<SessionMeta[]> {
+        const names = await this.listSessionNames();
+        const now = Date.now();
+        const inactive: SessionMeta[] = [];
+
+        for (const name of names) {
+            const meta = await this.getSessionMeta(name);
+
+            if (meta && now - meta.lastActivityAt >= thresholdMs) {
+                inactive.push(meta);
+            }
+        }
+
+        return inactive;
+    }
+
+    async resolveSessionInteractive(sessionFlag?: string): Promise<string[]> {
+        if (sessionFlag) {
+            const requested = parseVariadic(sessionFlag);
+            const names = await this.listSessionNames();
+            const resolved: string[] = [];
+
+            for (const req of requested) {
+                if (names.includes(req)) {
+                    resolved.push(req);
+                    continue;
+                }
+
+                const match = fuzzyFind(req, names);
+
+                if (match) {
+                    resolved.push(match);
+                } else {
+                    throw new Error(`Session "${req}" not found. Available: ${names.join(", ") || "(none)"}`);
+                }
+            }
+
+            return resolved;
+        }
+
+        const names = await this.listSessionNames();
+
+        if (names.length === 0) {
+            throw new Error(`No sessions found. Start one with:\n  ${TOOL_NAME} start --session <name>`);
+        }
+
+        if (names.length === 1) {
+            return [names[0]];
+        }
+
+        if (process.stdout.isTTY) {
+            const { multiselect } = await import("@clack/prompts");
+            const allMeta: Array<{ name: string; meta: SessionMeta | null }> = [];
+
+            for (const name of names) {
+                const meta = await this.getSessionMeta(name);
+                allMeta.push({ name, meta });
+            }
+
+            const now = Date.now();
+            const options = allMeta.map(({ name, meta }) => {
+                const isActive = meta ? now - meta.lastActivityAt < ACTIVE_THRESHOLD_MS : false;
+                const lastStr = meta?.lastActivityAt
+                    ? formatRelativeTime(new Date(meta.lastActivityAt), { compact: true })
+                    : "unknown";
+                const project = meta?.projectPath ? basename(meta.projectPath) : "";
+                const hint = [lastStr, project, isActive ? "active" : ""].filter(Boolean).join(" | ");
+                return { value: name, label: name, hint };
+            });
+
+            const selected = await multiselect({
+                message: "Select session(s)",
+                options,
+                required: true,
+            });
+
+            if (typeof selected === "symbol") {
+                throw new Error("Session selection cancelled.");
+            }
+
+            return selected as string[];
+        }
+
+        const allMeta: Array<{ name: string; meta: SessionMeta | null }> = [];
+
+        for (const name of names) {
+            const meta = await this.getSessionMeta(name);
+            allMeta.push({ name, meta });
+        }
+
+        const now = Date.now();
+        const headers = ["Name", "Last Activity", "Project", "Status"];
+        const rows = allMeta.map(({ name, meta }) => {
+            const isActive = meta ? now - meta.lastActivityAt < ACTIVE_THRESHOLD_MS : false;
+            const lastStr = meta?.lastActivityAt
+                ? formatRelativeTime(new Date(meta.lastActivityAt), { compact: true })
+                : "unknown";
+            const project = meta?.projectPath ? basename(meta.projectPath) : "unknown";
+            return [name, lastStr, project, isActive ? "active" : ""];
+        });
+
+        console.log(formatTable(rows, headers));
+        console.log("");
+
+        for (const { name } of allMeta) {
+            console.log(`  ${suggestCommand(TOOL_NAME, { add: ["--session", name] })}`);
+        }
+
+        throw new Error("Multiple sessions found. Specify one with --session (see above).");
     }
 }

--- a/src/debugging-master/core/session-manager.ts
+++ b/src/debugging-master/core/session-manager.ts
@@ -266,14 +266,15 @@ export class SessionManager {
             return [names[0]];
         }
 
+        const allMeta: Array<{ name: string; meta: SessionMeta | null }> = [];
+
+        for (const name of names) {
+            const meta = await this.getSessionMeta(name);
+            allMeta.push({ name, meta });
+        }
+
         if (process.stdout.isTTY) {
             const { multiselect } = await import("@clack/prompts");
-            const allMeta: Array<{ name: string; meta: SessionMeta | null }> = [];
-
-            for (const name of names) {
-                const meta = await this.getSessionMeta(name);
-                allMeta.push({ name, meta });
-            }
 
             const now = Date.now();
             const options = allMeta.map(({ name, meta }) => {
@@ -297,13 +298,6 @@ export class SessionManager {
             }
 
             return selected as string[];
-        }
-
-        const allMeta: Array<{ name: string; meta: SessionMeta | null }> = [];
-
-        for (const name of names) {
-            const meta = await this.getSessionMeta(name);
-            allMeta.push({ name, meta });
         }
 
         const now = Date.now();

--- a/src/debugging-master/index.ts
+++ b/src/debugging-master/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { registerCleanupCommand } from "./commands/cleanup";
+import { registerDeleteSessionCommand } from "./commands/delete-session";
 import { registerDiffCommand } from "./commands/diff";
 import { registerExpandCommand } from "./commands/expand";
 import { registerGetCommand } from "./commands/get";
@@ -26,5 +27,6 @@ registerSessionsCommand(program);
 registerTailCommand(program);
 registerCleanupCommand(program);
 registerDiffCommand(program);
+registerDeleteSessionCommand(program);
 
 program.parse();

--- a/src/e2e/debugging-master.e2e.test.ts
+++ b/src/e2e/debugging-master.e2e.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { runTool } from "./helpers";
+
+describe("tools debugging-master", () => {
+    describe("help", () => {
+        it("--help exits 0 and shows description", async () => {
+            const r = await runTool(["debugging-master", "--help"]);
+            expect(r.exitCode).toBe(0);
+            expect(r.stdout).toContain("debugging toolkit");
+        });
+    });
+
+    describe("sessions", () => {
+        it("sessions --help exits 0", async () => {
+            const r = await runTool(["debugging-master", "sessions", "--help"]);
+            expect(r.exitCode).toBe(0);
+            expect(r.stdout).toContain("sessions");
+        });
+    });
+
+    describe("tail", () => {
+        it("tail --help exits 0 and mentions --level", async () => {
+            const r = await runTool(["debugging-master", "tail", "--help"]);
+            expect(r.exitCode).toBe(0);
+            expect(r.stdout).toContain("Live-tail");
+            expect(r.stdout).toContain("--level");
+        });
+    });
+
+    describe("delete-session", () => {
+        it("delete-session --help exits 0 and shows --inactive, --all, --force", async () => {
+            const r = await runTool(["debugging-master", "delete-session", "--help"]);
+            expect(r.exitCode).toBe(0);
+            expect(r.stdout).toContain("--inactive");
+            expect(r.stdout).toContain("--all");
+            expect(r.stdout).toContain("--force");
+        });
+
+        it("delete-session with no args and no sessions exits with error", async () => {
+            const r = await runTool(["debugging-master", "delete-session"]);
+            expect(r.exitCode).not.toBe(0);
+            const output = r.stdout + r.stderr;
+            expect(output).toContain("No session names provided");
+        });
+
+        it("delete-session --inactive --force works even with no sessions", async () => {
+            const r = await runTool(["debugging-master", "delete-session", "--inactive", "--force"]);
+            expect(r.exitCode).toBe(0);
+            const output = r.stdout + r.stderr;
+            expect(output).toContain("No inactive sessions");
+        });
+    });
+});

--- a/src/utils/macos/index.ts
+++ b/src/utils/macos/index.ts
@@ -89,7 +89,6 @@ export type {
     LanguageResult,
     MethodCapability,
     NamedEntity,
-    Neighbor,
     NeighborsResult,
     NlpScheme,
     OcrBlock,

--- a/src/utils/macos/types.ts
+++ b/src/utils/macos/types.ts
@@ -14,7 +14,6 @@ export type {
     ICloudStatusResult,
     LanguageResult,
     MethodCapability,
-    Neighbor,
     NeighborsResult,
     OCRBlock as OcrBlock,
     OCRBounds as OcrBounds,


### PR DESCRIPTION
## Summary
- New `delete-session` command with `--inactive` (24h), `--all`, `--force` flags
- `tail` supports multi-session via `--session a,b,c` with merged chronological output
- TTY: `@clack/prompts` multiselect picker when multiple sessions available
- Non-TTY: sessions table + `suggestCommand()` for each session
- `ACTIVE_THRESHOLD_MS` changed from 1h to 2h
- 23 tests (17 unit + 6 e2e)

## Test plan
- [x] `bun test src/debugging-master/core/session-manager.test.ts` — 17 unit tests
- [x] `bun test src/e2e/debugging-master.e2e.test.ts` — 6 e2e tests
- [ ] Manual: `tools debugging-master tail` with multiple sessions
- [ ] Manual: `tools debugging-master delete-session --inactive --force`