### PR TITLE
feat(say): auto-fallback to macos TTS when cloud provider fails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,12 @@ See `.claude/docs/tool-template.md` for complete templates (@inquirer + @clack/p
 - When working with union types, use discriminant checks (e.g. `entity.className === "User"`).
 - Prefer `error: err` over `error: err instanceof Error ? err.message : String(err)` when the error field accepts unknown.
 
+## Debugging & Logging
+
+- **Triage from logs first.** When any tool misbehaves, the FIRST step is to read `~/.genesis-tools/logs/<today>.log` (and recent days) and `rg` for the tool name / error string — *before* forming hypotheses or reproducing. Logs are day-stamped pino JSON. This bug (`sqlite-vec extension failed to load`) was in the logs for weeks before it was triaged; checking them first collapses hours of guessing into one `rg`.
+- **Log enough to triage from logs alone.** Every tool must emit enough via `@app/logger` that a future reader can reconstruct what happened without re-running it: log key decision branches, every external-resource access (DB opens with their paths, spawned commands, API URLs), mode/config resolution, and result counts.
+- **Never swallow errors.** A bare `catch {}` is forbidden. At minimum `logger.debug` (or `.warn`) the caught error with context. A swallowed error is a future debugging session that did not have to happen.
+
 ## Claude Agent SDK Types Reference
 
 The session/message types in `src/utils/claude/` are aligned with `@anthropic-ai/claude-agent-sdk`. To check for upstream changes:

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
-preload = ["./src/utils/bun/preload-solid-scoped.ts"]
+preload = ["./src/utils/bun/preload-solid-scoped.ts", "./src/utils/search/stores/sqlite-vec-preload.ts"]
 
 [test]
 preload = [

--- a/src/azure-devops/commands/history-search.ts
+++ b/src/azure-devops/commands/history-search.ts
@@ -14,6 +14,7 @@ import { requireConfig } from "@app/azure-devops/utils";
 import { buildCombinedQuery, buildEverAssignedQuery } from "@app/azure-devops/wiql-builder";
 import logger from "@app/logger";
 import { suggestCommand } from "@app/utils/cli";
+import { formatLocalDate, formatLocalDateTimeStamp } from "@app/utils/date";
 import { formatDuration as _formatDuration } from "@app/utils/format";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
@@ -350,9 +351,9 @@ async function localSearch(options: SearchOptions): Promise<void> {
 
     // Output
     // Build cache stats
-    const dataFrom = oldestActivity < Infinity ? new Date(oldestActivity).toISOString().slice(0, 10) : "?";
-    const dataTo = newestActivity > 0 ? new Date(newestActivity).toISOString().slice(0, 10) : "?";
-    const syncDate = lastSyncTime > 0 ? new Date(lastSyncTime).toISOString().slice(0, 16).replace("T", " ") : "?";
+    const dataFrom = oldestActivity < Infinity ? formatLocalDate(new Date(oldestActivity)) : "?";
+    const dataTo = newestActivity > 0 ? formatLocalDate(new Date(newestActivity)) : "?";
+    const syncDate = lastSyncTime > 0 ? formatLocalDateTimeStamp(lastSyncTime, { seconds: false }) : "?";
 
     if (options.output === "json") {
         console.log(

--- a/src/azure-devops/commands/query.ts
+++ b/src/azure-devops/commands/query.ts
@@ -26,6 +26,7 @@ import {
     requireConfig,
 } from "@app/azure-devops/utils";
 import logger, { consoleLog } from "@app/logger";
+import { formatLocalDateTimeStamp } from "@app/utils/date";
 import type { Command } from "commander";
 
 // Silent mode for JSON output - suppresses progress messages
@@ -57,7 +58,7 @@ function formatAI(queryId: string, items: WorkItem[], changes: ChangeInfo[], cac
     lines.push("|-----|-------|-------|----------|---------|----------|");
     for (const item of items) {
         const title = item.title.length > 40 ? `${item.title.slice(0, 37)}...` : item.title;
-        const changed = item.changed ? new Date(item.changed).toISOString().slice(0, 16).replace("T", " ") : "-";
+        const changed = item.changed ? formatLocalDateTimeStamp(item.changed, { seconds: false }) : "-";
         lines.push(
             `| ${item.id} | ${title} | ${item.state} | ${item.severity || "-"} | ${changed} | ${item.assignee || "-"} |`
         );
@@ -102,7 +103,7 @@ function formatMD(items: WorkItem[]): string {
     lines.push("| ID | Title | State | Severity | Changed | Assignee |");
     lines.push("|---|---|---|---|---|---|");
     for (const item of items) {
-        const changed = item.changed ? new Date(item.changed).toISOString().slice(0, 16).replace("T", " ") : "-";
+        const changed = item.changed ? formatLocalDateTimeStamp(item.changed, { seconds: false }) : "-";
         lines.push(
             `| ${item.id} | ${item.title.slice(0, 50)} | ${item.state} | ${item.severity || "-"} | ${changed} | ${item.assignee || "-"} |`
         );

--- a/src/claude/commands/daemon.ts
+++ b/src/claude/commands/daemon.ts
@@ -25,6 +25,7 @@ export function registerDaemonCommand(program: Command): void {
                 command: `${bunPath()} run ${POLL_SCRIPT}`,
                 every: opts.interval,
                 retries: 1,
+                timeoutMs: 60_000,
                 description: "Poll Claude usage API and record to history DB",
                 overwrite: true,
                 notify: false,

--- a/src/claude/lib/usage/poll-daemon.ts
+++ b/src/claude/lib/usage/poll-daemon.ts
@@ -2,9 +2,13 @@ import { fetchAllAccountsUsage } from "@app/claude/lib/usage/api";
 import { loadDashboardConfig } from "@app/claude/lib/usage/dashboard-config";
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { NotificationManager } from "@app/claude/lib/usage/notification-manager";
+import logger from "@app/logger";
 import { Storage } from "@app/utils/storage/storage";
 
 async function main(): Promise<void> {
+    const startedAt = Date.now();
+    logger.info("[claude-usage] daemon poll starting");
+
     const dashConfig = await loadDashboardConfig();
 
     const db = new UsageHistoryDb();
@@ -18,6 +22,7 @@ async function main(): Promise<void> {
         const results = await fetchAllAccountsUsage();
 
         if (results.length === 0) {
+            logger.warn("[claude-usage] daemon poll found no configured accounts");
             console.error("No accounts configured. Run: tools claude login");
             process.exit(1);
         }
@@ -66,6 +71,10 @@ async function main(): Promise<void> {
 
         const accountNames = results.map((r) => r.accountName).join(", ");
         const errorCount = results.filter((r) => r.error).length;
+        logger.info(
+            { accounts: results.length, accountNames, errorCount, duration_ms: Date.now() - startedAt },
+            "[claude-usage] daemon poll completed"
+        );
         console.log(
             `Polled ${results.length} account(s): ${accountNames}${errorCount > 0 ? ` (${errorCount} error(s))` : ""}`
         );
@@ -74,7 +83,12 @@ async function main(): Promise<void> {
     }
 }
 
-main().catch((err) => {
-    console.error(err);
-    process.exit(1);
-});
+if (import.meta.main) {
+    main()
+        .then(() => process.exit(0))
+        .catch((err) => {
+            logger.error({ error: err }, "[claude-usage] daemon poll failed");
+            console.error(err);
+            process.exit(1);
+        });
+}

--- a/src/daemon/interactive/log-viewer.ts
+++ b/src/daemon/interactive/log-viewer.ts
@@ -1,3 +1,4 @@
+import { formatLocalDateTimeStamp } from "@app/utils/date";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { getLogsBaseDir } from "../lib/config";
@@ -98,7 +99,7 @@ function formatRunLabel(
     durationMs: number | null,
     attempt: number
 ): string {
-    const date = startedAt.replace("T", " ").slice(0, 19);
+    const date = formatLocalDateTimeStamp(startedAt);
     const code = exitCode === null ? pc.dim("?") : exitCode === 0 ? pc.green("0") : pc.red(String(exitCode));
     const dur = durationMs !== null ? formatDuration(durationMs) : "?";
     const att = attempt > 1 ? pc.dim(` attempt:${attempt}`) : "";

--- a/src/daemon/lib/register.ts
+++ b/src/daemon/lib/register.ts
@@ -9,6 +9,7 @@ export interface RegisterTaskOptions {
     retries?: number;
     enabled?: boolean;
     description?: string;
+    timeoutMs?: number;
     overwrite?: boolean;
     /** Send macOS notifications on start/complete/fail. Default: true */
     notify?: boolean;
@@ -38,6 +39,7 @@ export async function registerTask(opts: RegisterTaskOptions): Promise<boolean> 
         retries: opts.retries ?? 3,
         enabled: opts.enabled ?? true,
         description: opts.description,
+        ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
         ...(opts.notify === false ? { notify: false } : {}),
     };
 

--- a/src/daemon/lib/register.ts
+++ b/src/daemon/lib/register.ts
@@ -24,6 +24,11 @@ function validateTaskName(name: string): void {
 export async function registerTask(opts: RegisterTaskOptions): Promise<boolean> {
     validateTaskName(opts.name);
     parseInterval(opts.every);
+
+    if (opts.timeoutMs !== undefined && (!Number.isFinite(opts.timeoutMs) || opts.timeoutMs <= 0)) {
+        throw new Error(`Invalid timeoutMs "${String(opts.timeoutMs)}". Must be a finite number greater than 0.`);
+    }
+
     await ensureStorage();
 
     const existing = await getTask(opts.name);

--- a/src/daemon/lib/runner.test.ts
+++ b/src/daemon/lib/runner.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runTask } from "./runner";
+import type { DaemonTask } from "./types";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-runner-"));
+    tempDirs.push(dir);
+    return dir;
+}
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        if (existsSync(dir)) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe("runTask", () => {
+    it("times out a command that prints output but never exits", async () => {
+        const logsDir = makeTempDir();
+        const task: DaemonTask = {
+            name: "hung-task",
+            command: `${process.execPath} -e "console.log('work done'); setInterval(() => {}, 1000)"`,
+            every: "every 1 minute",
+            retries: 0,
+            enabled: true,
+            timeoutMs: 200,
+        };
+
+        const started = Date.now();
+        const result = await runTask(task, 1, logsDir);
+
+        expect(Date.now() - started).toBeLessThan(2_000);
+        expect(result.exitCode).toBeNull();
+
+        const log = readFileSync(result.logFile, "utf-8");
+        expect(log).toContain("work done");
+        expect(log).toContain('"timedOut":true');
+    });
+});

--- a/src/daemon/lib/runner.ts
+++ b/src/daemon/lib/runner.ts
@@ -1,10 +1,15 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import appLogger from "@app/logger";
+import { formatLocalFileTimestamp } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import type { DaemonTask, RunResult } from "./types";
 
+const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000;
+const FORCE_KILL_GRACE_MS = 500;
+
 function safeTimestamp(): string {
-    return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    return formatLocalFileTimestamp();
 }
 
 function appendJsonl(path: string, data: Record<string, unknown>): void {
@@ -56,6 +61,7 @@ export async function runTask(task: DaemonTask, attempt: number, logsBaseDir: st
     const logFile = join(taskLogDir, `${safeTimestamp()}-${runId}.jsonl`);
     const startedAt = new Date().toISOString();
     const startMs = Date.now();
+    const timeoutMs = task.timeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
 
     appendJsonl(logFile, {
         type: "meta",
@@ -64,7 +70,11 @@ export async function runTask(task: DaemonTask, attempt: number, logsBaseDir: st
         runId,
         attempt,
         startedAt,
+        timeoutMs,
     });
+
+    appLogger.info({ task: task.name, attempt, timeoutMs, logFile }, "[daemon] spawning task process");
+    appLogger.debug({ task: task.name, command: task.command }, "[daemon] task command");
 
     const proc = Bun.spawn(["sh", "-c", task.command], {
         stdout: "pipe",
@@ -74,16 +84,52 @@ export async function runTask(task: DaemonTask, attempt: number, logsBaseDir: st
 
     const stdoutDone = streamLines(proc.stdout, "stdout", logFile);
     const stderrDone = streamLines(proc.stderr, "stderr", logFile);
+    let timedOut = false;
+    let exited = false;
+    let forceKillTimer: Timer | undefined;
+    const timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        appLogger.warn({ task: task.name, attempt, timeoutMs, logFile }, "[daemon] task timed out, sending SIGTERM");
+        proc.kill("SIGTERM");
+        forceKillTimer = setTimeout(() => {
+            if (!exited) {
+                appLogger.warn(
+                    { task: task.name, attempt, timeoutMs, logFile },
+                    "[daemon] task still running, sending SIGKILL"
+                );
+                proc.kill("SIGKILL");
+            }
+        }, FORCE_KILL_GRACE_MS);
+    }, timeoutMs);
 
-    const [exitCode] = await Promise.all([proc.exited, stdoutDone, stderrDone]);
+    timeoutTimer.unref?.();
+
+    const exitPromise = proc.exited.finally(() => {
+        exited = true;
+        clearTimeout(timeoutTimer);
+
+        if (forceKillTimer) {
+            clearTimeout(forceKillTimer);
+        }
+    });
+
+    const [rawExitCode] = await Promise.all([exitPromise, stdoutDone, stderrDone]);
     const duration_ms = Date.now() - startMs;
+    const exitCode = timedOut ? null : rawExitCode;
 
     appendJsonl(logFile, {
         type: "exit",
         ts: new Date().toISOString(),
         code: exitCode,
         duration_ms,
+        ...(timedOut ? { timedOut: true } : {}),
     });
+
+    if (timedOut) {
+        appLogger.warn({ task: task.name, attempt, duration_ms, logFile }, "[daemon] task process timed out");
+    } else {
+        appLogger.info({ task: task.name, attempt, exitCode, duration_ms, logFile }, "[daemon] task process exited");
+    }
 
     return { exitCode, duration_ms, logFile };
 }

--- a/src/daemon/lib/scheduler.ts
+++ b/src/daemon/lib/scheduler.ts
@@ -1,4 +1,4 @@
-import { createLogger } from "@app/logger";
+import appLogger, { createLogger } from "@app/logger";
 import { dispatchNotification } from "@app/utils/notifications";
 import { loadConfig } from "./config";
 import { computeNextRunAt, parseInterval } from "./interval";
@@ -21,6 +21,7 @@ export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
     process.once("SIGINT", shutdown);
 
     log.info("Daemon scheduler started");
+    appLogger.info({ logsBaseDir }, "[daemon] scheduler started");
 
     await initializeTaskStates(taskStates, logsBaseDir);
 
@@ -49,7 +50,10 @@ export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
             state.running = true;
 
             executeTask(task, logsBaseDir)
-                .catch((err) => log.error({ err, task: task.name }, "Task execution error"))
+                .catch((err) => {
+                    log.error({ err, task: task.name }, "Task execution error");
+                    appLogger.error({ err, task: task.name }, "[daemon] task execution error");
+                })
                 .finally(() => {
                     activeRuns.delete(task.name);
                     const s = taskStates.get(task.name);
@@ -69,6 +73,10 @@ export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
 
     if (activeRuns.size > 0) {
         log.info({ activeCount: activeRuns.size }, "Waiting for active runs to finish...");
+        appLogger.info(
+            { activeCount: activeRuns.size, activeTasks: [...activeRuns] },
+            "[daemon] waiting for active runs"
+        );
         const deadline = Date.now() + 30_000;
 
         while (activeRuns.size > 0 && Date.now() < deadline) {
@@ -77,10 +85,12 @@ export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
 
         if (activeRuns.size > 0) {
             log.warn({ remaining: [...activeRuns] }, "Timed out waiting for active runs");
+            appLogger.warn({ remaining: [...activeRuns] }, "[daemon] timed out waiting for active runs");
         }
     }
 
     log.info("Daemon scheduler stopped");
+    appLogger.info("[daemon] scheduler stopped");
 }
 
 async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void> {
@@ -99,11 +109,16 @@ async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void>
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         log.info({ task: task.name, attempt, maxAttempts }, "Running task");
+        appLogger.info({ task: task.name, attempt, maxAttempts, timeoutMs: task.timeoutMs }, "[daemon] running task");
 
         const result = await runTask(task, attempt, logsBaseDir);
 
         if (result.exitCode === 0) {
             log.info({ task: task.name, duration: result.duration_ms }, "Task completed");
+            appLogger.info(
+                { task: task.name, duration_ms: result.duration_ms, logFile: result.logFile },
+                "[daemon] task completed"
+            );
 
             if (shouldNotify) {
                 dispatchNotification({
@@ -118,10 +133,15 @@ async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void>
         }
 
         log.warn({ task: task.name, exitCode: result.exitCode, attempt, maxAttempts }, "Task failed");
+        appLogger.warn(
+            { task: task.name, exitCode: result.exitCode, attempt, maxAttempts, logFile: result.logFile },
+            "[daemon] task failed"
+        );
 
         if (attempt < maxAttempts) {
             const backoffMs = Math.min(2 ** attempt * 1000, 60_000);
             log.info({ task: task.name, backoffMs }, "Retrying after backoff");
+            appLogger.info({ task: task.name, backoffMs }, "[daemon] retrying task after backoff");
             await Bun.sleep(backoffMs);
         }
     }

--- a/src/daemon/lib/types.ts
+++ b/src/daemon/lib/types.ts
@@ -5,6 +5,8 @@ export interface DaemonTask {
     retries: number;
     enabled: boolean;
     description?: string;
+    /** Kill a task that has not exited after this many milliseconds. Default: 10 minutes. */
+    timeoutMs?: number;
     /** Send macOS notifications on start/complete/fail. Default: true */
     notify?: boolean;
 }
@@ -33,6 +35,7 @@ export interface LogExit {
     ts: string;
     code: number | null;
     duration_ms: number;
+    timedOut?: boolean;
 }
 
 export type LogEntry = LogMeta | LogLine | LogExit;

--- a/src/doctor/ui/log.ts
+++ b/src/doctor/ui/log.ts
@@ -1,5 +1,6 @@
 import { readHistorySince } from "@app/doctor/lib/history";
 import { formatBytes } from "@app/doctor/lib/size";
+import { formatLocalDate, formatLocalDateTimeStamp } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import pc from "picocolors";
 
@@ -37,7 +38,7 @@ export async function runLog(opts: LogOpts): Promise<void> {
         return;
     }
 
-    console.log(pc.bold(`${filtered.length} actions since ${since.toISOString().slice(0, 10)}:`));
+    console.log(pc.bold(`${filtered.length} actions since ${formatLocalDate(since)}:`));
 
     for (const entry of filtered.slice(-50).reverse()) {
         const s = entry.action.status;
@@ -46,7 +47,7 @@ export async function runLog(opts: LogOpts): Promise<void> {
             ? pc.dim(` · ${formatBytes(entry.action.actualReclaimedBytes)}`)
             : "";
         console.log(
-            `${pc.dim(entry.timestamp.slice(0, 19).replace("T", " "))} ${statusColor(s.padEnd(7))} ${entry.action.actionId.padEnd(20)} ${entry.action.findingId}${bytes}`
+            `${pc.dim(formatLocalDateTimeStamp(entry.timestamp))} ${statusColor(s.padEnd(7))} ${entry.action.actionId.padEnd(20)} ${entry.action.findingId}${bytes}`
         );
     }
 }

--- a/src/github/commands/comments.ts
+++ b/src/github/commands/comments.ts
@@ -17,6 +17,7 @@ import { calculateStats, formatIssue } from "@app/github/lib/output";
 import { findReplyTarget, processQuotes } from "@app/github/lib/quotes";
 import type { CommentData, CommentRecord, GitHubComment, IssueData } from "@app/github/types";
 import logger from "@app/logger";
+import { formatLocalDateTimeStamp } from "@app/utils/date";
 import { getOctokit } from "@app/utils/github/octokit";
 import { withRetry } from "@app/utils/github/rate-limit";
 import { detectRepoFromGit, extractCommentId, parseGitHubUrl } from "@app/utils/github/url-parser";
@@ -71,7 +72,7 @@ function formatCacheDate(dateStr: string): string {
     if (Number.isNaN(d.getTime())) {
         return dateStr;
     }
-    return d.toISOString().replace("T", " ").slice(0, 16);
+    return formatLocalDateTimeStamp(d, { seconds: false });
 }
 
 function isBot(username: string, userType?: string): boolean {

--- a/src/github/lib/output.ts
+++ b/src/github/lib/output.ts
@@ -13,6 +13,7 @@ import type {
     ReviewData,
     SearchResult,
 } from "@app/github/types";
+import { formatLocalDateTimeStamp } from "@app/utils/date";
 import { sumReactions } from "@app/utils/github/utils";
 
 import { SafeJSON } from "@app/utils/json";
@@ -727,7 +728,7 @@ function formatDate(dateStr: string): string {
     if (Number.isNaN(date.getTime())) {
         return "-";
     }
-    return date.toISOString().replace("T", " ").slice(0, 16);
+    return formatLocalDateTimeStamp(date, { seconds: false });
 }
 
 function formatDateShort(dateStr: string): string {

--- a/src/indexer/lib/store.coverage.test.ts
+++ b/src/indexer/lib/store.coverage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { checkDateRangeCoverage } from "./store";
+
+const dateRangeMin = Date.UTC(2026, 1, 1) / 1000;
+const dateRangeMax = Date.UTC(2026, 3, 1) / 1000;
+
+describe("checkDateRangeCoverage", () => {
+    it("returns null when the index has no recorded coverage", () => {
+        expect(
+            checkDateRangeCoverage({ dateRangeMin: null, dateRangeMax: null, from: new Date("2026-01-01") })
+        ).toBeNull();
+    });
+
+    it("returns null when the requested window is fully inside coverage", () => {
+        expect(
+            checkDateRangeCoverage({
+                dateRangeMin,
+                dateRangeMax,
+                from: new Date("2026-02-15"),
+                to: new Date("2026-03-15"),
+            })
+        ).toBeNull();
+    });
+
+    it("returns an advisory when --from is before coverage starts", () => {
+        const advisory = checkDateRangeCoverage({
+            dateRangeMin,
+            dateRangeMax,
+            from: new Date("2026-01-01"),
+            to: new Date("2026-03-01"),
+        });
+
+        expect(advisory).toContain("partially outside indexed coverage");
+        expect(advisory).toContain("2026-02-01 -> 2026-04-01");
+    });
+
+    it("returns an advisory when --to is after coverage ends", () => {
+        const advisory = checkDateRangeCoverage({
+            dateRangeMin,
+            dateRangeMax,
+            from: new Date("2026-03-01"),
+            to: new Date("2026-05-01"),
+        });
+
+        expect(advisory).toContain("partially outside indexed coverage");
+    });
+
+    it("does not warn when --to is end-of-day on the coverage-max day (day-floor compare)", () => {
+        expect(
+            checkDateRangeCoverage({
+                dateRangeMin,
+                dateRangeMax,
+                from: new Date("2026-03-01"),
+                to: new Date("2026-04-01T23:59:59Z"),
+            })
+        ).toBeNull();
+    });
+});

--- a/src/indexer/lib/store.ts
+++ b/src/indexer/lib/store.ts
@@ -1,9 +1,9 @@
 import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import logger from "@app/logger";
 import { Embedder } from "@app/utils/ai/tasks/Embedder";
+import { attachReadonly, detachQuietly } from "@app/utils/database/attach";
 import { countActiveEmbeddings, countPairedEmbeddings } from "@app/utils/database/embedding-stats";
 import { getPendingMigrations, runMigrations } from "@app/utils/database/migrations";
 import { acquireLock, type LockHandle } from "@app/utils/fs/lock";
@@ -229,6 +229,8 @@ export type ReadonlySearchMode = "fulltext" | "hybrid" | "vector" | "auto";
 export interface ReadonlySearchOptions {
     mode?: ReadonlySearchMode;
     limit?: number;
+    /** Optional warning sink for callers that need stdout reserved for structured output. */
+    onWarning?: (message: string) => void;
     /** When false, skip vector-store/embedder construction even if hybrid/vector requested. Default: true. */
     enableVector?: boolean;
     /** Optional WHERE-clause predicate AND-appended to BM25/cosine queries. */
@@ -237,6 +239,21 @@ export interface ReadonlySearchOptions {
     attach?: { alias: string; dbPath: string; mode?: "ro" | "rw" };
     /** Optional typed metadata column filters AND-appended to BM25/cosine queries. */
     metadataFilters?: MetadataFilter[];
+    /**
+     * When set, compare the requested window against the index's recorded
+     * date coverage, reusing the meta this function already reads, and invoke
+     * `onOutside` with an advisory string.
+     */
+    coverageCheck?: { from?: Date; to?: Date; onOutside: (advisory: string) => void };
+}
+
+function readonlySearchWarn(opts: ReadonlySearchOptions | undefined, message: string): void {
+    if (opts?.onWarning) {
+        opts.onWarning(message);
+        return;
+    }
+
+    logger.warn(message);
 }
 
 async function createReadonlyEmbedder(meta: IndexMeta): Promise<Embedder | null> {
@@ -261,6 +278,42 @@ function sqliteTableExists(db: Database, name: string): boolean {
 }
 
 const pendingWarnedFor = new Set<string>();
+
+/**
+ * Compare a requested date window against the index's recorded coverage.
+ * Returns a stderr-ready advisory string when the window falls outside
+ * coverage, or null when it is fully covered or coverage is unknown.
+ */
+export function checkDateRangeCoverage(args: {
+    dateRangeMin: number | null | undefined;
+    dateRangeMax: number | null | undefined;
+    from?: Date;
+    to?: Date;
+}): string | null {
+    const min = args.dateRangeMin ?? null;
+    const max = args.dateRangeMax ?? null;
+
+    if (min === null || max === null) {
+        return null;
+    }
+
+    const isoDay = (ts: number): string => new Date(ts).toISOString().slice(0, 10);
+    const minDay = isoDay(min * 1000);
+    const maxDay = isoDay(max * 1000);
+    const fromDay = args.from ? isoDay(args.from.getTime()) : undefined;
+    const toDay = args.to ? isoDay(args.to.getTime()) : undefined;
+    const outsideLower = fromDay !== undefined && fromDay < minDay;
+    const outsideUpper = toDay !== undefined && toDay > maxDay;
+
+    if (!outsideLower && !outsideUpper) {
+        return null;
+    }
+
+    return (
+        `Requested range partially outside indexed coverage (${minDay} -> ${maxDay}). ` +
+        `Run "tools macos mail index" to refresh.\n`
+    );
+}
 
 /**
  * Search an index in read-only mode — no lock, safe for concurrent access.
@@ -291,18 +344,7 @@ export async function searchIndexReadonly(
 
     try {
         if (opts?.attach) {
-            const { alias, dbPath: attachPath, mode = "ro" } = opts.attach;
-
-            if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(alias)) {
-                throw new Error(`Invalid attach alias: ${alias}`);
-            }
-
-            const baseUri = pathToFileURL(resolve(attachPath));
-            if (mode === "ro") {
-                baseUri.search = "mode=ro";
-            }
-            const uri = baseUri.toString().replace(/'/g, "''");
-            db.run(`ATTACH DATABASE '${uri}' AS ${alias}`);
+            attachReadonly(db, opts.attach.alias, opts.attach.dbPath, opts.attach.mode ?? "ro");
         }
 
         if (sqliteTableExists(db, "_migrations")) {
@@ -310,19 +352,34 @@ export async function searchIndexReadonly(
 
             if (pending.length > 0 && !pendingWarnedFor.has(indexName)) {
                 pendingWarnedFor.add(indexName);
-                logger.warn(
+                readonlySearchWarn(
+                    opts,
                     `[indexer] outdated schema for "${indexName}" — next "tools macos mail index sync" will apply: ${pending.map((m) => m.id).join(", ")}`
                 );
             }
         }
 
         const meta = readMeta(db, { name: indexName } as IndexConfig, Date.now());
+        if (opts?.coverageCheck) {
+            const advisory = checkDateRangeCoverage({
+                dateRangeMin: meta.stats?.dateRangeMin,
+                dateRangeMax: meta.stats?.dateRangeMax,
+                from: opts.coverageCheck.from,
+                to: opts.coverageCheck.to,
+            });
+
+            if (advisory) {
+                opts.coverageCheck.onOutside(advisory);
+            }
+        }
+
         if (meta.indexingStatus === "in-progress") {
             const ageMs = Date.now() - (meta.lastSyncAt ?? 0);
             const staleThresholdMs = 30 * 60 * 1000;
 
             if (ageMs > staleThresholdMs) {
-                logger.warn(
+                readonlySearchWarn(
+                    opts,
                     `[indexer] "${indexName}" status is "in-progress" but last update was ${Math.round(ageMs / 60000)}min ago — likely interrupted. Run: tools macos mail index sync`
                 );
             }
@@ -353,7 +410,8 @@ export async function searchIndexReadonly(
                 .get(`${tableName}_embeddings`);
 
             if (!vecTableExists && !embTableExists) {
-                logger.warn(
+                readonlySearchWarn(
+                    opts,
                     `[searchIndexReadonly] index "${indexName}" has no vector tables — falling back to fulltext`
                 );
                 resolvedMode = "fulltext";
@@ -368,13 +426,15 @@ export async function searchIndexReadonly(
                 const e = await createReadonlyEmbedder(meta);
 
                 if (!e) {
-                    logger.warn(
+                    readonlySearchWarn(
+                        opts,
                         `[searchIndexReadonly] index "${indexName}" requested ${resolvedMode} but no embedder available — falling back to fulltext`
                     );
                     resolvedMode = "fulltext";
                     vectorDriver = undefined;
                 } else if (meta.indexEmbedding && e.dimensions !== meta.indexEmbedding.dimensions) {
-                    logger.warn(
+                    readonlySearchWarn(
+                        opts,
                         `[searchIndexReadonly] embedder dimensions ${e.dimensions} ≠ stored ${meta.indexEmbedding.dimensions} — falling back to fulltext`
                     );
                     resolvedMode = "fulltext";
@@ -384,6 +444,12 @@ export async function searchIndexReadonly(
                 }
             }
         }
+
+        logger.debug(
+            `[searchIndexReadonly] index="${indexName}" requestedMode=${requestedMode} ` +
+                `resolvedMode=${resolvedMode} hasEmbeddings=${hasEmbeddings} ` +
+                `embedder=${embedder ? "yes" : "no"} vectorDriver=${vectorDriver ?? "none"}`
+        );
 
         const fts = SearchEngine.fromDatabase<ChunkDoc>(db, {
             tableName,
@@ -423,12 +489,9 @@ export async function searchIndexReadonly(
         });
     } finally {
         if (opts?.attach) {
-            try {
-                db.run(`DETACH DATABASE ${opts.attach.alias}`);
-            } catch {
-                // detach failures shouldn't mask the search result
-            }
+            detachQuietly(db, opts.attach.alias);
         }
+
         db.close();
     }
 }

--- a/src/jenkins-mcp/lib/log.test.ts
+++ b/src/jenkins-mcp/lib/log.test.ts
@@ -39,6 +39,16 @@ describe("stripJenkinsHtml", () => {
         const input = "<b>bold</b> and <code>inline-code</code> and <em>emph</em>";
         expect(stripJenkinsHtml(input)).toBe("bold and inline-code and emph");
     });
+
+    it("strips ANSI-concealed Jenkins HashAnchored action IDs (ESC[8mha:...ESC[0m)", () => {
+        const input = `Started by upstream project "\x1b[8mha:////4Mp5CAuXu5Tk/kDm+5j8Xzl+BX5cMGKDLQ5zKFXwbr5qAAAAwB+LCAAAAAAAAP9b85aBtbiI\x1b[0mparent-job" build`;
+        expect(stripJenkinsHtml(input)).toBe('Started by upstream project "parent-job" build');
+    });
+
+    it("strips multiple ANSI conceal blocks on one line", () => {
+        const input = `a \x1b[8mha:////ABC\x1b[0m b \x1b[8mha:////DEF\x1b[0m c`;
+        expect(stripJenkinsHtml(input)).toBe("a  b  c");
+    });
 });
 
 describe("grepLog", () => {

--- a/src/jenkins-mcp/lib/log.ts
+++ b/src/jenkins-mcp/lib/log.ts
@@ -13,6 +13,13 @@ const ANY_SPAN_RE = /<span[^>]*>|<\/span>/g;
 // it can also emit <b>, <i>, etc. via console annotators. Strip all simple
 // tags but keep their inner text so URLs and other content survive.
 const SIMPLE_TAG_RE = /<\/?(?:a|b|i|u|em|strong|code|tt)\b[^>]*>/gi;
+// Jenkins workflow plugin wraps HashAnchored pipeline action IDs in an ANSI
+// "conceal" sequence (ESC[8m ... ESC[0m). Invisible in a real TTY, but they
+// leak into raw log files as ESC[8mha:////<base64>...ESC[0m noise.
+// Built via `new RegExp` (string form) to keep raw ESC out of the source —
+// biome's noControlCharactersInRegex rule rejects the literal `\x1b`.
+const ESC = "\\x1b";
+const ANSI_CONCEAL_HA_RE = new RegExp(`${ESC}\\[8mha:[^${ESC}]*${ESC}\\[0m`, "g");
 const CONSOLE_OUTPUT_RE = /<pre class="console-output">([\s\S]*?)<\/pre>/;
 const HTML_ENTITIES: Record<string, string> = {
     "&amp;": "&",
@@ -25,7 +32,11 @@ const HTML_ENTITIES: Record<string, string> = {
 };
 
 export function stripJenkinsHtml(text: string): string {
-    return text.replace(TIMESTAMP_SPAN_RE, "").replace(ANY_SPAN_RE, "").replace(SIMPLE_TAG_RE, "");
+    return text
+        .replace(TIMESTAMP_SPAN_RE, "")
+        .replace(ANY_SPAN_RE, "")
+        .replace(SIMPLE_TAG_RE, "")
+        .replace(ANSI_CONCEAL_HA_RE, "");
 }
 
 /**
@@ -70,6 +81,50 @@ export async function isBuildFinal(client: AxiosInstance, jobPath: string, build
 
     const data = res.data as { building?: boolean; result?: string | null };
     return data.building === false && data.result != null;
+}
+
+export interface BuildState {
+    building: boolean;
+    result: string | null;
+    duration: number;
+}
+
+/**
+ * Single-call probe of `/api/json?tree=building,result,duration`. Returns null on
+ * non-200 / network failure / malformed payload so callers can treat "no answer"
+ * uniformly. Used as wfapi-independent fallback when wfapi's run-level status
+ * lags behind the actual build state (common with multibranch dispatcher pipelines).
+ */
+export async function getBuildState(
+    client: AxiosInstance,
+    jobPath: string,
+    buildNumber: string
+): Promise<BuildState | null> {
+    let res: { status: number; data: unknown };
+
+    try {
+        res = await client.get(`/${jobPath}/${buildNumber}/api/json`, {
+            params: { tree: "building,result,duration" },
+        });
+    } catch {
+        return null;
+    }
+
+    if (res.status !== 200) {
+        return null;
+    }
+
+    const data = res.data as { building?: unknown; result?: unknown; duration?: unknown };
+
+    if (typeof data.building !== "boolean") {
+        return null;
+    }
+
+    return {
+        building: data.building,
+        result: typeof data.result === "string" ? data.result : null,
+        duration: typeof data.duration === "number" ? data.duration : 0,
+    };
 }
 
 export interface LogFetchOpts {

--- a/src/jenkins-mcp/lib/monitor.test.ts
+++ b/src/jenkins-mcp/lib/monitor.test.ts
@@ -23,6 +23,41 @@ function fakeClient(snapshots: unknown[]) {
     return instance;
 }
 
+function urlAwareClient(routes: {
+    snapshots: unknown[];
+    buildStates?: Array<{ building: boolean; result: string | null; duration: number }>;
+}) {
+    let snapIdx = 0;
+    let stateIdx = 0;
+    const instance = axios.create();
+    instance.interceptors.request.use((cfg) => {
+        cfg.adapter = async () => {
+            const url = cfg.url ?? "";
+            let data: unknown;
+
+            if (url.includes("/wfapi/describe")) {
+                data = routes.snapshots[Math.min(snapIdx++, routes.snapshots.length - 1)];
+            } else if (url.endsWith("/api/json")) {
+                const states = routes.buildStates ?? [{ building: true, result: null, duration: 0 }];
+                data = states[Math.min(stateIdx++, states.length - 1)];
+            } else {
+                throw new Error(`unexpected url: ${url}`);
+            }
+
+            return {
+                data,
+                status: 200,
+                statusText: "OK",
+                headers: {},
+                config: cfg,
+                request: {},
+            };
+        };
+        return cfg;
+    });
+    return instance;
+}
+
 describe("runMonitor", () => {
     it("emits snapshot for historical stages then stage transitions then end", async () => {
         const lines: string[] = [];
@@ -98,6 +133,149 @@ describe("runMonitor", () => {
 
         expect(result.timedOut).toBe(true);
         expect(result.result).toBe("ABORTED");
+    });
+
+    it("emits a 'run' event when wfapi's run-level status changes", async () => {
+        const lines: string[] = [];
+        const out = (l: string) => lines.push(l.trim());
+
+        const snapshots = [
+            {
+                name: "build",
+                status: "IN_PROGRESS",
+                startTimeMillis: 0,
+                durationMillis: 1_000,
+                stages: [{ id: "1", name: "S1", status: "IN_PROGRESS", durationMillis: 1_000 }],
+            },
+            {
+                name: "build",
+                status: "SUCCESS",
+                startTimeMillis: 0,
+                durationMillis: 5_000,
+                stages: [{ id: "1", name: "S1", status: "SUCCESS", durationMillis: 5_000 }],
+            },
+        ];
+
+        await runMonitor({
+            client: fakeClient(snapshots),
+            jobPath: "job/X",
+            build: "1",
+            baseUrl: "https://j.example",
+            timeoutMs: 5_000,
+            pollMs: 10,
+            out,
+        });
+
+        const events = lines.map((l) => SafeJSON.parse(l) as { event: string; status?: string });
+        const runStatuses = events.filter((e) => e.event === "run").map((e) => e.status);
+
+        expect(runStatuses).toEqual(["IN_PROGRESS", "SUCCESS"]);
+    });
+
+    it("falls back to /api/json when wfapi stays IN_PROGRESS after stage deltas stop", async () => {
+        const lines: string[] = [];
+        const out = (l: string) => lines.push(l.trim());
+
+        // wfapi stays IN_PROGRESS forever despite the single stage going SUCCESS
+        // — classic multibranch-dispatcher lag.
+        const stuck = {
+            name: "build",
+            status: "IN_PROGRESS",
+            startTimeMillis: 0,
+            durationMillis: 1_000,
+            stages: [{ id: "1", name: "Dispatch", status: "SUCCESS", durationMillis: -5 }],
+        };
+
+        const result = await runMonitor({
+            client: urlAwareClient({
+                snapshots: [stuck],
+                buildStates: [{ building: false, result: "SUCCESS", duration: 42_000 }],
+            }),
+            jobPath: "job/X",
+            build: "1",
+            baseUrl: "https://j.example",
+            timeoutMs: 5_000,
+            pollMs: 1, // 3 polls × 1ms ≈ <10ms before fallback fires
+            out,
+        });
+
+        expect(result.timedOut).toBe(false);
+        expect(result.result).toBe("SUCCESS");
+        expect(result.durationMs).toBe(42_000);
+
+        const events = lines.map((l) => SafeJSON.parse(l) as { event: string; via?: string; result?: string });
+        const end = events.find((e) => e.event === "end");
+        expect(end?.via).toBe("api-json");
+        expect(end?.result).toBe("SUCCESS");
+    });
+
+    it("api-json fallback maps FAILURE → FAILED and emits error blocks for failed stages", async () => {
+        const lines: string[] = [];
+        const out = (l: string) => lines.push(l.trim());
+
+        const stuckFailed = {
+            name: "build",
+            status: "IN_PROGRESS",
+            startTimeMillis: 0,
+            durationMillis: 1_000,
+            stages: [
+                {
+                    id: "1",
+                    name: "Compile",
+                    status: "FAILED",
+                    durationMillis: 10_000,
+                    stageFlowNodes: [{ id: "5", name: "sh", status: "FAILED", durationMillis: 9_000 }],
+                },
+            ],
+        };
+
+        // The fallback path calls fetchLog → which calls /api/json for isBuildFinal,
+        // then consoleFull HTML; we stub both. urlAwareClient routes by URL pattern.
+        const instance = axios.create();
+        instance.interceptors.request.use((cfg) => {
+            cfg.adapter = async () => {
+                const url = cfg.url ?? "";
+                let data: unknown = "";
+
+                if (url.includes("/wfapi/describe")) {
+                    data = stuckFailed;
+                } else if (url.endsWith("/api/json")) {
+                    data = { building: false, result: "FAILURE", duration: 12_000 };
+                } else if (url.includes("/log/?consoleFull") || url.includes("/log?consoleFull")) {
+                    data = `<pre class="console-output">make: *** Error 1%0Aexit code 2</pre>`;
+                } else if (url.includes("/wfapi/")) {
+                    data = { status: "FAILED" };
+                }
+
+                return {
+                    data,
+                    status: 200,
+                    statusText: "OK",
+                    headers: {},
+                    config: cfg,
+                    request: {},
+                };
+            };
+            return cfg;
+        });
+
+        const result = await runMonitor({
+            client: instance,
+            jobPath: "job/X",
+            build: "1",
+            baseUrl: "https://j.example",
+            timeoutMs: 5_000,
+            pollMs: 1,
+            out,
+        });
+
+        expect(result.result).toBe("FAILED");
+        expect(result.timedOut).toBe(false);
+
+        const events = lines.map((l) => SafeJSON.parse(l) as { event: string; via?: string; matched?: string });
+        const end = events.find((e) => e.event === "end");
+        expect(end?.via).toBe("api-json");
+        expect(events.some((e) => e.event === "error")).toBe(true);
     });
 
     it("does NOT fire historical-stage notifications on first poll", async () => {

--- a/src/jenkins-mcp/lib/monitor.ts
+++ b/src/jenkins-mcp/lib/monitor.ts
@@ -3,7 +3,7 @@ import { SafeJSON } from "@app/utils/json";
 import type { AxiosInstance } from "axios";
 import { type ErrorBlock, extractErrors } from "./errors";
 import { formatDuration, stageNotifyBody, statusBody } from "./format";
-import { fetchLog } from "./log";
+import { fetchLog, getBuildState } from "./log";
 import type { MonitorNotifier } from "./notify";
 import { getStages, type PipelineSnapshot, type RunStatus, type Stage, type StageStatus } from "./pipeline";
 import { buildUrl } from "./url";
@@ -44,7 +44,8 @@ export type MonitorEvent =
           matched: string;
           window: string[];
       }
-    | { event: "end"; ts: string; result: RunStatus; durationMillis: number };
+    | { event: "run"; ts: string; status: RunStatus }
+    | { event: "end"; ts: string; result: RunStatus; durationMillis: number; via?: "wfapi" | "api-json" };
 
 export interface MonitorOpts {
     client: AxiosInstance;
@@ -65,8 +66,32 @@ export interface MonitorResult {
 
 const TERMINAL_STAGE: StageStatus[] = ["SUCCESS", "FAILED", "UNSTABLE", "ABORTED", "NOT_EXECUTED"];
 
+// wfapi's run-level status can stay IN_PROGRESS for minutes after every visible
+// flow node finished (common with multibranch dispatcher pipelines that hold the
+// parent run open while downstream-build bookkeeping settles). After this many
+// consecutive polls with no stage/branch delta we cross-check `/api/json?tree=building,result`
+// which sees the build's authoritative state.
+const STALE_POLLS_BEFORE_API_FALLBACK = 3;
+
 function isTerminalRun(status: RunStatus): boolean {
     return status !== "IN_PROGRESS" && status !== "PAUSED_PENDING_INPUT" && status !== "QUEUED";
+}
+
+function mapJenkinsResult(result: string): RunStatus {
+    switch (result) {
+        case "SUCCESS":
+            return "SUCCESS";
+        case "FAILURE":
+            return "FAILED";
+        case "ABORTED":
+            return "ABORTED";
+        case "UNSTABLE":
+            return "UNSTABLE";
+        case "NOT_BUILT":
+            return "NOT_EXECUTED";
+        default:
+            return "FAILED";
+    }
 }
 
 export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
@@ -83,6 +108,8 @@ export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
     const seenBranches = new Map<string, StageStatus>();
     const reportedErrors = new Set<string>();
     const deadline = Date.now() + timeoutMs;
+    let lastRunStatus: RunStatus | null = null;
+    let pollsWithoutDelta = 0;
 
     while (Date.now() < deadline) {
         let snap: PipelineSnapshot;
@@ -101,11 +128,14 @@ export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
             seedSnapshotState(snap, seenStages, seenBranches, out);
         }
 
+        let stageDelta = false;
+
         for (const stage of snap.stages) {
             const lastStage = seenStages.get(stage.id);
             const stageUrl = buildUrl(baseUrl, { ...baseRef, nodeId: stage.id });
 
             if (lastStage !== stage.status) {
+                stageDelta = true;
                 seenStages.set(stage.id, stage.status);
                 emit(out, {
                     event: "stage",
@@ -141,6 +171,7 @@ export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
                     continue;
                 }
 
+                stageDelta = true;
                 seenBranches.set(key, branch.status);
                 const branchUrl = buildUrl(baseUrl, { ...baseRef, nodeId: branch.id });
                 emit(out, {
@@ -166,12 +197,18 @@ export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
             }
         }
 
+        if (snap.status !== lastRunStatus) {
+            lastRunStatus = snap.status;
+            emit(out, { event: "run", ts: new Date().toISOString(), status: snap.status });
+        }
+
         if (isTerminalRun(snap.status)) {
             emit(out, {
                 event: "end",
                 ts: new Date().toISOString(),
                 result: snap.status,
                 durationMillis: snap.durationMillis,
+                via: "wfapi",
             });
             notifyTransition(ctx, {
                 subtitle: "Build finished",
@@ -180,6 +217,36 @@ export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
                 openUrl: buildHref,
             });
             return { result: snap.status, durationMs: snap.durationMillis, timedOut: false };
+        }
+
+        pollsWithoutDelta = stageDelta ? 0 : pollsWithoutDelta + 1;
+
+        if (pollsWithoutDelta >= STALE_POLLS_BEFORE_API_FALLBACK) {
+            const state = await getBuildState(client, jobPath, build);
+
+            if (state && !state.building && state.result) {
+                const final = mapJenkinsResult(state.result);
+                const duration = state.duration || snap.durationMillis;
+
+                if (final === "FAILED") {
+                    await emitErrorsForFailedStages(opts, snap, reportedErrors);
+                }
+
+                emit(out, {
+                    event: "end",
+                    ts: new Date().toISOString(),
+                    result: final,
+                    durationMillis: duration,
+                    via: "api-json",
+                });
+                notifyTransition(ctx, {
+                    subtitle: "Build finished",
+                    body: `${statusBody(final)}  ${formatDuration(duration)}`,
+                    sound: final === "SUCCESS" ? "Glass" : "Basso",
+                    openUrl: buildHref,
+                });
+                return { result: final, durationMs: duration, timedOut: false };
+            }
         }
 
         await sleep(pollMs);
@@ -261,6 +328,26 @@ function isMultibranchDispatch(stage: Stage): boolean {
 function shortBranchName(name: string): string {
     const parts = name.split(" » ");
     return parts[parts.length - 1] ?? name;
+}
+
+/**
+ * Walk the latest snapshot and fire `emitErrorsForStage` for any FAILED stage
+ * we never reported during the normal transition loop. Used when the api-json
+ * fallback ends a run that wfapi never marked terminal.
+ */
+async function emitErrorsForFailedStages(
+    opts: MonitorOpts,
+    snap: PipelineSnapshot,
+    reportedErrors: Set<string>
+): Promise<void> {
+    for (const stage of snap.stages) {
+        if (stage.status !== "FAILED" || reportedErrors.has(stage.id)) {
+            continue;
+        }
+
+        reportedErrors.add(stage.id);
+        await emitErrorsForStage(opts, stage);
+    }
 }
 
 async function emitErrorsForStage(opts: MonitorOpts, stage: Stage): Promise<void> {

--- a/src/jenkins-mcp/lib/monitor.ts
+++ b/src/jenkins-mcp/lib/monitor.ts
@@ -90,6 +90,7 @@ function mapJenkinsResult(result: string): RunStatus {
         case "NOT_BUILT":
             return "NOT_EXECUTED";
         default:
+            logger.debug(`[mapJenkinsResult] unknown Jenkins result "${result}" — treating as FAILED`);
             return "FAILED";
     }
 }
@@ -222,11 +223,19 @@ export async function runMonitor(opts: MonitorOpts): Promise<MonitorResult> {
         pollsWithoutDelta = stageDelta ? 0 : pollsWithoutDelta + 1;
 
         if (pollsWithoutDelta >= STALE_POLLS_BEFORE_API_FALLBACK) {
-            const state = await getBuildState(client, jobPath, build);
+            let state: Awaited<ReturnType<typeof getBuildState>> | null = null;
+
+            try {
+                state = await getBuildState(client, jobPath, build);
+            } catch (error) {
+                logger.debug(
+                    `[runMonitor] api-json fallback failed: ${error instanceof Error ? error.message : error}`
+                );
+            }
 
             if (state && !state.building && state.result) {
                 const final = mapJenkinsResult(state.result);
-                const duration = state.duration || snap.durationMillis;
+                const duration = state.duration ?? snap.durationMillis ?? 0;
 
                 if (final === "FAILED") {
                     await emitErrorsForFailedStages(opts, snap, reportedErrors);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import path from "node:path";
+import { formatLocalDate } from "@app/utils/date";
 import { SafeJSON } from "@app/utils/json";
 import chalk from "chalk";
 import pino from "pino";
@@ -71,6 +72,7 @@ let globalConfig: LoggerConfig = {
     timestampFormat: "HH:MM:ss",
     sync: true, // Default: sync mode to ensure proper log ordering
 };
+let fileLogWarningShown = false;
 
 /**
  * Create a pino logger with pretty printing
@@ -91,13 +93,23 @@ export const createLogger = (options: LoggerOptions = {}): pino.Logger => {
 
     // File stream (if enabled) — always captures debug+ regardless of console level
     if (logToFile) {
-        const date = new Date().toISOString().split("T")[0];
+        const date = formatLocalDate(new Date());
         const logDir = path.join(homedir(), ".genesis-tools", "logs");
         const logFilePath = path.join(logDir, `${date}.log`);
-        streams.push({
-            level: "debug" as pino.Level,
-            stream: pino.destination({ dest: logFilePath, sync: true, mkdir: true }),
-        });
+
+        try {
+            streams.push({
+                level: "debug" as pino.Level,
+                stream: pino.destination({ dest: logFilePath, sync: true, mkdir: true }),
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+
+            if (!fileLogWarningShown && process.stderr && typeof process.stderr.write === "function") {
+                fileLogWarningShown = true;
+                process.stderr.write(`[logger] Failed to open log file ${logFilePath}: ${message}\n`);
+            }
+        }
     }
 
     // Console stream

--- a/src/macos/commands/mail/download.ts
+++ b/src/macos/commands/mail/download.ts
@@ -1,217 +1,100 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
 import logger from "@app/logger";
-import { parseMailDate } from "@app/macos/lib/mail/command-helpers";
-import { EmlxBodyExtractor } from "@app/macos/lib/mail/emlx";
-import { generateEmailMarkdown, generateIndexMarkdown, generateSlug } from "@app/macos/lib/mail/format";
-import { saveAttachment } from "@app/macos/lib/mail/jxa";
-import { MailStorage } from "@app/macos/lib/mail/mail-storage";
-import { truncateBody } from "@app/macos/lib/mail/transform";
+import { exportMessages, parseMailIds } from "@app/macos/lib/mail/export";
+import { rowToMessage } from "@app/macos/lib/mail/transform";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 
 export function registerDownloadCommand(program: Command): void {
     program
-        .command("download <output-dir>")
-        .description("Download search results as markdown files")
-        .option("--yes", "Skip all confirmations")
+        .command("download [ids...]")
+        .description("Download specific emails by ID (with attachments) to a directory")
+        .option("--ids <ids>", "Comma-delimited email IDs (alternative to positional args)")
+        .option("--output-dir <dir>", "Directory to write into")
+        .option("--save-attachments", "Download attachments to output-dir/attachments/")
+        .option("--attachments-only", "Write only attachments, skip the .md files")
+        .option("--body-max-chars <n>", "Max body characters per email")
         .option("--overwrite", "Overwrite existing index.md")
         .option("--append", "Append to existing index.md")
-        .option("--save-attachments", "Download attachments to output-dir/attachments/")
-        .option("--from <date>", "Only download emails sent after date (ISO format)")
-        .option("--to <date>", "Only download emails sent before date (ISO format)")
-        .option("--body-max-chars <n>", "Max body characters per email")
+        .option("--yes", "Skip all confirmations")
         .action(
             async (
-                outputDirArg: string,
+                idsArg: string[],
                 options: {
-                    yes?: boolean;
+                    ids?: string;
+                    outputDir?: string;
+                    saveAttachments?: boolean;
+                    attachmentsOnly?: boolean;
+                    bodyMaxChars?: string;
                     overwrite?: boolean;
                     append?: boolean;
-                    saveAttachments?: boolean;
-                    from?: string;
-                    to?: string;
-                    bodyMaxChars?: string;
+                    yes?: boolean;
                 }
             ) => {
                 const db = new MailDatabase();
 
                 try {
-                    const outputDir = resolve(outputDirArg);
-                    const isTTY = process.stdout.isTTY;
+                    const ids = parseMailIds(idsArg ?? [], options.ids);
 
-                    // Load last search results
-                    const mailStorage = new MailStorage();
-                    const messages = mailStorage.loadSearchResults();
-
-                    if (!messages || messages.length === 0) {
-                        p.log.error("No search results found. Run 'tools macos mail search <query>' first.");
+                    if (ids.length === 0) {
+                        p.log.error(
+                            "No email IDs given. Usage: tools macos mail download <id,id,...> --output-dir <dir>\n" +
+                                "To export a whole search instead, use: tools macos mail search-download <query> --output-dir <dir>"
+                        );
                         process.exit(1);
                     }
 
-                    p.log.info(`Downloading ${messages.length} emails to ${outputDir}`);
-
-                    // Check for existing index.md
-                    const indexPath = join(outputDir, "index.md");
-                    if (existsSync(indexPath) && !options.overwrite && !options.append) {
-                        if (!isTTY && !options.yes) {
-                            p.log.error(`${indexPath} already exists. Use --overwrite, --append, or --yes.`);
-                            process.exit(1);
-                        }
-
-                        if (isTTY && !options.yes) {
-                            const action = await p.select({
-                                message: `${indexPath} already exists. What to do?`,
-                                options: [
-                                    { value: "overwrite", label: "Overwrite" },
-                                    { value: "append", label: "Append" },
-                                    { value: "skip", label: "Cancel" },
-                                ],
-                            });
-
-                            if (p.isCancel(action) || action === "skip") {
-                                p.cancel("Download cancelled.");
-                                process.exit(0);
-                            }
-
-                            if (action === "overwrite") {
-                                options.overwrite = true;
-                            }
-                            if (action === "append") {
-                                options.append = true;
-                            }
-                        }
+                    if (!options.outputDir) {
+                        p.log.error("--output-dir is required.");
+                        process.exit(1);
                     }
 
-                    // Warn on large result sets
-                    if (messages.length > 100 && !options.yes) {
-                        if (!isTTY) {
-                            p.log.error(`${messages.length} messages to download. Use --yes to confirm.`);
-                            process.exit(1);
-                        }
+                    logger.info(`[mail/download] requested ids=${ids.join(",")} outputDir=${options.outputDir}`);
 
-                        const proceed = await p.confirm({
-                            message: `Download ${messages.length} emails? This may take a while.`,
-                        });
-                        if (p.isCancel(proceed) || !proceed) {
-                            p.cancel("Download cancelled.");
-                            process.exit(0);
-                        }
+                    const rows = await db.getMessagesByRowids(ids);
+
+                    if (rows.length === 0) {
+                        p.log.error(`No emails found for the given IDs: ${ids.join(", ")}`);
+                        process.exit(1);
                     }
 
-                    // Create directories
-                    const emailsDir = join(outputDir, "emails");
-                    mkdirSync(emailsDir, { recursive: true });
-
-                    if (options.saveAttachments) {
-                        mkdirSync(join(outputDir, "attachments"), { recursive: true });
+                    if (rows.length < ids.length) {
+                        const found = new Set(rows.map((r) => r.rowid));
+                        const missing = ids.filter((id) => !found.has(id));
+                        p.log.warn(`Not found: ${missing.join(", ")}`);
                     }
 
-                    // Apply date filters
-                    let filteredMessages = messages;
+                    const messages = rows.map(rowToMessage);
+                    const attachmentsMap = await db.getAttachments(messages.map((m) => m.rowid));
 
-                    const fromDate = parseMailDate(options.from);
-
-                    if (fromDate) {
-                        filteredMessages = filteredMessages.filter((m) => m.dateSent >= fromDate);
+                    for (const m of messages) {
+                        m.attachments = attachmentsMap.get(m.rowid) ?? [];
                     }
 
-                    const toDate = parseMailDate(options.to, true);
+                    const result = await exportMessages({
+                        messages,
+                        outputDir: options.outputDir,
+                        db,
+                        saveAttachments: options.saveAttachments,
+                        attachmentsOnly: options.attachmentsOnly,
+                        bodyMaxChars: options.bodyMaxChars ? Number.parseInt(options.bodyMaxChars, 10) : undefined,
+                        overwrite: options.overwrite,
+                        append: options.append,
+                        yes: options.yes,
+                    });
 
-                    if (toDate) {
-                        filteredMessages = filteredMessages.filter((m) => m.dateSent <= toDate);
+                    p.log.success(`Downloaded ${result.emailCount} email(s) to ${result.outputDir}`);
+
+                    if (result.emailsDir) {
+                        p.log.info(`  Emails: ${result.emailsDir}/`);
                     }
 
-                    if (filteredMessages.length === 0) {
-                        p.log.info("No messages match the date filter.");
-                        return;
-                    }
-
-                    if (filteredMessages.length !== messages.length) {
-                        p.log.info(
-                            `Filtered to ${filteredMessages.length} of ${messages.length} messages by date range`
-                        );
-                    }
-
-                    // Fetch recipients for all messages
-                    const rowids = filteredMessages.map((m) => m.rowid);
-                    const recipientsMap = await db.getRecipients(rowids);
-
-                    // Create EmlxBodyExtractor (fast: ~42 msg/s L2, instant L1)
-                    const emlx = await EmlxBodyExtractor.create();
-                    const bodyMaxChars = options.bodyMaxChars ? Number.parseInt(options.bodyMaxChars, 10) : undefined;
-
-                    // Process each email
-                    const spinner = p.spinner();
-                    spinner.start("Processing emails...");
-                    let processed = 0;
-
-                    for (const msg of filteredMessages) {
-                        processed++;
-                        spinner.message(`[${processed}/${filteredMessages.length}] ${msg.subject.slice(0, 50)}...`);
-
-                        // Attach recipients
-                        msg.recipients = recipientsMap.get(msg.rowid) ?? [];
-
-                        const body = await emlx.getBody(msg.rowid);
-                        msg.body = body && bodyMaxChars ? truncateBody(body, bodyMaxChars) : (body ?? undefined);
-
-                        // Generate markdown
-                        const slug = generateSlug(msg);
-                        const emailMd = generateEmailMarkdown(msg);
-                        writeFileSync(join(emailsDir, `${slug}.md`), emailMd);
-
-                        // Save attachments if requested
-                        if (options.saveAttachments && msg.attachments.length > 0) {
-                            for (const att of msg.attachments) {
-                                const safeAttName = basename(att.name).replace(/[^\w.-]/g, "_");
-                                const attPath = join(outputDir, "attachments", safeAttName);
-                                if (!existsSync(attPath)) {
-                                    await saveAttachment(
-                                        msg.subject,
-                                        msg.senderAddress ?? "unknown-sender",
-                                        att.name,
-                                        attPath
-                                    );
-                                } else {
-                                    // Disambiguate with rowid to avoid silently dropping duplicates
-                                    const dotIdx = safeAttName.lastIndexOf(".");
-                                    const ext = dotIdx !== -1 ? safeAttName.slice(dotIdx) : "";
-                                    const base = safeAttName.slice(0, safeAttName.length - ext.length);
-                                    const disambiguated = `${base}_${msg.rowid}${ext}`;
-                                    const altPath = join(outputDir, "attachments", disambiguated);
-                                    logger.debug(`Attachment collision: ${safeAttName} → saving as ${disambiguated}`);
-                                    await saveAttachment(
-                                        msg.subject,
-                                        msg.senderAddress ?? "unknown-sender",
-                                        att.name,
-                                        altPath
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    emlx.dispose();
-                    spinner.stop(`Processed ${processed} emails`);
-
-                    // Generate index.md
-                    const indexMd = generateIndexMarkdown(filteredMessages);
-                    if (options.append && existsSync(indexPath)) {
-                        const existing = readFileSync(indexPath, "utf-8");
-                        writeFileSync(indexPath, `${existing}\n\n---\n\n${indexMd}`);
-                    } else {
-                        writeFileSync(indexPath, indexMd);
-                    }
-
-                    p.log.success(`Downloaded to ${outputDir}`);
-                    p.log.info(`  Index: ${indexPath}`);
-                    p.log.info(`  Emails: ${emailsDir}/ (${filteredMessages.length} files)`);
-                    if (options.saveAttachments) {
-                        p.log.info(`  Attachments: ${join(outputDir, "attachments")}/`);
+                    if (result.attachmentsDir) {
+                        p.log.info(`  Attachments: ${result.attachmentsDir}/`);
                     }
                 } catch (error) {
                     p.log.error(error instanceof Error ? error.message : String(error));
+                    logger.error(`[mail/download] ${error instanceof Error ? error.stack : String(error)}`);
                     process.exit(1);
                 } finally {
                     db.close();

--- a/src/macos/commands/mail/index.ts
+++ b/src/macos/commands/mail/index.ts
@@ -5,17 +5,19 @@ import { registerIndexCommand } from "./index-cmd";
 import { registerListCommand } from "./list";
 import { registerMonitorCommand } from "./monitor";
 import { registerSearchCommand } from "./search";
+import { registerSearchDownloadCommand } from "./search-download";
 import { registerShowCommand } from "./show";
 
 /**
  * Register the `mail` subcommand on the parent program.
- * Usage: tools macos mail <search|list|download|index|monitor> [options]
+ * Usage: tools macos mail <search|search-download|download|list|index|monitor> [options]
  */
 export function registerMailCommand(program: Command): void {
     const mail = new Command("mail");
     mail.description("Search, list, and download emails from macOS Mail.app").showHelpAfterError(true);
 
     registerSearchCommand(mail);
+    registerSearchDownloadCommand(mail);
     registerListCommand(mail);
     registerDownloadCommand(mail);
     registerIndexCommand(mail);

--- a/src/macos/commands/mail/search-download.ts
+++ b/src/macos/commands/mail/search-download.ts
@@ -1,7 +1,7 @@
 import logger from "@app/logger";
 import { parseMailDate } from "@app/macos/lib/mail/command-helpers";
 import { exportMessages } from "@app/macos/lib/mail/export";
-import { runMailSearch, type MailSearchMode } from "@app/macos/lib/mail/search-runner";
+import { type MailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";

--- a/src/macos/commands/mail/search-download.ts
+++ b/src/macos/commands/mail/search-download.ts
@@ -1,7 +1,7 @@
 import logger from "@app/logger";
 import { parseMailDate } from "@app/macos/lib/mail/command-helpers";
 import { exportMessages } from "@app/macos/lib/mail/export";
-import { type MailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
+import { resolveMailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
@@ -70,7 +70,7 @@ export function registerSearchDownloadCommand(program: Command): void {
                     const spinner = p.spinner();
                     const outcome = await runMailSearch(query, {
                         searchOpts,
-                        mode: (options.mode as MailSearchMode) ?? "auto",
+                        mode: resolveMailSearchMode(options.mode),
                         jxa: options.jxa,
                         db,
                         onProgress: spinner,

--- a/src/macos/commands/mail/search-download.ts
+++ b/src/macos/commands/mail/search-download.ts
@@ -1,0 +1,115 @@
+import logger from "@app/logger";
+import { parseMailDate } from "@app/macos/lib/mail/command-helpers";
+import { exportMessages } from "@app/macos/lib/mail/export";
+import { runMailSearch, type MailSearchMode } from "@app/macos/lib/mail/search-runner";
+import { MailDatabase } from "@app/utils/macos/MailDatabase";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+
+export function registerSearchDownloadCommand(program: Command): void {
+    program
+        .command("search-download <query>")
+        .description("Re-run a search and write all results to disk as markdown")
+        .option("--output-dir <dir>", "Directory to write into")
+        .option("--receiver <email>", "Filter by receiver email address")
+        .option("--account <id>", "Filter by account (email address or UUID prefix)")
+        .option("--from <date>", "Search from date (ISO format)")
+        .option("--to <date>", "Search to date (ISO format)")
+        .option("--mailbox <name>", "Restrict to a specific mailbox")
+        .option("--limit <n>", "Max results", "100")
+        .option("--mode <mode>", "Search mode: auto | fulltext | hybrid | vector", "auto")
+        .option("--jxa", "Skip the FTS index, use SQLite LIKE search only")
+        .option("--without-body", "Skip body search entirely (metadata-only)")
+        .option("--yes", "Skip all confirmations")
+        .option("--overwrite", "Overwrite existing index.md")
+        .option("--append", "Append to existing index.md")
+        .option("--save-attachments", "Download attachments to output-dir/attachments/")
+        .option("--attachments-only", "Write only attachments, skip the .md files")
+        .option("--body-max-chars <n>", "Max body characters per email")
+        .action(
+            async (
+                query: string,
+                options: {
+                    outputDir?: string;
+                    receiver?: string;
+                    account?: string;
+                    from?: string;
+                    to?: string;
+                    mailbox?: string;
+                    limit?: string;
+                    mode?: string;
+                    jxa?: boolean;
+                    withoutBody?: boolean;
+                    yes?: boolean;
+                    overwrite?: boolean;
+                    append?: boolean;
+                    saveAttachments?: boolean;
+                    attachmentsOnly?: boolean;
+                    bodyMaxChars?: string;
+                }
+            ) => {
+                const db = new MailDatabase();
+
+                try {
+                    if (!options.outputDir) {
+                        p.log.error("--output-dir is required.");
+                        process.exit(1);
+                    }
+
+                    const searchOpts = db.resolveMailboxFilter({
+                        query,
+                        withoutBody: options.withoutBody,
+                        receiver: options.receiver,
+                        account: options.account,
+                        from: parseMailDate(options.from),
+                        to: parseMailDate(options.to, true),
+                        mailbox: options.mailbox,
+                        limit: Number.parseInt(options.limit ?? "100", 10),
+                        offset: 0,
+                    });
+                    const spinner = p.spinner();
+                    const outcome = await runMailSearch(query, {
+                        searchOpts,
+                        mode: (options.mode as MailSearchMode) ?? "auto",
+                        jxa: options.jxa,
+                        db,
+                        onProgress: spinner,
+                    });
+
+                    if (outcome.messages.length === 0) {
+                        p.log.info("No messages found matching your query.");
+                        return;
+                    }
+
+                    const result = await exportMessages({
+                        messages: outcome.messages,
+                        outputDir: options.outputDir,
+                        db,
+                        query,
+                        saveAttachments: options.saveAttachments,
+                        attachmentsOnly: options.attachmentsOnly,
+                        bodyMaxChars: options.bodyMaxChars ? Number.parseInt(options.bodyMaxChars, 10) : undefined,
+                        yes: options.yes,
+                        overwrite: options.overwrite,
+                        append: options.append,
+                    });
+
+                    p.log.success(`Downloaded ${result.emailCount} emails to ${result.outputDir}`);
+
+                    if (result.indexPath) {
+                        p.log.info(`  Index: ${result.indexPath}`);
+                    }
+
+                    if (result.attachmentsDir) {
+                        p.log.info(`  Attachments: ${result.attachmentsDir}/`);
+                    }
+                } catch (error) {
+                    p.log.error(error instanceof Error ? error.message : String(error));
+                    logger.error(`[mail/search-download] ${error instanceof Error ? error.stack : String(error)}`);
+                    process.exit(1);
+                } finally {
+                    db.close();
+                }
+            }
+        );
+}

--- a/src/macos/commands/mail/search.e2e.test.ts
+++ b/src/macos/commands/mail/search.e2e.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+
+const INDEX_DB = join(homedir(), ".genesis-tools/indexer/macos-mail/index.db");
+const TOOLS_BIN = join(import.meta.dir, "../../../../tools");
+const CAN_RUN = process.platform === "darwin" && existsSync(INDEX_DB) && existsSync(TOOLS_BIN);
+
+describe("tools macos mail search --mode auto (e2e)", () => {
+    it.skipIf(!CAN_RUN)(
+        "loads sqlite-vec and does not error",
+        async () => {
+            const proc = Bun.spawn(
+                [TOOLS_BIN, "macos", "mail", "search", "invoice", "--mode", "auto", "--limit", "1", "--format", "json"],
+                { stdout: "pipe", stderr: "pipe" }
+            );
+            const stdout = await new Response(proc.stdout).text();
+            const stderr = await new Response(proc.stderr).text();
+            const exitCode = await proc.exited;
+
+            expect(stderr).not.toContain("sqlite-vec extension failed to load");
+            expect(exitCode).toBe(0);
+            expect(() => SafeJSON.parse(stdout.trim() || "[]")).not.toThrow();
+        },
+        60_000
+    );
+
+    it.skipIf(!CAN_RUN)(
+        "JSON output has typed date/relevance/attachments",
+        async () => {
+            const proc = Bun.spawn(
+                [
+                    TOOLS_BIN,
+                    "macos",
+                    "mail",
+                    "search",
+                    "invoice",
+                    "--mode",
+                    "auto",
+                    "--limit",
+                    "3",
+                    "--columns",
+                    "id,date,relevance,attachments,subject",
+                    "--format",
+                    "json",
+                ],
+                { stdout: "pipe", stderr: "pipe" }
+            );
+            const stdout = await new Response(proc.stdout).text();
+            const exitCode = await proc.exited;
+            const rows = SafeJSON.parse(stdout.trim() || "[]") as Array<Record<string, unknown>>;
+
+            expect(exitCode).toBe(0);
+            expect(rows.length).toBeGreaterThan(0);
+
+            for (const row of rows) {
+                expect(typeof row.date).toBe("string");
+                expect(row.date as string).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+                expect(row.relevance === null || typeof row.relevance === "number").toBe(true);
+                expect(Array.isArray(row.attachments)).toBe(true);
+            }
+        },
+        60_000
+    );
+
+    it.skipIf(!CAN_RUN)(
+        "search-download writes results without a prior search call",
+        async () => {
+            const { existsSync, mkdtempSync } = await import("node:fs");
+            const { tmpdir } = await import("node:os");
+            const outDir = mkdtempSync(join(tmpdir(), "sd-e2e-"));
+            const proc = Bun.spawn(
+                [TOOLS_BIN, "macos", "mail", "search-download", "invoice", "--output-dir", outDir, "--limit", "3", "--yes"],
+                { stdout: "pipe", stderr: "pipe" }
+            );
+            const stderr = await new Response(proc.stderr).text();
+            const exitCode = await proc.exited;
+
+            expect(stderr).not.toContain("No search results found");
+            expect(exitCode).toBe(0);
+            expect(existsSync(join(outDir, "emails"))).toBe(true);
+        },
+        90_000
+    );
+
+    it.skipIf(!CAN_RUN)(
+        "show --json is not truncated through a slow pipe consumer",
+        async () => {
+            const idsProc = Bun.spawn(
+                [
+                    TOOLS_BIN,
+                    "macos",
+                    "mail",
+                    "search",
+                    "the",
+                    "--mode",
+                    "fulltext",
+                    "--limit",
+                    "30",
+                    "--columns",
+                    "id",
+                    "--format",
+                    "json",
+                ],
+                { stdout: "pipe", stderr: "pipe" }
+            );
+            const idsRaw = await new Response(idsProc.stdout).text();
+            await idsProc.exited;
+            const ids = (SafeJSON.parse(idsRaw.trim() || "[]") as Array<{ id: string }>).map((r) => Number(r.id));
+
+            let bigId: number | undefined;
+            let fileLen = 0;
+
+            for (const id of ids) {
+                const p = Bun.spawn([TOOLS_BIN, "macos", "mail", "show", String(id), "--json"], {
+                    stdout: "pipe",
+                    stderr: "pipe",
+                });
+                const text = await new Response(p.stdout).text();
+                await p.exited;
+
+                if (text.length > 90_000) {
+                    bigId = id;
+                    fileLen = text.length;
+                    break;
+                }
+            }
+
+            if (bigId === undefined) {
+                return;
+            }
+
+            const piped = Bun.spawn(["sh", "-c", `'${TOOLS_BIN}' macos mail show ${bigId} --json | cat`], {
+                stdout: "pipe",
+                stderr: "pipe",
+            });
+            const pipedText = await new Response(piped.stdout).text();
+            await piped.exited;
+
+            expect(pipedText.length).toBe(fileLen);
+            expect(() => SafeJSON.parse(pipedText, { strict: true })).not.toThrow();
+        },
+        120_000
+    );
+});

--- a/src/macos/commands/mail/search.e2e.test.ts
+++ b/src/macos/commands/mail/search.e2e.test.ts
@@ -72,7 +72,18 @@ describe("tools macos mail search --mode auto (e2e)", () => {
             const { tmpdir } = await import("node:os");
             const outDir = mkdtempSync(join(tmpdir(), "sd-e2e-"));
             const proc = Bun.spawn(
-                [TOOLS_BIN, "macos", "mail", "search-download", "invoice", "--output-dir", outDir, "--limit", "3", "--yes"],
+                [
+                    TOOLS_BIN,
+                    "macos",
+                    "mail",
+                    "search-download",
+                    "invoice",
+                    "--output-dir",
+                    outDir,
+                    "--limit",
+                    "3",
+                    "--yes",
+                ],
                 { stdout: "pipe", stderr: "pipe" }
             );
             const stderr = await new Response(proc.stderr).text();

--- a/src/macos/commands/mail/search.e2e.test.ts
+++ b/src/macos/commands/mail/search.e2e.test.ts
@@ -22,7 +22,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
 
             expect(stderr).not.toContain("sqlite-vec extension failed to load");
             expect(exitCode).toBe(0);
-            expect(() => SafeJSON.parse(stdout.trim() || "[]")).not.toThrow();
+            expect(() => SafeJSON.parse(stdout.trim() || "[]", { strict: true })).not.toThrow();
         },
         60_000
     );
@@ -50,7 +50,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
             );
             const stdout = await new Response(proc.stdout).text();
             const exitCode = await proc.exited;
-            const rows = SafeJSON.parse(stdout.trim() || "[]") as Array<Record<string, unknown>>;
+            const rows = SafeJSON.parse(stdout.trim() || "[]", { strict: true }) as Array<Record<string, unknown>>;
 
             expect(exitCode).toBe(0);
             expect(rows.length).toBeGreaterThan(0);
@@ -119,7 +119,9 @@ describe("tools macos mail search --mode auto (e2e)", () => {
             );
             const idsRaw = await new Response(idsProc.stdout).text();
             await idsProc.exited;
-            const ids = (SafeJSON.parse(idsRaw.trim() || "[]") as Array<{ id: string }>).map((r) => Number(r.id));
+            const ids = (SafeJSON.parse(idsRaw.trim() || "[]", { strict: true }) as Array<{ id: string }>).map((r) =>
+                Number(r.id)
+            );
 
             let bigId: number | undefined;
             let fileLen = 0;

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -7,30 +7,12 @@ import {
     parseMailDate,
     resolveColumnsFromFlag,
 } from "@app/macos/lib/mail/command-helpers";
-import { type MailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
+import { resolveMailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
 import type { SearchOptions } from "@app/macos/lib/mail/types";
 import { isQuietOutput } from "@app/utils/cli/output-mode";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
-
-const VALID_MAIL_SEARCH_MODES = new Set<MailSearchMode>(["auto", "fulltext", "hybrid", "vector"]);
-
-function isMailSearchMode(input: string): input is MailSearchMode {
-    return VALID_MAIL_SEARCH_MODES.has(input as MailSearchMode);
-}
-
-function resolveMailSearchMode(input: string | undefined): MailSearchMode {
-    if (!input) {
-        return "auto";
-    }
-
-    if (isMailSearchMode(input)) {
-        return input;
-    }
-
-    throw new Error(`Unknown --mode: "${input}". Valid: ${[...VALID_MAIL_SEARCH_MODES].join(", ")}`);
-}
 
 interface SearchCommandOptions {
     withoutBody?: boolean;

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -1,8 +1,3 @@
-import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { getIndexerStorage } from "@app/indexer/lib/storage";
-import { searchIndexReadonly } from "@app/indexer/lib/store";
 import logger from "@app/logger";
 import { ALL_COLUMN_KEYS, type MailColumnKey } from "@app/macos/lib/mail/columns";
 import {
@@ -12,28 +7,13 @@ import {
     parseMailDate,
     resolveColumnsFromFlag,
 } from "@app/macos/lib/mail/command-helpers";
-import { ENVELOPE_INDEX_PATH } from "@app/macos/lib/mail/constants";
-import { MailStorage } from "@app/macos/lib/mail/mail-storage";
-import { buildMailFilterPredicate } from "@app/macos/lib/mail/search-filters";
-import {
-    formatFallbackStart,
-    formatFallbackStop,
-    formatSearchLabelEmpty,
-    formatSearchLabelStart,
-    formatSearchLabelStop,
-    type ResolvedMethod,
-} from "@app/macos/lib/mail/search-label";
-import { mdfindMailRowids } from "@app/macos/lib/mail/spotlight";
-import { rowToMessage } from "@app/macos/lib/mail/transform";
-import type { MailMessage, MailMessageRow, SearchOptions } from "@app/macos/lib/mail/types";
+import { type MailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
+import type { SearchOptions } from "@app/macos/lib/mail/types";
 import { isQuietOutput } from "@app/utils/cli/output-mode";
-import { SafeJSON } from "@app/utils/json";
-import { closeDarwinKit, rankBySimilarity } from "@app/utils/macos";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 
-type MailSearchMode = "auto" | "fulltext" | "hybrid" | "vector";
 const VALID_MAIL_SEARCH_MODES = new Set<MailSearchMode>(["auto", "fulltext", "hybrid", "vector"]);
 
 function isMailSearchMode(input: string): input is MailSearchMode {
@@ -50,66 +30,6 @@ function resolveMailSearchMode(input: string | undefined): MailSearchMode {
     }
 
     throw new Error(`Unknown --mode: "${input}". Valid: ${[...VALID_MAIL_SEARCH_MODES].join(", ")}`);
-}
-
-/**
- * Emit a stderr advisory when the user's `--from` / `--to` window falls (even
- * partially) outside the date span actually covered by the index. Best-effort:
- * a missing or unreadable meta row silently skips the check — search is the
- * primary action, not coverage validation.
- *
- * stderr-only so `--format json` / `toon` stay machine-readable.
- */
-function warnIfDateRangeOutsideCoverage(args: { indexDbPath: string; from?: Date; to?: Date }): void {
-    const { indexDbPath, from, to } = args;
-
-    try {
-        const metaDb = new Database(indexDbPath, { readonly: true });
-
-        try {
-            const row = metaDb.query("SELECT value FROM index_meta WHERE key = 'meta'").get() as {
-                value: string;
-            } | null;
-
-            if (!row) {
-                return;
-            }
-
-            const meta = SafeJSON.parse(row.value) as {
-                stats?: { dateRangeMin?: number | null; dateRangeMax?: number | null };
-            };
-            const min = meta.stats?.dateRangeMin ?? null;
-            const max = meta.stats?.dateRangeMax ?? null;
-
-            if (min === null || max === null) {
-                return;
-            }
-
-            // Compare on day-floor to avoid spurious warnings when the user's
-            // `--to` is end-of-day but the indexed max is a message timestamp
-            // earlier in that same day.
-            const isoDay = (ts: number): string => new Date(ts).toISOString().slice(0, 10);
-            const minDay = isoDay(min * 1000);
-            const maxDay = isoDay(max * 1000);
-            const fromDay = from ? isoDay(from.getTime()) : undefined;
-            const toDay = to ? isoDay(to.getTime()) : undefined;
-            const outsideLower = fromDay !== undefined && fromDay < minDay;
-            const outsideUpper = toDay !== undefined && toDay > maxDay;
-
-            if (!outsideLower && !outsideUpper) {
-                return;
-            }
-
-            process.stderr.write(
-                `⚠  Requested range partially outside indexed coverage (${minDay} → ${maxDay}). ` +
-                    `Run "tools macos mail index" to refresh.\n`
-            );
-        } finally {
-            metaDb.close();
-        }
-    } catch (err) {
-        logger.debug(`[mail/search] coverage check skipped: ${err}`);
-    }
 }
 
 interface SearchCommandOptions {
@@ -164,11 +84,6 @@ function buildSearchColumns({
     return result;
 }
 
-const MAIL_INDEX_NAME = "macos-mail";
-// Keep hybrid/vector filtered searches under sqlite-vec's k=4096 cap while
-// making small pages stable enough that --limit 20 and --limit 50 share first-N.
-const STABLE_INDEX_FETCH_LIMIT = 250;
-
 interface QuietSpinner {
     start: (msg: string) => void;
     stop: (msg: string) => void;
@@ -179,6 +94,17 @@ function createQuietSpinner(): QuietSpinner {
         start: (): void => {},
         stop: (): void => {},
     };
+}
+
+function isVerboseErrorOutput(): boolean {
+    return (
+        process.env.LOG_DEBUG === "1" ||
+        process.env.LOG_TRACE === "1" ||
+        process.argv.includes("--verbose") ||
+        process.argv.includes("-v") ||
+        process.argv.includes("--trace") ||
+        process.argv.includes("-vv")
+    );
 }
 
 export function registerSearchCommand(program: Command): void {
@@ -244,183 +170,42 @@ export function registerSearchCommand(program: Command): void {
                     offset: Number.parseInt(options.offset ?? "0", 10),
                 });
 
-                const resolvedMode = resolveMailSearchMode(options.mode);
-                const filterPredicate = buildMailFilterPredicate(searchOpts);
-
-                const indexerStorage = getIndexerStorage();
-                const indexDbPath = join(indexerStorage.getIndexDir(MAIL_INDEX_NAME), "index.db");
-                const indexExists = existsSync(indexDbPath);
-                const willUseIndex = indexExists && !options.jxa && !searchOpts.withoutBody;
-
-                // Only warn about indexed coverage when the search will actually
-                // read the index. --jxa and --without-body bypass it, so the
-                // "run mail index to refresh" advice would be misleading.
-                if (willUseIndex && (searchOpts.from || searchOpts.to)) {
-                    warnIfDateRangeOutsideCoverage({
-                        indexDbPath,
-                        from: searchOpts.from,
-                        to: searchOpts.to,
-                    });
-                }
-
-                let rows: MailMessageRow[] = [];
-                const snippetByRowid = new Map<number, string>();
-                let searchMethod: "fts" | "spotlight+like" = "spotlight+like";
-                let resolvedMethod: ResolvedMethod | undefined;
-
-                if (willUseIndex) {
-                    spinner.start(formatSearchLabelStart(resolvedMode));
-                    const t0 = performance.now();
-
-                    const fetchLimit = Math.max(
-                        (searchOpts.offset ?? 0) + (searchOpts.limit ?? 100),
-                        STABLE_INDEX_FETCH_LIMIT
-                    );
-
-                    const ftsResults = await searchIndexReadonly(MAIL_INDEX_NAME, query, {
-                        mode: resolvedMode,
-                        limit: fetchLimit,
-                        ...(filterPredicate && {
-                            filters: filterPredicate,
-                            attach: { alias: "mailapp", dbPath: ENVELOPE_INDEX_PATH, mode: "ro" as const },
-                        }),
-                    });
-
-                    const ms = performance.now() - t0;
-                    const ftsRowids: number[] = [];
-
-                    for (const r of ftsResults) {
-                        const sid = r.doc.sourceId ?? (r.doc as unknown as { source_id?: string }).source_id;
-
-                        if (!sid) {
-                            continue;
+                const outcome = await runMailSearch(query, {
+                    searchOpts,
+                    mode: resolveMailSearchMode(options.mode),
+                    jxa: options.jxa,
+                    semantic: options.semantic,
+                    maxDistance: options.maxDistance ? Number.parseFloat(options.maxDistance) : undefined,
+                    db,
+                    onProgress: spinner,
+                    onWarning: (message): void => {
+                        if (isStructuredOutput || quiet) {
+                            process.stderr.write(`WARN: ${message}\n`);
+                            return;
                         }
 
-                        const rowid = Number(sid);
-                        ftsRowids.push(rowid);
+                        logger.warn(message);
+                    },
+                });
+                const messages = outcome.messages;
 
-                        if (!snippetByRowid.has(rowid)) {
-                            const snippet =
-                                r.ftsSnippet ??
-                                (typeof r.doc.content === "string"
-                                    ? r.doc.content.replace(/\s+/g, " ").trim().slice(0, 200)
-                                    : undefined);
-
-                            if (snippet) {
-                                snippetByRowid.set(rowid, snippet);
-                            }
-                        }
-                    }
-
-                    resolvedMethod = ftsResults[0]?.method;
-                    rows = ftsRowids.length > 0 ? await db.getMessagesByRowids(ftsRowids, searchOpts) : [];
-                    searchMethod = "fts";
-
-                    const orderByRowid = new Map(ftsRowids.map((rowid, index) => [rowid, index]));
-                    rows.sort(
-                        (a, b) => (orderByRowid.get(a.rowid) ?? Infinity) - (orderByRowid.get(b.rowid) ?? Infinity)
-                    );
-
-                    if (rows.length > 0) {
-                        spinner.stop(formatSearchLabelStop(resolvedMode, resolvedMethod, rows.length, ms));
-                    } else {
-                        spinner.stop(formatSearchLabelEmpty(resolvedMode));
-                    }
-                }
-
-                if (!indexExists || (options.jxa ?? false) || (searchOpts.withoutBody ?? false)) {
-                    spinner.start(formatFallbackStart());
-                    const t0 = performance.now();
-
-                    const [spotlightRowids, likeRows] = await Promise.all([
-                        mdfindMailRowids(query),
-                        db.searchMessages(searchOpts),
-                    ]);
-
-                    const rowidSet = new Set<number>(likeRows.map((r) => r.rowid));
-                    const newSpotlightIds = spotlightRowids.filter((r) => !rowidSet.has(r));
-
-                    const spotlightRows =
-                        newSpotlightIds.length > 0 ? await db.getMessagesByRowids(newSpotlightIds, searchOpts) : [];
-
-                    rows = [...likeRows, ...spotlightRows];
-                    const fallbackOrder = new Map(rows.map((row, index) => [row.rowid, index]));
-                    rows = [...new Map(rows.map((row) => [row.rowid, row])).values()].sort(
-                        (a, b) => (fallbackOrder.get(a.rowid) ?? Infinity) - (fallbackOrder.get(b.rowid) ?? Infinity)
-                    );
-                    const ms = performance.now() - t0;
-                    spinner.stop(formatFallbackStop(rows.length, ms));
-                }
-
-                if (rows.length === 0) {
+                if (messages.length === 0) {
                     announce("No messages found matching your query.");
                     return;
                 }
 
-                const isFts = searchMethod === "fts";
-                const rowids = rows.map((r) => r.rowid);
-                const attachmentsMap = await db.getAttachments(rowids);
-
-                const messages: MailMessage[] = rows.map((row) => {
-                    const msg = rowToMessage(row);
-                    msg.attachments = attachmentsMap.get(row.rowid) ?? [];
-                    msg.bodyMatchesQuery = isFts;
-                    msg.ftsSnippet = snippetByRowid.get(row.rowid);
-                    return msg;
-                });
-
                 await enrichWithBodies(messages, baseColumns);
-
-                let semanticActive = false;
-
-                if (options.semantic === true && messages.length > 0) {
-                    spinner.start(`Apple NL re-ranking ${messages.length} results…`);
-
-                    try {
-                        const maxDist = Number.parseFloat(options.maxDistance ?? "1.2");
-                        const items = messages.map((m) => ({
-                            ...m,
-                            text: [m.subject, m.senderName, m.senderAddress, m.ftsSnippet ?? m.body ?? ""]
-                                .filter(Boolean)
-                                .join(" ")
-                                .slice(0, 2000),
-                        }));
-                        const ranked = await rankBySimilarity(query, items, { maxDistance: maxDist, language: "en" });
-                        const reordered: MailMessage[] = ranked.map((r) => {
-                            const msg = r.item as MailMessage;
-                            msg.semanticScore = r.score;
-                            return msg;
-                        });
-                        const rankedIds = new Set(reordered.map((m) => m.rowid));
-
-                        for (const msg of messages) {
-                            if (!rankedIds.has(msg.rowid)) {
-                                reordered.push(msg);
-                            }
-                        }
-
-                        messages.length = 0;
-                        messages.push(...reordered);
-                        semanticActive = true;
-                        spinner.stop(`Semantic ranking complete (${ranked.length} relevant results)`);
-                    } catch (err) {
-                        spinner.stop(`Semantic ranking skipped: ${err instanceof Error ? err.message : String(err)}`);
-                        logger.warn(`Semantic ranking failed: ${err}`);
-                    } finally {
-                        closeDarwinKit();
-                    }
-                }
 
                 const finalColumns = buildSearchColumns({
                     columns: baseColumns,
                     withBody: !searchOpts.withoutBody,
-                    ftsActive: isFts,
-                    semanticActive,
+                    ftsActive: outcome.searchMethod === "fts",
+                    semanticActive: messages.some((m) => m.semanticScore !== undefined),
                     columnsExplicit: options.columns !== undefined,
                 });
 
                 if (needsRecipients(finalColumns)) {
-                    const recipientsMap = await db.getRecipients(rowids);
+                    const recipientsMap = await db.getRecipients(messages.map((m) => m.rowid));
 
                     for (const msg of messages) {
                         msg.recipients = recipientsMap.get(msg.rowid) ?? [];
@@ -429,7 +214,7 @@ export function registerSearchCommand(program: Command): void {
 
                 const paginationOffset = searchOpts.offset ?? 0;
                 const pageLimit = searchOpts.limit ?? 100;
-                const totalCount = messages.length;
+                const totalCount = outcome.totalCount;
                 const paginatedMessages = messages.slice(paginationOffset, paginationOffset + pageLimit);
 
                 await outputFormattedResults({
@@ -449,16 +234,18 @@ export function registerSearchCommand(program: Command): void {
                     );
                 }
 
-                const mailStorage = new MailStorage();
-                const resultsPath = mailStorage.saveSearchResults(messages);
-                logger.debug(`Saved search results to ${resultsPath}`);
             } catch (error) {
                 const msg = error instanceof Error ? error.message : String(error);
+                const verboseDetails = error instanceof Error ? (error.stack ?? error.message) : String(error);
 
                 if (quiet) {
                     logger.error(msg);
                 } else {
                     p.log.error(msg);
+                }
+
+                if (isVerboseErrorOutput()) {
+                    process.stderr.write(`\n[mail/search] stack trace:\n${verboseDetails}\n`);
                 }
 
                 process.exit(1);

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -233,7 +233,6 @@ export function registerSearchCommand(program: Command): void {
                         `${rangeLabel} results.${totalCount > pageLimit ? " Use --offset/--limit to paginate." : ""}`
                     );
                 }
-
             } catch (error) {
                 const msg = error instanceof Error ? error.message : String(error);
                 const verboseDetails = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/src/macos/commands/mail/show.ts
+++ b/src/macos/commands/mail/show.ts
@@ -1,5 +1,6 @@
 import { EmlxBodyExtractor } from "@app/macos/lib/mail/emlx";
 import { rowToMessage, truncateBody } from "@app/macos/lib/mail/transform";
+import { printLn } from "@app/utils/cli";
 import { formatBytes } from "@app/utils/format";
 import { SafeJSON } from "@app/utils/json";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
@@ -96,7 +97,7 @@ export function registerShowCommand(program: Command): void {
                 msg.bodyRaw = bodyRaw;
 
                 if (options.json) {
-                    console.log(
+                    await printLn(
                         SafeJSON.stringify(
                             {
                                 ...msg,
@@ -113,20 +114,20 @@ export function registerShowCommand(program: Command): void {
                     return;
                 }
 
-                // Pretty print
                 const isTTY = process.stdout.isTTY;
                 const dim = isTTY ? chalk.dim : (s: string) => s;
                 const bold = isTTY ? chalk.bold : (s: string) => s;
+                const out: string[] = [];
 
-                console.log();
-                console.log(bold(msg.subject));
-                console.log(dim("─".repeat(Math.min(msg.subject.length, 80))));
-                console.log(`From:     ${msg.senderName ?? ""} <${msg.senderAddress ?? "(no sender)"}>`);
+                out.push("");
+                out.push(bold(msg.subject));
+                out.push(dim("─".repeat(Math.min(msg.subject.length, 80))));
+                out.push(`From:     ${msg.senderName ?? ""} <${msg.senderAddress ?? "(no sender)"}>`);
 
                 const toRecipients = msg.recipients?.filter((r) => r.type === "to") ?? [];
 
                 if (toRecipients.length > 0) {
-                    console.log(
+                    out.push(
                         `To:       ${toRecipients.map((r) => (r.name ? `${r.name} <${r.address}>` : r.address)).join(", ")}`
                     );
                 }
@@ -134,30 +135,26 @@ export function registerShowCommand(program: Command): void {
                 const ccRecipients = msg.recipients?.filter((r) => r.type === "cc") ?? [];
 
                 if (ccRecipients.length > 0) {
-                    console.log(
+                    out.push(
                         `CC:       ${ccRecipients.map((r) => (r.name ? `${r.name} <${r.address}>` : r.address)).join(", ")}`
                     );
                 }
 
-                console.log(`Date:     ${msg.dateSent.toLocaleString()}`);
-                console.log(`Mailbox:  ${msg.mailbox}`);
-                console.log(`Size:     ${formatBytes(msg.size)}`);
-                console.log(`ID:       ${rowid}`);
-                console.log(`Body:     ${bodyFormat}`);
+                out.push(`Date:     ${msg.dateSent.toLocaleString()}`);
+                out.push(`Mailbox:  ${msg.mailbox}`);
+                out.push(`Size:     ${formatBytes(msg.size)}`);
+                out.push(`ID:       ${rowid}`);
+                out.push(`Body:     ${bodyFormat}`);
 
                 if (msg.attachments.length > 0) {
-                    console.log(`Attach:   ${msg.attachments.map((a) => a.name).join(", ")}`);
+                    out.push(`Attach:   ${msg.attachments.map((a) => a.name).join(", ")}`);
                 }
 
-                console.log();
+                out.push("");
+                out.push(displayBody ? displayBody : dim("(no body content available)"));
+                out.push("");
 
-                if (displayBody) {
-                    console.log(displayBody);
-                } else {
-                    console.log(dim("(no body content available)"));
-                }
-
-                console.log();
+                await printLn(out);
             } catch (error) {
                 console.error(error instanceof Error ? error.message : String(error));
                 process.exit(1);

--- a/src/macos/lib/mail/columns.test.ts
+++ b/src/macos/lib/mail/columns.test.ts
@@ -264,3 +264,67 @@ describe("columns", () => {
         });
     });
 });
+
+function fakeMessage(overrides: Partial<MailMessage> = {}): MailMessage {
+    return {
+        rowid: 1,
+        subject: "Test",
+        senderAddress: "a@b.com",
+        senderName: "A B",
+        dateSent: new Date("2026-05-12T09:30:00.000Z"),
+        dateReceived: new Date("2026-05-12T09:30:05.000Z"),
+        mailbox: "INBOX",
+        account: "acct",
+        read: true,
+        flagged: false,
+        size: 1234,
+        attachments: [
+            { name: "Invoice-VCQYKK0H.pdf", attachmentId: "att1" },
+            { name: "receipt.pdf", attachmentId: "att2" },
+        ],
+        ...overrides,
+    };
+}
+
+describe("MAIL_COLUMNS getValue (typed JSON values)", () => {
+    it("date getValue returns full ISO timestamp, not a relative string", () => {
+        const def = MAIL_COLUMNS.date;
+        expect(def.getValue).toBeDefined();
+        expect(def.getValue?.(fakeMessage())).toBe("2026-05-12T09:30:00.000Z");
+    });
+
+    it("attachments getValue returns an array of filenames", () => {
+        const def = MAIL_COLUMNS.attachments;
+        expect(def.getValue).toBeDefined();
+        expect(def.getValue?.(fakeMessage())).toEqual(["Invoice-VCQYKK0H.pdf", "receipt.pdf"]);
+    });
+
+    it("attachments getValue returns an empty array when there are none", () => {
+        expect(MAIL_COLUMNS.attachments.getValue?.(fakeMessage({ attachments: [] }))).toEqual([]);
+    });
+
+    it("date get (table) still returns the compact relative string", () => {
+        const out = MAIL_COLUMNS.date.get(fakeMessage());
+        expect(typeof out).toBe("string");
+        expect(out).not.toBe("2026-05-12T09:30:00.000Z");
+    });
+});
+
+describe("MAIL_COLUMNS relevance score", () => {
+    it("getValue returns the FTS searchScore when present", () => {
+        expect(MAIL_COLUMNS.relevance.getValue?.(fakeMessage({ searchScore: 0.87 }))).toBe(0.87);
+    });
+
+    it("getValue falls back to the semantic-derived similarity", () => {
+        expect(MAIL_COLUMNS.relevance.getValue?.(fakeMessage({ semanticScore: 0.4 }))).toBeCloseTo(0.8);
+    });
+
+    it("getValue returns null when no score is available", () => {
+        expect(MAIL_COLUMNS.relevance.getValue?.(fakeMessage())).toBeNull();
+    });
+
+    it("get (table) renders a 2-decimal string, or empty when no score", () => {
+        expect(MAIL_COLUMNS.relevance.get(fakeMessage({ searchScore: 0.87 }))).toBe("0.87");
+        expect(MAIL_COLUMNS.relevance.get(fakeMessage())).toBe("");
+    });
+});

--- a/src/macos/lib/mail/columns.ts
+++ b/src/macos/lib/mail/columns.ts
@@ -1,6 +1,15 @@
 import type { MailMessage } from "@app/macos/lib/mail/types";
 import { formatBytes, formatRelativeTime } from "@app/utils/format";
 
+export type JsonColumnValue = string | number | boolean | null | string[];
+
+export interface MailColumnDef {
+    label: string;
+    get: (m: MailMessage) => string;
+    /** Real typed value for structured output (--format json). Falls back to `get` when absent. */
+    getValue?: (m: MailMessage) => JsonColumnValue;
+}
+
 function formatRecipients(msg: MailMessage, type: "to" | "cc"): string {
     if (!msg.recipients) {
         return "";
@@ -32,6 +41,18 @@ function formatBodyPreview(text: string | undefined, maxChars = 120): string {
     return single.length > maxChars ? `${single.slice(0, maxChars)}…` : single;
 }
 
+function relevanceValue(m: MailMessage): number | null {
+    if (m.searchScore !== undefined) {
+        return m.searchScore;
+    }
+
+    if (m.semanticScore !== undefined) {
+        return 1 - m.semanticScore / 2;
+    }
+
+    return null;
+}
+
 export const MAIL_COLUMNS = {
     id: {
         label: "ID",
@@ -40,6 +61,7 @@ export const MAIL_COLUMNS = {
     date: {
         label: "Date",
         get: (m: MailMessage) => formatRelativeTime(m.dateSent, { compact: true }),
+        getValue: (m: MailMessage) => m.dateSent.toISOString(),
     },
     from: {
         label: "From",
@@ -90,6 +112,7 @@ export const MAIL_COLUMNS = {
     attachments: {
         label: "Attachments",
         get: (m: MailMessage) => (m.attachments.length > 0 ? String(m.attachments.length) : ""),
+        getValue: (m: MailMessage) => m.attachments.map((a) => a.name),
     },
     body: {
         label: "Body",
@@ -121,9 +144,13 @@ export const MAIL_COLUMNS = {
     },
     relevance: {
         label: "Relevance",
-        get: (m: MailMessage) => (m.semanticScore !== undefined ? (1 - m.semanticScore / 2).toFixed(2) : ""),
+        get: (m: MailMessage) => {
+            const v = relevanceValue(m);
+            return v === null ? "" : v.toFixed(2);
+        },
+        getValue: (m: MailMessage) => relevanceValue(m),
     },
-} as const;
+} satisfies Record<string, MailColumnDef>;
 
 export type MailColumnKey = keyof typeof MAIL_COLUMNS;
 export const DEFAULT_LIST_COLUMNS: MailColumnKey[] = ["id", "date", "from", "subject", "attachments"];

--- a/src/macos/lib/mail/command-helpers.ts
+++ b/src/macos/lib/mail/command-helpers.ts
@@ -1,14 +1,16 @@
 import {
     ALL_COLUMN_KEYS,
     DEFAULT_LIST_COLUMNS,
+    type JsonColumnValue,
     MAIL_COLUMNS,
+    type MailColumnDef,
     type MailColumnKey,
     RECIPIENT_COLUMNS,
 } from "@app/macos/lib/mail/columns";
 import { EmlxBodyExtractor } from "@app/macos/lib/mail/emlx";
 import { formatResultsTable } from "@app/macos/lib/mail/format";
 import type { MailMessage } from "@app/macos/lib/mail/types";
-import { isInteractive } from "@app/utils/cli";
+import { isInteractive, printLn } from "@app/utils/cli";
 import { parseVariadic } from "@app/utils/cli/variadic";
 import { SafeJSON } from "@app/utils/json";
 import * as p from "@clack/prompts";
@@ -149,10 +151,11 @@ export async function enrichWithBodies(messages: MailMessage[], columns: MailCol
 
 export function formatJsonOutput(messages: MailMessage[], columns: MailColumnKey[]): string {
     const data = messages.map((msg) => {
-        const obj: Record<string, string> = {};
+        const obj: Record<string, JsonColumnValue> = {};
 
         for (const col of columns) {
-            obj[col] = MAIL_COLUMNS[col].get(msg);
+            const def: MailColumnDef = MAIL_COLUMNS[col];
+            obj[col] = def.getValue ? def.getValue(msg) : def.get(msg);
         }
 
         return obj;
@@ -171,7 +174,7 @@ export async function outputFormattedResults({
     format: string;
 }): Promise<void> {
     if (format === "json") {
-        console.log(formatJsonOutput(messages, columns));
+        await printLn(formatJsonOutput(messages, columns));
         return;
     }
 
@@ -186,7 +189,7 @@ export async function outputFormattedResults({
 
         if (exitCode !== 0) {
             p.log.warn(`toon format failed (exit code ${exitCode}), falling back to JSON`);
-            console.log(jsonStr);
+            await printLn(jsonStr);
         }
 
         return;
@@ -196,6 +199,5 @@ export async function outputFormattedResults({
         p.log.warn(`Unknown format "${format}" — using table`);
     }
 
-    console.log("");
-    console.log(formatResultsTable(messages, columns));
+    await printLn(["", formatResultsTable(messages, columns)]);
 }

--- a/src/macos/lib/mail/export.test.ts
+++ b/src/macos/lib/mail/export.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { exportMessages, parseMailIds } from "@app/macos/lib/mail/export";
+import type { MailMessage } from "@app/macos/lib/mail/types";
+
+function msg(rowid: number, subject: string): MailMessage {
+    return {
+        rowid,
+        subject,
+        senderAddress: "vendor@example.com",
+        senderName: "Vendor Inc",
+        dateSent: new Date("2026-05-12T10:00:00.000Z"),
+        dateReceived: new Date("2026-05-12T10:00:01.000Z"),
+        mailbox: "INBOX",
+        account: "acct",
+        read: true,
+        flagged: false,
+        size: 100,
+        attachments: [],
+        body: `Body of ${subject}`,
+    };
+}
+
+describe("exportMessages", () => {
+    it("writes one markdown file per message under emails/", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "mailexport-"));
+        const result = await exportMessages({
+            messages: [msg(1, "First"), msg(2, "Second")],
+            outputDir: dir,
+            yes: true,
+        });
+
+        expect(result.emailCount).toBe(2);
+        expect(existsSync(join(dir, "emails"))).toBe(true);
+        expect(existsSync(join(dir, "index.md"))).toBe(true);
+        expect(readFileSync(join(dir, "index.md"), "utf-8")).toContain("Total: 2 emails");
+    });
+
+    it("skips index.md for a single message", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "mailexport-"));
+        await exportMessages({ messages: [msg(1, "Only")], outputDir: dir, yes: true });
+
+        expect(existsSync(join(dir, "index.md"))).toBe(false);
+    });
+});
+
+describe("parseMailIds", () => {
+    it("parses comma-delimited positional ids", () => {
+        expect(parseMailIds(["769643,769645,805843"], undefined)).toEqual([769643, 769645, 805843]);
+    });
+
+    it("parses space-delimited positional ids", () => {
+        expect(parseMailIds(["769643", "769645"], undefined)).toEqual([769643, 769645]);
+    });
+
+    it("parses the --ids flag and dedupes against positionals", () => {
+        expect(parseMailIds(["769643"], "769645,769643")).toEqual([769643, 769645]);
+    });
+
+    it("throws on a non-numeric id", () => {
+        expect(() => parseMailIds(["abc"], undefined)).toThrow(/invalid/i);
+    });
+
+    it("returns an empty array when nothing is supplied", () => {
+        expect(parseMailIds([], undefined)).toEqual([]);
+    });
+});
+
+describe("exportMessages attachmentsOnly", () => {
+    it("does not create the emails/ dir or index.md when attachmentsOnly is set", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "mailexport-ao-"));
+        const result = await exportMessages({
+            messages: [msg(1, "First"), msg(2, "Second")],
+            outputDir: dir,
+            attachmentsOnly: true,
+            yes: true,
+        });
+
+        expect(existsSync(join(dir, "emails"))).toBe(false);
+        expect(existsSync(join(dir, "index.md"))).toBe(false);
+        expect(existsSync(join(dir, "attachments"))).toBe(true);
+        expect(result.emailsDir).toBeUndefined();
+    });
+});

--- a/src/macos/lib/mail/export.ts
+++ b/src/macos/lib/mail/export.ts
@@ -1,0 +1,194 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import logger from "@app/logger";
+import { EmlxBodyExtractor } from "@app/macos/lib/mail/emlx";
+import {
+    generateAttachmentName,
+    generateEmailMarkdown,
+    generateIndexMarkdown,
+    generateSlug,
+} from "@app/macos/lib/mail/format";
+import { saveAttachment } from "@app/macos/lib/mail/jxa";
+import { truncateBody } from "@app/macos/lib/mail/transform";
+import type { MailMessage } from "@app/macos/lib/mail/types";
+import type { MailDatabase } from "@app/utils/macos/MailDatabase";
+import * as p from "@clack/prompts";
+
+export interface ExportOptions {
+    messages: MailMessage[];
+    outputDir: string;
+    db?: MailDatabase;
+    saveAttachments?: boolean;
+    attachmentsOnly?: boolean;
+    bodyMaxChars?: number;
+    query?: string;
+    overwrite?: boolean;
+    append?: boolean;
+    yes?: boolean;
+}
+
+export interface ExportResult {
+    outputDir: string;
+    emailCount: number;
+    emailsDir?: string;
+    attachmentsDir?: string;
+    indexPath?: string;
+}
+
+export async function exportMessages(options: ExportOptions): Promise<ExportResult> {
+    const outputDir = resolve(options.outputDir);
+    const isTTY = process.stdout.isTTY;
+    const messages = options.messages;
+    const writeMarkdown = !options.attachmentsOnly;
+    const saveAttachments = options.saveAttachments || options.attachmentsOnly === true;
+
+    if (messages.length === 0) {
+        p.log.info("No messages to export.");
+        return { outputDir, emailCount: 0 };
+    }
+
+    logger.debug(
+        `[mail/export] outputDir=${outputDir} count=${messages.length} ` +
+            `writeMarkdown=${writeMarkdown} saveAttachments=${saveAttachments}`
+    );
+
+    const indexPath = join(outputDir, "index.md");
+    const writeIndex = writeMarkdown && messages.length > 1;
+
+    if (writeIndex && existsSync(indexPath) && !options.overwrite && !options.append) {
+        if (!isTTY && !options.yes) {
+            throw new Error(`${indexPath} already exists. Use --overwrite, --append, or --yes.`);
+        }
+
+        if (isTTY && !options.yes) {
+            const action = await p.select({
+                message: `${indexPath} already exists. What to do?`,
+                options: [
+                    { value: "overwrite", label: "Overwrite" },
+                    { value: "append", label: "Append" },
+                    { value: "skip", label: "Cancel" },
+                ],
+            });
+
+            if (p.isCancel(action) || action === "skip") {
+                p.cancel("Export cancelled.");
+                process.exit(0);
+            }
+
+            if (action === "overwrite") {
+                options.overwrite = true;
+            }
+
+            if (action === "append") {
+                options.append = true;
+            }
+        }
+    }
+
+    if (messages.length > 100 && !options.yes) {
+        if (!isTTY) {
+            throw new Error(`${messages.length} messages to export. Use --yes to confirm.`);
+        }
+
+        const proceed = await p.confirm({ message: `Export ${messages.length} emails? This may take a while.` });
+
+        if (p.isCancel(proceed) || !proceed) {
+            p.cancel("Export cancelled.");
+            process.exit(0);
+        }
+    }
+
+    const emailsDir = join(outputDir, "emails");
+
+    if (writeMarkdown) {
+        mkdirSync(emailsDir, { recursive: true });
+    }
+
+    const attachmentsDir = join(outputDir, "attachments");
+
+    if (saveAttachments) {
+        mkdirSync(attachmentsDir, { recursive: true });
+    }
+
+    if (options.db) {
+        const recipientsMap = await options.db.getRecipients(messages.map((m) => m.rowid));
+
+        for (const m of messages) {
+            m.recipients = recipientsMap.get(m.rowid) ?? [];
+        }
+    }
+
+    const emlx = await EmlxBodyExtractor.create();
+    const spinner = p.spinner();
+    spinner.start("Processing emails...");
+    let processed = 0;
+
+    try {
+        for (const msg of messages) {
+            processed++;
+            spinner.message(`[${processed}/${messages.length}] ${msg.subject.slice(0, 50)}...`);
+
+            const body = await emlx.getBody(msg.rowid);
+            msg.body = body && options.bodyMaxChars ? truncateBody(body, options.bodyMaxChars) : (body ?? undefined);
+
+            if (writeMarkdown) {
+                const slug = generateSlug(msg);
+                writeFileSync(join(emailsDir, `${slug}.md`), generateEmailMarkdown(msg));
+            }
+
+            if (saveAttachments && msg.attachments.length > 0) {
+                for (const att of msg.attachments) {
+                    const attPath = join(attachmentsDir, generateAttachmentName(msg, att.name));
+                    await saveAttachment(msg.subject, msg.senderAddress ?? "unknown-sender", att.name, attPath);
+                }
+            }
+        }
+    } finally {
+        emlx.dispose();
+        spinner.stop(`Processed ${processed} emails`);
+    }
+
+    let finalIndexPath: string | undefined;
+
+    if (writeIndex) {
+        const indexMd = generateIndexMarkdown(messages, options.query);
+
+        if (options.append && existsSync(indexPath)) {
+            writeFileSync(indexPath, `${readFileSync(indexPath, "utf-8")}\n\n---\n\n${indexMd}`);
+        } else {
+            writeFileSync(indexPath, indexMd);
+        }
+
+        finalIndexPath = indexPath;
+    }
+
+    return {
+        outputDir,
+        emailCount: messages.length,
+        emailsDir: writeMarkdown ? emailsDir : undefined,
+        attachmentsDir: saveAttachments ? attachmentsDir : undefined,
+        indexPath: finalIndexPath,
+    };
+}
+
+export function parseMailIds(positional: string[], idsFlag: string | undefined): number[] {
+    const raw = [...positional, ...(idsFlag ? [idsFlag] : [])];
+    const tokens = raw.flatMap((chunk) => chunk.split(/[,\s]+/)).filter((t) => t.length > 0);
+    const seen = new Set<number>();
+    const result: number[] = [];
+
+    for (const token of tokens) {
+        const n = Number.parseInt(token, 10);
+
+        if (Number.isNaN(n) || n <= 0 || String(n) !== token) {
+            throw new Error(`Invalid email ID: "${token}". IDs are numeric ROWIDs from search results.`);
+        }
+
+        if (!seen.has(n)) {
+            seen.add(n);
+            result.push(n);
+        }
+    }
+
+    return result;
+}

--- a/src/macos/lib/mail/format.test.ts
+++ b/src/macos/lib/mail/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { generateAttachmentName } from "@app/macos/lib/mail/format";
+import type { MailMessage } from "@app/macos/lib/mail/types";
+
+function msg(subject: string): MailMessage {
+    return {
+        rowid: 42,
+        subject,
+        senderAddress: "v@example.com",
+        senderName: "V",
+        dateSent: new Date("2026-05-12T10:00:00.000Z"),
+        dateReceived: new Date("2026-05-12T10:00:00.000Z"),
+        mailbox: "INBOX",
+        account: "a",
+        read: true,
+        flagged: false,
+        size: 1,
+        attachments: [],
+    };
+}
+
+describe("generateAttachmentName", () => {
+    it("prefixes the attachment with date and subject slug", () => {
+        expect(generateAttachmentName(msg("March Invoice"), "Invoice-VCQYKK0H.pdf")).toBe(
+            "2026-05-12-march-invoice-Invoice-VCQYKK0H.pdf"
+        );
+    });
+
+    it("sanitizes path-unsafe characters in the original name", () => {
+        expect(generateAttachmentName(msg("Order #3"), "weird/na me.pdf")).toBe(
+            "2026-05-12-order-3-weird_na_me.pdf"
+        );
+    });
+});

--- a/src/macos/lib/mail/format.test.ts
+++ b/src/macos/lib/mail/format.test.ts
@@ -27,8 +27,6 @@ describe("generateAttachmentName", () => {
     });
 
     it("sanitizes path-unsafe characters in the original name", () => {
-        expect(generateAttachmentName(msg("Order #3"), "weird/na me.pdf")).toBe(
-            "2026-05-12-order-3-weird_na_me.pdf"
-        );
+        expect(generateAttachmentName(msg("Order #3"), "weird/na me.pdf")).toBe("2026-05-12-order-3-weird_na_me.pdf");
     });
 });

--- a/src/macos/lib/mail/format.ts
+++ b/src/macos/lib/mail/format.ts
@@ -122,3 +122,18 @@ export function generateSlug(msg: MailMessage): string {
         .slice(0, 50);
     return `${date}-${subjectSlug}-${msg.rowid}`;
 }
+
+/**
+ * Filename for a saved attachment: {YYYY-MM-DD}-{subject-slug}-{original-name}.
+ * The original name is sanitized to path-safe characters.
+ */
+export function generateAttachmentName(msg: MailMessage, attachmentName: string): string {
+    const date = msg.dateSent.toISOString().slice(0, 10);
+    const subjectSlug = msg.subject
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 50);
+    const safeName = attachmentName.replace(/[^\w.-]/g, "_");
+    return `${date}-${subjectSlug}-${safeName}`;
+}

--- a/src/macos/lib/mail/mail-storage.ts
+++ b/src/macos/lib/mail/mail-storage.ts
@@ -1,17 +1,9 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { MailMessage } from "@app/macos/lib/mail/types";
-import { SafeJSON } from "@app/utils/json";
 import { Storage } from "@app/utils/storage/storage";
 import { SeenStore } from "./seen-store";
 
-const SEARCH_RESULTS_FILE = "macos-mail-last-search.json";
-
 /**
  * Centralised storage facade for the mail tool.
- * Wraps Storage + SeenStore + temp-file persistence so commands
- * never need to know about paths or DB wiring.
  */
 export class MailStorage {
     private storage: Storage;
@@ -24,40 +16,5 @@ export class MailStorage {
     openSeenStore(): SeenStore {
         const dbPath = join(this.storage.getBaseDir(), "seen.db");
         return new SeenStore(dbPath);
-    }
-
-    /** Serialise search results to a temp file so `download` can pick them up. */
-    saveSearchResults(messages: MailMessage[]): string {
-        const serialized = SafeJSON.stringify(
-            messages.map((m) => ({
-                ...m,
-                dateSent: m.dateSent.toISOString(),
-                dateReceived: m.dateReceived.toISOString(),
-            }))
-        );
-        const path = join(tmpdir(), SEARCH_RESULTS_FILE);
-        writeFileSync(path, serialized);
-        return path;
-    }
-
-    /** Load previously-saved search results (or null if none exist). */
-    loadSearchResults(): MailMessage[] | null {
-        const path = join(tmpdir(), SEARCH_RESULTS_FILE);
-
-        if (!existsSync(path)) {
-            return null;
-        }
-
-        try {
-            const raw = readFileSync(path, "utf-8");
-            const parsed = SafeJSON.parse(raw, { strict: true }) as Array<Record<string, unknown>>;
-            return parsed.map((m) => ({
-                ...m,
-                dateSent: new Date(m.dateSent as string),
-                dateReceived: new Date(m.dateReceived as string),
-            })) as MailMessage[];
-        } catch {
-            return null;
-        }
     }
 }

--- a/src/macos/lib/mail/search-runner.ts
+++ b/src/macos/lib/mail/search-runner.ts
@@ -21,6 +21,24 @@ import type { MailDatabase } from "@app/utils/macos/MailDatabase";
 
 export type MailSearchMode = "auto" | "fulltext" | "hybrid" | "vector";
 
+const VALID_MAIL_SEARCH_MODES = new Set<MailSearchMode>(["auto", "fulltext", "hybrid", "vector"]);
+
+export function isMailSearchMode(input: string): input is MailSearchMode {
+    return VALID_MAIL_SEARCH_MODES.has(input as MailSearchMode);
+}
+
+export function resolveMailSearchMode(input: string | undefined): MailSearchMode {
+    if (!input) {
+        return "auto";
+    }
+
+    if (isMailSearchMode(input)) {
+        return input;
+    }
+
+    throw new Error(`Unknown --mode: "${input}". Valid: ${[...VALID_MAIL_SEARCH_MODES].join(", ")}`);
+}
+
 export interface RunMailSearchOptions {
     searchOpts: SearchOptions;
     mode: MailSearchMode;

--- a/src/macos/lib/mail/search-runner.ts
+++ b/src/macos/lib/mail/search-runner.ts
@@ -1,0 +1,214 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { getIndexerStorage } from "@app/indexer/lib/storage";
+import { searchIndexReadonly } from "@app/indexer/lib/store";
+import logger from "@app/logger";
+import { ENVELOPE_INDEX_PATH } from "@app/macos/lib/mail/constants";
+import { buildMailFilterPredicate } from "@app/macos/lib/mail/search-filters";
+import {
+    formatFallbackStart,
+    formatFallbackStop,
+    formatSearchLabelEmpty,
+    formatSearchLabelStart,
+    formatSearchLabelStop,
+    type ResolvedMethod,
+} from "@app/macos/lib/mail/search-label";
+import { mdfindMailRowids } from "@app/macos/lib/mail/spotlight";
+import { rowToMessage } from "@app/macos/lib/mail/transform";
+import type { MailMessage, MailMessageRow, SearchOptions } from "@app/macos/lib/mail/types";
+import { closeDarwinKit, rankBySimilarity } from "@app/utils/macos";
+import type { MailDatabase } from "@app/utils/macos/MailDatabase";
+
+export type MailSearchMode = "auto" | "fulltext" | "hybrid" | "vector";
+
+export interface RunMailSearchOptions {
+    searchOpts: SearchOptions;
+    mode: MailSearchMode;
+    jxa?: boolean;
+    semantic?: boolean;
+    maxDistance?: number;
+    db: MailDatabase;
+    onProgress?: { start: (msg: string) => void; stop: (msg: string) => void };
+    onWarning?: (message: string) => void;
+}
+
+export interface MailSearchOutcome {
+    messages: MailMessage[];
+    totalCount: number;
+    resolvedMethod: ResolvedMethod | undefined;
+    searchMethod: "fts" | "spotlight+like";
+    snippetByRowid: Map<number, string>;
+    scoreByRowid: Map<number, number>;
+}
+
+const MAIL_INDEX_NAME = "macos-mail";
+const STABLE_INDEX_FETCH_LIMIT = 250;
+
+export async function runMailSearch(query: string, options: RunMailSearchOptions): Promise<MailSearchOutcome> {
+    const searchOpts = options.searchOpts;
+    const resolvedMode = options.mode;
+    const filterPredicate = buildMailFilterPredicate(searchOpts);
+    const indexerStorage = getIndexerStorage();
+    const indexDbPath = join(indexerStorage.getIndexDir(MAIL_INDEX_NAME), "index.db");
+    const indexExists = existsSync(indexDbPath);
+    const willUseIndex = indexExists && !options.jxa && !searchOpts.withoutBody;
+    const snippetByRowid = new Map<number, string>();
+    const scoreByRowid = new Map<number, number>();
+    let rows: MailMessageRow[] = [];
+    let searchMethod: "fts" | "spotlight+like" = "spotlight+like";
+    let resolvedMethod: ResolvedMethod | undefined;
+
+    logger.debug(
+        `[mail/search] mode=${resolvedMode} willUseIndex=${willUseIndex} ` +
+            `indexExists=${indexExists} jxa=${options.jxa ?? false} ` +
+            `withoutBody=${searchOpts.withoutBody ?? false} indexDbPath=${indexDbPath}`
+    );
+
+    if (willUseIndex) {
+        options.onProgress?.start(formatSearchLabelStart(resolvedMode));
+        const t0 = performance.now();
+        const fetchLimit = Math.max((searchOpts.offset ?? 0) + (searchOpts.limit ?? 100), STABLE_INDEX_FETCH_LIMIT);
+
+        const ftsResults = await searchIndexReadonly(MAIL_INDEX_NAME, query, {
+            mode: resolvedMode,
+            limit: fetchLimit,
+            onWarning: options.onWarning,
+            ...((searchOpts.from || searchOpts.to) && {
+                coverageCheck: {
+                    from: searchOpts.from,
+                    to: searchOpts.to,
+                    onOutside: (advisory: string): void => {
+                        process.stderr.write(advisory);
+                    },
+                },
+            }),
+            ...(filterPredicate && {
+                filters: filterPredicate,
+                attach: { alias: "mailapp", dbPath: ENVELOPE_INDEX_PATH, mode: "ro" as const },
+            }),
+        });
+
+        const ms = performance.now() - t0;
+        const ftsRowids: number[] = [];
+
+        for (const r of ftsResults) {
+            const sid = r.doc.sourceId ?? (r.doc as unknown as { source_id?: string }).source_id;
+
+            if (!sid) {
+                continue;
+            }
+
+            const rowid = Number(sid);
+            ftsRowids.push(rowid);
+
+            if (!snippetByRowid.has(rowid)) {
+                const snippet =
+                    r.ftsSnippet ??
+                    (typeof r.doc.content === "string"
+                        ? r.doc.content.replace(/\s+/g, " ").trim().slice(0, 200)
+                        : undefined);
+
+                if (snippet) {
+                    snippetByRowid.set(rowid, snippet);
+                }
+            }
+
+            if (typeof r.score === "number" && !scoreByRowid.has(rowid)) {
+                scoreByRowid.set(rowid, r.score);
+            }
+        }
+
+        resolvedMethod = ftsResults[0]?.method;
+        rows = ftsRowids.length > 0 ? await options.db.getMessagesByRowids(ftsRowids, searchOpts) : [];
+        searchMethod = "fts";
+
+        const orderByRowid = new Map(ftsRowids.map((rowid, index) => [rowid, index]));
+        rows.sort((a, b) => (orderByRowid.get(a.rowid) ?? Infinity) - (orderByRowid.get(b.rowid) ?? Infinity));
+
+        if (rows.length > 0) {
+            options.onProgress?.stop(formatSearchLabelStop(resolvedMode, resolvedMethod, rows.length, ms));
+        } else {
+            options.onProgress?.stop(formatSearchLabelEmpty(resolvedMode));
+        }
+    }
+
+    if (!indexExists || (options.jxa ?? false) || (searchOpts.withoutBody ?? false)) {
+        options.onProgress?.start(formatFallbackStart());
+        const t0 = performance.now();
+
+        const [spotlightRowids, likeRows] = await Promise.all([
+            mdfindMailRowids(query),
+            options.db.searchMessages(searchOpts),
+        ]);
+        const rowidSet = new Set<number>(likeRows.map((r) => r.rowid));
+        const newSpotlightIds = spotlightRowids.filter((r) => !rowidSet.has(r));
+        const spotlightRows =
+            newSpotlightIds.length > 0 ? await options.db.getMessagesByRowids(newSpotlightIds, searchOpts) : [];
+
+        rows = [...likeRows, ...spotlightRows];
+        const fallbackOrder = new Map(rows.map((row, index) => [row.rowid, index]));
+        rows = [...new Map(rows.map((row) => [row.rowid, row])).values()].sort(
+            (a, b) => (fallbackOrder.get(a.rowid) ?? Infinity) - (fallbackOrder.get(b.rowid) ?? Infinity)
+        );
+        const ms = performance.now() - t0;
+        options.onProgress?.stop(formatFallbackStop(rows.length, ms));
+    }
+
+    const isFts = searchMethod === "fts";
+    const rowids = rows.map((r) => r.rowid);
+    const attachmentsMap = await options.db.getAttachments(rowids);
+    const messages: MailMessage[] = rows.map((row) => {
+        const msg = rowToMessage(row);
+        msg.attachments = attachmentsMap.get(row.rowid) ?? [];
+        msg.bodyMatchesQuery = isFts;
+        msg.ftsSnippet = snippetByRowid.get(row.rowid);
+        msg.searchScore = scoreByRowid.get(row.rowid);
+        return msg;
+    });
+
+    if (options.semantic === true && messages.length > 0) {
+        options.onProgress?.start(`Apple NL re-ranking ${messages.length} results...`);
+
+        try {
+            const maxDist = options.maxDistance ?? 1.2;
+            const items = messages.map((m) => ({
+                ...m,
+                text: [m.subject, m.senderName, m.senderAddress, m.ftsSnippet ?? m.body ?? ""]
+                    .filter(Boolean)
+                    .join(" ")
+                    .slice(0, 2000),
+            }));
+            const ranked = await rankBySimilarity(query, items, { maxDistance: maxDist, language: "en" });
+            const reordered: MailMessage[] = ranked.map((r) => {
+                const msg = r.item as MailMessage;
+                msg.semanticScore = r.score;
+                return msg;
+            });
+            const rankedIds = new Set(reordered.map((m) => m.rowid));
+
+            for (const msg of messages) {
+                if (!rankedIds.has(msg.rowid)) {
+                    reordered.push(msg);
+                }
+            }
+
+            messages.length = 0;
+            messages.push(...reordered);
+            options.onProgress?.stop(`Semantic ranking complete (${ranked.length} relevant results)`);
+        } catch (err) {
+            options.onProgress?.stop(`Semantic ranking skipped: ${err instanceof Error ? err.message : String(err)}`);
+            logger.warn(`Semantic ranking failed: ${err}`);
+        } finally {
+            closeDarwinKit();
+        }
+    }
+
+    return {
+        messages,
+        totalCount: messages.length,
+        resolvedMethod,
+        searchMethod,
+        snippetByRowid,
+        scoreByRowid,
+    };
+}

--- a/src/macos/lib/mail/types.ts
+++ b/src/macos/lib/mail/types.ts
@@ -39,6 +39,8 @@ export interface MailMessage {
     bodyMatchesQuery?: boolean;
     /** Cosine distance from query (0 = identical). Set when semantic ranking is active. */
     semanticScore?: number;
+    /** Relevance score from the FTS/vector/hybrid index (BM25 / cosine / RRF). Set for index-backed searches. */
+    searchScore?: number;
     recipients?: MailRecipient[];
 }
 

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -45,6 +45,7 @@ interface SayOptions {
     model?: string;
     save?: boolean;
     unset?: string[];
+    fallback?: boolean;
 }
 
 const program = new Command()
@@ -76,6 +77,7 @@ const program = new Command()
         parseVariadic,
         [] as string[]
     )
+    .option("--no-fallback", "Disable automatic fallback to macos TTS when a cloud provider fails")
     .action(async (messageParts: string[], opts: SayOptions, cmd: Command) => {
         const mgr = new SayConfigManager();
 
@@ -175,13 +177,31 @@ const program = new Command()
             await speakCached({ mgr, text, provider, effective: effectiveForRun, opts, stream });
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            console.error(pc.red(`[say] TTS failed: ${message}`));
 
             if (isVoiceNotFoundError(message)) {
+                console.error(pc.red(`[say] TTS failed: ${message}`));
                 await printVoiceList(provider);
+                process.exit(1);
             }
 
-            process.exit(1);
+            // Cloud TTS is transient; macos is always available — drop provider-specific voice/model in the retry.
+            if (provider === "macos" || opts.fallback === false) {
+                console.error(pc.red(`[say] TTS failed: ${message}`));
+                process.exit(1);
+            }
+
+            console.error(pc.yellow(`[say] ${provider} failed: ${message.slice(0, 200)}`));
+            console.error(pc.yellow("[say] falling back to macos"));
+
+            const macosRun: EffectiveSettings = { ...effectiveForRun, voice: null, model: null };
+
+            try {
+                await speakCached({ mgr, text, provider: "macos", effective: macosRun, opts, stream });
+            } catch (fallbackErr) {
+                const fmsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+                console.error(pc.red(`[say] macos fallback also failed: ${fmsg}`));
+                process.exit(1);
+            }
         }
 
         if (opts.save && saveApp && patch) {

--- a/src/utils/cli/__fixtures__/stdout-fixture.ts
+++ b/src/utils/cli/__fixtures__/stdout-fixture.ts
@@ -1,0 +1,4 @@
+import { printLn } from "@app/utils/cli/stdout";
+
+const size = Number.parseInt(process.argv[2] ?? "300000", 10);
+await printLn("X".repeat(size));

--- a/src/utils/cli/index.ts
+++ b/src/utils/cli/index.ts
@@ -1,6 +1,7 @@
 export type { ExecResult, ExecutorOptions } from "./executor";
 export { buildCommand, Executor, enhanceHelp, isInteractive, suggestCommand } from "./executor";
 export { isQuietOutput } from "./output-mode";
+export { printLn, writeStdout } from "./stdout";
 export type { RunToolOptions } from "./tools";
 export { runTool, runToolInteractive } from "./tools";
 export { parseVariadic } from "./variadic";

--- a/src/utils/cli/stdout.test.ts
+++ b/src/utils/cli/stdout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { join } from "node:path";
+import { printLn } from "./stdout";
+
+const FIXTURE = join(import.meta.dir, "__fixtures__/stdout-fixture.ts");
+
+describe("writeStdout", () => {
+    it("delivers a large payload intact through a slow pipe consumer", async () => {
+        const proc = Bun.spawn(["sh", "-c", `bun run '${FIXTURE}' 300000 | cat`], {
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        const out = await new Response(proc.stdout).text();
+        await proc.exited;
+        expect(out.length).toBe(300001);
+    });
+
+    it("plain console.log truncates the same payload", async () => {
+        const proc = Bun.spawn(["sh", "-c", `bun -e 'console.log("X".repeat(300000))' | cat`], {
+            stdout: "pipe",
+        });
+        const out = await new Response(proc.stdout).text();
+        await proc.exited;
+        expect(out.length).toBeLessThan(300001);
+    });
+});
+
+describe("printLn", () => {
+    it("writes the text with a trailing newline", async () => {
+        let output = "";
+        const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+            (
+                chunk: string | Uint8Array,
+                encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+                callback?: (error?: Error | null) => void
+            ) => {
+                output += String(chunk);
+                const cb = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+                cb?.();
+                return true;
+            }
+        );
+
+        try {
+            await printLn("hello");
+        } finally {
+            stdoutSpy.mockRestore();
+        }
+
+        expect(output).toBe("hello\n");
+    });
+
+    it("joins an array of strings with newlines", async () => {
+        let output = "";
+        const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+            (
+                chunk: string | Uint8Array,
+                encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+                callback?: (error?: Error | null) => void
+            ) => {
+                output += String(chunk);
+                const cb = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+                cb?.();
+                return true;
+            }
+        );
+
+        try {
+            await printLn(["hello", "world"]);
+        } finally {
+            stdoutSpy.mockRestore();
+        }
+
+        expect(output).toBe("hello\nworld\n");
+    });
+});

--- a/src/utils/cli/stdout.ts
+++ b/src/utils/cli/stdout.ts
@@ -1,0 +1,27 @@
+/**
+ * Write text to stdout and resolve only once every byte is committed.
+ *
+ * Bun leaves a piped stdout fd in non-blocking mode. A plain `console.log` of a
+ * large string can race process exit and be truncated at the OS pipe buffer
+ * when the consumer is slow to drain.
+ *
+ * Awaiting the stream write callback gives stdout a chance to drain before the
+ * action handler returns. `fs.writeSync(1, ...)` is not a safe replacement here;
+ * it can throw EAGAIN on Bun's non-blocking pipe fd.
+ */
+export async function writeStdout(text: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        process.stdout.write(text, (error?: Error | null) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+
+            resolve();
+        });
+    });
+}
+
+export async function printLn(text: string | string[] = ""): Promise<void> {
+    await writeStdout(`${Array.isArray(text) ? text.join("\n") : text}\n`);
+}

--- a/src/utils/database/attach.test.ts
+++ b/src/utils/database/attach.test.ts
@@ -1,0 +1,95 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { attachReadonly, detachQuietly } from "./attach";
+
+let dir: string;
+let extPath: string;
+
+beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "attach-helper-"));
+    extPath = join(dir, "ext.db");
+    const ext = new Database(extPath);
+    ext.run("CREATE TABLE t (id TEXT)");
+    ext.run("INSERT INTO t (id) VALUES ('a'), ('b')");
+    ext.close();
+});
+
+afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("attachReadonly / detachQuietly", () => {
+    it("attaches a DB under an alias and can query it", () => {
+        const db = new Database(":memory:");
+        attachReadonly(db, "ext", extPath);
+        const rows = db.query("SELECT id FROM ext.t ORDER BY id").all() as Array<{ id: string }>;
+
+        expect(rows.map((r) => r.id)).toEqual(["a", "b"]);
+        db.close();
+    });
+
+    it("rejects an unsafe alias (SQL identifier guard)", () => {
+        const db = new Database(":memory:");
+
+        expect(() => attachReadonly(db, "ext; DROP TABLE t", extPath)).toThrow(/Invalid attach alias/);
+        db.close();
+    });
+
+    it("mode=ro (default) forbids writes through the alias", () => {
+        const db = new Database(":memory:");
+        attachReadonly(db, "ext", extPath);
+
+        expect(() => db.run("INSERT INTO ext.t (id) VALUES ('c')")).toThrow();
+        db.close();
+    });
+
+    it("adds path and alias context when attach fails", () => {
+        const db = new Database(":memory:");
+        const missingPath = join(dir, "missing.db");
+
+        expect(() => attachReadonly(db, "missing", missingPath)).toThrow(
+            new RegExp(`Failed to attach SQLite database .*missing\\.db.* as missing`)
+        );
+        db.close();
+    });
+
+    it("attaches paths containing URI-reserved characters", () => {
+        const specialDir = mkdtempSync(join(tmpdir(), "attach special#dir?"));
+        const specialPath = join(specialDir, "quote'and#hash?.db");
+        const ext = new Database(specialPath);
+        ext.run("CREATE TABLE t (id TEXT)");
+        ext.run("INSERT INTO t (id) VALUES ('z')");
+        ext.close();
+
+        try {
+            const db = new Database(":memory:");
+            attachReadonly(db, "weird", specialPath);
+            const row = db.query("SELECT id FROM weird.t").get() as { id: string };
+
+            expect(row.id).toBe("z");
+            db.close();
+        } finally {
+            rmSync(specialDir, { recursive: true, force: true });
+        }
+    });
+
+    it("detachQuietly removes the alias", () => {
+        const db = new Database(":memory:");
+        attachReadonly(db, "ext", extPath);
+        detachQuietly(db, "ext");
+
+        expect(() => db.query("SELECT id FROM ext.t").all()).toThrow();
+        db.close();
+    });
+
+    it("detachQuietly never throws for an unknown or unsafe alias", () => {
+        const db = new Database(":memory:");
+
+        expect(() => detachQuietly(db, "never_attached")).not.toThrow();
+        expect(() => detachQuietly(db, "bad; alias")).not.toThrow();
+        db.close();
+    });
+});

--- a/src/utils/database/attach.test.ts
+++ b/src/utils/database/attach.test.ts
@@ -51,7 +51,7 @@ describe("attachReadonly / detachQuietly", () => {
         const missingPath = join(dir, "missing.db");
 
         expect(() => attachReadonly(db, "missing", missingPath)).toThrow(
-            new RegExp(`Failed to attach SQLite database .*missing\\.db.* as missing`)
+            /Failed to attach SQLite database .*missing\.db.* as missing/
         );
         db.close();
     });

--- a/src/utils/database/attach.ts
+++ b/src/utils/database/attach.ts
@@ -1,0 +1,58 @@
+import type { Database } from "bun:sqlite";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import logger from "@app/logger";
+
+const SAFE_ALIAS_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * ATTACH a SQLite database file under `alias`, read-only by default.
+ *
+ * Builds the `file:` URI via the URL object so reserved characters in the
+ * path are percent-encoded correctly, and applies `?mode=ro` so SQLite
+ * refuses writes through the alias. `alias` is interpolated into the ATTACH
+ * statement (SQLite cannot parameterise it) so it is validated as a bare SQL
+ * identifier first.
+ */
+export function attachReadonly(db: Database, alias: string, dbPath: string, mode: "ro" | "rw" = "ro"): void {
+    if (!SAFE_ALIAS_RE.test(alias)) {
+        throw new Error(`Invalid attach alias: ${alias}`);
+    }
+
+    const uri = pathToFileURL(resolve(dbPath));
+    if (mode === "ro") {
+        uri.search = "mode=ro";
+    }
+
+    const escaped = uri.toString().replace(/'/g, "''");
+
+    try {
+        db.run(`ATTACH DATABASE '${escaped}' AS ${alias}`);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+            `Failed to attach SQLite database ${resolve(dbPath)} as ${alias} (${mode}): ${message}`,
+            { cause: error }
+        );
+    }
+}
+
+/**
+ * DETACH `alias`, logging (not throwing) on failure. A failed DETACH must
+ * never mask the result of whatever query just used the attached DB. Also a
+ * no-op for an unsafe alias, so it is safe to call from a `finally` after a
+ * failed `attachReadonly`.
+ */
+export function detachQuietly(db: Database, alias: string): void {
+    if (!SAFE_ALIAS_RE.test(alias)) {
+        return;
+    }
+
+    try {
+        db.run(`DETACH DATABASE ${alias}`);
+    } catch (err) {
+        logger.debug(
+            `[db/attach] DETACH ${alias} failed (ignored): ${err instanceof Error ? err.message : String(err)}`
+        );
+    }
+}

--- a/src/utils/database/attach.ts
+++ b/src/utils/database/attach.ts
@@ -30,10 +30,9 @@ export function attachReadonly(db: Database, alias: string, dbPath: string, mode
         db.run(`ATTACH DATABASE '${escaped}' AS ${alias}`);
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(
-            `Failed to attach SQLite database ${resolve(dbPath)} as ${alias} (${mode}): ${message}`,
-            { cause: error }
-        );
+        throw new Error(`Failed to attach SQLite database ${resolve(dbPath)} as ${alias} (${mode}): ${message}`, {
+            cause: error,
+        });
     }
 }
 

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { getDatesInMonth, getMonthDateRange, parseDate } from "./date";
+import {
+    formatLocalDateTimeStamp,
+    formatLocalFileTimestamp,
+    formatLocalMonth,
+    getDatesInMonth,
+    getMonthDateRange,
+    parseDate,
+} from "./date";
 
 describe("parseDate", () => {
     it("parses valid date string", () => {
@@ -59,5 +66,23 @@ describe("getDatesInMonth", () => {
         for (const d of getDatesInMonth("2026-03")) {
             expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/);
         }
+    });
+});
+
+describe("local timestamp formatting", () => {
+    const d = new Date(2026, 4, 14, 20, 49, 3, 120);
+
+    it("formats display timestamps using local date/time fields", () => {
+        expect(formatLocalDateTimeStamp(d)).toBe("2026-05-14 20:49:03");
+        expect(formatLocalDateTimeStamp(d, { seconds: false })).toBe("2026-05-14 20:49");
+    });
+
+    it("formats filename-safe timestamps using local date/time fields", () => {
+        expect(formatLocalFileTimestamp(d)).toBe("2026-05-14T20-49-03");
+        expect(formatLocalFileTimestamp(d, { separator: "_", milliseconds: true })).toBe("2026-05-14_20-49-03-120");
+    });
+
+    it("formats local month", () => {
+        expect(formatLocalMonth(d)).toBe("2026-05");
     });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -288,6 +288,58 @@ export function formatLocalDate(d: Date): string {
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
+interface LocalDateTimeOptions {
+    seconds?: boolean;
+}
+
+interface LocalFileTimestampOptions {
+    separator?: "T" | "_";
+    milliseconds?: boolean;
+}
+
+function coerceDate(date: Date | string | number): Date {
+    return date instanceof Date ? date : new Date(date);
+}
+
+/**
+ * Format a date/time as a local, sortable timestamp for CLI display.
+ *
+ * Use this instead of `toISOString().slice(...).replace("T", " ")` when the
+ * string is shown to humans. ISO strings are UTC and look like local time after
+ * slicing, which creates timezone-skewed output.
+ */
+export function formatLocalDateTimeStamp(date: Date | string | number, options: LocalDateTimeOptions = {}): string {
+    const d = coerceDate(date);
+    const h = String(d.getHours()).padStart(2, "0");
+    const m = String(d.getMinutes()).padStart(2, "0");
+    const s = String(d.getSeconds()).padStart(2, "0");
+    const time = options.seconds === false ? `${h}:${m}` : `${h}:${m}:${s}`;
+
+    return `${formatLocalDate(d)} ${time}`;
+}
+
+/**
+ * Format a local timestamp safe for filenames/IDs.
+ */
+export function formatLocalFileTimestamp(
+    date: Date | string | number = new Date(),
+    options: LocalFileTimestampOptions = {}
+): string {
+    const d = coerceDate(date);
+    const h = String(d.getHours()).padStart(2, "0");
+    const m = String(d.getMinutes()).padStart(2, "0");
+    const s = String(d.getSeconds()).padStart(2, "0");
+    const ms = String(d.getMilliseconds()).padStart(3, "0");
+    const separator = options.separator ?? "T";
+    const suffix = options.milliseconds ? `-${ms}` : "";
+
+    return `${formatLocalDate(d)}${separator}${h}-${m}-${s}${suffix}`;
+}
+
+export function formatLocalMonth(d: Date): string {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
 /**
  * Get the ISO week (Mon–Sun) range for a given date.
  */

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -86,3 +86,26 @@ describe("parseJSON", () => {
         expect(result).toEqual({ a: 1 });
     });
 });
+
+describe("SafeJSON.stringify — control character escaping (BUG 2 regression guard)", () => {
+    it("escapes every C0 control char so output is strict-JSON-parseable", () => {
+        let body = "";
+
+        for (let i = 0; i <= 0x1f; i++) {
+            body += `chunk${i}${String.fromCharCode(i)}`;
+        }
+
+        const value = { rowid: 769643, body, bodyHtml: body, bodyMarkdown: body, bodyRaw: body };
+        const out = SafeJSON.stringify(value, null, 2);
+
+        expect(() => SafeJSON.parse(out, { strict: true })).not.toThrow();
+
+        for (let i = 0; i <= 0x1f; i++) {
+            if (i === 0x09 || i === 0x0a || i === 0x0d) {
+                continue;
+            }
+
+            expect(out.includes(String.fromCharCode(i))).toBe(false);
+        }
+    });
+});

--- a/src/utils/macos/MailDatabase.ts
+++ b/src/utils/macos/MailDatabase.ts
@@ -1,5 +1,4 @@
 import type { Database } from "bun:sqlite";
-import { pathToFileURL } from "node:url";
 import logger from "@app/logger";
 import { ENVELOPE_INDEX_PATH } from "@app/macos/lib/mail/constants";
 import type { MailDB } from "@app/macos/lib/mail/db-types";
@@ -12,6 +11,7 @@ import type {
     SearchOptions,
 } from "@app/macos/lib/mail/types";
 import { buildOrderedLikePattern, escapeLike } from "@app/utils/database";
+import { attachReadonly, detachQuietly } from "@app/utils/database/attach";
 import { type Expression, type SqlBool, sql } from "kysely";
 import { MacDatabase } from "./MacDatabase";
 import { type MailFilterOptions, resolveMailboxRowids, SQL_BIND_BATCH } from "./mail-sql";
@@ -73,8 +73,7 @@ export function selectStaleMailChunkIds(indexDb: Database, envelopeDb: Database,
         }
     }
 
-    const uri = pathToFileURL(envFilename).toString();
-    indexDb.run(`ATTACH DATABASE '${uri.replace(/'/g, "''")}?mode=ro' AS mailapp`);
+    attachReadonly(indexDb, "mailapp", envFilename);
 
     try {
         const result = indexDb.query(buildSql("mailapp.messages")).all() as Array<{ id: string }>;
@@ -85,11 +84,7 @@ export function selectStaleMailChunkIds(indexDb: Database, envelopeDb: Database,
 
         return result.map((r) => r.id);
     } finally {
-        try {
-            indexDb.run("DETACH DATABASE mailapp");
-        } catch {
-            // detach failures shouldn't mask the result
-        }
+        detachQuietly(indexDb, "mailapp");
     }
 }
 

--- a/src/utils/search/drivers/sqlite-fts5/index.ts
+++ b/src/utils/search/drivers/sqlite-fts5/index.ts
@@ -266,6 +266,11 @@ export class SearchEngine<TDoc extends Record<string, unknown> = Record<string, 
                 throw err;
             }
 
+            logger.debug(
+                `[search] sqlite-vec unavailable, falling back to brute-force vectors: ${
+                    err instanceof Error ? err.message : String(err)
+                }`
+            );
             // Fall through to brute-force
         }
 

--- a/src/utils/search/stores/sqlite-vec-loader.test.ts
+++ b/src/utils/search/stores/sqlite-vec-loader.test.ts
@@ -59,15 +59,12 @@ describe("sqlite-vec-loader ordering", () => {
         }
     );
 
-    it.skipIf(!RUN_ORDERING_TESTS)(
-        "loadSqliteVec returns true when the swap runs before any Database",
-        async () => {
-            const { stdout, exitCode } = await runFixture(FIXTURE_ENSURE_FIRST);
+    it.skipIf(!RUN_ORDERING_TESTS)("loadSqliteVec returns true when the swap runs before any Database", async () => {
+        const { stdout, exitCode } = await runFixture(FIXTURE_ENSURE_FIRST);
 
-            expect(exitCode).toBe(0);
-            expect(parseLastStdoutLine(stdout)).toEqual({ loaded: true });
-        }
-    );
+        expect(exitCode).toBe(0);
+        expect(parseLastStdoutLine(stdout)).toEqual({ loaded: true });
+    });
 
     it.skipIf(!RUN_ORDERING_TESTS)(
         "sqlite-vec-preload.ts defeats the ordering trap: Database-first still loads",

--- a/src/utils/search/stores/sqlite-vec-loader.test.ts
+++ b/src/utils/search/stores/sqlite-vec-loader.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+
+const HOMEBREW_DYLIB = "/opt/homebrew/opt/sqlite3/lib/libsqlite3.dylib";
+const RUN_ORDERING_TESTS = process.platform === "darwin" && existsSync(HOMEBREW_DYLIB);
+
+const LOADER_PATH = join(import.meta.dir, "sqlite-vec-loader.ts");
+const PRELOAD_PATH = join(import.meta.dir, "sqlite-vec-preload.ts");
+
+async function runFixture(source: string, preload?: string): Promise<{ stdout: string; exitCode: number }> {
+    const dir = mkdtempSync(join(tmpdir(), "vec-loader-"));
+    const fixturePath = join(dir, "fixture.ts");
+
+    await Bun.write(fixturePath, source);
+
+    try {
+        const args = preload ? ["--preload", preload, fixturePath] : ["run", fixturePath];
+        const proc = Bun.spawn(["bun", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+        const stdout = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+        return { stdout, exitCode };
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+function parseLastStdoutLine(stdout: string): unknown {
+    return SafeJSON.parse(stdout.trim().split("\n").at(-1) ?? "");
+}
+
+const FIXTURE_DATABASE_FIRST = `
+import { Database } from "bun:sqlite";
+import { ensureExtensionCapableSQLite, loadSqliteVec } from ${SafeJSON.stringify(LOADER_PATH)};
+new Database(":memory:");
+ensureExtensionCapableSQLite();
+const db = new Database(":memory:");
+console.log(\`{"loaded":\${loadSqliteVec(db) ? "true" : "false"}}\`);
+`;
+
+const FIXTURE_ENSURE_FIRST = `
+import { Database } from "bun:sqlite";
+import { ensureExtensionCapableSQLite, loadSqliteVec } from ${SafeJSON.stringify(LOADER_PATH)};
+ensureExtensionCapableSQLite();
+const db = new Database(":memory:");
+console.log(\`{"loaded":\${loadSqliteVec(db) ? "true" : "false"}}\`);
+`;
+
+describe("sqlite-vec-loader ordering", () => {
+    it.skipIf(!RUN_ORDERING_TESTS)(
+        "loadSqliteVec returns false when a Database is constructed before the swap",
+        async () => {
+            const { stdout, exitCode } = await runFixture(FIXTURE_DATABASE_FIRST);
+
+            expect(exitCode).toBe(0);
+            expect(parseLastStdoutLine(stdout)).toEqual({ loaded: false });
+        }
+    );
+
+    it.skipIf(!RUN_ORDERING_TESTS)(
+        "loadSqliteVec returns true when the swap runs before any Database",
+        async () => {
+            const { stdout, exitCode } = await runFixture(FIXTURE_ENSURE_FIRST);
+
+            expect(exitCode).toBe(0);
+            expect(parseLastStdoutLine(stdout)).toEqual({ loaded: true });
+        }
+    );
+
+    it.skipIf(!RUN_ORDERING_TESTS)(
+        "sqlite-vec-preload.ts defeats the ordering trap: Database-first still loads",
+        async () => {
+            const { stdout, exitCode } = await runFixture(FIXTURE_DATABASE_FIRST, PRELOAD_PATH);
+
+            expect(exitCode).toBe(0);
+            expect(parseLastStdoutLine(stdout)).toEqual({ loaded: true });
+        }
+    );
+});

--- a/src/utils/search/stores/sqlite-vec-loader.ts
+++ b/src/utils/search/stores/sqlite-vec-loader.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
+import logger from "@app/logger";
 
 let extensionAvailable: boolean | null = null;
 let customSqliteAttempted = false;
@@ -34,12 +35,25 @@ export function ensureExtensionCapableSQLite(): void {
 
     for (const libPath of HOMEBREW_SQLITE_PATHS) {
         if (existsSync(libPath)) {
-            homebrewDylibFound = true;
-
             try {
-                Database.setCustomSQLite(libPath);
-            } catch {
-                // Already set by preload or another module -- that's fine
+                const swapped = Database.setCustomSQLite(libPath);
+                if (swapped === false) {
+                    logger.warn(
+                        `[sqlite-vec] setCustomSQLite(${libPath}) returned false - a Database may have been ` +
+                            "created before the preload ran; sqlite-vec will be unavailable."
+                    );
+                    return;
+                }
+
+                homebrewDylibFound = true;
+                logger.debug(`[sqlite-vec] swapped in extension-capable SQLite: ${libPath}`);
+            } catch (err) {
+                logger.warn(
+                    `[sqlite-vec] setCustomSQLite(${libPath}) failed - a Database was created ` +
+                        "before the preload ran; sqlite-vec will be unavailable. " +
+                        "Wire sqlite-vec-preload.ts into the entry point. " +
+                        `Cause: ${err instanceof Error ? err.message : String(err)}`
+                );
             }
 
             return;
@@ -107,8 +121,13 @@ export function loadSqliteVec(db: Database): boolean {
         sqliteVec.load(db);
         extensionAvailable = true;
         return true;
-    } catch {
+    } catch (err) {
         extensionAvailable = false;
+        logger.warn(
+            `[sqlite-vec] loadSqliteVec failed - extension unavailable: ${
+                err instanceof Error ? err.message : String(err)
+            }`
+        );
         return false;
     }
 }

--- a/src/utils/search/stores/sqlite-vec-preload.ts
+++ b/src/utils/search/stores/sqlite-vec-preload.ts
@@ -1,27 +1,15 @@
 /**
- * Preload script for sqlite-vec tests.
- * Must be loaded BEFORE any Database instance is created.
+ * Preload script: swaps in extension-capable SQLite before any Database is
+ * created in the process. Wired into the `tools` launcher (see `tools`,
+ * executeTool) and into bunfig.toml's `preload` plus `[test].preload`.
  *
- * Usage: bun test --preload ./src/utils/search/stores/sqlite-vec-preload.ts
+ * Delegates to ensureExtensionCapableSQLite() so the loader's module-level
+ * state is set correctly and every later call is a clean no-op.
+ *
+ * Usage: bun run --preload ./src/utils/search/stores/sqlite-vec-preload.ts <entry>
  */
-import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
+import logger from "@app/logger";
+import { ensureExtensionCapableSQLite } from "./sqlite-vec-loader";
 
-const HOMEBREW_SQLITE_PATHS = [
-    "/opt/homebrew/opt/sqlite3/lib/libsqlite3.dylib",
-    "/usr/local/opt/sqlite3/lib/libsqlite3.dylib",
-];
-
-if (process.platform === "darwin") {
-    for (const libPath of HOMEBREW_SQLITE_PATHS) {
-        if (existsSync(libPath)) {
-            try {
-                Database.setCustomSQLite(libPath);
-            } catch {
-                // Already loaded -- nothing we can do
-            }
-
-            break;
-        }
-    }
-}
+ensureExtensionCapableSQLite();
+logger.debug("[sqlite-vec-preload] ensureExtensionCapableSQLite() ran at preload time");

--- a/tools
+++ b/tools
@@ -139,14 +139,15 @@ async function executeTool(scriptId, scriptArgs) {
         }
     }
 
-    // Pass bunfig.toml's preload via --preload so opentui's scoped JSX
-    // transform still loads even though we keep cwd at the user's shell —
-    // bun looks for bunfig.toml relative to cwd, so chdir'ing the spawn to
-    // workspaceRoot would break every tool that resolves user-project files
-    // (.claude/azure/config.json, .claude/azure/tasks/, etc.) via process.cwd().
-    const preloadAbs = join(workspaceRoot, "src/utils/bun/preload-solid-scoped.ts");
+    // Preloads run before any module code, and therefore before any
+    // `new Database()`. preload-solid-scoped.ts scopes the opentui JSX
+    // transform; sqlite-vec-preload.ts swaps in extension-capable SQLite so
+    // sqlite-vec can load. Bun looks for bunfig.toml relative to cwd, and we
+    // keep cwd at the user's shell, so both preloads are passed explicitly.
+    const solidPreload = join(workspaceRoot, "src/utils/bun/preload-solid-scoped.ts");
+    const sqliteVecPreload = join(workspaceRoot, "src/utils/search/stores/sqlite-vec-preload.ts");
     const exitCode = await runWithReinstallGuard(
-        ["run", "--preload", preloadAbs, targetScript, ...scriptArgs],
+        ["--preload", solidPreload, "--preload", sqliteVecPreload, targetScript, ...scriptArgs],
         workspaceRoot
     );
     process.exit(exitCode);


### PR DESCRIPTION
## Summary

`tools say` now retries on the macos TTS provider when a non-macos provider fails — voice and model are stripped in the retry since they're provider-specific. Triggered by hitting two cloud-TTS failures in one session:

- `xai` returning `500 Internal Server Error — "no healthy upstream"` (grpc_status:14)
- `openai` rejecting an xAI-shaped voice id with `invalid_request_error` when the saved `claude` profile was used via `--provider openai`

End-of-task chimes and other ambient signals shouldn't silently die on a transient cloud outage.

## Behavior

- **Default**: on any non-`macos` provider failure that isn't voice-not-found, prints a yellow warning, retries on macos (voice/model dropped).
- **Voice-not-found errors** (`404` / `voice X not found`) still print the voice list and exit — config error, not transient.
- **`--no-fallback`**: opt out for CI scripts that should hard-fail on a cloud outage.
- **Already on `macos`**: no retry, original red error + exit 1 (current behavior).

## Test plan

- [x] `X_AI_API_KEY=invalid-key tools say "fallback smoke test" --app claude --provider xai` → prints `[say] xai failed: ...` then `[say] falling back to macos`, macos voice speaks the phrase.
- [x] Same with `--no-fallback` → exits 1 with original error, no fallback.
- [x] `tools say "hello" --provider macos` with broken config → no retry loop (exits 1 as before).
- [x] `tsgo --noEmit` clean for `src/say/`.
- [x] `bunx biome check src/say/index.ts` clean.
- [ ] Verify voice-not-found path still prints the voice list (current behavior preserved by early `process.exit(1)` in that branch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS mail: new search-download + export (emails/attachments/index) and improved mail search with semantic re-ranking
  * CLI: reliable stdout helpers (printLn/writeStdout)
  * New local date/time formatting helpers for CLI outputs

* **Bug Fixes**
  * TTS: --no-fallback option and clearer fallback/error messages
  * Daemon: per-task timeouts recorded and timed-out exits handled
  * Safer logger file-open warnings to avoid init crashes

* **Documentation**
  * Added debugging & logging guidance

* **Tests**
  * Expanded test suites (mail, daemon runner, stdout, date formatting, search/vector loader)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/166)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->