### PR TITLE
feat(database): migrate raw bun:sqlite to Kysely (foundation + ask + automate + mail)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "ink-text-input": "^6.0.0",
         "jsdom": "^26.1.0",
         "jsonpath": "^1.1.1",
+        "kysely": "^0.28.16",
         "loglevel": "^1.9.2",
         "mailparser": "^3.9.4",
         "markdown-it": "^14.1.0",
@@ -2265,6 +2266,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "kysely": ["kysely@0.28.16", "", {}, "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
         "ink-text-input": "^6.0.0",
         "jsdom": "^26.1.0",
         "jsonpath": "^1.1.1",
+        "kysely": "^0.28.16",
         "loglevel": "^1.9.2",
         "mailparser": "^3.9.4",
         "markdown-it": "^14.1.0",

--- a/src/ask/lib/db-types.ts
+++ b/src/ask/lib/db-types.ts
@@ -1,0 +1,20 @@
+import type { ColumnType, Generated } from "kysely";
+
+export interface UsageRecordsTable {
+    id: Generated<number>;
+    session_id: string;
+    provider: string;
+    model: string;
+    input_tokens: ColumnType<number, number | undefined, number>;
+    output_tokens: ColumnType<number, number | undefined, number>;
+    cached_input_tokens: ColumnType<number, number | undefined, number>;
+    total_tokens: ColumnType<number, number | undefined, number>;
+    cost: ColumnType<number, number | undefined, number>;
+    timestamp: string;
+    message_index: number | null;
+    created_at: Generated<string>;
+}
+
+export interface AskDB {
+    usage_records: UsageRecordsTable;
+}

--- a/src/ask/lib/db.ts
+++ b/src/ask/lib/db.ts
@@ -1,0 +1,46 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createKyselyClient, type DatabaseClient } from "@app/utils/database";
+import type { AskDB } from "./db-types";
+
+const BOOTSTRAP: string[] = [
+    `CREATE TABLE IF NOT EXISTS usage_records (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+        total_tokens INTEGER NOT NULL DEFAULT 0,
+        cost REAL NOT NULL DEFAULT 0,
+        timestamp TEXT NOT NULL,
+        message_index INTEGER,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_session_id ON usage_records(session_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_timestamp ON usage_records(timestamp)`,
+    `CREATE INDEX IF NOT EXISTS idx_provider_model ON usage_records(provider, model)`,
+    `CREATE INDEX IF NOT EXISTS idx_date ON usage_records(date(timestamp))`,
+];
+
+export function defaultAskDbPath(): string {
+    return join(homedir(), ".genesis-tools", "ask.sqlite");
+}
+
+export function openAskDatabase(path?: string): DatabaseClient<AskDB> {
+    return createKyselyClient<AskDB>({
+        path: path ?? defaultAskDbPath(),
+        bootstrap: BOOTSTRAP,
+    });
+}
+
+let singleton: DatabaseClient<AskDB> | null = null;
+
+export function getAskDatabase(): DatabaseClient<AskDB> {
+    if (!singleton) {
+        singleton = openAskDatabase();
+    }
+
+    return singleton;
+}

--- a/src/ask/output/UsageDatabase.ts
+++ b/src/ask/output/UsageDatabase.ts
@@ -1,10 +1,10 @@
-import { sql } from "kysely";
-import logger from "@app/logger";
 import { getAskDatabase, openAskDatabase } from "@app/ask/lib/db";
 import type { AskDB } from "@app/ask/lib/db-types";
+import logger from "@app/logger";
 import type { DatabaseClient } from "@app/utils/database";
 import { SafeJSON } from "@app/utils/json";
 import type { LanguageModelUsage } from "ai";
