### PR TITLE
feat(cc): add tail command for live session/agent output streaming

### DIFF
--- a/.claude/plans/2026-03-19-CC-Tail.md
+++ b/.claude/plans/2026-03-19-CC-Tail.md
@@ -1,0 +1,847 @@
+# `tools cc tail` — Live Session/Agent Tail Command
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `tail` subcommand to the `claude` tool that live-streams JSONL session or subagent output with formatted, colorized display. Unified `--include` DSL controls what content is shown. Agent output is visually chunked in bordered sections.
+
+**Architecture:** Reusable utilities in `src/utils/claude/` (IncludeSpec parser, ClaudeSessionTailer, ClaudeSessionFormatter). Thin command layer in `src/claude/commands/tail.ts` wires them together with Commander CLI. The `cc` entry point routes subcommands instead of always forwarding to `resume`.
+
+**Tech Stack:** Bun, Commander.js, picocolors, `fs.watch` + 300ms poll fallback, `Bun.JSONL.parseChunk()`, `@clack/prompts`
+
+---
+
+## Data Model Reference
+
+```
+~/.claude/projects/<encoded-cwd>/
+  <session-uuid>.jsonl                    ← main session conversation
+  <session-uuid>/
+    subagents/
+      agent-<id>.jsonl                    ← subagent conversation
+      agent-<id>.meta.json               ← { agentType, description }
+
+~/.claude/statusline/
+  statusline.<session-uuid>.state         ← timestamp,byte-offset pairs (mtime = activity)
+```
+
+**JSONL record types:** `user`, `assistant` (or `A`), `progress`, `system`, `queue-operation`, `file-history-snapshot`, `agent-name`, `custom-title`
+
+**Agent meta.json:** `{ agentType: string, description: string }` — description is the human-readable name (e.g. "Research OAuth flow for E2E login script").
+
+**Completion signals (hook-independent — works on any machine):**
+- Agent finished: last assistant message has `stop_reason: "end_turn"` + JSONL file mtime stale >5s (agents don't wait for user input)
+- Session turn end: assistant `stop_reason: "end_turn"` + JSONL file mtime stale >30s (user might be thinking)
+- Do NOT rely on `hookEvent: "SubagentStop"` or `hookEvent: "Stop"` — those require GenesisTools hooks to be installed
+
+**Turn boundary detection (for `--max-turns`, `--last-turns`):**
+- A turn starts with a `type: "user"` record
+- A turn is complete when `stop_reason: "end_turn"` appears on an assistant message AND no new records arrive for the stale timeout (5s agent / 30s session)
+- This same logic is shared by `--stop-on-finish`, `--max-turns`, and `--max-calls`
+
+---
+
+## Full CLI Spec
+
+```
+tools cc tail [query]
+
+Positional:
+  query                         Session/agent ID prefix, agent description, or omit for most recent active
+
+Following:
+  -f, --follow                  Follow for new output (DEFAULT: on)
+  --no-follow                   Dump existing content and exit
+  --stop-on-finish              Exit 0 when session/agent finishes
+
+Content:
+  --include <spec>              Comma-separated content specifiers (see below)
+  -i, --interactive             Guided setup of --include via prompts
+  --no-colors                   Disable colors (auto-off in non-TTY)
+  --raw                         Raw JSONL, no formatting
+
+Navigation / Limits:
+  -t, --last-turns <n>          Show last N turns before following (default: 5)
+  -c, --last-calls <n>          Show last N individual calls before following
+  --max-turns <n>               Stop following after N new turns
+  --max-calls <n>               Stop following after N new calls
+
+Output:
+  -o, --output <file>           Write formatted output to file
+  --output-cli                  Also print to CLI (default when no -o)
+
+Search:
+  -p, --project <path>          Search in specific project directory (no global fallback)
+```
+
+### `--include` DSL
+
+```
+Specifiers (comma-separated):
+  thinking                      Show thinking/reasoning blocks
+  tools                         Shorthand for tools:in:500,tools:out:500
+  tools:in[:<N>]                Tool call inputs (default 500 chars)
+  tools:out[:<N>]               Tool call outputs (default 500 chars)
+  agents                        Shorthand for agents:input,agents:tools,agents:result
+  agents:input                  Agent launch prompt
+  agents:tools                  Shorthand for agents:tools:in:50,agents:tools:out:500
+  agents:tools:in[:<N>]         Agent tool inputs (default 50 chars)
+  agents:tools:out[:<N>]        Agent tool outputs (default 500 chars)
+  agents:result                 Agent final response
+  agents:thinking               Agent thinking blocks
+
+Default: thinking,tools:in:500,tools:out:500,agents:input,agents:tools:in:50,agents:tools:out:500,agents:result
+
+When tailing an agent directly, agents:* prefix is stripped
+(agents:tools:in:50 ≡ tools:in:50 when target is an agent)
+```
+
+### Startup Banner
+
+```
+┌ claude tail ── [agent] Research OAuth flow ──────────────
+│ Including: thinking, tools (in: 500, out: 500)
+│            agents (input, tools (in: 50, out: 500), result)
+│ Following: yes  Stop on finish: yes
+│ Source: ~/.claude/projects/...col-fe.../a48e.../subagents/agent-ae9cc...jsonl
+└──────────────────────────────────────────────────────────
+```
+
+### Agent Chunking UX
+
+When tailing a session with `--follow-agents` (default on), agent output appears in bordered, color-coded sections:
+
+```
+20:15:33 Claude: I'll research the OAuth flow in parallel.
+20:15:33   [Agent] Research OAuth flow for E2E login script
+
+  ┌─ Agent: Research OAuth flow for E2E login script ─────────
+  │ 20:15:36 Claude: I'll start by analyzing the HAR file...
+  │ 20:15:37   [Bash] ls -la ~/Downloads/failed-to-fetch.har
+  │ 20:15:38   [Read] auth/oauth/oauth.openid.config.ts
+  │ ...
+  │ 20:18:35 Claude: Exploration complete. Report saved to...
+  └──────────────────────────────────────── ✓ done (2m 39s) ─
+
+20:18:36 Claude: The agent found that the OAuth flow uses PKCE...
+```
+
+- Multiple concurrent agents get separate bordered sections with different colors (cyan, magenta, yellow)
+- Verbosity controlled by `--include agents:*` specifiers
+- At `agents:result` only (no border): `Agent "X" → <result text>`
+
+### Interactive Mode (`-i`)
+
+When `-i` or `--interactive` is given (or default in TTY without `--include`):
+1. **Multiselect:** "What to show?" → `[x] Thinking  [x] Tool calls  [x] Agent details`
+2. If **Tool calls** → "Tool input max chars?" (default 500) → "Tool output max chars?" (default 500)
+3. If **Agent details** → multiselect: `[x] Prompt  [x] Tool calls  [x] Final result  [ ] Thinking`
+4. If **Agent tool calls** → "Agent tool input max chars?" (default 50) → "Agent tool output max chars?" (default 500)
+5. In non-TTY without `--include` → print help with examples and exit
+
+### `--output` Behavior
+
+- `--output <file>` writes formatted output to file, suppresses CLI output
+- When `-o` given without `--output-cli`, print: `"Tailing to <file>..."` + `suggestCommand("tools cc", { add: ["--output-cli"] })`
+- `--output-cli` re-enables CLI output alongside file output
+
+---
+
+## File Structure
+
+### Existing (to refactor):
+```
+src/utils/claude/
+├── session.ts        → extract interfaces to session.types.ts
+│                     → extract helper functions (lines 0-280) to session.utils.ts
+│                     → add findSubagents() static method
+```
+
+### New files:
+```
+src/utils/
+├── storage/
+│   └── fs.ts                   ← FileWatcher class — reusable fs.watch + poll fallback
+├── jsonl.ts                    ← JSONL proxy: wraps Bun.JSONL.parseChunk() with typed API
+
+src/utils/claude/
+├── session.types.ts            ← extracted from session.ts: all export interface/type
+├── session.utils.ts            ← extracted from session.ts: helper functions (lines ~0-280)
+├── cli/
+│   └── dsl.ts                  ← IncludeSpec class (--include DSL parser)
+├── ClaudeSessionTailer.ts      ← live JSONL tailing (uses FileWatcher + JSONL utils)
+├── ClaudeSessionFormatter.ts   ← JSONL record → formatted terminal output
+
+src/cc/index.ts                 ← route subcommands
+src/claude/index.ts             ← register tail command
+src/claude/commands/tail.ts     ← thin CLI wiring
+```
+
+### Reusable Utilities (existing)
+
+| Utility | Location | Purpose |
+|---------|----------|---------|
+| `PROJECTS_DIR`, `encodedProjectDir()` | `src/utils/claude/index.ts` | Path resolution |
+| `parseJsonlTranscript()` | `src/utils/claude/index.ts` | Full JSONL parse |
+| `SafeJSON.parse()` | `src/utils/json.ts` | Safe JSON parsing |
+| `suggestCommand()` | `src/utils/cli/executor.ts` | CLI command suggestion |
+| `ClaudeSession.findSessions()` | `src/utils/claude/session.ts` | Session discovery |
+| `ClaudeSession.fromSessionId()` | `src/utils/claude/session.ts` | Session by ID prefix |
+| Message types | `src/utils/claude/types.ts` | `ConversationMessage`, content blocks |
+| `Bun.JSONL.parseChunk()` | Bun built-in | Native C++ JSONL parser, handles partial lines |
+
+### Key Technical Decisions
+
+**File watching:** `src/utils/storage/fs.ts` → `FileWatcher` class with `{options}` pattern. Uses `fs.watch` + 300ms poll fallback (pattern from `src/debugging-master/commands/tail.ts:47-114`). NOT chokidar — chokidar v4 dropped native fsevents and just wraps `fs.watch` now. Driver is swappable via options for future needs.
+
+**JSONL parsing:** `src/utils/jsonl.ts` → `parseJsonlChunk<T>()` proxy wrapping `Bun.JSONL.parseChunk()`. Native C++ implementation, handles partial lines, never throws. Consumers don't call Bun globals directly.
+
+**Stop detection:** Hook-independent — use `stop_reason: "end_turn"` on assistant messages + JSONL file mtime going stale (5s for agents, 30s for sessions). Do NOT depend on `hookEvent: "SubagentStop"` since that requires GenesisTools hooks installed.
+
+**Debouncing:** `fs.watch` may fire multiple times per write. Use `queueMicrotask` leading-edge debounce + `stat().size > offset` guard (naturally idempotent).
+
+---
+
+## Task 0: Create Shared Utilities — FileWatcher + JSONL
+
+### Step 1: Create `src/utils/storage/fs.ts` — FileWatcher
+
+Reusable file watcher with swappable driver pattern. Extracts the `fs.watch` + poll fallback pattern from `src/debugging-master/commands/tail.ts`.
+
+```typescript
+import { closeSync, openSync, readSync, statSync, watch, type FSWatcher } from "node:fs";
+
+interface FileWatcherOptions {
+    filePath: string;
+    onData: (newBytes: Buffer) => void;
+    pollInterval?: number;       // fallback poll frequency in ms (default: 300)
+    debounce?: boolean;          // debounce fs.watch events via queueMicrotask (default: true)
+}
+
+/**
+ * Watches a single file for new appended bytes.
+ * Uses fs.watch for instant kernel-level notifications + setInterval poll as fallback.
+ * Designed for append-only files (JSONL, logs). Handles file truncation.
+ *
+ * Future: driver can be swapped (fsevents, polling-only, etc.) via options.
+ */
+export class FileWatcher {
+    private offset = 0;
+    private watcher: FSWatcher | null = null;
+    private pollTimer: ReturnType<typeof setInterval> | null = null;
+    private checkScheduled = false;
+
+    constructor(private options: FileWatcherOptions) {}
+
+    /** Start watching from current file end (or specific offset) */
+    start(fromOffset?: number): void { /* ... */ }
+
+    /** Stop watching and clean up all resources */
+    stop(): void { /* ... */ }
+
+    /** Current byte offset */
+    get currentOffset(): number { return this.offset; }
+
+    /** Check if file is actively being written (mtime < threshold) */
+    isActive(thresholdMs = 10_000): boolean { /* ... */ }
+
+    private checkForNewData(): void {
+        const currentSize = statSync(this.options.filePath).size;
+        if (currentSize < this.offset) {
+            this.offset = 0; // truncation
+        }
+        if (currentSize <= this.offset) {
+            return;
+        }
+        const fd = openSync(this.options.filePath, "r");
+        const newBytes = Buffer.alloc(currentSize - this.offset);
+        readSync(fd, newBytes, 0, newBytes.length, this.offset);
+        closeSync(fd);
+        this.offset = currentSize;
+        this.options.onData(newBytes);
+    }
+}
+```
+
+### Step 2: Create `src/utils/jsonl.ts` — JSONL Parsing Proxy
+
+Typed wrapper around `Bun.JSONL.parseChunk()` so consumers don't call Bun globals directly.
+
+```typescript
+export interface JsonlParseResult<T = unknown> {
+    values: T[];
+    read: number;           // bytes consumed
+    done: boolean;          // true if all input consumed
+    remainder: Buffer;      // unconsumed bytes (partial line)
+}
+
+/**
+ * Parse a chunk of JSONL data, handling partial lines.
+ * Wraps Bun.JSONL.parseChunk() with typed return and remainder management.
+ */
+export function parseJsonlChunk<T = unknown>(
+    data: Buffer,
+    existingRemainder?: Buffer
+): JsonlParseResult<T> {
+    const combined = existingRemainder?.length
+        ? Buffer.concat([existingRemainder, data])
+        : data;
+
+    const result = Bun.JSONL.parseChunk(combined);
+
+    return {
+        values: result.values as T[],
+        read: result.read,
+        done: result.done,
+        remainder: combined.subarray(result.read),
+    };
+}
+
+/**
+ * Parse an entire JSONL buffer (no streaming/remainder).
+ */
+export function parseJsonl<T = unknown>(data: Buffer | string): T[] {
+    const result = Bun.JSONL.parseChunk(typeof data === "string" ? Buffer.from(data) : data);
+    return result.values as T[];
+}
+```
+
+### Step 3: Commit
+
+```bash
+git add src/utils/storage/fs.ts src/utils/jsonl.ts
+git commit -m "feat(utils): add FileWatcher class and JSONL parsing proxy"
+```
+
+---
+
+## Task 1: Refactor `session.ts` — Extract Types & Helpers
+
+**Files:**
+- Create: `src/utils/claude/session.types.ts`
+- Create: `src/utils/claude/session.utils.ts`
+- Modify: `src/utils/claude/session.ts` — import from new files, add `findSubagents()`
+
+### Step 1: Extract interfaces
+
+Move all exported interfaces from `session.ts` (lines ~50-155) to `session.types.ts`:
+- `ExtractTextOptions`, `PromptContentOptions`, `PreparedContent`, `SessionStats`
+- `SessionInfo`, `SessionDiscoveryOptions`
+- `TailTarget` (new — for tail command reuse)
+- `AgentMeta` (new — `{ agentType: string; description: string }`)
+
+### Step 2: Extract helper functions
+
+Move standalone functions from `session.ts` (lines ~0-280) to `session.utils.ts`:
+- `isSubagentFile()`
+- `readHeadTailLines()`
+- `hasTimestamp()`, `hasSessionId()`, `hasGitBranch()`, `hasCwd()` type guards
+- `getToolUseBlocks()`, `getSubagentToolUseBlocks()`
+- `extractFilePathFromInput()`
+
+### Step 3: Add `findSubagents()` to ClaudeSession
+
+Static method that scans `agent-*.meta.json` files across project dirs:
+
+```typescript
+static findSubagents(options: {
+    query?: string;        // ID prefix or description substring match
+    project?: string;      // path to scope search
+    sessionId?: string;    // scope to specific session's subagents
+}): TailTarget[]
+```
+
+Resolution order:
+1. Agent ID prefix match on `agent-<id>.jsonl` filenames
+2. Case-insensitive substring match on `meta.json` description
+3. Returns `TailTarget[]` with filePath, label, sessionId, agentId, agentDescription
+
+### Step 4: Update imports in session.ts
+
+`session.ts` imports from `session.types.ts` and `session.utils.ts`. All existing external consumers are unaffected (they import from `session.ts` which re-exports).
+
+### Step 5: Commit
+
+```bash
+git add src/utils/claude/session.types.ts src/utils/claude/session.utils.ts src/utils/claude/session.ts
+git commit -m "refactor(claude): extract session types and utils into separate files"
+```
+
+---
+
+## Task 2: Create `IncludeSpec` — `--include` DSL Parser
+
+**Files:**
+- Create: `src/utils/claude/cli/dsl.ts`
+
+### Step 1: Implement IncludeSpec class
+
+```typescript
+/**
+ * Parses and queries the --include DSL for controlling tail output content.
+ *
+ * Syntax: comma-separated specifiers with colon-delimited hierarchy.
+ * Numeric suffix sets truncation length.
+ *
+ * Examples:
+ *   "thinking,tools:in:500,tools:out:500"
+ *   "agents:input,agents:tools:in:50,agents:result"
+ *   "thinking,tools,agents" (shorthand expansions)
+ */
+export class IncludeSpec {
+    // Parsed state
+    thinking: boolean;
+    toolsIn: number | false;      // false = hidden, number = max chars
+    toolsOut: number | false;
+    agentsInput: boolean;
+    agentsToolsIn: number | false;
+    agentsToolsOut: number | false;
+    agentsResult: boolean;
+    agentsThinking: boolean;
+
+    static DEFAULT_SPEC = "thinking,tools:in:500,tools:out:500,agents:input,agents:tools:in:50,agents:tools:out:500,agents:result";
+
+    constructor(spec?: string) { /* parse spec or use defaults */ }
+
+    static parse(spec: string): IncludeSpec { /* factory */ }
+    static defaults(): IncludeSpec { /* DEFAULT_SPEC */ }
+
+    /** When tailing an agent, agents:* maps to top-level equivalents */
+    forAgent(): IncludeSpec { /* returns new spec with agents:* → top-level */ }
+
+    /** Human-readable summary for startup banner */
+    describe(): string { /* e.g. "thinking, tools (in: 500, out: 500), agents (input, result)" */ }
+
+    /** Check if a specific content type should be shown */
+    shouldShow(type: "thinking" | "tools:in" | "tools:out" | "agents:input" | ...): boolean
+
+    /** Get truncation length for a content type, or 0 for no limit */
+    truncationLength(type: "tools:in" | "tools:out" | "agents:tools:in" | "agents:tools:out"): number
+}
+```
+
+### Step 2: Add comprehensive Commander help text
+
+The `IncludeSpec` class should export a `INCLUDE_HELP` constant string with examples for Commander's `.addHelpText()`:
+
+```
+Include specifiers (comma-separated):
+  thinking                Show thinking/reasoning blocks
+  tools                   Shorthand: tools:in:500,tools:out:500
+  tools:in[:<chars>]      Tool call inputs, truncated (default: 500)
+  tools:out[:<chars>]     Tool call outputs, truncated (default: 500)
+  agents                  Shorthand: agents:input,agents:tools,agents:result
+  agents:input            Agent launch prompt
+  agents:tools            Shorthand: agents:tools:in:50,agents:tools:out:500
+  agents:tools:in[:<N>]   Agent tool inputs (default: 50)
+  agents:tools:out[:<N>]  Agent tool outputs (default: 500)
+  agents:result           Agent final response
+  agents:thinking         Agent thinking blocks
+
+Examples:
+  --include thinking,tools,agents           Everything (with defaults)
+  --include tools:in:200,agents:result      Tool inputs (200 chars) + agent results only
+  --include thinking,tools:out:0            Thinking + tool inputs only (no outputs)
+```
+
+### Step 3: Commit
+
+```bash
+git add src/utils/claude/cli/dsl.ts
+git commit -m "feat(claude): add IncludeSpec DSL parser for --include flag"
+```
+
+---
+
+## Task 3: Create `ClaudeSessionTailer` — Live JSONL Streaming
+
+**Reference implementations:**
+- `src/debugging-master/commands/tail.ts:47-114` — lean `fs.watch` + byte-offset pattern (closest to what we need)
+- `src/watch/index.ts` — triple-layer watcher (overkill for single file, but shows 300ms poll fallback pattern)
+- `src/daemon/lib/runner.ts` — partial-line buffering pattern
+
+**Files:**
+- Create: `src/utils/claude/ClaudeSessionTailer.ts`
+
+### Step 1: Implement the tailer class
+
+```typescript
+import { FileWatcher } from "@app/utils/storage/fs";
+import { parseJsonlChunk } from "@app/utils/jsonl";
+import type { ConversationMessage } from "./types";
+
+interface TailerOptions {
+    filePath: string;
+    onRecord: (record: ConversationMessage) => void;
+    onFinished?: () => void;
+    lastTurns?: number;           // initial display: last N turns (default 5)
+    lastCalls?: number;           // alternative: last N calls
+    maxTurns?: number;            // follow limit: stop after N new turns
+    maxCalls?: number;            // follow limit: stop after N new calls
+    follow?: boolean;             // default true
+    stopOnFinish?: boolean;       // exit on completion signal
+    isAgent?: boolean;            // affects stale timeout (5s agent vs 30s session)
+}
+
+/**
+ * Streams JSONL records from a Claude session/agent file.
+ *
+ * Uses fs.watch for instant notifications + 300ms setInterval as safety fallback.
+ * Parses JSONL via Bun.JSONL.parseChunk() (native C++, handles partial lines).
+ *
+ * Architecture:
+ *   FileWatcher (src/utils/storage/fs.ts)
+ *       │ onData(newBytes)
+ *       ▼
+ *   parseJsonlChunk<ConversationMessage>(newBytes, remainder)
+ *       │ values[]
+ *       ▼
+ *   emit parsed records via onRecord()
+ */
+export class ClaudeSessionTailer {
+    private offset = 0;
+    private remainder = Buffer.alloc(0);
+    private watcher: FSWatcher | null = null;
+    private pollInterval: ReturnType<typeof setInterval> | null = null;
+    private checkScheduled = false;
+
+    // Turn/call counting for --max-turns / --max-calls
+    private newTurnCount = 0;
+    private newCallCount = 0;
+    private lastEndTurnTimestamp = 0;
+    private staleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(private options: TailerOptions) {}
+
+    async start(): Promise<void> {
+        // Phase 1: History — read existing content, slice to last N turns/calls
+        await this.loadHistory();
+
+        if (!this.options.follow) {
+            return;
+        }
+
+        // Phase 2: Follow — watch for new content
+        this.offset = statSync(this.options.filePath).size;
+        this.remainder = Buffer.alloc(0);
+
+        // Primary: fs.watch for instant notification
+        this.watcher = watch(this.options.filePath, () => {
+            if (!this.checkScheduled) {
+                this.checkScheduled = true;
+                queueMicrotask(() => {
+                    this.checkScheduled = false;
+                    this.checkForNewData();
+                });
+            }
+        });
+
+        // Fallback: 300ms stat-poll (catches any coalesced/missed events)
+        this.pollInterval = setInterval(() => this.checkForNewData(), 300);
+    }
+
+    stop(): void {
+        this.watcher?.close();
+        this.watcher = null;
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+        }
+        if (this.staleTimer) {
+            clearTimeout(this.staleTimer);
+            this.staleTimer = null;
+        }
+    }
+
+    /** Check if the JSONL file is still actively being written to */
+    isActive(): boolean {
+        try {
+            const mtime = statSync(this.options.filePath).mtimeMs;
+            return Date.now() - mtime < 10_000;
+        } catch {
+            return false;
+        }
+    }
+
+    private checkForNewData(): void {
+        const currentSize = statSync(this.options.filePath).size;
+        if (currentSize <= this.offset) {
+            if (currentSize < this.offset) {
+                // File truncated — reset
+                this.offset = 0;
+                this.remainder = Buffer.alloc(0);
+            }
+            return;
+        }
+
+        // Read only new bytes
+        const fd = openSync(this.options.filePath, "r");
+        const newBytes = Buffer.alloc(currentSize - this.offset);
+        readSync(fd, newBytes, 0, newBytes.length, this.offset);
+        closeSync(fd);
+        this.offset = currentSize;
+
+        // Parse with Bun.JSONL.parseChunk (handles partial lines natively)
+        const combined = Buffer.concat([this.remainder, newBytes]);
+        const result = Bun.JSONL.parseChunk(combined);
+        this.remainder = combined.subarray(result.read);
+
+        for (const value of result.values) {
+            const record = value as ConversationMessage;
+            this.options.onRecord(record);
+            this.trackCompletion(record);
+
+            // Check limits
+            if (this.shouldStop()) {
+                this.stop();
+                this.options.onFinished?.();
+                return;
+            }
+        }
+    }
+
+    private trackCompletion(record: ConversationMessage): void {
+        // Count turns (new user message = new turn start)
+        if (record.type === "user") {
+            this.newTurnCount++;
+        }
+
+        // Count calls (each meaningful content item)
+        this.newCallCount++; // simplified — formatter can count more granularly
+
+        // Track end_turn for stop-on-finish
+        if ((record.type === "assistant" || record.type === "A") && record.message?.stop_reason === "end_turn") {
+            this.scheduleStaleCheck();
+        }
+    }
+
+    private scheduleStaleCheck(): void {
+        if (!this.options.stopOnFinish) {
+            return;
+        }
+        if (this.staleTimer) {
+            clearTimeout(this.staleTimer);
+        }
+        const timeout = this.options.isAgent ? 5_000 : 30_000;
+        this.staleTimer = setTimeout(() => {
+            if (!this.isActive()) {
+                this.stop();
+                this.options.onFinished?.();
+            }
+        }, timeout);
+    }
+
+    private shouldStop(): boolean {
+        if (this.options.maxTurns && this.newTurnCount >= this.options.maxTurns) {
+            return true;
+        }
+        if (this.options.maxCalls && this.newCallCount >= this.options.maxCalls) {
+            return true;
+        }
+        return false;
+    }
+
+    private async loadHistory(): Promise<void> {
+        // Read full file via Bun.JSONL.parseChunk, then slice to lastTurns/lastCalls
+        // ... (implementation details for history slicing)
+    }
+}
+```
+
+### Step 2: Commit
+
+```bash
+git add src/utils/claude/ClaudeSessionTailer.ts
+git commit -m "feat(claude): add ClaudeSessionTailer with fs.watch + Bun.JSONL.parseChunk"
+```
+
+---
+
+## Task 4: Create `ClaudeSessionFormatter` — Record Formatting
+
+**Files:**
+- Create: `src/utils/claude/ClaudeSessionFormatter.ts`
+
+### Step 1: Implement the formatter class
+
+```typescript
+import type { IncludeSpec } from "./cli/dsl";
+import type { ConversationMessage } from "./types";
+
+interface FormatterOptions {
+    includeSpec: IncludeSpec;
+    colors: boolean;              // default: process.stdout.isTTY
+    outputStream?: Writable;      // for --output file
+    cliStream?: Writable;         // for --output-cli (stdout)
+}
+
+/**
+ * Formats JSONL records into colorized terminal output.
+ * Handles agent bordered sections, content truncation, and dual output.
+ */
+export class ClaudeSessionFormatter {
+    private agentColors: Map<string, string>;   // agentId → color
+    private activeAgentSection: string | null;   // currently open bordered section
+
+    constructor(private options: FormatterOptions) {}
+
+    /** Format and write a single record */
+    format(record: ConversationMessage): void { /* ... */ }
+
+    /** Close any open agent section */
+    closeAgentSection(): void { /* ... */ }
+
+    /** Print the startup banner */
+    printBanner(options: {
+        target: TailTarget;
+        includeSpec: IncludeSpec;
+        follow: boolean;
+        stopOnFinish: boolean;
+    }): void { /* ... */ }
+}
+```
+
+Key behaviors:
+- **User messages:** `20:15:33 You: <text>` (green, bold)
+- **Assistant text:** `20:15:34 Claude: <text>` (blue, bold)
+- **Thinking:** `20:15:34 💭 <text>` (dim) — only if `includeSpec.thinking`
+- **Tool calls:** `20:15:35   [Bash] ls -la ~/... ` (dim) — input truncated to `includeSpec.toolsIn` chars
+- **Tool results:** `  → <output>` (dim) — truncated to `includeSpec.toolsOut` chars
+- **Agent sections:** Bordered with `│` prefix, header with description, footer with duration and ✓/✗
+- **Agent records:** Filtered through `includeSpec.agents*` settings
+- **Dual output:** Writes to both `outputStream` (file) and `cliStream` (stdout) when configured
+- **Color stripping:** When writing to file or `colors: false`, strip ANSI codes
+
+### Step 2: Commit
+
+```bash
+git add src/utils/claude/ClaudeSessionFormatter.ts
+git commit -m "feat(claude): add ClaudeSessionFormatter with agent chunking"
+```
+
+---
+
+## Task 5: Update `cc` Entry Point — Route Subcommands
+
+**Files:**
+- Modify: `src/cc/index.ts`
+
+### Step 1: Update routing
+
+Currently `cc` blindly forwards to `claude resume`. Change to detect known subcommands:
+
+```typescript
+const SUBCOMMANDS = new Set([
+    "tail", "history", "resume", "desktop", "usage", "config", "daemon", "migrate",
+]);
+
+const args = process.argv.slice(2);
+const firstArg = args[0]?.toLowerCase();
+
+const cmd = SUBCOMMANDS.has(firstArg ?? "")
+    ? ["bun", "run", claude, ...args]
+    : ["bun", "run", claude, "resume", ...args];
+```
+
+### Step 2: Commit
+
+```bash
+git add src/cc/index.ts
+git commit -m "feat(cc): route subcommands instead of always forwarding to resume"
+```
+
+---
+
+## Task 6: Create Tail Command — CLI Wiring
+
+**Files:**
+- Create: `src/claude/commands/tail.ts`
+- Modify: `src/claude/index.ts`
+
+### Step 1: Implement registerTailCommand
+
+Thin CLI layer that:
+1. Parses Commander options
+2. Resolves target (session/agent) via `ClaudeSession.findSubagents()` or session ID prefix
+3. If no query → find most recent active session (by statusline mtime)
+4. If multiple matches → interactive select via `@clack/prompts`
+5. Builds `IncludeSpec` from `--include` or runs interactive flow (`-i`)
+6. Creates `ClaudeSessionFormatter` and `ClaudeSessionTailer`, wires them together
+7. Handles `--output` / `--output-cli` / `suggestCommand()` nudge
+8. Sets up SIGINT handler for clean shutdown
+
+### Step 2: Interactive mode flow
+
+When `-i` or default TTY without `--include`:
+1. `p.multiselect` → "What to show?" → Thinking, Tool calls, Agent details
+2. If Tool calls → `p.text` → "Tool input max chars?" (default 500) → "Tool output max chars?" (default 500)
+3. If Agent details → `p.multiselect` → Prompt, Tool calls, Final result, Thinking
+4. If Agent tool calls → `p.text` → max chars prompts
+5. Build `IncludeSpec` from selections
+
+In non-TTY without `--include` → print `INCLUDE_HELP` and exit.
+
+### Step 3: Register in index.ts
+
+```typescript
+import { registerTailCommand } from "./commands/tail";
+registerTailCommand(program);
+```
+
+### Step 4: Commit
+
+```bash
+git add src/claude/commands/tail.ts src/claude/index.ts
+git commit -m "feat(claude): add tail command with interactive mode and full CLI options"
+```
+
+---
+
+## Task 7: Verification
+
+### Manual tests
+
+```bash
+# 1. Tail a session by ID prefix
+tools cc tail a48e868c --no-follow -t 3
+
+# 2. Tail an agent by description
+tools cc tail "Research OAuth" --no-follow
+
+# 3. Tail with follow + stop on finish (use a completed session to verify instant stop)
+tools cc tail a48e868c --stop-on-finish
+
+# 4. Cross-project search
+tools cc tail a48e868c -p ~/Tresors/Projects/CEZ/col-fe-native-upgrade
+
+# 5. Custom include spec
+tools cc tail a48e868c --include "tools:in:100,agents:result" --no-follow -t 2
+
+# 6. Raw mode
+tools cc tail a48e868c --raw -c 5 --no-follow
+
+# 7. Output to file
+tools cc tail a48e868c -o /tmp/tail-test.log --no-follow -t 2
+cat /tmp/tail-test.log
+
+# 8. Interactive mode
+tools cc tail a48e868c -i --no-follow
+
+# 9. Backward compat — cc still defaults to resume
+tools cc a48e868c  # should launch claude resume
+
+# 10. No-arg default — finds most recent active session
+tools cc tail --no-follow -t 1
+
+# 11. Max turns limit
+tools cc tail a48e868c --max-turns 2
+
+# 12. Last calls
+tools cc tail a48e868c -c 10 --no-follow
+```
+
+### Step: Final commit
+
+```bash
+git add -A
+git commit -m "feat(cc): add tail command for live session/agent output streaming"
+```

--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.90.21",
         "@types/babel__core": "^7.20.5",
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.11",
         "@types/markdown-it": "^14.1.2",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.2",
@@ -620,7 +620,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.0", "", { "dependencies": { "bun-types": "1.3.0" } }, "sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -858,7 +858,7 @@
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
-    "bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.90.21",
         "@types/babel__core": "^7.20.5",
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.11",
         "@types/markdown-it": "^14.1.2",
         "@types/object-hash": "^3.0.6",
         "@types/react": "^19.2.2",

--- a/src/cc/index.ts
+++ b/src/cc/index.ts
@@ -1,9 +1,27 @@
 #!/usr/bin/env bun
 import { resolve } from "node:path";
 
+const SUBCOMMANDS = new Set([
+    "tail",
+    "history",
+    "resume",
+    "desktop",
+    "usage",
+    "config",
+    "daemon",
+    "migrate",
+]);
+
 const claude = resolve(import.meta.dir, "../claude/index.ts");
+const args = process.argv.slice(2);
+const firstArg = args[0]?.toLowerCase();
+
+const cmd = SUBCOMMANDS.has(firstArg ?? "")
+    ? ["bun", "run", claude, ...args]
+    : ["bun", "run", claude, "resume", ...args];
+
 const proc = Bun.spawn({
-    cmd: ["bun", "run", claude, "resume", ...process.argv.slice(2)],
+    cmd,
     stdio: ["inherit", "inherit", "inherit"],
 });
 process.exit(await proc.exited);

--- a/src/cc/index.ts
+++ b/src/cc/index.ts
@@ -1,16 +1,7 @@
 #!/usr/bin/env bun
 import { resolve } from "node:path";
 
-const SUBCOMMANDS = new Set([
-    "tail",
-    "history",
-    "resume",
-    "desktop",
-    "usage",
-    "config",
-    "daemon",
-    "migrate",
-]);
+const SUBCOMMANDS = new Set(["tail", "history", "resume", "desktop", "usage", "config", "daemon", "migrate"]);
 
 const claude = resolve(import.meta.dir, "../claude/index.ts");
 const args = process.argv.slice(2);

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -298,15 +298,18 @@ async function resolveIncludeSpec(opts: TailOptions): Promise<IncludeSpec> {
         return IncludeSpec.parse(opts.include);
     }
 
-    if (opts.interactive) {
-        return await runInteractiveSetup();
-    }
-
     if (opts.raw) {
         return IncludeSpec.defaults();
     }
 
-    // Default: use defaults (no interactive prompt unless -i)
+    if (opts.interactive) {
+        return await runInteractiveSetup();
+    }
+
+    if (opts.follow && process.stdout.isTTY) {
+        return await runInteractiveSetup();
+    }
+
     return IncludeSpec.defaults();
 }
 

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -1,0 +1,418 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, resolve } from "node:path";
+import { ClaudeSessionFormatter } from "@app/utils/claude/ClaudeSessionFormatter";
+import { ClaudeSessionTailer } from "@app/utils/claude/ClaudeSessionTailer";
+import { INCLUDE_HELP, IncludeSpec } from "@app/utils/claude/cli/dsl";
+import { encodedProjectDir, PROJECTS_DIR } from "@app/utils/claude/index";
+import { ClaudeSession } from "@app/utils/claude/session";
+import type { TailTarget } from "@app/utils/claude/session.types";
+import { suggestCommand } from "@app/utils/cli/executor";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+const STATUSLINE_DIR = resolve(homedir(), ".claude", "statusline");
+
+interface TailOptions {
+    follow: boolean;
+    stopOnFinish: boolean;
+    include?: string;
+    interactive: boolean;
+    noColors: boolean;
+    raw: boolean;
+    lastTurns?: string;
+    lastCalls?: string;
+    maxTurns?: string;
+    maxCalls?: string;
+    output?: string;
+    outputCli: boolean;
+    project?: string;
+}
+
+export function registerTailCommand(program: Command): void {
+    program
+        .command("tail [query]")
+        .description("Live-tail a Claude session or agent")
+        .option("-f, --follow", "Follow for new output (default)", true)
+        .option("--no-follow", "Dump existing content and exit")
+        .option("--stop-on-finish", "Exit when session/agent finishes", false)
+        .option("--include <spec>", "Comma-separated content specifiers")
+        .option("-i, --interactive", "Guided setup of --include via prompts", false)
+        .option("--no-colors", "Disable colors")
+        .option("--raw", "Raw JSONL, no formatting", false)
+        .option("-t, --last-turns <n>", "Show last N turns (default: 5)")
+        .option("-c, --last-calls <n>", "Show last N individual calls")
+        .option("--max-turns <n>", "Stop following after N new turns")
+        .option("--max-calls <n>", "Stop following after N new calls")
+        .option("-o, --output <file>", "Write formatted output to file")
+        .option("--output-cli", "Also print to CLI when using -o", false)
+        .option("-p, --project <path>", "Search in specific project directory")
+        .addHelpText("after", `\n${INCLUDE_HELP}`)
+        .action(async (query: string | undefined, opts: TailOptions) => {
+            const target = await resolveTarget(query, opts);
+
+            if (!target) {
+                console.error(pc.red("No matching session or agent found."));
+                process.exit(1);
+            }
+
+            const includeSpec = await resolveIncludeSpec(opts);
+            const isAgent = target.isAgent;
+            const effectiveSpec = isAgent ? includeSpec.forAgent() : includeSpec;
+
+            const useColors = opts.noColors ? false : (process.stdout.isTTY ?? false);
+            const cliOutput = opts.output ? opts.outputCli : true;
+
+            if (opts.output && !opts.outputCli) {
+                console.log(pc.dim(`Tailing to ${opts.output}...`));
+                console.log(pc.dim(suggestCommand("tools cc", { add: ["--output-cli"] })));
+            }
+
+            const formatter = new ClaudeSessionFormatter({
+                includeSpec: effectiveSpec,
+                colors: useColors,
+                outputFile: opts.output,
+                cliOutput,
+                raw: opts.raw,
+            });
+
+            if (!opts.raw) {
+                formatter.printBanner({
+                    target,
+                    includeSpec: effectiveSpec,
+                    follow: opts.follow,
+                    stopOnFinish: opts.stopOnFinish,
+                });
+            }
+
+            const lastTurns = opts.lastCalls ? undefined : (opts.lastTurns ? Number.parseInt(opts.lastTurns, 10) : 5);
+            const lastCalls = opts.lastCalls ? Number.parseInt(opts.lastCalls, 10) : undefined;
+
+            const tailer = new ClaudeSessionTailer({
+                filePath: target.filePath,
+                onRecord: (record) => formatter.format(record),
+                onFinished: () => {
+                    formatter.close();
+
+                    if (opts.output) {
+                        console.log(pc.dim(`\nOutput written to ${opts.output}`));
+                    }
+
+                    process.exit(0);
+                },
+                lastTurns,
+                lastCalls,
+                maxTurns: opts.maxTurns ? Number.parseInt(opts.maxTurns, 10) : undefined,
+                maxCalls: opts.maxCalls ? Number.parseInt(opts.maxCalls, 10) : undefined,
+                follow: opts.follow,
+                stopOnFinish: opts.stopOnFinish,
+                isAgent,
+            });
+
+            process.on("SIGINT", () => {
+                tailer.stop();
+                formatter.close();
+                console.log(pc.dim("\nStopped tailing."));
+                process.exit(0);
+            });
+
+            await tailer.start();
+
+            if (opts.follow) {
+                await new Promise(() => {});
+            } else {
+                formatter.close();
+            }
+        });
+}
+
+async function resolveTarget(query: string | undefined, opts: TailOptions): Promise<TailTarget | null> {
+    const projectPath = opts.project;
+
+    if (query) {
+        // Try session ID prefix first
+        const sessionTarget = findSessionByPrefix(query, projectPath);
+
+        if (sessionTarget) {
+            return sessionTarget;
+        }
+
+        // Try agent search
+        const agents = ClaudeSession.findSubagents({
+            query,
+            project: projectPath,
+        });
+
+        if (agents.length === 1) {
+            return agents[0];
+        }
+
+        if (agents.length > 1) {
+            return await promptSelectTarget(agents);
+        }
+
+        return null;
+    }
+
+    // No query — find most recent active session
+    return findMostRecentSession(projectPath);
+}
+
+function findSessionByPrefix(prefix: string, projectPath?: string): TailTarget | null {
+    const baseDir = projectPath
+        ? resolve(PROJECTS_DIR, encodedProjectDir(projectPath))
+        : resolve(PROJECTS_DIR, encodedProjectDir());
+
+    if (!existsSync(baseDir)) {
+        return null;
+    }
+
+    const lowerPrefix = prefix.toLowerCase();
+
+    try {
+        const entries = readdirSync(baseDir);
+
+        for (const entry of entries) {
+            if (entry.endsWith(".jsonl") && entry.toLowerCase().startsWith(lowerPrefix)) {
+                const filePath = resolve(baseDir, entry);
+                const sessionId = entry.replace(".jsonl", "");
+                return {
+                    filePath,
+                    label: sessionId,
+                    sessionId,
+                    isAgent: false,
+                };
+            }
+        }
+    } catch {
+        // Ignore
+    }
+
+    return null;
+}
+
+function findMostRecentSession(projectPath?: string): TailTarget | null {
+    // Use statusline files to find the most recently active session
+    if (existsSync(STATUSLINE_DIR)) {
+        try {
+            const files = readdirSync(STATUSLINE_DIR)
+                .filter((f) => f.startsWith("statusline.") && f.endsWith(".state"))
+                .map((f) => ({
+                    name: f,
+                    sessionId: f.replace("statusline.", "").replace(".state", ""),
+                    mtime: statSync(resolve(STATUSLINE_DIR, f)).mtimeMs,
+                }))
+                .sort((a, b) => b.mtime - a.mtime);
+
+            const baseDir = projectPath
+                ? resolve(PROJECTS_DIR, encodedProjectDir(projectPath))
+                : resolve(PROJECTS_DIR, encodedProjectDir());
+
+            for (const file of files) {
+                const jsonlPath = resolve(baseDir, `${file.sessionId}.jsonl`);
+
+                if (existsSync(jsonlPath)) {
+                    return {
+                        filePath: jsonlPath,
+                        label: file.sessionId,
+                        sessionId: file.sessionId,
+                        isAgent: false,
+                    };
+                }
+            }
+        } catch {
+            // Fall through to directory scan
+        }
+    }
+
+    // Fallback: scan project directory for most recently modified .jsonl
+    const baseDir = projectPath
+        ? resolve(PROJECTS_DIR, encodedProjectDir(projectPath))
+        : resolve(PROJECTS_DIR, encodedProjectDir());
+
+    if (!existsSync(baseDir)) {
+        return null;
+    }
+
+    try {
+        const jsonlFiles = readdirSync(baseDir)
+            .filter((f) => f.endsWith(".jsonl"))
+            .map((f) => ({
+                name: f,
+                mtime: statSync(resolve(baseDir, f)).mtimeMs,
+            }))
+            .sort((a, b) => b.mtime - a.mtime);
+
+        if (jsonlFiles.length === 0) {
+            return null;
+        }
+
+        const most = jsonlFiles[0];
+        const sessionId = most.name.replace(".jsonl", "");
+        return {
+            filePath: resolve(baseDir, most.name),
+            label: sessionId,
+            sessionId,
+            isAgent: false,
+        };
+    } catch {
+        return null;
+    }
+}
+
+async function promptSelectTarget(targets: TailTarget[]): Promise<TailTarget | null> {
+    if (!process.stdout.isTTY) {
+        console.error(pc.yellow("Multiple matches found. Use a more specific query or run in a TTY."));
+
+        for (const t of targets) {
+            console.error(`  ${t.label} — ${t.agentDescription ?? t.filePath}`);
+        }
+
+        return null;
+    }
+
+    const result = await p.select({
+        message: "Multiple matches found. Select one:",
+        options: targets.map((t) => ({
+            value: t,
+            label: t.agentDescription ?? t.label,
+            hint: basename(t.filePath),
+        })),
+    });
+
+    if (p.isCancel(result)) {
+        process.exit(0);
+    }
+
+    return result;
+}
+
+async function resolveIncludeSpec(opts: TailOptions): Promise<IncludeSpec> {
+    if (opts.include) {
+        return IncludeSpec.parse(opts.include);
+    }
+
+    if (opts.interactive) {
+        return await runInteractiveSetup();
+    }
+
+    if (opts.raw) {
+        return IncludeSpec.defaults();
+    }
+
+    // Default: use defaults (no interactive prompt unless -i)
+    return IncludeSpec.defaults();
+}
+
+async function runInteractiveSetup(): Promise<IncludeSpec> {
+    if (!process.stdout.isTTY) {
+        console.log(INCLUDE_HELP);
+        process.exit(0);
+    }
+
+    p.intro(pc.cyan("Configure tail output"));
+
+    const categories = await p.multiselect({
+        message: "What to show?",
+        options: [
+            { value: "thinking", label: "Thinking/reasoning blocks" },
+            { value: "tools", label: "Tool calls" },
+            { value: "agents", label: "Agent details" },
+        ],
+        initialValues: ["thinking", "tools", "agents"],
+    });
+
+    if (p.isCancel(categories)) {
+        process.exit(0);
+    }
+
+    const parts: string[] = [];
+
+    if (categories.includes("thinking")) {
+        parts.push("thinking");
+    }
+
+    if (categories.includes("tools")) {
+        const toolInChars = await p.text({
+            message: "Tool input max chars?",
+            placeholder: "500",
+            defaultValue: "500",
+        });
+
+        if (p.isCancel(toolInChars)) {
+            process.exit(0);
+        }
+
+        const toolOutChars = await p.text({
+            message: "Tool output max chars?",
+            placeholder: "500",
+            defaultValue: "500",
+        });
+
+        if (p.isCancel(toolOutChars)) {
+            process.exit(0);
+        }
+
+        parts.push(`tools:in:${toolInChars}`);
+        parts.push(`tools:out:${toolOutChars}`);
+    }
+
+    if (categories.includes("agents")) {
+        const agentParts = await p.multiselect({
+            message: "Agent details to show?",
+            options: [
+                { value: "input", label: "Agent launch prompt" },
+                { value: "tools", label: "Agent tool calls" },
+                { value: "result", label: "Agent final result" },
+                { value: "thinking", label: "Agent thinking" },
+            ],
+            initialValues: ["input", "tools", "result"],
+        });
+
+        if (p.isCancel(agentParts)) {
+            process.exit(0);
+        }
+
+        if (agentParts.includes("input")) {
+            parts.push("agents:input");
+        }
+
+        if (agentParts.includes("tools")) {
+            const agentToolIn = await p.text({
+                message: "Agent tool input max chars?",
+                placeholder: "50",
+                defaultValue: "50",
+            });
+
+            if (p.isCancel(agentToolIn)) {
+                process.exit(0);
+            }
+
+            const agentToolOut = await p.text({
+                message: "Agent tool output max chars?",
+                placeholder: "500",
+                defaultValue: "500",
+            });
+
+            if (p.isCancel(agentToolOut)) {
+                process.exit(0);
+            }
+
+            parts.push(`agents:tools:in:${agentToolIn}`);
+            parts.push(`agents:tools:out:${agentToolOut}`);
+        }
+
+        if (agentParts.includes("result")) {
+            parts.push("agents:result");
+        }
+
+        if (agentParts.includes("thinking")) {
+            parts.push("agents:thinking");
+        }
+    }
+
+    p.outro(pc.dim(`--include ${parts.join(",")}`));
+
+    return IncludeSpec.parse(parts.join(","));
+}

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -86,7 +86,7 @@ export function registerTailCommand(program: Command): void {
                 });
             }
 
