### PR TITLE
feat(indexer): search output redesign — pretty/simple/table formatters, confidence, highlighting

### DIFF
--- a/src/e2e/indexer.e2e.test.ts
+++ b/src/e2e/indexer.e2e.test.ts
@@ -2,8 +2,8 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SafeJSON } from "@app/utils/json";
 import { runTool, stripAnsi } from "@app/utils/e2e/helpers";
+import { SafeJSON } from "@app/utils/json";
 
 const TEST_PREFIX = `test_e2e_${Date.now()}`;
 let tempDir: string;

--- a/src/indexer/commands/rebuild.ts
+++ b/src/indexer/commands/rebuild.ts
@@ -57,7 +57,7 @@ export function registerRebuildCommand(program: Command): void {
                         { value: "reindex-reembed", label: "Full reindex + re-embed" },
                     ];
 
-                    if (currentDriver && currentDriver !== "sqlite-vec") {
+                    if (currentDriver === "sqlite-brute") {
                         options.splice(1, 0, {
                             value: "migrate-driver",
                             label: `Migrate vector storage: ${currentDriver} → sqlite-vec`,

--- a/src/indexer/commands/rebuild.ts
+++ b/src/indexer/commands/rebuild.ts
@@ -1,3 +1,4 @@
+import { isInteractive } from "@app/utils/cli";
 import { formatDuration } from "@app/utils/format";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
@@ -24,7 +25,7 @@ export function registerRebuildCommand(program: Command): void {
                         return;
                     }
 
-                    if (process.stdout.isTTY && process.stdin.isTTY) {
+                    if (isInteractive()) {
                         const selected = await p.select({
                             message: "Select index to rebuild",
                             options: names.map((n) => ({ value: n, label: n })),
@@ -47,8 +48,8 @@ export function registerRebuildCommand(program: Command): void {
                 const metas = manager.listIndexes();
                 const meta = metas.find((m) => m.name === targetName);
 
-                if (process.stdout.isTTY && process.stdin.isTTY) {
-                    const currentDriver = meta?.config.storage?.vectorDriver ?? "sqlite-brute";
+                if (isInteractive()) {
+                    const currentDriver = meta?.config.storage?.vectorDriver;
 
                     const options: Array<{ value: string; label: string }> = [
                         { value: "reindex", label: "Full reindex (re-scan all files, re-chunk)" },
@@ -56,7 +57,7 @@ export function registerRebuildCommand(program: Command): void {
                         { value: "reindex-reembed", label: "Full reindex + re-embed" },
                     ];
 
-                    if (currentDriver !== "sqlite-vec") {
+                    if (currentDriver && currentDriver !== "sqlite-vec") {
                         options.splice(1, 0, {
                             value: "migrate-driver",
                             label: `Migrate vector storage: ${currentDriver} → sqlite-vec`,
@@ -74,11 +75,13 @@ export function registerRebuildCommand(program: Command): void {
                     }
 
                     if (action === "migrate-driver") {
-                        p.log.warn("Driver migration not yet implemented — running full reindex instead");
+                        p.log.warn("Driver migration is not implemented yet.");
+                        return;
                     }
 
                     if (action === "reembed") {
-                        p.log.warn("Re-embedding not yet implemented — running full reindex instead");
+                        p.log.warn("Re-embedding is not implemented yet.");
+                        return;
                     }
 
                     if (action === "reindex-reembed") {

--- a/src/indexer/commands/rebuild.ts
+++ b/src/indexer/commands/rebuild.ts
@@ -45,47 +45,14 @@ export function registerRebuildCommand(program: Command): void {
 
                 p.intro(pc.bgCyan(pc.white(` rebuild ${targetName} `)));
 
-                const metas = manager.listIndexes();
-                const meta = metas.find((m) => m.name === targetName);
-
                 if (isInteractive()) {
-                    const currentDriver = meta?.config.storage?.vectorDriver;
-
-                    const options: Array<{ value: string; label: string }> = [
-                        { value: "reindex", label: "Full reindex (re-scan all files, re-chunk)" },
-                        { value: "reembed", label: "Re-embed all chunks (regenerate vectors, keep content)" },
-                        { value: "reindex-reembed", label: "Full reindex + re-embed" },
-                    ];
-
-                    if (currentDriver === "sqlite-brute") {
-                        options.splice(1, 0, {
-                            value: "migrate-driver",
-                            label: `Migrate vector storage: ${currentDriver} → sqlite-vec`,
-                        });
-                    }
-
-                    const action = await p.select({
-                        message: `What would you like to do with "${targetName}"?`,
-                        options,
+                    const confirmed = await p.confirm({
+                        message: `Rebuild "${targetName}"? This will re-scan all source files and re-chunk.`,
                     });
 
-                    if (p.isCancel(action)) {
+                    if (p.isCancel(confirmed) || !confirmed) {
                         p.log.info("Cancelled");
                         return;
-                    }
-
-                    if (action === "migrate-driver") {
-                        p.log.warn("Driver migration is not implemented yet.");
-                        return;
-                    }
-
-                    if (action === "reembed") {
-                        p.log.warn("Re-embedding is not implemented yet.");
-                        return;
-                    }
-
-                    if (action === "reindex-reembed") {
-                        p.log.info("Full reindex with re-embedding");
                     }
                 }
 

--- a/src/indexer/commands/rebuild.ts
+++ b/src/indexer/commands/rebuild.ts
@@ -46,16 +46,43 @@ export function registerRebuildCommand(program: Command): void {
 
                 const metas = manager.listIndexes();
                 const meta = metas.find((m) => m.name === targetName);
-                const chunkCount = meta?.stats.totalChunks ?? 0;
 
-                if (process.stdout.isTTY && chunkCount > 0) {
-                    const confirmed = await p.confirm({
-                        message: `Rebuild "${targetName}" (${chunkCount.toLocaleString()} chunks)? This will re-scan all source files.`,
+                if (process.stdout.isTTY && process.stdin.isTTY) {
+                    const currentDriver = meta?.config.storage?.vectorDriver ?? "sqlite-brute";
+
+                    const options: Array<{ value: string; label: string }> = [
+                        { value: "reindex", label: "Full reindex (re-scan all files, re-chunk)" },
+                        { value: "reembed", label: "Re-embed all chunks (regenerate vectors, keep content)" },
+                        { value: "reindex-reembed", label: "Full reindex + re-embed" },
+                    ];
+
+                    if (currentDriver !== "sqlite-vec") {
+                        options.splice(1, 0, {
+                            value: "migrate-driver",
+                            label: `Migrate vector storage: ${currentDriver} → sqlite-vec`,
+                        });
+                    }
+
+                    const action = await p.select({
+                        message: `What would you like to do with "${targetName}"?`,
+                        options,
                     });
 
-                    if (p.isCancel(confirmed) || !confirmed) {
+                    if (p.isCancel(action)) {
                         p.log.info("Cancelled");
                         return;
+                    }
+
+                    if (action === "migrate-driver") {
+                        p.log.warn("Driver migration not yet implemented — running full reindex instead");
+                    }
+
+                    if (action === "reembed") {
+                        p.log.warn("Re-embedding not yet implemented — running full reindex instead");
+                    }
+
+                    if (action === "reindex-reembed") {
+                        p.log.info("Full reindex with re-embedding");
                     }
                 }
 

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -1,6 +1,7 @@
 import { toToon } from "@app/json/lib/toon";
 import { SafeJSON } from "@app/utils/json";
 import type { SearchResult } from "@app/utils/search/types";
+import { truncateText } from "@app/utils/string";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { normalizeConfidence } from "../lib/confidence";
@@ -19,6 +20,36 @@ interface SearchCommandOptions {
     file?: string;
     confidence?: number;
     contextChunks?: number;
+}
+
+type IndexResult = { indexName: string; result: SearchResult<ChunkRecord> };
+
+async function searchAndCollect(
+    manager: IndexerManager,
+    names: string[],
+    query: string,
+    mode: SearchMode,
+    limit: number,
+    fileFilter?: string
+): Promise<IndexResult[]> {
+    let allResults: IndexResult[] = [];
+
+    for (const name of names) {
+        const indexer = await manager.getIndex(name);
+        const results = await indexer.search(query, { mode, limit });
+
+        for (const result of results) {
+            allResults.push({ indexName: name, result });
+        }
+    }
+
+    allResults.sort((a, b) => b.result.score - a.result.score);
+
+    if (fileFilter) {
+        allResults = allResults.filter((r) => r.result.doc.filePath.includes(fileFilter));
+    }
+
+    return allResults.slice(0, limit);
 }
 
 export function registerSearchCommand(program: Command): void {
@@ -67,48 +98,15 @@ export function registerSearchCommand(program: Command): void {
                 let effectiveMode = mode;
                 const fetchLimit = opts.file ? limit * 3 : limit;
 
-                let allResults: Array<{ indexName: string; result: SearchResult<ChunkRecord> }> = [];
+                let allResults = await searchAndCollect(manager, names, query, mode, fetchLimit, opts.file);
 
-                for (const name of names) {
-                    const indexer = name === names[0] ? firstIndexer : await manager.getIndex(name);
-                    const results = await indexer.search(query, { mode, limit: fetchLimit });
-
-                    for (const result of results) {
-                        allResults.push({ indexName: name, result });
-                    }
-                }
-
-                allResults.sort((a, b) => b.result.score - a.result.score);
-
-                if (opts.file) {
-                    allResults = allResults.filter((r) => r.result.doc.filePath.includes(opts.file!));
-                }
-
-                allResults = allResults.slice(0, limit);
-
+                // Auto-fallback: if fulltext returned 0 results and embeddings exist, try hybrid
                 if (allResults.length === 0 && mode === "fulltext") {
                     const hasEmbeddings = firstIndexer.getConsistencyInfo().embeddingCount > 0;
 
                     if (hasEmbeddings) {
                         effectiveMode = "hybrid";
-                        allResults = [];
-
-                        for (const name of names) {
-                            const indexer = await manager.getIndex(name);
-                            const results = await indexer.search(query, { mode: "hybrid", limit: fetchLimit });
-
-                            for (const result of results) {
-                                allResults.push({ indexName: name, result });
-                            }
-                        }
-
-                        allResults.sort((a, b) => b.result.score - a.result.score);
-
-                        if (opts.file) {
-                            allResults = allResults.filter((r) => r.result.doc.filePath.includes(opts.file!));
-                        }
-
-                        allResults = allResults.slice(0, limit);
+                        allResults = await searchAndCollect(manager, names, query, "hybrid", fetchLimit, opts.file);
                     }
                 }
 
@@ -153,7 +151,7 @@ export function registerSearchCommand(program: Command): void {
                         confidence: r.confidence,
                         method: r.method,
                         lines: `${r.startLine}-${r.endLine}`,
-                        preview: r.content.replace(/\n/g, " ").replace(/\s+/g, " ").trim().slice(0, 200),
+                        preview: truncateText(r.content.replace(/\n/g, " ").replace(/\s+/g, " ").trim(), 200),
                     }));
 
                     if (format === "json") {

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -8,7 +8,7 @@ import { formatChunkDisplayName } from "../lib/display-name";
 import { parseQueryWords } from "../lib/highlight";
 import { IndexerManager } from "../lib/manager";
 import { detectMode, resolveSearchMode, type SearchMode } from "../lib/search-mode";
-import { formatSearchResults, type FormattedSearchResult, type OutputFormat } from "../lib/search-output";
+import { type FormattedSearchResult, formatSearchResults, type OutputFormat } from "../lib/search-output";
 import type { ChunkRecord } from "../lib/types";
 
 interface SearchCommandOptions {
@@ -139,9 +139,10 @@ export function registerSearchCommand(program: Command): void {
                     endLine: r.result.doc.endLine,
                 }));
 
-                const filtered = opts.confidence !== undefined
-                    ? formatted.filter((r) => r.confidence >= opts.confidence!)
-                    : formatted;
+                const filtered =
+                    opts.confidence !== undefined
+                        ? formatted.filter((r) => r.confidence >= opts.confidence!)
+                        : formatted;
 
                 if (format === "json" || format === "toon") {
                     const output = filtered.map((r) => ({

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -19,7 +19,6 @@ interface SearchCommandOptions {
     format?: "pretty" | "simple" | "table" | "json" | "toon";
     file?: string;
     confidence?: number;
-    contextChunks?: number;
 }
 
 type IndexResult = { indexName: string; result: SearchResult<ChunkRecord> };
@@ -63,13 +62,18 @@ export function registerSearchCommand(program: Command): void {
         .option("-f, --file <filter>", "Filter results to files matching this substring")
         .option("--format <type>", "Output format: pretty, simple, table, json, toon (default: pretty)")
         .option("-c, --confidence <min>", "Minimum confidence % (0-100)", parseInt)
-        .option("--context-chunks <n>", "Show N surrounding chunks for context", parseInt)
         .action(async (query: string, opts: SearchCommandOptions) => {
             const manager = await IndexerManager.load();
 
             try {
+                const validFormats = ["pretty", "simple", "table", "json", "toon"] as const;
                 const limit = opts.limit ?? 20;
                 const format = opts.format ?? (process.stdout.isTTY ? "pretty" : "simple");
+
+                if (!validFormats.includes(format as (typeof validFormats)[number])) {
+                    p.log.error(`Unknown format: "${format}". Valid: ${validFormats.join(", ")}`);
+                    return;
+                }
 
                 const names = opts.index ? [opts.index] : manager.getIndexNames();
 
@@ -100,8 +104,8 @@ export function registerSearchCommand(program: Command): void {
 
                 let allResults = await searchAndCollect(manager, names, query, mode, fetchLimit, opts.file);
 
-                // Auto-fallback: if fulltext returned 0 results and embeddings exist, try hybrid
-                if (allResults.length === 0 && mode === "fulltext") {
+                // Auto-fallback: only when mode was auto-detected (not explicitly requested)
+                if (allResults.length === 0 && mode === "fulltext" && !opts.mode) {
                     const hasEmbeddings = firstIndexer.getConsistencyInfo().embeddingCount > 0;
 
                     if (hasEmbeddings) {

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -1,72 +1,24 @@
 import { toToon } from "@app/json/lib/toon";
 import { SafeJSON } from "@app/utils/json";
 import type { SearchResult } from "@app/utils/search/types";
-import { truncateText } from "@app/utils/string";
-import { formatTable } from "@app/utils/table";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
-import pc from "picocolors";
+import { normalizeConfidence } from "../lib/confidence";
+import { formatChunkDisplayName } from "../lib/display-name";
+import { parseQueryWords } from "../lib/highlight";
 import { IndexerManager } from "../lib/manager";
-import { detectMode, type SearchMode } from "../lib/search-mode";
+import { detectMode, resolveSearchMode, type SearchMode } from "../lib/search-mode";
+import { formatSearchResults, type FormattedSearchResult, type OutputFormat } from "../lib/search-output";
 import type { ChunkRecord } from "../lib/types";
 
 interface SearchCommandOptions {
     index?: string;
-    mode?: SearchMode;
+    mode?: string;
     limit?: number;
-    format?: "table" | "json" | "toon";
+    format?: "pretty" | "simple" | "table" | "json" | "toon";
     file?: string;
-}
-
-/** Minimum cosine score below which vector/hybrid results are likely noise */
-const VECTOR_MIN_SCORE = 0.55;
-/** RRF scores are tiny — equivalent threshold for hybrid mode */
-const HYBRID_MIN_SCORE = VECTOR_MIN_SCORE * (1 / 60);
-
-function truncatePreview(text: string, maxLen: number): string {
-    const collapsed = text.replace(/\n/g, " ").replace(/\s+/g, " ").trim();
-    return truncateText(collapsed, maxLen);
-}
-
-/**
- * Apply a minimum score filter so irrelevant results don't pollute output.
- * Only applied to vector/hybrid modes where low-score noise is common.
- */
-function filterByMinScore(
-    results: Array<{ indexName: string; result: SearchResult<ChunkRecord> }>,
-    mode: SearchMode
-): Array<{ indexName: string; result: SearchResult<ChunkRecord> }> {
-    if (mode === "fulltext") {
-        return results;
-    }
-
-    const threshold = mode === "hybrid" ? HYBRID_MIN_SCORE : VECTOR_MIN_SCORE;
-    return results.filter((r) => r.result.score >= threshold);
-}
-
-async function searchIndexes(
-    manager: IndexerManager,
-    indexNames: string[],
-    query: string,
-    mode: SearchMode,
-    limit: number
-): Promise<Array<{ indexName: string; result: SearchResult<ChunkRecord> }>> {
-    let allResults: Array<{ indexName: string; result: SearchResult<ChunkRecord> }> = [];
-
-    for (const name of indexNames) {
-        const indexer = await manager.getIndex(name);
-        const results = await indexer.search(query, { mode, limit });
-
-        for (const result of results) {
-            allResults.push({ indexName: name, result });
-        }
-    }
-
-    allResults.sort((a, b) => b.result.score - a.result.score);
-    allResults = filterByMinScore(allResults, mode);
-    allResults = allResults.slice(0, limit);
-
-    return allResults;
+    confidence?: number;
+    contextChunks?: number;
 }
 
 export function registerSearchCommand(program: Command): void {
@@ -77,28 +29,22 @@ export function registerSearchCommand(program: Command): void {
         .option("-i, --index <name>", "Search specific index (default: all)")
         .option("-m, --mode <mode>", "Search mode: fulltext, vector, hybrid (default: auto-detect)")
         .option("-l, --limit <n>", "Max results", parseInt, 20)
-        .option("-f, --file <filter>", "Filter results to files matching this substring (e.g. '.ts', 'src/utils')")
-        .option("--format <type>", "Output format: table, json, toon (default: table)")
+        .option("-f, --file <filter>", "Filter results to files matching this substring")
+        .option("--format <type>", "Output format: pretty, simple, table, json, toon (default: pretty)")
+        .option("-c, --confidence <min>", "Minimum confidence % (0-100)", parseInt)
+        .option("--context-chunks <n>", "Show N surrounding chunks for context", parseInt)
         .action(async (query: string, opts: SearchCommandOptions) => {
             const manager = await IndexerManager.load();
 
             try {
                 const limit = opts.limit ?? 20;
-                const format = opts.format ?? "table";
+                const format = opts.format ?? (process.stdout.isTTY ? "pretty" : "simple");
 
-                const names: string[] = [];
+                const names = opts.index ? [opts.index] : manager.getIndexNames();
 
-                if (opts.index) {
-                    names.push(opts.index);
-                } else {
-                    const all = manager.getIndexNames();
-
-                    if (all.length === 0) {
-                        p.log.info("No indexes configured. Run: tools indexer add <path>");
-                        return;
-                    }
-
-                    names.push(...all);
+                if (names.length === 0) {
+                    p.log.info("No indexes configured. Run: tools indexer add <path>");
+                    return;
                 }
 
                 const firstIndexer = await manager.getIndex(names[0]);
@@ -106,32 +52,63 @@ export function registerSearchCommand(program: Command): void {
                 let mode: SearchMode;
 
                 if (opts.mode) {
-                    mode = opts.mode;
+                    const resolved = resolveSearchMode(opts.mode);
+
+                    if (!resolved) {
+                        p.log.error(`Unknown search mode: "${opts.mode}". Valid: fulltext, vector, hybrid, semantic`);
+                        return;
+                    }
+
+                    mode = resolved;
                 } else {
                     mode = detectMode(firstIndexer);
                 }
 
                 let effectiveMode = mode;
-
                 const fetchLimit = opts.file ? limit * 3 : limit;
-                let allResults = await searchIndexes(manager, names, query, mode, fetchLimit);
 
-                if (opts.file) {
-                    const filter = opts.file;
-                    allResults = allResults.filter((r) => r.result.doc.filePath.includes(filter));
-                    allResults = allResults.slice(0, limit);
+                let allResults: Array<{ indexName: string; result: SearchResult<ChunkRecord> }> = [];
+
+                for (const name of names) {
+                    const indexer = name === names[0] ? firstIndexer : await manager.getIndex(name);
+                    const results = await indexer.search(query, { mode, limit: fetchLimit });
+
+                    for (const result of results) {
+                        allResults.push({ indexName: name, result });
+                    }
                 }
 
-                if (allResults.length === 0 && mode === "fulltext" && !opts.mode) {
-                    const info = firstIndexer.getConsistencyInfo();
+                allResults.sort((a, b) => b.result.score - a.result.score);
 
-                    if (info.embeddingCount > 0) {
-                        allResults = await searchIndexes(manager, names, query, "hybrid", limit);
+                if (opts.file) {
+                    allResults = allResults.filter((r) => r.result.doc.filePath.includes(opts.file!));
+                }
+
+                allResults = allResults.slice(0, limit);
+
+                if (allResults.length === 0 && mode === "fulltext") {
+                    const hasEmbeddings = firstIndexer.getConsistencyInfo().embeddingCount > 0;
+
+                    if (hasEmbeddings) {
                         effectiveMode = "hybrid";
+                        allResults = [];
 
-                        if (allResults.length > 0) {
-                            p.log.info(pc.dim("No keyword matches — showing semantic results instead"));
+                        for (const name of names) {
+                            const indexer = await manager.getIndex(name);
+                            const results = await indexer.search(query, { mode: "hybrid", limit: fetchLimit });
+
+                            for (const result of results) {
+                                allResults.push({ indexName: name, result });
+                            }
                         }
+
+                        allResults.sort((a, b) => b.result.score - a.result.score);
+
+                        if (opts.file) {
+                            allResults = allResults.filter((r) => r.result.doc.filePath.includes(opts.file!));
+                        }
+
+                        allResults = allResults.slice(0, limit);
                     }
                 }
 
@@ -140,50 +117,62 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
-                function toOutputRow(r: { indexName: string; result: SearchResult<ChunkRecord> }) {
-                    return {
+                const maxBm25Score = allResults.reduce(
+                    (max, r) => (r.result.method === "bm25" ? Math.max(max, r.result.score) : max),
+                    0
+                );
+
+                const formatted: FormattedSearchResult[] = allResults.map((r) => ({
+                    filePath: r.result.doc.filePath,
+                    displayName: formatChunkDisplayName(
+                        r.result.doc.name,
+                        r.result.doc.startLine,
+                        r.result.doc.endLine,
+                        r.result.doc.kind
+                    ),
+                    language: r.result.doc.language ?? null,
+                    content: r.result.doc.content,
+                    confidence: normalizeConfidence(r.result.score, r.result.method, maxBm25Score),
+                    method: r.result.method,
+                    indexName: r.indexName,
+                    startLine: r.result.doc.startLine,
+                    endLine: r.result.doc.endLine,
+                }));
+
+                const filtered = opts.confidence !== undefined
+                    ? formatted.filter((r) => r.confidence >= opts.confidence!)
+                    : formatted;
+
+                if (format === "json" || format === "toon") {
+                    const output = filtered.map((r) => ({
                         index: r.indexName,
-                        file: r.result.doc.filePath,
-                        name: r.result.doc.name ?? "",
-                        kind: r.result.doc.kind,
-                        score: r.result.score,
-                        method: r.result.method,
-                        lines: `${r.result.doc.startLine}-${r.result.doc.endLine}`,
-                        preview: truncatePreview(r.result.doc.content, 200),
-                    };
-                }
+                        file: r.filePath,
+                        name: r.displayName,
+                        language: r.language,
+                        confidence: r.confidence,
+                        method: r.method,
+                        lines: `${r.startLine}-${r.endLine}`,
+                        preview: r.content.replace(/\n/g, " ").replace(/\s+/g, " ").trim().slice(0, 200),
+                    }));
 
-                if (format === "json") {
-                    const output = allResults.map(toOutputRow);
-                    console.log(SafeJSON.stringify(output, null, 2));
+                    if (format === "json") {
+                        console.log(SafeJSON.stringify(output, null, 2));
+                    } else {
+                        console.log(toToon(output));
+                    }
+
                     return;
                 }
 
-                if (format === "toon") {
-                    const output = allResults.map(toOutputRow);
-                    console.log(toToon(output));
-                    return;
-                }
-
-                const headers = ["File", "Name/Kind", "Score", "Method", "Preview"];
-                const rows = allResults.map((r) => {
-                    const filePath = r.result.doc.filePath;
-                    const shortPath = filePath.length > 40 ? `...${filePath.slice(-37)}` : filePath;
-
-                    return [
-                        shortPath,
-                        r.result.doc.name ?? r.result.doc.kind,
-                        r.result.score.toFixed(3),
-                        r.result.method,
-                        truncatePreview(r.result.doc.content, 80),
-                    ];
+                const words = parseQueryWords(query);
+                const output = formatSearchResults({
+                    results: filtered,
+                    format: format as OutputFormat,
+                    query,
+                    mode: effectiveMode,
+                    highlightWords: words,
                 });
-
-                console.log("");
-                console.log(pc.dim(`${allResults.length} results for "${query}" (${effectiveMode})`));
-                console.log("");
-                console.log(formatTable(rows, headers, { alignRight: [2] }));
-                console.log("");
+                console.log(output);
             } finally {
                 await manager.close();
             }

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -8,7 +8,7 @@ import { normalizeConfidence } from "../lib/confidence";
 import { formatChunkDisplayName } from "../lib/display-name";
 import { parseQueryWords } from "../lib/highlight";
 import { IndexerManager } from "../lib/manager";
-import { detectMode, resolveSearchMode, type SearchMode } from "../lib/search-mode";
+import { anyHaveEmbeddings, detectModeMulti, resolveSearchMode, type SearchMode } from "../lib/search-mode";
 import { type FormattedSearchResult, formatSearchResults, type OutputFormat } from "../lib/search-output";
 import type { ChunkRecord } from "../lib/types";
 
@@ -89,7 +89,8 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
-                const firstIndexer = await manager.getIndex(names[0]);
+                // Load all indexers upfront for mode detection across all indexes
+                const indexers = await Promise.all(names.map((n) => manager.getIndex(n)));
 
                 let mode: SearchMode;
 
@@ -103,7 +104,7 @@ export function registerSearchCommand(program: Command): void {
 
                     mode = resolved;
                 } else {
-                    mode = detectMode(firstIndexer);
+                    mode = detectModeMulti(indexers);
                 }
 
                 let effectiveMode = mode;
@@ -113,9 +114,7 @@ export function registerSearchCommand(program: Command): void {
 
                 // Auto-fallback: only when mode was auto-detected (not explicitly requested)
                 if (allResults.length === 0 && mode === "fulltext" && !opts.mode) {
-                    const hasEmbeddings = firstIndexer.getConsistencyInfo().embeddingCount > 0;
-
-                    if (hasEmbeddings) {
+                    if (anyHaveEmbeddings(indexers)) {
                         effectiveMode = "hybrid";
                         allResults = await searchAndCollect(manager, names, query, "hybrid", fetchLimit, opts.file);
                     }
@@ -149,9 +148,7 @@ export function registerSearchCommand(program: Command): void {
                 }));
 
                 const filtered =
-                    confidence !== undefined
-                        ? formatted.filter((r) => r.confidence >= confidence)
-                        : formatted;
+                    confidence !== undefined ? formatted.filter((r) => r.confidence >= confidence) : formatted;
 
                 if (format === "json" || format === "toon") {
                     const output = filtered.map((r) => ({
@@ -161,10 +158,7 @@ export function registerSearchCommand(program: Command): void {
                         language: r.language,
                         confidence: r.confidence,
                         method: r.method,
-                        lines:
-                            r.startLine != null && r.endLine != null
-                                ? `${r.startLine}-${r.endLine}`
-                                : null,
+                        lines: r.startLine != null && r.endLine != null ? `${r.startLine}-${r.endLine}` : null,
                         preview: truncateText(r.content.replace(/\n/g, " ").replace(/\s+/g, " ").trim(), 200),
                     }));
 

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -75,6 +75,13 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
+                const confidence = opts.confidence;
+
+                if (confidence !== undefined && (!Number.isFinite(confidence) || confidence < 0 || confidence > 100)) {
+                    p.log.error(`Invalid confidence: "${opts.confidence}". Expected 0-100.`);
+                    return;
+                }
+
                 const names = opts.index ? [opts.index] : manager.getIndexNames();
 
                 if (names.length === 0) {
@@ -142,8 +149,8 @@ export function registerSearchCommand(program: Command): void {
                 }));
 
                 const filtered =
-                    opts.confidence !== undefined
-                        ? formatted.filter((r) => r.confidence >= opts.confidence!)
+                    confidence !== undefined
+                        ? formatted.filter((r) => r.confidence >= confidence)
                         : formatted;
 
                 if (format === "json" || format === "toon") {
@@ -154,7 +161,10 @@ export function registerSearchCommand(program: Command): void {
                         language: r.language,
                         confidence: r.confidence,
                         method: r.method,
-                        lines: `${r.startLine}-${r.endLine}`,
+                        lines:
+                            r.startLine != null && r.endLine != null
+                                ? `${r.startLine}-${r.endLine}`
+                                : null,
                         preview: truncateText(r.content.replace(/\n/g, " ").replace(/\s+/g, " ").trim(), 200),
                     }));
 

--- a/src/indexer/lib/confidence.test.ts
+++ b/src/indexer/lib/confidence.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeConfidence } from "./confidence";
+
+describe("normalizeConfidence", () => {
+    describe("cosine", () => {
+        test("1.0 → 100", () => {
+            expect(normalizeConfidence(1.0, "cosine")).toBe(100);
+        });
+
+        test("0.75 → 75", () => {
+            expect(normalizeConfidence(0.75, "cosine")).toBe(75);
+        });
+
+        test("0 → 0", () => {
+            expect(normalizeConfidence(0, "cosine")).toBe(0);
+        });
+
+        test("negative → 0", () => {
+            expect(normalizeConfidence(-0.5, "cosine")).toBe(0);
+        });
+    });
+
+    describe("rrf", () => {
+        test("max theoretical (2/61) → 100", () => {
+            expect(normalizeConfidence(2 / 61, "rrf")).toBe(100);
+        });
+
+        test("typical top result 0.016 → ~49", () => {
+            const result = normalizeConfidence(0.016, "rrf");
+            expect(result).toBeGreaterThanOrEqual(48);
+            expect(result).toBeLessThanOrEqual(50);
+        });
+
+        test("0 → 0", () => {
+            expect(normalizeConfidence(0, "rrf")).toBe(0);
+        });
+    });
+
+    describe("bm25", () => {
+        test("with maxScore 30: 30 → 100", () => {
+            expect(normalizeConfidence(30, "bm25", 30)).toBe(100);
+        });
+
+        test("with maxScore 30: 15 → 50", () => {
+            expect(normalizeConfidence(15, "bm25", 30)).toBe(50);
+        });
+
+        test("without maxScore: returns 0-100 range", () => {
+            const low = normalizeConfidence(1, "bm25");
+            const mid = normalizeConfidence(10, "bm25");
+            const high = normalizeConfidence(25, "bm25");
+
+            expect(low).toBeGreaterThanOrEqual(0);
+            expect(low).toBeLessThanOrEqual(100);
+
+            expect(mid).toBeGreaterThanOrEqual(0);
+            expect(mid).toBeLessThanOrEqual(100);
+
+            expect(high).toBeGreaterThanOrEqual(0);
+            expect(high).toBeLessThanOrEqual(100);
+
+            expect(low).toBeLessThan(mid);
+            expect(mid).toBeLessThan(high);
+        });
+    });
+});

--- a/src/indexer/lib/confidence.test.ts
+++ b/src/indexer/lib/confidence.test.ts
@@ -45,6 +45,22 @@ describe("normalizeConfidence", () => {
             expect(normalizeConfidence(15, "bm25", 30)).toBe(50);
         });
 
+        test("with maxScore 0: falls back to heuristic", () => {
+            const low = normalizeConfidence(1, "bm25", 0);
+            const mid = normalizeConfidence(10, "bm25", 0);
+            const high = normalizeConfidence(25, "bm25", 0);
+
+            expect(low).toBeGreaterThanOrEqual(0);
+            expect(low).toBeLessThanOrEqual(100);
+            expect(mid).toBeGreaterThanOrEqual(0);
+            expect(mid).toBeLessThanOrEqual(100);
+            expect(high).toBeGreaterThanOrEqual(0);
+            expect(high).toBeLessThanOrEqual(100);
+
+            expect(low).toBeLessThan(mid);
+            expect(mid).toBeLessThan(high);
+        });
+
         test("without maxScore: returns 0-100 range", () => {
             const low = normalizeConfidence(1, "bm25");
             const mid = normalizeConfidence(10, "bm25");

--- a/src/indexer/lib/confidence.ts
+++ b/src/indexer/lib/confidence.ts
@@ -1,0 +1,27 @@
+type ScoreMethod = "cosine" | "rrf" | "bm25";
+
+const RRF_THEORETICAL_MAX = 2 / 61;
+
+export function normalizeConfidence(score: number, method: ScoreMethod, maxScore?: number): number {
+    let normalized: number;
+
+    switch (method) {
+        case "cosine":
+            normalized = score * 100;
+            break;
+
+        case "rrf":
+            normalized = (score / RRF_THEORETICAL_MAX) * 100;
+            break;
+
+        case "bm25":
+            if (maxScore !== undefined && maxScore > 0) {
+                normalized = (score / maxScore) * 100;
+            } else {
+                normalized = Math.min(score * 5, 100);
+            }
+            break;
+    }
+
+    return Math.round(Math.max(0, Math.min(100, normalized)));
+}

--- a/src/indexer/lib/confidence.ts
+++ b/src/indexer/lib/confidence.ts
@@ -1,4 +1,4 @@
-type ScoreMethod = "cosine" | "rrf" | "bm25";
+export type ScoreMethod = "cosine" | "rrf" | "bm25";
 
 const RRF_THEORETICAL_MAX = 2 / 61;
 

--- a/src/indexer/lib/display-name.test.ts
+++ b/src/indexer/lib/display-name.test.ts
@@ -6,8 +6,12 @@ describe("stripPartSuffixes", () => {
         expect(stripPartSuffixes("MyClass (part 2)")).toBe("MyClass");
     });
 
-    it("strips stacked part suffixes", () => {
-        expect(stripPartSuffixes("MyClass (part 3) (part 8)")).toBe("MyClass");
+    it("only strips the trailing part suffix", () => {
+        expect(stripPartSuffixes("MyClass (part 3) (part 8)")).toBe("MyClass (part 3)");
+    });
+
+    it("preserves internal (part N) in real symbol names", () => {
+        expect(stripPartSuffixes("RFC (part 2) parser")).toBe("RFC (part 2) parser");
     });
 
     it("leaves names without suffixes unchanged", () => {
@@ -20,8 +24,8 @@ describe("formatChunkDisplayName", () => {
         expect(formatChunkDisplayName("MyClass", 10, 45)).toBe("MyClass:10-45");
     });
 
-    it("strips stacked part suffixes", () => {
-        expect(formatChunkDisplayName("MyClass (part 3) (part 8)", 100, 150)).toBe("MyClass:100-150");
+    it("strips only trailing part suffix", () => {
+        expect(formatChunkDisplayName("MyClass (part 3) (part 8)", 100, 150)).toBe("MyClass (part 3):100-150");
     });
 
     it("strips single part suffix", () => {

--- a/src/indexer/lib/display-name.test.ts
+++ b/src/indexer/lib/display-name.test.ts
@@ -43,4 +43,13 @@ describe("formatChunkDisplayName", () => {
     it("handles single-line chunk", () => {
         expect(formatChunkDisplayName("handler", 42, 42)).toBe("handler:42");
     });
+
+    it("falls back to cleaned name when lines are undefined", () => {
+        expect(formatChunkDisplayName("MyClass (part 2)", undefined, undefined, "function")).toBe("MyClass");
+    });
+
+    it("falls back when lines are NaN", () => {
+        expect(formatChunkDisplayName(undefined, Number.NaN, 10, "function")).toBe("function");
+        expect(formatChunkDisplayName(undefined, Number.NaN, Number.NaN)).toBe("chunk");
+    });
 });

--- a/src/indexer/lib/display-name.test.ts
+++ b/src/indexer/lib/display-name.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { formatChunkDisplayName, stripPartSuffixes } from "./display-name";
+
+describe("stripPartSuffixes", () => {
+    it("strips single part suffix", () => {
+        expect(stripPartSuffixes("MyClass (part 2)")).toBe("MyClass");
+    });
+
+    it("strips stacked part suffixes", () => {
+        expect(stripPartSuffixes("MyClass (part 3) (part 8)")).toBe("MyClass");
+    });
+
+    it("leaves names without suffixes unchanged", () => {
+        expect(stripPartSuffixes("MyClass")).toBe("MyClass");
+    });
+});
+
+describe("formatChunkDisplayName", () => {
+    it("shows name:lines for named chunk", () => {
+        expect(formatChunkDisplayName("MyClass", 10, 45)).toBe("MyClass:10-45");
+    });
+
+    it("strips stacked part suffixes", () => {
+        expect(formatChunkDisplayName("MyClass (part 3) (part 8)", 100, 150)).toBe("MyClass:100-150");
+    });
+
+    it("strips single part suffix", () => {
+        expect(formatChunkDisplayName("MyClass (part 2)", 50, 80)).toBe("MyClass:50-80");
+    });
+
+    it("falls back to kind:lines when no name", () => {
+        expect(formatChunkDisplayName(undefined, 1, 30, "function")).toBe("function:1-30");
+    });
+
+    it("falls back to just lines when no name or kind", () => {
+        expect(formatChunkDisplayName(undefined, 1, 30)).toBe("L1-30");
+    });
+
+    it("handles single-line chunk", () => {
+        expect(formatChunkDisplayName("handler", 42, 42)).toBe("handler:42");
+    });
+});

--- a/src/indexer/lib/display-name.ts
+++ b/src/indexer/lib/display-name.ts
@@ -1,5 +1,5 @@
 export function stripPartSuffixes(name: string): string {
-    return name.replace(/\s*\(part\s+\d+\)/g, "").trim();
+    return name.replace(/\s*\(part\s+\d+\)\s*$/i, "").trim();
 }
 
 export function formatChunkDisplayName(

--- a/src/indexer/lib/display-name.ts
+++ b/src/indexer/lib/display-name.ts
@@ -4,12 +4,18 @@ export function stripPartSuffixes(name: string): string {
 
 export function formatChunkDisplayName(
     name: string | undefined,
-    startLine: number,
-    endLine: number,
-    kind?: string,
+    startLine: number | undefined,
+    endLine: number | undefined,
+    kind?: string
 ): string {
-    const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`;
     const cleanName = name ? stripPartSuffixes(name) : "";
+    const hasLines = startLine != null && endLine != null && !Number.isNaN(startLine) && !Number.isNaN(endLine);
+
+    if (!hasLines) {
+        return cleanName || kind || "chunk";
+    }
+
+    const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`;
 
     if (cleanName) {
         return `${cleanName}:${lineRange}`;

--- a/src/indexer/lib/display-name.ts
+++ b/src/indexer/lib/display-name.ts
@@ -1,0 +1,23 @@
+export function stripPartSuffixes(name: string): string {
+    return name.replace(/\s*\(part\s+\d+\)/g, "").trim();
+}
+
+export function formatChunkDisplayName(
+    name: string | undefined,
+    startLine: number,
+    endLine: number,
+    kind?: string,
+): string {
+    const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`;
+    const cleanName = name ? stripPartSuffixes(name) : "";
+
+    if (cleanName) {
+        return `${cleanName}:${lineRange}`;
+    }
+
+    if (kind) {
+        return `${kind}:${lineRange}`;
+    }
+
+    return `L${lineRange}`;
+}

--- a/src/indexer/lib/highlight.test.ts
+++ b/src/indexer/lib/highlight.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { stripAnsi } from "@app/utils/string";
-import pc from "picocolors";
+import { createColors } from "picocolors";
 import { highlightQueryWords, parseQueryWords } from "./highlight";
 
-const hasColors = pc.isColorSupported;
+const colorsOn = createColors(true);
+const colorsOff = createColors(false);
 
 describe("parseQueryWords", () => {
     it("splits query into lowercase words", () => {
@@ -25,26 +26,43 @@ describe("parseQueryWords", () => {
 });
 
 describe("highlightQueryWords", () => {
-    it("highlights matching words in text", () => {
-        const result = highlightQueryWords("Send telegram notification", ["telegram", "notification"]);
-        const plain = stripAnsi(result);
-        expect(plain).toBe("Send telegram notification");
-
-        if (hasColors) {
+    describe("with colors", () => {
+        it("wraps matching words with ANSI codes", () => {
+            const result = highlightQueryWords("Send telegram notification", ["telegram", "notification"], colorsOn);
+            const plain = stripAnsi(result);
+            expect(plain).toBe("Send telegram notification");
             expect(result.length).toBeGreaterThan(plain.length);
-        }
-    });
+        });
 
-    it("is case-insensitive", () => {
-        const result = highlightQueryWords("Telegram TELEGRAM telegram", ["telegram"]);
-        const plain = stripAnsi(result);
-        expect(plain).toBe("Telegram TELEGRAM telegram");
-
-        if (hasColors) {
+        it("is case-insensitive", () => {
+            const result = highlightQueryWords("Telegram TELEGRAM telegram", ["telegram"], colorsOn);
+            const plain = stripAnsi(result);
+            expect(plain).toBe("Telegram TELEGRAM telegram");
             // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape code matching
             const matches = result.match(/\x1b\[/g);
             expect(matches!.length).toBeGreaterThanOrEqual(3);
-        }
+        });
+
+        it("prefers longer matches over shorter overlapping ones", () => {
+            const result = highlightQueryWords("mapped map mapper", ["map", "mapped"], colorsOn);
+            const plain = stripAnsi(result);
+            expect(plain).toBe("mapped map mapper");
+            // "mapped" should be highlighted as a whole, not just the "map" prefix
+            expect(result).toContain(colorsOn.bold(colorsOn.yellow("mapped")));
+            expect(result).toContain(colorsOn.bold(colorsOn.yellow("map")));
+        });
+    });
+
+    describe("without colors", () => {
+        it("returns text unchanged when colors are disabled", () => {
+            const result = highlightQueryWords("Send telegram notification", ["telegram", "notification"], colorsOff);
+            expect(result).toBe("Send telegram notification");
+        });
+
+        it("is case-insensitive even without colors", () => {
+            const result = highlightQueryWords("Telegram TELEGRAM telegram", ["telegram"], colorsOff);
+            expect(result).toBe("Telegram TELEGRAM telegram");
+        });
     });
 
     it("handles no matches gracefully", () => {
@@ -53,9 +71,8 @@ describe("highlightQueryWords", () => {
     });
 
     it("handles special regex chars in query", () => {
-        const result = highlightQueryWords("cost is $100 (total)", ["$100", "(total)"]);
-        const plain = stripAnsi(result);
-        expect(plain).toBe("cost is $100 (total)");
+        const result = highlightQueryWords("cost is $100 (total)", ["$100", "(total)"], colorsOff);
+        expect(result).toBe("cost is $100 (total)");
     });
 
     it("returns empty string for empty input", () => {

--- a/src/indexer/lib/highlight.test.ts
+++ b/src/indexer/lib/highlight.test.ts
@@ -21,7 +21,7 @@ describe("parseQueryWords", () => {
         expect(result).toContain("the");
         expect(result).toContain("working");
         expect(result).not.toContain("is");
-        expect(result).not.toContain("AI");
+        expect(result).not.toContain("ai");
     });
 });
 

--- a/src/indexer/lib/highlight.test.ts
+++ b/src/indexer/lib/highlight.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { stripAnsi } from "@app/utils/string";
+import { highlightQueryWords, parseQueryWords } from "./highlight";
+
+describe("parseQueryWords", () => {
+    it("splits query into lowercase words", () => {
+        expect(parseQueryWords("Telegram bot Notification")).toEqual(["telegram", "bot", "notification"]);
+    });
+
+    it("deduplicates words", () => {
+        expect(parseQueryWords("test test Test")).toEqual(["test"]);
+    });
+
+    it("filters short words (<=2 chars)", () => {
+        const result = parseQueryWords("how is the AI working");
+        expect(result).toContain("how");
+        expect(result).toContain("the");
+        expect(result).toContain("working");
+        expect(result).not.toContain("is");
+        expect(result).not.toContain("AI");
+    });
+});
+
+describe("highlightQueryWords", () => {
+    it("highlights matching words in text", () => {
+        const result = highlightQueryWords("Send telegram notification", ["telegram", "notification"]);
+        const plain = stripAnsi(result);
+        expect(plain).toBe("Send telegram notification");
+        expect(result.length).toBeGreaterThan(plain.length);
+    });
+
+    it("is case-insensitive", () => {
+        const result = highlightQueryWords("Telegram TELEGRAM telegram", ["telegram"]);
+        const plain = stripAnsi(result);
+        expect(plain).toBe("Telegram TELEGRAM telegram");
+        // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape code matching
+        const matches = result.match(/\x1b\[/g);
+        expect(matches!.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("handles no matches gracefully", () => {
+        const result = highlightQueryWords("no match here", ["xyz"]);
+        expect(result).toBe("no match here");
+    });
+
+    it("handles special regex chars in query", () => {
+        const result = highlightQueryWords("cost is $100 (total)", ["$100", "(total)"]);
+        const plain = stripAnsi(result);
+        expect(plain).toBe("cost is $100 (total)");
+    });
+
+    it("returns empty string for empty input", () => {
+        expect(highlightQueryWords("", ["test"])).toBe("");
+    });
+});

--- a/src/indexer/lib/highlight.test.ts
+++ b/src/indexer/lib/highlight.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { stripAnsi } from "@app/utils/string";
+import pc from "picocolors";
 import { highlightQueryWords, parseQueryWords } from "./highlight";
+
+const hasColors = pc.isColorSupported;
 
 describe("parseQueryWords", () => {
     it("splits query into lowercase words", () => {
@@ -26,16 +29,22 @@ describe("highlightQueryWords", () => {
         const result = highlightQueryWords("Send telegram notification", ["telegram", "notification"]);
         const plain = stripAnsi(result);
         expect(plain).toBe("Send telegram notification");
-        expect(result.length).toBeGreaterThan(plain.length);
+
+        if (hasColors) {
+            expect(result.length).toBeGreaterThan(plain.length);
+        }
     });
 
     it("is case-insensitive", () => {
         const result = highlightQueryWords("Telegram TELEGRAM telegram", ["telegram"]);
         const plain = stripAnsi(result);
         expect(plain).toBe("Telegram TELEGRAM telegram");
-        // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape code matching
-        const matches = result.match(/\x1b\[/g);
-        expect(matches!.length).toBeGreaterThanOrEqual(3);
+
+        if (hasColors) {
+            // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape code matching
+            const matches = result.match(/\x1b\[/g);
+            expect(matches!.length).toBeGreaterThanOrEqual(3);
+        }
     });
 
     it("handles no matches gracefully", () => {

--- a/src/indexer/lib/highlight.ts
+++ b/src/indexer/lib/highlight.ts
@@ -1,0 +1,40 @@
+import { createColors } from "picocolors";
+
+const pc = createColors(true);
+
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function parseQueryWords(query: string): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+
+    for (const raw of query.split(/\s+/)) {
+        const word = raw.toLowerCase();
+
+        if (word.length <= 2) {
+            continue;
+        }
+
+        if (seen.has(word)) {
+            continue;
+        }
+
+        seen.add(word);
+        result.push(word);
+    }
+
+    return result;
+}
+
+export function highlightQueryWords(text: string, words: string[]): string {
+    if (!text || words.length === 0) {
+        return text;
+    }
+
+    const pattern = words.map(escapeRegex).join("|");
+    const regex = new RegExp(`(${pattern})`, "gi");
+
+    return text.replace(regex, (match) => pc.bold(pc.yellow(match)));
+}

--- a/src/indexer/lib/highlight.ts
+++ b/src/indexer/lib/highlight.ts
@@ -1,6 +1,4 @@
-import { createColors } from "picocolors";
-
-const pc = createColors(true);
+import pc from "picocolors";
 
 function escapeRegex(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -33,7 +31,10 @@ export function highlightQueryWords(text: string, words: string[]): string {
         return text;
     }
 
-    const pattern = words.map(escapeRegex).join("|");
+    const pattern = [...words]
+        .sort((a, b) => b.length - a.length)
+        .map(escapeRegex)
+        .join("|");
     const regex = new RegExp(`(${pattern})`, "gi");
 
     return text.replace(regex, (match) => pc.bold(pc.yellow(match)));

--- a/src/indexer/lib/highlight.ts
+++ b/src/indexer/lib/highlight.ts
@@ -26,10 +26,17 @@ export function parseQueryWords(query: string): string[] {
     return result;
 }
 
-export function highlightQueryWords(text: string, words: string[]): string {
+interface HighlightColors {
+    bold: (s: string) => string;
+    yellow: (s: string) => string;
+}
+
+export function highlightQueryWords(text: string, words: string[], colors?: HighlightColors): string {
     if (!text || words.length === 0) {
         return text;
     }
+
+    const { bold, yellow } = colors ?? pc;
 
     const pattern = [...words]
         .sort((a, b) => b.length - a.length)
@@ -37,5 +44,5 @@ export function highlightQueryWords(text: string, words: string[]): string {
         .join("|");
     const regex = new RegExp(`(${pattern})`, "gi");
 
-    return text.replace(regex, (match) => pc.bold(pc.yellow(match)));
+    return text.replace(regex, (match) => bold(yellow(match)));
 }

--- a/src/indexer/lib/search-mode.test.ts
+++ b/src/indexer/lib/search-mode.test.ts
@@ -4,7 +4,7 @@ import { detectMode, resolveSearchMode } from "./search-mode";
 
 function fakeIndexer(embeddingCount: number): Indexer {
     return {
-        getConsistencyInfo: () => ({ embeddingCount }),
+        getStore: () => ({ getEmbeddingCount: () => embeddingCount }),
     } as unknown as Indexer;
 }
 

--- a/src/indexer/lib/search-mode.test.ts
+++ b/src/indexer/lib/search-mode.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { resolveSearchMode } from "./search-mode";
+import type { Indexer } from "./indexer";
+import { detectMode, resolveSearchMode } from "./search-mode";
+
+function fakeIndexer(embeddingCount: number): Indexer {
+    return {
+        getConsistencyInfo: () => ({ embeddingCount }),
+    } as unknown as Indexer;
+}
 
 describe("resolveSearchMode", () => {
     it("passes through valid modes unchanged", () => {
@@ -14,5 +21,15 @@ describe("resolveSearchMode", () => {
 
     it("returns undefined for unknown modes", () => {
         expect(resolveSearchMode("banana")).toBeUndefined();
+    });
+});
+
+describe("detectMode", () => {
+    it("returns 'hybrid' when embeddings exist", () => {
+        expect(detectMode(fakeIndexer(100))).toBe("hybrid");
+    });
+
+    it("returns 'fulltext' when no embeddings", () => {
+        expect(detectMode(fakeIndexer(0))).toBe("fulltext");
     });
 });

--- a/src/indexer/lib/search-mode.test.ts
+++ b/src/indexer/lib/search-mode.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { resolveSearchMode } from "./search-mode";
+
+describe("resolveSearchMode", () => {
+    it("passes through valid modes unchanged", () => {
+        expect(resolveSearchMode("fulltext")).toBe("fulltext");
+        expect(resolveSearchMode("vector")).toBe("vector");
+        expect(resolveSearchMode("hybrid")).toBe("hybrid");
+    });
+
+    it("maps 'semantic' to 'vector'", () => {
+        expect(resolveSearchMode("semantic")).toBe("vector");
+    });
+
+    it("returns undefined for unknown modes", () => {
+        expect(resolveSearchMode("banana")).toBeUndefined();
+    });
+});

--- a/src/indexer/lib/search-mode.test.ts
+++ b/src/indexer/lib/search-mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Indexer } from "./indexer";
-import { detectMode, resolveSearchMode } from "./search-mode";
+import { anyHaveEmbeddings, detectMode, detectModeMulti, resolveSearchMode } from "./search-mode";
 
 function fakeIndexer(embeddingCount: number): Indexer {
     return {
@@ -31,5 +31,25 @@ describe("detectMode", () => {
 
     it("returns 'fulltext' when no embeddings", () => {
         expect(detectMode(fakeIndexer(0))).toBe("fulltext");
+    });
+});
+
+describe("detectModeMulti", () => {
+    it("returns 'hybrid' when any index has embeddings", () => {
+        expect(detectModeMulti([fakeIndexer(0), fakeIndexer(50)])).toBe("hybrid");
+    });
+
+    it("returns 'fulltext' when no indexes have embeddings", () => {
+        expect(detectModeMulti([fakeIndexer(0), fakeIndexer(0)])).toBe("fulltext");
+    });
+});
+
+describe("anyHaveEmbeddings", () => {
+    it("returns true when at least one index has embeddings", () => {
+        expect(anyHaveEmbeddings([fakeIndexer(0), fakeIndexer(10)])).toBe(true);
+    });
+
+    it("returns false when none have embeddings", () => {
+        expect(anyHaveEmbeddings([fakeIndexer(0)])).toBe(false);
     });
 });

--- a/src/indexer/lib/search-mode.ts
+++ b/src/indexer/lib/search-mode.ts
@@ -15,6 +15,16 @@ export function detectMode(indexer: Indexer): SearchMode {
     return indexer.getStore().getEmbeddingCount() > 0 ? "hybrid" : "fulltext";
 }
 
+/** Check if any of the given indexers have embeddings. */
+export function anyHaveEmbeddings(indexers: Indexer[]): boolean {
+    return indexers.some((idx) => idx.getStore().getEmbeddingCount() > 0);
+}
+
+/** Detect mode across multiple indexes — hybrid if any have embeddings. */
+export function detectModeMulti(indexers: Indexer[]): SearchMode {
+    return anyHaveEmbeddings(indexers) ? "hybrid" : "fulltext";
+}
+
 /** Resolve a user-provided mode string to a canonical SearchMode. Returns undefined for unknown modes. */
 export function resolveSearchMode(input: string): SearchMode | undefined {
     if (input === "fulltext" || input === "vector" || input === "hybrid") {

--- a/src/indexer/lib/search-mode.ts
+++ b/src/indexer/lib/search-mode.ts
@@ -2,6 +2,10 @@ import type { Indexer } from "./indexer";
 
 export type SearchMode = "fulltext" | "vector" | "hybrid";
 
+const MODE_ALIASES: Record<string, SearchMode> = {
+    semantic: "vector",
+};
+
 /**
  * Detect the best search mode for an index.
  * If the index has embeddings -> hybrid (combines BM25 + semantic).
@@ -9,4 +13,13 @@ export type SearchMode = "fulltext" | "vector" | "hybrid";
  */
 export function detectMode(indexer: Indexer): SearchMode {
     return indexer.getStore().getEmbeddingCount() > 0 ? "hybrid" : "fulltext";
+}
+
+/** Resolve a user-provided mode string to a canonical SearchMode. Returns undefined for unknown modes. */
+export function resolveSearchMode(input: string): SearchMode | undefined {
+    if (input === "fulltext" || input === "vector" || input === "hybrid") {
+        return input;
+    }
+
+    return MODE_ALIASES[input];
 }

--- a/src/indexer/lib/search-output-formats.test.ts
+++ b/src/indexer/lib/search-output-formats.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, test } from "bun:test";
+import { stripAnsi } from "@app/utils/string";
+import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+
+function makeResult(overrides: Partial<FormattedSearchResult> = {}): FormattedSearchResult {
+    return {
+        filePath: "/project/app/Services/BookingService.php",
+        displayName: "createReservation:45-120",
+        language: "php",
+        content: [
+            "public function createReservation(array $data): Reservation",
+            "{",
+            "    $reservation = new Reservation($data);",
+            "    $reservation->save();",
+            "    event(new ReservationCreated($reservation));",
+            "    return $reservation;",
+            "}",
+        ].join("\n"),
+        confidence: 85,
+        method: "rrf" as const,
+        indexName: "TestIndex",
+        startLine: 45,
+        endLine: 51,
+        ...overrides,
+    };
+}
+
+const defaultOpts = {
+    query: "create reservation",
+    mode: "hybrid",
+} as const;
+
+describe("formatSearchResults", () => {
+    describe("pretty format", () => {
+        test("contains fenced code block with correct language marker", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("```php");
+            // Closing fence exists (may be at end of output after trimEnd)
+            expect(plain).toMatch(/```\s*$/);
+        });
+
+        test("shows confidence as percentage", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ confidence: 85 })],
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("85%");
+        });
+
+        test("shows file path and display name in header", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("/project/app/Services/BookingService.php");
+            expect(plain).toContain("createReservation:45-120");
+        });
+
+        test("renders multiple results", () => {
+            const results = [
+                makeResult({ displayName: "methodA:1-10", confidence: 90 }),
+                makeResult({ displayName: "methodB:20-30", confidence: 60 }),
+            ];
+            const output = formatSearchResults({
+                results,
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("methodA:1-10");
+            expect(plain).toContain("methodB:20-30");
+            expect(plain).toContain("90%");
+            expect(plain).toContain("60%");
+        });
+
+        test("handles null language with empty code fence marker", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ language: null })],
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            // Should have ``` without a language suffix (just the fence)
+            expect(plain).toContain("```\n");
+            expect(plain).not.toContain("```php");
+        });
+
+        test("shows result count and query in header", () => {
+            const output = formatSearchResults({
+                results: [makeResult(), makeResult({ filePath: "/other/file.ts" })],
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("2 results");
+            expect(plain).toContain('"create reservation"');
+            expect(plain).toContain("(hybrid)");
+        });
+
+        test("shows singular 'result' for single result", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("1 result");
+            expect(plain).not.toContain("1 results");
+        });
+    });
+
+    describe("simple format", () => {
+        test("shows file path as heading with confidence", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("/project/app/Services/BookingService.php");
+            expect(plain).toContain("85%");
+        });
+
+        test("shows line numbers", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ startLine: 45 })],
+                format: "simple",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("45|");
+            expect(plain).toContain("46|");
+            expect(plain).toContain("47|");
+        });
+
+        test("highlights query words with ANSI codes", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                ...defaultOpts,
+                highlightWords: ["reservation"],
+            });
+            const plain = stripAnsi(output);
+
+            // The raw output should be longer than the stripped version
+            // because ANSI escape codes are present around highlighted words
+            expect(output.length).toBeGreaterThan(plain.length);
+        });
+    });
+
+    describe("table format", () => {
+        test("contains column headers: File, Symbol, Confidence, Method", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "table",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("File");
+            expect(plain).toContain("Symbol");
+            expect(plain).toContain("Confidence");
+            expect(plain).toContain("Method");
+        });
+
+        test("shows percentage in confidence column", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ confidence: 72 })],
+                format: "table",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("72%");
+        });
+
+        test("truncates long file paths with ellipsis", () => {
+            const longPath = "/very/long/deeply/nested/project/structure/src/modules/services/BookingService.php";
+            const output = formatSearchResults({
+                results: [makeResult({ filePath: longPath })],
+                format: "table",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            // Table format uses maxLen=40 for shortenPath
+            expect(plain).toContain("...");
+            expect(plain).not.toContain(longPath);
+        });
+
+        test("shows separator line with box-drawing character", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "table",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+
+            expect(plain).toContain("\u2500"); // ─
+        });
+    });
+
+    describe("edge cases", () => {
+        test("empty results returns 'No results' message", () => {
+            const output = formatSearchResults({
+                results: [],
+                format: "pretty",
+                ...defaultOpts,
+            });
+
+            expect(output).toContain("No results");
+        });
+
+        test("single-line chunk renders in pretty format without crashing", () => {
+            const result = makeResult({
+                content: "const x = 1;",
+                startLine: 1,
+                endLine: 1,
+            });
+            const output = formatSearchResults({
+                results: [result],
+                format: "pretty",
+                ...defaultOpts,
+            });
+
+            expect(output).toBeTruthy();
+            expect(stripAnsi(output)).toContain("const x = 1;");
+        });
+
+        test("single-line chunk renders in simple format without crashing", () => {
+            const result = makeResult({
+                content: "const x = 1;",
+                startLine: 1,
+                endLine: 1,
+            });
+            const output = formatSearchResults({
+                results: [result],
+                format: "simple",
+                ...defaultOpts,
+            });
+
+            expect(output).toBeTruthy();
+            expect(stripAnsi(output)).toContain("const x = 1;");
+        });
+
+        test("single-line chunk renders in table format without crashing", () => {
+            const result = makeResult({
+                content: "const x = 1;",
+                startLine: 1,
+                endLine: 1,
+            });
+            const output = formatSearchResults({
+                results: [result],
+                format: "table",
+                ...defaultOpts,
+            });
+
+            expect(output).toBeTruthy();
+        });
+
+        test("content with special characters does not crash", () => {
+            const result = makeResult({
+                content: 'const regex = /[a-z]+/g;\nconst html = "<div>&amp;</div>";',
+            });
+
+            for (const format of ["pretty", "simple", "table"] as const) {
+                const output = formatSearchResults({
+                    results: [result],
+                    format,
+                    ...defaultOpts,
+                });
+
+                expect(output).toBeTruthy();
+            }
+        });
+
+        test("very long content (5000 chars) does not crash", () => {
+            const longContent = "x".repeat(5000);
+            const result = makeResult({ content: longContent });
+
+            for (const format of ["pretty", "simple", "table"] as const) {
+                const output = formatSearchResults({
+                    results: [result],
+                    format,
+                    ...defaultOpts,
+                });
+
+                expect(output).toBeTruthy();
+            }
+        });
+
+        test("all three formats produce different output shapes", () => {
+            const results = [makeResult()];
+
+            const pretty = formatSearchResults({
+                results,
+                format: "pretty",
+                ...defaultOpts,
+            });
+            const simple = formatSearchResults({
+                results,
+                format: "simple",
+                ...defaultOpts,
+            });
+            const table = formatSearchResults({
+                results,
+                format: "table",
+                ...defaultOpts,
+            });
+
+            // All three should be distinct
+            expect(pretty).not.toBe(simple);
+            expect(pretty).not.toBe(table);
+            expect(simple).not.toBe(table);
+
+            // Pretty has code fences, simple has line numbers, table has column headers
+            const prettyPlain = stripAnsi(pretty);
+            const simplePlain = stripAnsi(simple);
+            const tablePlain = stripAnsi(table);
+
+            expect(prettyPlain).toContain("```");
+            expect(simplePlain).toContain("45|");
+            expect(tablePlain).toContain("File");
+        });
+    });
+
+    describe("coloring verification", () => {
+        test("simple format with highlightWords produces ANSI codes", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                ...defaultOpts,
+                highlightWords: ["reservation"],
+            });
+            const plain = stripAnsi(output);
+
+            // ANSI escape codes add bytes, so raw output must be longer
+            expect(output.length).toBeGreaterThan(plain.length);
+        });
+
+        test("high confidence (>=70) produces different ANSI than low confidence (<40)", () => {
+            const highConf = formatSearchResults({
+                results: [makeResult({ confidence: 90 })],
+                format: "simple",
+                ...defaultOpts,
+            });
+            const lowConf = formatSearchResults({
+                results: [makeResult({ confidence: 20 })],
+                format: "simple",
+                ...defaultOpts,
+            });
+
+            const highPlain = stripAnsi(highConf);
+            const lowPlain = stripAnsi(lowConf);
+
+            // Both should contain ANSI (raw longer than stripped)
+            expect(highConf.length).toBeGreaterThan(highPlain.length);
+            expect(lowConf.length).toBeGreaterThan(lowPlain.length);
+
+            // Extract the ANSI sequences around the confidence values.
+            // High confidence uses green (\x1b[32m), low uses red (\x1b[31m).
+            // We verify they use different escape codes by checking that the
+            // raw outputs differ even when their plain texts only differ in the number.
+            const highAnsiOnly = highConf.replace(highPlain.replace("90%", "XX%"), "");
+            const lowAnsiOnly = lowConf.replace(lowPlain.replace("20%", "XX%"), "");
+
+            expect(highAnsiOnly).not.toBe(lowAnsiOnly);
+        });
+
+        test("medium confidence (40-69) uses different color than high and low", () => {
+            const makeOutput = (confidence: number) =>
+                formatSearchResults({
+                    results: [makeResult({ confidence })],
+                    format: "pretty",
+                    ...defaultOpts,
+                });
+
+            const high = makeOutput(80);
+            const medium = makeOutput(55);
+            const low = makeOutput(30);
+
+            // All should contain ANSI codes
+            expect(high.length).toBeGreaterThan(stripAnsi(high).length);
+            expect(medium.length).toBeGreaterThan(stripAnsi(medium).length);
+            expect(low.length).toBeGreaterThan(stripAnsi(low).length);
+
+            // The ANSI codes should differ between confidence tiers
+            // We check by looking for the specific color escape sequences
+            // Green: \x1b[32m, Yellow: \x1b[33m, Red: \x1b[31m
+            expect(high).toContain("\x1b[32m"); // green for >=70
+            expect(medium).toContain("\x1b[33m"); // yellow for 40-69
+            expect(low).toContain("\x1b[31m"); // red for <40
+        });
+    });
+});

--- a/src/indexer/lib/search-output-formats.test.ts
+++ b/src/indexer/lib/search-output-formats.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { stripAnsi } from "@app/utils/string";
+import pc from "picocolors";
 import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+
+const hasColors = pc.isColorSupported;
 
 function makeResult(overrides: Partial<FormattedSearchResult> = {}): FormattedSearchResult {
     return {
@@ -160,9 +163,12 @@ describe("formatSearchResults", () => {
             });
             const plain = stripAnsi(output);
 
-            // The raw output should be longer than the stripped version
-            // because ANSI escape codes are present around highlighted words
-            expect(output.length).toBeGreaterThan(plain.length);
+            if (hasColors) {
+                expect(output.length).toBeGreaterThan(plain.length);
+            }
+
+            // Content is preserved regardless of color support
+            expect(plain).toContain("reservation");
         });
     });
 
@@ -342,7 +348,7 @@ describe("formatSearchResults", () => {
         });
     });
 
-    describe("coloring verification", () => {
+    describe.skipIf(!hasColors)("coloring verification", () => {
         test("simple format with highlightWords produces ANSI codes", () => {
             const output = formatSearchResults({
                 results: [makeResult()],
@@ -352,7 +358,6 @@ describe("formatSearchResults", () => {
             });
             const plain = stripAnsi(output);
 
-            // ANSI escape codes add bytes, so raw output must be longer
             expect(output.length).toBeGreaterThan(plain.length);
         });
 
@@ -371,14 +376,9 @@ describe("formatSearchResults", () => {
             const highPlain = stripAnsi(highConf);
             const lowPlain = stripAnsi(lowConf);
 
-            // Both should contain ANSI (raw longer than stripped)
             expect(highConf.length).toBeGreaterThan(highPlain.length);
             expect(lowConf.length).toBeGreaterThan(lowPlain.length);
 
-            // Extract the ANSI sequences around the confidence values.
-            // High confidence uses green (\x1b[32m), low uses red (\x1b[31m).
-            // We verify they use different escape codes by checking that the
-            // raw outputs differ even when their plain texts only differ in the number.
             const highAnsiOnly = highConf.replace(highPlain.replace("90%", "XX%"), "");
             const lowAnsiOnly = lowConf.replace(lowPlain.replace("20%", "XX%"), "");
 
@@ -397,14 +397,10 @@ describe("formatSearchResults", () => {
             const medium = makeOutput(55);
             const low = makeOutput(30);
 
-            // All should contain ANSI codes
             expect(high.length).toBeGreaterThan(stripAnsi(high).length);
             expect(medium.length).toBeGreaterThan(stripAnsi(medium).length);
             expect(low.length).toBeGreaterThan(stripAnsi(low).length);
 
-            // The ANSI codes should differ between confidence tiers
-            // We check by looking for the specific color escape sequences
-            // Green: \x1b[32m, Yellow: \x1b[33m, Red: \x1b[31m
             expect(high).toContain("\x1b[32m"); // green for >=70
             expect(medium).toContain("\x1b[33m"); // yellow for 40-69
             expect(low).toContain("\x1b[31m"); // red for <40

--- a/src/indexer/lib/search-output-formats.test.ts
+++ b/src/indexer/lib/search-output-formats.test.ts
@@ -158,16 +158,21 @@ describe("formatSearchResults", () => {
         });
 
         test("highlights query words with ANSI codes", () => {
-            const output = formatSearchResults({
+            const withHighlight = formatSearchResults({
                 results: [makeResult()],
                 format: "simple",
                 ...defaultOpts,
                 highlightWords: ["reservation"],
             });
-            const plain = stripAnsi(output);
+            const withoutHighlight = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                ...defaultOpts,
+            });
 
-            expect(output.length).toBeGreaterThan(plain.length);
-            expect(plain).toContain("reservation");
+            // Highlighting adds extra ANSI bytes around matched words
+            expect(withHighlight.length).toBeGreaterThan(withoutHighlight.length);
+            expect(stripAnsi(withHighlight)).toContain("reservation");
         });
     });
 
@@ -346,15 +351,19 @@ describe("formatSearchResults", () => {
 
     describe("coloring verification", () => {
         test("simple format with highlightWords produces ANSI codes", () => {
-            const output = formatSearchResults({
+            const withHighlight = formatSearchResults({
                 results: [makeResult()],
                 format: "simple",
                 ...defaultOpts,
                 highlightWords: ["reservation"],
             });
-            const plain = stripAnsi(output);
+            const withoutHighlight = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                ...defaultOpts,
+            });
 
-            expect(output.length).toBeGreaterThan(plain.length);
+            expect(withHighlight.length).toBeGreaterThan(withoutHighlight.length);
         });
 
         test("high confidence (>=70) produces different ANSI than low confidence (<40)", () => {

--- a/src/indexer/lib/search-output-formats.test.ts
+++ b/src/indexer/lib/search-output-formats.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, test } from "bun:test";
-import { stripAnsi } from "@app/utils/string";
-import pc from "picocolors";
-import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+import { describe, expect, mock, test } from "bun:test";
+import { createColors } from "picocolors";
 
-const hasColors = pc.isColorSupported;
+// Force colors on for all imports in this test file
+mock.module("picocolors", () => {
+    const forced = createColors(true);
+    return { default: forced, createColors };
+});
+
+import { stripAnsi } from "@app/utils/string";
+import { type FormattedSearchResult, formatSearchResults } from "./search-output";
 
 function makeResult(overrides: Partial<FormattedSearchResult> = {}): FormattedSearchResult {
     return {
@@ -44,7 +49,6 @@ describe("formatSearchResults", () => {
             const plain = stripAnsi(output);
 
             expect(plain).toContain("```php");
-            // Closing fence exists (may be at end of output after trimEnd)
             expect(plain).toMatch(/```\s*$/);
         });
 
@@ -97,7 +101,6 @@ describe("formatSearchResults", () => {
             });
             const plain = stripAnsi(output);
 
-            // Should have ``` without a language suffix (just the fence)
             expect(plain).toContain("```\n");
             expect(plain).not.toContain("```php");
         });
@@ -163,11 +166,7 @@ describe("formatSearchResults", () => {
             });
             const plain = stripAnsi(output);
 
-            if (hasColors) {
-                expect(output.length).toBeGreaterThan(plain.length);
-            }
-
-            // Content is preserved regardless of color support
+            expect(output.length).toBeGreaterThan(plain.length);
             expect(plain).toContain("reservation");
         });
     });
@@ -207,7 +206,6 @@ describe("formatSearchResults", () => {
             });
             const plain = stripAnsi(output);
 
-            // Table format uses maxLen=40 for shortenPath
             expect(plain).toContain("...");
             expect(plain).not.toContain(longPath);
         });
@@ -332,12 +330,10 @@ describe("formatSearchResults", () => {
                 ...defaultOpts,
             });
 
-            // All three should be distinct
             expect(pretty).not.toBe(simple);
             expect(pretty).not.toBe(table);
             expect(simple).not.toBe(table);
 
-            // Pretty has code fences, simple has line numbers, table has column headers
             const prettyPlain = stripAnsi(pretty);
             const simplePlain = stripAnsi(simple);
             const tablePlain = stripAnsi(table);
@@ -348,7 +344,7 @@ describe("formatSearchResults", () => {
         });
     });
 
-    describe.skipIf(!hasColors)("coloring verification", () => {
+    describe("coloring verification", () => {
         test("simple format with highlightWords produces ANSI codes", () => {
             const output = formatSearchResults({
                 results: [makeResult()],

--- a/src/indexer/lib/search-output.test.ts
+++ b/src/indexer/lib/search-output.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "bun:test";
+import { stripAnsi } from "@app/utils/string";
+import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+
+function makeResult(overrides?: Partial<FormattedSearchResult>): FormattedSearchResult {
+    return {
+        filePath: "/Users/dev/project/src/services/telegram/notification-handler.ts",
+        displayName: "sendNotification:45-72",
+        language: "typescript",
+        content: "export async function sendNotification(userId: string) {\n    const client = getClient();\n    await client.send(userId, 'hello');\n}",
+        confidence: 87,
+        method: "cosine",
+        indexName: "my-index",
+        startLine: 45,
+        endLine: 48,
+        ...overrides,
+    };
+}
+
+describe("formatSearchResults", () => {
+    describe("empty results", () => {
+        it("returns 'No results found.' for empty array", () => {
+            const result = formatSearchResults({
+                results: [],
+                format: "pretty",
+                query: "telegram",
+                mode: "hybrid",
+            });
+            expect(result).toBe("No results found.");
+        });
+
+        it("returns same message regardless of format", () => {
+            for (const format of ["pretty", "simple", "table"] as const) {
+                const result = formatSearchResults({
+                    results: [],
+                    format,
+                    query: "test",
+                    mode: "bm25",
+                });
+                expect(result).toBe("No results found.");
+            }
+        });
+    });
+
+    describe("pretty format", () => {
+        it("contains fenced code block with language marker", () => {
+            const result = formatSearchResults({
+                results: [makeResult({ language: "php" })],
+                format: "pretty",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("```php");
+            expect(plain).toMatch(/```\n|```$/);
+        });
+
+        it("contains confidence as percentage", () => {
+            const result = formatSearchResults({
+                results: [makeResult({ confidence: 87 })],
+                format: "pretty",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("87%");
+        });
+
+        it("contains file path and display name", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "pretty",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("notification-handler.ts");
+            expect(plain).toContain("sendNotification:45-72");
+        });
+
+        it("shows result count and query in header", () => {
+            const result = formatSearchResults({
+                results: [makeResult(), makeResult({ displayName: "other:10-20" })],
+                format: "pretty",
+                query: "telegram bot",
+                mode: "cosine",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("2 results");
+            expect(plain).toContain('"telegram bot"');
+            expect(plain).toContain("cosine");
+        });
+
+        it("groups multiple results from the same file", () => {
+            const r1 = makeResult({ displayName: "funcA:10-20", startLine: 10, endLine: 20 });
+            const r2 = makeResult({ displayName: "funcB:30-40", startLine: 30, endLine: 40 });
+            const result = formatSearchResults({
+                results: [r1, r2],
+                format: "pretty",
+                query: "test",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            const pathOccurrences = plain.split("notification-handler.ts").length - 1;
+            expect(pathOccurrences).toBe(1);
+        });
+
+        it("highlights query words in content", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "pretty",
+                query: "sendNotification",
+                mode: "hybrid",
+                highlightWords: ["sendNotification"],
+            });
+            const plain = stripAnsi(result);
+            expect(result.length).toBeGreaterThan(plain.length);
+        });
+    });
+
+    describe("simple format", () => {
+        it("contains file path", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("notification-handler.ts");
+        });
+
+        it("contains line numbers", () => {
+            const result = formatSearchResults({
+                results: [makeResult({ startLine: 45 })],
+                format: "simple",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("45|");
+        });
+
+        it("contains confidence percentage", () => {
+            const result = formatSearchResults({
+                results: [makeResult({ confidence: 92 })],
+                format: "simple",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("92%");
+        });
+
+        it("highlighted words produce ANSI codes", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "simple",
+                query: "sendNotification",
+                mode: "hybrid",
+                highlightWords: ["sendNotification"],
+            });
+            const plain = stripAnsi(result);
+            expect(result.length).toBeGreaterThan(plain.length);
+        });
+    });
+
+    describe("table format", () => {
+        it("contains column headers", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "table",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("File");
+            expect(plain).toContain("Symbol");
+            expect(plain).toContain("Confidence");
+            expect(plain).toContain("Method");
+        });
+
+        it("contains percentage in confidence column", () => {
+            const result = formatSearchResults({
+                results: [makeResult({ confidence: 87 })],
+                format: "table",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("87%");
+        });
+
+        it("contains display name", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "table",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("sendNotification:45-72");
+        });
+
+        it("truncates long file paths with ellipsis", () => {
+            const result = formatSearchResults({
+                results: [
+                    makeResult({
+                        filePath:
+                            "/Users/dev/project/src/very/deeply/nested/directory/structure/handlers/notification-handler.ts",
+                    }),
+                ],
+                format: "table",
+                query: "notification",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("...");
+        });
+
+        it("contains separator line", () => {
+            const result = formatSearchResults({
+                results: [makeResult()],
+                format: "table",
+                query: "notification",
+                mode: "hybrid",
+            });
+            expect(result).toContain("─");
+        });
+    });
+
+    describe("edge cases", () => {
+        it("single-line chunk renders in all formats", () => {
+            const singleLine = makeResult({
+                content: "const x = 42;",
+                startLine: 1,
+                endLine: 1,
+            });
+
+            for (const format of ["pretty", "simple", "table"] as const) {
+                const result = formatSearchResults({
+                    results: [singleLine],
+                    format,
+                    query: "test",
+                    mode: "bm25",
+                });
+                expect(result.length).toBeGreaterThan(0);
+            }
+        });
+
+        it("content with special chars does not crash", () => {
+            const special = makeResult({
+                content: "const regex = /[.*+?^${}()|[\\]\\\\]/g;\nconst tmpl = `${foo}<bar>&amp;`;",
+            });
+
+            for (const format of ["pretty", "simple", "table"] as const) {
+                expect(() =>
+                    formatSearchResults({
+                        results: [special],
+                        format,
+                        query: "regex",
+                        mode: "hybrid",
+                    })
+                ).not.toThrow();
+            }
+        });
+
+        it("all three formats produce different output shapes", () => {
+            const r = makeResult();
+            const outputs = (["pretty", "simple", "table"] as const).map((format) =>
+                stripAnsi(
+                    formatSearchResults({
+                        results: [r],
+                        format,
+                        query: "test",
+                        mode: "hybrid",
+                    })
+                )
+            );
+
+            expect(outputs[0]).not.toBe(outputs[1]);
+            expect(outputs[1]).not.toBe(outputs[2]);
+            expect(outputs[0]).not.toBe(outputs[2]);
+        });
+
+        it("null language uses plain code block in pretty format", () => {
+            const result = formatSearchResults({
+                results: [makeResult({ language: null })],
+                format: "pretty",
+                query: "test",
+                mode: "hybrid",
+            });
+            const plain = stripAnsi(result);
+            expect(plain).toContain("```\n");
+            expect(plain).not.toContain("```null");
+        });
+    });
+});

--- a/src/indexer/lib/search-output.test.ts
+++ b/src/indexer/lib/search-output.test.ts
@@ -7,7 +7,8 @@ function makeResult(overrides?: Partial<FormattedSearchResult>): FormattedSearch
         filePath: "/Users/dev/project/src/services/telegram/notification-handler.ts",
         displayName: "sendNotification:45-72",
         language: "typescript",
-        content: "export async function sendNotification(userId: string) {\n    const client = getClient();\n    await client.send(userId, 'hello');\n}",
+        content:
+            "export async function sendNotification(userId: string) {\n    const client = getClient();\n    await client.send(userId, 'hello');\n}",
         confidence: 87,
         method: "cosine",
         indexName: "my-index",

--- a/src/indexer/lib/search-output.test.ts
+++ b/src/indexer/lib/search-output.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from "bun:test";
-import { stripAnsi } from "@app/utils/string";
-import pc from "picocolors";
-import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+import { describe, expect, it, mock } from "bun:test";
+import { createColors } from "picocolors";
 
-const hasColors = pc.isColorSupported;
+// Force colors on for all imports in this test file (including search-output.ts and highlight.ts)
+mock.module("picocolors", () => {
+    const forced = createColors(true);
+    return { default: forced, createColors };
+});
+
+import { stripAnsi } from "@app/utils/string";
+import { type FormattedSearchResult, formatSearchResults } from "./search-output";
 
 function makeResult(overrides?: Partial<FormattedSearchResult>): FormattedSearchResult {
     return {
@@ -118,10 +123,7 @@ describe("formatSearchResults", () => {
                 highlightWords: ["sendNotification"],
             });
             const plain = stripAnsi(result);
-
-            if (hasColors) {
-                expect(result.length).toBeGreaterThan(plain.length);
-            }
+            expect(result.length).toBeGreaterThan(plain.length);
         });
     });
 
@@ -168,10 +170,7 @@ describe("formatSearchResults", () => {
                 highlightWords: ["sendNotification"],
             });
             const plain = stripAnsi(result);
-
-            if (hasColors) {
-                expect(result.length).toBeGreaterThan(plain.length);
-            }
+            expect(result.length).toBeGreaterThan(plain.length);
         });
     });
 

--- a/src/indexer/lib/search-output.test.ts
+++ b/src/indexer/lib/search-output.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { stripAnsi } from "@app/utils/string";
+import pc from "picocolors";
 import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+
+const hasColors = pc.isColorSupported;
 
 function makeResult(overrides?: Partial<FormattedSearchResult>): FormattedSearchResult {
     return {
@@ -115,7 +118,10 @@ describe("formatSearchResults", () => {
                 highlightWords: ["sendNotification"],
             });
             const plain = stripAnsi(result);
-            expect(result.length).toBeGreaterThan(plain.length);
+
+            if (hasColors) {
+                expect(result.length).toBeGreaterThan(plain.length);
+            }
         });
     });
 
@@ -162,7 +168,10 @@ describe("formatSearchResults", () => {
                 highlightWords: ["sendNotification"],
             });
             const plain = stripAnsi(result);
-            expect(result.length).toBeGreaterThan(plain.length);
+
+            if (hasColors) {
+                expect(result.length).toBeGreaterThan(plain.length);
+            }
         });
     });
 

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -1,8 +1,6 @@
 import { formatTable } from "@app/utils/table";
-import { createColors } from "picocolors";
+import pc from "picocolors";
 import { highlightQueryWords } from "./highlight";
-
-const pc = createColors(true);
 
 export interface FormattedSearchResult {
     filePath: string;

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -1,0 +1,165 @@
+import { createColors } from "picocolors";
+import { formatTable } from "@app/utils/table";
+import { highlightQueryWords } from "./highlight";
+
+const pc = createColors(true);
+
+export interface FormattedSearchResult {
+    filePath: string;
+    displayName: string;
+    language: string | null;
+    content: string;
+    confidence: number;
+    method: "bm25" | "cosine" | "rrf";
+    indexName: string;
+    startLine: number;
+    endLine: number;
+}
+
+export type OutputFormat = "pretty" | "simple" | "table";
+
+interface FormatOptions {
+    results: FormattedSearchResult[];
+    format: OutputFormat;
+    query: string;
+    mode: string;
+    highlightWords?: string[];
+}
+
+function shortenPath(filePath: string, maxLen: number): string {
+    if (filePath.length <= maxLen) {
+        return filePath;
+    }
+
+    return `...${filePath.slice(-(maxLen - 3))}`;
+}
+
+function colorConfidence(confidence: number): string {
+    const label = `${confidence}%`;
+
+    if (confidence >= 70) {
+        return pc.green(label);
+    }
+
+    if (confidence >= 40) {
+        return pc.yellow(label);
+    }
+
+    return pc.red(label);
+}
+
+function formatHeader(count: number, query: string, mode: string): string {
+    const noun = count === 1 ? "result" : "results";
+    return `${pc.bold(`${count} ${noun}`)} for ${pc.cyan(`"${query}"`)} ${pc.dim(`(${mode})`)}`;
+}
+
+function highlightContent(content: string, words: string[] | undefined): string {
+    if (!words || words.length === 0) {
+        return content;
+    }
+
+    return highlightQueryWords(content, words);
+}
+
+function formatPretty(opts: FormatOptions): string {
+    const lines: string[] = [formatHeader(opts.results.length, opts.query, opts.mode), ""];
+
+    const groups = new Map<string, FormattedSearchResult[]>();
+
+    for (const r of opts.results) {
+        const existing = groups.get(r.filePath);
+
+        if (existing) {
+            existing.push(r);
+        } else {
+            groups.set(r.filePath, [r]);
+        }
+    }
+
+    let groupIndex = 0;
+
+    for (const [filePath, results] of groups) {
+        if (groupIndex > 0) {
+            lines.push("");
+        }
+
+        lines.push(pc.cyan(shortenPath(filePath, 60)));
+        lines.push("");
+
+        for (const r of results) {
+            const header = [
+                pc.bold(r.displayName),
+                colorConfidence(r.confidence),
+                pc.dim(r.method),
+            ].join("  ");
+            lines.push(header);
+
+            const langMarker = r.language ?? "";
+            lines.push(`\`\`\`${langMarker}`);
+
+            const highlighted = highlightContent(r.content, opts.highlightWords);
+            lines.push(highlighted);
+
+            lines.push("```");
+            lines.push("");
+        }
+
+        groupIndex++;
+    }
+
+    return lines.join("\n").trimEnd();
+}
+
+function formatSimple(opts: FormatOptions): string {
+    const parts: string[] = [];
+
+    for (const r of opts.results) {
+        const shortPath = shortenPath(r.filePath, 60);
+        const header = `${pc.cyan(pc.bold(shortPath))} ${r.displayName} ${colorConfidence(r.confidence)} ${pc.dim(r.method)}`;
+        parts.push(header);
+
+        const highlighted = highlightContent(r.content, opts.highlightWords);
+        const contentLines = highlighted.split("\n");
+
+        for (let i = 0; i < contentLines.length; i++) {
+            const lineNum = r.startLine + i;
+            parts.push(`${pc.dim(`${lineNum}|`)}${contentLines[i]}`);
+        }
+
+        parts.push("");
+    }
+
+    return parts.join("\n").trimEnd();
+}
+
+function formatTableOutput(opts: FormatOptions): string {
+    const header = formatHeader(opts.results.length, opts.query, opts.mode);
+
+    const rows = opts.results.map((r) => [
+        shortenPath(r.filePath, 40),
+        r.displayName,
+        `${r.confidence}%`,
+        r.method,
+    ]);
+
+    const table = formatTable(rows, ["File", "Symbol", "Confidence", "Method"], {
+        alignRight: [2],
+    });
+
+    return `${header}\n\n${table}`;
+}
+
+export function formatSearchResults(opts: FormatOptions): string {
+    if (opts.results.length === 0) {
+        return "No results found.";
+    }
+
+    switch (opts.format) {
+        case "pretty":
+            return formatPretty(opts);
+        case "simple":
+            return formatSimple(opts);
+        case "table":
+            return formatTableOutput(opts);
+    }
+}

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -1,5 +1,5 @@
-import { createColors } from "picocolors";
 import { formatTable } from "@app/utils/table";
+import { createColors } from "picocolors";
 import { highlightQueryWords } from "./highlight";
 
 const pc = createColors(true);
@@ -87,11 +87,7 @@ function formatPretty(opts: FormatOptions): string {
         lines.push("");
 
         for (const r of results) {
-            const header = [
-                pc.bold(r.displayName),
-                colorConfidence(r.confidence),
-                pc.dim(r.method),
-            ].join("  ");
+            const header = [pc.bold(r.displayName), colorConfidence(r.confidence), pc.dim(r.method)].join("  ");
             lines.push(header);
 
             const langMarker = r.language ?? "";
@@ -120,10 +116,15 @@ function formatSimple(opts: FormatOptions): string {
 
         const highlighted = highlightContent(r.content, opts.highlightWords);
         const contentLines = highlighted.split("\n");
+        const hasLineNums = r.startLine != null && !Number.isNaN(r.startLine);
 
         for (let i = 0; i < contentLines.length; i++) {
-            const lineNum = r.startLine + i;
-            parts.push(`${pc.dim(`${lineNum}|`)}${contentLines[i]}`);
+            if (hasLineNums) {
+                const lineNum = r.startLine + i;
+                parts.push(`${pc.dim(`${lineNum}|`)}${contentLines[i]}`);
+            } else {
+                parts.push(`${pc.dim("|")}${contentLines[i]}`);
+            }
         }
 
         parts.push("");
@@ -135,12 +136,7 @@ function formatSimple(opts: FormatOptions): string {
 function formatTableOutput(opts: FormatOptions): string {
     const header = formatHeader(opts.results.length, opts.query, opts.mode);
 
-    const rows = opts.results.map((r) => [
-        shortenPath(r.filePath, 40),
-        r.displayName,
-        `${r.confidence}%`,
-        r.method,
-    ]);
+    const rows = opts.results.map((r) => [shortenPath(r.filePath, 40), r.displayName, `${r.confidence}%`, r.method]);
 
     const table = formatTable(rows, ["File", "Symbol", "Confidence", "Method"], {
         alignRight: [2],

--- a/src/utils/search/stores/sqlite-vector-store.ts
+++ b/src/utils/search/stores/sqlite-vector-store.ts
@@ -39,8 +39,8 @@ export class SqliteVectorStore implements VectorStore {
 
         if (!this.warnedLargeScan && rows.length > 10_000) {
             console.warn(
-                `[SqliteVectorStore] Brute-force scanning ${rows.length} vectors. ` +
-                    `Consider using sqlite-vec or LanceDB for better performance.`
+                `[indexer] Brute-force vector scan (${rows.length} vectors). ` +
+                    `Run "tools indexer rebuild" to migrate to sqlite-vec for faster search.`
             );
             this.warnedLargeScan = true;
         }


### PR DESCRIPTION
- **Confidence normalization** — cosine/rrf/bm25 scores mapped to 0-100% percentages
- **Display name cleanup** — `MyClass (part 3)` → `MyClass:10-45` with line ranges
- **Query word highlighter** — ANSI-colorized query terms in search results
- **Three output formatters** — `pretty` (default, syntax-highlighted), `simple` (grep-like), `table` (compact)
- **"semantic" mode alias** — maps to `vector` mode silently
- **Interactive rebuild** — prompts for driver migration, brute-force warning
- **Comprehensive tests** — confidence, display-name, highlight, search-output, search-output-formats
Plan: `.claude/plans/2026-03-25-IndexerSearchOutputRedesign.md`
- [ ] `tools indexer search "function" --format pretty` shows colorized output with confidence %
- [ ] `tools indexer search "function" --format simple` shows grep-like one-line output
- [ ] `tools indexer search "function" --format table` shows compact table
- [ ] `tools indexer search "function" --mode semantic` works as alias for vector
- [ ] `bunx tsgo --noEmit` passes with zero errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced rebuild command with interactive action selection menu for reindex, reembed, and migration options.
  * Added `--mode` option to search command for explicit search type control.
  * Added `--confidence` filtering option to search results.
  * Expanded search output formats: `pretty`, `simple`, `table`, `json`, and `toon`.
  * Search results now display confidence percentages alongside match results.

* **Documentation**
  * Updated vector store warning message to guide users toward performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->