### PR TITLE
feat: voice-memos interactive transcribe UX + system-wide locale dates

### DIFF
--- a/src/ask/audio/TranscriptionManager.ts
+++ b/src/ask/audio/TranscriptionManager.ts
@@ -114,7 +114,7 @@ export class TranscriptionManager {
     private async transcribeWithFallback(
         filePath: string,
         options: TranscriptionOptions,
-        initialTime: number
+        initialTime: number,
     ): Promise<TranscriptionResult> {
         const fallbackProviders = [
             { env: "ASSEMBLYAI_API_KEY", provider: "assemblyai" },
@@ -125,23 +125,43 @@ export class TranscriptionManager {
             { env: "OPENAI_API_KEY", provider: "openai" },
         ];
 
-        for (const { env, provider } of fallbackProviders) {
-            if (process.env[env] && provider !== options.provider) {
-                try {
-                    logger.info(`Trying fallback provider: ${pc.cyan(provider)}`);
-                    const result = await this.transcribeAudio(filePath, {
-                        ...options,
-                        provider,
-                    });
+        const triedProviders = new Set<string>([options.provider ?? ""]);
 
-                    // Add fallback information
-                    return {
-                        ...result,
-                        processingTime: Date.now() - initialTime,
-                    };
-                } catch (error) {
-                    logger.warn(`Fallback provider ${provider} failed: ${error}`);
+        for (const { env, provider } of fallbackProviders) {
+            if (!process.env[env] || triedProviders.has(provider)) {
+                continue;
+            }
+
+            triedProviders.add(provider);
+
+            try {
+                logger.info(`Trying fallback provider: ${pc.cyan(provider)}`);
+
+                const transcriptionModel = await this.getSpecificTranscriptionModel(
+                    provider,
+                    this.getDefaultModelForProvider(provider),
+                );
+
+                if (!transcriptionModel) {
+                    continue;
                 }
+
+                const audioBuffer = await Bun.file(filePath).arrayBuffer();
+                const model = getTranscriptionModel(transcriptionModel.providerInstance, transcriptionModel.model);
+                const result = await transcribe({
+                    model,
+                    audio: audioBuffer,
+                    ...(options.language && { language: options.language }),
+                });
+
+                return {
+                    text: result.text,
+                    provider,
+                    model: transcriptionModel.model,
+                    processingTime: Date.now() - initialTime,
+                };
+            } catch (error) {
+                logger.warn(`Fallback provider ${provider} failed: ${error}`);
             }
         }
 
@@ -294,6 +314,25 @@ export class TranscriptionManager {
         } catch (error) {
             logger.warn(`Failed to create transcription provider ${providerName}: ${error}`);
             return null;
+        }
+    }
+
+    private getDefaultModelForProvider(provider: string): string {
+        switch (provider) {
+            case "groq":
+                return "whisper-large-v3";
+            case "openrouter":
+                return "openai/whisper-1";
+            case "openai":
+                return "whisper-1";
+            case "assemblyai":
+                return "best";
+            case "deepgram":
+                return "nova-3";
+            case "gladia":
+                return "default";
+            default:
+                return "whisper-1";
         }
     }
 

--- a/src/ask/audio/TranscriptionManager.ts
+++ b/src/ask/audio/TranscriptionManager.ts
@@ -114,7 +114,7 @@ export class TranscriptionManager {
     private async transcribeWithFallback(
         filePath: string,
         options: TranscriptionOptions,
-        initialTime: number,
+        initialTime: number
     ): Promise<TranscriptionResult> {
         const fallbackProviders = [
             { env: "ASSEMBLYAI_API_KEY", provider: "assemblyai" },
@@ -139,7 +139,7 @@ export class TranscriptionManager {
 
                 const transcriptionModel = await this.getSpecificTranscriptionModel(
                     provider,
-                    this.getDefaultModelForProvider(provider),
+                    this.getDefaultModelForProvider(provider)
                 );
 
                 if (!transcriptionModel) {

--- a/src/azure-devops/commands/history-activity.ts
+++ b/src/azure-devops/commands/history-activity.ts
@@ -21,6 +21,7 @@ import type { Comment, IdentityRef, WorkItemUpdate } from "@app/azure-devops/typ
 import { requireConfig } from "@app/azure-devops/utils";
 import { escapeWiqlValue } from "@app/azure-devops/wiql-builder";
 import { suggestCommand } from "@app/utils/cli";
+import { formatDateTime } from "@app/utils/date";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 
@@ -328,7 +329,7 @@ function formatTime(isoDate: string): string {
 }
 
 function getDayName(dateStr: string): string {
-    return new Date(dateStr).toLocaleDateString("en-US", { weekday: "long" });
+    return formatDateTime(dateStr, { absolute: "weekday" });
 }
 
 function groupByDay(events: ActivityEvent[]): ActivityDay[] {

--- a/src/claude/commands/resume.ts
+++ b/src/claude/commands/resume.ts
@@ -8,7 +8,7 @@ import {
     searchConversations,
 } from "@app/claude/lib/history/search";
 import { detectCurrentProject, findClaudeCommand } from "@app/utils/claude";
-import { formatRelativeTime } from "@app/utils/format";
+import { formatDateTime } from "@app/utils/date";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
@@ -71,7 +71,7 @@ function formatDate(iso: string): string {
     if (!iso) {
         return "";
     }
-    return formatRelativeTime(new Date(iso), { compact: true });
+    return formatDateTime(iso, { relative: "always-relative-short" });
 }
 
 function dedup(sessions: DisplaySession[]): DisplaySession[] {

--- a/src/claude/lib/usage/display.ts
+++ b/src/claude/lib/usage/display.ts
@@ -1,3 +1,4 @@
+import { formatDateTime } from "@app/utils/date";
 import pc from "picocolors";
 import type { AccountUsage } from "./api";
 
@@ -72,20 +73,12 @@ function formatResetTime(resetsAt: string | null): string {
     const now = Date.now();
     const remainingMs = d.getTime() - now;
 
-    const timeFmt = new Intl.DateTimeFormat("en-US", {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-        timeZoneName: "short",
-    });
+    const formatted = formatDateTime(d, { absolute: "datetime-long" });
 
     if (remainingMs <= 0) {
-        return `Resets ${timeFmt.format(d)}`;
+        return `Resets ${formatted}`;
     }
-    return `Resets ${timeFmt.format(d)} (${formatDuration(remainingMs)})`;
+    return `Resets ${formatted} (${formatDuration(remainingMs)})`;
 }
 
 function calcProjection(utilization: number, resetsAt: string | null, bucketKey: string): number | null {

--- a/src/debugging-master/commands/diff.ts
+++ b/src/debugging-master/commands/diff.ts
@@ -1,6 +1,7 @@
 import { computeTimerPairs, filterByLevel, indexEntries } from "@app/debugging-master/core/log-parser";
 import { SessionManager } from "@app/debugging-master/core/session-manager";
 import type { IndexedLogEntry, LogLevel } from "@app/debugging-master/types";
+import { formatDateTime } from "@app/utils/date";
 import { formatDuration } from "@app/utils/format";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
@@ -23,7 +24,7 @@ function groupByLabel(entries: IndexedLogEntry[]): Map<string, IndexedLogEntry[]
 }
 
 function formatTime(ts: number): string {
-    return new Date(ts).toLocaleTimeString("en-GB", { hour12: false });
+    return formatDateTime(new Date(ts), { absolute: "time-seconds" });
 }
 
 function percentChange(a: number, b: number): string {

--- a/src/debugging-master/core/formatter.ts
+++ b/src/debugging-master/core/formatter.ts
@@ -1,6 +1,6 @@
 import type { IndexedLogEntry, OutputFormat, SessionStats } from "@app/debugging-master/types";
-import { formatDateTime } from "@app/utils/date";
 import { suggestCommand } from "@app/utils/cli/executor";
+import { formatDateTime } from "@app/utils/date";
 import { formatBytes, formatDuration } from "@app/utils/format";
 import { SafeJSON } from "@app/utils/json";
 import { stripAnsi } from "@app/utils/string";

--- a/src/debugging-master/core/formatter.ts
+++ b/src/debugging-master/core/formatter.ts
@@ -1,4 +1,5 @@
 import type { IndexedLogEntry, OutputFormat, SessionStats } from "@app/debugging-master/types";
+import { formatDateTime } from "@app/utils/date";
 import { suggestCommand } from "@app/utils/cli/executor";
 import { formatBytes, formatDuration } from "@app/utils/format";
 import { SafeJSON } from "@app/utils/json";
@@ -12,13 +13,7 @@ const TOOL = "tools debugging-master";
  */
 export function formatEntryLine(entry: IndexedLogEntry, pretty: boolean): string {
     const idx = `#${entry.index}`.padStart(4);
-    const time = new Date(entry.ts).toLocaleTimeString("en-GB", {
-        hour12: false,
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        fractionalSecondDigits: 3,
-    });
+    const time = formatDateTime(new Date(entry.ts), { absolute: "time-seconds" });
     const level = entry.level.padEnd(11);
     const label = entry.label ?? entry.msg ?? "";
 

--- a/src/git/commands/commits.ts
+++ b/src/git/commands/commits.ts
@@ -10,6 +10,7 @@
 
 import { extractFromMessage, loadWorkitemPatternsAsync } from "@app/git/workitem-patterns";
 import { Executor } from "@app/utils/cli";
+import { formatDateTime } from "@app/utils/date";
 import type { DetailedCommitInfo } from "@app/utils/git";
 import { SafeJSON } from "@app/utils/json";
 import { Storage } from "@app/utils/storage";
@@ -39,10 +40,7 @@ function addOneDay(dateStr: string): string {
 }
 
 function formatDateForDisplay(dateStr: string): string {
-    const d = new Date(dateStr);
-    const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    const day = dayNames[d.getDay()];
-    return `${day} ${dateStr}`;
+    return formatDateTime(dateStr, { absolute: "date-long" });
 }
 
 async function getCommitsByDate(

--- a/src/last-changes/index.ts
+++ b/src/last-changes/index.ts
@@ -1,6 +1,7 @@
 import { lstatSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { Executor } from "@app/utils/cli";
+import { formatDateTime } from "@app/utils/date";
 import { formatRelativeTime as _formatRelativeTime } from "@app/utils/format";
 import { handleReadmeFlag } from "@app/utils/readme";
 import chalk from "chalk";
@@ -31,25 +32,12 @@ interface TimeGroup {
 function formatRelativeTime(date: Date): string {
     return _formatRelativeTime(date, {
         maxDays: 7,
-        fallbackFormat: (d) =>
-            d.toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-            }),
+        fallbackFormat: (d) => formatDateTime(d, { absolute: "datetime" }),
     });
 }
 
 function formatAbsoluteTime(date: Date): string {
-    return date.toLocaleString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-    });
+    return formatDateTime(date, { absolute: "datetime" });
 }
 
 function getStatusColor(status: string): (text: string) => string {

--- a/src/macos/commands/voice-memos/index.ts
+++ b/src/macos/commands/voice-memos/index.ts
@@ -425,7 +425,7 @@ async function transcribeOne(opts: {
         ...(isTTY && !opts.lang
             ? {
                   confirmLanguage: async (
-                      detected: import("@app/utils/ai/LanguageDetector.ts").LanguageDetectionResult,
+                      detected: import("@app/utils/ai/LanguageDetector.ts").LanguageDetectionResult
                   ) => {
                       s.stop(`Detected: ${detected.language} (${Math.round(detected.confidence * 100)}%)`);
                       const confirmed = await promptLanguage(detected);

--- a/src/macos/commands/voice-memos/index.ts
+++ b/src/macos/commands/voice-memos/index.ts
@@ -1,9 +1,19 @@
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import {
+    confirmLanguage as promptLanguage,
+    selectAction,
+    selectFormat,
+    selectMemo,
+    selectModel,
+    selectOutput,
+    selectProvider,
+} from "@app/macos/lib/voice-memos/prompts.ts";
 import { AI } from "@app/utils/ai/index.ts";
 import { formatOutput, type OutputFormat } from "@app/utils/ai/transcription-format.ts";
 import type { AIProviderType } from "@app/utils/ai/types.ts";
 import { copyToClipboard } from "@app/utils/clipboard.ts";
+import { formatDateTime } from "@app/utils/date.ts";
 import { formatDuration } from "@app/utils/format.ts";
 import {
     extractTranscript,
@@ -13,10 +23,14 @@ import {
     type VoiceMemo,
     VoiceMemosError,
 } from "@app/utils/macos/voice-memos.ts";
+import { printSettingsSummary } from "@app/utils/prompts/clack/settings-summary.ts";
 import { formatTable } from "@app/utils/table.ts";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
+
+const VALID_PROVIDERS: AIProviderType[] = ["cloud", "local-hf", "darwinkit"];
+const TRANSCRIBE_PROVIDERS: AIProviderType[] = ["local-hf", "cloud"];
 
 export function registerVoiceMemosCommand(program: Command): void {
     const vm = new Command("voice-memos");
@@ -46,14 +60,14 @@ export function registerVoiceMemosCommand(program: Command): void {
 
     vm.command("transcribe")
         .description("Transcribe a voice memo (tsrp first, then AI fallback)")
-        .argument("[id]", "Memo ID (omit for --all)", (v) => parseInt(v, 10))
+        .argument("[id]", "Memo ID (omit for interactive selection)", (v) => parseInt(v, 10))
         .option("--all", "Transcribe all memos")
         .option("--force", "Re-transcribe even if tsrp transcript exists")
         .option("--lang <language>", "Language hint (e.g. cs, en, de) — auto-detected if omitted")
-        .option("--provider <provider>", "AI provider (local-hf, cloud, darwinkit)")
+        .option("--provider <provider>", "AI provider (local-hf, cloud)")
         .option("--local", "Shorthand for --provider local-hf")
         .option("--model <model>", "Model name/id to use")
-        .option("--format <format>", "Output format (text, json, srt, vtt)", "text")
+        .option("--format <format>", "Output format (text, json, srt, vtt)")
         .option("-o, --output <path>", "Write output to file")
         .option("-c, --clipboard", "Copy output to clipboard")
         .option("--sensitive", "Lower thresholds to capture quiet/background speakers")
@@ -100,13 +114,7 @@ async function handleErrors(fn: () => Promise<void> | void): Promise<void> {
 // ---------------------------------------------------------------------------
 
 function formatMemoDate(date: Date): string {
-    return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-    });
+    return formatDateTime(date, { absolute: "datetime" });
 }
 
 function formatMemoRow(memo: VoiceMemo): string[] {
@@ -187,6 +195,10 @@ function exportAction(id: number, dest: string): void {
     p.log.success(`Exported to ${pc.bold(destFile)}`);
 }
 
+// ---------------------------------------------------------------------------
+// Transcribe
+// ---------------------------------------------------------------------------
+
 interface TranscribeOpts {
     all?: boolean;
     force?: boolean;
@@ -201,27 +213,163 @@ interface TranscribeOpts {
 }
 
 async function transcribeAction(id: number | undefined, opts: TranscribeOpts): Promise<void> {
+    // Validate --provider and --model early
+    validateProviderOption(opts.provider);
+    validateModelOption(opts.model, opts.local ? "local-hf" : opts.provider);
+
     if (opts.all) {
         transcribeAll(opts.force ?? false);
         return;
     }
 
-    if (id === undefined) {
-        p.log.error("Provide a memo ID or use --all");
+    // If no ID provided, prompt for memo selection (TTY) or error (non-TTY)
+    let resolvedId = id;
+
+    if (resolvedId === undefined) {
+        if (!process.stdout.isTTY) {
+            p.log.error("Provide a memo ID or use --all (non-interactive mode)");
+            process.exit(1);
+        }
+
+        const memos = listMemos();
+        const selected = await selectMemo(memos);
+
+        if (!selected) {
+            return;
+        }
+
+        resolvedId = selected.id;
+    }
+
+    // Resolve all options — prompt for missing ones when TTY
+    const resolved = await resolveTranscribeOptions(opts);
+
+    await transcribeOne({
+        id: resolvedId!,
+        force: resolved.force,
+        lang: resolved.lang,
+        provider: resolved.provider,
+        model: resolved.model,
+        format: resolved.format,
+        output: resolved.output,
+        clipboard: resolved.clipboard,
+        sensitive: resolved.sensitive,
+    });
+}
+
+function validateProviderOption(provider: string | undefined): void {
+    if (provider === undefined) {
+        return;
+    }
+
+    if (!provider) {
+        p.log.error(
+            `Invalid --provider (empty). Choose from: ${TRANSCRIBE_PROVIDERS.join(", ")}\n` +
+                `  All providers: ${VALID_PROVIDERS.join(", ")}`
+        );
         process.exit(1);
     }
 
-    await transcribeOne({
-        id,
+    if (!VALID_PROVIDERS.includes(provider as AIProviderType)) {
+        p.log.error(
+            `Unknown provider "${provider}". Choose from: ${TRANSCRIBE_PROVIDERS.join(", ")}\n` +
+                `  All providers: ${VALID_PROVIDERS.join(", ")}`
+        );
+        process.exit(1);
+    }
+}
+
+function validateModelOption(model: string | undefined, provider: string | undefined): void {
+    if (model === undefined) {
+        return;
+    }
+
+    if (!model) {
+        const providerType = provider ?? "local-hf";
+        const suggestions =
+            providerType === "cloud"
+                ? "whisper-large-v3-turbo, whisper-large-v3, whisper-1"
+                : "onnx-community/whisper-large-v3-turbo, onnx-community/whisper-small, onnx-community/whisper-tiny";
+
+        p.log.error(`Invalid --model (empty). Available for ${providerType}: ${suggestions}`);
+        process.exit(1);
+    }
+}
+
+interface ResolvedTranscribeOpts {
+    force?: boolean;
+    lang?: string;
+    provider?: string;
+    model?: string;
+    format?: OutputFormat;
+    output?: string;
+    clipboard?: boolean;
+    sensitive?: boolean;
+}
+
+async function resolveTranscribeOptions(opts: TranscribeOpts): Promise<ResolvedTranscribeOpts> {
+    const resolved: ResolvedTranscribeOpts = {
         force: opts.force,
         lang: opts.lang,
-        provider: opts.local ? "local-hf" : opts.provider,
-        model: opts.model,
-        format: opts.format,
-        output: opts.output,
-        clipboard: opts.clipboard,
         sensitive: opts.sensitive,
-    });
+    };
+
+    const isTTY = !!process.stdout.isTTY;
+
+    // Provider
+    if (opts.local) {
+        resolved.provider = "local-hf";
+    } else if (opts.provider) {
+        resolved.provider = opts.provider;
+    } else if (isTTY) {
+        resolved.provider = await selectProvider();
+    }
+
+    // Model
+    if (opts.model) {
+        resolved.model = opts.model;
+    } else if (isTTY) {
+        resolved.model = await selectModel((resolved.provider ?? "local-hf") as AIProviderType);
+    }
+
+    // Format — opts.format is only set when --format is explicitly passed (no Commander default)
+    if (opts.format) {
+        resolved.format = opts.format;
+    } else if (isTTY) {
+        resolved.format = await selectFormat();
+    } else {
+        resolved.format = "text";
+    }
+
+    // Output destination
+    if (opts.output || opts.clipboard) {
+        resolved.output = opts.output;
+        resolved.clipboard = opts.clipboard;
+    } else if (isTTY) {
+        const outputChoice = await selectOutput();
+        resolved.output = outputChoice.output;
+        resolved.clipboard = outputChoice.clipboard;
+    }
+
+    // Show settings summary
+    if (isTTY) {
+        printSettingsSummary([
+            {
+                label: "Provider",
+                value: resolved.provider ?? "auto",
+                hint: opts.provider ? "from --provider" : undefined,
+            },
+            { label: "Model", value: resolved.model ?? "default", hint: opts.model ? "from --model" : undefined },
+            { label: "Format", value: resolved.format ?? "text" },
+            {
+                label: "Output",
+                value: resolved.clipboard ? "clipboard" : (resolved.output ?? "terminal"),
+            },
+            ...(resolved.lang ? [{ label: "Language", value: resolved.lang, hint: "from --lang" }] : []),
+        ]);
+    }
+
+    return resolved;
 }
 
 async function transcribeOne(opts: {
@@ -257,45 +405,89 @@ async function transcribeOne(opts: {
         }
     }
 
-    // AI transcription with full provider/model support (matching tools transcribe)
+    // AI transcription (retry once on corrupt cache)
     p.log.info(`Transcribing "${memo.title}" with AI...`);
     const s = p.spinner();
     s.start("Loading model...");
 
-    const transcriber = await AI.Transcriber.create({
+    const isTTY = !!process.stdout.isTTY;
+    let confirmedLang: string | undefined = opts.lang;
+
+    const transcribeOpts = {
+        language: opts.lang,
+        onProgress: (info: { message: string }) => {
+            s.message(info.message);
+        },
+        onSegment: (seg: { start: number; text: string }) => {
+            const ts = formatDuration(seg.start * 1000, "ms", "tiered");
+            s.message(`[${ts}] ${seg.text.trim()}`);
+        },
+        ...(isTTY && !opts.lang
+            ? {
+                  confirmLanguage: async (
+                      detected: import("@app/utils/ai/LanguageDetector.ts").LanguageDetectionResult,
+                  ) => {
+                      s.stop(`Detected: ${detected.language} (${Math.round(detected.confidence * 100)}%)`);
+                      const confirmed = await promptLanguage(detected);
+                      confirmedLang = confirmed;
+                      s.start("Transcribing...");
+                      return confirmed;
+                  },
+              }
+            : {}),
+        ...(opts.sensitive
+            ? {
+                  thresholds: {
+                      noSpeechThreshold: 0.3,
+                      logprobThreshold: -0.5,
+                      compressionRatioThreshold: 2.4,
+                  },
+              }
+            : {}),
+    };
+
+    let transcriber = await AI.Transcriber.create({
         provider: opts.provider as AIProviderType | undefined,
         model: opts.model,
     });
 
+    let result: import("@app/utils/ai/types.ts").TranscriptionResult;
+
     try {
-        const result = await transcriber.transcribe(memo.path, {
-            language: opts.lang,
-            onProgress: (info) => {
-                s.message(info.message);
-            },
-            onSegment: (seg) => {
-                const ts = formatDuration(seg.start * 1000, "ms", "tiered");
-                s.message(`[${ts}] ${seg.text.trim()}`);
-            },
-            // --sensitive lowers thresholds to capture quiet/background speakers
-            ...(opts.sensitive
-                ? {
-                      thresholds: {
-                          noSpeechThreshold: 0.3,
-                          logprobThreshold: -0.5,
-                          compressionRatioThreshold: 2.4,
-                      },
-                  }
-                : {}),
-        });
+        result = await transcriber.transcribe(memo.path, transcribeOpts);
+    } catch (err) {
+        transcriber.dispose();
+        const msg = err instanceof Error ? err.message : String(err);
 
-        s.stop("Transcription complete");
+        if (msg.includes("cache is corrupted")) {
+            s.stop("Model cache corrupted");
+            p.log.warning("Re-downloading model...");
+            s.start("Downloading model...");
 
-        // Format output using shared helpers
+            transcriber = await AI.Transcriber.create({
+                provider: opts.provider as AIProviderType | undefined,
+                model: opts.model,
+            });
+
+            // On retry: use the language already confirmed, skip re-detection/re-prompting
+            const retryOpts = {
+                ...transcribeOpts,
+                language: confirmedLang,
+                confirmLanguage: undefined,
+            };
+
+            result = await transcriber.transcribe(memo.path, retryOpts);
+        } else {
+            throw err;
+        }
+    }
+
+    s.stop("Transcription complete");
+
+    try {
         const format = opts.format ?? "text";
         const formatted = formatOutput(result, format);
 
-        // Output handling (matching tools transcribe pattern)
         if (opts.clipboard) {
             await copyToClipboard(formatted, { label: "transcription" });
         }
@@ -307,7 +499,6 @@ async function transcribeOne(opts: {
         }
 
         if (!opts.output) {
-            // Default: print to stdout (with timestamps for text format)
             if (format === "text" && result.segments?.length) {
                 console.log();
 
@@ -369,7 +560,7 @@ function searchAction(query: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Interactive mode
+// Interactive mode (uses shared prompts — DRY)
 // ---------------------------------------------------------------------------
 
 async function interactiveMode(): Promise<void> {
@@ -384,40 +575,16 @@ async function interactiveMode(): Promise<void> {
             return;
         }
 
-        const memoChoice = await p.select({
-            message: "Select a memo",
-            options: [
-                ...memos.map((m) => ({
-                    value: m.id,
-                    label: m.title,
-                    hint: `${formatMemoDate(m.date)} · ${formatDuration(m.duration, "s", "tiered")}${m.hasTranscript ? " · has transcript" : ""}`,
-                })),
-                { value: -1, label: pc.dim("Exit") },
-            ],
-        });
+        const memo = await selectMemo(memos);
 
-        if (p.isCancel(memoChoice) || memoChoice === -1) {
+        if (!memo) {
             p.outro("Done");
             return;
         }
 
-        const memo = memos.find((m) => m.id === memoChoice);
+        const action = await selectAction(memo);
 
-        if (!memo) {
-            continue;
-        }
-
-        const action = await p.select({
-            message: `${pc.bold(memo.title)} — choose action`,
-            options: [
-                { value: "play", label: "Play" },
-                { value: "export", label: "Export" },
-                { value: "transcribe", label: "Transcribe" },
-                { value: "back", label: pc.dim("Back") },
-            ],
-        });
-
-        if (p.isCancel(action) || action === "back") {
+        if (!action) {
             continue;
         }
 

--- a/src/macos/lib/voice-memos/prompts.ts
+++ b/src/macos/lib/voice-memos/prompts.ts
@@ -3,14 +3,14 @@
  * DRY: used by both interactive mode and the transcribe subcommand.
  */
 
-import type { OutputFormat } from "@app/utils/ai/transcription-format.ts";
-import type { AIProviderType } from "@app/utils/ai/types.ts";
 import type { LanguageDetectionResult } from "@app/utils/ai/LanguageDetector.ts";
 import { getModelsForTask, ModelManager } from "@app/utils/ai/ModelManager.ts";
+import type { OutputFormat } from "@app/utils/ai/transcription-format.ts";
+import type { AIProviderType } from "@app/utils/ai/types.ts";
 import { formatDateTime } from "@app/utils/date.ts";
 import { formatDuration } from "@app/utils/format.ts";
 import type { VoiceMemo } from "@app/utils/macos/voice-memos.ts";
-import { filePathInput, filePathCancelSymbol } from "@app/utils/prompts/clack/file-path.ts";
+import { filePathCancelSymbol, filePathInput } from "@app/utils/prompts/clack/file-path.ts";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 
@@ -19,26 +19,105 @@ import pc from "picocolors";
 // ============================================
 
 const LANG_NAMES: Record<string, string> = {
-    af: "Afrikaans", am: "Amharic", ar: "Arabic", as: "Assamese", az: "Azerbaijani",
-    ba: "Bashkir", be: "Belarusian", bg: "Bulgarian", bn: "Bengali", bo: "Tibetan",
-    br: "Breton", bs: "Bosnian", ca: "Catalan", cs: "Czech", cy: "Welsh",
-    da: "Danish", de: "German", el: "Greek", en: "English", es: "Spanish",
-    et: "Estonian", eu: "Basque", fa: "Persian", fi: "Finnish", fo: "Faroese",
-    fr: "French", gl: "Galician", gu: "Gujarati", ha: "Hausa", haw: "Hawaiian",
-    he: "Hebrew", hi: "Hindi", hr: "Croatian", ht: "Haitian", hu: "Hungarian",
-    hy: "Armenian", id: "Indonesian", is: "Icelandic", it: "Italian", ja: "Japanese",
-    jw: "Javanese", ka: "Georgian", kk: "Kazakh", km: "Khmer", kn: "Kannada",
-    ko: "Korean", la: "Latin", lb: "Luxembourgish", ln: "Lingala", lo: "Lao",
-    lt: "Lithuanian", lv: "Latvian", mg: "Malagasy", mi: "Maori", mk: "Macedonian",
-    ml: "Malayalam", mn: "Mongolian", mr: "Marathi", ms: "Malay", mt: "Maltese",
-    my: "Myanmar", ne: "Nepali", nl: "Dutch", nn: "Nynorsk", no: "Norwegian",
-    oc: "Occitan", pa: "Punjabi", pl: "Polish", ps: "Pashto", pt: "Portuguese",
-    ro: "Romanian", ru: "Russian", sa: "Sanskrit", sd: "Sindhi", si: "Sinhala",
-    sk: "Slovak", sl: "Slovenian", sn: "Shona", so: "Somali", sq: "Albanian",
-    sr: "Serbian", su: "Sundanese", sv: "Swedish", sw: "Swahili", ta: "Tamil",
-    te: "Telugu", tg: "Tajik", th: "Thai", tk: "Turkmen", tl: "Tagalog",
-    tr: "Turkish", tt: "Tatar", uk: "Ukrainian", ur: "Urdu", uz: "Uzbek",
-    vi: "Vietnamese", yi: "Yiddish", yo: "Yoruba", zh: "Chinese",
+    af: "Afrikaans",
+    am: "Amharic",
+    ar: "Arabic",
+    as: "Assamese",
+    az: "Azerbaijani",
+    ba: "Bashkir",
+    be: "Belarusian",
+    bg: "Bulgarian",
+    bn: "Bengali",
+    bo: "Tibetan",
+    br: "Breton",
+    bs: "Bosnian",
+    ca: "Catalan",
+    cs: "Czech",
+    cy: "Welsh",
+    da: "Danish",
+    de: "German",
+    el: "Greek",
+    en: "English",
+    es: "Spanish",
+    et: "Estonian",
+    eu: "Basque",
+    fa: "Persian",
+    fi: "Finnish",
+    fo: "Faroese",
+    fr: "French",
+    gl: "Galician",
+    gu: "Gujarati",
+    ha: "Hausa",
+    haw: "Hawaiian",
+    he: "Hebrew",
+    hi: "Hindi",
+    hr: "Croatian",
+    ht: "Haitian",
+    hu: "Hungarian",
+    hy: "Armenian",
+    id: "Indonesian",
+    is: "Icelandic",
+    it: "Italian",
+    ja: "Japanese",
+    jw: "Javanese",
+    ka: "Georgian",
+    kk: "Kazakh",
+    km: "Khmer",
+    kn: "Kannada",
+    ko: "Korean",
+    la: "Latin",
+    lb: "Luxembourgish",
+    ln: "Lingala",
+    lo: "Lao",
+    lt: "Lithuanian",
+    lv: "Latvian",
+    mg: "Malagasy",
+    mi: "Maori",
+    mk: "Macedonian",
+    ml: "Malayalam",
+    mn: "Mongolian",
+    mr: "Marathi",
+    ms: "Malay",
+    mt: "Maltese",
+    my: "Myanmar",
+    ne: "Nepali",
+    nl: "Dutch",
+    nn: "Nynorsk",
+    no: "Norwegian",
+    oc: "Occitan",
+    pa: "Punjabi",
+    pl: "Polish",
+    ps: "Pashto",
+    pt: "Portuguese",
+    ro: "Romanian",
+    ru: "Russian",
+    sa: "Sanskrit",
+    sd: "Sindhi",
+    si: "Sinhala",
+    sk: "Slovak",
+    sl: "Slovenian",
+    sn: "Shona",
+    so: "Somali",
+    sq: "Albanian",
+    sr: "Serbian",
+    su: "Sundanese",
+    sv: "Swedish",
+    sw: "Swahili",
+    ta: "Tamil",
+    te: "Telugu",
+    tg: "Tajik",
+    th: "Thai",
+    tk: "Turkmen",
+    tl: "Tagalog",
+    tr: "Turkish",
+    tt: "Tatar",
+    uk: "Ukrainian",
+    ur: "Urdu",
+    uz: "Uzbek",
+    vi: "Vietnamese",
+    yi: "Yiddish",
+    yo: "Yoruba",
+    zh: "Chinese",
 };
 
 function langName(code: string): string {
@@ -68,14 +147,16 @@ export async function selectMemo(memos: VoiceMemo[]): Promise<VoiceMemo | null> 
         options: [
             ...memos.map((m) => {
                 const isoTitle = isIsoDateTitle(m.title);
-                const dateStr = formatDateTime(m.date, { relative: "two-days", absolute: "datetime", first: "relative" });
+                const dateStr = formatDateTime(m.date, {
+                    relative: "two-days",
+                    absolute: "datetime",
+                    first: "relative",
+                });
                 const duration = formatDuration(m.duration, "s", "tiered");
                 const transcript = m.hasTranscript ? " · has transcript" : "";
 
                 const label = isoTitle ? dateStr : m.title;
-                const hint = isoTitle
-                    ? `${duration}${transcript}`
-                    : `${dateStr} · ${duration}${transcript}`;
+                const hint = isoTitle ? `${duration}${transcript}` : `${dateStr} · ${duration}${transcript}`;
 
                 return { value: m.id, label, hint };
             }),

--- a/src/macos/lib/voice-memos/prompts.ts
+++ b/src/macos/lib/voice-memos/prompts.ts
@@ -1,0 +1,350 @@
+/**
+ * Shared interactive prompts for the voice-memos tool.
+ * DRY: used by both interactive mode and the transcribe subcommand.
+ */
+
+import type { OutputFormat } from "@app/utils/ai/transcription-format.ts";
+import type { AIProviderType } from "@app/utils/ai/types.ts";
+import type { LanguageDetectionResult } from "@app/utils/ai/LanguageDetector.ts";
+import { getModelsForTask, ModelManager } from "@app/utils/ai/ModelManager.ts";
+import { formatDateTime } from "@app/utils/date.ts";
+import { formatDuration } from "@app/utils/format.ts";
+import type { VoiceMemo } from "@app/utils/macos/voice-memos.ts";
+import { filePathInput, filePathCancelSymbol } from "@app/utils/prompts/clack/file-path.ts";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+
+// ============================================
+// Language name lookup
+// ============================================
+
+const LANG_NAMES: Record<string, string> = {
+    af: "Afrikaans", am: "Amharic", ar: "Arabic", as: "Assamese", az: "Azerbaijani",
+    ba: "Bashkir", be: "Belarusian", bg: "Bulgarian", bn: "Bengali", bo: "Tibetan",
+    br: "Breton", bs: "Bosnian", ca: "Catalan", cs: "Czech", cy: "Welsh",
+    da: "Danish", de: "German", el: "Greek", en: "English", es: "Spanish",
+    et: "Estonian", eu: "Basque", fa: "Persian", fi: "Finnish", fo: "Faroese",
+    fr: "French", gl: "Galician", gu: "Gujarati", ha: "Hausa", haw: "Hawaiian",
+    he: "Hebrew", hi: "Hindi", hr: "Croatian", ht: "Haitian", hu: "Hungarian",
+    hy: "Armenian", id: "Indonesian", is: "Icelandic", it: "Italian", ja: "Japanese",
+    jw: "Javanese", ka: "Georgian", kk: "Kazakh", km: "Khmer", kn: "Kannada",
+    ko: "Korean", la: "Latin", lb: "Luxembourgish", ln: "Lingala", lo: "Lao",
+    lt: "Lithuanian", lv: "Latvian", mg: "Malagasy", mi: "Maori", mk: "Macedonian",
+    ml: "Malayalam", mn: "Mongolian", mr: "Marathi", ms: "Malay", mt: "Maltese",
+    my: "Myanmar", ne: "Nepali", nl: "Dutch", nn: "Nynorsk", no: "Norwegian",
+    oc: "Occitan", pa: "Punjabi", pl: "Polish", ps: "Pashto", pt: "Portuguese",
+    ro: "Romanian", ru: "Russian", sa: "Sanskrit", sd: "Sindhi", si: "Sinhala",
+    sk: "Slovak", sl: "Slovenian", sn: "Shona", so: "Somali", sq: "Albanian",
+    sr: "Serbian", su: "Sundanese", sv: "Swedish", sw: "Swahili", ta: "Tamil",
+    te: "Telugu", tg: "Tajik", th: "Thai", tk: "Turkmen", tl: "Tagalog",
+    tr: "Turkish", tt: "Tatar", uk: "Ukrainian", ur: "Urdu", uz: "Uzbek",
+    vi: "Vietnamese", yi: "Yiddish", yo: "Yoruba", zh: "Chinese",
+};
+
+function langName(code: string): string {
+    return LANG_NAMES[code] ?? code.toUpperCase();
+}
+
+// ============================================
+// Memo Selection
+// ============================================
+
+function isIsoDateTitle(title: string): boolean {
+    return /^\d{4}-\d{2}-\d{2}T/.test(title);
+}
+
+/**
+ * Interactive memo selection prompt.
+ * Returns the selected memo, or null if cancelled/exited.
+ */
+export async function selectMemo(memos: VoiceMemo[]): Promise<VoiceMemo | null> {
+    if (memos.length === 0) {
+        p.log.info("No voice memos found.");
+        return null;
+    }
+
+    const memoChoice = await p.select({
+        message: "Select a memo",
+        options: [
+            ...memos.map((m) => {
+                const isoTitle = isIsoDateTitle(m.title);
+                const dateStr = formatDateTime(m.date, { relative: "two-days", absolute: "datetime", first: "relative" });
+                const duration = formatDuration(m.duration, "s", "tiered");
+                const transcript = m.hasTranscript ? " · has transcript" : "";
+
+                const label = isoTitle ? dateStr : m.title;
+                const hint = isoTitle
+                    ? `${duration}${transcript}`
+                    : `${dateStr} · ${duration}${transcript}`;
+
+                return { value: m.id, label, hint };
+            }),
+            { value: -1, label: pc.dim("Exit") },
+        ],
+    });
+
+    if (p.isCancel(memoChoice) || memoChoice === -1) {
+        return null;
+    }
+
+    return memos.find((m) => m.id === memoChoice) ?? null;
+}
+
+// ============================================
+// Action Selection
+// ============================================
+
+export type MemoAction = "play" | "export" | "transcribe" | "back";
+
+/**
+ * Interactive action selection for a memo.
+ * Returns the selected action, or null if cancelled.
+ */
+export async function selectAction(memo: VoiceMemo): Promise<MemoAction | null> {
+    const action = await p.select({
+        message: `${pc.bold(memo.title)} — choose action`,
+        options: [
+            { value: "play" as const, label: "Play" },
+            { value: "export" as const, label: "Export" },
+            { value: "transcribe" as const, label: "Transcribe" },
+            { value: "back" as const, label: pc.dim("Back") },
+        ],
+    });
+
+    if (p.isCancel(action) || action === "back") {
+        return null;
+    }
+
+    return action;
+}
+
+// ============================================
+// Language Confirmation
+// ============================================
+
+/**
+ * Prompt user to confirm or change the detected language.
+ * Shows top-k alternatives with probabilities.
+ * Returns the confirmed language code.
+ */
+export async function confirmLanguage(detected: LanguageDetectionResult): Promise<string> {
+    const options: Array<{ value: string; label: string; hint?: string }> = [];
+
+    if (detected.alternatives && detected.alternatives.length > 0) {
+        for (const alt of detected.alternatives) {
+            const pct = Math.round(alt.confidence * 100);
+            options.push({
+                value: alt.language,
+                label: `${alt.language} — ${langName(alt.language)}`,
+                hint: `${pct}%`,
+            });
+        }
+    } else {
+        const pct = Math.round(detected.confidence * 100);
+        options.push({
+            value: detected.language,
+            label: `${detected.language} — ${langName(detected.language)}`,
+            hint: `${pct}% via ${detected.driver}`,
+        });
+    }
+
+    options.push({ value: "__other__", label: pc.dim("Other...") });
+
+    const choice = await p.select({
+        message: "Detected language — confirm or change",
+        options,
+    });
+
+    if (p.isCancel(choice)) {
+        return detected.language;
+    }
+
+    if (choice === "__other__") {
+        const custom = await p.text({
+            message: "Enter ISO language code (e.g. cs, en, de)",
+            placeholder: "cs",
+            validate: (val) => {
+                if (!val || !/^[a-z]{2,3}$/i.test(val)) {
+                    return "Enter a valid ISO language code (2-3 letters, e.g. cs, en, deu)";
+                }
+
+                return undefined;
+            },
+        });
+
+        if (p.isCancel(custom)) {
+            return detected.language;
+        }
+
+        return custom;
+    }
+
+    return choice;
+}
+
+// ============================================
+// Transcription Settings Prompts
+// ============================================
+
+/**
+ * Prompt for transcription provider.
+ * Only shows providers that support transcription.
+ */
+export async function selectProvider(): Promise<AIProviderType> {
+    const { getAllProviders } = await import("@app/utils/ai/providers/index.ts");
+    const providers = getAllProviders();
+    const available: Array<{ value: AIProviderType; label: string; hint: string }> = [];
+
+    for (const prov of providers) {
+        if (!prov.supports("transcribe")) {
+            continue;
+        }
+
+        const isAvail = await prov.isAvailable();
+        available.push({
+            value: prov.type,
+            label: providerLabel(prov.type),
+            hint: isAvail ? "available" : "not available",
+        });
+    }
+
+    if (available.length === 0) {
+        p.log.error("No transcription providers available");
+        process.exit(1);
+    }
+
+    const choice = await p.select({
+        message: "Transcription provider",
+        options: available,
+    });
+
+    if (p.isCancel(choice)) {
+        p.cancel("Cancelled");
+        process.exit(0);
+    }
+
+    return choice;
+}
+
+function providerLabel(type: AIProviderType): string {
+    switch (type) {
+        case "local-hf":
+            return "Local (HuggingFace Whisper)";
+        case "cloud":
+            return "Cloud (Groq/OpenAI)";
+        case "darwinkit":
+            return "DarwinKit (macOS native)";
+        default:
+            return type;
+    }
+}
+
+/**
+ * Prompt for model selection based on provider.
+ */
+export async function selectModel(provider: AIProviderType): Promise<string | undefined> {
+    const knownModels = getModelsForTask("transcribe", provider);
+
+    if (knownModels.length === 0) {
+        if (provider === "cloud") {
+            p.log.warning("No cloud API keys found. Set GROQ_API_KEY or OPENAI_API_KEY.");
+        }
+
+        return undefined;
+    }
+
+    // Resolve cache so we can show download status for local models
+    const mgr = new ModelManager();
+
+    if (provider === "local-hf") {
+        await mgr.resolveTransformersCache();
+    }
+
+    const models = knownModels.map((m) => {
+        let hint = m.description;
+
+        if (provider === "local-hf") {
+            const cached = mgr.isDownloaded(m.id);
+            const status = cached ? pc.green("downloaded") : pc.dim("not downloaded");
+            hint = `${m.description} · ${status}`;
+        }
+
+        return { value: m.id, label: m.name, hint };
+    });
+
+    if (models.length <= 1) {
+        return models[0]?.value;
+    }
+
+    const choice = await p.select({
+        message: "Model",
+        options: models,
+    });
+
+    if (p.isCancel(choice)) {
+        p.cancel("Cancelled");
+        process.exit(0);
+    }
+
+    return choice;
+}
+
+/**
+ * Prompt for output format.
+ */
+export async function selectFormat(): Promise<OutputFormat> {
+    const choice = await p.select({
+        message: "Output format",
+        options: [
+            { value: "text" as const, label: "Text", hint: "plain text with timestamps" },
+            { value: "srt" as const, label: "SRT", hint: "SubRip subtitle format" },
+            { value: "vtt" as const, label: "VTT", hint: "WebVTT subtitle format" },
+            { value: "json" as const, label: "JSON", hint: "structured with segments" },
+        ],
+    });
+
+    if (p.isCancel(choice)) {
+        p.cancel("Cancelled");
+        process.exit(0);
+    }
+
+    return choice;
+}
+
+/**
+ * Prompt for output destination.
+ */
+export async function selectOutput(): Promise<{ output?: string; clipboard?: boolean }> {
+    const choice = await p.select({
+        message: "Output destination",
+        options: [
+            { value: "stdout" as const, label: "Print to terminal" },
+            { value: "clipboard" as const, label: "Copy to clipboard" },
+            { value: "file" as const, label: "Write to file" },
+        ],
+    });
+
+    if (p.isCancel(choice)) {
+        p.cancel("Cancelled");
+        process.exit(0);
+    }
+
+    switch (choice) {
+        case "clipboard":
+            return { clipboard: true };
+        case "file": {
+            const filePath = await filePathInput({
+                message: "Output file path",
+            });
+
+            if (filePath === filePathCancelSymbol) {
+                p.cancel("Cancelled");
+                process.exit(0);
+            }
+
+            return { output: filePath as string };
+        }
+        default:
+            return {};
+    }
+}

--- a/src/telegram/lib/export.ts
+++ b/src/telegram/lib/export.ts
@@ -1,3 +1,4 @@
+import { formatDateTime } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import type { MessageRow } from "./types";
 
@@ -24,13 +25,7 @@ export function formatMessages(messages: MessageRow[], format: ExportFormat, con
         case "txt": {
             const lines = messages.map((m) => {
                 const date = new Date(m.date_unix * 1000);
-                const dateStr = date.toLocaleString("en-US", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                });
+                const dateStr = formatDateTime(date, { absolute: "datetime" });
                 const direction = m.is_outgoing ? "You" : contactName;
                 const text = m.text || m.media_desc || "(no content)";
                 return `[${dateStr}] ${direction}: ${text}`;

--- a/src/telegram/lib/search.ts
+++ b/src/telegram/lib/search.ts
@@ -1,3 +1,4 @@
+import { formatDateTime } from "@app/utils/date";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import type { SearchResult } from "./types";
@@ -5,13 +6,7 @@ import type { SearchResult } from "./types";
 export function formatSearchResult(result: SearchResult, contactName: string): string {
     const msg = result.message;
     const date = new Date(msg.date_unix * 1000);
-    const dateStr = date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-    });
+    const dateStr = formatDateTime(date, { absolute: "datetime" });
     const direction = msg.is_outgoing ? pc.blue("You") : pc.cyan(contactName);
     const text = msg.text || msg.media_desc || "(no text)";
     const preview = text.length > 120 ? `${text.slice(0, 120)}...` : text;

--- a/src/usage/index.ts
+++ b/src/usage/index.ts
@@ -2,6 +2,7 @@
 import { UsageDatabase } from "@app/ask/output/UsageDatabase";
 import { dynamicPricingManager } from "@app/ask/providers/DynamicPricing";
 import logger from "@app/logger";
+import { formatDateTime } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import chalk from "chalk";
 import Table from "cli-table3";
@@ -50,8 +51,7 @@ function formatTokens(tokens: number): string {
 }
 
 function formatDate(dateStr: string): string {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    return formatDateTime(dateStr, { absolute: "date" });
 }
 
 async function showSummary(db: UsageDatabase, days: number) {

--- a/src/utils/ai/AIConfig.ts
+++ b/src/utils/ai/AIConfig.ts
@@ -12,7 +12,7 @@ interface AIConfigData {
 }
 
 const DEFAULT_CONFIG: AIConfigData = {
-    transcribe: { provider: "local-hf", model: "whisper-small" },
+    transcribe: { provider: "local-hf" },
     translate: { provider: "local-hf" },
     summarize: { provider: "cloud" },
     classify: { provider: "darwinkit" },

--- a/src/utils/ai/LanguageDetector.ts
+++ b/src/utils/ai/LanguageDetector.ts
@@ -164,7 +164,7 @@ export class WhisperLanguageDriver implements LanguageDetectionDriver {
     private extractTopKLanguages(
         output: Record<string, unknown>,
         langToId: Record<string, number> | undefined,
-        topK = 5,
+        topK = 5
     ): Array<{ language: string; confidence: number }> | null {
         if (!langToId) {
             return null;

--- a/src/utils/ai/LanguageDetector.ts
+++ b/src/utils/ai/LanguageDetector.ts
@@ -11,6 +11,8 @@ export interface LanguageDetectionResult {
     confidence: number;
     /** Which driver produced this result */
     driver: string;
+    /** Top-k alternative languages with probabilities (if available from the driver) */
+    alternatives?: Array<{ language: string; confidence: number }>;
 }
 
 export interface LanguageDetectionDriver {
@@ -98,7 +100,7 @@ export class WhisperLanguageDriver implements LanguageDetectionDriver {
     readonly name = "whisper";
     private model: string;
     private whisperModel: {
-        generate: (opts: Record<string, unknown>) => Promise<{ data: ArrayLike<number | bigint> }>;
+        generate: (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
         generation_config: Record<string, unknown>;
     } | null = null;
     private processor: ((audio: Float32Array) => Promise<Record<string, unknown>>) | null = null;
@@ -120,17 +122,32 @@ export class WhisperLanguageDriver implements LanguageDetectionDriver {
 
         const genConfig = this.whisperModel!.generation_config;
         const sotId = genConfig.decoder_start_token_id as number;
+        const langToId = genConfig.lang_to_id as Record<string, number> | undefined;
 
         const output = await this.whisperModel!.generate({
             ...inputs,
             decoder_input_ids: [[sotId]],
             max_new_tokens: 1,
+            output_scores: true,
+            return_dict_in_generate: true,
         });
 
-        const rawData = output.data;
-        const langTokenId = Number(rawData[rawData.length - 1]);
+        // Extract top-k language probabilities from scores (logits)
+        const alternatives = this.extractTopKLanguages(output, langToId);
 
-        const langToId = genConfig.lang_to_id as Record<string, number> | undefined;
+        if (alternatives && alternatives.length > 0) {
+            return {
+                language: alternatives[0].language,
+                confidence: alternatives[0].confidence,
+                driver: this.name,
+                alternatives,
+            };
+        }
+
+        // Fallback: use the generated token ID directly
+        const sequences = output.sequences ?? output;
+        const rawData = (sequences as { data: ArrayLike<number | bigint> }).data;
+        const langTokenId = Number(rawData[rawData.length - 1]);
 
         if (langToId) {
             for (const [token, id] of Object.entries(langToId)) {
@@ -142,6 +159,56 @@ export class WhisperLanguageDriver implements LanguageDetectionDriver {
         }
 
         return { language: "en", confidence: 0.5, driver: this.name };
+    }
+
+    private extractTopKLanguages(
+        output: Record<string, unknown>,
+        langToId: Record<string, number> | undefined,
+        topK = 5,
+    ): Array<{ language: string; confidence: number }> | null {
+        if (!langToId) {
+            return null;
+        }
+
+        // output.scores is an array of logit tensors, one per generated token
+        const scores = output.scores as Array<{ data: Float32Array }> | undefined;
+
+        if (!scores || scores.length === 0) {
+            return null;
+        }
+
+        const logits = scores[0].data;
+
+        if (!logits) {
+            return null;
+        }
+
+        // Build language entries with their logit values
+        const entries: Array<{ language: string; logit: number }> = [];
+
+        for (const [token, id] of Object.entries(langToId)) {
+            const code = token.replace(/<\||\|>/g, "");
+
+            if (id < logits.length) {
+                entries.push({ language: code, logit: logits[id] });
+            }
+        }
+
+        if (entries.length === 0) {
+            return null;
+        }
+
+        // Softmax over language logits only
+        const maxLogit = Math.max(...entries.map((e) => e.logit));
+        const exps = entries.map((e) => ({ language: e.language, exp: Math.exp(e.logit - maxLogit) }));
+        const sumExp = exps.reduce((sum, e) => sum + e.exp, 0);
+
+        const probabilities = exps
+            .map((e) => ({ language: e.language, confidence: e.exp / sumExp }))
+            .sort((a, b) => b.confidence - a.confidence)
+            .slice(0, topK);
+
+        return probabilities;
     }
 
     private async ensureLoaded(): Promise<void> {

--- a/src/utils/ai/ModelManager.ts
+++ b/src/utils/ai/ModelManager.ts
@@ -6,7 +6,71 @@ import { formatBytes } from "@app/utils/format";
 
 const HF_CACHE_DIR = join(homedir(), ".cache", "huggingface", "hub");
 
+// ============================================
+// Model registry — known models per provider/task
+// ============================================
+
+export interface ModelInfo {
+    id: string;
+    name: string;
+    description: string;
+}
+
+const LOCAL_TRANSCRIPTION_MODELS: ModelInfo[] = [
+    { id: "onnx-community/whisper-large-v3-turbo", name: "whisper-large-v3-turbo", description: "best quality, ~1.5GB" },
+    { id: "onnx-community/whisper-large-v3", name: "whisper-large-v3", description: "highest quality, ~3GB" },
+    { id: "onnx-community/whisper-small", name: "whisper-small", description: "faster, lower quality" },
+    { id: "onnx-community/whisper-tiny", name: "whisper-tiny", description: "fastest, basic quality" },
+];
+
+function getCloudTranscriptionModels(): ModelInfo[] {
+    const models: ModelInfo[] = [];
+
+    if (process.env.GROQ_API_KEY) {
+        models.push(
+            { id: "whisper-large-v3-turbo", name: "Groq whisper-large-v3-turbo", description: "fast" },
+            { id: "whisper-large-v3", name: "Groq whisper-large-v3", description: "high quality" },
+        );
+    }
+
+    if (process.env.OPENAI_API_KEY) {
+        models.push({ id: "whisper-1", name: "OpenAI whisper-1", description: "reliable" });
+    }
+
+    return models;
+}
+
+/**
+ * Get the default (first/recommended) model for a task + provider.
+ * Returns the model ID string, or undefined if no models are known.
+ */
+export function getDefaultModel(task: string, provider: string): string | undefined {
+    return getModelsForTask(task, provider)[0]?.id;
+}
+
+/**
+ * Get known models for a task + provider combination.
+ * Cloud models are resolved lazily (checks env vars at call time).
+ */
+export function getModelsForTask(task: string, provider: string): ModelInfo[] {
+    if (task !== "transcribe") {
+        return [];
+    }
+
+    if (provider === "local-hf") {
+        return LOCAL_TRANSCRIPTION_MODELS;
+    }
+
+    if (provider === "cloud") {
+        return getCloudTranscriptionModels();
+    }
+
+    return [];
+}
+
 export class ModelManager {
+    private transformersCacheDir: string | null = null;
+
     async listDownloaded(): Promise<Array<{ modelId: string; sizeBytes: number }>> {
         if (!existsSync(HF_CACHE_DIR)) {
             return [];
@@ -46,8 +110,41 @@ export class ModelManager {
     }
 
     isDownloaded(modelId: string): boolean {
+        // Check HuggingFace hub cache (~/.cache/huggingface/hub/models--*)
         const dirName = `models--${modelId.replace(/\//g, "--")}`;
-        return existsSync(join(HF_CACHE_DIR, dirName));
+
+        if (existsSync(join(HF_CACHE_DIR, dirName))) {
+            return true;
+        }
+
+        // Check transformers.js local cache (node_modules/@huggingface/transformers/.cache/<org>/<model>)
+        if (this.transformersCacheDir) {
+            const localPath = join(this.transformersCacheDir, modelId);
+
+            if (existsSync(localPath)) {
+                const files = readdirSync(localPath);
+                return files.some((f) => f.endsWith(".json")) && files.length > 1;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve the transformers.js cache dir (lazy, async).
+     * Call once before using isDownloaded if you need transformers.js cache detection.
+     */
+    async resolveTransformersCache(): Promise<void> {
+        if (this.transformersCacheDir) {
+            return;
+        }
+
+        try {
+            const { env } = await import("@huggingface/transformers");
+            this.transformersCacheDir = env.cacheDir;
+        } catch {
+            // transformers.js not available
+        }
     }
 
     getModelPath(modelId: string): string | null {

--- a/src/utils/ai/ModelManager.ts
+++ b/src/utils/ai/ModelManager.ts
@@ -17,7 +17,11 @@ export interface ModelInfo {
 }
 
 const LOCAL_TRANSCRIPTION_MODELS: ModelInfo[] = [
-    { id: "onnx-community/whisper-large-v3-turbo", name: "whisper-large-v3-turbo", description: "best quality, ~1.5GB" },
+    {
+        id: "onnx-community/whisper-large-v3-turbo",
+        name: "whisper-large-v3-turbo",
+        description: "best quality, ~1.5GB",
+    },
     { id: "onnx-community/whisper-large-v3", name: "whisper-large-v3", description: "highest quality, ~3GB" },
     { id: "onnx-community/whisper-small", name: "whisper-small", description: "faster, lower quality" },
     { id: "onnx-community/whisper-tiny", name: "whisper-tiny", description: "fastest, basic quality" },
@@ -29,7 +33,7 @@ function getCloudTranscriptionModels(): ModelInfo[] {
     if (process.env.GROQ_API_KEY) {
         models.push(
             { id: "whisper-large-v3-turbo", name: "Groq whisper-large-v3-turbo", description: "fast" },
-            { id: "whisper-large-v3", name: "Groq whisper-large-v3", description: "high quality" },
+            { id: "whisper-large-v3", name: "Groq whisper-large-v3", description: "high quality" }
         );
     }
 

--- a/src/utils/ai/providers/AILocalProvider.ts
+++ b/src/utils/ai/providers/AILocalProvider.ts
@@ -146,7 +146,9 @@ export class AILocalProvider
                 const pct = Math.min(99, Math.round((lastTimestamp / durationSec) * 100));
                 const truncated = currentChunkText.length > 60 ? `...${currentChunkText.slice(-57)}` : currentChunkText;
 
-                logger.info(`[transcribe] progress: ${pct}% ts=${lastTimestamp.toFixed(1)}s elapsed_since_last=${elapsed}ms`);
+                logger.info(
+                    `[transcribe] progress: ${pct}% ts=${lastTimestamp.toFixed(1)}s elapsed_since_last=${elapsed}ms`
+                );
 
                 onProgress?.({
                     phase: "transcribe",
@@ -162,7 +164,9 @@ export class AILocalProvider
             },
             on_chunk_end: (time: number) => {
                 const elapsed = Date.now() - transcribeStart;
-                logger.info(`[transcribe] chunk_end: time=${time.toFixed(2)}s text="${currentChunkText.slice(0, 80)}" total_elapsed=${elapsed}ms`);
+                logger.info(
+                    `[transcribe] chunk_end: time=${time.toFixed(2)}s text="${currentChunkText.slice(0, 80)}" total_elapsed=${elapsed}ms`
+                );
                 lastTimestamp = time;
 
                 if (currentChunkText.trim()) {
@@ -175,7 +179,9 @@ export class AILocalProvider
             },
         });
 
-        logger.info(`[transcribe] calling pipeline with ${audioData.length} samples, chunk_length=${chunkLengthS}s, stride=5s`);
+        logger.info(
+            `[transcribe] calling pipeline with ${audioData.length} samples, chunk_length=${chunkLengthS}s, stride=5s`
+        );
         const pipeStart = Date.now();
 
         const result = (await pipe(audioData, {
@@ -201,7 +207,9 @@ export class AILocalProvider
 
         const pipeDuration = Date.now() - pipeStart;
         const totalDuration = Date.now() - transcribeStart;
-        logger.info(`[transcribe] pipeline done: ${pipeDuration}ms, total=${totalDuration}ms, chunks=${result.chunks?.length ?? 0}, text=${result.text.length} chars`);
+        logger.info(
+            `[transcribe] pipeline done: ${pipeDuration}ms, total=${totalDuration}ms, chunks=${result.chunks?.length ?? 0}, text=${result.text.length} chars`
+        );
 
         onProgress?.({ phase: "transcribe", percent: 100, message: "Transcription complete" });
 

--- a/src/utils/ai/providers/AILocalProvider.ts
+++ b/src/utils/ai/providers/AILocalProvider.ts
@@ -1,7 +1,10 @@
+import logger from "@app/logger";
 import { toFloat32Audio } from "@app/utils/audio/converter";
 import { formatBytes } from "@app/utils/format";
 import type { PipelineType } from "@huggingface/transformers";
 import { createLanguageDetector, type LanguageDetector } from "../LanguageDetector";
+import { getDefaultModel } from "../ModelManager";
+import { suppressConsoleWarnings } from "../suppress-warnings";
 import type {
     AIEmbeddingProvider,
     AISummarizationProvider,
@@ -15,7 +18,6 @@ import type {
     SummarizationResult,
     SummarizeOptions,
     TranscribeOptions,
-    TranscriptionChunk,
     TranscriptionResult,
     TranslateOptions,
     TranslationResult,
@@ -24,6 +26,7 @@ import type {
 type PipelineInstance = {
     (input: unknown, options?: Record<string, unknown>): Promise<unknown>;
     dispose(): Promise<void>;
+    tokenizer: unknown;
 };
 
 const SUPPORTED_TASKS: AITask[] = ["transcribe", "translate", "summarize", "embed"];
@@ -84,19 +87,30 @@ export class AILocalProvider
                 phase: "transcribe",
                 message: `Detected: ${language} (${Math.round(detected.confidence * 100)}% via ${detected.driver})`,
             });
+
+            // Allow caller to confirm/override the detected language (interactive prompt)
+            if (options?.confirmLanguage) {
+                const confirmed = await options.confirmLanguage(detected);
+
+                if (confirmed) {
+                    language = confirmed;
+                }
+            }
         }
 
         // whisper-large-v3-turbo: full large-v3 encoder (128 mel bins, 5M+ hours training data)
         // with only 4 decoder layers — near-large-v3 quality at ~2x speed. ~1.5GB (fp16 enc + q4 dec).
         // whisper-small was producing garbage for non-English (Czech especially).
-        const model = options?.model ?? "onnx-community/whisper-large-v3-turbo";
+        const model =
+            options?.model ?? getDefaultModel("transcribe", "local-hf") ?? "onnx-community/whisper-large-v3-turbo";
         const pipe = await this.getPipeline("automatic-speech-recognition", model, onProgress);
 
         const durationSec = audioData.length / 16000;
         // 29s instead of 30s: transformers.js bug #1358 causes timestamp collapse at exactly 30s
         const chunkLengthS = 29;
-        const totalChunks = Math.ceil(durationSec / chunkLengthS);
-        let processedChunks = 0;
+
+        logger.info(`[transcribe] start: ${Math.round(durationSec)}s audio, lang=${language}, model=${model}`);
+        const transcribeStart = Date.now();
 
         onProgress?.({
             phase: "transcribe",
@@ -104,12 +118,73 @@ export class AILocalProvider
             message: `Transcribing ${Math.round(durationSec)}s [${language}]...`,
         });
 
+        // WhisperTextStreamer (v3) fires on_chunk_start/on_chunk_end per timestamp
+        // token pair (every few seconds of audio), NOT per audio chunk.
+        // Use the timestamp time to calculate real progress against total duration.
+        const { WhisperTextStreamer } = await import("@huggingface/transformers");
+        let currentChunkText = "";
+        let lastProgressUpdate = 0;
+        let lastTimestamp = 0;
+        const PROGRESS_THROTTLE_MS = 300;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tokenizer type from pipeline internals
+        const streamer = new WhisperTextStreamer(pipe.tokenizer as any, {
+            skip_prompt: true,
+            skip_special_tokens: true,
+            callback_function: (text: string) => {
+                currentChunkText += text;
+                logger.debug(`[transcribe] token: "${text}" (accumulated ${currentChunkText.length} chars)`);
+
+                const now = Date.now();
+
+                if (now - lastProgressUpdate < PROGRESS_THROTTLE_MS) {
+                    return;
+                }
+
+                const elapsed = now - lastProgressUpdate;
+                lastProgressUpdate = now;
+                const pct = Math.min(99, Math.round((lastTimestamp / durationSec) * 100));
+                const truncated = currentChunkText.length > 60 ? `...${currentChunkText.slice(-57)}` : currentChunkText;
+
+                logger.info(`[transcribe] progress: ${pct}% ts=${lastTimestamp.toFixed(1)}s elapsed_since_last=${elapsed}ms`);
+
+                onProgress?.({
+                    phase: "transcribe",
+                    percent: pct,
+                    message: `[${language}] ${pct}% — ${truncated.trim()}`,
+                });
+            },
+            on_chunk_start: (time: number) => {
+                const elapsed = Date.now() - transcribeStart;
+                logger.info(`[transcribe] chunk_start: time=${time.toFixed(2)}s total_elapsed=${elapsed}ms`);
+                lastTimestamp = time;
+                currentChunkText = "";
+            },
+            on_chunk_end: (time: number) => {
+                const elapsed = Date.now() - transcribeStart;
+                logger.info(`[transcribe] chunk_end: time=${time.toFixed(2)}s text="${currentChunkText.slice(0, 80)}" total_elapsed=${elapsed}ms`);
+                lastTimestamp = time;
+
+                if (currentChunkText.trim()) {
+                    options?.onSegment?.({
+                        text: currentChunkText.trim(),
+                        start: time - chunkLengthS,
+                        end: time,
+                    });
+                }
+            },
+        });
+
+        logger.info(`[transcribe] calling pipeline with ${audioData.length} samples, chunk_length=${chunkLengthS}s, stride=5s`);
+        const pipeStart = Date.now();
+
         const result = (await pipe(audioData, {
             return_timestamps: true,
             chunk_length_s: chunkLengthS,
             stride_length_s: 5,
             language,
             task: "transcribe",
+            streamer,
             // Anti-hallucination params (from openai/whisper-large-v3 model card).
             // Without these, Whisper produces repetitive garbage for non-English languages
             // (e.g. "*vyskává výstře*" repeated 20+ times for Czech input).
@@ -119,41 +194,24 @@ export class AILocalProvider
             logprob_threshold: options?.thresholds?.logprobThreshold ?? -1.0,
             no_speech_threshold: options?.thresholds?.noSpeechThreshold ?? 0.45,
             no_repeat_ngram_size: options?.thresholds?.noRepeatNgramSize ?? 3,
-            // chunk_callback fires when each audio chunk is fully decoded — gives us
-            // the text + timestamps live, so the user sees progress as segments stream in.
-            chunk_callback: (chunk: TranscriptionChunk) => {
-                processedChunks++;
-                const pct = Math.min(100, Math.round((processedChunks / totalChunks) * 100));
-                const segText = chunk.text.trim();
-                const start = chunk.timestamp[0];
-                const end = chunk.timestamp[1] ?? start;
-
-                // Fire onSegment live so callers (spinner, UI) see text as it's transcribed
-                options?.onSegment?.({ text: segText, start, end });
-
-                onProgress?.({
-                    phase: "transcribe",
-                    percent: pct,
-                    message: `Transcribing [${language}]... ${pct}%`,
-                });
-            },
         })) as {
             text: string;
             chunks?: Array<{ text: string; timestamp: [number, number] }>;
         };
 
+        const pipeDuration = Date.now() - pipeStart;
+        const totalDuration = Date.now() - transcribeStart;
+        logger.info(`[transcribe] pipeline done: ${pipeDuration}ms, total=${totalDuration}ms, chunks=${result.chunks?.length ?? 0}, text=${result.text.length} chars`);
+
         onProgress?.({ phase: "transcribe", percent: 100, message: "Transcription complete" });
 
-        return {
-            text: result.text,
-            language,
-            duration: durationSec,
-            segments: result.chunks?.map((c) => ({
-                text: c.text,
-                start: c.timestamp[0],
-                end: c.timestamp[1],
-            })),
-        };
+        const segments = result.chunks?.map((c) => ({
+            text: c.text,
+            start: c.timestamp[0],
+            end: c.timestamp[1],
+        }));
+
+        return { text: result.text, language, duration: durationSec, segments };
     }
 
     async translate(text: string, options: TranslateOptions): Promise<TranslationResult> {
@@ -267,6 +325,10 @@ export class AILocalProvider
         const load = (async () => {
             const { pipeline, env } = await import("@huggingface/transformers");
 
+            const restoreWarnings = suppressConsoleWarnings({
+                patterns: ["Unable to determine content-length"],
+            });
+
             try {
                 const pipe = (await pipeline(task, model, {
                     // Whisper (encoder-decoder) is extremely sensitive to encoder quantization.
@@ -300,9 +362,11 @@ export class AILocalProvider
                         : undefined,
                 })) as unknown as PipelineInstance;
 
+                restoreWarnings();
                 this.pipelines.set(key, pipe);
                 return pipe;
             } catch (err) {
+                restoreWarnings();
                 const msg = err instanceof Error ? err.message : String(err);
 
                 if (msg.includes("Protobuf parsing failed") || msg.includes("Load model")) {
@@ -310,12 +374,18 @@ export class AILocalProvider
 
                     if (cacheDir) {
                         const { rmSync } = await import("node:fs");
-                        const modelCacheDir = `${cacheDir}/models--${model.replace(/\//g, "--")}`;
 
-                        try {
-                            rmSync(modelCacheDir, { recursive: true, force: true });
-                        } catch {
-                            // ignore cleanup errors
+                        // transformers.js uses <cacheDir>/<org>/<model>/ (direct path)
+                        const directCacheDir = `${cacheDir}/${model}`;
+                        // HF hub uses <cacheDir>/models--<org>--<model>/ (flattened)
+                        const hubCacheDir = `${cacheDir}/models--${model.replace(/\//g, "--")}`;
+
+                        for (const dir of [directCacheDir, hubCacheDir]) {
+                            try {
+                                rmSync(dir, { recursive: true, force: true });
+                            } catch {
+                                // ignore cleanup errors
+                            }
                         }
                     }
 

--- a/src/utils/ai/suppress-warnings.ts
+++ b/src/utils/ai/suppress-warnings.ts
@@ -1,0 +1,57 @@
+/**
+ * Suppress specific console.warn messages during noisy operations.
+ * Used to silence repeated warnings from libraries like @huggingface/transformers.
+ */
+
+export interface WarningSuppressionOptions {
+    /** Messages to suppress (partial match) */
+    patterns: string[];
+    /** Show the first occurrence of each pattern. Default: true */
+    showFirst?: boolean;
+}
+
+/**
+ * Monkey-patch console.warn to suppress specific messages.
+ * Returns a restore function — always call it in a finally block.
+ *
+ * ```typescript
+ * const restore = suppressConsoleWarnings({
+ *     patterns: ["Unable to determine content-length"],
+ * });
+ * try {
+ *     await noisyOperation();
+ * } finally {
+ *     restore();
+ * }
+ * ```
+ */
+// Global tracking — patterns shown once stay suppressed across calls
+const globalSeen = new Map<string, number>();
+
+export function suppressConsoleWarnings(options: WarningSuppressionOptions): () => void {
+    const original = console.warn;
+    const showFirst = options.showFirst ?? true;
+
+    console.warn = (...args: unknown[]) => {
+        const msg = args.map(String).join(" ");
+
+        for (const pattern of options.patterns) {
+            if (msg.includes(pattern)) {
+                const count = globalSeen.get(pattern) ?? 0;
+                globalSeen.set(pattern, count + 1);
+
+                if (count === 0 && showFirst) {
+                    original.call(console, ...args);
+                }
+
+                return;
+            }
+        }
+
+        original.call(console, ...args);
+    };
+
+    return () => {
+        console.warn = original;
+    };
+}

--- a/src/utils/ai/types.ts
+++ b/src/utils/ai/types.ts
@@ -38,6 +38,11 @@ export interface TranscribeOptions {
     /** Language detection config. Only used when `language` is not set. */
     languageDetection?: import("./LanguageDetector").LanguageDetectorOptions;
     /**
+     * Called after language auto-detection. Return a language code to override,
+     * or undefined to accept the detected language. Used for interactive confirmation.
+     */
+    confirmLanguage?: (detected: import("./LanguageDetector").LanguageDetectionResult) => Promise<string | undefined>;
+    /**
      * Whisper generation thresholds. Tune these for different audio types:
      * - Multi-speaker / background speech: lower noSpeechThreshold (e.g. 0.3), raise logprobThreshold (e.g. -0.5)
      * - Noisy recordings: raise compressionRatioThreshold (e.g. 2.0)

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -1,4 +1,5 @@
 import { createWriteStream, type WriteStream } from "node:fs";
+import { formatDateTime } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import pc from "picocolors";
 import type { IncludeSpec } from "./cli/dsl";
@@ -40,8 +41,7 @@ function stripAnsi(text: string): string {
 
 function formatTime(timestamp: string): string {
     try {
-        const d = new Date(timestamp);
-        return d.toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+        return formatDateTime(timestamp, { absolute: "time-seconds" });
     } catch {
         return "??:??:??";
     }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -110,10 +110,7 @@ export interface FormatDateTimeOptions {
  * - `{ relative: "two-days", absolute: "datetime", first: "relative" }` → "2h ago (22. 3. 2026, 20:53)"
  * - No options → defaults to `{ absolute: "datetime" }`
  */
-export function formatDateTime(
-    date: Date | string | number,
-    options: FormatDateTimeOptions = {},
-): string {
+export function formatDateTime(date: Date | string | number, options: FormatDateTimeOptions = {}): string {
     const d = date instanceof Date ? date : new Date(date);
     const locale = options.locale ?? getSystemLocale();
     const now = new Date();
@@ -148,19 +145,26 @@ export function formatDateTime(
 // ---- Absolute ----
 
 const ABSOLUTE_OPTIONS: Record<AbsoluteFormat, Intl.DateTimeFormatOptions> = {
-    "date": { year: "numeric", month: "numeric", day: "numeric" },
-    "time": { hour: "2-digit", minute: "2-digit" },
-    "datetime": {
-        year: "numeric", month: "numeric", day: "numeric",
-        hour: "2-digit", minute: "2-digit",
+    date: { year: "numeric", month: "numeric", day: "numeric" },
+    time: { hour: "2-digit", minute: "2-digit" },
+    datetime: {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
     },
     "date-long": { weekday: "long", year: "numeric", month: "long", day: "numeric" },
     "date-short": { month: "numeric", day: "numeric" },
     "datetime-long": {
-        weekday: "long", year: "numeric", month: "long", day: "numeric",
-        hour: "2-digit", minute: "2-digit",
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
     },
-    "weekday": { weekday: "long" },
+    weekday: { weekday: "long" },
     "month-day": { month: "short", day: "numeric" },
     "time-seconds": { hour: "2-digit", minute: "2-digit", second: "2-digit" },
 };
@@ -212,13 +216,7 @@ function relativeFormat(date: Date, now: Date, mode: RelativeFormat): string | n
     return relativeFormatShort(days, hours, minutes, seconds, suffix);
 }
 
-function relativeFormatLong(
-    days: number,
-    hours: number,
-    minutes: number,
-    seconds: number,
-    suffix: string,
-): string {
+function relativeFormatLong(days: number, hours: number, minutes: number, seconds: number, suffix: string): string {
     if (seconds < 60) {
         return `${seconds} second${seconds !== 1 ? "s" : ""} ${suffix}`;
     }
@@ -255,13 +253,7 @@ function relativeFormatLong(
     return `${parts.join(" ")} ${suffix}`;
 }
 
-function relativeFormatShort(
-    days: number,
-    hours: number,
-    minutes: number,
-    seconds: number,
-    suffix: string,
-): string {
+function relativeFormatShort(days: number, hours: number, minutes: number, seconds: number, suffix: string): string {
     if (seconds < 60) {
         return `${seconds}s ${suffix}`;
     }
@@ -278,11 +270,7 @@ function relativeFormatShort(
 }
 
 function isSameCalendarDay(a: Date, b: Date): boolean {
-    return (
-        a.getFullYear() === b.getFullYear() &&
-        a.getMonth() === b.getMonth() &&
-        a.getDate() === b.getDate()
-    );
+    return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 }
 
 // ============================================

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,6 +2,293 @@
  * Shared date utilities for CLI tools.
  */
 
+import { execSync } from "node:child_process";
+
+// ============================================
+// Locale Detection
+// ============================================
+
+let cachedLocale: string | undefined;
+
+/**
+ * Detect system locale.
+ * macOS: `defaults read NSGlobalDomain AppleLocale` (e.g. "cs_CZ" → "cs-CZ")
+ * Fallback: $LC_TIME / $LANG / $LC_ALL → Intl default
+ */
+export function getSystemLocale(): string {
+    if (cachedLocale) {
+        return cachedLocale;
+    }
+
+    if (process.platform === "darwin") {
+        try {
+            const raw = execSync("defaults read NSGlobalDomain AppleLocale", {
+                encoding: "utf-8",
+                timeout: 1000,
+            }).trim();
+
+            if (raw) {
+                // AppleLocale format: "en_US@rg=czzzzz" where:
+                // - "en_US" is language_region
+                // - "@rg=czzzzz" means "use Czech Republic regional formats" (24h time, date order, etc.)
+                // We parse the rg= suffix to get the actual regional country code,
+                // so "en_US@rg=czzzzz" → "en-CZ" (English with Czech regional formats → 24h time)
+                const [base, suffix] = raw.split("@");
+                let locale = base.replace(/_/g, "-");
+
+                if (suffix) {
+                    const rgMatch = suffix.match(/rg=([a-z]{2})/i);
+
+                    if (rgMatch) {
+                        const regionCode = rgMatch[1].toUpperCase();
+                        const lang = locale.split("-")[0];
+                        locale = `${lang}-${regionCode}`;
+                    }
+                }
+
+                cachedLocale = locale;
+                return cachedLocale;
+            }
+        } catch {
+            // fall through
+        }
+    }
+
+    const envLocale = process.env.LC_TIME || process.env.LANG || process.env.LC_ALL;
+
+    if (envLocale) {
+        cachedLocale = envLocale.split(".")[0].replace(/_/g, "-");
+        return cachedLocale;
+    }
+
+    cachedLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
+    return cachedLocale;
+}
+
+// ============================================
+// Locale-Aware Display Formatting
+// ============================================
+
+export type AbsoluteFormat =
+    | "date" // "21. 3. 2026" (locale)
+    | "time" // "20:53" (locale)
+    | "datetime" // "21. 3. 2026 20:53" (locale)
+    | "date-long" // "Saturday, 21 March 2026" (locale)
+    | "date-short" // "21. 3." or "3/21" (locale, no year)
+    | "datetime-long" // "Saturday, 21 March 2026, 20:53" (locale)
+    | "weekday" // "Saturday" (locale)
+    | "month-day" // "Mar 21" or "21. bře" (locale)
+    | "time-seconds"; // "20:53:12" (locale)
+
+export type RelativeFormat =
+    | "this-day" // relative only within today, absolute otherwise
+    | "two-days" // relative within 48h, absolute otherwise
+    | "always-relative-short" // "2h ago", "3d ago"
+    | "always-relative-long"; // "2 hours 30 minutes ago", shows seconds if < 1 min
+
+export interface FormatDateTimeOptions {
+    /** Show relative time. Controls the threshold for relative display. */
+    relative?: RelativeFormat;
+    /** Show absolute time. Controls the detail level. Default: "datetime" */
+    absolute?: AbsoluteFormat;
+    /**
+     * When both relative and absolute are requested, which comes first?
+     * Default: "absolute" → "22. 3. 2026, 20:04 (1h ago)"
+     * "relative" → "1h ago (22. 3. 2026, 20:04)"
+     */
+    first?: "absolute" | "relative";
+    /** Override locale (default: system locale via getSystemLocale()) */
+    locale?: string;
+}
+
+/**
+ * Format a date/time for CLI display using system locale.
+ *
+ * - `{ absolute: "datetime" }` → "21. 3. 2026 20:53" (locale-formatted)
+ * - `{ relative: "two-days" }` → "2 hours ago" or absolute if older
+ * - `{ relative: "two-days", absolute: "datetime" }` → "22. 3. 2026, 20:53 (2h ago)"
+ * - `{ relative: "two-days", absolute: "datetime", first: "relative" }` → "2h ago (22. 3. 2026, 20:53)"
+ * - No options → defaults to `{ absolute: "datetime" }`
+ */
+export function formatDateTime(
+    date: Date | string | number,
+    options: FormatDateTimeOptions = {},
+): string {
+    const d = date instanceof Date ? date : new Date(date);
+    const locale = options.locale ?? getSystemLocale();
+    const now = new Date();
+
+    const hasRelative = options.relative !== undefined;
+    const hasAbsolute = options.absolute !== undefined;
+
+    if (!hasRelative && !hasAbsolute) {
+        return absoluteFormat(d, "datetime", locale);
+    }
+
+    const relativeStr = hasRelative ? relativeFormat(d, now, options.relative!) : null;
+    const absoluteStr = hasAbsolute ? absoluteFormat(d, options.absolute!, locale) : null;
+
+    if (relativeStr && absoluteStr) {
+        const first = options.first ?? "absolute";
+
+        if (first === "relative") {
+            return `${relativeStr} (${absoluteStr})`;
+        }
+
+        return `${absoluteStr} (${relativeStr})`;
+    }
+
+    if (hasRelative && !hasAbsolute) {
+        return relativeStr ?? absoluteFormat(d, "datetime", locale);
+    }
+
+    return absoluteStr ?? absoluteFormat(d, "datetime", locale);
+}
+
+// ---- Absolute ----
+
+const ABSOLUTE_OPTIONS: Record<AbsoluteFormat, Intl.DateTimeFormatOptions> = {
+    "date": { year: "numeric", month: "numeric", day: "numeric" },
+    "time": { hour: "2-digit", minute: "2-digit" },
+    "datetime": {
+        year: "numeric", month: "numeric", day: "numeric",
+        hour: "2-digit", minute: "2-digit",
+    },
+    "date-long": { weekday: "long", year: "numeric", month: "long", day: "numeric" },
+    "date-short": { month: "numeric", day: "numeric" },
+    "datetime-long": {
+        weekday: "long", year: "numeric", month: "long", day: "numeric",
+        hour: "2-digit", minute: "2-digit",
+    },
+    "weekday": { weekday: "long" },
+    "month-day": { month: "short", day: "numeric" },
+    "time-seconds": { hour: "2-digit", minute: "2-digit", second: "2-digit" },
+};
+
+function absoluteFormat(date: Date, format: AbsoluteFormat, locale: string): string {
+    return new Intl.DateTimeFormat(locale, ABSOLUTE_OPTIONS[format]).format(date);
+}
+
+// ---- Relative ----
+
+function relativeFormat(date: Date, now: Date, mode: RelativeFormat): string | null {
+    const diffMs = now.getTime() - date.getTime();
+    const isFuture = diffMs < 0;
+    const absDiffMs = Math.abs(diffMs);
+
+    const seconds = Math.floor(absDiffMs / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    const suffix = isFuture ? "from now" : "ago";
+
+    switch (mode) {
+        case "this-day": {
+            if (!isSameCalendarDay(date, now)) {
+                return null;
+            }
+
+            break;
+        }
+
+        case "two-days": {
+            if (absDiffMs > 48 * 60 * 60 * 1000) {
+                return null;
+            }
+
+            break;
+        }
+
+        case "always-relative-short":
+        case "always-relative-long":
+            break;
+    }
+
+    if (mode === "always-relative-long") {
+        return relativeFormatLong(days, hours, minutes, seconds, suffix);
+    }
+
+    return relativeFormatShort(days, hours, minutes, seconds, suffix);
+}
+
+function relativeFormatLong(
+    days: number,
+    hours: number,
+    minutes: number,
+    seconds: number,
+    suffix: string,
+): string {
+    if (seconds < 60) {
+        return `${seconds} second${seconds !== 1 ? "s" : ""} ${suffix}`;
+    }
+
+    if (minutes < 60) {
+        const remSec = seconds % 60;
+        const parts = [`${minutes} minute${minutes !== 1 ? "s" : ""}`];
+
+        if (remSec > 0) {
+            parts.push(`${remSec} second${remSec !== 1 ? "s" : ""}`);
+        }
+
+        return `${parts.join(" ")} ${suffix}`;
+    }
+
+    if (hours < 24) {
+        const remMin = minutes % 60;
+        const parts = [`${hours} hour${hours !== 1 ? "s" : ""}`];
+
+        if (remMin > 0) {
+            parts.push(`${remMin} minute${remMin !== 1 ? "s" : ""}`);
+        }
+
+        return `${parts.join(" ")} ${suffix}`;
+    }
+
+    const remHours = hours % 24;
+    const parts = [`${days} day${days !== 1 ? "s" : ""}`];
+
+    if (remHours > 0) {
+        parts.push(`${remHours} hour${remHours !== 1 ? "s" : ""}`);
+    }
+
+    return `${parts.join(" ")} ${suffix}`;
+}
+
+function relativeFormatShort(
+    days: number,
+    hours: number,
+    minutes: number,
+    seconds: number,
+    suffix: string,
+): string {
+    if (seconds < 60) {
+        return `${seconds}s ${suffix}`;
+    }
+
+    if (minutes < 60) {
+        return `${minutes}m ${suffix}`;
+    }
+
+    if (hours < 24) {
+        return `${hours}h ${suffix}`;
+    }
+
+    return `${days}d ${suffix}`;
+}
+
+function isSameCalendarDay(a: Date, b: Date): boolean {
+    return (
+        a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+    );
+}
+
+// ============================================
+// Date Parsing & Calendar Utilities
+// ============================================
+
 /**
  * Parse a date string (e.g. "YYYY-MM-DD") and throw on invalid input.
  */

--- a/src/utils/macos/voice-memos.ts
+++ b/src/utils/macos/voice-memos.ts
@@ -121,7 +121,9 @@ function openDb(dbPath: string): Database {
 }
 
 function rowToMemo(row: DbRow, recordingsDir: string): VoiceMemo {
-    const title = row.ZCUSTOMLABEL || row.ZENCRYPTEDTITLE || "Untitled";
+    // ZENCRYPTEDTITLE has the human-readable name ("New Recording 64"),
+    // ZCUSTOMLABEL has the ISO timestamp used as a fallback identifier
+    const title = row.ZENCRYPTEDTITLE || row.ZCUSTOMLABEL || "Untitled";
     const date = new Date((row.ZDATE + APPLE_EPOCH_OFFSET) * 1000);
     const duration = row.ZDURATION;
 

--- a/src/utils/prompts/clack/file-path.test.ts
+++ b/src/utils/prompts/clack/file-path.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The filePathInput function is interactive (readline + raw mode), so we can't
+ * easily test the full prompt loop. Instead, we test the internal logic:
+ * - Path expansion (~/  ./  relative)
+ * - Directory reading + filtering
+ * - Tab completion (common prefix, single match)
+ * - Entry sorting (directories first)
+ * - Extension filtering
+ *
+ * We extract the pure functions and test them directly, then verify the
+ * module exports correctly.
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers that mirror the internal logic of file-path.ts
+// These are the same algorithms used inside the prompt — tested in isolation.
+// ---------------------------------------------------------------------------
+
+function expandPath(p: string): string {
+    if (p.startsWith("~/")) {
+        return join(homedir(), p.slice(2));
+    }
+
+    if (p.startsWith("./")) {
+        return join(process.cwd(), p.slice(2));
+    }
+
+    if (!p.startsWith("/")) {
+        return join(process.cwd(), p);
+    }
+
+    return p;
+}
+
+interface DirEntry {
+    name: string;
+    isDirectory: boolean;
+}
+
+function getCommonPrefix(entries: DirEntry[]): string {
+    if (entries.length === 0) {
+        return "";
+    }
+
+    let common = entries[0].name;
+
+    for (let i = 1; i < entries.length; i++) {
+        const name = entries[i].name;
+        let j = 0;
+
+        while (j < common.length && j < name.length && common[j] === name[j]) {
+            j++;
+        }
+
+        common = common.slice(0, j);
+    }
+
+    return common;
+}
+
+function sortEntries(entries: DirEntry[]): DirEntry[] {
+    return [...entries].sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) {
+            return a.isDirectory ? -1 : 1;
+        }
+
+        return a.name.localeCompare(b.name);
+    });
+}
+
+function filterEntries(
+    entries: DirEntry[],
+    opts: { filter?: "all" | "directories" | "files"; extensions?: string[]; prefix?: string },
+): DirEntry[] {
+    return entries.filter((entry) => {
+        if (entry.name.startsWith(".")) {
+            return false;
+        }
+
+        if (opts.filter === "directories" && !entry.isDirectory) {
+            return false;
+        }
+
+        if (opts.filter === "files" && entry.isDirectory) {
+            return false;
+        }
+
+        if (opts.extensions && !entry.isDirectory) {
+            const hasExt = opts.extensions.some((ext) => entry.name.endsWith(ext));
+
+            if (!hasExt) {
+                return false;
+            }
+        }
+
+        if (opts.prefix && !entry.name.toLowerCase().startsWith(opts.prefix.toLowerCase())) {
+            return false;
+        }
+
+        return true;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("file-path: expandPath", () => {
+    it("expands ~/ to home directory", () => {
+        const result = expandPath("~/Downloads");
+        expect(result).toBe(join(homedir(), "Downloads"));
+    });
+
+    it("expands ~/ with nested path", () => {
+        const result = expandPath("~/Documents/sub/file.txt");
+        expect(result).toBe(join(homedir(), "Documents/sub/file.txt"));
+    });
+
+    it("expands ./ to cwd", () => {
+        const result = expandPath("./src/file.ts");
+        expect(result).toBe(join(process.cwd(), "src/file.ts"));
+    });
+
+    it("keeps absolute paths unchanged", () => {
+        const result = expandPath("/usr/local/bin");
+        expect(result).toBe("/usr/local/bin");
+    });
+
+    it("treats relative paths as relative to cwd", () => {
+        const result = expandPath("src/file.ts");
+        expect(result).toBe(join(process.cwd(), "src/file.ts"));
+    });
+
+    it("handles ~/ with trailing slash", () => {
+        const result = expandPath("~/");
+        expect(result).toBe(homedir());
+    });
+});
+
+describe("file-path: getCommonPrefix", () => {
+    it("returns empty for empty array", () => {
+        expect(getCommonPrefix([])).toBe("");
+    });
+
+    it("returns full name for single entry", () => {
+        expect(getCommonPrefix([{ name: "file.txt", isDirectory: false }])).toBe("file.txt");
+    });
+
+    it("finds common prefix of multiple entries", () => {
+        const entries: DirEntry[] = [
+            { name: "transcript.srt", isDirectory: false },
+            { name: "transcript.vtt", isDirectory: false },
+            { name: "transcript.txt", isDirectory: false },
+        ];
+        expect(getCommonPrefix(entries)).toBe("transcript.");
+    });
+
+    it("returns empty when no common prefix", () => {
+        const entries: DirEntry[] = [
+            { name: "alpha.txt", isDirectory: false },
+            { name: "beta.txt", isDirectory: false },
+        ];
+        expect(getCommonPrefix(entries)).toBe("");
+    });
+
+    it("handles prefix of different lengths", () => {
+        const entries: DirEntry[] = [
+            { name: "App", isDirectory: true },
+            { name: "App.tsx", isDirectory: false },
+            { name: "Application", isDirectory: true },
+        ];
+        expect(getCommonPrefix(entries)).toBe("App");
+    });
+
+    it("handles single character common prefix", () => {
+        const entries: DirEntry[] = [
+            { name: "src", isDirectory: true },
+            { name: "scripts", isDirectory: true },
+        ];
+        expect(getCommonPrefix(entries)).toBe("s");
+    });
+});
+
+describe("file-path: sortEntries", () => {
+    it("sorts directories before files", () => {
+        const entries: DirEntry[] = [
+            { name: "file.txt", isDirectory: false },
+            { name: "dir", isDirectory: true },
+            { name: "another.ts", isDirectory: false },
+            { name: "adir", isDirectory: true },
+        ];
+
+        const sorted = sortEntries(entries);
+        expect(sorted[0].name).toBe("adir");
+        expect(sorted[1].name).toBe("dir");
+        expect(sorted[2].name).toBe("another.ts");
+        expect(sorted[3].name).toBe("file.txt");
+    });
+
+    it("sorts alphabetically within same type", () => {
+        const entries: DirEntry[] = [
+            { name: "zebra", isDirectory: true },
+            { name: "alpha", isDirectory: true },
+            { name: "middle", isDirectory: true },
+        ];
+
+        const sorted = sortEntries(entries);
+        expect(sorted.map((e) => e.name)).toEqual(["alpha", "middle", "zebra"]);
+    });
+
+    it("handles empty array", () => {
+        expect(sortEntries([])).toEqual([]);
+    });
+
+    it("handles single entry", () => {
+        const entries: DirEntry[] = [{ name: "only", isDirectory: false }];
+        expect(sortEntries(entries)).toEqual(entries);
+    });
+});
+
+describe("file-path: filterEntries", () => {
+    const testEntries: DirEntry[] = [
+        { name: ".hidden", isDirectory: false },
+        { name: "Documents", isDirectory: true },
+        { name: "Downloads", isDirectory: true },
+        { name: "file.txt", isDirectory: false },
+        { name: "image.png", isDirectory: false },
+        { name: "transcript.srt", isDirectory: false },
+        { name: "transcript.vtt", isDirectory: false },
+    ];
+
+    it("filters out hidden files (dotfiles)", () => {
+        const result = filterEntries(testEntries, {});
+        expect(result.some((e) => e.name === ".hidden")).toBe(false);
+        expect(result.length).toBe(6);
+    });
+
+    it("filters to directories only", () => {
+        const result = filterEntries(testEntries, { filter: "directories" });
+        expect(result.every((e) => e.isDirectory)).toBe(true);
+        expect(result.length).toBe(2);
+    });
+
+    it("filters to files only", () => {
+        const result = filterEntries(testEntries, { filter: "files" });
+        expect(result.every((e) => !e.isDirectory)).toBe(true);
+        expect(result.length).toBe(4); // excludes .hidden
+    });
+
+    it("filters by extension", () => {
+        const result = filterEntries(testEntries, { extensions: [".srt", ".vtt"] });
+        expect(result.map((e) => e.name)).toEqual([
+            "Documents",
+            "Downloads",
+            "transcript.srt",
+            "transcript.vtt",
+        ]);
+    });
+
+    it("filters by prefix", () => {
+        const result = filterEntries(testEntries, { prefix: "Do" });
+        expect(result.map((e) => e.name)).toEqual(["Documents", "Downloads"]);
+    });
+
+    it("prefix filter is case-insensitive", () => {
+        const result = filterEntries(testEntries, { prefix: "do" });
+        expect(result.map((e) => e.name)).toEqual(["Documents", "Downloads"]);
+    });
+
+    it("combines extension + prefix filters", () => {
+        const result = filterEntries(testEntries, { prefix: "trans", extensions: [".srt"] });
+        // Directories pass extension filter, plus matching files
+        expect(result.map((e) => e.name)).toEqual(["transcript.srt"]);
+    });
+
+    it("returns empty for no matches", () => {
+        const result = filterEntries(testEntries, { prefix: "zzz" });
+        expect(result).toEqual([]);
+    });
+
+    it("all filter passes everything except hidden", () => {
+        const result = filterEntries(testEntries, { filter: "all" });
+        expect(result.length).toBe(6);
+    });
+});
+
+describe("file-path: readDir integration", () => {
+    it("reads the actual cwd directory", () => {
+        const entries = readdirSync(process.cwd(), { withFileTypes: true });
+        expect(entries.length).toBeGreaterThan(0);
+    });
+
+    it("reads home directory via expandPath", () => {
+        const home = expandPath("~/");
+        const entries = readdirSync(home, { withFileTypes: true });
+        expect(entries.length).toBeGreaterThan(0);
+    });
+});
+
+describe("file-path: tab completion simulation", () => {
+    it("single match completes with / for directories", () => {
+        // Simulate: value = "~/Dow" → tab → "~/Downloads/"
+        const entries: DirEntry[] = [{ name: "Downloads", isDirectory: true }];
+        const common = getCommonPrefix(entries);
+        const entry = entries[0];
+        const suffix = entry.isDirectory ? "/" : "";
+        expect(common + suffix).toBe("Downloads/");
+    });
+
+    it("single match completes without / for files", () => {
+        const entries: DirEntry[] = [{ name: "transcript.srt", isDirectory: false }];
+        const common = getCommonPrefix(entries);
+        const entry = entries[0];
+        const suffix = entry.isDirectory ? "/" : "";
+        expect(common + suffix).toBe("transcript.srt");
+    });
+
+    it("multiple matches complete to common prefix only", () => {
+        const entries: DirEntry[] = [
+            { name: "Documents", isDirectory: true },
+            { name: "Downloads", isDirectory: true },
+        ];
+        const common = getCommonPrefix(entries);
+        expect(common).toBe("Do");
+    });
+
+    it("no common prefix means no completion", () => {
+        const entries: DirEntry[] = [
+            { name: "src", isDirectory: true },
+            { name: "package.json", isDirectory: false },
+        ];
+        const common = getCommonPrefix(entries);
+        expect(common).toBe("");
+    });
+});
+
+describe("file-path: module exports", () => {
+    it("exports filePathInput function", async () => {
+        const mod = await import("./file-path");
+        expect(typeof mod.filePathInput).toBe("function");
+    });
+
+    it("exports filePathCancelSymbol", async () => {
+        const mod = await import("./file-path");
+        expect(typeof mod.filePathCancelSymbol).toBe("symbol");
+    });
+
+    it("exports FilePathInputOptions type", async () => {
+        // Type-only check — if this compiles, the type exists
+        const mod = await import("./file-path");
+        const _fn: (opts: import("./file-path").FilePathInputOptions) => Promise<string | symbol> = mod.filePathInput;
+        expect(_fn).toBeDefined();
+    });
+});

--- a/src/utils/prompts/clack/file-path.test.ts
+++ b/src/utils/prompts/clack/file-path.test.ts
@@ -75,7 +75,7 @@ function sortEntries(entries: DirEntry[]): DirEntry[] {
 
 function filterEntries(
     entries: DirEntry[],
-    opts: { filter?: "all" | "directories" | "files"; extensions?: string[]; prefix?: string },
+    opts: { filter?: "all" | "directories" | "files"; extensions?: string[]; prefix?: string }
 ): DirEntry[] {
     return entries.filter((entry) => {
         if (entry.name.startsWith(".")) {
@@ -254,12 +254,7 @@ describe("file-path: filterEntries", () => {
 
     it("filters by extension", () => {
         const result = filterEntries(testEntries, { extensions: [".srt", ".vtt"] });
-        expect(result.map((e) => e.name)).toEqual([
-            "Documents",
-            "Downloads",
-            "transcript.srt",
-            "transcript.vtt",
-        ]);
+        expect(result.map((e) => e.name)).toEqual(["Documents", "Downloads", "transcript.srt", "transcript.vtt"]);
     });
 
     it("filters by prefix", () => {

--- a/src/utils/prompts/clack/file-path.ts
+++ b/src/utils/prompts/clack/file-path.ts
@@ -5,7 +5,7 @@
 
 import { readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, basename } from "node:path";
+import { basename, dirname, join } from "node:path";
 import * as readline from "node:readline";
 import { Writable } from "node:stream";
 import pc from "picocolors";
@@ -57,7 +57,7 @@ interface DirEntry {
 export async function filePathInput(options: FilePathInputOptions): Promise<string | symbol> {
     const {
         message,
-        initialValue = process.cwd() + "/",
+        initialValue = `${process.cwd()}/`,
         listPossibilities = true,
         filter = "all",
         extensions,
@@ -214,7 +214,9 @@ export async function filePathInput(options: FilePathInputOptions): Promise<stri
                         // Compute column widths
                         const maxNameLen = Math.min(
                             50,
-                            Math.max(...entries.slice(0, maxVisible).map((e) => (e.name + (e.isDirectory ? "/" : "")).length)),
+                            Math.max(
+                                ...entries.slice(0, maxVisible).map((e) => (e.name + (e.isDirectory ? "/" : "")).length)
+                            )
                         );
 
                         const visibleEntries = entries.slice(0, maxVisible);
@@ -227,7 +229,9 @@ export async function filePathInput(options: FilePathInputOptions): Promise<stri
                             const isCur = i === cursor;
 
                             if (isCur) {
-                                lines.push(`${S_BAR}  ${pc.cyan("\u276F")} ${pc.underline(padded)}${pc.dim(typeLabel)}`);
+                                lines.push(
+                                    `${S_BAR}  ${pc.cyan("\u276F")} ${pc.underline(padded)}${pc.dim(typeLabel)}`
+                                );
                             } else {
                                 lines.push(`${S_BAR}    ${padded}${pc.dim(typeLabel)}`);
                             }

--- a/src/utils/prompts/clack/file-path.ts
+++ b/src/utils/prompts/clack/file-path.ts
@@ -1,0 +1,395 @@
+/**
+ * Interactive file path input with zsh-style tab completion and live directory listing.
+ * Reusable utility — not specific to any tool.
+ */
+
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, basename } from "node:path";
+import * as readline from "node:readline";
+import { Writable } from "node:stream";
+import pc from "picocolors";
+
+// Silent writable stream to prevent readline from echoing input
+const silentOutput = new Writable({
+    write(_chunk, _encoding, callback) {
+        callback();
+    },
+});
+
+// Clack-consistent symbols
+const S_STEP_ACTIVE = pc.green("\u25C6");
+const S_STEP_CANCEL = pc.red("\u25A0");
+const S_STEP_SUBMIT = pc.green("\u25C7");
+const S_BAR = pc.dim("\u2502");
+
+export const filePathCancelSymbol = Symbol("cancel");
+
+export interface FilePathInputOptions {
+    message: string;
+    /** Initial path value. Defaults to cwd + "/" */
+    initialValue?: string;
+    /** Show live directory listing below input as user types. Default: true */
+    listPossibilities?: boolean;
+    /** Filter: "all" | "directories" | "files". Default: "all" */
+    filter?: "all" | "directories" | "files";
+    /** File extension filter, e.g. [".srt", ".vtt"] */
+    extensions?: string[];
+    /** Max entries to show in the listing. Default: 12 */
+    maxVisible?: number;
+}
+
+interface DirEntry {
+    name: string;
+    isDirectory: boolean;
+}
+
+/**
+ * Interactive file path input with zsh-style tab completion.
+ *
+ * Features:
+ * - Live directory listing below input as you type
+ * - Tab completion (single match → complete, multiple → common prefix)
+ * - Arrow keys to navigate listing, Enter to select
+ * - ~/  and ./ expansion
+ * - Two-column layout: name on left, type on right
+ */
+export async function filePathInput(options: FilePathInputOptions): Promise<string | symbol> {
+    const {
+        message,
+        initialValue = process.cwd() + "/",
+        listPossibilities = true,
+        filter = "all",
+        extensions,
+        maxVisible = 12,
+    } = options;
+
+    return new Promise((resolvePromise) => {
+        const rl = readline.createInterface({
+            input: process.stdin,
+            output: silentOutput,
+            terminal: false,
+        });
+
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+        }
+
+        readline.emitKeypressEvents(process.stdin, rl);
+
+        let value = initialValue;
+        let cursor = -1; // -1 = input focused (no listing highlight)
+        let lastRenderHeight = 0;
+
+        const expandPath = (p: string): string => {
+            if (p.startsWith("~/")) {
+                return join(homedir(), p.slice(2));
+            }
+
+            if (p.startsWith("./")) {
+                return join(process.cwd(), p.slice(2));
+            }
+
+            if (!p.startsWith("/")) {
+                return join(process.cwd(), p);
+            }
+
+            return p;
+        };
+
+        const readDir = (): DirEntry[] => {
+            const expanded = expandPath(value);
+            let dir: string;
+            let prefix: string;
+
+            if (value.endsWith("/")) {
+                dir = expanded;
+                prefix = "";
+            } else {
+                dir = dirname(expanded);
+                prefix = basename(expanded).toLowerCase();
+            }
+
+            try {
+                const entries = readdirSync(dir, { withFileTypes: true });
+                const result: DirEntry[] = [];
+
+                for (const entry of entries) {
+                    if (entry.name.startsWith(".")) {
+                        continue;
+                    }
+
+                    const isDir = entry.isDirectory();
+
+                    if (filter === "directories" && !isDir) {
+                        continue;
+                    }
+
+                    if (filter === "files" && isDir) {
+                        continue;
+                    }
+
+                    if (extensions && !isDir) {
+                        const hasExt = extensions.some((ext) => entry.name.endsWith(ext));
+
+                        if (!hasExt) {
+                            continue;
+                        }
+                    }
+
+                    if (prefix && !entry.name.toLowerCase().startsWith(prefix)) {
+                        continue;
+                    }
+
+                    result.push({ name: entry.name, isDirectory: isDir });
+                }
+
+                result.sort((a, b) => {
+                    if (a.isDirectory !== b.isDirectory) {
+                        return a.isDirectory ? -1 : 1;
+                    }
+
+                    return a.name.localeCompare(b.name);
+                });
+
+                return result;
+            } catch {
+                return [];
+            }
+        };
+
+        const getCommonPrefix = (entries: DirEntry[]): string => {
+            if (entries.length === 0) {
+                return "";
+            }
+
+            let common = entries[0].name;
+
+            for (let i = 1; i < entries.length; i++) {
+                const name = entries[i].name;
+                let j = 0;
+
+                while (j < common.length && j < name.length && common[j] === name[j]) {
+                    j++;
+                }
+
+                common = common.slice(0, j);
+            }
+
+            return common;
+        };
+
+        const clearRender = (): void => {
+            if (lastRenderHeight > 0) {
+                process.stdout.write(`\x1b[${lastRenderHeight}A`);
+
+                for (let i = 0; i < lastRenderHeight; i++) {
+                    process.stdout.write("\x1b[2K\x1b[1B");
+                }
+
+                process.stdout.write(`\x1b[${lastRenderHeight}A`);
+            }
+        };
+
+        const render = (state: "active" | "submit" | "cancel" = "active"): void => {
+            clearRender();
+
+            const lines: string[] = [];
+
+            // Header
+            const icon = state === "active" ? S_STEP_ACTIVE : state === "cancel" ? S_STEP_CANCEL : S_STEP_SUBMIT;
+            lines.push(`${icon}  ${pc.bold(message)}`);
+
+            if (state === "active") {
+                // Input line with cursor
+                const cursorChar = cursor === -1 ? pc.inverse(" ") : " ";
+                lines.push(`${S_BAR}  ${value}${cursorChar}`);
+
+                if (listPossibilities) {
+                    const entries = readDir();
+
+                    if (entries.length > 0) {
+                        lines.push(`${S_BAR}`);
+
+                        // Compute column widths
+                        const maxNameLen = Math.min(
+                            50,
+                            Math.max(...entries.slice(0, maxVisible).map((e) => (e.name + (e.isDirectory ? "/" : "")).length)),
+                        );
+
+                        const visibleEntries = entries.slice(0, maxVisible);
+
+                        for (let i = 0; i < visibleEntries.length; i++) {
+                            const entry = visibleEntries[i];
+                            const displayName = entry.name + (entry.isDirectory ? "/" : "");
+                            const typeLabel = entry.isDirectory ? "directory" : "file";
+                            const padded = displayName.padEnd(maxNameLen + 4);
+                            const isCur = i === cursor;
+
+                            if (isCur) {
+                                lines.push(`${S_BAR}  ${pc.cyan("\u276F")} ${pc.underline(padded)}${pc.dim(typeLabel)}`);
+                            } else {
+                                lines.push(`${S_BAR}    ${padded}${pc.dim(typeLabel)}`);
+                            }
+                        }
+
+                        if (entries.length > maxVisible) {
+                            lines.push(`${S_BAR}    ${pc.dim(`\u2193 ${entries.length - maxVisible} more`)}`);
+                        }
+                    } else {
+                        lines.push(`${S_BAR}`);
+                        lines.push(`${S_BAR}    ${pc.dim("No matches")}`);
+                    }
+                }
+
+                lines.push(`${S_BAR}  ${pc.dim("tab complete · \u2191\u2193 navigate · enter select")}`);
+                lines.push(`${pc.dim("\u2514")}`);
+            } else if (state === "submit") {
+                lines.push(`${S_BAR}  ${pc.dim(value)}`);
+            } else if (state === "cancel") {
+                lines.push(`${S_BAR}  ${pc.strikethrough(pc.dim("Cancelled"))}`);
+            }
+
+            process.stdout.write(`${lines.join("\n")}\n`);
+            lastRenderHeight = lines.length;
+        };
+
+        const cleanup = (): void => {
+            process.stdin.removeListener("keypress", keypressHandler);
+
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(false);
+            }
+
+            rl.close();
+        };
+
+        const submit = (): void => {
+            render("submit");
+            cleanup();
+            resolvePromise(expandPath(value));
+        };
+
+        const cancel = (): void => {
+            render("cancel");
+            cleanup();
+            resolvePromise(filePathCancelSymbol);
+        };
+
+        const tabComplete = (): void => {
+            const entries = readDir();
+
+            if (entries.length === 0) {
+                return;
+            }
+
+            if (entries.length === 1) {
+                // Single match — complete it
+                const entry = entries[0];
+                const dir = value.endsWith("/") ? value : value.slice(0, value.lastIndexOf("/") + 1);
+                value = dir + entry.name + (entry.isDirectory ? "/" : "");
+                cursor = -1;
+                render();
+                return;
+            }
+
+            // Multiple matches — complete common prefix
+            const common = getCommonPrefix(entries);
+
+            if (common) {
+                const dir = value.endsWith("/") ? value : value.slice(0, value.lastIndexOf("/") + 1);
+                const currentBasename = value.endsWith("/") ? "" : basename(value);
+
+                if (common.length > currentBasename.length) {
+                    value = dir + common;
+                    cursor = -1;
+                    render();
+                }
+            }
+        };
+
+        const selectEntry = (): void => {
+            const entries = readDir();
+
+            if (cursor < 0 || cursor >= entries.length) {
+                return;
+            }
+
+            const entry = entries[cursor];
+            const dir = value.endsWith("/") ? value : value.slice(0, value.lastIndexOf("/") + 1);
+            value = dir + entry.name + (entry.isDirectory ? "/" : "");
+            cursor = -1;
+            render();
+        };
+
+        const keypressHandler = (_str: string, key: readline.Key): void => {
+            if (!key) {
+                return;
+            }
+
+            if (key.name === "return") {
+                if (cursor >= 0) {
+                    selectEntry();
+                } else {
+                    submit();
+                }
+
+                return;
+            }
+
+            if (key.name === "escape" || (key.ctrl && key.name === "c")) {
+                cancel();
+                return;
+            }
+
+            if (key.name === "tab") {
+                tabComplete();
+                return;
+            }
+
+            if (key.name === "up") {
+                const entries = readDir();
+
+                if (entries.length > 0) {
+                    cursor = cursor <= 0 ? -1 : cursor - 1;
+                    render();
+                }
+
+                return;
+            }
+
+            if (key.name === "down") {
+                const entries = readDir();
+
+                if (entries.length > 0) {
+                    const max = Math.min(entries.length - 1, maxVisible - 1);
+                    cursor = cursor < max ? cursor + 1 : max;
+                    render();
+                }
+
+                return;
+            }
+
+            if (key.name === "backspace") {
+                if (value.length > 0) {
+                    value = value.slice(0, -1);
+                    cursor = -1;
+                    render();
+                }
+
+                return;
+            }
+
+            // Regular character input
+            if (key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
+                value += key.sequence;
+                cursor = -1;
+                render();
+                return;
+            }
+        };
+
+        process.stdin.on("keypress", keypressHandler);
+        render();
+    });
+}

--- a/src/utils/prompts/clack/index.ts
+++ b/src/utils/prompts/clack/index.ts
@@ -5,4 +5,6 @@ export * from "./helpers";
 export * from "./input";
 export * from "./multiline";
 export * from "./search-multiselect";
+export * from "./file-path";
 export * from "./search-select";
+export * from "./settings-summary";

--- a/src/utils/prompts/clack/index.ts
+++ b/src/utils/prompts/clack/index.ts
@@ -1,10 +1,11 @@
 /**
  * @clack/prompts utilities
  */
+
+export * from "./file-path";
 export * from "./helpers";
 export * from "./input";
 export * from "./multiline";
 export * from "./search-multiselect";
-export * from "./file-path";
 export * from "./search-select";
 export * from "./settings-summary";

--- a/src/utils/prompts/clack/settings-summary.ts
+++ b/src/utils/prompts/clack/settings-summary.ts
@@ -1,0 +1,36 @@
+/**
+ * Reusable settings summary display for CLI tools.
+ * Shows a formatted list of settings before execution.
+ */
+
+import pc from "picocolors";
+
+const S_STEP_SUBMIT = pc.green("\u25C7");
+const S_BAR = pc.dim("\u2502");
+
+export interface SettingsEntry {
+    label: string;
+    value: string;
+    /** Dim hint after value, e.g. "(default)" or "(from --provider)" */
+    hint?: string;
+}
+
+/**
+ * Print a formatted settings summary using clack-style symbols.
+ *
+ * ```
+ * ◇  Provider: local-hf (from --provider)
+ * ◇  Model: whisper-large-v3-turbo (default)
+ * ◇  Format: text
+ * ◇  Output: stdout
+ * ```
+ */
+export function printSettingsSummary(entries: SettingsEntry[]): void {
+    for (const entry of entries) {
+        const hint = entry.hint ? ` ${pc.dim(`(${entry.hint})`)}` : "";
+        console.log(`${S_BAR}`);
+        console.log(`${S_STEP_SUBMIT}  ${pc.dim(`${entry.label}:`)} ${entry.value}${hint}`);
+    }
+
+    console.log(`${S_BAR}`);
+}

--- a/src/voice-memos/index.ts
+++ b/src/voice-memos/index.ts
@@ -3,6 +3,7 @@
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import logger from "@app/logger";
+import { formatDateTime } from "@app/utils/date.ts";
 import { formatDuration } from "@app/utils/format.ts";
 import {
     extractTranscript,
@@ -77,13 +78,7 @@ program.action(async () => {
 // ---------------------------------------------------------------------------
 
 function formatMemoDate(date: Date): string {
-    return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-    });
+    return formatDateTime(date, { absolute: "datetime" });
 }
 
 function formatMemoRow(memo: VoiceMemo): string[] {


### PR DESCRIPTION
## Summary

- **System-wide date formatting** (`src/utils/date.ts`): `formatDateTime()` with locale detection (macOS AppleLocale → env vars → Intl fallback), supporting absolute (9 formats), relative (4 modes), and combined display
- **Date migration**: All 13 hardcoded `"en-US"`/`"en-GB"` date formatting callsites migrated to `formatDateTime()`
- **Voice memos transcribe UX overhaul**:
  - `transcribe` without `<id>` shows memo selector instead of erroring
  - Language detection returns top-k probabilities via softmax over whisper logits
  - Interactive language confirmation prompt with alternatives
  - Prompts for provider/model/format/output when not given via CLI
  - Settings summary displayed before transcription starts
  - Suppress repeated HF "content-length" download warnings
  - Better error messages for empty `--provider`/`--model`
- **New reusable utilities**:
  - `src/utils/prompts/clack/settings-summary.ts` — formatted settings display
  - `src/utils/ai/suppress-warnings.ts` — targeted console.warn suppression
  - `src/macos/lib/voice-memos/prompts.ts` — shared DRY prompts

## Test plan

- [ ] `tools macos voice-memos` — interactive mode uses shared prompts
- [ ] `tools macos voice-memos transcribe` — shows memo selector + all prompts
- [ ] `tools macos voice-memos transcribe --lang cs` — shows memo selector, skips lang prompt
- [ ] `tools macos voice-memos transcribe 5 --provider local-hf --format srt -o out.srt` — no prompts
- [ ] `tools macos voice-memos transcribe --provider ""` — shows valid providers
- [ ] `tools macos voice-memos list` — dates in system locale
- [ ] Verify no remaining hardcoded `"en-US"` in CLI tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive voice-memo flows (select memo/action, model/provider, output)
  * File-path prompt with tab-completion and cancel symbol
  * Settings-summary renderer for CLI confirmations

* **Improvements**
  * Consistent, locale-aware date/time formatting across the app
  * Interactive language confirmation during transcription
  * Better model/provider discovery, validation, and cache detection
  * Hardened transcription error recovery and retry behavior
  * Exposed multiple language-detection alternatives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->