### PR TITLE
feat(timely): create entries from auto-tracked memories (plan/apply)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.26",
+            "version": "1.0.27",
             "author": {
                 "name": "GenesisTools"
             },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.27",
+    "version": "1.0.28",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.27",
+            "version": "1.0.28",
             "author": {
                 "name": "GenesisTools"
             },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.28",
+            "version": "1.0.29",
             "author": {
                 "name": "GenesisTools"
             },

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.27",
+    "version": "1.0.28",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/skills/timely/SKILL.md
+++ b/plugins/genesis-tools/skills/timely/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: gt:timely
+description: Create Timely time-log entries from auto-tracked memories. Use when the user says "log my Timely day", "convert memories to events", "fill Timely from yesterday", "create timely entry from memory", or "categorize my Timely time". Triggers a heuristic that matches each day's memories against the user's last 8 weeks of logged events to suggest a project, then POSTs via the public OAuth API with full memory linkage. Does NOT cover ADO TimeLog or Clarity sync — for those, defer to /gt:timelog.
+---
+
+# Timely Create-from-Memory
+
+Drives the conversation that turns auto-tracked Timely memories into logged events with a heuristic project suggestion. The new event preserves the memory linkage (visible as auto-tracked tiles in the calendar UI) by passing `timestamps[].entry_ids` of the form `tool_tic_<memoryId>` to the public OAuth `POST /events` endpoint.
+
+> **For full sync (Timely → ADO → Clarity), invoke `/gt:timelog` instead.** This skill is the *missing first hop*: it creates Timely entries. The follow-up ADO/Clarity sync is `/gt:timelog`'s job.
+
+## CLI Reference
+
+```bash
+tools timely create --day 2026-04-24 -i               # interactive single day
+tools timely create --from 2026-04-21 --to 2026-04-25 -i
+tools timely create --day 2026-04-24 --dry-run        # preview payload
+tools timely create --day 2026-04-24 --chain-ado      # also propose ADO entry per day
+tools timely create --day 2026-04-24 -p 4344283 -n "feature work"  # non-interactive
+tools timely memories --day 2026-04-24                # see what would be logged
+tools timely events --day 2026-04-24                  # confirm after create
+```
+
+## Workflow
+
+When the user says "log my Timely day" or similar:
+
+1. **Pre-flight**
+   - `tools timely status` → verify OAuth login (run `tools timely login` if not authenticated)
+2. **Show the day**
+   - `tools timely memories --day <date>` → list memory buckets
+   - `tools timely events --day <date>` → flag if anything is already logged (warn before duplicating)
+3. **Create**
+   - `tools timely create --day <date> -i` → user confirms each suggestion, edits note, confirms post
+4. **Optional ADO hop**
+   - Append `--chain-ado` to spawn `tools azure-devops timelog add -i -d <date>` per day after each Timely post, OR invoke `/gt:timelog` separately.
+
+## Categorizer Behavior
+
+Heuristic in `src/timely/utils/categorizer.ts` ranks projects by:
+- Word similarity (Jaccard) between memory text and past notes / project name (60%)
+- Time-of-day overlap with past entries (20%)
+- Recency (8-week linear decay) (20%)
+
+Score is summed across all matching corpus entries — high match counts produce scores >1. The skill defers to user confirmation for any score; auto-pick only when `--project` is supplied or when running non-interactive.
+
+## Common User Intents
+
+| User says | Skill action |
+|---|---|
+| "Log yesterday in Timely" | `tools timely create --day <yesterday> -i` |
+| "Fill in this week" | `tools timely create --from <Mon> --to <Fri> -i` |
+| "What would be logged for Friday?" | `tools timely create --day <Fri> --dry-run` |
+| "Also push to ADO" | append `--chain-ado` |
+
+## When NOT to use this skill
+
+- Just *reading* memories or events → use the underlying commands directly, no skill orchestration needed
+- Full Timely → ADO → Clarity sync → `/gt:timelog`
+- Editing existing events → not supported yet

--- a/plugins/genesis-tools/skills/timely/SKILL.md
+++ b/plugins/genesis-tools/skills/timely/SKILL.md
@@ -1,57 +1,157 @@
 ---
 name: gt:timely
-description: Create Timely time-log entries from auto-tracked memories. Use when the user says "log my Timely day", "convert memories to events", "fill Timely from yesterday", "create timely entry from memory", or "categorize my Timely time". Triggers a heuristic that matches each day's memories against the user's last 8 weeks of logged events to suggest a project, then POSTs via the public OAuth API with full memory linkage. Does NOT cover ADO TimeLog or Clarity sync — for those, defer to /gt:timelog.
+description: Create Timely time-log entries from auto-tracked memories. Use when the user says "log my Timely day", "convert memories to events", "fill Timely from yesterday", "create timely entry from memory", "split my day into projects", or "categorize my Timely time". Drives a non-interactive **plan / apply** workflow that lets you (the LLM) split a day's memories across multiple projects. Does NOT cover ADO TimeLog or Clarity sync — for those, defer to /gt:timelog.
 ---
 
 # Timely Create-from-Memory
 
-Drives the conversation that turns auto-tracked Timely memories into logged events with a heuristic project suggestion. The new event preserves the memory linkage (visible as auto-tracked tiles in the calendar UI) by passing `timestamps[].entry_ids` of the form `tool_tic_<memoryId>` to the public OAuth `POST /events` endpoint.
+Drives the conversation that turns auto-tracked Timely memories into logged events. The new event preserves the memory linkage (visible as auto-tracked tiles in the calendar UI) by passing `timestamps[].entry_ids` of the form `tool_tic_<memoryId>` to the public OAuth `POST /events` endpoint.
 
 > **For full sync (Timely → ADO → Clarity), invoke `/gt:timelog` instead.** This skill is the *missing first hop*: it creates Timely entries. The follow-up ADO/Clarity sync is `/gt:timelog`'s job.
 
-## CLI Reference
+---
+
+## Primary Workflow (LLM, non-interactive)
+
+The plan/apply pattern is the default. It lets you split a day's memories across multiple projects and gives the user a single artifact to review before any POST.
+
+### Step 1 — Generate a plan
 
 ```bash
-tools timely create --day 2026-04-24 -i               # interactive single day
-tools timely create --from 2026-04-21 --to 2026-04-25 -i
-tools timely create --day 2026-04-24 --dry-run        # preview payload
-tools timely create --day 2026-04-24 --chain-ado      # also propose ADO entry per day
-tools timely create --day 2026-04-24 -p 4344283 -n "feature work"  # non-interactive
-tools timely memories --day 2026-04-24                # see what would be logged
-tools timely events --day 2026-04-24                  # confirm after create
+tools timely create --plan --from 2026-04-21 --to 2026-04-25 --out /tmp/timely-plan.json
+# or for one day:
+tools timely create --plan --day 2026-04-24 --out /tmp/timely-plan.json
 ```
 
-## Workflow
+The plan file contains, per day:
+- `available_memories[]` — every memory on that day with `id`, `app`, `note`, `from`, `to`, `duration_min`, `sub_notes[]`
+- `suggestions[]` — top-3 projects from the historical heuristic with `score` and `reasons`
+- `events: []` — empty; you fill this in
 
-When the user says "log my Timely day" or similar:
+### Step 2 — Read the plan and reason about it
 