-            const lastTurns = opts.lastCalls ? undefined : (opts.lastTurns ? Number.parseInt(opts.lastTurns, 10) : 5);
+            const lastTurns = opts.lastCalls ? undefined : opts.lastTurns ? Number.parseInt(opts.lastTurns, 10) : 5;
             const lastCalls = opts.lastCalls ? Number.parseInt(opts.lastCalls, 10) : undefined;
 
             const tailer = new ClaudeSessionTailer({

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -12,6 +12,21 @@ import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 
+function validatePositiveInt(value: string | undefined, name: string): number | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+
+    if (Number.isNaN(parsed) || parsed <= 0) {
+        console.error(pc.red(`--${name} must be a positive integer, got "${value}"`));
+        process.exit(1);
+    }
+
+    return parsed;
+}
+
 const STATUSLINE_DIR = resolve(homedir(), ".claude", "statusline");
 
 interface TailOptions {
@@ -19,7 +34,7 @@ interface TailOptions {
     stopOnFinish: boolean;
     include?: string;
     interactive: boolean;
-    noColors: boolean;
+    colors: boolean;
     raw: boolean;
     lastTurns?: string;
     lastCalls?: string;
@@ -61,7 +76,7 @@ export function registerTailCommand(program: Command): void {
             const isAgent = target.isAgent;
             const effectiveSpec = isAgent ? includeSpec.forAgent() : includeSpec;
 
-            const useColors = opts.noColors ? false : (process.stdout.isTTY ?? false);
+            const useColors = opts.colors !== false && (process.stdout.isTTY ?? false);
             const cliOutput = opts.output ? opts.outputCli : true;
 
             if (opts.output && !opts.outputCli) {
@@ -86,19 +101,16 @@ export function registerTailCommand(program: Command): void {
                 });
             }
 
-            const lastTurns = opts.lastCalls ? undefined : opts.lastTurns ? Number.parseInt(opts.lastTurns, 10) : 5;
-            const lastCalls = opts.lastCalls ? Number.parseInt(opts.lastCalls, 10) : undefined;
-
-            if (lastTurns === 0 || lastCalls === 0) {
-                p.log.error("-t/--last-turns and -c/--last-calls must be ≥ 1 (use --no-follow to skip history)");
-                process.exit(1);
-            }
+            const lastCalls = validatePositiveInt(opts.lastCalls, "last-calls");
+            const lastTurns = lastCalls ? undefined : validatePositiveInt(opts.lastTurns, "last-turns") ?? 5;
+            const maxTurns = validatePositiveInt(opts.maxTurns, "max-turns");
+            const maxCalls = validatePositiveInt(opts.maxCalls, "max-calls");
 
             const tailer = new ClaudeSessionTailer({
                 filePath: target.filePath,
                 onRecord: (record) => formatter.format(record),
-                onFinished: () => {
-                    formatter.close();
+                onFinished: async () => {
+                    await formatter.close();
 
                     if (opts.output) {
                         console.log(pc.dim(`\nOutput written to ${opts.output}`));
@@ -109,16 +121,16 @@ export function registerTailCommand(program: Command): void {
                 includeSpec: effectiveSpec,
                 lastTurns,
                 lastCalls,
-                maxTurns: opts.maxTurns ? Number.parseInt(opts.maxTurns, 10) : undefined,
-                maxCalls: opts.maxCalls ? Number.parseInt(opts.maxCalls, 10) : undefined,
+                maxTurns,
+                maxCalls,
                 follow: opts.follow,
                 stopOnFinish: opts.stopOnFinish,
                 isAgent,
             });
 
-            process.on("SIGINT", () => {
+            process.on("SIGINT", async () => {
                 tailer.stop();
-                formatter.close();
+                await formatter.close();
                 console.log(pc.dim("\nStopped tailing."));
                 process.exit(0);
             });
@@ -128,23 +140,21 @@ export function registerTailCommand(program: Command): void {
             if (opts.follow) {
                 await new Promise(() => {});
             } else {
-                formatter.close();
+                await formatter.close();
             }
         });
 }
 
 async function resolveTarget(query: string | undefined, opts: TailOptions): Promise<TailTarget | null> {
-    const projectPath = opts.project;
+    const projectPath = opts.project ? resolve(opts.project) : undefined;
 
     if (query) {
-        // Try session ID prefix first
-        const sessionTarget = findSessionByPrefix(query, projectPath);
+        const sessionTarget = await findSessionByPrefix(query, projectPath);
 
         if (sessionTarget) {
             return sessionTarget;
         }
 
-        // Try agent search
         const agents = ClaudeSession.findSubagents({
             query,
             project: projectPath,
@@ -185,22 +195,31 @@ function getProjectDirs(projectPath?: string): string[] {
     }
 }
 
-function findSessionByPrefix(prefix: string, projectPath?: string): TailTarget | null {
+async function findSessionByPrefix(prefix: string, projectPath?: string): Promise<TailTarget | null> {
     const lowerPrefix = prefix.toLowerCase();
+    const matches: TailTarget[] = [];
 
     for (const baseDir of getProjectDirs(projectPath)) {
         try {
             for (const entry of readdirSync(baseDir)) {
                 if (entry.endsWith(".jsonl") && entry.toLowerCase().startsWith(lowerPrefix)) {
-                    return {
+                    matches.push({
                         filePath: resolve(baseDir, entry),
                         label: entry.replace(".jsonl", ""),
                         sessionId: entry.replace(".jsonl", ""),
                         isAgent: false,
-                    };
+                    });
                 }
             }
         } catch {}
+    }
+
+    if (matches.length === 1) {
+        return matches[0];
+    }
+
+    if (matches.length > 1) {
+        return await promptSelectTarget(matches);
     }
 
     return null;
@@ -309,20 +328,24 @@ async function resolveIncludeSpec(opts: TailOptions): Promise<IncludeSpec> {
     }
 
     if (opts.interactive) {
-        return await runInteractiveSetup();
+        return await runInteractiveSetup(true);
     }
 
     if (opts.follow && process.stdout.isTTY) {
-        return await runInteractiveSetup();
+        return await runInteractiveSetup(false);
     }
 
     return IncludeSpec.defaults();
 }
 
-async function runInteractiveSetup(): Promise<IncludeSpec> {
+async function runInteractiveSetup(explicit: boolean): Promise<IncludeSpec> {
     if (!process.stdout.isTTY) {
-        console.log(INCLUDE_HELP);
-        process.exit(0);
+        if (explicit) {
+            console.error(pc.red("--interactive requires a TTY. Pipe-friendly alternative: --include <spec>"));
+            process.exit(1);
+        }
+
+        return IncludeSpec.defaults();
     }
 
     p.intro(pc.cyan("Configure tail output"));

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -200,9 +200,7 @@ function findSessionByPrefix(prefix: string, projectPath?: string): TailTarget |
                     };
                 }
             }
-        } catch {
-            continue;
-        }
+        } catch {}
     }
 
     return null;
@@ -259,9 +257,7 @@ function findMostRecentSession(projectPath?: string): TailTarget | null {
                     best = { filePath, sessionId: f.replace(".jsonl", ""), mtime };
                 }
             }
-        } catch {
-            continue;
-        }
+        } catch {}
     }
 
     if (!best) {

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -106,6 +106,7 @@ export function registerTailCommand(program: Command): void {
 
                     process.exit(0);
                 },
+                includeSpec: effectiveSpec,
                 lastTurns,
                 lastCalls,
                 maxTurns: opts.maxTurns ? Number.parseInt(opts.maxTurns, 10) : undefined,
@@ -147,6 +148,7 @@ async function resolveTarget(query: string | undefined, opts: TailOptions): Prom
         const agents = ClaudeSession.findSubagents({
             query,
             project: projectPath,
+            allProjects: !projectPath,
         });
 
         if (agents.length === 1) {
@@ -164,40 +166,51 @@ async function resolveTarget(query: string | undefined, opts: TailOptions): Prom
     return findMostRecentSession(projectPath);
 }
 
-function findSessionByPrefix(prefix: string, projectPath?: string): TailTarget | null {
-    const baseDir = projectPath
-        ? resolve(PROJECTS_DIR, encodedProjectDir(projectPath))
-        : resolve(PROJECTS_DIR, encodedProjectDir());
-
-    if (!existsSync(baseDir)) {
-        return null;
+function getProjectDirs(projectPath?: string): string[] {
+    if (projectPath) {
+        const dir = resolve(PROJECTS_DIR, encodedProjectDir(projectPath));
+        return existsSync(dir) ? [dir] : [];
     }
 
-    const lowerPrefix = prefix.toLowerCase();
+    if (!existsSync(PROJECTS_DIR)) {
+        return [];
+    }
 
     try {
-        const entries = readdirSync(baseDir);
-
-        for (const entry of entries) {
-            if (entry.endsWith(".jsonl") && entry.toLowerCase().startsWith(lowerPrefix)) {
-                const filePath = resolve(baseDir, entry);
-                const sessionId = entry.replace(".jsonl", "");
-                return {
-                    filePath,
-                    label: sessionId,
-                    sessionId,
-                    isAgent: false,
-                };
-            }
-        }
+        return readdirSync(PROJECTS_DIR)
+            .map((d) => resolve(PROJECTS_DIR, d))
+            .filter((d) => statSync(d).isDirectory());
     } catch {
-        // Ignore
+        return [];
+    }
+}
+
+function findSessionByPrefix(prefix: string, projectPath?: string): TailTarget | null {
+    const lowerPrefix = prefix.toLowerCase();
+
+    for (const baseDir of getProjectDirs(projectPath)) {
+        try {
+            for (const entry of readdirSync(baseDir)) {
+                if (entry.endsWith(".jsonl") && entry.toLowerCase().startsWith(lowerPrefix)) {
+                    return {
+                        filePath: resolve(baseDir, entry),
+                        label: entry.replace(".jsonl", ""),
+                        sessionId: entry.replace(".jsonl", ""),
+                        isAgent: false,
+                    };
+                }
+            }
+        } catch {
+            continue;
+        }
     }
 
     return null;
 }
 
 function findMostRecentSession(projectPath?: string): TailTarget | null {
+    const dirs = getProjectDirs(projectPath);
+
     // Use statusline files to find the most recently active session
     if (existsSync(STATUSLINE_DIR)) {
         try {
@@ -210,20 +223,18 @@ function findMostRecentSession(projectPath?: string): TailTarget | null {
                 }))
                 .sort((a, b) => b.mtime - a.mtime);
 
-            const baseDir = projectPath
-                ? resolve(PROJECTS_DIR, encodedProjectDir(projectPath))
-                : resolve(PROJECTS_DIR, encodedProjectDir());
-
             for (const file of files) {
-                const jsonlPath = resolve(baseDir, `${file.sessionId}.jsonl`);
+                for (const baseDir of dirs) {
+                    const jsonlPath = resolve(baseDir, `${file.sessionId}.jsonl`);
 
-                if (existsSync(jsonlPath)) {
-                    return {
-                        filePath: jsonlPath,
-                        label: file.sessionId,
-                        sessionId: file.sessionId,
-                        isAgent: false,
-                    };
+                    if (existsSync(jsonlPath)) {
+                        return {
+                            filePath: jsonlPath,
+                            label: file.sessionId,
+                            sessionId: file.sessionId,
+                            isAgent: false,
+                        };
+                    }
                 }
             }
         } catch {
@@ -231,39 +242,38 @@ function findMostRecentSession(projectPath?: string): TailTarget | null {
         }
     }
 
-    // Fallback: scan project directory for most recently modified .jsonl
-    const baseDir = projectPath
-        ? resolve(PROJECTS_DIR, encodedProjectDir(projectPath))
-        : resolve(PROJECTS_DIR, encodedProjectDir());
+    // Fallback: scan all project directories for most recently modified .jsonl
+    let best: { filePath: string; sessionId: string; mtime: number } | null = null;
 
-    if (!existsSync(baseDir)) {
-        return null;
-    }
+    for (const baseDir of dirs) {
+        try {
+            for (const f of readdirSync(baseDir)) {
+                if (!f.endsWith(".jsonl")) {
+                    continue;
+                }
 
-    try {
-        const jsonlFiles = readdirSync(baseDir)
-            .filter((f) => f.endsWith(".jsonl"))
-            .map((f) => ({
-                name: f,
-                mtime: statSync(resolve(baseDir, f)).mtimeMs,
-            }))
-            .sort((a, b) => b.mtime - a.mtime);
+                const filePath = resolve(baseDir, f);
+                const mtime = statSync(filePath).mtimeMs;
 
-        if (jsonlFiles.length === 0) {
-            return null;
+                if (!best || mtime > best.mtime) {
+                    best = { filePath, sessionId: f.replace(".jsonl", ""), mtime };
+                }
+            }
+        } catch {
+            continue;
         }
+    }
 
-        const most = jsonlFiles[0];
-        const sessionId = most.name.replace(".jsonl", "");
-        return {
-            filePath: resolve(baseDir, most.name),
-            label: sessionId,
-            sessionId,
-            isAgent: false,
-        };
-    } catch {
+    if (!best) {
         return null;
     }
+
+    return {
+        filePath: best.filePath,
+        label: best.sessionId,
+        sessionId: best.sessionId,
+        isAgent: false,
+    };
 }
 
 async function promptSelectTarget(targets: TailTarget[]): Promise<TailTarget | null> {

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -89,6 +89,11 @@ export function registerTailCommand(program: Command): void {
             const lastTurns = opts.lastCalls ? undefined : opts.lastTurns ? Number.parseInt(opts.lastTurns, 10) : 5;
             const lastCalls = opts.lastCalls ? Number.parseInt(opts.lastCalls, 10) : undefined;
 
+            if (lastTurns === 0 || lastCalls === 0) {
+                p.log.error("-t/--last-turns and -c/--last-calls must be ≥ 1 (use --no-follow to skip history)");
+                process.exit(1);
+            }
+
             const tailer = new ClaudeSessionTailer({
                 filePath: target.filePath,
                 onRecord: (record) => formatter.format(record),

--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -7,6 +7,7 @@ import { registerDesktopCommand } from "./commands/desktop";
 import { registerHistoryCommand } from "./commands/history";
 import { registerMigrateCommand } from "./commands/migrate";
 import { registerResumeCommand } from "./commands/resume";
+import { registerTailCommand } from "./commands/tail";
 import { registerUsageCommand } from "./commands/usage";
 
 const program = new Command();
@@ -19,6 +20,7 @@ program
 
 registerHistoryCommand(program);
 registerResumeCommand(program);
+registerTailCommand(program);
 registerDesktopCommand(program);
 registerUsageCommand(program);
 registerConfigCommand(program);

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -176,9 +176,7 @@ export class ClaudeSessionFormatter {
 
         this.writeLine(header);
         this.writeLine(
-            c
-                ? `${pc.cyan("│")} Including: ${includeSpec.describe()}`
-                : `│ Including: ${includeSpec.describe()}`
+            c ? `${pc.cyan("│")} Including: ${includeSpec.describe()}` : `│ Including: ${includeSpec.describe()}`
         );
         this.writeLine(
             c
@@ -228,11 +226,7 @@ export class ClaudeSessionFormatter {
                             const truncated = truncate(result.trim(), maxChars);
                             const prefix = isError ? "  ✗ " : "  → ";
                             const line = `${prefix}${truncated}`;
-                            const formatted = this.options.colors
-                                ? isError
-                                    ? pc.red(line)
-                                    : pc.dim(line)
-                                : line;
+                            const formatted = this.options.colors ? (isError ? pc.red(line) : pc.dim(line)) : line;
                             this.writeLine(formatted);
                         }
                     }

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -5,6 +5,7 @@ import type { IncludeSpec } from "./cli/dsl";
 import type { TailTarget } from "./session.types";
 import type {
     AssistantMessage,
+    AssistantMessageContent,
     ConversationMessage,
     SubagentMessage,
     TextBlock,
@@ -12,6 +13,13 @@ import type {
     ToolUseBlock,
     UserMessage,
 } from "./types";
+
+/** Shorthand "A" variant that some JSONL sessions use for assistant messages. */
+interface ShorthandAssistant {
+    type: "A";
+    message?: AssistantMessageContent;
+    timestamp?: string;
+}
 
 interface FormatterOptions {
     includeSpec: IncludeSpec;
@@ -136,8 +144,18 @@ export class ClaudeSessionFormatter {
                 break;
             case "summary":
                 break;
-            default:
+            default: {
+                const raw = record as unknown as ShorthandAssistant;
+
+                if (raw.type === "A" && raw.message) {
+                    this.formatAssistantMessage(
+                        { type: "assistant", message: raw.message } as AssistantMessage,
+                        raw.timestamp ?? timestamp,
+                    );
+                }
+
                 break;
+            }
         }
     }
 
@@ -184,13 +202,19 @@ export class ClaudeSessionFormatter {
         this.writeLine("");
     }
 
-    close(): void {
+    close(): Promise<void> {
         this.closeAgentSection();
 
-        if (this.fileStream) {
-            this.fileStream.end();
-            this.fileStream = null;
+        if (!this.fileStream) {
+            return Promise.resolve();
         }
+
+        return new Promise((resolve) => {
+            this.fileStream!.end(() => {
+                this.fileStream = null;
+                resolve();
+            });
+        });
     }
 
     private formatUserMessage(msg: UserMessage, timestamp: string): void {
@@ -314,11 +338,32 @@ export class ClaudeSessionFormatter {
         const message = msg.message;
 
         if (message.role === "user") {
+            const content = message.content;
+
+            if (typeof content !== "string" && this.options.includeSpec.shouldShow("agents:tools:out")) {
+                for (const block of content) {
+                    if (block.type === "tool_result") {
+                        const result = extractToolResultText(block);
+                        const maxChars = this.options.includeSpec.truncationLength("agents:tools:out");
+                        const isError = block.is_error;
+
+                        if (result) {
+                            const truncated = truncate(result.trim(), maxChars);
+                            const colorFn = this.getAgentColor(agentId);
+                            const prefix = this.activeAgentId === agentId ? colorFn("  │ ") : "    ";
+                            const marker = isError ? "  ✗ " : "  → ";
+                            const line = `${prefix}${marker}${truncated}`;
+                            const formatted = this.options.colors ? (isError ? pc.red(line) : pc.dim(line)) : line;
+                            this.writeLine(formatted);
+                        }
+                    }
+                }
+            }
+
             if (!this.options.includeSpec.shouldShow("agents:input")) {
                 return;
             }
 
-            const content = message.content;
             let text = "";
 
             if (typeof content === "string") {

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -1,18 +1,16 @@
 import { createWriteStream, type WriteStream } from "node:fs";
+import { SafeJSON } from "@app/utils/json";
 import pc from "picocolors";
 import type { IncludeSpec } from "./cli/dsl";
 import type { TailTarget } from "./session.types";
 import type {
     AssistantMessage,
-    AssistantMessageContent,
     ConversationMessage,
     SubagentMessage,
     TextBlock,
-    ThinkingBlock,
     ToolResultBlock,
     ToolUseBlock,
     UserMessage,
-    UserMessageContent,
 } from "./types";
 
 interface FormatterOptions {
@@ -95,8 +93,6 @@ function extractToolResultText(block: ToolResultBlock): string {
     return "";
 }
 
-import { SafeJSON } from "@app/utils/json";
-
 /**
  * Formats JSONL records into colorized terminal output.
  * Handles agent bordered sections, content truncation, and dual output.
@@ -124,13 +120,13 @@ export class ClaudeSessionFormatter {
 
         switch (record.type) {
             case "user":
-                this.formatUserMessage(record as UserMessage, timestamp);
+                this.formatUserMessage(record, timestamp);
                 break;
             case "assistant":
-                this.formatAssistantMessage(record as AssistantMessage, timestamp);
+                this.formatAssistantMessage(record, timestamp);
                 break;
             case "subagent":
-                this.formatSubagentMessage(record as SubagentMessage, timestamp);
+                this.formatSubagentMessage(record, timestamp);
                 break;
             case "system":
                 break;
@@ -208,19 +204,18 @@ export class ClaudeSessionFormatter {
 
             for (const block of content) {
                 if (block.type === "text") {
-                    textParts.push((block as TextBlock).text);
+                    textParts.push(block.text);
                 }
             }
 
             text = textParts.join("\n");
 
-            // Also emit tool results if included
             if (this.options.includeSpec.shouldShow("tools:out")) {
                 for (const block of content) {
                     if (block.type === "tool_result") {
-                        const result = extractToolResultText(block as ToolResultBlock);
+                        const result = extractToolResultText(block);
                         const maxChars = this.options.includeSpec.truncationLength("tools:out");
-                        const isError = (block as ToolResultBlock).is_error;
+                        const isError = block.is_error;
 
                         if (result) {
                             const truncated = truncate(result.trim(), maxChars);
@@ -265,7 +260,7 @@ export class ClaudeSessionFormatter {
 
         for (const block of blocks) {
             if (block.type === "thinking" && this.options.includeSpec.shouldShow("thinking")) {
-                const thinking = (block as ThinkingBlock).thinking.trim();
+                const thinking = block.thinking.trim();
 
                 if (thinking) {
                     const firstLine = thinking.split("\n")[0];
@@ -277,7 +272,7 @@ export class ClaudeSessionFormatter {
             }
 
             if (block.type === "text") {
-                const text = (block as TextBlock).text.trim();
+                const text = block.text.trim();
 
                 if (text) {
                     hasTextOutput = true;
@@ -309,17 +304,16 @@ export class ClaudeSessionFormatter {
             }
 
             if (block.type === "tool_use" && this.options.includeSpec.shouldShow("tools:in")) {
-                const tool = block as ToolUseBlock;
-                const inputSummary = extractToolInputSummary(tool);
+                const inputSummary = extractToolInputSummary(block);
                 const maxChars = this.options.includeSpec.truncationLength("tools:in");
                 const truncated = truncate(inputSummary, maxChars);
 
                 if (this.options.colors) {
                     this.writeLine(
-                        `${pc.dim(hasTextOutput ? "        " : time)}   ${pc.dim(`[${tool.name}]`)} ${pc.dim(truncated)}`
+                        `${pc.dim(hasTextOutput ? "        " : time)}   ${pc.dim(`[${block.name}]`)} ${pc.dim(truncated)}`
                     );
                 } else {
-                    this.writeLine(`${hasTextOutput ? "        " : time}   [${tool.name}] ${truncated}`);
+                    this.writeLine(`${hasTextOutput ? "        " : time}   [${block.name}] ${truncated}`);
                 }
             }
         }
@@ -328,13 +322,14 @@ export class ClaudeSessionFormatter {
     private formatSubagentMessage(msg: SubagentMessage, timestamp: string): void {
         const agentId = msg.agentId || "unknown";
         const time = formatTime(timestamp);
+        const message = msg.message;
 
-        if (msg.role === "user") {
+        if (message.role === "user") {
             if (!this.options.includeSpec.shouldShow("agents:input")) {
                 return;
             }
 
-            const content = (msg.message as UserMessageContent).content;
+            const content = message.content;
             let text = "";
 
             if (typeof content === "string") {
@@ -350,13 +345,11 @@ export class ClaudeSessionFormatter {
                 return;
             }
 
-            // Open agent section if needed
             this.openAgentSection(agentId, text.trim().split("\n")[0], timestamp);
             return;
         }
 
-        // Assistant role — agent response
-        const assistantContent = (msg.message as AssistantMessageContent).content;
+        const assistantContent = message.content;
 
         if (!Array.isArray(assistantContent)) {
             return;
@@ -367,7 +360,7 @@ export class ClaudeSessionFormatter {
 
         for (const block of assistantContent) {
             if (block.type === "thinking" && this.options.includeSpec.shouldShow("agents:thinking")) {
-                const thinking = (block as ThinkingBlock).thinking.trim();
+                const thinking = block.thinking.trim();
 
                 if (thinking) {
                     const firstLine = thinking.split("\n")[0];
@@ -382,7 +375,7 @@ export class ClaudeSessionFormatter {
                     continue;
                 }
 
-                const text = (block as TextBlock).text.trim();
+                const text = block.text.trim();
 
                 if (text) {
                     const firstLine = text.split("\n")[0];
@@ -396,21 +389,19 @@ export class ClaudeSessionFormatter {
             }
 
             if (block.type === "tool_use" && this.options.includeSpec.shouldShow("agents:tools:in")) {
-                const tool = block as ToolUseBlock;
-                const inputSummary = extractToolInputSummary(tool);
+                const inputSummary = extractToolInputSummary(block);
                 const maxChars = this.options.includeSpec.truncationLength("agents:tools:in");
                 const truncated = truncate(inputSummary, maxChars);
 
                 if (this.options.colors) {
-                    this.writeLine(`${prefix}${pc.dim(`  [${tool.name}]`)} ${pc.dim(truncated)}`);
+                    this.writeLine(`${prefix}${pc.dim(`  [${block.name}]`)} ${pc.dim(truncated)}`);
                 } else {
-                    this.writeLine(`${prefix}  [${tool.name}] ${truncated}`);
+                    this.writeLine(`${prefix}  [${block.name}] ${truncated}`);
                 }
             }
         }
 
-        // Check for agent completion
-        const stopReason = (msg.message as AssistantMessageContent).stop_reason;
+        const stopReason = message.stop_reason;
 
         if (stopReason === "end_turn" && this.activeAgentId === agentId) {
             this.closeAgentSection();

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -1,0 +1,480 @@
+import { createWriteStream, type WriteStream } from "node:fs";
+import pc from "picocolors";
+import type { IncludeSpec } from "./cli/dsl";
+import type { TailTarget } from "./session.types";
+import type {
+    AssistantMessage,
+    AssistantMessageContent,
+    ConversationMessage,
+    SubagentMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+    UserMessageContent,
+} from "./types";
+
+interface FormatterOptions {
+    includeSpec: IncludeSpec;
+    colors: boolean;
+    outputFile?: string;
+    cliOutput?: boolean;
+    raw?: boolean;
+}
+
+const AGENT_COLORS = [pc.cyan, pc.magenta, pc.yellow, pc.green, pc.blue] as const;
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes are the target
+const ANSI_REGEX = /\x1B\[\d+m/g;
+
+function stripAnsi(text: string): string {
+    return text.replace(ANSI_REGEX, "");
+}
+
+function formatTime(timestamp: string): string {
+    try {
+        const d = new Date(timestamp);
+        return d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    } catch {
+        return "??:??:??";
+    }
+}
+
+function truncate(text: string, maxChars: number): string {
+    if (maxChars <= 0) {
+        return "";
+    }
+
+    if (text.length <= maxChars) {
+        return text;
+    }
+
+    return `${text.slice(0, maxChars)}...`;
+}
+
+function extractToolInputSummary(tool: ToolUseBlock): string {
+    const input = tool.input;
+
+    if ("command" in input && typeof input.command === "string") {
+        return input.command;
+    }
+
+    if ("file_path" in input && typeof input.file_path === "string") {
+        return input.file_path;
+    }
+
+    if ("pattern" in input && typeof input.pattern === "string") {
+        return input.pattern;
+    }
+
+    if ("query" in input && typeof input.query === "string") {
+        return input.query;
+    }
+
+    if ("skill" in input && typeof input.skill === "string") {
+        return input.skill;
+    }
+
+    const safeInput = SafeJSON.stringify(input);
+    return safeInput;
+}
+
+function extractToolResultText(block: ToolResultBlock): string {
+    if (typeof block.content === "string") {
+        return block.content;
+    }
+
+    if (Array.isArray(block.content)) {
+        return block.content
+            .filter((b): b is TextBlock => b.type === "text")
+            .map((b) => b.text)
+            .join("\n");
+    }
+
+    return "";
+}
+
+import { SafeJSON } from "@app/utils/json";
+
+/**
+ * Formats JSONL records into colorized terminal output.
+ * Handles agent bordered sections, content truncation, and dual output.
+ */
+export class ClaudeSessionFormatter {
+    private agentColorMap = new Map<string, (typeof AGENT_COLORS)[number]>();
+    private nextColorIndex = 0;
+    private activeAgentId: string | null = null;
+    private agentStartTime = new Map<string, number>();
+    private fileStream: WriteStream | null = null;
+
+    constructor(private options: FormatterOptions) {
+        if (options.outputFile) {
+            this.fileStream = createWriteStream(options.outputFile, { flags: "a" });
+        }
+    }
+
+    format(record: ConversationMessage): void {
+        if (this.options.raw) {
+            this.writeLine(SafeJSON.stringify(record, null, 0));
+            return;
+        }
+
+        const timestamp = "timestamp" in record && typeof record.timestamp === "string" ? record.timestamp : "";
+
+        switch (record.type) {
+            case "user":
+                this.formatUserMessage(record as UserMessage, timestamp);
+                break;
+            case "assistant":
+                this.formatAssistantMessage(record as AssistantMessage, timestamp);
+                break;
+            case "subagent":
+                this.formatSubagentMessage(record as SubagentMessage, timestamp);
+                break;
+            case "system":
+                break;
+            case "progress":
+                break;
+            case "custom-title":
+                break;
+            case "summary":
+                break;
+            default:
+                break;
+        }
+    }
+
+    closeAgentSection(): void {
+        if (this.activeAgentId) {
+            const startTime = this.agentStartTime.get(this.activeAgentId);
+            const duration = startTime ? this.formatDuration(Date.now() - startTime) : "";
+            const colorFn = this.getAgentColor(this.activeAgentId);
+            const suffix = duration ? ` done (${duration})` : " done";
+            this.writeLine(
+                colorFn(`  \u2514${"─".repeat(40)}${"─".repeat(Math.max(0, 20 - suffix.length))} \u2713${suffix} ─`)
+            );
+            this.activeAgentId = null;
+        }
+    }
+
+    printBanner(options: {
+        target: TailTarget;
+        includeSpec: IncludeSpec;
+        follow: boolean;
+        stopOnFinish: boolean;
+    }): void {
+        const { target, includeSpec, follow, stopOnFinish } = options;
+        const c = this.options.colors;
+
+        const typeLabel = target.isAgent ? "agent" : "session";
+        const nameLabel = target.agentDescription || target.label;
+
+        const header = c
+            ? `${pc.bold(pc.cyan("┌ claude tail"))} ── ${pc.bold(`[${typeLabel}]`)} ${pc.bold(pc.green(nameLabel))} ${"─".repeat(20)}`
+            : `┌ claude tail ── [${typeLabel}] ${nameLabel} ${"─".repeat(20)}`;
+
+        this.writeLine(header);
+        this.writeLine(
+            c
+                ? `${pc.cyan("│")} Including: ${includeSpec.describe()}`
+                : `│ Including: ${includeSpec.describe()}`
+        );
+        this.writeLine(
+            c
+                ? `${pc.cyan("│")} Following: ${follow ? "yes" : "no"}  Stop on finish: ${stopOnFinish ? "yes" : "no"}`
+                : `│ Following: ${follow ? "yes" : "no"}  Stop on finish: ${stopOnFinish ? "yes" : "no"}`
+        );
+        this.writeLine(c ? `${pc.cyan("│")} Source: ${target.filePath}` : `│ Source: ${target.filePath}`);
+        this.writeLine(c ? `${pc.cyan("└")}${"─".repeat(60)}` : `└${"─".repeat(60)}`);
+        this.writeLine("");
+    }
+
+    close(): void {
+        this.closeAgentSection();
+
+        if (this.fileStream) {
+            this.fileStream.end();
+            this.fileStream = null;
+        }
+    }
+
+    private formatUserMessage(msg: UserMessage, timestamp: string): void {
+        const content = msg.message.content;
+        let text: string;
+
+        if (typeof content === "string") {
+            text = content;
+        } else {
+            const textParts: string[] = [];
+
+            for (const block of content) {
+                if (block.type === "text") {
+                    textParts.push((block as TextBlock).text);
+                }
+            }
+
+            text = textParts.join("\n");
+
+            // Also emit tool results if included
+            if (this.options.includeSpec.shouldShow("tools:out")) {
+                for (const block of content) {
+                    if (block.type === "tool_result") {
+                        const result = extractToolResultText(block as ToolResultBlock);
+                        const maxChars = this.options.includeSpec.truncationLength("tools:out");
+                        const isError = (block as ToolResultBlock).is_error;
+
+                        if (result) {
+                            const truncated = truncate(result.trim(), maxChars);
+                            const prefix = isError ? "  ✗ " : "  → ";
+                            const line = `${prefix}${truncated}`;
+                            const formatted = this.options.colors
+                                ? isError
+                                    ? pc.red(line)
+                                    : pc.dim(line)
+                                : line;
+                            this.writeLine(formatted);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!text.trim()) {
+            return;
+        }
+
+        // Skip meta/internal user messages
+        if (msg.isMeta) {
+            return;
+        }
+
+        const time = formatTime(timestamp);
+        const firstLine = text.trim().split("\n")[0];
+
+        if (this.options.colors) {
+            this.writeLine(`${pc.dim(time)} ${pc.bold(pc.green("You:"))} ${firstLine}`);
+        } else {
+            this.writeLine(`${time} You: ${firstLine}`);
+        }
+    }
+
+    private formatAssistantMessage(msg: AssistantMessage, timestamp: string): void {
+        const blocks = msg.message?.content;
+
+        if (!Array.isArray(blocks)) {
+            return;
+        }
+
+        const time = formatTime(timestamp);
+        let hasTextOutput = false;
+
+        for (const block of blocks) {
+            if (block.type === "thinking" && this.options.includeSpec.shouldShow("thinking")) {
+                const thinking = (block as ThinkingBlock).thinking.trim();
+
+                if (thinking) {
+                    const firstLine = thinking.split("\n")[0];
+                    const formatted = this.options.colors
+                        ? pc.dim(`${time} 💭 ${firstLine}`)
+                        : `${time} [thinking] ${firstLine}`;
+                    this.writeLine(formatted);
+                }
+            }
+
+            if (block.type === "text") {
+                const text = (block as TextBlock).text.trim();
+
+                if (text) {
+                    hasTextOutput = true;
+                    const firstLine = text.split("\n")[0];
+
+                    if (this.options.colors) {
+                        this.writeLine(`${pc.dim(time)} ${pc.bold(pc.blue("Claude:"))} ${firstLine}`);
+                    } else {
+                        this.writeLine(`${time} Claude: ${firstLine}`);
+                    }
+
+                    // Print remaining lines indented
+                    const remainingLines = text.split("\n").slice(1);
+
+                    for (const line of remainingLines.slice(0, 5)) {
+                        if (line.trim()) {
+                            this.writeLine(`         ${line}`);
+                        }
+                    }
+
+                    if (remainingLines.length > 5) {
+                        this.writeLine(
+                            this.options.colors
+                                ? pc.dim(`         ... (${remainingLines.length - 5} more lines)`)
+                                : `         ... (${remainingLines.length - 5} more lines)`
+                        );
+                    }
+                }
+            }
+
+            if (block.type === "tool_use" && this.options.includeSpec.shouldShow("tools:in")) {
+                const tool = block as ToolUseBlock;
+                const inputSummary = extractToolInputSummary(tool);
+                const maxChars = this.options.includeSpec.truncationLength("tools:in");
+                const truncated = truncate(inputSummary, maxChars);
+
+                if (this.options.colors) {
+                    this.writeLine(
+                        `${pc.dim(hasTextOutput ? "        " : time)}   ${pc.dim(`[${tool.name}]`)} ${pc.dim(truncated)}`
+                    );
+                } else {
+                    this.writeLine(`${hasTextOutput ? "        " : time}   [${tool.name}] ${truncated}`);
+                }
+            }
+        }
+    }
+
+    private formatSubagentMessage(msg: SubagentMessage, timestamp: string): void {
+        const agentId = msg.agentId || "unknown";
+        const time = formatTime(timestamp);
+
+        if (msg.role === "user") {
+            if (!this.options.includeSpec.shouldShow("agents:input")) {
+                return;
+            }
+
+            const content = (msg.message as UserMessageContent).content;
+            let text = "";
+
+            if (typeof content === "string") {
+                text = content;
+            } else {
+                text = content
+                    .filter((b): b is TextBlock => b.type === "text")
+                    .map((b) => b.text)
+                    .join("\n");
+            }
+
+            if (!text.trim()) {
+                return;
+            }
+
+            // Open agent section if needed
+            this.openAgentSection(agentId, text.trim().split("\n")[0], timestamp);
+            return;
+        }
+
+        // Assistant role — agent response
+        const assistantContent = (msg.message as AssistantMessageContent).content;
+
+        if (!Array.isArray(assistantContent)) {
+            return;
+        }
+
+        const colorFn = this.getAgentColor(agentId);
+        const prefix = this.activeAgentId === agentId ? colorFn("  │ ") : "    ";
+
+        for (const block of assistantContent) {
+            if (block.type === "thinking" && this.options.includeSpec.shouldShow("agents:thinking")) {
+                const thinking = (block as ThinkingBlock).thinking.trim();
+
+                if (thinking) {
+                    const firstLine = thinking.split("\n")[0];
+                    this.writeLine(
+                        `${prefix}${this.options.colors ? pc.dim(`${time} 💭 ${firstLine}`) : `${time} [thinking] ${firstLine}`}`
+                    );
+                }
+            }
+
+            if (block.type === "text") {
+                if (!this.options.includeSpec.shouldShow("agents:result")) {
+                    continue;
+                }
+
+                const text = (block as TextBlock).text.trim();
+
+                if (text) {
+                    const firstLine = text.split("\n")[0];
+
+                    if (this.options.colors) {
+                        this.writeLine(`${prefix}${pc.dim(time)} ${pc.bold(pc.blue("Claude:"))} ${firstLine}`);
+                    } else {
+                        this.writeLine(`${prefix}${time} Claude: ${firstLine}`);
+                    }
+                }
+            }
+
+            if (block.type === "tool_use" && this.options.includeSpec.shouldShow("agents:tools:in")) {
+                const tool = block as ToolUseBlock;
+                const inputSummary = extractToolInputSummary(tool);
+                const maxChars = this.options.includeSpec.truncationLength("agents:tools:in");
+                const truncated = truncate(inputSummary, maxChars);
+
+                if (this.options.colors) {
+                    this.writeLine(`${prefix}${pc.dim(`  [${tool.name}]`)} ${pc.dim(truncated)}`);
+                } else {
+                    this.writeLine(`${prefix}  [${tool.name}] ${truncated}`);
+                }
+            }
+        }
+
+        // Check for agent completion
+        const stopReason = (msg.message as AssistantMessageContent).stop_reason;
+
+        if (stopReason === "end_turn" && this.activeAgentId === agentId) {
+            this.closeAgentSection();
+        }
+    }
+
+    private openAgentSection(agentId: string, description: string, timestamp: string): void {
+        if (this.activeAgentId && this.activeAgentId !== agentId) {
+            this.closeAgentSection();
+        }
+
+        const colorFn = this.getAgentColor(agentId);
+        this.activeAgentId = agentId;
+        this.agentStartTime.set(agentId, Date.now());
+
+        const time = formatTime(timestamp);
+        this.writeLine("");
+        this.writeLine(
+            `${this.options.colors ? pc.dim(time) : time}   ${this.options.colors ? pc.bold("[Agent]") : "[Agent]"} ${description}`
+        );
+        this.writeLine(colorFn(`  ┌─ Agent: ${description} ${"─".repeat(Math.max(1, 50 - description.length))}`));
+    }
+
+    private getAgentColor(agentId: string): (typeof AGENT_COLORS)[number] {
+        let color = this.agentColorMap.get(agentId);
+
+        if (!color) {
+            color = AGENT_COLORS[this.nextColorIndex % AGENT_COLORS.length];
+            this.agentColorMap.set(agentId, color);
+            this.nextColorIndex++;
+        }
+
+        return color;
+    }
+
+    private formatDuration(ms: number): string {
+        if (ms < 1000) {
+            return `${ms}ms`;
+        }
+
+        const seconds = Math.floor(ms / 1000);
+
+        if (seconds < 60) {
+            return `${seconds}s`;
+        }
+
+        const minutes = Math.floor(seconds / 60);
+        const remainingSeconds = seconds % 60;
+        return `${minutes}m ${remainingSeconds}s`;
+    }
+
+    private writeLine(line: string): void {
+        if (this.options.cliOutput !== false) {
+            console.log(line);
+        }
+
+        if (this.fileStream) {
+            this.fileStream.write(`${stripAnsi(line)}\n`);
+        }
+    }
+}

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -284,21 +284,10 @@ export class ClaudeSessionFormatter {
                         this.writeLine(`${time} Claude: ${firstLine}`);
                     }
 
-                    // Print remaining lines indented
-                    const remainingLines = text.split("\n").slice(1);
-
-                    for (const line of remainingLines.slice(0, 5)) {
+                    for (const line of text.split("\n").slice(1)) {
                         if (line.trim()) {
                             this.writeLine(`         ${line}`);
                         }
-                    }
-
-                    if (remainingLines.length > 5) {
-                        this.writeLine(
-                            this.options.colors
-                                ? pc.dim(`         ... (${remainingLines.length - 5} more lines)`)
-                                : `         ... (${remainingLines.length - 5} more lines)`
-                        );
                     }
                 }
             }

--- a/src/utils/claude/ClaudeSessionTailer.ts
+++ b/src/utils/claude/ClaudeSessionTailer.ts
@@ -29,7 +29,7 @@ function isAssistantEndTurn(record: ConversationMessage): boolean {
 interface TailerOptions {
     filePath: string;
     onRecord: (record: ConversationMessage) => void;
-    onFinished?: () => void;
+    onFinished?: () => void | Promise<void>;
     includeSpec?: IncludeSpec;
     lastTurns?: number;
     lastCalls?: number;
@@ -56,7 +56,7 @@ export class ClaudeSessionTailer {
     constructor(private options: TailerOptions) {}
 
     async start(): Promise<void> {
-        this.loadHistory();
+        const historyOffset = this.loadHistory();
 
         if (this.options.follow === false) {
             return;
@@ -69,7 +69,7 @@ export class ClaudeSessionTailer {
             onData: (newBytes) => this.handleNewData(newBytes),
         });
 
-        this.watcher.start();
+        this.watcher.start(historyOffset);
     }
 
     stop(): void {
@@ -87,8 +87,8 @@ export class ClaudeSessionTailer {
         }
     }
 
-    isActive(): boolean {
-        return this.watcher?.isActive() ?? false;
+    isActive(thresholdMs?: number): boolean {
+        return this.watcher?.isActive(thresholdMs) ?? false;
     }
 
     private handleNewData(newBytes: Buffer): void {
@@ -145,7 +145,7 @@ export class ClaudeSessionTailer {
 
         const timeout = this.options.isAgent ? 5_000 : 30_000;
         this.staleTimer = setTimeout(() => {
-            if (!this.isActive()) {
+            if (!this.isActive(timeout)) {
                 this.stop();
                 this.options.onFinished?.();
             }
@@ -164,14 +164,15 @@ export class ClaudeSessionTailer {
         return false;
     }
 
-    private loadHistory(): void {
+    private loadHistory(): number {
         let fileContent: Buffer;
+        let size: number;
 
         try {
-            const size = statSync(this.options.filePath).size;
+            size = statSync(this.options.filePath).size;
 
             if (size === 0) {
-                return;
+                return 0;
             }
 
             const fd = openSync(this.options.filePath, "r");
@@ -179,13 +180,13 @@ export class ClaudeSessionTailer {
             readSync(fd, fileContent, 0, size, 0);
             closeSync(fd);
         } catch {
-            return;
+            return 0;
         }
 
         const allRecords = parseJsonl<ConversationMessage>(fileContent);
 
         if (allRecords.length === 0) {
-            return;
+            return size;
         }
 
         let startIndex = 0;
@@ -199,6 +200,16 @@ export class ClaudeSessionTailer {
         for (let i = startIndex; i < allRecords.length; i++) {
             this.options.onRecord(allRecords[i]);
         }
+
+        // t21: Seed completion detection — if the last record looks like a finished
+        // session and stopOnFinish is set, schedule a stale check immediately.
+        const lastRecord = allRecords[allRecords.length - 1];
+
+        if (this.options.stopOnFinish && isAssistantEndTurn(lastRecord)) {
+            this.scheduleStaleCheck();
+        }
+
+        return size;
     }
 
     private findTurnStart(records: ConversationMessage[], lastTurns: number): number {

--- a/src/utils/claude/ClaudeSessionTailer.ts
+++ b/src/utils/claude/ClaudeSessionTailer.ts
@@ -1,0 +1,253 @@
+import { closeSync, type FSWatcher, openSync, readSync, statSync, watch } from "node:fs";
+import { parseJsonl, parseJsonlChunk } from "@app/utils/jsonl";
+import type { AssistantMessage, ConversationMessage } from "./types";
+
+function isAssistantEndTurn(record: ConversationMessage): boolean {
+    if (record.type === "assistant") {
+        return (record as AssistantMessage).message?.stop_reason === "end_turn";
+    }
+
+    // "A" is a shorthand for "assistant" in some JSONL variants
+    const raw = record as unknown as { type: string; message?: { stop_reason?: string } };
+
+    if (raw.type === "A") {
+        return raw.message?.stop_reason === "end_turn";
+    }
+
+    return false;
+}
+
+interface TailerOptions {
+    filePath: string;
+    onRecord: (record: ConversationMessage) => void;
+    onFinished?: () => void;
+    lastTurns?: number;
+    lastCalls?: number;
+    maxTurns?: number;
+    maxCalls?: number;
+    follow?: boolean;
+    stopOnFinish?: boolean;
+    isAgent?: boolean;
+}
+
+/**
+ * Streams JSONL records from a Claude session/agent file.
+ *
+ * Uses fs.watch for instant notifications + 300ms setInterval as safety fallback.
+ * Handles partial lines via remainder buffering.
+ *
+ * Architecture:
+ *   fs.watch + poll fallback
+ *       | onData(newBytes)
+ *       v
+ *   parseJsonlChunk<ConversationMessage>(newBytes, remainder)
+ *       | values[]
+ *       v
+ *   emit parsed records via onRecord()
+ */
+export class ClaudeSessionTailer {
+    private offset = 0;
+    private remainder: Buffer<ArrayBuffer> = Buffer.alloc(0);
+    private watcher: FSWatcher | null = null;
+    private pollInterval: ReturnType<typeof setInterval> | null = null;
+    private checkScheduled = false;
+
+    private newTurnCount = 0;
+    private newCallCount = 0;
+    private staleTimer: ReturnType<typeof setTimeout> | null = null;
+    private stopped = false;
+
+    constructor(private options: TailerOptions) {}
+
+    async start(): Promise<void> {
+        this.loadHistory();
+
+        if (this.options.follow === false) {
+            return;
+        }
+
+        this.offset = statSync(this.options.filePath).size;
+        this.remainder = Buffer.alloc(0);
+
+        this.watcher = watch(this.options.filePath, () => {
+            if (!this.checkScheduled) {
+                this.checkScheduled = true;
+                queueMicrotask(() => {
+                    this.checkScheduled = false;
+                    this.checkForNewData();
+                });
+            }
+        });
+
+        this.pollInterval = setInterval(() => this.checkForNewData(), 300);
+    }
+
+    stop(): void {
+        if (this.stopped) {
+            return;
+        }
+
+        this.stopped = true;
+        this.watcher?.close();
+        this.watcher = null;
+
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+        }
+
+        if (this.staleTimer) {
+            clearTimeout(this.staleTimer);
+            this.staleTimer = null;
+        }
+    }
+
+    isActive(): boolean {
+        try {
+            const mtime = statSync(this.options.filePath).mtimeMs;
+            return Date.now() - mtime < 10_000;
+        } catch {
+            return false;
+        }
+    }
+
+    private checkForNewData(): void {
+        if (this.stopped) {
+            return;
+        }
+
+        let currentSize: number;
+
+        try {
+            currentSize = statSync(this.options.filePath).size;
+        } catch {
+            return;
+        }
+
+        if (currentSize < this.offset) {
+            this.offset = 0;
+            this.remainder = Buffer.alloc(0);
+        }
+
+        if (currentSize <= this.offset) {
+            return;
+        }
+
+        const fd = openSync(this.options.filePath, "r");
+        const newBytes = Buffer.alloc(currentSize - this.offset);
+        readSync(fd, newBytes, 0, newBytes.length, this.offset);
+        closeSync(fd);
+        this.offset = currentSize;
+
+        const result = parseJsonlChunk<ConversationMessage>(newBytes, this.remainder);
+        this.remainder = result.remainder;
+
+        for (const record of result.values) {
+            this.options.onRecord(record);
+            this.trackCompletion(record);
+
+            if (this.shouldStop()) {
+                this.stop();
+                this.options.onFinished?.();
+                return;
+            }
+        }
+    }
+
+    private trackCompletion(record: ConversationMessage): void {
+        if (record.type === "user") {
+            this.newTurnCount++;
+        }
+
+        this.newCallCount++;
+
+        const isEndTurn = isAssistantEndTurn(record);
+
+        if (isEndTurn) {
+            this.scheduleStaleCheck();
+        }
+    }
+
+    private scheduleStaleCheck(): void {
+        if (!this.options.stopOnFinish) {
+            return;
+        }
+
+        if (this.staleTimer) {
+            clearTimeout(this.staleTimer);
+        }
+
+        const timeout = this.options.isAgent ? 5_000 : 30_000;
+        this.staleTimer = setTimeout(() => {
+            if (!this.isActive()) {
+                this.stop();
+                this.options.onFinished?.();
+            }
+        }, timeout);
+    }
+
+    private shouldStop(): boolean {
+        if (this.options.maxTurns && this.newTurnCount >= this.options.maxTurns) {
+            return true;
+        }
+
+        if (this.options.maxCalls && this.newCallCount >= this.options.maxCalls) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private loadHistory(): void {
+        let fileContent: Buffer;
+
+        try {
+            const size = statSync(this.options.filePath).size;
+
+            if (size === 0) {
+                return;
+            }
+
+            const fd = openSync(this.options.filePath, "r");
+            fileContent = Buffer.alloc(size);
+            readSync(fd, fileContent, 0, size, 0);
+            closeSync(fd);
+        } catch {
+            return;
+        }
+
+        const allRecords = parseJsonl<ConversationMessage>(fileContent);
+
+        if (allRecords.length === 0) {
+            return;
+        }
+
+        let startIndex = 0;
+
+        if (this.options.lastTurns !== undefined) {
+            startIndex = this.findTurnStart(allRecords, this.options.lastTurns);
+        } else if (this.options.lastCalls !== undefined) {
+            startIndex = Math.max(0, allRecords.length - this.options.lastCalls);
+        }
+
+        for (let i = startIndex; i < allRecords.length; i++) {
+            this.options.onRecord(allRecords[i]);
+        }
+    }
+
+    private findTurnStart(records: ConversationMessage[], lastTurns: number): number {
+        const turnStarts: number[] = [];
+
+        for (let i = 0; i < records.length; i++) {
+            if (records[i].type === "user") {
+                turnStarts.push(i);
+            }
+        }
+
+        if (turnStarts.length <= lastTurns) {
+            return 0;
+        }
+
+        return turnStarts[turnStarts.length - lastTurns];
+    }
+}

--- a/src/utils/claude/ClaudeSessionTailer.ts
+++ b/src/utils/claude/ClaudeSessionTailer.ts
@@ -1,6 +1,7 @@
 import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { parseJsonl, parseJsonlChunk } from "@app/utils/jsonl";
 import { FileWatcher } from "@app/utils/storage/fs";
+import type { IncludeSpec } from "./cli/dsl";
 import type { ConversationMessage } from "./types";
 
 /** Shape of the shorthand "A" variant that some JSONL sessions use for assistant. */
@@ -29,6 +30,7 @@ interface TailerOptions {
     filePath: string;
     onRecord: (record: ConversationMessage) => void;
     onFinished?: () => void;
+    includeSpec?: IncludeSpec;
     lastTurns?: number;
     lastCalls?: number;
     maxTurns?: number;
@@ -109,12 +111,23 @@ export class ClaudeSessionTailer {
         }
     }
 
+    /**
+     * A record is displayable if the formatter would actually render it.
+     * Non-visible record types (progress, system, queue-operation, etc.) are skipped.
+     */
+    private isDisplayableRecord(record: ConversationMessage): boolean {
+        const type = record.type as string;
+        return type === "user" || type === "assistant" || type === "A" || type === "subagent";
+    }
+
     private trackCompletion(record: ConversationMessage): void {
         if (record.type === "user") {
             this.newTurnCount++;
         }
 
-        this.newCallCount++;
+        if (this.isDisplayableRecord(record)) {
+            this.newCallCount++;
+        }
 
         if (isAssistantEndTurn(record)) {
             this.scheduleStaleCheck();
@@ -180,7 +193,7 @@ export class ClaudeSessionTailer {
         if (this.options.lastTurns !== undefined) {
             startIndex = this.findTurnStart(allRecords, this.options.lastTurns);
         } else if (this.options.lastCalls !== undefined) {
-            startIndex = Math.max(0, allRecords.length - this.options.lastCalls);
+            startIndex = this.findCallStart(allRecords, this.options.lastCalls);
         }
 
         for (let i = startIndex; i < allRecords.length; i++) {
@@ -202,5 +215,21 @@ export class ClaudeSessionTailer {
         }
 
         return turnStarts[turnStarts.length - lastTurns];
+    }
+
+    private findCallStart(records: ConversationMessage[], lastCalls: number): number {
+        const displayableIndices: number[] = [];
+
+        for (let i = 0; i < records.length; i++) {
+            if (this.isDisplayableRecord(records[i])) {
+                displayableIndices.push(i);
+            }
+        }
+
+        if (displayableIndices.length <= lastCalls) {
+            return 0;
+        }
+
+        return displayableIndices[displayableIndices.length - lastCalls];
     }
 }

--- a/src/utils/claude/ClaudeSessionTailer.ts
+++ b/src/utils/claude/ClaudeSessionTailer.ts
@@ -1,20 +1,28 @@
-import { closeSync, type FSWatcher, openSync, readSync, statSync, watch } from "node:fs";
+import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { parseJsonl, parseJsonlChunk } from "@app/utils/jsonl";
-import type { AssistantMessage, ConversationMessage } from "./types";
+import { FileWatcher } from "@app/utils/storage/fs";
+import type { ConversationMessage } from "./types";
+
+/** Shape of the shorthand "A" variant that some JSONL sessions use for assistant. */
+interface ShorthandAssistant {
+    type: "A";
+    message?: { stop_reason?: string | null };
+}
 
 function isAssistantEndTurn(record: ConversationMessage): boolean {
     if (record.type === "assistant") {
-        return (record as AssistantMessage).message?.stop_reason === "end_turn";
+        return record.message?.stop_reason === "end_turn";
     }
 
-    // "A" is a shorthand for "assistant" in some JSONL variants
-    const raw = record as unknown as { type: string; message?: { stop_reason?: string } };
+    // parseJsonlChunk casts to ConversationMessage, but some sessions use
+    // shorthand type "A" for assistant — falls outside the discriminated union.
+    const raw = record as unknown as ShorthandAssistant;
 
-    if (raw.type === "A") {
-        return raw.message?.stop_reason === "end_turn";
+    if (raw.type !== "A") {
+        return false;
     }
 
-    return false;
+    return raw.message?.stop_reason === "end_turn";
 }
 
 interface TailerOptions {
@@ -32,25 +40,11 @@ interface TailerOptions {
 
 /**
  * Streams JSONL records from a Claude session/agent file.
- *
- * Uses fs.watch for instant notifications + 300ms setInterval as safety fallback.
- * Handles partial lines via remainder buffering.
- *
- * Architecture:
- *   fs.watch + poll fallback
- *       | onData(newBytes)
- *       v
- *   parseJsonlChunk<ConversationMessage>(newBytes, remainder)
- *       | values[]
- *       v
- *   emit parsed records via onRecord()
+ * Composes FileWatcher for fs.watch + poll fallback, adds JSONL parsing on top.
  */
 export class ClaudeSessionTailer {
-    private offset = 0;
     private remainder: Buffer<ArrayBuffer> = Buffer.alloc(0);
-    private watcher: FSWatcher | null = null;
-    private pollInterval: ReturnType<typeof setInterval> | null = null;
-    private checkScheduled = false;
+    private watcher: FileWatcher | null = null;
 
     private newTurnCount = 0;
     private newCallCount = 0;
@@ -66,20 +60,14 @@ export class ClaudeSessionTailer {
             return;
         }
 
-        this.offset = statSync(this.options.filePath).size;
         this.remainder = Buffer.alloc(0);
 
-        this.watcher = watch(this.options.filePath, () => {
-            if (!this.checkScheduled) {
-                this.checkScheduled = true;
-                queueMicrotask(() => {
-                    this.checkScheduled = false;
-                    this.checkForNewData();
-                });
-            }
+        this.watcher = new FileWatcher({
+            filePath: this.options.filePath,
+            onData: (newBytes) => this.handleNewData(newBytes),
         });
 
-        this.pollInterval = setInterval(() => this.checkForNewData(), 300);
+        this.watcher.start();
     }
 
     stop(): void {
@@ -88,13 +76,8 @@ export class ClaudeSessionTailer {
         }
 
         this.stopped = true;
-        this.watcher?.close();
+        this.watcher?.stop();
         this.watcher = null;
-
-        if (this.pollInterval) {
-            clearInterval(this.pollInterval);
-            this.pollInterval = null;
-        }
 
         if (this.staleTimer) {
             clearTimeout(this.staleTimer);
@@ -103,41 +86,13 @@ export class ClaudeSessionTailer {
     }
 
     isActive(): boolean {
-        try {
-            const mtime = statSync(this.options.filePath).mtimeMs;
-            return Date.now() - mtime < 10_000;
-        } catch {
-            return false;
-        }
+        return this.watcher?.isActive() ?? false;
     }
 
-    private checkForNewData(): void {
+    private handleNewData(newBytes: Buffer): void {
         if (this.stopped) {
             return;
         }
-
-        let currentSize: number;
-
-        try {
-            currentSize = statSync(this.options.filePath).size;
-        } catch {
-            return;
-        }
-
-        if (currentSize < this.offset) {
-            this.offset = 0;
-            this.remainder = Buffer.alloc(0);
-        }
-
-        if (currentSize <= this.offset) {
-            return;
-        }
-
-        const fd = openSync(this.options.filePath, "r");
-        const newBytes = Buffer.alloc(currentSize - this.offset);
-        readSync(fd, newBytes, 0, newBytes.length, this.offset);
-        closeSync(fd);
-        this.offset = currentSize;
 
         const result = parseJsonlChunk<ConversationMessage>(newBytes, this.remainder);
         this.remainder = result.remainder;
@@ -161,9 +116,7 @@ export class ClaudeSessionTailer {
 
         this.newCallCount++;
 
-        const isEndTurn = isAssistantEndTurn(record);
-
-        if (isEndTurn) {
+        if (isAssistantEndTurn(record)) {
             this.scheduleStaleCheck();
         }
     }

--- a/src/utils/claude/cli/dsl.ts
+++ b/src/utils/claude/cli/dsl.ts
@@ -257,6 +257,8 @@ Include specifiers (comma-separated):
   agents:result           Agent final response
   agents:thinking         Agent thinking blocks
 
+Note: later specifiers override earlier ones (e.g. "tools:in:100,tools" resets in to 500).
+
 Examples:
   --include thinking,tools,agents           Everything (with defaults)
   --include tools:in:200,agents:result      Tool inputs (200 chars) + agent results only

--- a/src/utils/claude/cli/dsl.ts
+++ b/src/utils/claude/cli/dsl.ts
@@ -1,0 +1,265 @@
+type TruncatableField = "toolsIn" | "toolsOut" | "agentsToolsIn" | "agentsToolsOut";
+type ContentType =
+    | "thinking"
+    | "tools:in"
+    | "tools:out"
+    | "agents:input"
+    | "agents:tools:in"
+    | "agents:tools:out"
+    | "agents:result"
+    | "agents:thinking";
+
+/**
+ * Parses and queries the --include DSL for controlling tail output content.
+ *
+ * Syntax: comma-separated specifiers with colon-delimited hierarchy.
+ * Numeric suffix sets truncation length.
+ *
+ * Examples:
+ *   "thinking,tools:in:500,tools:out:500"
+ *   "agents:input,agents:tools:in:50,agents:result"
+ *   "thinking,tools,agents" (shorthand expansions)
+ */
+export class IncludeSpec {
+    thinking: boolean;
+    toolsIn: number | false;
+    toolsOut: number | false;
+    agentsInput: boolean;
+    agentsToolsIn: number | false;
+    agentsToolsOut: number | false;
+    agentsResult: boolean;
+    agentsThinking: boolean;
+
+    static DEFAULT_SPEC =
+        "thinking,tools:in:500,tools:out:500,agents:input,agents:tools:in:50,agents:tools:out:500,agents:result";
+
+    constructor(spec?: string) {
+        this.thinking = false;
+        this.toolsIn = false;
+        this.toolsOut = false;
+        this.agentsInput = false;
+        this.agentsToolsIn = false;
+        this.agentsToolsOut = false;
+        this.agentsResult = false;
+        this.agentsThinking = false;
+
+        if (spec !== undefined) {
+            this.parseSpec(spec);
+        }
+    }
+
+    static parse(spec: string): IncludeSpec {
+        return new IncludeSpec(spec);
+    }
+
+    static defaults(): IncludeSpec {
+        return new IncludeSpec(IncludeSpec.DEFAULT_SPEC);
+    }
+
+    /** When tailing an agent, agents:* maps to top-level equivalents */
+    forAgent(): IncludeSpec {
+        const result = new IncludeSpec();
+        result.thinking = this.thinking || this.agentsThinking;
+        result.toolsIn = this.toolsIn !== false ? this.toolsIn : this.agentsToolsIn;
+        result.toolsOut = this.toolsOut !== false ? this.toolsOut : this.agentsToolsOut;
+        result.agentsInput = this.agentsInput;
+        result.agentsToolsIn = this.agentsToolsIn;
+        result.agentsToolsOut = this.agentsToolsOut;
+        result.agentsResult = this.agentsResult;
+        result.agentsThinking = this.agentsThinking;
+        return result;
+    }
+
+    /** Human-readable summary for startup banner */
+    describe(): string {
+        const parts: string[] = [];
+
+        if (this.thinking) {
+            parts.push("thinking");
+        }
+
+        const toolParts: string[] = [];
+
+        if (this.toolsIn !== false) {
+            toolParts.push(`in: ${this.toolsIn}`);
+        }
+
+        if (this.toolsOut !== false) {
+            toolParts.push(`out: ${this.toolsOut}`);
+        }
+
+        if (toolParts.length > 0) {
+            parts.push(`tools (${toolParts.join(", ")})`);
+        }
+
+        const agentParts: string[] = [];
+
+        if (this.agentsInput) {
+            agentParts.push("input");
+        }
+
+        const agentToolParts: string[] = [];
+
+        if (this.agentsToolsIn !== false) {
+            agentToolParts.push(`in: ${this.agentsToolsIn}`);
+        }
+
+        if (this.agentsToolsOut !== false) {
+            agentToolParts.push(`out: ${this.agentsToolsOut}`);
+        }
+
+        if (agentToolParts.length > 0) {
+            agentParts.push(`tools (${agentToolParts.join(", ")})`);
+        }
+
+        if (this.agentsResult) {
+            agentParts.push("result");
+        }
+
+        if (this.agentsThinking) {
+            agentParts.push("thinking");
+        }
+
+        if (agentParts.length > 0) {
+            parts.push(`agents (${agentParts.join(", ")})`);
+        }
+
+        return parts.join(", ");
+    }
+
+    shouldShow(type: ContentType): boolean {
+        switch (type) {
+            case "thinking":
+                return this.thinking;
+            case "tools:in":
+                return this.toolsIn !== false;
+            case "tools:out":
+                return this.toolsOut !== false;
+            case "agents:input":
+                return this.agentsInput;
+            case "agents:tools:in":
+                return this.agentsToolsIn !== false;
+            case "agents:tools:out":
+                return this.agentsToolsOut !== false;
+            case "agents:result":
+                return this.agentsResult;
+            case "agents:thinking":
+                return this.agentsThinking;
+        }
+    }
+
+    truncationLength(type: "tools:in" | "tools:out" | "agents:tools:in" | "agents:tools:out"): number {
+        const fieldMap: Record<string, TruncatableField> = {
+            "tools:in": "toolsIn",
+            "tools:out": "toolsOut",
+            "agents:tools:in": "agentsToolsIn",
+            "agents:tools:out": "agentsToolsOut",
+        };
+
+        const field = fieldMap[type];
+        const value = this[field];
+        return value === false ? 0 : value;
+    }
+
+    private parseSpec(spec: string): void {
+        const parts = spec.split(",").map((s) => s.trim().toLowerCase());
+
+        for (const part of parts) {
+            if (!part) {
+                continue;
+            }
+
+            if (part === "thinking") {
+                this.thinking = true;
+                continue;
+            }
+
+            if (part === "tools") {
+                this.toolsIn = 500;
+                this.toolsOut = 500;
+                continue;
+            }
+
+            if (part.startsWith("tools:in")) {
+                this.toolsIn = this.extractLimit(part, 500);
+                continue;
+            }
+
+            if (part.startsWith("tools:out")) {
+                this.toolsOut = this.extractLimit(part, 500);
+                continue;
+            }
+
+            if (part === "agents") {
+                this.agentsInput = true;
+                this.agentsToolsIn = 50;
+                this.agentsToolsOut = 500;
+                this.agentsResult = true;
+                continue;
+            }
+
+            if (part === "agents:input") {
+                this.agentsInput = true;
+                continue;
+            }
+
+            if (part === "agents:tools") {
+                this.agentsToolsIn = 50;
+                this.agentsToolsOut = 500;
+                continue;
+            }
+
+            if (part.startsWith("agents:tools:in")) {
+                this.agentsToolsIn = this.extractLimit(part, 50);
+                continue;
+            }
+
+            if (part.startsWith("agents:tools:out")) {
+                this.agentsToolsOut = this.extractLimit(part, 500);
+                continue;
+            }
+
+            if (part === "agents:result") {
+                this.agentsResult = true;
+                continue;
+            }
+
+            if (part === "agents:thinking") {
+                this.agentsThinking = true;
+                continue;
+            }
+        }
+    }
+
+    private extractLimit(part: string, defaultLimit: number): number {
+        const segments = part.split(":");
+        const lastSegment = segments[segments.length - 1];
+        const parsed = Number.parseInt(lastSegment, 10);
+
+        if (!Number.isNaN(parsed)) {
+            return parsed;
+        }
+
+        return defaultLimit;
+    }
+}
+
+export const INCLUDE_HELP = `
+Include specifiers (comma-separated):
+  thinking                Show thinking/reasoning blocks
+  tools                   Shorthand: tools:in:500,tools:out:500
+  tools:in[:<chars>]      Tool call inputs, truncated (default: 500)
+  tools:out[:<chars>]     Tool call outputs, truncated (default: 500)
+  agents                  Shorthand: agents:input,agents:tools,agents:result
+  agents:input            Agent launch prompt
+  agents:tools            Shorthand: agents:tools:in:50,agents:tools:out:500
+  agents:tools:in[:<N>]   Agent tool inputs (default: 50)
+  agents:tools:out[:<N>]  Agent tool outputs (default: 500)
+  agents:result           Agent final response
+  agents:thinking         Agent thinking blocks
+
+Examples:
+  --include thinking,tools,agents           Everything (with defaults)
+  --include tools:in:200,agents:result      Tool inputs (200 chars) + agent results only
+  --include thinking,tools:out:0            Thinking + tool inputs only (no outputs)
+`.trim();

--- a/src/utils/claude/cli/dsl.ts
+++ b/src/utils/claude/cli/dsl.ts
@@ -226,7 +226,6 @@ export class IncludeSpec {
 
             if (part === "agents:thinking") {
                 this.agentsThinking = true;
-                continue;
             }
         }
     }

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -12,13 +12,25 @@
  * ```
  */
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { stat } from "node:fs/promises";
-import { basename, resolve, sep } from "node:path";
+import { basename, dirname, resolve, sep } from "node:path";
 import { SafeJSON } from "@app/utils/json";
 import { estimateTokens } from "@app/utils/tokens";
 import { glob } from "glob";
 import { encodedProjectDir, PROJECTS_DIR, parseJsonlTranscript } from "./index";
+import {
+    extractFilePathFromInput,
+    extractUserText,
+    getSubagentToolUseBlocks,
+    getToolUseBlocks,
+    hasCwd,
+    hasGitBranch,
+    hasSessionId,
+    hasTimestamp,
+    isSubagentFile,
+    readHeadTailLines,
+} from "./session.utils";
 import type {
     AssistantMessage,
     AssistantMessageContent,
@@ -42,241 +54,42 @@ import type {
     UserMessageContent,
 } from "./types";
 
-// =============================================================================
-// Exported Interface Types
-// =============================================================================
+// Re-export types and utils for backward compatibility
+export type {
+    ExtractTextOptions,
+    PromptContentOptions,
+    PreparedContent,
+    SessionStats,
+    SessionInfo,
+    SessionDiscoveryOptions,
+    ToolCallSummary,
+    TailTarget,
+    AgentMeta,
+} from "./session.types";
+export {
+    extractFilePathFromInput,
+    extractUserText,
+    getSubagentToolUseBlocks,
+    getToolUseBlocks,
+    hasCwd,
+    hasGitBranch,
+    hasSessionId,
+    hasTimestamp,
+    isSubagentFile,
+    readHeadTailLines,
+} from "./session.utils";
 
-/** Options for extracting plain text from session messages. */
-export interface ExtractTextOptions {
-    /** Include tool result content in the extracted text. Default: false */
-    includeToolResults?: boolean;
-    /** Include thinking/reasoning blocks. Default: false */
-    includeThinking?: boolean;
-    /** Include system messages (errors, stop hooks). Default: false */
-    includeSystemMessages?: boolean;
-    /** Prefix tool calls with their name (e.g. "[Edit]"). Default: true */
-    includeToolNames?: boolean;
-    /** Maximum character length for the returned string. */
-    maxLength?: number;
-}
-
-/** Options for preparing session content for an LLM prompt. */
-export interface PromptContentOptions {
-    /** Maximum token budget for the prepared content. */
-    tokenBudget: number;
-    /** Content selection strategy when the session exceeds the budget. */
-    priority: "balanced" | "user-first" | "assistant-first" | "summary-first";
-    /** Include tool result blocks. Default: false */
-    includeToolResults?: boolean;
-    /** Include thinking/reasoning blocks. Default: false */
-    includeThinking?: boolean;
-    /** Prefix each message with its ISO timestamp. Default: false */
-    includeTimestamps?: boolean;
-}
-
-/** Result of `toPromptContent()` — token-budgeted session transcript. */
-export interface PreparedContent {
-    /** The formatted transcript string. */
-    content: string;
-    /** Estimated token count of `content`. */
-    tokenCount: number;
-    /** Whether the content was truncated to fit the budget. */
-    truncated: boolean;
-    /** Human-readable description of what was truncated. */
-    truncationInfo: string;
-    /** Summary statistics for the prepared content. */
-    stats: {
-        userMessages: number;
-        assistantMessages: number;
-        toolCalls: number;
-        filesModified: string[];
-    };
-}
-
-/** Aggregated statistics for a session. */
-export interface SessionStats {
-    /** Total number of JSONL entries (all types). */
-    messageCount: number;
-    /** Number of user-role messages. */
-    userMessageCount: number;
-    /** Number of assistant-role messages. */
-    assistantMessageCount: number;
-    /** Number of system messages (errors, stop hooks, etc.). */
-    systemMessageCount: number;
-    /** Number of subagent messages. */
-    subagentMessageCount: number;
-    /** Number of progress messages. */
-    progressMessageCount: number;
-    /** Number of PR link messages. */
-    prLinkCount: number;
-    /** Total number of tool_use blocks across all assistant and subagent messages. */
-    toolCallCount: number;
-    /** Tool name -> invocation count. */
-    toolUsage: Record<string, number>;
-    /** Aggregated API token usage from assistant message metadata. */
-    tokenUsage: { input: number; output: number; cached: number };
-    /** Distinct model IDs seen in assistant messages. */
-    modelsUsed: string[];
-    /** Unique file paths referenced in tool calls. */
-    filesModified: string[];
-    /** Duration in milliseconds between first and last timestamp. */
-    duration: number;
-    /** Earliest message timestamp. */
-    firstTimestamp: Date | null;
-    /** Latest message timestamp. */
-    lastTimestamp: Date | null;
-}
-
-/** Lightweight metadata for a discovered session file (no full parse). */
-export interface SessionInfo {
-    filePath: string;
-    sessionId: string | null;
-    title: string | null;
-    summary: string | null;
-    gitBranch: string | null;
-    project: string | null;
-    startDate: Date | null;
-    fileSize: number;
-    messageCount: number;
-    isSubagent: boolean;
-}
-
-/** Options for `ClaudeSession.findSessions()`. */
-export interface SessionDiscoveryOptions {
-    /** Project name (directory basename) to scope to. */
-    project?: string;
-    /** Only include sessions starting on or after this date. */
-    since?: Date;
-    /** Only include sessions starting on or before this date. */
-    until?: Date;
-    /** Include subagent sessions. Default: false */
-    includeSubagents?: boolean;
-    /** Maximum number of sessions to return. */
-    limit?: number;
-}
-
-/** Summary of a single tool invocation. */
-export interface ToolCallSummary {
-    /** Tool name (e.g. "Edit", "Bash"). */
-    name: string;
-    /** Full input object passed to the tool. */
-    input: Record<string, unknown>;
-    /** File path argument, if the tool accepts one. */
-    filePath?: string;
-    /** ISO timestamp of the parent message (if available). */
-    timestamp?: string;
-}
-
-// =============================================================================
-// Internal Helpers
-// =============================================================================
-
-/** Type guard for messages that carry a timestamp field. */
-function hasTimestamp(msg: ConversationMessage): msg is ConversationMessage & { timestamp: string } {
-    return "timestamp" in msg && typeof (msg as unknown as { timestamp: unknown }).timestamp === "string";
-}
-
-/** Type guard for messages that carry a sessionId field. */
-function hasSessionId(msg: ConversationMessage): msg is ConversationMessage & { sessionId: string } {
-    return "sessionId" in msg && typeof (msg as unknown as { sessionId: unknown }).sessionId === "string";
-}
-
-/** Type guard for messages with gitBranch. */
-function hasGitBranch(msg: ConversationMessage): msg is ConversationMessage & { gitBranch: string } {
-    return "gitBranch" in msg && typeof (msg as unknown as { gitBranch: unknown }).gitBranch === "string";
-}
-
-/** Type guard for messages with cwd. */
-function hasCwd(msg: ConversationMessage): msg is ConversationMessage & { cwd: string } {
-    return "cwd" in msg && typeof (msg as unknown as { cwd: unknown }).cwd === "string";
-}
-
-/** Extract readable text from a single user message content field. */
-function extractUserText(content: string | ContentBlock[]): string {
-    if (typeof content === "string") {
-        return content;
-    }
-    const parts: string[] = [];
-    for (const block of content) {
-        if (block.type === "text") {
-            parts.push((block as TextBlock).text);
-        } else if (block.type === "tool_result") {
-            const tr = block as ToolResultBlock;
-            if (typeof tr.content === "string") {
-                parts.push(tr.content);
-            } else if (Array.isArray(tr.content)) {
-                for (const inner of tr.content) {
-                    if (inner.type === "text") {
-                        parts.push((inner as TextBlock).text);
-                    } else if (inner.type === "image") {
-                        parts.push(`[Image: ${(inner as ImageBlock).source.media_type}]`);
-                    } else if (inner.type === "tool_reference") {
-                        parts.push(`[Tool Reference: ${(inner as ToolReferenceBlock).tool_name}]`);
-                    }
-                }
-            }
-        } else if (block.type === "image") {
-            parts.push(`[Image: ${(block as ImageBlock).source.media_type}]`);
-        } else if (block.type === "tool_reference") {
-            parts.push(`[Tool Reference: ${(block as ToolReferenceBlock).tool_name}]`);
-        }
-    }
-    return parts.join("\n");
-}
-
-/** Extract tool_use blocks from an assistant message. */
-function getToolUseBlocks(msg: AssistantMessage): ToolUseBlock[] {
-    if (!Array.isArray(msg.message?.content)) {
-        return [];
-    }
-    return msg.message.content.filter((b): b is ToolUseBlock => b.type === "tool_use");
-}
-
-/** Extract tool_use blocks from a subagent assistant message. */
-function getSubagentToolUseBlocks(msg: SubagentMessage): ToolUseBlock[] {
-    if (msg.role !== "assistant") {
-        return [];
-    }
-    const content = (msg.message as AssistantMessageContent).content;
-    if (!Array.isArray(content)) {
-        return [];
-    }
-    return content.filter((b): b is ToolUseBlock => b.type === "tool_use");
-}
-
-/** Extract file path from a tool input object, checking common field names. */
-function extractFilePathFromInput(input: Record<string, unknown>): string | undefined {
-    for (const field of ["file_path", "path", "filePath", "notebook_path"]) {
-        if (field in input && typeof input[field] === "string") {
-            return input[field] as string;
-        }
-    }
-    return undefined;
-}
-
-/** Check whether a JSONL file is from a subagent. */
-function isSubagentFile(filePath: string): boolean {
-    return filePath.includes(`${sep}subagents${sep}`) || basename(filePath).startsWith("agent-");
-}
-
-/**
- * Read just the first N and last N lines from a JSONL file for fast metadata extraction.
- * Uses Bun.file for performance.
- */
-async function readHeadTailLines(filePath: string, headCount: number, tailCount: number): Promise<string[]> {
-    const text = await Bun.file(filePath).text();
-    const allLines = text.split("\n").filter((l) => l.trim());
-    if (allLines.length <= headCount + tailCount) {
-        return allLines;
-    }
-    const head = allLines.slice(0, headCount);
-    const tail = allLines.slice(-tailCount);
-    return [...head, ...tail];
-}
-
-// =============================================================================
-// ClaudeSession Class
-// =============================================================================
+import type {
+    ExtractTextOptions,
+    PreparedContent,
+    PromptContentOptions,
+    SessionDiscoveryOptions,
+    SessionInfo,
+    SessionStats,
+    TailTarget,
+    ToolCallSummary,
+    AgentMeta,
+} from "./session.types";
 
 /**
  * A fully-typed, immutable wrapper around a Claude Code JSONL session file.
@@ -496,6 +309,132 @@ export class ClaudeSession {
         });
 
         return limit ? results.slice(0, limit) : results;
+    }
+
+    /**
+     * Discover subagent files matching a query (ID prefix or description substring).
+     *
+     * Scans `<session-id>/subagents/` directories for `agent-*.meta.json` files.
+     *
+     * @returns Array of `TailTarget` sorted by file mtime (newest first).
+     */
+    static findSubagents(options: {
+        query?: string;
+        project?: string;
+        sessionId?: string;
+    } = {}): TailTarget[] {
+        const { query, project, sessionId } = options;
+
+        const baseDir = project
+            ? resolve(PROJECTS_DIR, encodedProjectDir(project))
+            : resolve(PROJECTS_DIR, encodedProjectDir());
+
+        if (!existsSync(baseDir)) {
+            return [];
+        }
+
+        const results: TailTarget[] = [];
+        const lowerQuery = query?.toLowerCase();
+
+        // If scoped to a session, only look in that session's subagents dir
+        const sessionDirs: string[] = [];
+
+        if (sessionId) {
+            // Find directories matching the session ID prefix
+            try {
+                for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+                    if (entry.isDirectory() && entry.name.toLowerCase().startsWith(sessionId.toLowerCase())) {
+                        const subagentsDir = resolve(baseDir, entry.name, "subagents");
+
+                        if (existsSync(subagentsDir)) {
+                            sessionDirs.push(subagentsDir);
+                        }
+                    }
+                }
+            } catch {
+                // Skip unreadable directories
+            }
+        } else {
+            // Scan all session directories
+            try {
+                for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+                    if (entry.isDirectory()) {
+                        const subagentsDir = resolve(baseDir, entry.name, "subagents");
+
+                        if (existsSync(subagentsDir)) {
+                            sessionDirs.push(subagentsDir);
+                        }
+                    }
+                }
+            } catch {
+                // Skip unreadable directories
+            }
+        }
+
+        for (const subagentsDir of sessionDirs) {
+            let entries: string[];
+
+            try {
+                entries = readdirSync(subagentsDir);
+            } catch {
+                continue;
+            }
+
+            // Find all meta.json files
+            const metaFiles = entries.filter((e) => e.endsWith(".meta.json"));
+
+            for (const metaFile of metaFiles) {
+                const agentId = metaFile.replace(".meta.json", "").replace("agent-", "");
+                const jsonlFile = metaFile.replace(".meta.json", ".jsonl");
+                const jsonlPath = resolve(subagentsDir, jsonlFile);
+
+                if (!existsSync(jsonlPath)) {
+                    continue;
+                }
+
+                let meta: AgentMeta | null = null;
+
+                try {
+                    const metaText = readFileSync(resolve(subagentsDir, metaFile), "utf-8");
+                    meta = SafeJSON.parse(metaText, { strict: true }) as AgentMeta;
+                } catch {
+                    // Skip unreadable meta files
+                }
+
+                // Derive session ID from parent directory name
+                const parentDir = basename(dirname(subagentsDir));
+
+                // Match against query
+                if (lowerQuery) {
+                    const idMatch = agentId.toLowerCase().startsWith(lowerQuery);
+                    const descMatch = meta?.description?.toLowerCase().includes(lowerQuery) ?? false;
+
+                    if (!idMatch && !descMatch) {
+                        continue;
+                    }
+                }
+
+                results.push({
+                    filePath: jsonlPath,
+                    label: meta?.description ?? `agent-${agentId}`,
+                    sessionId: parentDir,
+                    agentId,
+                    agentDescription: meta?.description,
+                    isAgent: true,
+                });
+            }
+        }
+
+        // Sort by file mtime (newest first)
+        results.sort((a, b) => {
+            try {
+                return statSync(b.filePath).mtimeMs - statSync(a.filePath).mtimeMs;
+            } catch {
+                return 0;
+            }
+        });
+
+        return results;
     }
 
     // =========================================================================
@@ -759,7 +698,7 @@ export class ClaudeSession {
             const timestamp = hasTimestamp(msg) ? msg.timestamp : undefined;
 
             if (msg.type === "assistant") {
-                for (const block of getToolUseBlocks(msg as AssistantMessage)) {
+                for (const block of getToolUseBlocks((msg as AssistantMessage).message.content)) {
                     calls.push({
                         name: block.name,
                         input: block.input,
@@ -796,7 +735,7 @@ export class ClaudeSession {
         for (const msg of this._messages) {
             let toolBlocks: ToolUseBlock[] = [];
             if (msg.type === "assistant") {
-                toolBlocks = getToolUseBlocks(msg as AssistantMessage);
+                toolBlocks = getToolUseBlocks((msg as AssistantMessage).message.content);
             } else if (msg.type === "subagent") {
                 toolBlocks = getSubagentToolUseBlocks(msg as SubagentMessage);
             }
@@ -918,7 +857,7 @@ export class ClaudeSession {
         for (const msg of this._messages) {
             let tools: ToolUseBlock[] = [];
             if (msg.type === "assistant") {
-                tools = getToolUseBlocks(msg as AssistantMessage);
+                tools = getToolUseBlocks((msg as AssistantMessage).message.content);
             } else if (msg.type === "subagent") {
                 tools = getSubagentToolUseBlocks(msg as SubagentMessage);
             }
@@ -1092,7 +1031,7 @@ export class ClaudeSession {
                 }
 
                 // Tool calls
-                for (const tool of getToolUseBlocks(assistantMsg)) {
+                for (const tool of getToolUseBlocks(assistantMsg.message.content)) {
                     toolCallCount++;
                     toolUsage[tool.name] = (toolUsage[tool.name] || 0) + 1;
                     const fp = extractFilePathFromInput(tool.input);

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -330,7 +330,7 @@ export class ClaudeSession {
      * @returns Array of `TailTarget` sorted by file mtime (newest first).
      */
     static findSubagents(
-        options: { query?: string; project?: string; sessionId?: string; allProjects?: boolean } = {},
+        options: { query?: string; project?: string; sessionId?: string; allProjects?: boolean } = {}
     ): TailTarget[] {
         const { query, project, sessionId, allProjects = false } = options;
 

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -12,7 +12,7 @@
  * ```
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { basename, dirname, resolve, sep } from "node:path";
 import { SafeJSON } from "@app/utils/json";
@@ -56,15 +56,15 @@ import type {
 
 // Re-export types and utils for backward compatibility
 export type {
-    ExtractTextOptions,
-    PromptContentOptions,
-    PreparedContent,
-    SessionStats,
-    SessionInfo,
-    SessionDiscoveryOptions,
-    ToolCallSummary,
-    TailTarget,
     AgentMeta,
+    ExtractTextOptions,
+    PreparedContent,
+    PromptContentOptions,
+    SessionDiscoveryOptions,
+    SessionInfo,
+    SessionStats,
+    TailTarget,
+    ToolCallSummary,
 } from "./session.types";
 export {
     extractFilePathFromInput,
@@ -80,6 +80,7 @@ export {
 } from "./session.utils";
 
 import type {
+    AgentMeta,
     ExtractTextOptions,
     PreparedContent,
     PromptContentOptions,
@@ -88,7 +89,6 @@ import type {
     SessionStats,
     TailTarget,
     ToolCallSummary,
-    AgentMeta,
 } from "./session.types";
 
 /**
@@ -318,11 +318,7 @@ export class ClaudeSession {
      *
      * @returns Array of `TailTarget` sorted by file mtime (newest first).
      */
-    static findSubagents(options: {
-        query?: string;
-        project?: string;
-        sessionId?: string;
-    } = {}): TailTarget[] {
+    static findSubagents(options: { query?: string; project?: string; sessionId?: string } = {}): TailTarget[] {
         const { query, project, sessionId } = options;
 
         const baseDir = project

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -178,25 +178,36 @@ export class ClaudeSession {
      * @returns Array of `SessionInfo` sorted by start date (newest first).
      */
     static async findSessions(options: SessionDiscoveryOptions = {}): Promise<SessionInfo[]> {
-        const { project, since, until, includeSubagents = false, limit } = options;
-
-        // Determine search directory
-        const baseDir = project
-            ? resolve(PROJECTS_DIR, encodedProjectDir(project))
-            : resolve(PROJECTS_DIR, encodedProjectDir());
+        const { project, allProjects = false, since, until, includeSubagents = false, limit } = options;
 
         // Build glob patterns
         const patterns: string[] = [];
-        if (existsSync(baseDir)) {
-            patterns.push(resolve(baseDir, "*.jsonl"));
+
+        if (allProjects) {
+            patterns.push(resolve(PROJECTS_DIR, "*", "*.jsonl"));
+
             if (includeSubagents) {
-                patterns.push(resolve(baseDir, "subagents", "*.jsonl"));
+                patterns.push(resolve(PROJECTS_DIR, "*", "subagents", "*.jsonl"));
             }
-        } else if (project) {
-            // Fallback: glob for any dir containing the project name
-            patterns.push(`${PROJECTS_DIR}/*${project}*/*.jsonl`);
-            if (includeSubagents) {
-                patterns.push(`${PROJECTS_DIR}/*${project}*/subagents/*.jsonl`);
+        } else {
+            // Determine search directory
+            const baseDir = project
+                ? resolve(PROJECTS_DIR, encodedProjectDir(project))
+                : resolve(PROJECTS_DIR, encodedProjectDir());
+
+            if (existsSync(baseDir)) {
+                patterns.push(resolve(baseDir, "*.jsonl"));
+
+                if (includeSubagents) {
+                    patterns.push(resolve(baseDir, "subagents", "*.jsonl"));
+                }
+            } else if (project) {
+                // Fallback: glob for any dir containing the project name
+                patterns.push(`${PROJECTS_DIR}/*${project}*/*.jsonl`);
+
+                if (includeSubagents) {
+                    patterns.push(`${PROJECTS_DIR}/*${project}*/subagents/*.jsonl`);
+                }
             }
         }
 
@@ -318,52 +329,74 @@ export class ClaudeSession {
      *
      * @returns Array of `TailTarget` sorted by file mtime (newest first).
      */
-    static findSubagents(options: { query?: string; project?: string; sessionId?: string } = {}): TailTarget[] {
-        const { query, project, sessionId } = options;
+    static findSubagents(
+        options: { query?: string; project?: string; sessionId?: string; allProjects?: boolean } = {},
+    ): TailTarget[] {
+        const { query, project, sessionId, allProjects = false } = options;
 
-        const baseDir = project
-            ? resolve(PROJECTS_DIR, encodedProjectDir(project))
-            : resolve(PROJECTS_DIR, encodedProjectDir());
+        const baseDirs: string[] = [];
 
-        if (!existsSync(baseDir)) {
+        if (allProjects) {
+            if (existsSync(PROJECTS_DIR)) {
+                try {
+                    for (const entry of readdirSync(PROJECTS_DIR, { withFileTypes: true })) {
+                        if (entry.isDirectory()) {
+                            baseDirs.push(resolve(PROJECTS_DIR, entry.name));
+                        }
+                    }
+                } catch {
+                    // Skip unreadable
+                }
+            }
+        } else {
+            const dir = project
+                ? resolve(PROJECTS_DIR, encodedProjectDir(project))
+                : resolve(PROJECTS_DIR, encodedProjectDir());
+
+            if (existsSync(dir)) {
+                baseDirs.push(dir);
+            }
+        }
+
+        if (baseDirs.length === 0) {
             return [];
         }
 
         const results: TailTarget[] = [];
         const lowerQuery = query?.toLowerCase();
 
-        // If scoped to a session, only look in that session's subagents dir
+        // Collect subagent dirs from all base dirs
         const sessionDirs: string[] = [];
 
-        if (sessionId) {
-            // Find directories matching the session ID prefix
-            try {
-                for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
-                    if (entry.isDirectory() && entry.name.toLowerCase().startsWith(sessionId.toLowerCase())) {
-                        const subagentsDir = resolve(baseDir, entry.name, "subagents");
+        for (const baseDir of baseDirs) {
+            if (sessionId) {
+                try {
+                    for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+                        if (entry.isDirectory() && entry.name.toLowerCase().startsWith(sessionId.toLowerCase())) {
+                            const subagentsDir = resolve(baseDir, entry.name, "subagents");
 
-                        if (existsSync(subagentsDir)) {
-                            sessionDirs.push(subagentsDir);
+                            if (existsSync(subagentsDir)) {
+                                sessionDirs.push(subagentsDir);
+                            }
                         }
                     }
+                } catch {
+                    // Skip unreadable directories
                 }
-            } catch {
-                // Skip unreadable directories
-            }
-        } else {
-            // Scan all session directories
-            try {
-                for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
-                    if (entry.isDirectory()) {
-                        const subagentsDir = resolve(baseDir, entry.name, "subagents");
+            } else {
+                try {
+                    for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+                        if (entry.isDirectory()) {
+                            const subagentsDir = resolve(baseDir, entry.name, "subagents");
 
-                        if (existsSync(subagentsDir)) {
-                            sessionDirs.push(subagentsDir);
+                            if (existsSync(subagentsDir)) {
+                                sessionDirs.push(subagentsDir);
+                            }
                         }
                     }
+                } catch {
+                    // Skip unreadable directories
                 }
-            } catch {
-                // Skip unreadable directories
             }
         }
 

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -187,7 +187,7 @@ export class ClaudeSession {
             patterns.push(resolve(PROJECTS_DIR, "*", "*.jsonl"));
 
             if (includeSubagents) {
-                patterns.push(resolve(PROJECTS_DIR, "*", "subagents", "*.jsonl"));
+                patterns.push(resolve(PROJECTS_DIR, "*", "*", "subagents", "*.jsonl"));
             }
         } else {
             // Determine search directory
@@ -199,14 +199,14 @@ export class ClaudeSession {
                 patterns.push(resolve(baseDir, "*.jsonl"));
 
                 if (includeSubagents) {
-                    patterns.push(resolve(baseDir, "subagents", "*.jsonl"));
+                    patterns.push(resolve(baseDir, "*", "subagents", "*.jsonl"));
                 }
             } else if (project) {
                 // Fallback: glob for any dir containing the project name
                 patterns.push(`${PROJECTS_DIR}/*${project}*/*.jsonl`);
 
                 if (includeSubagents) {
-                    patterns.push(`${PROJECTS_DIR}/*${project}*/subagents/*.jsonl`);
+                    patterns.push(`${PROJECTS_DIR}/*${project}*/*/subagents/*.jsonl`);
                 }
             }
         }
@@ -454,14 +454,18 @@ export class ClaudeSession {
             }
         }
 
-        // Sort by file mtime (newest first)
-        results.sort((a, b) => {
+        // Pre-compute mtimes to avoid repeated statSync calls in comparator
+        const mtimeMap = new Map<string, number>();
+
+        for (const target of results) {
             try {
-                return statSync(b.filePath).mtimeMs - statSync(a.filePath).mtimeMs;
+                mtimeMap.set(target.filePath, statSync(target.filePath).mtimeMs);
             } catch {
-                return 0;
+                mtimeMap.set(target.filePath, 0);
             }
-        });
+        }
+
+        results.sort((a, b) => (mtimeMap.get(b.filePath) ?? 0) - (mtimeMap.get(a.filePath) ?? 0));
 
         return results;
     }

--- a/src/utils/claude/session.types.ts
+++ b/src/utils/claude/session.types.ts
@@ -1,0 +1,136 @@
+/** Options for extracting plain text from session messages. */
+export interface ExtractTextOptions {
+    /** Include tool result content in the extracted text. Default: false */
+    includeToolResults?: boolean;
+    /** Include thinking/reasoning blocks. Default: false */
+    includeThinking?: boolean;
+    /** Include system messages (errors, stop hooks). Default: false */
+    includeSystemMessages?: boolean;
+    /** Prefix tool calls with their name (e.g. "[Edit]"). Default: true */
+    includeToolNames?: boolean;
+    /** Maximum character length for the returned string. */
+    maxLength?: number;
+}
+
+/** Options for preparing session content for an LLM prompt. */
+export interface PromptContentOptions {
+    /** Maximum token budget for the prepared content. */
+    tokenBudget: number;
+    /** Content selection strategy when the session exceeds the budget. */
+    priority: "balanced" | "user-first" | "assistant-first" | "summary-first";
+    /** Include tool result blocks. Default: false */
+    includeToolResults?: boolean;
+    /** Include thinking/reasoning blocks. Default: false */
+    includeThinking?: boolean;
+    /** Prefix each message with its ISO timestamp. Default: false */
+    includeTimestamps?: boolean;
+}
+
+/** Result of `toPromptContent()` — token-budgeted session transcript. */
+export interface PreparedContent {
+    /** The formatted transcript string. */
+    content: string;
+    /** Estimated token count of `content`. */
+    tokenCount: number;
+    /** Whether the content was truncated to fit the budget. */
+    truncated: boolean;
+    /** Human-readable description of what was truncated. */
+    truncationInfo: string;
+    /** Summary statistics for the prepared content. */
+    stats: {
+        userMessages: number;
+        assistantMessages: number;
+        toolCalls: number;
+        filesModified: string[];
+    };
+}
+
+/** Aggregated statistics for a session. */
+export interface SessionStats {
+    /** Total number of JSONL entries (all types). */
+    messageCount: number;
+    /** Number of user-role messages. */
+    userMessageCount: number;
+    /** Number of assistant-role messages. */
+    assistantMessageCount: number;
+    /** Number of system messages (errors, stop hooks, etc.). */
+    systemMessageCount: number;
+    /** Number of subagent messages. */
+    subagentMessageCount: number;
+    /** Number of progress messages. */
+    progressMessageCount: number;
+    /** Number of PR link messages. */
+    prLinkCount: number;
+    /** Total number of tool_use blocks across all assistant and subagent messages. */
+    toolCallCount: number;
+    /** Tool name -> invocation count. */
+    toolUsage: Record<string, number>;
+    /** Aggregated API token usage from assistant message metadata. */
+    tokenUsage: { input: number; output: number; cached: number };
+    /** Distinct model IDs seen in assistant messages. */
+    modelsUsed: string[];
+    /** Unique file paths referenced in tool calls. */
+    filesModified: string[];
+    /** Duration in milliseconds between first and last timestamp. */
+    duration: number;
+    /** Earliest message timestamp. */
+    firstTimestamp: Date | null;
+    /** Latest message timestamp. */
+    lastTimestamp: Date | null;
+}
+
+/** Lightweight metadata for a discovered session file (no full parse). */
+export interface SessionInfo {
+    filePath: string;
+    sessionId: string | null;
+    title: string | null;
+    summary: string | null;
+    gitBranch: string | null;
+    project: string | null;
+    startDate: Date | null;
+    fileSize: number;
+    messageCount: number;
+    isSubagent: boolean;
+}
+
+/** Options for `ClaudeSession.findSessions()`. */
+export interface SessionDiscoveryOptions {
+    /** Project name (directory basename) to scope to. */
+    project?: string;
+    /** Only include sessions starting on or after this date. */
+    since?: Date;
+    /** Only include sessions starting on or before this date. */
+    until?: Date;
+    /** Include subagent sessions. Default: false */
+    includeSubagents?: boolean;
+    /** Maximum number of sessions to return. */
+    limit?: number;
+}
+
+/** Summary of a single tool invocation. */
+export interface ToolCallSummary {
+    /** Tool name (e.g. "Edit", "Bash"). */
+    name: string;
+    /** Full input object passed to the tool. */
+    input: Record<string, unknown>;
+    /** File path argument, if the tool accepts one. */
+    filePath?: string;
+    /** ISO timestamp of the parent message (if available). */
+    timestamp?: string;
+}
+
+/** Tail target — session or agent JSONL file resolved for tailing. */
+export interface TailTarget {
+    filePath: string;
+    label: string;
+    sessionId: string;
+    agentId?: string;
+    agentDescription?: string;
+    isAgent: boolean;
+}
+
+/** Agent meta.json schema. */
+export interface AgentMeta {
+    agentType: string;
+    description: string;
+}

--- a/src/utils/claude/session.types.ts
+++ b/src/utils/claude/session.types.ts
@@ -97,6 +97,8 @@ export interface SessionInfo {
 export interface SessionDiscoveryOptions {
     /** Project name (directory basename) to scope to. */
     project?: string;
+    /** Search all project dirs under ~/.claude/projects/. Default: false (current project only). */
+    allProjects?: boolean;
     /** Only include sessions starting on or after this date. */
     since?: Date;
     /** Only include sessions starting on or before this date. */

--- a/src/utils/claude/session.utils.ts
+++ b/src/utils/claude/session.utils.ts
@@ -1,34 +1,28 @@
 import { basename, sep } from "node:path";
-import type {
-    AssistantMessageContent,
-    ContentBlock,
-    ConversationMessage,
-    ImageBlock,
-    SubagentMessage,
-    TextBlock,
-    ToolReferenceBlock,
-    ToolResultBlock,
-    ToolUseBlock,
-} from "./types";
+import type { ContentBlock, ConversationMessage, SubagentMessage, ToolUseBlock } from "./types";
+
+function hasStringField<K extends string>(obj: object, key: K): obj is Record<K, string> {
+    return key in obj && typeof (obj as Record<K, unknown>)[key] === "string";
+}
 
 /** Type guard for messages that carry a timestamp field. */
 export function hasTimestamp(msg: ConversationMessage): msg is ConversationMessage & { timestamp: string } {
-    return "timestamp" in msg && typeof (msg as unknown as { timestamp: unknown }).timestamp === "string";
+    return hasStringField(msg, "timestamp");
 }
 
 /** Type guard for messages that carry a sessionId field. */
 export function hasSessionId(msg: ConversationMessage): msg is ConversationMessage & { sessionId: string } {
-    return "sessionId" in msg && typeof (msg as unknown as { sessionId: unknown }).sessionId === "string";
+    return hasStringField(msg, "sessionId");
 }
 
 /** Type guard for messages with gitBranch. */
 export function hasGitBranch(msg: ConversationMessage): msg is ConversationMessage & { gitBranch: string } {
-    return "gitBranch" in msg && typeof (msg as unknown as { gitBranch: unknown }).gitBranch === "string";
+    return hasStringField(msg, "gitBranch");
 }
 
 /** Type guard for messages with cwd. */
 export function hasCwd(msg: ConversationMessage): msg is ConversationMessage & { cwd: string } {
-    return "cwd" in msg && typeof (msg as unknown as { cwd: unknown }).cwd === "string";
+    return hasStringField(msg, "cwd");
 }
 
 /** Extract tool_use blocks from an assistant message content array. */
@@ -38,11 +32,11 @@ export function getToolUseBlocks(content: ContentBlock[]): ToolUseBlock[] {
 
 /** Extract tool_use blocks from a subagent assistant message. */
 export function getSubagentToolUseBlocks(msg: SubagentMessage): ToolUseBlock[] {
-    if (msg.role !== "assistant") {
+    if (msg.message.role !== "assistant") {
         return [];
     }
 
-    const content = (msg.message as AssistantMessageContent).content;
+    const content = msg.message.content;
 
     if (!Array.isArray(content)) {
         return [];
@@ -54,8 +48,10 @@ export function getSubagentToolUseBlocks(msg: SubagentMessage): ToolUseBlock[] {
 /** Extract file path from a tool input object, checking common field names. */
 export function extractFilePathFromInput(input: Record<string, unknown>): string | undefined {
     for (const field of ["file_path", "path", "filePath", "notebook_path"]) {
-        if (field in input && typeof input[field] === "string") {
-            return input[field] as string;
+        const value = input[field];
+
+        if (typeof value === "string") {
+            return value;
         }
     }
 
@@ -93,27 +89,25 @@ export function extractUserText(content: string | ContentBlock[]): string {
 
     for (const block of content) {
         if (block.type === "text") {
-            parts.push((block as TextBlock).text);
+            parts.push(block.text);
         } else if (block.type === "tool_result") {
-            const tr = block as ToolResultBlock;
-
-            if (typeof tr.content === "string") {
-                parts.push(tr.content);
-            } else if (Array.isArray(tr.content)) {
-                for (const inner of tr.content) {
+            if (typeof block.content === "string") {
+                parts.push(block.content);
+            } else if (Array.isArray(block.content)) {
+                for (const inner of block.content) {
                     if (inner.type === "text") {
-                        parts.push((inner as TextBlock).text);
+                        parts.push(inner.text);
                     } else if (inner.type === "image") {
-                        parts.push(`[Image: ${(inner as ImageBlock).source.media_type}]`);
+                        parts.push(`[Image: ${inner.source.media_type}]`);
                     } else if (inner.type === "tool_reference") {
-                        parts.push(`[Tool Reference: ${(inner as ToolReferenceBlock).tool_name}]`);
+                        parts.push(`[Tool Reference: ${inner.tool_name}]`);
                     }
                 }
             }
         } else if (block.type === "image") {
-            parts.push(`[Image: ${(block as ImageBlock).source.media_type}]`);
+            parts.push(`[Image: ${block.source.media_type}]`);
         } else if (block.type === "tool_reference") {
-            parts.push(`[Tool Reference: ${(block as ToolReferenceBlock).tool_name}]`);
+            parts.push(`[Tool Reference: ${block.tool_name}]`);
         }
     }
 

--- a/src/utils/claude/session.utils.ts
+++ b/src/utils/claude/session.utils.ts
@@ -1,0 +1,121 @@
+import { basename, sep } from "node:path";
+import type {
+    AssistantMessageContent,
+    ContentBlock,
+    ConversationMessage,
+    ImageBlock,
+    SubagentMessage,
+    TextBlock,
+    ToolReferenceBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+} from "./types";
+
+/** Type guard for messages that carry a timestamp field. */
+export function hasTimestamp(msg: ConversationMessage): msg is ConversationMessage & { timestamp: string } {
+    return "timestamp" in msg && typeof (msg as unknown as { timestamp: unknown }).timestamp === "string";
+}
+
+/** Type guard for messages that carry a sessionId field. */
+export function hasSessionId(msg: ConversationMessage): msg is ConversationMessage & { sessionId: string } {
+    return "sessionId" in msg && typeof (msg as unknown as { sessionId: unknown }).sessionId === "string";
+}
+
+/** Type guard for messages with gitBranch. */
+export function hasGitBranch(msg: ConversationMessage): msg is ConversationMessage & { gitBranch: string } {
+    return "gitBranch" in msg && typeof (msg as unknown as { gitBranch: unknown }).gitBranch === "string";
+}
+
+/** Type guard for messages with cwd. */
+export function hasCwd(msg: ConversationMessage): msg is ConversationMessage & { cwd: string } {
+    return "cwd" in msg && typeof (msg as unknown as { cwd: unknown }).cwd === "string";
+}
+
+/** Extract tool_use blocks from an assistant message content array. */
+export function getToolUseBlocks(content: ContentBlock[]): ToolUseBlock[] {
+    return content.filter((b): b is ToolUseBlock => b.type === "tool_use");
+}
+
+/** Extract tool_use blocks from a subagent assistant message. */
+export function getSubagentToolUseBlocks(msg: SubagentMessage): ToolUseBlock[] {
+    if (msg.role !== "assistant") {
+        return [];
+    }
+
+    const content = (msg.message as AssistantMessageContent).content;
+
+    if (!Array.isArray(content)) {
+        return [];
+    }
+
+    return content.filter((b): b is ToolUseBlock => b.type === "tool_use");
+}
+
+/** Extract file path from a tool input object, checking common field names. */
+export function extractFilePathFromInput(input: Record<string, unknown>): string | undefined {
+    for (const field of ["file_path", "path", "filePath", "notebook_path"]) {
+        if (field in input && typeof input[field] === "string") {
+            return input[field] as string;
+        }
+    }
+
+    return undefined;
+}
+
+/** Check whether a JSONL file is from a subagent. */
+export function isSubagentFile(filePath: string): boolean {
+    return filePath.includes(`${sep}subagents${sep}`) || basename(filePath).startsWith("agent-");
+}
+
+/**
+ * Read just the first N and last N lines from a JSONL file for fast metadata extraction.
+ */
+export async function readHeadTailLines(filePath: string, headCount: number, tailCount: number): Promise<string[]> {
+    const text = await Bun.file(filePath).text();
+    const allLines = text.split("\n").filter((l) => l.trim());
+
+    if (allLines.length <= headCount + tailCount) {
+        return allLines;
+    }
+
+    const head = allLines.slice(0, headCount);
+    const tail = allLines.slice(-tailCount);
+    return [...head, ...tail];
+}
+
+/** Extract readable text from a single user message content field. */
+export function extractUserText(content: string | ContentBlock[]): string {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    const parts: string[] = [];
+
+    for (const block of content) {
+        if (block.type === "text") {
+            parts.push((block as TextBlock).text);
+        } else if (block.type === "tool_result") {
+            const tr = block as ToolResultBlock;
+
+            if (typeof tr.content === "string") {
+                parts.push(tr.content);
+            } else if (Array.isArray(tr.content)) {
+                for (const inner of tr.content) {
+                    if (inner.type === "text") {
+                        parts.push((inner as TextBlock).text);
+                    } else if (inner.type === "image") {
+                        parts.push(`[Image: ${(inner as ImageBlock).source.media_type}]`);
+                    } else if (inner.type === "tool_reference") {
+                        parts.push(`[Tool Reference: ${(inner as ToolReferenceBlock).tool_name}]`);
+                    }
+                }
+            }
+        } else if (block.type === "image") {
+            parts.push(`[Image: ${(block as ImageBlock).source.media_type}]`);
+        } else if (block.type === "tool_reference") {
+            parts.push(`[Tool Reference: ${(block as ToolReferenceBlock).tool_name}]`);
+        }
+    }
+
+    return parts.join("\n");
+}

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -7,14 +7,54 @@ export interface JsonlParseResult<T = unknown> {
     remainder: Buffer<ArrayBuffer>;
 }
 
+const hasBunJsonl = typeof Bun !== "undefined" && typeof Bun.JSONL?.parseChunk === "function";
+
+if (!hasBunJsonl) {
+    console.error(
+        "[jsonl] Bun.JSONL not available — using slower JS fallback.\n" +
+            "        Run `bun upgrade` to get native C++ JSONL parsing (requires Bun ≥1.3.6).\n"
+    );
+}
+
 /**
  * Parse a chunk of JSONL data, handling partial lines.
- * Returns parsed values and any unconsumed remainder (partial last line).
+ * Uses native Bun.JSONL.parseChunk() when available (C++, ~10x faster),
+ * falls back to manual line splitting + JSON.parse otherwise.
  */
 export function parseJsonlChunk<T = unknown>(data: Buffer, existingRemainder?: Buffer): JsonlParseResult<T> {
     const combined = existingRemainder?.length ? Buffer.concat([existingRemainder, data]) : data;
-    const text = combined.toString("utf-8");
 
+    if (hasBunJsonl && Bun.JSONL) {
+        const result = Bun.JSONL.parseChunk(combined);
+        return {
+            values: result.values as T[],
+            read: result.read,
+            done: result.done,
+            remainder: Buffer.from(combined.subarray(result.read)),
+        };
+    }
+
+    return parseJsonlChunkFallback<T>(combined);
+}
+
+/**
+ * Parse an entire JSONL buffer (no streaming/remainder).
+ */
+export function parseJsonl<T = unknown>(data: Buffer | string): T[] {
+    if (hasBunJsonl && Bun.JSONL) {
+        const buf = typeof data === "string" ? Buffer.from(data) : data;
+        return Bun.JSONL.parse(buf) as T[];
+    }
+
+    return parseJsonlFallback<T>(data);
+}
+
+// ---------------------------------------------------------------------------
+// Fallback implementations (no Bun.JSONL)
+// ---------------------------------------------------------------------------
+
+function parseJsonlChunkFallback<T>(combined: Buffer): JsonlParseResult<T> {
+    const text = combined.toString("utf-8");
     const values: T[] = [];
     let lastNewline = -1;
 
@@ -41,7 +81,7 @@ export function parseJsonlChunk<T = unknown>(data: Buffer, existingRemainder?: B
         try {
             values.push(SafeJSON.parse(trimmed, { strict: true }) as T);
         } catch {
-            // Skip invalid JSON lines
+            // skip malformed lines
         }
     }
 
@@ -55,10 +95,7 @@ export function parseJsonlChunk<T = unknown>(data: Buffer, existingRemainder?: B
     };
 }
 
-/**
- * Parse an entire JSONL buffer (no streaming/remainder).
- */
-export function parseJsonl<T = unknown>(data: Buffer | string): T[] {
+function parseJsonlFallback<T>(data: Buffer | string): T[] {
     const text = typeof data === "string" ? data : data.toString("utf-8");
     const values: T[] = [];
 
@@ -72,7 +109,7 @@ export function parseJsonl<T = unknown>(data: Buffer | string): T[] {
         try {
             values.push(SafeJSON.parse(trimmed, { strict: true }) as T);
         } catch {
-            // Skip invalid JSON lines
+            // skip malformed lines
         }
     }
 

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -4,7 +4,7 @@ export interface JsonlParseResult<T = unknown> {
     values: T[];
     read: number;
     done: boolean;
-    remainder: Buffer;
+    remainder: Buffer<ArrayBuffer>;
 }
 
 /**
@@ -51,7 +51,7 @@ export function parseJsonlChunk<T = unknown>(data: Buffer, existingRemainder?: B
         values,
         read,
         done: read >= combined.length,
-        remainder: combined.subarray(read),
+        remainder: Buffer.from(combined.subarray(read)),
     };
 }
 

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -1,0 +1,80 @@
+import { SafeJSON } from "@app/utils/json";
+
+export interface JsonlParseResult<T = unknown> {
+    values: T[];
+    read: number;
+    done: boolean;
+    remainder: Buffer;
+}
+
+/**
+ * Parse a chunk of JSONL data, handling partial lines.
+ * Returns parsed values and any unconsumed remainder (partial last line).
+ */
+export function parseJsonlChunk<T = unknown>(data: Buffer, existingRemainder?: Buffer): JsonlParseResult<T> {
+    const combined = existingRemainder?.length ? Buffer.concat([existingRemainder, data]) : data;
+    const text = combined.toString("utf-8");
+
+    const values: T[] = [];
+    let lastNewline = -1;
+
+    const lines = text.split("\n");
+    let bytesConsumed = 0;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const lineBytes = Buffer.byteLength(line, "utf-8") + (i < lines.length - 1 ? 1 : 0);
+
+        if (i === lines.length - 1 && !text.endsWith("\n")) {
+            break;
+        }
+
+        bytesConsumed += lineBytes;
+        lastNewline = bytesConsumed;
+
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        try {
+            values.push(SafeJSON.parse(trimmed, { strict: true }) as T);
+        } catch {
+            // Skip invalid JSON lines
+        }
+    }
+
+    const read = lastNewline === -1 ? 0 : lastNewline;
+
+    return {
+        values,
+        read,
+        done: read >= combined.length,
+        remainder: combined.subarray(read),
+    };
+}
+
+/**
+ * Parse an entire JSONL buffer (no streaming/remainder).
+ */
+export function parseJsonl<T = unknown>(data: Buffer | string): T[] {
+    const text = typeof data === "string" ? data : data.toString("utf-8");
+    const values: T[] = [];
+
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        try {
+            values.push(SafeJSON.parse(trimmed, { strict: true }) as T);
+        } catch {
+            // Skip invalid JSON lines
+        }
+    }
+
+    return values;
+}

--- a/src/utils/jsonl.ts
+++ b/src/utils/jsonl.ts
@@ -8,8 +8,14 @@ export interface JsonlParseResult<T = unknown> {
 }
 
 const hasBunJsonl = typeof Bun !== "undefined" && typeof Bun.JSONL?.parseChunk === "function";
+let warnedFallback = false;
 
-if (!hasBunJsonl) {
+function warnFallback(): void {
+    if (warnedFallback) {
+        return;
+    }
+
+    warnedFallback = true;
     console.error(
         "[jsonl] Bun.JSONL not available — using slower JS fallback.\n" +
             "        Run `bun upgrade` to get native C++ JSONL parsing (requires Bun ≥1.3.6).\n"
@@ -34,6 +40,7 @@ export function parseJsonlChunk<T = unknown>(data: Buffer, existingRemainder?: B
         };
     }
 
+    warnFallback();
     return parseJsonlChunkFallback<T>(combined);
 }
 
@@ -46,6 +53,7 @@ export function parseJsonl<T = unknown>(data: Buffer | string): T[] {
         return Bun.JSONL.parse(buf) as T[];
     }
 
+    warnFallback();
     return parseJsonlFallback<T>(data);
 }
 

--- a/src/utils/macos/index.ts
+++ b/src/utils/macos/index.ts
@@ -89,7 +89,6 @@ export type {
     LanguageResult,
     MethodCapability,
     NamedEntity,
-    Neighbor,
     NeighborsResult,
     NlpScheme,
     OcrBlock,

--- a/src/utils/macos/types.ts
+++ b/src/utils/macos/types.ts
@@ -14,7 +14,6 @@ export type {
     ICloudStatusResult,
     LanguageResult,
     MethodCapability,
-    Neighbor,
     NeighborsResult,
     OCRBlock as OcrBlock,
     OCRBounds as OcrBounds,

--- a/src/utils/storage/fs.ts
+++ b/src/utils/storage/fs.ts
@@ -1,0 +1,101 @@
+import { closeSync, type FSWatcher, openSync, readSync, statSync, watch } from "node:fs";
+
+interface FileWatcherOptions {
+    filePath: string;
+    onData: (newBytes: Buffer) => void;
+    pollInterval?: number;
+    debounce?: boolean;
+}
+
+/**
+ * Watches a single file for new appended bytes.
+ * Uses fs.watch for instant kernel-level notifications + setInterval poll as fallback.
+ * Designed for append-only files (JSONL, logs). Handles file truncation.
+ */
+export class FileWatcher {
+    private offset = 0;
+    private watcher: FSWatcher | null = null;
+    private pollTimer: ReturnType<typeof setInterval> | null = null;
+    private checkScheduled = false;
+
+    constructor(private options: FileWatcherOptions) {}
+
+    start(fromOffset?: number): void {
+        if (fromOffset !== undefined) {
+            this.offset = fromOffset;
+        } else {
+            try {
+                this.offset = statSync(this.options.filePath).size;
+            } catch {
+                this.offset = 0;
+            }
+        }
+
+        const debounce = this.options.debounce ?? true;
+
+        this.watcher = watch(this.options.filePath, () => {
+            if (debounce) {
+                if (!this.checkScheduled) {
+                    this.checkScheduled = true;
+                    queueMicrotask(() => {
+                        this.checkScheduled = false;
+                        this.checkForNewData();
+                    });
+                }
+            } else {
+                this.checkForNewData();
+            }
+        });
+
+        const interval = this.options.pollInterval ?? 300;
+        this.pollTimer = setInterval(() => this.checkForNewData(), interval);
+    }
+
+    stop(): void {
+        this.watcher?.close();
+        this.watcher = null;
+
+        if (this.pollTimer) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+        }
+    }
+
+    get currentOffset(): number {
+        return this.offset;
+    }
+
+    isActive(thresholdMs = 10_000): boolean {
+        try {
+            const mtime = statSync(this.options.filePath).mtimeMs;
+            return Date.now() - mtime < thresholdMs;
+        } catch {
+            return false;
+        }
+    }
+
+    private checkForNewData(): void {
+        let currentSize: number;
+
+        try {
+            currentSize = statSync(this.options.filePath).size;
+        } catch {
+            return;
+        }
+
+        if (currentSize < this.offset) {
+            this.offset = 0;
+        }
+
+        if (currentSize <= this.offset) {
+            return;
+        }
+
+        const fd = openSync(this.options.filePath, "r");
+        const newBytes = Buffer.alloc(currentSize - this.offset);
+        readSync(fd, newBytes, 0, newBytes.length, this.offset);
+        closeSync(fd);
+        this.offset = currentSize;
+        this.options.onData(newBytes);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `tools cc tail` command that live-streams Claude Code session or subagent JSONL output with formatted, colorized display
- Unified `--include` DSL controls what content is shown (thinking, tools, agents with configurable truncation)
- Agent output visually chunked in bordered, color-coded sections
- Hook-independent stop detection (works on any machine, doesn't require GenesisTools hooks)

### New shared utilities
- `FileWatcher` class (`src/utils/storage/fs.ts`) — reusable `fs.watch` + 300ms poll fallback
- JSONL parsing proxy (`src/utils/jsonl.ts`) — wraps `Bun.JSONL.parseChunk` with typed API
- `IncludeSpec` DSL parser (`src/utils/claude/cli/dsl.ts`) — parses `--include` colon-separated specifiers

### Key features
- **Target resolution:** session ID prefix, agent ID, or fuzzy agent description match (e.g. `"Research OAuth"`)
- **`--include` DSL:** `thinking,tools:in:500,agents:result` with shorthand expansions
- **Interactive mode** (`-i`): guided multiselect setup of include options
- **Follow limits:** `--last-turns`, `--last-calls`, `--max-turns`, `--max-calls`
- **Dual output:** `--output <file>` + `--output-cli` with `suggestCommand()` nudge
- **Cross-project:** `--project <path>` scoped search
- **`cc` routing:** subcommands forwarded directly, unknown args default to `resume`

### Refactoring
- Extracted `session.types.ts` and `session.utils.ts` from `session.ts` (1600→400 lines)
- Added `findSubagents()` static method to `ClaudeSession`

## Test plan
- [ ] `tools cc tail <session-id> --no-follow -t 3` — session by ID prefix
- [ ] `tools cc tail "Research OAuth" -p <project-path> --no-follow` — agent by description
- [ ] `tools cc tail --no-follow -t 1` — most recent session auto-detect
- [ ] `tools cc tail <id> --include "tools:in:100,agents:result"` — custom include
- [ ] `tools cc tail <id> -o /tmp/test.log --no-follow` — file output
- [ ] `tools cc <id>` — backward compat (routes to resume)
- [ ] `tools cc tail --help` — shows include DSL examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live "tail" command to stream Claude sessions/subagents with include filters, interactive selection, raw JSONL mode, color control, optional file logging, follow/stop and max-turns/calls.
  * Automatic target resolution by session/agent (ID or most-recent) and clean SIGINT handling.
  * Improved incremental JSONL parsing and reliable single-file watching for live updates.
  * CLI routing updated so known subcommands are routed appropriately instead of always defaulting to resume.

* **Refactor**
  * Session metadata, types, and helper APIs reorganized for clearer discovery and reuse.

* **Chores**
  * Pinned Bun type dependency to a specific semver range.

* **Breaking Change**
  * Removed a previously exported macOS type from the public barrel exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->