### PR TITLE
feat: add `tools todo` — project-scoped task management for LLM workflows

### DIFF
--- a/plugins/genesis-tools/skills/todo/SKILL.md
+++ b/plugins/genesis-tools/skills/todo/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: gt:todo
+description: |
+  Manage project-scoped todos with rich context capture. Use when the user wants to track tasks, create reminders, link work items to PRs/issues, or manage work across sessions. Triggers on "add todo", "create task", "remind me to", "track this", "todo list", "what's on my plate", "mark done", "complete task", "what should I work on". Also use proactively when the user mentions wanting to remember something for later or needing to follow up.
+---
+
+# Todo Management Tool
+
+Create, track, and manage project-scoped todos with auto-captured git context, session tracking, and Apple Calendar/Reminders sync.
+
+Every todo is a **context capsule** — it captures the full git state (branch, commit, staged/unstaged changes), environment info, and session ID at creation time so any future session can pick up the work with zero context loss.
+
+## CLI Reference
+
+```bash
+# Create
+tools todo add "Fix the auth bug" \
+  --priority high \
+  --tag auth,backend \
+  --reminder "24h" --reminder "3d" \
+  --link pr:142 --link ado:78901 \
+  --session-id $CLAUDE_CODE_SESSION_ID \
+  --attach ./screenshot.png \
+  --md ./notes.md \
+  --description "The OAuth flow breaks when..."
+
+# List
+tools todo list                              # current project, active todos
+tools todo list --all                        # all projects
+tools todo list --status done                # filter by status
+tools todo list --priority critical,high     # filter by priority
+tools todo list --tag auth                   # filter by tag
+tools todo list --session $CLAUDE_CODE_SESSION_ID
+tools todo list --format ai|json|md|table
+
+# Show detail
+tools todo show <id>
+tools todo show <id> --format ai
+
+# Status transitions
+tools todo start <id>
+tools todo block <id>
+tools todo complete <id> --note "Fixed in commit abc123"
+tools todo reopen <id>
+
+# Edit
+tools todo edit <id> --priority critical
+tools todo edit <id> --add-tag urgent
+tools todo edit <id> --add-reminder "1h"
+tools todo edit <id> --add-link pr:99
+
+# Search
+tools todo search "auth bug"
+tools todo search "OAuth" --all
+
+# Remove
+tools todo remove <id>
+
+# Apple sync
+tools todo sync <id> --to calendar
+tools todo sync <id> --to reminders
+tools todo sync --all --to reminders
+
+# Import/Export
+tools todo export --format json > todos.json
+tools todo import todos.json
+```
+
+## LLM Usage Guidelines
+
+### Always Do
+
+1. **Pass session ID** on every `add` command:
+   ```bash
+   tools todo add "..." --session-id $CLAUDE_CODE_SESSION_ID
+   ```
+
+2. **Use `--format ai`** when reading todos back for context:
+   ```bash
+   tools todo list --format ai
+   tools todo show <id> --format ai
+   ```
+
+3. **Link external resources** when working on PRs, issues, or ADO work items:
+   ```bash
+   --link pr:142           # GitHub PR
+   --link issue:456        # GitHub issue
+   --link ado:78901        # Azure DevOps work item
+   --link https://...      # any URL
+   ```
+
+4. **Embed context** with `--md` for complex todos:
+   ```bash
+   --md ./spec.md          # inline the file content into the todo
+   ```
+
+5. **Set priority** based on conversation urgency:
+   - User says "urgent", "ASAP", "critical" → `--priority critical`
+   - User says "important", "soon" → `--priority high`
+   - Default → `--priority medium`
+   - User says "whenever", "low priority", "nice to have" → `--priority low`
+
+6. **Track status** as you work:
+   ```bash
+   tools todo start <id>                          # when beginning work
+   tools todo complete <id> --note "summary"      # when finishing
+   tools todo block <id>                          # when stuck
+   ```
+
+### Checking Session Todos
+
+At the start of a session, check for existing todos:
+```bash
+tools todo list --session $CLAUDE_CODE_SESSION_ID --format ai
+```
+
+Or check all active todos for the project:
+```bash
+tools todo list --format ai
+```
+
+### Creating From Conversation
+
+When the user says something like "remind me to..." or "I need to...", create a todo:
+```bash
+tools todo add "What the user wants to track" \
+  --priority <infer from context> \
+  --tag <relevant tags from the discussion> \
+  --session-id $CLAUDE_CODE_SESSION_ID \
+  --link <any relevant PR/issue> \
+  --description "Additional context from the conversation"
+```
+
+### Reminders
+
+Reminders support relative and absolute times:
+```bash
+--reminder "30m"                    # 30 minutes from now
+--reminder "24h"                    # 24 hours
+--reminder "3d"                     # 3 days
+--reminder "1w"                     # 1 week
+--reminder "2026-04-02 10:00"       # absolute datetime
+```
+
+Multiple reminders can be specified:
+```bash
+--reminder "24h" --reminder "3d"    # remind at 24h and again at 3d
+```
+
+## Output Formats
+
+| Format | Best For | Default When |
+|--------|----------|-------------|
+| `ai` | LLM consumption, compact | Non-TTY (piped) |
+| `table` | Human scanning of lists | TTY list |
+| `md` | Detailed single-todo view | TTY show |
+| `json` | Machine processing, export | Explicit only |
+
+## Storage
+
+Todos are stored per-project at `~/.genesis-tools/todo/projects/<hash>/todos.json`. Each todo captures the full git state at creation time. Use `--all` to query across all projects.

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -46,6 +46,7 @@ export function createAddCommand(): Command {
         .option("--project <path>", "Override project root")
         .option("--sync-to <target>", "Auto-sync reminders: calendar|reminders|both")
         .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (titleArg, opts) => {
             let title: string | undefined = titleArg;
             let priority: TodoPriority | undefined = opts.priority;
@@ -144,7 +145,7 @@ export function createAddCommand(): Command {
             });
 
             const format = resolveFormat(opts.format);
-            console.log(formatTodo(todo, format));
+            console.log(formatTodo(todo, format, { colors: opts.colors }));
 
             if (opts.syncTo && todo.reminders.length > 0) {
                 const target = opts.syncTo as SyncTarget;

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -2,8 +2,9 @@ import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodo } from "@app/todo/lib/format";
 import { parseLinks } from "@app/todo/lib/links";
 import { TodoStore } from "@app/todo/lib/store";
+import { type SyncTarget, syncTodo } from "@app/todo/lib/sync";
 import type { OutputFormat, TodoPriority } from "@app/todo/lib/types";
-import { isInteractive, suggestCommand } from "@app/utils/cli";
+import { isInteractive, parseVariadic, suggestCommand } from "@app/utils/cli";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
@@ -26,6 +27,10 @@ function resolveProjectRoot(flag: string | undefined): string {
     return findProjectRoot(process.cwd()) ?? process.cwd();
 }
 
+function collect(value: string, previous: string[]): string[] {
+    return [...previous, value];
+}
+
 export function createAddCommand(): Command {
     return new Command("add")
         .description("Add a new todo")
@@ -39,11 +44,12 @@ export function createAddCommand(): Command {
         .option("-a, --attach <path>", "File path to attach (repeatable)", collect, [])
         .option("--md <path>", "Markdown file to inline as content")
         .option("--project <path>", "Override project root")
+        .option("--sync-to <target>", "Auto-sync reminders: calendar|reminders|both")
         .option("-f, --format <format>", "Output format: ai|json|md|table")
         .action(async (titleArg, opts) => {
             let title: string | undefined = titleArg;
             let priority: TodoPriority | undefined = opts.priority;
-            let tags: string[] | undefined = opts.tag ? opts.tag.split(",").map((s: string) => s.trim()) : undefined;
+            let tags: string[] | undefined = opts.tag ? parseVariadic(opts.tag) : undefined;
             let description: string | undefined = opts.description;
 
             if (!title && !isInteractive()) {
@@ -97,10 +103,7 @@ export function createAddCommand(): Command {
                     }
 
                     if (result) {
-                        tags = result
-                            .split(",")
-                            .map((s) => s.trim())
-                            .filter(Boolean);
+                        tags = parseVariadic(result);
                     }
                 }
 
@@ -123,7 +126,10 @@ export function createAddCommand(): Command {
 
             const projectRoot = resolveProjectRoot(opts.project);
             const store = TodoStore.forProject(projectRoot);
-            const links = opts.link.length > 0 ? parseLinks(opts.link) : undefined;
+            const reminders = parseVariadic(opts.reminder);
+            const linkInputs = parseVariadic(opts.link);
+            const links = linkInputs.length > 0 ? parseLinks(linkInputs) : undefined;
+            const attachFiles = parseVariadic(opts.attach);
 
             const todo = await store.add({
                 title: title!,
@@ -131,22 +137,27 @@ export function createAddCommand(): Command {
                 priority,
                 tags,
                 links,
-                reminders: opts.reminder.length > 0 ? opts.reminder : undefined,
+                reminders: reminders.length > 0 ? reminders : undefined,
                 sessionId: opts.sessionId,
-                attachFiles: opts.attach.length > 0 ? opts.attach : undefined,
+                attachFiles: attachFiles.length > 0 ? attachFiles : undefined,
                 mdFile: opts.md,
             });
 
             const format = resolveFormat(opts.format);
             console.log(formatTodo(todo, format));
 
+            if (opts.syncTo && todo.reminders.length > 0) {
+                const target = opts.syncTo as SyncTarget;
+                const count = await syncTodo({ store, todo, target });
+
+                if (count > 0) {
+                    console.error(pc.green(`Synced ${count} reminder(s) to ${target}.`));
+                }
+            }
+
             if (isInteractive()) {
                 p.log.success(`Created ${todo.id}`);
                 p.outro("Done!");
             }
         });
-}
-
-function collect(value: string, previous: string[]): string[] {
-    return [...previous, value];
 }

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -147,7 +147,7 @@ export function createAddCommand(): Command {
             const format = resolveFormat(opts.format);
             console.log(formatTodo(todo, format, { colors: opts.colors }));
 
-            if (opts.syncTo && todo.reminders.length > 0) {
+            if (opts.syncTo) {
                 const target = opts.syncTo as SyncTarget;
                 const count = await syncTodo({ store, todo, target });
 

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -1,0 +1,149 @@
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import { findProjectRoot } from "@app/todo/lib/context";
+import { formatTodo } from "@app/todo/lib/format";
+import { parseLinks } from "@app/todo/lib/links";
+import { TodoStore } from "@app/todo/lib/store";
+import type { OutputFormat, TodoPriority } from "@app/todo/lib/types";
+import * as p from "@clack/prompts";
+import { Command } from "commander";
+import pc from "picocolors";
+
+const PRIORITIES: TodoPriority[] = ["critical", "high", "medium", "low"];
+
+function resolveFormat(format: string | undefined): OutputFormat {
+    if (format) {
+        return format as OutputFormat;
+    }
+
+    return isInteractive() ? "md" : "ai";
+}
+
+function resolveProjectRoot(flag: string | undefined): string {
+    if (flag) {
+        return flag;
+    }
+
+    return findProjectRoot(process.cwd()) ?? process.cwd();
+}
+
+export function createAddCommand(): Command {
+    return new Command("add")
+        .description("Add a new todo")
+        .argument("[title]", "Todo title")
+        .option("-d, --description <text>", "Description text")
+        .option("-p, --priority <priority>", "Priority: critical|high|medium|low")
+        .option("-t, --tag <tags>", "Comma-separated tags")
+        .option("-r, --reminder <time>", "Reminder time (repeatable)", collect, [])
+        .option("-l, --link <link>", "Link (repeatable): pr:123, issue:456, ado:789, URL", collect, [])
+        .option("-s, --session-id <id>", "Session ID for tracking")
+        .option("-a, --attach <path>", "File path to attach (repeatable)", collect, [])
+        .option("--md <path>", "Markdown file to inline as content")
+        .option("--project <path>", "Override project root")
+        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .action(async (titleArg, opts) => {
+            let title: string | undefined = titleArg;
+            let priority: TodoPriority | undefined = opts.priority;
+            let tags: string[] | undefined = opts.tag ? opts.tag.split(",").map((s: string) => s.trim()) : undefined;
+            let description: string | undefined = opts.description;
+
+            if (!title && !isInteractive()) {
+                console.error("Error: title is required in non-interactive mode.");
+                console.error(suggestCommand("tools todo add", { add: ["\"My todo title\""] }));
+                process.exit(1);
+            }
+
+            if (isInteractive()) {
+                p.intro(pc.bgCyan(pc.black(" todo add ")));
+
+                if (!title) {
+                    const result = await p.text({
+                        message: "Title",
+                        placeholder: "What needs to be done?",
+                        validate: (v) => (!v || v.length === 0 ? "Title is required" : undefined),
+                    });
+
+                    if (p.isCancel(result)) {
+                        p.cancel("Cancelled.");
+                        process.exit(0);
+                    }
+
+                    title = result;
+                }
+
+                if (!priority) {
+                    const result = await p.select({
+                        message: "Priority",
+                        options: PRIORITIES.map((pr) => ({ value: pr, label: pr })),
+                        initialValue: "medium" as TodoPriority,
+                    });
+
+                    if (p.isCancel(result)) {
+                        p.cancel("Cancelled.");
+                        process.exit(0);
+                    }
+
+                    priority = result;
+                }
+
+                if (!tags) {
+                    const result = await p.text({
+                        message: "Tags (comma-separated, optional)",
+                        placeholder: "e.g. auth, backend",
+                    });
+
+                    if (p.isCancel(result)) {
+                        p.cancel("Cancelled.");
+                        process.exit(0);
+                    }
+
+                    if (result) {
+                        tags = result.split(",").map((s) => s.trim()).filter(Boolean);
+                    }
+                }
+
+                if (!description) {
+                    const result = await p.text({
+                        message: "Description (optional)",
+                        placeholder: "Additional details...",
+                    });
+
+                    if (p.isCancel(result)) {
+                        p.cancel("Cancelled.");
+                        process.exit(0);
+                    }
+
+                    if (result) {
+                        description = result;
+                    }
+                }
+            }
+
+            const projectRoot = resolveProjectRoot(opts.project);
+            const store = TodoStore.forProject(projectRoot);
+            const links = opts.link.length > 0 ? parseLinks(opts.link) : undefined;
+
+            const todo = await store.add({
+                title: title!,
+                description,
+                priority,
+                tags,
+                links,
+                reminders: opts.reminder.length > 0 ? opts.reminder : undefined,
+                sessionId: opts.sessionId,
+                attachFiles: opts.attach.length > 0 ? opts.attach : undefined,
+                mdFile: opts.md,
+            });
+
+            const format = resolveFormat(opts.format);
+            console.log(formatTodo(todo, format));
+
+            if (isInteractive()) {
+                p.log.success(`Created ${todo.id}`);
+                p.outro("Done!");
+            }
+        });
+}
+
+function collect(value: string, previous: string[]): string[] {
+    return [...previous, value];
+}

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -1,9 +1,9 @@
-import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodo } from "@app/todo/lib/format";
 import { parseLinks } from "@app/todo/lib/links";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat, TodoPriority } from "@app/todo/lib/types";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
@@ -48,7 +48,7 @@ export function createAddCommand(): Command {
 
             if (!title && !isInteractive()) {
                 console.error("Error: title is required in non-interactive mode.");
-                console.error(suggestCommand("tools todo add", { add: ["\"My todo title\""] }));
+                console.error(suggestCommand("tools todo add", { add: ['"My todo title"'] }));
                 process.exit(1);
             }
 
@@ -97,7 +97,10 @@ export function createAddCommand(): Command {
                     }
 
                     if (result) {
-                        tags = result.split(",").map((s) => s.trim()).filter(Boolean);
+                        tags = result
+                            .split(",")
+                            .map((s) => s.trim())
+                            .filter(Boolean);
                     }
                 }
 

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -6,7 +6,7 @@ import { type SyncTarget, syncTodo } from "@app/todo/lib/sync";
 import type { OutputFormat, TodoPriority } from "@app/todo/lib/types";
 import { isInteractive, parseVariadic, suggestCommand } from "@app/utils/cli";
 import * as p from "@clack/prompts";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 
 const PRIORITIES: TodoPriority[] = ["critical", "high", "medium", "low"];
@@ -44,8 +44,8 @@ export function createAddCommand(): Command {
         .option("-a, --attach <path>", "File path to attach (repeatable)", collect, [])
         .option("--md <path>", "Markdown file to inline as content")
         .option("--project <path>", "Override project root")
-        .option("--sync-to <target>", "Auto-sync reminders: calendar|reminders|both")
-        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .addOption(new Option("--sync-to <target>", "Auto-sync reminders").choices(["calendar", "reminders", "both"]))
+        .addOption(new Option("-f, --format <format>", "Output format").choices(["ai", "json", "md", "table"]))
         .option("--colors", "Force colorized output even in non-TTY")
         .action(async (titleArg, opts) => {
             let title: string | undefined = titleArg;

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -100,7 +100,7 @@ export function createEditCommand(): Command {
             const todo = await store.update(id, patch);
             console.log(formatTodo(todo, resolveFormat(opts.format), { colors: opts.colors }));
 
-            if (opts.syncTo && todo.reminders.length > 0) {
+            if (opts.syncTo) {
                 const target = opts.syncTo as SyncTarget;
                 const count = await syncTodo({ store, todo, target });
 

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -3,9 +3,11 @@ import { formatTodo } from "@app/todo/lib/format";
 import { parseLink } from "@app/todo/lib/links";
 import { parseReminderTime } from "@app/todo/lib/reminders";
 import { TodoStore } from "@app/todo/lib/store";
+import { type SyncTarget, syncTodo } from "@app/todo/lib/sync";
 import type { OutputFormat, Todo, TodoPriority } from "@app/todo/lib/types";
-import { isInteractive } from "@app/utils/cli";
+import { isInteractive, parseVariadic } from "@app/utils/cli";
 import { Command } from "commander";
+import pc from "picocolors";
 
 function resolveFormat(format: string | undefined): OutputFormat {
     if (format) {
@@ -31,6 +33,7 @@ export function createEditCommand(): Command {
         .option("--add-reminder <time>", "Add a reminder", collect, [])
         .option("--add-link <link>", "Add a link", collect, [])
         .option("--session-id <id>", "Set session ID")
+        .option("--sync-to <target>", "Auto-sync reminders: calendar|reminders|both")
         .option("-f, --format <format>", "Output format")
         .action(async (id, opts) => {
             const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
@@ -64,32 +67,45 @@ export function createEditCommand(): Command {
                 let tags = [...existing.tags];
 
                 if (opts.addTag) {
-                    const newTags = (opts.addTag as string).split(",").map((s: string) => s.trim());
+                    const newTags = parseVariadic(opts.addTag);
                     tags = [...new Set([...tags, ...newTags])];
                 }
 
                 if (opts.removeTag) {
-                    const removeTags = new Set((opts.removeTag as string).split(",").map((s: string) => s.trim()));
+                    const removeTags = new Set(parseVariadic(opts.removeTag));
                     tags = tags.filter((t) => !removeTags.has(t));
                 }
 
                 patch.tags = tags;
             }
 
-            if (opts.addReminder.length > 0) {
-                const newReminders = (opts.addReminder as string[]).map((r) => ({
+            const addedReminders = parseVariadic(opts.addReminder);
+
+            if (addedReminders.length > 0) {
+                const newReminders = addedReminders.map((r) => ({
                     at: parseReminderTime(r),
                     synced: null as "calendar" | "reminders" | null,
                 }));
                 patch.reminders = [...existing.reminders, ...newReminders];
             }
 
-            if (opts.addLink.length > 0) {
-                const newLinks = (opts.addLink as string[]).map(parseLink);
+            const addedLinks = parseVariadic(opts.addLink);
+
+            if (addedLinks.length > 0) {
+                const newLinks = addedLinks.map(parseLink);
                 patch.links = [...existing.links, ...newLinks];
             }
 
             const todo = await store.update(id, patch);
             console.log(formatTodo(todo, resolveFormat(opts.format)));
+
+            if (opts.syncTo && todo.reminders.length > 0) {
+                const target = opts.syncTo as SyncTarget;
+                const count = await syncTodo({ store, todo, target });
+
+                if (count > 0) {
+                    console.error(pc.green(`Synced ${count} reminder(s) to ${target}.`));
+                }
+            }
         });
 }

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -6,7 +6,7 @@ import { TodoStore } from "@app/todo/lib/store";
 import { type SyncTarget, syncTodo } from "@app/todo/lib/sync";
 import type { OutputFormat, Todo, TodoPriority } from "@app/todo/lib/types";
 import { isInteractive, parseVariadic } from "@app/utils/cli";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 
 function resolveFormat(format: string | undefined): OutputFormat {
@@ -27,14 +27,14 @@ export function createEditCommand(): Command {
         .argument("<id>", "Todo ID")
         .option("--title <text>", "New title")
         .option("--description <text>", "New description")
-        .option("--priority <priority>", "New priority: critical|high|medium|low")
+        .addOption(new Option("--priority <priority>", "New priority").choices(["critical", "high", "medium", "low"]))
         .option("--add-tag <tags>", "Add tags (comma-separated)")
         .option("--remove-tag <tags>", "Remove tags (comma-separated)")
         .option("--add-reminder <time>", "Add a reminder", collect, [])
         .option("--add-link <link>", "Add a link", collect, [])
         .option("--session-id <id>", "Set session ID")
-        .option("--sync-to <target>", "Auto-sync reminders: calendar|reminders|both")
-        .option("-f, --format <format>", "Output format")
+        .addOption(new Option("--sync-to <target>", "Auto-sync reminders").choices(["calendar", "reminders", "both"]))
+        .addOption(new Option("-f, --format <format>", "Output format").choices(["ai", "json", "md", "table"]))
         .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -35,6 +35,7 @@ export function createEditCommand(): Command {
         .option("--session-id <id>", "Set session ID")
         .option("--sync-to <target>", "Auto-sync reminders: calendar|reminders|both")
         .option("-f, --format <format>", "Output format")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
             const store = TodoStore.forProject(projectRoot);
@@ -97,7 +98,7 @@ export function createEditCommand(): Command {
             }
 
             const todo = await store.update(id, patch);
-            console.log(formatTodo(todo, resolveFormat(opts.format)));
+            console.log(formatTodo(todo, resolveFormat(opts.format), { colors: opts.colors }));
 
             if (opts.syncTo && todo.reminders.length > 0) {
                 const target = opts.syncTo as SyncTarget;

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -1,10 +1,10 @@
-import { isInteractive } from "@app/utils/cli";
 import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodo } from "@app/todo/lib/format";
 import { parseLink } from "@app/todo/lib/links";
 import { parseReminderTime } from "@app/todo/lib/reminders";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat, Todo, TodoPriority } from "@app/todo/lib/types";
+import { isInteractive } from "@app/utils/cli";
 import { Command } from "commander";
 
 function resolveFormat(format: string | undefined): OutputFormat {

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -1,0 +1,95 @@
+import { isInteractive } from "@app/utils/cli";
+import { findProjectRoot } from "@app/todo/lib/context";
+import { formatTodo } from "@app/todo/lib/format";
+import { parseLink } from "@app/todo/lib/links";
+import { parseReminderTime } from "@app/todo/lib/reminders";
+import { TodoStore } from "@app/todo/lib/store";
+import type { OutputFormat, Todo, TodoPriority } from "@app/todo/lib/types";
+import { Command } from "commander";
+
+function resolveFormat(format: string | undefined): OutputFormat {
+    if (format) {
+        return format as OutputFormat;
+    }
+
+    return isInteractive() ? "md" : "ai";
+}
+
+function collect(value: string, previous: string[]): string[] {
+    return [...previous, value];
+}
+
+export function createEditCommand(): Command {
+    return new Command("edit")
+        .description("Edit an existing todo")
+        .argument("<id>", "Todo ID")
+        .option("--title <text>", "New title")
+        .option("--description <text>", "New description")
+        .option("--priority <priority>", "New priority: critical|high|medium|low")
+        .option("--add-tag <tags>", "Add tags (comma-separated)")
+        .option("--remove-tag <tags>", "Remove tags (comma-separated)")
+        .option("--add-reminder <time>", "Add a reminder", collect, [])
+        .option("--add-link <link>", "Add a link", collect, [])
+        .option("--session-id <id>", "Set session ID")
+        .option("-f, --format <format>", "Output format")
+        .action(async (id, opts) => {
+            const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+            const store = TodoStore.forProject(projectRoot);
+            const existing = await store.get(id);
+
+            if (!existing) {
+                console.error(`Todo not found: ${id}`);
+                process.exit(1);
+            }
+
+            const patch: Partial<Todo> = {};
+
+            if (opts.title) {
+                patch.title = opts.title;
+            }
+
+            if (opts.description) {
+                patch.description = opts.description;
+            }
+
+            if (opts.priority) {
+                patch.priority = opts.priority as TodoPriority;
+            }
+
+            if (opts.sessionId) {
+                patch.sessionId = opts.sessionId;
+            }
+
+            if (opts.addTag || opts.removeTag) {
+                let tags = [...existing.tags];
+
+                if (opts.addTag) {
+                    const newTags = (opts.addTag as string).split(",").map((s: string) => s.trim());
+                    tags = [...new Set([...tags, ...newTags])];
+                }
+
+                if (opts.removeTag) {
+                    const removeTags = new Set((opts.removeTag as string).split(",").map((s: string) => s.trim()));
+                    tags = tags.filter((t) => !removeTags.has(t));
+                }
+
+                patch.tags = tags;
+            }
+
+            if (opts.addReminder.length > 0) {
+                const newReminders = (opts.addReminder as string[]).map((r) => ({
+                    at: parseReminderTime(r),
+                    synced: null as "calendar" | "reminders" | null,
+                }));
+                patch.reminders = [...existing.reminders, ...newReminders];
+            }
+
+            if (opts.addLink.length > 0) {
+                const newLinks = (opts.addLink as string[]).map(parseLink);
+                patch.links = [...existing.links, ...newLinks];
+            }
+
+            const todo = await store.update(id, patch);
+            console.log(formatTodo(todo, resolveFormat(opts.format)));
+        });
+}

--- a/src/todo/commands/import-export.ts
+++ b/src/todo/commands/import-export.ts
@@ -15,7 +15,7 @@ function validateTodos(data: unknown): Todo[] {
     }
 
     for (let i = 0; i < data.length; i++) {
-        const item = data[i];
+        const item = data[i] as Record<string, unknown>;
 
         if (typeof item !== "object" || item === null) {
             throw new Error(`Item at index ${i} is not an object`);
@@ -26,6 +26,12 @@ function validateTodos(data: unknown): Todo[] {
                 throw new Error(`Item at index ${i} is missing required field: ${field}`);
             }
         }
+
+        // Default optional arrays to prevent runtime crashes
+        item.attachments ??= [];
+        item.links ??= [];
+        item.reminders ??= [];
+        item.tags ??= [];
     }
 
     return data as Todo[];

--- a/src/todo/commands/import-export.ts
+++ b/src/todo/commands/import-export.ts
@@ -1,0 +1,93 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { findProjectRoot } from "@app/todo/lib/context";
+import { TodoStore } from "@app/todo/lib/store";
+import type { Todo } from "@app/todo/lib/types";
+import { SafeJSON } from "@app/utils/json";
+import { Command } from "commander";
+
+const REQUIRED_FIELDS = ["id", "title", "status"] as const;
+
+function validateTodos(data: unknown): Todo[] {
+    if (!Array.isArray(data)) {
+        throw new Error("Import file must contain a JSON array of todos");
+    }
+
+    for (let i = 0; i < data.length; i++) {
+        const item = data[i];
+
+        if (typeof item !== "object" || item === null) {
+            throw new Error(`Item at index ${i} is not an object`);
+        }
+
+        for (const field of REQUIRED_FIELDS) {
+            if (!(field in item)) {
+                throw new Error(`Item at index ${i} is missing required field: ${field}`);
+            }
+        }
+    }
+
+    return data as Todo[];
+}
+
+export function createExportCommand(): Command {
+    return new Command("export")
+        .description("Export todos as JSON")
+        .option("--all", "Export across all projects")
+        .option("-o, --output <file>", "Write to file instead of stdout")
+        .action(async (opts) => {
+            let todos: Todo[];
+
+            if (opts.all) {
+                todos = await TodoStore.listAll();
+            } else {
+                const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+                const store = TodoStore.forProject(projectRoot);
+                todos = await store.list();
+            }
+
+            const output = SafeJSON.stringify(todos, null, 2);
+
+            if (opts.output) {
+                const outPath = resolve(opts.output);
+                await Bun.write(outPath, output);
+                console.error(`Exported ${todos.length} todo(s) to ${outPath}`);
+            } else {
+                console.log(output);
+            }
+        });
+}
+
+export function createImportCommand(): Command {
+    return new Command("import")
+        .description("Import todos from a JSON file")
+        .argument("<file>", "JSON file to import")
+        .option("--project <path>", "Override project root")
+        .action(async (file, opts) => {
+            const filePath = resolve(file);
+
+            if (!existsSync(filePath)) {
+                console.error(`File not found: ${filePath}`);
+                process.exit(1);
+            }
+
+            const content = await Bun.file(filePath).text();
+            let parsed: unknown;
+
+            try {
+                parsed = SafeJSON.parse(content);
+            } catch {
+                console.error("Failed to parse JSON from file");
+                process.exit(1);
+            }
+
+            const todos = validateTodos(parsed);
+            const projectRoot = opts.project
+                ? resolve(opts.project)
+                : (findProjectRoot(process.cwd()) ?? process.cwd());
+            const store = TodoStore.forProject(projectRoot);
+            const count = await store.bulkImport(todos);
+
+            console.log(`Imported ${count} todo(s)`);
+        });
+}

--- a/src/todo/commands/import-export.ts
+++ b/src/todo/commands/import-export.ts
@@ -6,7 +6,8 @@ import type { Todo } from "@app/todo/lib/types";
 import { SafeJSON } from "@app/utils/json";
 import { Command } from "commander";
 
-const REQUIRED_FIELDS = ["id", "title", "status"] as const;
+// Must match required fields in Todo (src/todo/lib/types.ts)
+const REQUIRED_FIELDS = ["id", "title", "status", "priority", "tags", "context"] as const;
 
 function validateTodos(data: unknown): Todo[] {
     if (!Array.isArray(data)) {

--- a/src/todo/commands/list.ts
+++ b/src/todo/commands/list.ts
@@ -25,6 +25,7 @@ export function createListCommand(): Command {
         .option("--tag <tags>", "Filter by tags (comma-separated)")
         .option("--session <id>", "Filter by session ID")
         .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (opts) => {
             const filters: TodoFilters = {};
 
@@ -57,6 +58,6 @@ export function createListCommand(): Command {
             }
 
             const format = resolveFormat(opts.format);
-            console.log(formatTodoList(todos, format));
+            console.log(formatTodoList(todos, format, { colors: opts.colors }));
         });
 }

--- a/src/todo/commands/list.ts
+++ b/src/todo/commands/list.ts
@@ -1,0 +1,62 @@
+import { findProjectRoot } from "@app/todo/lib/context";
+import { formatTodoList } from "@app/todo/lib/format";
+import { TodoStore } from "@app/todo/lib/store";
+import type { OutputFormat, Todo, TodoFilters, TodoPriority, TodoStatus } from "@app/todo/lib/types";
+import { isInteractive } from "@app/utils/cli";
+import { Command } from "commander";
+
+const ACTIVE_STATUSES: TodoStatus[] = ["todo", "in-progress", "blocked"];
+
+function resolveFormat(format: string | undefined): OutputFormat {
+    if (format) {
+        return format as OutputFormat;
+    }
+
+    return isInteractive() ? "table" : "ai";
+}
+
+export function createListCommand(): Command {
+    return new Command("list")
+        .alias("ls")
+        .description("List todos")
+        .option("--all", "List across all projects")
+        .option("--status <statuses>", "Filter by status (comma-separated)")
+        .option("--priority <priorities>", "Filter by priority (comma-separated)")
+        .option("--tag <tags>", "Filter by tags (comma-separated)")
+        .option("--session <id>", "Filter by session ID")
+        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .action(async (opts) => {
+            const filters: TodoFilters = {};
+
+            if (opts.status) {
+                filters.status = opts.status.split(",").map((s: string) => s.trim()) as TodoStatus[];
+            } else {
+                filters.status = ACTIVE_STATUSES;
+            }
+
+            if (opts.priority) {
+                filters.priority = opts.priority.split(",").map((s: string) => s.trim()) as TodoPriority[];
+            }
+
+            if (opts.tag) {
+                filters.tags = opts.tag.split(",").map((s: string) => s.trim());
+            }
+
+            if (opts.session) {
+                filters.sessionId = opts.session;
+            }
+
+            let todos: Todo[];
+
+            if (opts.all) {
+                todos = await TodoStore.listAll(filters);
+            } else {
+                const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+                const store = TodoStore.forProject(projectRoot);
+                todos = await store.list(filters);
+            }
+
+            const format = resolveFormat(opts.format);
+            console.log(formatTodoList(todos, format));
+        });
+}

--- a/src/todo/commands/list.ts
+++ b/src/todo/commands/list.ts
@@ -3,7 +3,7 @@ import { formatTodoList } from "@app/todo/lib/format";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat, Todo, TodoFilters, TodoPriority, TodoStatus } from "@app/todo/lib/types";
 import { isInteractive, parseVariadic } from "@app/utils/cli";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 
 const ACTIVE_STATUSES: TodoStatus[] = ["todo", "in-progress", "blocked"];
 
@@ -24,7 +24,7 @@ export function createListCommand(): Command {
         .option("--priority <priorities>", "Filter by priority (comma-separated)")
         .option("--tag <tags>", "Filter by tags (comma-separated)")
         .option("--session <id>", "Filter by session ID")
-        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .addOption(new Option("-f, --format <format>", "Output format").choices(["ai", "json", "md", "table"]))
         .option("--colors", "Force colorized output even in non-TTY")
         .action(async (opts) => {
             const filters: TodoFilters = {};

--- a/src/todo/commands/list.ts
+++ b/src/todo/commands/list.ts
@@ -2,7 +2,7 @@ import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodoList } from "@app/todo/lib/format";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat, Todo, TodoFilters, TodoPriority, TodoStatus } from "@app/todo/lib/types";
-import { isInteractive } from "@app/utils/cli";
+import { isInteractive, parseVariadic } from "@app/utils/cli";
 import { Command } from "commander";
 
 const ACTIVE_STATUSES: TodoStatus[] = ["todo", "in-progress", "blocked"];
@@ -29,17 +29,17 @@ export function createListCommand(): Command {
             const filters: TodoFilters = {};
 
             if (opts.status) {
-                filters.status = opts.status.split(",").map((s: string) => s.trim()) as TodoStatus[];
+                filters.status = parseVariadic(opts.status) as TodoStatus[];
             } else {
                 filters.status = ACTIVE_STATUSES;
             }
 
             if (opts.priority) {
-                filters.priority = opts.priority.split(",").map((s: string) => s.trim()) as TodoPriority[];
+                filters.priority = parseVariadic(opts.priority) as TodoPriority[];
             }
 
             if (opts.tag) {
-                filters.tags = opts.tag.split(",").map((s: string) => s.trim());
+                filters.tags = parseVariadic(opts.tag);
             }
 
             if (opts.session) {

--- a/src/todo/commands/remove.ts
+++ b/src/todo/commands/remove.ts
@@ -1,0 +1,42 @@
+import { isInteractive } from "@app/utils/cli";
+import { findProjectRoot } from "@app/todo/lib/context";
+import { TodoStore } from "@app/todo/lib/store";
+import * as p from "@clack/prompts";
+import { Command } from "commander";
+
+export function createRemoveCommand(): Command {
+    return new Command("remove")
+        .alias("rm")
+        .description("Remove a todo")
+        .argument("<id>", "Todo ID")
+        .action(async (id) => {
+            const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+            const store = TodoStore.forProject(projectRoot);
+            const existing = await store.get(id);
+
+            if (!existing) {
+                console.error(`Todo not found: ${id}`);
+                process.exit(1);
+            }
+
+            if (isInteractive()) {
+                const confirm = await p.confirm({
+                    message: `Remove "${existing.title}" (${id})?`,
+                });
+
+                if (p.isCancel(confirm) || !confirm) {
+                    p.cancel("Cancelled.");
+                    process.exit(0);
+                }
+            }
+
+            const removed = await store.remove(id);
+
+            if (removed) {
+                console.log(`Removed ${id}`);
+            } else {
+                console.error(`Failed to remove ${id}`);
+                process.exit(1);
+            }
+        });
+}

--- a/src/todo/commands/remove.ts
+++ b/src/todo/commands/remove.ts
@@ -1,6 +1,6 @@
-import { isInteractive } from "@app/utils/cli";
 import { findProjectRoot } from "@app/todo/lib/context";
 import { TodoStore } from "@app/todo/lib/store";
+import { isInteractive } from "@app/utils/cli";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 

--- a/src/todo/commands/remove.ts
+++ b/src/todo/commands/remove.ts
@@ -1,6 +1,6 @@
 import { findProjectRoot } from "@app/todo/lib/context";
 import { TodoStore } from "@app/todo/lib/store";
-import { isInteractive } from "@app/utils/cli";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 
@@ -9,7 +9,8 @@ export function createRemoveCommand(): Command {
         .alias("rm")
         .description("Remove a todo")
         .argument("<id>", "Todo ID")
-        .action(async (id) => {
+        .option("-y, --yes", "Skip confirmation (required in non-interactive mode)")
+        .action(async (id, opts) => {
             const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
             const store = TodoStore.forProject(projectRoot);
             const existing = await store.get(id);
@@ -19,7 +20,13 @@ export function createRemoveCommand(): Command {
                 process.exit(1);
             }
 
-            if (isInteractive()) {
+            if (!isInteractive() && !opts.yes) {
+                console.error("Error: --yes required for non-interactive removal.");
+                console.error(suggestCommand("tools todo remove", { add: [id, "--yes"] }));
+                process.exit(1);
+            }
+
+            if (isInteractive() && !opts.yes) {
                 const confirm = await p.confirm({
                     message: `Remove "${existing.title}" (${id})?`,
                 });

--- a/src/todo/commands/search.ts
+++ b/src/todo/commands/search.ts
@@ -3,7 +3,7 @@ import { formatTodoList } from "@app/todo/lib/format";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat, Todo } from "@app/todo/lib/types";
 import { isInteractive } from "@app/utils/cli";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 
 function resolveFormat(format: string | undefined): OutputFormat {
     if (format) {
@@ -18,7 +18,7 @@ export function createSearchCommand(): Command {
         .description("Search todos by text")
         .argument("<query>", "Search query")
         .option("--all", "Search across all projects")
-        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .addOption(new Option("-f, --format <format>", "Output format").choices(["ai", "json", "md", "table"]))
         .option("--colors", "Force colorized output even in non-TTY")
         .action(async (query, opts) => {
             let todos: Todo[];

--- a/src/todo/commands/search.ts
+++ b/src/todo/commands/search.ts
@@ -1,8 +1,8 @@
-import { isInteractive } from "@app/utils/cli";
 import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodoList } from "@app/todo/lib/format";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat, Todo } from "@app/todo/lib/types";
+import { isInteractive } from "@app/utils/cli";
 import { Command } from "commander";
 
 function resolveFormat(format: string | undefined): OutputFormat {

--- a/src/todo/commands/search.ts
+++ b/src/todo/commands/search.ts
@@ -1,0 +1,36 @@
+import { isInteractive } from "@app/utils/cli";
+import { findProjectRoot } from "@app/todo/lib/context";
+import { formatTodoList } from "@app/todo/lib/format";
+import { TodoStore } from "@app/todo/lib/store";
+import type { OutputFormat, Todo } from "@app/todo/lib/types";
+import { Command } from "commander";
+
+function resolveFormat(format: string | undefined): OutputFormat {
+    if (format) {
+        return format as OutputFormat;
+    }
+
+    return isInteractive() ? "table" : "ai";
+}
+
+export function createSearchCommand(): Command {
+    return new Command("search")
+        .description("Search todos by text")
+        .argument("<query>", "Search query")
+        .option("--all", "Search across all projects")
+        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .action(async (query, opts) => {
+            let todos: Todo[];
+
+            if (opts.all) {
+                todos = await TodoStore.listAll({ search: query });
+            } else {
+                const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+                const store = TodoStore.forProject(projectRoot);
+                todos = await store.search(query);
+            }
+
+            const format = resolveFormat(opts.format);
+            console.log(formatTodoList(todos, format));
+        });
+}

--- a/src/todo/commands/search.ts
+++ b/src/todo/commands/search.ts
@@ -19,6 +19,7 @@ export function createSearchCommand(): Command {
         .argument("<query>", "Search query")
         .option("--all", "Search across all projects")
         .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (query, opts) => {
             let todos: Todo[];
 
@@ -31,6 +32,6 @@ export function createSearchCommand(): Command {
             }
 
             const format = resolveFormat(opts.format);
-            console.log(formatTodoList(todos, format));
+            console.log(formatTodoList(todos, format, { colors: opts.colors }));
         });
 }

--- a/src/todo/commands/show.ts
+++ b/src/todo/commands/show.ts
@@ -3,7 +3,7 @@ import { formatTodo } from "@app/todo/lib/format";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat } from "@app/todo/lib/types";
 import { isInteractive } from "@app/utils/cli";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 
 function resolveFormat(format: string | undefined): OutputFormat {
     if (format) {
@@ -17,7 +17,7 @@ export function createShowCommand(): Command {
     return new Command("show")
         .description("Show a single todo in detail")
         .argument("<id>", "Todo ID")
-        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .addOption(new Option("-f, --format <format>", "Output format").choices(["ai", "json", "md", "table"]))
         .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();

--- a/src/todo/commands/show.ts
+++ b/src/todo/commands/show.ts
@@ -18,6 +18,7 @@ export function createShowCommand(): Command {
         .description("Show a single todo in detail")
         .argument("<id>", "Todo ID")
         .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
             const store = TodoStore.forProject(projectRoot);
@@ -34,6 +35,6 @@ export function createShowCommand(): Command {
             }
 
             const format = resolveFormat(opts.format);
-            console.log(formatTodo(todo, format));
+            console.log(formatTodo(todo, format, { colors: opts.colors }));
         });
 }

--- a/src/todo/commands/show.ts
+++ b/src/todo/commands/show.ts
@@ -1,0 +1,39 @@
+import { findProjectRoot } from "@app/todo/lib/context";
+import { formatTodo } from "@app/todo/lib/format";
+import { TodoStore } from "@app/todo/lib/store";
+import type { OutputFormat } from "@app/todo/lib/types";
+import { isInteractive } from "@app/utils/cli";
+import { Command } from "commander";
+
+function resolveFormat(format: string | undefined): OutputFormat {
+    if (format) {
+        return format as OutputFormat;
+    }
+
+    return isInteractive() ? "md" : "ai";
+}
+
+export function createShowCommand(): Command {
+    return new Command("show")
+        .description("Show a single todo in detail")
+        .argument("<id>", "Todo ID")
+        .option("-f, --format <format>", "Output format: ai|json|md|table")
+        .action(async (id, opts) => {
+            const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+            const store = TodoStore.forProject(projectRoot);
+            let todo = await store.get(id);
+
+            if (!todo) {
+                const allTodos = await TodoStore.listAll();
+                todo = allTodos.find((t) => t.id === id) ?? null;
+            }
+
+            if (!todo) {
+                console.error(`Todo not found: ${id}`);
+                process.exit(1);
+            }
+
+            const format = resolveFormat(opts.format);
+            console.log(formatTodo(todo, format));
+        });
+}

--- a/src/todo/commands/status.ts
+++ b/src/todo/commands/status.ts
@@ -1,8 +1,8 @@
-import { isInteractive } from "@app/utils/cli";
 import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodo } from "@app/todo/lib/format";
 import { TodoStore } from "@app/todo/lib/store";
 import type { OutputFormat } from "@app/todo/lib/types";
+import { isInteractive } from "@app/utils/cli";
 import { Command } from "commander";
 
 function resolveFormat(format: string | undefined): OutputFormat {

--- a/src/todo/commands/status.ts
+++ b/src/todo/commands/status.ts
@@ -22,10 +22,11 @@ export function createStartCommand(): Command {
         .description("Mark a todo as in-progress")
         .argument("<id>", "Todo ID")
         .option("-f, --format <format>", "Output format")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const store = TodoStore.forProject(resolveProjectRoot());
             const todo = await store.update(id, { status: "in-progress" });
-            console.log(formatTodo(todo, resolveFormat(opts.format)));
+            console.log(formatTodo(todo, resolveFormat(opts.format), { colors: opts.colors }));
         });
 }
 
@@ -34,10 +35,11 @@ export function createBlockCommand(): Command {
         .description("Mark a todo as blocked")
         .argument("<id>", "Todo ID")
         .option("-f, --format <format>", "Output format")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const store = TodoStore.forProject(resolveProjectRoot());
             const todo = await store.update(id, { status: "blocked" });
-            console.log(formatTodo(todo, resolveFormat(opts.format)));
+            console.log(formatTodo(todo, resolveFormat(opts.format), { colors: opts.colors }));
         });
 }
 
@@ -48,10 +50,11 @@ export function createCompleteCommand(): Command {
         .argument("<id>", "Todo ID")
         .option("-n, --note <text>", "Completion note")
         .option("-f, --format <format>", "Output format")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const store = TodoStore.forProject(resolveProjectRoot());
             const todo = await store.complete(id, opts.note);
-            console.log(formatTodo(todo, resolveFormat(opts.format)));
+            console.log(formatTodo(todo, resolveFormat(opts.format), { colors: opts.colors }));
         });
 }
 
@@ -60,6 +63,7 @@ export function createReopenCommand(): Command {
         .description("Reopen a completed todo")
         .argument("<id>", "Todo ID")
         .option("-f, --format <format>", "Output format")
+        .option("--colors", "Force colorized output even in non-TTY")
         .action(async (id, opts) => {
             const store = TodoStore.forProject(resolveProjectRoot());
             const todo = await store.update(id, {
@@ -67,6 +71,6 @@ export function createReopenCommand(): Command {
                 completedAt: undefined,
                 completionNote: undefined,
             });
-            console.log(formatTodo(todo, resolveFormat(opts.format)));
+            console.log(formatTodo(todo, resolveFormat(opts.format), { colors: opts.colors }));
         });
 }

--- a/src/todo/commands/status.ts
+++ b/src/todo/commands/status.ts
@@ -1,0 +1,72 @@
+import { isInteractive } from "@app/utils/cli";
+import { findProjectRoot } from "@app/todo/lib/context";
+import { formatTodo } from "@app/todo/lib/format";
+import { TodoStore } from "@app/todo/lib/store";
+import type { OutputFormat } from "@app/todo/lib/types";
+import { Command } from "commander";
+
+function resolveFormat(format: string | undefined): OutputFormat {
+    if (format) {
+        return format as OutputFormat;
+    }
+
+    return isInteractive() ? "md" : "ai";
+}
+
+function resolveProjectRoot(): string {
+    return findProjectRoot(process.cwd()) ?? process.cwd();
+}
+
+export function createStartCommand(): Command {
+    return new Command("start")
+        .description("Mark a todo as in-progress")
+        .argument("<id>", "Todo ID")
+        .option("-f, --format <format>", "Output format")
+        .action(async (id, opts) => {
+            const store = TodoStore.forProject(resolveProjectRoot());
+            const todo = await store.update(id, { status: "in-progress" });
+            console.log(formatTodo(todo, resolveFormat(opts.format)));
+        });
+}
+
+export function createBlockCommand(): Command {
+    return new Command("block")
+        .description("Mark a todo as blocked")
+        .argument("<id>", "Todo ID")
+        .option("-f, --format <format>", "Output format")
+        .action(async (id, opts) => {
+            const store = TodoStore.forProject(resolveProjectRoot());
+            const todo = await store.update(id, { status: "blocked" });
+            console.log(formatTodo(todo, resolveFormat(opts.format)));
+        });
+}
+
+export function createCompleteCommand(): Command {
+    return new Command("complete")
+        .alias("done")
+        .description("Mark a todo as completed")
+        .argument("<id>", "Todo ID")
+        .option("-n, --note <text>", "Completion note")
+        .option("-f, --format <format>", "Output format")
+        .action(async (id, opts) => {
+            const store = TodoStore.forProject(resolveProjectRoot());
+            const todo = await store.complete(id, opts.note);
+            console.log(formatTodo(todo, resolveFormat(opts.format)));
+        });
+}
+
+export function createReopenCommand(): Command {
+    return new Command("reopen")
+        .description("Reopen a completed todo")
+        .argument("<id>", "Todo ID")
+        .option("-f, --format <format>", "Output format")
+        .action(async (id, opts) => {
+            const store = TodoStore.forProject(resolveProjectRoot());
+            const todo = await store.update(id, {
+                status: "todo",
+                completedAt: undefined,
+                completionNote: undefined,
+            });
+            console.log(formatTodo(todo, resolveFormat(opts.format)));
+        });
+}

--- a/src/todo/commands/sync.ts
+++ b/src/todo/commands/sync.ts
@@ -1,95 +1,20 @@
 import { findProjectRoot } from "@app/todo/lib/context";
 import { TodoStore } from "@app/todo/lib/store";
-import type { Todo, TodoReminder } from "@app/todo/lib/types";
-import { createCalendarEvent } from "@app/utils/macos/apple-calendar";
-import { createReminder, todoPriorityToApple } from "@app/utils/macos/apple-reminders";
-import chalk from "chalk";
+import { type SyncTarget, syncTodo } from "@app/todo/lib/sync";
 import { Command } from "commander";
-
-type SyncTarget = "calendar" | "reminders";
-
-function syncReminderToCalendar(todo: Todo, reminder: TodoReminder): string {
-    const startDate = new Date(reminder.at);
-    const label = reminder.label ?? todo.title;
-
-    return createCalendarEvent({
-        title: label,
-        notes: todo.description ?? `Todo: ${todo.id}`,
-        startDate,
-        alerts: [10],
-    });
-}
-
-function syncTodoToReminders(todo: Todo): string {
-    const firstReminder = todo.reminders.find((r) => !r.synced);
-    const dueDate = firstReminder ? new Date(firstReminder.at) : undefined;
-
-    return createReminder({
-        title: todo.title,
-        notes: todo.description ?? `Todo: ${todo.id}`,
-        dueDate,
-        priority: todoPriorityToApple(todo.priority),
-    });
-}
-
-async function syncSingleTodo(options: { store: TodoStore; todo: Todo; target: SyncTarget }): Promise<number> {
-    const { store, todo, target } = options;
-    let syncCount = 0;
-
-    if (target === "calendar") {
-        const updatedReminders = [...todo.reminders];
-        let changed = false;
-
-        for (let i = 0; i < updatedReminders.length; i++) {
-            const reminder = updatedReminders[i];
-
-            if (reminder.synced === "calendar" && reminder.syncId) {
-                continue;
-            }
-
-            const eventId = syncReminderToCalendar(todo, reminder);
-            updatedReminders[i] = { ...reminder, synced: "calendar", syncId: eventId };
-            changed = true;
-            syncCount++;
-        }
-
-        if (changed) {
-            await store.update(todo.id, { reminders: updatedReminders });
-        }
-    } else {
-        const alreadySynced = todo.reminders.some((r) => r.synced === "reminders" && r.syncId);
-
-        if (alreadySynced) {
-            return 0;
-        }
-
-        const reminderId = syncTodoToReminders(todo);
-        const updatedReminders = todo.reminders.map((r, i) => {
-            if (i === 0) {
-                return { ...r, synced: "reminders" as const, syncId: reminderId };
-            }
-
-            return r;
-        });
-
-        await store.update(todo.id, { reminders: updatedReminders });
-        syncCount = 1;
-    }
-
-    return syncCount;
-}
+import pc from "picocolors";
 
 export function createSyncCommand(): Command {
     return new Command("sync")
         .description("Sync todos to Apple Calendar or Reminders")
         .argument("[id]", "Todo ID (required unless --all)")
-        .requiredOption("--to <target>", "Sync target: calendar|reminders")
+        .requiredOption("--to <target>", "Sync target: calendar|reminders|both")
         .option("--all", "Sync all open todos with reminders")
         .action(async (id: string | undefined, opts: { to: string; all?: boolean }) => {
             const target = opts.to as SyncTarget;
 
-            if (target !== "calendar" && target !== "reminders") {
-                console.error(`Invalid sync target: ${opts.to}. Use "calendar" or "reminders".`);
+            if (target !== "calendar" && target !== "reminders" && target !== "both") {
+                console.error(`Invalid sync target: ${opts.to}. Use "calendar", "reminders", or "both".`);
                 process.exit(1);
             }
 
@@ -108,10 +33,10 @@ export function createSyncCommand(): Command {
                 let totalSynced = 0;
 
                 for (const todo of withReminders) {
-                    const count = await syncSingleTodo({ store, todo, target });
+                    const count = await syncTodo({ store, todo, target });
 
                     if (count > 0) {
-                        console.log(chalk.green(`  ✓ ${todo.id}: ${todo.title} (${count} synced)`));
+                        console.log(pc.green(`  ✓ ${todo.id}: ${todo.title} (${count} synced)`));
                         totalSynced += count;
                     }
                 }
@@ -132,12 +57,12 @@ export function createSyncCommand(): Command {
                 process.exit(1);
             }
 
-            if (todo.reminders.length === 0 && target === "calendar") {
+            if (todo.reminders.length === 0 && target !== "reminders") {
                 console.error("This todo has no reminders to sync to calendar.");
                 process.exit(1);
             }
 
-            const count = await syncSingleTodo({ store, todo, target });
-            console.log(chalk.green(`Synced ${count} item(s) to ${target} for ${todo.id}.`));
+            const count = await syncTodo({ store, todo, target });
+            console.log(pc.green(`Synced ${count} item(s) to ${target} for ${todo.id}.`));
         });
 }

--- a/src/todo/commands/sync.ts
+++ b/src/todo/commands/sync.ts
@@ -1,0 +1,147 @@
+import { findProjectRoot } from "@app/todo/lib/context";
+import { TodoStore } from "@app/todo/lib/store";
+import type { Todo, TodoReminder } from "@app/todo/lib/types";
+import { createCalendarEvent } from "@app/utils/macos/apple-calendar";
+import { createReminder, todoPriorityToApple } from "@app/utils/macos/apple-reminders";
+import chalk from "chalk";
+import { Command } from "commander";
+
+type SyncTarget = "calendar" | "reminders";
+
+function syncReminderToCalendar(todo: Todo, reminder: TodoReminder): string {
+    const startDate = new Date(reminder.at);
+    const label = reminder.label ?? todo.title;
+
+    return createCalendarEvent({
+        title: label,
+        notes: todo.description ?? `Todo: ${todo.id}`,
+        startDate,
+        alerts: [10],
+    });
+}
+
+function syncTodoToReminders(todo: Todo): string {
+    const firstReminder = todo.reminders.find((r) => !r.synced);
+    const dueDate = firstReminder ? new Date(firstReminder.at) : undefined;
+
+    return createReminder({
+        title: todo.title,
+        notes: todo.description ?? `Todo: ${todo.id}`,
+        dueDate,
+        priority: todoPriorityToApple(todo.priority),
+    });
+}
+
+async function syncSingleTodo(options: {
+    store: TodoStore;
+    todo: Todo;
+    target: SyncTarget;
+}): Promise<number> {
+    const { store, todo, target } = options;
+    let syncCount = 0;
+
+    if (target === "calendar") {
+        const updatedReminders = [...todo.reminders];
+        let changed = false;
+
+        for (let i = 0; i < updatedReminders.length; i++) {
+            const reminder = updatedReminders[i];
+
+            if (reminder.synced === "calendar" && reminder.syncId) {
+                continue;
+            }
+
+            const eventId = syncReminderToCalendar(todo, reminder);
+            updatedReminders[i] = { ...reminder, synced: "calendar", syncId: eventId };
+            changed = true;
+            syncCount++;
+        }
+
+        if (changed) {
+            await store.update(todo.id, { reminders: updatedReminders });
+        }
+    } else {
+        const alreadySynced = todo.reminders.some((r) => r.synced === "reminders" && r.syncId);
+
+        if (alreadySynced) {
+            return 0;
+        }
+
+        const reminderId = syncTodoToReminders(todo);
+        const updatedReminders = todo.reminders.map((r, i) => {
+            if (i === 0) {
+                return { ...r, synced: "reminders" as const, syncId: reminderId };
+            }
+
+            return r;
+        });
+
+        await store.update(todo.id, { reminders: updatedReminders });
+        syncCount = 1;
+    }
+
+    return syncCount;
+}
+
+export function createSyncCommand(): Command {
+    return new Command("sync")
+        .description("Sync todos to Apple Calendar or Reminders")
+        .argument("[id]", "Todo ID (required unless --all)")
+        .requiredOption("--to <target>", "Sync target: calendar|reminders")
+        .option("--all", "Sync all open todos with reminders")
+        .action(async (id: string | undefined, opts: { to: string; all?: boolean }) => {
+            const target = opts.to as SyncTarget;
+
+            if (target !== "calendar" && target !== "reminders") {
+                console.error(`Invalid sync target: ${opts.to}. Use "calendar" or "reminders".`);
+                process.exit(1);
+            }
+
+            const projectRoot = findProjectRoot(process.cwd()) ?? process.cwd();
+            const store = TodoStore.forProject(projectRoot);
+
+            if (opts.all) {
+                const todos = await store.list({ status: ["todo", "in-progress", "blocked"] });
+                const withReminders = todos.filter((t) => t.reminders.length > 0);
+
+                if (withReminders.length === 0) {
+                    console.log("No open todos with reminders to sync.");
+                    return;
+                }
+
+                let totalSynced = 0;
+
+                for (const todo of withReminders) {
+                    const count = await syncSingleTodo({ store, todo, target });
+
+                    if (count > 0) {
+                        console.log(chalk.green(`  ✓ ${todo.id}: ${todo.title} (${count} synced)`));
+                        totalSynced += count;
+                    }
+                }
+
+                console.log(`\nSynced ${totalSynced} item(s) to ${target}.`);
+                return;
+            }
+
+            if (!id) {
+                console.error("Provide a todo ID or use --all.");
+                process.exit(1);
+            }
+
+            const todo = await store.get(id);
+
+            if (!todo) {
+                console.error(`Todo not found: ${id}`);
+                process.exit(1);
+            }
+
+            if (todo.reminders.length === 0 && target === "calendar") {
+                console.error("This todo has no reminders to sync to calendar.");
+                process.exit(1);
+            }
+
+            const count = await syncSingleTodo({ store, todo, target });
+            console.log(chalk.green(`Synced ${count} item(s) to ${target} for ${todo.id}.`));
+        });
+}

--- a/src/todo/commands/sync.ts
+++ b/src/todo/commands/sync.ts
@@ -32,11 +32,7 @@ function syncTodoToReminders(todo: Todo): string {
     });
 }
 
-async function syncSingleTodo(options: {
-    store: TodoStore;
-    todo: Todo;
-    target: SyncTarget;
-}): Promise<number> {
+async function syncSingleTodo(options: { store: TodoStore; todo: Todo; target: SyncTarget }): Promise<number> {
     const { store, todo, target } = options;
     let syncCount = 0;
 

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -6,13 +6,13 @@ import { createListCommand } from "@app/todo/commands/list";
 import { createRemoveCommand } from "@app/todo/commands/remove";
 import { createSearchCommand } from "@app/todo/commands/search";
 import { createShowCommand } from "@app/todo/commands/show";
-import { createSyncCommand } from "@app/todo/commands/sync";
 import {
     createBlockCommand,
     createCompleteCommand,
     createReopenCommand,
     createStartCommand,
 } from "@app/todo/commands/status";
+import { createSyncCommand } from "@app/todo/commands/sync";
 import { enhanceHelp } from "@app/utils/cli";
 import { Command } from "commander";
 

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -3,6 +3,12 @@
 import { createAddCommand } from "@app/todo/commands/add";
 import { createListCommand } from "@app/todo/commands/list";
 import { createShowCommand } from "@app/todo/commands/show";
+import {
+    createBlockCommand,
+    createCompleteCommand,
+    createReopenCommand,
+    createStartCommand,
+} from "@app/todo/commands/status";
 import { enhanceHelp } from "@app/utils/cli";
 import { Command } from "commander";
 
@@ -13,6 +19,10 @@ program.name("todo").description("Task tracking for AI-assisted development sess
 program.addCommand(createAddCommand());
 program.addCommand(createListCommand());
 program.addCommand(createShowCommand());
+program.addCommand(createStartCommand());
+program.addCommand(createBlockCommand());
+program.addCommand(createCompleteCommand());
+program.addCommand(createReopenCommand());
 
 enhanceHelp(program);
 

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -2,6 +2,7 @@
 
 import { createAddCommand } from "@app/todo/commands/add";
 import { createEditCommand } from "@app/todo/commands/edit";
+import { createExportCommand, createImportCommand } from "@app/todo/commands/import-export";
 import { createListCommand } from "@app/todo/commands/list";
 import { createRemoveCommand } from "@app/todo/commands/remove";
 import { createSearchCommand } from "@app/todo/commands/search";
@@ -31,6 +32,8 @@ program.addCommand(createEditCommand());
 program.addCommand(createRemoveCommand());
 program.addCommand(createSearchCommand());
 program.addCommand(createSyncCommand());
+program.addCommand(createExportCommand());
+program.addCommand(createImportCommand());
 
 enhanceHelp(program);
 

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 import { createAddCommand } from "@app/todo/commands/add";
+import { createEditCommand } from "@app/todo/commands/edit";
 import { createListCommand } from "@app/todo/commands/list";
+import { createRemoveCommand } from "@app/todo/commands/remove";
+import { createSearchCommand } from "@app/todo/commands/search";
 import { createShowCommand } from "@app/todo/commands/show";
 import {
     createBlockCommand,
@@ -23,6 +26,9 @@ program.addCommand(createStartCommand());
 program.addCommand(createBlockCommand());
 program.addCommand(createCompleteCommand());
 program.addCommand(createReopenCommand());
+program.addCommand(createEditCommand());
+program.addCommand(createRemoveCommand());
+program.addCommand(createSearchCommand());
 
 enhanceHelp(program);
 

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+
+import { createAddCommand } from "@app/todo/commands/add";
+import { enhanceHelp } from "@app/utils/cli";
+import { Command } from "commander";
+
+const program = new Command();
+
+program
+    .name("todo")
+    .description("Task tracking for AI-assisted development sessions")
+    .version("1.0.0");
+
+program.addCommand(createAddCommand());
+
+enhanceHelp(program);
+
+async function main(): Promise<void> {
+    try {
+        await program.parseAsync(process.argv);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Error: ${message}`);
+        process.exit(1);
+    }
+}
+
+main().catch((err) => {
+    console.error(`Unexpected error: ${err}`);
+    process.exit(1);
+});

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -6,6 +6,7 @@ import { createListCommand } from "@app/todo/commands/list";
 import { createRemoveCommand } from "@app/todo/commands/remove";
 import { createSearchCommand } from "@app/todo/commands/search";
 import { createShowCommand } from "@app/todo/commands/show";
+import { createSyncCommand } from "@app/todo/commands/sync";
 import {
     createBlockCommand,
     createCompleteCommand,
@@ -29,6 +30,7 @@ program.addCommand(createReopenCommand());
 program.addCommand(createEditCommand());
 program.addCommand(createRemoveCommand());
 program.addCommand(createSearchCommand());
+program.addCommand(createSyncCommand());
 
 enhanceHelp(program);
 

--- a/src/todo/index.ts
+++ b/src/todo/index.ts
@@ -1,17 +1,18 @@
 #!/usr/bin/env bun
 
 import { createAddCommand } from "@app/todo/commands/add";
+import { createListCommand } from "@app/todo/commands/list";
+import { createShowCommand } from "@app/todo/commands/show";
 import { enhanceHelp } from "@app/utils/cli";
 import { Command } from "commander";
 
 const program = new Command();
 
-program
-    .name("todo")
-    .description("Task tracking for AI-assisted development sessions")
-    .version("1.0.0");
+program.name("todo").description("Task tracking for AI-assisted development sessions").version("1.0.0");
 
 program.addCommand(createAddCommand());
+program.addCommand(createListCommand());
+program.addCommand(createShowCommand());
 
 enhanceHelp(program);
 

--- a/src/todo/lib/__tests__/context.test.ts
+++ b/src/todo/lib/__tests__/context.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { captureContext, findProjectRoot } from "../context";
+
+describe("findProjectRoot", () => {
+    it("finds .git directory walking up from a nested path", () => {
+        const root = findProjectRoot(resolve(import.meta.dir, ".."));
+        expect(root).not.toBeNull();
+        expect(root!.endsWith("GenesisTools")).toBe(true);
+    });
+
+    it("finds .git from the repo root itself", () => {
+        const repoRoot = findProjectRoot(import.meta.dir);
+        expect(repoRoot).not.toBeNull();
+    });
+
+    it("returns null for a path outside any git repo", () => {
+        const result = findProjectRoot("/tmp");
+        expect(result).toBeNull();
+    });
+});
+
+describe("captureContext", () => {
+    it("captures git info when inside a repo", async () => {
+        const ctx = await captureContext();
+
+        expect(ctx.cwd).toBe(process.cwd());
+        expect(ctx.hostname).toBeTruthy();
+        expect(ctx.createdAt).toBeTruthy();
+        expect(ctx.updatedAt).toBeTruthy();
+        expect(new Date(ctx.createdAt).toISOString()).toBe(ctx.createdAt);
+
+        expect(ctx.git).toBeDefined();
+        expect(ctx.git!.branch).toBeTruthy();
+        expect(ctx.git!.commitSha).toMatch(/^[a-f0-9]{40}$/);
+        expect(ctx.git!.commitMessage).toBeTruthy();
+        expect(Array.isArray(ctx.git!.stagedFiles)).toBe(true);
+        expect(Array.isArray(ctx.git!.unstagedFiles)).toBe(true);
+        expect(Array.isArray(ctx.git!.untrackedFiles)).toBe(true);
+    });
+
+    it("uses explicit projectRoot when provided", async () => {
+        const ctx = await captureContext({ projectRoot: process.cwd() });
+
+        expect(ctx.projectRoot).toBe(process.cwd());
+        expect(ctx.git).toBeDefined();
+    });
+
+    it("returns undefined git for a non-repo path", async () => {
+        const ctx = await captureContext({ projectRoot: "/tmp" });
+
+        expect(ctx.git).toBeUndefined();
+        expect(ctx.projectRoot).toBe("/tmp");
+        expect(ctx.cwd).toBe(process.cwd());
+        expect(ctx.hostname).toBeTruthy();
+    });
+
+    it("captures remote URL when available", async () => {
+        const ctx = await captureContext();
+
+        if (ctx.git?.remote) {
+            expect(ctx.git.remote).toMatch(/github\.com|gitlab|bitbucket|origin/);
+        }
+    });
+});

--- a/src/todo/lib/__tests__/context.test.ts
+++ b/src/todo/lib/__tests__/context.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { captureContext, findProjectRoot } from "../context";
 
 describe("findProjectRoot", () => {
     it("finds .git directory walking up from a nested path", () => {
         const root = findProjectRoot(resolve(import.meta.dir, ".."));
         expect(root).not.toBeNull();
-        expect(root!.endsWith("GenesisTools")).toBe(true);
+        // Works in both main repo and worktrees
+        expect(existsSync(join(root!, ".git"))).toBe(true);
     });
 
     it("finds .git from the repo root itself", () => {

--- a/src/todo/lib/__tests__/format.test.ts
+++ b/src/todo/lib/__tests__/format.test.ts
@@ -53,41 +53,51 @@ describe("formatTodo", () => {
         });
     });
 
-    describe("ai format", () => {
-        it("includes id, title, priority and status on first line", () => {
+    describe("ai/md format (markdown)", () => {
+        it("includes title in heading", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("[todo_x7k2m] Fix auth bug (critical, in-progress)");
+            expect(output).toContain("Fix auth bug");
+        });
+
+        it("includes id, priority, and status", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("todo_x7k2m");
+            expect(output).toContain("critical");
+            expect(output).toContain("in-progress");
         });
 
         it("includes tags", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("tags: auth, backend");
+            expect(output).toContain("auth");
+            expect(output).toContain("backend");
         });
 
         it("includes branch and commit", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("branch: feat/auth");
-            expect(output).toContain("commit: abc1234");
+            expect(output).toContain("feat/auth");
+            expect(output).toContain("abc12345");
         });
 
         it("includes session", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("session: ses_xyz");
+            expect(output).toContain("ses_xyz");
         });
 
         it("includes links", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("links: pr:142, ado:78901");
+            expect(output).toContain("pr:142");
+            expect(output).toContain("ado:78901");
         });
 
         it("includes reminders", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("reminders: 2026-04-02T12:00:00Z, 2026-04-03T12:00:00Z");
+            expect(output).toContain("2026-04-02T12:00:00Z");
+            expect(output).toContain("2026-04-03T12:00:00Z");
         });
 
-        it("includes description after separator", () => {
+        it("includes description", () => {
             const output = formatTodo(todo, "ai");
-            expect(output).toContain("---\nThe OAuth flow breaks");
+            expect(output).toContain("The OAuth flow breaks");
         });
 
         it("skips empty sections", () => {
@@ -103,42 +113,29 @@ describe("formatTodo", () => {
                 },
             });
             const output = formatTodo(minimal, "ai");
-            expect(output).not.toContain("tags:");
-            expect(output).not.toContain("links:");
-            expect(output).not.toContain("reminders:");
-            expect(output).not.toContain("session:");
-            expect(output).not.toContain("branch:");
-        });
-    });
-
-    describe("md format", () => {
-        it("includes header with id and title", () => {
-            const output = formatTodo(todo, "md");
-            expect(output).toContain("## todo_x7k2m: Fix auth bug");
+            expect(output).not.toContain("Tags:");
+            expect(output).not.toContain("Links:");
+            expect(output).not.toContain("Reminders:");
+            expect(output).not.toContain("Session:");
+            expect(output).not.toContain("Branch:");
         });
 
-        it("includes status and priority", () => {
-            const output = formatTodo(todo, "md");
-            expect(output).toContain("**Status:** in-progress");
-            expect(output).toContain("**Priority:** critical");
+        it("md format produces same markdown as ai", () => {
+            const ai = formatTodo(todo, "ai");
+            const md = formatTodo(todo, "md");
+            expect(ai).toBe(md);
         });
 
-        it("includes tags", () => {
-            const output = formatTodo(todo, "md");
-            expect(output).toContain("**Tags:** auth, backend");
+        it("shows status icon for done todos", () => {
+            const done = makeTodo({ status: "done", completedAt: "2026-04-01T15:00:00Z" });
+            const output = formatTodo(done, "ai");
+            expect(output).toContain("[x]");
         });
 
-        it("includes context section with branch and commit", () => {
-            const output = formatTodo(todo, "md");
-            expect(output).toContain("### Context");
-            expect(output).toContain("- Branch: `feat/auth`");
-            expect(output).toContain("- Commit: `abc12345`");
-        });
-
-        it("includes description section", () => {
-            const output = formatTodo(todo, "md");
-            expect(output).toContain("### Description");
-            expect(output).toContain("The OAuth flow breaks");
+        it("shows status icon for blocked todos", () => {
+            const blocked = makeTodo({ status: "blocked" });
+            const output = formatTodo(blocked, "ai");
+            expect(output).toContain("[!]");
         });
     });
 
@@ -167,17 +164,15 @@ describe("formatTodoList", () => {
         expect(parsed).toHaveLength(2);
     });
 
-    it("ai format joins with double newline", () => {
+    it("ai format includes all todos", () => {
         const output = formatTodoList(todos, "ai");
-        expect(output).toContain("[todo_x7k2m]");
-        expect(output).toContain("[todo_abc12]");
-        expect(output).toContain("\n\n");
+        expect(output).toContain("Fix auth bug");
+        expect(output).toContain("Second task");
     });
 
-    it("md format produces bullet list", () => {
-        const output = formatTodoList(todos, "md");
-        expect(output).toContain("- **todo_x7k2m**:");
-        expect(output).toContain("- **todo_abc12**:");
+    it("ai format separates todos", () => {
+        const output = formatTodoList(todos, "ai");
+        expect(output).toContain("---");
     });
 
     it("table format includes all rows", () => {
@@ -186,9 +181,11 @@ describe("formatTodoList", () => {
         expect(output).toContain("todo_abc12");
     });
 
-    it("handles empty list", () => {
+    it("handles empty list for md", () => {
         expect(formatTodoList([], "md")).toContain("No todos");
+    });
+
+    it("handles empty list for table", () => {
         expect(formatTodoList([], "table")).toContain("No todos");
-        expect(formatTodoList([], "ai")).toBe("");
     });
 });

--- a/src/todo/lib/__tests__/format.test.ts
+++ b/src/todo/lib/__tests__/format.test.ts
@@ -1,5 +1,5 @@
-import { SafeJSON } from "@app/utils/json";
 import { describe, expect, it } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
 import { formatTodo, formatTodoList } from "../format";
 import type { Todo } from "../types";
 

--- a/src/todo/lib/__tests__/format.test.ts
+++ b/src/todo/lib/__tests__/format.test.ts
@@ -1,0 +1,194 @@
+import { SafeJSON } from "@app/utils/json";
+import { describe, expect, it } from "bun:test";
+import { formatTodo, formatTodoList } from "../format";
+import type { Todo } from "../types";
+
+function makeTodo(overrides?: Partial<Todo>): Todo {
+    return {
+        id: "todo_x7k2m",
+        title: "Fix auth bug",
+        description: "The OAuth flow breaks when token expires",
+        status: "in-progress",
+        priority: "critical",
+        tags: ["auth", "backend"],
+        attachments: [],
+        context: {
+            git: {
+                branch: "feat/auth",
+                commitSha: "abc1234567890",
+                commitMessage: "Fix login flow",
+                stagedFiles: [],
+                unstagedFiles: [],
+                untrackedFiles: [],
+            },
+            cwd: "/projects/myapp",
+            projectRoot: "/projects/myapp",
+            hostname: "devbox",
+            createdAt: "2026-04-01T10:00:00Z",
+            updatedAt: "2026-04-01T12:00:00Z",
+        },
+        sessionId: "ses_xyz",
+        links: [
+            { type: "pr", ref: "142" },
+            { type: "ado", ref: "78901" },
+        ],
+        reminders: [
+            { at: "2026-04-02T12:00:00Z", synced: null },
+            { at: "2026-04-03T12:00:00Z", synced: null },
+        ],
+        ...overrides,
+    };
+}
+
+describe("formatTodo", () => {
+    const todo = makeTodo();
+
+    describe("json format", () => {
+        it("produces valid JSON with all fields", () => {
+            const output = formatTodo(todo, "json");
+            const parsed = SafeJSON.parse(output);
+            expect(parsed.id).toBe("todo_x7k2m");
+            expect(parsed.title).toBe("Fix auth bug");
+            expect(parsed.priority).toBe("critical");
+        });
+    });
+
+    describe("ai format", () => {
+        it("includes id, title, priority and status on first line", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("[todo_x7k2m] Fix auth bug (critical, in-progress)");
+        });
+
+        it("includes tags", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("tags: auth, backend");
+        });
+
+        it("includes branch and commit", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("branch: feat/auth");
+            expect(output).toContain("commit: abc1234");
+        });
+
+        it("includes session", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("session: ses_xyz");
+        });
+
+        it("includes links", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("links: pr:142, ado:78901");
+        });
+
+        it("includes reminders", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("reminders: 2026-04-02T12:00:00Z, 2026-04-03T12:00:00Z");
+        });
+
+        it("includes description after separator", () => {
+            const output = formatTodo(todo, "ai");
+            expect(output).toContain("---\nThe OAuth flow breaks");
+        });
+
+        it("skips empty sections", () => {
+            const minimal = makeTodo({
+                tags: [],
+                links: [],
+                reminders: [],
+                description: undefined,
+                sessionId: undefined,
+                context: {
+                    ...todo.context,
+                    git: undefined,
+                },
+            });
+            const output = formatTodo(minimal, "ai");
+            expect(output).not.toContain("tags:");
+            expect(output).not.toContain("links:");
+            expect(output).not.toContain("reminders:");
+            expect(output).not.toContain("session:");
+            expect(output).not.toContain("branch:");
+        });
+    });
+
+    describe("md format", () => {
+        it("includes header with id and title", () => {
+            const output = formatTodo(todo, "md");
+            expect(output).toContain("## todo_x7k2m: Fix auth bug");
+        });
+
+        it("includes status and priority", () => {
+            const output = formatTodo(todo, "md");
+            expect(output).toContain("**Status:** in-progress");
+            expect(output).toContain("**Priority:** critical");
+        });
+
+        it("includes tags", () => {
+            const output = formatTodo(todo, "md");
+            expect(output).toContain("**Tags:** auth, backend");
+        });
+
+        it("includes context section with branch and commit", () => {
+            const output = formatTodo(todo, "md");
+            expect(output).toContain("### Context");
+            expect(output).toContain("- Branch: `feat/auth`");
+            expect(output).toContain("- Commit: `abc12345`");
+        });
+
+        it("includes description section", () => {
+            const output = formatTodo(todo, "md");
+            expect(output).toContain("### Description");
+            expect(output).toContain("The OAuth flow breaks");
+        });
+    });
+
+    describe("table format", () => {
+        it("includes header row and todo data", () => {
+            const output = formatTodo(todo, "table");
+            expect(output).toContain("ID");
+            expect(output).toContain("Status");
+            expect(output).toContain("Priority");
+            expect(output).toContain("Title");
+            expect(output).toContain("todo_x7k2m");
+            expect(output).toContain("critical");
+        });
+    });
+});
+
+describe("formatTodoList", () => {
+    const todos = [
+        makeTodo(),
+        makeTodo({ id: "todo_abc12", title: "Second task", status: "todo", priority: "low", tags: [] }),
+    ];
+
+    it("json format returns array", () => {
+        const output = formatTodoList(todos, "json");
+        const parsed = SafeJSON.parse(output);
+        expect(parsed).toHaveLength(2);
+    });
+
+    it("ai format joins with double newline", () => {
+        const output = formatTodoList(todos, "ai");
+        expect(output).toContain("[todo_x7k2m]");
+        expect(output).toContain("[todo_abc12]");
+        expect(output).toContain("\n\n");
+    });
+
+    it("md format produces bullet list", () => {
+        const output = formatTodoList(todos, "md");
+        expect(output).toContain("- **todo_x7k2m**:");
+        expect(output).toContain("- **todo_abc12**:");
+    });
+
+    it("table format includes all rows", () => {
+        const output = formatTodoList(todos, "table");
+        expect(output).toContain("todo_x7k2m");
+        expect(output).toContain("todo_abc12");
+    });
+
+    it("handles empty list", () => {
+        expect(formatTodoList([], "md")).toContain("No todos");
+        expect(formatTodoList([], "table")).toContain("No todos");
+        expect(formatTodoList([], "ai")).toBe("");
+    });
+});

--- a/src/todo/lib/__tests__/links.test.ts
+++ b/src/todo/lib/__tests__/links.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { parseLink, parseLinks } from "../links";
+
+describe("parseLink", () => {
+    it("parses PR shorthand", () => {
+        const link = parseLink("pr:142");
+        expect(link).toEqual({ type: "pr", ref: "142" });
+    });
+
+    it("parses issue shorthand", () => {
+        const link = parseLink("issue:456");
+        expect(link).toEqual({ type: "issue", ref: "456" });
+    });
+
+    it("parses ADO shorthand", () => {
+        const link = parseLink("ado:78901");
+        expect(link).toEqual({ type: "ado", ref: "78901" });
+    });
+
+    it("is case-insensitive for shorthand prefix", () => {
+        const link = parseLink("PR:99");
+        expect(link.type).toBe("pr");
+        expect(link.ref).toBe("99");
+    });
+
+    it("parses GitHub PR URL with repo extraction", () => {
+        const link = parseLink("https://github.com/anomalyco/opencode/pull/42");
+        expect(link.type).toBe("pr");
+        expect(link.ref).toBe("42");
+        expect(link.repo).toBe("anomalyco/opencode");
+    });
+
+    it("parses GitHub issue URL with repo extraction", () => {
+        const link = parseLink("https://github.com/anomalyco/opencode/issues/100");
+        expect(link.type).toBe("issue");
+        expect(link.ref).toBe("100");
+        expect(link.repo).toBe("anomalyco/opencode");
+    });
+
+    it("handles HTTP (non-HTTPS) GitHub URLs", () => {
+        const link = parseLink("http://github.com/owner/repo/pull/7");
+        expect(link.type).toBe("pr");
+        expect(link.ref).toBe("7");
+        expect(link.repo).toBe("owner/repo");
+    });
+
+    it("parses arbitrary URL as url type", () => {
+        const link = parseLink("https://jira.example.com/browse/PROJ-123");
+        expect(link.type).toBe("url");
+        expect(link.ref).toBe("https://jira.example.com/browse/PROJ-123");
+        expect(link.repo).toBeUndefined();
+    });
+
+    it("throws on empty string", () => {
+        expect(() => parseLink("")).toThrow();
+    });
+});
+
+describe("parseLinks", () => {
+    it("maps an array of inputs to TodoLink objects", () => {
+        const links = parseLinks(["pr:42", "https://github.com/org/repo/issues/10", "https://example.com"]);
+
+        expect(links).toHaveLength(3);
+        expect(links[0].type).toBe("pr");
+        expect(links[1].type).toBe("issue");
+        expect(links[1].repo).toBe("org/repo");
+        expect(links[2].type).toBe("url");
+    });
+
+    it("returns empty array for empty input", () => {
+        expect(parseLinks([])).toEqual([]);
+    });
+});

--- a/src/todo/lib/__tests__/reminders.test.ts
+++ b/src/todo/lib/__tests__/reminders.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { parseReminders, parseReminderTime } from "../reminders";
+
+const FIXED_NOW = new Date("2026-04-01T12:00:00.000Z");
+
+describe("parseReminderTime", () => {
+    it("parses minutes (30m)", () => {
+        const result = parseReminderTime("30m", FIXED_NOW);
+        expect(result).toBe("2026-04-01T12:30:00.000Z");
+    });
+
+    it("parses hours (24h)", () => {
+        const result = parseReminderTime("24h", FIXED_NOW);
+        expect(result).toBe("2026-04-02T12:00:00.000Z");
+    });
+
+    it("parses days (3d)", () => {
+        const result = parseReminderTime("3d", FIXED_NOW);
+        expect(result).toBe("2026-04-04T12:00:00.000Z");
+    });
+
+    it("parses weeks (1w)", () => {
+        const result = parseReminderTime("1w", FIXED_NOW);
+        expect(result).toBe("2026-04-08T12:00:00.000Z");
+    });
+
+    it("is case-insensitive for units", () => {
+        const result = parseReminderTime("2H", FIXED_NOW);
+        expect(result).toBe("2026-04-01T14:00:00.000Z");
+    });
+
+    it("parses absolute ISO datetime", () => {
+        const result = parseReminderTime("2026-04-02T10:00:00.000Z");
+        expect(result).toBe("2026-04-02T10:00:00.000Z");
+    });
+
+    it("parses absolute YYYY-MM-DD HH:MM format", () => {
+        const result = parseReminderTime("2026-04-02 10:00");
+        const parsed = new Date(result);
+        expect(parsed.getFullYear()).toBe(2026);
+        expect(parsed.getMonth()).toBe(3);
+        expect(parsed.getDate()).toBe(2);
+    });
+
+    it("throws on invalid input", () => {
+        expect(() => parseReminderTime("")).toThrow();
+        expect(() => parseReminderTime("abc")).toThrow();
+        expect(() => parseReminderTime("10x")).toThrow();
+    });
+});
+
+describe("parseReminders", () => {
+    it("maps array of strings to TodoReminder objects", () => {
+        const reminders = parseReminders(["24h", "2026-04-05T09:00:00.000Z"]);
+
+        expect(reminders).toHaveLength(2);
+        expect(reminders[0].at).toBeTruthy();
+        expect(reminders[0].synced).toBeNull();
+        expect(reminders[1].at).toBe("2026-04-05T09:00:00.000Z");
+        expect(reminders[1].synced).toBeNull();
+    });
+
+    it("returns empty array for empty input", () => {
+        expect(parseReminders([])).toEqual([]);
+    });
+});

--- a/src/todo/lib/__tests__/store.test.ts
+++ b/src/todo/lib/__tests__/store.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { TodoStore } from "../store";
+import type { Todo } from "../types";
+
+const TEST_DIR = join(import.meta.dir, ".test-store-" + Date.now());
+
+let store: TodoStore;
+
+beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    store = TodoStore.forProject(TEST_DIR, { storageRoot: join(TEST_DIR, ".storage") });
+});
+
+afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("add()", () => {
+    it("creates a todo with generated id", async () => {
+        const todo = await store.add({ title: "Write tests" });
+
+        expect(todo.id).toMatch(/^todo_/);
+        expect(todo.id).toHaveLength("todo_".length + 8);
+        expect(todo.title).toBe("Write tests");
+    });
+
+    it("persists to disk", async () => {
+        await store.add({ title: "Persist me" });
+        const todos = await store.list();
+
+        expect(todos).toHaveLength(1);
+        expect(todos[0].title).toBe("Persist me");
+    });
+
+    it("respects priority and tags", async () => {
+        const todo = await store.add({
+            title: "Urgent fix",
+            priority: "critical",
+            tags: ["bug", "hotfix"],
+        });
+
+        expect(todo.priority).toBe("critical");
+        expect(todo.tags).toEqual(["bug", "hotfix"]);
+    });
+
+    it("defaults status to 'todo' and priority to 'medium'", async () => {
+        const todo = await store.add({ title: "Defaults check" });
+
+        expect(todo.status).toBe("todo");
+        expect(todo.priority).toBe("medium");
+        expect(todo.tags).toEqual([]);
+    });
+
+    it("captures context with projectRoot", async () => {
+        const todo = await store.add({ title: "Context check" });
+
+        expect(todo.context).toBeDefined();
+        expect(todo.context.projectRoot).toBe(TEST_DIR);
+        expect(todo.context.createdAt).toBeTruthy();
+    });
+
+    it("stores sessionId when provided", async () => {
+        const todo = await store.add({ title: "Session todo", sessionId: "abc-123" });
+
+        expect(todo.sessionId).toBe("abc-123");
+    });
+
+    it("parses reminders from string inputs", async () => {
+        const todo = await store.add({
+            title: "Reminder test",
+            reminders: ["2030-01-01T12:00:00Z"],
+        });
+
+        expect(todo.reminders).toHaveLength(1);
+        expect(todo.reminders[0].at).toBe("2030-01-01T12:00:00.000Z");
+    });
+
+    it("reads mdFile content as inlineContent", async () => {
+        const mdPath = join(TEST_DIR, "notes.md");
+        writeFileSync(mdPath, "# My Notes\nSome content here.");
+
+        const todo = await store.add({ title: "MD todo", mdFile: mdPath });
+
+        expect(todo.inlineContent).toBe("# My Notes\nSome content here.");
+    });
+
+    it("copies attached files", async () => {
+        const filePath = join(TEST_DIR, "data.txt");
+        writeFileSync(filePath, "file content");
+
+        const todo = await store.add({ title: "Attach test", attachFiles: [filePath] });
+
+        expect(todo.attachments).toHaveLength(1);
+        expect(todo.attachments[0].filename).toBe("data.txt");
+        expect(todo.attachments[0].originalPath).toBe(filePath);
+
+        const storedContent = await Bun.file(todo.attachments[0].storedPath).text();
+        expect(storedContent).toBe("file content");
+    });
+});
+
+describe("get()", () => {
+    it("returns todo by id", async () => {
+        const added = await store.add({ title: "Find me" });
+        const found = await store.get(added.id);
+
+        expect(found).not.toBeNull();
+        expect(found!.title).toBe("Find me");
+    });
+
+    it("returns null for non-existent id", async () => {
+        const found = await store.get("todo_nonexist");
+
+        expect(found).toBeNull();
+    });
+});
+
+describe("update()", () => {
+    it("updates fields", async () => {
+        const added = await store.add({ title: "Original" });
+        const updated = await store.update(added.id, { title: "Updated", priority: "high" });
+
+        expect(updated.title).toBe("Updated");
+        expect(updated.priority).toBe("high");
+    });
+
+    it("updates updatedAt timestamp", async () => {
+        const added = await store.add({ title: "Timestamp check" });
+        const originalUpdatedAt = added.context.updatedAt;
+
+        await new Promise((r) => setTimeout(r, 10));
+        const updated = await store.update(added.id, { title: "Changed" });
+
+        expect(updated.context.updatedAt).not.toBe(originalUpdatedAt);
+    });
+
+    it("throws for non-existent id", async () => {
+        expect(store.update("todo_nonexist", { title: "Nope" })).rejects.toThrow();
+    });
+});
+
+describe("remove()", () => {
+    it("deletes a todo", async () => {
+        const added = await store.add({ title: "Delete me" });
+        const removed = await store.remove(added.id);
+
+        expect(removed).toBe(true);
+
+        const found = await store.get(added.id);
+        expect(found).toBeNull();
+    });
+
+    it("returns false for non-existent id", async () => {
+        const removed = await store.remove("todo_nonexist");
+
+        expect(removed).toBe(false);
+    });
+});
+
+describe("complete()", () => {
+    it("sets status to 'done' and completedAt", async () => {
+        const added = await store.add({ title: "Finish this" });
+        const completed = await store.complete(added.id);
+
+        expect(completed.status).toBe("done");
+        expect(completed.completedAt).toBeTruthy();
+    });
+
+    it("stores completionNote", async () => {
+        const added = await store.add({ title: "Note test" });
+        const completed = await store.complete(added.id, "Shipped in v2.0");
+
+        expect(completed.completionNote).toBe("Shipped in v2.0");
+    });
+});
+
+describe("list() with filters", () => {
+    beforeEach(async () => {
+        await store.add({ title: "Open bug", priority: "high", tags: ["bug"] });
+        await store.add({ title: "Done feature", priority: "low", tags: ["feature"] });
+        await store.add({ title: "Blocked task", priority: "medium", tags: ["bug", "backend"], sessionId: "sess-1" });
+
+        const todos = await store.list();
+        const doneTodo = todos.find((t: Todo) => t.title === "Done feature");
+
+        if (doneTodo) {
+            await store.complete(doneTodo.id);
+        }
+    });
+
+    it("returns all todos without filters", async () => {
+        const todos = await store.list();
+
+        expect(todos).toHaveLength(3);
+    });
+
+    it("filters by status", async () => {
+        const done = await store.list({ status: ["done"] });
+
+        expect(done).toHaveLength(1);
+        expect(done[0].title).toBe("Done feature");
+    });
+
+    it("filters by priority", async () => {
+        const high = await store.list({ priority: ["high"] });
+
+        expect(high).toHaveLength(1);
+        expect(high[0].title).toBe("Open bug");
+    });
+
+    it("filters by tag", async () => {
+        const bugs = await store.list({ tags: ["bug"] });
+
+        expect(bugs).toHaveLength(2);
+    });
+
+    it("filters by sessionId", async () => {
+        const session = await store.list({ sessionId: "sess-1" });
+
+        expect(session).toHaveLength(1);
+        expect(session[0].title).toBe("Blocked task");
+    });
+
+    it("combines multiple filters", async () => {
+        const result = await store.list({ tags: ["bug"], priority: ["medium"] });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].title).toBe("Blocked task");
+    });
+});
+
+describe("search()", () => {
+    beforeEach(async () => {
+        await store.add({ title: "Fix login bug", description: "Users can't authenticate" });
+        await store.add({ title: "Add dashboard", tags: ["frontend"] });
+        await store.add({ title: "Refactor API" });
+    });
+
+    it("finds by title substring", async () => {
+        const results = await store.search("login");
+
+        expect(results).toHaveLength(1);
+        expect(results[0].title).toBe("Fix login bug");
+    });
+
+    it("finds by description substring", async () => {
+        const results = await store.search("authenticate");
+
+        expect(results).toHaveLength(1);
+        expect(results[0].title).toBe("Fix login bug");
+    });
+
+    it("is case-insensitive", async () => {
+        const results = await store.search("DASHBOARD");
+
+        expect(results).toHaveLength(1);
+        expect(results[0].title).toBe("Add dashboard");
+    });
+
+    it("finds by tag", async () => {
+        const results = await store.search("frontend");
+
+        expect(results).toHaveLength(1);
+        expect(results[0].title).toBe("Add dashboard");
+    });
+
+    it("returns empty for no match", async () => {
+        const results = await store.search("nonexistent");
+
+        expect(results).toHaveLength(0);
+    });
+});
+
+describe("cross-project operations", () => {
+    it("listAllProjects returns project metadata", async () => {
+        const storageRoot = join(TEST_DIR, ".storage");
+        const store1 = TodoStore.forProject(join(TEST_DIR, "project-a"), { storageRoot });
+        const store2 = TodoStore.forProject(join(TEST_DIR, "project-b"), { storageRoot });
+
+        await store1.add({ title: "Task A" });
+        await store2.add({ title: "Task B" });
+
+        const projects = await TodoStore.listAllProjects(storageRoot);
+
+        expect(projects).toHaveLength(2);
+        expect(projects.every((p: { todoCount: number }) => p.todoCount === 1)).toBe(true);
+    });
+
+    it("listAll aggregates todos across projects", async () => {
+        const storageRoot = join(TEST_DIR, ".storage");
+        const store1 = TodoStore.forProject(join(TEST_DIR, "project-a"), { storageRoot });
+        const store2 = TodoStore.forProject(join(TEST_DIR, "project-b"), { storageRoot });
+
+        await store1.add({ title: "Task A", priority: "high" });
+        await store2.add({ title: "Task B", priority: "low" });
+
+        const all = await TodoStore.listAll(undefined, storageRoot);
+
+        expect(all).toHaveLength(2);
+    });
+
+    it("listAll applies filters across projects", async () => {
+        const storageRoot = join(TEST_DIR, ".storage");
+        const store1 = TodoStore.forProject(join(TEST_DIR, "project-a"), { storageRoot });
+        const store2 = TodoStore.forProject(join(TEST_DIR, "project-b"), { storageRoot });
+
+        await store1.add({ title: "Task A", priority: "high" });
+        await store2.add({ title: "Task B", priority: "low" });
+
+        const highOnly = await TodoStore.listAll({ priority: ["high"] }, storageRoot);
+
+        expect(highOnly).toHaveLength(1);
+        expect(highOnly[0].title).toBe("Task A");
+    });
+});

--- a/src/todo/lib/context.ts
+++ b/src/todo/lib/context.ts
@@ -1,0 +1,112 @@
+import { existsSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, resolve } from "node:path";
+import type { GitContext, TodoContext } from "./types";
+
+export function findProjectRoot(from: string): string | null {
+    let dir = resolve(from);
+
+    while (true) {
+        if (existsSync(resolve(dir, ".git"))) {
+            return dir;
+        }
+
+        const parent = dirname(dir);
+
+        if (parent === dir) {
+            return null;
+        }
+
+        dir = parent;
+    }
+}
+
+async function git(args: string[], cwd: string): Promise<string | null> {
+    try {
+        const proc = Bun.spawn(["git", ...args], {
+            cwd,
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+
+        const output = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+
+        if (exitCode !== 0) {
+            return null;
+        }
+
+        return output.trim();
+    } catch {
+        return null;
+    }
+}
+
+async function captureGitContext(cwd: string): Promise<GitContext | undefined> {
+    const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+
+    if (branch === null) {
+        return undefined;
+    }
+
+    const [commitSha, commitMessage, remote, statusOutput] = await Promise.all([
+        git(["rev-parse", "HEAD"], cwd),
+        git(["log", "-1", "--format=%s"], cwd),
+        git(["remote", "get-url", "origin"], cwd),
+        git(["status", "--porcelain"], cwd),
+    ]);
+
+    const staged: string[] = [];
+    const unstaged: string[] = [];
+    const untracked: string[] = [];
+
+    if (statusOutput) {
+        for (const line of statusOutput.split("\n")) {
+            if (!line) {
+                continue;
+            }
+
+            const x = line[0];
+            const y = line[1];
+            const file = line.slice(3);
+
+            if (x === "?") {
+                untracked.push(file);
+            } else {
+                if (x !== " " && x !== "?") {
+                    staged.push(file);
+                }
+
+                if (y !== " " && y !== "?") {
+                    unstaged.push(file);
+                }
+            }
+        }
+    }
+
+    return {
+        branch,
+        commitSha: commitSha ?? "",
+        commitMessage: commitMessage ?? "",
+        stagedFiles: staged,
+        unstagedFiles: unstaged,
+        untrackedFiles: untracked,
+        remote: remote ?? undefined,
+    };
+}
+
+export async function captureContext(options?: { projectRoot?: string }): Promise<TodoContext> {
+    const projectRoot = options?.projectRoot ?? findProjectRoot(process.cwd()) ?? process.cwd();
+
+    const now = new Date().toISOString();
+    const gitContext = await captureGitContext(projectRoot);
+
+    return {
+        git: gitContext,
+        cwd: process.cwd(),
+        projectRoot,
+        hostname: hostname(),
+        createdAt: now,
+        updatedAt: now,
+    };
+}

--- a/src/todo/lib/format.ts
+++ b/src/todo/lib/format.ts
@@ -1,7 +1,7 @@
+import { isInteractive } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import { renderMarkdownToCli } from "@app/utils/markdown/index.js";
 import { formatTable } from "@app/utils/table";
-import { isInteractive } from "@app/utils/cli";
 import type { OutputFormat, Todo, TodoLink, TodoReminder } from "./types";
 
 function formatLinkCompact(link: TodoLink): string {
@@ -33,7 +33,7 @@ function formatTodoMarkdown(todo: Todo): string {
     lines.push(`**${todo.id}** | **${todo.priority}** | **${todo.status}**`);
 
     if (todo.tags.length > 0) {
-        lines.push(`Tags: \`${todo.tags.join("\`, \`")}\``);
+        lines.push(`Tags: \`${todo.tags.join("`, `")}\``);
     }
 
     lines.push("");

--- a/src/todo/lib/format.ts
+++ b/src/todo/lib/format.ts
@@ -105,6 +105,14 @@ function renderForTerminal(markdown: string): string {
     return renderMarkdownToCli(markdown, { theme: "dark" });
 }
 
+function shouldColorize(forceColors?: boolean): boolean {
+    if (forceColors !== undefined) {
+        return forceColors;
+    }
+
+    return isInteractive();
+}
+
 function formatTodoTable(todos: Todo[]): string {
     if (todos.length === 0) {
         return "No todos found.";
@@ -116,28 +124,32 @@ function formatTodoTable(todos: Todo[]): string {
     return formatTable(rows, headers, { maxColWidth: 40 });
 }
 
-export function formatTodo(todo: Todo, format: OutputFormat): string {
+export interface FormatOptions {
+    colors?: boolean;
+}
+
+export function formatTodo(todo: Todo, format: OutputFormat, options?: FormatOptions): string {
     switch (format) {
         case "json":
             return SafeJSON.stringify(todo, null, 2);
         case "ai":
         case "md": {
             const md = formatTodoMarkdown(todo);
-            return isInteractive() ? renderForTerminal(md) : md;
+            return shouldColorize(options?.colors) ? renderForTerminal(md) : md;
         }
         case "table":
             return formatTodoTable([todo]);
     }
 }
 
-export function formatTodoList(todos: Todo[], format: OutputFormat): string {
+export function formatTodoList(todos: Todo[], format: OutputFormat, options?: FormatOptions): string {
     switch (format) {
         case "json":
             return SafeJSON.stringify(todos, null, 2);
         case "ai":
         case "md": {
             const md = formatTodoListMarkdown(todos);
-            return isInteractive() ? renderForTerminal(md) : md;
+            return shouldColorize(options?.colors) ? renderForTerminal(md) : md;
         }
         case "table":
             return formatTodoTable(todos);

--- a/src/todo/lib/format.ts
+++ b/src/todo/lib/format.ts
@@ -161,13 +161,7 @@ function formatTodoTable(todos: Todo[]): string {
     }
 
     const headers = ["ID", "Status", "Priority", "Title", "Tags"];
-    const rows = todos.map((t) => [
-        t.id,
-        t.status,
-        t.priority,
-        t.title,
-        t.tags.join(", "),
-    ]);
+    const rows = todos.map((t) => [t.id, t.status, t.priority, t.title, t.tags.join(", ")]);
 
     return formatTable(rows, headers, { maxColWidth: 40 });
 }

--- a/src/todo/lib/format.ts
+++ b/src/todo/lib/format.ts
@@ -1,5 +1,7 @@
 import { SafeJSON } from "@app/utils/json";
+import { renderMarkdownToCli } from "@app/utils/markdown/index.js";
 import { formatTable } from "@app/utils/table";
+import { isInteractive } from "@app/utils/cli";
 import type { OutputFormat, Todo, TodoLink, TodoReminder } from "./types";
 
 function formatLinkCompact(link: TodoLink): string {
@@ -15,103 +17,53 @@ function formatReminderCompact(reminder: TodoReminder): string {
     return reminder.label ? `${reminder.at} (${reminder.label})` : reminder.at;
 }
 
-function formatTodoAi(todo: Todo): string {
+function formatTodoMarkdown(todo: Todo): string {
     const lines: string[] = [];
-    lines.push(`[${todo.id}] ${todo.title} (${todo.priority}, ${todo.status})`);
+
+    const statusIcon =
+        todo.status === "done"
+            ? "[x]"
+            : todo.status === "in-progress"
+              ? "[-]"
+              : todo.status === "blocked"
+                ? "[!]"
+                : "[ ]";
+
+    lines.push(`## ${statusIcon} ${todo.title}`);
+    lines.push(`**${todo.id}** | **${todo.priority}** | **${todo.status}**`);
 
     if (todo.tags.length > 0) {
-        lines.push(`tags: ${todo.tags.join(", ")}`);
-    }
-
-    const ctxParts: string[] = [];
-
-    if (todo.context.git?.branch) {
-        ctxParts.push(`branch: ${todo.context.git.branch}`);
-    }
-
-    if (todo.context.git?.commitSha) {
-        ctxParts.push(`commit: ${todo.context.git.commitSha.slice(0, 7)}`);
-    }
-
-    if (ctxParts.length > 0) {
-        lines.push(ctxParts.join(" | "));
-    }
-
-    if (todo.sessionId) {
-        lines.push(`session: ${todo.sessionId}`);
-    }
-
-    if (todo.links.length > 0) {
-        lines.push(`links: ${todo.links.map(formatLinkCompact).join(", ")}`);
-    }
-
-    if (todo.reminders.length > 0) {
-        lines.push(`reminders: ${todo.reminders.map(formatReminderCompact).join(", ")}`);
-    }
-
-    if (todo.completedAt) {
-        lines.push(`completed: ${todo.completedAt}`);
-    }
-
-    if (todo.completionNote) {
-        lines.push(`note: ${todo.completionNote}`);
-    }
-
-    if (todo.description) {
-        lines.push("---");
-        lines.push(todo.description);
-    }
-
-    if (todo.inlineContent) {
-        lines.push("---");
-        lines.push(todo.inlineContent);
-    }
-
-    return lines.join("\n");
-}
-
-function formatTodoMdShow(todo: Todo): string {
-    const lines: string[] = [];
-    lines.push(`## ${todo.id}: ${todo.title}`);
-
-    const statusParts = [`**Status:** ${todo.status}`, `**Priority:** ${todo.priority}`];
-    lines.push(statusParts.join(" | "));
-
-    if (todo.tags.length > 0) {
-        lines.push(`**Tags:** ${todo.tags.join(", ")}`);
+        lines.push(`Tags: \`${todo.tags.join("\`, \`")}\``);
     }
 
     lines.push("");
 
-    const hasContext =
-        todo.context.git?.branch ||
-        todo.context.git?.commitSha ||
-        todo.sessionId ||
-        todo.links.length > 0 ||
-        todo.reminders.length > 0;
+    const contextParts: string[] = [];
 
-    if (hasContext) {
-        lines.push("### Context");
+    if (todo.context.git?.branch) {
+        contextParts.push(`Branch: \`${todo.context.git.branch}\``);
+    }
 
-        if (todo.context.git?.branch) {
-            lines.push(`- Branch: \`${todo.context.git.branch}\``);
-        }
+    if (todo.context.git?.commitSha) {
+        const msg = todo.context.git.commitMessage ? ` — ${todo.context.git.commitMessage}` : "";
+        contextParts.push(`Commit: \`${todo.context.git.commitSha.slice(0, 8)}\`${msg}`);
+    }
 
-        if (todo.context.git?.commitSha) {
-            const msg = todo.context.git.commitMessage ? ` — ${todo.context.git.commitMessage}` : "";
-            lines.push(`- Commit: \`${todo.context.git.commitSha.slice(0, 8)}\`${msg}`);
-        }
+    if (todo.sessionId) {
+        contextParts.push(`Session: \`${todo.sessionId}\``);
+    }
 
-        if (todo.sessionId) {
-            lines.push(`- Session: \`${todo.sessionId}\``);
-        }
+    if (todo.links.length > 0) {
+        contextParts.push(`Links: ${todo.links.map(formatLinkCompact).join(", ")}`);
+    }
 
-        if (todo.links.length > 0) {
-            lines.push(`- Links: ${todo.links.map(formatLinkCompact).join(", ")}`);
-        }
+    if (todo.reminders.length > 0) {
+        contextParts.push(`Reminders: ${todo.reminders.map(formatReminderCompact).join(", ")}`);
+    }
 
-        if (todo.reminders.length > 0) {
-            lines.push(`- Reminders: ${todo.reminders.map(formatReminderCompact).join(", ")}`);
+    if (contextParts.length > 0) {
+        for (const part of contextParts) {
+            lines.push(`- ${part}`);
         }
 
         lines.push("");
@@ -128,13 +80,12 @@ function formatTodoMdShow(todo: Todo): string {
     }
 
     if (todo.description) {
-        lines.push("### Description");
         lines.push(todo.description);
         lines.push("");
     }
 
     if (todo.inlineContent) {
-        lines.push("### Content");
+        lines.push("---");
         lines.push(todo.inlineContent);
         lines.push("");
     }
@@ -142,17 +93,16 @@ function formatTodoMdShow(todo: Todo): string {
     return lines.join("\n").trimEnd();
 }
 
-function formatTodoMdList(todos: Todo[]): string {
+function formatTodoListMarkdown(todos: Todo[]): string {
     if (todos.length === 0) {
         return "_No todos found._";
     }
 
-    const lines = todos.map((t) => {
-        const tags = t.tags.length > 0 ? ` [${t.tags.join(", ")}]` : "";
-        return `- **${t.id}**: ${t.title} (${t.priority}, ${t.status})${tags}`;
-    });
+    return todos.map(formatTodoMarkdown).join("\n\n---\n\n");
+}
 
-    return lines.join("\n");
+function renderForTerminal(markdown: string): string {
+    return renderMarkdownToCli(markdown, { theme: "dark" });
 }
 
 function formatTodoTable(todos: Todo[]): string {
@@ -171,9 +121,10 @@ export function formatTodo(todo: Todo, format: OutputFormat): string {
         case "json":
             return SafeJSON.stringify(todo, null, 2);
         case "ai":
-            return formatTodoAi(todo);
-        case "md":
-            return formatTodoMdShow(todo);
+        case "md": {
+            const md = formatTodoMarkdown(todo);
+            return isInteractive() ? renderForTerminal(md) : md;
+        }
         case "table":
             return formatTodoTable([todo]);
     }
@@ -184,9 +135,10 @@ export function formatTodoList(todos: Todo[], format: OutputFormat): string {
         case "json":
             return SafeJSON.stringify(todos, null, 2);
         case "ai":
-            return todos.map(formatTodoAi).join("\n\n");
-        case "md":
-            return formatTodoMdList(todos);
+        case "md": {
+            const md = formatTodoListMarkdown(todos);
+            return isInteractive() ? renderForTerminal(md) : md;
+        }
         case "table":
             return formatTodoTable(todos);
     }

--- a/src/todo/lib/format.ts
+++ b/src/todo/lib/format.ts
@@ -1,0 +1,199 @@
+import { SafeJSON } from "@app/utils/json";
+import { formatTable } from "@app/utils/table";
+import type { OutputFormat, Todo, TodoLink, TodoReminder } from "./types";
+
+function formatLinkCompact(link: TodoLink): string {
+    if (link.type === "url") {
+        return link.ref;
+    }
+
+    const repo = link.repo ? `${link.repo}#` : "";
+    return `${link.type}:${repo}${link.ref}`;
+}
+
+function formatReminderCompact(reminder: TodoReminder): string {
+    return reminder.label ? `${reminder.at} (${reminder.label})` : reminder.at;
+}
+
+function formatTodoAi(todo: Todo): string {
+    const lines: string[] = [];
+    lines.push(`[${todo.id}] ${todo.title} (${todo.priority}, ${todo.status})`);
+
+    if (todo.tags.length > 0) {
+        lines.push(`tags: ${todo.tags.join(", ")}`);
+    }
+
+    const ctxParts: string[] = [];
+
+    if (todo.context.git?.branch) {
+        ctxParts.push(`branch: ${todo.context.git.branch}`);
+    }
+
+    if (todo.context.git?.commitSha) {
+        ctxParts.push(`commit: ${todo.context.git.commitSha.slice(0, 7)}`);
+    }
+
+    if (ctxParts.length > 0) {
+        lines.push(ctxParts.join(" | "));
+    }
+
+    if (todo.sessionId) {
+        lines.push(`session: ${todo.sessionId}`);
+    }
+
+    if (todo.links.length > 0) {
+        lines.push(`links: ${todo.links.map(formatLinkCompact).join(", ")}`);
+    }
+
+    if (todo.reminders.length > 0) {
+        lines.push(`reminders: ${todo.reminders.map(formatReminderCompact).join(", ")}`);
+    }
+
+    if (todo.completedAt) {
+        lines.push(`completed: ${todo.completedAt}`);
+    }
+
+    if (todo.completionNote) {
+        lines.push(`note: ${todo.completionNote}`);
+    }
+
+    if (todo.description) {
+        lines.push("---");
+        lines.push(todo.description);
+    }
+
+    if (todo.inlineContent) {
+        lines.push("---");
+        lines.push(todo.inlineContent);
+    }
+
+    return lines.join("\n");
+}
+
+function formatTodoMdShow(todo: Todo): string {
+    const lines: string[] = [];
+    lines.push(`## ${todo.id}: ${todo.title}`);
+
+    const statusParts = [`**Status:** ${todo.status}`, `**Priority:** ${todo.priority}`];
+    lines.push(statusParts.join(" | "));
+
+    if (todo.tags.length > 0) {
+        lines.push(`**Tags:** ${todo.tags.join(", ")}`);
+    }
+
+    lines.push("");
+
+    const hasContext =
+        todo.context.git?.branch ||
+        todo.context.git?.commitSha ||
+        todo.sessionId ||
+        todo.links.length > 0 ||
+        todo.reminders.length > 0;
+
+    if (hasContext) {
+        lines.push("### Context");
+
+        if (todo.context.git?.branch) {
+            lines.push(`- Branch: \`${todo.context.git.branch}\``);
+        }
+
+        if (todo.context.git?.commitSha) {
+            const msg = todo.context.git.commitMessage ? ` — ${todo.context.git.commitMessage}` : "";
+            lines.push(`- Commit: \`${todo.context.git.commitSha.slice(0, 8)}\`${msg}`);
+        }
+
+        if (todo.sessionId) {
+            lines.push(`- Session: \`${todo.sessionId}\``);
+        }
+
+        if (todo.links.length > 0) {
+            lines.push(`- Links: ${todo.links.map(formatLinkCompact).join(", ")}`);
+        }
+
+        if (todo.reminders.length > 0) {
+            lines.push(`- Reminders: ${todo.reminders.map(formatReminderCompact).join(", ")}`);
+        }
+
+        lines.push("");
+    }
+
+    if (todo.completedAt) {
+        lines.push(`**Completed:** ${todo.completedAt}`);
+
+        if (todo.completionNote) {
+            lines.push(`**Note:** ${todo.completionNote}`);
+        }
+
+        lines.push("");
+    }
+
+    if (todo.description) {
+        lines.push("### Description");
+        lines.push(todo.description);
+        lines.push("");
+    }
+
+    if (todo.inlineContent) {
+        lines.push("### Content");
+        lines.push(todo.inlineContent);
+        lines.push("");
+    }
+
+    return lines.join("\n").trimEnd();
+}
+
+function formatTodoMdList(todos: Todo[]): string {
+    if (todos.length === 0) {
+        return "_No todos found._";
+    }
+
+    const lines = todos.map((t) => {
+        const tags = t.tags.length > 0 ? ` [${t.tags.join(", ")}]` : "";
+        return `- **${t.id}**: ${t.title} (${t.priority}, ${t.status})${tags}`;
+    });
+
+    return lines.join("\n");
+}
+
+function formatTodoTable(todos: Todo[]): string {
+    if (todos.length === 0) {
+        return "No todos found.";
+    }
+
+    const headers = ["ID", "Status", "Priority", "Title", "Tags"];
+    const rows = todos.map((t) => [
+        t.id,
+        t.status,
+        t.priority,
+        t.title,
+        t.tags.join(", "),
+    ]);
+
+    return formatTable(rows, headers, { maxColWidth: 40 });
+}
+
+export function formatTodo(todo: Todo, format: OutputFormat): string {
+    switch (format) {
+        case "json":
+            return SafeJSON.stringify(todo, null, 2);
+        case "ai":
+            return formatTodoAi(todo);
+        case "md":
+            return formatTodoMdShow(todo);
+        case "table":
+            return formatTodoTable([todo]);
+    }
+}
+
+export function formatTodoList(todos: Todo[], format: OutputFormat): string {
+    switch (format) {
+        case "json":
+            return SafeJSON.stringify(todos, null, 2);
+        case "ai":
+            return todos.map(formatTodoAi).join("\n\n");
+        case "md":
+            return formatTodoMdList(todos);
+        case "table":
+            return formatTodoTable(todos);
+    }
+}

--- a/src/todo/lib/links.ts
+++ b/src/todo/lib/links.ts
@@ -1,0 +1,43 @@
+import type { TodoLink } from "./types";
+
+const SHORTHAND_RE = /^(pr|issue|ado):(.+)$/i;
+const GITHUB_PR_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/;
+const GITHUB_ISSUE_RE = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/;
+const URL_RE = /^https?:\/\//;
+
+export function parseLink(input: string): TodoLink {
+    if (!input) {
+        throw new Error("Link cannot be empty");
+    }
+
+    const shorthand = input.match(SHORTHAND_RE);
+
+    if (shorthand) {
+        return {
+            type: shorthand[1].toLowerCase() as TodoLink["type"],
+            ref: shorthand[2],
+        };
+    }
+
+    const prMatch = input.match(GITHUB_PR_RE);
+
+    if (prMatch) {
+        return { type: "pr", ref: prMatch[2], repo: prMatch[1] };
+    }
+
+    const issueMatch = input.match(GITHUB_ISSUE_RE);
+
+    if (issueMatch) {
+        return { type: "issue", ref: issueMatch[2], repo: issueMatch[1] };
+    }
+
+    if (URL_RE.test(input)) {
+        return { type: "url", ref: input };
+    }
+
+    throw new Error(`Unrecognized link format: ${input}`);
+}
+
+export function parseLinks(inputs: string[]): TodoLink[] {
+    return inputs.map(parseLink);
+}

--- a/src/todo/lib/reminders.ts
+++ b/src/todo/lib/reminders.ts
@@ -1,0 +1,52 @@
+import type { TodoReminder } from "./types";
+
+const RELATIVE_RE = /^(\d+)(m|h|d|w)$/i;
+
+const MULTIPLIERS: Record<string, number> = {
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+    w: 604_800_000,
+};
+
+export function parseReminderTime(input: string, now?: Date): string {
+    if (!input) {
+        throw new Error("Reminder time cannot be empty");
+    }
+
+    const match = input.match(RELATIVE_RE);
+
+    if (match) {
+        const amount = parseInt(match[1], 10);
+        const unit = match[2].toLowerCase();
+        const base = now ?? new Date();
+        return new Date(base.getTime() + amount * MULTIPLIERS[unit]).toISOString();
+    }
+
+    const dateWithTime = input.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+
+    if (dateWithTime) {
+        const parsed = new Date(input.replace(" ", "T"));
+
+        if (Number.isNaN(parsed.getTime())) {
+            throw new Error(`Invalid date format: ${input}`);
+        }
+
+        return parsed.toISOString();
+    }
+
+    const parsed = new Date(input);
+
+    if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`Invalid reminder time: ${input}`);
+    }
+
+    return parsed.toISOString();
+}
+
+export function parseReminders(inputs: string[]): TodoReminder[] {
+    return inputs.map((input) => ({
+        at: parseReminderTime(input),
+        synced: null,
+    }));
+}

--- a/src/todo/lib/store.ts
+++ b/src/todo/lib/store.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
@@ -199,6 +199,12 @@ export class TodoStore {
             return false;
         }
 
+        const todoAttachDir = join(this.attachmentsDir, id);
+
+        if (existsSync(todoAttachDir)) {
+            rmSync(todoAttachDir, { recursive: true, force: true });
+        }
+
         await this.writeTodos(filtered);
         await this.writeMeta(filtered);
 
@@ -220,10 +226,17 @@ export class TodoStore {
 
     async bulkImport(incoming: Todo[]): Promise<number> {
         const todos = await this.readTodos();
-        todos.push(...incoming);
+        const existingIds = new Set(todos.map((t) => t.id));
+        const toImport = incoming.filter((t) => !existingIds.has(t.id));
+
+        if (toImport.length === 0) {
+            return 0;
+        }
+
+        todos.push(...toImport);
         await this.writeTodos(todos);
         await this.writeMeta(todos);
-        return incoming.length;
+        return toImport.length;
     }
 
     static async listAllProjects(storageRoot?: string): Promise<ProjectMeta[]> {

--- a/src/todo/lib/store.ts
+++ b/src/todo/lib/store.ts
@@ -218,6 +218,14 @@ export class TodoStore {
         return applyFilters(todos, { search: query });
     }
 
+    async bulkImport(incoming: Todo[]): Promise<number> {
+        const todos = await this.readTodos();
+        todos.push(...incoming);
+        await this.writeTodos(todos);
+        await this.writeMeta(todos);
+        return incoming.length;
+    }
+
     static async listAllProjects(storageRoot?: string): Promise<ProjectMeta[]> {
         const root = storageRoot ?? defaultStorageRoot();
         const projectsDir = join(root, "projects");

--- a/src/todo/lib/store.ts
+++ b/src/todo/lib/store.ts
@@ -1,0 +1,284 @@
+import { createHash } from "node:crypto";
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { nanoid } from "nanoid";
+import { captureContext } from "./context";
+import { parseReminders } from "./reminders";
+import type { AddTodoInput, ProjectMeta, Todo, TodoFilters } from "./types";
+
+function projectHash(projectRoot: string): string {
+    return createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+}
+
+function defaultStorageRoot(): string {
+    return join(homedir(), ".genesis-tools", "todo");
+}
+
+function applyFilters(todos: Todo[], filters: TodoFilters): Todo[] {
+    let result = todos;
+
+    if (filters.status?.length) {
+        result = result.filter((t) => filters.status!.includes(t.status));
+    }
+
+    if (filters.priority?.length) {
+        result = result.filter((t) => filters.priority!.includes(t.priority));
+    }
+
+    if (filters.tags?.length) {
+        result = result.filter((t) => t.tags.some((tag) => filters.tags!.includes(tag)));
+    }
+
+    if (filters.sessionId) {
+        result = result.filter((t) => t.sessionId === filters.sessionId);
+    }
+
+    if (filters.search) {
+        const q = filters.search.toLowerCase();
+        result = result.filter(
+            (t) =>
+                t.title.toLowerCase().includes(q) ||
+                t.description?.toLowerCase().includes(q) ||
+                t.inlineContent?.toLowerCase().includes(q) ||
+                t.tags.some((tag) => tag.toLowerCase().includes(q))
+        );
+    }
+
+    return result;
+}
+
+export class TodoStore {
+    private projectRoot: string;
+    private projectDir: string;
+    private todosPath: string;
+    private metaPath: string;
+    private attachmentsDir: string;
+
+    private constructor(projectRoot: string, storageRoot: string) {
+        this.projectRoot = projectRoot;
+        const hash = projectHash(projectRoot);
+        this.projectDir = join(storageRoot, "projects", hash);
+        this.todosPath = join(this.projectDir, "todos.json");
+        this.metaPath = join(this.projectDir, "meta.json");
+        this.attachmentsDir = join(this.projectDir, "attachments");
+    }
+
+    static forProject(projectRoot: string, options?: { storageRoot?: string }): TodoStore {
+        return new TodoStore(projectRoot, options?.storageRoot ?? defaultStorageRoot());
+    }
+
+    private ensureDir(): void {
+        if (!existsSync(this.projectDir)) {
+            mkdirSync(this.projectDir, { recursive: true });
+        }
+    }
+
+    private async readTodos(): Promise<Todo[]> {
+        if (!existsSync(this.todosPath)) {
+            return [];
+        }
+
+        const content = await Bun.file(this.todosPath).text();
+        return SafeJSON.parse(content) as Todo[];
+    }
+
+    private async writeTodos(todos: Todo[]): Promise<void> {
+        this.ensureDir();
+        await Bun.write(this.todosPath, SafeJSON.stringify(todos, null, 2));
+    }
+
+    private async writeMeta(todos: Todo[]): Promise<void> {
+        const meta: ProjectMeta = {
+            projectRoot: this.projectRoot,
+            name: basename(this.projectRoot),
+            lastAccessed: new Date().toISOString(),
+            todoCount: todos.length,
+        };
+
+        await Bun.write(this.metaPath, SafeJSON.stringify(meta, null, 2));
+    }
+
+    async add(input: AddTodoInput): Promise<Todo> {
+        const id = "todo_" + nanoid(8);
+        const context = await captureContext({ projectRoot: this.projectRoot });
+        const reminders = parseReminders(input.reminders ?? []);
+        const links = input.links ?? [];
+
+        let inlineContent: string | undefined;
+
+        if (input.mdFile) {
+            inlineContent = await Bun.file(input.mdFile).text();
+        }
+
+        const attachments: Todo["attachments"] = [];
+
+        if (input.attachFiles?.length) {
+            const todoAttachDir = join(this.attachmentsDir, id);
+            mkdirSync(todoAttachDir, { recursive: true });
+
+            for (const filePath of input.attachFiles) {
+                const filename = basename(filePath);
+                const storedPath = join(todoAttachDir, filename);
+                copyFileSync(filePath, storedPath);
+                attachments.push({ originalPath: filePath, storedPath, filename });
+            }
+        }
+
+        const todo: Todo = {
+            id,
+            title: input.title,
+            description: input.description,
+            status: "todo",
+            priority: input.priority ?? "medium",
+            tags: input.tags ?? [],
+            attachments,
+            inlineContent,
+            context,
+            sessionId: input.sessionId,
+            links,
+            reminders,
+        };
+
+        const todos = await this.readTodos();
+        todos.push(todo);
+        await this.writeTodos(todos);
+        await this.writeMeta(todos);
+
+        return todo;
+    }
+
+    async list(filters?: TodoFilters): Promise<Todo[]> {
+        const todos = await this.readTodos();
+
+        if (!filters) {
+            return todos;
+        }
+
+        return applyFilters(todos, filters);
+    }
+
+    async get(id: string): Promise<Todo | null> {
+        const todos = await this.readTodos();
+        return todos.find((t) => t.id === id) ?? null;
+    }
+
+    async update(id: string, patch: Partial<Todo>): Promise<Todo> {
+        const todos = await this.readTodos();
+        const index = todos.findIndex((t) => t.id === id);
+
+        if (index === -1) {
+            throw new Error(`Todo not found: ${id}`);
+        }
+
+        const existing = todos[index];
+        const updated: Todo = {
+            ...existing,
+            ...patch,
+            id: existing.id,
+            context: {
+                ...existing.context,
+                ...patch.context,
+                updatedAt: new Date().toISOString(),
+            },
+        };
+
+        todos[index] = updated;
+        await this.writeTodos(todos);
+        await this.writeMeta(todos);
+
+        return updated;
+    }
+
+    async remove(id: string): Promise<boolean> {
+        const todos = await this.readTodos();
+        const filtered = todos.filter((t) => t.id !== id);
+
+        if (filtered.length === todos.length) {
+            return false;
+        }
+
+        await this.writeTodos(filtered);
+        await this.writeMeta(filtered);
+
+        return true;
+    }
+
+    async complete(id: string, note?: string): Promise<Todo> {
+        return this.update(id, {
+            status: "done",
+            completedAt: new Date().toISOString(),
+            completionNote: note,
+        });
+    }
+
+    async search(query: string): Promise<Todo[]> {
+        const todos = await this.readTodos();
+        return applyFilters(todos, { search: query });
+    }
+
+    static async listAllProjects(storageRoot?: string): Promise<ProjectMeta[]> {
+        const root = storageRoot ?? defaultStorageRoot();
+        const projectsDir = join(root, "projects");
+
+        if (!existsSync(projectsDir)) {
+            return [];
+        }
+
+        const entries = readdirSync(projectsDir, { withFileTypes: true });
+        const projects: ProjectMeta[] = [];
+
+        for (const entry of entries) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+
+            const metaPath = join(projectsDir, entry.name, "meta.json");
+
+            if (!existsSync(metaPath)) {
+                continue;
+            }
+
+            const content = await Bun.file(metaPath).text();
+            projects.push(SafeJSON.parse(content) as ProjectMeta);
+        }
+
+        return projects;
+    }
+
+    static async listAll(filters?: TodoFilters, storageRoot?: string): Promise<Todo[]> {
+        const root = storageRoot ?? defaultStorageRoot();
+        const projectsDir = join(root, "projects");
+
+        if (!existsSync(projectsDir)) {
+            return [];
+        }
+
+        const entries = readdirSync(projectsDir, { withFileTypes: true });
+        const allTodos: Todo[] = [];
+
+        for (const entry of entries) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+
+            const todosPath = join(projectsDir, entry.name, "todos.json");
+
+            if (!existsSync(todosPath)) {
+                continue;
+            }
+
+            const content = await Bun.file(todosPath).text();
+            const todos = SafeJSON.parse(content) as Todo[];
+
+            if (filters) {
+                allTodos.push(...applyFilters(todos, filters));
+            } else {
+                allTodos.push(...todos);
+            }
+        }
+
+        return allTodos;
+    }
+}

--- a/src/todo/lib/sync.ts
+++ b/src/todo/lib/sync.ts
@@ -18,8 +18,8 @@ function syncReminderToCalendar(todo: Todo, reminder: TodoReminder): string {
 }
 
 function syncTodoToReminders(todo: Todo): string {
-    const firstReminder = todo.reminders.find((r) => !r.synced);
-    const dueDate = firstReminder ? new Date(firstReminder.at) : undefined;
+    const firstUnsynced = todo.reminders.find((r) => !r.synced);
+    const dueDate = firstUnsynced ? new Date(firstUnsynced.at) : undefined;
 
     return createReminder({
         title: todo.title,
@@ -31,16 +31,16 @@ function syncTodoToReminders(todo: Todo): string {
 
 /**
  * Sync a todo's reminders to Calendar and/or Reminders.app.
+ * Performs a single store.update at the end regardless of target.
  * Returns the number of items synced.
  */
 export async function syncTodo(options: { store: TodoStore; todo: Todo; target: SyncTarget }): Promise<number> {
     const { store, todo, target } = options;
     let totalSynced = 0;
+    let updatedReminders = [...todo.reminders];
+    let changed = false;
 
     if (target === "calendar" || target === "both") {
-        const updatedReminders = [...todo.reminders];
-        let changed = false;
-
         for (let i = 0; i < updatedReminders.length; i++) {
             const reminder = updatedReminders[i];
 
@@ -53,34 +53,32 @@ export async function syncTodo(options: { store: TodoStore; todo: Todo; target: 
             changed = true;
             totalSynced++;
         }
-
-        if (changed) {
-            await store.update(todo.id, { reminders: updatedReminders });
-        }
     }
 
     if (target === "reminders" || target === "both") {
-        const freshTodo = await store.get(todo.id);
-
-        if (!freshTodo) {
-            return totalSynced;
-        }
-
-        const alreadySynced = freshTodo.reminders.some((r) => r.synced === "reminders" && r.syncId);
+        const alreadySynced = updatedReminders.some((r) => r.synced === "reminders" && r.syncId);
 
         if (!alreadySynced) {
-            const reminderId = syncTodoToReminders(freshTodo);
-            const updatedReminders = freshTodo.reminders.map((r, i) => {
-                if (i === 0) {
-                    return { ...r, synced: "reminders" as const, syncId: reminderId };
-                }
+            const todoWithUpdatedReminders = { ...todo, reminders: updatedReminders };
+            const reminderId = syncTodoToReminders(todoWithUpdatedReminders);
 
-                return r;
-            });
+            if (updatedReminders.length > 0) {
+                updatedReminders = updatedReminders.map((r, i) => {
+                    if (i === 0) {
+                        return { ...r, synced: "reminders" as const, syncId: reminderId };
+                    }
 
-            await store.update(freshTodo.id, { reminders: updatedReminders });
+                    return r;
+                });
+            }
+
+            changed = true;
             totalSynced++;
         }
+    }
+
+    if (changed) {
+        await store.update(todo.id, { reminders: updatedReminders });
     }
 
     return totalSynced;

--- a/src/todo/lib/sync.ts
+++ b/src/todo/lib/sync.ts
@@ -1,7 +1,7 @@
-import type { Todo, TodoReminder } from "./types";
 import { createCalendarEvent } from "@app/utils/macos/apple-calendar";
 import { createReminder, todoPriorityToApple } from "@app/utils/macos/apple-reminders";
 import type { TodoStore } from "./store";
+import type { Todo, TodoReminder } from "./types";
 
 export type SyncTarget = "calendar" | "reminders" | "both";
 
@@ -33,11 +33,7 @@ function syncTodoToReminders(todo: Todo): string {
  * Sync a todo's reminders to Calendar and/or Reminders.app.
  * Returns the number of items synced.
  */
-export async function syncTodo(options: {
-    store: TodoStore;
-    todo: Todo;
-    target: SyncTarget;
-}): Promise<number> {
+export async function syncTodo(options: { store: TodoStore; todo: Todo; target: SyncTarget }): Promise<number> {
     const { store, todo, target } = options;
     let totalSynced = 0;
 

--- a/src/todo/lib/sync.ts
+++ b/src/todo/lib/sync.ts
@@ -1,0 +1,91 @@
+import type { Todo, TodoReminder } from "./types";
+import { createCalendarEvent } from "@app/utils/macos/apple-calendar";
+import { createReminder, todoPriorityToApple } from "@app/utils/macos/apple-reminders";
+import type { TodoStore } from "./store";
+
+export type SyncTarget = "calendar" | "reminders" | "both";
+
+function syncReminderToCalendar(todo: Todo, reminder: TodoReminder): string {
+    const startDate = new Date(reminder.at);
+    const label = reminder.label ?? todo.title;
+
+    return createCalendarEvent({
+        title: label,
+        notes: todo.description ?? `Todo: ${todo.id}`,
+        startDate,
+        alerts: [10],
+    });
+}
+
+function syncTodoToReminders(todo: Todo): string {
+    const firstReminder = todo.reminders.find((r) => !r.synced);
+    const dueDate = firstReminder ? new Date(firstReminder.at) : undefined;
+
+    return createReminder({
+        title: todo.title,
+        notes: todo.description ?? `Todo: ${todo.id}`,
+        dueDate,
+        priority: todoPriorityToApple(todo.priority),
+    });
+}
+
+/**
+ * Sync a todo's reminders to Calendar and/or Reminders.app.
+ * Returns the number of items synced.
+ */
+export async function syncTodo(options: {
+    store: TodoStore;
+    todo: Todo;
+    target: SyncTarget;
+}): Promise<number> {
+    const { store, todo, target } = options;
+    let totalSynced = 0;
+
+    if (target === "calendar" || target === "both") {
+        const updatedReminders = [...todo.reminders];
+        let changed = false;
+
+        for (let i = 0; i < updatedReminders.length; i++) {
+            const reminder = updatedReminders[i];
+
+            if (reminder.synced === "calendar" && reminder.syncId) {
+                continue;
+            }
+
+            const eventId = syncReminderToCalendar(todo, reminder);
+            updatedReminders[i] = { ...reminder, synced: "calendar", syncId: eventId };
+            changed = true;
+            totalSynced++;
+        }
+
+        if (changed) {
+            await store.update(todo.id, { reminders: updatedReminders });
+        }
+    }
+
+    if (target === "reminders" || target === "both") {
+        const freshTodo = await store.get(todo.id);
+
+        if (!freshTodo) {
+            return totalSynced;
+        }
+
+        const alreadySynced = freshTodo.reminders.some((r) => r.synced === "reminders" && r.syncId);
+
+        if (!alreadySynced) {
+            const reminderId = syncTodoToReminders(freshTodo);
+            const updatedReminders = freshTodo.reminders.map((r, i) => {
+                if (i === 0) {
+                    return { ...r, synced: "reminders" as const, syncId: reminderId };
+                }
+
+                return r;
+            });
+
+            await store.update(freshTodo.id, { reminders: updatedReminders });
+            totalSynced++;
+        }
+    }
+
+    return totalSynced;
+}

--- a/src/todo/lib/types.ts
+++ b/src/todo/lib/types.ts
@@ -1,0 +1,88 @@
+export interface GitContext {
+    branch: string;
+    commitSha: string;
+    commitMessage: string;
+    stagedFiles: string[];
+    unstagedFiles: string[];
+    untrackedFiles: string[];
+    remote?: string;
+}
+
+export interface TodoContext {
+    git?: GitContext;
+    cwd: string;
+    projectRoot: string;
+    hostname: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface TodoAttachment {
+    originalPath: string;
+    storedPath: string;
+    filename: string;
+    mimeType?: string;
+}
+
+export interface TodoLink {
+    type: "pr" | "issue" | "ado" | "url";
+    ref: string;
+    repo?: string;
+}
+
+export interface TodoReminder {
+    at: string;
+    label?: string;
+    synced?: "calendar" | "reminders" | null;
+    syncId?: string;
+}
+
+export type TodoStatus = "todo" | "in-progress" | "blocked" | "done";
+export type TodoPriority = "critical" | "high" | "medium" | "low";
+
+export interface Todo {
+    id: string;
+    title: string;
+    description?: string;
+    status: TodoStatus;
+    priority: TodoPriority;
+    tags: string[];
+    attachments: TodoAttachment[];
+    inlineContent?: string;
+    context: TodoContext;
+    sessionId?: string;
+    links: TodoLink[];
+    reminders: TodoReminder[];
+    completedAt?: string;
+    completionNote?: string;
+}
+
+export interface AddTodoInput {
+    title: string;
+    description?: string;
+    priority?: TodoPriority;
+    tags?: string[];
+    links?: TodoLink[];
+    reminders?: string[];
+    sessionId?: string;
+    attachFiles?: string[];
+    mdFile?: string;
+    projectRoot?: string;
+}
+
+export interface TodoFilters {
+    status?: TodoStatus[];
+    priority?: TodoPriority[];
+    tags?: string[];
+    sessionId?: string;
+    search?: string;
+}
+
+export interface ProjectMeta {
+    projectRoot: string;
+    name: string;
+    lastAccessed: string;
+    todoCount: number;
+}
+
+export type OutputFormat = "ai" | "json" | "md" | "table";

--- a/src/utils/macos/apple-calendar.ts
+++ b/src/utils/macos/apple-calendar.ts
@@ -22,11 +22,7 @@ function runJxa(script: string, timeout = 15_000): string {
 }
 
 function escapeJxa(str: string): string {
-    return str
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/\n/g, "\\n")
-        .replace(/\r/g, "\\r");
+    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
 }
 
 export function ensureCalendarExists(name: string): void {

--- a/src/utils/macos/apple-calendar.ts
+++ b/src/utils/macos/apple-calendar.ts
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+
+import { SafeJSON } from "@app/utils/json";
+
+function ensureMacOS(): void {
+    if (process.platform !== "darwin") {
+        throw new Error("Apple Calendar is only available on macOS");
+    }
+}
+
+function runJxa(script: string, timeout = 15_000): string {
+    const proc = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
+        encoding: "utf-8",
+        timeout,
+    });
+
+    if (proc.status !== 0) {
+        throw new Error(`JXA error: ${proc.stderr?.trim() || "unknown error"}`);
+    }
+
+    return proc.stdout.trim();
+}
+
+function escapeJxa(str: string): string {
+    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function ensureCalendarExists(name: string): void {
+    ensureMacOS();
+
+    const escapedName = escapeJxa(name);
+
+    const script = `
+const Calendar = Application("Calendar");
+const calendars = Calendar.calendars.whose({name: "${escapedName}"});
+if (calendars.length === 0) {
+    Calendar.Calendar({name: "${escapedName}"}).make();
+}
+"ok";
+`;
+
+    runJxa(script);
+}
+
+export function createCalendarEvent(options: {
+    title: string;
+    notes?: string;
+    startDate: Date;
+    endDate?: Date;
+    alerts?: number[];
+    calendarName?: string;
+}): string {
+    ensureMacOS();
+
+    const calendarName = options.calendarName ?? "GenesisTools";
+    const startMs = options.startDate.getTime();
+    const endMs = options.endDate?.getTime() ?? startMs + 30 * 60_000;
+    const escapedTitle = escapeJxa(options.title);
+    const escapedCalendar = escapeJxa(calendarName);
+    const escapedNotes = options.notes ? escapeJxa(options.notes) : "";
+    const alertsJson = SafeJSON.stringify(options.alerts ?? []);
+
+    const script = `
+const Calendar = Application("Calendar");
+const calendars = Calendar.calendars.whose({name: "${escapedCalendar}"});
+if (calendars.length === 0) {
+    Calendar.Calendar({name: "${escapedCalendar}"}).make();
+}
+
+const cal = Calendar.calendars.whose({name: "${escapedCalendar}"})[0];
+const event = Calendar.Event({
+    summary: "${escapedTitle}",
+    startDate: new Date(${startMs}),
+    endDate: new Date(${endMs}),
+    description: "${escapedNotes}"
+});
+cal.events.push(event);
+
+const alerts = ${alertsJson};
+for (const mins of alerts) {
+    const alarm = Calendar.DisplayAlarm({triggerInterval: -mins * 60});
+    event.displayAlarms.push(alarm);
+}
+
+event.uid();
+`;
+
+    return runJxa(script, 30_000);
+}
+
+export function deleteCalendarEvent(options: { eventId: string; calendarName?: string }): boolean {
+    ensureMacOS();
+
+    const calendarName = options.calendarName ?? "GenesisTools";
+    const escapedCalendar = escapeJxa(calendarName);
+    const escapedId = escapeJxa(options.eventId);
+
+    const script = `
+const Calendar = Application("Calendar");
+const calendars = Calendar.calendars.whose({name: "${escapedCalendar}"});
+if (calendars.length === 0) {
+    "false";
+} else {
+    const cal = calendars[0];
+    const events = cal.events.whose({uid: "${escapedId}"});
+    if (events.length === 0) {
+        "false";
+    } else {
+        Calendar.delete(events[0]);
+        "true";
+    }
+}
+`;
+
+    const result = runJxa(script, 30_000);
+    return result === "true";
+}

--- a/src/utils/macos/apple-calendar.ts
+++ b/src/utils/macos/apple-calendar.ts
@@ -22,7 +22,11 @@ function runJxa(script: string, timeout = 15_000): string {
 }
 
 function escapeJxa(str: string): string {
-    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    return str
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r");
 }
 
 export function ensureCalendarExists(name: string): void {

--- a/src/utils/macos/apple-reminders.ts
+++ b/src/utils/macos/apple-reminders.ts
@@ -79,10 +79,7 @@ reminder.id();
     return runJxa(script, 30_000);
 }
 
-export function completeReminder(options: {
-    reminderId: string;
-    listName?: string;
-}): boolean {
+export function completeReminder(options: { reminderId: string; listName?: string }): boolean {
     ensureMacOS();
 
     const listName = options.listName ?? "GenesisTools";
@@ -110,10 +107,7 @@ if (lists.length === 0) {
     return result === "true";
 }
 
-export function deleteReminder(options: {
-    reminderId: string;
-    listName?: string;
-}): boolean {
+export function deleteReminder(options: { reminderId: string; listName?: string }): boolean {
     ensureMacOS();
 
     const listName = options.listName ?? "GenesisTools";

--- a/src/utils/macos/apple-reminders.ts
+++ b/src/utils/macos/apple-reminders.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+
+function ensureMacOS(): void {
+    if (process.platform !== "darwin") {
+        throw new Error("Apple Reminders is only available on macOS");
+    }
+}
+
+function runJxa(script: string, timeout = 15_000): string {
+    const proc = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
+        encoding: "utf-8",
+        timeout,
+    });
+
+    if (proc.status !== 0) {
+        throw new Error(`JXA error: ${proc.stderr?.trim() || "unknown error"}`);
+    }
+
+    return proc.stdout.trim();
+}
+
+function escapeJxa(str: string): string {
+    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function ensureReminderListExists(name: string): void {
+    ensureMacOS();
+
+    const escapedName = escapeJxa(name);
+
+    const script = `
+const Reminders = Application("Reminders");
+const lists = Reminders.lists.whose({name: "${escapedName}"});
+if (lists.length === 0) {
+    Reminders.List({name: "${escapedName}"}).make();
+}
+"ok";
+`;
+
+    runJxa(script);
+}
+
+export function createReminder(options: {
+    title: string;
+    notes?: string;
+    dueDate?: Date;
+    priority?: number;
+    listName?: string;
+}): string {
+    ensureMacOS();
+
+    const listName = options.listName ?? "GenesisTools";
+    const escapedList = escapeJxa(listName);
+    const escapedTitle = escapeJxa(options.title);
+    const escapedNotes = options.notes ? escapeJxa(options.notes) : "";
+    const priority = options.priority ?? 0;
+    const dueDateMs = options.dueDate?.getTime();
+
+    const dueDateLine = dueDateMs != null ? `dueDate: new Date(${dueDateMs}),` : "";
+
+    const script = `
+const Reminders = Application("Reminders");
+const lists = Reminders.lists.whose({name: "${escapedList}"});
+if (lists.length === 0) {
+    Reminders.List({name: "${escapedList}"}).make();
+}
+
+const list = Reminders.lists.whose({name: "${escapedList}"})[0];
+const reminder = Reminders.Reminder({
+    name: "${escapedTitle}",
+    body: "${escapedNotes}",
+    ${dueDateLine}
+    priority: ${priority}
+});
+list.reminders.push(reminder);
+reminder.id();
+`;
+
+    return runJxa(script, 30_000);
+}
+
+export function completeReminder(options: {
+    reminderId: string;
+    listName?: string;
+}): boolean {
+    ensureMacOS();
+
+    const listName = options.listName ?? "GenesisTools";
+    const escapedList = escapeJxa(listName);
+    const escapedId = escapeJxa(options.reminderId);
+
+    const script = `
+const Reminders = Application("Reminders");
+const lists = Reminders.lists.whose({name: "${escapedList}"});
+if (lists.length === 0) {
+    "false";
+} else {
+    const list = lists[0];
+    const reminders = list.reminders.whose({id: "${escapedId}"});
+    if (reminders.length === 0) {
+        "false";
+    } else {
+        reminders[0].completed = true;
+        "true";
+    }
+}
+`;
+
+    const result = runJxa(script, 30_000);
+    return result === "true";
+}
+
+export function deleteReminder(options: {
+    reminderId: string;
+    listName?: string;
+}): boolean {
+    ensureMacOS();
+
+    const listName = options.listName ?? "GenesisTools";
+    const escapedList = escapeJxa(listName);
+    const escapedId = escapeJxa(options.reminderId);
+
+    const script = `
+const Reminders = Application("Reminders");
+const lists = Reminders.lists.whose({name: "${escapedList}"});
+if (lists.length === 0) {
+    "false";
+} else {
+    const list = lists[0];
+    const reminders = list.reminders.whose({id: "${escapedId}"});
+    if (reminders.length === 0) {
+        "false";
+    } else {
+        Reminders.delete(reminders[0]);
+        "true";
+    }
+}
+`;
+
+    const result = runJxa(script, 30_000);
+    return result === "true";
+}
+
+const PRIORITY_MAP: Record<string, number> = {
+    critical: 1,
+    high: 5,
+    medium: 9,
+    low: 0,
+};
+
+export function todoPriorityToApple(priority: "critical" | "high" | "medium" | "low"): number {
+    return PRIORITY_MAP[priority];
+}

--- a/src/utils/macos/apple-reminders.ts
+++ b/src/utils/macos/apple-reminders.ts
@@ -20,11 +20,7 @@ function runJxa(script: string, timeout = 15_000): string {
 }
 
 function escapeJxa(str: string): string {
-    return str
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/\n/g, "\\n")
-        .replace(/\r/g, "\\r");
+    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
 }
 
 export function ensureReminderListExists(name: string): void {

--- a/src/utils/macos/apple-reminders.ts
+++ b/src/utils/macos/apple-reminders.ts
@@ -20,7 +20,11 @@ function runJxa(script: string, timeout = 15_000): string {
 }
 
 function escapeJxa(str: string): string {
-    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    return str
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r");
 }
 
 export function ensureReminderListExists(name: string): void {

--- a/src/utils/macos/index.ts
+++ b/src/utils/macos/index.ts
@@ -1,3 +1,13 @@
+// Apple Calendar
+export { createCalendarEvent, deleteCalendarEvent, ensureCalendarExists } from "./apple-calendar";
+// Apple Reminders
+export {
+    completeReminder,
+    createReminder,
+    deleteReminder,
+    ensureReminderListExists,
+    todoPriorityToApple,
+} from "./apple-reminders";
 // Auth
 export { authenticate, checkBiometry } from "./auth";
 // Classification


### PR DESCRIPTION
## Summary

- Adds a new `tools todo` CLI tool — project-scoped task tracking optimized for LLM-driven workflows
- Every todo is a **context capsule**: auto-captures git state (branch, commit, staged/unstaged changes, remote), environment metadata, and session ID
- Includes Apple Calendar and Reminders integration via JXA (reusable utils in `src/utils/macos/`)

## Key Features

| Feature | Details |
|---------|---------|
| **CRUD** | `add`, `list`, `show`, `edit`, `remove`, `search` |
| **Status workflow** | `start` (in-progress), `block`, `complete` (with notes), `reopen` |
| **Auto-context** | Git branch/commit/staged/unstaged, CWD, project root, hostname, timestamp |
| **Session tracking** | `--session-id $CLAUDE_CODE_SESSION_ID` for cross-session continuity |
| **Reminders** | Relative (`24h`, `3d`, `1w`) and absolute (`2026-04-02 10:00`) |
| **External links** | `--link pr:142`, `--link issue:456`, `--link ado:78901`, GitHub URL parsing |
| **Apple sync** | `--sync-to calendar\|reminders\|both` on add/edit, or `tools todo sync` |
| **Attachments** | `--attach <file>` copies files, `--md <file>` inlines markdown content |
| **Output** | Markdown (ai/md), JSON, table — TTY gets colorized rendering via `renderMarkdownToCli` |
| **Import/Export** | `tools todo export --format json`, `tools todo import <file>` |
| **SKILL.md** | LLM integration guide at `plugins/genesis-tools/skills/todo/` |

## Architecture

- `src/todo/lib/store.ts` — `TodoStore` class as single persistence layer (future HTTP-server ready)
- `src/todo/lib/` — context capture, reminder parsing, link parsing, formatters, sync logic
- `src/todo/commands/` — thin commander wrappers calling into lib/
- `src/utils/macos/apple-calendar.ts` + `apple-reminders.ts` — reusable JXA integrations
- Storage: `~/.genesis-tools/todo/projects/<hash>/todos.json`

## Tests

80 tests across 5 files covering store CRUD, filters, search, context capture, reminder parsing, link parsing, and output formatters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-featured Todo CLI: add/list/show/edit/remove, status transitions (start/block/complete/reopen), search/filtering, import/export, and sync to Apple Calendar & Reminders; reminders, attachments, inline markdown, session-scoped workflows, and multiple output formats (ai/md/json/table)

* **Documentation**
  * Added end-user guide describing todo commands, flags, output formats, and sync usage

* **Tests**
  * Added comprehensive tests for storage, formatting, links, reminders, context capture, and CLI behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->