### PR TITLE
feat(indexer): search output overhaul + Qdrant Docker

### DIFF
--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -104,7 +104,7 @@ export function registerSearchCommand(program: Command): void {
                         const cwd = process.cwd();
                         const cwdMatch = allMeta.find((m) => {
                             const baseDir = m.config.baseDir;
-                            return cwd === baseDir || cwd.startsWith(baseDir + "/");
+                            return cwd === baseDir || cwd.startsWith(`${baseDir}/`);
                         });
 
                         if (cwdMatch) {

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -1,9 +1,11 @@
 import { toToon } from "@app/json/lib/toon";
+import { isInteractive } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import type { SearchResult } from "@app/utils/search/types";
 import { truncateText } from "@app/utils/string";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
+import pc from "picocolors";
 import { normalizeConfidence } from "../lib/confidence";
 import { formatChunkDisplayName } from "../lib/display-name";
 import { parseQueryWords } from "../lib/highlight";
@@ -56,7 +58,7 @@ export function registerSearchCommand(program: Command): void {
         .command("search")
         .description("Search across indexes")
         .argument("<query>", "Search query")
-        .option("-i, --index <name>", "Search specific index (default: all)")
+        .option("-i, --index <name>", "Index to search (auto-detect from cwd; 'all' for all)")
         .option("-m, --mode <mode>", "Search mode: fulltext, vector, hybrid (default: auto-detect)")
         .option("-l, --limit <n>", "Max results", parseInt, 20)
         .option("-f, --file <filter>", "Filter results to files matching this substring")
@@ -82,14 +84,60 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
-                const names = opts.index ? [opts.index] : manager.getIndexNames();
+                let names: string[];
+
+                if (opts.index === "all") {
+                    names = manager.getIndexNames();
+                } else if (opts.index) {
+                    names = [opts.index];
+                } else {
+                    const allMeta = manager.listIndexes();
+
+                    if (allMeta.length === 0) {
+                        p.log.info("No indexes configured. Run: tools indexer add <path>");
+                        return;
+                    }
+
+                    if (allMeta.length === 1) {
+                        names = [allMeta[0].name];
+                    } else {
+                        const cwd = process.cwd();
+                        const cwdMatch = allMeta.find((m) => {
+                            const baseDir = m.config.baseDir;
+                            return cwd === baseDir || cwd.startsWith(baseDir + "/");
+                        });
+
+                        if (cwdMatch) {
+                            names = [cwdMatch.name];
+                            p.log.info(pc.dim(`(using index "${cwdMatch.name}" from cwd)`));
+                        } else if (isInteractive()) {
+                            const allNames = allMeta.map((m) => m.name);
+                            const selected = await p.select({
+                                message: "Select index to search",
+                                options: [
+                                    { value: "__all__", label: "All indexes" },
+                                    ...allNames.map((n) => ({ value: n, label: n })),
+                                ],
+                            });
+
+                            if (p.isCancel(selected)) {
+                                p.log.info("Cancelled");
+                                return;
+                            }
+
+                            names = selected === "__all__" ? allNames : [selected];
+                        } else {
+                            p.log.error("Multiple indexes found. Use -i <name> or -i all.");
+                            return;
+                        }
+                    }
+                }
 
                 if (names.length === 0) {
                     p.log.info("No indexes configured. Run: tools indexer add <path>");
                     return;
                 }
 
-                // Load all indexers upfront for mode detection across all indexes
                 const indexers = await Promise.all(names.map((n) => manager.getIndex(n)));
 
                 let mode: SearchMode;
@@ -171,6 +219,13 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
+                const baseDirs = new Map<string, string>();
+
+                for (const indexer of indexers) {
+                    const cfg = indexer.getConfig();
+                    baseDirs.set(cfg.name, cfg.baseDir);
+                }
+
                 const words = parseQueryWords(query);
                 const output = formatSearchResults({
                     results: filtered,
@@ -178,6 +233,8 @@ export function registerSearchCommand(program: Command): void {
                     query,
                     mode: effectiveMode,
                     highlightWords: words,
+                    baseDirs,
+                    multiIndex: names.length > 1,
                 });
                 console.log(output);
             } finally {

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, relative } from "node:path";
 import { toToon } from "@app/json/lib/toon";
 import { isInteractive } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
@@ -5,7 +6,6 @@ import type { SearchResult } from "@app/utils/search/types";
 import { truncateText } from "@app/utils/string";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
-import { isAbsolute, relative, sep } from "node:path";
 import pc from "picocolors";
 import { normalizeConfidence } from "../lib/confidence";
 import { formatChunkDisplayName } from "../lib/display-name";
@@ -106,7 +106,7 @@ export function registerSearchCommand(program: Command): void {
                         const cwdMatches = allMeta
                             .filter((m) => {
                                 const rel = relative(m.config.baseDir, cwd);
-                                return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+                                return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
                             })
                             .sort((a, b) => b.config.baseDir.length - a.config.baseDir.length);
 

--- a/src/indexer/commands/search.ts
+++ b/src/indexer/commands/search.ts
@@ -5,6 +5,7 @@ import type { SearchResult } from "@app/utils/search/types";
 import { truncateText } from "@app/utils/string";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
+import { isAbsolute, relative, sep } from "node:path";
 import pc from "picocolors";
 import { normalizeConfidence } from "../lib/confidence";
 import { formatChunkDisplayName } from "../lib/display-name";
@@ -102,12 +103,19 @@ export function registerSearchCommand(program: Command): void {
                         names = [allMeta[0].name];
                     } else {
                         const cwd = process.cwd();
-                        const cwdMatch = allMeta.find((m) => {
-                            const baseDir = m.config.baseDir;
-                            return cwd === baseDir || cwd.startsWith(`${baseDir}/`);
-                        });
+                        const cwdMatches = allMeta
+                            .filter((m) => {
+                                const rel = relative(m.config.baseDir, cwd);
+                                return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+                            })
+                            .sort((a, b) => b.config.baseDir.length - a.config.baseDir.length);
 
-                        if (cwdMatch) {
+                        const cwdMatch = cwdMatches[0];
+                        const isUniqueDeepest =
+                            cwdMatches.length < 2 ||
+                            cwdMatches[0].config.baseDir.length > cwdMatches[1].config.baseDir.length;
+
+                        if (cwdMatch && isUniqueDeepest) {
                             names = [cwdMatch.name];
                             p.log.info(pc.dim(`(using index "${cwdMatch.name}" from cwd)`));
                         } else if (isInteractive()) {

--- a/src/indexer/lib/chunker.test.ts
+++ b/src/indexer/lib/chunker.test.ts
@@ -1092,4 +1092,104 @@ import { c } from "./c";
             expect(result.chunks.length).toBe(1);
         });
     });
+
+    describe("Heading strategy — improved splitting", () => {
+        it("preserves heading context in sub-chunks of large sections", () => {
+            const bigBody = Array.from({ length: 200 }, (_, i) => `Line ${i} of content with enough words to consume tokens.`).join("\n\n");
+            const content = `## Big Section\n\n${bigBody}`;
+
+            const result = chunkFile({
+                filePath: "doc.md",
+                content,
+                strategy: "heading",
+                maxTokens: 100,
+            });
+
+            expect(result.parser).toBe("heading");
+            expect(result.chunks.length).toBeGreaterThan(1);
+
+            // Every sub-chunk after the first should contain the heading
+            for (const chunk of result.chunks.slice(1)) {
+                expect(chunk.content).toContain("## Big Section");
+            }
+        });
+
+        it("splits at paragraph boundaries, not mid-paragraph", () => {
+            const para1 = "First paragraph with several words that make it meaningful.";
+            const para2 = "Second paragraph also has content that should stay together.";
+            const para3 = "Third paragraph is the final one in this section.";
+            const content = `## Section\n\n${para1}\n\n${para2}\n\n${para3}`;
+
+            const result = chunkFile({
+                filePath: "doc.md",
+                content,
+                strategy: "heading",
+                maxTokens: 50,
+            });
+
+            expect(result.parser).toBe("heading");
+
+            for (const chunk of result.chunks) {
+                // No paragraph should be cut in the middle — each paragraph
+                // should appear fully in exactly one chunk
+                if (chunk.content.includes("First paragraph")) {
+                    expect(chunk.content).toContain(para1);
+                }
+
+                if (chunk.content.includes("Second paragraph")) {
+                    expect(chunk.content).toContain(para2);
+                }
+
+                if (chunk.content.includes("Third paragraph")) {
+                    expect(chunk.content).toContain(para3);
+                }
+            }
+        });
+
+        it("names preamble content before first heading", () => {
+            const content = `This is preamble text before any heading.\n\nMore preamble.\n\n## First Heading\n\nContent here.`;
+
+            const result = chunkFile({
+                filePath: "doc.md",
+                content,
+                strategy: "heading",
+            });
+
+            expect(result.parser).toBe("heading");
+
+            const preambleChunk = result.chunks[0];
+            expect(preambleChunk.name).toBeDefined();
+            expect(preambleChunk.name).not.toBe("chunk");
+            expect(preambleChunk.content).toContain("preamble text");
+        });
+
+        it("keeps small sections as single chunks", () => {
+            const content = `## Small Section\n\nJust a few words here.`;
+
+            const result = chunkFile({
+                filePath: "doc.md",
+                content,
+                strategy: "heading",
+            });
+
+            expect(result.parser).toBe("heading");
+            expect(result.chunks.length).toBe(1);
+            expect(result.chunks[0].name).toBe("Small Section");
+            expect(result.chunks[0].name).not.toContain("(part");
+        });
+
+        it("handles markdown with no headings at all", () => {
+            const content = `Just plain text.\n\nWith some paragraphs.\n\nAnd nothing else.`;
+
+            const result = chunkFile({
+                filePath: "doc.md",
+                content,
+                strategy: "heading",
+            });
+
+            expect(result.parser).toBe("heading");
+            expect(result.chunks.length).toBeGreaterThanOrEqual(1);
+            expect(result.chunks[0].name).toBeDefined();
+        });
+    });
 });

--- a/src/indexer/lib/chunker.ts
+++ b/src/indexer/lib/chunker.ts
@@ -642,25 +642,27 @@ function splitByParagraphs(opts: {
             return;
         }
 
-        let chunkContent = accumulated.join("\n\n");
+        const sourceContent = accumulated.join("\n\n");
 
-        if (chunkContent.trim().length === 0) {
+        if (sourceContent.trim().length === 0) {
             return;
         }
 
+        let chunkContent = sourceContent;
+
         // Prepend heading to sub-chunks after the first for context
         if (chunks.length > 0 && headingLine) {
-            chunkContent = `${headingLine}\n\n${chunkContent}`;
+            chunkContent = `${headingLine}\n\n${sourceContent}`;
         }
 
-        const lineCount = chunkContent.split("\n").length;
+        const sourceLineCount = sourceContent.split("\n").length;
         const partLabel = chunks.length > 0 ? ` (part ${chunks.length + 1})` : "";
 
         chunks.push({
             id: xxhash(chunkContent),
             filePath,
             startLine: accStartLine,
-            endLine: accStartLine + lineCount - 1,
+            endLine: accStartLine + sourceLineCount - 1,
             content: chunkContent,
             kind,
             name: name ? `${name}${partLabel}` : undefined,
@@ -673,6 +675,23 @@ function splitByParagraphs(opts: {
     let lineOffset = startLine;
 
     for (const para of paragraphs) {
+        // If a single paragraph exceeds maxTokens, fall back to line splitting
+        if (accumulated.length === 0 && estimateTokens(para) > maxTokens) {
+            const paraChunks = splitChunkByLines({
+                content: headingLine ? `${headingLine}\n\n${para}` : para,
+                filePath,
+                startLine: lineOffset,
+                kind,
+                name,
+                language: "markdown",
+                maxTokens,
+            });
+            chunks.push(...paraChunks);
+            lineOffset += para.split("\n").length + 1;
+            accStartLine = lineOffset;
+            continue;
+        }
+
         const candidate = [...accumulated, para].join("\n\n");
         const withHeading = chunks.length > 0 && headingLine ? `${headingLine}\n\n${candidate}` : candidate;
 
@@ -682,7 +701,7 @@ function splitByParagraphs(opts: {
         }
 
         accumulated.push(para);
-        lineOffset += para.split("\n").length + 1; // +1 for the blank line separator
+        lineOffset += para.split("\n").length + 1;
     }
 
     flush();

--- a/src/indexer/lib/chunker.ts
+++ b/src/indexer/lib/chunker.ts
@@ -608,6 +608,88 @@ function chunkByLine(opts: { filePath: string; content: string; maxTokens: numbe
     return { chunks, language, parser: "line" };
 }
 
+// ─── Paragraph-aware splitting for markdown ─────────────────────
+function splitByParagraphs(opts: {
+    content: string;
+    filePath: string;
+    startLine: number;
+    kind: string;
+    name?: string;
+    maxTokens: number;
+    headingLine?: string;
+}): ChunkRecord[] {
+    const { content, filePath, startLine, kind, name, maxTokens, headingLine } = opts;
+    const paragraphs = content.split(/\n\n+/);
+
+    if (paragraphs.length <= 1) {
+        return splitChunkByLines({
+            content,
+            filePath,
+            startLine,
+            kind,
+            name,
+            language: "markdown",
+            maxTokens,
+        });
+    }
+
+    const chunks: ChunkRecord[] = [];
+    let accumulated: string[] = [];
+    let accStartLine = startLine;
+
+    function flush(): void {
+        if (accumulated.length === 0) {
+            return;
+        }
+
+        let chunkContent = accumulated.join("\n\n");
+
+        if (chunkContent.trim().length === 0) {
+            return;
+        }
+
+        // Prepend heading to sub-chunks after the first for context
+        if (chunks.length > 0 && headingLine) {
+            chunkContent = `${headingLine}\n\n${chunkContent}`;
+        }
+
+        const lineCount = chunkContent.split("\n").length;
+        const partLabel = chunks.length > 0 ? ` (part ${chunks.length + 1})` : "";
+
+        chunks.push({
+            id: xxhash(chunkContent),
+            filePath,
+            startLine: accStartLine,
+            endLine: accStartLine + lineCount - 1,
+            content: chunkContent,
+            kind,
+            name: name ? `${name}${partLabel}` : undefined,
+            language: "markdown",
+        });
+
+        accumulated = [];
+    }
+
+    let lineOffset = startLine;
+
+    for (const para of paragraphs) {
+        const candidate = [...accumulated, para].join("\n\n");
+        const withHeading = chunks.length > 0 && headingLine ? `${headingLine}\n\n${candidate}` : candidate;
+
+        if (estimateTokens(withHeading) > maxTokens && accumulated.length > 0) {
+            flush();
+            accStartLine = lineOffset;
+        }
+
+        accumulated.push(para);
+        lineOffset += para.split("\n").length + 1; // +1 for the blank line separator
+    }
+
+    flush();
+
+    return chunks;
+}
+
 // ─── Heading strategy (markdown) ────────────────────────────────
 function chunkByHeading(opts: { filePath: string; content: string; maxTokens: number }): ChunkResult {
     const { filePath, content, maxTokens } = opts;
@@ -615,7 +697,9 @@ function chunkByHeading(opts: { filePath: string; content: string; maxTokens: nu
     const chunks: ChunkRecord[] = [];
     let currentLines: string[] = [];
     let currentName: string | undefined;
+    let currentHeadingLine: string | undefined;
     let currentStartLine = 0;
+    let seenHeading = false;
 
     function flushSection(): void {
         if (currentLines.length === 0) {
@@ -628,14 +712,28 @@ function chunkByHeading(opts: { filePath: string; content: string; maxTokens: nu
             return;
         }
 
-        const subChunks = splitChunkByLines({
+        if (estimateTokens(sectionContent) <= maxTokens) {
+            chunks.push({
+                id: xxhash(sectionContent),
+                filePath,
+                startLine: currentStartLine,
+                endLine: currentStartLine + currentLines.length - 1,
+                content: sectionContent,
+                kind: "heading",
+                name: currentName,
+                language: "markdown",
+            });
+            return;
+        }
+
+        const subChunks = splitByParagraphs({
             content: sectionContent,
             filePath,
             startLine: currentStartLine,
             kind: "heading",
             name: currentName,
-            language: "markdown",
             maxTokens,
+            headingLine: currentHeadingLine,
         });
 
         chunks.push(...subChunks);
@@ -649,8 +747,15 @@ function chunkByHeading(opts: { filePath: string; content: string; maxTokens: nu
             flushSection();
             currentLines = [line];
             currentName = headingMatch[2].trim();
+            currentHeadingLine = line;
             currentStartLine = i;
+            seenHeading = true;
         } else {
+            // Name preamble content (before first heading)
+            if (!seenHeading && !currentName && line.trim().length > 0) {
+                currentName = line.trim().length > 50 ? `${line.trim().slice(0, 50)}...` : line.trim();
+            }
+
             currentLines.push(line);
         }
     }

--- a/src/indexer/lib/search-output-formats.test.ts
+++ b/src/indexer/lib/search-output-formats.test.ts
@@ -8,7 +8,7 @@ mock.module("picocolors", () => {
 });
 
 import { stripAnsi } from "@app/utils/string";
-import { type FormattedSearchResult, formatSearchResults } from "./search-output";
+import { type FormattedSearchResult, formatSearchResults, renderCodeBlock, toDisplayPath } from "./search-output";
 
 function makeResult(overrides: Partial<FormattedSearchResult> = {}): FormattedSearchResult {
     return {
@@ -40,7 +40,7 @@ const defaultOpts = {
 
 describe("formatSearchResults", () => {
     describe("pretty format", () => {
-        test("contains fenced code block with correct language marker", () => {
+        test("contains rendered code block with box-drawing and language label", () => {
             const output = formatSearchResults({
                 results: [makeResult()],
                 format: "pretty",
@@ -48,8 +48,9 @@ describe("formatSearchResults", () => {
             });
             const plain = stripAnsi(output);
 
-            expect(plain).toContain("```php");
-            expect(plain).toMatch(/```\s*$/);
+            expect(plain).toContain("\u256D\u2500 php");
+            expect(plain).toContain("\u2502");
+            expect(plain).toContain("\u2570");
         });
 
         test("shows confidence as percentage", () => {
@@ -93,16 +94,18 @@ describe("formatSearchResults", () => {
             expect(plain).toContain("60%");
         });
 
-        test("handles null language with empty code fence marker", () => {
+        test("handles null language with box-drawing header (no language label)", () => {
             const output = formatSearchResults({
                 results: [makeResult({ language: null })],
                 format: "pretty",
                 ...defaultOpts,
             });
             const plain = stripAnsi(output);
+            const headerLine = plain.split("\n").find((l) => l.includes("\u256D\u2500"));
 
-            expect(plain).toContain("```\n");
-            expect(plain).not.toContain("```php");
+            expect(headerLine).toBeDefined();
+            expect(headerLine).toContain("\u256D\u2500 L45");
+            expect(headerLine).not.toContain("php");
         });
 
         test("shows result count and query in header", () => {
@@ -343,7 +346,7 @@ describe("formatSearchResults", () => {
             const simplePlain = stripAnsi(simple);
             const tablePlain = stripAnsi(table);
 
-            expect(prettyPlain).toContain("```");
+            expect(prettyPlain).toContain("\u256D\u2500");
             expect(simplePlain).toContain("45|");
             expect(tablePlain).toContain("File");
         });
@@ -409,6 +412,167 @@ describe("formatSearchResults", () => {
             expect(high).toContain("\x1b[32m"); // green for >=70
             expect(medium).toContain("\x1b[33m"); // yellow for 40-69
             expect(low).toContain("\x1b[31m"); // red for <40
+        });
+    });
+
+    describe("toDisplayPath", () => {
+        test("returns relative path when baseDir matches", () => {
+            const baseDirs = new Map([["TestIndex", "/project"]]);
+            const result = toDisplayPath("/project/app/Services/BookingService.php", "TestIndex", baseDirs);
+            expect(result).toBe("app/Services/BookingService.php");
+        });
+
+        test("returns original path when no baseDirs provided", () => {
+            const result = toDisplayPath("/project/app/Services/BookingService.php", "TestIndex");
+            expect(result).toBe("/project/app/Services/BookingService.php");
+        });
+
+        test("returns original path when index not in baseDirs", () => {
+            const baseDirs = new Map([["OtherIndex", "/other"]]);
+            const result = toDisplayPath("/project/app/Services/BookingService.php", "TestIndex", baseDirs);
+            expect(result).toBe("/project/app/Services/BookingService.php");
+        });
+
+        test("returns original path when filePath is not absolute", () => {
+            const baseDirs = new Map([["TestIndex", "/project"]]);
+            const result = toDisplayPath("relative/path.ts", "TestIndex", baseDirs);
+            expect(result).toBe("relative/path.ts");
+        });
+    });
+
+    describe("renderCodeBlock", () => {
+        test("includes language label and line range in header", () => {
+            const output = renderCodeBlock("const x = 1;", "typescript", 10, 10);
+            const plain = stripAnsi(output);
+            expect(plain).toContain("\u256D\u2500 typescript L10\u201310");
+        });
+
+        test("omits language label when null", () => {
+            const output = renderCodeBlock("const x = 1;", null, 5, 5);
+            const plain = stripAnsi(output);
+            expect(plain).toContain("\u256D\u2500 L5\u20135");
+            expect(plain).not.toContain("null");
+        });
+
+        test("renders line numbers with gutter", () => {
+            const output = renderCodeBlock("line1\nline2\nline3", "js", 98, 100);
+            const plain = stripAnsi(output);
+            expect(plain).toContain(" 98 \u2502 line1");
+            expect(plain).toContain(" 99 \u2502 line2");
+            expect(plain).toContain("100 \u2502 line3");
+        });
+
+        test("right-aligns line numbers to gutter width", () => {
+            const output = renderCodeBlock("a\nb", "ts", 9, 10);
+            const plain = stripAnsi(output);
+            expect(plain).toContain(" 9 \u2502 a");
+            expect(plain).toContain("10 \u2502 b");
+        });
+
+        test("includes closing border", () => {
+            const output = renderCodeBlock("x", null, 1, 1);
+            const plain = stripAnsi(output);
+            expect(plain).toContain("\u2570");
+            expect(plain).toContain("\u2500".repeat(40));
+        });
+    });
+
+    describe("multiIndex labels", () => {
+        test("pretty format shows index name above file path when multiIndex", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ indexName: "BackendIndex" })],
+                format: "pretty",
+                ...defaultOpts,
+                multiIndex: true,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).toContain("[BackendIndex]");
+        });
+
+        test("pretty format hides index name when not multiIndex", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ indexName: "BackendIndex" })],
+                format: "pretty",
+                ...defaultOpts,
+                multiIndex: false,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).not.toContain("[BackendIndex]");
+        });
+
+        test("simple format appends index label when multiIndex", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ indexName: "FrontendIndex" })],
+                format: "simple",
+                ...defaultOpts,
+                multiIndex: true,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).toContain("[FrontendIndex]");
+        });
+
+        test("simple format hides index label when not multiIndex", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ indexName: "FrontendIndex" })],
+                format: "simple",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).not.toContain("[FrontendIndex]");
+        });
+
+        test("table format adds Index column when multiIndex", () => {
+            const output = formatSearchResults({
+                results: [makeResult({ indexName: "TestIndex" })],
+                format: "table",
+                ...defaultOpts,
+                multiIndex: true,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).toContain("Index");
+            expect(plain).toContain("TestIndex");
+        });
+
+        test("table format has no Index column when not multiIndex", () => {
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "table",
+                ...defaultOpts,
+            });
+            const plain = stripAnsi(output);
+            const lines = plain.split("\n");
+            const headerLine = lines.find((l) => l.includes("File"));
+            expect(headerLine).toBeDefined();
+            expect(headerLine).not.toContain("Index");
+        });
+    });
+
+    describe("baseDirs relative path display", () => {
+        test("pretty format shows relative paths with baseDirs", () => {
+            const baseDirs = new Map([["TestIndex", "/project"]]);
+            const output = formatSearchResults({
+                results: [makeResult()],
+                format: "pretty",
+                ...defaultOpts,
+                baseDirs,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).toContain("app/Services/BookingService.php");
+            expect(plain).not.toContain("/project/app");
+        });
+
+        test("table format truncates long relative paths from left", () => {
+            const baseDirs = new Map([["TestIndex", "/root"]]);
+            const longPath = "/root/src/modules/services/handlers/controllers/deeply/nested/structure/file.ts";
+            const output = formatSearchResults({
+                results: [makeResult({ filePath: longPath })],
+                format: "table",
+                ...defaultOpts,
+                baseDirs,
+            });
+            const plain = stripAnsi(output);
+            expect(plain).toContain("...");
+            expect(plain).not.toContain(longPath);
         });
     });
 });

--- a/src/indexer/lib/search-output.test.ts
+++ b/src/indexer/lib/search-output.test.ts
@@ -52,7 +52,7 @@ describe("formatSearchResults", () => {
     });
 
     describe("pretty format", () => {
-        it("contains fenced code block with language marker", () => {
+        it("contains rendered code block with box-drawing and language label", () => {
             const result = formatSearchResults({
                 results: [makeResult({ language: "php" })],
                 format: "pretty",
@@ -60,8 +60,9 @@ describe("formatSearchResults", () => {
                 mode: "hybrid",
             });
             const plain = stripAnsi(result);
-            expect(plain).toContain("```php");
-            expect(plain).toMatch(/```\n|```$/);
+            expect(plain).toContain("\u256D\u2500 php");
+            expect(plain).toContain("\u2502");
+            expect(plain).toContain("\u2570");
         });
 
         it("contains confidence as percentage", () => {
@@ -114,16 +115,17 @@ describe("formatSearchResults", () => {
             expect(pathOccurrences).toBe(1);
         });
 
-        it("highlights query words in content", () => {
+        it("renders code block with line numbers", () => {
             const result = formatSearchResults({
-                results: [makeResult()],
+                results: [makeResult({ startLine: 45, endLine: 48 })],
                 format: "pretty",
                 query: "sendNotification",
                 mode: "hybrid",
-                highlightWords: ["sendNotification"],
             });
             const plain = stripAnsi(result);
-            expect(result.length).toBeGreaterThan(plain.length);
+            expect(plain).toContain("45 \u2502");
+            expect(plain).toContain("48 \u2502");
+            expect(plain).toContain("L45\u201348");
         });
     });
 
@@ -292,7 +294,7 @@ describe("formatSearchResults", () => {
             expect(outputs[0]).not.toBe(outputs[2]);
         });
 
-        it("null language uses plain code block in pretty format", () => {
+        it("null language omits language label in code block header", () => {
             const result = formatSearchResults({
                 results: [makeResult({ language: null })],
                 format: "pretty",
@@ -300,8 +302,8 @@ describe("formatSearchResults", () => {
                 mode: "hybrid",
             });
             const plain = stripAnsi(result);
-            expect(plain).toContain("```\n");
-            expect(plain).not.toContain("```null");
+            expect(plain).toContain("\u256D\u2500 L45");
+            expect(plain).not.toContain("null");
         });
     });
 });

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -30,7 +30,7 @@ interface FormatOptions {
 export function toDisplayPath(filePath: string, indexName: string, baseDirs?: Map<string, string>): string {
     const baseDir = baseDirs?.get(indexName);
 
-    if (baseDir && filePath.startsWith("/")) {
+    if (baseDir && filePath.startsWith(baseDir)) {
         return relative(baseDir, filePath);
     }
 

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -1,4 +1,4 @@
-import { relative } from "node:path";
+import { isAbsolute, relative } from "node:path";
 import { formatTable } from "@app/utils/table";
 import pc from "picocolors";
 import { highlightQueryWords } from "./highlight";
@@ -30,8 +30,12 @@ interface FormatOptions {
 export function toDisplayPath(filePath: string, indexName: string, baseDirs?: Map<string, string>): string {
     const baseDir = baseDirs?.get(indexName);
 
-    if (baseDir && filePath.startsWith(baseDir)) {
-        return relative(baseDir, filePath);
+    if (baseDir) {
+        const rel = relative(baseDir, filePath);
+
+        if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+            return rel;
+        }
     }
 
     return filePath;

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -126,7 +126,8 @@ function formatPretty(opts: FormatOptions): string {
             const header = [pc.bold(r.displayName), colorConfidence(r.confidence), pc.dim(r.method)].join("  ");
             lines.push(header);
 
-            const codeBlock = renderCodeBlock(r.content, r.language, r.startLine, r.endLine);
+            const highlighted = highlightContent(r.content, opts.highlightWords);
+            const codeBlock = renderCodeBlock(highlighted, r.language, r.startLine, r.endLine);
             lines.push(codeBlock);
             lines.push("");
         }

--- a/src/indexer/lib/search-output.ts
+++ b/src/indexer/lib/search-output.ts
@@ -1,3 +1,4 @@
+import { relative } from "node:path";
 import { formatTable } from "@app/utils/table";
 import pc from "picocolors";
 import { highlightQueryWords } from "./highlight";
@@ -22,14 +23,26 @@ interface FormatOptions {
     query: string;
     mode: string;
     highlightWords?: string[];
+    baseDirs?: Map<string, string>;
+    multiIndex?: boolean;
 }
 
-function shortenPath(filePath: string, maxLen: number): string {
-    if (filePath.length <= maxLen) {
-        return filePath;
+export function toDisplayPath(filePath: string, indexName: string, baseDirs?: Map<string, string>): string {
+    const baseDir = baseDirs?.get(indexName);
+
+    if (baseDir && filePath.startsWith("/")) {
+        return relative(baseDir, filePath);
     }
 
-    return `...${filePath.slice(-(maxLen - 3))}`;
+    return filePath;
+}
+
+function truncateLeft(path: string, maxLen: number): string {
+    if (path.length <= maxLen) {
+        return path;
+    }
+
+    return `...${path.slice(-(maxLen - 3))}`;
 }
 
 function colorConfidence(confidence: number): string {
@@ -59,42 +72,62 @@ function highlightContent(content: string, words: string[] | undefined): string 
     return highlightQueryWords(content, words);
 }
 
+export function renderCodeBlock(content: string, language: string | null, startLine: number, endLine: number): string {
+    const lines = content.split("\n");
+    const gutterWidth = String(endLine).length;
+    const langLabel = language ? ` ${language}` : "";
+    const lineRange = `L${startLine}\u2013${endLine}`;
+
+    const parts: string[] = [];
+    parts.push(pc.dim(`\u256D\u2500${langLabel} ${lineRange}`));
+
+    for (let i = 0; i < lines.length; i++) {
+        const lineNo = String(startLine + i).padStart(gutterWidth);
+        parts.push(`${pc.dim(`${lineNo} \u2502`)} ${lines[i]}`);
+    }
+
+    parts.push(pc.dim(`\u2570${"\u2500".repeat(40)}`));
+    return parts.join("\n");
+}
+
 function formatPretty(opts: FormatOptions): string {
     const lines: string[] = [formatHeader(opts.results.length, opts.query, opts.mode), ""];
 
-    const groups = new Map<string, FormattedSearchResult[]>();
+    type GroupKey = string;
+    const groups = new Map<GroupKey, { filePath: string; indexName: string; results: FormattedSearchResult[] }>();
 
     for (const r of opts.results) {
-        const existing = groups.get(r.filePath);
+        const key = `${r.indexName}::${r.filePath}`;
+        const existing = groups.get(key);
 
         if (existing) {
-            existing.push(r);
+            existing.results.push(r);
         } else {
-            groups.set(r.filePath, [r]);
+            groups.set(key, { filePath: r.filePath, indexName: r.indexName, results: [r] });
         }
     }
 
     let groupIndex = 0;
 
-    for (const [filePath, results] of groups) {
+    for (const [, group] of groups) {
         if (groupIndex > 0) {
             lines.push("");
         }
 
-        lines.push(pc.cyan(shortenPath(filePath, 60)));
+        if (opts.multiIndex) {
+            lines.push(pc.dim(`[${group.indexName}]`));
+        }
+
+        const displayPath = toDisplayPath(group.filePath, group.indexName, opts.baseDirs);
+        lines.push(pc.cyan(displayPath));
         lines.push("");
 
-        for (const r of results) {
+        for (const r of group.results) {
             const header = [pc.bold(r.displayName), colorConfidence(r.confidence), pc.dim(r.method)].join("  ");
             lines.push(header);
 
-            const langMarker = r.language ?? "";
-            lines.push(`\`\`\`${langMarker}`);
-
-            const highlighted = highlightContent(r.content, opts.highlightWords);
-            lines.push(highlighted);
-
-            lines.push("```");
+            const codeBlock = renderCodeBlock(r.content, r.language, r.startLine, r.endLine);
+            lines.push(codeBlock);
             lines.push("");
         }
 
@@ -108,8 +141,9 @@ function formatSimple(opts: FormatOptions): string {
     const parts: string[] = [];
 
     for (const r of opts.results) {
-        const shortPath = shortenPath(r.filePath, 60);
-        const header = `${pc.cyan(pc.bold(shortPath))} ${r.displayName} ${colorConfidence(r.confidence)} ${pc.dim(r.method)}`;
+        const displayPath = toDisplayPath(r.filePath, r.indexName, opts.baseDirs);
+        const indexLabel = opts.multiIndex ? ` ${pc.dim(`[${r.indexName}]`)}` : "";
+        const header = `${pc.cyan(pc.bold(displayPath))} ${r.displayName} ${colorConfidence(r.confidence)} ${pc.dim(r.method)}${indexLabel}`;
         parts.push(header);
 
         const highlighted = highlightContent(r.content, opts.highlightWords);
@@ -134,7 +168,23 @@ function formatSimple(opts: FormatOptions): string {
 function formatTableOutput(opts: FormatOptions): string {
     const header = formatHeader(opts.results.length, opts.query, opts.mode);
 
-    const rows = opts.results.map((r) => [shortenPath(r.filePath, 40), r.displayName, `${r.confidence}%`, r.method]);
+    if (opts.multiIndex) {
+        const rows = opts.results.map((r) => {
+            const displayPath = toDisplayPath(r.filePath, r.indexName, opts.baseDirs);
+            return [r.indexName, truncateLeft(displayPath, 60), r.displayName, `${r.confidence}%`, r.method];
+        });
+
+        const table = formatTable(rows, ["Index", "File", "Symbol", "Confidence", "Method"], {
+            alignRight: [3],
+        });
+
+        return `${header}\n\n${table}`;
+    }
+
+    const rows = opts.results.map((r) => {
+        const displayPath = toDisplayPath(r.filePath, r.indexName, opts.baseDirs);
+        return [truncateLeft(displayPath, 60), r.displayName, `${r.confidence}%`, r.method];
+    });
 
     const table = formatTable(rows, ["File", "Symbol", "Confidence", "Method"], {
         alignRight: [2],

--- a/src/utils/docker/docker-container.ts
+++ b/src/utils/docker/docker-container.ts
@@ -31,12 +31,7 @@ export class DockerContainer {
 
     async isImagePresent(): Promise<boolean> {
         try {
-            const stdout = await this.run([
-                "images",
-                "--format",
-                "{{.Repository}}:{{.Tag}}",
-                this.config.image,
-            ]);
+            const stdout = await this.run(["images", "--format", "{{.Repository}}:{{.Tag}}", this.config.image]);
             return stdout.includes(this.config.image);
         } catch {
             return false;
@@ -53,12 +48,12 @@ export class DockerContainer {
 
             if (msg.includes("timed out")) {
                 throw new Error(
-                    `Image download timed out after 10 minutes. Check your network connection and try again.`,
+                    `Image download timed out after 10 minutes. Check your network connection and try again.`
                 );
             }
 
             throw new Error(
-                `Failed to download image ${this.config.image}. Check your network connection and available disk space.\nDetails: ${msg}`,
+                `Failed to download image ${this.config.image}. Check your network connection and available disk space.\nDetails: ${msg}`
             );
         }
     }
@@ -68,11 +63,11 @@ export class DockerContainer {
             const stdout = await this.run([
                 "ps",
                 "--filter",
-                `name=${this.config.name}`,
+                `name=^${this.config.name}$`,
                 "--format",
                 "{{.Names}}",
             ]);
-            return stdout.trim().includes(this.config.name);
+            return stdout.trim().split("\n").includes(this.config.name);
         } catch {
             return false;
         }
@@ -84,11 +79,11 @@ export class DockerContainer {
                 "ps",
                 "-a",
                 "--filter",
-                `name=${this.config.name}`,
+                `name=^${this.config.name}$`,
                 "--format",
                 "{{.Names}}",
             ]);
-            return stdout.trim().includes(this.config.name);
+            return stdout.trim().split("\n").includes(this.config.name);
         } catch {
             return false;
         }
@@ -136,7 +131,7 @@ export class DockerContainer {
             const msg = error instanceof Error ? error.message : String(error);
             const portList = this.config.ports.map((p) => p.host).join(", ");
             throw new Error(
-                `Failed to start container ${this.config.name}. Are ports ${portList} already in use?\nDetails: ${msg}`,
+                `Failed to start container ${this.config.name}. Are ports ${portList} already in use?\nDetails: ${msg}`
             );
         }
 
@@ -156,7 +151,7 @@ export class DockerContainer {
 
         if (!(await this.isDockerAvailable())) {
             throw new Error(
-                "Docker is not available. Please install Docker Desktop (https://www.docker.com/products/docker-desktop/) and make sure it is running.",
+                "Docker is not available. Please install Docker Desktop (https://www.docker.com/products/docker-desktop/) and make sure it is running."
             );
         }
 
@@ -189,11 +184,16 @@ export class DockerContainer {
             stderr: "pipe",
         });
 
+        let timer: Timer | undefined;
+
         const result = await (timeoutMs > 0
             ? Promise.race([
-                  proc.exited,
+                  proc.exited.then((code) => {
+                      clearTimeout(timer);
+                      return code;
+                  }),
                   new Promise<never>((_resolve, reject) => {
-                      setTimeout(() => {
+                      timer = setTimeout(() => {
                           proc.kill();
                           reject(new Error(`docker ${args[0]} timed out after ${timeoutMs / 1000}s`));
                       }, timeoutMs);
@@ -227,7 +227,7 @@ export class DockerContainer {
         }
 
         throw new Error(
-            `${this.config.name} did not become ready at ${this.config.healthUrl} within ${(retries * delayMs) / 1000}s`,
+            `${this.config.name} did not become ready at ${this.config.healthUrl} within ${(retries * delayMs) / 1000}s`
         );
     }
 }

--- a/src/utils/docker/docker-container.ts
+++ b/src/utils/docker/docker-container.ts
@@ -1,0 +1,233 @@
+export interface DockerContainerConfig {
+    name: string;
+    image: string;
+    ports: Array<{ host: number; container: number }>;
+    volumes: Array<{ host: string; container: string }>;
+    healthUrl: string;
+    restartPolicy?: string;
+    env?: Record<string, string>;
+}
+
+export type DockerProgressCallback = (message: string) => void;
+
+const READINESS_TTL_MS = 60_000;
+
+export class DockerContainer {
+    private config: DockerContainerConfig;
+    private readyAt = 0;
+
+    constructor(config: DockerContainerConfig) {
+        this.config = config;
+    }
+
+    async isDockerAvailable(): Promise<boolean> {
+        try {
+            await this.run(["info"]);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    async isImagePresent(): Promise<boolean> {
+        try {
+            const stdout = await this.run([
+                "images",
+                "--format",
+                "{{.Repository}}:{{.Tag}}",
+                this.config.image,
+            ]);
+            return stdout.includes(this.config.image);
+        } catch {
+            return false;
+        }
+    }
+
+    async pullImage(onProgress?: DockerProgressCallback): Promise<void> {
+        onProgress?.(`Downloading Docker image ${this.config.image} (first time only, may take a few minutes)...`);
+
+        try {
+            await this.run(["pull", this.config.image], 10 * 60_000);
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+
+            if (msg.includes("timed out")) {
+                throw new Error(
+                    `Image download timed out after 10 minutes. Check your network connection and try again.`,
+                );
+            }
+
+            throw new Error(
+                `Failed to download image ${this.config.image}. Check your network connection and available disk space.\nDetails: ${msg}`,
+            );
+        }
+    }
+
+    async isRunning(): Promise<boolean> {
+        try {
+            const stdout = await this.run([
+                "ps",
+                "--filter",
+                `name=${this.config.name}`,
+                "--format",
+                "{{.Names}}",
+            ]);
+            return stdout.trim().includes(this.config.name);
+        } catch {
+            return false;
+        }
+    }
+
+    async containerExists(): Promise<boolean> {
+        try {
+            const stdout = await this.run([
+                "ps",
+                "-a",
+                "--filter",
+                `name=${this.config.name}`,
+                "--format",
+                "{{.Names}}",
+            ]);
+            return stdout.trim().includes(this.config.name);
+        } catch {
+            return false;
+        }
+    }
+
+    async start(onProgress?: DockerProgressCallback): Promise<void> {
+        if (await this.isRunning()) {
+            return;
+        }
+
+        if (await this.containerExists()) {
+            onProgress?.(`Starting existing ${this.config.name} container...`);
+            await this.run(["start", this.config.name]);
+            onProgress?.("Waiting for service to be ready...");
+            await this.waitForService();
+            return;
+        }
+
+        onProgress?.(`Creating and starting ${this.config.name} container...`);
+
+        const args = ["run", "-d", "--name", this.config.name];
+
+        for (const port of this.config.ports) {
+            args.push("-p", `${port.host}:${port.container}`);
+        }
+
+        for (const vol of this.config.volumes) {
+            args.push("-v", `${vol.host}:${vol.container}`);
+        }
+
+        const restartPolicy = this.config.restartPolicy ?? "unless-stopped";
+        args.push("--restart", restartPolicy);
+
+        if (this.config.env) {
+            for (const [key, value] of Object.entries(this.config.env)) {
+                args.push("-e", `${key}=${value}`);
+            }
+        }
+
+        args.push(this.config.image);
+
+        try {
+            await this.run(args);
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            const portList = this.config.ports.map((p) => p.host).join(", ");
+            throw new Error(
+                `Failed to start container ${this.config.name}. Are ports ${portList} already in use?\nDetails: ${msg}`,
+            );
+        }
+
+        onProgress?.("Waiting for service to be ready...");
+        await this.waitForService();
+    }
+
+    async stop(): Promise<void> {
+        await this.run(["stop", this.config.name]);
+        this.readyAt = 0;
+    }
+
+    async ensureReady(onProgress?: DockerProgressCallback): Promise<{ started: boolean; pulled: boolean }> {
+        if (Date.now() - this.readyAt < READINESS_TTL_MS) {
+            return { started: false, pulled: false };
+        }
+
+        if (!(await this.isDockerAvailable())) {
+            throw new Error(
+                "Docker is not available. Please install Docker Desktop (https://www.docker.com/products/docker-desktop/) and make sure it is running.",
+            );
+        }
+
+        let pulled = false;
+        let started = false;
+
+        onProgress?.(`Checking ${this.config.name}...`);
+
+        if (!(await this.isImagePresent())) {
+            await this.pullImage(onProgress);
+            pulled = true;
+        }
+
+        if (!(await this.isRunning())) {
+            await this.start(onProgress);
+            started = true;
+        }
+
+        this.readyAt = Date.now();
+        return { started, pulled };
+    }
+
+    resetReadinessCache(): void {
+        this.readyAt = 0;
+    }
+
+    private async run(args: string[], timeoutMs = 30_000): Promise<string> {
+        const proc = Bun.spawn(["docker", ...args], {
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+
+        const result = await (timeoutMs > 0
+            ? Promise.race([
+                  proc.exited,
+                  new Promise<never>((_resolve, reject) => {
+                      setTimeout(() => {
+                          proc.kill();
+                          reject(new Error(`docker ${args[0]} timed out after ${timeoutMs / 1000}s`));
+                      }, timeoutMs);
+                  }),
+              ])
+            : proc.exited);
+
+        const stdout = await new Response(proc.stdout).text();
+
+        if (result !== 0) {
+            const stderr = await new Response(proc.stderr).text();
+            throw new Error(`docker ${args[0]} failed: ${stderr.trim()}`);
+        }
+
+        return stdout;
+    }
+
+    private async waitForService(retries = 30, delayMs = 1000): Promise<void> {
+        for (let i = 0; i < retries; i++) {
+            try {
+                const resp = await fetch(this.config.healthUrl);
+
+                if (resp.ok) {
+                    return;
+                }
+            } catch {
+                // not ready yet
+            }
+
+            await new Promise((r) => setTimeout(r, delayMs));
+        }
+
+        throw new Error(
+            `${this.config.name} did not become ready at ${this.config.healthUrl} within ${(retries * delayMs) / 1000}s`,
+        );
+    }
+}

--- a/src/utils/docker/index.ts
+++ b/src/utils/docker/index.ts
@@ -1,0 +1,2 @@
+export { DockerContainer, type DockerContainerConfig, type DockerProgressCallback } from "./docker-container";
+export { ensureQdrantReady, getQdrantContainer, getQdrantUrl } from "./qdrant";

--- a/src/utils/docker/qdrant.ts
+++ b/src/utils/docker/qdrant.ts
@@ -5,8 +5,22 @@ import { DockerContainer, type DockerProgressCallback } from "./docker-container
 
 const QDRANT_IMAGE = "qdrant/qdrant:v1.17.0";
 const QDRANT_CONTAINER_NAME = "genesis-tools-qdrant";
-const QDRANT_PORT = parseInt(process.env.GENESIS_QDRANT_PORT || "16335", 10);
-const QDRANT_GRPC_PORT = parseInt(process.env.GENESIS_QDRANT_GRPC_PORT || "16336", 10);
+const QDRANT_PORT = parsePort(process.env.GENESIS_QDRANT_PORT, 16335);
+const QDRANT_GRPC_PORT = parsePort(process.env.GENESIS_QDRANT_GRPC_PORT, 16336);
+
+function parsePort(envValue: string | undefined, defaultPort: number): number {
+    if (!envValue) {
+        return defaultPort;
+    }
+
+    const parsed = parseInt(envValue, 10);
+
+    if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+        throw new Error(`Invalid port value: "${envValue}". Expected a number between 1 and 65535.`);
+    }
+
+    return parsed;
+}
 const QDRANT_STORAGE = join(homedir(), ".genesis-tools", "indexes", "qdrant");
 
 let instance: DockerContainer | null = null;
@@ -34,7 +48,7 @@ export function getQdrantContainer(): DockerContainer {
 }
 
 export async function ensureQdrantReady(
-    onProgress?: DockerProgressCallback,
+    onProgress?: DockerProgressCallback
 ): Promise<{ started: boolean; pulled: boolean }> {
     return getQdrantContainer().ensureReady(onProgress);
 }

--- a/src/utils/docker/qdrant.ts
+++ b/src/utils/docker/qdrant.ts
@@ -1,0 +1,44 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DockerContainer, type DockerProgressCallback } from "./docker-container";
+
+const QDRANT_IMAGE = "qdrant/qdrant:v1.17.0";
+const QDRANT_CONTAINER_NAME = "genesis-tools-qdrant";
+const QDRANT_PORT = parseInt(process.env.GENESIS_QDRANT_PORT || "16335", 10);
+const QDRANT_GRPC_PORT = parseInt(process.env.GENESIS_QDRANT_GRPC_PORT || "16336", 10);
+const QDRANT_STORAGE = join(homedir(), ".genesis-tools", "indexes", "qdrant");
+
+let instance: DockerContainer | null = null;
+
+export function getQdrantContainer(): DockerContainer {
+    if (instance) {
+        return instance;
+    }
+
+    mkdirSync(QDRANT_STORAGE, { recursive: true });
+
+    instance = new DockerContainer({
+        name: QDRANT_CONTAINER_NAME,
+        image: QDRANT_IMAGE,
+        ports: [
+            { host: QDRANT_PORT, container: 6333 },
+            { host: QDRANT_GRPC_PORT, container: 6334 },
+        ],
+        volumes: [{ host: QDRANT_STORAGE, container: "/qdrant/storage" }],
+        healthUrl: `http://localhost:${QDRANT_PORT}/healthz`,
+        restartPolicy: "unless-stopped",
+    });
+
+    return instance;
+}
+
+export async function ensureQdrantReady(
+    onProgress?: DockerProgressCallback,
+): Promise<{ started: boolean; pulled: boolean }> {
+    return getQdrantContainer().ensureReady(onProgress);
+}
+
+export function getQdrantUrl(): string {
+    return `http://localhost:${QDRANT_PORT}`;
+}

--- a/src/utils/search/stores/qdrant-vector-store.ts
+++ b/src/utils/search/stores/qdrant-vector-store.ts
@@ -90,9 +90,16 @@ export class QdrantVectorStore implements VectorStore {
      */
     async init(): Promise<void> {
         if (!this.client) {
+            const url = this.config.url ?? "http://localhost:16335";
+
+            if (url.includes("localhost") || url.includes("127.0.0.1")) {
+                const { ensureQdrantReady } = await import("@app/utils/docker/qdrant");
+                await ensureQdrantReady();
+            }
+
             const { QdrantClient } = await import("@qdrant/js-client-rest");
             this.client = new QdrantClient({
-                url: this.config.url ?? "http://localhost:6333",
+                url,
                 apiKey: this.config.apiKey,
             }) as unknown as QdrantClientLike;
         }

--- a/src/utils/search/stores/qdrant-vector-store.ts
+++ b/src/utils/search/stores/qdrant-vector-store.ts
@@ -90,11 +90,12 @@ export class QdrantVectorStore implements VectorStore {
      */
     async init(): Promise<void> {
         if (!this.client) {
-            const url = this.config.url ?? "http://localhost:16335";
+            let url = this.config.url;
 
-            if (url.includes("localhost") || url.includes("127.0.0.1")) {
-                const { ensureQdrantReady } = await import("@app/utils/docker/qdrant");
+            if (!url || url.includes("localhost") || url.includes("127.0.0.1")) {
+                const { ensureQdrantReady, getQdrantUrl } = await import("@app/utils/docker/qdrant");
                 await ensureQdrantReady();
+                url = url ?? getQdrantUrl();
             }
 
             const { QdrantClient } = await import("@qdrant/js-client-rest");


### PR DESCRIPTION
- **Search output**: Auto-detect index from cwd, full relative paths (replaces `...` truncation), index name labels for multi-index searches, box-drawing code blocks with line numbers and language headers
- **Markdown chunking**: Paragraph-aware splitting that preserves heading context in sub-chunks, names preamble content before first heading
- **Qdrant Docker**: Generic `DockerContainer` class at `src/utils/docker/`, Qdrant factory with auto-pull/start on localhost (ports 16335/16336), integrated into `QdrantVectorStore.init()`
- [ ] `tools indexer search "where is reservation"` — verify full relative paths, rendered code blocks with line numbers
- [ ] `tools indexer search "where is reservation" --mode vector` — verify same improvements in vector mode
- [ ] `tools indexer search "..." -i all` with multiple indexes — verify index labels appear
- [ ] Rebuild a markdown-heavy index, search it — verify chunks are coherent with heading context
- [ ] Set `vectorDriver: "qdrant"` on an index → verify container auto-starts, data persists at `~/.genesis-tools/indexes/qdrant/`
- [ ] `bun test src/indexer/lib/` — 414 tests pass
- [ ] `tsgo --noEmit` — 0 type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search: auto-detects target index from current directory, supports "--index all", and shows an interactive chooser when multiple indexes match.
  * Results: code blocks render in a boxed style with language labels and line numbers; displayed paths are relative to index base directories and show index labels in multi-index mode.
  * Qdrant: local vector store will auto-initialize/start via Docker when needed.
  * Chunking: markdown chunking preserves headings, names preambles, and splits at paragraph boundaries.

* **Tests**
  * Added coverage for markdown chunking and updated search-output format tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->