+import { sql } from "kysely";
 
 export interface UsageRecord {
     id?: number;
@@ -60,7 +60,7 @@ export class UsageDatabase {
         model: string,
         usage: LanguageModelUsage,
         cost: number,
-        messageIndex?: number,
+        messageIndex?: number
     ): Promise<number> {
         logger.debug(`[UsageDatabase] recordUsage called for ${provider}/${model}`);
         logger.debug({ usage: SafeJSON.stringify(usage, null, 2) }, `[UsageDatabase] usage object`);
@@ -72,7 +72,7 @@ export class UsageDatabase {
 
         logger.debug(
             { inputTokens, outputTokens, cachedInputTokens, totalTokens, cost },
-            `[UsageDatabase] Storing tokens`,
+            `[UsageDatabase] Storing tokens`
         );
 
         const result = await this.client.kysely
@@ -212,12 +212,14 @@ export class UsageDatabase {
         messageCount: number;
         sessionCount: number;
     }> {
-        let query = this.client.kysely.selectFrom("usage_records").select([
-            sql<number | null>`SUM(cost)`.as("total_cost"),
-            sql<number | null>`SUM(total_tokens)`.as("total_tokens"),
-            sql<number>`COUNT(*)`.as("message_count"),
-            sql<number>`COUNT(DISTINCT session_id)`.as("session_count"),
-        ]);
+        let query = this.client.kysely
+            .selectFrom("usage_records")
+            .select([
+                sql<number | null>`SUM(cost)`.as("total_cost"),
+                sql<number | null>`SUM(total_tokens)`.as("total_tokens"),
+                sql<number>`COUNT(*)`.as("message_count"),
+                sql<number>`COUNT(DISTINCT session_id)`.as("session_count"),
+            ]);
 
         if (days) {
             query = query.where(sql<string>`date(timestamp)`, ">=", sinceDays(days));
@@ -246,24 +248,22 @@ export class UsageDatabase {
     }
 
     async getTopModels(limit = 10, days?: number): Promise<ModelUsage[]> {
-        let query = this.client.kysely.selectFrom("usage_records").select([
-            "provider",
-            "model",
-            sql<number>`SUM(cost)`.as("total_cost"),
-            sql<number>`SUM(total_tokens)`.as("total_tokens"),
-            sql<number>`COUNT(*)`.as("message_count"),
-            sql<number>`AVG(cost)`.as("avg_cost_per_message"),
-        ]);
+        let query = this.client.kysely
+            .selectFrom("usage_records")
+            .select([
+                "provider",
+                "model",
+                sql<number>`SUM(cost)`.as("total_cost"),
+                sql<number>`SUM(total_tokens)`.as("total_tokens"),
+                sql<number>`COUNT(*)`.as("message_count"),
+                sql<number>`AVG(cost)`.as("avg_cost_per_message"),
+            ]);
 
         if (days) {
             query = query.where(sql<string>`date(timestamp)`, ">=", sinceDays(days));
         }
 
-        const rows = await query
-            .groupBy(["provider", "model"])
-            .orderBy("total_cost", "desc")
-            .limit(limit)
-            .execute();
+        const rows = await query.groupBy(["provider", "model"]).orderBy("total_cost", "desc").limit(limit).execute();
 
         return rows.map((row) => ({
             provider: row.provider,

--- a/src/ask/output/UsageDatabase.ts
+++ b/src/ask/output/UsageDatabase.ts
@@ -1,8 +1,8 @@
-import { Database, type Statement } from "bun:sqlite";
-import { existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { sql } from "kysely";
 import logger from "@app/logger";
+import { getAskDatabase, openAskDatabase } from "@app/ask/lib/db";
+import type { AskDB } from "@app/ask/lib/db-types";
+import type { DatabaseClient } from "@app/utils/database";
 import { SafeJSON } from "@app/utils/json";
 import type { LanguageModelUsage } from "ai";
 
@@ -45,57 +45,13 @@ export interface ModelUsage {
     avgCostPerMessage: number;
 }
 
+const sinceDays = (days: number) => sql<string>`date('now', ${`-${days} days`})`;
+
 export class UsageDatabase {
-    private db: Database;
-    private dbPath: string;
+    private readonly client: DatabaseClient<AskDB>;
 
     constructor(dbPath?: string) {
-        // Default to ~/.genesis-tools/ask.sqlite
-        const defaultPath = join(homedir(), ".genesis-tools", "ask.sqlite");
-        this.dbPath = dbPath || defaultPath;
-
-        // Ensure directory exists
-        const dbDir = dirname(this.dbPath);
-        if (!existsSync(dbDir)) {
-            mkdirSync(dbDir, { recursive: true });
-            logger.info(`Created directory: ${dbDir}`);
-        }
-
-        // Open database
-        this.db = new Database(this.dbPath);
-        this.db.exec("PRAGMA journal_mode = WAL;"); // Better concurrency
-
-        this.initializeSchema();
-    }
-
-    private initializeSchema(): void {
-        // Usage records table
-        this.db.exec(`
-            CREATE TABLE IF NOT EXISTS usage_records (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id TEXT NOT NULL,
-                provider TEXT NOT NULL,
-                model TEXT NOT NULL,
-                input_tokens INTEGER NOT NULL DEFAULT 0,
-                output_tokens INTEGER NOT NULL DEFAULT 0,
-                cached_input_tokens INTEGER NOT NULL DEFAULT 0,
-                total_tokens INTEGER NOT NULL DEFAULT 0,
-                cost REAL NOT NULL DEFAULT 0,
-                timestamp TEXT NOT NULL,
-                message_index INTEGER,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-            )
-        `);
-
-        // Indexes for faster queries
-        this.db.exec(`
-            CREATE INDEX IF NOT EXISTS idx_session_id ON usage_records(session_id);
-            CREATE INDEX IF NOT EXISTS idx_timestamp ON usage_records(timestamp);
-            CREATE INDEX IF NOT EXISTS idx_provider_model ON usage_records(provider, model);
-            CREATE INDEX IF NOT EXISTS idx_date ON usage_records(date(timestamp));
-        `);
-
-        logger.debug("Usage database schema initialized");
+        this.client = dbPath ? openAskDatabase(dbPath) : getAskDatabase();
     }
 
     async recordUsage(
@@ -104,13 +60,11 @@ export class UsageDatabase {
         model: string,
         usage: LanguageModelUsage,
         cost: number,
-        messageIndex?: number
+        messageIndex?: number,
     ): Promise<number> {
-        // DEBUG: Log what we're storing
         logger.debug(`[UsageDatabase] recordUsage called for ${provider}/${model}`);
         logger.debug({ usage: SafeJSON.stringify(usage, null, 2) }, `[UsageDatabase] usage object`);
 
-        // Extract tokens using new API naming
         const inputTokens = usage.inputTokens ?? 0;
         const outputTokens = usage.outputTokens ?? 0;
         const cachedInputTokens = usage.cachedInputTokens ?? 0;
@@ -118,58 +72,45 @@ export class UsageDatabase {
 
         logger.debug(
             { inputTokens, outputTokens, cachedInputTokens, totalTokens, cost },
-            `[UsageDatabase] Storing tokens`
+            `[UsageDatabase] Storing tokens`,
         );
 
-        const timestamp = new Date().toISOString();
+        const result = await this.client.kysely
+            .insertInto("usage_records")
+            .values({
+                session_id: sessionId,
+                provider,
+                model,
+                input_tokens: inputTokens,
+                output_tokens: outputTokens,
+                cached_input_tokens: cachedInputTokens,
+                total_tokens: totalTokens,
+                cost,
+                timestamp: new Date().toISOString(),
+                message_index: messageIndex ?? null,
+            })
+            .executeTakeFirstOrThrow();
 
-        const stmt = this.db.prepare(`
-            INSERT INTO usage_records (
-                session_id, provider, model,
-                input_tokens, output_tokens, cached_input_tokens, total_tokens,
-                cost, timestamp, message_index
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `);
+        const id = Number(result.insertId ?? 0);
+        logger.debug(`[UsageDatabase] Record inserted with ID: ${id}`);
 
-        const result = stmt.run(
-            sessionId,
-            provider,
-            model,
-            inputTokens,
-            outputTokens,
-            cachedInputTokens,
-            totalTokens,
-            cost,
-            timestamp,
-            messageIndex ?? null
-        );
-
-        logger.debug(`[UsageDatabase] Record inserted with ID: ${result.lastInsertRowid}`);
-
-        return result.lastInsertRowid as number;
+        return id;
     }
 
-    getDailyUsage(days: number = 30): DailyUsage[] {
-        const stmt = this.db.prepare(`
-            SELECT 
-                date(timestamp) as date,
-                SUM(cost) as total_cost,
-                SUM(total_tokens) as total_tokens,
-                COUNT(*) as message_count,
-                COUNT(DISTINCT provider) as provider_count
-            FROM usage_records
-            WHERE date(timestamp) >= date('now', '-' || ? || ' days')
-            GROUP BY date(timestamp)
-            ORDER BY date DESC
-        `);
-
-        const rows = stmt.all(days) as Array<{
-            date: string;
-            total_cost: number;
-            total_tokens: number;
-            message_count: number;
-            provider_count: number;
-        }>;
+    async getDailyUsage(days = 30): Promise<DailyUsage[]> {
+        const rows = await this.client.kysely
+            .selectFrom("usage_records")
+            .select([
+                sql<string>`date(timestamp)`.as("date"),
+                sql<number>`SUM(cost)`.as("total_cost"),
+                sql<number>`SUM(total_tokens)`.as("total_tokens"),
+                sql<number>`COUNT(*)`.as("message_count"),
+                sql<number>`COUNT(DISTINCT provider)`.as("provider_count"),
+            ])
+            .where(sql<string>`date(timestamp)`, ">=", sinceDays(days))
+            .groupBy(sql`date(timestamp)`)
+            .orderBy("date", "desc")
+            .execute();
 
         return rows.map((row) => ({
             date: row.date,
@@ -180,27 +121,20 @@ export class UsageDatabase {
         }));
     }
 
-    getProviderUsage(days: number = 30): ProviderUsage[] {
-        const stmt = this.db.prepare(`
-            SELECT 
-                provider,
-                SUM(cost) as total_cost,
-                SUM(total_tokens) as total_tokens,
-                COUNT(*) as message_count,
-                AVG(cost) as avg_cost_per_message
-            FROM usage_records
-            WHERE date(timestamp) >= date('now', '-' || ? || ' days')
-            GROUP BY provider
-            ORDER BY total_cost DESC
-        `);
-
-        const rows = stmt.all(days) as Array<{
-            provider: string;
-            total_cost: number;
-            total_tokens: number;
-            message_count: number;
-            avg_cost_per_message: number;
-        }>;
+    async getProviderUsage(days = 30): Promise<ProviderUsage[]> {
+        const rows = await this.client.kysely
+            .selectFrom("usage_records")
+            .select([
+                "provider",
+                sql<number>`SUM(cost)`.as("total_cost"),
+                sql<number>`SUM(total_tokens)`.as("total_tokens"),
+                sql<number>`COUNT(*)`.as("message_count"),
+                sql<number>`AVG(cost)`.as("avg_cost_per_message"),
+            ])
+            .where(sql<string>`date(timestamp)`, ">=", sinceDays(days))
+            .groupBy("provider")
+            .orderBy("total_cost", "desc")
+            .execute();
 
         return rows.map((row) => ({
             provider: row.provider,
@@ -211,29 +145,21 @@ export class UsageDatabase {
         }));
     }
 
-    getModelUsage(days: number = 30): ModelUsage[] {
-        const stmt = this.db.prepare(`
-            SELECT 
-                provider,
-                model,
-                SUM(cost) as total_cost,
-                SUM(total_tokens) as total_tokens,
-                COUNT(*) as message_count,
-                AVG(cost) as avg_cost_per_message
-            FROM usage_records
-            WHERE date(timestamp) >= date('now', '-' || ? || ' days')
-            GROUP BY provider, model
-            ORDER BY total_cost DESC
-        `);
-
-        const rows = stmt.all(days) as Array<{
-            provider: string;
-            model: string;
-            total_cost: number;
-            total_tokens: number;
-            message_count: number;
-            avg_cost_per_message: number;
-        }>;
+    async getModelUsage(days = 30): Promise<ModelUsage[]> {
+        const rows = await this.client.kysely
+            .selectFrom("usage_records")
+            .select([
+                "provider",
+                "model",
+                sql<number>`SUM(cost)`.as("total_cost"),
+                sql<number>`SUM(total_tokens)`.as("total_tokens"),
+                sql<number>`COUNT(*)`.as("message_count"),
+                sql<number>`AVG(cost)`.as("avg_cost_per_message"),
+            ])
+            .where(sql<string>`date(timestamp)`, ">=", sinceDays(days))
+            .groupBy(["provider", "model"])
+            .orderBy("total_cost", "desc")
+            .execute();
 
         return rows.map((row) => ({
             provider: row.provider,
@@ -245,30 +171,25 @@ export class UsageDatabase {
         }));
     }
 
-    getSessionUsage(sessionId: string): UsageRecord[] {
-        const stmt = this.db.prepare(`
-            SELECT 
-                id, session_id, provider, model,
-                input_tokens, output_tokens, cached_input_tokens, total_tokens,
-                cost, timestamp, message_index
-            FROM usage_records
-            WHERE session_id = ?
-            ORDER BY timestamp ASC
-        `);
-
-        const rows = stmt.all(sessionId) as Array<{
-            id: number;
-            session_id: string;
-            provider: string;
-            model: string;
-            input_tokens: number;
-            output_tokens: number;
-            cached_input_tokens: number;
-            total_tokens: number;
-            cost: number;
-            timestamp: string;
-            message_index: number | null;
-        }>;
+    async getSessionUsage(sessionId: string): Promise<UsageRecord[]> {
+        const rows = await this.client.kysely
+            .selectFrom("usage_records")
+            .select([
+                "id",
+                "session_id",
+                "provider",
+                "model",
+                "input_tokens",
+                "output_tokens",
+                "cached_input_tokens",
+                "total_tokens",
+                "cost",
+                "timestamp",
+                "message_index",
+            ])
+            .where("session_id", "=", sessionId)
+            .orderBy("timestamp", "asc")
+            .execute();
 
         return rows.map((row) => ({
             id: row.id,
@@ -285,109 +206,64 @@ export class UsageDatabase {
         }));
     }
 
-    getTotalUsage(days?: number): {
+    async getTotalUsage(days?: number): Promise<{
         totalCost: number;
         totalTokens: number;
         messageCount: number;
         sessionCount: number;
-    } {
-        let stmt: Statement;
+    }> {
+        let query = this.client.kysely.selectFrom("usage_records").select([
+            sql<number | null>`SUM(cost)`.as("total_cost"),
+            sql<number | null>`SUM(total_tokens)`.as("total_tokens"),
+            sql<number>`COUNT(*)`.as("message_count"),
+            sql<number>`COUNT(DISTINCT session_id)`.as("session_count"),
+        ]);
+
         if (days) {
-            stmt = this.db.prepare(`
-                SELECT
-                    SUM(cost) as total_cost,
-                    SUM(total_tokens) as total_tokens,
-                    COUNT(*) as message_count,
-                    COUNT(DISTINCT session_id) as session_count
-                FROM usage_records
-                WHERE date(timestamp) >= date('now', '-' || ? || ' days')
-            `);
-        } else {
-            stmt = this.db.prepare(`
-                SELECT
-                    SUM(cost) as total_cost,
-                    SUM(total_tokens) as total_tokens,
-                    COUNT(*) as message_count,
-                    COUNT(DISTINCT session_id) as session_count
-                FROM usage_records
-            `);
+            query = query.where(sql<string>`date(timestamp)`, ">=", sinceDays(days));
         }
 
-        const row = (days ? stmt.get(days) : stmt.get()) as {
-            total_cost: number | null;
-            total_tokens: number | null;
-            message_count: number;
-            session_count: number;
-        };
+        const row = await query.executeTakeFirstOrThrow();
 
         return {
-            totalCost: row.total_cost || 0,
-            totalTokens: row.total_tokens || 0,
+            totalCost: row.total_cost ?? 0,
+            totalTokens: row.total_tokens ?? 0,
             messageCount: row.message_count,
             sessionCount: row.session_count,
         };
     }
 
-    getCostTrend(days: number = 7): Array<{ date: string; cost: number }> {
-        const stmt = this.db.prepare(`
-            SELECT 
-                date(timestamp) as date,
-                SUM(cost) as cost
-            FROM usage_records
-            WHERE date(timestamp) >= date('now', '-' || ? || ' days')
-            GROUP BY date(timestamp)
-            ORDER BY date ASC
-        `);
+    async getCostTrend(days = 7): Promise<Array<{ date: string; cost: number }>> {
+        const rows = await this.client.kysely
+            .selectFrom("usage_records")
+            .select([sql<string>`date(timestamp)`.as("date"), sql<number>`SUM(cost)`.as("cost")])
+            .where(sql<string>`date(timestamp)`, ">=", sinceDays(days))
+            .groupBy(sql`date(timestamp)`)
+            .orderBy("date", "asc")
+            .execute();
 
-        const rows = stmt.all(days) as Array<{ date: string; cost: number }>;
-
-        return rows.map((row) => ({
-            date: row.date,
-            cost: row.cost,
-        }));
+        return rows.map((row) => ({ date: row.date, cost: row.cost }));
     }
 
-    getTopModels(limit: number = 10, days?: number): ModelUsage[] {
-        let stmt: Statement;
+    async getTopModels(limit = 10, days?: number): Promise<ModelUsage[]> {
+        let query = this.client.kysely.selectFrom("usage_records").select([
+            "provider",
+            "model",
+            sql<number>`SUM(cost)`.as("total_cost"),
+            sql<number>`SUM(total_tokens)`.as("total_tokens"),
+            sql<number>`COUNT(*)`.as("message_count"),
+            sql<number>`AVG(cost)`.as("avg_cost_per_message"),
+        ]);
+
         if (days) {
-            stmt = this.db.prepare(`
-                SELECT 
-                    provider,
-                    model,
-                    SUM(cost) as total_cost,
-                    SUM(total_tokens) as total_tokens,
-                    COUNT(*) as message_count,
-                    AVG(cost) as avg_cost_per_message
-                FROM usage_records
-                WHERE date(timestamp) >= date('now', '-' || ? || ' days')
-                GROUP BY provider, model
-                ORDER BY total_cost DESC
-                LIMIT ?
-            `);
-        } else {
-            stmt = this.db.prepare(`
-                SELECT 
-                    provider,
-                    model,
-                    SUM(cost) as total_cost,
-                    SUM(total_tokens) as total_tokens,
-                    COUNT(*) as message_count,
-                    AVG(cost) as avg_cost_per_message
-                FROM usage_records
-                GROUP BY provider, model
-                ORDER BY total_cost DESC
-                LIMIT ?
-            `);
+            query = query.where(sql<string>`date(timestamp)`, ">=", sinceDays(days));
         }
 
-        const rows = (days ? stmt.all(days, limit) : stmt.all(limit)) as Array<{
-            provider: string;
-            model: string;
-            total_cost: number;
-            total_tokens: number;
-            message_count: number;
-            avg_cost_per_message: number;
-        }>;
+        const rows = await query
+            .groupBy(["provider", "model"])
+            .orderBy("total_cost", "desc")
+            .limit(limit)
+            .execute();
 
         return rows.map((row) => ({
             provider: row.provider,
@@ -400,9 +276,8 @@ export class UsageDatabase {
     }
 
     close(): void {
-        this.db.close();
+        this.client.close();
     }
 }
 
-// Singleton instance
 export const usageDatabase = new UsageDatabase();

--- a/src/automate/commands/run.ts
+++ b/src/automate/commands/run.ts
@@ -37,8 +37,7 @@ export function registerRunCommand(program: Command): void {
                 p.log.info(pc.dim(preset.description));
             }
 
-            // Create run logger for SQLite tracking (skip for dry runs)
-            const runLogger = opts.dryRun ? undefined : createRunLogger(preset.name, null, "manual");
+            const runLogger = opts.dryRun ? undefined : await createRunLogger(preset.name, null, "manual");
 
             // Execute the preset
             const result = await runPreset(

--- a/src/automate/commands/task.ts
+++ b/src/automate/commands/task.ts
@@ -16,13 +16,15 @@ export function registerTaskCommand(parent: Command): void {
         .command("list", { isDefault: true })
         .alias("ls")
         .description("Show all scheduled tasks")
-        .action(() => {
+        .action(async () => {
             const db = getDb();
-            const schedules = db.listSchedules();
+            const schedules = await db.listSchedules();
+
             if (schedules.length === 0) {
                 p.log.info("No scheduled tasks. Run: tools automate task create");
                 return;
             }
+
             const headers = ["Name", "Preset", "Interval", "Enabled", "Last Run", "Next Run"];
             const rows = schedules.map((s) => [
                 s.name,
@@ -67,12 +69,17 @@ export function registerTaskCommand(parent: Command): void {
                     if (!val || !/^[a-zA-Z0-9_-]+$/.test(val)) {
                         return "Only alphanumeric, hyphens, underscores";
                     }
-                    const db = getDb();
-                    if (db.getSchedule(val)) {
-                        return "Task name already exists";
-                    }
                 },
             });
+
+            if (!p.isCancel(name)) {
+                const db = getDb();
+
+                if (await db.getSchedule(name as string)) {
+                    p.log.error("Task name already exists");
+                    return;
+                }
+            }
             if (p.isCancel(name)) {
                 return;
             }
@@ -99,7 +106,7 @@ export function registerTaskCommand(parent: Command): void {
             const nextRunAt = computeNextRunAt(parsed).toISOString();
 
             const db = getDb();
-            db.createSchedule(name as string, presetName as string, interval as string, nextRunAt);
+            await db.createSchedule(name as string, presetName as string, interval as string, nextRunAt);
             p.log.success(`Task "${name}" created. Next run: ${nextRunAt}`);
             p.log.info("Start the daemon to begin executing: tools automate daemon start");
             p.outro("");
@@ -109,13 +116,13 @@ export function registerTaskCommand(parent: Command): void {
     parent
         .command("show <name-or-id>")
         .description("Show task details (by name) or run details (by numeric ID)")
-        .action((arg: string) => {
+        .action(async (arg: string) => {
             const db = getDb();
             const asNum = parseInt(arg, 10);
 
-            // If it's a number, show run details
             if (!Number.isNaN(asNum) && String(asNum) === arg) {
-                const run = db.getRun(asNum);
+                const run = await db.getRun(asNum);
+
                 if (!run) {
                     p.log.error(`Run #${asNum} not found`);
                     return;
@@ -125,11 +132,13 @@ export function registerTaskCommand(parent: Command): void {
                 p.log.info(
                     `Trigger: ${run.trigger_type} | Status: ${run.status} | Duration: ${run.duration_ms != null ? formatDuration(run.duration_ms) : "running"}`
                 );
+
                 if (run.error) {
                     p.log.error(`Error: ${run.error}`);
                 }
 
-                const logs = db.getRunLogs(asNum);
+                const logs = await db.getRunLogs(asNum);
+
                 if (logs.length === 0) {
                     p.log.info("No step logs recorded.");
                     return;
@@ -152,8 +161,8 @@ export function registerTaskCommand(parent: Command): void {
                 return;
             }
 
-            // Otherwise, show schedule details
-            const schedule = db.getSchedule(arg);
+            const schedule = await db.getSchedule(arg);
+
             if (!schedule) {
                 p.log.error(`Task "${arg}" not found`);
                 return;
@@ -166,8 +175,7 @@ export function registerTaskCommand(parent: Command): void {
             p.log.info(`Last run: ${schedule.last_run_at ?? pc.dim("never")}`);
             p.log.info(`Next run: ${schedule.enabled ? schedule.next_run_at : pc.dim("—")}`);
 
-            // Show recent runs for this schedule
-            const runs = db.listRuns(10);
+            const runs = await db.listRuns(10);
             const scheduleRuns = runs.filter(
                 (r) => r.preset_name === schedule.preset_name && r.trigger_type === "schedule"
             );
@@ -188,35 +196,37 @@ export function registerTaskCommand(parent: Command): void {
             }
         });
 
-    // task enable <name>
     parent
         .command("enable <name>")
         .description("Enable a scheduled task")
-        .action((name: string) => {
+        .action(async (name: string) => {
             const db = getDb();
-            const existing = db.getSchedule(name);
+            const existing = await db.getSchedule(name);
+
             if (!existing) {
                 p.log.error(`Task "${name}" not found`);
                 return;
             }
+
             const parsed = parseInterval(existing.interval);
             const nextRunAt = computeNextRunAt(parsed).toISOString();
-            db.setScheduleEnabled(name, true);
-            db.updateScheduleAfterRun(existing.id, nextRunAt);
+            await db.setScheduleEnabled(name, true);
+            await db.updateScheduleAfterRun(existing.id, nextRunAt);
             p.log.success(`Task "${name}" enabled. Next run: ${nextRunAt}`);
         });
 
-    // task disable <name>
     parent
         .command("disable <name>")
         .description("Disable a scheduled task")
-        .action((name: string) => {
+        .action(async (name: string) => {
             const db = getDb();
-            if (!db.getSchedule(name)) {
+
+            if (!(await db.getSchedule(name))) {
                 p.log.error(`Task "${name}" not found`);
                 return;
             }
-            db.setScheduleEnabled(name, false);
+
+            await db.setScheduleEnabled(name, false);
             p.log.success(`Task "${name}" disabled`);
         });
 
@@ -226,15 +236,19 @@ export function registerTaskCommand(parent: Command): void {
         .description("Delete a scheduled task")
         .action(async (name: string) => {
             const db = getDb();
-            if (!db.getSchedule(name)) {
+
+            if (!(await db.getSchedule(name))) {
                 p.log.error(`Task "${name}" not found`);
                 return;
             }
+
             const confirm = await p.confirm({ message: `Delete task "${name}"?` });
+
             if (p.isCancel(confirm) || !confirm) {
                 return;
             }
-            db.deleteSchedule(name);
+
+            await db.deleteSchedule(name);
             p.log.success(`Task "${name}" deleted`);
         });
 
@@ -245,7 +259,8 @@ export function registerTaskCommand(parent: Command): void {
         .option("-v, --verbose", "Verbose output")
         .action(async (name: string, opts: { verbose?: boolean }) => {
             const db = getDb();
-            const schedule = db.getSchedule(name);
+            const schedule = await db.getSchedule(name);
+
             if (!schedule) {
                 p.log.error(`Task "${name}" not found`);
                 return;
@@ -257,7 +272,7 @@ export function registerTaskCommand(parent: Command): void {
             const vars = schedule.vars_json
                 ? (SafeJSON.parse(schedule.vars_json, { strict: true }) as Record<string, string>)
                 : undefined;
-            const runLogger = createRunLogger(preset.name, schedule.id, "manual");
+            const runLogger = await createRunLogger(preset.name, schedule.id, "manual");
 
             const result = await runPreset(
                 preset,
@@ -294,9 +309,10 @@ export function registerTaskCommand(parent: Command): void {
         .command("history")
         .description("Show recent execution runs")
         .option("-n, --limit <n>", "Number of runs to show", "20")
-        .action((opts) => {
+        .action(async (opts) => {
             const db = getDb();
-            const runs = db.listRuns(parseInt(opts.limit, 10));
+            const runs = await db.listRuns(parseInt(opts.limit, 10));
+
             if (runs.length === 0) {
                 p.log.info("No runs recorded yet.");
                 return;

--- a/src/automate/lib/db-types.ts
+++ b/src/automate/lib/db-types.ts
@@ -1,0 +1,92 @@
+import type { Generated } from "kysely";
+
+export interface SchedulesTable {
+    id: Generated<number>;
+    name: string;
+    preset_name: string;
+    interval: string;
+    enabled: Generated<number>;
+    last_run_at: string | null;
+    next_run_at: string;
+    created_at: Generated<string>;
+    updated_at: Generated<string>;
+    vars_json: string | null;
+}
+
+export interface RunsTable {
+    id: Generated<number>;
+    schedule_id: number | null;
+    preset_name: string;
+    trigger_type: Generated<string>;
+    started_at: string;
+    finished_at: string | null;
+    status: Generated<string>;
+    step_count: Generated<number>;
+    duration_ms: number | null;
+    error: string | null;
+}
+
+export interface RunLogsTable {
+    id: Generated<number>;
+    run_id: number;
+    step_index: number;
+    step_id: string;
+    step_name: string;
+    action: string;
+    status: string;
+    output: string | null;
+    duration_ms: Generated<number>;
+    error: string | null;
+    logged_at: Generated<string>;
+}
+
+export interface SchemaVersionTable {
+    version: number;
+}
+
+export interface AutomateDB {
+    schedules: SchedulesTable;
+    runs: RunsTable;
+    run_logs: RunLogsTable;
+    schema_version: SchemaVersionTable;
+}
+
+export interface ScheduleRow {
+    id: number;
+    name: string;
+    preset_name: string;
+    interval: string;
+    enabled: number;
+    last_run_at: string | null;
+    next_run_at: string;
+    created_at: string;
+    updated_at: string;
+    vars_json: string | null;
+}
+
+export interface RunRow {
+    id: number;
+    schedule_id: number | null;
+    preset_name: string;
+    trigger_type: string;
+    started_at: string;
+    finished_at: string | null;
+    status: string;
+    step_count: number;
+    duration_ms: number | null;
+    error: string | null;
+}
+
+export interface RunLogRow {
+    id: number;
+    run_id: number;
+    step_index: number;
+    step_id: string;
+    step_name: string;
+    action: string;
+    status: string;
+    output: string | null;
+    duration_ms: number;
+    error: string | null;
+    logged_at: string;
+}

--- a/src/automate/lib/db.ts
+++ b/src/automate/lib/db.ts
@@ -1,145 +1,178 @@
-import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import logger from "@app/logger";
+import { createKyselyClient, type DatabaseClient } from "@app/utils/database";
+import { sql } from "kysely";
+import type { AutomateDB, RunLogRow, RunRow, ScheduleRow } from "./db-types";
+
+export type { RunLogRow, RunRow, ScheduleRow } from "./db-types";
 
 const DB_PATH = join(homedir(), ".genesis-tools", "automate", "automate.db");
 const SCHEMA_VERSION = 1;
 
+const BOOTSTRAP: string[] = [
+    `CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS schedules (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        name        TEXT NOT NULL UNIQUE,
+        preset_name TEXT NOT NULL,
+        interval    TEXT NOT NULL,
+        enabled     INTEGER NOT NULL DEFAULT 1,
+        last_run_at TEXT,
+        next_run_at TEXT NOT NULL,
+        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        vars_json   TEXT
+    )`,
+    `CREATE TABLE IF NOT EXISTS runs (
+        id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        schedule_id  INTEGER,
+        preset_name  TEXT NOT NULL,
+        trigger_type TEXT NOT NULL DEFAULT 'manual',
+        started_at   TEXT NOT NULL,
+        finished_at  TEXT,
+        status       TEXT NOT NULL DEFAULT 'running',
+        step_count   INTEGER NOT NULL DEFAULT 0,
+        duration_ms  INTEGER,
+        error        TEXT,
+        FOREIGN KEY (schedule_id) REFERENCES schedules(id) ON DELETE SET NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS run_logs (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id      INTEGER NOT NULL,
+        step_index  INTEGER NOT NULL,
+        step_id     TEXT NOT NULL,
+        step_name   TEXT NOT NULL,
+        action      TEXT NOT NULL,
+        status      TEXT NOT NULL,
+        output      TEXT,
+        duration_ms INTEGER NOT NULL DEFAULT 0,
+        error       TEXT,
+        logged_at   TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_runs_schedule_id ON runs(schedule_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_runs_preset_name ON runs(preset_name)`,
+    `CREATE INDEX IF NOT EXISTS idx_runs_started_at ON runs(started_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_run_logs_run_id ON run_logs(run_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_schedules_next_run ON schedules(next_run_at) WHERE enabled = 1`,
+];
+
 export class AutomateDatabase {
-    private db: Database;
+    private readonly client: DatabaseClient<AutomateDB>;
 
     constructor(dbPath: string = DB_PATH) {
-        const dir = dirname(dbPath);
-        if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true });
-        }
+        this.client = createKyselyClient<AutomateDB>({
+            path: dbPath,
+            bootstrap: BOOTSTRAP,
+            pragmas: { foreignKeys: true },
+        });
 
-        this.db = new Database(dbPath);
-        this.db.exec("PRAGMA journal_mode = WAL");
-        this.db.exec("PRAGMA foreign_keys = ON");
-        this.initSchema();
+        this.recordSchemaVersionIfNeeded();
     }
 
-    private initSchema(): void {
-        this.db.exec(`
-      CREATE TABLE IF NOT EXISTS schema_version (
-        version INTEGER NOT NULL
-      );
-    `);
+    private recordSchemaVersionIfNeeded(): void {
+        const row = this.client.raw.query("SELECT version FROM schema_version LIMIT 1").get() as {
+            version: number;
+        } | null;
 
-        const row = this.db.query("SELECT version FROM schema_version LIMIT 1").get() as { version: number } | null;
         if (!row || row.version < SCHEMA_VERSION) {
-            this.db.exec(`
-        CREATE TABLE IF NOT EXISTS schedules (
-          id          INTEGER PRIMARY KEY AUTOINCREMENT,
-          name        TEXT NOT NULL UNIQUE,
-          preset_name TEXT NOT NULL,
-          interval    TEXT NOT NULL,
-          enabled     INTEGER NOT NULL DEFAULT 1,
-          last_run_at TEXT,
-          next_run_at TEXT NOT NULL,
-          created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-          updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
-          vars_json   TEXT
-        );
-
-        CREATE TABLE IF NOT EXISTS runs (
-          id           INTEGER PRIMARY KEY AUTOINCREMENT,
-          schedule_id  INTEGER,
-          preset_name  TEXT NOT NULL,
-          trigger_type TEXT NOT NULL DEFAULT 'manual',
-          started_at   TEXT NOT NULL,
-          finished_at  TEXT,
-          status       TEXT NOT NULL DEFAULT 'running',
-          step_count   INTEGER NOT NULL DEFAULT 0,
-          duration_ms  INTEGER,
-          error        TEXT,
-          FOREIGN KEY (schedule_id) REFERENCES schedules(id) ON DELETE SET NULL
-        );
-
-        CREATE TABLE IF NOT EXISTS run_logs (
-          id          INTEGER PRIMARY KEY AUTOINCREMENT,
-          run_id      INTEGER NOT NULL,
-          step_index  INTEGER NOT NULL,
-          step_id     TEXT NOT NULL,
-          step_name   TEXT NOT NULL,
-          action      TEXT NOT NULL,
-          status      TEXT NOT NULL,
-          output      TEXT,
-          duration_ms INTEGER NOT NULL DEFAULT 0,
-          error       TEXT,
-          logged_at   TEXT NOT NULL DEFAULT (datetime('now')),
-          FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE CASCADE
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_runs_schedule_id ON runs(schedule_id);
-        CREATE INDEX IF NOT EXISTS idx_runs_preset_name ON runs(preset_name);
-        CREATE INDEX IF NOT EXISTS idx_runs_started_at ON runs(started_at);
-        CREATE INDEX IF NOT EXISTS idx_run_logs_run_id ON run_logs(run_id);
-        CREATE INDEX IF NOT EXISTS idx_schedules_next_run ON schedules(next_run_at) WHERE enabled = 1;
-
-        INSERT OR REPLACE INTO schema_version (rowid, version) VALUES (1, ${SCHEMA_VERSION});
-      `);
+            this.client.raw.run("INSERT OR REPLACE INTO schema_version (rowid, version) VALUES (1, ?)", [
+                SCHEMA_VERSION,
+            ]);
             logger.debug("AutomateDatabase schema initialized");
         }
     }
 
-    // --- Schedule CRUD ---
+    async createSchedule(
+        name: string,
+        presetName: string,
+        interval: string,
+        nextRunAt: string,
+        varsJson?: string
+    ): Promise<number> {
+        const result = await this.client.kysely
+            .insertInto("schedules")
+            .values({
+                name,
+                preset_name: presetName,
+                interval,
+                next_run_at: nextRunAt,
+                vars_json: varsJson ?? null,
+            })
+            .executeTakeFirstOrThrow();
 
-    createSchedule(name: string, presetName: string, interval: string, nextRunAt: string, varsJson?: string): number {
-        const stmt = this.db.prepare(`
-      INSERT INTO schedules (name, preset_name, interval, next_run_at, vars_json)
-      VALUES (?, ?, ?, ?, ?)
-    `);
-        const result = stmt.run(name, presetName, interval, nextRunAt, varsJson ?? null);
-        return Number(result.lastInsertRowid);
+        return Number(result.insertId ?? 0);
     }
 
-    getSchedule(name: string): ScheduleRow | null {
-        return this.db.query("SELECT * FROM schedules WHERE name = ?").get(name) as ScheduleRow | null;
+    async getSchedule(name: string): Promise<ScheduleRow | null> {
+        const row = await this.client.kysely
+            .selectFrom("schedules")
+            .selectAll()
+            .where("name", "=", name)
+            .executeTakeFirst();
+
+        return (row as ScheduleRow | undefined) ?? null;
     }
 
-    listSchedules(): ScheduleRow[] {
-        return this.db.query("SELECT * FROM schedules ORDER BY name").all() as ScheduleRow[];
+    async listSchedules(): Promise<ScheduleRow[]> {
+        const rows = await this.client.kysely.selectFrom("schedules").selectAll().orderBy("name").execute();
+        return rows as ScheduleRow[];
     }
 
-    getDueSchedules(now: string): ScheduleRow[] {
-        return this.db
-            .query("SELECT * FROM schedules WHERE enabled = 1 AND next_run_at <= ? ORDER BY next_run_at")
-            .all(now) as ScheduleRow[];
+    async getDueSchedules(now: string): Promise<ScheduleRow[]> {
+        const rows = await this.client.kysely
+            .selectFrom("schedules")
+            .selectAll()
+            .where("enabled", "=", 1)
+            .where("next_run_at", "<=", now)
+            .orderBy("next_run_at")
+            .execute();
+        return rows as ScheduleRow[];
     }
 
-    setScheduleEnabled(name: string, enabled: boolean): void {
-        this.db
-            .prepare("UPDATE schedules SET enabled = ?, updated_at = datetime('now') WHERE name = ?")
-            .run(enabled ? 1 : 0, name);
+    async setScheduleEnabled(name: string, enabled: boolean): Promise<void> {
+        await this.client.kysely
+            .updateTable("schedules")
+            .set({ enabled: enabled ? 1 : 0, updated_at: sql`datetime('now')` })
+            .where("name", "=", name)
+            .execute();
     }
 
-    deleteSchedule(name: string): void {
-        this.db.prepare("DELETE FROM schedules WHERE name = ?").run(name);
+    async deleteSchedule(name: string): Promise<void> {
+        await this.client.kysely.deleteFrom("schedules").where("name", "=", name).execute();
     }
 
-    updateScheduleAfterRun(id: number, nextRunAt: string): void {
-        this.db
-            .prepare(
-                "UPDATE schedules SET last_run_at = datetime('now'), next_run_at = ?, updated_at = datetime('now') WHERE id = ?"
-            )
-            .run(nextRunAt, id);
+    async updateScheduleAfterRun(id: number, nextRunAt: string): Promise<void> {
+        await this.client.kysely
+            .updateTable("schedules")
+            .set({
+                last_run_at: sql`datetime('now')`,
+                next_run_at: nextRunAt,
+                updated_at: sql`datetime('now')`,
+            })
+            .where("id", "=", id)
+            .execute();
     }
 
-    // --- Run tracking ---
+    async startRun(presetName: string, scheduleId: number | null, triggerType: "manual" | "schedule"): Promise<number> {
+        const result = await this.client.kysely
+            .insertInto("runs")
+            .values({
+                schedule_id: scheduleId,
+                preset_name: presetName,
+                trigger_type: triggerType,
+                started_at: sql`datetime('now')`,
+                status: "running",
+            })
+            .executeTakeFirstOrThrow();
 
-    startRun(presetName: string, scheduleId: number | null, triggerType: "manual" | "schedule"): number {
-        const stmt = this.db.prepare(`
-      INSERT INTO runs (schedule_id, preset_name, trigger_type, started_at, status)
-      VALUES (?, ?, ?, datetime('now'), 'running')
-    `);
-        return Number(stmt.run(scheduleId, presetName, triggerType).lastInsertRowid);
+        return Number(result.insertId ?? 0);
     }
 
-    logStep(
+    async logStep(
         runId: number,
         stepIndex: number,
         stepId: string,
@@ -149,101 +182,82 @@ export class AutomateDatabase {
         output: string | null,
         durationMs: number,
         error: string | null
-    ): void {
+    ): Promise<void> {
         const truncatedOutput = output && output.length > 65536 ? `${output.slice(0, 65536)}\n... (truncated)` : output;
-        this.db
-            .prepare(`
-      INSERT INTO run_logs (run_id, step_index, step_id, step_name, action, status, output, duration_ms, error)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `)
-            .run(runId, stepIndex, stepId, stepName, action, status, truncatedOutput, Math.round(durationMs), error);
+
+        await this.client.kysely
+            .insertInto("run_logs")
+            .values({
+                run_id: runId,
+                step_index: stepIndex,
+                step_id: stepId,
+                step_name: stepName,
+                action,
+                status,
+                output: truncatedOutput,
+                duration_ms: Math.round(durationMs),
+                error,
+            })
+            .execute();
     }
 
-    finishRun(
+    async finishRun(
         runId: number,
         status: "success" | "error" | "cancelled",
         stepCount: number,
         durationMs: number,
         error?: string
-    ): void {
-        this.db
-            .prepare(`
-      UPDATE runs SET finished_at = datetime('now'), status = ?, step_count = ?, duration_ms = ?, error = ?
-      WHERE id = ?
-    `)
-            .run(status, stepCount, Math.round(durationMs), error ?? null, runId);
+    ): Promise<void> {
+        await this.client.kysely
+            .updateTable("runs")
+            .set({
+                finished_at: sql`datetime('now')`,
+                status,
+                step_count: stepCount,
+                duration_ms: Math.round(durationMs),
+                error: error ?? null,
+            })
+            .where("id", "=", runId)
+            .execute();
     }
 
-    // --- Query runs ---
-
-    listRuns(limit: number = 50): RunRow[] {
-        return this.db.query("SELECT * FROM runs ORDER BY started_at DESC LIMIT ?").all(limit) as RunRow[];
+    async listRuns(limit = 50): Promise<RunRow[]> {
+        const rows = await this.client.kysely
+            .selectFrom("runs")
+            .selectAll()
+            .orderBy("started_at", "desc")
+            .limit(limit)
+            .execute();
+        return rows as RunRow[];
     }
 
-    getRun(runId: number): RunRow | null {
-        return this.db.query("SELECT * FROM runs WHERE id = ?").get(runId) as RunRow | null;
+    async getRun(runId: number): Promise<RunRow | null> {
+        const row = await this.client.kysely.selectFrom("runs").selectAll().where("id", "=", runId).executeTakeFirst();
+        return (row as RunRow | undefined) ?? null;
     }
 
-    getRunLogs(runId: number): RunLogRow[] {
-        return this.db.query("SELECT * FROM run_logs WHERE run_id = ? ORDER BY step_index").all(runId) as RunLogRow[];
+    async getRunLogs(runId: number): Promise<RunLogRow[]> {
+        const rows = await this.client.kysely
+            .selectFrom("run_logs")
+            .selectAll()
+            .where("run_id", "=", runId)
+            .orderBy("step_index")
+            .execute();
+        return rows as RunLogRow[];
     }
-
-    // --- Cleanup ---
 
     close(): void {
-        this.db.close();
+        this.client.close();
     }
 }
 
-// --- Row types ---
-
-export interface ScheduleRow {
-    id: number;
-    name: string;
-    preset_name: string;
-    interval: string;
-    enabled: number;
-    last_run_at: string | null;
-    next_run_at: string;
-    created_at: string;
-    updated_at: string;
-    vars_json: string | null;
-}
-
-export interface RunRow {
-    id: number;
-    schedule_id: number | null;
-    preset_name: string;
-    trigger_type: string;
-    started_at: string;
-    finished_at: string | null;
-    status: string;
-    step_count: number;
-    duration_ms: number | null;
-    error: string | null;
-}
-
-export interface RunLogRow {
-    id: number;
-    run_id: number;
-    step_index: number;
-    step_id: string;
-    step_name: string;
-    action: string;
-    status: string;
-    output: string | null;
-    duration_ms: number;
-    error: string | null;
-    logged_at: string;
-}
-
-// --- Singleton ---
 let _instance: AutomateDatabase | null = null;
 
 export function getDb(): AutomateDatabase {
     if (!_instance) {
         _instance = new AutomateDatabase();
     }
+
     return _instance;
 }
 

--- a/src/automate/lib/engine.ts
+++ b/src/automate/lib/engine.ts
@@ -108,8 +108,7 @@ export async function runPreset(
 
             results.push({ id: step.id, name: step.name, result });
 
-            // Log step to SQLite
-            runLogger?.logStep(i, step.id, step.name, step.action, result);
+            await runLogger?.logStep(i, step.id, step.name, step.action, result);
 
             if (result.status === "success") {
                 spinner.stop(pc.green(`${stepLabel} (${formatDuration(result.duration)})`));
@@ -153,7 +152,7 @@ export async function runPreset(
             ctx.steps[step.id] = exceptionResult;
             results.push({ id: step.id, name: step.name, result: exceptionResult });
 
-            runLogger?.logStep(i, step.id, step.name, step.action, exceptionResult);
+            await runLogger?.logStep(i, step.id, step.name, step.action, exceptionResult);
 
             const errorStrategy = step.onError ?? "stop";
             if (errorStrategy === "stop") {
@@ -167,8 +166,7 @@ export async function runPreset(
     const totalDuration = Date.now() - totalStart;
     const allSuccess = results.every((r) => r.result.status === "success" || r.result.status === "skipped");
 
-    // Finish run logging
-    runLogger?.finishRun(
+    await runLogger?.finishRun(
         allSuccess,
         results.length,
         totalDuration,

--- a/src/automate/lib/run-logger.ts
+++ b/src/automate/lib/run-logger.ts
@@ -4,30 +4,31 @@ import type { StepResult } from "./types";
 
 export interface RunLogger {
     runId: number;
-    logStep(stepIndex: number, stepId: string, stepName: string, action: string, result: StepResult): void;
-    finishRun(success: boolean, stepCount: number, totalDuration: number, error?: string): void;
+    logStep(stepIndex: number, stepId: string, stepName: string, action: string, result: StepResult): Promise<void>;
+    finishRun(success: boolean, stepCount: number, totalDuration: number, error?: string): Promise<void>;
 }
 
-export function createRunLogger(
+export async function createRunLogger(
     presetName: string,
     scheduleId: number | null,
     triggerType: "manual" | "schedule",
     db?: AutomateDatabase
-): RunLogger {
+): Promise<RunLogger> {
     const database = db ?? getDb();
-    const runId = database.startRun(presetName, scheduleId, triggerType);
+    const runId = await database.startRun(presetName, scheduleId, triggerType);
 
     return {
         runId,
 
-        logStep(stepIndex, stepId, stepName, action, result) {
+        async logStep(stepIndex, stepId, stepName, action, result) {
             const output =
                 result.output != null
                     ? typeof result.output === "string"
                         ? result.output
                         : SafeJSON.stringify(result.output)
                     : null;
-            database.logStep(
+
+            await database.logStep(
                 runId,
                 stepIndex,
                 stepId,
@@ -40,8 +41,8 @@ export function createRunLogger(
             );
         },
 
-        finishRun(success, stepCount, totalDuration, error) {
-            database.finishRun(runId, success ? "success" : "error", stepCount, totalDuration, error);
+        async finishRun(success, stepCount, totalDuration, error) {
+            await database.finishRun(runId, success ? "success" : "error", stepCount, totalDuration, error);
         },
     };
 }

--- a/src/automate/lib/scheduler.ts
+++ b/src/automate/lib/scheduler.ts
@@ -20,7 +20,7 @@ export async function runSchedulerLoop(db: AutomateDatabase): Promise<void> {
 
     while (running) {
         const now = new Date().toISOString();
-        const dueSchedules = db.getDueSchedules(now);
+        const dueSchedules = await db.getDueSchedules(now);
 
         for (const schedule of dueSchedules) {
             if (activeRuns.has(schedule.id)) {
@@ -31,19 +31,19 @@ export async function runSchedulerLoop(db: AutomateDatabase): Promise<void> {
             activeRuns.add(schedule.id);
             executeDueSchedule(db, schedule)
                 .catch((err) => logger.error({ err, scheduleId: schedule.id }, "Schedule execution failed"))
-                .finally(() => {
+                .finally(async () => {
                     activeRuns.delete(schedule.id);
                     try {
                         const parsed = parseInterval(schedule.interval);
                         const nextRunAt = computeNextRunAt(parsed).toISOString();
-                        db.updateScheduleAfterRun(schedule.id, nextRunAt);
+                        await db.updateScheduleAfterRun(schedule.id, nextRunAt);
                     } catch (err) {
                         logger.error({ err, scheduleId: schedule.id }, "Failed to update next_run_at");
                     }
                 });
         }
 
-        const nextWakeup = getNextWakeupMs(db);
+        const nextWakeup = await getNextWakeupMs(db);
         const sleepMs = Math.min(Math.max(nextWakeup, 1000), 60_000);
         logger.debug({ sleepMs }, "Sleeping until next schedule");
         await Bun.sleep(sleepMs);
@@ -63,7 +63,7 @@ export async function runSchedulerLoop(db: AutomateDatabase): Promise<void> {
 async function executeDueSchedule(db: AutomateDatabase, schedule: ScheduleRow): Promise<void> {
     logger.info({ name: schedule.name, preset: schedule.preset_name }, "Executing scheduled preset");
     const preset = await loadPreset(schedule.preset_name);
-    const runLogger = createRunLogger(preset.name, schedule.id, "schedule", db);
+    const runLogger = await createRunLogger(preset.name, schedule.id, "schedule", db);
     const vars = schedule.vars_json ? (SafeJSON.parse(schedule.vars_json) as Record<string, string>) : undefined;
     const options = {
         vars: vars ? Object.entries(vars).map(([k, v]) => `${k}=${v}`) : undefined,
@@ -76,18 +76,23 @@ async function executeDueSchedule(db: AutomateDatabase, schedule: ScheduleRow): 
     );
 }
 
-function getNextWakeupMs(db: AutomateDatabase): number {
-    const schedules = db.listSchedules().filter((s) => s.enabled);
+async function getNextWakeupMs(db: AutomateDatabase): Promise<number> {
+    const schedules = (await db.listSchedules()).filter((s) => s.enabled);
+
     if (schedules.length === 0) {
         return 60_000;
     }
+
     const now = Date.now();
-    let earliest = Infinity;
+    let earliest = Number.POSITIVE_INFINITY;
+
     for (const s of schedules) {
         const nextMs = new Date(s.next_run_at).getTime() - now;
+
         if (nextMs < earliest) {
             earliest = nextMs;
         }
     }
+
     return earliest;
 }

--- a/src/macos/commands/mail/accounts.ts
+++ b/src/macos/commands/mail/accounts.ts
@@ -8,11 +8,11 @@ export function registerAccountsCommand(program: Command): void {
     program
         .command("accounts")
         .description("List configured mail accounts")
-        .action(() => {
+        .action(async () => {
             const db = new MailDatabase();
 
             try {
-                const accounts = db.listAccounts();
+                const accounts = await db.listAccounts();
 
                 if (accounts.length === 0) {
                     console.log("No mail accounts found.");

--- a/src/macos/commands/mail/download.ts
+++ b/src/macos/commands/mail/download.ts
@@ -136,7 +136,7 @@ export function registerDownloadCommand(program: Command): void {
 
                     // Fetch recipients for all messages
                     const rowids = filteredMessages.map((m) => m.rowid);
-                    const recipientsMap = db.getRecipients(rowids);
+                    const recipientsMap = await db.getRecipients(rowids);
 
                     // Create EmlxBodyExtractor (fast: ~42 msg/s L2, instant L1)
                     const emlx = await EmlxBodyExtractor.create();

--- a/src/macos/commands/mail/list.ts
+++ b/src/macos/commands/mail/list.ts
@@ -43,7 +43,7 @@ export function registerListCommand(program: Command): void {
                 const spinner = p.spinner();
                 spinner.start(`Fetching latest ${limit} emails from ${targetMailbox}...`);
 
-                let rows = db.listMessages(targetMailbox, limit);
+                let rows = await db.listMessages(targetMailbox, limit);
 
                 if (options.sinceLastCheck) {
                     const mailStorage = new MailStorage();
@@ -59,9 +59,8 @@ export function registerListCommand(program: Command): void {
                     return;
                 }
 
-                // Enrich with attachments
                 const rowids = rows.map((r) => r.rowid);
-                const attachmentsMap = db.getAttachments(rowids);
+                const attachmentsMap = await db.getAttachments(rowids);
                 const messages: MailMessage[] = rows.map((row) => {
                     const msg = rowToMessage(row);
                     msg.attachments = attachmentsMap.get(row.rowid) ?? [];
@@ -72,7 +71,7 @@ export function registerListCommand(program: Command): void {
 
                 // Enrich with recipients if any recipient column is selected
                 if (needsRecipients(columns)) {
-                    const recipientsMap = db.getRecipients(rowids);
+                    const recipientsMap = await db.getRecipients(rowids);
 
                     for (const msg of messages) {
                         msg.recipients = recipientsMap.get(msg.rowid) ?? [];

--- a/src/macos/commands/mail/monitor.ts
+++ b/src/macos/commands/mail/monitor.ts
@@ -142,17 +142,16 @@ export function registerMonitorCommand(program: Command): void {
                 const spinner = p.spinner();
                 spinner.start(`Fetching latest ${limit} messages from INBOX...`);
 
-                const rows = db.listMessages("INBOX", limit);
+                const rows = await db.listMessages("INBOX", limit);
 
                 if (rows.length === 0) {
                     spinner.stop("No messages found in INBOX.");
                     return;
                 }
 
-                // Build MailMessage objects
                 const rowids = rows.map((r) => r.rowid);
-                const attachmentsMap = db.getAttachments(rowids);
-                const recipientsMap = db.getRecipients(rowids);
+                const attachmentsMap = await db.getAttachments(rowids);
+                const recipientsMap = await db.getRecipients(rowids);
                 const messages: MailMessage[] = rows.map((row) => {
                     const msg = rowToMessage(row);
                     msg.attachments = attachmentsMap.get(row.rowid) ?? [];

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -153,7 +153,7 @@ export function registerSearchCommand(program: Command): void {
 
             try {
                 if (options.helpReceivers) {
-                    const receivers = db.listReceivers();
+                    const receivers = await db.listReceivers();
                     announce("\nReceiver addresses (by message count):\n");
 
                     for (const r of receivers) {
@@ -239,7 +239,7 @@ export function registerSearchCommand(program: Command): void {
                     }
 
                     resolvedMethod = ftsResults[0]?.method;
-                    rows = ftsRowids.length > 0 ? db.getMessagesByRowids(ftsRowids) : [];
+                    rows = ftsRowids.length > 0 ? await db.getMessagesByRowids(ftsRowids) : [];
                     searchMethod = "fts";
 
                     const orderByRowid = new Map(ftsRowids.map((rowid, index) => [rowid, index]));
@@ -260,7 +260,7 @@ export function registerSearchCommand(program: Command): void {
 
                     const [spotlightRowids, likeRows] = await Promise.all([
                         mdfindMailRowids(query),
-                        Promise.resolve(db.searchMessages(searchOpts)),
+                        db.searchMessages(searchOpts),
                     ]);
 
                     const rowidSet = new Set<number>(likeRows.map((r) => r.rowid));
@@ -268,7 +268,7 @@ export function registerSearchCommand(program: Command): void {
 
                     const spotlightRows =
                         newSpotlightIds.length > 0
-                            ? db.getMessagesByRowids(newSpotlightIds, {
+                            ? await db.getMessagesByRowids(newSpotlightIds, {
                                   from: searchOpts.from,
                                   to: searchOpts.to,
                                   mailbox: searchOpts.mailbox,
@@ -293,7 +293,7 @@ export function registerSearchCommand(program: Command): void {
 
                 const isFts = searchMethod === "fts";
                 const rowids = rows.map((r) => r.rowid);
-                const attachmentsMap = db.getAttachments(rowids);
+                const attachmentsMap = await db.getAttachments(rowids);
 
                 const messages: MailMessage[] = rows.map((row) => {
                     const msg = rowToMessage(row);
@@ -354,7 +354,7 @@ export function registerSearchCommand(program: Command): void {
                 });
 
                 if (needsRecipients(finalColumns)) {
-                    const recipientsMap = db.getRecipients(rowids);
+                    const recipientsMap = await db.getRecipients(rowids);
 
                     for (const msg of messages) {
                         msg.recipients = recipientsMap.get(msg.rowid) ?? [];

--- a/src/macos/commands/mail/show.ts
+++ b/src/macos/commands/mail/show.ts
@@ -63,7 +63,7 @@ export function registerShowCommand(program: Command): void {
                     process.exit(1);
                 }
 
-                const row = db.getMessageById(rowid);
+                const row = await db.getMessageById(rowid);
 
                 if (!row) {
                     console.error(`Message ${rowid} not found.`);
@@ -72,10 +72,9 @@ export function registerShowCommand(program: Command): void {
 
                 const msg = rowToMessage(row);
 
-                // Enrich with recipients and attachments
-                const recipientsMap = db.getRecipients([rowid]);
+                const recipientsMap = await db.getRecipients([rowid]);
                 msg.recipients = recipientsMap.get(rowid) ?? [];
-                const attachmentsMap = db.getAttachments([rowid]);
+                const attachmentsMap = await db.getAttachments([rowid]);
                 msg.attachments = attachmentsMap.get(rowid) ?? [];
 
                 // Get body via EmlxBodyExtractor

--- a/src/macos/lib/mail/db-types.ts
+++ b/src/macos/lib/mail/db-types.ts
@@ -1,0 +1,61 @@
+/**
+ * Apple Mail Envelope Index schema (readonly).
+ *
+ * Mirrors the proprietary Mail.app schema. Because we never write, all columns
+ * are typed as plain values (no Generated<>). If macOS updates change the
+ * schema, the introspection helper in MacDatabase will warn on first open.
+ */
+export interface MessagesTable {
+    ROWID: number;
+    subject: number;
+    sender: number;
+    mailbox: number;
+    date_sent: number;
+    date_received: number;
+    deleted: number;
+    read: number;
+    flagged: number;
+    size: number;
+}
+
+export interface SubjectsTable {
+    ROWID: number;
+    subject: string | null;
+}
+
+export interface AddressesTable {
+    ROWID: number;
+    address: string | null;
+    comment: string | null;
+}
+
+export interface MailboxesTable {
+    ROWID: number;
+    url: string;
+    total_count: number;
+    unread_count: number;
+}
+
+export interface AttachmentsTable {
+    ROWID: number;
+    message: number;
+    name: string | null;
+    attachment_id: string | null;
+}
+
+export interface RecipientsTable {
+    ROWID: number;
+    message: number;
+    address: number;
+    type: number;
+    position: number;
+}
+
+export interface MailDB {
+    messages: MessagesTable;
+    subjects: SubjectsTable;
+    addresses: AddressesTable;
+    mailboxes: MailboxesTable;
+    attachments: AttachmentsTable;
+    recipients: RecipientsTable;
+}

--- a/src/telegram-bot/lib/handlers/status.ts
+++ b/src/telegram-bot/lib/handlers/status.ts
@@ -10,7 +10,7 @@ export function registerStatusCommand(bot: Bot): void {
         const daemonStatus = await getDaemonStatus();
         const fgPid = getDaemonPid();
         const db = getDb();
-        const schedules = db.listSchedules();
+        const schedules = await db.listSchedules();
         const enabled = schedules.filter((s) => s.enabled);
 
         const lines = [

--- a/src/telegram-bot/lib/handlers/tasks.ts
+++ b/src/telegram-bot/lib/handlers/tasks.ts
@@ -7,7 +7,7 @@ export function registerTasksCommand(bot: Bot): void {
     bot.command("tasks", async (ctx) => {
         p.log.step("/tasks → fetching run history");
         const db = getDb();
-        const runs = db.listRuns(10);
+        const runs = await db.listRuns(10);
 
         if (runs.length === 0) {
             p.log.success("/tasks → no runs");

--- a/src/usage/index.ts
+++ b/src/usage/index.ts
@@ -55,7 +55,7 @@ function formatDate(dateStr: string): string {
 }
 
 async function showSummary(db: UsageDatabase, days: number) {
-    const total = db.getTotalUsage(days);
+    const total = await db.getTotalUsage(days);
 
     console.log(chalk.bold.cyan("\n📊 USAGE SUMMARY\n"));
     console.log(chalk.white(`Period: Last ${days} days`));
@@ -73,7 +73,7 @@ async function showSummary(db: UsageDatabase, days: number) {
 }
 
 async function showDailyUsage(db: UsageDatabase, days: number) {
-    const dailyUsage = db.getDailyUsage(days);
+    const dailyUsage = await db.getDailyUsage(days);
 
     if (dailyUsage.length === 0) {
         console.log(chalk.yellow("\nNo usage data found for the specified period."));
@@ -101,7 +101,7 @@ async function showDailyUsage(db: UsageDatabase, days: number) {
 }
 
 async function showProviderUsage(db: UsageDatabase, days: number) {
-    const providerUsage = db.getProviderUsage(days);
+    const providerUsage = await db.getProviderUsage(days);
 
     if (providerUsage.length === 0) {
         return;
@@ -128,7 +128,7 @@ async function showProviderUsage(db: UsageDatabase, days: number) {
 }
 
 async function showModelUsage(db: UsageDatabase, days: number) {
-    const modelUsage = db.getModelUsage(days);
+    const modelUsage = await db.getModelUsage(days);
 
     if (modelUsage.length === 0) {
         return;
@@ -163,7 +163,7 @@ async function showModelUsage(db: UsageDatabase, days: number) {
 }
 
 async function showCostTrend(db: UsageDatabase, days: number) {
-    const trend = db.getCostTrend(Math.min(days, 7)); // Show last 7 days for trend
+    const trend = await db.getCostTrend(Math.min(days, 7));
 
     if (trend.length === 0) {
         return;
@@ -182,10 +182,10 @@ async function showCostTrend(db: UsageDatabase, days: number) {
 }
 
 async function showJSON(db: UsageDatabase, days: number, _provider?: string, _model?: string) {
-    const total = db.getTotalUsage(days);
-    const dailyUsage = db.getDailyUsage(days);
-    const providerUsage = db.getProviderUsage(days);
-    const modelUsage = db.getModelUsage(days);
+    const total = await db.getTotalUsage(days);
+    const dailyUsage = await db.getDailyUsage(days);
+    const providerUsage = await db.getProviderUsage(days);
+    const modelUsage = await db.getModelUsage(days);
 
     const output = {
         period: {

--- a/src/utils/database/README.md
+++ b/src/utils/database/README.md
@@ -1,0 +1,65 @@
+# `src/utils/database/` — Kysely + bun:sqlite
+
+Thin shared layer over `bun:sqlite`. **Use `createKyselyClient<DB>()` for new code.**
+
+## Why Kysely (not Drizzle / Prisma)
+
+- **Half the owned DBs use FTS5/sqlite-vec.** Drizzle's auto-migration generator does not understand `CREATE VIRTUAL TABLE` ([drizzle-orm#2046](https://github.com/drizzle-team/drizzle-orm/issues/2046)).
+- **3 readonly Apple system DBs** (Mail, Contacts, Voice Memos). Schema-as-code is a liability there — Kysely's interface-only typing is right.
+- **Indexer has dynamic per-source columns.** No static schema can model that — Kysely lets us mix typed and untyped paths.
+- **Most call sites already use parameterized SQL.** They need typed results + composable predicates, not an ORM.
+
+## Quick start
+
+```ts
+import { createKyselyClient } from "@app/utils/database";
+import type { DB } from "./db-types";
+
+const client = createKyselyClient<DB>({
+    path: "/path/to/file.db",
+    bootstrap: [
+        `CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        )`,
+    ],
+});
+
+await client.kysely.selectFrom("users").select(["id", "name"]).execute();
+```
+
+## When to use what
+
+| Need | Use |
+|---|---|
+| Type-safe SELECT/INSERT/UPDATE/DELETE | `client.kysely.<query>` |
+| Composable WHERE clauses with tokens | `buildLikePredicate(tokens, columns)` from `@app/utils/database` |
+| FTS5 `CREATE VIRTUAL TABLE` | `migrations` option on `createKyselyClient` (existing `runMigrations` framework) |
+| FTS5 `MATCH` operator | `sql\`${col} MATCH ${query}\`` inside `where(...)` |
+| sqlite-vec extension | Load via `onOpen`; query via `client.raw` (vec0 doesn't fit a static interface) |
+| `ATTACH DATABASE` | `client.raw.run("ATTACH DATABASE '...' AS x")` |
+| `PRAGMA table_info(...)` | `client.raw.prepare(...).all()` |
+| Dynamic schema (indexer per-source columns) | Stays raw (`client.raw` + `migrations`) |
+
+## Per-tool layout
+
+```
+src/<tool>/lib/
+├── db-types.ts        # interface DB { table_a: {...}; table_b: {...} }
+├── db.ts              # getDatabase() singleton returning DatabaseClient<DB>
+└── ... use the typed client ...
+```
+
+## Migrations
+
+The existing `runMigrations()` framework handles versioned DDL — pass `migrations` to `createKyselyClient`. Used for:
+
+- FTS5 virtual table creation + sync triggers
+- One-off data fixes
+- Schema changes that aren't expressible as `CREATE TABLE IF NOT EXISTS`
+
+For greenfield tables, the `bootstrap` option (`CREATE TABLE IF NOT EXISTS …`) is enough — no migration needed because there's nothing to migrate from.
+
+## Future swap to Drizzle / Prisma
+
+Each tool owns its own `db-types.ts` + `db.ts`. To swap, rewrite those two files for that tool only. The thin contract makes it local — no codebase-wide refactor.

--- a/src/utils/database/base.ts
+++ b/src/utils/database/base.ts
@@ -8,6 +8,13 @@ export { nowUtcIso, parseSqliteOrIsoDate, SQL_NOW_UTC } from "@app/utils/sql-tim
 
 const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
+/**
+ * Base class for tools that historically held a raw `bun:sqlite` handle.
+ *
+ * **Prefer `createKyselyClient` for new code.** This class remains for adapters
+ * that haven't migrated yet (FTS5 drivers, dynamic-column subsystems) and for
+ * legacy `pruneTable` ergonomics.
+ */
 export abstract class BaseDatabase {
     protected db: BunDatabase;
 
@@ -26,7 +33,6 @@ export abstract class BaseDatabase {
 
     protected abstract initSchema(): void;
 
-    /** Expose raw database for modules that need to add tables */
     getDb(): BunDatabase {
         return this.db;
     }
@@ -35,12 +41,10 @@ export abstract class BaseDatabase {
         this.db.close();
     }
 
-    /** Returns the current UTC time as an ISO-8601 string (matches `SQL_NOW_UTC` shape). */
     static nowUtcIso(): string {
         return nowUtcIso();
     }
 
-    /** Parse a SQLite/ISO timestamp string into a UTC Date (or null if unparseable). */
     static parseDate(value: string | null | undefined): Date | null {
         return parseSqliteOrIsoDate(value);
     }

--- a/src/utils/database/client.test.ts
+++ b/src/utils/database/client.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type Generated, sql } from "kysely";
+import { buildLikePredicate, buildOrderedLikePattern, createKyselyClient } from ".";
+
+interface TestDB {
+    users: { id: Generated<number>; name: string; email: string };
+}
+
+function mkClient() {
+    const dir = mkdtempSync(join(tmpdir(), "kysely-bun-"));
+    const path = join(dir, "test.db");
+
+    return createKyselyClient<TestDB>({
+        path,
+        bootstrap: [
+            `CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL
+            )`,
+        ],
+    });
+}
+
+describe("createKyselyClient", () => {
+    it("inserts and reads via Kysely DSL", async () => {
+        const client = mkClient();
+        const result = await client.kysely
+            .insertInto("users")
+            .values({ name: "Martin", email: "m@example.com" })
+            .returning(["id", "name"])
+            .executeTakeFirst();
+
+        expect(result?.name).toBe("Martin");
+        expect(typeof result?.id).toBe("number");
+
+        const rows = await client.kysely.selectFrom("users").selectAll().execute();
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.email).toBe("m@example.com");
+        client.close();
+    });
+
+    it("applies WAL pragma and busy_timeout by default", () => {
+        const client = mkClient();
+        const journal = client.raw.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
+        expect(journal.journal_mode).toBe("wal");
+        client.close();
+    });
+
+    it("supports raw access for FTS5-style virtual tables", () => {
+        const client = mkClient();
+        client.raw.exec(`CREATE VIRTUAL TABLE fts_test USING fts5(body)`);
+        client.raw.run(`INSERT INTO fts_test (body) VALUES (?)`, ["hello world"]);
+        const row = client.raw.prepare(`SELECT body FROM fts_test WHERE fts_test MATCH ?`).get("hello") as {
+            body: string;
+        };
+        expect(row.body).toBe("hello world");
+        client.close();
+    });
+
+    it("buildLikePredicate composes multi-token any-order match", async () => {
+        const client = mkClient();
+        await client.kysely
+            .insertInto("users")
+            .values([
+                { name: "Alice Anderson", email: "alice@x.com" },
+                { name: "Bob Beats", email: "bob@y.com" },
+                { name: "Charlie", email: "c@z.com" },
+            ])
+            .execute();
+
+        const tokens = ["alice", "anderson"];
+        const pred = buildLikePredicate<TestDB, "users">(tokens, ["name", "email"]);
+        const rows = await client.kysely
+            .selectFrom("users")
+            .selectAll()
+            .where((eb) => eb.and(pred.expressions(eb)))
+            .execute();
+
+        expect(rows.map((r) => r.name)).toEqual(["Alice Anderson"]);
+        client.close();
+    });
+
+    it("transactions roll back on throw", async () => {
+        const client = mkClient();
+
+        await expect(
+            client.kysely.transaction().execute(async (trx) => {
+                await trx.insertInto("users").values({ name: "rollback", email: "x" }).execute();
+                throw new Error("boom");
+            })
+        ).rejects.toThrow("boom");
+
+        const rows = await client.kysely.selectFrom("users").selectAll().execute();
+        expect(rows).toHaveLength(0);
+        client.close();
+    });
+
+    it("sql tag works for raw fragments inside Kysely queries", async () => {
+        const client = mkClient();
+        await client.kysely.insertInto("users").values({ name: "lower-test", email: "MIX@example.COM" }).execute();
+
+        const row = await client.kysely
+            .selectFrom("users")
+            .select(["id", sql<string>`lower(email)`.as("lower_email")])
+            .executeTakeFirstOrThrow();
+
+        expect(row.lower_email).toBe("mix@example.com");
+        client.close();
+    });
+
+    it("buildOrderedLikePattern escapes wildcards", () => {
+        expect(buildOrderedLikePattern(["foo", "bar"])).toBe("%foo%bar%");
+        expect(buildOrderedLikePattern(["50%", "off"])).toBe("%50\\%%off%");
+    });
+});

--- a/src/utils/database/client.ts
+++ b/src/utils/database/client.ts
@@ -1,0 +1,82 @@
+import { Database as BunDatabase } from "bun:sqlite";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import logger from "@app/logger";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "./dialect";
+import { type Migration, type MigrationContext, runMigrations } from "./migrations";
+import { applyPragmas, type Pragmas } from "./pragmas";
+
+export interface DatabaseClient<DB> {
+    /** Typed Kysely query builder. */
+    readonly kysely: Kysely<DB>;
+    /** Underlying bun:sqlite handle for FTS5 virtual tables, sqlite-vec, ATTACH, PRAGMA. */
+    readonly raw: BunDatabase;
+    /** Path the database is opened from. */
+    readonly path: string;
+    close(): void;
+}
+
+export interface CreateKyselyClientOptions<DB> {
+    path: string;
+    /** DDL run on every open via `IF NOT EXISTS`. Use for fresh-install bootstrap. */
+    bootstrap?: string[];
+    /** FTS5/trigger DDL or one-off data fixes via the existing migrations framework. */
+    migrations?: Migration[];
+    /** Migration scope identifier (defaults to a stable name derived from the path). */
+    migrationContext?: MigrationContext;
+    pragmas?: Pragmas;
+    /** Open in read-only mode (system databases). */
+    readonly?: boolean;
+    /** Hook to load extensions (e.g. sqlite-vec) before pragmas/bootstrap run. */
+    onOpen?: (db: BunDatabase) => void;
+    /** Optional schema-typed reference; only used to anchor the DB type parameter. */
+    _schema?: DB;
+}
+
+export function createKyselyClient<DB>(opts: CreateKyselyClientOptions<DB>): DatabaseClient<DB> {
+    const { path, bootstrap, migrations, migrationContext, pragmas, readonly = false, onOpen } = opts;
+
+    if (!readonly) {
+        const dir = dirname(path);
+
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+    }
+
+    const raw = new BunDatabase(path, readonly ? { readonly: true } : undefined);
+    onOpen?.(raw);
+    applyPragmas(raw, pragmas, readonly);
+
+    if (!readonly && bootstrap && bootstrap.length > 0) {
+        for (const ddl of bootstrap) {
+            raw.exec(ddl);
+        }
+    }
+
+    if (!readonly && migrations && migrations.length > 0) {
+        const ctx = migrationContext ?? { tableName: deriveScope(path) };
+        runMigrations(raw, migrations, ctx);
+    }
+
+    const kysely = new Kysely<DB>({
+        dialect: new BunSqliteDialect({ database: raw }),
+    });
+
+    logger.debug(`[db] opened ${path}${readonly ? " (readonly)" : ""}`);
+
+    return {
+        kysely,
+        raw,
+        path,
+        close() {
+            kysely.destroy().catch(() => {});
+            raw.close();
+        },
+    };
+}
+
+function deriveScope(path: string): string {
+    return path.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}

--- a/src/utils/database/client.ts
+++ b/src/utils/database/client.ts
@@ -23,7 +23,12 @@ export interface CreateKyselyClientOptions<DB> {
     bootstrap?: string[];
     /** FTS5/trigger DDL or one-off data fixes via the existing migrations framework. */
     migrations?: Migration[];
-    /** Migration scope identifier (defaults to a stable name derived from the path). */
+    /**
+     * Migration scope identifier. **Strongly recommended when `migrations` is set** —
+     * the path-derived fallback changes if the database file moves, which would cause
+     * applied migrations to re-run on the new path. Pin this to a stable string
+     * (e.g. the tool name) so migration history is portable.
+     */
     migrationContext?: MigrationContext;
     pragmas?: Pragmas;
     /** Open in read-only mode (system databases). */
@@ -56,7 +61,18 @@ export function createKyselyClient<DB>(opts: CreateKyselyClientOptions<DB>): Dat
     }
 
     if (!readonly && migrations && migrations.length > 0) {
-        const ctx = migrationContext ?? { tableName: deriveScope(path) };
+        let ctx: MigrationContext;
+
+        if (migrationContext) {
+            ctx = migrationContext;
+        } else {
+            ctx = { tableName: deriveScope(path) };
+            logger.debug(
+                `[db] migrationContext not provided for ${path} — derived "${ctx.tableName}". ` +
+                    `Pin an explicit migrationContext to keep migration history stable across path changes.`,
+            );
+        }
+
         runMigrations(raw, migrations, ctx);
     }
 
@@ -71,7 +87,9 @@ export function createKyselyClient<DB>(opts: CreateKyselyClientOptions<DB>): Dat
         raw,
         path,
         close() {
-            kysely.destroy().catch(() => {});
+            // Don't call kysely.destroy() — it would race with raw.close() to close
+            // the same handle. Our BunSqliteDriver.destroy() does exactly raw.close().
+            // Closing raw directly is safe and synchronous.
             raw.close();
         },
     };

--- a/src/utils/database/dialect.ts
+++ b/src/utils/database/dialect.ts
@@ -1,0 +1,165 @@
+import type { Database as BunDatabase } from "bun:sqlite";
+import {
+    CompiledQuery,
+    type DatabaseConnection,
+    type DatabaseIntrospector,
+    type Dialect,
+    type DialectAdapter,
+    type Driver,
+    type Kysely,
+    type QueryCompiler,
+    type QueryResult,
+    SqliteAdapter,
+    SqliteIntrospector,
+    SqliteQueryCompiler,
+} from "kysely";
+
+export interface BunSqliteDialectConfig {
+    database: BunDatabase | (() => BunDatabase | Promise<BunDatabase>);
+    onCreateConnection?: (connection: DatabaseConnection) => Promise<void>;
+}
+
+export class BunSqliteDialect implements Dialect {
+    readonly #config: BunSqliteDialectConfig;
+
+    constructor(config: BunSqliteDialectConfig) {
+        this.#config = Object.freeze({ ...config });
+    }
+
+    createDriver(): Driver {
+        return new BunSqliteDriver(this.#config);
+    }
+
+    createQueryCompiler(): QueryCompiler {
+        return new SqliteQueryCompiler();
+    }
+
+    createAdapter(): DialectAdapter {
+        return new SqliteAdapter();
+    }
+
+    createIntrospector(db: Kysely<unknown>): DatabaseIntrospector {
+        return new SqliteIntrospector(db);
+    }
+}
+
+class BunSqliteDriver implements Driver {
+    readonly #config: BunSqliteDialectConfig;
+    readonly #mutex = new ConnectionMutex();
+    #db?: BunDatabase;
+    #connection?: BunSqliteConnection;
+
+    constructor(config: BunSqliteDialectConfig) {
+        this.#config = config;
+    }
+
+    async init(): Promise<void> {
+        this.#db = typeof this.#config.database === "function" ? await this.#config.database() : this.#config.database;
+        this.#connection = new BunSqliteConnection(this.#db);
+
+        if (this.#config.onCreateConnection) {
+            await this.#config.onCreateConnection(this.#connection);
+        }
+    }
+
+    async acquireConnection(): Promise<DatabaseConnection> {
+        await this.#mutex.lock();
+
+        if (!this.#connection) {
+            throw new Error("BunSqliteDriver not initialized");
+        }
+
+        return this.#connection;
+    }
+
+    async beginTransaction(connection: DatabaseConnection): Promise<void> {
+        await connection.executeQuery(CompiledQuery.raw("begin"));
+    }
+
+    async commitTransaction(connection: DatabaseConnection): Promise<void> {
+        await connection.executeQuery(CompiledQuery.raw("commit"));
+    }
+
+    async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
+        await connection.executeQuery(CompiledQuery.raw("rollback"));
+    }
+
+    async releaseConnection(): Promise<void> {
+        this.#mutex.unlock();
+    }
+
+    async destroy(): Promise<void> {
+        this.#db?.close();
+    }
+}
+
+class BunSqliteConnection implements DatabaseConnection {
+    readonly #db: BunDatabase;
+
+    constructor(db: BunDatabase) {
+        this.#db = db;
+    }
+
+    executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+        const { sql, parameters } = compiledQuery;
+        const stmt = this.#db.prepare(sql);
+        const params = parameters as unknown[];
+        const isSelectLike = stmt.columnNames.length > 0;
+
+        if (isSelectLike) {
+            const rows = stmt.all(...(params as Parameters<typeof stmt.all>)) as R[];
+
+            return Promise.resolve({ rows });
+        }
+
+        const result = stmt.run(...(params as Parameters<typeof stmt.run>));
+        const changes = typeof result.changes === "number" ? BigInt(result.changes) : undefined;
+        const insertId =
+            typeof result.lastInsertRowid === "bigint"
+                ? result.lastInsertRowid
+                : typeof result.lastInsertRowid === "number"
+                  ? BigInt(result.lastInsertRowid)
+                  : undefined;
+
+        return Promise.resolve({
+            numAffectedRows: changes,
+            insertId,
+            rows: [] as R[],
+        });
+    }
+
+    async *streamQuery<R>(compiledQuery: CompiledQuery): AsyncIterableIterator<QueryResult<R>> {
+        const { sql, parameters } = compiledQuery;
+        const stmt = this.#db.prepare(sql);
+
+        if (stmt.columnNames.length === 0) {
+            throw new Error("BunSqliteDialect only supports streaming of select queries");
+        }
+
+        for (const row of stmt.iterate(...(parameters as Parameters<typeof stmt.iterate>))) {
+            yield { rows: [row as R] };
+        }
+    }
+}
+
+class ConnectionMutex {
+    #promise?: Promise<void>;
+    #resolve?: () => void;
+
+    async lock(): Promise<void> {
+        while (this.#promise) {
+            await this.#promise;
+        }
+
+        this.#promise = new Promise((resolve) => {
+            this.#resolve = resolve;
+        });
+    }
+
+    unlock(): void {
+        const resolve = this.#resolve;
+        this.#promise = undefined;
+        this.#resolve = undefined;
+        resolve?.();
+    }
+}

--- a/src/utils/database/index.ts
+++ b/src/utils/database/index.ts
@@ -1,0 +1,17 @@
+export { BaseDatabase, nowUtcIso, parseSqliteOrIsoDate, SQL_NOW_UTC } from "./base";
+export { type CreateKyselyClientOptions, createKyselyClient, type DatabaseClient } from "./client";
+export { BunSqliteDialect, type BunSqliteDialectConfig } from "./dialect";
+export {
+    getPendingMigrations,
+    type Migration,
+    type MigrationContext,
+    Migrator,
+    runMigrations,
+} from "./migrations";
+export { applyPragmas, DEFAULT_PRAGMAS, type Pragmas } from "./pragmas";
+export {
+    buildLikePredicate,
+    buildOrderedLikePattern,
+    escapeLike,
+    type LikePredicateBuilder,
+} from "./predicates";

--- a/src/utils/database/pragmas.ts
+++ b/src/utils/database/pragmas.ts
@@ -1,0 +1,33 @@
+import type { Database as BunDatabase } from "bun:sqlite";
+
+export interface Pragmas {
+    journalMode?: "WAL" | "DELETE" | "TRUNCATE" | "PERSIST" | "MEMORY" | "OFF";
+    busyTimeoutMs?: number;
+    foreignKeys?: boolean;
+    synchronous?: "OFF" | "NORMAL" | "FULL" | "EXTRA";
+}
+
+export const DEFAULT_PRAGMAS: Required<Pick<Pragmas, "journalMode" | "busyTimeoutMs">> = {
+    journalMode: "WAL",
+    busyTimeoutMs: 5000,
+};
+
+export function applyPragmas(db: BunDatabase, pragmas?: Pragmas, readonly = false): void {
+    const merged: Pragmas = { ...DEFAULT_PRAGMAS, ...pragmas };
+
+    if (!readonly && merged.journalMode) {
+        db.exec(`PRAGMA journal_mode = ${merged.journalMode};`);
+    }
+
+    if (typeof merged.busyTimeoutMs === "number") {
+        db.exec(`PRAGMA busy_timeout = ${merged.busyTimeoutMs};`);
+    }
+
+    if (merged.foreignKeys !== undefined) {
+        db.exec(`PRAGMA foreign_keys = ${merged.foreignKeys ? "ON" : "OFF"};`);
+    }
+
+    if (merged.synchronous) {
+        db.exec(`PRAGMA synchronous = ${merged.synchronous};`);
+    }
+}

--- a/src/utils/database/predicates.ts
+++ b/src/utils/database/predicates.ts
@@ -1,0 +1,40 @@
+import { type Expression, type ExpressionBuilder, type ReferenceExpression, type SqlBool, sql } from "kysely";
+
+export function escapeLike(value: string, escapeChar = "\\"): string {
+    return value.replace(/[\\%_]/g, (match) => `${escapeChar}${match}`);
+}
+
+export interface LikePredicateBuilder<DB, TB extends keyof DB> {
+    /** Returns one Expression per token: each token must match at least one column. */
+    expressions(eb: ExpressionBuilder<DB, TB>): Expression<SqlBool>[];
+}
+
+/**
+ * Build a tokenized LIKE predicate: each token must match at least one of the
+ * provided columns (any-order match). Pair with an ordered `%tok1%tok2%` pattern
+ * if you also want to bias toward in-order phrases.
+ *
+ * Example:
+ *   const pred = buildLikePredicate(tokens, ["s.subject", "a.address"]);
+ *   .where(eb => eb.and(pred.expressions(eb)))
+ */
+export function buildLikePredicate<DB, TB extends keyof DB>(
+    tokens: string[],
+    columns: ReferenceExpression<DB, TB>[],
+    escapeChar = "\\"
+): LikePredicateBuilder<DB, TB> {
+    const escapedTokens = tokens.map((t) => `%${escapeLike(t, escapeChar)}%`);
+
+    return {
+        expressions(eb) {
+            return escapedTokens.map((pattern) =>
+                eb.or(columns.map((col) => sql<SqlBool>`${eb.ref(col as never)} LIKE ${pattern} ESCAPE ${escapeChar}`))
+            );
+        },
+    };
+}
+
+/** Build an ordered wildcard pattern: %tok1%tok2%tok3%. Useful for phrase-like matches. */
+export function buildOrderedLikePattern(tokens: string[], escapeChar = "\\"): string {
+    return `%${tokens.map((t) => escapeLike(t, escapeChar)).join("%")}%`;
+}

--- a/src/utils/macos/MacDatabase.ts
+++ b/src/utils/macos/MacDatabase.ts
@@ -1,16 +1,23 @@
 import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import logger from "@app/logger";
+import { BunSqliteDialect } from "@app/utils/database";
 import { type Migration, Migrator } from "@app/utils/database/migrations";
 import { MacOS } from "@app/utils/macos/MacOS";
 import { detectTerminalApp } from "@app/utils/terminal";
+import { Kysely } from "kysely";
 
 /**
  * Base class for readonly macOS SQLite databases with lazy connection
  * and automatic cleanup on process exit.
+ *
+ * Subclasses can use either:
+ *   - `getDb()` for raw bun:sqlite (legacy / FTS5 / introspection)
+ *   - `getKysely<DB>()` for typed Kysely queries against the schema interface
  */
 export abstract class MacDatabase {
     private db: Database | null = null;
+    private kysely: Kysely<unknown> | null = null;
     protected readonly migrations: Migration[] = [];
     protected readonly migrationTableName?: string;
 
@@ -66,7 +73,22 @@ export abstract class MacDatabase {
         return this.db;
     }
 
+    protected getKysely<DB>(): Kysely<DB> {
+        if (!this.kysely) {
+            this.kysely = new Kysely<unknown>({
+                dialect: new BunSqliteDialect({ database: this.getDb() }),
+            });
+        }
+
+        return this.kysely as Kysely<DB>;
+    }
+
     close(): void {
+        if (this.kysely) {
+            this.kysely.destroy().catch(() => {});
+            this.kysely = null;
+        }
+
         if (this.db) {
             this.db.close();
             this.db = null;

--- a/src/utils/macos/MailDatabase.ts
+++ b/src/utils/macos/MailDatabase.ts
@@ -1,5 +1,6 @@
 import logger from "@app/logger";
 import { ENVELOPE_INDEX_PATH } from "@app/macos/lib/mail/constants";
+import type { MailDB } from "@app/macos/lib/mail/db-types";
 import type {
     AccountInfo,
     MailAttachment,
@@ -8,163 +9,209 @@ import type {
     ReceiverInfo,
     SearchOptions,
 } from "@app/macos/lib/mail/types";
+import { buildOrderedLikePattern, escapeLike } from "@app/utils/database";
+import { type Expression, type SqlBool, sql } from "kysely";
 import { MacDatabase } from "./MacDatabase";
-import {
-    ATTACHMENT_JOIN,
-    buildFilters,
-    escapeLike,
-    LIKE_ESCAPE_CLAUSE,
-    type MailFilterOptions,
-    MESSAGE_SELECT,
-    SQL_BIND_BATCH,
-} from "./mail-sql";
+import { type MailFilterOptions, SQL_BIND_BATCH } from "./mail-sql";
+
+/**
+ * Build raw SQL filter fragments for date range / mailbox / receiver / account.
+ * Returned as boolean Expressions to be combined with `eb.and(...)`.
+ */
+function buildMailFilterExpressions(opts: MailFilterOptions): Expression<SqlBool>[] {
+    const filters: Expression<SqlBool>[] = [];
+
+    if (opts.from) {
+        const seconds = Math.floor(opts.from.getTime() / 1000);
+        filters.push(sql<SqlBool>`m.date_sent >= ${seconds}`);
+    }
+
+    if (opts.to) {
+        const seconds = Math.floor(opts.to.getTime() / 1000);
+        filters.push(sql<SqlBool>`m.date_sent <= ${seconds}`);
+    }
+
+    if (opts.mailbox) {
+        const pattern = `%${escapeLike(opts.mailbox)}%`;
+        filters.push(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`);
+    }
+
+    if (opts.receiver) {
+        const pattern = `%${escapeLike(opts.receiver)}%`;
+        filters.push(sql<SqlBool>`m.ROWID IN (
+            SELECT r.message FROM recipients r
+            JOIN addresses a ON r.address = a.ROWID
+            WHERE a.address LIKE ${pattern} ESCAPE '\\'
+        )`);
+    }
+
+    if (opts.account) {
+        const pattern = `%${escapeLike(opts.account)}%`;
+        filters.push(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`);
+    }
+
+    return filters;
+}
+
+const MESSAGE_SELECT_COLUMNS = [
+    sql<number>`m.ROWID`.as("rowid"),
+    "s.subject",
+    sql<string>`a.address`.as("senderAddress"),
+    sql<string | null>`a.comment`.as("senderName"),
+    sql<number>`m.date_sent`.as("dateSent"),
+    sql<number>`m.date_received`.as("dateReceived"),
+    sql<string>`mb.url`.as("mailboxUrl"),
+    "m.read",
+    "m.flagged",
+    "m.deleted",
+    "m.size",
+] as const;
 
 export class MailDatabase extends MacDatabase {
     protected readonly dbPath = ENVELOPE_INDEX_PATH;
     protected readonly dbLabel = "Mail database";
     protected readonly notFoundMessage = "Make sure Mail.app is configured and has downloaded messages.";
 
-    searchMessages(opts: SearchOptions): MailMessageRow[] {
-        const db = this.getDb();
-        const params: Record<string, string | number> = {};
+    private k() {
+        return this.getKysely<MailDB>();
+    }
 
+    async searchMessages(opts: SearchOptions): Promise<MailMessageRow[]> {
         const tokens = opts.query.split(/\s+/).filter((t) => t.length > 0);
 
         if (tokens.length === 0) {
             return [];
         }
 
-        // Two complementary patterns:
-        //  - ordered wildcard: %tok1%tok2%tok3% — matches "invoice pay now" within longer text
-        //  - any-order ANDed: each individual %tokN% must match somewhere
-        const orderedPattern = `%${tokens.map((t) => escapeLike(t)).join("%")}%`;
-        params.$ordered = orderedPattern;
-
-        const orderedClause = `(s.subject LIKE $ordered ${LIKE_ESCAPE_CLAUSE} OR a.address LIKE $ordered ${LIKE_ESCAPE_CLAUSE} OR a.comment LIKE $ordered ${LIKE_ESCAPE_CLAUSE} OR att.name LIKE $ordered ${LIKE_ESCAPE_CLAUSE})`;
-
-        const anyOrderClauses: string[] = tokens.map((_, i) => {
-            const key = `$tok${i}`;
-            return `(s.subject LIKE ${key} ${LIKE_ESCAPE_CLAUSE} OR a.address LIKE ${key} ${LIKE_ESCAPE_CLAUSE} OR a.comment LIKE ${key} ${LIKE_ESCAPE_CLAUSE} OR att.name LIKE ${key} ${LIKE_ESCAPE_CLAUSE})`;
-        });
-
-        for (let i = 0; i < tokens.length; i++) {
-            params[`$tok${i}`] = `%${escapeLike(tokens[i])}%`;
-        }
-
-        const filters: string[] = ["m.deleted = 0", ...buildFilters(opts, params)];
-        const whereClause = filters.length > 0 ? `AND ${filters.join(" AND ")}` : "";
-
-        // Drop the LIMIT — fallback path takes care of pagination after merge.
-        const sql = `${MESSAGE_SELECT}
-            ${ATTACHMENT_JOIN}
-            WHERE (${orderedClause} OR (${anyOrderClauses.join(" AND ")}))
-            ${whereClause}
-            ORDER BY m.date_sent DESC`;
+        const ordered = buildOrderedLikePattern(tokens);
+        const escapedTokens = tokens.map((t) => `%${escapeLike(t)}%`);
+        const filterExpressions = buildMailFilterExpressions(opts);
 
         logger.debug(`Running search query (wildcard) with ${tokens.length} token(s): ${tokens.join(", ")}`);
-        return db.prepare(sql).all(params) as MailMessageRow[];
+
+        const rows = await this.k()
+            .selectFrom("messages as m")
+            .innerJoin("subjects as s", "s.ROWID", "m.subject")
+            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
+            .leftJoin("attachments as att", "att.message", "m.ROWID")
+            .select(MESSAGE_SELECT_COLUMNS as never)
+            .distinct()
+            .where("m.deleted", "=", 0)
+            .where((eb) =>
+                eb.or([
+                    sql<SqlBool>`s.subject LIKE ${ordered} ESCAPE '\\'`,
+                    sql<SqlBool>`a.address LIKE ${ordered} ESCAPE '\\'`,
+                    sql<SqlBool>`a.comment LIKE ${ordered} ESCAPE '\\'`,
+                    sql<SqlBool>`att.name LIKE ${ordered} ESCAPE '\\'`,
+                    eb.and(
+                        escapedTokens.map(
+                            (pattern) => sql<SqlBool>`(
+                                s.subject LIKE ${pattern} ESCAPE '\\'
+                                OR a.address LIKE ${pattern} ESCAPE '\\'
+                                OR a.comment LIKE ${pattern} ESCAPE '\\'
+                                OR att.name LIKE ${pattern} ESCAPE '\\'
+                            )`
+                        )
+                    ),
+                ])
+            )
+            .where((eb) => eb.and(filterExpressions))
+            .orderBy("m.date_sent", "desc")
+            .execute();
+
+        return rows as unknown as MailMessageRow[];
     }
 
-    getMessagesByRowids(rowids: number[], opts?: MailFilterOptions): MailMessageRow[] {
+    async getMessagesByRowids(rowids: number[], opts?: MailFilterOptions): Promise<MailMessageRow[]> {
         if (rowids.length === 0) {
             return [];
         }
 
-        const db = this.getDb();
         const results: MailMessageRow[] = [];
+        const filterExpressions = opts ? buildMailFilterExpressions(opts) : [];
 
         for (let offset = 0; offset < rowids.length; offset += SQL_BIND_BATCH) {
             const batch = rowids.slice(offset, offset + SQL_BIND_BATCH);
-            const params: Record<string, string | number> = {};
-            const filters: string[] = ["m.deleted = 0"];
 
-            const placeholders = batch.map((_, i) => `$r${i}`).join(",");
+            const rows = await this.k()
+                .selectFrom("messages as m")
+                .innerJoin("subjects as s", "s.ROWID", "m.subject")
+                .innerJoin("addresses as a", "a.ROWID", "m.sender")
+                .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
+                .select(MESSAGE_SELECT_COLUMNS as never)
+                .distinct()
+                .where("m.deleted", "=", 0)
+                .where("m.ROWID", "in", batch)
+                .where((eb) => eb.and(filterExpressions))
+                .orderBy("m.date_sent", "desc")
+                .execute();
 
-            for (let i = 0; i < batch.length; i++) {
-                params[`$r${i}`] = batch[i];
-            }
-
-            filters.push(`m.ROWID IN (${placeholders})`);
-
-            if (opts) {
-                filters.push(...buildFilters(opts, params));
-            }
-
-            const sql = `${MESSAGE_SELECT}
-                WHERE ${filters.join(" AND ")}
-                ORDER BY m.date_sent DESC`;
-
-            results.push(...(db.prepare(sql).all(params) as MailMessageRow[]));
+            results.push(...(rows as unknown as MailMessageRow[]));
         }
 
         return results;
     }
 
-    listMessages(mailbox: string, limit: number): MailMessageRow[] {
-        const db = this.getDb();
-        const mailboxPattern = `%${escapeLike(mailbox)}%`;
+    async listMessages(mailbox: string, limit: number): Promise<MailMessageRow[]> {
+        const pattern = `%${escapeLike(mailbox)}%`;
 
-        const sql = `${MESSAGE_SELECT}
-            WHERE m.deleted = 0
-              AND mb.url LIKE $mailbox ${LIKE_ESCAPE_CLAUSE}
-            ORDER BY m.date_sent DESC
-            LIMIT $limit`;
+        const rows = await this.k()
+            .selectFrom("messages as m")
+            .innerJoin("subjects as s", "s.ROWID", "m.subject")
+            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
+            .select(MESSAGE_SELECT_COLUMNS as never)
+            .distinct()
+            .where("m.deleted", "=", 0)
+            .where(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`)
+            .orderBy("m.date_sent", "desc")
+            .limit(limit)
+            .execute();
 
-        return db.prepare(sql).all({ $mailbox: mailboxPattern, $limit: limit }) as MailMessageRow[];
+        return rows as unknown as MailMessageRow[];
     }
 
-    getAttachments(messageRowids: number[]): Map<number, MailAttachment[]> {
+    async getAttachments(messageRowids: number[]): Promise<Map<number, MailAttachment[]>> {
         if (messageRowids.length === 0) {
             return new Map();
         }
 
-        const db = this.getDb();
-        const placeholders = messageRowids.map(() => "?").join(",");
-        const sql = `
-            SELECT message, name, attachment_id as attachmentId
-            FROM attachments
-            WHERE message IN (${placeholders})
-            ORDER BY message, ROWID
-        `;
-
-        const rows = db.prepare(sql).all(...messageRowids) as Array<{
-            message: number;
-            name: string;
-            attachmentId: string | null;
-        }>;
+        const rows = await this.k()
+            .selectFrom("attachments")
+            .select(["message", "name", "attachment_id as attachmentId", "ROWID"])
+            .where("message", "in", messageRowids)
+            .orderBy(["message", "ROWID"])
+            .execute();
 
         const map = new Map<number, MailAttachment[]>();
 
         for (const row of rows) {
             const list = map.get(row.message) ?? [];
-            list.push({ name: row.name, attachmentId: row.attachmentId ?? "" });
+            list.push({ name: row.name ?? "", attachmentId: row.attachmentId ?? "" });
             map.set(row.message, list);
         }
 
         return map;
     }
 
-    getRecipients(messageRowids: number[]): Map<number, MailRecipient[]> {
+    async getRecipients(messageRowids: number[]): Promise<Map<number, MailRecipient[]>> {
         if (messageRowids.length === 0) {
             return new Map();
         }
 
-        const db = this.getDb();
-        const placeholders = messageRowids.map(() => "?").join(",");
-        const sql = `
-            SELECT r.message, a.address, a.comment as name, r.type
-            FROM recipients r
-            JOIN addresses a ON r.address = a.ROWID
-            WHERE r.message IN (${placeholders})
-            ORDER BY r.message, r.type, r.position
-        `;
-
-        const rows = db.prepare(sql).all(...messageRowids) as Array<{
-            message: number;
-            address: string;
-            name: string;
-            type: number;
-        }>;
+        const rows = await this.k()
+            .selectFrom("recipients as r")
+            .innerJoin("addresses as a", "a.ROWID", "r.address")
+            .select([
+                sql<number>`r.message`.as("message"),
+                sql<string>`a.address`.as("address"),
+                sql<string | null>`a.comment`.as("name"),
+                sql<number>`r.type`.as("type"),
+            ])
+            .where("r.message", "in", messageRowids)
+            .orderBy(["r.message", "r.type", "r.position"])
+            .execute();
 
         const map = new Map<number, MailRecipient[]>();
 
@@ -172,7 +219,7 @@ export class MailDatabase extends MacDatabase {
             const list = map.get(row.message) ?? [];
             list.push({
                 address: row.address,
-                name: row.name,
+                name: row.name ?? "",
                 type: row.type === 0 ? "to" : "cc",
             });
             map.set(row.message, list);
@@ -181,48 +228,70 @@ export class MailDatabase extends MacDatabase {
         return map;
     }
 
-    listReceivers(): ReceiverInfo[] {
-        const db = this.getDb();
-        const sql = `
-            SELECT
-                a.address,
-                a.comment as name,
-                COUNT(DISTINCT r.message) as messageCount
-            FROM recipients r
-            JOIN addresses a ON r.address = a.ROWID
-            WHERE r.type = 0
-            GROUP BY a.address, a.comment
-            HAVING messageCount > 10
-            ORDER BY messageCount DESC
-            LIMIT 50
-        `;
-        return db.prepare(sql).all() as ReceiverInfo[];
+    async listReceivers(): Promise<ReceiverInfo[]> {
+        const rows = await this.k()
+            .selectFrom("recipients as r")
+            .innerJoin("addresses as a", "a.ROWID", "r.address")
+            .select([
+                sql<string>`a.address`.as("address"),
+                sql<string | null>`a.comment`.as("name"),
+                sql<number>`COUNT(DISTINCT r.message)`.as("messageCount"),
+            ])
+            .where("r.type", "=", 0)
+            .groupBy(["a.address", "a.comment"])
+            .having(sql`COUNT(DISTINCT r.message)`, ">", 10)
+            .orderBy("messageCount", "desc")
+            .limit(50)
+            .execute();
+
+        return rows.map((r) => ({
+            address: r.address,
+            name: r.name ?? "",
+            messageCount: r.messageCount,
+        }));
     }
 
-    listMailboxes(): Array<{ url: string; totalCount: number; unreadCount: number }> {
-        const db = this.getDb();
-        const sql = `
-            SELECT url, total_count as totalCount, unread_count as unreadCount
-            FROM mailboxes
-            WHERE total_count > 0
-            ORDER BY total_count DESC
-        `;
-        return db.prepare(sql).all() as Array<{ url: string; totalCount: number; unreadCount: number }>;
+    async listMailboxes(): Promise<Array<{ url: string; totalCount: number; unreadCount: number }>> {
+        const rows = await this.k()
+            .selectFrom("mailboxes")
+            .select(["url", sql<number>`total_count`.as("totalCount"), sql<number>`unread_count`.as("unreadCount")])
+            .where("total_count", ">", 0)
+            .orderBy("total_count", "desc")
+            .execute();
+
+        return rows;
     }
 
-    getMessageById(rowid: number): MailMessageRow | null {
-        const db = this.getDb();
-        const sql = `${MESSAGE_SELECT}
-            WHERE m.ROWID = $rowid`;
-        return (db.prepare(sql).get({ $rowid: rowid }) as MailMessageRow) ?? null;
+    async getMessageById(rowid: number): Promise<MailMessageRow | null> {
+        const row = await this.k()
+            .selectFrom("messages as m")
+            .innerJoin("subjects as s", "s.ROWID", "m.subject")
+            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
+            .select(MESSAGE_SELECT_COLUMNS as never)
+            .distinct()
+            .where("m.ROWID", "=", rowid)
+            .executeTakeFirst();
+
+        return (row as unknown as MailMessageRow | undefined) ?? null;
     }
 
-    listAccounts(): AccountInfo[] {
-        const db = this.getDb();
+    async getMessageCount(): Promise<number> {
+        const row = await this.k()
+            .selectFrom("messages")
+            .select(sql<number>`COUNT(*)`.as("cnt"))
+            .where("deleted", "=", 0)
+            .executeTakeFirstOrThrow();
 
-        const mailboxes = db
-            .prepare("SELECT url, total_count as totalCount FROM mailboxes WHERE total_count > 0")
-            .all() as Array<{ url: string; totalCount: number }>;
+        return row.cnt;
+    }
+
+    async listAccounts(): Promise<AccountInfo[]> {
+        const mailboxes = await this.k()
+            .selectFrom("mailboxes")
+            .select(["url", sql<number>`total_count`.as("totalCount")])
+            .where("total_count", ">", 0)
+            .execute();
 
         const accounts = new Map<string, { protocol: string; mailboxCount: number; messageCount: number }>();
 
@@ -241,51 +310,52 @@ export class MailDatabase extends MacDatabase {
             accounts.set(uuid, existing);
         }
 
-        type AccountEmailRow = { accountUuid: string; address: string; cnt: number };
+        const accountUuidExpr = sql<string>`SUBSTR(mb.url, INSTR(mb.url, '://') + 3,
+            INSTR(SUBSTR(mb.url, INSTR(mb.url, '://') + 3), '/') - 1)`;
 
-        // Primary: messages.sender in Sent/Drafts/Outbox folders — strongest signal.
-        const sentSenders = db
-            .prepare(
-                `SELECT
-                    SUBSTR(mb.url, INSTR(mb.url, '://') + 3,
-                        INSTR(SUBSTR(mb.url, INSTR(mb.url, '://') + 3), '/') - 1) AS accountUuid,
-                    a.address,
-                    COUNT(*) AS cnt
-                FROM messages m
-                JOIN mailboxes mb ON m.mailbox = mb.ROWID
-                JOIN addresses a ON m.sender = a.ROWID
-                WHERE m.deleted = 0
-                  AND (mb.url LIKE '%/Sent%' OR mb.url LIKE '%Sent%20Items%'
-                       OR mb.url LIKE '%Sent%20Messages%' OR mb.url LIKE '%Outbox%'
-                       OR mb.url LIKE '%Drafts%')
-                GROUP BY accountUuid, a.address
-                ORDER BY accountUuid, cnt DESC`
+        const sentSenders = await this.k()
+            .selectFrom("messages as m")
+            .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
+            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .select([
+                accountUuidExpr.as("accountUuid"),
+                sql<string>`a.address`.as("address"),
+                sql<number>`COUNT(*)`.as("cnt"),
+            ])
+            .where("m.deleted", "=", 0)
+            .where((eb) =>
+                eb.or([
+                    sql<boolean>`mb.url LIKE '%/Sent%'`,
+                    sql<boolean>`mb.url LIKE '%Sent%20Items%'`,
+                    sql<boolean>`mb.url LIKE '%Sent%20Messages%'`,
+                    sql<boolean>`mb.url LIKE '%Outbox%'`,
+                    sql<boolean>`mb.url LIKE '%Drafts%'`,
+                ])
             )
-            .all() as AccountEmailRow[];
+            .groupBy(["accountUuid", "a.address"])
+            .orderBy(["accountUuid", "cnt desc"])
+            .execute();
 
-        // Fallback: most-frequent type=0 (To) recipient across non-sent folders.
-        const inboxRecipients = db
-            .prepare(
-                `SELECT
-                    SUBSTR(mb.url, INSTR(mb.url, '://') + 3,
-                        INSTR(SUBSTR(mb.url, INSTR(mb.url, '://') + 3), '/') - 1) AS accountUuid,
-                    a.address,
-                    COUNT(*) AS cnt
-                FROM messages m
-                JOIN mailboxes mb ON m.mailbox = mb.ROWID
-                JOIN recipients r ON r.message = m.ROWID
-                JOIN addresses a ON r.address = a.ROWID
-                WHERE m.deleted = 0
-                  AND r.type = 0
-                  AND mb.url NOT LIKE '%/Sent%'
-                  AND mb.url NOT LIKE '%Sent%20Items%'
-                  AND mb.url NOT LIKE '%Sent%20Messages%'
-                  AND mb.url NOT LIKE '%Outbox%'
-                  AND mb.url NOT LIKE '%Drafts%'
-                GROUP BY accountUuid, a.address
-                ORDER BY accountUuid, cnt DESC`
-            )
-            .all() as AccountEmailRow[];
+        const inboxRecipients = await this.k()
+            .selectFrom("messages as m")
+            .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
+            .innerJoin("recipients as r", "r.message", "m.ROWID")
+            .innerJoin("addresses as a", "a.ROWID", "r.address")
+            .select([
+                accountUuidExpr.as("accountUuid"),
+                sql<string>`a.address`.as("address"),
+                sql<number>`COUNT(*)`.as("cnt"),
+            ])
+            .where("m.deleted", "=", 0)
+            .where("r.type", "=", 0)
+            .where(sql<boolean>`mb.url NOT LIKE '%/Sent%'`)
+            .where(sql<boolean>`mb.url NOT LIKE '%Sent%20Items%'`)
+            .where(sql<boolean>`mb.url NOT LIKE '%Sent%20Messages%'`)
+            .where(sql<boolean>`mb.url NOT LIKE '%Outbox%'`)
+            .where(sql<boolean>`mb.url NOT LIKE '%Drafts%'`)
+            .groupBy(["accountUuid", "a.address"])
+            .orderBy(["accountUuid", "cnt desc"])
+            .execute();
 
         const emailByAccount = new Map<string, string>();
 
@@ -314,11 +384,5 @@ export class MailDatabase extends MacDatabase {
         }
 
         return result.sort((a, b) => b.messageCount - a.messageCount);
-    }
-
-    getMessageCount(): number {
-        const db = this.getDb();
-        const row = db.prepare("SELECT COUNT(*) as cnt FROM messages WHERE deleted = 0").get() as { cnt: number };
-        return row.cnt;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the mail search pipeline where `tools macos mail search` returned 2 RRF hits at `--limit 50` while `--limit 20` returned 0 + 20 unrelated metadata fallbacks. Filters were being applied **after** FTS instead of pushed **into** it; FTS had no diacritic folding; there was no `source_id` index; and the fallback path had no body coverage.

- Push filters into the search query via SQLite `ATTACH DATABASE` of Mail.app's Envelope Index (read-only) + `c.source_id IN (SELECT m.ROWID ...)` predicate. Bench: 7-55ms vs 300ms broken pipeline.
- Generic migration engine (`src/utils/database/migrations.ts`) used for: `source_id` B-tree index, FTS5 rebuild with `unicode61 remove_diacritics 2`, and `metadata_json` column.
- Typed-metadata-columns + JSON-bag library (`metadata-schema.ts`, `filters.ts`) — library-level, no first adopter yet.
- FTS-missing fallback rewritten: Spotlight `mdfind` for body coverage + `%token%token%` ordered + any-order ANDed LIKE patterns.
- Centralize mail SQL helpers in `src/utils/macos/mail-sql.ts` (`escapeLike`, `LIKE_ESCAPE_CLAUSE`, `MESSAGE_SELECT`, `buildFilters`) so the SQLite ESCAPE rule can't drift between callers.
- Backfill correctness: page through distinct `source_id`s and `UPDATE WHERE source_id = ?` so multi-chunk sources don't lose N-1 chunks; shared `coerceMetadataValue` helper handles boolean/Date.
- `tools macos mail accounts` no longer shows "unknown" for receive-only accounts: derive emails from Sent-folder senders first, fall back to non-Sent type=0 recipients.
- `--format json` is pipeable (no Clack spinners on stdout) via new `isQuietOutput()` helper.

## Test plan

- [x] `bun test src/macos/lib/mail/` — sqlite-escape, search-filters, spotlight, emlx
- [x] `bun test src/indexer/lib/` — migrations, metadata-schema, store.search-attach, metadata-pushdown.e2e
- [x] `bun test src/utils/database/migrations.test.ts src/utils/cli/output-mode.test.ts`
- [x] `tsgo --noEmit` clean
- [ ] Manual: `tools macos mail search "premier" --from 2026-01-01 --to 2026-03-10 --format json --columns id,date,from,subject --limit 50` returns expected count of body matches
- [ ] Manual: `tools macos mail accounts` shows real email for every account (no "unknown")
