### PR TITLE
fix(mcp-manager): non-TTY guard with suggestCommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ When creating a new tool and writing helper functions, check if the utility is *
 - `src/utils/format.ts` - Formatting: bytes, duration, tokens, numbers, lists
 - `src/utils/table.ts` - Text table formatting
 - `src/utils/string.ts` - String utilities (glob matching, ANSI stripping)
+- `src/utils/cli/executor.ts` - CLI helpers: `suggestCommand()`, `isInteractive()`, `buildCommand()`, `Executor`, `enhanceHelp()`
 - `src/utils/storage/storage.ts` - Config & cache management
 - `src/utils/async.ts` - Async helpers (concurrency, etc.)
 - `src/utils/json-schema.ts` - JSON schema inference: `inferSchema()`, `formatSchema(value, "skeleton"|"typescript"|"schema")`
@@ -96,6 +97,17 @@ Most tools follow these common patterns:
 -   Common prompt types: `select`, `input`, `confirm`, `checkbox`/`multiselect`
 -   Handle user cancellation gracefully
 -   Provide sensible defaults and suggestions in prompts
+-   **Non-TTY guard**: Always check `isInteractive()` (from `@app/utils/cli`) before showing prompts. When non-interactive, either error with `suggestCommand()` showing required CLI flags, or use a sensible default:
+    ```typescript
+    import { isInteractive, suggestCommand } from "@app/utils/cli";
+
+    if (!isInteractive()) {
+        logger.error("--provider required in non-interactive mode.");
+        logger.info(suggestCommand("tools my-tool", { add: ["--provider", "claude"] }));
+        return;
+    }
+    // ... interactive prompt here
+    ```
 
 **Output Handling**:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Most tools follow these common patterns:
 -   Handle user cancellation gracefully
 -   Provide sensible defaults and suggestions in prompts
 -   **Non-TTY guard**: Always check `isInteractive()` (from `@app/utils/cli`) before showing prompts. When non-interactive, either error with `suggestCommand()` showing required CLI flags, or use a sensible default:
