### PR TITLE
feat(macos): calendar/reminders CLI tools + fix todo sync bugs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@babel/core": "^7.28.6",
         "@babel/preset-typescript": "^7.28.5",
         "@clack/prompts": "^1.0.0",
-        "@genesiscz/darwinkit": "^0.2.0",
+        "@genesiscz/darwinkit": "0.6.8",
         "@gitbeaker/rest": "^43.5.0",
         "@iarna/toml": "^2.2.5",
         "@inquirer/prompts": "^8.2.0",
@@ -344,7 +344,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
-    "@genesiscz/darwinkit": ["@genesiscz/darwinkit@0.2.0", "", { "dependencies": { "tar": "^7.0.0" } }, "sha512-tB/NzXMfDB8+ZOAg2mFey2PHaGnun8B0j1YFQvqBZyQi1G38d2KcJUr5JgCusxeCnIu137J6vsQ4ja0Jr+CpAA=="],
+    "@genesiscz/darwinkit": ["@genesiscz/darwinkit@0.6.8", "", { "dependencies": { "tar": "^7.0.0" } }, "sha512-AtSLKszyqzAGHCqUpT1bRWNXT+8Uwy8fkYlyXCOugOhy2oTGyes4diOKiYA/ym0EA4ZWv6YFyVT/q6hoD/q8xw=="],
 
     "@gitbeaker/core": ["@gitbeaker/core@43.5.0", "", { "dependencies": { "@gitbeaker/requester-utils": "^43.5.0", "qs": "^6.14.0", "xcase": "^2.0.1" } }, "sha512-Lfsl6DE/2RkFvpSEhMEnN6sNuY0IeR68UEQq2qzR0MkUF1RMCmOFlD3OydnT9yY+fkWjB4FPSG4SA/oBVZYTFQ=="],
 
