### PR TITLE
feat(cc-tail): display agent progress events in tail output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,13 +181,9 @@ Key SDK type files: `sdk.d.ts` (session/message/streaming types), `sdk-tools.d.t
 
 **Known gaps vs SDK** (as of v0.2.81):
 
-| SDK Feature | Status | Priority |
-|-------------|--------|----------|
-| `AgentOutput` (totalToolUseCount, totalDurationMs, totalTokens, service_tier) | Missing | Medium |
-| `FileReadOutput` (image base64+dimensions, PDF, notebook) | Missing | Low |
-| `Usage.cache_creation` (ephemeral_5m/1h tokens) | Partial | Low |
-| `Usage.service_tier` (standard/priority/batch) | Missing | Low |
-| `Usage.server_tool_use` (web_search_requests, web_fetch_requests) | Missing | Low |
+| SDK Feature | Status |
+|-------------|--------|
+| `FileReadOutput` (image base64+dimensions, PDF, notebook) | Not tracked (tool output type, not message type) |
 
 ## Important Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,39 @@ See `.claude/docs/tool-template.md` for complete templates (@inquirer + @clack/p
 - When working with union types, use discriminant checks (e.g. `entity.className === "User"`).
 - Prefer `error: err` over `error: err instanceof Error ? err.message : String(err)` when the error field accepts unknown.
 
+## Claude Agent SDK Types Reference
+
+The session/message types in `src/utils/claude/` are aligned with `@anthropic-ai/claude-agent-sdk`. To check for upstream changes:
+
+```bash
+# Check latest version
+npm view @anthropic-ai/claude-agent-sdk version
+
+# Diff types between versions (no install needed)
+npm diff \
+  --diff=@anthropic-ai/claude-agent-sdk@<old> \
+  --diff=@anthropic-ai/claude-agent-sdk@<new> \
+  '**/*.d.ts'
+
+# Read full current types (extracts ~270KB of .d.ts, no node_modules)
+cd /tmp && npm pack @anthropic-ai/claude-agent-sdk && \
+  mkdir -p sdk-types && \
+  tar xzf anthropic-ai-claude-agent-sdk-*.tgz -C sdk-types --strip-components=1 '*.d.ts'
+# Then read: /tmp/sdk-types/sdk.d.ts and /tmp/sdk-types/sdk-tools.d.ts
+```
+
+Key SDK type files: `sdk.d.ts` (session/message/streaming types), `sdk-tools.d.ts` (tool I/O schemas).
+
+**Known gaps vs SDK** (as of v0.2.81):
+
+| SDK Feature | Status | Priority |
+|-------------|--------|----------|
+| `AgentOutput` (totalToolUseCount, totalDurationMs, totalTokens, service_tier) | Missing | Medium |
+| `FileReadOutput` (image base64+dimensions, PDF, notebook) | Missing | Low |
+| `Usage.cache_creation` (ephemeral_5m/1h tokens) | Partial | Low |
+| `Usage.service_tier` (standard/priority/batch) | Missing | Low |
+| `Usage.server_tool_use` (web_search_requests, web_fetch_requests) | Missing | Low |
+
 ## Important Notes
 
 -   **Runtime**: This project requires Bun as it uses Bun-specific APIs (e.g., `Bun.spawn`)

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -3,7 +3,7 @@ import { formatDateTime } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import pc from "picocolors";
 import type { IncludeSpec } from "./cli/dsl";
-import { agentProgressToSubagent } from "./session.utils";
+import { agentProgressToSubagent, parseAgentCompletionStats } from "./session.utils";
 import type { TailTarget } from "./session.types";
 import type {
     AssistantMessage,
@@ -249,21 +249,35 @@ export class ClaudeSessionFormatter {
 
             text = textParts.join("\n");
 
-            if (this.options.includeSpec.shouldShow("tools:out")) {
-                for (const block of content) {
-                    if (block.type === "tool_result") {
-                        const result = extractToolResultText(block);
-                        const maxChars = this.options.includeSpec.truncationLength("tools:out");
-                        const isError = block.is_error;
+            for (const block of content) {
+                if (block.type !== "tool_result") {
+                    continue;
+                }
 
-                        if (result) {
-                            const truncated = truncate(result.trim(), maxChars);
-                            const prefix = isError ? "  ✗ " : "  → ";
-                            const line = `${prefix}${truncated}`;
-                            const formatted = this.options.colors ? (isError ? pc.red(line) : pc.dim(line)) : line;
-                            this.writeLine(formatted);
-                        }
-                    }
+                const result = extractToolResultText(block);
+
+                if (!result) {
+                    continue;
+                }
+
+                // Show agent completion stats from Agent tool_result
+                const agentStats = parseAgentCompletionStats(result);
+
+                if (agentStats && this.options.includeSpec.shouldShow("agents:result")) {
+                    const dur = this.formatDuration(agentStats.durationMs);
+                    const line = `  ⏱ Agent ${agentStats.agentId.slice(0, 8)}: ${dur}, ${agentStats.toolUses} tools, ${agentStats.totalTokens.toLocaleString()} tokens`;
+                    this.writeLine(this.options.colors ? pc.dim(line) : line);
+                    continue;
+                }
+
+                if (this.options.includeSpec.shouldShow("tools:out")) {
+                    const maxChars = this.options.includeSpec.truncationLength("tools:out");
+                    const isError = block.is_error;
+                    const truncated = truncate(result.trim(), maxChars);
+                    const prefix = isError ? "  ✗ " : "  → ";
+                    const line = `${prefix}${truncated}`;
+                    const formatted = this.options.colors ? (isError ? pc.red(line) : pc.dim(line)) : line;
+                    this.writeLine(formatted);
                 }
             }
         }

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -3,11 +3,13 @@ import { formatDateTime } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import pc from "picocolors";
 import type { IncludeSpec } from "./cli/dsl";
+import { agentProgressToSubagent } from "./session.utils";
 import type { TailTarget } from "./session.types";
 import type {
     AssistantMessage,
     AssistantMessageContent,
     ConversationMessage,
+    ProgressMessage,
     SubagentMessage,
     TextBlock,
     ToolResultBlock,
@@ -124,6 +126,12 @@ export class ClaudeSessionFormatter {
             return;
         }
 
+        // Auto-close agent section when parent conversation resumes.
+        // Hook progress can interleave within agent sequences — don't close on those.
+        if (this.activeAgentId && record.type !== "progress" && record.type !== "subagent") {
+            this.closeAgentSection();
+        }
+
         const timestamp = "timestamp" in record && typeof record.timestamp === "string" ? record.timestamp : "";
 
         switch (record.type) {
@@ -138,8 +146,15 @@ export class ClaudeSessionFormatter {
                 break;
             case "system":
                 break;
-            case "progress":
+            case "progress": {
+                const converted = agentProgressToSubagent(record as ProgressMessage);
+
+                if (converted) {
+                    this.formatSubagentMessage(converted, timestamp);
+                }
+
                 break;
+            }
             case "custom-title":
                 break;
             case "summary":

--- a/src/utils/claude/ClaudeSessionTailer.ts
+++ b/src/utils/claude/ClaudeSessionTailer.ts
@@ -2,7 +2,7 @@ import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { parseJsonl, parseJsonlChunk } from "@app/utils/jsonl";
 import { FileWatcher } from "@app/utils/storage/fs";
 import type { IncludeSpec } from "./cli/dsl";
-import type { ConversationMessage } from "./types";
+import type { ConversationMessage, ProgressMessage } from "./types";
 
 /** Shape of the shorthand "A" variant that some JSONL sessions use for assistant. */
 interface ShorthandAssistant {
@@ -117,7 +117,17 @@ export class ClaudeSessionTailer {
      */
     private isDisplayableRecord(record: ConversationMessage): boolean {
         const type = record.type as string;
-        return type === "user" || type === "assistant" || type === "A" || type === "subagent";
+
+        if (type === "user" || type === "assistant" || type === "A" || type === "subagent") {
+            return true;
+        }
+
+        if (type === "progress") {
+            const prog = record as ProgressMessage;
+            return prog.data?.type === "agent_progress";
+        }
+
+        return false;
     }
 
     private trackCompletion(record: ConversationMessage): void {

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -20,6 +20,7 @@ import { estimateTokens } from "@app/utils/tokens";
 import { glob } from "glob";
 import { encodedProjectDir, PROJECTS_DIR, parseJsonlTranscript } from "./index";
 import {
+    agentProgressToSubagent,
     extractFilePathFromInput,
     extractUserText,
     getSubagentToolUseBlocks,
@@ -119,7 +120,14 @@ export class ClaudeSession {
      * @param filePath Absolute path to the .jsonl session file.
      */
     static async fromFile(filePath: string): Promise<ClaudeSession> {
-        const messages = await parseJsonlTranscript<ConversationMessage>(filePath);
+        const raw = await parseJsonlTranscript<ConversationMessage>(filePath);
+        const messages = raw.map((msg) => {
+            if (msg.type === "progress") {
+                return agentProgressToSubagent(msg as ProgressMessage) ?? msg;
+            }
+
+            return msg;
+        });
         return new ClaudeSession(filePath, messages);
     }
 

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -1001,7 +1001,7 @@ export class ClaudeSession {
             } else if (msg.type === "pr-link") {
                 text = (msg as PrLinkMessage).url;
             }
-            return text.toLowerCase().includes(lowerQuery);
+            return (text ?? "").toLowerCase().includes(lowerQuery);
         });
 
         return new ClaudeSession(this._filePath, filtered);

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -1035,6 +1035,7 @@ export class ClaudeSession {
         let toolCallCount = 0;
         const toolUsage: Record<string, number> = {};
         const tokenUsage = { input: 0, output: 0, cached: 0 };
+        const serverToolUse = { webSearchRequests: 0, webFetchRequests: 0 };
         const modelsSet = new Set<string>();
         const filesSet = new Set<string>();
         let firstTimestamp: Date | null = null;
@@ -1069,6 +1070,11 @@ export class ClaudeSession {
                     tokenUsage.input += usage.input_tokens || 0;
                     tokenUsage.output += usage.output_tokens || 0;
                     tokenUsage.cached += usage.cache_read_input_tokens || 0;
+
+                    if (usage.server_tool_use) {
+                        serverToolUse.webSearchRequests += usage.server_tool_use.web_search_requests || 0;
+                        serverToolUse.webFetchRequests += usage.server_tool_use.web_fetch_requests || 0;
+                    }
                 }
 
                 // Tool calls
@@ -1096,7 +1102,15 @@ export class ClaudeSession {
                         tokenUsage.input += assistantContent.usage.input_tokens || 0;
                         tokenUsage.output += assistantContent.usage.output_tokens || 0;
                         tokenUsage.cached += assistantContent.usage.cache_read_input_tokens || 0;
+
+                        if (assistantContent.usage.server_tool_use) {
+                            serverToolUse.webSearchRequests +=
+                                assistantContent.usage.server_tool_use.web_search_requests || 0;
+                            serverToolUse.webFetchRequests +=
+                                assistantContent.usage.server_tool_use.web_fetch_requests || 0;
+                        }
                     }
+
                     // Track subagent tool calls
                     for (const tool of getSubagentToolUseBlocks(sub)) {
                         toolCallCount++;
@@ -1127,6 +1141,7 @@ export class ClaudeSession {
             toolCallCount,
             toolUsage,
             tokenUsage,
+            serverToolUse,
             modelsUsed: [...modelsSet],
             filesModified: [...filesSet],
             duration,

--- a/src/utils/claude/session.types.ts
+++ b/src/utils/claude/session.types.ts
@@ -67,6 +67,8 @@ export interface SessionStats {
     toolUsage: Record<string, number>;
     /** Aggregated API token usage from assistant message metadata. */
     tokenUsage: { input: number; output: number; cached: number };
+    /** Aggregated server-side tool usage (web search/fetch requests). */
+    serverToolUse: { webSearchRequests: number; webFetchRequests: number };
     /** Distinct model IDs seen in assistant messages. */
     modelsUsed: string[];
     /** Unique file paths referenced in tool calls. */

--- a/src/utils/claude/session.utils.ts
+++ b/src/utils/claude/session.utils.ts
@@ -1,5 +1,6 @@
 import { basename, sep } from "node:path";
 import type {
+    AgentCompletionStats,
     AgentProgressData,
     ContentBlock,
     ConversationMessage,
@@ -147,4 +148,27 @@ export function agentProgressToSubagent(msg: ProgressMessage): SubagentMessage |
         agentId: data.agentId,
         ...(msg.timestamp ? { timestamp: msg.timestamp } : {}),
     } as SubagentMessage;
+}
+
+const AGENT_STATS_RE = /agentId:\s*(\S+)[\s\S]*?<usage>\s*total_tokens:\s*(\d+)\s*\ntool_uses:\s*(\d+)\s*\nduration_ms:\s*(\d+)\s*<\/usage>/;
+
+/**
+ * Parse agent completion stats from a tool_result text block.
+ * Returns null if the text doesn't match the expected agent result format.
+ *
+ * Format: `agentId: <id> (...)\n<usage>total_tokens: N\ntool_uses: N\nduration_ms: N</usage>`
+ */
+export function parseAgentCompletionStats(text: string): AgentCompletionStats | null {
+    const match = AGENT_STATS_RE.exec(text);
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        agentId: match[1],
+        totalTokens: Number.parseInt(match[2], 10),
+        toolUses: Number.parseInt(match[3], 10),
+        durationMs: Number.parseInt(match[4], 10),
+    };
 }

--- a/src/utils/claude/session.utils.ts
+++ b/src/utils/claude/session.utils.ts
@@ -1,5 +1,12 @@
 import { basename, sep } from "node:path";
-import type { ContentBlock, ConversationMessage, SubagentMessage, ToolUseBlock } from "./types";
+import type {
+    AgentProgressData,
+    ContentBlock,
+    ConversationMessage,
+    ProgressMessage,
+    SubagentMessage,
+    ToolUseBlock,
+} from "./types";
 
 function hasStringField<K extends string>(obj: object, key: K): obj is Record<K, string> {
     return key in obj && typeof (obj as Record<K, unknown>)[key] === "string";
@@ -112,4 +119,32 @@ export function extractUserText(content: string | ContentBlock[]): string {
     }
 
     return parts.join("\n");
+}
+
+/**
+ * Convert an agent_progress ProgressMessage to a SubagentMessage.
+ * Returns null if the progress message is not agent_progress or has no inner message.
+ *
+ * Modern Claude Code records agent work as progress events with data.type === "agent_progress"
+ * instead of the legacy "subagent" message type. This normalizes the new format into the
+ * SubagentMessage shape so all downstream code works unchanged.
+ */
+export function agentProgressToSubagent(msg: ProgressMessage): SubagentMessage | null {
+    if (msg.data.type !== "agent_progress") {
+        return null;
+    }
+
+    const data = msg.data as AgentProgressData;
+
+    if (!data.message?.message) {
+        return null;
+    }
+
+    return {
+        type: "subagent",
+        role: data.message.type,
+        message: data.message.message,
+        agentId: data.agentId,
+        ...(msg.timestamp ? { timestamp: msg.timestamp } : {}),
+    } as SubagentMessage;
 }

--- a/src/utils/claude/types.ts
+++ b/src/utils/claude/types.ts
@@ -84,14 +84,30 @@ export interface CacheCreation {
     ephemeral_1h_input_tokens: number;
 }
 
+export interface ServerToolUse {
+    web_search_requests: number;
+    web_fetch_requests: number;
+}
+
+export type ServiceTier = "standard" | "priority" | "batch";
+
 export interface Usage {
     input_tokens: number;
     output_tokens: number;
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
     cache_creation?: CacheCreation;
-    service_tier?: string;
+    server_tool_use?: ServerToolUse | null;
+    service_tier?: ServiceTier | null;
     inference_geo?: string;
+}
+
+/** Parsed from agent tool_result text: `<usage>total_tokens: N\ntool_uses: N\nduration_ms: N</usage>` */
+export interface AgentCompletionStats {
+    agentId: string;
+    totalTokens: number;
+    toolUses: number;
+    durationMs: number;
 }
 
 // =============================================================================

--- a/src/utils/claude/types.ts
+++ b/src/utils/claude/types.ts
@@ -225,9 +225,18 @@ export interface BashProgressData {
     totalLines: number;
 }
 
+export interface AgentProgressInnerMessage {
+    type: "user" | "assistant";
+    message: UserMessageContent | AssistantMessageContent;
+    uuid?: string;
+    timestamp?: string;
+}
+
 export interface AgentProgressData {
     type: "agent_progress";
-    [key: string]: unknown;
+    agentId?: string;
+    prompt?: string;
+    message?: AgentProgressInnerMessage;
 }
 
 export interface McpProgressData {


### PR DESCRIPTION
## Summary

- Modern Claude Code records agent work as `progress` events with `data.type === "agent_progress"` instead of the legacy `subagent` message type. The tail formatter was silently dropping all of these (empty `case "progress": break;`).
- Adds `agentProgressToSubagent()` converter that normalizes agent_progress into SubagentMessage at the boundary — both for streaming (formatter) and batch (ClaudeSession.fromFile).
- Auto-closes agent sections when parent conversation resumes, while tolerating interleaved hook_progress.
- Fixes pre-existing `filterByContent` crash on unknown message types.
- Adds Claude Agent SDK types reference + known gaps to CLAUDE.md.

## Test plan

- [x] 17 E2E tests pass (agent visibility, section open/close balance, include flags, raw mode, per-agent JSONL, cross-project, ClaudeSession API, type check, unit tests)
- [x] Verified on session `85e83e11` (19 agents, 1791 agent_progress events) and `9b0c83a3` (darwinkit)
- [x] `bunx tsgo --noEmit` — zero errors
- [x] `bun test src/` — 998/1021 pass (18 pre-existing pricing test failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Progress messages now display with agent completion statistics including duration, tool uses, and token counts.
  * Server-side tool usage tracking added for web searches and fetch requests.

* **Improvements**
  * Better handling of progress records with automatic agent section closing when conversation resumes.

* **Documentation**
  * Added Claude agent SDK types reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->