+
     ```typescript
     import { isInteractive, suggestCommand } from "@app/utils/cli";
 

--- a/src/mcp-manager/commands/config.ts
+++ b/src/mcp-manager/commands/config.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import logger from "@app/logger";
+import { isInteractive } from "@app/utils/cli";
 import { getUnifiedConfigPath } from "@app/mcp-manager/utils/config.utils.js";
 import type { UnifiedMCPConfig } from "@app/mcp-manager/utils/providers/types.js";
 import { Storage } from "@app/utils/storage";
@@ -32,8 +33,8 @@ export async function openConfig(options: ConfigOptions = {}): Promise<void> {
     // Always show the path first
     logger.info(`Config file: ${configPath}`);
 
-    // If --path flag, just show the path and exit
-    if (options.path) {
+    // If --path flag or non-interactive, just show the path and exit
+    if (options.path || !isInteractive()) {
         return;
     }
 

--- a/src/mcp-manager/commands/config.ts
+++ b/src/mcp-manager/commands/config.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "node:fs";
 import logger from "@app/logger";
-import { isInteractive } from "@app/utils/cli";
 import { getUnifiedConfigPath } from "@app/mcp-manager/utils/config.utils.js";
 import type { UnifiedMCPConfig } from "@app/mcp-manager/utils/providers/types.js";
+import { isInteractive } from "@app/utils/cli";
 import { Storage } from "@app/utils/storage";
 
 const storage = new Storage("mcp-manager");

--- a/src/mcp-manager/commands/install.ts
+++ b/src/mcp-manager/commands/install.ts
@@ -1,9 +1,9 @@
 import logger from "@app/logger";
-import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { parseCommandString, parseEnvString, parseHeaderString } from "@app/mcp-manager/utils/command.utils.js";
 import { readUnifiedConfig, stripMeta, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
 import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import { ExitPromptError } from "@inquirer/core";
 import { input, search, select } from "@inquirer/prompts";
@@ -41,7 +41,7 @@ export async function installServer(
 
     // Scenario 1: No server name provided - prompt for it with autocomplete
     if (!finalServerName) {
-        if (isNonInteractive || options.provider || !isInteractive()) {
+        if (!isInteractive()) {
             logger.error("Server name is required in non-interactive mode.");
             logger.info('Usage: tools mcp-manager install <name> "<command>" --type stdio --provider claude');
             process.exit(1);
@@ -107,7 +107,7 @@ export async function installServer(
         }
 
         // If type not provided and non-interactive mode, error out
-        if (!transportType && (isNonInteractive || !isInteractive())) {
+        if (!transportType && !isInteractive()) {
             logger.error("Transport type (--type) is required in non-interactive mode.");
             logger.info(suggestCommand("tools mcp-manager", { add: ["--type", "stdio"] }));
             process.exit(1);

--- a/src/mcp-manager/commands/install.ts
+++ b/src/mcp-manager/commands/install.ts
@@ -1,4 +1,5 @@
 import logger from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { parseCommandString, parseEnvString, parseHeaderString } from "@app/mcp-manager/utils/command.utils.js";
 import { readUnifiedConfig, stripMeta, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
@@ -40,10 +41,12 @@ export async function installServer(
 
     // Scenario 1: No server name provided - prompt for it with autocomplete
     if (!finalServerName) {
-        if (isNonInteractive || options.provider) {
-            logger.error("Server name is required for non-interactive mode.");
+        if (isNonInteractive || options.provider || !isInteractive()) {
+            logger.error("Server name is required in non-interactive mode.");
+            logger.info('Usage: tools mcp-manager install <name> "<command>" --type stdio --provider claude');
             process.exit(1);
         }
+
         try {
             const existingServers = Object.keys(config.mcpServers).sort();
             const choices = [
@@ -104,8 +107,9 @@ export async function installServer(
         }
 
         // If type not provided and non-interactive mode, error out
-        if (!transportType && isNonInteractive) {
-            logger.error("Transport type (--type) is required for non-interactive mode.");
+        if (!transportType && (isNonInteractive || !isInteractive())) {
+            logger.error("Transport type (--type) is required in non-interactive mode.");
+            logger.info(suggestCommand("tools mcp-manager", { add: ["--type", "stdio"] }));
             process.exit(1);
         }
 
@@ -134,6 +138,17 @@ export async function installServer(
         let finalCommandOrUrl = commandOrUrl;
 
         // Prompt for command or URL based on type
+        if (!finalCommandOrUrl && !isInteractive()) {
+            const isRemote = transportType === "sse" || transportType === "http";
+            logger.error(`${isRemote ? "URL" : "Command"} is required in non-interactive mode.`);
+            logger.info(
+                suggestCommand("tools mcp-manager", {
+                    add: [isRemote ? '"https://server.example.com/sse"' : '"npx -y @org/server"'],
+                })
+            );
+            process.exit(1);
+        }
+
         if (!finalCommandOrUrl) {
             try {
                 const isRemote = transportType === "sse" || transportType === "http";
@@ -283,10 +298,10 @@ export async function installServer(
             process.exit(1);
         }
         selectedProviderNames = [requestedProvider.getName()];
-    } else if (isNonInteractive) {
-        logger.error(
-            `Provider (--provider) is required for non-interactive mode. Available: ${availableProviders.map((p) => p.getName()).join(", ")}`
-        );
+    } else if (isNonInteractive || !isInteractive()) {
+        const names = availableProviders.map((p) => p.getName()).join(", ");
+        logger.error(`--provider required in non-interactive mode. Available: ${names}`);
+        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "claude"] }));
         process.exit(1);
     } else {
         try {

--- a/src/mcp-manager/commands/install.ts
+++ b/src/mcp-manager/commands/install.ts
@@ -278,7 +278,12 @@ export async function installServer(
     }
 
     // Install to provider
-    const availableProviders = providers.filter((p) => p.configExists());
+    const availableProviders: typeof providers = [];
+    for (const provider of providers) {
+        if (await provider.configExists()) {
+            availableProviders.push(provider);
+        }
+    }
 
     if (availableProviders.length === 0) {
         logger.warn("No provider configuration files found.");
@@ -301,7 +306,9 @@ export async function installServer(
     } else if (isNonInteractive || !isInteractive()) {
         const names = availableProviders.map((p) => p.getName()).join(", ");
         logger.error(`--provider required in non-interactive mode. Available: ${names}`);
-        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", availableProviders[0]?.getName() ?? "claude"] }));
+        logger.info(
+            suggestCommand("tools mcp-manager", { add: ["--provider", availableProviders[0]?.getName() ?? "claude"] })
+        );
         process.exit(1);
     } else {
         try {

--- a/src/mcp-manager/commands/install.ts
+++ b/src/mcp-manager/commands/install.ts
@@ -301,7 +301,7 @@ export async function installServer(
     } else if (isNonInteractive || !isInteractive()) {
         const names = availableProviders.map((p) => p.getName()).join(", ");
         logger.error(`--provider required in non-interactive mode. Available: ${names}`);
-        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "claude"] }));
+        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", availableProviders[0]?.getName() ?? "claude"] }));
         process.exit(1);
     } else {
         try {

--- a/src/mcp-manager/commands/rename.ts
+++ b/src/mcp-manager/commands/rename.ts
@@ -1,4 +1,5 @@
 import logger from "@app/logger";
+import { isInteractive } from "@app/utils/cli";
 import { readUnifiedConfig, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider } from "@app/mcp-manager/utils/providers/types.js";
 import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
@@ -25,6 +26,12 @@ export async function renameServer(
 
     // Get old name - from args or prompt
     let finalOldName = oldName;
+    if (!finalOldName && !isInteractive()) {
+        logger.error("Old name and new name required in non-interactive mode.");
+        logger.info("Usage: tools mcp-manager rename <oldName> <newName>");
+        return;
+    }
+
     if (!finalOldName) {
         const serverNames = Object.keys(config.mcpServers).sort();
         try {
@@ -60,6 +67,12 @@ export async function renameServer(
 
     // Get new name - from args or prompt
     let finalNewName = newName;
+    if (!finalNewName && !isInteractive()) {
+        logger.error("New name required in non-interactive mode.");
+        logger.info(`Usage: tools mcp-manager rename ${finalOldName} <newName>`);
+        return;
+    }
+
     if (!finalNewName) {
         try {
             const inputNewName = await input({
@@ -107,6 +120,11 @@ export async function renameServer(
             `existing '${finalNewName}'`,
             `'${finalOldName}' (will replace)`
         );
+
+        if (!isInteractive()) {
+            logger.error(`Server '${finalNewName}' already exists. Cannot auto-replace in non-interactive mode.`);
+            return;
+        }
 
         try {
             const confirmed = await confirm({
@@ -161,20 +179,25 @@ export async function renameServer(
 
     // Select providers to sync to
     let selectedProviderNames: string[];
-    try {
-        selectedProviderNames = await checkbox({
-            message: "Select providers to sync rename to:",
-            choices: availableProviders.map((p) => ({
-                value: p.getName(),
-                name: `${p.getName()} (${p.getConfigPath()})`,
-            })),
-        });
-    } catch (error) {
-        if (error instanceof ExitPromptError) {
-            logger.info("\nOperation cancelled by user.");
-            return;
+    if (!isInteractive()) {
+        // Non-interactive: sync to all available providers
+        selectedProviderNames = availableProviders.map((p) => p.getName());
+    } else {
+        try {
+            selectedProviderNames = await checkbox({
+                message: "Select providers to sync rename to:",
+                choices: availableProviders.map((p) => ({
+                    value: p.getName(),
+                    name: `${p.getName()} (${p.getConfigPath()})`,
+                })),
+            });
+        } catch (error) {
+            if (error instanceof ExitPromptError) {
+                logger.info("\nOperation cancelled by user.");
+                return;
+            }
+            throw error;
         }
-        throw error;
     }
 
     if (selectedProviderNames.length === 0) {
@@ -230,6 +253,11 @@ async function renameServerInProvider(
         const replacingConfig = SafeJSON.stringify(serverConfig, null, 2);
 
         logger.warn(`\n⚠ Conflict in ${provider.getName()}: Server '${newName}' already exists.`);
+
+        if (!isInteractive()) {
+            logger.error(`Cannot auto-replace in non-interactive mode. Skipping ${provider.getName()}.`);
+            return;
+        }
 
         await DiffUtil.showDiff(
             existingConfig,

--- a/src/mcp-manager/commands/rename.ts
+++ b/src/mcp-manager/commands/rename.ts
@@ -1,8 +1,8 @@
 import logger from "@app/logger";
-import { isInteractive } from "@app/utils/cli";
 import { readUnifiedConfig, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider } from "@app/mcp-manager/utils/providers/types.js";
 import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
+import { isInteractive } from "@app/utils/cli";
 import { DiffUtil } from "@app/utils/diff";
 import { SafeJSON } from "@app/utils/json";
 import { ExitPromptError } from "@inquirer/core";
@@ -29,7 +29,7 @@ export async function renameServer(
     if (!finalOldName && !isInteractive()) {
         logger.error("Old name and new name required in non-interactive mode.");
         logger.info("Usage: tools mcp-manager rename <oldName> <newName>");
-        return;
+        process.exit(1);
     }
 
     if (!finalOldName) {
@@ -62,7 +62,7 @@ export async function renameServer(
     // Validate old name exists
     if (!config.mcpServers[finalOldName]) {
         logger.error(`Server '${finalOldName}' not found in unified config.`);
-        return;
+        process.exit(1);
     }
 
     // Get new name - from args or prompt
@@ -70,7 +70,7 @@ export async function renameServer(
     if (!finalNewName && !isInteractive()) {
         logger.error("New name required in non-interactive mode.");
         logger.info(`Usage: tools mcp-manager rename ${finalOldName} <newName>`);
-        return;
+        process.exit(1);
     }
 
     if (!finalNewName) {
@@ -123,7 +123,7 @@ export async function renameServer(
 
         if (!isInteractive()) {
             logger.error(`Server '${finalNewName}' already exists. Cannot auto-replace in non-interactive mode.`);
-            return;
+            process.exit(1);
         }
 
         try {
@@ -213,8 +213,10 @@ export async function renameServer(
         }
 
         try {
-            await renameServerInProvider(provider, finalOldName, finalNewName, serverConfig);
-            logger.info(`✓ Renamed '${finalOldName}' to '${finalNewName}' in ${providerName}`);
+            const applied = await renameServerInProvider(provider, finalOldName, finalNewName, serverConfig);
+            if (applied) {
+                logger.info(`✓ Renamed '${finalOldName}' to '${finalNewName}' in ${providerName}`);
+            }
         } catch (error: unknown) {
             if (error instanceof Error) {
                 logger.error(`✗ Failed to rename in ${providerName}: ${error.message}`);
@@ -225,13 +227,14 @@ export async function renameServer(
 
 /**
  * Rename a server in a specific provider
+ * @returns true if rename was applied, false if skipped
  */
 async function renameServerInProvider(
     provider: MCPProvider,
     oldName: string,
     newName: string,
     serverConfig: unknown
-): Promise<void> {
+): Promise<boolean> {
     // Check if provider has the old or new server
     const providerServers = await provider.listServers();
     const hasOldServer = providerServers.some((s) => s.name === oldName);
@@ -239,7 +242,7 @@ async function renameServerInProvider(
 
     if (!hasOldServer && !hasNewServer) {
         // Server doesn't exist in this provider, skip
-        return;
+        return false;
     }
 
     // Convert provider config to unified format to check for conflicts
@@ -256,7 +259,7 @@ async function renameServerInProvider(
 
         if (!isInteractive()) {
             logger.error(`Cannot auto-replace in non-interactive mode. Skipping ${provider.getName()}.`);
-            return;
+            return false;
         }
 
         await DiffUtil.showDiff(
@@ -274,12 +277,12 @@ async function renameServerInProvider(
 
             if (!confirmed) {
                 logger.info(`Skipping rename in ${provider.getName()}.`);
-                return;
+                return false;
             }
         } catch (error) {
             if (error instanceof ExitPromptError) {
                 logger.info(`\nSkipping rename in ${provider.getName()}.`);
-                return;
+                return false;
             }
             throw error;
         }
@@ -306,7 +309,7 @@ async function renameServerInProvider(
 
     if (syncResult === WriteResult.Rejected) {
         logger.info(`Skipped ${provider.getName()} - user rejected confirmation`);
-        return;
+        return false;
     }
 
     // IMPORTANT: syncServers only adds/updates servers, it doesn't remove servers not in the map
@@ -314,6 +317,8 @@ async function renameServerInProvider(
     if (hasOldServer && oldName !== newName) {
         await removeServerFromProvider(provider, oldName);
     }
+
+    return true;
 }
 
 /**

--- a/src/mcp-manager/commands/rename.ts
+++ b/src/mcp-manager/commands/rename.ts
@@ -170,7 +170,12 @@ export async function renameServer(
     logger.info(`✓ Renamed '${finalOldName}' to '${finalNewName}' in unified config`);
 
     // Sync to providers
-    const availableProviders = providers.filter((p) => p.configExists());
+    const availableProviders: typeof providers = [];
+    for (const provider of providers) {
+        if (await provider.configExists()) {
+            availableProviders.push(provider);
+        }
+    }
 
     if (availableProviders.length === 0) {
         logger.warn("No provider configuration files found.");

--- a/src/mcp-manager/commands/rename.ts
+++ b/src/mcp-manager/commands/rename.ts
@@ -211,6 +211,8 @@ export async function renameServer(
     }
 
     // Sync rename to each selected provider
+    let skippedCount = 0;
+
     for (const providerName of selectedProviderNames) {
         const provider = providers.find((p) => p.getName() === providerName);
         if (!provider) {
@@ -221,12 +223,19 @@ export async function renameServer(
             const applied = await renameServerInProvider(provider, finalOldName, finalNewName, serverConfig);
             if (applied) {
                 logger.info(`✓ Renamed '${finalOldName}' to '${finalNewName}' in ${providerName}`);
+            } else {
+                skippedCount++;
             }
         } catch (error: unknown) {
             if (error instanceof Error) {
                 logger.error(`✗ Failed to rename in ${providerName}: ${error.message}`);
             }
+            skippedCount++;
         }
+    }
+
+    if (skippedCount > 0 && !isInteractive()) {
+        process.exitCode = 1;
     }
 }
 

--- a/src/mcp-manager/commands/sync-from-providers.ts
+++ b/src/mcp-manager/commands/sync-from-providers.ts
@@ -47,7 +47,7 @@ export async function syncFromProviders(providers: MCPProvider[], options: SyncF
         const names = availableProviders.map((p) => p.getName()).join(", ");
         logger.error(`--provider required in non-interactive mode. Available: ${names}`);
         logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "all"] }));
-        return;
+        process.exit(1);
     } else {
         try {
             selectedProviders = await checkbox({

--- a/src/mcp-manager/commands/sync-from-providers.ts
+++ b/src/mcp-manager/commands/sync-from-providers.ts
@@ -1,4 +1,5 @@
 import logger from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { readUnifiedConfig, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
 import type { MCPProviderName, PerProjectEnabledState, ProviderEnabledState } from "@app/mcp-manager/utils/types.js";
@@ -42,6 +43,11 @@ export async function syncFromProviders(providers: MCPProvider[], options: SyncF
             logger.warn(`No matching providers found for: ${options.provider}`);
             return;
         }
+    } else if (!isInteractive()) {
+        const names = availableProviders.map((p) => p.getName()).join(", ");
+        logger.error(`--provider required in non-interactive mode. Available: ${names}`);
+        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "all"] }));
+        return;
     } else {
         try {
             selectedProviders = await checkbox({
@@ -266,53 +272,59 @@ export async function syncFromProviders(providers: MCPProvider[], options: SyncF
                 `Incoming (${conflict.provider})`
             );
 
-            // Ask user to choose
-            try {
-                const choice = await select({
-                    message: `Which version should be kept for '${serverName}'?`,
-                    choices: [
-                        {
-                            value: "current",
-                            name: `Keep current (unified config)`,
-                        },
-                        {
-                            value: "incoming",
-                            name: `Use incoming (${conflict.provider})`,
-                        },
-                    ],
-                });
-
-                if (choice === "incoming") {
-                    // Merge _meta.enabled from both versions when using incoming version
-                    const existingMeta = mergedServers[serverName]?._meta;
-                    const incomingMeta = conflict.incoming._meta;
-                    const mergedMeta = {
-                        enabled: {
-                            ...existingMeta?.enabled,
-                            ...incomingMeta?.enabled,
-                        },
-                    };
-                    mergedServers[serverName] = { ...conflict.incoming, _meta: mergedMeta };
-                    logger.info(chalk.green(`✓ Using incoming version from ${conflict.provider}`));
-                } else {
-                    // Merge enabled state from incoming into existing
-                    const existingMeta = mergedServers[serverName]?._meta || { enabled: {} };
-                    const incomingMeta = conflict.incoming._meta;
-                    if (incomingMeta?.enabled) {
-                        existingMeta.enabled = {
-                            ...existingMeta.enabled,
-                            ...incomingMeta.enabled,
-                        };
+            // Ask user to choose (or auto-keep current in non-TTY)
+            let choice: string;
+            if (!isInteractive()) {
+                logger.info(`Non-interactive: keeping current version for '${serverName}'`);
+                choice = "current";
+            } else {
+                try {
+                    choice = await select({
+                        message: `Which version should be kept for '${serverName}'?`,
+                        choices: [
+                            {
+                                value: "current",
+                                name: `Keep current (unified config)`,
+                            },
+                            {
+                                value: "incoming",
+                                name: `Use incoming (${conflict.provider})`,
+                            },
+                        ],
+                    });
+                } catch (error) {
+                    if (error instanceof ExitPromptError) {
+                        logger.info("\nOperation cancelled by user.");
+                        return;
                     }
-                    mergedServers[serverName] = { ...mergedServers[serverName], _meta: existingMeta };
-                    logger.info(chalk.green(`✓ Keeping current version (merged enabled state)`));
+                    throw error;
                 }
-            } catch (error) {
-                if (error instanceof ExitPromptError) {
-                    logger.info("\nOperation cancelled by user.");
-                    return;
+            }
+
+            if (choice === "incoming") {
+                // Merge _meta.enabled from both versions when using incoming version
+                const existingMeta = mergedServers[serverName]?._meta;
+                const incomingMeta = conflict.incoming._meta;
+                const mergedMeta = {
+                    enabled: {
+                        ...existingMeta?.enabled,
+                        ...incomingMeta?.enabled,
+                    },
+                };
+                mergedServers[serverName] = { ...conflict.incoming, _meta: mergedMeta };
+                logger.info(chalk.green(`✓ Using incoming version from ${conflict.provider}`));
+            } else {
+                // Merge enabled state from incoming into existing
+                const existingMeta = mergedServers[serverName]?._meta || { enabled: {} };
+                const incomingMeta = conflict.incoming._meta;
+                if (incomingMeta?.enabled) {
+                    existingMeta.enabled = {
+                        ...existingMeta.enabled,
+                        ...incomingMeta.enabled,
+                    };
                 }
-                throw error;
+                mergedServers[serverName] = { ...mergedServers[serverName], _meta: existingMeta };
+                logger.info(chalk.green(`✓ Keeping current version (merged enabled state)`));
             }
         }
     }

--- a/src/mcp-manager/commands/sync-from-providers.ts
+++ b/src/mcp-manager/commands/sync-from-providers.ts
@@ -1,8 +1,8 @@
 import logger from "@app/logger";
-import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { readUnifiedConfig, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
 import type { MCPProviderName, PerProjectEnabledState, ProviderEnabledState } from "@app/mcp-manager/utils/types.js";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { DiffUtil } from "@app/utils/diff";
 import { SafeJSON } from "@app/utils/json";
 import { ExitPromptError } from "@inquirer/core";

--- a/src/mcp-manager/commands/sync.ts
+++ b/src/mcp-manager/commands/sync.ts
@@ -46,7 +46,7 @@ export async function syncServers(providers: MCPProvider[], options: SyncOptions
         const names = availableProviders.map((p) => p.getName()).join(", ");
         logger.error(`--provider required in non-interactive mode. Available: ${names}`);
         logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "all"] }));
-        return;
+        process.exit(1);
     } else {
         try {
             selectedProviders = await checkbox({

--- a/src/mcp-manager/commands/sync.ts
+++ b/src/mcp-manager/commands/sync.ts
@@ -1,4 +1,5 @@
 import logger from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { readUnifiedConfig, stripMeta } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider } from "@app/mcp-manager/utils/providers/types.js";
 import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
@@ -41,6 +42,11 @@ export async function syncServers(providers: MCPProvider[], options: SyncOptions
         // before being passed to this function, so we select all providers here since they
         // are already the subset that was requested via --provider flag.
         selectedProviders = availableProviders.map((p) => p.getName());
+    } else if (!isInteractive()) {
+        const names = availableProviders.map((p) => p.getName()).join(", ");
+        logger.error(`--provider required in non-interactive mode. Available: ${names}`);
+        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "all"] }));
+        return;
     } else {
         try {
             selectedProviders = await checkbox({

--- a/src/mcp-manager/commands/sync.ts
+++ b/src/mcp-manager/commands/sync.ts
@@ -1,8 +1,8 @@
 import logger from "@app/logger";
-import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { readUnifiedConfig, stripMeta } from "@app/mcp-manager/utils/config.utils.js";
 import type { MCPProvider } from "@app/mcp-manager/utils/providers/types.js";
 import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { ExitPromptError } from "@inquirer/core";
 import { checkbox } from "@inquirer/prompts";
 

--- a/src/mcp-manager/index.ts
+++ b/src/mcp-manager/index.ts
@@ -1,5 +1,5 @@
 import logger, { configureLogger } from "@app/logger";
-import { enhanceHelp } from "@app/utils/cli";
+import { enhanceHelp, isInteractive } from "@app/utils/cli";
 import { handleReadmeFlag } from "@app/utils/readme";
 import { ExitPromptError } from "@inquirer/core";
 import { input, select } from "@inquirer/prompts";
@@ -245,6 +245,11 @@ program.action(async () => {
     const opts = program.opts();
     const allProviders = getProviders();
     const providers = parseProviderArg(opts.provider, allProviders);
+
+    if (!isInteractive()) {
+        showHelp();
+        process.exit(1);
+    }
 
     try {
         const action = await select({

--- a/src/mcp-manager/utils/command.utils.ts
+++ b/src/mcp-manager/utils/command.utils.ts
@@ -361,9 +361,7 @@ export async function getServerNames(
     // Otherwise, prompt for selection (TTY only)
     if (!isInteractive()) {
         const serverNames = Object.keys(config.mcpServers).sort();
-        logger.error(
-            `Server name(s) required in non-interactive mode. Available: ${serverNames.join(", ")}`
-        );
+        logger.error(`Server name(s) required in non-interactive mode. Available: ${serverNames.join(", ")}`);
         logger.info(suggestCommand("tools mcp-manager", { add: ["<server1,server2>"] }));
         return null;
     }

--- a/src/mcp-manager/utils/command.utils.ts
+++ b/src/mcp-manager/utils/command.utils.ts
@@ -1,4 +1,5 @@
 import logger from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import { ExitPromptError } from "@inquirer/core";
 import { checkbox } from "@inquirer/prompts";
@@ -357,7 +358,16 @@ export async function getServerNames(
         return parsedNames;
     }
 
-    // Otherwise, prompt for selection
+    // Otherwise, prompt for selection (TTY only)
+    if (!isInteractive()) {
+        const serverNames = Object.keys(config.mcpServers).sort();
+        logger.error(
+            `Server name(s) required in non-interactive mode. Available: ${serverNames.join(", ")}`
+        );
+        logger.info(suggestCommand("tools mcp-manager", { add: ["<server1,server2>"] }));
+        return null;
+    }
+
     return await promptForServers(config, promptMessage);
 }
 
@@ -367,6 +377,13 @@ export async function getServerNames(
 export async function promptForProviders(availableProviders: MCPProvider[], message: string): Promise<string[] | null> {
     if (availableProviders.length === 0) {
         logger.warn("No provider configuration files found.");
+        return null;
+    }
+
+    if (!isInteractive()) {
+        const names = availableProviders.map((p) => p.getName()).join(", ");
+        logger.error(`--provider required in non-interactive mode. Available: ${names}`);
+        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "claude"] }));
         return null;
     }
 
@@ -401,6 +418,11 @@ export interface ProjectChoice {
  * Prompt user to select projects for a provider that supports project-level configuration
  */
 export async function promptForProjects(projects: string[], message: string): Promise<ProjectChoice[] | null> {
+    if (!isInteractive()) {
+        // Non-interactive: default to global (all projects)
+        return [{ projectPath: null, displayName: "Global (all projects)" }];
+    }
+
     const choices = [
         {
             value: "global",

--- a/src/mcp-manager/utils/command.utils.ts
+++ b/src/mcp-manager/utils/command.utils.ts
@@ -381,7 +381,9 @@ export async function promptForProviders(availableProviders: MCPProvider[], mess
     if (!isInteractive()) {
         const names = availableProviders.map((p) => p.getName()).join(", ");
         logger.error(`--provider required in non-interactive mode. Available: ${names}`);
-        logger.info(suggestCommand("tools mcp-manager", { add: ["--provider", "claude"] }));
+        logger.info(
+            suggestCommand("tools mcp-manager", { add: ["--provider", availableProviders[0]?.getName() ?? "claude"] })
+        );
         return null;
     }
 

--- a/src/utils/cli/executor.ts
+++ b/src/utils/cli/executor.ts
@@ -2,6 +2,14 @@ import type { Command } from "commander";
 import pc from "picocolors";
 
 /**
+ * Check if we're in an interactive TTY context.
+ * When false, prompts would hang — callers should suggest CLI flags instead.
+ */
+export function isInteractive(): boolean {
+    return !!process.stdin.isTTY;
+}
+
+/**
  * Enhance a Commander program with better help UX:
  * - Shows help after errors (e.g. too many arguments)
  * - Expands subcommand options in the parent's help output

--- a/src/utils/cli/index.ts
+++ b/src/utils/cli/index.ts
@@ -1,5 +1,5 @@
 export type { ExecResult, ExecutorOptions } from "./executor";
-export { buildCommand, Executor, enhanceHelp, suggestCommand } from "./executor";
+export { buildCommand, Executor, enhanceHelp, isInteractive, suggestCommand } from "./executor";
 export type { RunToolOptions } from "./tools";
 export { runTool, runToolInteractive } from "./tools";
 export { parseVariadic } from "./variadic";


### PR DESCRIPTION
- Add `isInteractive()` utility to `src/utils/cli` — checks `process.stdin.isTTY`
- Guard all interactive prompts in mcp-manager (sync, install, enable/disable, rename, config, sync-from-providers) to error with `suggestCommand()` hints instead of hanging in non-TTY
- `promptForProjects()` defaults to "Global" in non-TTY; conflict resolution in sync-from-providers auto-keeps current
- Document `isInteractive()`, `suggestCommand()` and the non-TTY guard pattern in CLAUDE.md
- [x] `tools mcp-manager sync 2>&1` → shows `--provider all` suggestion
- [x] `tools mcp-manager enable 2>&1` → shows available servers
- [x] `tools mcp-manager install 2>&1` → shows usage example
- [x] `tools mcp-manager rename 2>&1` → shows usage
- [x] `tools mcp-manager config 2>&1` → prints path only (no editor)
- [x] `tools mcp-manager 2>&1` → shows help
- [x] `tools mcp-manager enable github --provider claude 2>&1` → works end-to-end
- [x] `bunx tsgo --noEmit` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now detects non‑interactive (non‑TTY) runs and short‑circuits interactive prompts, returning sensible defaults or exiting with help.

* **Bug Fixes**
  * Commands exit cleanly in non‑interactive mode with clear, actionable messages and suggested invocations.
  * Provider discovery now verifies availability before presenting options to users.

* **Documentation**
  * Contributor guidance updated to document the new CLI helper and non‑interactive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->