@@ -1948,7 +1948,7 @@
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
-    "tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
+    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
     "telegram": ["telegram@2.26.22", "", { "dependencies": { "@cryptography/aes": "^0.1.1", "async-mutex": "^0.3.0", "big-integer": "^1.6.48", "buffer": "^6.0.3", "htmlparser2": "^6.1.0", "mime": "^3.0.0", "node-localstorage": "^2.2.1", "pako": "^2.0.3", "path-browserify": "^1.0.1", "real-cancellable-promise": "^1.1.1", "socks": "^2.6.2", "store2": "^2.13.0", "ts-custom-error": "^3.2.0", "websocket": "^1.0.34" }, "optionalDependencies": { "bufferutil": "^4.0.3", "utf-8-validate": "^5.0.5" } }, "sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@babel/core": "^7.28.6",
         "@babel/preset-typescript": "^7.28.5",
         "@clack/prompts": "^1.0.0",
-        "@genesiscz/darwinkit": "^0.2.0",
+        "@genesiscz/darwinkit": "0.6.8",
         "@gitbeaker/rest": "^43.5.0",
         "@iarna/toml": "^2.2.5",
         "@inquirer/prompts": "^8.2.0",

--- a/src/macos/commands/calendar/add.ts
+++ b/src/macos/commands/calendar/add.ts
@@ -1,0 +1,56 @@
+import { parseDate } from "@app/utils/date";
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { createAlertOption } from "./format";
+
+export function registerAddCommand(program: Command): void {
+    program
+        .command("add <title>")
+        .description("Create a new calendar event")
+        .requiredOption("--start <datetime>", "Start date/time (e.g. 2026-04-10T14:00)")
+        .option("--end <datetime>", "End date/time (defaults to 30 min after start)")
+        .option("--calendar <name>", "Calendar name", "GenesisTools")
+        .option("--notes <text>", "Event notes")
+        .option("--url <url>", "Event URL")
+        .option("--location <text>", "Event location")
+        .addOption(createAlertOption())
+        .option("--all-day", "Mark as all-day event")
+        .action(
+            async (
+                title: string,
+                options: {
+                    start: string;
+                    end?: string;
+                    calendar: string;
+                    notes?: string;
+                    url?: string;
+                    location?: string;
+                    alert: number[];
+                    allDay?: boolean;
+                }
+            ) => {
+                try {
+                    const startDate = parseDate(options.start);
+                    const endDate = options.end ? parseDate(options.end) : undefined;
+
+                    const eventId = await MacCalendar.createEvent({
+                        title,
+                        startDate,
+                        endDate,
+                        calendarName: options.calendar,
+                        notes: options.notes,
+                        url: options.url,
+                        location: options.location,
+                        alerts: options.alert.length > 0 ? options.alert : undefined,
+                        isAllDay: options.allDay,
+                    });
+
+                    console.log(`${pc.green("Event created")} — ID: ${eventId}`);
+                } catch (error) {
+                    console.error(error instanceof Error ? error.message : String(error));
+                    process.exit(1);
+                }
+            }
+        );
+}

--- a/src/macos/commands/calendar/delete.ts
+++ b/src/macos/commands/calendar/delete.ts
@@ -1,0 +1,24 @@
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+export function registerDeleteCommand(program: Command): void {
+    program
+        .command("delete <event-id>")
+        .description("Delete a calendar event by its identifier")
+        .action(async (eventId: string) => {
+            try {
+                const ok = await MacCalendar.deleteEvent({ eventId });
+
+                if (ok) {
+                    console.log(`${pc.green("Event deleted")} — ID: ${eventId}`);
+                } else {
+                    console.error(`${pc.red("Failed to delete event")} — ID: ${eventId}`);
+                    process.exit(1);
+                }
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/calendar/format.ts
+++ b/src/macos/commands/calendar/format.ts
@@ -1,0 +1,52 @@
+import type { CalendarEventInfo } from "@app/utils/macos/apple-calendar";
+import { formatTable } from "@app/utils/table";
+import { Option } from "commander";
+
+export function formatDateTime(iso: string): string {
+    const d = new Date(iso);
+
+    if (Number.isNaN(d.getTime())) {
+        return "";
+    }
+
+    return d.toLocaleString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+}
+
+export function normalizeEndOfDay(date: Date): Date {
+    if (date.getHours() === 0 && date.getMinutes() === 0 && date.getSeconds() === 0) {
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
+    }
+
+    return date;
+}
+
+export function createAlertOption(): Option {
+    return new Option("--alert <minutes>", "Alert before event in minutes (repeatable)")
+        .argParser((value: string, previous: number[]) => {
+            const mins = Number(value);
+
+            if (!Number.isInteger(mins)) {
+                throw new Error(`Invalid alert value: ${value}`);
+            }
+
+            return [...(previous ?? []), mins];
+        })
+        .default([]);
+}
+
+export function formatEventsTable(events: CalendarEventInfo[]): string {
+    const rows = events.map((e) => [
+        e.title,
+        e.is_all_day ? "All day" : formatDateTime(e.start_date),
+        e.is_all_day ? "" : formatDateTime(e.end_date),
+        e.calendar_title,
+        e.location ?? "",
+    ]);
+
+    return formatTable(rows, ["Title", "Start", "End", "Calendar", "Location"]);
+}

--- a/src/macos/commands/calendar/index.ts
+++ b/src/macos/commands/calendar/index.ts
@@ -1,0 +1,21 @@
+import { Command } from "commander";
+import { registerAddCommand } from "./add";
+import { registerDeleteCommand } from "./delete";
+import { registerListCommand } from "./list";
+import { registerListCalendarsCommand } from "./list-calendars";
+import { registerSearchCommand } from "./search";
+import { registerUpdateCommand } from "./update";
+
+export function registerCalendarCommand(program: Command): void {
+    const calendar = new Command("calendar");
+    calendar.description("Manage macOS Calendar events (list, search, add, update, delete)").showHelpAfterError(true);
+
+    registerListCalendarsCommand(calendar);
+    registerListCommand(calendar);
+    registerSearchCommand(calendar);
+    registerAddCommand(calendar);
+    registerUpdateCommand(calendar);
+    registerDeleteCommand(calendar);
+
+    program.addCommand(calendar);
+}

--- a/src/macos/commands/calendar/list-calendars.ts
+++ b/src/macos/commands/calendar/list-calendars.ts
@@ -1,0 +1,33 @@
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import { formatTable } from "@app/utils/table";
+import chalk from "chalk";
+import type { Command } from "commander";
+
+export function registerListCalendarsCommand(program: Command): void {
+    program
+        .command("list-calendars")
+        .description("List all available calendars")
+        .action(async () => {
+            try {
+                const calendars = await MacCalendar.listCalendars();
+
+                if (calendars.length === 0) {
+                    console.log("No calendars found.");
+                    return;
+                }
+
+                const rows = calendars.map((cal) => [
+                    chalk.hex(cal.color)(`● ${cal.title}`),
+                    cal.source,
+                    cal.type,
+                    cal.allows_content_modifications ? chalk.green("Yes") : chalk.red("No"),
+                ]);
+
+                const table = formatTable(rows, ["Title", "Source", "Type", "Editable"]);
+                console.log(table);
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/calendar/list.ts
+++ b/src/macos/commands/calendar/list.ts
@@ -1,0 +1,65 @@
+import { parseDate } from "@app/utils/date";
+import { SafeJSON } from "@app/utils/json";
+import type { CalendarEventInfo } from "@app/utils/macos/apple-calendar";
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import { type Command, Option } from "commander";
+import { formatDateTime, formatEventsTable, normalizeEndOfDay } from "./format";
+
+interface ListOptions {
+    from?: string;
+    to?: string;
+    format?: string;
+}
+
+function formatEventsMd(events: CalendarEventInfo[]): string {
+    const lines = events.map((e) => {
+        const time = e.is_all_day ? "All day" : `${formatDateTime(e.start_date)} - ${formatDateTime(e.end_date)}`;
+        const location = e.location ? ` | ${e.location}` : "";
+        return `- **${e.title}** — ${time} [${e.calendar_title}]${location}`;
+    });
+
+    return lines.join("\n");
+}
+
+export function registerListCommand(program: Command): void {
+    program
+        .command("list [name]")
+        .description("List calendar events (optionally filtered by calendar name)")
+        .option("--from <date>", "Start date (e.g. 2026-04-01)")
+        .option("--to <date>", "End date (e.g. 2026-04-30)")
+        .addOption(
+            new Option("-f, --format <type>", "Output format: table, json, md")
+                .choices(["table", "json", "md"])
+                .default("table")
+        )
+        .action(async (name: string | undefined, options: ListOptions) => {
+            try {
+                const from = options.from ? parseDate(options.from) : undefined;
+                const to = options.to ? normalizeEndOfDay(parseDate(options.to)) : undefined;
+
+                const events = await MacCalendar.listEvents({
+                    calendarName: name,
+                    from,
+                    to,
+                });
+
+                const format = options.format ?? "table";
+
+                if (events.length === 0) {
+                    console.log(format === "json" ? "[]" : "No events found.");
+                    return;
+                }
+
+                if (format === "json") {
+                    console.log(SafeJSON.stringify(events, null, 2));
+                } else if (format === "md") {
+                    console.log(formatEventsMd(events));
+                } else {
+                    console.log(formatEventsTable(events));
+                }
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/calendar/search.ts
+++ b/src/macos/commands/calendar/search.ts
@@ -1,0 +1,41 @@
+import { parseDate } from "@app/utils/date";
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import type { Command } from "commander";
+import { formatEventsTable, normalizeEndOfDay } from "./format";
+
+interface SearchOptions {
+    calendar?: string;
+    from?: string;
+    to?: string;
+}
+
+export function registerSearchCommand(program: Command): void {
+    program
+        .command("search <query>")
+        .description("Search calendar events by title, notes, or location")
+        .option("--calendar <name>", "Filter by calendar name")
+        .option("--from <date>", "Start date (e.g. 2026-04-01)")
+        .option("--to <date>", "End date (e.g. 2026-04-30)")
+        .action(async (query: string, options: SearchOptions) => {
+            try {
+                const from = options.from ? parseDate(options.from) : undefined;
+                const to = options.to ? normalizeEndOfDay(parseDate(options.to)) : undefined;
+
+                const events = await MacCalendar.searchEvents(query, {
+                    calendarName: options.calendar,
+                    from,
+                    to,
+                });
+
+                if (events.length === 0) {
+                    console.log("No events found matching your query.");
+                    return;
+                }
+
+                console.log(formatEventsTable(events));
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/calendar/update.ts
+++ b/src/macos/commands/calendar/update.ts
@@ -1,0 +1,55 @@
+import { parseDate } from "@app/utils/date";
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { createAlertOption } from "./format";
+
+export function registerUpdateCommand(program: Command): void {
+    program
+        .command("update <event-id>")
+        .description("Update an existing calendar event")
+        .option("--title <text>", "New event title")
+        .option("--start <datetime>", "New start date/time")
+        .option("--end <datetime>", "New end date/time")
+        .option("--notes <text>", "Update event notes")
+        .option("--url <url>", "Update event URL")
+        .option("--location <text>", "Update event location")
+        .addOption(createAlertOption())
+        .option("--all-day", "Mark as all-day event")
+        .action(
+            async (
+                eventId: string,
+                options: {
+                    title?: string;
+                    start?: string;
+                    end?: string;
+                    notes?: string;
+                    url?: string;
+                    location?: string;
+                    alert: number[];
+                    allDay?: boolean;
+                }
+            ) => {
+                try {
+                    const startDate = options.start ? parseDate(options.start) : undefined;
+                    const endDate = options.end ? parseDate(options.end) : undefined;
+
+                    const updatedId = await MacCalendar.updateEvent(eventId, {
+                        title: options.title,
+                        startDate,
+                        endDate,
+                        notes: options.notes,
+                        url: options.url,
+                        location: options.location,
+                        alerts: options.alert.length > 0 ? options.alert : undefined,
+                        isAllDay: options.allDay,
+                    });
+
+                    console.log(`${pc.green("Event updated")} — ID: ${updatedId}`);
+                } catch (error) {
+                    console.error(error instanceof Error ? error.message : String(error));
+                    process.exit(1);
+                }
+            }
+        );
+}

--- a/src/macos/commands/reminders/add.ts
+++ b/src/macos/commands/reminders/add.ts
@@ -1,0 +1,54 @@
+import { parseDate } from "@app/utils/date";
+import { MacReminders, ReminderPriority } from "@app/utils/macos/apple-reminders";
+import { type Command, Option } from "commander";
+import pc from "picocolors";
+
+export function registerAddCommand(program: Command): void {
+    program
+        .command("add <title>")
+        .description("Create a new reminder")
+        .option("--list <name>", "Reminder list name", "GenesisTools")
+        .option("--due <datetime>", "Due date/time (e.g. 2026-04-10T14:00)")
+        .addOption(
+            new Option("--priority <level>", "Priority level")
+                .choices(["high", "medium", "low", "none"])
+                .default("none")
+        )
+        .option("--notes <text>", "Reminder notes")
+        .option("--url <url>", "Reminder URL")
+        .action(
+            async (
+                title: string,
+                options: {
+                    list: string;
+                    due?: string;
+                    priority: string;
+                    notes?: string;
+                    url?: string;
+                }
+            ) => {
+                try {
+                    const dueDate = options.due ? parseDate(options.due) : undefined;
+
+                    const priority =
+                        options.priority === "none"
+                            ? ReminderPriority.none
+                            : ReminderPriority[options.priority as keyof typeof ReminderPriority];
+
+                    const reminderId = await MacReminders.createReminder({
+                        title,
+                        listName: options.list,
+                        dueDate,
+                        priority,
+                        notes: options.notes,
+                        url: options.url,
+                    });
+
+                    console.log(`${pc.green("Reminder created")} — ID: ${reminderId}`);
+                } catch (error) {
+                    console.error(error instanceof Error ? error.message : String(error));
+                    process.exit(1);
+                }
+            }
+        );
+}

--- a/src/macos/commands/reminders/format.ts
+++ b/src/macos/commands/reminders/format.ts
@@ -1,0 +1,24 @@
+import type { ReminderInfo } from "@app/utils/macos/apple-reminders";
+import { formatTable } from "@app/utils/table";
+import { formatReminderPriority } from "@genesiscz/darwinkit";
+import { formatDateTime } from "../calendar/format";
+
+export function formatDueDate(iso?: string): string {
+    if (!iso) {
+        return "";
+    }
+
+    return formatDateTime(iso);
+}
+
+export function formatRemindersTable(reminders: ReminderInfo[]): string {
+    const rows = reminders.map((r) => [
+        r.title,
+        formatDueDate(r.due_date),
+        formatReminderPriority(r.priority),
+        r.is_completed ? "Yes" : "No",
+        r.list_title,
+    ]);
+
+    return formatTable(rows, ["Title", "Due Date", "Priority", "Completed", "List"]);
+}

--- a/src/macos/commands/reminders/index.ts
+++ b/src/macos/commands/reminders/index.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+import { registerAddCommand } from "./add";
+import { registerListCommand } from "./list";
+import { registerListListsCommand } from "./list-lists";
+import { registerRemoveCommand } from "./remove";
+import { registerSearchCommand } from "./search";
+
+export function registerRemindersCommand(program: Command): void {
+    const reminders = new Command("reminders");
+    reminders.description("Manage macOS Reminders (list, search, add, remove)").showHelpAfterError(true);
+
+    registerListListsCommand(reminders);
+    registerListCommand(reminders);
+    registerSearchCommand(reminders);
+    registerAddCommand(reminders);
+    registerRemoveCommand(reminders);
+
+    program.addCommand(reminders);
+}

--- a/src/macos/commands/reminders/list-lists.ts
+++ b/src/macos/commands/reminders/list-lists.ts
@@ -1,0 +1,28 @@
+import { MacReminders } from "@app/utils/macos/apple-reminders";
+import { formatTable } from "@app/utils/table";
+import chalk from "chalk";
+import type { Command } from "commander";
+
+export function registerListListsCommand(program: Command): void {
+    program
+        .command("list-lists")
+        .description("List all available reminder lists")
+        .action(async () => {
+            try {
+                const lists = await MacReminders.listLists();
+
+                if (lists.length === 0) {
+                    console.log("No reminder lists found.");
+                    return;
+                }
+
+                const rows = lists.map((list) => [chalk.hex(list.color)(`● ${list.title}`), list.source]);
+
+                const table = formatTable(rows, ["Title", "Source"]);
+                console.log(table);
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/reminders/list.ts
+++ b/src/macos/commands/reminders/list.ts
@@ -1,0 +1,42 @@
+import { SafeJSON } from "@app/utils/json";
+import { MacReminders } from "@app/utils/macos/apple-reminders";
+import { type Command, Option } from "commander";
+import { formatRemindersTable } from "./format";
+
+interface ListOptions {
+    includeCompleted?: boolean;
+    format?: string;
+}
+
+export function registerListCommand(program: Command): void {
+    program
+        .command("list [name]")
+        .description("List reminders (optionally filtered by list name)")
+        .option("--include-completed", "Include completed reminders")
+        .addOption(
+            new Option("-f, --format <type>", "Output format: table, json").choices(["table", "json"]).default("table")
+        )
+        .action(async (name: string | undefined, options: ListOptions) => {
+            try {
+                const reminders = await MacReminders.listReminders(name, {
+                    includeCompleted: options.includeCompleted,
+                });
+
+                if (reminders.length === 0) {
+                    console.log("No reminders found.");
+                    return;
+                }
+
+                const format = options.format ?? "table";
+
+                if (format === "json") {
+                    console.log(SafeJSON.stringify(reminders, null, 2));
+                } else {
+                    console.log(formatRemindersTable(reminders));
+                }
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/reminders/remove.ts
+++ b/src/macos/commands/reminders/remove.ts
@@ -1,0 +1,46 @@
+import { MacReminders } from "@app/utils/macos/apple-reminders";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+interface RemoveOptions {
+    complete?: boolean;
+}
+
+export function registerRemoveCommand(program: Command): void {
+    program
+        .command("remove <id>")
+        .description("Remove a reminder (or mark it as complete)")
+        .option("--complete", "Mark as complete instead of deleting")
+        .action(async (id: string, options: RemoveOptions) => {
+            try {
+                if (options.complete) {
+                    const ok = await MacReminders.completeReminder({
+                        reminderId: id,
+                    });
+
+                    if (ok) {
+                        console.log(`${pc.green("Reminder completed")} — ID: ${id}`);
+                    } else {
+                        console.error(`${pc.red("Failed to complete reminder")} — ID: ${id}`);
+                        process.exit(1);
+                    }
+
+                    return;
+                }
+
+                const ok = await MacReminders.deleteReminder({
+                    reminderId: id,
+                });
+
+                if (ok) {
+                    console.log(`${pc.green("Reminder deleted")} — ID: ${id}`);
+                } else {
+                    console.error(`${pc.red("Failed to delete reminder")} — ID: ${id}`);
+                    process.exit(1);
+                }
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/commands/reminders/search.ts
+++ b/src/macos/commands/reminders/search.ts
@@ -1,0 +1,29 @@
+import { MacReminders } from "@app/utils/macos/apple-reminders";
+import type { Command } from "commander";
+import { formatRemindersTable } from "./format";
+
+interface SearchOptions {
+    list?: string;
+}
+
+export function registerSearchCommand(program: Command): void {
+    program
+        .command("search <query>")
+        .description("Search reminders by title or notes")
+        .option("--list <name>", "Filter by reminder list name")
+        .action(async (query: string, options: SearchOptions) => {
+            try {
+                const reminders = await MacReminders.searchReminders(query, options.list);
+
+                if (reminders.length === 0) {
+                    console.log("No reminders found matching your query.");
+                    return;
+                }
+
+                console.log(formatRemindersTable(reminders));
+            } catch (error) {
+                console.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/macos/index.ts
+++ b/src/macos/index.ts
@@ -16,15 +16,30 @@
  *   tools macos voice-memos transcribe [id] [--all] [--force]
  *   tools macos voice-memos search <query>
  *
+ *   tools macos calendar list-calendars
+ *   tools macos calendar list [name] [--from/--to]
+ *   tools macos calendar search <query>
+ *   tools macos calendar add <title> --start <datetime>
+ *   tools macos calendar update <event-id> [options]
+ *   tools macos calendar delete <event-id>
+ *
+ *   tools macos reminders list-lists
+ *   tools macos reminders list [name] [--include-completed]
+ *   tools macos reminders search <query> [--list <name>]
+ *   tools macos reminders add <title> [--list/--due/--priority/--notes/--url]
+ *   tools macos reminders remove <id> [--complete]
+ *
  * Future subcommands:
- *   tools macos calendar events
  *   tools macos contacts search
  */
 
 import logger from "@app/logger";
+import { registerCalendarCommand } from "@app/macos/commands/calendar/index";
 import { registerMailCommand } from "@app/macos/commands/mail/index";
+import { registerRemindersCommand } from "@app/macos/commands/reminders/index";
 import { registerSleepCommand } from "@app/macos/commands/sleep/index";
 import { registerVoiceMemosCommand } from "@app/macos/commands/voice-memos/index";
+import { closeDarwinKit } from "@app/utils/macos/darwinkit";
 import { Command } from "commander";
 
 const program = new Command();
@@ -35,7 +50,9 @@ program
     .version("1.0.0")
     .showHelpAfterError(true);
 
+registerCalendarCommand(program);
 registerMailCommand(program);
+registerRemindersCommand(program);
 registerSleepCommand(program);
 registerVoiceMemosCommand(program);
 
@@ -54,6 +71,8 @@ async function main(): Promise<void> {
         }
 
         process.exit(1);
+    } finally {
+        closeDarwinKit();
     }
 }
 

--- a/src/todo/commands/add.ts
+++ b/src/todo/commands/add.ts
@@ -1,6 +1,7 @@
 import { findProjectRoot } from "@app/todo/lib/context";
 import { formatTodo } from "@app/todo/lib/format";
 import { parseLinks } from "@app/todo/lib/links";
+import { parseReminderTime } from "@app/todo/lib/reminders";
 import { TodoStore } from "@app/todo/lib/store";
 import { type SyncTarget, syncTodo } from "@app/todo/lib/sync";
 import type { OutputFormat, TodoPriority } from "@app/todo/lib/types";
@@ -39,6 +40,7 @@ export function createAddCommand(): Command {
         .option("-p, --priority <priority>", "Priority: critical|high|medium|low")
         .option("-t, --tag <tags>", "Comma-separated tags")
         .option("-r, --reminder <time>", "Reminder time (repeatable)", collect, [])
+        .option("--at <datetime>", "Event time for calendar sync (ISO datetime or relative like '3h')")
         .option("-l, --link <link>", "Link (repeatable): pr:123, issue:456, ado:789, URL", collect, [])
         .option("-s, --session-id <id>", "Session ID for tracking")
         .option("-a, --attach <path>", "File path to attach (repeatable)", collect, [])
@@ -132,6 +134,8 @@ export function createAddCommand(): Command {
             const links = linkInputs.length > 0 ? parseLinks(linkInputs) : undefined;
             const attachFiles = parseVariadic(opts.attach);
 
+            const at = opts.at ? parseReminderTime(opts.at) : undefined;
+
             const todo = await store.add({
                 title: title!,
                 description,
@@ -139,6 +143,7 @@ export function createAddCommand(): Command {
                 tags,
                 links,
                 reminders: reminders.length > 0 ? reminders : undefined,
+                at,
                 sessionId: opts.sessionId,
                 attachFiles: attachFiles.length > 0 ? attachFiles : undefined,
                 mdFile: opts.md,

--- a/src/todo/commands/edit.ts
+++ b/src/todo/commands/edit.ts
@@ -31,6 +31,7 @@ export function createEditCommand(): Command {
         .option("--add-tag <tags>", "Add tags (comma-separated)")
         .option("--remove-tag <tags>", "Remove tags (comma-separated)")
         .option("--add-reminder <time>", "Add a reminder", collect, [])
+        .option("--at <datetime>", "Set event time for calendar sync")
         .option("--add-link <link>", "Add a link", collect, [])
         .option("--session-id <id>", "Set session ID")
         .addOption(new Option("--sync-to <target>", "Auto-sync reminders").choices(["calendar", "reminders", "both"]))
@@ -62,6 +63,10 @@ export function createEditCommand(): Command {
 
             if (opts.sessionId) {
                 patch.sessionId = opts.sessionId;
+            }
+
+            if (opts.at) {
+                patch.at = parseReminderTime(opts.at);
             }
 
             if (opts.addTag || opts.removeTag) {

--- a/src/todo/lib/__tests__/store.test.ts
+++ b/src/todo/lib/__tests__/store.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { TodoStore } from "../store";
 import type { Todo } from "../types";
 
-const TEST_DIR = join(import.meta.dir, ".test-store-" + Date.now());
+const TEST_DIR = join(import.meta.dir, `.test-store-${Date.now()}`);
 
 let store: TodoStore;
 

--- a/src/todo/lib/store.ts
+++ b/src/todo/lib/store.ts
@@ -101,7 +101,7 @@ export class TodoStore {
     }
 
     async add(input: AddTodoInput): Promise<Todo> {
-        const id = "todo_" + nanoid(8);
+        const id = `todo_${nanoid(8)}`;
         const context = await captureContext({ projectRoot: this.projectRoot });
         const reminders = parseReminders(input.reminders ?? []);
         const links = input.links ?? [];
@@ -139,6 +139,7 @@ export class TodoStore {
             sessionId: input.sessionId,
             links,
             reminders,
+            at: input.at,
         };
 
         const todos = await this.readTodos();

--- a/src/todo/lib/sync.ts
+++ b/src/todo/lib/sync.ts
@@ -1,36 +1,98 @@
-import { createCalendarEvent } from "@app/utils/macos/apple-calendar";
-import { createReminder, todoPriorityToApple } from "@app/utils/macos/apple-reminders";
+import { MacCalendar } from "@app/utils/macos/apple-calendar";
+import { MacReminders, todoPriorityToApple } from "@app/utils/macos/apple-reminders";
 import type { TodoStore } from "./store";
-import type { Todo, TodoReminder } from "./types";
+import type { Todo, TodoLink, TodoReminder } from "./types";
 
 export type SyncTarget = "calendar" | "reminders" | "both";
 
-function syncReminderToCalendar(todo: Todo, reminder: TodoReminder): string {
-    const startDate = new Date(reminder.at);
-    const label = reminder.label ?? todo.title;
-
-    return createCalendarEvent({
-        title: label,
-        notes: todo.description ?? `Todo: ${todo.id}`,
-        startDate,
-        alerts: [10],
+/**
+ * Compute alert offsets in minutes from event start for each reminder.
+ * E.g. if event is at 21:00 and reminders are at 20:00, 20:30, 20:55,
+ * returns [60, 30, 5].
+ */
+function computeAlertOffsets(eventStartMs: number, reminders: TodoReminder[]): number[] {
+    return reminders.map((r) => {
+        const diffMinutes = Math.round((eventStartMs - new Date(r.at).getTime()) / 60_000);
+        return Math.max(0, diffMinutes);
     });
 }
 
-function syncTodoToReminders(todo: Todo): string {
+/**
+ * Extract the first URL from a todo's links array.
+ * Prefers explicit URL links, falls back to GitHub PR/issue URLs.
+ */
+function extractUrl(links: TodoLink[]): string | undefined {
+    const urlLink = links.find((l) => l.type === "url");
+
+    if (urlLink) {
+        return urlLink.ref;
+    }
+
+    const prLink = links.find((l) => l.type === "pr");
+
+    if (prLink?.repo) {
+        return `https://github.com/${prLink.repo}/pull/${prLink.ref}`;
+    }
+
+    const issueLink = links.find((l) => l.type === "issue");
+
+    if (issueLink?.repo) {
+        return `https://github.com/${issueLink.repo}/issues/${issueLink.ref}`;
+    }
+
+    return undefined;
+}
+
+/**
+ * Sync a todo to Calendar: creates ONE event with multiple alerts.
+ * Uses todo.at as event start time, or falls back to the latest reminder time.
+ * Returns the event identifier.
+ */
+async function syncTodoToCalendar(todo: Todo): Promise<string> {
+    if (!todo.at && todo.reminders.length === 0) {
+        throw new Error("Cannot sync to calendar: no event time (--at) or reminders specified");
+    }
+
+    const eventStartMs = todo.at
+        ? new Date(todo.at).getTime()
+        : Math.max(...todo.reminders.map((r) => new Date(r.at).getTime()));
+
+    const eventStart = new Date(eventStartMs);
+    const alerts = computeAlertOffsets(eventStartMs, todo.reminders);
+    const url = extractUrl(todo.links);
+
+    return MacCalendar.createEvent({
+        title: todo.title,
+        notes: todo.description ?? `Todo: ${todo.id}`,
+        startDate: eventStart,
+        alerts,
+        url,
+    });
+}
+
+/**
+ * Sync a todo to Reminders: creates ONE reminder entry.
+ * Uses the first reminder's time as the due date.
+ * Returns the reminder identifier.
+ */
+async function syncTodoToReminders(todo: Todo): Promise<string> {
     const firstUnsynced = todo.reminders.find((r) => !r.synced);
     const dueDate = firstUnsynced ? new Date(firstUnsynced.at) : undefined;
+    const url = extractUrl(todo.links);
 
-    return createReminder({
+    return MacReminders.createReminder({
         title: todo.title,
         notes: todo.description ?? `Todo: ${todo.id}`,
         dueDate,
         priority: todoPriorityToApple(todo.priority),
+        url,
     });
 }
 
 /**
  * Sync a todo's reminders to Calendar and/or Reminders.app.
+ * Calendar: creates ONE event with all reminders as alert offsets.
+ * Reminders: creates ONE reminder entry.
  * Performs a single store.update at the end regardless of target.
  * Returns the number of items synced.
  */
@@ -41,15 +103,16 @@ export async function syncTodo(options: { store: TodoStore; todo: Todo; target: 
     let changed = false;
 
     if (target === "calendar" || target === "both") {
-        for (let i = 0; i < updatedReminders.length; i++) {
-            const reminder = updatedReminders[i];
+        const alreadySynced = updatedReminders.some((r) => r.synced === "calendar" && r.syncId);
 
-            if (reminder.synced === "calendar" && reminder.syncId) {
-                continue;
-            }
+        if (!alreadySynced && updatedReminders.length > 0) {
+            const eventId = await syncTodoToCalendar(todo);
 
-            const eventId = syncReminderToCalendar(todo, reminder);
-            updatedReminders[i] = { ...reminder, synced: "calendar", syncId: eventId };
+            updatedReminders = updatedReminders.map((r) => ({
+                ...r,
+                synced: "calendar" as const,
+                syncId: eventId,
+            }));
             changed = true;
             totalSynced++;
         }
@@ -59,8 +122,7 @@ export async function syncTodo(options: { store: TodoStore; todo: Todo; target: 
         const alreadySynced = updatedReminders.some((r) => r.synced === "reminders" && r.syncId);
 
         if (!alreadySynced) {
-            const todoWithUpdatedReminders = { ...todo, reminders: updatedReminders };
-            const reminderId = syncTodoToReminders(todoWithUpdatedReminders);
+            const reminderId = await syncTodoToReminders({ ...todo, reminders: updatedReminders });
 
             if (updatedReminders.length > 0) {
                 updatedReminders = updatedReminders.map((r, i) => {

--- a/src/todo/lib/types.ts
+++ b/src/todo/lib/types.ts
@@ -53,6 +53,7 @@ export interface Todo {
     sessionId?: string;
     links: TodoLink[];
     reminders: TodoReminder[];
+    at?: string;
     completedAt?: string;
     completionNote?: string;
 }
@@ -64,6 +65,7 @@ export interface AddTodoInput {
     tags?: string[];
     links?: TodoLink[];
     reminders?: string[];
+    at?: string;
     sessionId?: string;
     attachFiles?: string[];
     mdFile?: string;

--- a/src/utils/macos/apple-calendar.ts
+++ b/src/utils/macos/apple-calendar.ts
@@ -1,117 +1,215 @@
-import { spawnSync } from "node:child_process";
+import type { CalendarEventInfo, CalendarInfo, SourceInfo } from "@genesiscz/darwinkit";
 
-import { SafeJSON } from "@app/utils/json";
+import { getDarwinKit } from "./darwinkit";
 
-function ensureMacOS(): void {
-    if (process.platform !== "darwin") {
-        throw new Error("Apple Calendar is only available on macOS");
-    }
-}
+export type { CalendarEventInfo, CalendarInfo, SourceInfo };
 
-function runJxa(script: string, timeout = 15_000): string {
-    const proc = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
-        encoding: "utf-8",
-        timeout,
-    });
-
-    if (proc.status !== 0) {
-        throw new Error(`JXA error: ${proc.stderr?.trim() || "unknown error"}`);
-    }
-
-    return proc.stdout.trim();
-}
-
-function escapeJxa(str: string): string {
-    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
-}
-
-export function ensureCalendarExists(name: string): void {
-    ensureMacOS();
-
-    const escapedName = escapeJxa(name);
-
-    const script = `
-const Calendar = Application("Calendar");
-const calendars = Calendar.calendars.whose({name: "${escapedName}"});
-if (calendars.length === 0) {
-    Calendar.Calendar({name: "${escapedName}"}).make();
-}
-"ok";
-`;
-
-    runJxa(script);
-}
-
-export function createCalendarEvent(options: {
+export interface CreateEventOptions {
     title: string;
     notes?: string;
     startDate: Date;
     endDate?: Date;
     alerts?: number[];
+    url?: string;
+    location?: string;
+    isAllDay?: boolean;
+    availability?: "free" | "busy" | "tentative" | "unavailable";
     calendarName?: string;
-}): string {
-    ensureMacOS();
-
-    const calendarName = options.calendarName ?? "GenesisTools";
-    const startMs = options.startDate.getTime();
-    const endMs = options.endDate?.getTime() ?? startMs + 30 * 60_000;
-    const escapedTitle = escapeJxa(options.title);
-    const escapedCalendar = escapeJxa(calendarName);
-    const escapedNotes = options.notes ? escapeJxa(options.notes) : "";
-    const alertsJson = SafeJSON.stringify(options.alerts ?? []);
-
-    const script = `
-const Calendar = Application("Calendar");
-const calendars = Calendar.calendars.whose({name: "${escapedCalendar}"});
-if (calendars.length === 0) {
-    Calendar.Calendar({name: "${escapedCalendar}"}).make();
 }
 
-const cal = Calendar.calendars.whose({name: "${escapedCalendar}"})[0];
-const event = Calendar.Event({
-    summary: "${escapedTitle}",
-    startDate: new Date(${startMs}),
-    endDate: new Date(${endMs}),
-    description: "${escapedNotes}"
-});
-cal.events.push(event);
-
-const alerts = ${alertsJson};
-for (const mins of alerts) {
-    const alarm = Calendar.DisplayAlarm({triggerInterval: -mins * 60});
-    event.displayAlarms.push(alarm);
+export interface UpdateEventOptions {
+    title?: string;
+    notes?: string;
+    startDate?: Date;
+    endDate?: Date;
+    alerts?: number[];
+    url?: string;
+    location?: string;
+    isAllDay?: boolean;
+    availability?: "free" | "busy" | "tentative" | "unavailable";
 }
 
-event.uid();
-`;
+export class MacCalendar {
+    static async ensureAuthorized(): Promise<void> {
+        const dk = getDarwinKit();
+        const auth = await dk.calendar.authorized();
 
-    return runJxa(script, 30_000);
-}
-
-export function deleteCalendarEvent(options: { eventId: string; calendarName?: string }): boolean {
-    ensureMacOS();
-
-    const calendarName = options.calendarName ?? "GenesisTools";
-    const escapedCalendar = escapeJxa(calendarName);
-    const escapedId = escapeJxa(options.eventId);
-
-    const script = `
-const Calendar = Application("Calendar");
-const calendars = Calendar.calendars.whose({name: "${escapedCalendar}"});
-if (calendars.length === 0) {
-    "false";
-} else {
-    const cal = calendars[0];
-    const events = cal.events.whose({uid: "${escapedId}"});
-    if (events.length === 0) {
-        "false";
-    } else {
-        Calendar.delete(events[0]);
-        "true";
+        if (!auth.authorized && auth.status !== "writeOnly") {
+            throw new Error(
+                `Calendar access not authorized (status: ${auth.status}). Grant at least write access in System Settings > Privacy & Security > Calendars.`
+            );
+        }
     }
-}
-`;
 
-    const result = runJxa(script, 30_000);
-    return result === "true";
+    static async listCalendars(): Promise<CalendarInfo[]> {
+        const dk = getDarwinKit();
+        const result = await dk.calendar.calendars();
+        return result.calendars;
+    }
+
+    static async listEvents(options: { calendarName?: string; from?: Date; to?: Date }): Promise<CalendarEventInfo[]> {
+        const dk = getDarwinKit();
+        const from = options.from ?? new Date();
+        const to = options.to ?? new Date(from.getTime() + 30 * 24 * 60 * 60_000);
+
+        let calendarIdentifiers: string[] | undefined;
+
+        if (options.calendarName) {
+            const calendars = await MacCalendar.listCalendars();
+            const filtered = calendars.filter((c) => c.title === options.calendarName);
+
+            if (filtered.length === 0) {
+                throw new Error(`Calendar not found: "${options.calendarName}"`);
+            }
+
+            if (filtered.length > 1) {
+                throw new Error(
+                    `Multiple calendars found with name "${options.calendarName}". Please use a unique calendar name.`
+                );
+            }
+
+            calendarIdentifiers = [filtered[0].identifier];
+        }
+
+        const result = await dk.calendar.events({
+            start_date: from.toISOString(),
+            end_date: to.toISOString(),
+            calendar_identifiers: calendarIdentifiers,
+        });
+        return result.events;
+    }
+
+    static async searchEvents(
+        query: string,
+        options?: { calendarName?: string; from?: Date; to?: Date }
+    ): Promise<CalendarEventInfo[]> {
+        const events = await MacCalendar.listEvents(options ?? {});
+        const q = query.toLowerCase();
+        return events.filter(
+            (e) =>
+                e.title.toLowerCase().includes(q) ||
+                e.notes?.toLowerCase().includes(q) ||
+                e.location?.toLowerCase().includes(q)
+        );
+    }
+
+    static async createEvent(options: CreateEventOptions): Promise<string> {
+        const dk = getDarwinKit();
+        const calendarId = await MacCalendar.ensureCalendarExists(options.calendarName ?? "GenesisTools");
+        let startDate = options.startDate;
+        let endDate = options.endDate ?? new Date(startDate.getTime() + 30 * 60_000);
+
+        if (options.isAllDay) {
+            startDate = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+            endDate = new Date(startDate.getTime() + 24 * 60 * 60_000);
+        }
+
+        if (endDate.getTime() < startDate.getTime()) {
+            throw new Error("Event end date must be on or after the start date");
+        }
+
+        const result = await dk.calendar.saveEvent({
+            calendar_identifier: calendarId,
+            title: options.title,
+            start_date: startDate.toISOString(),
+            end_date: endDate.toISOString(),
+            notes: options.notes,
+            location: options.location,
+            url: options.url,
+            is_all_day: options.isAllDay,
+            availability: options.availability,
+            alarms: options.alerts,
+        });
+
+        if (!result.success || !result.identifier) {
+            throw new Error(`Failed to create event: ${result.error ?? "unknown error"}`);
+        }
+
+        return result.identifier;
+    }
+
+    static async updateEvent(eventId: string, options: UpdateEventOptions): Promise<string> {
+        const dk = getDarwinKit();
+        const existing = await dk.calendar.event({ identifier: eventId });
+
+        if (!existing || !existing.identifier) {
+            throw new Error(`Event not found: ${eventId}`);
+        }
+
+        const startDate = options.startDate ?? new Date(existing.start_date);
+        const endDate = options.endDate ?? new Date(existing.end_date);
+
+        if (endDate.getTime() < startDate.getTime()) {
+            throw new Error("Event end date must be on or after the start date");
+        }
+
+        const result = await dk.calendar.saveEvent({
+            id: eventId,
+            calendar_identifier: existing.calendar_identifier,
+            title: options.title ?? existing.title,
+            start_date: startDate.toISOString(),
+            end_date: endDate.toISOString(),
+            notes: options.notes ?? existing.notes,
+            location: options.location ?? existing.location,
+            url: options.url ?? existing.url,
+            is_all_day: options.isAllDay ?? existing.is_all_day,
+            availability: options.availability ?? existing.availability,
+            alarms: options.alerts ?? existing.alarms,
+        });
+
+        if (!result.success || !result.identifier) {
+            throw new Error(`Failed to update event: ${result.error ?? "unknown error"}`);
+        }
+
+        return result.identifier;
+    }
+
+    static async deleteEvent(options: { eventId: string }): Promise<boolean> {
+        const dk = getDarwinKit();
+        const result = await dk.calendar.removeEvent({
+            identifier: options.eventId,
+        });
+        return result.ok;
+    }
+
+    static async getSources(): Promise<SourceInfo[]> {
+        const dk = getDarwinKit();
+        const result = await dk.calendar.sources();
+        return result.sources;
+    }
+
+    static async ensureCalendarExists(name: string, calendars?: CalendarInfo[]): Promise<string> {
+        const allCalendars = calendars ?? (await MacCalendar.listCalendars());
+        const filtered = allCalendars.filter((c) => c.title === name);
+
+        if (filtered.length > 1) {
+            throw new Error(`Multiple calendars found with name "${name}". Please use a unique calendar name.`);
+        }
+
+        if (filtered.length === 1) {
+            return filtered[0].identifier;
+        }
+
+        const sources = await MacCalendar.getSources();
+        const icloudSource =
+            sources.find((s) => s.title.toLowerCase().includes("icloud")) ??
+            sources.find((s) => s.source_type === "calDAV");
+        const sourceId = icloudSource?.identifier ?? sources[0]?.identifier;
+
+        if (!sourceId) {
+            throw new Error("No calendar source available");
+        }
+
+        const dk = getDarwinKit();
+        const result = await dk.calendar.saveCalendar({
+            title: name,
+            source_identifier: sourceId,
+        });
+
+        if (!result.success || !result.identifier) {
+            throw new Error(`Failed to create calendar "${name}": ${result.error ?? "unknown error"}`);
+        }
+
+        return result.identifier;
+    }
 }

--- a/src/utils/macos/apple-notes.ts
+++ b/src/utils/macos/apple-notes.ts
@@ -3,35 +3,17 @@
  * macOS only — uses osascript to interact with the Notes app.
  */
 
-import { spawnSync } from "node:child_process";
 import { unlinkSync, writeFileSync } from "node:fs";
 
 import { SafeJSON } from "@app/utils/json";
+
+import { ensureMacOS, escapeJxa, runJxa } from "./jxa";
 
 export interface AppleNotesFolder {
     name: string;
     id: string;
     noteCount: number;
     account: string;
-}
-
-function ensureMacOS(): void {
-    if (process.platform !== "darwin") {
-        throw new Error("Apple Notes is only available on macOS");
-    }
-}
-
-function runJxa(script: string, timeout = 15_000): string {
-    const proc = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
-        encoding: "utf-8",
-        timeout,
-    });
-
-    if (proc.status !== 0) {
-        throw new Error(`JXA error: ${proc.stderr?.trim() || "unknown error"}`);
-    }
-
-    return proc.stdout.trim();
 }
 
 /**
@@ -72,8 +54,8 @@ export function createAppleNote(options: { folderId: string; title: string; body
     const tmpFile = `/tmp/apple-note-${Date.now()}.txt`;
     writeFileSync(tmpFile, options.body, "utf-8");
 
-    const escapedTitle = options.title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    const escapedFolderId = options.folderId.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const escapedTitle = escapeJxa(options.title);
+    const escapedFolderId = escapeJxa(options.folderId);
 
     const script = `
 ObjC.import("Foundation");

--- a/src/utils/macos/apple-reminders.ts
+++ b/src/utils/macos/apple-reminders.ts
@@ -1,147 +1,130 @@
-import { spawnSync } from "node:child_process";
+import logger from "@app/logger";
+import type { ReminderInfo, ReminderListInfo } from "@genesiscz/darwinkit";
+import { ReminderPriority } from "@genesiscz/darwinkit";
+import { getDarwinKit } from "./darwinkit";
 
-function ensureMacOS(): void {
-    if (process.platform !== "darwin") {
-        throw new Error("Apple Reminders is only available on macOS");
-    }
-}
-
-function runJxa(script: string, timeout = 15_000): string {
-    const proc = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
-        encoding: "utf-8",
-        timeout,
-    });
-
-    if (proc.status !== 0) {
-        throw new Error(`JXA error: ${proc.stderr?.trim() || "unknown error"}`);
-    }
-
-    return proc.stdout.trim();
-}
-
-function escapeJxa(str: string): string {
-    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
-}
-
-export function ensureReminderListExists(name: string): void {
-    ensureMacOS();
-
-    const escapedName = escapeJxa(name);
-
-    const script = `
-const Reminders = Application("Reminders");
-const lists = Reminders.lists.whose({name: "${escapedName}"});
-if (lists.length === 0) {
-    Reminders.List({name: "${escapedName}"}).make();
-}
-"ok";
-`;
-
-    runJxa(script);
-}
-
-export function createReminder(options: {
-    title: string;
-    notes?: string;
-    dueDate?: Date;
-    priority?: number;
-    listName?: string;
-}): string {
-    ensureMacOS();
-
-    const listName = options.listName ?? "GenesisTools";
-    const escapedList = escapeJxa(listName);
-    const escapedTitle = escapeJxa(options.title);
-    const escapedNotes = options.notes ? escapeJxa(options.notes) : "";
-    const priority = options.priority ?? 0;
-    const dueDateMs = options.dueDate?.getTime();
-
-    const dueDateLine = dueDateMs != null ? `dueDate: new Date(${dueDateMs}),` : "";
-
-    const script = `
-const Reminders = Application("Reminders");
-const lists = Reminders.lists.whose({name: "${escapedList}"});
-if (lists.length === 0) {
-    Reminders.List({name: "${escapedList}"}).make();
-}
-
-const list = Reminders.lists.whose({name: "${escapedList}"})[0];
-const reminder = Reminders.Reminder({
-    name: "${escapedTitle}",
-    body: "${escapedNotes}",
-    ${dueDateLine}
-    priority: ${priority}
-});
-list.reminders.push(reminder);
-reminder.id();
-`;
-
-    return runJxa(script, 30_000);
-}
-
-export function completeReminder(options: { reminderId: string; listName?: string }): boolean {
-    ensureMacOS();
-
-    const listName = options.listName ?? "GenesisTools";
-    const escapedList = escapeJxa(listName);
-    const escapedId = escapeJxa(options.reminderId);
-
-    const script = `
-const Reminders = Application("Reminders");
-const lists = Reminders.lists.whose({name: "${escapedList}"});
-if (lists.length === 0) {
-    "false";
-} else {
-    const list = lists[0];
-    const reminders = list.reminders.whose({id: "${escapedId}"});
-    if (reminders.length === 0) {
-        "false";
-    } else {
-        reminders[0].completed = true;
-        "true";
-    }
-}
-`;
-
-    const result = runJxa(script, 30_000);
-    return result === "true";
-}
-
-export function deleteReminder(options: { reminderId: string; listName?: string }): boolean {
-    ensureMacOS();
-
-    const listName = options.listName ?? "GenesisTools";
-    const escapedList = escapeJxa(listName);
-    const escapedId = escapeJxa(options.reminderId);
-
-    const script = `
-const Reminders = Application("Reminders");
-const lists = Reminders.lists.whose({name: "${escapedList}"});
-if (lists.length === 0) {
-    "false";
-} else {
-    const list = lists[0];
-    const reminders = list.reminders.whose({id: "${escapedId}"});
-    if (reminders.length === 0) {
-        "false";
-    } else {
-        Reminders.delete(reminders[0]);
-        "true";
-    }
-}
-`;
-
-    const result = runJxa(script, 30_000);
-    return result === "true";
-}
-
-const PRIORITY_MAP: Record<string, number> = {
-    critical: 1,
-    high: 5,
-    medium: 9,
-    low: 0,
-};
+export type { ReminderInfo, ReminderListInfo };
+export { ReminderPriority };
 
 export function todoPriorityToApple(priority: "critical" | "high" | "medium" | "low"): number {
-    return PRIORITY_MAP[priority];
+    return ReminderPriority[priority === "critical" ? "high" : priority];
+}
+
+export class MacReminders {
+    static async ensureAuthorized(): Promise<void> {
+        const dk = getDarwinKit();
+        const auth = await dk.reminders.authorized();
+
+        if (!auth.authorized) {
+            throw new Error(
+                `Reminders access not authorized (status: ${auth.status}). Grant access in System Settings > Privacy & Security > Reminders.`
+            );
+        }
+    }
+
+    static async listLists(): Promise<ReminderListInfo[]> {
+        const dk = getDarwinKit();
+        const result = await dk.reminders.lists();
+        return result.lists;
+    }
+
+    static async listReminders(listName?: string, options?: { includeCompleted?: boolean }): Promise<ReminderInfo[]> {
+        const dk = getDarwinKit();
+        let listIdentifiers: string[] | undefined;
+
+        if (listName) {
+            const lists = await MacReminders.listLists();
+            const match = lists.find((l) => l.title === listName);
+
+            if (!match) {
+                return [];
+            }
+
+            listIdentifiers = [match.identifier];
+        }
+
+        if (options?.includeCompleted) {
+            const result = await dk.reminders.items({
+                list_identifiers: listIdentifiers,
+            });
+            return result.reminders;
+        }
+
+        const result = await dk.reminders.incomplete({
+            list_identifiers: listIdentifiers,
+        });
+        return result.reminders;
+    }
+
+    static async searchReminders(query: string, listName?: string): Promise<ReminderInfo[]> {
+        const reminders = await MacReminders.listReminders(listName, { includeCompleted: true });
+        const q = query.toLowerCase();
+        return reminders.filter((r) => r.title.toLowerCase().includes(q) || r.notes?.toLowerCase().includes(q));
+    }
+
+    static async createReminder(options: {
+        title: string;
+        notes?: string;
+        dueDate?: Date;
+        priority?: number;
+        listName?: string;
+        url?: string;
+    }): Promise<string> {
+        const dk = getDarwinKit();
+        const listId = await MacReminders.ensureListExists(options.listName ?? "GenesisTools");
+
+        const result = await dk.reminders.saveItem({
+            calendar_identifier: listId,
+            title: options.title,
+            notes: options.notes,
+            due_date: options.dueDate?.toISOString(),
+            priority: options.priority ?? 0,
+            url: options.url,
+        });
+
+        if (!result.success || !result.identifier) {
+            throw new Error(`Failed to create reminder: ${result.error ?? "unknown error"}`);
+        }
+
+        return result.identifier;
+    }
+
+    static async completeReminder(options: { reminderId: string }): Promise<boolean> {
+        const dk = getDarwinKit();
+
+        try {
+            await dk.reminders.completeItem({
+                identifier: options.reminderId,
+            });
+            return true;
+        } catch (error) {
+            logger.error({ error, reminderId: options.reminderId }, "Failed to complete reminder");
+            return false;
+        }
+    }
+
+    static async deleteReminder(options: { reminderId: string }): Promise<boolean> {
+        const dk = getDarwinKit();
+
+        try {
+            const result = await dk.reminders.removeItem({
+                identifier: options.reminderId,
+            });
+            return result.ok;
+        } catch (error) {
+            logger.error({ error, reminderId: options.reminderId }, "Failed to delete reminder");
+            return false;
+        }
+    }
+
+    static async ensureListExists(name: string, lists?: ReminderListInfo[]): Promise<string> {
+        const allLists = lists ?? (await MacReminders.listLists());
+        const existing = allLists.find((l) => l.title === name);
+
+        if (existing) {
+            return existing.identifier;
+        }
+
+        throw new Error(`Reminder list "${name}" does not exist. Create it manually in Reminders.app.`);
+    }
 }

--- a/src/utils/macos/darwinkit.ts
+++ b/src/utils/macos/darwinkit.ts
@@ -7,6 +7,10 @@ export { DarwinKit, DarwinKitError } from "@genesiscz/darwinkit";
 
 let _instance: DarwinKit | null = null;
 
+export function hasDarwinKit(): boolean {
+    return _instance !== null;
+}
+
 export function getDarwinKit(options?: DarwinKitOptions): DarwinKit {
     if (_instance) {
         if (options && Object.keys(options).length > 0) {

--- a/src/utils/macos/index.ts
+++ b/src/utils/macos/index.ts
@@ -1,11 +1,12 @@
 // Apple Calendar
-export { createCalendarEvent, deleteCalendarEvent, ensureCalendarExists } from "./apple-calendar";
+
+export type { CalendarEventInfo, CalendarInfo, SourceInfo } from "./apple-calendar";
+export { MacCalendar } from "./apple-calendar";
+export type { ReminderInfo, ReminderListInfo } from "./apple-reminders";
 // Apple Reminders
 export {
-    completeReminder,
-    createReminder,
-    deleteReminder,
-    ensureReminderListExists,
+    MacReminders,
+    ReminderPriority,
     todoPriorityToApple,
 } from "./apple-reminders";
 // Auth
@@ -13,7 +14,7 @@ export { authenticate, checkBiometry } from "./auth";
 // Classification
 export { classifyBatch, classifyText, groupByCategory } from "./classification";
 export type { DarwinKitOptions } from "./darwinkit";
-export { closeDarwinKit, DarwinKit, DarwinKitError, getDarwinKit } from "./darwinkit";
+export { closeDarwinKit, DarwinKit, DarwinKitError, getDarwinKit, hasDarwinKit } from "./darwinkit";
 // iCloud
 export {
     icloudCopy,
@@ -29,6 +30,8 @@ export {
     icloudWriteBytes,
     onIcloudFilesChanged,
 } from "./icloud";
+// JXA helpers
+export { ensureMacOS, escapeJxa, runJxa } from "./jxa";
 // MacOS namespace
 export { MacOS } from "./MacOS";
 // NLP

--- a/src/utils/macos/jxa.ts
+++ b/src/utils/macos/jxa.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+
+export function ensureMacOS(): void {
+    if (process.platform !== "darwin") {
+        throw new Error("This feature is only available on macOS");
+    }
+}
+
+export function runJxa(script: string, timeout = 15_000): string {
+    const proc = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
+        encoding: "utf-8",
+        timeout,
+    });
+
+    if (proc.status !== 0) {
+        throw new Error(`JXA error: ${proc.stderr?.trim() || "unknown error"}`);
+    }
+
+    return proc.stdout.trim();
+}
+
+export function escapeJxa(str: string): string {
+    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+}

--- a/src/utils/macos/notifications.ts
+++ b/src/utils/macos/notifications.ts
@@ -2,6 +2,9 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import logger from "@app/logger";
+import type { DarwinKit } from "@app/utils/macos/darwinkit";
+import { getDarwinKit, hasDarwinKit } from "@app/utils/macos/darwinkit";
+import { escapeJxa } from "@app/utils/macos/jxa";
 import { Storage } from "@app/utils/storage/storage";
 
 export interface NotificationOptions {
@@ -15,6 +18,10 @@ export interface NotificationOptions {
     appIcon?: string;
     ignoreDnD?: boolean;
     say?: boolean;
+    /** DarwinKit-exclusive: action buttons via registered category */
+    categoryIdentifier?: string;
+    /** DarwinKit-exclusive: notification attachments (file paths) */
+    attachments?: string[];
 }
 
 const storage = new Storage("notify");
@@ -154,14 +161,11 @@ function sendViaTerminalNotifier(bin: string, opts: NotificationOptions): boolea
  * Send a notification using osascript as fallback.
  */
 function sendViaOsascript(opts: NotificationOptions): void {
-    const escaped = (s: string) =>
-        s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
-
     const params = [
-        `"${escaped(opts.message)}"`,
-        opts.title ? `with title "${escaped(opts.title)}"` : "",
-        opts.subtitle ? `subtitle "${escaped(opts.subtitle)}"` : "",
-        `sound name "${escaped(opts.sound ?? "default")}"`,
+        `"${escapeJxa(opts.message)}"`,
+        opts.title ? `with title "${escapeJxa(opts.title)}"` : "",
+        opts.subtitle ? `subtitle "${escapeJxa(opts.subtitle)}"` : "",
+        `sound name "${escapeJxa(opts.sound ?? "default")}"`,
     ]
         .filter(Boolean)
         .join(" ");
@@ -173,25 +177,72 @@ function sendViaOsascript(opts: NotificationOptions): void {
 }
 
 /**
+ * Try sending via DarwinKit's native UNUserNotificationCenter bridge.
+ * Returns true if successful, false if darwinkit is unavailable or fails.
+ */
+async function sendViaDarwinKit(opts: NotificationOptions): Promise<boolean> {
+    if (!hasDarwinKit()) {
+        return false;
+    }
+
+    try {
+        const dk = getDarwinKit() as DarwinKit & {
+            notifications?: { send(opts: Record<string, unknown>): Promise<void> };
+        };
+
+        if (!dk.notifications) {
+            return false;
+        }
+
+        await dk.notifications.send({
+            title: opts.title ?? "GenesisTools",
+            body: opts.message,
+            subtitle: opts.subtitle,
+            sound: opts.sound ? { named: opts.sound } : "default",
+            thread_identifier: opts.group,
+            category_identifier: opts.categoryIdentifier,
+            attachments: opts.attachments,
+            user_info: {
+                ...(opts.open ? { open: opts.open } : {}),
+                ...(opts.execute ? { execute: opts.execute } : {}),
+            },
+        });
+        return true;
+    } catch (error) {
+        logger.debug(`DarwinKit notification failed: ${error instanceof Error ? error.message : error}`);
+        return false;
+    }
+}
+
+/**
  * Send a macOS notification.
- * Primary: terminal-notifier (supports stacking, click actions, DnD bypass).
+ * Primary: DarwinKit native UNUserNotificationCenter (full feature support).
+ * Secondary: terminal-notifier (supports stacking, click actions, DnD bypass).
  * Fallback: osascript.
  */
 export async function sendNotification(opts: NotificationOptions): Promise<void> {
-    const bin = await resolveTerminalNotifier();
+    // Try DarwinKit first (native UNUserNotificationCenter)
+    const sentViaDarwinKit = await sendViaDarwinKit(opts);
 
-    if (bin) {
-        const sent = sendViaTerminalNotifier(bin, opts);
+    if (sentViaDarwinKit) {
+        logger.debug(`Notification sent via DarwinKit: ${opts.message}`);
+    } else {
+        // Fall back to terminal-notifier / osascript
+        const bin = await resolveTerminalNotifier();
 
-        if (sent) {
-            logger.debug(`Notification sent via terminal-notifier: ${opts.message}`);
+        if (bin) {
+            const sent = sendViaTerminalNotifier(bin, opts);
+
+            if (sent) {
+                logger.debug(`Notification sent via terminal-notifier: ${opts.message}`);
+            } else {
+                logger.debug("terminal-notifier failed, falling back to osascript");
+                sendViaOsascript(opts);
+            }
         } else {
-            logger.debug("terminal-notifier failed, falling back to osascript");
+            logger.debug("terminal-notifier not found, using osascript fallback");
             sendViaOsascript(opts);
         }
-    } else {
-        logger.debug("terminal-notifier not found, using osascript fallback");
-        sendViaOsascript(opts);
     }
 
     if (opts.say) {


### PR DESCRIPTION
- Replace JXA-based Calendar/Reminders utils with DarwinKit (native EventKit via Swift)
- Add `tools macos calendar` CLI (list-calendars, list, search, add, update, delete)
- Add `tools macos reminders` CLI (list-lists, list, search, add, remove)
- Fix 4 todo sync bugs: single event with multiple alerts, URL passthrough, computed alert offsets, reliable Reminders creation
- Add `--at` flag to `todo add`/`todo edit` for explicit event time
- Extract shared JXA helpers to `jxa.ts` for `apple-notes.ts`
- [x] `tools macos calendar list-calendars` — shows calendars
- [x] `tools macos calendar add` — creates event with alerts
- [x] `tools macos reminders list-lists` — shows all lists (Připomínky, Screenpipe, Groceries, GenesisTools)
- [x] `tools macos reminders add` — creates reminder with due date and priority
- [x] `tools macos reminders remove` — deletes reminder
- [x] `tsgo --noEmit` — zero type errors
- [x] Pre-commit hooks pass (biome lint + tsc)
- [ ] Grant Full Calendar Access for full read visibility (currently writeOnly)
- [ ] Test `todo add --at ... -r ... --sync-to calendar` end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar CLI: add/list/search/update/delete events (alerts, all‑day, URL/location) with table/JSON/Markdown outputs; list calendars.
  * Reminders CLI: create/list/search/complete/remove reminders with lists, due dates, priorities and formatted tables; list reminder lists.
  * Todo CLI: new --at option to attach an event time to todos.

* **Enhancements**
  * macOS integration: native DarwinKit-backed Calendar/Reminders with safer execution and cleanup.
  * Notifications: prefer DarwinKit delivery with attachments/category support and robust fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->