-1. **Pre-flight**
-   - `tools timely status` → verify OAuth login (run `tools timely login` if not authenticated)
-2. **Show the day**
-   - `tools timely memories --day <date>` → list memory buckets
-   - `tools timely events --day <date>` → flag if anything is already logged (warn before duplicating)
-3. **Create**
-   - `tools timely create --day <date> -i` → user confirms each suggestion, edits note, confirms post
-4. **Optional ADO hop**
-   - Append `--chain-ado` to spawn `tools azure-devops timelog add -i -d <date>` per day after each Timely post, OR invoke `/gt:timelog` separately.
+Read `/tmp/timely-plan.json`. For each day, look at:
+- The `available_memories[]` (apps, notes, time ranges, sub-notes — these often contain repo names, branch names, file paths)
+- `suggestions[]` (heuristic prior — high score = strong historical pattern, but **don't blindly trust** if the memories clearly tell a different story)
+- Any prior conversation context the user gave you (e.g. "I worked on Reservine in the morning")
 
-## Categorizer Behavior
+### Step 3 — Fill in `events[]`
 
-Heuristic in `src/timely/utils/categorizer.ts` ranks projects by:
+Group memory IDs by intended project. Multiple events per day are fine — each gets its own project + note + memory_ids subset. Example:
+
+```json
+"events": [
+  {
+    "project_id": 4250000,
+    "note": "Reservine — col-fe migration",
+    "memory_ids": [2084994045, 2085026565]
+  },
+  {
+    "project_id": 4344283,
+    "note": "ČEZ — Timely tooling",
+    "memory_ids": [2085118879, 2085658439]
+  }
+]
+```
+
+**Rules:**
+- Every `memory_id` must appear in `available_memories[].id` (validation will error otherwise)
+- A `memory_id` should appear in **at most one** event (validation warns on duplicates)
+- Memories you intentionally skip (lunch, idle, personal) — just leave them out of every `events[]`. Validation **warns** but doesn't error
+- Notes should be human-readable, not just app names. Look at `sub_notes[]` for repo / branch / file-path hints
+- Use `project_id` from `suggestions[]` when the heuristic matches your reasoning; otherwise use `tools timely projects --format json` to look up other project IDs
+
+### Step 4 — Write the file back
+
+After editing, save the JSON.
+
+### Step 5 — Dry-run
+
+```bash
+tools timely create --apply /tmp/timely-plan.json --dry-run
+```
+
+This re-validates and prints each event's `CreateEventInput` payload (with `timestamps[]` filtered to that event's `memory_ids`). Show the user a tight summary:
+
+```
+2026-04-21#0 [proj 4250000] DRY 03:21 (5 memories)  Reservine — col-fe migration
+2026-04-21#1 [proj 4344283] DRY 04:15 (8 memories)  ČEZ — Timely tooling
+```
+
+### Step 6 — Apply
+
+After user confirms:
+
+```bash
+tools timely create --apply /tmp/timely-plan.json --yes
+```
+
+`--yes` skips the warning confirmation (you've already shown the user the dry-run). On success: `✓ <day>#<N> [proj <id>] event <evId> (HH:MM, N memories)`.
+
+---
+
+## Validation rules (so you can pre-check before --dry-run)
+
+| Severity | Rule |
+|---|---|
+| error | `memory_id` not in `available_memories` |
+| error | duplicate `memory_id` within a single event |
+| error | `memory_ids` is empty |
+| error | `project_id` ≤ 0 |
+| warn | `memory_id` assigned to multiple events on the same day (intentional split) |
+| warn | some `available_memories` are not assigned to any event (intentional drop) |
+
+---
+
+## Manual Fallback (Human, no LLM driver)
+
+If the user wants to do it themselves:
+
+```bash
+tools timely create --day 2026-04-24 -i                  # clack interactive flow
+tools timely create --day 2026-04-24 -p 4344283 -n "..."  # one-shot, all-day, one project
+tools timely create --day 2026-04-24 --dry-run           # preview the all-day single-project payload
+```
+
+The interactive `-i` flow puts every memory on a day into ONE event (no splitting). For per-memory selection, use the plan/apply flow above.
+
+---
+
+## Read-only context commands
+
+```bash
+tools timely status                            # verify OAuth login (run `tools timely login` if not)
+tools timely memories --day 2026-04-24         # raw memories for one day
+tools timely events --day 2026-04-24           # what's already logged (warn before duplicating!)
+tools timely projects --format json            # list project IDs + names
+```
+
+Always run `tools timely events --day <date>` before posting to avoid double-logging.
+
+---
+
+## Common User Intents
+
+| User says | First action |
+|---|---|
+| "Log yesterday in Timely" | `tools timely create --plan --day <yesterday> --out /tmp/p.json`, then read + fill |
+| "Fill in this week" | `tools timely create --plan --from <Mon> --to <Fri> --out /tmp/p.json` |
+| "Split Friday — morning was Reservine, afternoon ČEZ" | Plan for Friday, place morning memory_ids in one event, afternoon in another |
+| "Skip the lunch memories" | Leave their IDs out of every event; validation warns and proceeds |
+| "Re-run with the same plan" | Re-run `--apply <path> --yes` |
+
+---
+
+## Categorizer details (for reasoning context)
+
+`src/timely/utils/categorizer.ts` ranks projects by:
 - Word similarity (Jaccard) between memory text and past notes / project name (60%)
 - Time-of-day overlap with past entries (20%)
 - Recency (8-week linear decay) (20%)
 
-Score is summed across all matching corpus entries — high match counts produce scores >1. The skill defers to user confirmation for any score; auto-pick only when `--project` is supplied or when running non-interactive.
+Score is summed across all matching corpus entries. High match counts produce scores >1. Use `score` and `reasons[]` as priors; override when the memory text clearly indicates a different project.
 
-## Common User Intents
-
-| User says | Skill action |
-|---|---|
-| "Log yesterday in Timely" | `tools timely create --day <yesterday> -i` |
-| "Fill in this week" | `tools timely create --from <Mon> --to <Fri> -i` |
-| "What would be logged for Friday?" | `tools timely create --day <Fri> --dry-run` |
-| "Also push to ADO" | append `--chain-ado` |
+---
 
 ## When NOT to use this skill
 

--- a/plugins/genesis-tools/skills/timely/SKILL.md
+++ b/plugins/genesis-tools/skills/timely/SKILL.md
@@ -15,6 +15,8 @@ Drives the conversation that turns auto-tracked Timely memories into logged even
 
 The plan/apply pattern is the default. It lets you split a day's memories across multiple projects and gives the user a single artifact to review before any POST.
 
+> **DO NOT use python, jq, awk, or shell loops to inspect or edit the plan.** The tool prints the summary itself and you have the `Edit` / `Read` / `Write` tools. Using shell scripts to extract memory IDs is an anti-pattern — it hides your reasoning from the user and is unnecessary now that the tool ships a summary.
+
 ### Step 1 — Generate a plan
 
 ```bash
@@ -23,26 +25,44 @@ tools timely create --plan --from 2026-04-21 --to 2026-04-25 --out /tmp/timely-p
 tools timely create --plan --day 2026-04-24 --out /tmp/timely-plan.json
 ```
 
-The plan file contains, per day:
-- `available_memories[]` — every memory on that day with `id`, `app`, `note`, `from`, `to`, `duration_min`, `sub_notes[]`
-- `suggestions[]` — top-3 projects from the historical heuristic with `score` and `reasons`
-- `events: []` — empty; you fill this in
+The command does two things:
+1. **Writes** the JSON plan file to `--out`
+2. **Prints** a compact per-day summary to stdout — this is what you reason over
 
-### Step 2 — Read the plan and reason about it
+The summary looks like:
 
-Read `/tmp/timely-plan.json`. For each day, look at:
-- The `available_memories[]` (apps, notes, time ranges, sub-notes — these often contain repo names, branch names, file paths)
-- `suggestions[]` (heuristic prior — high score = strong historical pattern, but **don't blindly trust** if the memories clearly tell a different story)
+```
+=== 2026-04-19 (2 memories) ===
+  Suggestions:
+    proj  4344283  ČEZ          score  2.88  27 similar past entries · top word similarity 0.00
+    proj  5190862  Reservine    score  0.05   1 similar past entries · top word similarity 0.00
+  Memories (id  from-to  min  app  note | sub_notes):
+    2079040832  21:03-22:07    65m  cmux       col-fe | tools claude usage; col-fe2
+    2079063024  22:23-22:29     6m  cmux       col-fe
+```
+
+The plan JSON file contains the same data with full ISO timestamps and is the artifact `--apply` consumes.
+
+### Step 2 — Reason from the printed summary (no Read of JSON needed)
+
+Look at the summary the tool printed for:
+- App names + notes + sub_notes (often contain repo names, branch names, file paths — strong project signal)
+- Time ranges (split a day by morning/afternoon/evening blocks)
+- `suggestions[]` (heuristic prior — high score = strong historical pattern, but **don't blindly trust** if the memories clearly say something else)
 - Any prior conversation context the user gave you (e.g. "I worked on Reservine in the morning")
 
-### Step 3 — Fill in `events[]`
+State your splits in chat — group memory IDs into time-block buckets per intended project. Be explicit so the user can correct you before you Edit.
 
-Group memory IDs by intended project. Multiple events per day are fine — each gets its own project + note + memory_ids subset. Example:
+### Step 3 — Fill in `events[]` with the Edit tool
+
+Use the `Edit` tool to replace `"events": []` in the plan JSON file with your filled events. **Don't use shell scripts** — the Edit tool is the right primitive.
+
+Multiple events per day are fine — each gets its own project + note + memory_ids subset. Example:
 
 ```json
 "events": [
   {
-    "project_id": 4250000,
+    "project_id": 5190862,
     "note": "Reservine — col-fe migration",
     "memory_ids": [2084994045, 2085026565]
   },
@@ -55,15 +75,16 @@ Group memory IDs by intended project. Multiple events per day are fine — each 
 ```
 
 **Rules:**
-- Every `memory_id` must appear in `available_memories[].id` (validation will error otherwise)
+- Every `memory_id` must appear in `available_memories[].id` (validation errors otherwise — re-Read the JSON if you forget an ID)
 - A `memory_id` should appear in **at most one** event (validation warns on duplicates)
-- Memories you intentionally skip (lunch, idle, personal) — just leave them out of every `events[]`. Validation **warns** but doesn't error
-- Notes should be human-readable, not just app names. Look at `sub_notes[]` for repo / branch / file-path hints
-- Use `project_id` from `suggestions[]` when the heuristic matches your reasoning; otherwise use `tools timely projects --format json` to look up other project IDs
+- Memories you intentionally skip (lunch, idle, personal, leisure YouTube/Instagram/Messages-with-partner) — just leave them out. Validation **warns**, doesn't error
+- Notes should be human-readable, not just app names. Steal phrasing from `sub_notes[]` (repo names, branch names, PR titles)
+- Use `project_id` from `suggestions[]` when it matches your reasoning. Run `tools timely projects --format json` to look up other project IDs
+- **Memory linkage caveat**: a single memory's wall-clock window is atomic — you can't split *one* memory across two projects. If memory `X` shows mixed work (e.g. cmux session that touched two repos), pick the dominant project for the whole window
 
-### Step 4 — Write the file back
+### Step 4 — Verify the file
 
-After editing, save the JSON.
+The Edit tool already wrote the changes. No additional save step needed. If you're worried, `Read` the relevant slice of the file to confirm.
 
 ### Step 5 — Dry-run
 

--- a/src/timely/README.md
+++ b/src/timely/README.md
@@ -58,6 +58,7 @@ tools timely export-month 2026-04 --format detailed-summary --silent
 | `projects [--select]` | List projects, optionally pick default |
 | `events [--from/--to/--day]` | List logged time entries |
 | `memories [--from/--to/--day]` | Auto-tracked activities (suggested entries) |
+| `create [--day/--from/--to] [-i] [--dry-run] [--chain-ado]` | Create events from memories with heuristic project suggestion |
 | `export-month <YYYY-MM>` | Export all entries for a month |
 | `cache [list\|clear]` | Manage the local Timely cache |
 

--- a/src/timely/README.md
+++ b/src/timely/README.md
@@ -58,7 +58,7 @@ tools timely export-month 2026-04 --format detailed-summary --silent
 | `projects [--select]` | List projects, optionally pick default |
 | `events [--from/--to/--day]` | List logged time entries |
 | `memories [--from/--to/--day]` | Auto-tracked activities (suggested entries) |
-| `create [--day/--from/--to] [-i] [--dry-run] [--chain-ado]` | Create events from memories with heuristic project suggestion (interactive single-event-per-day) |
+| `create [--day/--from/--to] [-i] [--dry-run]` | Create events from memories with heuristic project suggestion (interactive single-event-per-day) |
 | `create --plan --out <path>` / `create --apply <path> [--yes] [--dry-run]` | LLM-friendly plan/apply: generate a JSON, fill `events[]` per day with `memory_ids` subsets, then apply |
 | `export-month <YYYY-MM>` | Export all entries for a month |
 | `cache [list\|clear]` | Manage the local Timely cache |

--- a/src/timely/README.md
+++ b/src/timely/README.md
@@ -58,7 +58,8 @@ tools timely export-month 2026-04 --format detailed-summary --silent
 | `projects [--select]` | List projects, optionally pick default |
 | `events [--from/--to/--day]` | List logged time entries |
 | `memories [--from/--to/--day]` | Auto-tracked activities (suggested entries) |
-| `create [--day/--from/--to] [-i] [--dry-run] [--chain-ado]` | Create events from memories with heuristic project suggestion |
+| `create [--day/--from/--to] [-i] [--dry-run] [--chain-ado]` | Create events from memories with heuristic project suggestion (interactive single-event-per-day) |
+| `create --plan --out <path>` / `create --apply <path> [--yes] [--dry-run]` | LLM-friendly plan/apply: generate a JSON, fill `events[]` per day with `memory_ids` subsets, then apply |
 | `export-month <YYYY-MM>` | Export all entries for a month |
 | `cache [list\|clear]` | Manage the local Timely cache |
 

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import logger from "@app/logger";
 import type { TimelyService } from "@app/timely/api/service";
@@ -25,7 +24,6 @@ interface CreateOptions {
     note?: string;
     interactive?: boolean;
     dryRun?: boolean;
-    chainAdo?: boolean;
     plan?: boolean;
     out?: string;
     apply?: string;
@@ -212,18 +210,6 @@ async function runCreate(storage: Storage, service: TimelyService, options: Crea
     }
 
     p.outro(`Created ${created.length} event(s).`);
-
-    if (options.chainAdo && created.length > 0) {
-        for (const date of dates) {
-            console.log(chalk.cyan(`\n→ Launching ADO TimeLog for ${date}...`));
-            await new Promise<void>((resolve) => {
-                const proc = spawn("tools", ["azure-devops", "timelog", "add", "-i", "-d", date], {
-                    stdio: "inherit",
-                });
-                proc.on("exit", () => resolve());
-            });
-        }
-    }
 }
 
 async function runPlan(storage: Storage, service: TimelyService, options: CreateOptions): Promise<void> {
@@ -254,7 +240,9 @@ async function runPlan(storage: Storage, service: TimelyService, options: Create
     } else {
         writeFileSync(out, `${json}\n`, "utf8");
         logger.info(chalk.green(`✓ Plan written to ${out}`));
-        logger.info(`  ${plan.days.length} day(s), ${plan.days.reduce((s, d) => s + d.available_memories.length, 0)} memories`);
+        logger.info(
+            `  ${plan.days.length} day(s), ${plan.days.reduce((s, d) => s + d.available_memories.length, 0)} memories`
+        );
         logger.info("  Edit events[] per day, then: tools timely create --apply " + out + " --dry-run");
     }
 }
@@ -348,9 +336,17 @@ async function runApply(storage: Storage, service: TimelyService, options: Creat
             console.log(chalk.red(`✗ ${r.day}#${r.eventIdx} [proj ${r.project_id}]: ${r.error}`));
             failed++;
         } else if (options.dryRun) {
-            console.log(chalk.cyan(`◯ ${r.day}#${r.eventIdx} [proj ${r.project_id}] DRY ${r.duration} (${r.memoryCount} memories)`));
+            console.log(
+                chalk.cyan(
+                    `◯ ${r.day}#${r.eventIdx} [proj ${r.project_id}] DRY ${r.duration} (${r.memoryCount} memories)`
+                )
+            );
         } else {
-            console.log(chalk.green(`✓ ${r.day}#${r.eventIdx} [proj ${r.project_id}] event ${r.eventId} (${r.duration}, ${r.memoryCount} memories)`));
+            console.log(
+                chalk.green(
+                    `✓ ${r.day}#${r.eventIdx} [proj ${r.project_id}] event ${r.eventId} (${r.duration}, ${r.memoryCount} memories)`
+                )
+            );
             created++;
         }
     }
@@ -376,7 +372,6 @@ export function registerCreateCommand(program: Command, storage: Storage, servic
         .option("-n, --note <text>", "Override note (default: derived from memory titles)")
         .option("-i, --interactive", "Interactive mode (default if TTY)")
         .option("--dry-run", "Show payload without posting (works with create + apply)")
-        .option("--chain-ado", "After create, run `tools azure-devops timelog add -i` per day")
         .option("--plan", "Generate a JSON plan instead of posting (LLM-friendly)")
         .option("--out <path>", "Output path for --plan (default: stdout)", "-")
         .option("--apply <path>", "Apply a plan JSON file (use - for stdin)")

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -1,15 +1,15 @@
 import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
 import logger from "@app/logger";
 import type { TimelyService } from "@app/timely/api/service";
 import type { OAuth2Tokens, TimelyEntry } from "@app/timely/types";
+import type { CreatePlanV1, PlanIssue } from "@app/timely/types/plan";
 import { type CategorySuggestion, suggestProjects } from "@app/timely/utils/categorizer";
 import { loadEventCorpus } from "@app/timely/utils/event-corpus";
-import {
-    type BuiltPayload,
-    buildPayloadFromFlat,
-    flattenMemories,
-} from "@app/timely/utils/flatten-memories";
+import { type BuiltPayload, buildPayloadFromFlat, flattenMemories } from "@app/timely/utils/flatten-memories";
 import { fetchMemoriesForDates } from "@app/timely/utils/memories";
+import { applyPlan, validatePlan } from "@app/timely/utils/plan-apply";
+import { buildPlan } from "@app/timely/utils/plan-build";
 import { isInteractive } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import type { Storage } from "@app/utils/storage";
@@ -26,6 +26,10 @@ interface CreateOptions {
     interactive?: boolean;
     dryRun?: boolean;
     chainAdo?: boolean;
+    plan?: boolean;
+    out?: string;
+    apply?: string;
+    yes?: boolean;
 }
 
 function buildPayload(memories: TimelyEntry[], day: string, projectId: number, note: string): BuiltPayload {
@@ -222,6 +226,145 @@ async function runCreate(storage: Storage, service: TimelyService, options: Crea
     }
 }
 
+async function runPlan(storage: Storage, service: TimelyService, options: CreateOptions): Promise<void> {
+    const accountId = await storage.getConfigValue<number>("selectedAccountId");
+    const tokens = await storage.getConfigValue<OAuth2Tokens>("tokens");
+    if (!accountId || !tokens?.access_token) {
+        logger.error("Not authenticated. Run 'tools timely login' first.");
+        process.exit(1);
+    }
+
+    const dates = expandDates(options);
+    if (dates.length === 0) {
+        logger.error("Provide --from/--to or --day with --plan");
+        process.exit(1);
+    }
+
+    const [memoriesResult, corpus] = await Promise.all([
+        fetchMemoriesForDates({ accountId, accessToken: tokens.access_token, dates, storage }),
+        loadEventCorpus(storage, service, accountId),
+    ]);
+
+    const plan = buildPlan({ memoriesByDate: memoriesResult.byDate, corpus, dates });
+    const json = SafeJSON.stringify(plan, null, 2);
+
+    const out = options.out ?? "-";
+    if (out === "-") {
+        process.stdout.write(`${json}\n`);
+    } else {
+        writeFileSync(out, `${json}\n`, "utf8");
+        logger.info(chalk.green(`✓ Plan written to ${out}`));
+        logger.info(`  ${plan.days.length} day(s), ${plan.days.reduce((s, d) => s + d.available_memories.length, 0)} memories`);
+        logger.info("  Edit events[] per day, then: tools timely create --apply " + out + " --dry-run");
+    }
+}
+
+function readPlanFile(path: string): CreatePlanV1 {
+    const text = path === "-" ? readFromStdin() : readFileSync(path, "utf8");
+    const parsed = SafeJSON.parse(text);
+    return parsed as CreatePlanV1;
+}
+
+function readFromStdin(): string {
+    const chunks: Buffer[] = [];
+    const fd = 0;
+    const buf = Buffer.alloc(65_536);
+    let n: number;
+    do {
+        try {
+            n = require("node:fs").readSync(fd, buf, 0, buf.length, null);
+        } catch {
+            break;
+        }
+        if (n > 0) {
+            chunks.push(Buffer.from(buf.subarray(0, n)));
+        }
+    } while (n > 0);
+
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+function printIssues(issues: PlanIssue[]): { errors: number; warnings: number } {
+    let errors = 0;
+    let warnings = 0;
+    for (const issue of issues) {
+        const tag = issue.severity === "error" ? chalk.red("✗") : chalk.yellow("!");
+        const where = issue.eventIdx !== undefined ? `${issue.day}#${issue.eventIdx}` : issue.day;
+        console.log(`${tag} ${where}: ${issue.message}`);
+        if (issue.severity === "error") {
+            errors++;
+        } else {
+            warnings++;
+        }
+    }
+
+    return { errors, warnings };
+}
+
+async function runApply(storage: Storage, service: TimelyService, options: CreateOptions): Promise<void> {
+    const accountId = await storage.getConfigValue<number>("selectedAccountId");
+    const tokens = await storage.getConfigValue<OAuth2Tokens>("tokens");
+    if (!accountId || !tokens?.access_token) {
+        logger.error("Not authenticated. Run 'tools timely login' first.");
+        process.exit(1);
+    }
+
+    const path = options.apply!;
+    const plan = readPlanFile(path);
+
+    const issues = validatePlan(plan);
+    const { errors, warnings } = printIssues(issues);
+    if (errors > 0) {
+        logger.error(`Plan has ${errors} error(s). Fix and retry.`);
+        process.exit(1);
+    }
+
+    const interactive = isInteractive();
+    if (warnings > 0 && interactive && !options.yes) {
+        const ok = await p.confirm({ message: `${warnings} warning(s). Proceed?`, initialValue: false });
+        if (p.isCancel(ok) || !ok) {
+            logger.info("Cancelled.");
+            return;
+        }
+    }
+
+    const results = await applyPlan({
+        plan,
+        service,
+        storage,
+        accountId,
+        accessToken: tokens.access_token,
+        dryRun: options.dryRun ?? false,
+        onPayload: (day, idx, payload) => {
+            console.log(chalk.dim(`\n--- ${day} event #${idx} ---`));
+            console.log(SafeJSON.stringify(payload, null, 2));
+        },
+    });
+
+    let created = 0;
+    let failed = 0;
+    for (const r of results) {
+        if (r.error) {
+            console.log(chalk.red(`✗ ${r.day}#${r.eventIdx} [proj ${r.project_id}]: ${r.error}`));
+            failed++;
+        } else if (options.dryRun) {
+            console.log(chalk.cyan(`◯ ${r.day}#${r.eventIdx} [proj ${r.project_id}] DRY ${r.duration} (${r.memoryCount} memories)`));
+        } else {
+            console.log(chalk.green(`✓ ${r.day}#${r.eventIdx} [proj ${r.project_id}] event ${r.eventId} (${r.duration}, ${r.memoryCount} memories)`));
+            created++;
+        }
+    }
+
+    if (options.dryRun) {
+        logger.info(`Dry-run complete: ${results.length} event(s) would be created.`);
+    } else {
+        logger.info(`Created ${created} event(s)${failed > 0 ? `, ${failed} failed` : ""}.`);
+        if (failed > 0) {
+            process.exit(1);
+        }
+    }
+}
+
 export function registerCreateCommand(program: Command, storage: Storage, service: TimelyService): void {
     program
         .command("create")
@@ -232,9 +375,29 @@ export function registerCreateCommand(program: Command, storage: Storage, servic
         .option("-p, --project <id>", "Force project ID (skip categorizer)")
         .option("-n, --note <text>", "Override note (default: derived from memory titles)")
         .option("-i, --interactive", "Interactive mode (default if TTY)")
-        .option("--dry-run", "Show payload without posting")
+        .option("--dry-run", "Show payload without posting (works with create + apply)")
         .option("--chain-ado", "After create, run `tools azure-devops timelog add -i` per day")
+        .option("--plan", "Generate a JSON plan instead of posting (LLM-friendly)")
+        .option("--out <path>", "Output path for --plan (default: stdout)", "-")
+        .option("--apply <path>", "Apply a plan JSON file (use - for stdin)")
+        .option("--yes", "Skip warning confirmation when applying")
         .action(async (options: CreateOptions) => {
+            const modes = [options.plan, !!options.apply].filter(Boolean).length;
+            if (modes > 1) {
+                logger.error("--plan and --apply are mutually exclusive");
+                process.exit(1);
+            }
+
+            if (options.plan) {
+                await runPlan(storage, service, options);
+                return;
+            }
+
+            if (options.apply) {
+                await runApply(storage, service, options);
+                return;
+            }
+
             await runCreate(storage, service, options);
         });
 }

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import logger from "@app/logger";
 import type { TimelyService } from "@app/timely/api/service";
 import type { OAuth2Tokens, TimelyEntry } from "@app/timely/types";
@@ -11,7 +12,6 @@ import type { Storage } from "@app/utils/storage";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
 import type { Command } from "commander";
-import { spawn } from "node:child_process";
 
 interface CreateOptions {
     from?: string;

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -243,8 +243,37 @@ async function runPlan(storage: Storage, service: TimelyService, options: Create
         logger.info(
             `  ${plan.days.length} day(s), ${plan.days.reduce((s, d) => s + d.available_memories.length, 0)} memories`
         );
-        logger.info(`  Edit events[] per day, then: tools timely create --apply ${out} --dry-run`);
+        printPlanSummary(plan);
+        logger.info(`Edit events[] per day, then: tools timely create --apply ${out} --dry-run`);
     }
+}
+
+function printPlanSummary(plan: CreatePlanV1): void {
+    for (const day of plan.days) {
+        console.log(chalk.bold(`\n=== ${day.day} (${day.available_memories.length} memories) ===`));
+        if (day.suggestions.length > 0) {
+            console.log(chalk.dim("  Suggestions:"));
+            for (const s of day.suggestions) {
+                console.log(
+                    chalk.dim(
+                        `    proj ${String(s.project_id).padStart(8)}  ${s.project_name.padEnd(20)}  score ${s.score.toFixed(2).padStart(5)}  ${s.reasons.join(" · ")}`
+                    )
+                );
+            }
+        }
+
+        console.log(chalk.dim("  Memories (id  from-to  min  app  note | sub_notes):"));
+        for (const m of day.available_memories) {
+            const f = m.from.split("T")[1]?.slice(0, 5) ?? "??:??";
+            const t = m.to.split("T")[1]?.slice(0, 5) ?? "??:??";
+            const app = (m.app || "").slice(0, 20).padEnd(20);
+            const note = (m.note || "").slice(0, 70);
+            const sub = m.sub_notes.length > 0 ? ` | ${m.sub_notes.slice(0, 2).join("; ").slice(0, 80)}` : "";
+            console.log(`    ${String(m.id).padStart(10)}  ${f}-${t}  ${String(m.duration_min).padStart(4)}m  ${app}  ${note}${sub}`);
+        }
+    }
+
+    console.log("");
 }
 
 function readPlanFile(path: string): CreatePlanV1 {

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -2,9 +2,13 @@ import { spawn } from "node:child_process";
 import logger from "@app/logger";
 import type { TimelyService } from "@app/timely/api/service";
 import type { OAuth2Tokens, TimelyEntry } from "@app/timely/types";
-import type { CreateEventInput, CreateEventTimestamp } from "@app/timely/types/api";
 import { type CategorySuggestion, suggestProjects } from "@app/timely/utils/categorizer";
 import { loadEventCorpus } from "@app/timely/utils/event-corpus";
+import {
+    type BuiltPayload,
+    buildPayloadFromFlat,
+    flattenMemories,
+} from "@app/timely/utils/flatten-memories";
 import { fetchMemoriesForDates } from "@app/timely/utils/memories";
 import { isInteractive } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
@@ -24,83 +28,8 @@ interface CreateOptions {
     chainAdo?: boolean;
 }
 
-interface BuiltPayload {
-    input: CreateEventInput;
-    totalSeconds: number;
-}
-
-interface FlatEntry {
-    id: number;
-    from: string;
-    to: string;
-}
-
-function flattenMemories(memories: TimelyEntry[]): FlatEntry[] {
-    const flat: FlatEntry[] = [];
-    for (const bucket of memories) {
-        const inner = bucket.entries ?? [];
-        if (inner.length === 0) {
-            // Some payloads return a single entry without an `entries` wrapper
-            if (bucket.id && bucket.from && bucket.to) {
-                flat.push({ id: bucket.id, from: bucket.from, to: bucket.to });
-            }
-
-            continue;
-        }
-
-        for (const entry of inner) {
-            const subs = entry.sub_entries ?? [];
-            if (subs.length === 0) {
-                flat.push({ id: entry.id, from: entry.from, to: entry.to });
-            } else {
-                for (const sub of subs) {
-                    flat.push({ id: entry.id, from: sub.from, to: sub.to });
-                }
-            }
-        }
-    }
-
-    return flat.sort((a, b) => a.from.localeCompare(b.from));
-}
-
 function buildPayload(memories: TimelyEntry[], day: string, projectId: number, note: string): BuiltPayload {
-    const flat = flattenMemories(memories);
-    if (flat.length === 0) {
-        throw new Error(`No usable entries on ${day} — memories are empty or malformed`);
-    }
-
-    let totalSec = 0;
-    const timestamps: CreateEventTimestamp[] = flat.map((f) => {
-        const fromMs = new Date(f.from).getTime();
-        const toMs = new Date(f.to).getTime();
-        totalSec += Math.max(0, (toMs - fromMs) / 1000);
-        return {
-            from: f.from,
-            to: f.to,
-            entry_ids: [`tool_tic_${f.id}`],
-        };
-    });
-
-    const hours = Math.floor(totalSec / 3600);
-    const minutes = Math.floor((totalSec % 3600) / 60);
-    const seconds = Math.floor(totalSec % 60);
-
-    return {
-        input: {
-            day,
-            project_id: projectId,
-            note,
-            from: flat[0].from,
-            to: flat[flat.length - 1].to,
-            hours,
-            minutes,
-            seconds,
-            timestamps,
-            created_from: "GenesisTools",
-            updated_from: "GenesisTools",
-        },
-        totalSeconds: totalSec,
-    };
+    return buildPayloadFromFlat(flattenMemories(memories), day, projectId, note);
 }
 
 function expandDates(options: CreateOptions): string[] {

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -5,7 +5,7 @@ import type { OAuth2Tokens, TimelyEntry } from "@app/timely/types";
 import type { CreatePlanV1, PlanIssue } from "@app/timely/types/plan";
 import { type CategorySuggestion, suggestProjects } from "@app/timely/utils/categorizer";
 import { loadEventCorpus } from "@app/timely/utils/event-corpus";
-import { type BuiltPayload, buildPayloadFromFlat, flattenMemories } from "@app/timely/utils/flatten-memories";
+import { buildPayloadFromFlat, flattenMemories } from "@app/timely/utils/flatten-memories";
 import { fetchMemoriesForDates } from "@app/timely/utils/memories";
 import { applyPlan, validatePlan } from "@app/timely/utils/plan-apply";
 import { buildPlan } from "@app/timely/utils/plan-build";
@@ -28,10 +28,6 @@ interface CreateOptions {
     out?: string;
     apply?: string;
     yes?: boolean;
-}
-
-function buildPayload(memories: TimelyEntry[], day: string, projectId: number, note: string): BuiltPayload {
-    return buildPayloadFromFlat(flattenMemories(memories), day, projectId, note);
 }
 
 function expandDates(options: CreateOptions): string[] {
@@ -186,7 +182,13 @@ async function runCreate(storage: Storage, service: TimelyService, options: Crea
             projectId = suggestions[0].projectId;
         }
 
-        const { input, totalSeconds } = buildPayload(dayMemories, date, projectId, note);
+        const flat = flattenMemories(dayMemories);
+        if (flat.length === 0) {
+            p.log.warn(`${date}: all memories filtered out (too short) — skipping`);
+            continue;
+        }
+
+        const { input, totalSeconds } = buildPayloadFromFlat(flat, date, projectId, note);
 
         if (options.dryRun) {
             p.log.info(`${date} DRY-RUN payload:\n${SafeJSON.stringify(input, null, 2)}`);
@@ -269,7 +271,9 @@ function printPlanSummary(plan: CreatePlanV1): void {
             const app = (m.app || "").slice(0, 20).padEnd(20);
             const note = (m.note || "").slice(0, 70);
             const sub = m.sub_notes.length > 0 ? ` | ${m.sub_notes.slice(0, 2).join("; ").slice(0, 80)}` : "";
-            console.log(`    ${String(m.id).padStart(10)}  ${f}-${t}  ${String(m.duration_min).padStart(4)}m  ${app}  ${note}${sub}`);
+            console.log(
+                `    ${String(m.id).padStart(10)}  ${f}-${t}  ${String(m.duration_min).padStart(4)}m  ${app}  ${note}${sub}`
+            );
         }
     }
 
@@ -277,28 +281,9 @@ function printPlanSummary(plan: CreatePlanV1): void {
 }
 
 function readPlanFile(path: string): CreatePlanV1 {
-    const text = path === "-" ? readFromStdin() : readFileSync(path, "utf8");
+    const text = readFileSync(path === "-" ? 0 : path, "utf8");
     const parsed = SafeJSON.parse(text);
     return parsed as CreatePlanV1;
-}
-
-function readFromStdin(): string {
-    const chunks: Buffer[] = [];
-    const fd = 0;
-    const buf = Buffer.alloc(65_536);
-    let n: number;
-    do {
-        try {
-            n = require("node:fs").readSync(fd, buf, 0, buf.length, null);
-        } catch {
-            break;
-        }
-        if (n > 0) {
-            chunks.push(Buffer.from(buf.subarray(0, n)));
-        }
-    } while (n > 0);
-
-    return Buffer.concat(chunks).toString("utf8");
 }
 
 function printIssues(issues: PlanIssue[]): { errors: number; warnings: number } {
@@ -406,6 +391,11 @@ export function registerCreateCommand(program: Command, storage: Storage, servic
         .option("--apply <path>", "Apply a plan JSON file (use - for stdin)")
         .option("--yes", "Skip warning confirmation when applying")
         .action(async (options: CreateOptions) => {
+            if (options.project !== undefined && Number.isNaN(parseInt(options.project, 10))) {
+                logger.error(`Invalid --project: ${options.project} (must be numeric)`);
+                process.exit(1);
+            }
+
             const modes = [options.plan, !!options.apply].filter(Boolean).length;
             if (modes > 1) {
                 logger.error("--plan and --apply are mutually exclusive");

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -37,11 +37,11 @@ function expandDates(options: CreateOptions): string[] {
 
     if (options.from && options.to) {
         const dates: string[] = [];
-        const cur = new Date(options.from);
-        const end = new Date(options.to);
+        const cur = new Date(`${options.from}T00:00:00Z`);
+        const end = new Date(`${options.to}T00:00:00Z`);
         while (cur <= end) {
             dates.push(cur.toISOString().slice(0, 10));
-            cur.setDate(cur.getDate() + 1);
+            cur.setUTCDate(cur.getUTCDate() + 1);
         }
 
         return dates;
@@ -287,9 +287,24 @@ function printPlanSummary(plan: CreatePlanV1): void {
 }
 
 function readPlanFile(path: string): CreatePlanV1 {
-    const text = readFileSync(path === "-" ? 0 : path, "utf8");
-    const parsed = SafeJSON.parse(text);
-    return parsed as CreatePlanV1;
+    let text: string;
+    try {
+        text = readFileSync(path === "-" ? 0 : path, "utf8");
+    } catch (error) {
+        logger.error(
+            `Cannot read plan from ${path === "-" ? "stdin" : path}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+    }
+
+    try {
+        return SafeJSON.parse(text) as CreatePlanV1;
+    } catch (error) {
+        logger.error(
+            `Invalid plan JSON in ${path === "-" ? "stdin" : path}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+    }
 }
 
 function printIssues(issues: PlanIssue[]): { errors: number; warnings: number } {

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -1,0 +1,311 @@
+import logger from "@app/logger";
+import type { TimelyService } from "@app/timely/api/service";
+import type { OAuth2Tokens, TimelyEntry } from "@app/timely/types";
+import type { CreateEventInput, CreateEventTimestamp } from "@app/timely/types/api";
+import { type CategorySuggestion, suggestProjects } from "@app/timely/utils/categorizer";
+import { loadEventCorpus } from "@app/timely/utils/event-corpus";
+import { fetchMemoriesForDates } from "@app/timely/utils/memories";
+import { isInteractive } from "@app/utils/cli";
+import { SafeJSON } from "@app/utils/json";
+import type { Storage } from "@app/utils/storage";
+import * as p from "@clack/prompts";
+import chalk from "chalk";
+import type { Command } from "commander";
+import { spawn } from "node:child_process";
+
+interface CreateOptions {
+    from?: string;
+    to?: string;
+    day?: string;
+    project?: string;
+    note?: string;
+    interactive?: boolean;
+    dryRun?: boolean;
+    chainAdo?: boolean;
+}
+
+interface BuiltPayload {
+    input: CreateEventInput;
+    totalSeconds: number;
+}
+
+interface FlatEntry {
+    id: number;
+    from: string;
+    to: string;
+}
+
+function flattenMemories(memories: TimelyEntry[]): FlatEntry[] {
+    const flat: FlatEntry[] = [];
+    for (const bucket of memories) {
+        const inner = bucket.entries ?? [];
+        if (inner.length === 0) {
+            // Some payloads return a single entry without an `entries` wrapper
+            if (bucket.id && bucket.from && bucket.to) {
+                flat.push({ id: bucket.id, from: bucket.from, to: bucket.to });
+            }
+
+            continue;
+        }
+
+        for (const entry of inner) {
+            const subs = entry.sub_entries ?? [];
+            if (subs.length === 0) {
+                flat.push({ id: entry.id, from: entry.from, to: entry.to });
+            } else {
+                for (const sub of subs) {
+                    flat.push({ id: entry.id, from: sub.from, to: sub.to });
+                }
+            }
+        }
+    }
+
+    return flat.sort((a, b) => a.from.localeCompare(b.from));
+}
+
+function buildPayload(memories: TimelyEntry[], day: string, projectId: number, note: string): BuiltPayload {
+    const flat = flattenMemories(memories);
+    if (flat.length === 0) {
+        throw new Error(`No usable entries on ${day} — memories are empty or malformed`);
+    }
+
+    let totalSec = 0;
+    const timestamps: CreateEventTimestamp[] = flat.map((f) => {
+        const fromMs = new Date(f.from).getTime();
+        const toMs = new Date(f.to).getTime();
+        totalSec += Math.max(0, (toMs - fromMs) / 1000);
+        return {
+            from: f.from,
+            to: f.to,
+            entry_ids: [`tool_tic_${f.id}`],
+        };
+    });
+
+    const hours = Math.floor(totalSec / 3600);
+    const minutes = Math.floor((totalSec % 3600) / 60);
+    const seconds = Math.floor(totalSec % 60);
+
+    return {
+        input: {
+            day,
+            project_id: projectId,
+            note,
+            from: flat[0].from,
+            to: flat[flat.length - 1].to,
+            hours,
+            minutes,
+            seconds,
+            timestamps,
+            created_from: "GenesisTools",
+            updated_from: "GenesisTools",
+        },
+        totalSeconds: totalSec,
+    };
+}
+
+function expandDates(options: CreateOptions): string[] {
+    if (options.day) {
+        return [options.day];
+    }
+
+    if (options.from && options.to) {
+        const dates: string[] = [];
+        const cur = new Date(options.from);
+        const end = new Date(options.to);
+        while (cur <= end) {
+            dates.push(cur.toISOString().slice(0, 10));
+            cur.setDate(cur.getDate() + 1);
+        }
+
+        return dates;
+    }
+
+    return [];
+}
+
+function defaultNote(memories: TimelyEntry[]): string {
+    const titles = Array.from(new Set(memories.map((m) => m.title).filter((t): t is string => Boolean(t))));
+    return titles.slice(0, 3).join(", ");
+}
+
+function fmtDuration(totalSec: number): string {
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+async function pickProject(
+    service: TimelyService,
+    accountId: number,
+    date: string,
+    suggestions: CategorySuggestion[]
+): Promise<number | null> {
+    if (suggestions.length === 0) {
+        const projects = await service.getProjects(accountId);
+        const picked = await p.select({
+            message: `${date} — pick project`,
+            options: projects.slice(0, 50).map((pr) => ({ value: pr.id, label: pr.name })),
+        });
+        if (p.isCancel(picked)) {
+            return null;
+        }
+
+        return picked as number;
+    }
+
+    const picked = await p.select({
+        message: `${date} — suggested project`,
+        options: [
+            ...suggestions.map((s) => ({
+                value: s.projectId,
+                label: `${s.projectName} (score ${s.score.toFixed(2)})`,
+                hint: s.reasons.join(" · "),
+            })),
+            { value: -1, label: "Pick another...", hint: "browse all projects" },
+        ],
+    });
+    if (p.isCancel(picked)) {
+        return null;
+    }
+
+    if (picked === -1) {
+        const projects = await service.getProjects(accountId);
+        const browsed = await p.select({
+            message: "Pick project",
+            options: projects.slice(0, 50).map((pr) => ({ value: pr.id, label: pr.name })),
+        });
+        if (p.isCancel(browsed)) {
+            return null;
+        }
+
+        return browsed as number;
+    }
+
+    return picked as number;
+}
+
+async function runCreate(storage: Storage, service: TimelyService, options: CreateOptions): Promise<void> {
+    const accountId = await storage.getConfigValue<number>("selectedAccountId");
+    const tokens = await storage.getConfigValue<OAuth2Tokens>("tokens");
+    if (!accountId || !tokens?.access_token) {
+        logger.error("Not authenticated. Run 'tools timely login' first.");
+        process.exit(1);
+    }
+
+    const dates = expandDates(options);
+    if (dates.length === 0) {
+        logger.error("Provide --from/--to or --day");
+        process.exit(1);
+    }
+
+    const interactive = options.interactive ?? isInteractive();
+
+    p.intro(chalk.cyan(`Timely create — ${dates.length} day(s)`));
+
+    const spin = p.spinner();
+    spin.start("Loading memories + 8-week corpus...");
+    const [memoriesResult, corpus] = await Promise.all([
+        fetchMemoriesForDates({ accountId, accessToken: tokens.access_token, dates, storage }),
+        loadEventCorpus(storage, service, accountId),
+    ]);
+    spin.stop(`Loaded ${memoriesResult.entries.length} memories, ${corpus.length} past entries.`);
+
+    const created: number[] = [];
+
+    for (const date of dates) {
+        const dayMemories = memoriesResult.byDate.get(date) ?? [];
+        if (dayMemories.length === 0) {
+            p.log.info(`${date}: no memories`);
+            continue;
+        }
+
+        const suggestions = options.project ? [] : suggestProjects(dayMemories, corpus);
+
+        let projectId: number;
+        let note = options.note ?? defaultNote(dayMemories);
+
+        if (options.project) {
+            projectId = parseInt(options.project, 10);
+        } else if (interactive) {
+            const picked = await pickProject(service, accountId, date, suggestions);
+            if (picked === null) {
+                p.cancel("Cancelled.");
+                return;
+            }
+
+            projectId = picked;
+
+            const editedNote = await p.text({
+                message: "Note",
+                initialValue: note,
+                defaultValue: note,
+            });
+            if (p.isCancel(editedNote)) {
+                p.cancel("Cancelled.");
+                return;
+            }
+
+            note = editedNote;
+        } else {
+            if (suggestions.length === 0) {
+                logger.error(`${date}: no suggestion + no --project — skipping`);
+                continue;
+            }
+
+            projectId = suggestions[0].projectId;
+        }
+
+        const { input, totalSeconds } = buildPayload(dayMemories, date, projectId, note);
+
+        if (options.dryRun) {
+            p.log.info(`${date} DRY-RUN payload:\n${SafeJSON.stringify(input, null, 2)}`);
+            continue;
+        }
+
+        if (interactive) {
+            const ok = await p.confirm({
+                message: `Post ${fmtDuration(totalSeconds)} to project ${projectId}?`,
+                initialValue: true,
+            });
+            if (p.isCancel(ok) || !ok) {
+                p.log.warn(`${date} skipped`);
+                continue;
+            }
+        }
+
+        const ev = await service.createEvent(accountId, input);
+        created.push(ev.id);
+        p.log.success(`${date} → event ${ev.id} (${ev.duration.formatted})`);
+    }
+
+    p.outro(`Created ${created.length} event(s).`);
+
+    if (options.chainAdo && created.length > 0) {
+        for (const date of dates) {
+            console.log(chalk.cyan(`\n→ Launching ADO TimeLog for ${date}...`));
+            await new Promise<void>((resolve) => {
+                const proc = spawn("tools", ["azure-devops", "timelog", "add", "-i", "-d", date], {
+                    stdio: "inherit",
+                });
+                proc.on("exit", () => resolve());
+            });
+        }
+    }
+}
+
+export function registerCreateCommand(program: Command, storage: Storage, service: TimelyService): void {
+    program
+        .command("create")
+        .description("Create Timely events from auto-tracked memories (interactive by default)")
+        .option("--from <date>", "Start date (YYYY-MM-DD)")
+        .option("--to <date>", "End date (YYYY-MM-DD)")
+        .option("--day <date>", "Single day")
+        .option("-p, --project <id>", "Force project ID (skip categorizer)")
+        .option("-n, --note <text>", "Override note (default: derived from memory titles)")
+        .option("-i, --interactive", "Interactive mode (default if TTY)")
+        .option("--dry-run", "Show payload without posting")
+        .option("--chain-ado", "After create, run `tools azure-devops timelog add -i` per day")
+        .action(async (options: CreateOptions) => {
+            await runCreate(storage, service, options);
+        });
+}

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -125,7 +125,13 @@ async function runCreate(storage: Storage, service: TimelyService, options: Crea
         process.exit(1);
     }
 
-    const interactive = options.interactive ?? isInteractive();
+    const ttyInteractive = isInteractive();
+    if (options.interactive && !ttyInteractive) {
+        logger.error("--interactive requires a TTY; rerun with -p <id> [-n <note>] for non-TTY contexts.");
+        process.exit(1);
+    }
+
+    const interactive = options.interactive ?? ttyInteractive;
 
     p.intro(chalk.cyan(`Timely create — ${dates.length} day(s)`));
 
@@ -391,9 +397,12 @@ export function registerCreateCommand(program: Command, storage: Storage, servic
         .option("--apply <path>", "Apply a plan JSON file (use - for stdin)")
         .option("--yes", "Skip warning confirmation when applying")
         .action(async (options: CreateOptions) => {
-            if (options.project !== undefined && Number.isNaN(parseInt(options.project, 10))) {
-                logger.error(`Invalid --project: ${options.project} (must be numeric)`);
-                process.exit(1);
+            if (options.project !== undefined) {
+                const parsed = Number(options.project);
+                if (!Number.isInteger(parsed) || parsed <= 0) {
+                    logger.error(`Invalid --project: ${options.project} (must be a positive integer)`);
+                    process.exit(1);
+                }
             }
 
             const modes = [options.plan, !!options.apply].filter(Boolean).length;

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -243,7 +243,7 @@ async function runPlan(storage: Storage, service: TimelyService, options: Create
         logger.info(
             `  ${plan.days.length} day(s), ${plan.days.reduce((s, d) => s + d.available_memories.length, 0)} memories`
         );
-        logger.info("  Edit events[] per day, then: tools timely create --apply " + out + " --dry-run");
+        logger.info(`  Edit events[] per day, then: tools timely create --apply ${out} --dry-run`);
     }
 }
 

--- a/src/timely/index.ts
+++ b/src/timely/index.ts
@@ -11,6 +11,7 @@ import { TimelyApiClient } from "./api/client";
 import { TimelyService } from "./api/service";
 import { registerAccountsCommand } from "./commands/accounts";
 import { registerCacheCommand } from "./commands/cache";
+import { registerCreateCommand } from "./commands/create";
 import { registerEventsCommand } from "./commands/events";
 import { registerExportMonthCommand } from "./commands/export-month";
 // Commands
@@ -43,6 +44,7 @@ ${chalk.cyan("Commands:")}
   projects                List all projects (--select to choose default)
   events                  List time entries (with memories + unlinked by default)
   memories                List auto-tracked activities (suggested entries)
+  create                  Create events from memories (interactive heuristic)
   export-month <YYYY-MM>  Export all entries for a month
   cache [list|clear]      Manage cache
 
@@ -102,6 +104,7 @@ async function main(): Promise<void> {
     registerExportMonthCommand(program, storage, service);
     registerCacheCommand(program, storage);
     registerMemoriesCommand(program, storage, service);
+    registerCreateCommand(program, storage, service);
     enhanceHelp(program);
 
     // Parse and execute

--- a/src/timely/types/api.ts
+++ b/src/timely/types/api.ts
@@ -262,19 +262,19 @@ export interface TimelyExtraAttribute {
     value: string;
 }
 
-export interface TimelyEntry {
-    id: number;
-    type: string; // e.g., "macOS"
+export interface TimelyAppEntry {
+    id: number; // memory ID — used in `tool_tic_<id>` for timestamps[].entry_ids
+    type: string;
     uid: string;
-    title: string; // Application name, e.g., "Cursor"
-    note: string; // Main note/description
+    title: string;
+    note: string;
     description: string;
-    date: string; // YYYY-MM-DD
+    date: string;
     from: string; // ISO datetime
     to: string; // ISO datetime
     entry_type: string | null;
     duration: Duration;
-    at: string; // ISO datetime
+    at: string;
     extra_attributes: TimelyExtraAttribute[];
     icon: string | null;
     color: string | null;
@@ -282,7 +282,33 @@ export interface TimelyEntry {
     icon_url: string;
     icon_fallback_url: string;
     url: string;
-    entry_ids?: number[]; // Present on suggested_entries (memories) — IDs of sub-entries
+    importance?: number;
+    spam?: boolean;
+    updated_by?: string;
+}
+
+export interface TimelyEntry {
+    id: number;
+    type: string;
+    uid: string;
+    title: string;
+    note: string;
+    description: string;
+    date: string;
+    from: string;
+    to: string;
+    entry_type: string | null;
+    duration: Duration;
+    at: string;
+    extra_attributes: TimelyExtraAttribute[];
+    icon: string | null;
+    color: string | null;
+    sub_entries: TimelySubEntry[];
+    icon_url: string;
+    icon_fallback_url: string;
+    url: string;
+    entry_ids?: number[]; // top-level memory bucket: IDs of contained entries
+    entries?: TimelyAppEntry[]; // top-level memory bucket: actual app entries with from/to
 }
 
 // TimelyEntryResponse is now just an array of TimelyEntry

--- a/src/timely/types/api.ts
+++ b/src/timely/types/api.ts
@@ -217,19 +217,30 @@ export interface TimelyEvent {
 // Create Event Input
 // ============================================
 
+export interface CreateEventTimestamp {
+    from: string; // ISO datetime
+    to: string; // ISO datetime
+    entry_ids: string[]; // e.g. ["tool_tic_<memoryId>"]
+}
+
 export interface CreateEventInput {
     day: string; // YYYY-MM-DD
     hours: number;
     minutes: number;
+    seconds?: number;
     note?: string;
     project_id?: number;
     user_id?: number;
-    from?: string; // HH:MM
-    to?: string; // HH:MM
+    from?: string; // ISO datetime or HH:MM
+    to?: string;
     estimated_hours?: number;
     estimated_minutes?: number;
     label_ids?: number[];
     external_id?: string;
+    timestamps?: CreateEventTimestamp[];
+    created_from?: string;
+    updated_from?: string;
+    timer_state?: number;
 }
 
 // ============================================

--- a/src/timely/types/plan.ts
+++ b/src/timely/types/plan.ts
@@ -1,0 +1,42 @@
+export interface AvailableMemory {
+    id: number;
+    app: string;
+    note: string;
+    from: string;
+    to: string;
+    duration_min: number;
+    sub_notes: string[];
+}
+
+export interface PlanSuggestion {
+    project_id: number;
+    project_name: string;
+    score: number;
+    reasons: string[];
+}
+
+export interface PlanEvent {
+    project_id: number;
+    note: string;
+    memory_ids: number[];
+}
+
+export interface PlanDay {
+    day: string;
+    available_memories: AvailableMemory[];
+    suggestions: PlanSuggestion[];
+    events: PlanEvent[];
+}
+
+export interface CreatePlanV1 {
+    version: 1;
+    generated_at: string;
+    days: PlanDay[];
+}
+
+export interface PlanIssue {
+    severity: "error" | "warn";
+    day: string;
+    eventIdx?: number;
+    message: string;
+}

--- a/src/timely/utils/categorizer.ts
+++ b/src/timely/utils/categorizer.ts
@@ -1,0 +1,97 @@
+import type { TimelyEntry } from "@app/timely/types/api";
+import type { CorpusEntry } from "@app/timely/utils/event-corpus";
+import { timeOverlapRatio, wordSimilarity } from "@app/utils/fuzzy-match";
+
+export interface CategorySuggestion {
+    projectId: number;
+    projectName: string;
+    score: number;
+    reasons: string[];
+    sampleNotes: string[];
+}
+
+const CORPUS_WINDOW_DAYS = 56;
+
+function recencyWeight(daysAgo: number): number {
+    return Math.max(0, 1 - daysAgo / CORPUS_WINDOW_DAYS);
+}
+
+function memoryText(memory: TimelyEntry): string {
+    const subNotes = (memory.sub_entries ?? []).map((s) => s.note).join(" ");
+    return `${memory.title ?? ""} ${memory.note ?? ""} ${memory.description ?? ""} ${subNotes}`.trim();
+}
+
+function memoryRange(memory: TimelyEntry): { from: string; to: string } | null {
+    if (!memory.from || !memory.to) {
+        return null;
+    }
+
+    return { from: memory.from, to: memory.to };
+}
+
+interface Bucket {
+    name: string;
+    score: number;
+    matches: number;
+    notes: { note: string; sim: number }[];
+}
+
+export function suggestProjects(memories: TimelyEntry[], corpus: CorpusEntry[]): CategorySuggestion[] {
+    if (memories.length === 0 || corpus.length === 0) {
+        return [];
+    }
+
+    const text = memories.map(memoryText).join(" ");
+    if (!text.trim()) {
+        return [];
+    }
+
+    const ranges = memories.map(memoryRange).filter((r): r is { from: string; to: string } => r !== null);
+
+    const buckets = new Map<number, Bucket>();
+
+    for (const entry of corpus) {
+        const target = `${entry.note} ${entry.projectName}`.trim();
+        const wordSim = wordSimilarity(text, target);
+        const timeSim =
+            ranges.length > 0 && entry.from && entry.to
+                ? Math.max(...ranges.map((r) => timeOverlapRatio(r, { from: entry.from, to: entry.to })))
+                : 0;
+        const r = recencyWeight(entry.daysAgo);
+        const contribution = wordSim * 0.6 + timeSim * 0.2 + r * 0.2;
+        if (contribution < 0.05) {
+            continue;
+        }
+
+        const bucket = buckets.get(entry.projectId) ?? {
+            name: entry.projectName,
+            score: 0,
+            matches: 0,
+            notes: [],
+        };
+        bucket.score += contribution;
+        bucket.matches += 1;
+        if (entry.note) {
+            bucket.notes.push({ note: entry.note, sim: wordSim });
+        }
+
+        buckets.set(entry.projectId, bucket);
+    }
+
+    return Array.from(buckets.entries())
+        .map(([projectId, b]): CategorySuggestion => {
+            const topSim = b.notes.length > 0 ? Math.max(...b.notes.map((n) => n.sim)) : 0;
+            return {
+                projectId,
+                projectName: b.name,
+                score: b.score,
+                reasons: [`${b.matches} similar past entries`, `top word similarity ${topSim.toFixed(2)}`],
+                sampleNotes: b.notes
+                    .sort((a, b2) => b2.sim - a.sim)
+                    .slice(0, 3)
+                    .map((n) => n.note),
+            };
+        })
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3);
+}

--- a/src/timely/utils/event-corpus.ts
+++ b/src/timely/utils/event-corpus.ts
@@ -1,0 +1,53 @@
+import type { TimelyService } from "@app/timely/api/service";
+import type { TimelyEvent } from "@app/timely/types/api";
+import type { Storage } from "@app/utils/storage";
+
+const CORPUS_TTL = "1 day";
+const CORPUS_WINDOW_DAYS = 56; // 8 weeks
+
+export interface CorpusEntry {
+    eventId: number;
+    day: string;
+    daysAgo: number;
+    projectId: number;
+    projectName: string;
+    note: string;
+    from: string | null;
+    to: string | null;
+}
+
+export async function loadEventCorpus(
+    storage: Storage,
+    service: TimelyService,
+    accountId: number,
+    today: Date = new Date()
+): Promise<CorpusEntry[]> {
+    const end = today.toISOString().slice(0, 10);
+    const startDate = new Date(today);
+    startDate.setDate(startDate.getDate() - CORPUS_WINDOW_DAYS);
+    const start = startDate.toISOString().slice(0, 10);
+
+    const cacheKey = `corpus/events-${start}_${end}.json`;
+    const events = await storage.getFileOrPut<TimelyEvent[]>(
+        cacheKey,
+        () => service.getAllEvents(accountId, { since: start, upto: end }),
+        CORPUS_TTL
+    );
+
+    return events
+        .filter((e) => e.project?.id)
+        .map<CorpusEntry>((e) => {
+            const dayDate = new Date(`${e.day}T00:00:00`);
+            const daysAgo = Math.floor((today.getTime() - dayDate.getTime()) / 86_400_000);
+            return {
+                eventId: e.id,
+                day: e.day,
+                daysAgo,
+                projectId: e.project!.id,
+                projectName: e.project!.name,
+                note: e.note ?? "",
+                from: e.from ?? null,
+                to: e.to ?? null,
+            };
+        });
+}

--- a/src/timely/utils/flatten-memories.ts
+++ b/src/timely/utils/flatten-memories.ts
@@ -53,23 +53,57 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
     return flat.sort((a, b) => a.from.localeCompare(b.from));
 }
 
+/**
+ * Compute wall-clock duration as the UNION of (possibly overlapping) intervals.
+ * Memories from different apps frequently overlap (cmux + Cursor + Teams running
+ * concurrently); summing them double-counts. The server expects merged duration.
+ */
+function unionDurationSeconds(flat: FlatEntry[]): number {
+    if (flat.length === 0) {
+        return 0;
+    }
+
+    const intervals = flat
+        .map((f) => ({ from: new Date(f.from).getTime(), to: new Date(f.to).getTime() }))
+        .filter((iv) => iv.to > iv.from)
+        .sort((a, b) => a.from - b.from);
+
+    if (intervals.length === 0) {
+        return 0;
+    }
+
+    let totalMs = 0;
+    let curFrom = intervals[0].from;
+    let curTo = intervals[0].to;
+    for (let i = 1; i < intervals.length; i++) {
+        const iv = intervals[i];
+        if (iv.from <= curTo) {
+            if (iv.to > curTo) {
+                curTo = iv.to;
+            }
+        } else {
+            totalMs += curTo - curFrom;
+            curFrom = iv.from;
+            curTo = iv.to;
+        }
+    }
+
+    totalMs += curTo - curFrom;
+    return totalMs / 1000;
+}
+
 export function buildPayloadFromFlat(flat: FlatEntry[], day: string, projectId: number, note: string): BuiltPayload {
     if (flat.length === 0) {
         throw new Error(`No usable entries on ${day} — memories are empty or filtered out`);
     }
 
-    let totalSec = 0;
-    const timestamps: CreateEventTimestamp[] = flat.map((f) => {
-        const fromMs = new Date(f.from).getTime();
-        const toMs = new Date(f.to).getTime();
-        totalSec += Math.max(0, (toMs - fromMs) / 1000);
-        return {
-            from: f.from,
-            to: f.to,
-            entry_ids: [`tool_tic_${f.id}`],
-        };
-    });
+    const timestamps: CreateEventTimestamp[] = flat.map((f) => ({
+        from: f.from,
+        to: f.to,
+        entry_ids: [`tool_tic_${f.id}`],
+    }));
 
+    const totalSec = unionDurationSeconds(flat);
     const hours = Math.floor(totalSec / 3600);
     const minutes = Math.floor((totalSec % 3600) / 60);
     const seconds = Math.floor(totalSec % 60);

--- a/src/timely/utils/flatten-memories.ts
+++ b/src/timely/utils/flatten-memories.ts
@@ -20,7 +20,7 @@ export interface BuiltPayload {
  * returned. Used by the plan/apply flow to filter to a specific event's IDs.
  */
 export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number>): FlatEntry[] {
-    const flat: FlatEntry[] = [];
+    const raw: FlatEntry[] = [];
 
     const allowed = (id: number): boolean => !allowedIds || allowedIds.has(id);
 
@@ -28,7 +28,7 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
         const inner = bucket.entries ?? [];
         if (inner.length === 0) {
             if (bucket.id && bucket.from && bucket.to && allowed(bucket.id)) {
-                flat.push({ id: bucket.id, from: bucket.from, to: bucket.to });
+                raw.push({ id: bucket.id, from: bucket.from, to: bucket.to });
             }
 
             continue;
@@ -41,16 +41,57 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
 
             const subs = entry.sub_entries ?? [];
             if (subs.length === 0) {
-                flat.push({ id: entry.id, from: entry.from, to: entry.to });
+                raw.push({ id: entry.id, from: entry.from, to: entry.to });
             } else {
                 for (const sub of subs) {
-                    flat.push({ id: entry.id, from: sub.from, to: sub.to });
+                    raw.push({ id: entry.id, from: sub.from, to: sub.to });
                 }
             }
         }
     }
 
-    return flat.sort((a, b) => a.from.localeCompare(b.from));
+    // Merge overlapping/touching intervals PER memory id to keep the visible
+    // timestamps[] in the Timely UI minimal (otherwise dozens of 1-min rows).
+    const byId = new Map<number, FlatEntry[]>();
+    for (const f of raw) {
+        const arr = byId.get(f.id) ?? [];
+        arr.push(f);
+        byId.set(f.id, arr);
+    }
+
+    const merged: FlatEntry[] = [];
+    for (const [id, items] of byId) {
+        const sorted = items
+            .map((it) => ({ id, fromMs: new Date(it.from).getTime(), toMs: new Date(it.to).getTime(), from: it.from, to: it.to }))
+            .filter((it) => it.toMs > it.fromMs)
+            .sort((a, b) => a.fromMs - b.fromMs);
+
+        if (sorted.length === 0) {
+            continue;
+        }
+
+        let curFrom = sorted[0].from;
+        let curTo = sorted[0].to;
+        let curToMs = sorted[0].toMs;
+        for (let i = 1; i < sorted.length; i++) {
+            const it = sorted[i];
+            if (it.fromMs <= curToMs) {
+                if (it.toMs > curToMs) {
+                    curTo = it.to;
+                    curToMs = it.toMs;
+                }
+            } else {
+                merged.push({ id, from: curFrom, to: curTo });
+                curFrom = it.from;
+                curTo = it.to;
+                curToMs = it.toMs;
+            }
+        }
+
+        merged.push({ id, from: curFrom, to: curTo });
+    }
+
+    return merged.sort((a, b) => a.from.localeCompare(b.from));
 }
 
 /**

--- a/src/timely/utils/flatten-memories.ts
+++ b/src/timely/utils/flatten-memories.ts
@@ -53,12 +53,7 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
     return flat.sort((a, b) => a.from.localeCompare(b.from));
 }
 
-export function buildPayloadFromFlat(
-    flat: FlatEntry[],
-    day: string,
-    projectId: number,
-    note: string
-): BuiltPayload {
+export function buildPayloadFromFlat(flat: FlatEntry[], day: string, projectId: number, note: string): BuiltPayload {
     if (flat.length === 0) {
         throw new Error(`No usable entries on ${day} — memories are empty or filtered out`);
     }

--- a/src/timely/utils/flatten-memories.ts
+++ b/src/timely/utils/flatten-memories.ts
@@ -1,0 +1,98 @@
+import type { CreateEventInput, CreateEventTimestamp, TimelyEntry } from "@app/timely/types/api";
+
+export interface FlatEntry {
+    id: number;
+    from: string;
+    to: string;
+}
+
+export interface BuiltPayload {
+    input: CreateEventInput;
+    totalSeconds: number;
+}
+
+/**
+ * Walk memory buckets → app entries → sub-entries, returning a flat list of
+ * (memoryId, from, to) triples sorted by `from`. Each item maps to one
+ * `timestamps[]` entry on the Timely event payload.
+ *
+ * If `allowedIds` is provided, only entries whose memory id is in the set are
+ * returned. Used by the plan/apply flow to filter to a specific event's IDs.
+ */
+export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number>): FlatEntry[] {
+    const flat: FlatEntry[] = [];
+
+    const allowed = (id: number): boolean => !allowedIds || allowedIds.has(id);
+
+    for (const bucket of memories) {
+        const inner = bucket.entries ?? [];
+        if (inner.length === 0) {
+            if (bucket.id && bucket.from && bucket.to && allowed(bucket.id)) {
+                flat.push({ id: bucket.id, from: bucket.from, to: bucket.to });
+            }
+
+            continue;
+        }
+
+        for (const entry of inner) {
+            if (!allowed(entry.id)) {
+                continue;
+            }
+
+            const subs = entry.sub_entries ?? [];
+            if (subs.length === 0) {
+                flat.push({ id: entry.id, from: entry.from, to: entry.to });
+            } else {
+                for (const sub of subs) {
+                    flat.push({ id: entry.id, from: sub.from, to: sub.to });
+                }
+            }
+        }
+    }
+
+    return flat.sort((a, b) => a.from.localeCompare(b.from));
+}
+
+export function buildPayloadFromFlat(
+    flat: FlatEntry[],
+    day: string,
+    projectId: number,
+    note: string
+): BuiltPayload {
+    if (flat.length === 0) {
+        throw new Error(`No usable entries on ${day} — memories are empty or filtered out`);
+    }
+
+    let totalSec = 0;
+    const timestamps: CreateEventTimestamp[] = flat.map((f) => {
+        const fromMs = new Date(f.from).getTime();
+        const toMs = new Date(f.to).getTime();
+        totalSec += Math.max(0, (toMs - fromMs) / 1000);
+        return {
+            from: f.from,
+            to: f.to,
+            entry_ids: [`tool_tic_${f.id}`],
+        };
+    });
+
+    const hours = Math.floor(totalSec / 3600);
+    const minutes = Math.floor((totalSec % 3600) / 60);
+    const seconds = Math.floor(totalSec % 60);
+
+    return {
+        input: {
+            day,
+            project_id: projectId,
+            note,
+            from: flat[0].from,
+            to: flat[flat.length - 1].to,
+            hours,
+            minutes,
+            seconds,
+            timestamps,
+            created_from: "GenesisTools",
+            updated_from: "GenesisTools",
+        },
+        totalSeconds: totalSec,
+    };
+}

--- a/src/timely/utils/flatten-memories.ts
+++ b/src/timely/utils/flatten-memories.ts
@@ -11,6 +11,11 @@ export interface BuiltPayload {
     totalSeconds: number;
 }
 
+/** Merge intervals within a memory if the gap between them is at most this many seconds. */
+const MERGE_GAP_TOLERANCE_SEC = 60;
+/** Drop merged intervals shorter than this — too noisy to log. */
+const MIN_BLOCK_SEC = 5 * 60;
+
 /**
  * Walk memory buckets → app entries → sub-entries, returning a flat list of
  * (memoryId, from, to) triples sorted by `from`. Each item maps to one
@@ -59,6 +64,9 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
         byId.set(f.id, arr);
     }
 
+    const mergeToleranceMs = MERGE_GAP_TOLERANCE_SEC * 1000;
+    const minBlockMs = MIN_BLOCK_SEC * 1000;
+
     const merged: FlatEntry[] = [];
     for (const [id, items] of byId) {
         const sorted = items
@@ -70,25 +78,34 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
             continue;
         }
 
+        const memoryMerged: { from: string; to: string; durationMs: number }[] = [];
         let curFrom = sorted[0].from;
         let curTo = sorted[0].to;
+        let curFromMs = sorted[0].fromMs;
         let curToMs = sorted[0].toMs;
         for (let i = 1; i < sorted.length; i++) {
             const it = sorted[i];
-            if (it.fromMs <= curToMs) {
+            if (it.fromMs - curToMs <= mergeToleranceMs) {
                 if (it.toMs > curToMs) {
                     curTo = it.to;
                     curToMs = it.toMs;
                 }
             } else {
-                merged.push({ id, from: curFrom, to: curTo });
+                memoryMerged.push({ from: curFrom, to: curTo, durationMs: curToMs - curFromMs });
                 curFrom = it.from;
                 curTo = it.to;
+                curFromMs = it.fromMs;
                 curToMs = it.toMs;
             }
         }
 
-        merged.push({ id, from: curFrom, to: curTo });
+        memoryMerged.push({ from: curFrom, to: curTo, durationMs: curToMs - curFromMs });
+
+        for (const block of memoryMerged) {
+            if (block.durationMs >= minBlockMs) {
+                merged.push({ id, from: block.from, to: block.to });
+            }
+        }
     }
 
     return merged.sort((a, b) => a.from.localeCompare(b.from));

--- a/src/timely/utils/flatten-memories.ts
+++ b/src/timely/utils/flatten-memories.ts
@@ -70,7 +70,13 @@ export function flattenMemories(memories: TimelyEntry[], allowedIds?: Set<number
     const merged: FlatEntry[] = [];
     for (const [id, items] of byId) {
         const sorted = items
-            .map((it) => ({ id, fromMs: new Date(it.from).getTime(), toMs: new Date(it.to).getTime(), from: it.from, to: it.to }))
+            .map((it) => ({
+                id,
+                fromMs: new Date(it.from).getTime(),
+                toMs: new Date(it.to).getTime(),
+                from: it.from,
+                to: it.to,
+            }))
             .filter((it) => it.toMs > it.fromMs)
             .sort((a, b) => a.fromMs - b.fromMs);
 
@@ -166,13 +172,16 @@ export function buildPayloadFromFlat(flat: FlatEntry[], day: string, projectId: 
     const minutes = Math.floor((totalSec % 3600) / 60);
     const seconds = Math.floor(totalSec % 60);
 
+    const minFrom = flat.reduce((min, f) => (f.from < min ? f.from : min), flat[0].from);
+    const maxTo = flat.reduce((max, f) => (f.to > max ? f.to : max), flat[0].to);
+
     return {
         input: {
             day,
             project_id: projectId,
             note,
-            from: flat[0].from,
-            to: flat[flat.length - 1].to,
+            from: minFrom,
+            to: maxTo,
             hours,
             minutes,
             seconds,

--- a/src/timely/utils/plan-apply.ts
+++ b/src/timely/utils/plan-apply.ts
@@ -1,0 +1,183 @@
+import type { TimelyService } from "@app/timely/api/service";
+import type { TimelyEvent } from "@app/timely/types/api";
+import type { CreatePlanV1, PlanIssue } from "@app/timely/types/plan";
+import { buildPayloadFromFlat, flattenMemories } from "@app/timely/utils/flatten-memories";
+import { fetchMemoriesForDates } from "@app/timely/utils/memories";
+import type { Storage } from "@app/utils/storage";
+
+export function validatePlan(plan: CreatePlanV1): PlanIssue[] {
+    const issues: PlanIssue[] = [];
+
+    if (plan.version !== 1) {
+        issues.push({ severity: "error", day: "*", message: `unsupported plan version ${plan.version}` });
+        return issues;
+    }
+
+    for (const day of plan.days) {
+        const availableIds = new Set(day.available_memories.map((m) => m.id));
+        const seenInDay = new Set<number>();
+
+        for (const [i, ev] of day.events.entries()) {
+            if (ev.memory_ids.length === 0) {
+                issues.push({
+                    severity: "error",
+                    day: day.day,
+                    eventIdx: i,
+                    message: "event has no memory_ids",
+                });
+                continue;
+            }
+
+            if (!ev.project_id || ev.project_id <= 0) {
+                issues.push({
+                    severity: "error",
+                    day: day.day,
+                    eventIdx: i,
+                    message: `invalid project_id ${ev.project_id}`,
+                });
+            }
+
+            const dupInEvent = new Set<number>();
+            for (const mid of ev.memory_ids) {
+                if (!availableIds.has(mid)) {
+                    issues.push({
+                        severity: "error",
+                        day: day.day,
+                        eventIdx: i,
+                        message: `memory_id ${mid} not in available_memories`,
+                    });
+                }
+
+                if (dupInEvent.has(mid)) {
+                    issues.push({
+                        severity: "error",
+                        day: day.day,
+                        eventIdx: i,
+                        message: `duplicate memory_id ${mid} within event`,
+                    });
+                }
+
+                dupInEvent.add(mid);
+
+                if (seenInDay.has(mid)) {
+                    issues.push({
+                        severity: "warn",
+                        day: day.day,
+                        eventIdx: i,
+                        message: `memory_id ${mid} assigned to multiple events on this day`,
+                    });
+                }
+
+                seenInDay.add(mid);
+            }
+        }
+
+        if (day.events.length > 0) {
+            const unassigned = day.available_memories.filter((m) => !seenInDay.has(m.id));
+            if (unassigned.length > 0) {
+                const totalMin = unassigned.reduce((sum, m) => sum + m.duration_min, 0);
+                issues.push({
+                    severity: "warn",
+                    day: day.day,
+                    message: `${unassigned.length} memory IDs unassigned (~${totalMin}min) — will not be logged`,
+                });
+            }
+        }
+    }
+
+    return issues;
+}
+
+export interface ApplyResult {
+    day: string;
+    eventIdx: number;
+    eventId?: number;
+    project_id: number;
+    duration: string;
+    memoryCount: number;
+    error?: string;
+}
+
+export async function applyPlan(args: {
+    plan: CreatePlanV1;
+    service: TimelyService;
+    storage: Storage;
+    accountId: number;
+    accessToken: string;
+    dryRun: boolean;
+    onPayload?: (day: string, eventIdx: number, payload: unknown) => void;
+}): Promise<ApplyResult[]> {
+    const dates = args.plan.days.map((d) => d.day);
+    const memoriesResult = await fetchMemoriesForDates({
+        accountId: args.accountId,
+        accessToken: args.accessToken,
+        dates,
+        storage: args.storage,
+    });
+
+    const results: ApplyResult[] = [];
+
+    for (const planDay of args.plan.days) {
+        const rawMemories = memoriesResult.byDate.get(planDay.day) ?? [];
+
+        for (const [eventIdx, ev] of planDay.events.entries()) {
+            const allowed = new Set(ev.memory_ids);
+            const flat = flattenMemories(rawMemories, allowed);
+            if (flat.length === 0) {
+                results.push({
+                    day: planDay.day,
+                    eventIdx,
+                    project_id: ev.project_id,
+                    duration: "00:00",
+                    memoryCount: 0,
+                    error: `no flat entries after filter (memory_ids ${ev.memory_ids.join(",")} not found in raw memories)`,
+                });
+                continue;
+            }
+
+            const { input, totalSeconds } = buildPayloadFromFlat(flat, planDay.day, ev.project_id, ev.note);
+            const duration = formatDuration(totalSeconds);
+
+            if (args.dryRun) {
+                args.onPayload?.(planDay.day, eventIdx, input);
+                results.push({
+                    day: planDay.day,
+                    eventIdx,
+                    project_id: ev.project_id,
+                    duration,
+                    memoryCount: ev.memory_ids.length,
+                });
+                continue;
+            }
+
+            try {
+                const created: TimelyEvent = await args.service.createEvent(args.accountId, input);
+                results.push({
+                    day: planDay.day,
+                    eventIdx,
+                    eventId: created.id,
+                    project_id: ev.project_id,
+                    duration: created.duration.formatted,
+                    memoryCount: ev.memory_ids.length,
+                });
+            } catch (err) {
+                results.push({
+                    day: planDay.day,
+                    eventIdx,
+                    project_id: ev.project_id,
+                    duration,
+                    memoryCount: ev.memory_ids.length,
+                    error: err instanceof Error ? err.message : String(err),
+                });
+            }
+        }
+    }
+
+    return results;
+}
+
+function formatDuration(totalSec: number): string {
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}

--- a/src/timely/utils/plan-apply.ts
+++ b/src/timely/utils/plan-apply.ts
@@ -13,11 +13,35 @@ export function validatePlan(plan: CreatePlanV1): PlanIssue[] {
         return issues;
     }
 
+    if (!Array.isArray(plan.days)) {
+        issues.push({ severity: "error", day: "*", message: "plan.days must be an array" });
+        return issues;
+    }
+
     for (const day of plan.days) {
+        if (!Array.isArray(day.available_memories) || !Array.isArray(day.events)) {
+            issues.push({
+                severity: "error",
+                day: day?.day ?? "*",
+                message: "day must have array `available_memories` and `events`",
+            });
+            continue;
+        }
+
         const availableIds = new Set(day.available_memories.map((m) => m.id));
         const seenInDay = new Set<number>();
 
         for (const [i, ev] of day.events.entries()) {
+            if (!Array.isArray(ev.memory_ids)) {
+                issues.push({
+                    severity: "error",
+                    day: day.day,
+                    eventIdx: i,
+                    message: "event.memory_ids must be an array",
+                });
+                continue;
+            }
+
             if (ev.memory_ids.length === 0) {
                 issues.push({
                     severity: "error",

--- a/src/timely/utils/plan-apply.ts
+++ b/src/timely/utils/plan-apply.ts
@@ -130,7 +130,7 @@ export async function applyPlan(args: {
                     project_id: ev.project_id,
                     duration: "00:00",
                     memoryCount: 0,
-                    error: `no flat entries after filter (memory_ids ${ev.memory_ids.join(",")} not found in raw memories)`,
+                    error: `no flat entries after filter (${ev.memory_ids.length} memory_ids not found in raw memories)`,
                 });
                 continue;
             }

--- a/src/timely/utils/plan-build.ts
+++ b/src/timely/utils/plan-build.ts
@@ -1,0 +1,82 @@
+import type { TimelyEntry } from "@app/timely/types/api";
+import type { AvailableMemory, CreatePlanV1, PlanDay, PlanSuggestion } from "@app/timely/types/plan";
+import { suggestProjects } from "@app/timely/utils/categorizer";
+import type { CorpusEntry } from "@app/timely/utils/event-corpus";
+
+function toAvailableMemories(buckets: TimelyEntry[]): AvailableMemory[] {
+    const out: AvailableMemory[] = [];
+
+    for (const bucket of buckets) {
+        const inner = bucket.entries ?? [];
+        if (inner.length === 0) {
+            // Single-entry bucket without nested `entries[]`
+            if (bucket.id && bucket.from && bucket.to) {
+                const fromMs = new Date(bucket.from).getTime();
+                const toMs = new Date(bucket.to).getTime();
+                out.push({
+                    id: bucket.id,
+                    app: bucket.title ?? "",
+                    note: bucket.note ?? "",
+                    from: bucket.from,
+                    to: bucket.to,
+                    duration_min: Math.round(Math.max(0, (toMs - fromMs) / 60_000)),
+                    sub_notes: [],
+                });
+            }
+
+            continue;
+        }
+
+        for (const entry of inner) {
+            const fromMs = new Date(entry.from).getTime();
+            const toMs = new Date(entry.to).getTime();
+            const subs = entry.sub_entries ?? [];
+            const subNotes = Array.from(
+                new Set(subs.map((s) => s.note).filter((n): n is string => Boolean(n) && n !== entry.note))
+            );
+            out.push({
+                id: entry.id,
+                app: entry.title ?? bucket.title ?? "",
+                note: entry.note ?? "",
+                from: entry.from,
+                to: entry.to,
+                duration_min: Math.round(Math.max(0, (toMs - fromMs) / 60_000)),
+                sub_notes: subNotes,
+            });
+        }
+    }
+
+    return out.sort((a, b) => a.from.localeCompare(b.from));
+}
+
+function toSuggestions(buckets: TimelyEntry[], corpus: CorpusEntry[]): PlanSuggestion[] {
+    return suggestProjects(buckets, corpus).map((s) => ({
+        project_id: s.projectId,
+        project_name: s.projectName,
+        score: Number(s.score.toFixed(3)),
+        reasons: s.reasons,
+    }));
+}
+
+export function buildPlan(args: {
+    memoriesByDate: Map<string, TimelyEntry[]>;
+    corpus: CorpusEntry[];
+    dates: string[];
+    now?: Date;
+}): CreatePlanV1 {
+    const days: PlanDay[] = args.dates.map((day) => {
+        const buckets = args.memoriesByDate.get(day) ?? [];
+        return {
+            day,
+            available_memories: toAvailableMemories(buckets),
+            suggestions: toSuggestions(buckets, args.corpus),
+            events: [],
+        };
+    });
+
+    return {
+        version: 1,
+        generated_at: (args.now ?? new Date()).toISOString(),
+        days,
+    };
+}


### PR DESCRIPTION
## Summary
- New `tools timely create` command that turns auto-tracked Timely memories into logged events via the public OAuth `POST /events` endpoint, preserving memory linkage through `timestamps[].entry_ids` of the form `tool_tic_<memoryId>`.
- Adds a non-interactive **plan / apply** workflow that lets an LLM split a day's memories across multiple projects via a JSON artifact, with validation, dry-run, and confirmation gates.
- Bundles an 8-week event corpus + heuristic categorizer (word similarity, time-of-day, recency) to suggest projects per day, plus a `gt:timely` skill (plugin 1.0.29) that drives the plan/apply flow end-to-end.

## What's new

**Commands**
- `tools timely create [--day | --from --to] [-i] [-p] [-n] [--dry-run]` — single-day or date-range creation, interactive picker, or one-shot all-day single-project.
- `tools timely create --plan --out <path>` — generate a per-day plan JSON + print a compact summary.
- `tools timely create --apply <path> [--dry-run] [--yes]` — validate, optionally dry-run, then post events.

**Library**
- `src/timely/types/plan.ts` — `CreatePlanV1` schema.
- `src/timely/utils/flatten-memories.ts` — flattens memory buckets, merges per-memory intervals (60s tolerance), drops blocks <5min, computes wall-clock duration as the **union** of overlapping intervals (cmux + Cursor + Teams concurrent tracking would otherwise double-count).
- `src/timely/utils/event-corpus.ts` — 8-week event history with 24h cache.
- `src/timely/utils/categorizer.ts` — Jaccard word similarity (60%) + time-of-day overlap (20%) + recency decay (20%).
- `src/timely/utils/plan-build.ts` + `plan-apply.ts` — plan generation, validation, application.

**Plugin / skill**
- `plugins/genesis-tools/skills/timely/SKILL.md` v1.0.29 — primary workflow is plan/apply; manual fallback covers `-i` and one-shot. Explicit "DO NOT use python/jq/awk" rule (the tool now prints its own summary so the LLM reasons from chat output rather than parsing JSON).

## Test plan
- [x] OAuth spike confirmed `timestamps[].entry_ids` round-trips on public API.
- [x] Real-day apply: posted 2 events on 2026-04-16 (Reservine 8:08 + ČEZ 10:47, 17 + 42 memories).
- [x] Per-memory merge collapses sub-second-gap intervals; <5min blocks dropped.
- [x] Interval-union duration matches server's own deduplication.
- [x] Plan validation: errors on missing/duplicate IDs and bad project_id; warns on intentional drops.
- [ ] Re-run apply for 17.4 + 18.4 with the merged-interval logic (next).
- [ ] Sequential ADO TimeLog handoff via `/gt:timelog` (out of scope for this PR — tracked separately).

## Known caveat
Events created via OAuth API receive a `created_from` value derived from the OAuth application name (Timely overrides the client value). The Timely web UI treats any non-`Desktop`/`Web`/`Mobile`/`iOS`/`Android` value as "external integration" and hides memory-unlink controls, even though `manage: true` and `locked: false`. API edits still work; UI editability is restricted by Timely's own policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "create" workflow: generate per-day plans from auto-tracked memories, review (dry-run), and apply events with interactive confirmations and per-event reporting.
  * Heuristic project suggestions with scored explanations and interactive project/note editing.
  * Improved event payloads: supports timestamped intervals and accurate duration building from merged memory segments.

* **Documentation**
  * CLI docs and a detailed skill guide covering workflows, validation rules, and fallbacks.

* **Chores**
  * Marketplace and plugin versions bumped to 1.0.29.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->