### PR TITLE
fix(clarity): dual React SSR crash, client node:child_process, and TLS cert rejection

### DIFF
--- a/src/clarity/ui/bun.lock
+++ b/src/clarity/ui/bun.lock
@@ -19,6 +19,7 @@
         "lucide-react": "^0.544.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "^4.0.6",
       },
@@ -532,6 +533,8 @@
     "seroval": ["seroval@1.5.0", "", {}, "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/src/clarity/ui/package.json
+++ b/src/clarity/ui/package.json
@@ -21,6 +21,7 @@
 		"cmdk": "^1.1.1",
 		"lucide-react": "^0.544.0",
 		"react": "^19.2.1",
+		"sonner": "^2.0.7",
 		"react-dom": "^19.2.1",
 		"tailwind-merge": "^3.0.2",
 		"tailwindcss": "^4.0.6"

--- a/src/utils/clarity/api.ts
+++ b/src/utils/clarity/api.ts
@@ -28,6 +28,7 @@ export class ClarityApi {
         const response = await fetch(url, {
             ...options,
             signal,
+            tls: { rejectUnauthorized: false },
             headers: {
                 Accept: "application/json, text/plain, */*",
                 "Content-Type": "application/json",
@@ -103,6 +104,7 @@ export class ClarityApi {
 
         const response = await fetch(url, {
             method: "PUT",
+            tls: { rejectUnauthorized: false },
             headers: {
                 Accept: "application/json, text/plain, */*",
                 "Content-Type": "application/json",

--- a/src/utils/date-locale.ts
+++ b/src/utils/date-locale.ts
@@ -1,0 +1,63 @@
+/**
+ * System locale detection — requires Node.js (child_process).
+ * Separated from date.ts so pure date math stays browser-safe.
+ */
+
+import { execSync } from "node:child_process";
+
+let cachedLocale: string | undefined;
+
+/**
+ * Detect system locale.
+ * macOS: `defaults read NSGlobalDomain AppleLocale` (e.g. "cs_CZ" → "cs-CZ")
+ * Fallback: $LC_TIME / $LANG / $LC_ALL → Intl default
+ */
+export function getSystemLocale(): string {
+    if (cachedLocale) {
+        return cachedLocale;
+    }
+
+    if (process.platform === "darwin") {
+        try {
+            const raw = execSync("defaults read NSGlobalDomain AppleLocale", {
+                encoding: "utf-8",
+                timeout: 1000,
+            }).trim();
+
+            if (raw) {
+                // AppleLocale format: "en_US@rg=czzzzz" where:
+                // - "en_US" is language_region
+                // - "@rg=czzzzz" means "use Czech Republic regional formats" (24h time, date order, etc.)
+                // We parse the rg= suffix to get the actual regional country code,
+                // so "en_US@rg=czzzzz" → "en-CZ" (English with Czech regional formats → 24h time)
+                const [base, suffix] = raw.split("@");
+                let locale = base.replace(/_/g, "-");
+
+                if (suffix) {
+                    const rgMatch = suffix.match(/rg=([a-z]{2})/i);
+
+                    if (rgMatch) {
+                        const regionCode = rgMatch[1].toUpperCase();
+                        const lang = locale.split("-")[0];
+                        locale = `${lang}-${regionCode}`;
+                    }
+                }
+
+                cachedLocale = locale;
+                return cachedLocale;
+            }
+        } catch {
+            // fall through
+        }
+    }
+
+    const envLocale = process.env.LC_TIME || process.env.LANG || process.env.LC_ALL;
+
+    if (envLocale) {
+        cachedLocale = envLocale.split(".")[0].replace(/_/g, "-");
+        return cachedLocale;
+    }
+
+    cachedLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
+    return cachedLocale;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,68 +1,23 @@
 /**
- * Shared date utilities for CLI tools.
+ * Shared date utilities — browser-safe (no Node.js imports at top level).
+ * For locale detection (requires Node.js), see ./date-locale.ts.
  */
 
-import { execSync } from "node:child_process";
+let _resolveLocale: (() => string) | undefined;
 
-// ============================================
-// Locale Detection
-// ============================================
-
-let cachedLocale: string | undefined;
-
-/**
- * Detect system locale.
- * macOS: `defaults read NSGlobalDomain AppleLocale` (e.g. "cs_CZ" → "cs-CZ")
- * Fallback: $LC_TIME / $LANG / $LC_ALL → Intl default
- */
-export function getSystemLocale(): string {
-    if (cachedLocale) {
-        return cachedLocale;
+function resolveLocale(override?: string): string {
+    if (override) {
+        return override;
     }
 
-    if (process.platform === "darwin") {
-        try {
-            const raw = execSync("defaults read NSGlobalDomain AppleLocale", {
-                encoding: "utf-8",
-                timeout: 1000,
-            }).trim();
-
-            if (raw) {
-                // AppleLocale format: "en_US@rg=czzzzz" where:
-                // - "en_US" is language_region
-                // - "@rg=czzzzz" means "use Czech Republic regional formats" (24h time, date order, etc.)
-                // We parse the rg= suffix to get the actual regional country code,
-                // so "en_US@rg=czzzzz" → "en-CZ" (English with Czech regional formats → 24h time)
-                const [base, suffix] = raw.split("@");
-                let locale = base.replace(/_/g, "-");
-
-                if (suffix) {
-                    const rgMatch = suffix.match(/rg=([a-z]{2})/i);
-
-                    if (rgMatch) {
-                        const regionCode = rgMatch[1].toUpperCase();
-                        const lang = locale.split("-")[0];
-                        locale = `${lang}-${regionCode}`;
-                    }
-                }
-
-                cachedLocale = locale;
-                return cachedLocale;
-            }
-        } catch {
-            // fall through
-        }
+    if (!_resolveLocale) {
+        // Lazy require so Vite won't bundle node:child_process into client code.
+        // Only formatDateTime (server/CLI-only) calls this path.
+        // biome-ignore lint/style/noCommonJs: intentional lazy require to avoid static bundling
+        _resolveLocale = (require("./date-locale") as { getSystemLocale: () => string }).getSystemLocale;
     }
 
-    const envLocale = process.env.LC_TIME || process.env.LANG || process.env.LC_ALL;
-
-    if (envLocale) {
-        cachedLocale = envLocale.split(".")[0].replace(/_/g, "-");
-        return cachedLocale;
-    }
-
-    cachedLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
-    return cachedLocale;
+    return _resolveLocale();
 }
 
 // ============================================
@@ -112,7 +67,7 @@ export interface FormatDateTimeOptions {
  */
 export function formatDateTime(date: Date | string | number, options: FormatDateTimeOptions = {}): string {
     const d = date instanceof Date ? date : new Date(date);
-    const locale = options.locale ?? getSystemLocale();
+    const locale = resolveLocale(options.locale);
     const now = new Date();
 
     const hasRelative = options.relative !== undefined;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -12,8 +12,6 @@ function resolveLocale(override?: string): string {
 
     if (!_resolveLocale) {
         // Lazy require so Vite won't bundle node:child_process into client code.
-        // Only formatDateTime (server/CLI-only) calls this path.
-        // biome-ignore lint/style/noCommonJs: intentional lazy require to avoid static bundling
         _resolveLocale = (require("./date-locale") as { getSystemLocale: () => string }).getSystemLocale;
     }
 


### PR DESCRIPTION
Fixes #124

## Summary
- **Dual React instance SSR crash**: Added `sonner` to `src/clarity/ui/package.json` so it resolves the same react instance as the app during SSR
- **`node:child_process` in client bundle**: Extracted locale detection (`execSync`) into `src/utils/date-locale.ts`, switched `date.ts` to lazy `require()` — zero static Node.js imports, fully browser-safe
- **Self-signed TLS cert rejection**: Added `tls: { rejectUnauthorized: false }` to all `ClarityApi` fetch calls for corporate self-signed certs

## Test plan
- [ ] `tools clarity ui` starts without SSR crash
- [ ] `/import` route loads without `node:child_process` error
- [ ] `tools clarity configure auth` connects successfully with pasted cURL
- [ ] CLI tools using `formatDateTime` still show correct locale-formatted dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Toast notification system now available for enhanced user feedback and alerts

* **Improvements**
  * Enhanced system locale detection to ensure dates and times are formatted according to your system preferences
  * Optimized locale resolution handling for better support of international language and regional settings

* **Chores**
  * Refactored date utility modules for improved code organization and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->