### PR TITLE
feat(say): config v2, xAI TTS polish, normalized --rate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,19 @@ tools npm-package-diff react 18.0.0 18.2.0
 tools ask --readme  # View ask tool documentation
 ```
 
+### `tools say` — config v2 with per-app profiles
+
+`tools say` loads voice / volume / provider / model / language / format from a per-app profile (`--app <name>`), inheriting unset fields from a `default` profile. Notable rules:
+
+- `--save` persists explicitly-passed flags to `--app`'s profile (requires `--app`; in TTY without it, prompts; in non-TTY, errors).
+- `--save` with no message text is a save-only invocation (does not speak, does not enter interactive mode).
+- `--mute` / `--unmute` require `--save` to persist (breaking change vs. older builds — they are no longer standalone state-write commands).
+- `--unset <fields>` (comma-separated): without `--save`, ignores those fields for this run; with `--save`, deletes the keys from the saved profile.
+- Run `tools say config` for an interactive profile manager.
+- Config lives at `~/.genesis-tools/say/config.json`; old v1 configs are auto-migrated and the original is backed up once to `config.v1.bak.json`.
+
+So when you write the end-of-task notification, you can typically rely on a saved `claude` profile and just call `tools say "<xxx> done" --app claude` — voice etc. come from the profile.
+
 ### Installation & Setup
 
 ```bash

--- a/src/darwinkit/lib/commands.ts
+++ b/src/darwinkit/lib/commands.ts
@@ -34,10 +34,10 @@ import {
     rankBySimilarity,
     recognizeText,
     scoreRelevance,
-    speak,
     tagText,
     textDistance,
 } from "@app/utils/macos";
+import { speak } from "@app/utils/macos/tts";
 
 // ─── Types ──────────────────────────────────────────────────────────────────────
 

