### PR TITLE
feat(debugging-master): session reuse, LAN IP, server sharing

### DIFF
--- a/src/debugging-master/commands/start.ts
+++ b/src/debugging-master/commands/start.ts
@@ -147,7 +147,7 @@ export function registerStartCommand(program: Command): void {
                     ? `${formatRelativeTime(new Date(reused.lastLogAt))} (${reused.totalLogs} total)`
                     : "no logs yet";
                 const startup = formatRelativeTime(new Date(reused.createdAt));
-                console.log(pc.yellow(`⚠ Session re-used. Last log ${lastLog}, started ${startup} ago`));
+                console.log(pc.yellow(`⚠ Session re-used. Last log ${lastLog}, started ${startup}`));
             } else {
                 console.log(pc.green(pc.bold("Session created")));
             }
@@ -187,7 +187,7 @@ export function registerStartCommand(program: Command): void {
                     // Port busy — check if it's already our server
                     try {
                         const res = await fetch(`http://127.0.0.1:${port}/health`);
-                        const body = await res.json() as { status?: string };
+                        const body = (await res.json()) as { status?: string };
 
                         if (res.ok && body.status === "ok") {
                             actualPort = port;

--- a/src/debugging-master/commands/start.ts
+++ b/src/debugging-master/commands/start.ts
@@ -4,6 +4,8 @@ import { startServer } from "@app/debugging-master/core/http-server";
 import { SessionManager } from "@app/debugging-master/core/session-manager";
 import type { ProjectConfig } from "@app/debugging-master/types";
 import { suggestCommand } from "@app/utils/cli/executor";
+import { formatRelativeTime } from "@app/utils/format";
+import { getLocalIpv4 } from "@app/utils/network";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
@@ -123,7 +125,7 @@ export function registerStartCommand(program: Command): void {
 
             // --- Create session ---
             const sm = new SessionManager();
-            const jsonlPath = await sm.createSession(sessionName, projectPath, {
+            const { jsonlPath, reused } = await sm.createSession(sessionName, projectPath, {
                 serve: opts.serve,
                 port: opts.serve ? port : undefined,
             });
@@ -140,7 +142,16 @@ export function registerStartCommand(program: Command): void {
             const importPath = `./${relSnippet.replace(/\.(ts|php)$/, "")}`;
 
             console.log("");
-            console.log(pc.green(pc.bold("Session created")));
+            if (reused) {
+                const lastLog = reused.lastLogAt
+                    ? `${formatRelativeTime(new Date(reused.lastLogAt))} (${reused.totalLogs} total)`
+                    : "no logs yet";
+                const startup = formatRelativeTime(new Date(reused.createdAt));
+                console.log(pc.yellow(`⚠ Session re-used. Last log ${lastLog}, started ${startup} ago`));
+            } else {
+                console.log(pc.green(pc.bold("Session created")));
+            }
+
             console.log("");
             console.log(`  ${pc.dim("Session:")}   ${sessionName}`);
             console.log(`  ${pc.dim("Project:")}   ${projectPath}`);
@@ -168,18 +179,44 @@ export function registerStartCommand(program: Command): void {
             // --- Optionally start HTTP server ---
             if (opts.serve) {
                 let actualPort: number;
+                let reused = false;
+
                 try {
                     ({ port: actualPort } = startServer(port));
-                } catch (err) {
-                    console.error(`Failed to start HTTP server on port ${port}: ${(err as Error).message}`);
-                    process.exit(1);
+                } catch {
+                    // Port busy — check if it's already our server
+                    try {
+                        const res = await fetch(`http://127.0.0.1:${port}/health`);
+                        const body = await res.json() as { status?: string };
+
+                        if (res.ok && body.status === "ok") {
+                            actualPort = port;
+                            reused = true;
+                        } else {
+                            console.error(`Port ${port} is in use by another process`);
+                            process.exit(1);
+                        }
+                    } catch {
+                        console.error(`Port ${port} is in use by another process`);
+                        process.exit(1);
+                    }
                 }
-                console.log(pc.green(`HTTP server listening on port ${actualPort}`));
-                console.log(pc.dim(`POST http://localhost:${actualPort}/log/${sessionName}`));
+
+                if (reused) {
+                    console.log(pc.green(`Reusing HTTP server on port ${actualPort}`));
+                } else {
+                    console.log(pc.green(`HTTP server listening on port ${actualPort}`));
+                }
+
+                const lanIp = getLocalIpv4();
+                console.log(pc.dim(`POST http://${lanIp}:${actualPort}/log/${sessionName}`));
+                console.log(pc.dim(`GET  http://${lanIp}:${actualPort}/health`));
                 console.log("");
 
-                // Keep process alive
-                await new Promise(() => {});
+                if (!reused) {
+                    // Keep process alive only if we own the server
+                    await new Promise(() => {});
+                }
             }
         });
 }

--- a/src/debugging-master/commands/start.ts
+++ b/src/debugging-master/commands/start.ts
@@ -179,7 +179,7 @@ export function registerStartCommand(program: Command): void {
             // --- Optionally start HTTP server ---
             if (opts.serve) {
                 let actualPort: number;
-                let reused = false;
+                let serverReused = false;
 
                 try {
                     ({ port: actualPort } = startServer(port));
@@ -191,7 +191,7 @@ export function registerStartCommand(program: Command): void {
 
                         if (res.ok && body.status === "ok") {
                             actualPort = port;
-                            reused = true;
+                            serverReused = true;
                         } else {
                             console.error(`Port ${port} is in use by another process`);
                             process.exit(1);
@@ -202,7 +202,7 @@ export function registerStartCommand(program: Command): void {
                     }
                 }
 
-                if (reused) {
+                if (serverReused) {
                     console.log(pc.green(`Reusing HTTP server on port ${actualPort}`));
                 } else {
                     console.log(pc.green(`HTTP server listening on port ${actualPort}`));
@@ -213,7 +213,7 @@ export function registerStartCommand(program: Command): void {
                 console.log(pc.dim(`GET  http://${lanIp}:${actualPort}/health`));
                 console.log("");
 
-                if (!reused) {
+                if (!serverReused) {
                     // Keep process alive only if we own the server
                     await new Promise(() => {});
                 }

--- a/src/debugging-master/core/http-server.ts
+++ b/src/debugging-master/core/http-server.ts
@@ -63,7 +63,7 @@ export function startServer(port: number = 7243): { server: ReturnType<typeof Bu
 
     const server = Bun.serve({
         port,
-        hostname: "127.0.0.1",
+        hostname: "0.0.0.0",
         async fetch(req) {
             const url = new URL(req.url);
 

--- a/src/debugging-master/core/session-manager.ts
+++ b/src/debugging-master/core/session-manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { LogEntry, SessionMeta } from "@app/debugging-master/types";
 import { suggestCommand } from "@app/utils/cli/executor";
@@ -37,16 +37,18 @@ export class SessionManager {
         return dir;
     }
 
-    async createSession(name: string, projectPath: string, opts?: { serve?: boolean; port?: number }): Promise<CreateSessionResult> {
+    async createSession(
+        name: string,
+        projectPath: string,
+        opts?: { serve?: boolean; port?: number }
+    ): Promise<CreateSessionResult> {
         const dir = await this.getSessionsDir();
         const jsonlPath = join(dir, `${name}.jsonl`);
         const metaPath = join(dir, `${name}.meta.json`);
 
         if (existsSync(jsonlPath)) {
             const stat = statSync(jsonlPath);
-            const meta = existsSync(metaPath)
-                ? (SafeJSON.parse(await Bun.file(metaPath).text()) as SessionMeta)
-                : null;
+            const meta = existsSync(metaPath) ? (SafeJSON.parse(await Bun.file(metaPath).text()) as SessionMeta) : null;
             const content = stat.size > 0 ? readFileSync(jsonlPath, "utf-8") : "";
             const totalLogs = content ? content.trimEnd().split("\n").length : 0;
 

--- a/src/debugging-master/core/session-manager.ts
+++ b/src/debugging-master/core/session-manager.ts
@@ -1,10 +1,19 @@
-import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { LogEntry, SessionMeta } from "@app/debugging-master/types";
 import { suggestCommand } from "@app/utils/cli/executor";
 import { SafeJSON } from "@app/utils/json";
 import { fuzzyFind } from "@app/utils/string";
 import { ConfigManager } from "./config-manager";
+
+export interface CreateSessionResult {
+    jsonlPath: string;
+    reused?: {
+        lastLogAt: number | null;
+        createdAt: number;
+        totalLogs: number;
+    };
+}
 
 export const ACTIVE_THRESHOLD_MS = 60 * 60 * 1000;
 const TOOL_NAME = "tools debugging-master";
@@ -28,13 +37,28 @@ export class SessionManager {
         return dir;
     }
 
-    async createSession(name: string, projectPath: string, opts?: { serve?: boolean; port?: number }): Promise<string> {
+    async createSession(name: string, projectPath: string, opts?: { serve?: boolean; port?: number }): Promise<CreateSessionResult> {
         const dir = await this.getSessionsDir();
         const jsonlPath = join(dir, `${name}.jsonl`);
         const metaPath = join(dir, `${name}.meta.json`);
 
         if (existsSync(jsonlPath)) {
-            throw new Error(`Session "${name}" already exists. Use a different name or remove it first.`);
+            const stat = statSync(jsonlPath);
+            const meta = existsSync(metaPath)
+                ? (SafeJSON.parse(await Bun.file(metaPath).text()) as SessionMeta)
+                : null;
+            const content = stat.size > 0 ? readFileSync(jsonlPath, "utf-8") : "";
+            const totalLogs = content ? content.trimEnd().split("\n").length : 0;
+
+            await this.config.setRecentSession(name);
+            return {
+                jsonlPath,
+                reused: {
+                    lastLogAt: stat.size > 0 ? stat.mtimeMs : null,
+                    createdAt: meta?.createdAt ?? stat.mtimeMs,
+                    totalLogs,
+                },
+            };
         }
 
         const now = Date.now();
@@ -52,7 +76,7 @@ export class SessionManager {
 
         await this.config.setRecentSession(name);
 
-        return jsonlPath;
+        return { jsonlPath };
     }
 
     async resolveSession(sessionFlag?: string): Promise<string> {

--- a/src/debugging-master/core/session-manager.ts
+++ b/src/debugging-master/core/session-manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readSync, readdirSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { LogEntry, SessionMeta } from "@app/debugging-master/types";
 import { suggestCommand } from "@app/utils/cli/executor";
@@ -13,6 +13,31 @@ export interface CreateSessionResult {
         createdAt: number;
         totalLogs: number;
     };
+}
+
+const NEWLINE = 0x0a;
+const COUNT_BUF_SIZE = 16_384;
+
+/** Count newline bytes in a file without reading it into a JS string. */
+function countNewlines(filePath: string, fileSize: number): number {
+    const fd = openSync(filePath, "r");
+    const buf = Buffer.allocUnsafe(Math.min(COUNT_BUF_SIZE, fileSize));
+    let count = 0;
+    let pos = 0;
+
+    while (pos < fileSize) {
+        const bytesRead = readSync(fd, buf, 0, buf.length, pos);
+        for (let i = 0; i < bytesRead; i++) {
+            if (buf[i] === NEWLINE) {
+                count++;
+            }
+        }
+
+        pos += bytesRead;
+    }
+
+    closeSync(fd);
+    return count;
 }
 
 export const ACTIVE_THRESHOLD_MS = 60 * 60 * 1000;
@@ -49,15 +74,14 @@ export class SessionManager {
         if (existsSync(jsonlPath)) {
             const stat = statSync(jsonlPath);
             const meta = existsSync(metaPath) ? (SafeJSON.parse(await Bun.file(metaPath).text()) as SessionMeta) : null;
-            const content = stat.size > 0 ? readFileSync(jsonlPath, "utf-8") : "";
-            const totalLogs = content ? content.trimEnd().split("\n").length : 0;
+            const totalLogs = stat.size > 0 ? countNewlines(jsonlPath, stat.size) : 0;
 
             await this.config.setRecentSession(name);
             return {
                 jsonlPath,
                 reused: {
                     lastLogAt: stat.size > 0 ? stat.mtimeMs : null,
-                    createdAt: meta?.createdAt ?? stat.mtimeMs,
+                    createdAt: meta?.createdAt ?? stat.birthtimeMs,
                     totalLogs,
                 },
             };

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,17 @@
+import { networkInterfaces } from "node:os";
+
+/**
+ * Returns the first non-internal IPv4 address (LAN IP).
+ * Falls back to 127.0.0.1 when no external interface is found.
+ */
+export function getLocalIpv4(): string {
+    for (const ifaces of Object.values(networkInterfaces())) {
+        for (const iface of ifaces ?? []) {
+            if (iface.family === "IPv4" && !iface.internal) {
+                return iface.address;
+            }
+        }
+    }
+
+    return "127.0.0.1";
+}


### PR DESCRIPTION
- **Session reuse**: `start --serve` no longer errors on existing sessions — shows a yellow warning with last log time and total log count instead
- **LAN IP**: Output shows the machine's IPv4 LAN address instead of `localhost`, so remote devices (phones, other machines) can copy-paste the URL directly
- **Server sharing**: If port 7243 is already taken by another debugging-master server, reuse it via `/health` check instead of crashing
- **0.0.0.0 bind**: HTTP server now listens on all interfaces (was `127.0.0.1`), enabling WiFi access from physical devices
- **`getLocalIpv4()`**: Extracted to `src/utils/network.ts` for reuse by other tools
- [ ] `tools debugging-master start --session test1 --serve` → creates session, starts server
- [ ] `tools debugging-master start --session test1 --serve` again → reuses session with yellow warning showing log count
- [ ] Verify output shows LAN IP (e.g. `172.x.x.x`) not `localhost`
- [ ] Verify `/health` endpoint shown in output
- [ ] Start server on port 7243, then start another session with `--serve` → reuses existing server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now report whether they were newly created or reused and show related metadata (timestamps, log counts).
  * Endpoint links show the machine's LAN IPv4 address.

* **Improvements**
  * Server binds to all network interfaces, allowing LAN access.
  * Start logic performs health checks and can detect/reuse existing server instances.
  * Process lifetime under serve mode only blocks when a new server is started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->