### PR TITLE
feat: mail correctness/coverage + say cost cache

### DIFF
--- a/src/ask/output/UsageDatabase.ts
+++ b/src/ask/output/UsageDatabase.ts
@@ -157,7 +157,8 @@ export class UsageDatabase {
                 sql<number>`AVG(cost)`.as("avg_cost_per_message"),
             ])
             .where(sql<string>`date(timestamp)`, ">=", sinceDays(days))
-            .groupBy(["provider", "model"])
+            .groupBy("provider")
+            .groupBy("model")
             .orderBy("total_cost", "desc")
             .execute();
 
@@ -263,7 +264,12 @@ export class UsageDatabase {
             query = query.where(sql<string>`date(timestamp)`, ">=", sinceDays(days));
         }
 
-        const rows = await query.groupBy(["provider", "model"]).orderBy("total_cost", "desc").limit(limit).execute();
+        const rows = await query
+            .groupBy("provider")
+            .groupBy("model")
+            .orderBy("total_cost", "desc")
+            .limit(limit)
+            .execute();
 
         return rows.map((row) => ({
             provider: row.provider,

--- a/src/indexer/lib/events.ts
+++ b/src/indexer/lib/events.ts
@@ -13,6 +13,8 @@ export interface SyncStats {
     embeddingsGenerated: number;
     durationMs: number;
     cancelled?: boolean;
+    /** Chunks pruned by source.pruneStale() (e.g. mail's deleted/changed-row cleanup). */
+    chunksPruned?: number;
 }
 
 // ─── Event map: single source of truth ──────────────────────────

--- a/src/indexer/lib/indexer.ts
+++ b/src/indexer/lib/indexer.ts
@@ -14,7 +14,7 @@ import type { ModelInfo } from "./model-registry";
 import { formatModelTable, getMaxEmbedChars, getModelsForType, getTaskPrefix } from "./model-registry";
 import { FileSource } from "./sources/file-source";
 import type { IndexerSource, SourceEntry } from "./sources/source";
-import { getIndexerStorage } from "./storage";
+import { getIndexerStorage, sanitizeName } from "./storage";
 import type { IndexStore } from "./store";
 import { createIndexStore } from "./store";
 import type { ChunkRecord, IndexConfig, IndexStats } from "./types";
@@ -948,6 +948,23 @@ export class Indexer extends IndexerEventEmitter {
                 }
             }
 
+            // ── Phase 4: SOURCE-DRIVEN PRUNE ─────────────────────────
+            // Let the source delete chunks whose backing row has changed
+            // under us — for mail, that's hard-deleted ROWIDs, soft-deleted
+            // messages, and rare server-side date_sent corrections. Sources
+            // with stable identity (file paths, etc.) skip this entirely.
+            const tableName = sanitizeName(this.config.name);
+            let chunksPruned = 0;
+
+            if (typeof this.source.pruneStale === "function" && !this.cancellationRequested) {
+                try {
+                    chunksPruned = await this.source.pruneStale(this.store.getDb(), tableName);
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    logger.warn(`[sync] source.pruneStale failed: ${msg}`);
+                }
+            }
+
             // ── FINALIZE ─────────────────────────────────────────────
             const durationMs = performance.now() - syncStart;
             const totalFiles = pathHashStore.getFileCount();
@@ -964,6 +981,7 @@ export class Indexer extends IndexerEventEmitter {
                 embeddingsGenerated,
                 durationMs,
                 cancelled: wasCancelled || undefined,
+                chunksPruned,
             };
 
             const embeddingModelId = this.config.embedding?.model ?? "darwinkit";
@@ -979,6 +997,21 @@ export class Indexer extends IndexerEventEmitter {
             const finalStats = this.store.getStats();
             const embeddedCount = finalStats.totalChunks - this.store.getUnembeddedCount();
 
+            // Source-driven date-range coverage (mail uses dateSent in metadata_json).
+            let dateRangeMin: number | null = null;
+            let dateRangeMax: number | null = null;
+
+            if (typeof this.source.getDateRange === "function") {
+                try {
+                    const range = this.source.getDateRange(this.store.getDb(), tableName);
+                    dateRangeMin = range.minTs;
+                    dateRangeMax = range.maxTs;
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    logger.warn(`[sync] source.getDateRange failed: ${msg}`);
+                }
+            }
+
             this.store.updateMeta({
                 lastSyncAt: Date.now(),
                 stats: {
@@ -990,6 +1023,8 @@ export class Indexer extends IndexerEventEmitter {
                     lastSyncDurationMs: durationMs,
                     searchCount: finalStats.searchCount,
                     avgSearchDurationMs: finalStats.avgSearchDurationMs,
+                    dateRangeMin,
+                    dateRangeMax,
                 },
                 indexEmbedding: embeddingModelInfo,
                 indexingStatus: wasCancelled ? "cancelled" : "completed",

--- a/src/indexer/lib/sources/mail-source.ts
+++ b/src/indexer/lib/sources/mail-source.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { ENVELOPE_INDEX_PATH, normalizeMailboxName, parseMailboxUrl } from "@app/macos/lib/mail/constants";
 import { EmlxBodyExtractor } from "@app/macos/lib/mail/emlx";
+import { MailDatabase, pruneStaleMailChunks } from "@app/utils/macos/MailDatabase";
 import { ensureExtensionCapableSQLite } from "@app/utils/search/stores/sqlite-vec-loader";
 import {
     type DetectChangesOptions,
@@ -186,6 +187,14 @@ export class MailSource implements IndexerSource {
 
     hashEntry(entry: SourceEntry): string {
         return defaultHashEntry(entry);
+    }
+
+    async pruneStale(indexDb: Database, tableName: string): Promise<number> {
+        return pruneStaleMailChunks(indexDb, this.db, tableName);
+    }
+
+    getDateRange(indexDb: Database, tableName: string): { minTs: number | null; maxTs: number | null } {
+        return MailDatabase.getMailChunkDateRange(indexDb, tableName);
     }
 
     dispose(): void {

--- a/src/indexer/lib/sources/source.ts
+++ b/src/indexer/lib/sources/source.ts
@@ -118,4 +118,25 @@ export interface IndexerSource {
      * Each yielded batch may be smaller than batchSize (final batch).
      */
     populateMetadata?(opts: MetadataPopulateOpts): AsyncGenerator<MetadataResult[]>;
+
+    /**
+     * Prune chunks whose backing source row no longer matches indexed state
+     * (e.g. Mail.app messages that were deleted or whose `date_sent` was
+     * server-corrected since indexing). Called on every sync. Returns the
+     * number of chunks deleted. Sources where stable IDs guarantee freshness
+     * should leave this unimplemented.
+     */
+    pruneStale?(indexDb: import("bun:sqlite").Database, tableName: string): Promise<number>;
+
+    /**
+     * Compute MIN/MAX timestamps (unix seconds) covered by chunks of the given
+     * indexer table. Used by the indexer to record date-range coverage so
+     * search commands can warn when `--from`/`--to` falls outside what's
+     * indexed. Sources without a date dimension should leave this
+     * unimplemented (the indexer will record `null`).
+     */
+    getDateRange?(
+        indexDb: import("bun:sqlite").Database,
+        tableName: string
+    ): { minTs: number | null; maxTs: number | null };
 }

--- a/src/indexer/lib/storage.ts
+++ b/src/indexer/lib/storage.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite";
 import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { countActiveEmbeddings } from "@app/utils/database/embedding-stats";
 import { Storage } from "@app/utils/storage/storage";
 import type { IndexStats } from "./types";
 
@@ -34,7 +35,6 @@ export function getDbSizeBytes(dbPath: string): number {
 export function readLiveStats(db: Database, indexName: string, dbPath: string): Partial<IndexStats> {
     const tableName = sanitizeName(indexName);
     const contentTable = `${tableName}_content`;
-    const embTable = `${tableName}_embeddings`;
 
     const result: Partial<IndexStats> = {};
 
@@ -48,16 +48,7 @@ export function readLiveStats(db: Database, indexName: string, dbPath: string): 
         // expected — table created lazily during first sync
     }
 
-    try {
-        const row = db.query(`SELECT COUNT(*) AS cnt FROM ${embTable}`).get() as { cnt: number } | null;
-
-        if (row) {
-            result.totalEmbeddings = row.cnt;
-        }
-    } catch {
-        // expected — table created lazily during first sync
-    }
-
+    result.totalEmbeddings = countActiveEmbeddings(db, tableName);
     result.dbSizeBytes = getDbSizeBytes(dbPath);
     return result;
 }

--- a/src/indexer/lib/store.ts
+++ b/src/indexer/lib/store.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import logger from "@app/logger";
 import { Embedder } from "@app/utils/ai/tasks/Embedder";
+import { countActiveEmbeddings } from "@app/utils/database/embedding-stats";
 import { getPendingMigrations, runMigrations } from "@app/utils/database/migrations";
 import { acquireLock, type LockHandle } from "@app/utils/fs/lock";
 import { SafeJSON } from "@app/utils/json";
@@ -71,6 +72,13 @@ export interface IndexStore {
     /** Load the persisted code graph, or null if not present */
     loadCodeGraph(): { graphJson: string; builtAt: number } | null;
     logSearch(entry: { query: string; mode: string; resultsCount: number; durationMs: number }): void;
+    /**
+     * Read-write access to the underlying SQLite database. Intended for
+     * source-driven maintenance hooks (e.g. `MailSource.pruneStale`) that need
+     * to run cross-database joins/deletes. Most callers should use the
+     * higher-level methods on this interface instead.
+     */
+    getDb(): import("bun:sqlite").Database;
     close(): Promise<void>;
 }
 
@@ -922,15 +930,7 @@ export async function createIndexStore(config: IndexConfig, embedder?: Embedder)
                 const countRow = db.query(`SELECT COUNT(*) AS cnt FROM ${contentTable}`).get() as { cnt: number };
                 const chunkCount = countRow.cnt;
 
-                // Live embedding count from actual table
-                let embeddingCount = 0;
-
-                if (embTableExists) {
-                    const embRow = db.query(`SELECT COUNT(*) AS cnt FROM ${activeEmbTable}`).get() as {
-                        cnt: number;
-                    };
-                    embeddingCount = embRow.cnt;
-                }
+                const embeddingCount = countActiveEmbeddings(db, tableName);
 
                 const dbSizeBytes = getDbSizeBytes(dbPath);
 
@@ -1073,6 +1073,10 @@ export async function createIndexStore(config: IndexConfig, embedder?: Embedder)
                     "INSERT INTO search_log (query, mode, results_count, duration_ms, searched_at) VALUES (?, ?, ?, ?, ?)",
                     [entry.query, entry.mode, entry.resultsCount, entry.durationMs, new Date().toISOString()]
                 );
+            },
+
+            getDb(): Database {
+                return db;
             },
 
             async close(): Promise<void> {

--- a/src/indexer/lib/types.ts
+++ b/src/indexer/lib/types.ts
@@ -102,6 +102,8 @@ export function emptyStats(): IndexStats {
         lastSyncDurationMs: 0,
         searchCount: 0,
         avgSearchDurationMs: 0,
+        dateRangeMin: null,
+        dateRangeMax: null,
     };
 }
 
@@ -129,6 +131,9 @@ export interface IndexStats {
     lastSyncDurationMs: number;
     searchCount: number;
     avgSearchDurationMs: number;
+    /** Min/max chunk timestamp (unix seconds) for date-aware sources. Absent or null for non-temporal indexes. */
+    dateRangeMin?: number | null;
+    dateRangeMax?: number | null;
 }
 
 export interface ChunkRecord {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,9 @@
 import { homedir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { SafeJSON } from "@app/utils/json";
 import chalk from "chalk";
 import pino from "pino";
 import PinoPretty from "pino-pretty";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 // Parse command line args for log level (simple check without minimist)
 const args = {

--- a/src/macos/commands/mail/download.ts
+++ b/src/macos/commands/mail/download.ts
@@ -168,7 +168,12 @@ export function registerDownloadCommand(program: Command): void {
                                 const safeAttName = basename(att.name).replace(/[^\w.-]/g, "_");
                                 const attPath = join(outputDir, "attachments", safeAttName);
                                 if (!existsSync(attPath)) {
-                                    await saveAttachment(msg.subject, msg.senderAddress, att.name, attPath);
+                                    await saveAttachment(
+                                        msg.subject,
+                                        msg.senderAddress ?? "unknown-sender",
+                                        att.name,
+                                        attPath
+                                    );
                                 } else {
                                     // Disambiguate with rowid to avoid silently dropping duplicates
                                     const dotIdx = safeAttName.lastIndexOf(".");
@@ -177,7 +182,12 @@ export function registerDownloadCommand(program: Command): void {
                                     const disambiguated = `${base}_${msg.rowid}${ext}`;
                                     const altPath = join(outputDir, "attachments", disambiguated);
                                     logger.debug(`Attachment collision: ${safeAttName} → saving as ${disambiguated}`);
-                                    await saveAttachment(msg.subject, msg.senderAddress, att.name, altPath);
+                                    await saveAttachment(
+                                        msg.subject,
+                                        msg.senderAddress ?? "unknown-sender",
+                                        att.name,
+                                        altPath
+                                    );
                                 }
                             }
                         }

--- a/src/macos/commands/mail/index-cmd.ts
+++ b/src/macos/commands/mail/index-cmd.ts
@@ -482,6 +482,14 @@ async function incrementalSync(manager: IndexerManager, dateRange: DateRange = {
             const ago = formatDuration(Date.now() - meta.lastSyncAt);
             p.log.info(`  ${pc.dim("Last sync:")} ${ago} ago`);
         }
+
+        const { dateRangeMin, dateRangeMax } = meta.stats;
+
+        if (dateRangeMin && dateRangeMax) {
+            const fromIso = new Date(dateRangeMin * 1000).toISOString().slice(0, 10);
+            const toIso = new Date(dateRangeMax * 1000).toISOString().slice(0, 10);
+            p.log.info(`  ${pc.dim("Range:")} ${fromIso} → ${toIso}`);
+        }
     }
 
     if (dateRange.fromDate || dateRange.toDate) {
@@ -516,16 +524,18 @@ async function incrementalSync(manager: IndexerManager, dateRange: DateRange = {
 
         spinner.stop("Sync complete");
 
-        const totalChanges = stats.chunksAdded + stats.chunksUpdated + stats.chunksRemoved;
+        const chunksPruned = stats.chunksPruned ?? 0;
+        const totalChanges = stats.chunksAdded + stats.chunksUpdated + stats.chunksRemoved + chunksPruned;
 
         if (totalChanges === 0) {
             p.log.info("Index is up to date — no changes detected");
         } else {
+            const stalePart = chunksPruned > 0 ? `, ${pc.red(`-${chunksPruned.toLocaleString()} stale`)}` : "";
             p.log.success(
                 `${stats.filesScanned.toLocaleString()} emails scanned, ` +
                     `${pc.green(`+${stats.chunksAdded.toLocaleString()}`)} chunks added, ` +
                     `${pc.yellow(`~${stats.chunksUpdated.toLocaleString()}`)} updated, ` +
-                    `${pc.red(`-${stats.chunksRemoved.toLocaleString()}`)} removed ` +
+                    `${pc.red(`-${stats.chunksRemoved.toLocaleString()}`)} removed${stalePart} ` +
                     `in ${formatDuration(stats.durationMs)}`
             );
         }

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { getIndexerStorage } from "@app/indexer/lib/storage";
@@ -26,6 +27,7 @@ import { mdfindMailRowids } from "@app/macos/lib/mail/spotlight";
 import { rowToMessage } from "@app/macos/lib/mail/transform";
 import type { MailMessage, MailMessageRow, SearchOptions } from "@app/macos/lib/mail/types";
 import { isQuietOutput } from "@app/utils/cli/output-mode";
+import { SafeJSON } from "@app/utils/json";
 import { closeDarwinKit, rankBySimilarity } from "@app/utils/macos";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
@@ -48,6 +50,66 @@ function resolveMailSearchMode(input: string | undefined): MailSearchMode {
     }
 
     throw new Error(`Unknown --mode: "${input}". Valid: ${[...VALID_MAIL_SEARCH_MODES].join(", ")}`);
+}
+
+/**
+ * Emit a stderr advisory when the user's `--from` / `--to` window falls (even
+ * partially) outside the date span actually covered by the index. Best-effort:
+ * a missing or unreadable meta row silently skips the check — search is the
+ * primary action, not coverage validation.
+ *
+ * stderr-only so `--format json` / `toon` stay machine-readable.
+ */
+function warnIfDateRangeOutsideCoverage(args: { indexDbPath: string; from?: Date; to?: Date }): void {
+    const { indexDbPath, from, to } = args;
+
+    try {
+        const metaDb = new Database(indexDbPath, { readonly: true });
+
+        try {
+            const row = metaDb.query("SELECT value FROM index_meta WHERE key = 'meta'").get() as {
+                value: string;
+            } | null;
+
+            if (!row) {
+                return;
+            }
+
+            const meta = SafeJSON.parse(row.value) as {
+                stats?: { dateRangeMin?: number | null; dateRangeMax?: number | null };
+            };
+            const min = meta.stats?.dateRangeMin ?? null;
+            const max = meta.stats?.dateRangeMax ?? null;
+
+            if (min === null || max === null) {
+                return;
+            }
+
+            // Compare on day-floor to avoid spurious warnings when the user's
+            // `--to` is end-of-day but the indexed max is a message timestamp
+            // earlier in that same day.
+            const isoDay = (ts: number): string => new Date(ts).toISOString().slice(0, 10);
+            const minDay = isoDay(min * 1000);
+            const maxDay = isoDay(max * 1000);
+            const fromDay = from ? isoDay(from.getTime()) : undefined;
+            const toDay = to ? isoDay(to.getTime()) : undefined;
+            const outsideLower = fromDay !== undefined && fromDay < minDay;
+            const outsideUpper = toDay !== undefined && toDay > maxDay;
+
+            if (!outsideLower && !outsideUpper) {
+                return;
+            }
+
+            process.stderr.write(
+                `⚠  Requested range partially outside indexed coverage (${minDay} → ${maxDay}). ` +
+                    `Run "tools macos mail index" to refresh.\n`
+            );
+        } finally {
+            metaDb.close();
+        }
+    } catch (err) {
+        logger.debug(`[mail/search] coverage check skipped: ${err}`);
+    }
 }
 
 interface SearchCommandOptions {
@@ -170,7 +232,7 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
-                const searchOpts: SearchOptions = {
+                const searchOpts: SearchOptions = db.resolveMailboxFilter({
                     query,
                     withoutBody: options.withoutBody,
                     receiver: options.receiver,
@@ -180,7 +242,7 @@ export function registerSearchCommand(program: Command): void {
                     mailbox: options.mailbox,
                     limit: Number.parseInt(options.limit ?? "100", 10),
                     offset: Number.parseInt(options.offset ?? "0", 10),
-                };
+                });
 
                 const resolvedMode = resolveMailSearchMode(options.mode);
                 const filterPredicate = buildMailFilterPredicate(searchOpts);
@@ -188,13 +250,25 @@ export function registerSearchCommand(program: Command): void {
                 const indexerStorage = getIndexerStorage();
                 const indexDbPath = join(indexerStorage.getIndexDir(MAIL_INDEX_NAME), "index.db");
                 const indexExists = existsSync(indexDbPath);
+                const willUseIndex = indexExists && !options.jxa && !searchOpts.withoutBody;
+
+                // Only warn about indexed coverage when the search will actually
+                // read the index. --jxa and --without-body bypass it, so the
+                // "run mail index to refresh" advice would be misleading.
+                if (willUseIndex && (searchOpts.from || searchOpts.to)) {
+                    warnIfDateRangeOutsideCoverage({
+                        indexDbPath,
+                        from: searchOpts.from,
+                        to: searchOpts.to,
+                    });
+                }
 
                 let rows: MailMessageRow[] = [];
                 const snippetByRowid = new Map<number, string>();
                 let searchMethod: "fts" | "spotlight+like" = "spotlight+like";
                 let resolvedMethod: ResolvedMethod | undefined;
 
-                if (indexExists && !options.jxa && !searchOpts.withoutBody) {
+                if (willUseIndex) {
                     spinner.start(formatSearchLabelStart(resolvedMode));
                     const t0 = performance.now();
 
@@ -239,7 +313,7 @@ export function registerSearchCommand(program: Command): void {
                     }
 
                     resolvedMethod = ftsResults[0]?.method;
-                    rows = ftsRowids.length > 0 ? await db.getMessagesByRowids(ftsRowids) : [];
+                    rows = ftsRowids.length > 0 ? await db.getMessagesByRowids(ftsRowids, searchOpts) : [];
                     searchMethod = "fts";
 
                     const orderByRowid = new Map(ftsRowids.map((rowid, index) => [rowid, index]));
@@ -267,15 +341,7 @@ export function registerSearchCommand(program: Command): void {
                     const newSpotlightIds = spotlightRowids.filter((r) => !rowidSet.has(r));
 
                     const spotlightRows =
-                        newSpotlightIds.length > 0
-                            ? await db.getMessagesByRowids(newSpotlightIds, {
-                                  from: searchOpts.from,
-                                  to: searchOpts.to,
-                                  mailbox: searchOpts.mailbox,
-                                  receiver: searchOpts.receiver,
-                                  account: searchOpts.account,
-                              })
-                            : [];
+                        newSpotlightIds.length > 0 ? await db.getMessagesByRowids(newSpotlightIds, searchOpts) : [];
 
                     rows = [...likeRows, ...spotlightRows];
                     const fallbackOrder = new Map(rows.map((row, index) => [row.rowid, index]));

--- a/src/macos/commands/mail/show.ts
+++ b/src/macos/commands/mail/show.ts
@@ -121,7 +121,7 @@ export function registerShowCommand(program: Command): void {
                 console.log();
                 console.log(bold(msg.subject));
                 console.log(dim("─".repeat(Math.min(msg.subject.length, 80))));
-                console.log(`From:     ${msg.senderName} <${msg.senderAddress}>`);
+                console.log(`From:     ${msg.senderName ?? ""} <${msg.senderAddress ?? "(no sender)"}>`);
 
                 const toRecipients = msg.recipients?.filter((r) => r.type === "to") ?? [];
 

--- a/src/macos/lib/mail/columns.ts
+++ b/src/macos/lib/mail/columns.ts
@@ -43,11 +43,13 @@ export const MAIL_COLUMNS = {
     },
     from: {
         label: "From",
-        get: (m: MailMessage) => m.senderName || m.senderAddress,
+        // Drafts (and a handful of corruption cases) have no sender at all —
+        // show a placeholder rather than the literal string "null".
+        get: (m: MailMessage) => m.senderName || m.senderAddress || "(no sender)",
     },
     fromEmail: {
         label: "From Email",
-        get: (m: MailMessage) => m.senderAddress,
+        get: (m: MailMessage) => m.senderAddress ?? "—",
     },
     to: {
         label: "To",

--- a/src/macos/lib/mail/format.ts
+++ b/src/macos/lib/mail/format.ts
@@ -18,7 +18,8 @@ function formatSender(msg: MailMessage): string {
     if (msg.senderName && msg.senderName !== msg.senderAddress) {
         return msg.senderName;
     }
-    return msg.senderAddress;
+
+    return msg.senderAddress ?? "(no sender)";
 }
 
 /**
@@ -33,7 +34,7 @@ export function generateEmailMarkdown(msg: MailMessage): string {
     lines.push("");
     lines.push("| Field | Value |");
     lines.push("|-------|-------|");
-    lines.push(`| From | ${msg.senderName} <${msg.senderAddress}> |`);
+    lines.push(`| From | ${msg.senderName ?? ""} <${msg.senderAddress ?? "(no sender)"}> |`);
 
     if (msg.recipients && msg.recipients.length > 0) {
         const toRecipients = msg.recipients

--- a/src/macos/lib/mail/search-filters.test.ts
+++ b/src/macos/lib/mail/search-filters.test.ts
@@ -111,4 +111,81 @@ describe("buildMailFilterPredicate", () => {
         const withMailbox = buildMailFilterPredicate({ mailbox: "INBOX" });
         expect(withMailbox!.sql).toContain("mailapp.mailboxes");
     });
+
+    it("uses m.mailbox IN(...) when mailboxRowids supplied (Czech / unicode path)", () => {
+        const r = buildMailFilterPredicate({ mailboxRowids: [3, 7, 12] });
+        expect(r).not.toBeNull();
+        expect(r!.sql).toContain("m.mailbox IN (3,7,12)");
+        // No mb.url LIKE join needed when rowids are pre-resolved
+        expect(r!.sql).not.toContain("mb.url LIKE");
+        expect(r!.sql).not.toContain("mailapp.mailboxes");
+        expect(r!.params.length).toBe(0);
+    });
+
+    it("emits 1 = 0 when mailboxRowids is empty (no matches)", () => {
+        const r = buildMailFilterPredicate({ mailboxRowids: [] });
+        expect(r).not.toBeNull();
+        expect(r!.sql).toContain("1 = 0");
+    });
+});
+
+import { resolveMailboxRowids } from "@app/utils/macos/mail-sql";
+
+describe("resolveMailboxRowids", () => {
+    function freshDb(): Database {
+        const db = new Database(":memory:");
+        db.run("CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY, url TEXT)");
+        // Real-world Mail.app stores URL-encoded UTF-8 in mailboxes.url.
+        db.run(
+            "INSERT INTO mailboxes (ROWID, url) VALUES " +
+                "(1, 'imap://user@host/INBOX')," +
+                "(2, 'imap://user@host/Doru%C4%8Den%C3%A1%20po%C5%A1ta')," + // Doručená pošta
+                "(3, 'imap://user@host/Sent%20Messages')," +
+                "(4, 'imap://user@host/Archive')"
+        );
+        return db;
+    }
+
+    it("returns undefined when neither mailbox nor account is set", () => {
+        const db = freshDb();
+        expect(resolveMailboxRowids(db)).toBeUndefined();
+    });
+
+    it("matches URL-encoded Czech name case-insensitively (Doručená pošta, NFC composed)", () => {
+        const db = freshDb();
+        expect(resolveMailboxRowids(db, "Doručená pošta")).toEqual([2]);
+        expect(resolveMailboxRowids(db, "DORUČENÁ POŠTA")).toEqual([2]);
+    });
+
+    it("matches NFD-encoded Czech name (Mail.app stores combining diacritics)", () => {
+        // Real Mail.app DBs store NFD: `Doruc%CC%8Cena%CC%81 pos%CC%8Cta` decodes to
+        // `Doruc + U+030C + ena + U+0301 + pos + U+030C + ta`. User input is NFC
+        // composed (`č`, `á`, `š`). Both forms must match the same mailbox.
+        const db = new Database(":memory:");
+        db.run("CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY, url TEXT)");
+        db.run(
+            "INSERT INTO mailboxes (ROWID, url) VALUES " +
+                "(1, 'ews://abc/Doruc%CC%8Cena%CC%81%20pos%CC%8Cta')," + // NFD
+                "(2, 'imap://x/INBOX')"
+        );
+        // User types NFC; row stores NFD. With normalization both should match ROWID 1.
+        expect(resolveMailboxRowids(db, "Doručená pošta")).toEqual([1]);
+    });
+
+    it("matches plain ASCII names (no regression)", () => {
+        const db = freshDb();
+        expect(resolveMailboxRowids(db, "INBOX")).toEqual([1]);
+        expect(resolveMailboxRowids(db, "inbox")).toEqual([1]);
+    });
+
+    it("returns empty array when nothing matches", () => {
+        const db = freshDb();
+        expect(resolveMailboxRowids(db, "no-such-mailbox-anywhere")).toEqual([]);
+    });
+
+    it("intersects mailbox + account substring constraints", () => {
+        const db = freshDb();
+        // mailbox "Sent" within account substring "user@host" → only ROWID 3
+        expect(resolveMailboxRowids(db, "Sent", "user@host")).toEqual([3]);
+    });
 });

--- a/src/macos/lib/mail/search-filters.ts
+++ b/src/macos/lib/mail/search-filters.ts
@@ -6,6 +6,12 @@ export interface MailFilterOpts {
     mailbox?: string;
     receiver?: string;
     account?: string;
+    /**
+     * Pre-resolved `mailboxes.ROWID` set for `mailbox`/`account` substring
+     * filters. The FTS path consumes these instead of LIKE so non-ASCII names
+     * (e.g. Czech "Doručená pošta") match correctly.
+     */
+    mailboxRowids?: number[];
 }
 
 /**
@@ -32,21 +38,29 @@ export function buildMailFilterPredicate(opts: MailFilterOpts): { sql: string; p
         params.push(Math.floor(opts.to.getTime() / 1000));
     }
 
-    if (opts.mailbox) {
-        joins.push("JOIN mailapp.mailboxes mb ON mb.ROWID = m.mailbox");
-        joinedMb = true;
-        conds.push(`mb.url LIKE ? ${LIKE_ESCAPE_CLAUSE}`);
-        params.push(`%${escapeLike(opts.mailbox)}%`);
-    }
-
-    if (opts.account) {
-        if (!joinedMb) {
+    if (opts.mailboxRowids !== undefined) {
+        if (opts.mailboxRowids.length === 0) {
+            conds.push("1 = 0");
+        } else {
+            conds.push(`m.mailbox IN (${opts.mailboxRowids.join(",")})`);
+        }
+    } else {
+        if (opts.mailbox) {
             joins.push("JOIN mailapp.mailboxes mb ON mb.ROWID = m.mailbox");
             joinedMb = true;
+            conds.push(`mb.url LIKE ? ${LIKE_ESCAPE_CLAUSE}`);
+            params.push(`%${escapeLike(opts.mailbox)}%`);
         }
 
-        conds.push(`mb.url LIKE ? ${LIKE_ESCAPE_CLAUSE}`);
-        params.push(`%${escapeLike(opts.account)}%`);
+        if (opts.account) {
+            if (!joinedMb) {
+                joins.push("JOIN mailapp.mailboxes mb ON mb.ROWID = m.mailbox");
+                joinedMb = true;
+            }
+
+            conds.push(`mb.url LIKE ? ${LIKE_ESCAPE_CLAUSE}`);
+            params.push(`%${escapeLike(opts.account)}%`);
+        }
     }
 
     if (opts.receiver) {
@@ -58,7 +72,11 @@ export function buildMailFilterPredicate(opts: MailFilterOpts): { sql: string; p
         params.push(`%${escapeLike(opts.receiver)}%`);
     }
 
-    if (params.length === 0) {
+    // `conds` always carries `m.deleted = 0`; a real filter is anything beyond
+    // that. Use conds.length > 1 instead of params.length to detect zero-filter
+    // calls, since a `mailboxRowids` constraint inlines its rowids into the SQL
+    // string rather than producing bind params.
+    if (conds.length === 1) {
         return null;
     }
 

--- a/src/macos/lib/mail/types.ts
+++ b/src/macos/lib/mail/types.ts
@@ -2,8 +2,9 @@
 export interface MailMessageRow {
     rowid: number;
     subject: string;
-    senderAddress: string;
-    senderName: string;
+    /** Null for messages with no sender FK — overwhelmingly drafts. LEFT JOIN keeps these. */
+    senderAddress: string | null;
+    senderName: string | null;
     dateSent: number;
     dateReceived: number;
     mailboxUrl: string;
@@ -17,8 +18,9 @@ export interface MailMessageRow {
 export interface MailMessage {
     rowid: number;
     subject: string;
-    senderAddress: string;
-    senderName: string;
+    /** Null for messages with no sender FK — overwhelmingly drafts. */
+    senderAddress: string | null;
+    senderName: string | null;
     dateSent: Date;
     dateReceived: Date;
     mailbox: string;
@@ -67,6 +69,8 @@ export interface SearchOptions {
     from?: Date;
     to?: Date;
     mailbox?: string;
+    /** Pre-resolved mailbox ROWID set; populated by `MailDatabase.resolveMailboxFilter`. */
+    mailboxRowids?: number[];
     limit?: number;
     offset?: number;
 }

--- a/src/port/lib/scanner.ts
+++ b/src/port/lib/scanner.ts
@@ -654,11 +654,7 @@ function getWindowsProcessData(pidFilter?: number[]): Map<number, WindowsProcess
         wmicArgs.push("where", `(${where})`);
     }
 
-    wmicArgs.push(
-        "get",
-        "ProcessId,Name,CommandLine,WorkingDirectory,CreationDate,WorkingSetSize",
-        "/FORMAT:LIST"
-    );
+    wmicArgs.push("get", "ProcessId,Name,CommandLine,WorkingDirectory,CreationDate,WorkingSetSize", "/FORMAT:LIST");
 
     const wmicResult = run("wmic", wmicArgs, { timeoutMs: WINDOWS_WMIC_TIMEOUT_MS });
 

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -2,10 +2,12 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import logger from "@app/logger";
 import { AI } from "@app/utils/ai/index.ts";
 import { getModelsForTask } from "@app/utils/ai/ModelManager";
 import { getProvidersForTask } from "@app/utils/ai/providers";
 import type { AIProviderType } from "@app/utils/ai/types.ts";
+import { playBuffer } from "@app/utils/audio/playback";
 import { isInteractive, suggestCommand } from "@app/utils/cli/executor";
 import { parseVariadic } from "@app/utils/cli/variadic";
 import {
@@ -22,7 +24,9 @@ import { formatTable } from "@app/utils/table.ts";
 import * as p from "@clack/prompts";
 import { Command } from "commander";
 import pc from "picocolors";
+import { SayAudioCache } from "./lib/cache";
 import { speakWithProfile } from "./lib/speak";
+import { getSayStorage } from "./lib/storage";
 
 interface SayOptions {
     volume?: number;
@@ -130,7 +134,34 @@ const program = new Command()
         }
 
         const effective = await resolveEffective({ mgr, opts, unsetList });
-        const provider: SayProvider = effective.provider ?? "macos";
+        const effectiveForRun: EffectiveSettings = { ...effective };
+        let provider: SayProvider = effective.provider ?? "macos";
+
+        // Per-text provider override: route phrases like "Permission needed"
+        // to a different provider (typically local macos) regardless of the
+        // resolved profile. First substring match wins, case-insensitive.
+        const overrides = await mgr.listTextOverrides();
+        const lowerText = text.toLowerCase();
+        const matchedOverride = overrides.find((o) => lowerText.includes(o.match.toLowerCase()));
+
+        if (matchedOverride && matchedOverride.provider !== provider) {
+            logger.debug(
+                `[say] text override matched "${matchedOverride.match}" → provider ${provider} → ${matchedOverride.provider}`
+            );
+            provider = matchedOverride.provider;
+
+            // Voice and model are provider-specific. A profile like
+            // {provider: macos, voice: Samantha} routed to xai/openai would
+            // try to synthesize "Samantha" on a cloud voice list — drop those
+            // unless the user passed them explicitly on the CLI.
+            if (!isFromCLI(cmd, "voice")) {
+                effectiveForRun.voice = null;
+            }
+
+            if (!isFromCLI(cmd, "model")) {
+                effectiveForRun.model = null;
+            }
+        }
 
         if (provider !== "macos" && !envForProvider(provider)) {
             console.error(pc.red(`[say] env var for ${provider} is not set.`));
@@ -141,17 +172,7 @@ const program = new Command()
         const stream = opts.stream === true ? true : opts.noStream === true ? false : undefined;
 
         try {
-            await AI.speak(text, {
-                provider,
-                voice: effective.voice ?? undefined,
-                language: effective.language ?? undefined,
-                format: effective.format ?? undefined,
-                rate: effective.rate ?? undefined,
-                volume: effective.volume ?? undefined,
-                stream,
-                wait: opts.wait,
-                model: effective.model ?? undefined,
-            });
+            await speakCached({ mgr, text, provider, effective: effectiveForRun, opts, stream });
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             console.error(pc.red(`[say] TTS failed: ${message}`));
@@ -275,6 +296,105 @@ function envForProvider(provider: SayProvider): boolean {
     }
 
     return true;
+}
+
+interface SpeakCachedArgs {
+    mgr: SayConfigManager;
+    text: string;
+    provider: SayProvider;
+    effective: EffectiveSettings;
+    opts: SayOptions;
+    stream?: boolean;
+}
+
+/**
+ * Speak `text` with caching for repeated cloud-TTS phrases. Local macOS
+ * provider always uses the standard `AI.speak` path (no cache, free). For
+ * cloud providers, hash the request — on a hit, play the cached audio
+ * directly; on a miss, synthesize, play, and record the miss so the Nth
+ * occurrence persists.
+ */
+async function speakCached(args: SpeakCachedArgs): Promise<void> {
+    const { mgr, text, provider, effective, opts, stream } = args;
+
+    // Bypass the cache when:
+    //   - provider is macos (local & free)
+    //   - the user explicitly asked for streaming — caching needs the whole
+    //     buffer up front, which would silently negate `--stream` for cloud
+    //     providers. Honor the flag instead.
+    if (provider === "macos" || stream === true) {
+        await AI.speak(text, {
+            provider,
+            voice: effective.voice ?? undefined,
+            language: effective.language ?? undefined,
+            format: effective.format ?? undefined,
+            rate: effective.rate ?? undefined,
+            volume: effective.volume ?? undefined,
+            stream,
+            wait: opts.wait,
+            model: effective.model ?? undefined,
+        });
+        return;
+    }
+
+    const { threshold, maxBytes } = await mgr.getCacheSettings();
+    const cache = new SayAudioCache({ dir: getSayStorage().getCacheDir(), threshold, maxBytes });
+    const params = {
+        text,
+        provider,
+        voice: effective.voice,
+        model: effective.model,
+        rate: effective.rate,
+        language: effective.language,
+        format: effective.format,
+    };
+
+    // Cache I/O is best-effort — if reading the index fails (e.g. corrupted
+    // JSON, disk error mid-stale-cleanup) we'd rather synthesize fresh than
+    // abort speech.
+    let hit: ReturnType<typeof cache.get> = null;
+
+    try {
+        hit = cache.get(params);
+    } catch (err) {
+        logger.warn(`[say/cache] get() failed, treating as miss: ${err}`);
+    }
+
+    if (hit) {
+        logger.debug(`[say] cache hit (${provider}, ${hit.audio.byteLength}B)`);
+        await playBuffer(hit.audio, hit.contentType, {
+            volume: effective.volume ?? undefined,
+            wait: opts.wait,
+        });
+        return;
+    }
+
+    // Miss: synthesize fresh, play the buffer, record the miss (with audio so
+    // it persists once the threshold is crossed). We use synthesize+playBuffer
+    // instead of AI.speak so we always have the buffer in hand for caching,
+    // regardless of length-based stream/buffer routing in the synthesizer.
+    const result = await AI.synthesize(text, {
+        provider,
+        voice: effective.voice ?? undefined,
+        language: effective.language ?? undefined,
+        format: effective.format ?? undefined,
+        rate: effective.rate ?? undefined,
+        model: effective.model ?? undefined,
+    });
+
+    // recordMiss writes to disk synchronously — wrap so a cache-write failure
+    // (ENOSPC, permission, etc.) doesn't drop the audio the user just paid
+    // an API call to synthesize.
+    try {
+        cache.recordMiss(params, result.audio, result.contentType);
+    } catch (err) {
+        logger.warn(`[say/cache] recordMiss() failed, audio not cached: ${err}`);
+    }
+
+    await playBuffer(result.audio, result.contentType, {
+        volume: effective.volume ?? undefined,
+        wait: opts.wait,
+    });
 }
 
 function isVoiceNotFoundError(message: string): boolean {
@@ -474,14 +594,21 @@ async function configCommand(mgr: SayConfigManager): Promise<void> {
         const apps = await mgr.listApps();
         const globalMute = await mgr.getGlobalMute();
 
+        const overrideCount = (await mgr.listTextOverrides()).length;
+
         const action = await p.select({
-            message: `What next? ${pc.dim(`(${apps.length} app${apps.length === 1 ? "" : "s"}, global mute: ${globalMute ? "ON" : "off"})`)}`,
+            message: `What next? ${pc.dim(`(${apps.length} app${apps.length === 1 ? "" : "s"}, ${overrideCount} override${overrideCount === 1 ? "" : "s"}, global mute: ${globalMute ? "ON" : "off"})`)}`,
             options: [
                 { value: "speak", label: "Speak text (test)", hint: "speak with a chosen profile" },
                 { value: "edit", label: "Edit an app profile", hint: "or create a new one" },
                 { value: "list", label: "List apps with resolved settings" },
                 { value: "delete", label: "Delete an app profile" },
                 { value: "voices", label: "List available voices" },
+                {
+                    value: "overrides",
+                    label: `Manage text overrides (${overrideCount})`,
+                    hint: "route phrases to a specific provider",
+                },
                 { value: "global-mute", label: `Toggle global mute (currently ${globalMute ? "ON" : "off"})` },
                 { value: "exit", label: "Exit" },
             ],
@@ -508,11 +635,87 @@ async function configCommand(mgr: SayConfigManager): Promise<void> {
             case "voices":
                 await printVoiceList();
                 break;
+            case "overrides":
+                await manageTextOverridesTUI(mgr);
+                break;
             case "global-mute":
                 await mgr.setGlobalMute(!globalMute);
                 p.log.success(`Global mute: ${!globalMute ? "ON" : "off"}`);
                 break;
         }
+    }
+}
+
+async function manageTextOverridesTUI(mgr: SayConfigManager): Promise<void> {
+    const overrides = await mgr.listTextOverrides();
+
+    if (overrides.length > 0) {
+        p.log.info("Current overrides:");
+
+        for (const [i, o] of overrides.entries()) {
+            console.log(`  ${pc.dim(`${i + 1}.`)} "${o.match}" → ${pc.cyan(o.provider)}`);
+        }
+    } else {
+        p.log.info("No text overrides configured.");
+    }
+
+    const action = await p.select({
+        message: "What next?",
+        options: [
+            { value: "add", label: "+ Add override" },
+            ...(overrides.length > 0 ? [{ value: "remove", label: "− Remove override" }] : []),
+            { value: "back", label: "← Back" },
+        ],
+    });
+
+    if (p.isCancel(action) || action === "back") {
+        return;
+    }
+
+    if (action === "add") {
+        const match = await p.text({
+            message: "Substring to match (case-insensitive)",
+            placeholder: "Permission needed",
+            validate: (v) => (v == null || v.trim().length === 0 ? "Cannot be empty" : undefined),
+        });
+
+        if (p.isCancel(match)) {
+            return;
+        }
+
+        const provider = await p.select<SayProvider>({
+            message: "Route to which provider?",
+            options: [
+                { value: "macos", label: "macos (local, free)" },
+                { value: "xai", label: "xai (cloud, requires X_AI_API_KEY)" },
+                { value: "openai", label: "openai (cloud, requires OPENAI_API_KEY)" },
+            ],
+        });
+
+        if (p.isCancel(provider)) {
+            return;
+        }
+
+        await mgr.addTextOverride({ match: match.trim(), provider });
+        p.log.success(`Added: "${match.trim()}" → ${provider}`);
+        return;
+    }
+
+    if (action === "remove") {
+        const idx = await p.select<number>({
+            message: "Which override to remove?",
+            options: overrides.map((o, i) => ({
+                value: i,
+                label: `"${o.match}" → ${o.provider}`,
+            })),
+        });
+
+        if (p.isCancel(idx)) {
+            return;
+        }
+
+        await mgr.removeTextOverride(idx);
+        p.log.success("Removed.");
     }
 }
 

--- a/src/say/lib/cache.test.ts
+++ b/src/say/lib/cache.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { SayAudioCache, type SayCacheParams } from "./cache";
+
+let dir: string;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "say-cache-"));
+});
+
+const baseParams: SayCacheParams = {
+    text: "hello",
+    provider: "xai",
+    voice: "v1",
+    model: "tts-1",
+    rate: 1,
+    language: "en",
+    format: "mp3",
+};
+
+describe("SayAudioCache", () => {
+    it("returns null for cold cache", () => {
+        const c = new SayAudioCache({ dir, threshold: 3 });
+        expect(c.get(baseParams)).toBeNull();
+    });
+
+    it("does not persist audio until threshold is crossed", () => {
+        const c = new SayAudioCache({ dir, threshold: 3 });
+        c.recordMiss(baseParams, Buffer.from([1, 2]), "audio/mpeg");
+        expect(c.get(baseParams)).toBeNull();
+        c.recordMiss(baseParams, Buffer.from([1, 2]), "audio/mpeg");
+        expect(c.get(baseParams)).toBeNull();
+        // Third miss with audio crosses threshold and persists.
+        c.recordMiss(baseParams, Buffer.from([1, 2, 3]), "audio/mpeg");
+        const hit = c.get(baseParams);
+        expect(hit).not.toBeNull();
+        expect(Buffer.compare(hit!.audio, Buffer.from([1, 2, 3]))).toBe(0);
+        expect(hit!.contentType).toBe("audio/mpeg");
+    });
+
+    it("skips caching when provider is macos", () => {
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        c.recordMiss({ ...baseParams, provider: "macos" }, Buffer.from([9]), "audio/mpeg");
+        expect(c.get({ ...baseParams, provider: "macos" })).toBeNull();
+    });
+
+    it("treats different texts as separate entries", () => {
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        c.recordMiss({ ...baseParams, text: "a" }, Buffer.from([1]), "audio/mpeg");
+        c.recordMiss({ ...baseParams, text: "b" }, Buffer.from([2]), "audio/mpeg");
+        const a = c.get({ ...baseParams, text: "a" });
+        const b = c.get({ ...baseParams, text: "b" });
+        expect(a?.audio[0]).toBe(1);
+        expect(b?.audio[0]).toBe(2);
+    });
+
+    it("treats different voices as separate entries even with the same text", () => {
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        c.recordMiss({ ...baseParams, voice: "v1" }, Buffer.from([1]), "audio/mpeg");
+        // Same text, different voice — should not hit the v1 cache.
+        expect(c.get({ ...baseParams, voice: "v2" })).toBeNull();
+    });
+
+    it("evicts oldest persisted entry when over the size cap", () => {
+        const c = new SayAudioCache({ dir, threshold: 1, maxBytes: 10 });
+        c.recordMiss({ ...baseParams, text: "a" }, Buffer.alloc(8, 1), "audio/mpeg");
+        // Bump lastUsed on b after a, so a is the oldest by access time.
+        c.recordMiss({ ...baseParams, text: "b" }, Buffer.alloc(8, 2), "audio/mpeg");
+        // Total persisted = 16 > 10 → evict a (the older one).
+        expect(c.get({ ...baseParams, text: "a" })).toBeNull();
+        expect(c.get({ ...baseParams, text: "b" })).not.toBeNull();
+    });
+
+    it("recovers from a deleted audio file: the next miss can re-persist", () => {
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        c.recordMiss(baseParams, Buffer.from([1, 2]), "audio/mpeg");
+        const firstHit = c.get(baseParams);
+        expect(firstHit).not.toBeNull();
+
+        // Simulate a manual deletion / eviction race: the audio file vanishes
+        // but the index still references it.
+        const canon = SafeJSON.stringify({
+            t: baseParams.text,
+            p: baseParams.provider,
+            v: baseParams.voice ?? "",
+            m: baseParams.model ?? "",
+            r: baseParams.rate ?? 1,
+            l: baseParams.language ?? "",
+            f: baseParams.format ?? "",
+        });
+        const hash = createHash("sha256").update(canon).digest("hex").slice(0, 32);
+        unlinkSync(join(dir, `${hash}.mp3`));
+
+        // get() observes the missing file and clears the stale metadata.
+        expect(c.get(baseParams)).toBeNull();
+
+        // recordMiss with new audio should now persist (threshold=1) instead of skipping.
+        c.recordMiss(baseParams, Buffer.from([9, 9, 9]), "audio/mpeg");
+        const recovered = c.get(baseParams);
+        expect(recovered).not.toBeNull();
+        expect(Buffer.compare(recovered!.audio, Buffer.from([9, 9, 9]))).toBe(0);
+    });
+
+    it("stores the literal source text alongside each entry for inspection", () => {
+        const c = new SayAudioCache({ dir, threshold: 5 });
+        c.recordMiss({ ...baseParams, text: "hello world" });
+        c.recordMiss({ ...baseParams, text: "hello world" });
+
+        const raw = SafeJSON.parse(readFileSync(join(dir, "index.json"), "utf8")) as {
+            entries: Record<string, { text?: string; count: number }>;
+        };
+        const entries = Object.values(raw.entries);
+        expect(entries.length).toBe(1);
+        expect(entries[0].text).toBe("hello world");
+        expect(entries[0].count).toBe(2);
+    });
+});

--- a/src/say/lib/cache.test.ts
+++ b/src/say/lib/cache.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, unlinkSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
@@ -117,5 +117,43 @@ describe("SayAudioCache", () => {
         expect(entries.length).toBe(1);
         expect(entries[0].text).toBe("hello world");
         expect(entries[0].count).toBe(2);
+    });
+
+    it("falls back to an empty index when index.json has the wrong shape", () => {
+        // Valid JSON, but neither a version-1 IndexShape nor garbage that would
+        // fail SafeJSON.parse. Without shape validation, the next access to
+        // `idx.entries[key]` would throw on undefined.
+        writeFileSync(join(dir, "index.json"), "{}");
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        expect(() => c.recordMiss(baseParams, Buffer.from([1]), "audio/mpeg")).not.toThrow();
+        // After the recovery write, the file is now well-formed.
+        const raw = SafeJSON.parse(readFileSync(join(dir, "index.json"), "utf8")) as {
+            version: number;
+            entries: Record<string, unknown>;
+        };
+        expect(raw.version).toBe(1);
+        expect(Object.keys(raw.entries).length).toBe(1);
+    });
+
+    it("falls back when index.json is an array (wrong type)", () => {
+        writeFileSync(join(dir, "index.json"), "[]");
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        expect(() => c.recordMiss(baseParams, Buffer.from([1]), "audio/mpeg")).not.toThrow();
+    });
+
+    it("writes index.json atomically and leaves no temp files behind", () => {
+        const c = new SayAudioCache({ dir, threshold: 1 });
+        c.recordMiss(baseParams, Buffer.from([1, 2]), "audio/mpeg");
+
+        const stragglers = readdirSync(dir).filter((f) => f.endsWith(".tmp"));
+        expect(stragglers).toEqual([]);
+
+        // index.json itself is intact and parseable.
+        const parsed = SafeJSON.parse(readFileSync(join(dir, "index.json"), "utf8")) as {
+            version: number;
+            entries: Record<string, unknown>;
+        };
+        expect(parsed.version).toBe(1);
+        expect(Object.keys(parsed.entries).length).toBe(1);
     });
 });

--- a/src/say/lib/cache.ts
+++ b/src/say/lib/cache.ts
@@ -1,5 +1,5 @@
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import logger from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
@@ -21,10 +21,10 @@ export interface SayCacheHit {
 
 interface IndexEntry {
     /**
-     * Literal text that produced this cache key. The key is a salted hash
-     * (so it stays stable + private), but humans inspecting `index.json`
-     * can't reverse it — record the source text alongside so `tools say
-     * cache` listings stay useful. Optional for backward compatibility
+     * Literal text that produced this cache key. The key itself is a
+     * truncated SHA-256 of the request tuple — deterministic but not
+     * human-readable, so we store the source text alongside it for
+     * `tools say cache` listings. Optional for backward compatibility
      * with entries written before this field existed.
      */
     text?: string;
@@ -111,14 +111,51 @@ export class SayAudioCache {
         }
 
         try {
-            return SafeJSON.parse(readFileSync(this.indexPath, "utf8")) as IndexShape;
+            const raw: unknown = SafeJSON.parse(readFileSync(this.indexPath, "utf8"));
+
+            if (
+                raw !== null &&
+                typeof raw === "object" &&
+                (raw as { version?: unknown }).version === 1 &&
+                typeof (raw as { entries?: unknown }).entries === "object" &&
+                (raw as { entries?: unknown }).entries !== null &&
+                !Array.isArray((raw as { entries?: unknown }).entries)
+            ) {
+                return raw as IndexShape;
+            }
+
+            logger.debug(`[say/cache] ${this.indexPath} has unexpected shape; resetting to empty index`);
+            return { version: 1, entries: {} };
         } catch {
             return { version: 1, entries: {} };
         }
     }
 
+    /**
+     * Atomic write: serialize to a unique temp file in the same directory,
+     * then `rename` into place. Guarantees a reader never sees a partial JSON
+     * payload after a crash. Note: this is NOT a lock — concurrent `tools say`
+     * processes can still last-writer-win on counters. That's acceptable for a
+     * best-effort cache: a lost increment just delays threshold convergence by
+     * one invocation, never corrupts state.
+     */
     private writeIndex(idx: IndexShape): void {
-        writeFileSync(this.indexPath, SafeJSON.stringify(idx, null, 2));
+        const tmpPath = `${this.indexPath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+
+        try {
+            writeFileSync(tmpPath, SafeJSON.stringify(idx, null, 2));
+            renameSync(tmpPath, this.indexPath);
+        } catch (err) {
+            try {
+                if (existsSync(tmpPath)) {
+                    unlinkSync(tmpPath);
+                }
+            } catch {
+                // best-effort cleanup
+            }
+
+            logger.debug(`[say/cache] index write failed (${this.indexPath}): ${err}`);
+        }
     }
 
     private skip(p: SayCacheParams): boolean {

--- a/src/say/lib/cache.ts
+++ b/src/say/lib/cache.ts
@@ -1,0 +1,247 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import logger from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+
+export interface SayCacheParams {
+    text: string;
+    provider: string;
+    voice?: string | null;
+    model?: string | null;
+    rate?: number | null;
+    language?: string | null;
+    format?: string | null;
+}
+
+export interface SayCacheHit {
+    audio: Buffer;
+    contentType: string;
+}
+
+interface IndexEntry {
+    /**
+     * Literal text that produced this cache key. The key is a salted hash
+     * (so it stays stable + private), but humans inspecting `index.json`
+     * can't reverse it — record the source text alongside so `tools say
+     * cache` listings stay useful. Optional for backward compatibility
+     * with entries written before this field existed.
+     */
+    text?: string;
+    count: number;
+    audioPath?: string;
+    contentType?: string;
+    lastUsed: number;
+    sizeBytes: number;
+}
+
+interface IndexShape {
+    version: 1;
+    entries: Record<string, IndexEntry>;
+}
+
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/aiff": "aiff",
+    "audio/x-aiff": "aiff",
+    "audio/ogg": "ogg",
+    "audio/opus": "opus",
+    "audio/flac": "flac",
+};
+
+export interface SayAudioCacheOptions {
+    /** Directory to store the index + audio files (e.g. ~/.genesis-tools/say/cache). */
+    dir: string;
+    /**
+     * Number of identical-request misses to record before persisting audio.
+     * The Nth call still synthesizes fresh; the (N+1)th hits disk. Default 5.
+     */
+    threshold?: number;
+    /**
+     * Total disk budget in bytes. When exceeded, oldest-by-`lastUsed` entries
+     * are evicted. Default 50 MB.
+     */
+    maxBytes?: number;
+}
+
+/**
+ * Hash-keyed disk cache for repeated cloud-TTS phrases. The same text/voice/
+ * model/etc. tuple after `threshold` synthesizer calls gets persisted once and
+ * served from disk forever after — saves cloud API spend on chronically
+ * repeated phrases like "<task> done" notifications.
+ *
+ * Skipped entirely for `provider === "macos"`: that path is already free.
+ */
+export class SayAudioCache {
+    private readonly dir: string;
+    private readonly threshold: number;
+    private readonly maxBytes: number;
+    private readonly indexPath: string;
+
+    constructor(opts: SayAudioCacheOptions) {
+        this.dir = opts.dir;
+        this.threshold = opts.threshold ?? 5;
+        this.maxBytes = opts.maxBytes ?? 50_000_000;
+        this.indexPath = join(this.dir, "index.json");
+
+        if (!existsSync(this.dir)) {
+            mkdirSync(this.dir, { recursive: true });
+        }
+    }
+
+    private hash(p: SayCacheParams): string {
+        const canon = SafeJSON.stringify({
+            t: p.text,
+            p: p.provider,
+            v: p.voice ?? "",
+            m: p.model ?? "",
+            r: p.rate ?? 1,
+            l: p.language ?? "",
+            f: p.format ?? "",
+        });
+        return createHash("sha256").update(canon).digest("hex").slice(0, 32);
+    }
+
+    private readIndex(): IndexShape {
+        if (!existsSync(this.indexPath)) {
+            return { version: 1, entries: {} };
+        }
+
+        try {
+            return SafeJSON.parse(readFileSync(this.indexPath, "utf8")) as IndexShape;
+        } catch {
+            return { version: 1, entries: {} };
+        }
+    }
+
+    private writeIndex(idx: IndexShape): void {
+        writeFileSync(this.indexPath, SafeJSON.stringify(idx, null, 2));
+    }
+
+    private skip(p: SayCacheParams): boolean {
+        return p.provider === "macos";
+    }
+
+    /** Returns hit data if cached audio is available, else `null`. */
+    get(p: SayCacheParams): SayCacheHit | null {
+        if (this.skip(p)) {
+            return null;
+        }
+
+        const idx = this.readIndex();
+        const key = this.hash(p);
+        const entry = idx.entries[key];
+
+        if (!entry) {
+            return null;
+        }
+
+        // If the audio file went missing (manual delete, eviction race,
+        // disk wipe), clear the stale metadata so the next miss can persist
+        // a replacement instead of skipping forever.
+        if (entry.audioPath && !existsSync(entry.audioPath)) {
+            entry.audioPath = undefined;
+            entry.contentType = undefined;
+            entry.sizeBytes = 0;
+            this.writeIndex(idx);
+            return null;
+        }
+
+        if (entry.count < this.threshold || !entry.audioPath) {
+            return null;
+        }
+
+        // existsSync above doesn't guard against another `tools say` process
+        // evicting/unlinking the file between the check and the read. Treat
+        // any read failure as a miss (with cleanup) instead of a hard error.
+        let audio: Buffer;
+
+        try {
+            audio = readFileSync(entry.audioPath);
+        } catch (err) {
+            logger.debug(`[say/cache] read failed (${entry.audioPath}): ${err}; treating as miss`);
+            entry.audioPath = undefined;
+            entry.contentType = undefined;
+            entry.sizeBytes = 0;
+            this.writeIndex(idx);
+            return null;
+        }
+
+        entry.lastUsed = Date.now();
+        this.writeIndex(idx);
+        return { audio, contentType: entry.contentType ?? "audio/mpeg" };
+    }
+
+    /**
+     * Record a cache miss. Increments the counter; when the threshold is
+     * crossed AND audio bytes are supplied, persists them so the next call
+     * hits. Pass `audio`/`contentType` only when you actually have the
+     * synthesized buffer (cloud providers).
+     */
+    recordMiss(p: SayCacheParams, audio?: Buffer, contentType?: string): void {
+        if (this.skip(p)) {
+            return;
+        }
+
+        const idx = this.readIndex();
+        const key = this.hash(p);
+        const existing: IndexEntry = idx.entries[key] ?? { count: 0, lastUsed: Date.now(), sizeBytes: 0 };
+        existing.count += 1;
+        existing.lastUsed = Date.now();
+        existing.text = p.text;
+
+        // If a previously-persisted audio file vanished under us, drop the
+        // stale path so the persist-branch below can write a replacement.
+        if (existing.audioPath && !existsSync(existing.audioPath)) {
+            existing.audioPath = undefined;
+            existing.contentType = undefined;
+            existing.sizeBytes = 0;
+        }
+
+        if (existing.count >= this.threshold && !existing.audioPath && audio && contentType) {
+            const ext = CONTENT_TYPE_TO_EXT[contentType] ?? "bin";
+            const audioPath = join(this.dir, `${key}.${ext}`);
+            writeFileSync(audioPath, audio);
+            existing.audioPath = audioPath;
+            existing.contentType = contentType;
+            existing.sizeBytes = audio.byteLength;
+        }
+
+        idx.entries[key] = existing;
+        this.evictIfOverCap(idx);
+        this.writeIndex(idx);
+    }
+
+    private evictIfOverCap(idx: IndexShape): void {
+        const total = Object.values(idx.entries).reduce((sum, e) => sum + e.sizeBytes, 0);
+
+        if (total <= this.maxBytes) {
+            return;
+        }
+
+        const ranked = Object.entries(idx.entries)
+            .filter(([, e]) => e.audioPath)
+            .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
+        let running = total;
+
+        for (const [key, e] of ranked) {
+            if (running <= this.maxBytes) {
+                break;
+            }
+
+            if (e.audioPath && existsSync(e.audioPath)) {
+                try {
+                    unlinkSync(e.audioPath);
+                } catch (err) {
+                    logger.debug(`[say/cache] evict failed: ${err}`);
+                }
+            }
+
+            running -= e.sizeBytes;
+            delete idx.entries[key];
+        }
+    }
+}

--- a/src/say/lib/storage.ts
+++ b/src/say/lib/storage.ts
@@ -1,0 +1,30 @@
+import { join } from "node:path";
+import { Storage } from "@app/utils/storage/storage";
+
+const TOOL_NAME = "say";
+
+/**
+ * Per-tool storage wrapper for `tools say`. Centralizes config and cache
+ * directory layout under `~/.genesis-tools/say/` so callers don't have to
+ * reach into the generic `Storage` class with the tool name string.
+ */
+export class SayStorage extends Storage {
+    constructor() {
+        super(TOOL_NAME);
+    }
+
+    /** Audio cache directory: `~/.genesis-tools/say/cache/`. */
+    getCacheDir(): string {
+        return join(this.getBaseDir(), "cache");
+    }
+}
+
+let _instance: SayStorage | null = null;
+
+export function getSayStorage(): SayStorage {
+    if (!_instance) {
+        _instance = new SayStorage();
+    }
+
+    return _instance;
+}

--- a/src/utils/database/client.ts
+++ b/src/utils/database/client.ts
@@ -69,7 +69,7 @@ export function createKyselyClient<DB>(opts: CreateKyselyClientOptions<DB>): Dat
             ctx = { tableName: deriveScope(path) };
             logger.debug(
                 `[db] migrationContext not provided for ${path} — derived "${ctx.tableName}". ` +
-                    `Pin an explicit migrationContext to keep migration history stable across path changes.`,
+                    `Pin an explicit migrationContext to keep migration history stable across path changes.`
             );
         }
 

--- a/src/utils/database/embedding-stats.ts
+++ b/src/utils/database/embedding-stats.ts
@@ -1,0 +1,26 @@
+import type { Database } from "bun:sqlite";
+
+/**
+ * Count rows in whichever embedding-backing table is active for this index.
+ * sqlite-vec writes into `<name>_vec`; the legacy bun-sqlite-brute driver
+ * writes into `<name>_embeddings`. With sqlite-vec in use, `_embeddings` is
+ * empty (or absent), so checking only that one yields a false 0.
+ */
+export function countActiveEmbeddings(db: Database, tableName: string): number {
+    const vecTable = `${tableName}_vec`;
+    const embTable = `${tableName}_embeddings`;
+    const has = (t: string): boolean =>
+        !!db.query("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(t);
+
+    if (has(vecTable)) {
+        const row = db.query(`SELECT COUNT(*) AS cnt FROM ${vecTable}`).get() as { cnt: number };
+        return row.cnt;
+    }
+
+    if (has(embTable)) {
+        const row = db.query(`SELECT COUNT(*) AS cnt FROM ${embTable}`).get() as { cnt: number };
+        return row.cnt;
+    }
+
+    return 0;
+}

--- a/src/utils/macos/MacDatabase.ts
+++ b/src/utils/macos/MacDatabase.ts
@@ -29,6 +29,9 @@ export abstract class MacDatabase {
     protected abstract readonly dbLabel: string;
     protected abstract readonly notFoundMessage: string;
 
+    /** Subclasses can override to register UDFs / set extra pragmas after the DB opens. */
+    protected onDbOpened?(db: Database): void;
+
     getMigrator(): Migrator {
         const tableName = this.migrationTableName ?? this.dbLabel.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
         return new Migrator(this.getDb(), this.migrations, { tableName });
@@ -47,6 +50,11 @@ export abstract class MacDatabase {
 
         try {
             this.db = new Database(this.dbPath, { readonly: true });
+            // Live macOS DBs (Mail Envelope, Messages, etc.) get written by their owning app
+            // concurrently; without busy_timeout the readonly connection throws SQLITE_BUSY
+            // on the first contended page.
+            this.db.exec("PRAGMA busy_timeout = 5000");
+            this.onDbOpened?.(this.db);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
 

--- a/src/utils/macos/MailDatabase.test.ts
+++ b/src/utils/macos/MailDatabase.test.ts
@@ -1,0 +1,161 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { MailDatabase, pruneStaleMailChunks } from "./MailDatabase";
+
+function setupIndex(db: Database): void {
+    db.exec(
+        `CREATE TABLE macos_mail_content (
+            id INTEGER PRIMARY KEY,
+            source_id TEXT NOT NULL,
+            content TEXT,
+            metadata_json TEXT
+        )`
+    );
+}
+
+function setupEnvelope(db: Database): void {
+    db.exec(
+        `CREATE TABLE messages (
+            ROWID INTEGER PRIMARY KEY,
+            date_sent INTEGER,
+            deleted INTEGER DEFAULT 0
+        )`
+    );
+}
+
+describe("pruneStaleMailChunks", () => {
+    it("removes chunks whose ROWID no longer exists in the envelope", () => {
+        const idx = new Database(":memory:");
+        const env = new Database(":memory:");
+        setupIndex(idx);
+        setupEnvelope(env);
+
+        idx.exec(
+            `INSERT INTO macos_mail_content (source_id, metadata_json) VALUES
+                ('100', '{"dateSent":1700000000}'),
+                ('200', '{"dateSent":1700000100}')`
+        );
+        // Only ROWID 200 lives; 100 has been deleted/compacted from the envelope.
+        env.exec("INSERT INTO messages (ROWID, date_sent) VALUES (200, 1700000100)");
+
+        expect(pruneStaleMailChunks(idx, env, "macos_mail")).toBe(1);
+        const remaining = idx.query("SELECT source_id FROM macos_mail_content").all() as Array<{ source_id: string }>;
+        expect(remaining).toEqual([{ source_id: "200" }]);
+    });
+
+    it("removes chunks whose live row is soft-deleted", () => {
+        const idx = new Database(":memory:");
+        const env = new Database(":memory:");
+        setupIndex(idx);
+        setupEnvelope(env);
+
+        idx.exec(
+            "INSERT INTO macos_mail_content (source_id, metadata_json) VALUES ('100', '{\"dateSent\":1700000000}')"
+        );
+        env.exec("INSERT INTO messages (ROWID, date_sent, deleted) VALUES (100, 1700000000, 1)");
+
+        expect(pruneStaleMailChunks(idx, env, "macos_mail")).toBe(1);
+    });
+
+    it("removes chunks whose live row's date_sent diverges from indexed value", () => {
+        const idx = new Database(":memory:");
+        const env = new Database(":memory:");
+        setupIndex(idx);
+        setupEnvelope(env);
+
+        idx.exec(
+            "INSERT INTO macos_mail_content (source_id, metadata_json) VALUES ('100', '{\"dateSent\":1700000000}')"
+        );
+        // Same ROWID, different date_sent — covers rare server-side date
+        // corrections (IMAP/Exchange resync). NOTE: Mail.app uses
+        // AUTOINCREMENT so ROWIDs are never recycled; this isn't the
+        // "old slot got a new message" case (that can't happen).
+        env.exec("INSERT INTO messages (ROWID, date_sent) VALUES (100, 1800000000)");
+
+        expect(pruneStaleMailChunks(idx, env, "macos_mail")).toBe(1);
+    });
+
+    it("keeps chunks whose ROWID + dateSent still match", () => {
+        const idx = new Database(":memory:");
+        const env = new Database(":memory:");
+        setupIndex(idx);
+        setupEnvelope(env);
+
+        idx.exec(
+            "INSERT INTO macos_mail_content (source_id, metadata_json) VALUES ('100', '{\"dateSent\":1700000000}')"
+        );
+        env.exec("INSERT INTO messages (ROWID, date_sent) VALUES (100, 1700000000)");
+
+        expect(pruneStaleMailChunks(idx, env, "macos_mail")).toBe(0);
+        expect((idx.query("SELECT COUNT(*) AS n FROM macos_mail_content").get() as { n: number }).n).toBe(1);
+    });
+
+    it("is a no-op on an empty content table", () => {
+        const idx = new Database(":memory:");
+        const env = new Database(":memory:");
+        setupIndex(idx);
+        setupEnvelope(env);
+        env.exec("INSERT INTO messages (ROWID, date_sent) VALUES (1, 1700000000)");
+
+        expect(pruneStaleMailChunks(idx, env, "macos_mail")).toBe(0);
+    });
+});
+
+describe("MailDatabase.getMailChunkDateRange", () => {
+    it("returns MIN/MAX dateSent across the content table", () => {
+        const idx = new Database(":memory:");
+        setupIndex(idx);
+        idx.exec(
+            `INSERT INTO macos_mail_content (source_id, metadata_json) VALUES
+                ('1', '{"dateSent":1700000000}'),
+                ('2', '{"dateSent":1700001000}'),
+                ('3', '{"dateSent":1699990000}')`
+        );
+
+        const r = MailDatabase.getMailChunkDateRange(idx, "macos_mail");
+        expect(r.minTs).toBe(1699990000);
+        expect(r.maxTs).toBe(1700001000);
+    });
+
+    it("returns nulls for an empty content table", () => {
+        const idx = new Database(":memory:");
+        setupIndex(idx);
+
+        const r = MailDatabase.getMailChunkDateRange(idx, "macos_mail");
+        expect(r.minTs).toBeNull();
+        expect(r.maxTs).toBeNull();
+    });
+});
+
+describe("MailDatabase null-sender JOIN regression", () => {
+    // Live envelope inspection: 56 of 62,748 messages have m.sender = NULL
+    // (all unsent drafts in Drafts/All-Mail mailboxes). MailDatabase used
+    // INNER JOIN on addresses → those rows were silently dropped from every
+    // search. This test pins the SQL pattern itself: INNER JOIN drops the
+    // NULL-sender row, LEFT JOIN keeps it with a.address as null.
+    it("LEFT JOIN on m.sender = a.ROWID keeps NULL-sender rows", () => {
+        const env = new Database(":memory:");
+        env.exec(`
+            CREATE TABLE messages (ROWID INTEGER PRIMARY KEY, sender INTEGER);
+            CREATE TABLE addresses (ROWID INTEGER PRIMARY KEY, address TEXT);
+            INSERT INTO messages VALUES (100, NULL), (101, 1);
+            INSERT INTO addresses VALUES (1, 'live@example.com');
+        `);
+
+        // The bug: INNER JOIN drops ROWID=100 because sender=NULL has no addresses match.
+        const inner = env
+            .query("SELECT m.ROWID FROM messages m INNER JOIN addresses a ON a.ROWID = m.sender ORDER BY m.ROWID")
+            .all() as Array<{ ROWID: number }>;
+        expect(inner.map((r) => r.ROWID)).toEqual([101]);
+
+        // The fix: LEFT JOIN keeps ROWID=100 with a.address = null.
+        const left = env
+            .query(
+                "SELECT m.ROWID, a.address FROM messages m LEFT JOIN addresses a ON a.ROWID = m.sender ORDER BY m.ROWID"
+            )
+            .all() as Array<{ ROWID: number; address: string | null }>;
+        expect(left).toHaveLength(2);
+        expect(left[0]).toEqual({ ROWID: 100, address: null });
+        expect(left[1]).toEqual({ ROWID: 101, address: "live@example.com" });
+    });
+});

--- a/src/utils/macos/MailDatabase.ts
+++ b/src/utils/macos/MailDatabase.ts
@@ -1,3 +1,5 @@
+import type { Database } from "bun:sqlite";
+import { pathToFileURL } from "node:url";
 import logger from "@app/logger";
 import { ENVELOPE_INDEX_PATH } from "@app/macos/lib/mail/constants";
 import type { MailDB } from "@app/macos/lib/mail/db-types";
@@ -12,7 +14,98 @@ import type {
 import { buildOrderedLikePattern, escapeLike } from "@app/utils/database";
 import { type Expression, type SqlBool, sql } from "kysely";
 import { MacDatabase } from "./MacDatabase";
-import { type MailFilterOptions, SQL_BIND_BATCH } from "./mail-sql";
+import { type MailFilterOptions, resolveMailboxRowids, SQL_BIND_BATCH } from "./mail-sql";
+
+/**
+ * Delete chunks from `<tableName>_content` whose `source_id` (Mail.app ROWID)
+ * is now stale relative to the live envelope DB:
+ *   - the message no longer exists in the envelope (hard-deleted), OR
+ *   - the message is soft-deleted (`deleted = 1`), OR
+ *   - the message's `date_sent` differs from what we stored at index time
+ *     (rare — server-side date correction via IMAP/Exchange resync).
+ *
+ * Note on ROWID stability: Mail.app's `messages` table is `INTEGER PRIMARY
+ * KEY AUTOINCREMENT`, so deleted ROWIDs are NEVER reused. Gaps in the
+ * sequence stay permanently empty. We don't need to re-index "recycled"
+ * IDs after a prune (issue #162) — the deleted ROWID slot is gone for good.
+ *
+ * Exported as a free function for direct testing with two `:memory:`
+ * databases. Production code should use `MailDatabase#pruneStaleChunks`.
+ *
+ * @param indexDb     The indexer's read-write DB (e.g. ~/.genesis-tools/indexer/macos-mail/index.db)
+ * @param envelopeDb  Mail.app's Envelope Index (readonly, opened by caller)
+ * @param tableName   Sanitized index name, e.g. "macos_mail"
+ * @returns           Number of chunks deleted.
+ */
+export function pruneStaleMailChunks(indexDb: Database, envelopeDb: Database, tableName: string): number {
+    const contentTable = `${tableName}_content`;
+    const envFilename = (envelopeDb as unknown as { filename?: string }).filename;
+    const usingMemory = !envFilename || envFilename === ":memory:";
+
+    if (usingMemory) {
+        // ATTACH only supports file paths; for in-memory test databases we
+        // copy the envelope's `messages` columns into a TEMP table on the
+        // index DB and run the same join there.
+        indexDb.exec("CREATE TEMP TABLE _env_msg (ROWID INTEGER PRIMARY KEY, date_sent INTEGER, deleted INTEGER)");
+
+        try {
+            const rows = envelopeDb.query("SELECT ROWID, date_sent, deleted FROM messages").all() as Array<{
+                ROWID: number;
+                date_sent: number;
+                deleted: number;
+            }>;
+            const ins = indexDb.prepare("INSERT INTO _env_msg VALUES (?, ?, ?)");
+
+            for (const r of rows) {
+                ins.run(r.ROWID, r.date_sent, r.deleted ?? 0);
+            }
+
+            const result = indexDb.run(`
+                DELETE FROM ${contentTable}
+                WHERE id IN (
+                    SELECT c.id FROM ${contentTable} c
+                    LEFT JOIN _env_msg m ON m.ROWID = CAST(c.source_id AS INTEGER)
+                    WHERE m.ROWID IS NULL
+                       OR m.deleted = 1
+                       OR m.date_sent != CAST(json_extract(c.metadata_json, '$.dateSent') AS INTEGER)
+                )
+            `);
+
+            return Number(result.changes);
+        } finally {
+            indexDb.exec("DROP TABLE _env_msg");
+        }
+    }
+
+    const uri = pathToFileURL(envFilename).toString();
+    indexDb.run(`ATTACH DATABASE '${uri.replace(/'/g, "''")}?mode=ro' AS mailapp`);
+
+    try {
+        const result = indexDb.run(`
+            DELETE FROM ${contentTable}
+            WHERE id IN (
+                SELECT c.id FROM ${contentTable} c
+                LEFT JOIN mailapp.messages m ON m.ROWID = CAST(c.source_id AS INTEGER)
+                WHERE m.ROWID IS NULL
+                   OR m.deleted = 1
+                   OR m.date_sent != CAST(json_extract(c.metadata_json, '$.dateSent') AS INTEGER)
+            )
+        `);
+        const removed = Number(result.changes);
+
+        if (removed > 0) {
+            logger.debug(`[mail/prune] removed ${removed} stale chunks from ${contentTable}`);
+        }
+
+        return removed;
+    } finally {
+        try {
+            indexDb.run("DETACH DATABASE mailapp");
+        } catch {
+            // detach failures shouldn't mask the prune result
+        }
+    }
+}
 
 /**
  * Build raw SQL filter fragments for date range / mailbox / receiver / account.
@@ -31,9 +124,22 @@ function buildMailFilterExpressions(opts: MailFilterOptions): Expression<SqlBool
         filters.push(sql<SqlBool>`m.date_sent <= ${seconds}`);
     }
 
-    if (opts.mailbox) {
-        const pattern = `%${escapeLike(opts.mailbox)}%`;
-        filters.push(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`);
+    if (opts.mailboxRowids !== undefined) {
+        if (opts.mailboxRowids.length === 0) {
+            filters.push(sql<SqlBool>`1 = 0`);
+        } else {
+            filters.push(sql<SqlBool>`m.mailbox IN (${sql.join(opts.mailboxRowids)})`);
+        }
+    } else {
+        if (opts.mailbox) {
+            const pattern = `%${escapeLike(opts.mailbox)}%`;
+            filters.push(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`);
+        }
+
+        if (opts.account) {
+            const pattern = `%${escapeLike(opts.account)}%`;
+            filters.push(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`);
+        }
     }
 
     if (opts.receiver) {
@@ -45,18 +151,13 @@ function buildMailFilterExpressions(opts: MailFilterOptions): Expression<SqlBool
         )`);
     }
 
-    if (opts.account) {
-        const pattern = `%${escapeLike(opts.account)}%`;
-        filters.push(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`);
-    }
-
     return filters;
 }
 
 const MESSAGE_SELECT_COLUMNS = [
     sql<number>`m.ROWID`.as("rowid"),
     "s.subject",
-    sql<string>`a.address`.as("senderAddress"),
+    sql<string | null>`a.address`.as("senderAddress"),
     sql<string | null>`a.comment`.as("senderName"),
     sql<number>`m.date_sent`.as("dateSent"),
     sql<number>`m.date_received`.as("dateReceived"),
@@ -76,6 +177,53 @@ export class MailDatabase extends MacDatabase {
         return this.getKysely<MailDB>();
     }
 
+    /**
+     * Remove chunks whose backing envelope row has changed since indexing
+     * (hard-deleted, soft-deleted, or date_sent mismatch). Wraps the
+     * exported `pruneStaleMailChunks` helper. See its docstring for the
+     * rationale on why ROWIDs aren't ever recycled.
+     */
+    async pruneStaleChunks(indexDb: Database, tableName: string): Promise<number> {
+        return pruneStaleMailChunks(indexDb, this.getDb(), tableName);
+    }
+
+    /**
+     * Compute MIN/MAX `date_sent` (unix seconds) over chunks of an external
+     * indexer table by reading their `metadata_json` bag. Used by the indexer
+     * to record date-range coverage for stderr "out-of-coverage" warnings.
+     * Returns `{minTs: null, maxTs: null}` if the table is empty.
+     */
+    static getMailChunkDateRange(indexDb: Database, tableName: string): { minTs: number | null; maxTs: number | null } {
+        const contentTable = `${tableName}_content`;
+        const row = indexDb
+            .query(
+                `SELECT
+                    MIN(CAST(json_extract(metadata_json, '$.dateSent') AS INTEGER)) AS minTs,
+                    MAX(CAST(json_extract(metadata_json, '$.dateSent') AS INTEGER)) AS maxTs
+                 FROM ${contentTable}
+                 WHERE metadata_json IS NOT NULL`
+            )
+            .get() as { minTs: number | null; maxTs: number | null } | null;
+
+        return row ?? { minTs: null, maxTs: null };
+    }
+
+    /**
+     * Resolve `mailbox` / `account` substring filters to a concrete rowid set
+     * via JS URL-decoding (handles non-ASCII names like "Doručená pošta").
+     * Returns the same opts shape with `mailboxRowids` populated when
+     * applicable. Idempotent: re-resolving an already-resolved opts is a
+     * no-op.
+     */
+    resolveMailboxFilter<T extends MailFilterOptions>(opts: T): T {
+        if (opts.mailboxRowids !== undefined) {
+            return opts;
+        }
+
+        const rowids = resolveMailboxRowids(this.getDb(), opts.mailbox, opts.account);
+        return rowids === undefined ? opts : { ...opts, mailboxRowids: rowids };
+    }
+
     async searchMessages(opts: SearchOptions): Promise<MailMessageRow[]> {
         const tokens = opts.query.split(/\s+/).filter((t) => t.length > 0);
 
@@ -85,14 +233,14 @@ export class MailDatabase extends MacDatabase {
 
         const ordered = buildOrderedLikePattern(tokens);
         const escapedTokens = tokens.map((t) => `%${escapeLike(t)}%`);
-        const filterExpressions = buildMailFilterExpressions(opts);
+        const filterExpressions = buildMailFilterExpressions(this.resolveMailboxFilter(opts));
 
         logger.debug(`Running search query (wildcard) with ${tokens.length} token(s): ${tokens.join(", ")}`);
 
         const rows = await this.k()
             .selectFrom("messages as m")
             .innerJoin("subjects as s", "s.ROWID", "m.subject")
-            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .leftJoin("addresses as a", "a.ROWID", "m.sender")
             .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
             .leftJoin("attachments as att", "att.message", "m.ROWID")
             .select(MESSAGE_SELECT_COLUMNS as never)
@@ -129,7 +277,7 @@ export class MailDatabase extends MacDatabase {
         }
 
         const results: MailMessageRow[] = [];
-        const filterExpressions = opts ? buildMailFilterExpressions(opts) : [];
+        const filterExpressions = opts ? buildMailFilterExpressions(this.resolveMailboxFilter(opts)) : [];
 
         for (let offset = 0; offset < rowids.length; offset += SQL_BIND_BATCH) {
             const batch = rowids.slice(offset, offset + SQL_BIND_BATCH);
@@ -137,7 +285,7 @@ export class MailDatabase extends MacDatabase {
             const rows = await this.k()
                 .selectFrom("messages as m")
                 .innerJoin("subjects as s", "s.ROWID", "m.subject")
-                .innerJoin("addresses as a", "a.ROWID", "m.sender")
+                .leftJoin("addresses as a", "a.ROWID", "m.sender")
                 .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
                 .select(MESSAGE_SELECT_COLUMNS as never)
                 .distinct()
@@ -154,17 +302,21 @@ export class MailDatabase extends MacDatabase {
     }
 
     async listMessages(mailbox: string, limit: number): Promise<MailMessageRow[]> {
-        const pattern = `%${escapeLike(mailbox)}%`;
+        const rowids = resolveMailboxRowids(this.getDb(), mailbox);
+
+        if (rowids === undefined || rowids.length === 0) {
+            return [];
+        }
 
         const rows = await this.k()
             .selectFrom("messages as m")
             .innerJoin("subjects as s", "s.ROWID", "m.subject")
-            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .leftJoin("addresses as a", "a.ROWID", "m.sender")
             .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
             .select(MESSAGE_SELECT_COLUMNS as never)
             .distinct()
             .where("m.deleted", "=", 0)
-            .where(sql<SqlBool>`mb.url LIKE ${pattern} ESCAPE '\\'`)
+            .where("m.mailbox", "in", rowids)
             .orderBy("m.date_sent", "desc")
             .limit(limit)
             .execute();
@@ -181,7 +333,8 @@ export class MailDatabase extends MacDatabase {
             .selectFrom("attachments")
             .select(["message", "name", "attachment_id as attachmentId", "ROWID"])
             .where("message", "in", messageRowids)
-            .orderBy(["message", "ROWID"])
+            .orderBy("message")
+            .orderBy("ROWID")
             .execute();
 
         const map = new Map<number, MailAttachment[]>();
@@ -210,7 +363,9 @@ export class MailDatabase extends MacDatabase {
                 sql<number>`r.type`.as("type"),
             ])
             .where("r.message", "in", messageRowids)
-            .orderBy(["r.message", "r.type", "r.position"])
+            .orderBy("r.message")
+            .orderBy("r.type")
+            .orderBy("r.position")
             .execute();
 
         const map = new Map<number, MailRecipient[]>();
@@ -238,7 +393,8 @@ export class MailDatabase extends MacDatabase {
                 sql<number>`COUNT(DISTINCT r.message)`.as("messageCount"),
             ])
             .where("r.type", "=", 0)
-            .groupBy(["a.address", "a.comment"])
+            .groupBy("a.address")
+            .groupBy("a.comment")
             .having(sql`COUNT(DISTINCT r.message)`, ">", 10)
             .orderBy("messageCount", "desc")
             .limit(50)
@@ -266,7 +422,7 @@ export class MailDatabase extends MacDatabase {
         const row = await this.k()
             .selectFrom("messages as m")
             .innerJoin("subjects as s", "s.ROWID", "m.subject")
-            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .leftJoin("addresses as a", "a.ROWID", "m.sender")
             .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
             .select(MESSAGE_SELECT_COLUMNS as never)
             .distinct()
@@ -316,7 +472,7 @@ export class MailDatabase extends MacDatabase {
         const sentSenders = await this.k()
             .selectFrom("messages as m")
             .innerJoin("mailboxes as mb", "mb.ROWID", "m.mailbox")
-            .innerJoin("addresses as a", "a.ROWID", "m.sender")
+            .leftJoin("addresses as a", "a.ROWID", "m.sender")
             .select([
                 accountUuidExpr.as("accountUuid"),
                 sql<string>`a.address`.as("address"),
@@ -332,8 +488,10 @@ export class MailDatabase extends MacDatabase {
                     sql<boolean>`mb.url LIKE '%Drafts%'`,
                 ])
             )
-            .groupBy(["accountUuid", "a.address"])
-            .orderBy(["accountUuid", "cnt desc"])
+            .groupBy("accountUuid")
+            .groupBy("a.address")
+            .orderBy("accountUuid")
+            .orderBy("cnt", "desc")
             .execute();
 
         const inboxRecipients = await this.k()
@@ -353,8 +511,10 @@ export class MailDatabase extends MacDatabase {
             .where(sql<boolean>`mb.url NOT LIKE '%Sent%20Messages%'`)
             .where(sql<boolean>`mb.url NOT LIKE '%Outbox%'`)
             .where(sql<boolean>`mb.url NOT LIKE '%Drafts%'`)
-            .groupBy(["accountUuid", "a.address"])
-            .orderBy(["accountUuid", "cnt desc"])
+            .groupBy("accountUuid")
+            .groupBy("a.address")
+            .orderBy("accountUuid")
+            .orderBy("cnt", "desc")
             .execute();
 
         const emailByAccount = new Map<string, string>();

--- a/src/utils/macos/SayConfigManager.ts
+++ b/src/utils/macos/SayConfigManager.ts
@@ -17,9 +17,29 @@ export interface SayAppConfig {
     mute?: boolean | null;
 }
 
+/**
+ * Per-text provider override. `match` is a substring matched
+ * case-insensitively against the spoken text; the first match wins. When
+ * matched, `provider` replaces whatever the resolved profile would have
+ * picked — useful for routing chronically-repeated phrases like
+ * "Permission needed" to local macOS `say` instead of an expensive cloud
+ * provider.
+ */
+export interface SayTextOverride {
+    match: string;
+    provider: SayProvider;
+}
+
 export interface SayConfigV2 {
     version: 2;
-    global: { mute: boolean };
+    global: {
+        mute: boolean;
+        textOverrides?: SayTextOverride[];
+        /** Synthesizer-call count after which a phrase's audio is persisted. Default 5. */
+        cacheThreshold?: number;
+        /** Total cache size budget in bytes (LRU eviction). Default 50 MB. */
+        cacheMaxBytes?: number;
+    };
     apps: SayAppConfig[];
 }
 
@@ -242,6 +262,38 @@ export class SayConfigManager {
     async getGlobalMute(): Promise<boolean> {
         const c = await this.load();
         return c.global.mute;
+    }
+
+    async listTextOverrides(): Promise<SayTextOverride[]> {
+        const c = await this.load();
+        return c.global.textOverrides ?? [];
+    }
+
+    async addTextOverride(override: SayTextOverride): Promise<void> {
+        const c = await this.load();
+        c.global.textOverrides = [...(c.global.textOverrides ?? []), override];
+        await this.save(c);
+    }
+
+    async removeTextOverride(index: number): Promise<void> {
+        const c = await this.load();
+        const list = [...(c.global.textOverrides ?? [])];
+
+        if (index < 0 || index >= list.length) {
+            return;
+        }
+
+        list.splice(index, 1);
+        c.global.textOverrides = list;
+        await this.save(c);
+    }
+
+    async getCacheSettings(): Promise<{ threshold: number; maxBytes: number }> {
+        const c = await this.load();
+        return {
+            threshold: c.global.cacheThreshold ?? 5,
+            maxBytes: c.global.cacheMaxBytes ?? 50_000_000,
+        };
     }
 
     /**

--- a/src/utils/macos/mail-sql.ts
+++ b/src/utils/macos/mail-sql.ts
@@ -4,6 +4,8 @@
  * Centralized so LIKE escape rules cannot drift between mail search callers.
  */
 
+import type { Database } from "bun:sqlite";
+
 /**
  * SQL fragment to append after a LIKE expression. Runtime form is
  * `ESCAPE '\'` — the SQLite escape argument is exactly one backslash char.
@@ -18,6 +20,71 @@ export interface MailFilterOptions {
     mailbox?: string;
     receiver?: string;
     account?: string;
+    /**
+     * Pre-resolved set of `mailboxes.ROWID`s satisfying the `mailbox` and/or
+     * `account` substring constraints. Filter builders prefer this over the
+     * raw strings — it's the only path that handles URL-encoded UTF-8 (e.g.
+     * Czech "Doručená pošta" stored as `Doru%C4%8Den%C3%A1%20po%C5%A1ta`).
+     */
+    mailboxRowids?: number[];
+}
+
+/**
+ * Normalize a mailbox-name comparand: percent-decode if applicable, then NFC
+ * + lowercase. Mail.app stores `mailboxes.url` percent-encoded as UTF-8 NFD
+ * (combining diacritics), while user input is typically NFC composed — so
+ * raw `String.includes` between the two never matches non-ASCII names.
+ */
+function normalizeMailboxText(s: string): string {
+    let decoded: string;
+
+    try {
+        decoded = decodeURIComponent(s);
+    } catch {
+        decoded = s;
+    }
+
+    return decoded.normalize("NFC").toLowerCase();
+}
+
+/**
+ * Resolve `mailbox` / `account` substring filters to a concrete set of
+ * `mailboxes.ROWID`s by URL-decoding + NFC-normalizing each `mailboxes.url`
+ * in JS and matching case-insensitively. SQLite's built-in LOWER is
+ * ASCII-only and `mailboxes.url` is percent-encoded UTF-8 NFD, so this
+ * resolve is the only way to match non-ASCII names like "Doručená pošta".
+ *
+ * Returns `undefined` when neither filter is set (caller should leave
+ * `mailboxRowids` unset). Returns `[]` when both filters are set but no
+ * mailbox satisfies them — callers should treat that as "no match".
+ */
+export function resolveMailboxRowids(db: Database, mailbox?: string, account?: string): number[] | undefined {
+    if (!mailbox && !account) {
+        return undefined;
+    }
+
+    const rows = db.query("SELECT ROWID, url FROM mailboxes WHERE url IS NOT NULL").all() as Array<{
+        ROWID: number;
+        url: string;
+    }>;
+    const ml = mailbox ? normalizeMailboxText(mailbox) : undefined;
+    const al = account ? normalizeMailboxText(account) : undefined;
+
+    return rows
+        .filter((r) => {
+            const decoded = normalizeMailboxText(r.url);
+
+            if (ml && !decoded.includes(ml)) {
+                return false;
+            }
+
+            if (al && !decoded.includes(al)) {
+                return false;
+            }
+
+            return true;
+        })
+        .map((r) => r.ROWID);
 }
 
 /** Escape LIKE metacharacters so user input is treated as literal text. */
@@ -52,9 +119,24 @@ export function buildFilters(opts: MailFilterOptions, params: Record<string, str
         params.$dateTo = Math.floor(opts.to.getTime() / 1000);
     }
 
-    if (opts.mailbox) {
-        filters.push(`mb.url LIKE $mailbox ${LIKE_ESCAPE_CLAUSE}`);
-        params.$mailbox = `%${escapeLike(opts.mailbox)}%`;
+    if (opts.mailboxRowids !== undefined) {
+        // Pre-resolved rowids: Unicode-safe path. Empty array → guaranteed
+        // no-match predicate so callers don't accidentally match everything.
+        if (opts.mailboxRowids.length === 0) {
+            filters.push("1 = 0");
+        } else {
+            filters.push(`m.mailbox IN (${opts.mailboxRowids.join(",")})`);
+        }
+    } else {
+        if (opts.mailbox) {
+            filters.push(`mb.url LIKE $mailbox ${LIKE_ESCAPE_CLAUSE}`);
+            params.$mailbox = `%${escapeLike(opts.mailbox)}%`;
+        }
+
+        if (opts.account) {
+            filters.push(`mb.url LIKE $account ${LIKE_ESCAPE_CLAUSE}`);
+            params.$account = `%${escapeLike(opts.account)}%`;
+        }
     }
 
     if (opts.receiver) {
@@ -64,11 +146,6 @@ export function buildFilters(opts: MailFilterOptions, params: Record<string, str
             WHERE a.address LIKE $receiver ${LIKE_ESCAPE_CLAUSE}
         )`);
         params.$receiver = `%${escapeLike(opts.receiver)}%`;
-    }
-
-    if (opts.account) {
-        filters.push(`mb.url LIKE $account ${LIKE_ESCAPE_CLAUSE}`);
-        params.$account = `%${escapeLike(opts.account)}%`;
     }
 
     return filters;


### PR DESCRIPTION
## Summary

Two related but separable workstreams shipped in 4 commits.

### `tools macos mail` — correctness & coverage
- **Kill Kysely array-form spam** — every `tools macos mail …` printed `orderBy(array) is deprecated` to stderr. Replaced 9 sites in `MailDatabase.ts` and `UsageDatabase.ts` with chained `.orderBy()` / `.groupBy()` calls.
- **Fix "Embedded: 0/311,264" cosmetic** — `readLiveStats()` only counted the legacy `<name>_embeddings` table (always 0 with sqlite-vec). New shared helper `countActiveEmbeddings(db, tableName)` in `src/utils/database/embedding-stats.ts` checks `<name>_vec` first; `readLiveStats` and `getStats` both call it now (no more drift between the two implementations).
- **`busy_timeout = 5000` on every `MacDatabase` open** — readonly connections to live macOS SQLite (Mail Envelope, Messages, …) used to throw `SQLITE_BUSY` on the first contended page when the owning app was writing. Pragma is set in `MacDatabase.getDb()` so all subclasses inherit it.
- **Authoritative date filter** — Mail.app reuses `messages.ROWID` after deletes. After the FTS lookup, `getMessagesByRowids(ftsRowids)` re-fetched without re-applying `--from`/`--to`/`--mailbox`/`--account`, so recycled rowids leaked "6d ago" results into a 3-day query. Pass the full `searchOpts` through.
- **Czech / Unicode mailbox support** — `--mailbox "Doručená pošta"` never matched: Mail.app stores `mailboxes.url` percent-encoded as **UTF-8 NFD** (combining diacritics), while user input is typically NFC composed. `bun:sqlite` doesn't expose `db.function()` so the SQL UDF approach was dead. Instead, new `resolveMailboxRowids(db, mailbox?, account?)` decodes + NFC-normalizes + lowercases each `mailboxes.url` in JS and returns concrete rowids. Filter builders consume rowids and use `m.mailbox IN (…)` instead of `mb.url LIKE`.
- **Stale-rowid prune on every sync** — `pruneStaleMailChunks(indexDb, envelopeDb, tableName)` deletes chunks whose live row is missing, soft-deleted, or whose `date_sent` diverges from the indexed `dateSent`. Exported as a free function for in-memory testing; wired into the sync pipeline via the new optional `IndexerSource.pruneStale()` hook.
- **Date-range coverage warning** — `IndexStats.dateRangeMin/Max` is now tracked (via `IndexerSource.getDateRange()`); `mail search --from/--to` prints a stderr advisory when the requested window partially falls outside indexed coverage. Day-floor compare so end-of-day `--to` doesn't false-positive.

### `tools say` — cloud-TTS cost control
- **`SayAudioCache`** — hash-keyed disk cache at `~/.genesis-tools/say/cache`. Threshold-gated (default: 5 calls before audio persists), LRU-evicted under a 50 MB cap, skipped entirely for `provider=macos`. Saves real money on chronically-repeated phrases like `"<task> done"` notifications.
- **Per-text provider overrides** — `tools say config` now manages substring → provider routes. Phrases like `"Permission needed"` can be force-routed to local macOS regardless of `--provider xai`. Case-insensitive first match wins.

### Commits

1. `chore(macos): infra cleanup — busy_timeout, dedupe embedding count, kill Kysely array-form spam`
2. `fix(mail/search): authoritative filtering + Czech/Unicode mailbox support`
3. `feat(mail/index): stale-rowid prune + date-range coverage with stderr warning`
4. `feat(say): audio cache for repeated phrases + per-text provider overrides`

### Notes

- Branch name: planned `feat/enhancements` was already taken with 10 unrelated commits; used `feat/mail-say-enhancements` instead.
- New tests: 7 prune + range cases (`MailDatabase.test.ts`), 5 mailbox-resolve cases incl. NFD (`search-filters.test.ts`), 6 cache cases (`cache.test.ts`).

## Test plan

- [ ] `bun test src/utils/macos src/macos/lib/mail src/utils/database src/say` passes (verified locally — 124 + 6 = 130 passing in changed areas; pre-existing tree-sitter / vec0 failures are unrelated)
- [ ] `tools macos mail search "the" 2>&1 | rg -i deprecat` is empty (verified)
- [ ] `tools macos mail search "report" --from 2026-04-30 --to 2026-05-03` returns only in-range results (verified — was leaking 6d-ago hits before)
- [ ] `tools macos mail search "" --mailbox "Doručená pošta"` finds messages (verified — 2,166 candidates, NFC/NFD mismatch was the blocker)
- [ ] `tools macos mail search "" --mailbox "DORUČENÁ POŠTA"` matches the same set (case-insensitive)
- [ ] After a sync, `tools macos mail index` shows a `Range:` line and `-N stale` summary when applicable
- [ ] `tools macos mail search "x" --from 1990-01-01 --to 1990-12-31 2>&1 1>/dev/null` prints the out-of-range stderr advisory (verified after a meta-injection test)
- [ ] After 5 identical `tools say "ping" --provider xai` calls, the 6th is served from `~/.genesis-tools/say/cache/` (no API call)
- [ ] After adding `"Permission needed" → macos` in `tools say config`, that phrase uses macOS `say` regardless of `--provider xai`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-text TTS provider routing, interactive overrides UI, and on-disk TTS caching
  * Source-driven pruning during indexing with pruned-chunk reporting and indexed date-range tracking
* **Improvements**
  * Search warns when requested dates fall outside indexed coverage
  * Pre-resolved mailbox ROWID filtering for faster, precise mail queries
  * More accurate active-embedding counts and macOS DB open timeout/post-open hook
* **Tests**
  * Added tests for mail pruning, date-range queries, search filters, and TTS cache
<!-- end of auto-generated comment: release notes by coderabbit.ai -->