--- a/src/e2e/say.e2e.test.ts
+++ b/src/e2e/say.e2e.test.ts
@@ -44,7 +44,11 @@ describe("tools say", () => {
         });
 
         it("speech without --app reports muted when default is muted", async () => {
-            await runTool(["say", "--mute", "--save", "--app", "default"]);
+            // Verify the mute setup succeeded — otherwise the speak below would
+            // actually play audio out of the speakers.
+            const setup = await runTool(["say", "--mute", "--save", "--app", "default"]);
+            expect(setup.exitCode).toBe(0);
+
             const r = await runTool(["say", "should be muted"]);
             expect(r.exitCode).toBe(0);
             expect(getOutput(r).toLowerCase()).toContain("muted");
@@ -63,7 +67,9 @@ describe("tools say", () => {
         });
 
         it("speech with muted app reports muted", async () => {
-            await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+            const setup = await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+            expect(setup.exitCode).toBe(0);
+
             const r = await runTool(["say", "should be muted", "--app", "e2e-test"]);
             expect(r.exitCode).toBe(0);
             expect(getOutput(r).toLowerCase()).toContain("muted");
@@ -75,17 +81,28 @@ describe("tools say", () => {
         });
 
         it("--unmute --save through a muted profile (PR #157 t3)", async () => {
-            // Set the profile to muted first.
-            await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+            // Pre-condition: profile is muted (assert it actually took).
+            const setup = await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+            expect(setup.exitCode).toBe(0);
 
-            // --unmute --save must not be blocked by the existing mute state.
-            const r = await runTool(["say", "ping", "--unmute", "--save", "--app", "e2e-test"]);
+            const muted = await runTool(["say", "should be muted", "--app", "e2e-test"]);
+            expect(muted.exitCode).toBe(0);
+            expect(getOutput(muted).toLowerCase()).toContain("muted");
+
+            // --unmute --save (save-only invocation: no message text, no speak)
+            // must not be blocked by the current mute state.
+            const r = await runTool(["say", "--unmute", "--save", "--app", "e2e-test"]);
             expect(r.exitCode).toBe(0);
 
-            // After unmuting, plain speech should not say "muted".
-            const after = await runTool(["say", "should now run", "--app", "e2e-test"]);
-            expect(after.exitCode).toBe(0);
-            expect(getOutput(after).toLowerCase()).not.toContain("[say] muted");
+            // Re-mute and verify mute is back — confirms the previous --unmute
+            // --save actually toggled the persisted state. Avoids a real speak
+            // call which would hit the macOS synthesizer in subprocess.
+            const remute = await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+            expect(remute.exitCode).toBe(0);
+
+            const reMuted = await runTool(["say", "should be muted", "--app", "e2e-test"]);
+            expect(reMuted.exitCode).toBe(0);
+            expect(getOutput(reMuted).toLowerCase()).toContain("muted");
         });
     });
 

--- a/src/e2e/say.e2e.test.ts
+++ b/src/e2e/say.e2e.test.ts
@@ -3,8 +3,9 @@ import { getOutput, runTool } from "@app/utils/e2e/helpers";
 
 describe("tools say", () => {
     afterAll(async () => {
-        await runTool(["say", "--unmute"]);
-        await runTool(["say", "--unmute", "--app", "e2e-test"]);
+        // Restore default + e2e-test profiles to unmuted state.
+        await runTool(["say", "--unmute", "--save", "--app", "default"]);
+        await runTool(["say", "--unmute", "--save", "--app", "e2e-test"]);
     });
 
     describe("help", () => {
@@ -22,47 +23,75 @@ describe("tools say", () => {
         });
     });
 
-    describe("mute lifecycle", () => {
-        it("--mute exits 0", async () => {
+    describe("mute requires --save", () => {
+        it("--mute without --save exits 1", async () => {
             const r = await runTool(["say", "--mute"]);
+            expect(r.exitCode).toBe(1);
+            expect(getOutput(r).toLowerCase()).toContain("require --save");
+        });
+
+        it("--unmute without --save exits 1", async () => {
+            const r = await runTool(["say", "--unmute"]);
+            expect(r.exitCode).toBe(1);
+            expect(getOutput(r).toLowerCase()).toContain("require --save");
+        });
+    });
+
+    describe("default-profile mute (silences no-app calls)", () => {
+        it("--mute --save --app default exits 0", async () => {
+            const r = await runTool(["say", "--mute", "--save", "--app", "default"]);
             expect(r.exitCode).toBe(0);
         });
 
-        it("speech while muted reports muted", async () => {
-            await runTool(["say", "--mute"]);
+        it("speech without --app reports muted when default is muted", async () => {
+            await runTool(["say", "--mute", "--save", "--app", "default"]);
             const r = await runTool(["say", "should be muted"]);
             expect(r.exitCode).toBe(0);
             expect(getOutput(r).toLowerCase()).toContain("muted");
         });
 
-        it("--unmute exits 0", async () => {
-            const r = await runTool(["say", "--unmute"]);
+        it("--unmute --save --app default exits 0", async () => {
+            const r = await runTool(["say", "--unmute", "--save", "--app", "default"]);
             expect(r.exitCode).toBe(0);
         });
     });
 
     describe("per-app mute", () => {
-        it("--mute --app e2e-test exits 0", async () => {
-            const r = await runTool(["say", "--mute", "--app", "e2e-test"]);
+        it("--mute --save --app e2e-test exits 0", async () => {
+            const r = await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
             expect(r.exitCode).toBe(0);
         });
 
         it("speech with muted app reports muted", async () => {
-            await runTool(["say", "--mute", "--app", "e2e-test"]);
-            const r = await runTool(["say", "test", "--app", "e2e-test"]);
+            await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+            const r = await runTool(["say", "should be muted", "--app", "e2e-test"]);
             expect(r.exitCode).toBe(0);
             expect(getOutput(r).toLowerCase()).toContain("muted");
         });
 
-        it("--unmute --app e2e-test exits 0", async () => {
-            const r = await runTool(["say", "--unmute", "--app", "e2e-test"]);
+        it("--unmute --save --app e2e-test exits 0", async () => {
+            const r = await runTool(["say", "--unmute", "--save", "--app", "e2e-test"]);
             expect(r.exitCode).toBe(0);
+        });
+
+        it("--unmute --save through a muted profile (PR #157 t3)", async () => {
+            // Set the profile to muted first.
+            await runTool(["say", "--mute", "--save", "--app", "e2e-test"]);
+
+            // --unmute --save must not be blocked by the existing mute state.
+            const r = await runTool(["say", "ping", "--unmute", "--save", "--app", "e2e-test"]);
+            expect(r.exitCode).toBe(0);
+
+            // After unmuting, plain speech should not say "muted".
+            const after = await runTool(["say", "should now run", "--app", "e2e-test"]);
+            expect(after.exitCode).toBe(0);
+            expect(getOutput(after).toLowerCase()).not.toContain("[say] muted");
         });
     });
 
     describe("speech options", () => {
-        // macOS `say` command hangs when spawned from subprocess (no TTY audio context)
-        // These flags are validated via --help output instead
+        // macOS `say` command hangs when spawned from subprocess (no TTY audio context).
+        // Flags validated via --help output instead.
         it("--help shows volume and rate flags", async () => {
             const r = await runTool(["say", "--help"]);
             expect(r.stdout).toContain("--volume");

--- a/src/say/README.md
+++ b/src/say/README.md
@@ -89,7 +89,7 @@ Mute is a logical-OR of `global.mute` and the app's **own** `mute` field — eit
 
 Some fields are provider-specific:
 
-- `rate` — macOS only (`say -r <wpm>`). xAI / OpenAI ignore it.
+- `rate` — normalized `0..2` multiplier (or `0..200%`). `0`=slowest, `1`=default cadence, `2`=fastest. Provider speeds are matched to macOS native (~0.81×..1.86×) so the same `--rate` sounds identical on macOS, xAI, and OpenAI.
 - `model` — OpenAI only (`tts-1`, `gpt-4o-mini-tts`). xAI uses a hardcoded model; macOS ignores it.
 - `language` — xAI only (BCP-47 hint).
 - `format` — only meaningful for cloud providers writing audio files.
@@ -172,15 +172,16 @@ $ tools say --app claude --mute
 
 ## Interactive config (`tools say config`)
 
-`tools say config` opens a clack-driven manager:
+`tools say config` (or just `tools say` with no args) opens the same clack-driven manager:
 
+- **Speak text (test)** — pick a profile, type something, hear it
+- **Edit an app profile** — pick an existing app or `+ new app`; walks every field once (⏎ keep, `-` inherit, value to set), summary, confirm
 - **List** apps with their resolved (post-inherit) settings
-- **Edit** any app's profile field-by-field (set value, clear, or back)
-- **Add** a new app (name + initial fields)
 - **Delete** an app (the `default` profile is non-removable)
+- **List available voices**
 - **Toggle global mute**
 
-`tools say` with no args still opens the simpler legacy picker (test voice, set default voice/volume, etc.); pick "Full config (apps, profiles)…" from there to drop into the same `config` TUI.
+In a non-TTY context both entry points fail fast — pass `--app <name> --save` (or `<message>`) instead.
 
 ---
 
@@ -191,7 +192,7 @@ $ tools say --app claude --mute
 | `[message...]` | Text to speak (positional, joined with spaces) |
 | `--volume <n>` | Volume `0.0-1.0` or `0-100%` |
 | `--voice [name]` | Voice id; pass without value to list available voices |
-| `--rate <wpm>` | Words per minute (macOS only) |
+| `--rate <n>` | Speed: `0..2` multiplier or `0..200%` (`1` = default). Matched across providers. |
 | `--wait` | Block until speech finishes |
 | `--app <name>` | App profile to load; required target for `--save` |
 | `--mute` | Mute the app (requires `--save`) |

--- a/src/say/README.md
+++ b/src/say/README.md
@@ -3,75 +3,243 @@
 ![Status](https://img.shields.io/badge/Status-Active-success?style=flat-square)
 ![Platform](https://img.shields.io/badge/Platform-macOS-blue?style=flat-square)
 
-> **Text-to-speech with volume control, auto language detection, and per-app mute.**
+> **Text-to-speech with per-app config profiles, multiple backends (macOS / xAI / OpenAI), and saved-and-recalled defaults.**
 
-A macOS `say` wrapper that remembers per-app volume and mute state, auto-picks a voice for the detected language, and supports both one-shot speech and an interactive prompt mode.
-
----
-
-## Key Features
-
-| Feature | Description |
-|---------|-------------|
-| **Per-app mute** | `--app <name>` scopes mute/unmute and volume to a caller identity |
-| **Auto voice/lang** | Voice is picked from the text's language if not overridden |
-| **Volume units** | `--volume 0.6` or `--volume 60%` — both work |
-| **Blocking mode** | `--wait` blocks until speech finishes (useful in scripts) |
-| **Interactive mode** | `tools say` with no args opens a prompt |
+A `say` CLI that loads its voice / volume / provider / rate / model / language / format from a named profile (`--app <name>`), so callers don't have to re-pass flags every invocation. Profiles inherit unset fields from a `default` profile.
 
 ---
 
 ## Quick Start
 
 ```bash
-# One-shot
+# One-shot speech with system defaults
 tools say "Build finished"
 
-# From another tool (mute-able per app)
-tools say "Timer done" --app timer --wait
+# Save settings under an app profile
+tools say --app claude --voice Samantha --provider macos --save
 
-# Mute all say output from one caller
-tools say --mute --app claude
-tools say --unmute --app claude
+# Subsequent calls just use the profile — no flags needed
+tools say "x done" --app claude
 
-# Change the voice for a run
-tools say "Hola amigo" --voice Paulina
+# Override one field on a single run (does NOT persist)
+tools say "x done" --app claude --voice Daniel
+
+# Manage profiles interactively
+tools say config
 ```
 
 ---
 
-## Options
+## Profiles & inheritance
+
+Config lives at `~/.genesis-tools/say/config.json`. Every app entry carries the full schema — fields are `null` when they should fall through to `default`:
+
+```json
+{
+    "version": 2,
+    "global": { "mute": false },
+    "apps": [
+        {
+            "name": "default",
+            "voice": "Samantha",
+            "volume": 0.5,
+            "provider": null,
+            "rate": null,
+            "model": null,
+            "format": null,
+            "language": null,
+            "mute": null
+        },
+        {
+            "name": "claude",
+            "voice": "Daniel",
+            "volume": null,
+            "provider": null,
+            "rate": null,
+            "model": null,
+            "format": null,
+            "language": null,
+            "mute": null
+        },
+        {
+            "name": "build",
+            "voice": "alloy",
+            "volume": null,
+            "provider": "openai",
+            "rate": null,
+            "model": "tts-1",
+            "format": null,
+            "language": null,
+            "mute": null
+        }
+    ]
+}
+```
+
+Resolution for a given run, **most-specific wins**:
+
+1. Explicit CLI flag on this invocation
+2. The `--app <name>` profile's field (if present)
+3. The `default` profile's field
+4. Provider / built-in default
+
+Mute is a logical-OR of `global.mute` and the app's **own** `mute` field — either is sufficient to silence. (Note: `mute` does not inherit from `default` to other apps; if you want a single switch that silences everything, use `global.mute`.)
+
+`null` / missing on a per-app field means **inherit**, not "use null". So `apps[claude]` with `"volume": null` picks up `default.volume`.
+
+Some fields are provider-specific:
+
+- `rate` — macOS only (`say -r <wpm>`). xAI / OpenAI ignore it.
+- `model` — OpenAI only (`tts-1`, `gpt-4o-mini-tts`). xAI uses a hardcoded model; macOS ignores it.
+- `language` — xAI only (BCP-47 hint).
+- `format` — only meaningful for cloud providers writing audio files.
+
+Storing them on apps that don't use them is harmless — the relevant provider just ignores them.
+
+---
+
+## Saving (`--save`)
+
+`--save` persists the flags **explicitly passed on this invocation** to the `--app` profile. Other fields are left alone.
+
+```bash
+# Save voice + provider for the "claude" profile
+tools say --app claude --voice Samantha --provider macos --save
+
+# Save only volume — voice/provider untouched
+tools say --app claude --volume 0.5 --save
+
+# Save-and-speak: speaks first, persists after success
+tools say "deploy done" --app claude --voice Samantha --save
+```
+
+Rules:
+
+- **`--save` requires `--app <name>`.**
+  - Non-TTY (no terminal): hard error with the suggested form.
+  - TTY: prompts you to pick an existing profile or create a new one (the `default` name is reserved).
+- **Save-only invocation:** if `--save` is set and **no message text** is supplied (no positional args, no `--file`), nothing is spoken — only config is written.
+- **Save-and-speak:** if a message is supplied, the speech runs first, then config is persisted only on success.
+- **Only the flags you typed get saved.** Unspecified flags do not overwrite existing profile values.
+- **Volume is normalized:** `--volume 50%` and `--volume 0.5` both store as `0.5`.
+
+---
+
+## Unsetting fields (`--unset`)
+
+`--unset <fields>` takes a comma-separated list of profile fields to clear. It works in two modes:
+
+```bash
+# Ephemeral: ignore the saved voice for this single run
+tools say "test" --app claude --unset voice
+
+# Persisted: remove the voice key from the saved profile
+tools say --app claude --unset voice --save
+
+# Multiple fields at once
+tools say --app claude --unset voice,volume,provider --save
+```
+
+Valid field names: `voice`, `volume`, `provider`, `rate`, `model`, `format`, `language`, `mute`.
+
+With `--save`, the keys are reset to `null` (not deleted), so the profile keeps the full schema visible while the resolution chain falls through to the `default` profile.
+
+---
+
+## Mute / unmute
+
+`--mute` and `--unmute` are now `--save`-dependent. Without `--save` they error — they no longer write config implicitly.
+
+```bash
+# Mute the "claude" profile (persisted)
+tools say --app claude --mute --save
+
+# Unmute it
+tools say --app claude --unmute --save
+
+# Toggle global mute interactively
+tools say config   # → "Toggle global mute"
+```
+
+Without `--save`:
+
+```bash
+$ tools say --app claude --mute
+[say] --mute / --unmute now require --save to persist.
+```
+
+---
+
+## Interactive config (`tools say config`)
+
+`tools say config` opens a clack-driven manager:
+
+- **List** apps with their resolved (post-inherit) settings
+- **Edit** any app's profile field-by-field (set value, clear, or back)
+- **Add** a new app (name + initial fields)
+- **Delete** an app (the `default` profile is non-removable)
+- **Toggle global mute**
+
+`tools say` with no args still opens the simpler legacy picker (test voice, set default voice/volume, etc.); pick "Full config (apps, profiles)…" from there to drop into the same `config` TUI.
+
+---
+
+## All options
 
 | Option | Description |
 |--------|-------------|
 | `[message...]` | Text to speak (positional, joined with spaces) |
-| `--volume <n>` | Volume `0.0-1.0` or `0-100%`; persisted per-app when `--app` is set |
-| `--voice <name>` | Override the macOS voice |
-| `--rate <wpm>` | Words per minute |
+| `--volume <n>` | Volume `0.0-1.0` or `0-100%` |
+| `--voice [name]` | Voice id; pass without value to list available voices |
+| `--rate <wpm>` | Words per minute (macOS only) |
 | `--wait` | Block until speech finishes |
-| `--app <name>` | Caller identity for per-app mute/volume |
-| `--mute` | Mute globally, or per-app with `--app` |
-| `--unmute` | Unmute globally, or per-app with `--app` |
+| `--app <name>` | App profile to load; required target for `--save` |
+| `--mute` | Mute the app (requires `--save`) |
+| `--unmute` | Unmute the app (requires `--save`) |
+| `--provider <name>` | TTS backend: `macos`, `xai`, `openai` |
+| `--language <bcp47>` | Language hint (xAI) |
+| `--format <codec>` | `mp3` or `wav` |
+| `--file <path>` | Read text from a file |
+| `--stream` / `--no-stream` | Force streaming mode on/off |
+| `--model <id>` | Provider-specific model (OpenAI: `tts-1`, `gpt-4o-mini-tts`) |
+| `--save` | Persist explicitly-passed flags to `--app`'s profile |
+| `--unset <fields>` | Comma-separated profile fields to ignore (or remove with `--save`) |
+
+Subcommands:
+
+- `tools say voices` — list voices grouped by provider
+- `tools say models` — list downloadable TTS models
+- `tools say config` — interactive profile manager
 
 ---
 
-## Examples
+## Migration from v1
 
-Scripting (e.g. a build finished in the background):
+The first time the new build runs against a v1 config (the old `defaultVoice` / `defaultVolume` / `globalMute` / `appMute` / `appVolume` shape), it migrates lazily:
 
-```bash
-long-build && tools say "Build done" --app build-scripts --wait
+- `defaultVoice` / `defaultVolume` → `apps[default].voice` / `.volume`
+- `globalMute` → `global.mute`
+- Each name in `appMute ∪ appVolume` → its own profile entry, with the v1 mute and volume preserved.
+
+Before the first overwrite, the original v1 file is copied to `~/.genesis-tools/say/config.v1.bak.json` (only if no backup already exists). To roll back, restore that file over `config.json`.
+
+---
+
+## Programmatic use
+
+```ts
+import { speak } from "@app/utils/macos/tts";
+
+await speak("Build done", { app: "build" }); // resolves the "build" profile
 ```
 
-Silence just one caller without touching global settings:
+For full config CRUD:
 
-```bash
-tools say --mute --app timer    # timer stays quiet
-tools say "Still speaking"       # other callers still work
-```
+```ts
+import { SayConfigManager } from "@app/utils/macos/SayConfigManager";
 
-Interactive voice picker:
-
-```bash
-tools say
+const mgr = new SayConfigManager();
+await mgr.patchApp("claude", { voice: "Samantha", provider: "macos" });
+await mgr.unsetAppFields("claude", ["volume"]);
+const effective = await mgr.resolveApp("claude"); // merged with default
 ```

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -6,15 +6,22 @@ import { AI } from "@app/utils/ai/index.ts";
 import { getModelsForTask } from "@app/utils/ai/ModelManager";
 import { getProvidersForTask } from "@app/utils/ai/providers";
 import type { AIProviderType } from "@app/utils/ai/types.ts";
-import { suggestCommand } from "@app/utils/cli/executor";
-import type { SayConfig } from "@app/utils/macos/tts.ts";
-import { getConfigForRead, listVoicesStructured, normalizeVolume, setConfig, setMute } from "@app/utils/macos/tts.ts";
+import { isInteractive, suggestCommand } from "@app/utils/cli/executor";
+import { parseVariadic } from "@app/utils/cli/variadic";
+import {
+    DEFAULT_APP_NAME,
+    isSettableField,
+    type SayAppConfig,
+    SayConfigManager,
+    type SayProvider,
+    SETTABLE_FIELDS,
+    type SettableField,
+} from "@app/utils/macos/SayConfigManager.ts";
+import { listVoicesStructured, normalizeVolume } from "@app/utils/macos/tts.ts";
 import { formatTable } from "@app/utils/table.ts";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
-
-type SayProvider = "macos" | "xai" | "openai";
 
 interface SayOptions {
     volume?: number;
@@ -31,59 +38,87 @@ interface SayOptions {
     stream?: boolean;
     noStream?: boolean;
     model?: string;
+    save?: boolean;
+    unset?: string[];
 }
 
 const program = new Command()
     .name("say")
-    .description("Text-to-speech with pluggable backends (macOS, xAI Grok, OpenAI)")
+    .description("Text-to-speech with pluggable backends (macOS, xAI Grok, OpenAI). Supports per-app config profiles.")
     .argument("[message...]", "Text to speak (omit to read --file or enter interactive mode)")
-    .option("--volume <n>", "Volume (0.0-1.0 or 0-100%); saved per-app with --app", parseFloat)
+    .option("--volume <n>", "Volume (0.0-1.0 or 0-100%)", parseFloat)
     .option("--voice [name]", "Voice id (provider-specific). Pass --voice with no value to list available voices.")
-    .option("--rate <wpm>", "Words per minute (macOS only)", parseInt)
+    .option(
+        "--rate <n>",
+        "Speed: 0..2 multiplier or 0..200%. 0=slowest, 1 (or 100)=default, 2 (or 200)=fastest. Provider speeds are matched to macOS native (~0.81×..1.86×) so the same --rate sounds identical on macOS and xAI.",
+        parseFloat
+    )
     .option("--wait", "Block until speech finishes")
-    .option("--app <name>", "Caller identity for per-app mute")
-    .option("--mute", "Mute (global or per-app with --app)")
-    .option("--unmute", "Unmute (global or per-app with --app)")
-    .option("--provider <name>", "TTS backend: macos (default), xai, openai")
+    .option("--app <name>", "App profile to load (and required target for --save)")
+    .option("--mute", "Mute (requires --save to persist)")
+    .option("--unmute", "Unmute (requires --save to persist)")
+    .option("--provider <name>", "TTS backend: macos, xai, openai (defaults to profile or macos)")
     .option("--language <bcp47>", "Language hint (xai only; defaults to 'auto')")
-    .option("--format <codec>", "Output codec: mp3 (default) or wav")
+    .option("--format <codec>", "Output codec: mp3 or wav")
     .option("--file <path>", "Read text from a file instead of args")
     .option("--stream", "Force streaming path")
     .option("--no-stream", "Force REST/non-streaming path")
     .option("--model <id>", "Provider-specific model (e.g. tts-1, gpt-4o-mini-tts for openai)")
-    .action(async (messageParts: string[], opts: SayOptions) => {
-        if (opts.mute) {
-            await setMute(true, opts.app);
-            console.log(pc.yellow(`[say] ${opts.app ? `app "${opts.app}"` : "global"} muted`));
-            return;
+    .option("--save", "Persist explicitly-passed flags to the --app profile")
+    .option(
+        "--unset <fields>",
+        "Comma-separated profile fields to ignore this run (or remove with --save)",
+        parseVariadic,
+        [] as string[]
+    )
+    .action(async (messageParts: string[], opts: SayOptions, cmd: Command) => {
+        const mgr = new SayConfigManager();
+
+        if (opts.mute && opts.unmute) {
+            console.error(pc.red("[say] --mute and --unmute are mutually exclusive."));
+            process.exit(1);
         }
 
-        if (opts.unmute) {
-            await setMute(false, opts.app);
-            console.log(pc.green(`[say] ${opts.app ? `app "${opts.app}"` : "global"} unmuted`));
-            return;
-        }
+        const unsetList = validateUnsetFields(opts.unset ?? []);
 
         if (opts.voice === true) {
             await printVoiceList(opts.provider);
             return;
         }
 
+        if ((opts.mute || opts.unmute) && !opts.save) {
+            console.error(pc.red("[say] --mute / --unmute now require --save to persist."));
+            console.error(pc.dim("  e.g.: tools say --app claude --mute --save"));
+            console.error(pc.dim("  or:   tools say config   (interactive)"));
+            process.exit(1);
+        }
+
         const text = await resolveText(messageParts, opts.file);
 
-        if (text == null) {
-            await interactiveMode();
+        const saveApp = opts.save ? await resolveSaveApp(opts.app, mgr) : undefined;
+        const patch = opts.save ? buildPatchFromCLI(cmd, opts) : null;
+
+        // Save-only invocation: --save without text. Persist and exit, do not speak,
+        // do not enter interactive mode.
+        if (opts.save && text == null) {
+            await applySave({ mgr, app: saveApp as string, patch: patch as Partial<SayAppConfig>, unsetList });
+            console.log(pc.green(`[say] saved profile "${saveApp}"`));
             return;
         }
 
-        const muted = await isMutedForApp(opts.app);
+        // No text and no save: drop into legacy interactive picker.
+        if (text == null) {
+            await interactiveMode(mgr);
+            return;
+        }
 
-        if (muted) {
+        if (await mgr.isMuted(opts.app)) {
             process.stderr.write("[say] muted\n");
             return;
         }
 
-        const provider: SayProvider = opts.provider ?? "macos";
+        const effective = await resolveEffective({ mgr, opts, unsetList: opts.save ? [] : unsetList });
+        const provider: SayProvider = effective.provider ?? "macos";
 
         if (provider !== "macos" && !envForProvider(provider)) {
             console.error(pc.red(`[say] env var for ${provider} is not set.`));
@@ -91,20 +126,19 @@ const program = new Command()
             process.exit(1);
         }
 
-        const volume = opts.volume != null ? normalizeVolume(opts.volume) : undefined;
         const stream = opts.stream === true ? true : opts.noStream === true ? false : undefined;
 
         try {
             await AI.speak(text, {
                 provider,
-                voice: typeof opts.voice === "string" ? opts.voice : undefined,
-                language: opts.language,
-                format: opts.format,
-                rate: opts.rate,
-                volume,
+                voice: effective.voice ?? undefined,
+                language: effective.language ?? undefined,
+                format: effective.format ?? undefined,
+                rate: effective.rate ?? undefined,
+                volume: effective.volume ?? undefined,
                 stream,
                 wait: opts.wait,
-                model: opts.model,
+                model: effective.model ?? undefined,
             });
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
@@ -116,11 +150,13 @@ const program = new Command()
 
             process.exit(1);
         }
+
+        if (opts.save && saveApp && patch) {
+            await applySave({ mgr, app: saveApp, patch, unsetList });
+            console.log(pc.green(`[say] saved profile "${saveApp}"`));
+        }
     });
 
-// `tools say voices` subcommand
-// Note: --provider lives on the root command (program.opts()), not here.
-// Commander parses root options globally, so reading from opts would always be undefined.
 program
     .command("voices")
     .description("List voices grouped by provider (use root --provider to filter)")
@@ -129,18 +165,13 @@ program
         await printVoiceList(rootOpts.provider);
     });
 
-// `tools say models` subcommand
 program
     .command("models")
     .description("List downloadable TTS/STT models grouped by provider")
     .option("--task <task>", "Filter by task: tts | transcribe", "tts")
     .action(async (opts: { task?: string }) => {
         const task = (opts.task ?? "tts") as "tts" | "transcribe";
-
-        // Collect provider types: those that claim to support the task + "local-hf" always
-        // (AILocalProvider supports transcribe but not tts at runtime — yet the registry has
-        // downloadable TTS models registered under local-hf for future use.)
-        const providerTypes = new Set<string>(getProvidersForTask(task).map((p) => p.type));
+        const providerTypes = new Set<string>(getProvidersForTask(task).map((pr) => pr.type));
         providerTypes.add("local-hf");
 
         for (const provider of providerTypes) {
@@ -159,6 +190,43 @@ program
         console.log();
         console.log(pc.dim("Download with: tools ai models download <id>"));
     });
+
+program
+    .command("config")
+    .description("Manage per-app TTS profiles (add/edit/delete) interactively")
+    .action(async () => {
+        await configCommand(new SayConfigManager());
+    });
+
+// ============================================
+// Helpers
+// ============================================
+
+interface EffectiveSettings {
+    voice?: string | null;
+    volume?: number | null;
+    provider?: SayProvider | null;
+    rate?: number | null;
+    model?: string | null;
+    format?: "mp3" | "wav" | null;
+    language?: string | null;
+}
+
+function validateUnsetFields(raw: string[]): SettableField[] {
+    const out: SettableField[] = [];
+
+    for (const u of raw) {
+        if (!isSettableField(u)) {
+            console.error(pc.red(`[say] --unset: unknown field "${u}"`));
+            console.error(pc.dim(`  valid: ${SETTABLE_FIELDS.join(", ")}`));
+            process.exit(1);
+        }
+
+        out.push(u);
+    }
+
+    return out;
+}
 
 async function resolveText(messageParts: string[], filePath?: string): Promise<string | null> {
     if (filePath) {
@@ -191,18 +259,151 @@ function envForProvider(provider: SayProvider): boolean {
     return true;
 }
 
-async function isMutedForApp(app: string | undefined): Promise<boolean> {
-    const config = await getConfigForRead();
-
-    if (app && app in config.appMute) {
-        return config.appMute[app];
-    }
-
-    return config.globalMute;
-}
-
 function isVoiceNotFoundError(message: string): boolean {
     return /\b404\b/.test(message) || /voice .* not found/i.test(message);
+}
+
+async function resolveSaveApp(app: string | undefined, mgr: SayConfigManager): Promise<string> {
+    if (app) {
+        return app;
+    }
+
+    if (!isInteractive()) {
+        console.error(pc.red("[say] --save requires --app <name> in non-interactive mode."));
+        console.error(pc.dim(suggestCommand("tools say", { add: ["--app", "<name>"] })));
+        process.exit(1);
+    }
+
+    const apps = await mgr.listApps();
+    const NEW_APP = "__new__";
+
+    const choice = await p.select({
+        message: "Save to which app profile?",
+        options: [
+            ...apps.map((a) => ({ value: a.name, label: a.name })),
+            { value: NEW_APP, label: pc.cyan("+ new app") },
+        ],
+    });
+
+    if (p.isCancel(choice)) {
+        p.cancel("Cancelled");
+        process.exit(1);
+    }
+
+    if (choice !== NEW_APP) {
+        return String(choice);
+    }
+
+    const name = await p.text({
+        message: "New app name:",
+        validate(v: string | undefined) {
+            if (!v) {
+                return "Name required";
+            }
+
+            if (v === DEFAULT_APP_NAME) {
+                return `"${DEFAULT_APP_NAME}" is reserved`;
+            }
+
+            if (apps.some((a) => a.name === v)) {
+                return `"${v}" already exists`;
+            }
+        },
+    });
+
+    if (p.isCancel(name)) {
+        p.cancel("Cancelled");
+        process.exit(1);
+    }
+
+    return String(name);
+}
+
+function isFromCLI(cmd: Command, key: string): boolean {
+    return cmd.getOptionValueSource(key) === "cli";
+}
+
+function buildPatchFromCLI(cmd: Command, opts: SayOptions): Partial<SayAppConfig> {
+    const patch: Partial<SayAppConfig> = {};
+
+    if (isFromCLI(cmd, "voice") && typeof opts.voice === "string") {
+        patch.voice = opts.voice;
+    }
+
+    if (isFromCLI(cmd, "volume") && opts.volume != null) {
+        patch.volume = normalizeVolume(opts.volume);
+    }
+
+    if (isFromCLI(cmd, "provider") && opts.provider) {
+        patch.provider = opts.provider;
+    }
+
+    if (isFromCLI(cmd, "rate") && opts.rate != null) {
+        patch.rate = opts.rate;
+    }
+
+    if (isFromCLI(cmd, "model") && opts.model) {
+        patch.model = opts.model;
+    }
+
+    if (isFromCLI(cmd, "format") && opts.format) {
+        patch.format = opts.format;
+    }
+
+    if (isFromCLI(cmd, "language") && opts.language) {
+        patch.language = opts.language;
+    }
+
+    if (isFromCLI(cmd, "mute") && opts.mute) {
+        patch.mute = true;
+    } else if (isFromCLI(cmd, "unmute") && opts.unmute) {
+        patch.mute = false;
+    }
+
+    return patch;
+}
+
+async function applySave(args: {
+    mgr: SayConfigManager;
+    app: string;
+    patch: Partial<SayAppConfig>;
+    unsetList: SettableField[];
+}): Promise<void> {
+    const { mgr, app, patch, unsetList } = args;
+
+    if (Object.keys(patch).length > 0) {
+        await mgr.patchApp(app, patch);
+    } else if (unsetList.length === 0) {
+        // Edge: --save with no flags and no --unset → ensure the app exists.
+        await mgr.patchApp(app, {});
+    }
+
+    if (unsetList.length > 0) {
+        await mgr.unsetAppFields(app, unsetList);
+    }
+}
+
+async function resolveEffective(args: {
+    mgr: SayConfigManager;
+    opts: SayOptions;
+    unsetList: SettableField[];
+}): Promise<EffectiveSettings> {
+    const { mgr, opts, unsetList } = args;
+    const profile = await mgr.resolveApp(opts.app);
+
+    for (const f of unsetList) {
+        delete profile[f];
+    }
+
+    return {
+        voice: typeof opts.voice === "string" ? opts.voice : (profile.voice ?? null),
+        volume: opts.volume != null ? normalizeVolume(opts.volume) : (profile.volume ?? null),
+        provider: opts.provider ?? profile.provider ?? null,
+        rate: opts.rate ?? profile.rate ?? null,
+        model: opts.model ?? profile.model ?? null,
+        format: opts.format ?? profile.format ?? null,
+        language: opts.language ?? profile.language ?? null,
+    };
 }
 
 async function printVoiceList(filter?: SayProvider): Promise<void> {
@@ -245,24 +446,24 @@ async function main(): Promise<void> {
 main();
 
 // ============================================
-// Interactive mode
+// Interactive mode (legacy "no args" picker)
 // ============================================
 
-async function interactiveMode(): Promise<void> {
+async function interactiveMode(mgr: SayConfigManager): Promise<void> {
     p.intro(pc.bgCyan(pc.black(" tools say ")));
 
-    const config = await getConfigForRead();
-    showStatus(config);
+    await showStatus(mgr);
 
     const action = await p.select({
         message: "What would you like to do?",
         options: [
             { value: "test", label: "Test voice", hint: "speak a sample" },
-            { value: "mute", label: "Toggle mute", hint: config.globalMute ? "currently muted" : "currently unmuted" },
-            { value: "app-mute", label: "App mute settings", hint: `${Object.keys(config.appMute).length} apps` },
+            { value: "mute", label: "Toggle global mute" },
+            { value: "app-mute", label: "App mute settings" },
             { value: "voice", label: "Set default voice" },
-            { value: "volume", label: "Set default volume", hint: `current: ${config.defaultVolume}` },
+            { value: "volume", label: "Set default volume" },
             { value: "voices", label: "List available voices" },
+            { value: "config", label: "Full config (apps, profiles)…" },
         ],
     });
 
@@ -273,46 +474,52 @@ async function interactiveMode(): Promise<void> {
 
     switch (action) {
         case "test":
-            await handleTest(config);
+            await handleTest(mgr);
             break;
         case "mute":
-            await handleToggleMute(config);
+            await handleToggleMute(mgr);
             break;
         case "app-mute":
-            await handleAppMute(config);
+            await handleAppMute(mgr);
             break;
         case "voice":
-            await handleSetVoice(config);
+            await handleSetVoice(mgr);
             break;
         case "volume":
-            await handleSetVolume(config);
+            await handleSetVolume(mgr);
             break;
         case "voices":
             await handleListVoices();
+            break;
+        case "config":
+            await configCommand(mgr);
             break;
     }
 
     p.outro(pc.green("Done"));
 }
 
-function showStatus(config: SayConfig): void {
-    const muteStatus = config.globalMute ? pc.red("MUTED") : pc.green("active");
-    const voice = config.defaultVoice ?? "auto-detect";
-    const volume = `${Math.round(config.defaultVolume * 100)}%`;
+async function showStatus(mgr: SayConfigManager): Promise<void> {
+    const def = await mgr.getDefaultApp();
+    const globalMute = await mgr.getGlobalMute();
+    const apps = await mgr.listApps();
+    const muteStatus = globalMute ? pc.red("MUTED (global)") : pc.green("active");
+    const voice = def.voice ?? "auto-detect";
+    const volume = def.volume != null ? `${Math.round(def.volume * 100)}%` : "100%";
 
     console.log();
-    console.log(`  Status: ${muteStatus}  |  Voice: ${pc.cyan(voice)}  |  Volume: ${pc.cyan(volume)}`);
+    console.log(`  Default: ${muteStatus}  |  Voice: ${pc.cyan(voice)}  |  Volume: ${pc.cyan(volume)}`);
 
-    const mutedApps = Object.entries(config.appMute).filter(([, v]) => v);
+    const mutedApps = apps.filter((a) => a.mute);
 
     if (mutedApps.length > 0) {
-        console.log(`  Muted apps: ${mutedApps.map(([k]) => pc.red(k)).join(", ")}`);
+        console.log(`  Muted apps: ${mutedApps.map((a) => pc.red(a.name)).join(", ")}`);
     }
 
     console.log();
 }
 
-async function handleTest(config: SayConfig): Promise<void> {
+async function handleTest(mgr: SayConfigManager): Promise<void> {
     const text = await p.text({
         message: "Text to speak:",
         placeholder: "Hello world",
@@ -323,44 +530,45 @@ async function handleTest(config: SayConfig): Promise<void> {
         return;
     }
 
+    const profile = await mgr.getDefaultApp();
     const s = p.spinner();
     s.start("Speaking...");
-    await AI.speak(String(text), { provider: "macos", volume: config.defaultVolume, wait: true });
+    await AI.speak(String(text), { provider: "macos", volume: profile.volume ?? undefined, wait: true });
     s.stop("Done");
 }
 
-async function handleToggleMute(config: SayConfig): Promise<void> {
-    const newState = !config.globalMute;
-    await setMute(newState);
+async function handleToggleMute(mgr: SayConfigManager): Promise<void> {
+    const cur = await mgr.getGlobalMute();
+    await mgr.setGlobalMute(!cur);
 
-    if (newState) {
+    if (!cur) {
         p.log.warn("Global mute: ON");
     } else {
         p.log.success("Global mute: OFF");
     }
 }
 
-async function handleAppMute(config: SayConfig): Promise<void> {
-    const apps = Object.entries(config.appMute);
+async function handleAppMute(mgr: SayConfigManager): Promise<void> {
+    const apps = (await mgr.listApps()).filter((a) => a.name !== DEFAULT_APP_NAME);
 
     if (apps.length === 0) {
-        p.log.info("No apps registered yet. Apps are auto-registered on first use via --app flag.");
+        p.log.info("No app profiles yet. Create one with `tools say config` or `--save`.");
         return;
     }
 
-    const rows = apps.map(([name, muted]) => {
-        const vol = config.appVolume[name];
+    const rows = apps.map((a) => {
+        const vol = a.volume;
         const volStr = vol != null ? `${Math.round(vol * 100)}%` : "default";
-        return [name, muted ? pc.red("muted") : pc.green("active"), pc.cyan(volStr)];
+        return [a.name, a.mute ? pc.red("muted") : pc.green("active"), pc.cyan(volStr)];
     });
     console.log(formatTable(rows, ["App", "Status", "Volume"]));
 
     const appToToggle = await p.select({
         message: "Toggle mute for app:",
-        options: apps.map(([name, muted]) => ({
-            value: name,
-            label: name,
-            hint: muted ? "muted -> unmute" : "active -> mute",
+        options: apps.map((a) => ({
+            value: a.name,
+            label: a.name,
+            hint: a.mute ? "muted -> unmute" : "active -> mute",
         })),
     });
 
@@ -368,21 +576,21 @@ async function handleAppMute(config: SayConfig): Promise<void> {
         return;
     }
 
-    const currentlyMuted = config.appMute[appToToggle];
-    await setMute(!currentlyMuted, appToToggle);
+    const target = apps.find((a) => a.name === appToToggle);
+    const muted = target?.mute === true;
+    await mgr.setMute({ app: String(appToToggle), mute: !muted });
 
-    if (currentlyMuted) {
+    if (muted) {
         p.log.success(`${appToToggle}: unmuted`);
     } else {
         p.log.warn(`${appToToggle}: muted`);
     }
 }
 
-async function handleSetVoice(config: SayConfig): Promise<void> {
+async function handleSetVoice(mgr: SayConfigManager): Promise<void> {
     const voices = await listVoicesStructured();
-
     const options = [
-        { value: "__auto__" as string, label: "Auto-detect", hint: "detect language automatically" },
+        { value: "__auto__", label: "Auto-detect", hint: "detect language automatically" },
         ...voices.map((v) => ({
             value: v.name,
             label: v.name,
@@ -390,27 +598,32 @@ async function handleSetVoice(config: SayConfig): Promise<void> {
         })),
     ];
 
-    const selected = await p.select({
-        message: "Default voice:",
-        options,
-    });
+    const selected = await p.select({ message: "Default voice:", options });
 
     if (p.isCancel(selected)) {
         return;
     }
 
-    config.defaultVoice = selected === "__auto__" ? null : selected;
-    await setConfig(config);
-    p.log.success(`Default voice: ${config.defaultVoice ?? "auto-detect"}`);
+    if (selected === "__auto__") {
+        await mgr.unsetAppFields(DEFAULT_APP_NAME, ["voice"]);
+        p.log.success("Default voice: auto-detect");
+        return;
+    }
+
+    await mgr.setVoice({ app: DEFAULT_APP_NAME, voice: String(selected) });
+    p.log.success(`Default voice: ${selected}`);
 }
 
-async function handleSetVolume(config: SayConfig): Promise<void> {
+async function handleSetVolume(mgr: SayConfigManager): Promise<void> {
+    const def = await mgr.getDefaultApp();
+    const placeholder = def.volume != null ? String(def.volume) : "1";
+
     const input = await p.text({
         message: "Default volume (0.0-1.0 or 0-100%):",
-        placeholder: String(config.defaultVolume),
-        defaultValue: String(config.defaultVolume),
+        placeholder,
+        defaultValue: placeholder,
         validate(value: string | undefined) {
-            const n = parseFloat(value ?? "");
+            const n = Number.parseFloat(value ?? "");
 
             if (Number.isNaN(n) || n < 0) {
                 return "Must be a non-negative number (0.0-1.0 or 0-100)";
@@ -422,13 +635,315 @@ async function handleSetVolume(config: SayConfig): Promise<void> {
         return;
     }
 
-    config.defaultVolume = normalizeVolume(parseFloat(input));
-    await setConfig(config);
-    p.log.success(`Default volume: ${config.defaultVolume}`);
+    const v = normalizeVolume(Number.parseFloat(String(input)));
+    await mgr.setVolume({ app: DEFAULT_APP_NAME, volume: v });
+    p.log.success(`Default volume: ${v}`);
 }
 
 async function handleListVoices(): Promise<void> {
     const voices = await listVoicesStructured();
     const rows = voices.map((v) => [v.lang, v.name, v.locale, v.sample.slice(0, 50)]);
     console.log(formatTable(rows, ["Lang", "Voice", "Locale", "Sample"]));
+}
+
+// ============================================
+// `tools say config` — full app/profile manager
+// ============================================
+
+async function configCommand(mgr: SayConfigManager): Promise<void> {
+    p.intro(pc.bgCyan(pc.black(" tools say config ")));
+
+    while (true) {
+        const apps = await mgr.listApps();
+        const globalMute = await mgr.getGlobalMute();
+
+        const action = await p.select({
+            message: `What next? ${pc.dim(`(${apps.length} app${apps.length === 1 ? "" : "s"}, global mute: ${globalMute ? "ON" : "off"})`)}`,
+            options: [
+                { value: "list", label: "List apps with resolved settings" },
+                { value: "edit", label: "Edit an app profile" },
+                { value: "add", label: "Add a new app profile" },
+                { value: "delete", label: "Delete an app profile" },
+                { value: "global-mute", label: `Toggle global mute (currently ${globalMute ? "ON" : "off"})` },
+                { value: "exit", label: "Exit" },
+            ],
+        });
+
+        if (p.isCancel(action) || action === "exit") {
+            p.outro(pc.green("Done"));
+            return;
+        }
+
+        switch (action) {
+            case "list":
+                await listAppsTUI(mgr);
+                break;
+            case "edit":
+                await editAppTUI(mgr);
+                break;
+            case "add":
+                await addAppTUI(mgr);
+                break;
+            case "delete":
+                await deleteAppTUI(mgr);
+                break;
+            case "global-mute":
+                await mgr.setGlobalMute(!globalMute);
+                p.log.success(`Global mute: ${!globalMute ? "ON" : "off"}`);
+                break;
+        }
+    }
+}
+
+async function listAppsTUI(mgr: SayConfigManager): Promise<void> {
+    const apps = await mgr.listApps();
+    const rows: string[][] = [];
+
+    for (const a of apps) {
+        const eff = a.name === DEFAULT_APP_NAME ? a : await mgr.resolveApp(a.name);
+        rows.push([
+            a.name + (a.name === DEFAULT_APP_NAME ? pc.dim(" (base)") : ""),
+            eff.voice ?? pc.dim("(auto)"),
+            eff.volume != null ? `${Math.round(eff.volume * 100)}%` : pc.dim("(default)"),
+            eff.provider ?? pc.dim("(macos)"),
+            a.mute ? pc.red("muted") : pc.green("active"),
+        ]);
+    }
+
+    console.log(formatTable(rows, ["App", "Voice", "Volume", "Provider", "Mute"]));
+}
+
+async function addAppTUI(mgr: SayConfigManager): Promise<void> {
+    const apps = await mgr.listApps();
+
+    const name = await p.text({
+        message: "App name:",
+        validate(v: string | undefined) {
+            if (!v) {
+                return "Name required";
+            }
+
+            if (v === DEFAULT_APP_NAME) {
+                return `"${DEFAULT_APP_NAME}" is reserved`;
+            }
+
+            if (apps.some((a) => a.name === v)) {
+                return `"${v}" already exists — pick "Edit" instead`;
+            }
+        },
+    });
+
+    if (p.isCancel(name)) {
+        return;
+    }
+
+    await mgr.upsertApp({ name: String(name) });
+    p.log.success(`Created profile "${name}"`);
+    await editAppFields(mgr, String(name));
+}
+
+async function editAppTUI(mgr: SayConfigManager): Promise<void> {
+    const apps = await mgr.listApps();
+
+    const target = await p.select({
+        message: "Edit which profile?",
+        options: apps.map((a) => ({
+            value: a.name,
+            label: a.name + (a.name === DEFAULT_APP_NAME ? " (base)" : ""),
+        })),
+    });
+
+    if (p.isCancel(target)) {
+        return;
+    }
+
+    await editAppFields(mgr, String(target));
+}
+
+async function editAppFields(mgr: SayConfigManager, app: string): Promise<void> {
+    while (true) {
+        const profile = (await mgr.getApp(app)) ?? { name: app };
+
+        const field = await p.select({
+            message: `Edit "${app}" — pick a field`,
+            options: [
+                ...SETTABLE_FIELDS.map((f) => ({
+                    value: f,
+                    label: f,
+                    hint: formatFieldValue(profile, f),
+                })),
+                { value: "__back__", label: pc.dim("← back") },
+            ],
+        });
+
+        if (p.isCancel(field) || field === "__back__") {
+            return;
+        }
+
+        await editSingleField(mgr, app, field as SettableField);
+    }
+}
+
+function formatFieldValue(profile: SayAppConfig, field: SettableField): string {
+    const v = profile[field];
+
+    if (v === undefined || v === null) {
+        return pc.dim("(inherit)");
+    }
+
+    if (field === "volume" && typeof v === "number") {
+        return `${Math.round(v * 100)}%`;
+    }
+
+    return String(v);
+}
+
+async function editSingleField(mgr: SayConfigManager, app: string, field: SettableField): Promise<void> {
+    if (field === "mute") {
+        const profile = (await mgr.getApp(app)) ?? { name: app };
+        const current = profile.mute === true;
+        await mgr.setMute({ app, mute: !current });
+        p.log.success(`${app}.mute = ${!current}`);
+        return;
+    }
+
+    const action = await p.select({
+        message: `${field}:`,
+        options: [
+            { value: "set", label: "Set value" },
+            { value: "clear", label: "Clear (inherit from default)" },
+            { value: "back", label: pc.dim("← back") },
+        ],
+    });
+
+    if (p.isCancel(action) || action === "back") {
+        return;
+    }
+
+    if (action === "clear") {
+        await mgr.unsetAppFields(app, [field]);
+        p.log.success(`${app}.${field} cleared`);
+        return;
+    }
+
+    if (field === "provider") {
+        const v = await p.select({
+            message: "Provider:",
+            options: [
+                { value: "macos", label: "macos" },
+                { value: "xai", label: "xai" },
+                { value: "openai", label: "openai" },
+            ],
+        });
+
+        if (p.isCancel(v)) {
+            return;
+        }
+
+        await mgr.setProvider({ app, provider: v as SayProvider });
+        p.log.success(`${app}.provider = ${v}`);
+        return;
+    }
+
+    if (field === "format") {
+        const v = await p.select({
+            message: "Format:",
+            options: [
+                { value: "mp3", label: "mp3" },
+                { value: "wav", label: "wav" },
+            ],
+        });
+
+        if (p.isCancel(v)) {
+            return;
+        }
+
+        await mgr.setFormat({ app, format: v as "mp3" | "wav" });
+        p.log.success(`${app}.format = ${v}`);
+        return;
+    }
+
+    if (field === "voice") {
+        const voices = await listVoicesStructured();
+
+        const v = await p.select({
+            message: "Voice (macOS list shown — for xai/openai pass any provider voice id manually via --save):",
+            options: voices.map((vc) => ({
+                value: vc.name,
+                label: vc.name,
+                hint: vc.locale,
+            })),
+        });
+
+        if (p.isCancel(v)) {
+            return;
+        }
+
+        await mgr.setVoice({ app, voice: String(v) });
+        p.log.success(`${app}.voice = ${v}`);
+        return;
+    }
+
+    const input = await p.text({
+        message: `${field}:`,
+        validate(v: string | undefined) {
+            if (!v) {
+                return "Value required";
+            }
+
+            if (field === "volume" || field === "rate") {
+                const n = Number.parseFloat(v);
+
+                if (Number.isNaN(n) || n < 0) {
+                    return "Must be a non-negative number";
+                }
+            }
+        },
+    });
+
+    if (p.isCancel(input)) {
+        return;
+    }
+
+    if (field === "volume") {
+        await mgr.setVolume({ app, volume: normalizeVolume(Number.parseFloat(String(input))) });
+    } else if (field === "rate") {
+        await mgr.setRate({ app, rate: Number.parseInt(String(input), 10) });
+    } else if (field === "model") {
+        await mgr.setModel({ app, model: String(input) });
+    } else if (field === "language") {
+        await mgr.setLanguage({ app, language: String(input) });
+    }
+
+    p.log.success(`${app}.${field} = ${input}`);
+}
+
+async function deleteAppTUI(mgr: SayConfigManager): Promise<void> {
+    const apps = (await mgr.listApps()).filter((a) => a.name !== DEFAULT_APP_NAME);
+
+    if (apps.length === 0) {
+        p.log.info("No deletable apps (the default profile is non-removable).");
+        return;
+    }
+
+    const target = await p.select({
+        message: "Delete which profile?",
+        options: apps.map((a) => ({ value: a.name, label: a.name })),
+    });
+
+    if (p.isCancel(target)) {
+        return;
+    }
+
+    const confirmed = await p.confirm({
+        message: `Really delete "${target}"? This cannot be undone.`,
+        initialValue: false,
+    });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+        return;
+    }
+
+    await mgr.deleteApp(String(target));
+    p.log.success(`Deleted "${target}"`);
 }

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -17,7 +17,7 @@ import {
     SETTABLE_FIELDS,
     type SettableField,
 } from "@app/utils/macos/SayConfigManager.ts";
-import { listVoicesStructured, normalizeVolume } from "@app/utils/macos/tts.ts";
+import { normalizeVolume } from "@app/utils/macos/tts.ts";
 import { formatTable } from "@app/utils/table.ts";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
@@ -659,28 +659,71 @@ async function listAppsTUI(mgr: SayConfigManager): Promise<void> {
     console.log(formatTable(rows, ["App", "Voice", "Volume", "Provider", "Mute"]));
 }
 
+/**
+ * Sequential single-pass editor: cycles through every settable field once,
+ * accepts ⏎ to keep / "-" to inherit / a value to set, then commits all
+ * changes atomically after a confirm. Cancelling at any prompt aborts with
+ * no writes.
+ */
 async function editAppFields(mgr: SayConfigManager, app: string): Promise<void> {
-    while (true) {
-        const profile = (await mgr.getApp(app)) ?? { name: app };
+    const profile = (await mgr.getApp(app)) ?? { name: app };
+    renderProfileHeader(app, profile);
 
-        const field = await p.select({
-            message: `Edit "${app}" — pick a field`,
-            options: [
-                ...SETTABLE_FIELDS.map((f) => ({
-                    value: f,
-                    label: f,
-                    hint: formatFieldValue(profile, f),
-                })),
-                { value: "__back__", label: pc.dim("← back") },
-            ],
-        });
+    const patch: Partial<SayAppConfig> = {};
+    const clearList: SettableField[] = [];
 
-        if (p.isCancel(field) || field === "__back__") {
+    for (const field of SETTABLE_FIELDS) {
+        const decision = await promptField(field, profile);
+
+        if (decision === "cancel") {
+            p.log.info(pc.dim("Cancelled — no changes saved."));
             return;
         }
 
-        await editSingleField(mgr, app, field as SettableField);
+        if (decision === "keep") {
+            continue;
+        }
+
+        if (decision.kind === "clear") {
+            clearList.push(field);
+            continue;
+        }
+
+        Object.assign(patch, decision.patch);
     }
+
+    if (Object.keys(patch).length === 0 && clearList.length === 0) {
+        p.log.info(pc.dim("Nothing changed."));
+        return;
+    }
+
+    p.log.message(buildSummary(patch, clearList));
+
+    const confirmed = await p.confirm({ message: "Save changes?", initialValue: true });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+        p.log.info(pc.dim("Cancelled — no changes saved."));
+        return;
+    }
+
+    if (Object.keys(patch).length > 0) {
+        await mgr.patchApp(app, patch);
+    }
+
+    if (clearList.length > 0) {
+        await mgr.unsetAppFields(app, clearList);
+    }
+
+    p.log.success(`Saved "${app}".`);
+}
+
+function renderProfileHeader(app: string, profile: SayAppConfig): void {
+    const rows = SETTABLE_FIELDS.map((f) => [f, formatFieldValue(profile, f)]);
+    console.log();
+    console.log(pc.bold(`Edit "${app}"`));
+    console.log(formatTable(rows, ["Field", "Current"]));
+    console.log(pc.dim("  ⏎ keep  ·  - inherit (clear)  ·  any value to set"));
+    console.log();
 }
 
 function formatFieldValue(profile: SayAppConfig, field: SettableField): string {
@@ -697,97 +740,99 @@ function formatFieldValue(profile: SayAppConfig, field: SettableField): string {
     return String(v);
 }
 
-async function editSingleField(mgr: SayConfigManager, app: string, field: SettableField): Promise<void> {
+type FieldDecision = "keep" | "cancel" | { kind: "clear" } | { kind: "set"; patch: Partial<SayAppConfig> };
+
+const KEEP = "__keep__";
+const CLEAR = "__clear__";
+
+async function promptField(field: SettableField, profile: SayAppConfig): Promise<FieldDecision> {
     if (field === "mute") {
-        const profile = (await mgr.getApp(app)) ?? { name: app };
-        const current = profile.mute === true;
-        await mgr.setMute({ app, mute: !current });
-        p.log.success(`${app}.mute = ${!current}`);
-        return;
-    }
-
-    const action = await p.select({
-        message: `${field}:`,
-        options: [
-            { value: "set", label: "Set value" },
-            { value: "clear", label: "Clear (inherit from default)" },
-            { value: "back", label: pc.dim("← back") },
-        ],
-    });
-
-    if (p.isCancel(action) || action === "back") {
-        return;
-    }
-
-    if (action === "clear") {
-        await mgr.unsetAppFields(app, [field]);
-        p.log.success(`${app}.${field} cleared`);
-        return;
+        return promptMute(profile);
     }
 
     if (field === "provider") {
-        const v = await p.select({
-            message: "Provider:",
-            options: [
-                { value: "macos", label: "macos" },
-                { value: "xai", label: "xai" },
-                { value: "openai", label: "openai" },
-            ],
-        });
-
-        if (p.isCancel(v)) {
-            return;
-        }
-
-        await mgr.setProvider({ app, provider: v as SayProvider });
-        p.log.success(`${app}.provider = ${v}`);
-        return;
+        return promptEnum(field, profile, ["macos", "xai", "openai"]);
     }
 
     if (field === "format") {
-        const v = await p.select({
-            message: "Format:",
-            options: [
-                { value: "mp3", label: "mp3" },
-                { value: "wav", label: "wav" },
-            ],
-        });
-
-        if (p.isCancel(v)) {
-            return;
-        }
-
-        await mgr.setFormat({ app, format: v as "mp3" | "wav" });
-        p.log.success(`${app}.format = ${v}`);
-        return;
+        return promptEnum(field, profile, ["mp3", "wav"]);
     }
 
-    if (field === "voice") {
-        const voices = await listVoicesStructured();
+    return promptText(field, profile);
+}
 
-        const v = await p.select({
-            message: "Voice (macOS list shown — for xai/openai pass any provider voice id manually via --save):",
-            options: voices.map((vc) => ({
-                value: vc.name,
-                label: vc.name,
-                hint: vc.locale,
-            })),
-        });
+async function promptMute(profile: SayAppConfig): Promise<FieldDecision> {
+    const current = profile.mute === null || profile.mute === undefined ? "(inherit)" : String(profile.mute);
+    const choice = await p.select({
+        message: `mute  [${current}]`,
+        options: [
+            { value: KEEP, label: "Keep" },
+            { value: "true", label: "Mute" },
+            { value: "false", label: "Unmute" },
+            { value: CLEAR, label: pc.dim("Inherit (clear)") },
+        ],
+        initialValue: KEEP,
+    });
 
-        if (p.isCancel(v)) {
-            return;
-        }
-
-        await mgr.setVoice({ app, voice: String(v) });
-        p.log.success(`${app}.voice = ${v}`);
-        return;
+    if (p.isCancel(choice)) {
+        return "cancel";
     }
 
+    if (choice === KEEP) {
+        return "keep";
+    }
+
+    if (choice === CLEAR) {
+        return { kind: "clear" };
+    }
+
+    return { kind: "set", patch: { mute: choice === "true" } };
+}
+
+async function promptEnum(
+    field: "provider" | "format",
+    profile: SayAppConfig,
+    values: readonly string[]
+): Promise<FieldDecision> {
+    const current = formatFieldValue(profile, field);
+    const choice = await p.select({
+        message: `${field}  [${current}]`,
+        options: [
+            { value: KEEP, label: "Keep" },
+            { value: CLEAR, label: pc.dim("Inherit (clear)") },
+            ...values.map((v) => ({ value: v, label: v })),
+        ],
+        initialValue: KEEP,
+    });
+
+    if (p.isCancel(choice)) {
+        return "cancel";
+    }
+
+    if (choice === KEEP) {
+        return "keep";
+    }
+
+    if (choice === CLEAR) {
+        return { kind: "clear" };
+    }
+
+    if (field === "provider") {
+        return { kind: "set", patch: { provider: choice as SayProvider } };
+    }
+
+    return { kind: "set", patch: { format: choice as "mp3" | "wav" } };
+}
+
+async function promptText(field: SettableField, profile: SayAppConfig): Promise<FieldDecision> {
+    const current = formatFieldValue(profile, field);
     const input = await p.text({
-        message: `${field}:`,
+        message: `${field}  [${current}]`,
+        placeholder: "⏎ keep  ·  - inherit  ·  value to set",
+        defaultValue: "",
         validate(v: string | undefined) {
-            if (!v) {
-                return "Value required";
+            if (!v || v === "-") {
+                return;
             }
 
             if (field === "volume" || field === "rate") {
@@ -801,20 +846,66 @@ async function editSingleField(mgr: SayConfigManager, app: string, field: Settab
     });
 
     if (p.isCancel(input)) {
-        return;
+        return "cancel";
+    }
+
+    const raw = String(input);
+
+    if (raw === "") {
+        return "keep";
+    }
+
+    if (raw === "-") {
+        return { kind: "clear" };
     }
 
     if (field === "volume") {
-        await mgr.setVolume({ app, volume: normalizeVolume(Number.parseFloat(String(input))) });
-    } else if (field === "rate") {
-        await mgr.setRate({ app, rate: Number.parseFloat(String(input)) });
-    } else if (field === "model") {
-        await mgr.setModel({ app, model: String(input) });
-    } else if (field === "language") {
-        await mgr.setLanguage({ app, language: String(input) });
+        return { kind: "set", patch: { volume: normalizeVolume(Number.parseFloat(raw)) } };
     }
 
-    p.log.success(`${app}.${field} = ${input}`);
+    if (field === "rate") {
+        return { kind: "set", patch: { rate: Number.parseFloat(raw) } };
+    }
+
+    if (field === "voice") {
+        return { kind: "set", patch: { voice: raw } };
+    }
+
+    if (field === "model") {
+        return { kind: "set", patch: { model: raw } };
+    }
+
+    if (field === "language") {
+        return { kind: "set", patch: { language: raw } };
+    }
+
+    return "keep";
+}
+
+function buildSummary(patch: Partial<SayAppConfig>, clearList: SettableField[]): string {
+    const parts: string[] = [];
+    const changed = Object.keys(patch);
+
+    if (changed.length > 0) {
+        const formatted = changed.map((k) => `${k}=${formatPatchValue(patch, k as keyof SayAppConfig)}`);
+        parts.push(`${pc.green("changed:")} ${formatted.join(", ")}`);
+    }
+
+    if (clearList.length > 0) {
+        parts.push(`${pc.yellow("cleared:")} ${clearList.join(", ")}`);
+    }
+
+    return parts.join("   ");
+}
+
+function formatPatchValue(patch: Partial<SayAppConfig>, key: keyof SayAppConfig): string {
+    const v = patch[key];
+
+    if (key === "volume" && typeof v === "number") {
+        return `${Math.round(v * 100)}%`;
+    }
+
+    return String(v);
 }
 
 async function deleteAppTUI(mgr: SayConfigManager): Promise<void> {

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -112,12 +112,17 @@ const program = new Command()
             return;
         }
 
-        if (await mgr.isMuted(opts.app)) {
+        // If --save is requesting a mute change, don't short-circuit on the
+        // existing mute state — otherwise --unmute --save / --unset mute --save
+        // can never be persisted from a currently-muted profile.
+        const wantsMuteWrite = opts.save === true && (opts.unmute === true || unsetList.includes("mute"));
+
+        if (!wantsMuteWrite && (await mgr.isMuted(opts.app))) {
             process.stderr.write("[say] muted\n");
             return;
         }
 
-        const effective = await resolveEffective({ mgr, opts, unsetList: opts.save ? [] : unsetList });
+        const effective = await resolveEffective({ mgr, opts, unsetList });
         const provider: SayProvider = effective.provider ?? "macos";
 
         if (provider !== "macos" && !envForProvider(provider)) {
@@ -908,7 +913,7 @@ async function editSingleField(mgr: SayConfigManager, app: string, field: Settab
     if (field === "volume") {
         await mgr.setVolume({ app, volume: normalizeVolume(Number.parseFloat(String(input))) });
     } else if (field === "rate") {
-        await mgr.setRate({ app, rate: Number.parseInt(String(input), 10) });
+        await mgr.setRate({ app, rate: Number.parseFloat(String(input)) });
     } else if (field === "model") {
         await mgr.setModel({ app, model: String(input) });
     } else if (field === "language") {

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -22,6 +22,7 @@ import { formatTable } from "@app/utils/table.ts";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
+import { speakWithProfile } from "./lib/speak";
 
 interface SayOptions {
     volume?: number;
@@ -45,7 +46,7 @@ interface SayOptions {
 const program = new Command()
     .name("say")
     .description("Text-to-speech with pluggable backends (macOS, xAI Grok, OpenAI). Supports per-app config profiles.")
-    .argument("[message...]", "Text to speak (omit to read --file or enter interactive mode)")
+    .argument("[message...]", "Text to speak (omit to read --file or open the config TUI)")
     .option("--volume <n>", "Volume (0.0-1.0 or 0-100%)", parseFloat)
     .option("--voice [name]", "Voice id (provider-specific). Pass --voice with no value to list available voices.")
     .option(
@@ -106,9 +107,15 @@ const program = new Command()
             return;
         }
 
-        // No text and no save: drop into legacy interactive picker.
+        // No text and no save: open the unified config TUI (TTY only).
         if (text == null) {
-            await interactiveMode(mgr);
+            if (!isInteractive()) {
+                console.error(pc.red("[say] no message provided."));
+                console.error(pc.dim(suggestCommand("tools say", { add: ["<message>"] })));
+                process.exit(1);
+            }
+
+            await configCommand(mgr);
             return;
         }
 
@@ -200,6 +207,12 @@ program
     .command("config")
     .description("Manage per-app TTS profiles (add/edit/delete) interactively")
     .action(async () => {
+        if (!isInteractive()) {
+            console.error(pc.red("[say] config requires a TTY."));
+            console.error(pc.dim(suggestCommand("tools say", { add: ["--app", "<name>", "--save"] })));
+            process.exit(1);
+        }
+
         await configCommand(new SayConfigManager());
     });
 
@@ -451,208 +464,7 @@ async function main(): Promise<void> {
 main();
 
 // ============================================
-// Interactive mode (legacy "no args" picker)
-// ============================================
-
-async function interactiveMode(mgr: SayConfigManager): Promise<void> {
-    p.intro(pc.bgCyan(pc.black(" tools say ")));
-
-    await showStatus(mgr);
-
-    const action = await p.select({
-        message: "What would you like to do?",
-        options: [
-            { value: "test", label: "Test voice", hint: "speak a sample" },
-            { value: "mute", label: "Toggle global mute" },
-            { value: "app-mute", label: "App mute settings" },
-            { value: "voice", label: "Set default voice" },
-            { value: "volume", label: "Set default volume" },
-            { value: "voices", label: "List available voices" },
-            { value: "config", label: "Full config (apps, profiles)…" },
-        ],
-    });
-
-    if (p.isCancel(action)) {
-        p.cancel("Cancelled");
-        return;
-    }
-
-    switch (action) {
-        case "test":
-            await handleTest(mgr);
-            break;
-        case "mute":
-            await handleToggleMute(mgr);
-            break;
-        case "app-mute":
-            await handleAppMute(mgr);
-            break;
-        case "voice":
-            await handleSetVoice(mgr);
-            break;
-        case "volume":
-            await handleSetVolume(mgr);
-            break;
-        case "voices":
-            await handleListVoices();
-            break;
-        case "config":
-            await configCommand(mgr);
-            break;
-    }
-
-    p.outro(pc.green("Done"));
-}
-
-async function showStatus(mgr: SayConfigManager): Promise<void> {
-    const def = await mgr.getDefaultApp();
-    const globalMute = await mgr.getGlobalMute();
-    const apps = await mgr.listApps();
-    const muteStatus = globalMute ? pc.red("MUTED (global)") : pc.green("active");
-    const voice = def.voice ?? "auto-detect";
-    const volume = def.volume != null ? `${Math.round(def.volume * 100)}%` : "100%";
-
-    console.log();
-    console.log(`  Default: ${muteStatus}  |  Voice: ${pc.cyan(voice)}  |  Volume: ${pc.cyan(volume)}`);
-
-    const mutedApps = apps.filter((a) => a.mute);
-
-    if (mutedApps.length > 0) {
-        console.log(`  Muted apps: ${mutedApps.map((a) => pc.red(a.name)).join(", ")}`);
-    }
-
-    console.log();
-}
-
-async function handleTest(mgr: SayConfigManager): Promise<void> {
-    const text = await p.text({
-        message: "Text to speak:",
-        placeholder: "Hello world",
-        defaultValue: "Hello world",
-    });
-
-    if (p.isCancel(text)) {
-        return;
-    }
-
-    const profile = await mgr.getDefaultApp();
-    const s = p.spinner();
-    s.start("Speaking...");
-    await AI.speak(String(text), { provider: "macos", volume: profile.volume ?? undefined, wait: true });
-    s.stop("Done");
-}
-
-async function handleToggleMute(mgr: SayConfigManager): Promise<void> {
-    const cur = await mgr.getGlobalMute();
-    await mgr.setGlobalMute(!cur);
-
-    if (!cur) {
-        p.log.warn("Global mute: ON");
-    } else {
-        p.log.success("Global mute: OFF");
-    }
-}
-
-async function handleAppMute(mgr: SayConfigManager): Promise<void> {
-    const apps = (await mgr.listApps()).filter((a) => a.name !== DEFAULT_APP_NAME);
-
-    if (apps.length === 0) {
-        p.log.info("No app profiles yet. Create one with `tools say config` or `--save`.");
-        return;
-    }
-
-    const rows = apps.map((a) => {
-        const vol = a.volume;
-        const volStr = vol != null ? `${Math.round(vol * 100)}%` : "default";
-        return [a.name, a.mute ? pc.red("muted") : pc.green("active"), pc.cyan(volStr)];
-    });
-    console.log(formatTable(rows, ["App", "Status", "Volume"]));
-
-    const appToToggle = await p.select({
-        message: "Toggle mute for app:",
-        options: apps.map((a) => ({
-            value: a.name,
-            label: a.name,
-            hint: a.mute ? "muted -> unmute" : "active -> mute",
-        })),
-    });
-
-    if (p.isCancel(appToToggle)) {
-        return;
-    }
-
-    const target = apps.find((a) => a.name === appToToggle);
-    const muted = target?.mute === true;
-    await mgr.setMute({ app: String(appToToggle), mute: !muted });
-
-    if (muted) {
-        p.log.success(`${appToToggle}: unmuted`);
-    } else {
-        p.log.warn(`${appToToggle}: muted`);
-    }
-}
-
-async function handleSetVoice(mgr: SayConfigManager): Promise<void> {
-    const voices = await listVoicesStructured();
-    const options = [
-        { value: "__auto__", label: "Auto-detect", hint: "detect language automatically" },
-        ...voices.map((v) => ({
-            value: v.name,
-            label: v.name,
-            hint: `${v.locale} — ${v.sample.slice(0, 40)}`,
-        })),
-    ];
-
-    const selected = await p.select({ message: "Default voice:", options });
-
-    if (p.isCancel(selected)) {
-        return;
-    }
-
-    if (selected === "__auto__") {
-        await mgr.unsetAppFields(DEFAULT_APP_NAME, ["voice"]);
-        p.log.success("Default voice: auto-detect");
-        return;
-    }
-
-    await mgr.setVoice({ app: DEFAULT_APP_NAME, voice: String(selected) });
-    p.log.success(`Default voice: ${selected}`);
-}
-
-async function handleSetVolume(mgr: SayConfigManager): Promise<void> {
-    const def = await mgr.getDefaultApp();
-    const placeholder = def.volume != null ? String(def.volume) : "1";
-
-    const input = await p.text({
-        message: "Default volume (0.0-1.0 or 0-100%):",
-        placeholder,
-        defaultValue: placeholder,
-        validate(value: string | undefined) {
-            const n = Number.parseFloat(value ?? "");
-
-            if (Number.isNaN(n) || n < 0) {
-                return "Must be a non-negative number (0.0-1.0 or 0-100)";
-            }
-        },
-    });
-
-    if (p.isCancel(input)) {
-        return;
-    }
-
-    const v = normalizeVolume(Number.parseFloat(String(input)));
-    await mgr.setVolume({ app: DEFAULT_APP_NAME, volume: v });
-    p.log.success(`Default volume: ${v}`);
-}
-
-async function handleListVoices(): Promise<void> {
-    const voices = await listVoicesStructured();
-    const rows = voices.map((v) => [v.lang, v.name, v.locale, v.sample.slice(0, 50)]);
-    console.log(formatTable(rows, ["Lang", "Voice", "Locale", "Sample"]));
-}
-
-// ============================================
-// `tools say config` — full app/profile manager
+// `tools say config` — unified app/profile manager
 // ============================================
 
 async function configCommand(mgr: SayConfigManager): Promise<void> {
@@ -665,10 +477,11 @@ async function configCommand(mgr: SayConfigManager): Promise<void> {
         const action = await p.select({
             message: `What next? ${pc.dim(`(${apps.length} app${apps.length === 1 ? "" : "s"}, global mute: ${globalMute ? "ON" : "off"})`)}`,
             options: [
+                { value: "speak", label: "Speak text (test)", hint: "speak with a chosen profile" },
+                { value: "edit", label: "Edit an app profile", hint: "or create a new one" },
                 { value: "list", label: "List apps with resolved settings" },
-                { value: "edit", label: "Edit an app profile" },
-                { value: "add", label: "Add a new app profile" },
                 { value: "delete", label: "Delete an app profile" },
+                { value: "voices", label: "List available voices" },
                 { value: "global-mute", label: `Toggle global mute (currently ${globalMute ? "ON" : "off"})` },
                 { value: "exit", label: "Exit" },
             ],
@@ -680,23 +493,151 @@ async function configCommand(mgr: SayConfigManager): Promise<void> {
         }
 
         switch (action) {
+            case "speak":
+                await speakActionTUI(mgr);
+                break;
+            case "edit":
+                await pickAndEditAppTUI(mgr);
+                break;
             case "list":
                 await listAppsTUI(mgr);
                 break;
-            case "edit":
-                await editAppTUI(mgr);
-                break;
-            case "add":
-                await addAppTUI(mgr);
-                break;
             case "delete":
                 await deleteAppTUI(mgr);
+                break;
+            case "voices":
+                await printVoiceList();
                 break;
             case "global-mute":
                 await mgr.setGlobalMute(!globalMute);
                 p.log.success(`Global mute: ${!globalMute ? "ON" : "off"}`);
                 break;
         }
+    }
+}
+
+const NEW_APP_SENTINEL = "__new__";
+
+async function pickAndEditAppTUI(mgr: SayConfigManager): Promise<void> {
+    const apps = await mgr.listApps();
+
+    const target = await p.select({
+        message: "Which profile?",
+        options: [
+            ...apps.map((a) => ({
+                value: a.name,
+                label: a.name + (a.name === DEFAULT_APP_NAME ? pc.dim(" (base)") : ""),
+                hint: appPickerHint(a),
+            })),
+            { value: NEW_APP_SENTINEL, label: pc.cyan("+ new app") },
+        ],
+    });
+
+    if (p.isCancel(target)) {
+        return;
+    }
+
+    if (target === NEW_APP_SENTINEL) {
+        const name = await promptNewAppName(apps);
+
+        if (name == null) {
+            return;
+        }
+
+        await mgr.upsertApp({ name });
+        p.log.success(`Created profile "${name}"`);
+        await editAppFields(mgr, name);
+        return;
+    }
+
+    await editAppFields(mgr, String(target));
+}
+
+function appPickerHint(a: SayAppConfig): string {
+    const bits: string[] = [];
+
+    if (a.voice) {
+        bits.push(`voice=${a.voice}`);
+    }
+
+    if (a.volume != null) {
+        bits.push(`vol=${Math.round(a.volume * 100)}%`);
+    }
+
+    if (a.provider) {
+        bits.push(a.provider);
+    }
+
+    if (a.mute) {
+        bits.push("muted");
+    }
+
+    return bits.join(" · ");
+}
+
+async function promptNewAppName(apps: SayAppConfig[]): Promise<string | null> {
+    const name = await p.text({
+        message: "App name:",
+        validate(v: string | undefined) {
+            if (!v) {
+                return "Name required";
+            }
+
+            if (v === DEFAULT_APP_NAME) {
+                return `"${DEFAULT_APP_NAME}" is reserved`;
+            }
+
+            if (apps.some((a) => a.name === v)) {
+                return `"${v}" already exists — pick "Edit" instead`;
+            }
+        },
+    });
+
+    if (p.isCancel(name)) {
+        return null;
+    }
+
+    return String(name);
+}
+
+async function speakActionTUI(mgr: SayConfigManager): Promise<void> {
+    const apps = await mgr.listApps();
+
+    const appChoice = await p.select({
+        message: "Speak with which profile?",
+        options: apps.map((a) => ({
+            value: a.name,
+            label: a.name + (a.name === DEFAULT_APP_NAME ? pc.dim(" (base)") : ""),
+            hint: appPickerHint(a),
+        })),
+    });
+
+    if (p.isCancel(appChoice)) {
+        return;
+    }
+
+    const text = await p.text({
+        message: "Text to speak:",
+        placeholder: "Hello world",
+        defaultValue: "Hello world",
+    });
+
+    if (p.isCancel(text)) {
+        return;
+    }
+
+    const s = p.spinner();
+    s.start("Speaking...");
+    try {
+        await speakWithProfile({
+            text: String(text),
+            app: String(appChoice) === DEFAULT_APP_NAME ? undefined : String(appChoice),
+            wait: true,
+        });
+        s.stop("Done");
+    } catch (err) {
+        s.stop(pc.red("Failed"));
+        p.log.error(err instanceof Error ? err.message : String(err));
     }
 }
 
@@ -716,53 +657,6 @@ async function listAppsTUI(mgr: SayConfigManager): Promise<void> {
     }
 
     console.log(formatTable(rows, ["App", "Voice", "Volume", "Provider", "Mute"]));
-}
-
-async function addAppTUI(mgr: SayConfigManager): Promise<void> {
-    const apps = await mgr.listApps();
-
-    const name = await p.text({
-        message: "App name:",
-        validate(v: string | undefined) {
-            if (!v) {
-                return "Name required";
-            }
-
-            if (v === DEFAULT_APP_NAME) {
-                return `"${DEFAULT_APP_NAME}" is reserved`;
-            }
-
-            if (apps.some((a) => a.name === v)) {
-                return `"${v}" already exists — pick "Edit" instead`;
-            }
-        },
-    });
-
-    if (p.isCancel(name)) {
-        return;
-    }
-
-    await mgr.upsertApp({ name: String(name) });
-    p.log.success(`Created profile "${name}"`);
-    await editAppFields(mgr, String(name));
-}
-
-async function editAppTUI(mgr: SayConfigManager): Promise<void> {
-    const apps = await mgr.listApps();
-
-    const target = await p.select({
-        message: "Edit which profile?",
-        options: apps.map((a) => ({
-            value: a.name,
-            label: a.name + (a.name === DEFAULT_APP_NAME ? " (base)" : ""),
-        })),
-    });
-
-    if (p.isCancel(target)) {
-        return;
-    }
-
-    await editAppFields(mgr, String(target));
 }
 
 async function editAppFields(mgr: SayConfigManager, app: string): Promise<void> {

--- a/src/say/lib/speak.ts
+++ b/src/say/lib/speak.ts
@@ -1,0 +1,39 @@
+import { AI } from "@app/utils/ai/index";
+import { SayConfigManager } from "@app/utils/macos/SayConfigManager";
+import { normalizeVolume } from "@app/utils/macos/tts";
+
+export interface SpeakWithProfileOptions {
+    text: string;
+    app?: string;
+    wait?: boolean;
+}
+
+/**
+ * Resolve the per-app `say` profile (mute, voice, rate, volume), then speak via the
+ * macOS TTS provider. Used by callers that want the same profile-aware behaviour as
+ * the `tools say` CLI without re-implementing config resolution.
+ *
+ * Mute precedence:
+ *   - global.mute → silence
+ *   - apps[<app>|default].mute === true → silence
+ */
+export async function speakWithProfile(options: SpeakWithProfileOptions): Promise<void> {
+    const { text, app, wait } = options;
+    const mgr = new SayConfigManager();
+
+    if (await mgr.isMuted(app)) {
+        process.stderr.write("[say] muted\n");
+        return;
+    }
+
+    const profile = await mgr.resolveApp(app);
+    const volume = profile.volume != null ? normalizeVolume(profile.volume) : undefined;
+
+    await AI.speak(text, {
+        provider: "local",
+        voice: profile.voice ?? undefined,
+        rate: profile.rate ?? undefined,
+        volume,
+        wait,
+    });
+}

--- a/src/telegram/lib/actions/say.ts
+++ b/src/telegram/lib/actions/say.ts
@@ -1,4 +1,4 @@
-import { speak } from "@app/utils/macos/tts";
+import { speakWithProfile } from "@app/say/lib/speak";
 import type { ActionHandler } from "../types";
 
 export const handleSay: ActionHandler = async (message, contact) => {
@@ -9,7 +9,7 @@ export const handleSay: ActionHandler = async (message, contact) => {
         : `${contact.displayName} says: ${message.text}`;
 
     try {
-        await speak(text);
+        await speakWithProfile({ text });
 
         return {
             action: "say",

--- a/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.bench.ts
+++ b/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.bench.ts
@@ -1,0 +1,58 @@
+import { performance } from "node:perf_hooks";
+import { AIXAITextToSpeechProvider } from "./AIXAITextToSpeechProvider";
+
+const SAMPLE = [
+    "In quiet hours when the screen is bright, the cursor blinks against the night.",
+    "Through tangled trees of thought I roam, and find at last the syntax of home.",
+    "Each function called, each variable named, builds quiet stanzas, gently framed.",
+    "The compiler hums a steady tune; the bug, once feared, departs by noon.",
+].join(" ");
+
+if (!process.env.X_AI_API_KEY) {
+    console.error("X_AI_API_KEY not set — skipping benchmark.");
+    process.exit(1);
+}
+
+const provider = new AIXAITextToSpeechProvider();
+
+async function timeRest(): Promise<{ ttfbMs: number; totalMs: number; bytes: number }> {
+    const start = performance.now();
+    const result = await provider.synthesize(SAMPLE);
+    const total = performance.now() - start;
+
+    return { ttfbMs: total, totalMs: total, bytes: result.audio.byteLength };
+}
+
+async function timeWs(): Promise<{ ttfbMs: number; totalMs: number; bytes: number }> {
+    const start = performance.now();
+    const { audio } = provider.synthesizeStream(SAMPLE);
+    let firstByteMs = 0;
+    let bytes = 0;
+
+    for await (const chunk of audio) {
+        if (firstByteMs === 0 && chunk.byteLength > 0) {
+            firstByteMs = performance.now() - start;
+        }
+
+        bytes += chunk.byteLength;
+    }
+
+    const total = performance.now() - start;
+    return { ttfbMs: firstByteMs, totalMs: total, bytes };
+}
+
+console.log(`Sample: ${SAMPLE.length} chars`);
+
+const rest = await timeRest();
+console.log(
+    `REST  /v1/tts (HTTP)  → TTFB ${rest.ttfbMs.toFixed(0)}ms, total ${rest.totalMs.toFixed(0)}ms, ${rest.bytes} bytes`
+);
+
+const ws = await timeWs();
+console.log(
+    `WS    /v1/tts (WSS)   → TTFB ${ws.ttfbMs.toFixed(0)}ms, total ${ws.totalMs.toFixed(0)}ms, ${ws.bytes} bytes`
+);
+
+const winner = ws.ttfbMs < rest.ttfbMs ? "WS" : "REST";
+const delta = Math.abs(ws.ttfbMs - rest.ttfbMs).toFixed(0);
+console.log(`\nFirst-byte winner: ${winner} (by ${delta}ms)`);

--- a/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.test.ts
+++ b/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
 import { AIXAITextToSpeechProvider } from "./AIXAITextToSpeechProvider";
 
 describe("AIXAITextToSpeechProvider", () => {
@@ -74,5 +75,141 @@ describe("AIXAITextToSpeechProvider", () => {
         } finally {
             globalThis.fetch = originalFetch;
         }
+    });
+});
+
+type Listener = (ev: unknown) => void;
+
+class FakeWebSocket {
+    private listeners: Record<string, Listener[]> = {};
+    sent: string[] = [];
+
+    addEventListener(name: string, fn: Listener): void {
+        if (!this.listeners[name]) {
+            this.listeners[name] = [];
+        }
+
+        this.listeners[name].push(fn);
+    }
+
+    send(payload: string): void {
+        this.sent.push(payload);
+    }
+
+    close(): void {
+        /* noop */
+    }
+
+    emit(name: string, ev: unknown): void {
+        for (const fn of this.listeners[name] ?? []) {
+            fn(ev);
+        }
+    }
+}
+
+function withFakeWs(provider: AIXAITextToSpeechProvider): FakeWebSocket {
+    const fake = new FakeWebSocket();
+    const client = (provider as unknown as { client: { openWebSocket: () => FakeWebSocket } }).client;
+    client.openWebSocket = () => fake;
+    return fake;
+}
+
+describe("AIXAITextToSpeechProvider.synthesizeStream", () => {
+    test("sends text.delta + text.done and yields decoded audio.delta until audio.done", async () => {
+        const provider = new AIXAITextToSpeechProvider();
+        const fake = withFakeWs(provider);
+
+        const { audio, contentType } = provider.synthesizeStream("hello world", { voice: "eve", language: "en" });
+        expect(contentType).toBe("audio/mpeg");
+
+        const collected: Uint8Array[] = [];
+        const consumer = (async () => {
+            for await (const chunk of audio) {
+                collected.push(chunk);
+            }
+        })();
+
+        fake.emit("open", {});
+        fake.emit("message", {
+            data: SafeJSON.stringify({ type: "audio.delta", delta: Buffer.from("AAAA").toString("base64") }),
+        });
+        fake.emit("message", {
+            data: SafeJSON.stringify({ type: "audio.delta", delta: Buffer.from("BBBB").toString("base64") }),
+        });
+        fake.emit("message", { data: SafeJSON.stringify({ type: "audio.done" }) });
+
+        await consumer;
+
+        expect(fake.sent).toEqual([
+            SafeJSON.stringify({ type: "text.delta", delta: "hello world" }),
+            SafeJSON.stringify({ type: "text.done" }),
+        ]);
+        expect(Buffer.concat(collected).toString("utf8")).toBe("AAAABBBB");
+    });
+
+    test("splits text > 5000 chars into multiple text.delta frames", async () => {
+        const provider = new AIXAITextToSpeechProvider();
+        const fake = withFakeWs(provider);
+
+        const long = "x".repeat(12_500);
+        const { audio } = provider.synthesizeStream(long);
+
+        const consumer = (async () => {
+            for await (const _ of audio) {
+                /* drain */
+            }
+        })();
+
+        fake.emit("open", {});
+        fake.emit("message", { data: SafeJSON.stringify({ type: "audio.done" }) });
+        await consumer;
+
+        const deltas = fake.sent.filter((s) => s.includes('"text.delta"'));
+        const done = fake.sent.filter((s) => s.includes('"text.done"'));
+        expect(deltas).toHaveLength(3); // 5000 + 5000 + 2500
+        expect(done).toHaveLength(1);
+    });
+
+    test("uses audio/wav content type when format=wav", () => {
+        const provider = new AIXAITextToSpeechProvider();
+        withFakeWs(provider);
+        const { contentType } = provider.synthesizeStream("hi", { format: "wav" });
+        expect(contentType).toBe("audio/wav");
+    });
+
+    test("surfaces error frames as iterator throw", async () => {
+        const provider = new AIXAITextToSpeechProvider();
+        const fake = withFakeWs(provider);
+
+        const { audio } = provider.synthesizeStream("test");
+
+        const consumer = (async () => {
+            for await (const _ of audio) {
+                /* drain */
+            }
+        })();
+
+        fake.emit("open", {});
+        fake.emit("message", { data: SafeJSON.stringify({ type: "error", message: "voice not found" }) });
+
+        await expect(consumer).rejects.toThrow(/xAI TTS error: voice not found/);
+    });
+
+    test("flags unexpected close (code 1006) before audio.done", async () => {
+        const provider = new AIXAITextToSpeechProvider();
+        const fake = withFakeWs(provider);
+
+        const { audio } = provider.synthesizeStream("test");
+
+        const consumer = (async () => {
+            for await (const _ of audio) {
+                /* drain */
+            }
+        })();
+
+        fake.emit("open", {});
+        fake.emit("close", { code: 1006 });
+
+        await expect(consumer).rejects.toThrow(/closed before audio\.done \(code 1006\)/);
     });
 });

--- a/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.ts
+++ b/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.ts
@@ -47,6 +47,15 @@ export interface AIXAITextToSpeechProviderOptions {
 
 export class AIXAITextToSpeechProvider implements AITextToSpeechProvider {
     readonly type: AIProviderType = "xai";
+    /**
+     * Measured against macOS `say` rendered to AIFF (Samantha voice) using `ffmpeg volumedetect`:
+     *   macOS native: mean -16.2 dB / peak -1.6 dB / -16.5 LUFS
+     *   xAI mp3 raw:  mean -23.3 dB / peak -6.7 dB / -23.0 LUFS
+     * Mean delta = 7.1 dB. With `volume=7dB,alimiter=limit=0.97`, xAI lands at mean -16.3 dB /
+     * peak -0.3 dB / -16.1 LUFS — within 0.1 dB of native on the channel humans perceive as
+     * loudness. The limiter keeps peaks below -0.3 dBFS so no audible distortion at any user volume.
+     */
+    readonly loudnessOffsetDb = 7;
     private readonly client = new XAIClient();
     private readonly storage = new Storage("ai");
     private readonly forceFreshVoices: boolean;

--- a/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.ts
+++ b/src/utils/ai/providers/xai/AIXAITextToSpeechProvider.ts
@@ -1,4 +1,3 @@
-import logger from "@app/logger";
 import { rateLimitAwareDelay, retry } from "@app/utils/async";
 import type { AIProviderType } from "@app/utils/config/ai.types";
 import { SafeJSON } from "@app/utils/json";
@@ -9,13 +8,7 @@ import { XAIClient } from "./XAIClient";
 const MAX_TTS_DELTA_CHARS = 15_000;
 const VOICE_CACHE_TTL = "7 days";
 const VOICE_CACHE_KEY = "xai-voices.json";
-
-/**
- * Realtime endpoint model — best quality for grok-voice-think-fast-1.0.
- * The `/v1/realtime` endpoint uses OpenAI-compatible event protocol.
- * Audio output is PCM16 24kHz mono, delivered as base64 in response.audio.delta.
- */
-const REALTIME_MODEL = "grok-voice-think-fast-1.0";
+const TEXT_DELTA_CHUNK_SIZE = 5_000;
 
 const SUPPORTED_TASKS: ReadonlySet<AITask> = new Set(["tts"]);
 const SYNTHESIZE_RETRY_DELAY = rateLimitAwareDelay();
@@ -28,35 +21,6 @@ interface XAIVoiceResponse {
         locale?: string;
     }>;
 }
-
-// ---------------------------------------------------------------------------
-// Realtime WebSocket event types (OpenAI-realtime-compatible protocol)
-// ---------------------------------------------------------------------------
-
-interface XAIRealtimeAudioDelta {
-    type: "response.audio.delta";
-    delta: string; // base64-encoded PCM16 24kHz mono
-}
-
-interface XAIRealtimeDone {
-    type: "response.done";
-}
-
-interface XAIRealtimeError {
-    type: "error";
-    error: { message: string; code?: string };
-}
-
-interface XAIRealtimeConversationCreated {
-    type: "conversation.created";
-}
-
-type XAIRealtimeEvent =
-    | XAIRealtimeAudioDelta
-    | XAIRealtimeDone
-    | XAIRealtimeError
-    | XAIRealtimeConversationCreated
-    | { type: string };
 
 function shouldRetrySynthesize(error: unknown): boolean {
     const msg = error instanceof Error ? error.message : String(error);
@@ -146,20 +110,30 @@ export class AIXAITextToSpeechProvider implements AITextToSpeechProvider {
     }
 
     /**
-     * Yields audio chunks via the xAI Realtime WebSocket (`wss://api.x.ai/v1/realtime`).
+     * Streams audio from xAI's dedicated TTS WebSocket (`wss://api.x.ai/v1/tts`).
      *
-     * Protocol (OpenAI-realtime-compatible):
-     *   1. Server sends `conversation.created` on connect.
-     *   2. Client sends `conversation.item.create` (input_text) + `response.create` (modalities: ["audio"]).
-     *   3. Server sends `response.audio.delta` events (base64 PCM16 24kHz mono).
-     *   4. Server sends `response.done` when finished.
+     * Protocol:
+     *   client → {type: "text.delta", delta: <chunk>} (one or many)
+     *   client → {type: "text.done"}
+     *   server → {type: "audio.delta", delta: <base64>}
+     *   server → {type: "audio.done"}            // graceful end
+     *   server → {type: "error", message: <msg>} // failure
      *
-     * Audio format is PCM16 24kHz mono — content-type: audio/pcm.
+     * Cost is identical to REST ($4.20 / 1M input chars). No total-text limit.
      */
     synthesizeStream(text: string, options?: TTSOptions): { audio: AsyncIterable<Uint8Array>; contentType: string } {
         const client = this.client;
         const voice = options?.voice ?? "eve";
-        const realtimeParams = new URLSearchParams({ model: REALTIME_MODEL });
+        const language = options?.language ?? "auto";
+        const codec = options?.format ?? "mp3";
+        const contentType = codec === "wav" ? "audio/wav" : "audio/mpeg";
+
+        const params = new URLSearchParams({
+            language,
+            voice,
+            codec,
+            sample_rate: "24000",
+        });
 
         const audio = (async function* iter(): AsyncIterable<Uint8Array> {
             const queue: Uint8Array[] = [];
@@ -167,7 +141,7 @@ export class AIXAITextToSpeechProvider implements AITextToSpeechProvider {
             let done = false;
             let error: Error | null = null;
 
-            const ws = client.openWebSocket("/realtime", realtimeParams);
+            const ws = client.openWebSocket("/tts", params);
 
             const push = (chunk: Uint8Array): void => {
                 if (resolveNext) {
@@ -180,6 +154,10 @@ export class AIXAITextToSpeechProvider implements AITextToSpeechProvider {
             };
 
             const finish = (err?: Error): void => {
+                if (done) {
+                    return;
+                }
+
                 done = true;
 
                 if (err) {
@@ -194,78 +172,61 @@ export class AIXAITextToSpeechProvider implements AITextToSpeechProvider {
             };
 
             ws.addEventListener("open", () => {
-                // Send the text input and request an audio response
-                ws.send(
-                    SafeJSON.stringify({
-                        type: "conversation.item.create",
-                        item: {
-                            type: "message",
-                            role: "user",
-                            content: [{ type: "input_text", text }],
-                        },
-                    })
-                );
-                ws.send(
-                    SafeJSON.stringify({
-                        type: "response.create",
-                        response: {
-                            modalities: ["audio"],
-                            voice,
-                        },
-                    })
-                );
+                for (let i = 0; i < text.length; i += TEXT_DELTA_CHUNK_SIZE) {
+                    ws.send(
+                        SafeJSON.stringify({
+                            type: "text.delta",
+                            delta: text.slice(i, i + TEXT_DELTA_CHUNK_SIZE),
+                        })
+                    );
+                }
+
+                ws.send(SafeJSON.stringify({ type: "text.done" }));
             });
 
-            ws.addEventListener("error", () => finish(new Error("xAI Realtime WebSocket error")));
+            ws.addEventListener("error", () => finish(new Error("xAI TTS WebSocket transport error")));
 
             ws.addEventListener("close", (ev) => {
                 if (!done) {
-                    finish(new Error(`xAI Realtime WebSocket closed unexpectedly (code ${ev.code})`));
+                    finish(new Error(`xAI TTS WebSocket closed before audio.done (code ${ev.code})`));
                 }
             });
 
             ws.addEventListener("message", (event) => {
-                let parsed: XAIRealtimeEvent;
+                let parsed: { type: string; delta?: string; message?: string };
 
                 try {
                     parsed = SafeJSON.parse(typeof event.data === "string" ? event.data : event.data.toString());
-                } catch (err) {
-                    logger.debug(`xAI Realtime: malformed event: ${err}`);
+                } catch {
                     return;
                 }
 
                 switch (parsed.type) {
-                    case "conversation.created":
-                        // Connection established — messages already queued in open handler
-                        break;
-                    case "response.audio.delta": {
-                        const delta = (parsed as XAIRealtimeAudioDelta).delta;
-                        push(Buffer.from(delta, "base64"));
-                        break;
-                    }
-                    case "response.done":
-                        try {
-                            ws.close();
-                        } catch {
-                            /* noop */
+                    case "audio.delta":
+                        if (parsed.delta) {
+                            push(Buffer.from(parsed.delta, "base64"));
                         }
+                        break;
+                    case "audio.done":
                         finish();
-                        break;
-                    case "error": {
-                        const errEvent = parsed as XAIRealtimeError;
-                        const msg = errEvent.error?.message ?? "Unknown realtime error";
 
                         try {
                             ws.close();
                         } catch {
                             /* noop */
                         }
-
-                        finish(new Error(`xAI Realtime error: ${msg}`));
                         break;
-                    }
+                    case "error":
+                        finish(new Error(`xAI TTS error: ${parsed.message ?? "unknown"}`));
+
+                        try {
+                            ws.close();
+                        } catch {
+                            /* noop */
+                        }
+                        break;
                     default:
-                        logger.debug(`xAI Realtime: unhandled event type: ${parsed.type}`);
+                        break;
                 }
             });
 
@@ -307,8 +268,7 @@ export class AIXAITextToSpeechProvider implements AITextToSpeechProvider {
             }
         })();
 
-        // Realtime endpoint delivers PCM16 24kHz mono
-        return { audio, contentType: "audio/pcm" };
+        return { audio, contentType };
     }
 
     async listVoices(): Promise<TTSVoice[]> {

--- a/src/utils/ai/tasks/Synthesizer.ts
+++ b/src/utils/ai/tasks/Synthesizer.ts
@@ -22,9 +22,65 @@ export interface SpeakOptions extends TTSOptions {
     provider?: ProviderSelector;
     model?: string;
     volume?: number;
+    /**
+     * Normalized rate on a 0..2 scale: 0 = slowest the provider produces intelligibly, 1 =
+     * provider default cadence, 2 = fastest. Linearly interpolated to `say -r N` (80..175..350 wpm)
+     * for macOS native, and to ffmpeg `atempo` (0.5..1.0..2.0, pitch-preserving) for cloud providers.
+     * Values outside [0, 2] are clamped.
+     */
     rate?: number;
     wait?: boolean;
     app?: string;
+}
+
+const MACOS_MIN_WPM = 80;
+const MACOS_DEFAULT_WPM = 175;
+const MACOS_MAX_WPM = 350;
+/**
+ * macOS `say -r` is heavily non-linear (engine clamps for intelligibility):
+ *   -r 80  → 0.81× actual playback speed
+ *   -r 128 → 0.90×
+ *   -r 175 → 1.00× (default)
+ *   -r 263 → 1.43×
+ *   -r 350 → 1.86×
+ * To make `--rate N` sound the same across providers, we clamp xAI atempo to the same delivered
+ * range — so rate=0 plays at ~0.81× on both providers, rate=2 at ~1.86× on both.
+ */
+const ATEMPO_MIN = 0.81;
+const ATEMPO_DEFAULT = 1;
+const ATEMPO_MAX = 1.86;
+
+function lerp(a: number, b: number, t: number): number {
+    return a + (b - a) * t;
+}
+
+/**
+ * Accept either 0..2 (multiplier) or 0..200 (percent). Anything > 2 is treated as percent and
+ * divided by 100 — so `--rate 150` and `--rate 1.5` both mean "150% of default cadence".
+ */
+function normalizeRate(rate: number): number {
+    const v = rate > 2 ? rate / 100 : rate;
+    return Math.max(0, Math.min(2, v));
+}
+
+function rateToMacosWpm(rate: number): number {
+    const r = normalizeRate(rate);
+
+    if (r <= 1) {
+        return Math.round(lerp(MACOS_MIN_WPM, MACOS_DEFAULT_WPM, r));
+    }
+
+    return Math.round(lerp(MACOS_DEFAULT_WPM, MACOS_MAX_WPM, r - 1));
+}
+
+function rateToAtempo(rate: number): number {
+    const r = normalizeRate(rate);
+
+    if (r <= 1) {
+        return lerp(ATEMPO_MIN, ATEMPO_DEFAULT, r);
+    }
+
+    return lerp(ATEMPO_DEFAULT, ATEMPO_MAX, r - 1);
 }
 
 const REST_STREAM_THRESHOLD_CHARS = 80;
@@ -54,30 +110,45 @@ export class Synthesizer {
     async speak(text: string, options?: SpeakOptions): Promise<void> {
         const provider = await this.providerFor(options);
         const ttsOpts = toTTSOptions(options);
+        const rate = options?.rate;
+        const macRateWpm = rate != null ? rateToMacosWpm(rate) : undefined;
+        const atempo = rate != null ? rateToAtempo(rate) : undefined;
 
         // 1. Native short-circuit — macOS provider has a speak() that avoids temp-file roundtrip.
         if (provider.speak) {
             await provider.speak(text, {
                 ...ttsOpts,
                 volume: options?.volume,
-                rate: options?.rate,
+                rate: macRateWpm,
                 wait: options?.wait,
             });
             return;
         }
 
         const wantStream = shouldStream(text, options);
+        const gainDb = provider.loudnessOffsetDb;
+        const tempo = atempo;
 
         // 2. Streaming → playStream.
         if (wantStream && provider.synthesizeStream) {
             const { audio, contentType } = provider.synthesizeStream(text, ttsOpts);
-            await playStream(audio, contentType, { volume: options?.volume, wait: options?.wait });
+            await playStream(audio, contentType, {
+                volume: options?.volume,
+                gainDb,
+                tempo,
+                wait: options?.wait,
+            });
             return;
         }
 
         // 3. Fallback: synthesize → playBuffer.
         const result = await provider.synthesize(text, ttsOpts);
-        await playBuffer(result.audio, result.contentType, { volume: options?.volume, wait: options?.wait });
+        await playBuffer(result.audio, result.contentType, {
+            volume: options?.volume,
+            gainDb,
+            tempo,
+            wait: options?.wait,
+        });
     }
 
     async synthesize(text: string, options?: SpeakOptions): Promise<TTSResult> {

--- a/src/utils/ai/types.ts
+++ b/src/utils/ai/types.ts
@@ -180,6 +180,13 @@ export interface AITextToSpeechProvider extends AIProvider {
      */
     speak?(text: string, options?: TTSOptions & { volume?: number; rate?: number; wait?: boolean }): Promise<void>;
     listVoices?(): Promise<TTSVoice[]>;
+    /**
+     * Loudness offset (dB) applied during playback so that --volume 100 matches macOS native `say`
+     * perceived loudness. Cloud TTS sources are typically mastered quieter than native speech
+     * synthesis; positive values boost. Bounded to ≤24 dB by the player and combined with a peak
+     * limiter so the boost never clips. Omit (or set 0) for sources already matched to native.
+     */
+    readonly loudnessOffsetDb?: number;
 }
 
 export interface AITranslationProvider extends AIProvider {

--- a/src/utils/audio/playback.ts
+++ b/src/utils/audio/playback.ts
@@ -15,23 +15,39 @@ export function isFfplayAvailable(): boolean {
 }
 
 export interface PlayOptions {
+    /** User-visible volume on the same scale as `afplay -v` and `say [[volm V]]`: 0..1 (also accepts 0..100). */
     volume?: number;
+    /**
+     * Loudness offset in dB to compensate for sources mastered quieter than native synthesis.
+     * Cloud TTS providers (e.g. xAI mp3) need a positive offset to match macOS `say` perceived loudness.
+     * The limiter chain prevents the boost from ever clipping.
+     */
+    gainDb?: number;
+    /**
+     * Playback speed multiplier (1.0 = original). Implemented via ffmpeg's `atempo` filter, which
+     * preserves pitch — no chipmunk effect. ffmpeg auto-chains `atempo` for ratios outside its
+     * single-instance 0.5..2.0 range. Ignored on the afplay fallback path (no equivalent knob).
+     */
+    tempo?: number;
     wait?: boolean;
 }
 
-export async function playBuffer(audio: Buffer, contentType: string, opts?: PlayOptions): Promise<void> {
-    const volume = clampVolume(opts?.volume);
+const PEAK_CEILING = 0.97; // -0.3 dBFS — alimiter ceiling that prevents inter-sample clipping
+const MAX_GAIN_DB = 24;
+const MIN_TEMPO = 0.25;
+const MAX_TEMPO = 4;
 
+export async function playBuffer(audio: Buffer, contentType: string, opts?: PlayOptions): Promise<void> {
     if (audio.length === 0) {
         return;
     }
 
     if (isFfplayAvailable()) {
-        await runFfplayWithBuffer(audio, volume, opts?.wait, contentType);
+        await runFfplayWithBuffer(audio, opts, contentType);
         return;
     }
 
-    await runAfplayFromTmpFile(audio, contentType, volume, opts?.wait);
+    await runAfplayFromTmpFile(audio, contentType, afplayVolume(opts), opts?.wait);
 }
 
 export async function playStream(
@@ -39,10 +55,8 @@ export async function playStream(
     contentType: string,
     opts?: PlayOptions
 ): Promise<void> {
-    const volume = clampVolume(opts?.volume);
-
     if (isFfplayAvailable()) {
-        await runFfplayWithStream(audio, volume, opts?.wait, contentType);
+        await runFfplayWithStream(audio, opts, contentType);
         return;
     }
 
@@ -53,10 +67,10 @@ export async function playStream(
     }
 
     const combined = Buffer.concat(chunks);
-    await runAfplayFromTmpFile(combined, contentType, volume, opts?.wait);
+    await runAfplayFromTmpFile(combined, contentType, afplayVolume(opts), opts?.wait);
 }
 
-function clampVolume(v: number | undefined): number {
+function userVolumeLinear(v: number | undefined): number {
     if (v == null) {
         return 1;
     }
@@ -65,29 +79,113 @@ function clampVolume(v: number | undefined): number {
     return Math.max(0, Math.min(1, normalized));
 }
 
+function clampGainDb(db: number | undefined): number {
+    if (db == null || !Number.isFinite(db)) {
+        return 0;
+    }
+
+    return Math.max(0, Math.min(MAX_GAIN_DB, db));
+}
+
+/**
+ * afplay can't limit, so we fold the gain into the linear volume and rely on afplay's headroom.
+ * macOS afplay accepts -v > 1; clipping risk is real, but ffplay is the primary path and
+ * almost always available. Cap the linear factor so grossly-misconfigured gains don't blast
+ * speakers — 4× linear is the same ceiling as the alimiter chain.
+ */
+function afplayVolume(opts: PlayOptions | undefined): number {
+    const linear = userVolumeLinear(opts?.volume);
+    const gainLinear = 10 ** (clampGainDb(opts?.gainDb) / 20);
+    return Math.max(0, Math.min(4, linear * gainLinear));
+}
+
 /**
  * Build ffplay argument list for streaming stdin.
  * PCM16 24kHz mono (audio/pcm) needs explicit format hints — ffplay cannot
  * auto-detect raw PCM from stdin with no magic bytes.
  */
-function ffplayArgs(volume: number, contentType?: string): string[] {
-    const base = ["-hide_banner", "-nodisp", "-autoexit", "-loglevel", "error", "-af", `volume=${volume}`];
+function ffplayArgs(opts: PlayOptions | undefined, contentType?: string): string[] {
+    const userVol = userVolumeLinear(opts?.volume);
+    const gainDb = clampGainDb(opts?.gainDb);
+    const tempo = clampTempo(opts?.tempo);
+    const filter = buildFilterChain(userVol, gainDb, tempo);
+    const base = ["-hide_banner", "-nodisp", "-autoexit", "-loglevel", "error", "-af", filter];
 
     if (contentType?.includes("pcm")) {
-        // Raw signed 16-bit little-endian PCM at 24kHz mono
         return [...base, "-f", "s16le", "-ar", "24000", "-ac", "1", "-i", "-"];
     }
 
     return [...base, "-i", "-"];
 }
 
-async function runFfplayWithBuffer(
-    audio: Buffer,
-    volume: number,
-    wait: boolean | undefined,
-    contentType?: string
-): Promise<void> {
-    const proc = Bun.spawn(["ffplay", ...ffplayArgs(volume, contentType)], {
+/**
+ * Build the ffmpeg filter chain. Order matters: user volume → loudness offset → peak limiter →
+ * tempo. Limiter sits *before* atempo so the boost can't push transients past -0.3 dBFS regardless
+ * of speed. The limiter only engages on actual peaks — quiet samples pass through untouched, so
+ * 50% stays linearly 50% and there is no audible compression at typical TTS levels.
+ */
+function buildFilterChain(userVolumeLinearValue: number, gainDb: number, tempo: number): string {
+    const parts: string[] = [];
+
+    if (userVolumeLinearValue !== 1) {
+        parts.push(`volume=${userVolumeLinearValue.toFixed(4)}`);
+    }
+
+    if (gainDb > 0) {
+        parts.push(`volume=${gainDb}dB`);
+        parts.push(`alimiter=limit=${PEAK_CEILING}:level=disabled`);
+    }
+
+    if (tempo !== 1) {
+        for (const segment of atempoChain(tempo)) {
+            parts.push(`atempo=${segment.toFixed(4)}`);
+        }
+    }
+
+    if (parts.length === 0) {
+        return "anull";
+    }
+
+    return parts.join(",");
+}
+
+/**
+ * Single ffmpeg `atempo` instance accepts ratios in [0.5, 100]. For values below 0.5 we chain
+ * 0.5-multipliers (e.g. 0.4 → 0.5 * 0.8). For values above 2 a single instance still works in
+ * modern ffmpeg, but quality is better when chained at ≤2x — so split anything above 2.
+ */
+function atempoChain(tempo: number): number[] {
+    if (tempo >= 0.5 && tempo <= 2) {
+        return [tempo];
+    }
+
+    const out: number[] = [];
+    let remaining = tempo;
+
+    while (remaining > 2) {
+        out.push(2);
+        remaining /= 2;
+    }
+
+    while (remaining < 0.5) {
+        out.push(0.5);
+        remaining /= 0.5;
+    }
+
+    out.push(remaining);
+    return out;
+}
+
+function clampTempo(t: number | undefined): number {
+    if (t == null || !Number.isFinite(t) || t === 1) {
+        return 1;
+    }
+
+    return Math.max(MIN_TEMPO, Math.min(MAX_TEMPO, t));
+}
+
+async function runFfplayWithBuffer(audio: Buffer, opts: PlayOptions | undefined, contentType?: string): Promise<void> {
+    const proc = Bun.spawn(["ffplay", ...ffplayArgs(opts, contentType)], {
         stdin: "pipe",
         stdout: "ignore",
         stderr: "ignore",
@@ -102,18 +200,17 @@ async function runFfplayWithBuffer(
     sink.write(new Uint8Array(audio));
     await sink.end();
 
-    if (wait) {
+    if (opts?.wait) {
         await proc.exited;
     }
 }
 
 async function runFfplayWithStream(
     audio: AsyncIterable<Uint8Array>,
-    volume: number,
-    wait: boolean | undefined,
+    opts: PlayOptions | undefined,
     contentType?: string
 ): Promise<void> {
-    const proc = Bun.spawn(["ffplay", ...ffplayArgs(volume, contentType)], {
+    const proc = Bun.spawn(["ffplay", ...ffplayArgs(opts, contentType)], {
         stdin: "pipe",
         stdout: "ignore",
         stderr: "ignore",
@@ -135,7 +232,7 @@ async function runFfplayWithStream(
         }
     };
 
-    if (wait) {
+    if (opts?.wait) {
         await finish();
         await proc.exited;
     } else {

--- a/src/utils/macos/SayConfigManager.ts
+++ b/src/utils/macos/SayConfigManager.ts
@@ -363,7 +363,7 @@ export class SayConfigManager {
         await this.patchApp(args.app, { mute: args.mute });
     }
 
-    /** Whether a given app (or the implicit caller) is muted. */
+    /** Whether a given app (or the implicit caller using the default profile) is muted. */
     async isMuted(app?: string): Promise<boolean> {
         const c = await this.load();
 
@@ -371,11 +371,8 @@ export class SayConfigManager {
             return true;
         }
 
-        if (!app) {
-            return false;
-        }
-
-        const a = c.apps.find((x) => x.name === app);
+        const targetApp = app ?? DEFAULT_APP_NAME;
+        const a = c.apps.find((x) => x.name === targetApp);
         return a?.mute === true;
     }
 }

--- a/src/utils/macos/SayConfigManager.ts
+++ b/src/utils/macos/SayConfigManager.ts
@@ -1,0 +1,381 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { Storage } from "@app/utils/storage/storage.ts";
+
+export type SayProvider = "macos" | "xai" | "openai";
+
+export interface SayAppConfig {
+    name: string;
+    voice?: string | null;
+    volume?: number | null;
+    provider?: SayProvider | null;
+    rate?: number | null;
+    model?: string | null;
+    format?: "mp3" | "wav" | null;
+    language?: string | null;
+    mute?: boolean | null;
+}
+
+export interface SayConfigV2 {
+    version: 2;
+    global: { mute: boolean };
+    apps: SayAppConfig[];
+}
+
+interface SayConfigV1 {
+    defaultVoice?: string | null;
+    defaultVolume?: number;
+    globalMute?: boolean;
+    appMute?: Record<string, boolean>;
+    appVolume?: Record<string, number>;
+}
+
+export const DEFAULT_APP_NAME = "default";
+
+/** Fields persistable per app via `--save` and the interactive config TUI. */
+export const SETTABLE_FIELDS = [
+    "voice",
+    "volume",
+    "provider",
+    "rate",
+    "model",
+    "format",
+    "language",
+    "mute",
+] as const satisfies readonly Exclude<keyof SayAppConfig, "name">[];
+
+export type SettableField = (typeof SETTABLE_FIELDS)[number];
+
+export function isSettableField(s: string): s is SettableField {
+    return (SETTABLE_FIELDS as readonly string[]).includes(s);
+}
+
+function stripUndefined<T extends object>(o: T): Partial<T> {
+    const out: Partial<T> = {};
+
+    for (const k of Object.keys(o) as (keyof T)[]) {
+        const v = o[k];
+
+        if (v !== undefined) {
+            out[k] = v;
+        }
+    }
+
+    return out;
+}
+
+function freshDefaultApp(): SayAppConfig {
+    return normalizeAppShape({ name: DEFAULT_APP_NAME });
+}
+
+/**
+ * Ensure every settable field exists on the saved app entry, using `null` when
+ * unset. This keeps the on-disk JSON self-documenting (you can see all available
+ * fields) and makes "fall through to default" explicit. Resolution treats null
+ * and missing identically — both mean "inherit".
+ */
+function normalizeAppShape(app: SayAppConfig): SayAppConfig {
+    const out: SayAppConfig = { name: app.name };
+
+    for (const field of SETTABLE_FIELDS) {
+        const v = app[field];
+        out[field] = (v ?? null) as never;
+    }
+
+    return out;
+}
+
+function freshV2(): SayConfigV2 {
+    return { version: 2, global: { mute: false }, apps: [freshDefaultApp()] };
+}
+
+function isV2(raw: unknown): raw is SayConfigV2 {
+    if (typeof raw !== "object" || raw === null) {
+        return false;
+    }
+
+    const v = (raw as { version?: unknown }).version;
+    return v === 2;
+}
+
+function ensureDefaultApp(c: SayConfigV2): SayConfigV2 {
+    if (!c.apps.some((a) => a.name === DEFAULT_APP_NAME)) {
+        c.apps.unshift(freshDefaultApp());
+    }
+
+    return c;
+}
+
+function migrateV1(raw: SayConfigV1): SayConfigV2 {
+    const v2 = freshV2();
+    const def = v2.apps[0];
+
+    if (raw.defaultVoice != null) {
+        def.voice = raw.defaultVoice;
+    }
+
+    if (raw.defaultVolume != null) {
+        def.volume = raw.defaultVolume;
+    }
+
+    if (raw.globalMute) {
+        v2.global.mute = true;
+    }
+
+    const names = new Set<string>([...Object.keys(raw.appMute ?? {}), ...Object.keys(raw.appVolume ?? {})]);
+
+    for (const name of names) {
+        if (name === DEFAULT_APP_NAME) {
+            continue;
+        }
+
+        const app: SayAppConfig = { name };
+
+        if (raw.appMute?.[name]) {
+            app.mute = true;
+        }
+
+        if (raw.appVolume?.[name] != null) {
+            app.volume = raw.appVolume[name];
+        }
+
+        v2.apps.push(app);
+    }
+
+    return v2;
+}
+
+/**
+ * Resolve effective config for an app by layering it over the default app.
+ * Missing/null fields on the target app inherit from default; missing on
+ * default mean "no preference" (caller / provider applies its own default).
+ */
+export function resolveOver(target: SayAppConfig, base: SayAppConfig): SayAppConfig {
+    const merged: SayAppConfig = { name: target.name };
+
+    for (const field of SETTABLE_FIELDS) {
+        const fromTarget = target[field];
+
+        if (fromTarget != null) {
+            merged[field] = fromTarget as never;
+            continue;
+        }
+
+        const fromBase = base[field];
+
+        if (fromBase != null) {
+            merged[field] = fromBase as never;
+        }
+    }
+
+    return merged;
+}
+
+export class SayConfigManager {
+    private cache: SayConfigV2 | null = null;
+    private pendingV1Backup: string | null = null;
+
+    constructor(private readonly storage = new Storage("say")) {}
+
+    async load(): Promise<SayConfigV2> {
+        if (this.cache) {
+            return this.cache;
+        }
+
+        const raw = await this.storage.getConfig<Record<string, unknown>>();
+
+        if (raw === null || raw === undefined) {
+            this.cache = freshV2();
+            return this.cache;
+        }
+
+        if (isV2(raw)) {
+            this.cache = ensureDefaultApp(raw);
+            return this.cache;
+        }
+
+        this.pendingV1Backup = SafeJSON.stringify(raw, null, 2);
+        this.cache = migrateV1(raw as SayConfigV1);
+        return this.cache;
+    }
+
+    async save(c: SayConfigV2): Promise<void> {
+        if (this.pendingV1Backup) {
+            const backupPath = join(dirname(this.storage.getConfigPath()), "config.v1.bak.json");
+
+            if (!existsSync(backupPath)) {
+                await Bun.write(backupPath, this.pendingV1Backup);
+            }
+
+            this.pendingV1Backup = null;
+        }
+
+        const out = ensureDefaultApp({ version: 2, global: c.global, apps: c.apps.map(normalizeAppShape) });
+        await this.storage.setConfig(out);
+        this.cache = out;
+    }
+
+    async getApp(name: string): Promise<SayAppConfig | undefined> {
+        const c = await this.load();
+        return c.apps.find((a) => a.name === name);
+    }
+
+    async getDefaultApp(): Promise<SayAppConfig> {
+        const c = await this.load();
+        const def = c.apps.find((a) => a.name === DEFAULT_APP_NAME);
+
+        if (!def) {
+            const fresh = freshDefaultApp();
+            c.apps.unshift(fresh);
+            return fresh;
+        }
+
+        return def;
+    }
+
+    async listApps(): Promise<SayAppConfig[]> {
+        const c = await this.load();
+        return c.apps;
+    }
+
+    async getGlobalMute(): Promise<boolean> {
+        const c = await this.load();
+        return c.global.mute;
+    }
+
+    /**
+     * Return a merged config for the given app: app fields layered over the
+     * default app's fields. If `name` is undefined, returns the default app.
+     */
+    async resolveApp(name?: string): Promise<SayAppConfig> {
+        const def = await this.getDefaultApp();
+
+        if (!name || name === DEFAULT_APP_NAME) {
+            return { ...def };
+        }
+
+        const target = await this.getApp(name);
+
+        if (!target) {
+            return { ...def, name };
+        }
+
+        return resolveOver(target, def);
+    }
+
+    async upsertApp(app: SayAppConfig): Promise<void> {
+        if (!app.name) {
+            throw new Error("App name is required");
+        }
+
+        const c = await this.load();
+        const idx = c.apps.findIndex((a) => a.name === app.name);
+
+        if (idx === -1) {
+            c.apps.push(app);
+        } else {
+            c.apps[idx] = app;
+        }
+
+        await this.save(c);
+    }
+
+    async patchApp(name: string, patch: Partial<Omit<SayAppConfig, "name">>): Promise<SayAppConfig> {
+        const c = await this.load();
+        let app = c.apps.find((a) => a.name === name);
+
+        if (!app) {
+            app = { name };
+            c.apps.push(app);
+        }
+
+        Object.assign(app, stripUndefined(patch));
+
+        await this.save(c);
+        return app;
+    }
+
+    async unsetAppFields(name: string, fields: readonly SettableField[]): Promise<void> {
+        if (fields.length === 0) {
+            return;
+        }
+
+        const c = await this.load();
+        const app = c.apps.find((a) => a.name === name);
+
+        if (!app) {
+            return;
+        }
+
+        for (const f of fields) {
+            app[f] = null as never;
+        }
+
+        await this.save(c);
+    }
+
+    async deleteApp(name: string): Promise<void> {
+        if (name === DEFAULT_APP_NAME) {
+            throw new Error(`Cannot delete the "${DEFAULT_APP_NAME}" app — it is the inherit base for all other apps.`);
+        }
+
+        const c = await this.load();
+        c.apps = c.apps.filter((a) => a.name !== name);
+        await this.save(c);
+    }
+
+    async setGlobalMute(mute: boolean): Promise<void> {
+        const c = await this.load();
+        c.global.mute = mute;
+        await this.save(c);
+    }
+
+    async setVoice(args: { app: string; voice: string | null }): Promise<void> {
+        await this.patchApp(args.app, { voice: args.voice });
+    }
+
+    async setVolume(args: { app: string; volume: number | null }): Promise<void> {
+        await this.patchApp(args.app, { volume: args.volume });
+    }
+
+    async setProvider(args: { app: string; provider: SayProvider | null }): Promise<void> {
+        await this.patchApp(args.app, { provider: args.provider });
+    }
+
+    async setRate(args: { app: string; rate: number | null }): Promise<void> {
+        await this.patchApp(args.app, { rate: args.rate });
+    }
+
+    async setModel(args: { app: string; model: string | null }): Promise<void> {
+        await this.patchApp(args.app, { model: args.model });
+    }
+
+    async setFormat(args: { app: string; format: "mp3" | "wav" | null }): Promise<void> {
+        await this.patchApp(args.app, { format: args.format });
+    }
+
+    async setLanguage(args: { app: string; language: string | null }): Promise<void> {
+        await this.patchApp(args.app, { language: args.language });
+    }
+
+    async setMute(args: { app: string; mute: boolean }): Promise<void> {
+        await this.patchApp(args.app, { mute: args.mute });
+    }
+
+    /** Whether a given app (or the implicit caller) is muted. */
+    async isMuted(app?: string): Promise<boolean> {
+        const c = await this.load();
+
+        if (c.global.mute) {
+            return true;
+        }
+
+        if (!app) {
+            return false;
+        }
+
+        const a = c.apps.find((x) => x.name === app);
+        return a?.mute === true;
+    }
+}

--- a/src/utils/macos/index.ts
+++ b/src/utils/macos/index.ts
@@ -76,6 +76,8 @@ export {
     recognizeText,
     recognizeTextFromBuffer,
 } from "./ocr";
+export type { SayAppConfig, SayConfigV2, SayProvider, SettableField } from "./SayConfigManager";
+export { DEFAULT_APP_NAME, isSettableField, SayConfigManager, SETTABLE_FIELDS } from "./SayConfigManager";
 // System
 export { getCapabilities } from "./system";
 export type {
@@ -95,9 +97,9 @@ export {
     groupByLanguage,
     rankBySimilarity,
 } from "./text-analysis";
-export type { SayConfig, SpeakOptions, VoiceInfo } from "./tts";
+export type { SpeakOptions, VoiceInfo } from "./tts";
 // TTS
-export { getConfigForRead, getVoiceMap, listVoices, setConfig as setTtsConfig, speak } from "./tts";
+export { getVoiceMap, listVoices, speak } from "./tts";
 // Types
 export type {
     AuthAvailableResult,

--- a/src/utils/macos/index.ts
+++ b/src/utils/macos/index.ts
@@ -97,9 +97,9 @@ export {
     groupByLanguage,
     rankBySimilarity,
 } from "./text-analysis";
-export type { SpeakOptions, VoiceInfo } from "./tts";
-// TTS
-export { getVoiceMap, listVoices, speak } from "./tts";
+export type { VoiceInfo } from "./tts";
+// TTS primitives. Profile-aware speech lives in `@app/say/lib/speak`.
+export { getVoiceMap, listVoices } from "./tts";
 // Types
 export type {
     AuthAvailableResult,

--- a/src/utils/macos/tts.ts
+++ b/src/utils/macos/tts.ts
@@ -3,7 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Storage } from "@app/utils/storage/storage.ts";
 import { detectLanguage } from "./nlp";
-import { SayConfigManager } from "./SayConfigManager.ts";
 
 const storage = new Storage("say");
 
@@ -21,14 +20,12 @@ export interface VoiceInfo {
 export interface SpeakOptions {
     /** Override voice (skips language detection) */
     voice?: string;
-    /** Words per minute (default: macOS default ~175) */
+    /** Normalized rate on a 0..2 scale (1 = default cadence). See AI Synthesizer for mapping. */
     rate?: number;
     /** Volume 0.0 - 1.0, default: 1 */
     volume?: number;
     /** Block until done, default: false */
     wait?: boolean;
-    /** Caller identity for per-app mute */
-    app?: string;
 }
 
 /**
@@ -100,30 +97,21 @@ export async function getVoiceMap(): Promise<Map<string, VoiceInfo>> {
 // ============================================
 
 /**
- * Speak text aloud, resolving voice/volume/etc. through the v2 SayConfig profile
- * for `options.app` (falls back to the "default" profile). Caller-supplied
- * options override profile values. Background by default; `wait: true` blocks.
+ * Pure macOS TTS pass-through. Speaks `text` via the local provider with the
+ * caller-supplied options. Profile / mute / app resolution live at the CLI layer
+ * (`src/say/lib/speak.ts:speakWithProfile`); this primitive intentionally has no
+ * `SayConfig` knowledge so it can be reused by non-CLI callers.
+ *
+ * Dynamic `AI` import avoids a load-time cycle: `AIMacOSTextToSpeechProvider`
+ * imports `renderToBuffer` / `listVoicesStructured` from this file.
  */
 export async function speak(text: string, options?: SpeakOptions): Promise<void> {
-    const mgr = new SayConfigManager();
-
-    if (await mgr.isMuted(options?.app)) {
-        process.stderr.write("[say] muted\n");
-        return;
-    }
-
-    const profile = await mgr.resolveApp(options?.app);
-    const rawVolume = options?.volume ?? profile.volume ?? 1;
-    const volume = normalizeVolume(rawVolume);
-
-    // Dynamic import avoids a circular module init:
-    // AIMacOSTextToSpeechProvider -> tts.ts (renderToBuffer, listVoicesStructured)
-    // tts.ts -> ai/index -> AIMacOSTextToSpeechProvider
+    const volume = options?.volume != null ? normalizeVolume(options.volume) : undefined;
     const { AI } = await import("@app/utils/ai/index");
     await AI.speak(text, {
         provider: "local",
-        voice: options?.voice ?? profile.voice ?? undefined,
-        rate: options?.rate ?? profile.rate ?? undefined,
+        voice: options?.voice,
+        rate: options?.rate,
         volume,
         wait: options?.wait,
     });

--- a/src/utils/macos/tts.ts
+++ b/src/utils/macos/tts.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Storage } from "@app/utils/storage/storage.ts";
 import { detectLanguage } from "./nlp";
+import { SayConfigManager } from "./SayConfigManager.ts";
 
 const storage = new Storage("say");
 
@@ -29,22 +30,6 @@ export interface SpeakOptions {
     /** Caller identity for per-app mute */
     app?: string;
 }
-
-export interface SayConfig {
-    defaultVoice: string | null;
-    defaultVolume: number;
-    globalMute: boolean;
-    appMute: Record<string, boolean>;
-    appVolume: Record<string, number>;
-}
-
-const DEFAULT_CONFIG: SayConfig = {
-    defaultVoice: null,
-    defaultVolume: 1,
-    globalMute: false,
-    appMute: {},
-    appVolume: {},
-};
 
 /**
  * Normalize volume: if <= 1, treat as 0.0–1.0 range.
@@ -111,83 +96,24 @@ export async function getVoiceMap(): Promise<Map<string, VoiceInfo>> {
 }
 
 // ============================================
-// Config helpers
-// ============================================
-
-async function getConfig(): Promise<SayConfig> {
-    const config = await storage.getConfig<SayConfig>();
-    return { ...DEFAULT_CONFIG, ...config };
-}
-
-export async function setConfig(config: SayConfig): Promise<void> {
-    await storage.setConfig(config);
-}
-
-export async function getConfigForRead(): Promise<SayConfig> {
-    return getConfig();
-}
-
-// ============================================
-// Mute helpers
-// ============================================
-
-function isMuted(config: SayConfig, app?: string): boolean {
-    if (app && app in config.appMute) {
-        return config.appMute[app];
-    }
-
-    return config.globalMute;
-}
-
-export async function setMute(muted: boolean, app?: string): Promise<void> {
-    const config = await getConfig();
-
-    if (app) {
-        config.appMute[app] = muted;
-    } else {
-        config.globalMute = muted;
-    }
-
-    await setConfig(config);
-}
-
-// ============================================
 // Core TTS
 // ============================================
 
 /**
- * Speak text aloud using macOS `say` command.
- * Automatically detects language and selects appropriate voice.
- * Supports volume control via render-to-AIFF + afplay.
- * Background by default; use `wait: true` to block.
+ * Speak text aloud, resolving voice/volume/etc. through the v2 SayConfig profile
+ * for `options.app` (falls back to the "default" profile). Caller-supplied
+ * options override profile values. Background by default; `wait: true` blocks.
  */
 export async function speak(text: string, options?: SpeakOptions): Promise<void> {
-    const config = await getConfig();
+    const mgr = new SayConfigManager();
 
-    if (isMuted(config, options?.app)) {
+    if (await mgr.isMuted(options?.app)) {
         process.stderr.write("[say] muted\n");
         return;
     }
 
-    // Auto-create app entry on first use + save per-app volume
-    const app = options?.app;
-    let configDirty = false;
-
-    if (app && !(app in config.appMute)) {
-        config.appMute[app] = false;
-        configDirty = true;
-    }
-
-    if (app && options?.volume != null) {
-        config.appVolume[app] = normalizeVolume(options.volume);
-        configDirty = true;
-    }
-
-    if (configDirty) {
-        await setConfig(config);
-    }
-
-    const rawVolume = options?.volume ?? (app ? config.appVolume[app] : undefined) ?? config.defaultVolume ?? 1;
+    const profile = await mgr.resolveApp(options?.app);
+    const rawVolume = options?.volume ?? profile.volume ?? 1;
     const volume = normalizeVolume(rawVolume);
 
     // Dynamic import avoids a circular module init:
@@ -196,8 +122,8 @@ export async function speak(text: string, options?: SpeakOptions): Promise<void>
     const { AI } = await import("@app/utils/ai/index");
     await AI.speak(text, {
         provider: "local",
-        voice: options?.voice,
-        rate: options?.rate,
+        voice: options?.voice ?? profile.voice ?? undefined,
+        rate: options?.rate ?? profile.rate ?? undefined,
         volume,
         wait: options?.wait,
     });


### PR DESCRIPTION
## Summary

- Per-app config v2 for `tools say` — voice / volume / provider / model / language / format are loaded from `~/.genesis-tools/say/config.json` keyed by `--app <name>`, with auto-migration from v1.
- `tools say config` interactive profile manager (set / unset / mute / list).
- xAI TTS streams via the dedicated `wss://api.x.ai/v1/tts` (was wrongly using the voice-agent realtime endpoint and silently 1000'd on long text).
- Loudness-matched: xAI declares `loudnessOffsetDb = 7` (measured: macOS native -16.2 dB mean / xAI raw -23.3 dB mean → +7 dB lands at -16.3 dB, within 0.1 dB of native). Player applies `volume,boost,alimiter` filter — limiter peak ceiling at -0.3 dBFS so the boost never clips at any user volume.
- Unified `--rate <n>` knob (0..2 or 0..200%) — normalized to each provider's actual delivered speed (`say -r 80..350` is non-linear, so the xAI atempo curve is clamped to **0.81..1.86** to match macOS's real ratios). `--rate 1` = default on both providers.
- Pitch-preserving `atempo` post-process for cloud rate changes (no chipmunk effect).
- Added regression tests for the xAI TTS WS protocol and a REST-vs-WS first-byte benchmark.

## Test plan

- [ ] `tools say "hello" --provider macos --rate 1.5 --wait` → ~1.4× actual playback (macOS engine clamps natively)
- [ ] `tools say "hello" --provider xai --rate 1.5 --wait` → ~1.43× (matches macOS perceptually)
- [ ] `tools say "hello" --provider xai --rate 0 --wait` and `--rate 2 --wait` — no clipping at any speed, both bounds match macOS
- [ ] `tools say "hello" --provider xai --rate 200` (percent form) behaves same as `--rate 2`
- [ ] `tools say "<long text >120 chars>" --provider xai --wait` — uses the WS path, audible end-to-end
- [ ] Loudness sanity: xAI default volume should sound ~the same as `say "hello"` directly
- [ ] `tools say config` interactive manager loads, edits, persists profile state
- [ ] `--save` requires `--app` (errors in non-TTY without it; prompts in TTY)
- [ ] v1 config auto-migrates on first run; `config.v1.bak.json` written once
- [ ] `bun test src/utils/ai/providers/xai/AIXAITextToSpeechProvider.test.ts` — 11 green
- [ ] `bun run src/utils/ai/providers/xai/AIXAITextToSpeechProvider.bench.ts` — REST vs WS TTFB comparison runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-application speech profiles with inheritance from defaults
  * `tools say config` subcommand to manage, add, edit, and delete profiles
  * Speech rate control and support for multiple TTS providers
  * `--save` flag to persist profile settings; `--unset` to clear specific fields

* **Changes**
  * `--mute`/`--unmute` now require `--save` to persist changes

* **Improvements**
  * Enhanced audio playback with gain and tempo adjustments
  * Automatic v1 configuration migration with backup creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->