### PR TITLE
feat(macos): add tools macos swap — per-process swap leaderboard

### DIFF
--- a/src/macos/commands/swap/index.ts
+++ b/src/macos/commands/swap/index.ts
@@ -15,9 +15,9 @@ export function registerSwapCommand(program: Command): void {
     const swap = new Command("swap");
 
     swap.description("List processes by swap usage (with RSS and uptime)")
-        .option("-l, --limit <n>", "number of top-RSS processes to vmmap-scan", "60")
+        .option("-l, --limit <n>", "number of top-RSS processes to vmmap-scan", "30")
         .option("-t, --top <n>", "number of rows to display", "25")
-        .option("-a, --all", "scan ALL processes (slow, 1–2 min)", false)
+        .option("-a, --all", "scan ALL processes with RSS ≥ 25 MB (slow)", false)
         .option("--json", "machine-readable JSON output", false)
         .action(async (options: SwapOptions) => {
             try {
@@ -34,20 +34,21 @@ export function registerSwapCommand(program: Command): void {
 }
 
 async function main(options: SwapOptions): Promise<void> {
-    const limit = Math.max(1, Number.parseInt(options.limit, 10) || 60);
+    const limit = Math.max(1, Number.parseInt(options.limit, 10) || 30);
     const top = Math.max(1, Number.parseInt(options.top, 10) || 25);
     const all = Boolean(options.all);
 
-    if (!options.json) {
-        p.log.info(`Scanning ${all ? "all" : `top ${limit} by RSS`}…`);
-    }
-
-    const result = await scan({ limit, all });
-
     if (options.json) {
+        const result = await scan({ limit, all });
         renderJson(result);
         return;
     }
 
+    const spinner = p.spinner();
+    spinner.start(all ? "Scanning all processes (this can take a while)…" : `Scanning top ${limit} by RSS…`);
+
+    const result = await scan({ limit, all });
+
+    spinner.stop(`Scanned ${result.scannedCount} of ${result.totalProcesses} processes`);
     renderResult(result, top);
 }

--- a/src/macos/commands/swap/index.ts
+++ b/src/macos/commands/swap/index.ts
@@ -34,8 +34,10 @@ export function registerSwapCommand(program: Command): void {
 }
 
 async function main(options: SwapOptions): Promise<void> {
-    const limit = Math.max(1, Number.parseInt(options.limit, 10) || 30);
-    const top = Math.max(1, Number.parseInt(options.top, 10) || 25);
+    const parsedLimit = Number.parseInt(options.limit, 10);
+    const parsedTop = Number.parseInt(options.top, 10);
+    const limit = Number.isNaN(parsedLimit) ? 30 : Math.max(1, parsedLimit);
+    const top = Number.isNaN(parsedTop) ? 25 : Math.max(1, parsedTop);
     const all = Boolean(options.all);
 
     if (options.json) {

--- a/src/macos/commands/swap/index.ts
+++ b/src/macos/commands/swap/index.ts
@@ -1,0 +1,53 @@
+import logger from "@app/logger";
+import { renderJson, renderResult } from "@app/macos/lib/swap/display";
+import { scan } from "@app/macos/lib/swap/scanner";
+import * as p from "@clack/prompts";
+import { Command } from "commander";
+
+interface SwapOptions {
+    limit: string;
+    top: string;
+    all?: boolean;
+    json?: boolean;
+}
+
+export function registerSwapCommand(program: Command): void {
+    const swap = new Command("swap");
+
+    swap.description("List processes by swap usage (with RSS and uptime)")
+        .option("-l, --limit <n>", "number of top-RSS processes to vmmap-scan", "60")
+        .option("-t, --top <n>", "number of rows to display", "25")
+        .option("-a, --all", "scan ALL processes (slow, 1–2 min)", false)
+        .option("--json", "machine-readable JSON output", false)
+        .action(async (options: SwapOptions) => {
+            try {
+                await main(options);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                logger.error(`swap command failed: ${message}`);
+                p.log.error(message);
+                process.exit(1);
+            }
+        });
+
+    program.addCommand(swap);
+}
+
+async function main(options: SwapOptions): Promise<void> {
+    const limit = Math.max(1, Number.parseInt(options.limit, 10) || 60);
+    const top = Math.max(1, Number.parseInt(options.top, 10) || 25);
+    const all = Boolean(options.all);
+
+    if (!options.json) {
+        p.log.info(`Scanning ${all ? "all" : `top ${limit} by RSS`}…`);
+    }
+
+    const result = await scan({ limit, all });
+
+    if (options.json) {
+        renderJson(result);
+        return;
+    }
+
+    renderResult(result, top);
+}

--- a/src/macos/index.ts
+++ b/src/macos/index.ts
@@ -33,6 +33,8 @@
  *   tools macos messages search <query> [options]
  *   tools macos messages show <identifier> [options]
  *
+ *   tools macos swap [--limit n] [--top n] [--all] [--json]
+ *
  * Future subcommands:
  *   tools macos contacts search
  */
@@ -43,6 +45,7 @@ import { registerMailCommand } from "@app/macos/commands/mail/index";
 import { registerMessagesCommand } from "@app/macos/commands/messages/index";
 import { registerRemindersCommand } from "@app/macos/commands/reminders/index";
 import { registerSleepCommand } from "@app/macos/commands/sleep/index";
+import { registerSwapCommand } from "@app/macos/commands/swap/index";
 import { registerVoiceMemosCommand } from "@app/macos/commands/voice-memos/index";
 import { closeDarwinKit } from "@app/utils/macos/darwinkit";
 import { Command } from "commander";
@@ -60,6 +63,7 @@ registerMailCommand(program);
 registerMessagesCommand(program);
 registerRemindersCommand(program);
 registerSleepCommand(program);
+registerSwapCommand(program);
 registerVoiceMemosCommand(program);
 
 async function main(): Promise<void> {

--- a/src/macos/lib/swap/display.ts
+++ b/src/macos/lib/swap/display.ts
@@ -60,8 +60,13 @@ function renderSummary(result: ScanResult): void {
     console.log(
         `  ${pc.dim("System swap")} ${usedColor(formatBytes(system.usedBytes))}${pc.dim(" / ")}${pc.white(formatBytes(system.totalBytes))} ${pc.dim(`(${pct}%)`)}`
     );
+    const cacheNote =
+        result.cacheHits > 0
+            ? `${pc.dim("  ·  ")}${pc.white(String(result.freshScans))}${pc.dim(" fresh, ")}${pc.green(String(result.cacheHits))}${pc.dim(" cached")}`
+            : "";
+
     console.log(
-        `  ${pc.dim("Scanned")}     ${pc.white(String(scannedCount))}${pc.dim(" of ")}${pc.white(String(totalProcesses))}${pc.dim(" processes  ·  ")}${pc.white(String(processes.length))}${pc.dim(" with swap > 0")}`
+        `  ${pc.dim("Scanned")}     ${pc.white(String(scannedCount))}${pc.dim(" of ")}${pc.white(String(totalProcesses))}${pc.dim(" processes  ·  ")}${pc.white(String(processes.length))}${pc.dim(" with swap > 0")}${cacheNote}`
     );
     console.log();
 }

--- a/src/macos/lib/swap/display.ts
+++ b/src/macos/lib/swap/display.ts
@@ -1,0 +1,130 @@
+import { formatBytes, formatDuration } from "@app/utils/format";
+import { SafeJSON } from "@app/utils/json";
+import Table from "cli-table3";
+import pc from "picocolors";
+import type { ScanResult } from "./types";
+
+const HEADER_TEXT_MAX_WIDTH = 31;
+
+function truncate(value: string, max: number): string {
+    if (value.length <= max) {
+        return value;
+    }
+
+    return `${value.slice(0, max - 1)}…`;
+}
+
+function shortName(fullPath: string): string {
+    const last = fullPath.split("/").pop() ?? fullPath;
+    const appMatch = fullPath.match(/\/([^/]+)\.app\//);
+
+    if (appMatch && appMatch[1] !== last) {
+        return `${appMatch[1]} (${last})`;
+    }
+
+    return last;
+}
+
+function colorSwap(bytes: number): string {
+    const formatted = formatBytes(bytes);
+
+    if (bytes >= 500 * 1024 ** 2) {
+        return pc.red(pc.bold(formatted));
+    }
+
+    if (bytes >= 100 * 1024 ** 2) {
+        return pc.yellow(formatted);
+    }
+
+    return pc.green(formatted);
+}
+
+function renderHeader(): void {
+    const border = pc.cyan(pc.bold(" │"));
+    const title = "Swap Usage";
+    const subtitle = "what's hogging your swap";
+    console.log();
+    console.log(pc.cyan(pc.bold(" ┌─────────────────────────────────────┐")));
+    console.log(`${border}${pc.white(pc.bold(`  ${title.padEnd(HEADER_TEXT_MAX_WIDTH)}`))}${pc.cyan(pc.bold("│"))}`);
+    console.log(`${border}${pc.dim(`  ${subtitle.padEnd(HEADER_TEXT_MAX_WIDTH)}`)}${pc.cyan(pc.bold("│"))}`);
+    console.log(pc.cyan(pc.bold(" └─────────────────────────────────────┘")));
+    console.log();
+}
+
+function renderSummary(result: ScanResult): void {
+    const { system, scannedCount, totalProcesses, processes } = result;
+    const pctNum = system.totalBytes > 0 ? (system.usedBytes / system.totalBytes) * 100 : 0;
+    const pct = pctNum.toFixed(1);
+    const usedColor = pctNum >= 90 ? pc.red : pctNum >= 70 ? pc.yellow : pc.green;
+
+    console.log(
+        `  ${pc.dim("System swap")} ${usedColor(formatBytes(system.usedBytes))}${pc.dim(" / ")}${pc.white(formatBytes(system.totalBytes))} ${pc.dim(`(${pct}%)`)}`
+    );
+    console.log(
+        `  ${pc.dim("Scanned")}     ${pc.white(String(scannedCount))}${pc.dim(" of ")}${pc.white(String(totalProcesses))}${pc.dim(" processes  ·  ")}${pc.white(String(processes.length))}${pc.dim(" with swap > 0")}`
+    );
+    console.log();
+}
+
+function createTable(): Table.Table {
+    return new Table({
+        chars: {
+            top: "─",
+            "top-mid": "┬",
+            "top-left": "┌",
+            "top-right": "┐",
+            bottom: "─",
+            "bottom-mid": "┴",
+            "bottom-left": "└",
+            "bottom-right": "┘",
+            left: "│",
+            "left-mid": "├",
+            mid: "─",
+            "mid-mid": "┼",
+            right: "│",
+            "right-mid": "┤",
+            middle: "│",
+        },
+        head: ["PID", "PROCESS", "RSS", "SWAP", "UPTIME"].map((h) => pc.cyan(pc.bold(h))),
+        style: { head: [], border: ["gray"], "padding-left": 1, "padding-right": 1 },
+    });
+}
+
+export function renderResult(result: ScanResult, top: number): void {
+    renderHeader();
+    renderSummary(result);
+
+    if (result.processes.length === 0) {
+        console.log(pc.dim("  No processes with swap usage found among the scanned set.\n"));
+        console.log(pc.dim(`  Try ${pc.cyan("tools macos swap --all")} to scan every process (slow).\n`));
+        return;
+    }
+
+    const sorted = [...result.processes].sort((a, b) => b.swapBytes - a.swapBytes).slice(0, top);
+    const table = createTable();
+
+    for (const proc of sorted) {
+        table.push([
+            pc.dim(String(proc.pid)),
+            pc.white(truncate(shortName(proc.name), 50)),
+            pc.cyan(formatBytes(proc.rssBytes)),
+            colorSwap(proc.swapBytes),
+            pc.yellow(formatDuration(proc.uptimeMs, "ms", "hm-smart")),
+        ]);
+    }
+
+    console.log(table.toString());
+    console.log();
+
+    const totalSwap = sorted.reduce((acc, p) => acc + p.swapBytes, 0);
+    console.log(
+        `${pc.dim(`  Top-${sorted.length} swap total: `)}${pc.white(formatBytes(totalSwap))}${pc.dim("  ·  Run ")}${pc.cyan("tools macos swap --all")}${pc.dim(" to scan everything")}`
+    );
+    console.log();
+}
+
+export function renderJson(result: ScanResult): void {
+    const sorted = [...result.processes].sort((a, b) => b.swapBytes - a.swapBytes);
+    process.stdout.write(SafeJSON.stringify({ ...result, processes: sorted }, null, 2));
+    process.stdout.write("\n");
+}

--- a/src/macos/lib/swap/display.ts
+++ b/src/macos/lib/swap/display.ts
@@ -64,9 +64,13 @@ function renderSummary(result: ScanResult): void {
         result.cacheHits > 0
             ? `${pc.dim("  ·  ")}${pc.white(String(result.freshScans))}${pc.dim(" fresh, ")}${pc.green(String(result.cacheHits))}${pc.dim(" cached")}`
             : "";
+    const inaccessibleNote =
+        result.inaccessibleCount > 0
+            ? `${pc.dim("  ·  ")}${pc.yellow(String(result.inaccessibleCount))}${pc.dim(" inaccessible (root needed)")}`
+            : "";
 
     console.log(
-        `  ${pc.dim("Scanned")}     ${pc.white(String(scannedCount))}${pc.dim(" of ")}${pc.white(String(totalProcesses))}${pc.dim(" processes  ·  ")}${pc.white(String(processes.length))}${pc.dim(" with swap > 0")}${cacheNote}`
+        `  ${pc.dim("Scanned")}     ${pc.white(String(scannedCount))}${pc.dim(" of ")}${pc.white(String(totalProcesses))}${pc.dim(" processes  ·  ")}${pc.white(String(processes.length))}${pc.dim(" with swap > 0")}${cacheNote}${inaccessibleNote}`
     );
     console.log();
 }
@@ -99,9 +103,15 @@ export function renderResult(result: ScanResult, top: number): void {
     renderHeader();
     renderSummary(result);
 
+    const showAllHint = !result.wasAllMode;
+
     if (result.processes.length === 0) {
         console.log(pc.dim("  No processes with swap usage found among the scanned set.\n"));
-        console.log(pc.dim(`  Try ${pc.cyan("tools macos swap --all")} to scan every process (slow).\n`));
+
+        if (showAllHint) {
+            console.log(pc.dim(`  Try ${pc.cyan("tools macos swap --all")} to scan every process (slow).\n`));
+        }
+
         return;
     }
 
@@ -122,9 +132,10 @@ export function renderResult(result: ScanResult, top: number): void {
     console.log();
 
     const totalSwap = sorted.reduce((acc, p) => acc + p.swapBytes, 0);
-    console.log(
-        `${pc.dim(`  Top-${sorted.length} swap total: `)}${pc.white(formatBytes(totalSwap))}${pc.dim("  ·  Run ")}${pc.cyan("tools macos swap --all")}${pc.dim(" to scan everything")}`
-    );
+    const trailing = showAllHint
+        ? `${pc.dim("  ·  Run ")}${pc.cyan("tools macos swap --all")}${pc.dim(" to scan everything")}`
+        : "";
+    console.log(`${pc.dim(`  Top-${sorted.length} swap total: `)}${pc.white(formatBytes(totalSwap))}${trailing}`);
     console.log();
 }
 

--- a/src/macos/lib/swap/scanner.test.ts
+++ b/src/macos/lib/swap/scanner.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { parseSwapUsage } from "./scanner";
+
+describe("parseSwapUsage", () => {
+    it("parses standard sysctl output in MB", () => {
+        const out = "vm.swapusage: total = 19456.00M  used = 18617.75M  free = 838.25M  (encrypted)";
+        const result = parseSwapUsage(out);
+        expect(result.totalBytes).toBe(19456 * 1024 * 1024);
+        expect(result.usedBytes).toBeCloseTo(18617.75 * 1024 * 1024);
+        expect(result.freeBytes).toBeCloseTo(838.25 * 1024 * 1024);
+    });
+
+    it("returns zeros when output is empty", () => {
+        const result = parseSwapUsage("");
+        expect(result.totalBytes).toBe(0);
+        expect(result.usedBytes).toBe(0);
+        expect(result.freeBytes).toBe(0);
+    });
+});

--- a/src/macos/lib/swap/scanner.test.ts
+++ b/src/macos/lib/swap/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseEtime, parsePsOutput, parseSwapUsage } from "./scanner";
+import { parseEtime, parsePsOutput, parseSwapUsage, parseVmmapSwap } from "./scanner";
 
 describe("parseSwapUsage", () => {
     it("parses standard sysctl output in MB", () => {
@@ -59,5 +59,28 @@ describe("parsePsOutput", () => {
         const rows = parsePsOutput(out);
         expect(rows).toHaveLength(1);
         expect(rows[0].pid).toBe(123);
+    });
+});
+
+describe("parseVmmapSwap", () => {
+    it("parses GB swap with percent suffix", () => {
+        const out =
+            "Writable regions: Total=5.5G written=4.2G(76%) resident=1.9G(35%) swapped_out=2.4G(44%) unallocated=1.2G(21%)";
+        expect(parseVmmapSwap(out)).toBeCloseTo(2.4 * 1024 ** 3);
+    });
+
+    it("parses MB swap", () => {
+        const out =
+            "Writable regions: Total=900M written=500M(55%) resident=200M(22%) swapped_out=210.5M(23%) unallocated=89.5M(10%)";
+        expect(parseVmmapSwap(out)).toBeCloseTo(210.5 * 1024 ** 2);
+    });
+
+    it("parses zero swap with no unit", () => {
+        const out = "Writable regions: Total=10M written=5M resident=5M swapped_out=0 unallocated=0";
+        expect(parseVmmapSwap(out)).toBe(0);
+    });
+
+    it("returns 0 when no Writable regions line is present", () => {
+        expect(parseVmmapSwap("garbage\noutput")).toBe(0);
     });
 });

--- a/src/macos/lib/swap/scanner.test.ts
+++ b/src/macos/lib/swap/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseSwapUsage } from "./scanner";
+import { parseEtime, parsePsOutput, parseSwapUsage } from "./scanner";
 
 describe("parseSwapUsage", () => {
     it("parses standard sysctl output in MB", () => {
@@ -15,5 +15,49 @@ describe("parseSwapUsage", () => {
         expect(result.totalBytes).toBe(0);
         expect(result.usedBytes).toBe(0);
         expect(result.freeBytes).toBe(0);
+    });
+});
+
+describe("parseEtime", () => {
+    it("parses MM:SS", () => {
+        expect(parseEtime("01:30")).toBe(90 * 1000);
+    });
+
+    it("parses HH:MM:SS", () => {
+        expect(parseEtime("01:00:00")).toBe(3600 * 1000);
+    });
+
+    it("parses D-HH:MM:SS", () => {
+        expect(parseEtime("2-03:04:05")).toBe((2 * 86400 + 3 * 3600 + 4 * 60 + 5) * 1000);
+    });
+
+    it("returns 0 on garbage", () => {
+        expect(parseEtime("xyz")).toBe(0);
+    });
+});
+
+describe("parsePsOutput", () => {
+    it("parses three rows with RSS in KB and full command names", () => {
+        const out = [
+            "70285 2076800 2-04:32:01 /Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            "  411  413072 9-14:02:00 /System/Library/WindowServer",
+            "14483    640      01:05 tsgo",
+        ].join("\n");
+
+        const rows = parsePsOutput(out);
+        expect(rows).toHaveLength(3);
+        expect(rows[0].pid).toBe(70285);
+        expect(rows[0].rssBytes).toBe(2076800 * 1024);
+        expect(rows[0].name).toContain("Brave Browser");
+        expect(rows[2].pid).toBe(14483);
+        expect(rows[2].name).toBe("tsgo");
+        expect(rows[2].uptimeMs).toBe(65 * 1000);
+    });
+
+    it("skips blank lines and malformed rows", () => {
+        const out = "\n  \nfoobar\n123 456 00:01 ok\n";
+        const rows = parsePsOutput(out);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].pid).toBe(123);
     });
 });

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -1,3 +1,7 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
 import type { ProcessSwap, ScanOptions, ScanResult, SystemSwap } from "./types";
 
 const UNIT_MULT: Record<string, number> = {
@@ -107,6 +111,54 @@ export function parseVmmapSwap(output: string): number {
 const VMMAP_TIMEOUT_MS = 4000;
 const VMMAP_CONCURRENCY = 32;
 const RSS_FLOOR_BYTES = 25 * 1024 * 1024;
+const CACHE_TTL_MS = 2 * 60 * 1000;
+const START_TIME_TOLERANCE_MS = 5000;
+const CACHE_PATH = join(homedir(), ".genesis-tools", "macos-swap", "cache.json");
+
+interface CachedEntry {
+    pid: number;
+    name: string;
+    swapBytes: number;
+    startTimeMs: number;
+    cachedAt: number;
+}
+
+interface CacheFile {
+    entries: CachedEntry[];
+}
+
+async function loadCache(): Promise<Map<number, CachedEntry>> {
+    const map = new Map<number, CachedEntry>();
+
+    try {
+        const text = await Bun.file(CACHE_PATH).text();
+        const data = SafeJSON.parse(text) as CacheFile;
+        const now = Date.now();
+
+        for (const entry of data.entries ?? []) {
+            if (now - entry.cachedAt < CACHE_TTL_MS) {
+                map.set(entry.pid, entry);
+            }
+        }
+    } catch {
+        // missing or corrupt cache — treat as empty
+    }
+
+    return map;
+}
+
+async function saveCache(entries: CachedEntry[]): Promise<void> {
+    try {
+        mkdirSync(dirname(CACHE_PATH), { recursive: true });
+        await Bun.write(CACHE_PATH, SafeJSON.stringify({ entries }));
+    } catch {
+        // cache is best-effort; don't fail the scan if disk is full
+    }
+}
+
+function sameProcess(cachedStart: number, currentStart: number): boolean {
+    return Math.abs(cachedStart - currentStart) < START_TIME_TOLERANCE_MS;
+}
 
 async function spawn(cmd: string[], timeoutMs?: number): Promise<{ stdout: string; exitCode: number }> {
     const proc = Bun.spawn({ cmd, stdio: ["ignore", "pipe", "pipe"] });
@@ -163,29 +215,73 @@ async function pool<T, R>(items: T[], concurrency: number, worker: (item: T) => 
 }
 
 export async function scan(options: ScanOptions): Promise<ScanResult> {
-    const [system, psRows] = await Promise.all([getSystemSwap(), getAllPsRows()]);
+    const [system, psRows, cache] = await Promise.all([getSystemSwap(), getAllPsRows(), loadCache()]);
+    const now = Date.now();
 
     const sortedByRss = [...psRows].sort((a, b) => b.rssBytes - a.rssBytes);
     const candidates = options.all
         ? sortedByRss.filter((row) => row.rssBytes >= RSS_FLOOR_BYTES)
         : sortedByRss.slice(0, options.limit);
 
-    const swaps = await pool(candidates, VMMAP_CONCURRENCY, (row) => getProcSwap(row.pid));
+    const cacheHitEntries: ProcessSwap[] = [];
+    const toScan: PsRow[] = [];
 
-    const processes: ProcessSwap[] = candidates
-        .map((row, i) => ({
-            pid: row.pid,
-            name: row.name,
-            rssBytes: row.rssBytes,
-            swapBytes: swaps[i],
-            uptimeMs: row.uptimeMs,
-        }))
-        .filter((entry) => entry.swapBytes > 0);
+    for (const row of candidates) {
+        const cached = cache.get(row.pid);
+        const currentStart = now - row.uptimeMs;
+
+        if (cached && sameProcess(cached.startTimeMs, currentStart)) {
+            cacheHitEntries.push({
+                pid: row.pid,
+                name: row.name,
+                rssBytes: row.rssBytes,
+                swapBytes: cached.swapBytes,
+                uptimeMs: row.uptimeMs,
+            });
+        } else {
+            toScan.push(row);
+        }
+    }
+
+    const freshSwaps = await pool(toScan, VMMAP_CONCURRENCY, (row) => getProcSwap(row.pid));
+    const freshEntries: ProcessSwap[] = toScan.map((row, i) => ({
+        pid: row.pid,
+        name: row.name,
+        rssBytes: row.rssBytes,
+        swapBytes: freshSwaps[i],
+        uptimeMs: row.uptimeMs,
+    }));
+
+    const livePids = new Set(psRows.map((r) => r.pid));
+    const newCacheEntries: CachedEntry[] = toScan.map((row, i) => ({
+        pid: row.pid,
+        name: row.name,
+        swapBytes: freshSwaps[i],
+        startTimeMs: now - row.uptimeMs,
+        cachedAt: now,
+    }));
+    const rescannedPids = new Set(newCacheEntries.map((e) => e.pid));
+
+    const survivingCacheEntries: CachedEntry[] = [];
+
+    for (const entry of cache.values()) {
+        if (!livePids.has(entry.pid) || rescannedPids.has(entry.pid)) {
+            continue;
+        }
+
+        survivingCacheEntries.push(entry);
+    }
+
+    void saveCache([...newCacheEntries, ...survivingCacheEntries]);
+
+    const processes: ProcessSwap[] = [...cacheHitEntries, ...freshEntries].filter((p) => p.swapBytes > 0);
 
     return {
         system,
         processes,
         scannedCount: candidates.length,
         totalProcesses: psRows.length,
+        cacheHits: cacheHitEntries.length,
+        freshScans: toScan.length,
     };
 }

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -1,0 +1,26 @@
+import type { SystemSwap } from "./types";
+
+const UNIT_MULT: Record<string, number> = {
+    K: 1024,
+    M: 1024 ** 2,
+    G: 1024 ** 3,
+};
+
+function unitToBytes(value: number, unit: string): number {
+    return value * (UNIT_MULT[unit.toUpperCase()] ?? 1);
+}
+
+export function parseSwapUsage(output: string): SystemSwap {
+    const empty: SystemSwap = { totalBytes: 0, usedBytes: 0, freeBytes: 0 };
+    const m = output.match(/total\s*=\s*([\d.]+)([KMG])\s+used\s*=\s*([\d.]+)([KMG])\s+free\s*=\s*([\d.]+)([KMG])/);
+
+    if (!m) {
+        return empty;
+    }
+
+    return {
+        totalBytes: unitToBytes(Number.parseFloat(m[1]), m[2]),
+        usedBytes: unitToBytes(Number.parseFloat(m[3]), m[4]),
+        freeBytes: unitToBytes(Number.parseFloat(m[5]), m[6]),
+    };
+}

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -1,4 +1,4 @@
-import type { SystemSwap } from "./types";
+import type { ProcessSwap, ScanOptions, ScanResult, SystemSwap } from "./types";
 
 const UNIT_MULT: Record<string, number> = {
     K: 1024,
@@ -102,4 +102,87 @@ export function parseVmmapSwap(output: string): number {
     }
 
     return 0;
+}
+
+const VMMAP_TIMEOUT_MS = 4000;
+const VMMAP_CONCURRENCY = 8;
+
+async function spawn(cmd: string[], timeoutMs?: number): Promise<{ stdout: string; exitCode: number }> {
+    const proc = Bun.spawn({ cmd, stdio: ["ignore", "pipe", "pipe"] });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (timeoutMs !== undefined) {
+        timer = setTimeout(() => proc.kill(), timeoutMs);
+    }
+
+    try {
+        const stdout = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+        return { stdout, exitCode };
+    } finally {
+        if (timer) {
+            clearTimeout(timer);
+        }
+    }
+}
+
+async function getSystemSwap(): Promise<SystemSwap> {
+    const { stdout } = await spawn(["sysctl", "vm.swapusage"]);
+    return parseSwapUsage(stdout);
+}
+
+async function getAllPsRows(): Promise<PsRow[]> {
+    const { stdout } = await spawn(["ps", "-A", "-o", "pid=,rss=,etime=,comm="]);
+    return parsePsOutput(stdout);
+}
+
+async function getProcSwap(pid: number): Promise<number> {
+    const { stdout, exitCode } = await spawn(["vmmap", "-summary", String(pid)], VMMAP_TIMEOUT_MS);
+
+    if (exitCode !== 0) {
+        return 0;
+    }
+
+    return parseVmmapSwap(stdout);
+}
+
+async function pool<T, R>(items: T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let cursor = 0;
+
+    async function run(): Promise<void> {
+        while (cursor < items.length) {
+            const i = cursor++;
+            results[i] = await worker(items[i]);
+        }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, run));
+    return results;
+}
+
+export async function scan(options: ScanOptions): Promise<ScanResult> {
+    const [system, psRows] = await Promise.all([getSystemSwap(), getAllPsRows()]);
+
+    const sortedByRss = [...psRows].sort((a, b) => b.rssBytes - a.rssBytes);
+    const candidates = options.all ? sortedByRss : sortedByRss.slice(0, options.limit);
+
+    const swaps = await pool(candidates, VMMAP_CONCURRENCY, (row) => getProcSwap(row.pid));
+
+    const processes: ProcessSwap[] = candidates
+        .map((row, i) => ({
+            pid: row.pid,
+            name: row.name,
+            rssBytes: row.rssBytes,
+            swapBytes: swaps[i],
+            uptimeMs: row.uptimeMs,
+        }))
+        .filter((entry) => entry.swapBytes > 0);
+
+    return {
+        system,
+        processes,
+        scannedCount: candidates.length,
+        totalProcesses: psRows.length,
+    };
 }

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -24,3 +24,62 @@ export function parseSwapUsage(output: string): SystemSwap {
         freeBytes: unitToBytes(Number.parseFloat(m[5]), m[6]),
     };
 }
+
+export function parseEtime(etime: string): number {
+    const trimmed = etime.trim();
+    const match = trimmed.match(/^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
+
+    if (!match) {
+        return 0;
+    }
+
+    const days = match[1] ? Number.parseInt(match[1], 10) : 0;
+    const hours = match[2] ? Number.parseInt(match[2], 10) : 0;
+    const minutes = Number.parseInt(match[3], 10);
+    const seconds = Number.parseInt(match[4], 10);
+    return (days * 86400 + hours * 3600 + minutes * 60 + seconds) * 1000;
+}
+
+export interface PsRow {
+    pid: number;
+    rssBytes: number;
+    uptimeMs: number;
+    name: string;
+}
+
+export function parsePsOutput(output: string): PsRow[] {
+    const rows: PsRow[] = [];
+
+    for (const raw of output.split("\n")) {
+        const line = raw.trim();
+
+        if (line === "") {
+            continue;
+        }
+
+        const parts = line.split(/\s+/);
+
+        if (parts.length < 4) {
+            continue;
+        }
+
+        const pid = Number.parseInt(parts[0], 10);
+        const rssKb = Number.parseInt(parts[1], 10);
+
+        if (Number.isNaN(pid) || Number.isNaN(rssKb)) {
+            continue;
+        }
+
+        const etime = parts[2];
+        const name = parts.slice(3).join(" ");
+
+        rows.push({
+            pid,
+            rssBytes: rssKb * 1024,
+            uptimeMs: parseEtime(etime),
+            name,
+        });
+    }
+
+    return rows;
+}

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -83,3 +83,23 @@ export function parsePsOutput(output: string): PsRow[] {
 
     return rows;
 }
+
+export function parseVmmapSwap(output: string): number {
+    for (const line of output.split("\n")) {
+        if (!line.startsWith("Writable regions:")) {
+            continue;
+        }
+
+        const m = line.match(/swapped_out=([\d.]+)\s*([KMG])?/);
+
+        if (!m) {
+            return 0;
+        }
+
+        const value = Number.parseFloat(m[1]);
+        const unit = m[2] ?? "";
+        return value * (UNIT_MULT[unit.toUpperCase()] ?? 1);
+    }
+
+    return 0;
+}

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -105,7 +105,8 @@ export function parseVmmapSwap(output: string): number {
 }
 
 const VMMAP_TIMEOUT_MS = 4000;
-const VMMAP_CONCURRENCY = 8;
+const VMMAP_CONCURRENCY = 32;
+const RSS_FLOOR_BYTES = 25 * 1024 * 1024;
 
 async function spawn(cmd: string[], timeoutMs?: number): Promise<{ stdout: string; exitCode: number }> {
     const proc = Bun.spawn({ cmd, stdio: ["ignore", "pipe", "pipe"] });
@@ -165,7 +166,9 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
     const [system, psRows] = await Promise.all([getSystemSwap(), getAllPsRows()]);
 
     const sortedByRss = [...psRows].sort((a, b) => b.rssBytes - a.rssBytes);
-    const candidates = options.all ? sortedByRss : sortedByRss.slice(0, options.limit);
+    const candidates = options.all
+        ? sortedByRss.filter((row) => row.rssBytes >= RSS_FLOOR_BYTES)
+        : sortedByRss.slice(0, options.limit);
 
     const swaps = await pool(candidates, VMMAP_CONCURRENCY, (row) => getProcSwap(row.pid));
 

--- a/src/macos/lib/swap/scanner.ts
+++ b/src/macos/lib/swap/scanner.ts
@@ -161,7 +161,7 @@ function sameProcess(cachedStart: number, currentStart: number): boolean {
 }
 
 async function spawn(cmd: string[], timeoutMs?: number): Promise<{ stdout: string; exitCode: number }> {
-    const proc = Bun.spawn({ cmd, stdio: ["ignore", "pipe", "pipe"] });
+    const proc = Bun.spawn({ cmd, stdio: ["ignore", "pipe", "ignore"] });
     let timer: ReturnType<typeof setTimeout> | undefined;
 
     if (timeoutMs !== undefined) {
@@ -180,23 +180,38 @@ async function spawn(cmd: string[], timeoutMs?: number): Promise<{ stdout: strin
 }
 
 async function getSystemSwap(): Promise<SystemSwap> {
-    const { stdout } = await spawn(["sysctl", "vm.swapusage"]);
+    const { stdout, exitCode } = await spawn(["sysctl", "vm.swapusage"]);
+
+    if (exitCode !== 0) {
+        throw new Error(`sysctl vm.swapusage failed with exit code ${exitCode}`);
+    }
+
     return parseSwapUsage(stdout);
 }
 
 async function getAllPsRows(): Promise<PsRow[]> {
-    const { stdout } = await spawn(["ps", "-A", "-o", "pid=,rss=,etime=,comm="]);
+    const { stdout, exitCode } = await spawn(["ps", "-A", "-o", "pid=,rss=,etime=,comm="]);
+
+    if (exitCode !== 0) {
+        throw new Error(`ps -A failed with exit code ${exitCode}`);
+    }
+
     return parsePsOutput(stdout);
 }
 
-async function getProcSwap(pid: number): Promise<number> {
+interface ProbeResult {
+    swapBytes: number;
+    accessible: boolean;
+}
+
+async function getProcSwap(pid: number): Promise<ProbeResult> {
     const { stdout, exitCode } = await spawn(["vmmap", "-summary", String(pid)], VMMAP_TIMEOUT_MS);
 
     if (exitCode !== 0) {
-        return 0;
+        return { swapBytes: 0, accessible: false };
     }
 
-    return parseVmmapSwap(stdout);
+    return { swapBytes: parseVmmapSwap(stdout), accessible: true };
 }
 
 async function pool<T, R>(items: T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
@@ -243,24 +258,28 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
         }
     }
 
-    const freshSwaps = await pool(toScan, VMMAP_CONCURRENCY, (row) => getProcSwap(row.pid));
+    const freshProbes = await pool(toScan, VMMAP_CONCURRENCY, (row) => getProcSwap(row.pid));
     const freshEntries: ProcessSwap[] = toScan.map((row, i) => ({
         pid: row.pid,
         name: row.name,
         rssBytes: row.rssBytes,
-        swapBytes: freshSwaps[i],
+        swapBytes: freshProbes[i].swapBytes,
         uptimeMs: row.uptimeMs,
     }));
+    const inaccessibleCount = freshProbes.filter((probe) => !probe.accessible).length;
 
     const livePids = new Set(psRows.map((r) => r.pid));
-    const newCacheEntries: CachedEntry[] = toScan.map((row, i) => ({
-        pid: row.pid,
-        name: row.name,
-        swapBytes: freshSwaps[i],
-        startTimeMs: now - row.uptimeMs,
-        cachedAt: now,
-    }));
-    const rescannedPids = new Set(newCacheEntries.map((e) => e.pid));
+    const newCacheEntries: CachedEntry[] = toScan
+        .map((row, i) => ({ row, probe: freshProbes[i] }))
+        .filter(({ probe }) => probe.accessible)
+        .map(({ row, probe }) => ({
+            pid: row.pid,
+            name: row.name,
+            swapBytes: probe.swapBytes,
+            startTimeMs: now - row.uptimeMs,
+            cachedAt: now,
+        }));
+    const rescannedPids = new Set(toScan.map((row) => row.pid));
 
     const survivingCacheEntries: CachedEntry[] = [];
 
@@ -283,5 +302,7 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
         totalProcesses: psRows.length,
         cacheHits: cacheHitEntries.length,
         freshScans: toScan.length,
+        inaccessibleCount,
+        wasAllMode: options.all,
     };
 }

--- a/src/macos/lib/swap/types.ts
+++ b/src/macos/lib/swap/types.ts
@@ -22,4 +22,6 @@ export interface ScanResult {
     processes: ProcessSwap[];
     scannedCount: number;
     totalProcesses: number;
+    cacheHits: number;
+    freshScans: number;
 }

--- a/src/macos/lib/swap/types.ts
+++ b/src/macos/lib/swap/types.ts
@@ -1,0 +1,25 @@
+export interface ProcessSwap {
+    pid: number;
+    name: string;
+    rssBytes: number;
+    swapBytes: number;
+    uptimeMs: number;
+}
+
+export interface SystemSwap {
+    totalBytes: number;
+    usedBytes: number;
+    freeBytes: number;
+}
+
+export interface ScanOptions {
+    limit: number;
+    all: boolean;
+}
+
+export interface ScanResult {
+    system: SystemSwap;
+    processes: ProcessSwap[];
+    scannedCount: number;
+    totalProcesses: number;
+}

--- a/src/macos/lib/swap/types.ts
+++ b/src/macos/lib/swap/types.ts
@@ -24,4 +24,6 @@ export interface ScanResult {
     totalProcesses: number;
     cacheHits: number;
     freshScans: number;
+    inaccessibleCount: number;
+    wasAllMode: boolean;
 }


### PR DESCRIPTION
## Summary

Adds `tools macos swap` — a per-process swap leaderboard for macOS, modeled on `tools port`'s output style. Useful when the system feels sluggish and you want to know which apps drifted the most pages onto disk over a long uptime.

- Three-layer split mirroring `src/port/`: `commands/swap/` (commander) → `lib/swap/scanner.ts` (ps + vmmap + sysctl) → `lib/swap/display.ts` (cli-table3 + picocolors)
- Fast scan path: one `ps` call, take top-N by RSS, then `vmmap -summary` only on those (full-system vmmap takes minutes)
- Color-coded SWAP column (green < 100 MB, yellow 100–500 MB, red ≥ 500 MB), `--all`, `--top`, `--limit`, `--json` flags

## Output

```
 ┌─────────────────────────────────────┐
 │  Swap Usage                         │
 │  what's hogging your swap           │
 └─────────────────────────────────────┘

  System swap 17.7 GB / 19.0 GB (93.0%)
  Scanned     30 of 1467 processes  ·  21 with swap > 0

  PID    PROCESS                          RSS       SWAP      UPTIME
  70285  Brave Browser                    3.6 GB    1.1 GB    34h 37m
  66716  com.apple.WebKit.WebContent      1.8 GB    844.5 MB  201h
  ...
```

## Files

- New: `src/macos/lib/swap/{types,scanner,scanner.test,display}.ts`
- New: `src/macos/commands/swap/index.ts`
- Modified: `src/macos/index.ts` (registration + JSDoc usage line)

## Test plan

- [x] `bun test src/macos/lib/swap/` — 12 tests pass (parsers for sysctl, ps + etime, vmmap)
- [x] `tsgo --noEmit` clean across new files
- [x] `tools macos swap` — boxed header + table renders correctly on live system
- [x] `tools macos swap --json | jq` — valid JSON
- [x] `tools macos swap --help` — help text reads cleanly
- [ ] `tools macos swap --all` — slow path on a fresh boot

## Plan

Detailed implementation plan in `.claude/plans/2026-04-30-MacosSwap.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new macOS "swap" command to analyze process swap usage with --limit, --top, --all and --json options.
  * Shows a progress spinner and scanned/total counts; displays a colored summary and a sorted table (PID, process name, RSS, SWAP, uptime) with totals and conditional follow-up hints.
  * Pretty-printed JSON output available via --json.

* **Tests**
  * Added tests for swap parsing and uptime/process parsing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->