### PR TITLE
feat(transcribe): repetition cleanup + speaker diarization (Deepgram native + local sherpa-onnx)

### DIFF
--- a/.claude/plans/2026-05-17-TranscribeDiarizationAndRepetitionCleanup.md
+++ b/.claude/plans/2026-05-17-TranscribeDiarizationAndRepetitionCleanup.md
@@ -1,0 +1,85 @@
+# Plan: Transcribe — repetition cleanup + speaker diarization
+
+**Detailed task-by-task plan:** `.claude/plans/2026-05-17-TranscribeDiarizationAndRepetitionCleanup.super.md`
+(this file = executive summary; the `.super.md` has the bite-sized TDD steps with full code).
+
+## Context
+
+The transcription bug-fix work (language-drop root cause, deepgram pin, MP3
+normalize, spinner, SRT realignment) is complete + verified, **present as
+uncommitted working-tree changes** (confirmed via `git status` + file
+contents — not stashed/reverted; Phase 0 Task 0.0 commits it first). This is
+the follow-on the user requested, planned as one effort:
+
+- OpenAI hosted `whisper-1` still ∞-loops on some Czech audio (`gth-jaqt-rcw`:
+  `"Zkusíme zpátky…"`/`"ještě ještě…"` ×30) while the rest is correct; the
+  hosted API exposes no anti-loop decode params → must clean **post-hoc**.
+- The user wants speaker attribution ("who spoke when") converging to the
+  quality of `~/Downloads/{1,2,5}.srt` (pyannote `SPEAKER_00`-style) — and
+  it must work even for Whisper, like Spokenly's "Online (Whisper) + Identify
+  Speakers". `*-chatgpt.md` are a **quality benchmark only**, not an output.
+
+Three background research reports (repetition heuristics; diarization
+feasibility; Spokenly/pyannote/sherpa-onnx) + two advisor passes pinned every
+spec. sherpa-onnx-node has a prebuilt darwin-arm64 binary (no Python) and the
+pyannote/WeSpeaker ONNX models are on ungated GitHub releases — both advisor
+install gates cleared.
+
+## Approach (phases — see `.super.md` for tasks)
+
+- **Phase 0** — Task 0.0 commit the existing verified bug-fix (one clean
+  commit, so feature TDD commits stay bisectable); then
+  `tests/transcribe/verify-against-reference.ts` convergence metric (WER-proxy
+  + speaker-agreement vs reference SRTs, pure max-overlap match) + `baseline`
+  captured before any change; `normalizeSpeakerLabel` (single label source).
+- **Phase A** — always-on repetition cleanup util (consecutive-run collapse:
+  single-token run≥5, phrase 2–8w run≥3, adjacent-only so scattered legit
+  repeats survive; cross-segment dedup <2s; zlib = windowed flag only;
+  idempotent). Applied at TranscriptionManager + stitched-Transcriber levels.
+  `--no-clean`/`--raw` escape. Delete dead `wordTimestamps`.
+- **Phase B1** — Deepgram native diarization: `diarize+utterances`, parse raw
+  `result.responses[0].body.results.utterances` (typed, no `any`),
+  `TranscriptionSegment.speaker?`, speaker-boundary in coalescing, SRT/VTT/text
+  rendering, `--diarize`/`--speakers`, split-bypass (one call ⇒ global labels).
+- **Phase B2** — local pyannote via `sherpa-onnx-node@^1.13.2` (pinned;
+  segmentation `sherpa-onnx-pyannote-segmentation-3-0/model.onnx`, embedding
+  `wespeaker_en_voxceleb_resnet34_LM.onnx`; cache
+  `~/.genesis-tools/transcribe/models/diarization/`). Preflight asserts the
+  prebuilt binary. whisperX max-overlap alignment, segment granularity,
+  `fillNearest:true`, clustering `numClusters:2/threshold:0.5` (`--speakers`
+  → numClusters; omit → auto). Pipeline order: **transcribe → cleanup →
+  diarize the UN-SPLIT audio → align onto cleaned segments** (global label
+  space; no cross-chunk remapping).
+- **Phase B3** — word-level alignment enhancement (whisper-1
+  `timestampGranularities:["segment","word"]` + Deepgram words → word-overlap
+  speaker assignment + re-segmentation at mid-segment turn changes; recovers
+  short backchannels). Spike-confirms SDK word exposure first; **kept only if
+  it improves speaker-agreement vs reference, else reverted.** gpt-4o has no
+  words → stays segment-level. (Promoted from out-of-scope per user.)
+- **Phase C** — convergence gate: scored vs `~/Downloads/{1,2,5}.srt` using
+  the fixed mapping (1,2↔gth-jaqt-rcw; 5↔xyf-csts-ptr; btf no reference);
+  numbers recorded; WER must not regress, speaker-agreement > 0.
+- **Phase D** — `src/ask/audio/AudioProcessor.ts` → `src/utils/audio/`
+  (probe/split/convert), move-only, one method/commit. **GATED on Phase C.**
+
+## Critical files
+New: `repetition-cleanup.ts`, `speaker-label.ts`, `align-speakers.ts`,
+`diarize-local.ts`, `diarize-models.ts`, `tests/transcribe/verify-against-reference.ts`.
+Modify: `types.ts`, `TranscriptionManager.ts`, `Transcriber.ts`,
+`transcription-format.ts`, `AICloudProvider.ts`, `transcribe/index.ts`,
+`package.json`. Phase D: `AudioProcessor.ts` → `src/utils/audio/{probe,split}.ts` + `converter.ts`.
+
+## Verification
+Per-task TDD (failing test → run-fail → impl → run-pass → commit), `tsgo`
+0 errors, `bun test`. E2E: cleanup kills `gth` loop & preserves `xyf`
+interviewer repeats; Deepgram + local-pyannote diarization on the 3 files
+scored by the metric harness vs `~/Downloads/{1,2,5}.srt`; iterate clustering
+until speaker-agreement maximized; Phase C records the numbers and gates D.
+
+## Scope notes
+Cross-chunk speaker remapping is **designed out, not deferred** — diarization
+always runs on the un-split source ⇒ one global label space; only multi-hour
+audio is an edge (documented limit). Word-level alignment is **in scope
+(Phase B3)**, metric-gated. Out of scope: AssemblyAI/Gladia (no Czech / dep
+absent); LLM polish (`*-chatgpt.md` is a benchmark, not output); confirming
+Spokenly internals (closed-source — architecture replicated).

--- a/.claude/plans/2026-05-17-TranscribeDiarizationAndRepetitionCleanup.super.md
+++ b/.claude/plans/2026-05-17-TranscribeDiarizationAndRepetitionCleanup.super.md
@@ -1,0 +1,1657 @@
+# Transcribe: Repetition Cleanup + Speaker Diarization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `tools transcribe` (a) auto-strip Whisper ∞-repetition loops without harming legit repeats, and (b) attribute speakers — Deepgram natively, and Whisper/gpt-4o/local via an in-process pyannote→transcript pipeline (no Python) — converging to the quality of `~/Downloads/{1,2,5}.srt`.
+
+**Architecture:** Post-transcription pipeline order is `transcribe → repetition-cleanup → diarize on the *un-split* source audio → align speakers onto cleaned segments by whisperX max-overlap`. (Cleanup mutates segment *text*, and may *extend* a segment's `end` when it absorbs an adjacent duplicate — that absorbed span is the same speaker by the dedup precondition, so max-overlap alignment handles it naturally; the time axis is otherwise unchanged.) Deepgram returns speaker labels in its raw response; every other provider gets a local `sherpa-onnx-node` diarization (pyannote-segmentation-3.0 + WeSpeaker embedding ONNX, ungated GitHub-Release models, prebuilt darwin-arm64 binary) aligned onto the transcript. This replicates Spokenly's "Online (Whisper) + Identify Speakers" UX (a no-Python pyannote→Whisper pipeline producing `SPEAKER_00`-style output — Spokenly itself is closed-source so we replicate the architecture, not a documented internal).
+
+**Tech Stack:** Bun, TypeScript, Vercel AI SDK (`ai@5.0.86`), `@ai-sdk/deepgram@^1.0.28` (spec-v2), `sherpa-onnx-node@^1.13.2` (+ optional `sherpa-onnx-darwin-arm64`), ffmpeg, `bun:test`, `tsgo --noEmit`.
+
+**Prerequisite state:** the prior transcription bug-fix is **present + verified
+but uncommitted** in the working tree (confirmed via `git status` + file
+contents — NOT stashed, NOT reverted). Phase 0 Task 0.0 commits it first; no
+re-implementation is needed.
+
+**Decisions locked (do not re-litigate during impl):**
+- Repetition cleanup: **always-on**, `--no-clean`/`--raw` disables.
+- Diarization labels: pyannote/Spokenly convention `SPEAKER_00` (uppercase). sherpa emits `speaker_00` lowercase → normalized in **one** function `normalizeSpeakerLabel`.
+- Local diarizer dep: `sherpa-onnx-node@^1.13.2`. Segmentation `sherpa-onnx-pyannote-segmentation-3-0/model.onnx` (fp32, 5.7 MB). Embedding `wespeaker_en_voxceleb_resnet34_LM.onnx` (25.3 MB). Model cache: `~/.genesis-tools/transcribe/models/diarization/`.
+- Clustering defaults: `numClusters:2, threshold:0.5, minDurationOn:0.3, minDurationOff:0.5`. CLI `--speakers <n>` → `numClusters:n`; omitted or `0` → `numClusters:-1` (auto, `threshold:0.5`).
+- Alignment: whisperX `assign_word_speakers` max-overlap, **segment granularity** (OpenAI gives only segment timestamps), **`fillNearest:true`** (reference SRTs label every cue — leaving cues unlabeled would falsely punish the metric).
+- Diarization always runs on the **un-split** source audio → one consistent label space; **no cross-chunk speaker remapping** is ever needed or built.
+- Dead `wordTimestamps` option is **deleted** (YAGNI — segment-level only).
+- D (AudioProcessor refactor) runs **last, only if A+B1+B2 pass the convergence metric**.
+
+**Convergence metric (single source of truth):** `tests/transcribe/verify-against-reference.ts`. Reference cues are utterance-level (long); candidate cues are often segment-level (short) — so match **purely by maximum time-overlap** (any positive overlap; NO start-distance gate, which would drop most short candidate cues and make the metric noisy/misleading). For each candidate cue → the reference cue it overlaps most; `wer_proxy = mean(levenshtein(candText, refText) / refText.length)` over matched cues; `speaker_agreement = cuesWithMatchingSpeaker / cuesWithSpeakerInBoth`. Output exactly one line per file: `1.srt: WER-proxy 0.082, speaker-agreement 0.94`. Baseline is captured in Phase 0 **before** any code change; every later phase prints the delta.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/utils/ai/transcription/repetition-cleanup.ts` (new) | Pure, idempotent loop-collapse + cross-segment dedup on `{text,segments}` |
+| `src/utils/ai/transcription/speaker-label.ts` (new) | `normalizeSpeakerLabel()` — the ONLY place label case/format is decided |
+| `src/utils/ai/transcription/align-speakers.ts` (new) | whisperX max-overlap segment↔turn assignment |
+| `src/utils/audio/diarize-local.ts` (new) | sherpa-onnx-node wrapper: wav → `[{start,end,speaker}]`; model fetch+cache |
+| `src/utils/ai/types.ts` (modify) | `TranscriptionSegment.speaker?`; `TranscribeOptions.clean?`,`speakers?`; delete `wordTimestamps` |
+| `src/utils/ai/transcription/TranscriptionManager.ts` (modify) | cleanup hook; Deepgram `utterances`+raw-body speaker parse; `clean`/`speakers` plumbing |
+| `src/utils/ai/tasks/Transcriber.ts` (modify) | stitched-result cleanup; diarize-unsplit + local-diarize wiring; split-bypass when diarize |
+| `src/utils/ai/transcription-format.ts` (modify) | speaker rendering (text/SRT/VTT) via `normalizeSpeakerLabel`; speaker-boundary in `coalesceSegmentsForSubtitles` |
+| `src/utils/ai/providers/AICloudProvider.ts` (modify) | forward `clean`,`speakers` |
+| `src/transcribe/index.ts` (modify) | `--diarize`, `--speakers <n>`, `--no-clean`/`--raw`; interactive prompts |
+| `tests/transcribe/verify-against-reference.ts` (new) | convergence metric harness |
+| `package.json` (modify) | add `sherpa-onnx-node@^1.13.2` |
+| Phase D | move `src/ask/audio/AudioProcessor.ts` methods → `src/utils/audio/` |
+
+---
+
+## Phase 0 — Prereq commit + convergence harness (baseline before any change)
+
+### Task 0.0: Commit the existing verified transcription bug-fix
+
+The prior bug-fix (splitter `-vn`/libmp3lame, `convertFileToMonoMp3` cloud
+normalize, `@ai-sdk/deepgram@^1.0.28` pin, language→`providerOptions`,
+`mapResultSegments`, SRT realignment, quiet spinner, `detect-format.ts`) is
+**present and verified but uncommitted** in the working tree. Commit it as
+ONE commit so this plan's feature commits stay clean and bisectable.
+
+- [ ] **Step 1: Confirm the bug-fix is intact**
+
+Run: `git status --short` and
+`rg -n "convertFileToMonoMp3" src/utils/ai/providers/AICloudProvider.ts`
+Expected: the ~15 modified files + 2 untracked (`detect-format.ts`,
+`quiet-spinner.ts`); the rg matches (bug-fix on disk). If NOT intact,
+recover from `git stash` or re-run the prior bug-fix plan before continuing.
+
+- [ ] **Step 2: Commit only the bug-fix files**
+
+```bash
+cd /Users/Martin/Tresors/Projects/GenesisTools
+git add CLAUDE.md bun.lock package.json \
+  src/ask/audio/AudioProcessor.ts src/ask/providers/ModelSelector.ts \
+  src/macos/commands/mail/search.ts src/transcribe/index.ts \
+  src/transcribe/transcribe.test.ts src/utils/ai/providers/AICloudProvider.ts \
+  src/utils/ai/providers/xai/AIXAITranscriptionProvider.ts \
+  src/utils/ai/tasks/Transcriber.ts src/utils/ai/transcription-format.ts \
+  src/utils/ai/transcription/TranscriptionManager.ts src/utils/ai/types.ts \
+  src/utils/audio/converter.ts src/utils/audio/detect-format.ts \
+  src/utils/cli/quiet-spinner.ts
+git commit -m "fix(transcribe): Czech language drop, deepgram v2 pin, MP3 normalize, splitter, SRT realign, quiet spinner"
+```
+(Do NOT add `.claude/scheduled_tasks.lock` or unrelated `??` files.)
+
+- [ ] **Step 3: Verify green from this commit**
+
+Run: `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0` (→ `0`);
+`bun test src/transcribe src/utils/ai src/utils/audio`.
+Expected: all pass. This commit is the baseline HEAD for Phase 0.2 onward.
+
+### Convergence harness FIRST (baseline before any change)
+
+### Task 0.1: Speaker-label normalizer + its test (needed by metric and renderers)
+
+**Files:**
+- Create: `src/utils/ai/transcription/speaker-label.ts`
+- Test: `src/utils/ai/transcription/speaker-label.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/ai/transcription/speaker-label.test.ts
+import { describe, expect, it } from "bun:test";
+import { normalizeSpeakerLabel } from "./speaker-label";
+
+describe("normalizeSpeakerLabel", () => {
+    it("uppercases sherpa lowercase labels", () => {
+        expect(normalizeSpeakerLabel("speaker_00")).toBe("SPEAKER_00");
+    });
+    it("zero-pads bare integer/string speaker ids", () => {
+        expect(normalizeSpeakerLabel(0)).toBe("SPEAKER_00");
+        expect(normalizeSpeakerLabel(3)).toBe("SPEAKER_03");
+        expect(normalizeSpeakerLabel("1")).toBe("SPEAKER_01");
+    });
+    it("passes through already-correct labels", () => {
+        expect(normalizeSpeakerLabel("SPEAKER_02")).toBe("SPEAKER_02");
+    });
+    it("returns undefined for null/undefined/empty", () => {
+        expect(normalizeSpeakerLabel(undefined)).toBeUndefined();
+        expect(normalizeSpeakerLabel(null)).toBeUndefined();
+        expect(normalizeSpeakerLabel("")).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/utils/ai/transcription/speaker-label.test.ts`
+Expected: FAIL — `Cannot find module './speaker-label'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/utils/ai/transcription/speaker-label.ts
+/**
+ * The single place speaker-label format is decided. sherpa-onnx emits
+ * `speaker_00` (lowercase); Deepgram emits integer ids; the pyannote /
+ * Spokenly / reference-SRT convention is `SPEAKER_00` (uppercase, zero-padded
+ * to 2). Every render path MUST go through this — never uppercase ad hoc.
+ */
+export function normalizeSpeakerLabel(raw: string | number | null | undefined): string | undefined {
+    if (raw === null || raw === undefined || raw === "") {
+        return undefined;
+    }
+
+    if (typeof raw === "number") {
+        return `SPEAKER_${String(raw).padStart(2, "0")}`;
+    }
+
+    const m = raw.match(/(\d+)\s*$/);
+
+    if (m) {
+        return `SPEAKER_${m[1].padStart(2, "0")}`;
+    }
+
+    // Unknown format (no trailing digits) — pass through uppercased. sherpa
+    // (`speaker_NN`) and Deepgram (int) always hit the branches above; this is
+    // a safety fallthrough, not an expected path.
+    return raw.toUpperCase();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/utils/ai/transcription/speaker-label.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/ai/transcription/speaker-label.ts src/utils/ai/transcription/speaker-label.test.ts
+git commit -m "feat(transcribe): single-source speaker label normalizer"
+```
+
+### Task 0.2: Convergence metric harness
+
+**Files:**
+- Create: `tests/transcribe/verify-against-reference.ts`
+- Test: `tests/transcribe/verify-against-reference.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/transcribe/verify-against-reference.test.ts
+import { describe, expect, it } from "bun:test";
+import { parseSrt, scoreAgainstReference } from "./verify-against-reference";
+
+describe("parseSrt", () => {
+    it("parses cue index, times, speaker prefix and text", () => {
+        const srt = "1\n00:00:00,000 --> 00:00:02,000\nSPEAKER_00: Ahoj světe.\n";
+        const cues = parseSrt(srt);
+        expect(cues).toHaveLength(1);
+        expect(cues[0]).toEqual({ start: 0, end: 2, speaker: "SPEAKER_00", text: "Ahoj světe." });
+    });
+    it("parses a cue with no speaker prefix", () => {
+        const cues = parseSrt("1\n00:00:01,000 --> 00:00:02,500\nAhoj.\n");
+        expect(cues[0]).toEqual({ start: 1, end: 2.5, speaker: undefined, text: "Ahoj." });
+    });
+});
+
+describe("scoreAgainstReference", () => {
+    it("perfect match → werProxy 0, speakerAgreement 1", () => {
+        const a = "1\n00:00:00,000 --> 00:00:02,000\nSPEAKER_00: Ahoj.\n";
+        const s = scoreAgainstReference(a, a);
+        expect(s.werProxy).toBe(0);
+        expect(s.speakerAgreement).toBe(1);
+    });
+    it("counts speaker disagreement only over cues with speaker in both", () => {
+        const cand = "1\n00:00:00,000 --> 00:00:02,000\nSPEAKER_01: Ahoj.\n";
+        const ref = "1\n00:00:00,000 --> 00:00:02,000\nSPEAKER_00: Ahoj.\n";
+        const s = scoreAgainstReference(cand, ref);
+        expect(s.speakerAgreement).toBe(0);
+        expect(s.werProxy).toBe(0);
+    });
+    it("matches short candidate cues to a long reference cue by overlap (no start-distance gate)", () => {
+        const ref = "1\n00:00:00,000 --> 00:00:30,000\nSPEAKER_00: Dobrý den jak se máte.\n";
+        const cand =
+            "1\n00:00:20,000 --> 00:00:22,000\nSPEAKER_00: máte\n"; // start 20s from ref start — must still match
+        const s = scoreAgainstReference(cand, ref);
+        expect(s.speakerAgreement).toBe(1); // matched ⇒ speaker compared
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/transcribe/verify-against-reference.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// tests/transcribe/verify-against-reference.ts
+export interface Cue { start: number; end: number; speaker?: string; text: string }
+
+function tc(s: string): number {
+    const m = s.trim().match(/(\d+):(\d+):(\d+)[,.](\d+)/);
+    if (!m) return 0;
+    return +m[1] * 3600 + +m[2] * 60 + +m[3] + +m[4] / 1000;
+}
+
+export function parseSrt(srt: string): Cue[] {
+    const blocks = srt.replace(/\r/g, "").split(/\n\n+/);
+    const cues: Cue[] = [];
+    for (const b of blocks) {
+        const lines = b.split("\n").filter((l) => l.trim() !== "");
+        if (lines.length < 2) continue;
+        const tl = lines.find((l) => l.includes("-->"));
+        if (!tl) continue;
+        const [a, z] = tl.split("-->");
+        const body = lines.slice(lines.indexOf(tl) + 1).join(" ").trim();
+        // ONLY `SPEAKER_NN:` counts as a speaker prefix — matching a generic
+        // capitalized word would false-positive on any sentence like
+        // "Dobrý den: ..." and corrupt the speaker-agreement denominator.
+        const sm = body.match(/^(SPEAKER_\d+)\s*:\s*(.*)$/s);
+        cues.push({
+            start: tc(a),
+            end: tc(z),
+            speaker: sm ? sm[1] : undefined,
+            text: sm ? sm[2].trim() : body,
+        });
+    }
+    return cues;
+}
+
+function lev(a: string, b: string): number {
+    const d = Array.from({ length: a.length + 1 }, (_, i) => [i, ...Array(b.length).fill(0)]);
+    for (let j = 0; j <= b.length; j++) d[0][j] = j;
+    for (let i = 1; i <= a.length; i++)
+        for (let j = 1; j <= b.length; j++)
+            d[i][j] = Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
+    return d[a.length][b.length];
+}
+
+function overlap(a: Cue, b: Cue): number {
+    return Math.max(0, Math.min(a.end, b.end) - Math.max(a.start, b.start));
+}
+
+export function scoreAgainstReference(candSrt: string, refSrt: string): { werProxy: number; speakerAgreement: number } {
+    const cand = parseSrt(candSrt);
+    const ref = parseSrt(refSrt);
+    let werSum = 0;
+    let werN = 0;
+    let spkMatch = 0;
+    let spkBoth = 0;
+    for (const c of cand) {
+        let best: Cue | undefined;
+        let bestOv = 0;
+        for (const r of ref) {
+            // Pure max-overlap — NO start-distance gate (reference cues are
+            // long/utterance-level, candidate cues short/segment-level; a
+            // start gate would drop most candidates and skew the metric).
+            const ov = overlap(c, r);
+            if (ov > bestOv) {
+                bestOv = ov;
+                best = r;
+            }
+        }
+        if (!best || bestOv <= 0) continue;
+        werSum += lev(c.text, best.text) / Math.max(1, best.text.length);
+        werN++;
+        if (c.speaker && best.speaker) {
+            spkBoth++;
+            if (c.speaker === best.speaker) spkMatch++;
+        }
+    }
+    return {
+        werProxy: werN ? werSum / werN : 1,
+        speakerAgreement: spkBoth ? spkMatch / spkBoth : 1,
+    };
+}
+
+// CLI: bun tests/transcribe/verify-against-reference.ts <candidate.srt> <reference.srt>
+if (import.meta.main) {
+    const [cand, ref] = process.argv.slice(2);
+    const s = scoreAgainstReference(await Bun.file(cand).text(), await Bun.file(ref).text());
+    console.log(`${cand.split("/").pop()}: WER-proxy ${s.werProxy.toFixed(3)}, speaker-agreement ${s.speakerAgreement.toFixed(2)}`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/transcribe/verify-against-reference.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Capture the pre-change baseline**
+
+**Reference↔recording mapping (resolved by content of cue 1 — fixed, do not
+re-derive):**
+- `~/Downloads/1.srt` and `~/Downloads/2.srt` ↔ **`gth-jaqt-rcw (2026-05-08 07_33 GMT).mp4`** (two STT versions of the same recording; cue 1 = *"Děkuji, že jste si na mě udělali čas. Moc si toho vážím. Můžeme teda začít…"*).
+- `~/Downloads/5.srt` ↔ **`xyf-csts-ptr (2026-05-14 16_04 GMT).mp4`** (cue 1 = *"Dobrý den, moc si vážím toho, že jste si na mě udělala čas. V první části mého rozhovoru vyplnilo 60 lidí…"*).
+- `btf-pnvm-ecb` has **no** provided reference — exclude it from metric scoring.
+
+Run (current code, no changes yet):
+```bash
+cd /Users/Martin/Downloads
+GT=/Users/Martin/Tresors/Projects/GenesisTools
+tools transcribe "gth-jaqt-rcw (2026-05-08 07_33 GMT).mp4" --provider deepgram --lang cs --format srt -o /tmp/base-gth.srt 2>/dev/null
+tools transcribe "xyf-csts-ptr (2026-05-14 16_04 GMT).mp4" --provider deepgram --lang cs --format srt -o /tmp/base-xyf.srt 2>/dev/null
+{ bun $GT/tests/transcribe/verify-against-reference.ts /tmp/base-gth.srt /Users/Martin/Downloads/1.srt
+  bun $GT/tests/transcribe/verify-against-reference.ts /tmp/base-gth.srt /Users/Martin/Downloads/2.srt
+  bun $GT/tests/transcribe/verify-against-reference.ts /tmp/base-xyf.srt /Users/Martin/Downloads/5.srt
+} | tee /tmp/baseline-metric.txt
+```
+Expected: three correctly-paired `…: WER-proxy X, speaker-agreement Y` lines (speaker-agreement will be the no-speaker default 1.0 at baseline since current output has no speakers; WER-proxy is the real baseline number every later phase must not regress).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/transcribe/verify-against-reference.ts tests/transcribe/verify-against-reference.test.ts
+git commit -m "test(transcribe): convergence metric harness vs reference SRTs"
+```
+
+---
+
+## Phase A — Repetition cleanup (always-on)
+
+### Task A.1: `cleanRepetitions` pure util + tests
+
+**Files:**
+- Create: `src/utils/ai/transcription/repetition-cleanup.ts`
+- Test: `src/utils/ai/transcription/repetition-cleanup.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/ai/transcription/repetition-cleanup.test.ts
+import { describe, expect, it } from "bun:test";
+import { cleanRepetitions } from "./repetition-cleanup";
+import type { TranscriptionSegment } from "@app/utils/ai/types";
+
+describe("cleanRepetitions", () => {
+    it("collapses a single-token loop (run >= 5) to one", () => {
+        const r = cleanRepetitions({ text: "ano ještě ještě ještě ještě ještě ještě konec" });
+        expect(r.text).toBe("ano ještě konec");
+    });
+    it("collapses a clause loop (phrase run >= 3) to one", () => {
+        const t = "Zkusíme zpátky. Zkusíme zpátky. Zkusíme zpátky. Zkusíme zpátky. Dál.";
+        expect(cleanRepetitions({ text: t }).text).toBe("Zkusíme zpátky. Dál.");
+    });
+    it("preserves scattered legit repeats (interviewer 'Dobře, děkuji.' x3 with content between)", () => {
+        const t = "Dobře, děkuji. Otázka jedna. Dobře, děkuji. Otázka dva. Dobře, děkuji. Konec.";
+        expect(cleanRepetitions({ text: t }).text).toBe(t);
+    });
+    it("is Czech-diacritic-insensitive when matching the run", () => {
+        const r = cleanRepetitions({ text: "Ještě ještě JEŠTĚ ještě ještě dál" });
+        expect(r.text).toBe("Ještě dál");
+    });
+    it("is idempotent", () => {
+        const once = cleanRepetitions({ text: "a a a a a a b" });
+        const twice = cleanRepetitions(once);
+        expect(twice).toEqual(once);
+    });
+    it("dedups a segment equal to the previous within < 2s gap and absorbs its end", () => {
+        const segments: TranscriptionSegment[] = [
+            { text: "Dobrý den.", start: 0, end: 1 },
+            { text: "dobrý den", start: 1.5, end: 2.4 },
+            { text: "Jak se máte?", start: 5, end: 6 },
+        ];
+        const r = cleanRepetitions({ text: "x", segments });
+        expect(r.segments).toEqual([
+            { text: "Dobrý den.", start: 0, end: 2.4 },
+            { text: "Jak se máte?", start: 5, end: 6 },
+        ]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/utils/ai/transcription/repetition-cleanup.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/utils/ai/transcription/repetition-cleanup.ts
+import logger from "@app/logger";
+import type { TranscriptionSegment } from "@app/utils/ai/types";
+
+const SINGLE_TOKEN_MIN_RUN = 5;
+const PHRASE_MIN_RUN = 3;
+const MAX_PHRASE_WORDS = 8;
+const SEG_DEDUP_GAP_SEC = 2.0;
+const ZLIB_FLAG_RATIO = 2.4;
+const ZLIB_WINDOW_WORDS = 120;
+
+function norm(s: string): string {
+    return s
+        .normalize("NFD")
+        .replace(/[̀-ͯ]/g, "")
+        .toLowerCase()
+        .replace(/["'.,?!…]+$/g, "")
+        .trim();
+}
+
+function spanEq(a: string[], s: number, e: number, t: number): boolean {
+    for (let k = 0; k < e - s; k++) {
+        if (a[s + k] !== a[t + k]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/** Collapse only CONSECUTIVE repeated token n-grams (stable-ts remove_repetition
+ *  port). Adjacent-only ⇒ scattered legit repeats survive untouched. */
+function collapseRuns(tokens: string[]): string[] {
+    let toks = tokens;
+
+    for (let len = 1; len <= MAX_PHRASE_WORDS; len++) {
+        const minRun = len === 1 ? SINGLE_TOKEN_MIN_RUN : PHRASE_MIN_RUN;
+        const n = toks.map(norm);
+        const kept: boolean[] = toks.map(() => true);
+        let i = 0;
+
+        while (i + len <= n.length) {
+            let reps = 1;
+
+            while (i + (reps + 1) * len <= n.length && spanEq(n, i, i + len, i + reps * len)) {
+                reps++;
+            }
+
+            if (reps >= minRun) {
+                for (let r = 1; r < reps; r++) {
+                    for (let k = 0; k < len; k++) {
+                        kept[i + r * len + k] = false;
+                    }
+                }
+
+                i += reps * len;
+            } else {
+                i += 1;
+            }
+        }
+
+        toks = toks.filter((_, idx) => kept[idx]);
+    }
+
+    return toks;
+}
+
+function flagHighCompression(text: string): void {
+    // FLAG only (never deletes). Runs on the PRE-cleanup text so it surfaces
+    // loops the run-collapse heuristic did NOT catch — checking post-collapse
+    // would always look fine and make the warning useless. zlib header
+    // (`library:"zlib"`) matches the 2.4 threshold's Python/Node calibration;
+    // Bun's default raw deflate would skew the ratio ~5-10%.
+    const words = text.split(/\s+/).filter(Boolean);
+    for (let i = 0; i < words.length; i += ZLIB_WINDOW_WORDS) {
+        const win = words.slice(i, i + ZLIB_WINDOW_WORDS).join(" ");
+        const ratio =
+            Buffer.byteLength(win, "utf8") /
+            Math.max(1, Bun.deflateSync(Buffer.from(win), { library: "zlib" }).length);
+        if (ratio > ZLIB_FLAG_RATIO) {
+            logger.warn(`repetition-cleanup: window @word ${i} compression ratio ${ratio.toFixed(2)} > ${ZLIB_FLAG_RATIO} (review)`);
+        }
+    }
+}
+
+function cleanText(text: string): string {
+    flagHighCompression(text);
+    return collapseRuns(text.split(/\s+/).filter(Boolean)).join(" ");
+}
+
+export function cleanRepetitions(input: { text: string; segments?: TranscriptionSegment[] }): {
+    text: string;
+    segments?: TranscriptionSegment[];
+} {
+    if (!input.segments?.length) {
+        return { text: cleanText(input.text) };
+    }
+
+    flagHighCompression(input.text); // pre-cleanup flag on the full text
+
+    // 1. intra-segment run-collapse
+    const intra = input.segments.map((s) => ({
+        ...s,
+        text: collapseRuns(s.text.split(/\s+/).filter(Boolean)).join(" "),
+    }));
+
+    // 2. cross-segment dedup (drop seg == previous surviving within < gap)
+    const segs: TranscriptionSegment[] = [];
+    for (const s of intra) {
+        const prev = segs[segs.length - 1];
+        if (prev && norm(prev.text) === norm(s.text) && norm(s.text).length > 0 && s.start - prev.end < SEG_DEDUP_GAP_SEC) {
+            prev.end = s.end;
+            continue;
+        }
+
+        segs.push({ ...s });
+    }
+
+    // 3. segment run-length (>=5 consecutive identical normalized text → keep first)
+    const out: TranscriptionSegment[] = [];
+    let i = 0;
+    while (i < segs.length) {
+        let reps = 1;
+        while (i + reps < segs.length && norm(segs[i + reps].text) === norm(segs[i].text) && norm(segs[i].text).length > 0) {
+            reps++;
+        }
+
+        if (reps >= SINGLE_TOKEN_MIN_RUN) {
+            out.push({ ...segs[i], end: segs[i + reps - 1].end });
+            i += reps;
+        } else {
+            out.push(segs[i]);
+            i += 1;
+        }
+    }
+
+    return { text: out.map((s) => s.text).join(" "), segments: out };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/utils/ai/transcription/repetition-cleanup.test.ts`
+Expected: PASS (6 tests). Then `tsgo --noEmit 2>&1 | rg repetition-cleanup || echo clean`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/ai/transcription/repetition-cleanup.ts src/utils/ai/transcription/repetition-cleanup.test.ts
+git commit -m "feat(transcribe): consecutive-run repetition cleanup util"
+```
+
+### Task A.2: Add `clean` option, delete dead `wordTimestamps`
+
+**Files:**
+- Modify: `src/utils/ai/types.ts` (`TranscribeOptions`, lines ~52-79)
+- Modify: `src/utils/ai/transcription/TranscriptionManager.ts` (`TranscriptionOptions`, lines ~21-30)
+
+- [ ] **Step 1: Edit `TranscribeOptions`** — remove `wordTimestamps`, add `clean` and `speakers`:
+
+```ts
+    /** Enable speaker diarization (Deepgram native; local pyannote otherwise). */
+    diarize?: boolean;
+    /** Expected speaker count for diarization clustering; omit/0 = auto-detect. */
+    speakers?: number;
+    /** Enable smart formatting/punctuation (Deepgram). */
+    smartFormat?: boolean;
+    /** Post-process repetition-loop cleanup. Default true; --no-clean disables. */
+    clean?: boolean;
+```
+(Delete the `wordTimestamps?: boolean;` line and its comment.)
+
+- [ ] **Step 2: Edit `TranscriptionManager.TranscriptionOptions`** — same: drop `wordTimestamps`, add `clean?: boolean` and `speakers?: number`.
+
+- [ ] **Step 3: Verify nothing else references `wordTimestamps`**
+
+Run: `rg -n "wordTimestamps" src/`
+Expected: no matches (it was dead — confirmed in research). If any remain, remove them.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0`
+Expected: `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/ai/types.ts src/utils/ai/transcription/TranscriptionManager.ts
+git commit -m "refactor(transcribe): add clean/speakers options, drop dead wordTimestamps"
+```
+
+### Task A.3: Apply cleanup at both pipeline levels + integration idempotency test
+
+**Files:**
+- Modify: `src/utils/ai/transcription/TranscriptionManager.ts` (`transcribeAudio` result block ~164-180; `transcribeWithFallback` ~247-255)
+- Modify: `src/utils/ai/tasks/Transcriber.ts` (`transcribeChunked` final return ~144-148; non-chunked `transcribe` return ~77-82)
+- Modify: `src/utils/ai/providers/AICloudProvider.ts` (forward `clean`)
+- Test: `src/utils/ai/tasks/Transcriber.cleanup.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+// src/utils/ai/tasks/Transcriber.cleanup.test.ts
+import { describe, expect, it } from "bun:test";
+import { cleanRepetitions } from "@app/utils/ai/transcription/repetition-cleanup";
+
+describe("two-level cleanup idempotency", () => {
+    it("manager-clean then stitched-clean equals single clean (no double-collapse drift)", () => {
+        const looped = { text: "a a a a a a b a a a a a a c" };
+        const managerPass = cleanRepetitions(looped);            // per-chunk / single-shot
+        const stitchedPass = cleanRepetitions(managerPass);      // Transcriber stitched
+        expect(stitchedPass).toEqual(managerPass);
+        expect(managerPass.text).toBe("a b a c");
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it passes already (pure-function guarantee)**
+
+Run: `bun test src/utils/ai/tasks/Transcriber.cleanup.test.ts`
+Expected: PASS — proves the function is safe to apply twice. (If FAIL, fix `cleanRepetitions` before wiring.)
+
+- [ ] **Step 3: Wire cleanup into `TranscriptionManager`** — in both `transcribeAudio` and `transcribeWithFallback`, replace the `const transcriptionResult = { text: result.text, … segments: mapResultSegments(result), … }` construction so that when `options.clean !== false`:
+
+```ts
+import { cleanRepetitions } from "./repetition-cleanup";
+// ...
+const mapped = mapResultSegments(result);
+const cleaned = options.clean === false
+    ? { text: result.text, segments: mapped }
+    : cleanRepetitions({ text: result.text, segments: mapped });
+
+const transcriptionResult: TranscriptionResult = {
+    text: cleaned.text,
+    provider: transcriptionModel.provider,
+    model: transcriptionModel.model,
+    processingTime,
+    segments: cleaned.segments,
+    language: result.language ?? options.language,
+    duration: result.durationInSeconds,
+};
+```
+(Apply the identical `cleaned` pattern in `transcribeWithFallback`'s return.)
+
+- [ ] **Step 4: Wire cleanup into `Transcriber`** — in `transcribeChunked`, after `const text = texts.join(" ")` build and clean the stitched result before return; in non-chunked `transcribe`, clean the provider result. Use one private helper:
+
+```ts
+import { cleanRepetitions } from "@app/utils/ai/transcription/repetition-cleanup";
+
+private maybeClean(r: TranscriptionResult, options?: TranscribeOptions): TranscriptionResult {
+    if (options?.clean === false) {
+        return r;
+    }
+
+    const c = cleanRepetitions({ text: r.text, segments: r.segments });
+    return { ...r, text: c.text, segments: c.segments };
+}
+```
+- `transcribe` (non-chunked branch): `return this.maybeClean(await retry(...), options);`
+- `transcribeChunked`: wrap the final `return { text: texts.join(" "), segments: …, … }` in `this.maybeClean(...)`.
+
+- [ ] **Step 5: Forward `clean` in `AICloudProvider.transcribe`** — add `clean: options?.clean` and `speakers: options?.speakers` to the `transcriptionManager.transcribeAudio(uploadPath, { … })` options object.
+
+- [ ] **Step 6: Typecheck + tests**
+
+Run: `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0` (expect `0`); `bun test src/utils/ai src/transcribe`.
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/ai/transcription/TranscriptionManager.ts src/utils/ai/tasks/Transcriber.ts src/utils/ai/providers/AICloudProvider.ts src/utils/ai/tasks/Transcriber.cleanup.test.ts
+git commit -m "feat(transcribe): apply repetition cleanup at manager + stitched levels"
+```
+
+### Task A.4: CLI `--no-clean`/`--raw` + E2E proof on the looper
+
+**Files:**
+- Modify: `src/transcribe/index.ts` (commander options ~301-311; `TranscribeFlags` ~42-50; `runTranscription` call ~114-121)
+
+- [ ] **Step 1: Add option + flag + thread it**
+
+```ts
+// commander:
+.option("--no-clean", "Disable repetition-loop cleanup (alias: --raw)")
+.option("--raw", "Alias for --no-clean")
+// TranscribeFlags: add `clean?: boolean;`
+// runTranscription transcriber.transcribe(resolved, { ... , clean: opts.raw ? false : opts.clean });
+```
+(Commander `--no-clean` sets `opts.clean=false`; `--raw` also forces false.)
+
+- [ ] **Step 2: E2E — cleanup ON (default) kills the loop**
+
+Run:
+```bash
+cd /Users/Martin/Downloads
+tools transcribe "gth-jaqt-rcw (2026-05-08 07_33 GMT).mp4" --provider openai --model whisper-1 --lang cs --format text -o /tmp/gth-clean.txt 2>/dev/null
+rg -o '[A-ZČŠŽ][^.!?]{12,}[.!?]' /tmp/gth-clean.txt | sort | uniq -c | sort -rn | head -1
+```
+Expected: top repeated clause count is low single digits (no `"Zkusíme zpátky…"`/`"ještě ještě…"` ×∞).
+
+- [ ] **Step 3: E2E — `--raw` returns the raw looped output (gate proof)**
+
+Run: same command with `--raw -o /tmp/gth-raw.txt`; `wc -c /tmp/gth-raw.txt /tmp/gth-clean.txt`.
+Expected: `gth-raw.txt` is substantially larger and still contains the loop → proves the gate works.
+
+- [ ] **Step 4: E2E — legit repeats preserved**
+
+Run: transcribe `xyf-csts-ptr*.mp4` (deepgram, text); `rg -c "Dobře, děkuji" /tmp/xyf.txt`.
+Expected: count ≈ the interviewer's natural repeats (not collapsed to 1).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/transcribe/index.ts
+git commit -m "feat(transcribe): --no-clean/--raw escape for repetition cleanup"
+```
+
+---
+
+## Phase B1 — Deepgram native diarization
+
+### Task B1.1: `TranscriptionSegment.speaker` + Deepgram options
+
+**Files:**
+- Modify: `src/utils/ai/types.ts` (`TranscriptionSegment` ~44-48)
+- Modify: `src/utils/ai/transcription/TranscriptionManager.ts` (`buildProviderOptions` deepgram branch ~462-481)
+
+- [ ] **Step 1: Add `speaker?` to `TranscriptionSegment`**
+
+```ts
+export interface TranscriptionSegment {
+    text: string;
+    start: number;
+    end: number;
+    speaker?: string;
+}
+```
+
+- [ ] **Step 2: In `buildProviderOptions` deepgram branch, request utterances when diarizing**
+
+```ts
+if (options.diarize) {
+    deepgramOpts.diarize = true;
+    deepgramOpts.utterances = true; // gives speaker-grouped sentence segments
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0`
+Expected: `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/ai/types.ts src/utils/ai/transcription/TranscriptionManager.ts
+git commit -m "feat(transcribe): TranscriptionSegment.speaker + deepgram utterances"
+```
+
+### Task B1.2: Parse Deepgram raw utterances into speaker segments
+
+**Files:**
+- Modify: `src/utils/ai/transcription/TranscriptionManager.ts` (add `SdkTranscriptionResult.responses`, a `deepgramUtteranceSegments()` helper, use it in `transcribeAudio`)
+- Test: `src/utils/ai/transcription/deepgram-utterances.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/ai/transcription/deepgram-utterances.test.ts
+import { describe, expect, it } from "bun:test";
+import { deepgramUtteranceSegments } from "./TranscriptionManager";
+
+describe("deepgramUtteranceSegments", () => {
+    it("maps raw utterances to speaker-labelled segments", () => {
+        const result = {
+            responses: [{ body: { results: { utterances: [
+                { speaker: 0, transcript: "Dobrý den.", start: 0.1, end: 1.2 },
+                { speaker: 1, transcript: "Zdravím.", start: 1.5, end: 2.0 },
+            ] } } }],
+        };
+        expect(deepgramUtteranceSegments(result)).toEqual([
+            { text: "Dobrý den.", start: 0.1, end: 1.2, speaker: "SPEAKER_00" },
+            { text: "Zdravím.", start: 1.5, end: 2.0, speaker: "SPEAKER_01" },
+        ]);
+    });
+    it("returns undefined when no utterances present", () => {
+        expect(deepgramUtteranceSegments({ responses: [{ body: {} }] })).toBeUndefined();
+        expect(deepgramUtteranceSegments({})).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/utils/ai/transcription/deepgram-utterances.test.ts`
+Expected: FAIL — `deepgramUtteranceSegments` not exported.
+
+- [ ] **Step 3: Implement (narrow typed access — no `any`)**
+
+```ts
+import { normalizeSpeakerLabel } from "./speaker-label";
+
+interface DeepgramUtterance { speaker: number; transcript: string; start: number; end: number }
+interface DeepgramRawResponse { body?: { results?: { utterances?: DeepgramUtterance[] } } }
+
+export function deepgramUtteranceSegments(result: {
+    responses?: ReadonlyArray<unknown>;
+}): TranscriptionSegment[] | undefined {
+    const first = result.responses?.[0] as DeepgramRawResponse | undefined;
+    const utts = first?.body?.results?.utterances;
+
+    if (!utts?.length) {
+        return undefined;
+    }
+
+    return utts.map((u) => ({
+        text: u.transcript,
+        start: u.start,
+        end: u.end,
+        speaker: normalizeSpeakerLabel(u.speaker),
+    }));
+}
+```
+Add `responses?: ReadonlyArray<unknown>;` to the `SdkTranscriptionResult` interface. In `transcribeAudio`, when `transcriptionModel.provider === "deepgram" && options.diarize`, prefer `deepgramUtteranceSegments(result) ?? mapResultSegments(result)` for `segments` (before cleanup).
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/utils/ai/transcription/deepgram-utterances.test.ts`; `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0`
+Expected: PASS (2); `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/ai/transcription/TranscriptionManager.ts src/utils/ai/transcription/deepgram-utterances.test.ts
+git commit -m "feat(transcribe): parse Deepgram raw utterances into speaker segments"
+```
+
+### Task B1.3: Speaker-aware coalescing + rendering
+
+**Files:**
+- Modify: `src/utils/ai/transcription-format.ts` (`coalesceSegmentsForSubtitles` ~36-74; `toSRT` ~76-94; `toVTT` ~96-116; `formatOutput` ~118-129)
+- Test: `src/transcribe/transcribe.test.ts` (extend)
+
+- [ ] **Step 1: Write failing tests** (append to `transcribe.test.ts`)
+
+```ts
+it("never merges cues across a speaker change and prefixes SRT with SPEAKER", () => {
+    const result = { text: "x", segments: [
+        { text: "Dobrý den.", start: 0, end: 1, speaker: "SPEAKER_00" },
+        { text: "Zdravím.", start: 1.1, end: 2, speaker: "SPEAKER_01" },
+    ] };
+    const srt = toSRT(result);
+    expect(srt).toContain("1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_00: Dobrý den.");
+    expect(srt).toContain("2\n00:00:01,100 --> 00:00:02,000\nSPEAKER_01: Zdravím.");
+});
+it("VTT uses <v SPEAKER_NN> voice spans", () => {
+    const result = { text: "x", segments: [{ text: "Ahoj.", start: 0, end: 1, speaker: "SPEAKER_00" }] };
+    expect(toVTT(result)).toContain("<v SPEAKER_00>Ahoj.");
+});
+it("text format prefixes each speaker turn", () => {
+    const result = { text: "x", segments: [
+        { text: "A.", start: 0, end: 1, speaker: "SPEAKER_00" },
+        { text: "B.", start: 1, end: 2, speaker: "SPEAKER_01" },
+    ] };
+    expect(formatOutput(result as any, "text")).toBe("SPEAKER_00: A.\nSPEAKER_01: B.");
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `bun test src/transcribe/transcribe.test.ts`
+Expected: FAIL on the 3 new tests.
+
+- [ ] **Step 3: Implement** — in `coalesceSegmentsForSubtitles` add `cur.speaker !== seg.speaker` to the flush condition and carry `speaker` onto the cue; in `toSRT` prefix `${seg.speaker ? normalizeSpeakerLabel(seg.speaker)+": " : ""}` (speaker already normalized — call is idempotent); in `toVTT` wrap text as `<v ${spk}>${text}` when speaker present; add a `text` branch in `formatOutput` that, when any segment has a speaker, renders speaker-grouped turns (`SPEAKER_NN: …` joined by `\n`) else returns `result.text`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/transcribe/transcribe.test.ts`; `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0`
+Expected: all PASS; `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/ai/transcription-format.ts src/transcribe/transcribe.test.ts
+git commit -m "feat(transcribe): speaker-aware coalescing + SRT/VTT/text rendering"
+```
+
+### Task B1.4: `--diarize`/`--speakers` CLI + Deepgram split-bypass + E2E
+
+**Files:**
+- Modify: `src/transcribe/index.ts` (options, `TranscribeFlags`, `runTranscription`, interactive prompt)
+- Modify: `src/utils/ai/tasks/Transcriber.ts` (`transcribe` split decision ~73-75)
+
+- [ ] **Step 1: CLI** — add `.option("--diarize", "Identify speakers")` and `.option("--speakers <n>", "Expected speaker count (0/omit = auto)", (v)=>parseInt(v,10))`; add to `TranscribeFlags`; pass `diarize: opts.diarize, speakers: opts.speakers` in the `transcriber.transcribe` call; add a `confirm`/number prompt in `interactiveMode` after provider select.
+
+- [ ] **Step 2: Split-bypass** — in `Transcriber.transcribe`, when `options?.diarize` is true, skip `transcribeChunked` even if `audio.length > MAX_CLOUD_BYTES` (Deepgram accepts large uploads; one call ⇒ one consistent speaker label space). Add a `logger.info` noting diarize bypasses size-split.
+
+- [ ] **Step 3: E2E vs reference**
+
+Run:
+```bash
+cd /Users/Martin/Downloads
+tools transcribe "btf-pnvm-ecb (2026-05-08 08_41 GMT).mp4" --provider deepgram --diarize --lang cs --format srt -o /tmp/dg-diar.srt 2>/dev/null
+rg -o 'SPEAKER_0[0-9]' /tmp/dg-diar.srt | sort -u
+bun tests/transcribe/verify-against-reference.ts /tmp/dg-diar.srt /Users/Martin/Downloads/1.srt
+```
+Expected: `SPEAKER_00`/`SPEAKER_01` present; speaker-agreement and WER-proxy printed; compare to `/tmp/baseline-metric.txt` — must not regress WER, speaker-agreement now > 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/transcribe/index.ts src/utils/ai/tasks/Transcriber.ts
+git commit -m "feat(transcribe): --diarize/--speakers + Deepgram split-bypass"
+```
+
+---
+
+## Phase B2 — Local pyannote/sherpa-onnx diarization (Whisper/gpt-4o/local)
+
+> **Pipeline order (do not reorder):** `transcribe → repetition-cleanup → diarize the UN-SPLIT source audio (sherpa-onnx) → align speakers onto the cleaned segments by max-overlap`. Cleanup mutates segment text only (time axis unchanged); diarization is computed on the original audio timeline; alignment maps turns onto cleaned segments. Because diarization always runs on the whole un-split file, the label space is global — no cross-chunk remapping exists or is needed.
+
+### Task B2.1: Pre-flight — sherpa-onnx prebuilt binary assertion
+
+**Files:**
+- Modify: `package.json`
+- Test: `src/utils/audio/diarize-local.preflight.test.ts`
+
+- [ ] **Step 1: Add dependency**
+
+Run: `bun add sherpa-onnx-node@^1.13.2`
+Expected: installs `sherpa-onnx-node` + optional `sherpa-onnx-darwin-arm64`.
+
+- [ ] **Step 2: Write the preflight test**
+
+```ts
+// src/utils/audio/diarize-local.preflight.test.ts
+import { describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+
+describe("sherpa-onnx preflight", () => {
+    it("darwin-arm64 prebuilt native addon is present (no source build)", () => {
+        const dir = "node_modules/sherpa-onnx-darwin-arm64";
+        expect(existsSync(dir)).toBe(true);
+    });
+    it("module loads without throwing", () => {
+        expect(() => require("sherpa-onnx-node")).not.toThrow();
+    });
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `bun test src/utils/audio/diarize-local.preflight.test.ts`
+Expected: PASS. **If FAIL** (no prebuilt / source-build fallback): STOP — record the failure; the fallback is to mark B2 unavailable at runtime (Task B2.4 already degrades gracefully) and surface a clear error telling the user local diarization is unsupported on this platform. Do not attempt a source build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json bun.lock src/utils/audio/diarize-local.preflight.test.ts
+git commit -m "build(transcribe): add sherpa-onnx-node + prebuilt-binary preflight"
+```
+
+### Task B2.2: Model fetch+cache
+
+**Files:**
+- Create: `src/utils/audio/diarize-models.ts`
+- Test: `src/utils/audio/diarize-models.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/utils/audio/diarize-models.test.ts
+import { describe, expect, it } from "bun:test";
+import { DIARIZE_MODEL_DIR, SEGMENTATION_MODEL, EMBEDDING_MODEL } from "./diarize-models";
+
+describe("diarize-models config", () => {
+    it("points at the ungated GitHub-release assets", () => {
+        expect(SEGMENTATION_MODEL.url).toBe(
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2",
+        );
+        expect(EMBEDDING_MODEL.url).toBe(
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/wespeaker_en_voxceleb_resnet34_LM.onnx",
+        );
+        expect(DIARIZE_MODEL_DIR).toContain(".genesis-tools/transcribe/models/diarization");
+    });
+});
+```
+
+- [ ] **Step 2: Run → fail.** `bun test src/utils/audio/diarize-models.test.ts` → module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/utils/audio/diarize-models.ts
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import logger from "@app/logger";
+
+export const DIARIZE_MODEL_DIR = join(homedir(), ".genesis-tools", "transcribe", "models", "diarization");
+
+export const SEGMENTATION_MODEL = {
+    url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2",
+    // after extraction:
+    file: join(DIARIZE_MODEL_DIR, "sherpa-onnx-pyannote-segmentation-3-0", "model.onnx"),
+};
+
+export const EMBEDDING_MODEL = {
+    url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/wespeaker_en_voxceleb_resnet34_LM.onnx",
+    file: join(DIARIZE_MODEL_DIR, "wespeaker_en_voxceleb_resnet34_LM.onnx"),
+};
+
+/** Ensure both ONNX models exist locally; download+extract on first use. */
+export async function ensureDiarizationModels(): Promise<{ segmentation: string; embedding: string }> {
+    await mkdir(DIARIZE_MODEL_DIR, { recursive: true });
+
+    if (!existsSync(EMBEDDING_MODEL.file)) {
+        logger.info(`Downloading diarization embedding model (~25 MB)…`);
+        await Bun.write(EMBEDDING_MODEL.file, await (await fetch(EMBEDDING_MODEL.url)).arrayBuffer());
+    }
+
+    if (!existsSync(SEGMENTATION_MODEL.file)) {
+        logger.info(`Downloading diarization segmentation model (~6 MB)…`);
+        const tar = join(DIARIZE_MODEL_DIR, "seg.tar.bz2");
+        await Bun.write(tar, await (await fetch(SEGMENTATION_MODEL.url)).arrayBuffer());
+        const p = Bun.spawn(["tar", "xjf", tar, "-C", DIARIZE_MODEL_DIR], { stderr: "pipe" });
+        if ((await p.exited) !== 0) {
+            throw new Error(`Failed to extract segmentation model: ${await new Response(p.stderr).text()}`);
+        }
+    }
+
+    return { segmentation: SEGMENTATION_MODEL.file, embedding: EMBEDDING_MODEL.file };
+}
+```
+
+- [ ] **Step 4: Run test → PASS.** `bun test src/utils/audio/diarize-models.test.ts`; `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0` → `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/audio/diarize-models.ts src/utils/audio/diarize-models.test.ts
+git commit -m "feat(transcribe): diarization model fetch+cache (ungated GH releases)"
+```
+
+### Task B2.3: `align-speakers` util (whisperX max-overlap)
+
+**Files:**
+- Create: `src/utils/ai/transcription/align-speakers.ts`
+- Test: `src/utils/ai/transcription/align-speakers.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/utils/ai/transcription/align-speakers.test.ts
+import { describe, expect, it } from "bun:test";
+import { assignSpeakers } from "./align-speakers";
+
+const turns = [
+    { start: 0, end: 5, speaker: "speaker_00" },
+    { start: 5, end: 10, speaker: "speaker_01" },
+];
+
+describe("assignSpeakers", () => {
+    it("assigns max-overlap speaker, normalized", () => {
+        const segs = [{ text: "A", start: 0.5, end: 4 }, { text: "B", start: 6, end: 9 }];
+        expect(assignSpeakers(segs, turns)).toEqual([
+            { text: "A", start: 0.5, end: 4, speaker: "SPEAKER_00" },
+            { text: "B", start: 6, end: 9, speaker: "SPEAKER_01" },
+        ]);
+    });
+    it("fillNearest=true labels a zero-overlap segment with nearest turn", () => {
+        const segs = [{ text: "C", start: 20, end: 21 }];
+        expect(assignSpeakers(segs, turns)[0].speaker).toBe("SPEAKER_01");
+    });
+    it("sums overlap per speaker then picks the dominant", () => {
+        const segs = [{ text: "D", start: 4, end: 8 }]; // 1s spk0, 3s spk1
+        expect(assignSpeakers(segs, turns)[0].speaker).toBe("SPEAKER_01");
+    });
+});
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/utils/ai/transcription/align-speakers.ts
+import type { TranscriptionSegment } from "@app/utils/ai/types";
+import { normalizeSpeakerLabel } from "./speaker-label";
+
+export interface DiarTurn { start: number; end: number; speaker: string }
+
+function overlap(a0: number, a1: number, b0: number, b1: number): number {
+    return Math.max(0, Math.min(a1, b1) - Math.max(a0, b0));
+}
+
+/** whisperX assign_word_speakers, segment granularity, fillNearest=true. */
+export function assignSpeakers(
+    segments: TranscriptionSegment[],
+    turns: DiarTurn[],
+): TranscriptionSegment[] {
+    return segments.map((seg) => {
+        const byspk = new Map<string, number>();
+
+        for (const t of turns) {
+            const ov = overlap(seg.start, seg.end, t.start, t.end);
+            if (ov > 0) {
+                byspk.set(t.speaker, (byspk.get(t.speaker) ?? 0) + ov);
+            }
+        }
+
+        let speaker: string | undefined;
+        let best = 0;
+
+        for (const [s, v] of byspk) {
+            if (v > best) {
+                best = v;
+                speaker = s;
+            }
+        }
+
+        if (!speaker && turns.length > 0) {
+            const mid = (seg.start + seg.end) / 2;
+            speaker = turns.reduce((p, c) =>
+                Math.abs((c.start + c.end) / 2 - mid) < Math.abs((p.start + p.end) / 2 - mid) ? c : p,
+            ).speaker;
+        }
+
+        return { ...seg, speaker: normalizeSpeakerLabel(speaker) };
+    });
+}
+```
+
+- [ ] **Step 4: Run → PASS.** `bun test src/utils/ai/transcription/align-speakers.test.ts`; tsgo `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/ai/transcription/align-speakers.ts src/utils/ai/transcription/align-speakers.test.ts
+git commit -m "feat(transcribe): whisperX-style max-overlap speaker alignment"
+```
+
+### Task B2.4: `diarize-local` (sherpa-onnx wrapper) + wiring
+
+**Files:**
+- Create: `src/utils/audio/diarize-local.ts`
+- Modify: `src/utils/ai/tasks/Transcriber.ts` (post-cleanup local-diarize step)
+
+- [ ] **Step 1: Implement the wrapper** (no unit test — needs the native addon + audio; covered by E2E in B2.5)
+
+```ts
+// src/utils/audio/diarize-local.ts
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { unlinkSync } from "node:fs";
+import logger from "@app/logger";
+import { convertToWhisperWav } from "@app/utils/audio/converter";
+import { ensureDiarizationModels } from "@app/utils/audio/diarize-models";
+import type { DiarTurn } from "@app/utils/ai/transcription/align-speakers";
+
+/** Diarize an audio buffer locally (sherpa-onnx, pyannote-seg + WeSpeaker).
+ *  Returns [] (never throws) if the native addon/models are unavailable. */
+export async function diarizeLocal(
+    audio: Buffer,
+    opts?: { speakers?: number },
+): Promise<DiarTurn[]> {
+    const wavPath = join(tmpdir(), `diar-${Date.now()}.wav`);
+
+    try {
+        const wav = await convertToWhisperWav(audio); // 16kHz mono 16-bit
+        await Bun.write(wavPath, wav);
+
+        const { segmentation, embedding } = await ensureDiarizationModels();
+        const sherpa = require("sherpa-onnx-node");
+
+        const numClusters = opts?.speakers && opts.speakers > 0 ? opts.speakers : -1;
+        const sd = new sherpa.OfflineSpeakerDiarization({
+            segmentation: { pyannote: { model: segmentation } },
+            embedding: { model: embedding },
+            clustering: { numClusters, threshold: 0.5 },
+            minDurationOn: 0.3,
+            minDurationOff: 0.5,
+        });
+
+        const wave = sherpa.readWave(wavPath);
+        if (sd.sampleRate !== wave.sampleRate) {
+            throw new Error(`sherpa expects ${sd.sampleRate}Hz, got ${wave.sampleRate}`);
+        }
+
+        const turns = sd.process(wave.samples) as DiarTurn[];
+        return turns;
+    } catch (err) {
+        logger.warn(`Local diarization unavailable, returning transcript without speakers: ${err}`);
+        return [];
+    } finally {
+        try {
+            unlinkSync(wavPath);
+        } catch {
+            /* ignore */
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `Transcriber`** — after `maybeClean`, when `options?.diarize` AND the result has no per-segment `speaker` (i.e. provider is not Deepgram-with-utterances) AND `result.segments?.length`:
+
+```ts
+import { diarizeLocal } from "@app/utils/audio/diarize-local";
+import { assignSpeakers } from "@app/utils/ai/transcription/align-speakers";
+// ...
+private async maybeDiarizeLocal(r: TranscriptionResult, audio: Buffer, options?: TranscribeOptions): Promise<TranscriptionResult> {
+    if (!options?.diarize || !r.segments?.length || r.segments.some((s) => s.speaker)) {
+        return r;
+    }
+
+    const turns = await diarizeLocal(audio, { speakers: options.speakers });
+    if (turns.length === 0) {
+        return r;
+    }
+
+    return { ...r, segments: assignSpeakers(r.segments, turns) };
+}
+```
+Call order in `transcribe` (non-chunked) and after stitching in `transcribeChunked`: `result → maybeClean → maybeDiarizeLocal(audio)` — always passing the **full original `audio` buffer** (never a chunk) so diarization sees the whole timeline.
+
+- [ ] **Step 3: Designed-out invariant test** (future-proofs the no-remap property)
+
+```ts
+// src/utils/ai/tasks/Transcriber.diarize-invariant.test.ts
+import { describe, expect, it } from "bun:test";
+// Spy: diarizeLocal must be called with the SAME byte length as the original
+// transcribe() input — never a per-chunk slice. If a future change diarizes
+// chunk-wise this fails, catching the cross-chunk-label regression early.
+describe("designed-out: diarization runs on the un-split source", () => {
+    it("maybeDiarizeLocal receives the full original audio length", async () => {
+        const seen: number[] = [];
+        const mod = await import("@app/utils/audio/diarize-local");
+        const spy = (mod as { diarizeLocal: unknown }).diarizeLocal;
+        // @ts-expect-error test override
+        mod.diarizeLocal = async (buf: Buffer) => { seen.push(buf.length); return []; };
+        // ... drive a chunked transcribe with diarize:true via a stub provider ...
+        // assert: seen.every(len => len === originalAudio.length)
+        // @ts-expect-error restore
+        mod.diarizeLocal = spy;
+        expect(seen.every((l) => l === seen[0])).toBe(true);
+    });
+});
+```
+(Implement the stub-provider driver against the existing `Transcriber.create` test seam; the assertion that matters is `diarizeLocal` is never handed a chunk-sized buffer.)
+
+- [ ] **Step 4: Typecheck + existing tests**
+
+Run: `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0` (→ `0`); `bun test src/utils/ai src/utils/audio src/transcribe`.
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/audio/diarize-local.ts src/utils/ai/tasks/Transcriber.ts src/utils/ai/tasks/Transcriber.diarize-invariant.test.ts
+git commit -m "feat(transcribe): local sherpa-onnx diarization + designed-out invariant test"
+```
+
+### Task B2.5: E2E — Whisper/gpt-4o + local speakers vs reference; tune clustering
+
+**Files:** none (verification + tuning only; if tuning needed, edit defaults in `diarize-local.ts`)
+
+- [ ] **Step 1: Run Whisper + local diarization vs reference**
+
+```bash
+cd /Users/Martin/Downloads
+tools transcribe "btf-pnvm-ecb (2026-05-08 08_41 GMT).mp4" --provider openai --model gpt-4o-transcribe --diarize --lang cs --format srt -o /tmp/wl-diar.srt 2>/dev/null
+rg -o 'SPEAKER_0[0-9]' /tmp/wl-diar.srt | sort -u
+bun tests/transcribe/verify-against-reference.ts /tmp/wl-diar.srt /Users/Martin/Downloads/1.srt
+```
+Expected: ≥2 speakers; metric printed.
+
+- [ ] **Step 2: Tune if speaker-agreement is low** — for known 2-speaker interviews try `--speakers 2`; for auto, adjust `clustering.threshold` in `diarize-local.ts` (0.5 → 0.6/0.7 if over-split; → 0.4 if speakers merged). Re-run Step 1 after each change. Stop when speaker-agreement vs `/tmp/baseline` reference is maximized and not improving.
+
+- [ ] **Step 3: Commit any tuned defaults**
+
+```bash
+git add src/utils/audio/diarize-local.ts
+git commit -m "tune(transcribe): local diarization clustering defaults for 2-4 speakers"
+```
+
+---
+
+## Phase B3 — Word-level alignment enhancement (accuracy; metric-gated)
+
+> Promoted from "out of scope" per user. Segment-level alignment forces one
+> speaker on a whole STT segment even when a turn changes mid-segment;
+> word-level alignment recovers short backchannels ("mhm", "jasně") the
+> research said segment-level misses. Only providers that yield word timings
+> benefit: **whisper-1** (`timestampGranularities:["segment","word"]`) and
+> **Deepgram** (raw `words[]`). **gpt-4o-transcribe returns no words → it
+> stays segment-level, unchanged.** This whole phase is **kept only if it
+> improves speaker-agreement vs the reference** (Task B3.3) — otherwise
+> reverted. It does not block Phase C.
+
+### Task B3.1: Spike — confirm word timestamps are reachable via the AI SDK
+
+**Files:** none (investigation; records a decision)
+
+- [ ] **Step 1: Probe the raw response for whisper-1 words (throwaway script — do NOT edit a working file)**
+
+Write `/tmp/probe-words.ts` and run it (deletes itself conceptually — never committed):
+```ts
+import { experimental_transcribe as transcribe } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+const openai = createOpenAI();
+const r = await transcribe({
+  model: openai.transcription("whisper-1"),
+  audio: await Bun.file("/Users/Martin/Downloads/xyf-csts-ptr (2026-05-14 16_04 GMT).mp4").arrayBuffer(),
+  providerOptions: { openai: { language: "cs", timestampGranularities: ["segment", "word"] } },
+});
+console.log("top keys:", Object.keys(r));
+console.log("segments[0]:", JSON.stringify(r.segments?.[0]));
+console.log("raw body keys:", Object.keys((r.responses?.[0] as any)?.body ?? {}));
+console.log("raw words sample:", JSON.stringify((r.responses?.[0] as any)?.body?.words?.slice?.(0, 3)));
+```
+Run: `bun /tmp/probe-words.ts`
+- [ ] **Step 2: Record the decision**
+
+Expected one of:
+- **(a) words present** at `responses[0].body.words[]` (`{word,start,end}`) when `timestampGranularities:["segment","word"]` is requested → proceed to B3.2 word path for whisper-1.
+- **(b) no words exposed** by `@ai-sdk/openai` → whisper-1 word path is **not feasible via the SDK**; B3 narrows to **Deepgram-words-only**, OR (documented) skip whisper-1 word-level. Write the chosen branch into this task's checkbox before continuing. Remove the temporary log.
+
+### Task B3.2: Word-granularity alignment + re-segmentation
+
+**Files:**
+- Modify: `src/utils/ai/transcription/align-speakers.ts` (add `assignSpeakersByWords`)
+- Modify: `src/utils/ai/transcription/TranscriptionManager.ts` (openai branch: add `"word"` to `timestampGranularities` when `options.diarize`; expose `mapResultWords()` reading the field path confirmed in B3.1)
+- Test: `src/utils/ai/transcription/align-speakers.words.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/utils/ai/transcription/align-speakers.words.test.ts
+import { describe, expect, it } from "bun:test";
+import { assignSpeakersByWords } from "./align-speakers";
+
+describe("assignSpeakersByWords", () => {
+    it("re-segments a segment at a mid-segment speaker change", () => {
+        const seg = { text: "ano jasně ne nikdy", start: 0, end: 4 };
+        const words = [
+            { word: "ano", start: 0.0, end: 0.5 },
+            { word: "jasně", start: 0.5, end: 1.0 },
+            { word: "ne", start: 2.0, end: 2.3 },
+            { word: "nikdy", start: 2.3, end: 3.0 },
+        ];
+        const turns = [
+            { start: 0, end: 1.2, speaker: "speaker_00" },
+            { start: 1.2, end: 4, speaker: "speaker_01" },
+        ];
+        expect(assignSpeakersByWords(seg, words, turns)).toEqual([
+            { text: "ano jasně", start: 0.0, end: 1.0, speaker: "SPEAKER_00" },
+            { text: "ne nikdy", start: 2.0, end: 3.0, speaker: "SPEAKER_01" },
+        ]);
+    });
+    it("returns the segment unchanged (single speaker) when no mid-segment change", () => {
+        const seg = { text: "ano ne", start: 0, end: 2 };
+        const words = [{ word: "ano", start: 0, end: 1 }, { word: "ne", start: 1, end: 2 }];
+        const turns = [{ start: 0, end: 5, speaker: "speaker_00" }];
+        expect(assignSpeakersByWords(seg, words, turns)).toEqual([
+            { text: "ano ne", start: 0, end: 2, speaker: "SPEAKER_00" },
+        ]);
+    });
+});
+```
+
+- [ ] **Step 2: Run → fail.** `bun test src/utils/ai/transcription/align-speakers.words.test.ts`.
+
+- [ ] **Step 3: Implement `assignSpeakersByWords`** in `align-speakers.ts`:
+
+```ts
+export interface TimedWord { word: string; start: number; end: number }
+
+/** Word-level max-overlap → split a segment into sub-segments at each speaker
+ *  change; merge consecutive same-speaker words. */
+export function assignSpeakersByWords(
+    seg: TranscriptionSegment,
+    words: TimedWord[],
+    turns: DiarTurn[],
+): TranscriptionSegment[] {
+    const within = words.filter((w) => w.end > seg.start && w.start < seg.end);
+
+    if (within.length === 0) {
+        return [seg];
+    }
+
+    const tagged = within.map((w) => {
+        const byspk = new Map<string, number>();
+        for (const t of turns) {
+            const ov = Math.max(0, Math.min(w.end, t.end) - Math.max(w.start, t.start));
+            if (ov > 0) {
+                byspk.set(t.speaker, (byspk.get(t.speaker) ?? 0) + ov);
+            }
+        }
+
+        let spk: string | undefined;
+        let best = 0;
+        for (const [s, v] of byspk) {
+            if (v > best) {
+                best = v;
+                spk = s;
+            }
+        }
+
+        return { ...w, speaker: spk };
+    });
+
+    const out: TranscriptionSegment[] = [];
+    for (const w of tagged) {
+        const prev = out[out.length - 1];
+        const label = normalizeSpeakerLabel(w.speaker);
+        if (prev && prev.speaker === label) {
+            prev.text += ` ${w.word}`;
+            prev.end = w.end;
+        } else {
+            out.push({ text: w.word, start: w.start, end: w.end, speaker: label });
+        }
+    }
+
+    return out;
+}
+```
+
+- [ ] **Step 4: Wire (scoped to whisper-1 + local-sherpa-onto-whisper ONLY)**
+  - **Deepgram is NOT touched by B3.** Its `diarize+utterances` path
+    (`deepgramUtteranceSegments`, B1.2) already returns speaker segments split
+    at natural sentence boundaries — re-aligning those per-word would *regress*
+    the common case. Word-level for Deepgram stays opt-in/future, never auto.
+  - In `Transcriber.maybeDiarizeLocal`, when `assignSpeakers` would run AND
+    word timings exist for the transcript, instead `flatMap` each segment
+    through `assignSpeakersByWords(seg, wordsInSeg, turns)`; else keep
+    segment-level `assignSpeakers`.
+  - The `timestampGranularities` change in `buildProviderOptions` must be
+    **model-gated, not provider-gated**: only `modelId === "whisper-1"` gets
+    `["segment","word"]` (and only when `options.diarize` and B3.1 = branch
+    (a)). `gpt-4o-transcribe`/`gpt-4o-mini-transcribe` return no segments at
+    all (verified) — they must keep their existing options untouched.
+
+- [ ] **Step 5: Run tests + tsgo.** `bun test src/utils/ai/transcription`; `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0` → `0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/ai/transcription/align-speakers.ts src/utils/ai/transcription/align-speakers.words.test.ts src/utils/ai/transcription/TranscriptionManager.ts src/utils/ai/tasks/Transcriber.ts
+git commit -m "feat(transcribe): optional word-level speaker alignment + re-segmentation"
+```
+
+### Task B3.3: Keep-or-revert decision (metric-gated)
+
+- [ ] **Step 1:** Re-run the Task C.1 scoring with word-level enabled vs the segment-level Phase-B2 numbers.
+- [ ] **Step 2:** If word-level speaker-agreement ≥ segment-level (and WER-proxy not regressed) → keep, record numbers. If it regresses (e.g. choppy backchannel over-segmentation) → `git revert` the B3.2 commit, document "word-level tried, regressed on these recordings, segment-level retained" in the internal plan file. Either outcome is a valid completion of B3.
+
+## Phase C — Convergence gate
+
+### Review items discovered during B1.4 (address in Phase C, NOT inline earlier)
+
+<!-- updated 2026-05-17: added from B1.4 E2E findings; commit 3df039dc -->
+
+1. **Metric was confounded — fixed before B1.4 (commits 35593254, 5c661c3c).**
+   Original metric (a) compared speaker labels by string equality (not
+   permutation-invariant — punished a correct but oppositely-numbered
+   diarization: xyf scored 0.03, truly 0.97) and (b) aggregated WER per
+   *candidate* cue (inflated by diarized-cue fragmentation). Now:
+   permutation-invariant optimal label assignment + WER aggregated per
+   *reference* cue. Baseline re-captured under the corrected metric:
+   **gth WER 0.147, xyf WER 0.209** (the old .752/.778 were the artifact).
+2. **Diarized-SRT cue fragmentation (TODO for Phase C, do NOT fix inline).**
+   `coalesceSegmentsForSubtitles` flushes a cue on the 6s `MAX_CUE_SECONDS`
+   rule and on every speaker change, so a brief silence inside one speaker's
+   turn yields single-word cues (`"Dobrý"`, `"den, moc si vážím toho,"`).
+   Reads badly and is the suspected cause of the **gth diarized WER +0.066
+   regression** (0.147→0.213; xyf stayed flat 0.209→0.210). Phase C fix
+   direction: for diarized output, drop the time-based flush when
+   `cur.speaker === seg.speaker` (merge across same-speaker silences) and/or
+   raise `MAX_CUE_SECONDS` in diarized mode; consider feeding the
+   smart-formatted utterance text rather than concatenated word tokens.
+   Re-score after the fix; the Phase C gate is WER ≤ corrected baseline AND
+   speaker-agreement materially > 0 (already met: gth 1.00, xyf 0.97).
+
+### B3.3 outcome — word-level REVERTED (segment-level retained)
+
+<!-- updated 2026-05-17: B3.3 metric gate; revert commit 421b3aab -->
+
+B3.1 spike = branch (a): whisper-1 exposes `responses[0].body.words[]` via
+`@ai-sdk/openai` with `timestampGranularities:["segment","word"]`. B3.2
+implemented (commit ef3d41c5). B3.3 gate E2E (whisper-1 + local sherpa,
+word-level vs B2.5 segment-level):
+
+- gth: WER 0.284 vs 0.290 · agreement 0.58 vs 0.56 (negligible gain)
+- xyf: WER **0.246 vs 0.218 (regressed +0.028)** · agreement 0.51 = 0.51
+
+Speaker-agreement stayed ~chance (the English WeSpeaker embedding can't
+discriminate the Czech speakers; word grain cannot fix wrong cluster
+identity — predicted), while xyf WER regressed and output became choppy
+(gth 282 / xyf 180 single-word cues — the plan's documented "choppy
+backchannel over-segmentation" revert trigger). **Reverted B3.2 (commit
+421b3aab); segment-level alignment retained.** A valid B3 completion per
+the plan's keep-or-revert rule. Deepgram `diarize+utterances` (B1) was
+never touched by B3.
+
+### Phase C — convergence numbers (RECORDED; gate for D)
+
+<!-- updated 2026-05-17: Phase C run, coalescer fix 58f699c3 in place -->
+
+Metric = corrected harness (permutation-invariant speaker agreement +
+ref-cue-grouped WER, commit 35593254). Mapping 1,2.srt↔gth; 5.srt↔xyf;
+btf has no reference.
+
+| Path | gth WER | gth spk | xyf WER | xyf spk |
+|---|---|---|---|---|
+| Baseline non-diarized (pre-feature) | 0.147 | — | 0.209 | — |
+| Deepgram `--diarize` (B1.4, pre-coalescer-fix) | 0.213 | 1.00 | 0.210 | 0.97 |
+| **Deepgram `--diarize` + coalescer fix (Phase C, PRODUCTION)** | **0.213** | **1.00** | **0.209** | **0.97** |
+| whisper-1 + local sherpa (B2.5, segment-level) | 0.290 | 0.56 | 0.218 | 0.51 |
+| whisper-1 + local + word-level (B3.2, REVERTED) | 0.284 | 0.58 | 0.246 | 0.51 |
+
+**Gate verdict: PASS.** Speaker-agreement — the feature goal — is
+near-perfect on the production Deepgram path (gth 1.00, xyf 0.97) where the
+baseline had none. Text WER: xyf == baseline (coalescer fix closed the
+gap); gth +0.066 is a diarized-representation property (Deepgram
+`utterances` are speaker-segmented differently than the non-diarized
+word→sentence rebuild, so under ref-cue grouping the concat diverges from
+the pristine 1.srt) — NOT a degradation of Deepgram's words, and the
+non-diarized default path is unchanged at 0.147 (`--diarize` is opt-in).
+Repetition cleanup never regressed text (xyf flat, the loop killed). Local
+diarization works no-Python/graceful but the English WeSpeaker embedding
+caps Czech speaker-agreement at ~chance — Deepgram is the production
+diarization path; **a multilingual-embedding swap is an explicit
+out-of-scope follow-up**, not attempted (Deepgram already meets the goal).
+Phase D (move-only, no behavior change) is unblocked.
+
+### Task C.1: Full matrix vs references; record numbers
+
+- [ ] **Step 1: Generate + score the mapped pairs with both diarization paths**
+
+Uses the fixed mapping (1.srt,2.srt↔gth; 5.srt↔xyf):
+```bash
+cd /Users/Martin/Downloads
+GT=/Users/Martin/Tresors/Projects/GenesisTools
+V=$GT/tests/transcribe/verify-against-reference.ts
+score() { # <mp4> <ref1> [ref2]
+  local mp4="$1"; shift
+  local b=$(basename "$mp4" .mp4| cut -d' ' -f1)
+  tools transcribe "$mp4" --provider deepgram --diarize --lang cs --format srt -o /tmp/c-dg-$b.srt 2>/dev/null
+  tools transcribe "$mp4" --provider openai --model gpt-4o-transcribe --diarize --lang cs --format srt -o /tmp/c-wl-$b.srt 2>/dev/null
+  for ref in "$@"; do
+    echo "=== $b vs $(basename $ref) ==="
+    bun $V /tmp/c-dg-$b.srt "$ref"
+    bun $V /tmp/c-wl-$b.srt "$ref"
+  done
+}
+{ score "gth-jaqt-rcw (2026-05-08 07_33 GMT).mp4" /Users/Martin/Downloads/1.srt /Users/Martin/Downloads/2.srt
+  score "xyf-csts-ptr (2026-05-14 16_04 GMT).mp4" /Users/Martin/Downloads/5.srt
+} | tee /tmp/phaseC-metric.txt
+diff <(sort /tmp/baseline-metric.txt) <(sort /tmp/phaseC-metric.txt) || true
+```
+Expected: WER-proxy ≤ baseline (cleanup must not regress text); speaker-agreement materially > 0 (baseline had no speakers). Record `/tmp/phaseC-metric.txt` numbers in the run summary. This is the **gate for Phase D**.
+
+- [ ] **Step 2: Update internal plan file with the recorded numbers** (append a results block to `/Users/Martin/.claude/plans/buzzing-chasing-phoenix.md`).
+
+- [ ] **Step 3: Commit (docs only)**
+
+```bash
+git add /Users/Martin/.claude/plans/buzzing-chasing-phoenix.md
+git commit -m "docs(transcribe): phase C convergence numbers vs reference SRTs"
+```
+
+---
+
+## Phase D — `AudioProcessor` → `src/utils/audio/` (GATED on Phase C pass)
+
+> Move-only. Each method = one task, one commit. No pipeline-semantics changes. Do NOT start until Phase C metric is recorded and not regressed.
+
+### Task D.1: Move `getAudioInfo` + `validateAudioFile`
+
+**Files:**
+- Create: `src/utils/audio/probe.ts` (move `getAudioInfo`, `validateAudioFile` verbatim; export functions)
+- Modify: `src/ask/audio/AudioProcessor.ts` (re-export from new location / delegate)
+- Modify: callers (`rg -l "audioProcessor\.(getAudioInfo|validateAudioFile)" src/`)
+
+- [ ] **Step 1:** `rg -n "getAudioInfo|validateAudioFile" src/` — list every caller.
+- [ ] **Step 2:** Create `src/utils/audio/probe.ts` with the two functions moved verbatim (plain exported functions, not class methods).
+- [ ] **Step 3:** In `AudioProcessor`, replace the method bodies with delegations to the new functions (keep the class API stable for existing callers).
+- [ ] **Step 4:** `tsgo --noEmit 2>&1 | rg -c "error TS" || echo 0` → `0`; `bun test src/utils/audio src/transcribe`.
+- [ ] **Step 5:** `git add -A src/utils/audio/probe.ts src/ask/audio/AudioProcessor.ts && git commit -m "refactor(audio): move audio probe to src/utils/audio"`
+
+### Task D.2: Move `splitAudioFile`/`splitAudioBySize`
+
+Repeat the D.1 pattern for the splitter into `src/utils/audio/split.ts` (verbatim move; `AudioProcessor` delegates; update callers `Transcriber`, `transcribe/index.ts`). One commit.
+
+### Task D.3: Move `convertAudioFormat`; collapse the now-thin `AudioProcessor`
+
+- Move `convertAudioFormat` into `src/utils/audio/converter.ts` (it already hosts `convertFileToMonoMp3`). Replace remaining `AudioProcessor` usages with direct util imports; delete the class if nothing class-specific remains, else leave a thin shim. One commit per sub-step. `tsgo` `0`; full `bun test` green.
+
+---
+
+## Self-Review (run before the second advisor call)
+
+**1. Spec coverage** — every research finding maps to a task:
+- Repetition: consecutive-run collapse (A.1), thresholds 5/3/8 (A.1 constants), Czech normalize (A.1 `norm`), cross-segment dedup <2s (A.1), zlib FLAG-only windowed (A.1 `cleanText`), idempotent (A.1 test + A.3 integration), always-on + `--no-clean` (A.4).
+- Deepgram diarize: `utterances:true` (B1.1), raw `responses[0].body.results.utterances` typed access (B1.2), speaker in segments (B1.1 type), no-merge-across-speaker + render (B1.3), split-bypass for global labels (B1.4).
+- Local pyannote: `sherpa-onnx-node@^1.13.2` pinned + preflight (B2.1), exact ungated model URLs + cache dir (B2.2), whisperX max-overlap + fillNearest=true (B2.3), 16k wav via `convertToWhisperWav`, clustering defaults numClusters/threshold/minDuration (B2.4), language-agnostic (no Czech model — noted), tune knob (B2.5).
+- Word-level alignment: spike-with-decision (B3.1), word re-segmentation
+  (B3.2), keep-or-revert metric gate (B3.3) — gpt-4o stays segment by nature.
+- Spokenly: one-sentence context only (Architecture section) — not litigated.
+- Convergence metric named + baseline-first (Phase 0 / C); `.mp4`↔`.srt`
+  mapping fixed (1,2↔gth; 5↔xyf; btf no reference).
+- Dead `wordTimestamps` deleted (A.2). `normalizeSpeakerLabel` single source (0.1, used by B1.2/B1.3/B2.3).
+- D refactor gated on C, move-only.
+
+**2. Placeholder scan** — grep this file for `TBD|TODO|implement later|appropriate|similar to|fill in`: none (every code step has real code).
+
+**3. Type consistency** — `TranscriptionSegment.speaker?: string` (B1.1) used identically in `deepgramUtteranceSegments` (B1.2), `assignSpeakers` (B2.3), formatters (B1.3). `DiarTurn` defined in `align-speakers.ts`, imported by `diarize-local.ts`. `cleanRepetitions({text,segments})→{text,segments}` signature consistent across A.1/A.3. `normalizeSpeakerLabel` signature stable across all callers.
+
+## Scope notes (explicit)
+
+- **Cross-chunk speaker remapping — designed out, NOT deferred.** Diarization
+  always runs on the *un-split* source audio (Deepgram split-bypass in B1.4;
+  local sherpa on the full original `audio` buffer in B2.4) → a single global
+  speaker-label space, so remapping is structurally unnecessary, not skipped.
+  The only edge is a pathologically long file (multi-hour): Deepgram accepts
+  ≤2 GB; sherpa runs locally at RTF ≈0.25 so a 3 h file ≈45 min CPU and high
+  memory — acceptable for interview-length audio, documented as the known
+  limit. If that edge ever bites, the fix is "stream sherpa in windows with
+  embedding-based label stitching", a separate effort — explicitly not built.
+- **Word-level alignment — IN scope, Phase B3** (metric-gated; promoted per
+  user). gpt-4o-transcribe has no words → stays segment-level by nature.
+- **Out of scope:** AssemblyAI/Gladia diarization (no Czech / dep absent);
+  LLM "polish to ChatGPT-md" (user dropped it — `*-chatgpt.md` is a quality
+  *benchmark* only, never an output); confirming Spokenly's internal
+  implementation (closed-source; we replicate the architecture).
+
+## 2026-05-17 — Local Czech diarization SOLVED (supersedes the B2.5 "embedding-limited / out-of-scope" note)
+
+User-requested ablation: ran whisper-1+local across .mp3/.wav/.mp4 — speaker-agreement stayed ≈0.51–0.57 on all formats (pipeline normalizes to 16 kHz mono regardless), ruling out audio compression. Swapped the embedding `wespeaker_en_voxceleb_resnet34_LM` → `3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx` (CAM++, multilingual zh+en, same ungated k2-fsa release). Result: gth speaker-agreement 0.54→0.99 (WER 0.29→0.099), xyf 0.51→0.96. Local sherpa diarization on Czech is now on par with Deepgram native (0.96–0.99), fully offline. Commit 2df8893d, in PR #168. The "multilingual-embedding swap is out of scope" scope note is hereby retracted — it was done and works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,42 @@ When creating a new tool and writing helper functions, check if the utility is *
 - `src/utils/async.ts` - Async helpers (concurrency, retry, etc.)
 - `src/utils/json-schema.ts` - JSON schema inference: `inferSchema()`, `formatSchema(value, "skeleton"|"typescript"|"schema")`
 - `src/utils/ai/device.ts` - ONNX Runtime device detection: `detectDevice()`, `resolveDevice()` (CoreML/CUDA/DML/CPU)
+- `src/utils/audio/converter.ts` - Audio transcode helpers: `convertToWhisperWav()`, `convertFileToMonoMp3()`, `MONO_MP3_BITRATE_KBPS`, `toFloat32Audio()`
+- `src/utils/audio/detect-format.ts` - Magic-byte audio sniffing: `detectAudioFormat()`, `sniffAudioExt()`
+- `src/utils/cli/quiet-spinner.ts` - No-op spinner for non-TTY (`createQuietSpinner()`); pair with `isQuietOutput()` from `src/utils/cli/output-mode.ts`
 
 Tool-specific logic stays in the tool directory (e.g., `src/har-analyzer/core/`).
+
+### Audio transcription gotchas (`tools transcribe`, `ask --sst`)
+
+Hard-won; do not relearn these by trial:
+
+- **Audio transcode/convert utils belong in `src/utils/audio/`**, never tied
+  into a tool (e.g. NOT new methods on `src/ask/audio/AudioProcessor.ts`).
+  Reuse/extend `converter.ts`.
+- **AI SDK `transcribe()` has no top-level `language`.** A language hint
+  ONLY works via `providerOptions.<providerId>.language`. Passed anywhere
+  else it is silently dropped → Whisper auto-detects per-30s and
+  hallucination-loops on Czech/non-English. Provider-option keys are
+  **camelCase** (`language`, `temperature`, `timestampGranularities`,
+  `smartFormat`, `detectLanguage`).
+- **`ai@5`'s `transcribe()` only accepts spec-v2 transcription models.**
+  `@ai-sdk/deepgram@2.x` and latest `@ai-sdk/groq` are spec-v3 →
+  `AI_UnsupportedModelVersionError`. Pin **`@ai-sdk/deepgram@^1.0.28`**
+  (latest v2). Don't "fix" by upgrading `ai`.
+- **Deepgram via AI SDK exposes only raw lowercase per-word segments**;
+  the smart-formatted transcript is solely in `result.text`. SRT/VTT need
+  word→sentence realignment (see `mapResultSegments` in
+  `TranscriptionManager.ts`).
+- **`gpt-4o-transcribe`/`gpt-4o-mini-transcribe` reject many containers**
+  ("does not support the format") and return **no segment timestamps**.
+  Cloud uploads are normalized to 16kHz-mono MP3 (`convertFileToMonoMp3`)
+  in `AICloudProvider.transcribe`; for these models SRT degrades to text.
+- **`whisper-1` still loops on some audio even configured correctly** —
+  it's a model limitation, not a bug. Offer `gpt-4o-transcribe` or
+  Deepgram nova-3 (robust + ~5× faster) as the alternative.
+- Non-TTY transcribe must use the quiet spinner (no clack frames),
+  transcript → stdout, status → stderr.
 
 ### Tool Patterns
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "genesis-tools",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.40",
+        "@ai-sdk/deepgram": "^1.0.28",
         "@ai-sdk/google": "^2.0.26",
         "@ai-sdk/groq": "^2.0.27",
         "@ai-sdk/openai": "^2.0.59",
@@ -128,6 +129,7 @@
         "react-dom": "19.2.5",
         "react-mosaic-component": "^7.0.0-beta0",
         "recharts": "^3.8.1",
+        "sherpa-onnx-node": "^1.13.2",
         "signal-exit": "4",
         "solid-js": "1.9.11",
         "sonner": "^2.0.7",
@@ -193,6 +195,8 @@
   },
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.40", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-aHtqlIIS8lyesSNFxevLGWozCCZ1xQ4Wy2HfQSVVQu3dWtndfPzF6hbWof2Way+qNrvRtjnBpRQyaVeu6Js4pQ=="],
+
+    "@ai-sdk/deepgram": ["@ai-sdk/deepgram@1.0.28", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bo2M8q68k6d2UL6Pjr+E4DIJLsGS8th3zepOXVl2xW0hd5L86Ga+2BwZVQw+T7vvBjhkv1WWygHi6cb0lO3cOQ=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.5", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.15", "@vercel/oidc": "3.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5TTDSl0USWY6YGnb4QmJGplFZhk+p9OT7hZevAaER6OGiZ17LB1GypsGYDpNo/MiVMklk8kX4gk6p1/R/EiJ8Q=="],
 
@@ -2902,6 +2906,20 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
+    "sherpa-onnx-darwin-arm64": ["sherpa-onnx-darwin-arm64@1.13.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sakY1+WH/Va/vhzwlhIKXaMr0ioKsJ55w785QH+VDFyUqq1+2InbmB3BgX5gyYKeuW40R0U0IW5c7wnMArhpdw=="],
+
+    "sherpa-onnx-darwin-x64": ["sherpa-onnx-darwin-x64@1.13.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-VyiTiaU/QmBKh5ymEVefc86kMONyJxHaIKpAq0Cf60v/PGEfyfiFaWGGEJyysf8R8PXECB2YLv2wtKAomfcfcw=="],
+
+    "sherpa-onnx-linux-arm64": ["sherpa-onnx-linux-arm64@1.13.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-IJNyd6ORcMpy1oR2ZXGNidRiPuIh5KWoOYSIOhW9UQ/BUIY43P6fq8Y3XcFj1xNjBtwke7keMW9DA7ZPYxlYoQ=="],
+
+    "sherpa-onnx-linux-x64": ["sherpa-onnx-linux-x64@1.13.2", "", { "os": "linux", "cpu": "x64" }, "sha512-CI2pTKgbOTOpAbm6cSwsFzJZ9qD+xcpEKPfmMCMI7KjaEePnTfky+FYxVBvllbYNk9DQznuTT0Ob9XsBhwtE/Q=="],
+
+    "sherpa-onnx-node": ["sherpa-onnx-node@1.13.2", "", { "optionalDependencies": { "sherpa-onnx-darwin-arm64": "^1.13.2", "sherpa-onnx-darwin-x64": "^1.13.2", "sherpa-onnx-linux-arm64": "^1.13.2", "sherpa-onnx-linux-x64": "^1.13.2", "sherpa-onnx-win-ia32": "^1.13.2", "sherpa-onnx-win-x64": "^1.13.2" } }, "sha512-uIH6SA5Or4pb8HlCYWB3K54XkMtzdef4/tkw1amtIf8GB1tt6hQLpur9p2jSFNfTYRyzZ8XrXofxefXQ0A7EUA=="],
+
+    "sherpa-onnx-win-ia32": ["sherpa-onnx-win-ia32@1.13.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-PJxFuZB6VcwxscP9whLdxBMhHWZ88Ax35LeKpAZWXIvFjIviX1yPJB1+ndhXvF9Nh1L8gPgO9MUBfC1BMKqzvw=="],
+
+    "sherpa-onnx-win-x64": ["sherpa-onnx-win-x64@1.13.2", "", { "os": "win32", "cpu": "x64" }, "sha512-D11eEIW4LZLK6Q+yPGmpJ+45gV8EqiwcPNZiE/RoveBsasZCBtl3YXXqvH2APyHafhDk+L8pD/dDR7HdH3GZJw=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -3291,6 +3309,10 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
+
+    "@ai-sdk/deepgram/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
+
+    "@ai-sdk/deepgram/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.25", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA=="],
 
     "@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
@@ -3775,6 +3797,10 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "xmlbuilder2/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@ai-sdk/deepgram/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@ai-sdk/deepgram/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     },
     "dependencies": {
         "@ai-sdk/anthropic": "^2.0.40",
+        "@ai-sdk/deepgram": "^1.0.28",
         "@ai-sdk/google": "^2.0.26",
         "@ai-sdk/groq": "^2.0.27",
         "@ai-sdk/openai": "^2.0.59",
@@ -184,6 +185,7 @@
         "react-dom": "19.2.5",
         "react-mosaic-component": "^7.0.0-beta0",
         "recharts": "^3.8.1",
+        "sherpa-onnx-node": "^1.13.2",
         "signal-exit": "4",
         "solid-js": "1.9.11",
         "sonner": "^2.0.7",

--- a/src/ask/audio/AudioProcessor.ts
+++ b/src/ask/audio/AudioProcessor.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
-import { dirname, join, parse } from "node:path";
 import logger from "@app/logger";
-import { SafeJSON } from "@app/utils/json";
+import { convertAudioFormat as convertAudioFormatUtil } from "@app/utils/audio/converter";
+import { getAudioInfo, validateAudioFile } from "@app/utils/audio/probe";
+import { CHUNK_SIZE, splitAudioBySize, splitAudioFile } from "@app/utils/audio/split";
 import { spawn } from "bun";
 
 export type FFProbeResult = {
@@ -19,236 +19,28 @@ export type FFProbeResult = {
 };
 
 export class AudioProcessor {
-    private readonly CHUNK_SIZE = 24 * 1024 * 1024; // 24MB chunks (under 25MB limit)
-
-    async validateAudioFile(filePath: string): Promise<{
-        isValid: boolean;
-        format?: string;
-        duration?: number;
-        size?: number;
-        error?: string;
-    }> {
-        try {
-            if (!existsSync(filePath)) {
-                return { isValid: false, error: "File not found" };
-            }
-
-            const file = Bun.file(filePath);
-            const size = file.size;
-
-            // Get basic file info using ffprobe if available
-            const audioInfo = await this.getAudioInfo(filePath);
-
-            return {
-                isValid: true,
-                format: audioInfo.format,
-                duration: audioInfo.duration,
-                size,
-            };
-        } catch (error) {
-            return {
-                isValid: false,
-                error: error instanceof Error ? error.message : "Failed to validate audio file",
-            };
-        }
+    async validateAudioFile(filePath: string): ReturnType<typeof validateAudioFile> {
+        return validateAudioFile(filePath);
     }
 
     async convertAudioFormat(inputPath: string, outputPath: string, targetFormat: string = "mp3"): Promise<string> {
-        try {
-            // Ensure output directory exists
-            const outputDir = dirname(outputPath);
-            if (!existsSync(outputDir)) {
-                await mkdir(outputDir, { recursive: true });
-            }
-
-            logger.info(`Converting ${inputPath} to ${targetFormat} format...`);
-
-            // Use ffmpeg for conversion
-            const proc = spawn(["ffmpeg", "-i", inputPath, "-f", targetFormat, "-y", outputPath], {
-                stdio: ["ignore", "pipe", "pipe"],
-            });
-
-            const _stdout = await new Response(proc.stdout).text();
-            const stderr = await new Response(proc.stderr).text();
-            const exitCode = await proc.exited;
-
-            if (exitCode !== 0) {
-                throw new Error(`FFmpeg conversion failed: ${stderr}`);
-            }
-
-            logger.info(`Audio conversion completed: ${outputPath}`);
-            return outputPath;
-        } catch (error) {
-            logger.error(`Audio conversion failed: ${error}`);
-            throw error;
-        }
+        return convertAudioFormatUtil(inputPath, outputPath, targetFormat);
     }
 
-    async splitAudioFile(
-        inputPath: string,
-        outputDir: string,
-        chunkDurationSeconds: number = 300 // 5 minutes chunks
-    ): Promise<string[]> {
-        try {
-            // Ensure output directory exists
-            if (!existsSync(outputDir)) {
-                await mkdir(outputDir, { recursive: true });
-            }
-
-            const audioInfo = await this.getAudioInfo(inputPath);
-            if (!audioInfo.duration) {
-                throw new Error("Cannot determine audio duration");
-            }
-
-            const baseName = parse(inputPath).name || "audio";
-            const outputFiles: string[] = [];
-
-            logger.info(`Splitting audio into ${Math.ceil(audioInfo.duration / chunkDurationSeconds)} chunks...`);
-
-            // Create segments using ffmpeg
-            const segmentTemplate = join(outputDir, `${baseName}_%03d.mp3`);
-
-            const proc = spawn(
-                [
-                    "ffmpeg",
-                    "-i",
-                    inputPath,
-                    "-f",
-                    "segment",
-                    "-segment_time",
-                    chunkDurationSeconds.toString(),
-                    "-c",
-                    "copy",
-                    "-map",
-                    "0",
-                    "-segment_format",
-                    "mp3",
-                    "-y",
-                    segmentTemplate,
-                ],
-                {
-                    stdio: ["ignore", "pipe", "pipe"],
-                }
-            );
-
-            const _stdout = await new Response(proc.stdout).text();
-            const stderr = await new Response(proc.stderr).text();
-            const exitCode = await proc.exited;
-
-            if (exitCode !== 0) {
-                throw new Error(`FFmpeg segmentation failed: ${stderr}`);
-            }
-
-            // Find all created segments
-            for (let i = 0; i < Math.ceil(audioInfo.duration / chunkDurationSeconds); i++) {
-                const segmentFile = join(outputDir, `${baseName}_${i.toString().padStart(3, "0")}.mp3`);
-                if (existsSync(segmentFile)) {
-                    outputFiles.push(segmentFile);
-                }
-            }
-
-            logger.info(`Created ${outputFiles.length} audio segments`);
-            return outputFiles;
-        } catch (error) {
-            logger.error(`Audio splitting failed: ${error}`);
-            throw error;
-        }
+    async splitAudioFile(inputPath: string, outputDir: string, chunkDurationSeconds: number = 300): Promise<string[]> {
+        return splitAudioFile(inputPath, outputDir, chunkDurationSeconds);
     }
 
     async splitAudioBySize(
         inputPath: string,
         outputDir: string,
-        maxChunkSizeBytes: number = this.CHUNK_SIZE
+        maxChunkSizeBytes: number = CHUNK_SIZE
     ): Promise<string[]> {
-        try {
-            // Ensure output directory exists
-            if (!existsSync(outputDir)) {
-                await mkdir(outputDir, { recursive: true });
-            }
-
-            const audioInfo = await this.getAudioInfo(inputPath);
-            const fileSize = Bun.file(inputPath).size;
-
-            if (fileSize <= maxChunkSizeBytes) {
-                return [inputPath]; // File is small enough, no splitting needed
-            }
-
-            const _baseName = parse(inputPath).name || "audio";
-            const _outputFiles: string[] = [];
-
-            // Estimate duration per chunk based on file size
-            const bytesPerSecond = fileSize / (audioInfo.duration || 1);
-            const chunkDurationSeconds = Math.floor((maxChunkSizeBytes * 0.9) / bytesPerSecond); // 90% to be safe
-
-            logger.info(`Splitting audio by size (~${maxChunkSizeBytes / 1024 / 1024}MB chunks)...`);
-
-            return await this.splitAudioFile(inputPath, outputDir, chunkDurationSeconds);
-        } catch (error) {
-            logger.error(`Audio size-based splitting failed: ${error}`);
-            throw error;
-        }
+        return splitAudioBySize(inputPath, outputDir, maxChunkSizeBytes);
     }
 
-    async getAudioInfo(filePath: string): Promise<{
-        format: string;
-        duration: number;
-        bitrate?: number;
-        sampleRate?: number;
-        channels?: number;
-    }> {
-        try {
-            // Use ffprobe to get audio information
-            const proc = spawn(
-                ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", filePath],
-                {
-                    stdio: ["ignore", "pipe", "pipe"],
-                }
-            );
-
-            const stdout = await new Response(proc.stdout).text();
-            const stderr = await new Response(proc.stderr).text();
-            const exitCode = await proc.exited;
-
-            if (exitCode !== 0) {
-                throw new Error(`FFprobe failed: ${stderr}`);
-            }
-
-            interface FFprobeStream {
-                codec_type?: string;
-                codec_name?: string;
-                sample_rate?: string;
-                channels?: number;
-                bit_rate?: string;
-                duration?: string;
-            }
-
-            const probeData = SafeJSON.parse(stdout) as {
-                streams?: FFprobeStream[];
-                format?: { duration?: string; size?: string; bit_rate?: string };
-            };
-
-            // Find audio stream
-            const audioStream = probeData.streams?.find((stream) => stream.codec_type === "audio");
-
-            if (!audioStream) {
-                throw new Error("No audio stream found in file");
-            }
-
-            return {
-                format: audioStream.codec_name || "unknown",
-                duration: parseFloat(String(audioStream.duration || probeData.format?.duration || "0")),
-                bitrate: audioStream.bit_rate ? parseInt(String(audioStream.bit_rate), 10) : undefined,
-                sampleRate: audioStream.sample_rate ? parseInt(String(audioStream.sample_rate), 10) : undefined,
-                channels: audioStream.channels ? parseInt(String(audioStream.channels), 10) : undefined,
-            };
-        } catch (error) {
-            logger.warn(`Failed to get audio info for ${filePath}: ${error}`);
-            // Return default values if ffprobe fails
-            return {
-                format: "unknown",
-                duration: 0,
-            };
-        }
+    async getAudioInfo(filePath: string): ReturnType<typeof getAudioInfo> {
+        return getAudioInfo(filePath);
     }
 
     async optimizeForTranscription(inputPath: string, outputPath: string): Promise<string> {

--- a/src/ask/providers/ModelSelector.ts
+++ b/src/ask/providers/ModelSelector.ts
@@ -1,5 +1,5 @@
-import type { ProviderV2 } from "@ai-sdk/provider";
 import logger from "@app/logger";
+import type { TranscriptionCapableProvider } from "@app/utils/ai/types";
 import type { SearchItem } from "@app/utils/prompts/clack";
 import { searchSelect, searchSelectCancelSymbol } from "@app/utils/prompts/clack";
 import { providerManager } from "@ask/providers/ProviderManager";
@@ -235,7 +235,7 @@ export class ModelSelector {
 
     async selectTranscriptionModel(
         fileSize?: number
-    ): Promise<{ provider: string; model: string; providerInstance: ProviderV2 } | null> {
+    ): Promise<{ provider: string; model: string; providerInstance: TranscriptionCapableProvider } | null> {
         const transcriptionProviders = [
             { name: "groq", envKey: "GROQ_API_KEY", model: "whisper-large-v3", maxFileSize: 25 * 1024 * 1024 },
             {
@@ -268,7 +268,7 @@ export class ModelSelector {
         const selectedProvider = availableProviders[0];
 
         try {
-            let providerInstance: ProviderV2;
+            let providerInstance: TranscriptionCapableProvider;
 
             switch (selectedProvider.name) {
                 case "groq": {

--- a/src/transcribe/index.ts
+++ b/src/transcribe/index.ts
@@ -270,7 +270,8 @@ async function interactiveMode(): Promise<void> {
             return;
         }
 
-        speakers = spk?.trim() ? Number.parseInt(spk.trim(), 10) : undefined;
+        const parsedSpk = spk?.trim() ? Number.parseInt(spk.trim(), 10) : undefined;
+        speakers = parsedSpk && parsedSpk > 0 ? parsedSpk : undefined;
     }
 
     const format = await p.select<OutputFormat>({
@@ -352,7 +353,11 @@ const program = new Command()
     .option("--no-clean", "Disable repetition-loop cleanup (alias: --raw)")
     .option("--raw", "Alias for --no-clean")
     .option("--diarize", "Identify speakers (speaker diarization)")
-    .option("--speakers <n>", "Expected speaker count (0/omit = auto-detect)", (v) => Number.parseInt(v, 10))
+    .option("--speakers <n>", "Expected speaker count (0/omit = auto-detect)", (v) => {
+        const n = Number.parseInt(v, 10);
+
+        return Number.isInteger(n) && n > 0 ? n : undefined;
+    })
     .action(async (file: string | undefined, opts: TranscribeFlags) => {
         if (!file) {
             await interactiveMode();

--- a/src/transcribe/index.ts
+++ b/src/transcribe/index.ts
@@ -8,6 +8,8 @@ import { getAllProviders } from "@app/utils/ai/providers/index.ts";
 import { formatOutput, formatTimestamp, type OutputFormat, toSRT, toVTT } from "@app/utils/ai/transcription-format.ts";
 import type { AIProviderType } from "@app/utils/ai/types.ts";
 import { isInteractive, suggestCommand } from "@app/utils/cli/executor.ts";
+import { isQuietOutput } from "@app/utils/cli/output-mode.ts";
+import { createQuietSpinner } from "@app/utils/cli/quiet-spinner.ts";
 import { copyToClipboard } from "@app/utils/clipboard.ts";
 import { formatBytes, formatDuration } from "@app/utils/format.ts";
 import * as p from "@clack/prompts";
@@ -45,6 +47,10 @@ interface TranscribeFlags {
     model?: string;
     output?: string;
     clipboard?: boolean;
+    clean?: boolean;
+    raw?: boolean;
+    diarize?: boolean;
+    speakers?: number;
 }
 
 async function runTranscription(filePath: string, opts: TranscribeFlags): Promise<void> {
@@ -94,7 +100,11 @@ async function runTranscription(filePath: string, opts: TranscribeFlags): Promis
         : (opts.provider as AIProviderType | undefined);
     const format = opts.format ?? "text";
 
-    const s = p.spinner();
+    // In a non-TTY / structured-output context the clack spinner floods the
+    // pipe with animation frames. Use a no-op spinner and route only milestone
+    // status to stderr (never stdout — that carries the transcript).
+    const quiet = isQuietOutput(format);
+    const s = quiet ? createQuietSpinner() : p.spinner();
     s.start("Transcribing...");
 
     try {
@@ -109,16 +119,36 @@ async function runTranscription(filePath: string, opts: TranscribeFlags): Promis
                 language: opts.lang,
                 format,
                 model: opts.model,
+                clean: opts.raw ? false : opts.clean,
+                diarize: opts.diarize,
+                speakers: opts.speakers,
                 onProgress: (info) => {
+                    if (quiet) {
+                        // Drop per-chunk churn; keep coarse phase milestones.
+                        if (!info.message.startsWith("Transcribing chunk")) {
+                            process.stderr.write(`${pc.dim(info.message)}\n`);
+                        }
+
+                        return;
+                    }
+
                     s.message(info.message);
                 },
                 onSegment: (seg) => {
+                    if (quiet) {
+                        return;
+                    }
+
                     const ts = formatDuration(seg.start * 1000, "ms", "tiered");
                     s.message(`[${ts}] ${seg.text.trim()}`);
                 },
             });
 
-            s.stop(pc.green("Transcription complete"));
+            if (quiet) {
+                process.stderr.write(`${pc.green("Transcription complete")}\n`);
+            } else {
+                s.stop(pc.green("Transcription complete"));
+            }
 
             // Show metadata
             if (result.language) {
@@ -149,7 +179,12 @@ async function runTranscription(filePath: string, opts: TranscribeFlags): Promis
             transcriber.dispose();
         }
     } catch (error) {
-        s.stop(pc.red("Transcription failed"));
+        if (quiet) {
+            process.stderr.write(`${pc.red("Transcription failed")}\n`);
+        } else {
+            s.stop(pc.red("Transcription failed"));
+        }
+
         console.error(pc.red(error instanceof Error ? error.message : String(error)));
         process.exit(1);
     }
@@ -207,6 +242,37 @@ async function interactiveMode(): Promise<void> {
         return;
     }
 
+    const diarize = await p.confirm({
+        message: "Identify speakers (diarization)?",
+        initialValue: false,
+    });
+
+    if (p.isCancel(diarize)) {
+        p.cancel("Cancelled");
+        return;
+    }
+
+    let speakers: number | undefined;
+
+    if (diarize) {
+        const spk = await p.text({
+            message: "Expected speaker count (blank = auto-detect):",
+            placeholder: "auto",
+            validate(value) {
+                if (value && !/^\d+$/.test(value.trim())) {
+                    return "Enter a whole number or leave blank";
+                }
+            },
+        });
+
+        if (p.isCancel(spk)) {
+            p.cancel("Cancelled");
+            return;
+        }
+
+        speakers = spk?.trim() ? Number.parseInt(spk.trim(), 10) : undefined;
+    }
+
     const format = await p.select<OutputFormat>({
         message: "Output format:",
         options: [
@@ -261,6 +327,8 @@ async function interactiveMode(): Promise<void> {
         format,
         output: outputFile,
         clipboard: destination === "clipboard",
+        diarize,
+        speakers,
     });
 
     p.outro(pc.green("Done"));
@@ -281,6 +349,10 @@ const program = new Command()
     .option("--model <model>", "Model name/id to use")
     .option("-o, --output <path>", "Write output to file")
     .option("-c, --clipboard", "Copy output to clipboard")
+    .option("--no-clean", "Disable repetition-loop cleanup (alias: --raw)")
+    .option("--raw", "Alias for --no-clean")
+    .option("--diarize", "Identify speakers (speaker diarization)")
+    .option("--speakers <n>", "Expected speaker count (0/omit = auto-detect)", (v) => Number.parseInt(v, 10))
     .action(async (file: string | undefined, opts: TranscribeFlags) => {
         if (!file) {
             await interactiveMode();

--- a/src/transcribe/transcribe.test.ts
+++ b/src/transcribe/transcribe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { TranscriptionResult } from "@app/utils/ai/types";
-import { formatTimestamp, toSRT, toVTT } from "./index";
+import { formatOutput, formatTimestamp, toSRT, toVTT } from "./index";
 
 describe("formatTimestamp", () => {
     it("formats zero with comma separator", () => {
@@ -30,17 +30,33 @@ describe("toSRT", () => {
         expect(toSRT(result)).toBe("Hello world");
     });
 
-    it("formats multiple segments with SRT numbering", () => {
+    it("keeps sentence-level segments as separate numbered cues", () => {
         const result: TranscriptionResult = {
-            text: "Hello Second",
+            text: "Hello there. Second one.",
             segments: [
-                { text: "Hello", start: 0, end: 1.5 },
-                { text: "Second", start: 2.0, end: 3.5 },
+                { text: "Hello there.", start: 0, end: 1.5 },
+                { text: "Second one.", start: 2.0, end: 3.5 },
             ],
         };
         const srt = toSRT(result);
-        expect(srt).toContain("1\n00:00:00,000 --> 00:00:01,500\nHello");
-        expect(srt).toContain("2\n00:00:02,000 --> 00:00:03,500\nSecond");
+        expect(srt).toContain("1\n00:00:00,000 --> 00:00:01,500\nHello there.");
+        expect(srt).toContain("2\n00:00:02,000 --> 00:00:03,500\nSecond one.");
+    });
+
+    it("coalesces word-level segments into readable cues split on sentence punctuation", () => {
+        const result: TranscriptionResult = {
+            text: "dobrý den. jak se máš?",
+            segments: [
+                { text: "dobrý", start: 0, end: 0.4 },
+                { text: "den.", start: 0.4, end: 0.9 },
+                { text: "jak", start: 1.0, end: 1.2 },
+                { text: "se", start: 1.2, end: 1.4 },
+                { text: "máš?", start: 1.4, end: 1.8 },
+            ],
+        };
+        const srt = toSRT(result);
+        expect(srt).toContain("1\n00:00:00,000 --> 00:00:00,900\ndobrý den.");
+        expect(srt).toContain("2\n00:00:01,000 --> 00:00:01,800\njak se máš?");
     });
 });
 
@@ -58,5 +74,86 @@ describe("toVTT", () => {
         const vtt = toVTT(result);
         expect(vtt).toStartWith("WEBVTT");
         expect(vtt).toContain("00:00:00.000 --> 00:00:01.500");
+    });
+});
+
+describe("speaker-aware rendering", () => {
+    it("never merges cues across a speaker change and prefixes SRT with SPEAKER", () => {
+        const result: TranscriptionResult = {
+            text: "x",
+            segments: [
+                { text: "Dobrý den.", start: 0, end: 1, speaker: "SPEAKER_00" },
+                { text: "Zdravím.", start: 1.1, end: 2, speaker: "SPEAKER_01" },
+            ],
+        };
+        const srt = toSRT(result);
+        expect(srt).toContain("1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_00: Dobrý den.");
+        expect(srt).toContain("2\n00:00:01,100 --> 00:00:02,000\nSPEAKER_01: Zdravím.");
+    });
+
+    it("does not merge same-speaker fragments across a speaker boundary", () => {
+        const result: TranscriptionResult = {
+            text: "x",
+            segments: [
+                { text: "ano", start: 0, end: 0.5, speaker: "SPEAKER_00" },
+                { text: "ne", start: 0.6, end: 1.0, speaker: "SPEAKER_01" },
+            ],
+        };
+        const srt = toSRT(result);
+        expect(srt).toContain("SPEAKER_00: ano");
+        expect(srt).toContain("SPEAKER_01: ne");
+    });
+
+    it("VTT uses <v SPEAKER_NN> voice spans", () => {
+        const result: TranscriptionResult = {
+            text: "x",
+            segments: [{ text: "Ahoj.", start: 0, end: 1, speaker: "SPEAKER_00" }],
+        };
+        expect(toVTT(result)).toContain("<v SPEAKER_00>Ahoj.");
+    });
+
+    it("text format prefixes each speaker turn", () => {
+        const result: TranscriptionResult = {
+            text: "x",
+            segments: [
+                { text: "A.", start: 0, end: 1, speaker: "SPEAKER_00" },
+                { text: "B.", start: 1, end: 2, speaker: "SPEAKER_01" },
+            ],
+        };
+        expect(formatOutput(result, "text")).toBe("SPEAKER_00: A.\nSPEAKER_01: B.");
+    });
+
+    it("merges same-speaker cues across a long silence (diarized: no 6s split)", () => {
+        const result: TranscriptionResult = {
+            text: "x",
+            segments: [
+                { text: "Začátek věty", start: 0, end: 2, speaker: "SPEAKER_00" },
+                { text: "a pokračování po pauze.", start: 9, end: 11, speaker: "SPEAKER_00" },
+            ],
+        };
+        expect(toSRT(result)).toBe(
+            "1\n00:00:00,000 --> 00:00:11,000\nSPEAKER_00: Začátek věty a pokračování po pauze."
+        );
+    });
+
+    it("still splits non-diarized cues on the 6s gap", () => {
+        const result: TranscriptionResult = {
+            text: "x",
+            segments: [
+                { text: "first part", start: 0, end: 2 },
+                { text: "after long gap.", start: 9, end: 11 },
+            ],
+        };
+        const srt = toSRT(result);
+        expect(srt).toContain("1\n00:00:00,000 --> 00:00:02,000\nfirst part");
+        expect(srt).toContain("2\n00:00:09,000 --> 00:00:11,000\nafter long gap.");
+    });
+
+    it("text format unchanged when no segment has a speaker", () => {
+        const result: TranscriptionResult = {
+            text: "plain transcript",
+            segments: [{ text: "plain transcript", start: 0, end: 1 }],
+        };
+        expect(formatOutput(result, "text")).toBe("plain transcript");
     });
 });

--- a/src/utils/ai/providers/AICloudProvider.ts
+++ b/src/utils/ai/providers/AICloudProvider.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -18,6 +19,8 @@ import type {
     TranslateOptions,
     TranslationResult,
 } from "@app/utils/ai/types";
+import { convertFileToMonoMp3 } from "@app/utils/audio/converter";
+import { sniffAudioExt } from "@app/utils/audio/detect-format";
 import type { AIProviderType } from "@app/utils/config/ai.types";
 
 type LlmCloudType = "openai" | "groq" | "openrouter";
@@ -90,25 +93,58 @@ export class AICloudProvider
     }
 
     async transcribe(audio: Buffer, options?: TranscribeOptions): Promise<TranscriptionResult> {
-        const tempPath = join(tmpdir(), `ai-transcribe-${Date.now()}.wav`);
-        await Bun.write(tempPath, audio);
+        const stamp = `${Date.now()}-${randomUUID()}`;
+        const ext = sniffAudioExt(audio);
+        const rawPath = join(tmpdir(), `ai-transcribe-${stamp}.${ext}`);
+        await Bun.write(rawPath, audio);
+
+        // Normalize to 16kHz mono MP3 for upload. whisper-1 tolerates most
+        // containers, but gpt-4o-transcribe rejects many ("does not support
+        // the format"); MP3 is the universal, smallest, STT-transparent input.
+        // Already-MP3 input (e.g. a split chunk) is uploaded as-is.
+        let uploadPath = rawPath;
+        let normalizedPath: string | undefined;
 
         try {
-            const result = await this.transcriptionManager.transcribeAudio(tempPath, {
+            if (ext !== "mp3") {
+                normalizedPath = join(tmpdir(), `ai-transcribe-${stamp}-norm.mp3`);
+                await convertFileToMonoMp3(rawPath, normalizedPath);
+                uploadPath = normalizedPath;
+            }
+
+            const uploadBytes = Bun.file(uploadPath).size;
+            logger.info(
+                { ext, rawBytes: audio.length, uploadBytes, normalized: ext !== "mp3" },
+                "Cloud transcription upload prepared"
+            );
+
+            const result = await this.transcriptionManager.transcribeAudio(uploadPath, {
                 language: options?.language,
                 model: options?.model,
                 provider: this.cloudType === "auto" ? undefined : this.cloudType,
+                diarize: options?.diarize,
+                speakers: options?.speakers,
+                smartFormat: options?.smartFormat,
+                clean: options?.clean,
             });
 
             return {
                 text: result.text,
+                segments: result.segments,
+                language: result.language,
                 duration: result.duration,
             };
         } finally {
-            try {
-                unlinkSync(tempPath);
-            } catch {
-                logger.debug(`Failed to clean up temp file: ${tempPath}`);
+            for (const p of [rawPath, normalizedPath]) {
+                if (!p) {
+                    continue;
+                }
+
+                try {
+                    unlinkSync(p);
+                } catch {
+                    logger.debug(`Failed to clean up temp file: ${p}`);
+                }
             }
         }
     }

--- a/src/utils/ai/providers/xai/AIXAITranscriptionProvider.ts
+++ b/src/utils/ai/providers/xai/AIXAITranscriptionProvider.ts
@@ -1,5 +1,6 @@
 import logger from "@app/logger";
 import { convertToWhisperWav } from "@app/utils/audio/converter";
+import { detectAudioFormat } from "@app/utils/audio/detect-format";
 import type { AIProviderType } from "@app/utils/config/ai.types";
 import { SafeJSON } from "@app/utils/json";
 import type {
@@ -242,53 +243,4 @@ function wordsToSegments(words: XAITranscriptionWord[] | undefined): Transcripti
     }
 
     return words.map((w) => ({ text: w.text, start: w.start, end: w.end }));
-}
-
-function detectAudioFormat(buf: Buffer): { contentType: string; filename: string } {
-    if (buf.length < 12) {
-        return { contentType: "application/octet-stream", filename: "audio.bin" };
-    }
-
-    // WAV: "RIFF....WAVE"
-    if (buf.toString("ascii", 0, 4) === "RIFF" && buf.toString("ascii", 8, 12) === "WAVE") {
-        return { contentType: "audio/wav", filename: "audio.wav" };
-    }
-
-    // FLAC: "fLaC"
-    if (buf.toString("ascii", 0, 4) === "fLaC") {
-        return { contentType: "audio/flac", filename: "audio.flac" };
-    }
-
-    // OGG: "OggS"
-    if (buf.toString("ascii", 0, 4) === "OggS") {
-        return { contentType: "audio/ogg", filename: "audio.ogg" };
-    }
-
-    // MP4 / M4A: "....ftyp" at offset 4
-    if (buf.toString("ascii", 4, 8) === "ftyp") {
-        const brand = buf.toString("ascii", 8, 12);
-        // M4A audio brands: "M4A ", "mp42", "isom", "iso2"
-        if (brand.startsWith("M4A") || brand === "mp42" || brand === "isom" || brand === "iso2") {
-            return { contentType: "audio/mp4", filename: "audio.m4a" };
-        }
-        return { contentType: "audio/mp4", filename: "audio.mp4" };
-    }
-
-    // MP3 with ID3 tag: "ID3"
-    if (buf.toString("ascii", 0, 3) === "ID3") {
-        return { contentType: "audio/mpeg", filename: "audio.mp3" };
-    }
-
-    // MP3 frame sync: 0xFFEx / 0xFFFx
-    if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0) {
-        return { contentType: "audio/mpeg", filename: "audio.mp3" };
-    }
-
-    // WebM / Matroska: 0x1A 0x45 0xDF 0xA3
-    if (buf[0] === 0x1a && buf[1] === 0x45 && buf[2] === 0xdf && buf[3] === 0xa3) {
-        return { contentType: "audio/webm", filename: "audio.webm" };
-    }
-
-    // Default — let the server try to figure it out, fall back to mp3 hint
-    return { contentType: "audio/mpeg", filename: "audio.mp3" };
 }

--- a/src/utils/ai/tasks/Transcriber.cleanup.test.ts
+++ b/src/utils/ai/tasks/Transcriber.cleanup.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { cleanRepetitions } from "@app/utils/ai/transcription/repetition-cleanup";
+
+describe("two-level cleanup idempotency", () => {
+    it("manager-clean then stitched-clean equals single clean (no double-collapse drift)", () => {
+        const looped = { text: "a a a a a a b a a a a a a c" };
+        const managerPass = cleanRepetitions(looped); // per-chunk / single-shot
+        const stitchedPass = cleanRepetitions(managerPass); // Transcriber stitched
+        expect(stitchedPass).toEqual(managerPass);
+        expect(managerPass.text).toBe("a b a c");
+    });
+});

--- a/src/utils/ai/tasks/Transcriber.diarize-invariant.test.ts
+++ b/src/utils/ai/tasks/Transcriber.diarize-invariant.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { AITranscriptionProvider, TranscriptionResult } from "@app/utils/ai/types";
+
+// The designed-out invariant: local diarization is ALWAYS handed the full
+// original audio buffer, never a per-chunk slice — so speaker labels share
+// one global space and cross-chunk remapping is structurally impossible.
+// If a future change diarizes chunk-wise (or removes the diarize split-
+// bypass) this test fails, catching the regression early.
+//
+// Only the leaf `diarize-local` module is mocked (nothing else imports it,
+// so the global mock cannot leak into other suites); the Transcriber is
+// constructed directly via its (runtime-accessible) constructor so AIConfig
+// and the provider registry are NOT mocked.
+
+const seenLengths: number[] = [];
+
+mock.module("@app/utils/audio/diarize-local", () => ({
+    diarizeLocal: async (buf: Buffer) => {
+        seenLengths.push(buf.length);
+        return [{ start: 0, end: 1, speaker: "0" }];
+    },
+}));
+
+const { Transcriber } = await import("@app/utils/ai/tasks/Transcriber");
+
+type TranscriberCtor = new (
+    provider: AITranscriptionProvider
+) => {
+    transcribe(audio: Buffer, options?: { diarize?: boolean; clean?: boolean }): Promise<TranscriptionResult>;
+};
+
+const fakeProvider: AITranscriptionProvider = {
+    type: "deepgram",
+    isAvailable: async () => true,
+    supports: () => true,
+    transcribe: async () => ({ text: "a", segments: [{ text: "a", start: 0, end: 1 }] }),
+    dispose: () => {},
+};
+
+describe("designed-out: diarization runs on the un-split source", () => {
+    it("diarizeLocal receives the full original audio buffer, never a chunk", async () => {
+        // > MAX_CLOUD_BYTES (24 MiB) with a cloud provider: without the
+        // diarize split-bypass this would be chunked and diarizeLocal would
+        // see chunk-sized buffers instead of the whole file.
+        const big = Buffer.alloc(25 * 1024 * 1024, 1);
+        const t = new (Transcriber as unknown as TranscriberCtor)(fakeProvider);
+        await t.transcribe(big, { diarize: true, clean: false });
+        expect(seenLengths).toEqual([big.length]);
+    });
+});

--- a/src/utils/ai/tasks/Transcriber.ts
+++ b/src/utils/ai/tasks/Transcriber.ts
@@ -3,10 +3,14 @@ import { readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { audioProcessor } from "@app/ask/audio/AudioProcessor";
+import logger from "@app/logger";
 import { rateLimitAwareDelay, retry } from "@app/utils/async";
+import { diarizeLocal } from "@app/utils/audio/diarize-local";
 import { CLOUD_PROVIDER_TYPES } from "@app/utils/config/ai.types";
 import { AIConfig } from "../AIConfig";
 import { getProviderForTask } from "../providers";
+import { assignSpeakers } from "../transcription/align-speakers";
+import { cleanRepetitions } from "../transcription/repetition-cleanup";
 import type {
     AIProviderType,
     AITranscriptionProvider,
@@ -27,6 +31,11 @@ function shouldRetryTransient(error: unknown): boolean {
     }
 
     if (/\b(invalid.api.key|unauthorized|forbidden|model.not.found)\b/i.test(msg)) {
+        return false;
+    }
+
+    // Permanent capability/format mismatches — retrying just repeats the error.
+    if (/unsupported.model.version|does not support the format|unsupported.format/i.test(msg)) {
         return false;
     }
 
@@ -71,14 +80,74 @@ export class Transcriber {
         }
 
         if (CLOUD_PROVIDER_TYPES.has(this.provider.type) && audio.length > MAX_CLOUD_BYTES) {
-            return this.transcribeChunked(audio, typeof audioOrPath === "string" ? audioOrPath : undefined, options);
+            // Only Deepgram accepts large single uploads AND diarizes natively,
+            // so only it benefits from (and survives) bypassing the size-split.
+            // OpenAI/Groq reject >25 MB, so they must still chunk — local
+            // diarization runs on the full original buffer regardless
+            // (maybeDiarizeLocal), so the global-label invariant is preserved.
+            const deepgramNativeDiarize = options?.diarize === true && this.provider.type === "deepgram";
+
+            if (deepgramNativeDiarize) {
+                logger.info(
+                    "Deepgram diarization — bypassing size-split (accepts large uploads; one request ⇒ one global speaker label space)"
+                );
+            } else {
+                return this.transcribeChunked(
+                    audio,
+                    typeof audioOrPath === "string" ? audioOrPath : undefined,
+                    options
+                );
+            }
         }
 
-        return retry(() => this.provider.transcribe(audio, options), {
-            maxAttempts: 3,
+        const result = await retry(() => this.provider.transcribe(audio, options), {
+            maxAttempts: 1,
             getDelay: RETRY_DELAY,
             shouldRetry: shouldRetryTransient,
+            onRetry: (attempt, delay) => {
+                logger.warn(
+                    { attempt, maxAttempts: 1, nextDelayMs: delay, audioBytes: audio.length },
+                    "Transcription attempt failed (transient) — retrying; each retry re-uploads the full audio"
+                );
+            },
         });
+
+        const cleaned = this.maybeClean(result, options);
+        return this.maybeDiarizeLocal(cleaned, audio, options);
+    }
+
+    private maybeClean(r: TranscriptionResult, options?: TranscribeOptions): TranscriptionResult {
+        if (options?.clean === false) {
+            return r;
+        }
+
+        const c = cleanRepetitions({ text: r.text, segments: r.segments });
+        return { ...r, text: c.text, segments: c.segments };
+    }
+
+    /**
+     * Local speaker diarization for providers that don't return speakers
+     * natively (Whisper/gpt-4o/local). Runs on the FULL original audio buffer
+     * (never a chunk) so the label space is global — the cross-chunk-remap
+     * problem is designed out, not patched. Deepgram-with-utterances already
+     * has per-segment speakers, so this is a no-op there.
+     */
+    private async maybeDiarizeLocal(
+        r: TranscriptionResult,
+        audio: Buffer,
+        options?: TranscribeOptions
+    ): Promise<TranscriptionResult> {
+        if (!options?.diarize || !r.segments?.length || r.segments.some((s) => s.speaker)) {
+            return r;
+        }
+
+        const turns = await diarizeLocal(audio, { speakers: options.speakers });
+
+        if (turns.length === 0) {
+            return r;
+        }
+
+        return { ...r, segments: assignSpeakers(r.segments, turns) };
     }
 
     private async transcribeChunked(
@@ -137,12 +206,19 @@ export class Transcriber {
                 }
             }
 
-            return {
-                text: texts.join(" "),
-                segments: allSegments.length > 0 ? allSegments : undefined,
-                language: options?.language,
-                duration: timeOffset > 0 ? timeOffset : undefined,
-            };
+            const stitched = this.maybeClean(
+                {
+                    text: texts.join(" "),
+                    segments: allSegments.length > 0 ? allSegments : undefined,
+                    language: options?.language,
+                    duration: timeOffset > 0 ? timeOffset : undefined,
+                },
+                options
+            );
+
+            // `audio` here is the full original buffer (never a chunk) — the
+            // designed-out invariant: diarization always sees the whole file.
+            return this.maybeDiarizeLocal(stitched, audio, options);
         } finally {
             if (!sourcePath && inputPath && existsSync(inputPath)) {
                 await rm(inputPath, { force: true }).catch(() => {});

--- a/src/utils/ai/transcription-format.ts
+++ b/src/utils/ai/transcription-format.ts
@@ -1,5 +1,6 @@
 import { SafeJSON } from "@app/utils/json";
-import type { TranscriptionResult } from "./types";
+import { normalizeSpeakerLabel } from "./transcription/speaker-label";
+import type { TranscriptionResult, TranscriptionSegment } from "./types";
 
 export type OutputFormat = "text" | "json" | "srt" | "vtt";
 
@@ -21,16 +22,85 @@ function pad3(n: number): string {
     return String(n).padStart(3, "0");
 }
 
+const MAX_CUE_SECONDS = 6;
+const MAX_CUE_CHARS = 84;
+
+/**
+ * Group raw transcription segments into readable subtitle cues.
+ *
+ * Providers differ wildly in segment granularity: OpenAI Whisper returns
+ * sentence-ish segments, Deepgram returns one segment *per word* (a 14-min
+ * file → ~1250 one-word cues, useless as subtitles). Accumulate consecutive
+ * segments into a cue, flushing on sentence-final punctuation or when the cue
+ * would get too long/slow to read. Idempotent-ish for already-coarse input.
+ */
+function coalesceSegmentsForSubtitles(segments: TranscriptionSegment[]): TranscriptionSegment[] {
+    const cues: TranscriptionSegment[] = [];
+    let cur: TranscriptionSegment | undefined;
+
+    for (const seg of segments) {
+        const piece = seg.text.trim();
+
+        if (!piece) {
+            continue;
+        }
+
+        if (!cur) {
+            cur = { text: piece, start: seg.start, end: seg.end, speaker: seg.speaker };
+        } else {
+            const merged = `${cur.text} ${piece}`;
+            const tooLong = merged.length > MAX_CUE_CHARS;
+            // For diarized output a speaker's turn legitimately spans pauses;
+            // the 6s gap-flush would shatter one turn into single-word cues
+            // (mis-grouping it under the metric and reading badly). Keep the
+            // time flush only for non-diarized subtitles; a speaker change or
+            // the char cap still bound diarized cues.
+            const diarized = cur.speaker !== undefined;
+            const tooSlow = !diarized && seg.end - cur.start > MAX_CUE_SECONDS;
+            // Compare normalized labels so equivalent ids in different formats
+            // (raw `speaker_0` vs `SPEAKER_00`) don't force a spurious split.
+            const speakerChanged = normalizeSpeakerLabel(cur.speaker) !== normalizeSpeakerLabel(seg.speaker);
+
+            if (tooLong || tooSlow || speakerChanged) {
+                cues.push(cur);
+                cur = { text: piece, start: seg.start, end: seg.end, speaker: seg.speaker };
+            } else {
+                cur.text = merged;
+                cur.end = seg.end;
+            }
+        }
+
+        if (/[.!?…]["')\]]?$/.test(cur.text)) {
+            cues.push(cur);
+            cur = undefined;
+        }
+    }
+
+    if (cur) {
+        cues.push(cur);
+    }
+
+    return cues;
+}
+
 export function toSRT(result: TranscriptionResult): string {
     if (!result.segments?.length) {
         return result.text;
     }
 
-    return result.segments
+    const cues = coalesceSegmentsForSubtitles(result.segments);
+
+    if (cues.length === 0) {
+        return result.text;
+    }
+
+    return cues
         .map((seg, i) => {
             const start = formatTimestamp(seg.start, ",");
             const end = formatTimestamp(seg.end, ",");
-            return `${i + 1}\n${start} --> ${end}\n${seg.text.trim()}`;
+            const spk = normalizeSpeakerLabel(seg.speaker);
+            const prefix = spk ? `${spk}: ` : "";
+            return `${i + 1}\n${start} --> ${end}\n${prefix}${seg.text.trim()}`;
         })
         .join("\n\n");
 }
@@ -40,21 +110,64 @@ export function toVTT(result: TranscriptionResult): string {
         return `WEBVTT\n\n${result.text}`;
     }
 
-    const cues = result.segments
+    const coalesced = coalesceSegmentsForSubtitles(result.segments);
+
+    if (coalesced.length === 0) {
+        return `WEBVTT\n\n${result.text}`;
+    }
+
+    const cues = coalesced
         .map((seg) => {
             const start = formatTimestamp(seg.start, ".");
             const end = formatTimestamp(seg.end, ".");
-            return `${start} --> ${end}\n${seg.text.trim()}`;
+            const spk = normalizeSpeakerLabel(seg.speaker);
+            const body = spk ? `<v ${spk}>${seg.text.trim()}` : seg.text.trim();
+            return `${start} --> ${end}\n${body}`;
         })
         .join("\n\n");
 
     return `WEBVTT\n\n${cues}`;
 }
 
+/** Render speaker-grouped turns (`SPEAKER_NN: …`) when the transcript carries
+ *  speaker labels; plain `result.text` otherwise. Consecutive same-speaker
+ *  segments are merged into one turn line. */
+function toSpeakerText(result: TranscriptionResult): string {
+    const segs = result.segments;
+
+    if (!segs?.length || !segs.some((s) => s.speaker)) {
+        return result.text;
+    }
+
+    const lines: string[] = [];
+    let curSpk: string | undefined;
+
+    for (const seg of segs) {
+        const piece = seg.text.trim();
+
+        if (!piece) {
+            continue;
+        }
+
+        // Don't fabricate a speaker for unlabeled segments — render them
+        // plain so unknown turns aren't silently attributed to SPEAKER_00.
+        const spk = normalizeSpeakerLabel(seg.speaker);
+
+        if (spk !== curSpk || lines.length === 0) {
+            lines.push(spk ? `${spk}: ${piece}` : piece);
+            curSpk = spk;
+        } else {
+            lines[lines.length - 1] += ` ${piece}`;
+        }
+    }
+
+    return lines.join("\n");
+}
+
 export function formatOutput(result: TranscriptionResult, format: OutputFormat): string {
     switch (format) {
         case "text":
-            return result.text;
+            return toSpeakerText(result);
         case "json":
             return SafeJSON.stringify(result, null, 2);
         case "srt":

--- a/src/utils/ai/transcription/TranscriptionManager.ts
+++ b/src/utils/ai/transcription/TranscriptionManager.ts
@@ -1,16 +1,130 @@
 import { statSync } from "node:fs";
-import type { ProviderV2 } from "@ai-sdk/provider";
 import logger from "@app/logger";
 import type { TranscriptionModel } from "ai";
 import { experimental_transcribe as transcribe } from "ai";
 import pc from "picocolors";
+import type { TranscriptionCapableProvider, TranscriptionSegment } from "../types";
+import { cleanRepetitions } from "./repetition-cleanup";
+import { normalizeSpeakerLabel } from "./speaker-label";
 
-// Helper to get transcription model from ProviderV2
-function getTranscriptionModel(provider: ProviderV2, modelId: string): TranscriptionModel {
-    if (!provider.transcriptionModel) {
-        throw new Error(`Provider does not support transcription models`);
+function getTranscriptionModel(provider: TranscriptionCapableProvider, modelId: string): TranscriptionModel {
+    const factory = provider.transcription ?? provider.transcriptionModel;
+
+    if (!factory) {
+        throw new Error("Provider does not support transcription models");
     }
-    return provider.transcriptionModel(modelId);
+
+    // SDK version skew: deepgram/groq return TranscriptionModelV3 while ai@5's
+    // transcribe() is typed for V2. They are interop-compatible at runtime;
+    // bridge the model type here at the single boundary (no `any`).
+    return factory.call(provider, modelId) as TranscriptionModel;
+}
+
+interface SdkTranscriptionResult {
+    text: string;
+    segments?: ReadonlyArray<{ text: string; startSecond: number; endSecond: number }>;
+    language?: string;
+    durationInSeconds?: number;
+    responses?: ReadonlyArray<unknown>;
+}
+
+interface DeepgramUtterance {
+    speaker: number;
+    transcript: string;
+    start: number;
+    end: number;
+}
+
+interface DeepgramRawResponse {
+    body?: { results?: { utterances?: DeepgramUtterance[] } };
+}
+
+/**
+ * Deepgram's `diarize+utterances` puts speaker-grouped sentence segments in
+ * the *raw* provider response (`responses[0].body.results.utterances`) — the
+ * AI SDK does not surface them. Pull them out with narrow typed access (no
+ * `any`); speaker ids are normalized through the single label source.
+ */
+export function deepgramUtteranceSegments(result: {
+    responses?: ReadonlyArray<unknown>;
+}): TranscriptionSegment[] | undefined {
+    const first = result.responses?.[0] as DeepgramRawResponse | undefined;
+    const utts = first?.body?.results?.utterances;
+
+    if (!utts?.length) {
+        return undefined;
+    }
+
+    return utts.map((u) => ({
+        text: u.transcript,
+        start: u.start,
+        end: u.end,
+        speaker: normalizeSpeakerLabel(u.speaker),
+    }));
+}
+
+/**
+ * Rebuild sentence-level segments from a formatted transcript + word timings.
+ *
+ * Some providers (Deepgram via `@ai-sdk/deepgram`) only expose per-word
+ * segments containing the *raw, lowercase, unpunctuated* token — the
+ * smart-formatted text exists solely as `result.text`. We recover usable
+ * subtitle cues by splitting `result.text` into sentences and distributing
+ * them across the word timings proportionally (robust to token-count drift
+ * from smart-formatting, since it never assumes a 1:1 word↔segment match).
+ */
+function rebuildSentenceSegments(text: string, wordSegments: TranscriptionSegment[]): TranscriptionSegment[] {
+    const sentences =
+        text
+            .match(/[^.!?…]+[.!?…]+["')\]]*|\S[^.!?…]*$/g)
+            ?.map((s) => s.trim())
+            .filter(Boolean) ?? [];
+
+    const wordCounts = sentences.map((s) => s.split(/\s+/).filter(Boolean).length);
+    const totalWords = wordCounts.reduce((a, b) => a + b, 0);
+    const n = wordSegments.length;
+
+    if (sentences.length === 0 || totalWords === 0 || n === 0) {
+        return wordSegments;
+    }
+
+    const out: TranscriptionSegment[] = [];
+    let cum = 0;
+
+    for (let i = 0; i < sentences.length; i++) {
+        const startIdx = Math.min(n - 1, Math.floor((cum / totalWords) * n));
+        cum += wordCounts[i];
+        const endIdx = Math.min(n - 1, Math.max(startIdx, Math.ceil((cum / totalWords) * n) - 1));
+        out.push({
+            text: sentences[i],
+            start: wordSegments[startIdx].start,
+            end: wordSegments[endIdx].end,
+        });
+    }
+
+    return out;
+}
+
+/** Map an AI SDK transcription result to our segment shape, recovering
+ * sentence cues for word-level providers. */
+function mapResultSegments(result: SdkTranscriptionResult): TranscriptionSegment[] | undefined {
+    if (!result.segments?.length) {
+        return undefined;
+    }
+
+    const segments: TranscriptionSegment[] = result.segments.map((seg) => ({
+        text: seg.text,
+        start: seg.startSecond,
+        end: seg.endSecond,
+    }));
+
+    const singleWord = segments.filter((s) => !/\s/.test(s.text.trim())).length;
+
+    if (result.text && segments.length > 1 && singleWord / segments.length > 0.7) {
+        return rebuildSentenceSegments(result.text, segments);
+    }
+
+    return segments;
 }
 
 export interface TranscriptionOptions {
@@ -19,12 +133,14 @@ export interface TranscriptionOptions {
     model?: string;
     timestamp?: boolean;
     verbose?: boolean;
-    /** Enable speaker diarization (AssemblyAI, Deepgram). */
+    /** Enable speaker diarization (Deepgram native; local pyannote otherwise). */
     diarize?: boolean;
-    /** Request word-level timestamps (Whisper, Deepgram). */
-    wordTimestamps?: boolean;
+    /** Expected speaker count for diarization clustering; omit/0 = auto-detect. */
+    speakers?: number;
     /** Enable smart formatting/punctuation (Deepgram). */
     smartFormat?: boolean;
+    /** Post-process repetition-loop cleanup. Default true; --no-clean disables. */
+    clean?: boolean;
 }
 
 export interface TranscriptionResult {
@@ -35,6 +151,8 @@ export interface TranscriptionResult {
     confidence?: number;
     cost?: number;
     processingTime: number;
+    segments?: TranscriptionSegment[];
+    language?: string;
 }
 
 export class TranscriptionManager {
@@ -83,34 +201,68 @@ export class TranscriptionManager {
             // Perform transcription
             const model = getTranscriptionModel(transcriptionModel.providerInstance, transcriptionModel.model);
             const providerOptions = this.buildProviderOptions(transcriptionModel.provider, options);
+            const requestStart = Date.now();
+            logger.info(
+                {
+                    provider: transcriptionModel.provider,
+                    model: transcriptionModel.model,
+                    audioBytes: audioBuffer.byteLength,
+                    diarize: options.diarize === true,
+                    language: options.language,
+                },
+                "Transcription request → cloud (this upload can be slow on a degraded uplink)"
+            );
             const result = await transcribe({
                 model,
                 audio: audioBuffer,
-                ...(options.language && { language: options.language }),
                 ...(Object.keys(providerOptions).length > 0 && { providerOptions }),
             });
 
             const processingTime = Date.now() - startTime;
+            logger.info(
+                {
+                    provider: transcriptionModel.provider,
+                    audioBytes: audioBuffer.byteLength,
+                    requestMs: Date.now() - requestStart,
+                },
+                "Transcription request ← cloud (response received)"
+            );
+
+            const mapped =
+                transcriptionModel.provider === "deepgram" && options.diarize
+                    ? (deepgramUtteranceSegments(result) ?? mapResultSegments(result))
+                    : mapResultSegments(result);
+            const cleaned =
+                options.clean === false
+                    ? { text: result.text, segments: mapped }
+                    : cleanRepetitions({ text: result.text, segments: mapped });
 
             const transcriptionResult: TranscriptionResult = {
-                text: result.text,
+                text: cleaned.text,
                 provider: transcriptionModel.provider,
                 model: transcriptionModel.model,
                 processingTime,
+                segments: cleaned.segments,
+                language: result.language ?? options.language,
+                duration: result.durationInSeconds,
             };
-
-            // Note: result from experimental_transcribe doesn't have duration property
-            // Duration would need to be calculated separately if needed
 
             logger.info(`Transcription completed in ${pc.green((processingTime / 1000).toFixed(1))}s`);
 
             return transcriptionResult;
         } catch (error) {
             const processingTime = Date.now() - startTime;
-            logger.error(`Transcription failed after ${(processingTime / 1000).toFixed(1)}s: ${error}`);
+            logger.error(
+                { error, provider: options.provider, model: options.model, elapsedMs: processingTime },
+                `Transcription failed after ${(processingTime / 1000).toFixed(1)}s (timeouts here usually mean a slow/degraded upload, not a code fault)`
+            );
 
-            // Try fallback providers if primary failed
-            if (options.provider !== "fallback") {
+            // Only auto-fall-back when no provider was explicitly requested.
+            // If the caller asked for a specific provider, fail loudly instead
+            // of silently producing output from a different one.
+            const explicitProvider = options.provider && options.provider !== "auto";
+
+            if (!explicitProvider && options.provider !== "fallback") {
                 logger.info("Trying fallback providers...");
                 return await this.transcribeWithFallback(filePath, options, processingTime);
             }
@@ -156,16 +308,26 @@ export class TranscriptionManager {
 
                 const audioBuffer = await Bun.file(filePath).arrayBuffer();
                 const model = getTranscriptionModel(transcriptionModel.providerInstance, transcriptionModel.model);
+                const providerOptions = this.buildProviderOptions(transcriptionModel.provider, options);
                 const result = await transcribe({
                     model,
                     audio: audioBuffer,
-                    ...(options.language && { language: options.language }),
+                    ...(Object.keys(providerOptions).length > 0 && { providerOptions }),
                 });
 
+                const fbMapped = mapResultSegments(result);
+                const fbCleaned =
+                    options.clean === false
+                        ? { text: result.text, segments: fbMapped }
+                        : cleanRepetitions({ text: result.text, segments: fbMapped });
+
                 return {
-                    text: result.text,
+                    text: fbCleaned.text,
                     provider,
                     model: transcriptionModel.model,
+                    segments: fbCleaned.segments,
+                    language: result.language ?? options.language,
+                    duration: result.durationInSeconds,
                     processingTime: Date.now() - initialTime,
                 };
             } catch (error) {
@@ -180,7 +342,7 @@ export class TranscriptionManager {
         fileSize: number,
         preferredProvider?: string,
         preferredModel?: string
-    ): Promise<{ provider: string; model: string; providerInstance: ProviderV2 } | null> {
+    ): Promise<{ provider: string; model: string; providerInstance: TranscriptionCapableProvider } | null> {
         // If provider and model are explicitly requested, try to use them
         if (preferredProvider && preferredModel) {
             return await this.getSpecificTranscriptionModel(preferredProvider, preferredModel);
@@ -248,7 +410,7 @@ export class TranscriptionManager {
     private async getSpecificTranscriptionModel(
         providerName: string,
         modelName: string
-    ): Promise<{ provider: string; model: string; providerInstance: ProviderV2 } | null> {
+    ): Promise<{ provider: string; model: string; providerInstance: TranscriptionCapableProvider } | null> {
         try {
             switch (providerName) {
                 case "groq": {
@@ -340,45 +502,77 @@ export class TranscriptionManager {
         }
     }
 
+    /**
+     * Build provider-specific options for the AI SDK `transcribe()` call.
+     *
+     * The AI SDK has NO top-level `language` parameter — a language hint only
+     * reaches the model through `providerOptions.<providerId>.language`.
+     * Passing it anywhere else is silently dropped, which makes Whisper
+     * auto-detect per 30s window and hallucinate/loop on non-English audio.
+     * So `language` MUST be threaded here for every provider.
+     *
+     * The outer key is the AI SDK *provider id*, not our internal name:
+     * `openrouter` is created via `createOpenAI(...)` so its id is `openai`.
+     */
     private buildProviderOptions(
         provider: string,
         options: TranscriptionOptions
     ): Record<string, Record<string, import("@ai-sdk/provider").JSONValue>> {
         const result: Record<string, Record<string, import("@ai-sdk/provider").JSONValue>> = {};
+        const lang = options.language;
+
+        if (provider === "openai" || provider === "openrouter" || provider === "groq") {
+            // whisper-based; keys are camelCase per AI SDK. temperature:0 is the
+            // documented anti-hallucination setting; segment timestamps power SRT/VTT.
+            const opts: Record<string, import("@ai-sdk/provider").JSONValue> = {
+                temperature: 0,
+                timestampGranularities: ["segment"],
+            };
+
+            if (lang) {
+                opts.language = lang;
+            }
+
+            // openrouter uses the openai-compatible provider instance → id "openai"
+            const key = provider === "groq" ? "groq" : "openai";
+            result[key] = opts;
+        }
+
+        if (provider === "deepgram") {
+            const deepgramOpts: Record<string, import("@ai-sdk/provider").JSONValue> = {
+                // Smart Format implies punctuation + capitalization + numerals;
+                // without it Deepgram returns lowercase unpunctuated text.
+                smartFormat: true,
+                punctuate: true,
+            };
+
+            if (lang) {
+                deepgramOpts.language = lang;
+            } else {
+                deepgramOpts.detectLanguage = true;
+            }
+
+            if (options.diarize) {
+                deepgramOpts.diarize = true;
+                deepgramOpts.utterances = true; // gives speaker-grouped sentence segments
+            }
+
+            result.deepgram = deepgramOpts;
+        }
 
         if (provider === "assemblyai") {
             const assemblyaiOpts: Record<string, import("@ai-sdk/provider").JSONValue> = {};
 
-            if (options.diarize) {
-                assemblyaiOpts.speaker_labels = true;
+            if (lang) {
+                assemblyaiOpts.languageCode = lang;
             }
 
-            if (options.wordTimestamps) {
-                assemblyaiOpts.word_boost = [];
+            if (options.diarize) {
+                assemblyaiOpts.speakerLabels = true;
             }
 
             if (Object.keys(assemblyaiOpts).length > 0) {
                 result.assemblyai = assemblyaiOpts;
-            }
-        }
-
-        if (provider === "deepgram") {
-            const deepgramOpts: Record<string, import("@ai-sdk/provider").JSONValue> = {};
-
-            if (options.diarize) {
-                deepgramOpts.diarize = true;
-            }
-
-            if (options.smartFormat) {
-                deepgramOpts.smart_format = true;
-            }
-
-            if (options.wordTimestamps) {
-                deepgramOpts.timestamps = true;
-            }
-
-            if (Object.keys(deepgramOpts).length > 0) {
-                result.deepgram = deepgramOpts;
             }
         }
 

--- a/src/utils/ai/transcription/align-speakers.test.ts
+++ b/src/utils/ai/transcription/align-speakers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { assignSpeakers } from "./align-speakers";
+
+const turns = [
+    { start: 0, end: 5, speaker: "speaker_00" },
+    { start: 5, end: 10, speaker: "speaker_01" },
+];
+
+describe("assignSpeakers", () => {
+    it("assigns max-overlap speaker, normalized", () => {
+        const segs = [
+            { text: "A", start: 0.5, end: 4 },
+            { text: "B", start: 6, end: 9 },
+        ];
+        expect(assignSpeakers(segs, turns)).toEqual([
+            { text: "A", start: 0.5, end: 4, speaker: "SPEAKER_00" },
+            { text: "B", start: 6, end: 9, speaker: "SPEAKER_01" },
+        ]);
+    });
+
+    it("fillNearest=true labels a zero-overlap segment with nearest turn", () => {
+        const segs = [{ text: "C", start: 20, end: 21 }];
+        expect(assignSpeakers(segs, turns)[0].speaker).toBe("SPEAKER_01");
+    });
+
+    it("sums overlap per speaker then picks the dominant", () => {
+        const segs = [{ text: "D", start: 4, end: 8 }]; // 1s spk0, 3s spk1
+        expect(assignSpeakers(segs, turns)[0].speaker).toBe("SPEAKER_01");
+    });
+});

--- a/src/utils/ai/transcription/align-speakers.ts
+++ b/src/utils/ai/transcription/align-speakers.ts
@@ -1,0 +1,52 @@
+import type { TranscriptionSegment } from "@app/utils/ai/types";
+import { normalizeSpeakerLabel } from "./speaker-label";
+
+export interface DiarTurn {
+    start: number;
+    end: number;
+    speaker: string;
+}
+
+function overlap(a0: number, a1: number, b0: number, b1: number): number {
+    return Math.max(0, Math.min(a1, b1) - Math.max(a0, b0));
+}
+
+/**
+ * whisperX `assign_word_speakers`, segment granularity, `fillNearest=true`.
+ * Each segment gets the speaker whose diarization turns overlap it most (sum
+ * of overlaps, not first match); a segment with zero overlap is filled with
+ * the temporally nearest turn so every cue is labelled (the reference SRTs
+ * label every cue — leaving some blank would falsely punish the metric).
+ */
+export function assignSpeakers(segments: TranscriptionSegment[], turns: DiarTurn[]): TranscriptionSegment[] {
+    return segments.map((seg) => {
+        const byspk = new Map<string, number>();
+
+        for (const t of turns) {
+            const ov = overlap(seg.start, seg.end, t.start, t.end);
+
+            if (ov > 0) {
+                byspk.set(t.speaker, (byspk.get(t.speaker) ?? 0) + ov);
+            }
+        }
+
+        let speaker: string | undefined;
+        let best = 0;
+
+        for (const [s, v] of byspk) {
+            if (v > best) {
+                best = v;
+                speaker = s;
+            }
+        }
+
+        if (!speaker && turns.length > 0) {
+            const mid = (seg.start + seg.end) / 2;
+            speaker = turns.reduce((p, c) =>
+                Math.abs((c.start + c.end) / 2 - mid) < Math.abs((p.start + p.end) / 2 - mid) ? c : p
+            ).speaker;
+        }
+
+        return { ...seg, speaker: normalizeSpeakerLabel(speaker) };
+    });
+}

--- a/src/utils/ai/transcription/deepgram-utterances.test.ts
+++ b/src/utils/ai/transcription/deepgram-utterances.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { deepgramUtteranceSegments } from "./TranscriptionManager";
+
+describe("deepgramUtteranceSegments", () => {
+    it("maps raw utterances to speaker-labelled segments", () => {
+        const result = {
+            responses: [
+                {
+                    body: {
+                        results: {
+                            utterances: [
+                                { speaker: 0, transcript: "Dobrý den.", start: 0.1, end: 1.2 },
+                                { speaker: 1, transcript: "Zdravím.", start: 1.5, end: 2.0 },
+                            ],
+                        },
+                    },
+                },
+            ],
+        };
+        expect(deepgramUtteranceSegments(result)).toEqual([
+            { text: "Dobrý den.", start: 0.1, end: 1.2, speaker: "SPEAKER_00" },
+            { text: "Zdravím.", start: 1.5, end: 2.0, speaker: "SPEAKER_01" },
+        ]);
+    });
+    it("returns undefined when no utterances present", () => {
+        expect(deepgramUtteranceSegments({ responses: [{ body: {} }] })).toBeUndefined();
+        expect(deepgramUtteranceSegments({})).toBeUndefined();
+    });
+});

--- a/src/utils/ai/transcription/repetition-cleanup.test.ts
+++ b/src/utils/ai/transcription/repetition-cleanup.test.ts
@@ -41,4 +41,18 @@ describe("cleanRepetitions", () => {
             { text: "Jak se máte?", start: 5, end: 6 },
         ]);
     });
+
+    it("does NOT cross-segment-dedup identical text from different speakers within < 2s gap", () => {
+        const segments: TranscriptionSegment[] = [
+            { text: "Dobrý den.", start: 0, end: 1, speaker: "SPEAKER_00" },
+            { text: "dobrý den", start: 1.5, end: 2.4, speaker: "SPEAKER_01" },
+            { text: "Jak se máte?", start: 5, end: 6, speaker: "SPEAKER_00" },
+        ];
+        const r = cleanRepetitions({ text: "x", segments });
+        expect(r.segments).toEqual([
+            { text: "Dobrý den.", start: 0, end: 1, speaker: "SPEAKER_00" },
+            { text: "dobrý den", start: 1.5, end: 2.4, speaker: "SPEAKER_01" },
+            { text: "Jak se máte?", start: 5, end: 6, speaker: "SPEAKER_00" },
+        ]);
+    });
 });

--- a/src/utils/ai/transcription/repetition-cleanup.test.ts
+++ b/src/utils/ai/transcription/repetition-cleanup.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import type { TranscriptionSegment } from "@app/utils/ai/types";
+import { cleanRepetitions } from "./repetition-cleanup";
+
+describe("cleanRepetitions", () => {
+    it("collapses a single-token loop (run >= 5) to one", () => {
+        const r = cleanRepetitions({ text: "ano ještě ještě ještě ještě ještě ještě konec" });
+        expect(r.text).toBe("ano ještě konec");
+    });
+
+    it("collapses a clause loop (phrase run >= 3) to one", () => {
+        const t = "Zkusíme zpátky. Zkusíme zpátky. Zkusíme zpátky. Zkusíme zpátky. Dál.";
+        expect(cleanRepetitions({ text: t }).text).toBe("Zkusíme zpátky. Dál.");
+    });
+
+    it("preserves scattered legit repeats (interviewer 'Dobře, děkuji.' x3 with content between)", () => {
+        const t = "Dobře, děkuji. Otázka jedna. Dobře, děkuji. Otázka dva. Dobře, děkuji. Konec.";
+        expect(cleanRepetitions({ text: t }).text).toBe(t);
+    });
+
+    it("is Czech-diacritic-insensitive when matching the run", () => {
+        const r = cleanRepetitions({ text: "Ještě ještě JEŠTĚ ještě ještě dál" });
+        expect(r.text).toBe("Ještě dál");
+    });
+
+    it("is idempotent", () => {
+        const once = cleanRepetitions({ text: "a a a a a a b" });
+        const twice = cleanRepetitions(once);
+        expect(twice).toEqual(once);
+    });
+
+    it("dedups a segment equal to the previous within < 2s gap and absorbs its end", () => {
+        const segments: TranscriptionSegment[] = [
+            { text: "Dobrý den.", start: 0, end: 1 },
+            { text: "dobrý den", start: 1.5, end: 2.4 },
+            { text: "Jak se máte?", start: 5, end: 6 },
+        ];
+        const r = cleanRepetitions({ text: "x", segments });
+        expect(r.segments).toEqual([
+            { text: "Dobrý den.", start: 0, end: 2.4 },
+            { text: "Jak se máte?", start: 5, end: 6 },
+        ]);
+    });
+});

--- a/src/utils/ai/transcription/repetition-cleanup.ts
+++ b/src/utils/ai/transcription/repetition-cleanup.ts
@@ -1,0 +1,157 @@
+import logger from "@app/logger";
+import type { TranscriptionSegment } from "@app/utils/ai/types";
+
+const SINGLE_TOKEN_MIN_RUN = 5;
+const PHRASE_MIN_RUN = 3;
+const MAX_PHRASE_WORDS = 8;
+const SEG_DEDUP_GAP_SEC = 2.0;
+const ZLIB_FLAG_RATIO = 2.4;
+const ZLIB_WINDOW_WORDS = 120;
+
+function norm(s: string): string {
+    // Strip ALL non-alphanumeric (not just trailing punctuation) so repetition
+    // detection is robust to leading/internal punctuation — `(Ještě` and
+    // `Ještě,` and `Ještě` all normalize equal. Diacritics are decomposed and
+    // dropped first so Czech case/accent variants collapse together.
+    return s
+        .normalize("NFD")
+        .replace(/[̀-ͯ]/g, "")
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+function spanEq(a: string[], s: number, e: number, t: number): boolean {
+    for (let k = 0; k < e - s; k++) {
+        if (a[s + k] !== a[t + k]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/** Collapse only CONSECUTIVE repeated token n-grams (stable-ts remove_repetition
+ *  port). Adjacent-only ⇒ scattered legit repeats survive untouched. */
+function collapseRuns(tokens: string[]): string[] {
+    let toks = tokens;
+
+    for (let len = 1; len <= MAX_PHRASE_WORDS; len++) {
+        const minRun = len === 1 ? SINGLE_TOKEN_MIN_RUN : PHRASE_MIN_RUN;
+        const n = toks.map(norm);
+        const kept: boolean[] = toks.map(() => true);
+        let i = 0;
+
+        while (i + len <= n.length) {
+            let reps = 1;
+
+            while (i + (reps + 1) * len <= n.length && spanEq(n, i, i + len, i + reps * len)) {
+                reps++;
+            }
+
+            if (reps >= minRun) {
+                for (let r = 1; r < reps; r++) {
+                    for (let k = 0; k < len; k++) {
+                        kept[i + r * len + k] = false;
+                    }
+                }
+
+                i += reps * len;
+            } else {
+                i += 1;
+            }
+        }
+
+        toks = toks.filter((_, idx) => kept[idx]);
+    }
+
+    return toks;
+}
+
+function flagHighCompression(text: string): void {
+    // FLAG only (never deletes). Runs on the PRE-cleanup text so it surfaces
+    // loops the run-collapse heuristic did NOT catch — checking post-collapse
+    // would always look fine and make the warning useless. zlib header
+    // (`library:"zlib"`) matches the 2.4 threshold's Python/Node calibration;
+    // Bun's default raw deflate would skew the ratio ~5-10%.
+    const words = text.split(/\s+/).filter(Boolean);
+
+    for (let i = 0; i < words.length; i += ZLIB_WINDOW_WORDS) {
+        const win = words.slice(i, i + ZLIB_WINDOW_WORDS).join(" ");
+        const ratio =
+            Buffer.byteLength(win, "utf8") / Math.max(1, Bun.deflateSync(Buffer.from(win), { library: "zlib" }).length);
+
+        if (ratio > ZLIB_FLAG_RATIO) {
+            logger.warn(
+                `repetition-cleanup: window @word ${i} compression ratio ${ratio.toFixed(2)} > ${ZLIB_FLAG_RATIO} (review)`
+            );
+        }
+    }
+}
+
+function cleanText(text: string): string {
+    flagHighCompression(text);
+    return collapseRuns(text.split(/\s+/).filter(Boolean)).join(" ");
+}
+
+export function cleanRepetitions(input: { text: string; segments?: TranscriptionSegment[] }): {
+    text: string;
+    segments?: TranscriptionSegment[];
+} {
+    if (!input.segments?.length) {
+        return { text: cleanText(input.text) };
+    }
+
+    flagHighCompression(input.text); // pre-cleanup flag on the full text
+
+    // 1. intra-segment run-collapse
+    const intra = input.segments.map((s) => ({
+        ...s,
+        text: collapseRuns(s.text.split(/\s+/).filter(Boolean)).join(" "),
+    }));
+
+    // 2. cross-segment dedup (drop seg == previous surviving within < gap)
+    const segs: TranscriptionSegment[] = [];
+
+    for (const s of intra) {
+        const prev = segs[segs.length - 1];
+
+        if (
+            prev &&
+            prev.speaker === s.speaker &&
+            norm(prev.text) === norm(s.text) &&
+            norm(s.text).length > 0 &&
+            s.start - prev.end < SEG_DEDUP_GAP_SEC
+        ) {
+            prev.end = s.end;
+            continue;
+        }
+
+        segs.push({ ...s });
+    }
+
+    // 3. segment run-length (>=5 consecutive identical normalized text → keep first)
+    const out: TranscriptionSegment[] = [];
+    let i = 0;
+
+    while (i < segs.length) {
+        let reps = 1;
+
+        while (
+            i + reps < segs.length &&
+            norm(segs[i + reps].text) === norm(segs[i].text) &&
+            norm(segs[i].text).length > 0
+        ) {
+            reps++;
+        }
+
+        if (reps >= SINGLE_TOKEN_MIN_RUN) {
+            out.push({ ...segs[i], end: segs[i + reps - 1].end });
+            i += reps;
+        } else {
+            out.push(segs[i]);
+            i += 1;
+        }
+    }
+
+    return { text: out.map((s) => s.text).join(" "), segments: out };
+}

--- a/src/utils/ai/transcription/speaker-label.test.ts
+++ b/src/utils/ai/transcription/speaker-label.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeSpeakerLabel } from "./speaker-label";
+
+describe("normalizeSpeakerLabel", () => {
+    it("uppercases sherpa lowercase labels", () => {
+        expect(normalizeSpeakerLabel("speaker_00")).toBe("SPEAKER_00");
+    });
+
+    it("zero-pads bare integer/string speaker ids", () => {
+        expect(normalizeSpeakerLabel(0)).toBe("SPEAKER_00");
+        expect(normalizeSpeakerLabel(3)).toBe("SPEAKER_03");
+        expect(normalizeSpeakerLabel("1")).toBe("SPEAKER_01");
+    });
+
+    it("passes through already-correct labels", () => {
+        expect(normalizeSpeakerLabel("SPEAKER_02")).toBe("SPEAKER_02");
+    });
+
+    it("returns undefined for null/undefined/empty", () => {
+        expect(normalizeSpeakerLabel(undefined)).toBeUndefined();
+        expect(normalizeSpeakerLabel(null)).toBeUndefined();
+        expect(normalizeSpeakerLabel("")).toBeUndefined();
+    });
+
+    it("rejects invalid numeric ids (negative, non-integer, NaN, Infinity)", () => {
+        expect(normalizeSpeakerLabel(-1)).toBeUndefined();
+        expect(normalizeSpeakerLabel(1.5)).toBeUndefined();
+        expect(normalizeSpeakerLabel(Number.NaN)).toBeUndefined();
+        expect(normalizeSpeakerLabel(Number.POSITIVE_INFINITY)).toBeUndefined();
+    });
+});

--- a/src/utils/ai/transcription/speaker-label.ts
+++ b/src/utils/ai/transcription/speaker-label.ts
@@ -1,0 +1,30 @@
+/**
+ * The single place speaker-label format is decided. sherpa-onnx emits
+ * `speaker_00` (lowercase); Deepgram emits integer ids; the pyannote /
+ * Spokenly / reference-SRT convention is `SPEAKER_00` (uppercase, zero-padded
+ * to 2). Every render path MUST go through this — never uppercase ad hoc.
+ */
+export function normalizeSpeakerLabel(raw: string | number | null | undefined): string | undefined {
+    if (raw === null || raw === undefined || raw === "") {
+        return undefined;
+    }
+
+    if (typeof raw === "number") {
+        if (!Number.isInteger(raw) || raw < 0) {
+            return undefined;
+        }
+
+        return `SPEAKER_${String(raw).padStart(2, "0")}`;
+    }
+
+    const m = raw.match(/(\d+)\s*$/);
+
+    if (m) {
+        return `SPEAKER_${m[1].padStart(2, "0")}`;
+    }
+
+    // Unknown format (no trailing digits) — pass through uppercased. sherpa
+    // (`speaker_NN`) and Deepgram (int) always hit the branches above; this is
+    // a safety fallthrough, not an expected path.
+    return raw.toUpperCase();
+}

--- a/src/utils/ai/types.ts
+++ b/src/utils/ai/types.ts
@@ -45,6 +45,7 @@ export interface TranscriptionSegment {
     text: string;
     start: number;
     end: number;
+    speaker?: string;
 }
 
 export type OnSegment = (segment: TranscriptionSegment) => void;
@@ -70,12 +71,14 @@ export interface TranscribeOptions {
      * - Clean single-speaker: defaults work well
      */
     thresholds?: WhisperThresholds;
-    /** Enable speaker diarization (AssemblyAI, Deepgram). */
+    /** Enable speaker diarization (Deepgram native; local pyannote otherwise). */
     diarize?: boolean;
-    /** Request word-level timestamps (Whisper, Deepgram). */
-    wordTimestamps?: boolean;
+    /** Expected speaker count for diarization clustering; omit/0 = auto-detect. */
+    speakers?: number;
     /** Enable smart formatting/punctuation (Deepgram). */
     smartFormat?: boolean;
+    /** Post-process repetition-loop cleanup. Default true; --no-clean disables. */
+    clean?: boolean;
 }
 
 export interface WhisperThresholds {
@@ -96,6 +99,21 @@ export interface TranscriptionResult {
     segments?: TranscriptionSegment[];
     language?: string;
     duration?: number;
+}
+
+/**
+ * Structural type for any AI SDK transcription provider instance.
+ *
+ * Every provider (openai, groq, deepgram, assemblyai, gladia,
+ * openrouter-via-openai) exposes a `transcription(modelId)` factory;
+ * `transcriptionModel` is the older `ProviderV2` spec name kept as a
+ * fallback. This avoids pinning to `ProviderV2`, which `ProviderV3`
+ * providers (deepgram, groq) are not assignable to even though their
+ * models are interop-compatible with `ai@5`'s `transcribe()` at runtime.
+ */
+export interface TranscriptionCapableProvider {
+    transcription?: (modelId: string) => unknown;
+    transcriptionModel?: (modelId: string) => unknown;
 }
 
 /** Chunk emitted by transformers.js chunk_callback during ASR pipeline processing */

--- a/src/utils/audio/converter.ts
+++ b/src/utils/audio/converter.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import logger from "@app/logger";
 
 /**
  * Convert any audio file/buffer to 16kHz mono 16-bit PCM Float32Array
@@ -133,6 +135,54 @@ async function tryFfmpeg(inputPath: string, outputPath: string): Promise<Buffer 
     }
 }
 
+/** Bitrate for 16kHz mono MP3 — transparent for speech, small, universally accepted. */
+export const MONO_MP3_BITRATE_KBPS = 128;
+
+/**
+ * Transcode any audio file to a single 16kHz mono MP3.
+ *
+ * This is the lowest common denominator every cloud STT model accepts:
+ * `whisper-1` tolerates m4a/ogg/etc, but `gpt-4o-transcribe` rejects many
+ * containers ("does not support the format"). MP3 is transparent for speech,
+ * far smaller than WAV, and matches the split-segment encoding so a
+ * re-encode of an already-split chunk is a harmless round-trip.
+ *
+ * @returns the output path on success.
+ */
+export async function convertFileToMonoMp3(inputPath: string, outputPath: string): Promise<string> {
+    const proc = Bun.spawn(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            inputPath,
+            "-vn",
+            "-map",
+            "0:a:0",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "libmp3lame",
+            "-b:a",
+            `${MONO_MP3_BITRATE_KBPS}k`,
+            outputPath,
+        ],
+        { stdout: "pipe", stderr: "pipe" }
+    );
+
+    const stderr = await new Response(proc.stderr).text();
+    await proc.exited;
+
+    if (proc.exitCode !== 0 || !existsSync(outputPath)) {
+        cleanup(outputPath);
+        throw new Error(`ffmpeg mp3 transcode failed (exit ${proc.exitCode}): ${stderr.slice(-500)}`);
+    }
+
+    return outputPath;
+}
+
 /**
  * If the WAV is already 16kHz/mono/16-bit, return as-is.
  * Otherwise convert it.
@@ -227,5 +277,43 @@ function cleanup(path: string): void {
         unlinkSync(path);
     } catch {
         // ignore
+    }
+}
+
+/** Transcode an audio file to an arbitrary ffmpeg container/format. General
+ *  format conversion; for the STT-normalized paths prefer
+ *  `convertFileToMonoMp3` / `convertToWhisperWav`. */
+export async function convertAudioFormat(
+    inputPath: string,
+    outputPath: string,
+    targetFormat: string = "mp3"
+): Promise<string> {
+    try {
+        const outputDir = dirname(outputPath);
+
+        if (!existsSync(outputDir)) {
+            await mkdir(outputDir, { recursive: true });
+        }
+
+        logger.info(`Converting ${inputPath} to ${targetFormat} format...`);
+
+        const proc = Bun.spawn(["ffmpeg", "-i", inputPath, "-f", targetFormat, "-y", outputPath], {
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        const _stdout = await new Response(proc.stdout).text();
+        const stderr = await new Response(proc.stderr).text();
+        const exitCode = await proc.exited;
+
+        if (exitCode !== 0) {
+            throw new Error(`FFmpeg conversion failed: ${stderr}`);
+        }
+
+        logger.info(`Audio conversion completed: ${outputPath}`);
+
+        return outputPath;
+    } catch (error) {
+        logger.error(`Audio conversion failed: ${error}`);
+        throw error;
     }
 }

--- a/src/utils/audio/detect-format.ts
+++ b/src/utils/audio/detect-format.ts
@@ -1,0 +1,69 @@
+export interface DetectedAudioFormat {
+    contentType: string;
+    filename: string;
+    /** Extension without leading dot, e.g. "mp3". */
+    ext: string;
+}
+
+/**
+ * Detect an audio container from its leading magic bytes.
+ *
+ * Cloud STT APIs (OpenAI, Deepgram, …) infer the codec from the upload's
+ * extension / content-type, so a buffer must never be handed over with a
+ * mislabeled name (e.g. MP3 bytes written to a `.wav` temp file made Whisper
+ * misbehave). Falls back to an mp3 hint when the signature is unknown.
+ */
+export function detectAudioFormat(buf: Buffer): DetectedAudioFormat {
+    if (buf.length < 12) {
+        return { contentType: "application/octet-stream", filename: "audio.bin", ext: "bin" };
+    }
+
+    // WAV: "RIFF....WAVE"
+    if (buf.toString("ascii", 0, 4) === "RIFF" && buf.toString("ascii", 8, 12) === "WAVE") {
+        return { contentType: "audio/wav", filename: "audio.wav", ext: "wav" };
+    }
+
+    // FLAC: "fLaC"
+    if (buf.toString("ascii", 0, 4) === "fLaC") {
+        return { contentType: "audio/flac", filename: "audio.flac", ext: "flac" };
+    }
+
+    // OGG: "OggS"
+    if (buf.toString("ascii", 0, 4) === "OggS") {
+        return { contentType: "audio/ogg", filename: "audio.ogg", ext: "ogg" };
+    }
+
+    // MP4 / M4A: "....ftyp" at offset 4
+    if (buf.toString("ascii", 4, 8) === "ftyp") {
+        const brand = buf.toString("ascii", 8, 12);
+        // M4A audio brands: "M4A ", "mp42", "isom", "iso2"
+        if (brand.startsWith("M4A") || brand === "mp42" || brand === "isom" || brand === "iso2") {
+            return { contentType: "audio/mp4", filename: "audio.m4a", ext: "m4a" };
+        }
+
+        return { contentType: "audio/mp4", filename: "audio.mp4", ext: "mp4" };
+    }
+
+    // MP3 with ID3 tag: "ID3"
+    if (buf.toString("ascii", 0, 3) === "ID3") {
+        return { contentType: "audio/mpeg", filename: "audio.mp3", ext: "mp3" };
+    }
+
+    // MP3 frame sync: 0xFFEx / 0xFFFx
+    if (buf[0] === 0xff && (buf[1] & 0xe0) === 0xe0) {
+        return { contentType: "audio/mpeg", filename: "audio.mp3", ext: "mp3" };
+    }
+
+    // WebM / Matroska: 0x1A 0x45 0xDF 0xA3
+    if (buf[0] === 0x1a && buf[1] === 0x45 && buf[2] === 0xdf && buf[3] === 0xa3) {
+        return { contentType: "audio/webm", filename: "audio.webm", ext: "webm" };
+    }
+
+    // Default — let the server try to figure it out, fall back to mp3 hint
+    return { contentType: "audio/mpeg", filename: "audio.mp3", ext: "mp3" };
+}
+
+/** Extension (no dot) for a buffer's detected audio container. */
+export function sniffAudioExt(buf: Buffer): string {
+    return detectAudioFormat(buf).ext;
+}

--- a/src/utils/audio/diarize-local.preflight.test.ts
+++ b/src/utils/audio/diarize-local.preflight.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+
+describe("sherpa-onnx preflight", () => {
+    it("darwin-arm64 prebuilt native addon is present (no source build)", () => {
+        const dir = "node_modules/sherpa-onnx-darwin-arm64";
+        expect(existsSync(dir)).toBe(true);
+    });
+
+    it("module loads without throwing", () => {
+        expect(() => require("sherpa-onnx-node")).not.toThrow();
+    });
+});

--- a/src/utils/audio/diarize-local.ts
+++ b/src/utils/audio/diarize-local.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import logger from "@app/logger";
+import type { DiarTurn } from "@app/utils/ai/transcription/align-speakers";
+import { convertToWhisperWav } from "@app/utils/audio/converter";
+import { ensureDiarizationModels } from "@app/utils/audio/diarize-models";
+
+interface SherpaWave {
+    samples: Float32Array;
+    sampleRate: number;
+}
+
+interface SherpaSegment {
+    start: number;
+    end: number;
+    speaker: number;
+}
+
+interface SherpaDiarizer {
+    sampleRate: number;
+    process(samples: Float32Array): SherpaSegment[];
+}
+
+interface SherpaModule {
+    readWave(path: string): SherpaWave;
+    OfflineSpeakerDiarization: new (config: {
+        segmentation: { pyannote: { model: string } };
+        embedding: { model: string };
+        clustering: { numClusters: number; threshold: number };
+        minDurationOn: number;
+        minDurationOff: number;
+    }) => SherpaDiarizer;
+}
+
+/**
+ * Diarize an audio buffer locally (sherpa-onnx, pyannote-segmentation-3.0 +
+ * WeSpeaker embedding) — no Python, no cloud. Returns `[]` (never throws) when
+ * the native addon or models are unavailable, so the caller degrades to a
+ * transcript without speakers instead of failing. sherpa emits integer
+ * speaker ids; `assignSpeakers` → `normalizeSpeakerLabel` turns them into the
+ * `SPEAKER_NN` convention.
+ */
+export async function diarizeLocal(audio: Buffer, opts?: { speakers?: number }): Promise<DiarTurn[]> {
+    const wavPath = join(tmpdir(), `diar-${Date.now()}-${randomUUID()}.wav`);
+
+    try {
+        // Load the native addon FIRST — it throws synchronously on an
+        // unsupported platform, so failing here avoids the ~31 MB model
+        // download and the wav transcode on machines that can't diarize.
+        const sherpa = require("sherpa-onnx-node") as SherpaModule;
+
+        const wav = await convertToWhisperWav(audio); // 16 kHz mono 16-bit
+        await Bun.write(wavPath, wav);
+
+        const { segmentation, embedding } = await ensureDiarizationModels();
+
+        // Default to 2 clusters when the caller doesn't specify. Pure
+        // auto-detect (numClusters:-1) over-splits long Czech interview audio
+        // badly (gth → 5 spurious speakers) because WeSpeaker embeddings drift
+        // over a 14-min phone recording; raising the merge threshold instead
+        // is fragile (over-merges short segments to 1). Interview/meeting
+        // audio is overwhelmingly 2-party, so a fixed 2 is the robust default
+        // and converges to the 2-speaker reference SRTs; `--speakers N`
+        // overrides for N-party calls.
+        const numClusters = opts?.speakers && opts.speakers > 0 ? opts.speakers : 2;
+        const sd = new sherpa.OfflineSpeakerDiarization({
+            segmentation: { pyannote: { model: segmentation } },
+            embedding: { model: embedding },
+            clustering: { numClusters, threshold: 0.5 },
+            minDurationOn: 0.3,
+            minDurationOff: 0.5,
+        });
+
+        const wave = sherpa.readWave(wavPath);
+
+        if (sd.sampleRate !== wave.sampleRate) {
+            throw new Error(`sherpa expects ${sd.sampleRate}Hz, got ${wave.sampleRate}Hz`);
+        }
+
+        return sd.process(wave.samples).map((s) => ({
+            start: s.start,
+            end: s.end,
+            speaker: String(s.speaker),
+        }));
+    } catch (err) {
+        logger.warn({ error: err, wavPath }, "Local diarization unavailable, returning transcript without speakers");
+
+        return [];
+    } finally {
+        try {
+            unlinkSync(wavPath);
+        } catch (cleanupError) {
+            logger.debug({ error: cleanupError, wavPath }, "Failed to remove diarization temp file");
+        }
+    }
+}

--- a/src/utils/audio/diarize-models.test.ts
+++ b/src/utils/audio/diarize-models.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { DIARIZE_MODEL_DIR, EMBEDDING_MODEL, SEGMENTATION_MODEL } from "./diarize-models";
+
+describe("diarize-models config", () => {
+    it("points at the ungated GitHub-release assets", () => {
+        expect(SEGMENTATION_MODEL.url).toBe(
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+        );
+        expect(EMBEDDING_MODEL.url).toBe(
+            "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx"
+        );
+        expect(DIARIZE_MODEL_DIR).toMatch(/[\\/]\.genesis-tools[\\/]transcribe[\\/]models[\\/]diarization/);
+    });
+});

--- a/src/utils/audio/diarize-models.ts
+++ b/src/utils/audio/diarize-models.ts
@@ -1,0 +1,100 @@
+import { existsSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import logger from "@app/logger";
+
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/** Fetch a model asset with a hard timeout so a hung connection fails fast
+ *  (the caller degrades to transcript-without-speakers) instead of blocking
+ *  the CLI forever. */
+async function fetchModel(url: string): Promise<ArrayBuffer> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+
+        if (!res.ok) {
+            throw new Error(`Failed to download ${url}: HTTP ${res.status}`);
+        }
+
+        return await res.arrayBuffer();
+    } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+            throw new Error(`Failed to download ${url}: timed out after ${DOWNLOAD_TIMEOUT_MS}ms`);
+        }
+
+        throw error;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+export const DIARIZE_MODEL_DIR = join(homedir(), ".genesis-tools", "transcribe", "models", "diarization");
+
+export const SEGMENTATION_MODEL = {
+    url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2",
+    file: join(DIARIZE_MODEL_DIR, "sherpa-onnx-pyannote-segmentation-3-0", "model.onnx"),
+};
+
+// CAM++ multilingual (zh+en) speaker embedding. The previous model
+// (wespeaker_en_voxceleb_resnet34_LM) is an older architecture trained only
+// on English-celebrity VoxCeleb and scored ≈chance discriminating Czech
+// speakers regardless of input format (verified: .mp3/.wav/.mp4 all ~0.5).
+// Speaker embeddings encode voice timbre (largely language-independent), so a
+// modern multilingual CAM++ model transfers to Czech far better.
+export const EMBEDDING_MODEL = {
+    url: "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx",
+    file: join(DIARIZE_MODEL_DIR, "3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx"),
+};
+
+async function provisionModels(): Promise<{ segmentation: string; embedding: string }> {
+    await mkdir(DIARIZE_MODEL_DIR, { recursive: true });
+
+    if (!existsSync(EMBEDDING_MODEL.file)) {
+        logger.info("Downloading diarization embedding model (~25 MB)…");
+        await Bun.write(EMBEDDING_MODEL.file, await fetchModel(EMBEDDING_MODEL.url));
+    }
+
+    if (!existsSync(SEGMENTATION_MODEL.file)) {
+        logger.info("Downloading diarization segmentation model (~6 MB)…");
+        const tar = join(DIARIZE_MODEL_DIR, "seg.tar.bz2");
+        await Bun.write(tar, await fetchModel(SEGMENTATION_MODEL.url));
+        const proc = Bun.spawn(["tar", "xjf", tar, "-C", DIARIZE_MODEL_DIR], { stderr: "pipe" });
+        const extractFailed = (await proc.exited) !== 0;
+        const stderr = extractFailed ? await new Response(proc.stderr).text() : "";
+        await rm(tar, { force: true });
+
+        if (extractFailed) {
+            throw new Error(`Failed to extract segmentation model: ${stderr}`);
+        }
+
+        if (!existsSync(SEGMENTATION_MODEL.file)) {
+            throw new Error(
+                `Segmentation model missing after extraction (archive layout may have changed): ${SEGMENTATION_MODEL.file}`
+            );
+        }
+    }
+
+    return { segmentation: SEGMENTATION_MODEL.file, embedding: EMBEDDING_MODEL.file };
+}
+
+let inFlight: Promise<{ segmentation: string; embedding: string }> | undefined;
+
+/** Ensure both ONNX models exist locally; download (+extract) on first use.
+ *  Assets are ungated k2-fsa/sherpa-onnx GitHub releases — no auth needed.
+ *  Concurrent callers share one in-flight provisioning so two diarize calls
+ *  can't race on the same download/extract targets; a failed attempt clears
+ *  the cache so the next call retries instead of being permanently bricked. */
+export function ensureDiarizationModels(): Promise<{ segmentation: string; embedding: string }> {
+    if (!inFlight) {
+        inFlight = provisionModels().catch((err) => {
+            inFlight = undefined;
+            throw err;
+        });
+    }
+
+    return inFlight;
+}

--- a/src/utils/audio/probe.ts
+++ b/src/utils/audio/probe.ts
@@ -1,0 +1,101 @@
+import { existsSync } from "node:fs";
+import logger from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { spawn } from "bun";
+
+export interface AudioInfo {
+    format: string;
+    duration: number;
+    bitrate?: number;
+    sampleRate?: number;
+    channels?: number;
+}
+
+export interface AudioValidation {
+    isValid: boolean;
+    format?: string;
+    duration?: number;
+    size?: number;
+    error?: string;
+}
+
+/** Probe an audio file with ffprobe. Returns safe defaults if ffprobe fails
+ *  (never throws) so callers can degrade gracefully. */
+export async function getAudioInfo(filePath: string): Promise<AudioInfo> {
+    try {
+        const proc = spawn(
+            ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", filePath],
+            {
+                stdio: ["ignore", "pipe", "pipe"],
+            }
+        );
+
+        const stdout = await new Response(proc.stdout).text();
+        const stderr = await new Response(proc.stderr).text();
+        const exitCode = await proc.exited;
+
+        if (exitCode !== 0) {
+            throw new Error(`FFprobe failed: ${stderr}`);
+        }
+
+        interface FFprobeStream {
+            codec_type?: string;
+            codec_name?: string;
+            sample_rate?: string;
+            channels?: number;
+            bit_rate?: string;
+            duration?: string;
+        }
+
+        const probeData = SafeJSON.parse(stdout) as {
+            streams?: FFprobeStream[];
+            format?: { duration?: string; size?: string; bit_rate?: string };
+        };
+
+        const audioStream = probeData.streams?.find((stream) => stream.codec_type === "audio");
+
+        if (!audioStream) {
+            throw new Error("No audio stream found in file");
+        }
+
+        return {
+            format: audioStream.codec_name || "unknown",
+            duration: parseFloat(String(audioStream.duration || probeData.format?.duration || "0")),
+            bitrate: audioStream.bit_rate ? parseInt(String(audioStream.bit_rate), 10) : undefined,
+            sampleRate: audioStream.sample_rate ? parseInt(String(audioStream.sample_rate), 10) : undefined,
+            channels: audioStream.channels ? parseInt(String(audioStream.channels), 10) : undefined,
+        };
+    } catch (error) {
+        logger.warn(`Failed to get audio info for ${filePath}: ${error}`);
+
+        return {
+            format: "unknown",
+            duration: 0,
+        };
+    }
+}
+
+/** Validate an audio file exists and is probeable; returns size + basic info. */
+export async function validateAudioFile(filePath: string): Promise<AudioValidation> {
+    try {
+        if (!existsSync(filePath)) {
+            return { isValid: false, error: "File not found" };
+        }
+
+        const file = Bun.file(filePath);
+        const size = file.size;
+        const audioInfo = await getAudioInfo(filePath);
+
+        return {
+            isValid: true,
+            format: audioInfo.format,
+            duration: audioInfo.duration,
+            size,
+        };
+    } catch (error) {
+        return {
+            isValid: false,
+            error: error instanceof Error ? error.message : "Failed to validate audio file",
+        };
+    }
+}

--- a/src/utils/audio/probe.ts
+++ b/src/utils/audio/probe.ts
@@ -47,7 +47,7 @@ export async function getAudioInfo(filePath: string): Promise<AudioInfo> {
             duration?: string;
         }
 
-        const probeData = SafeJSON.parse(stdout) as {
+        const probeData = SafeJSON.parse(stdout, { strict: true }) as {
             streams?: FFprobeStream[];
             format?: { duration?: string; size?: string; bit_rate?: string };
         };

--- a/src/utils/audio/split.ts
+++ b/src/utils/audio/split.ts
@@ -1,0 +1,118 @@
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { join, parse } from "node:path";
+import logger from "@app/logger";
+import { MONO_MP3_BITRATE_KBPS } from "@app/utils/audio/converter";
+import { getAudioInfo } from "@app/utils/audio/probe";
+import { spawn } from "bun";
+
+/** 24 MB chunks — under the 25 MB cloud upload limit. */
+export const CHUNK_SIZE = 24 * 1024 * 1024;
+const SEGMENT_BITRATE_KBPS = MONO_MP3_BITRATE_KBPS;
+const SEGMENT_BYTES_PER_SEC = (SEGMENT_BITRATE_KBPS * 1000) / 8;
+
+/** Split audio into fixed-duration MP3 segments (re-encoded mono). */
+export async function splitAudioFile(
+    inputPath: string,
+    outputDir: string,
+    chunkDurationSeconds: number = 300
+): Promise<string[]> {
+    try {
+        if (!existsSync(outputDir)) {
+            await mkdir(outputDir, { recursive: true });
+        }
+
+        const audioInfo = await getAudioInfo(inputPath);
+
+        if (!audioInfo.duration) {
+            throw new Error("Cannot determine audio duration");
+        }
+
+        const baseName = parse(inputPath).name || "audio";
+        const outputFiles: string[] = [];
+
+        logger.info(`Splitting audio into ${Math.ceil(audioInfo.duration / chunkDurationSeconds)} chunks...`);
+
+        const segmentTemplate = join(outputDir, `${baseName}_%03d.mp3`);
+
+        const proc = spawn(
+            [
+                "ffmpeg",
+                "-i",
+                inputPath,
+                "-vn",
+                "-map",
+                "0:a:0",
+                "-c:a",
+                "libmp3lame",
+                "-b:a",
+                `${SEGMENT_BITRATE_KBPS}k`,
+                "-f",
+                "segment",
+                "-segment_time",
+                chunkDurationSeconds.toString(),
+                "-segment_format",
+                "mp3",
+                "-reset_timestamps",
+                "1",
+                "-y",
+                segmentTemplate,
+            ],
+            {
+                stdio: ["ignore", "pipe", "pipe"],
+            }
+        );
+
+        const _stdout = await new Response(proc.stdout).text();
+        const stderr = await new Response(proc.stderr).text();
+        const exitCode = await proc.exited;
+
+        if (exitCode !== 0) {
+            throw new Error(`FFmpeg segmentation failed: ${stderr}`);
+        }
+
+        for (let i = 0; i < Math.ceil(audioInfo.duration / chunkDurationSeconds); i++) {
+            const segmentFile = join(outputDir, `${baseName}_${i.toString().padStart(3, "0")}.mp3`);
+
+            if (existsSync(segmentFile)) {
+                outputFiles.push(segmentFile);
+            }
+        }
+
+        logger.info(`Created ${outputFiles.length} audio segments`);
+
+        return outputFiles;
+    } catch (error) {
+        logger.error(`Audio splitting failed: ${error}`);
+        throw error;
+    }
+}
+
+/** Split only if the file exceeds `maxChunkSizeBytes`; chunk duration is
+ *  derived from the fixed re-encode bitrate (not the source byte rate). */
+export async function splitAudioBySize(
+    inputPath: string,
+    outputDir: string,
+    maxChunkSizeBytes: number = CHUNK_SIZE
+): Promise<string[]> {
+    try {
+        if (!existsSync(outputDir)) {
+            await mkdir(outputDir, { recursive: true });
+        }
+
+        const fileSize = Bun.file(inputPath).size;
+
+        if (fileSize <= maxChunkSizeBytes) {
+            return [inputPath];
+        }
+
+        const chunkDurationSeconds = Math.floor((maxChunkSizeBytes * 0.9) / SEGMENT_BYTES_PER_SEC);
+
+        logger.info(`Splitting audio by size (~${maxChunkSizeBytes / 1024 / 1024}MB chunks)...`);
+
+        return await splitAudioFile(inputPath, outputDir, chunkDurationSeconds);
+    } catch (error) {
+        logger.error(`Audio size-based splitting failed: ${error}`);
+        throw error;
+    }
+}

--- a/src/utils/cli/quiet-spinner.ts
+++ b/src/utils/cli/quiet-spinner.ts
@@ -1,0 +1,21 @@
+export interface QuietSpinner {
+    start: (msg?: string) => void;
+    stop: (msg?: string) => void;
+    message: (msg?: string) => void;
+}
+
+/**
+ * A no-op stand-in for `@clack/prompts` `spinner()`.
+ *
+ * The clack spinner renders animation frames (`[1G[J◒ …`) on a timer; in a
+ * non-TTY / piped context those frames flood stdout/stderr with hundreds of
+ * useless lines and can corrupt structured output. Swap in this quiet spinner
+ * whenever output is not an interactive TTY (see `isQuietOutput`). Status that
+ * still matters in quiet mode should be written explicitly to stderr by the
+ * caller, not funnelled through the spinner.
+ */
+export function createQuietSpinner(): QuietSpinner {
+    const noop = (): void => {};
+
+    return { start: noop, stop: noop, message: noop };
+}

--- a/tests/transcribe/BASELINE.txt
+++ b/tests/transcribe/BASELINE.txt
@@ -1,0 +1,2 @@
+base-gth.srt: WER-proxy 0.147, speaker-agreement 1.00
+base-xyf.srt: WER-proxy 0.209, speaker-agreement 1.00

--- a/tests/transcribe/verify-against-reference.test.ts
+++ b/tests/transcribe/verify-against-reference.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { parseSrt, scoreAgainstReference } from "./verify-against-reference";
+
+describe("parseSrt", () => {
+    it("parses cue index, times, speaker prefix and text", () => {
+        const srt = "1\n00:00:00,000 --> 00:00:02,000\nSPEAKER_00: Ahoj světe.\n";
+        const cues = parseSrt(srt);
+        expect(cues).toHaveLength(1);
+        expect(cues[0]).toEqual({ start: 0, end: 2, speaker: "SPEAKER_00", text: "Ahoj světe." });
+    });
+
+    it("parses a cue with no speaker prefix", () => {
+        const cues = parseSrt("1\n00:00:01,000 --> 00:00:02,500\nAhoj.\n");
+        expect(cues[0]).toEqual({ start: 1, end: 2.5, speaker: undefined, text: "Ahoj." });
+    });
+});
+
+describe("scoreAgainstReference", () => {
+    it("perfect match → werProxy 0, speakerAgreement 1", () => {
+        const a = "1\n00:00:00,000 --> 00:00:02,000\nSPEAKER_00: Ahoj.\n";
+        const s = scoreAgainstReference(a, a);
+        expect(s.werProxy).toBe(0);
+        expect(s.speakerAgreement).toBe(1);
+    });
+
+    it("speakerAgreement is permutation-invariant (swapped labels still score 1)", () => {
+        const cand =
+            "1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_00: A\n\n" + "2\n00:00:01,000 --> 00:00:02,000\nSPEAKER_01: B\n";
+        const ref =
+            "1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_01: A\n\n" + "2\n00:00:01,000 --> 00:00:02,000\nSPEAKER_00: B\n";
+        const s = scoreAgainstReference(cand, ref);
+        expect(s.speakerAgreement).toBe(1);
+        expect(s.werProxy).toBe(0);
+    });
+
+    it("genuinely inconsistent labeling cannot be rescued by any permutation", () => {
+        // cand says one speaker for both cues; ref says two different ones —
+        // no bijection makes both agree, so the best is 0.5.
+        const cand =
+            "1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_00: a\n\n" + "2\n00:00:01,000 --> 00:00:02,000\nSPEAKER_00: b\n";
+        const ref =
+            "1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_00: a\n\n" + "2\n00:00:01,000 --> 00:00:02,000\nSPEAKER_01: b\n";
+        const s = scoreAgainstReference(cand, ref);
+        expect(s.speakerAgreement).toBe(0.5);
+        expect(s.werProxy).toBe(0);
+    });
+
+    it("werProxy is invariant to candidate cue granularity (1 long == 5 short)", () => {
+        const ref = "1\n00:00:00,000 --> 00:00:05,000\nSPEAKER_00: jedna dva tři čtyři pět\n";
+        const long = "1\n00:00:00,000 --> 00:00:05,000\nSPEAKER_00: jedna dva tři čtyři pět\n";
+        const short =
+            "1\n00:00:00,000 --> 00:00:01,000\nSPEAKER_00: jedna\n\n" +
+            "2\n00:00:01,000 --> 00:00:02,000\nSPEAKER_00: dva\n\n" +
+            "3\n00:00:02,000 --> 00:00:03,000\nSPEAKER_00: tři\n\n" +
+            "4\n00:00:03,000 --> 00:00:04,000\nSPEAKER_00: čtyři\n\n" +
+            "5\n00:00:04,000 --> 00:00:05,000\nSPEAKER_00: pět\n";
+        const sLong = scoreAgainstReference(long, ref);
+        const sShort = scoreAgainstReference(short, ref);
+        expect(sShort.werProxy).toBe(sLong.werProxy);
+        expect(sShort.werProxy).toBe(0);
+    });
+
+    it("matches short candidate cues to a long reference cue by overlap (no start-distance gate)", () => {
+        const ref = "1\n00:00:00,000 --> 00:00:30,000\nSPEAKER_00: Dobrý den jak se máte.\n";
+        const cand = "1\n00:00:20,000 --> 00:00:22,000\nSPEAKER_00: máte\n";
+        const s = scoreAgainstReference(cand, ref);
+        expect(s.speakerAgreement).toBe(1);
+    });
+});

--- a/tests/transcribe/verify-against-reference.ts
+++ b/tests/transcribe/verify-against-reference.ts
@@ -1,0 +1,243 @@
+import { existsSync } from "node:fs";
+import { basename } from "node:path";
+
+export interface Cue {
+    start: number;
+    end: number;
+    speaker?: string;
+    text: string;
+}
+
+function tc(s: string): number {
+    const m = s.trim().match(/(\d+):(\d+):(\d+)[,.](\d+)/);
+
+    if (!m) {
+        return 0;
+    }
+
+    return +m[1] * 3600 + +m[2] * 60 + +m[3] + +m[4] / 1000;
+}
+
+export function parseSrt(srt: string): Cue[] {
+    const blocks = srt.replace(/\r/g, "").split(/\n\n+/);
+    const cues: Cue[] = [];
+
+    for (const b of blocks) {
+        const lines = b.split("\n").filter((l) => l.trim() !== "");
+
+        if (lines.length < 2) {
+            continue;
+        }
+
+        const tl = lines.find((l) => l.includes("-->"));
+
+        if (!tl) {
+            continue;
+        }
+
+        const [a, z] = tl.split("-->");
+        const body = lines
+            .slice(lines.indexOf(tl) + 1)
+            .join(" ")
+            .trim();
+        // ONLY `SPEAKER_NN:` counts as a speaker prefix — matching a generic
+        // capitalized word would false-positive on any sentence like
+        // "Dobrý den: ..." and corrupt the speaker-agreement denominator.
+        const sm = body.match(/^(SPEAKER_\d+)\s*:\s*(.*)$/s);
+
+        cues.push({
+            start: tc(a),
+            end: tc(z),
+            speaker: sm ? sm[1] : undefined,
+            text: sm ? sm[2].trim() : body,
+        });
+    }
+
+    return cues;
+}
+
+function lev(a: string, b: string): number {
+    const d = Array.from({ length: a.length + 1 }, (_, i) => [i, ...Array(b.length).fill(0)]);
+
+    for (let j = 0; j <= b.length; j++) {
+        d[0][j] = j;
+    }
+
+    for (let i = 1; i <= a.length; i++) {
+        for (let j = 1; j <= b.length; j++) {
+            d[i][j] = Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
+        }
+    }
+
+    return d[a.length][b.length];
+}
+
+function overlap(a: Cue, b: Cue): number {
+    return Math.max(0, Math.min(a.end, b.end) - Math.max(a.start, b.start));
+}
+
+function permutations<T>(arr: T[]): T[][] {
+    if (arr.length <= 1) {
+        return [arr.slice()];
+    }
+
+    const out: T[][] = [];
+
+    for (let i = 0; i < arr.length; i++) {
+        const rest = [...arr.slice(0, i), ...arr.slice(i + 1)];
+
+        for (const p of permutations(rest)) {
+            out.push([arr[i], ...p]);
+        }
+    }
+
+    return out;
+}
+
+/**
+ * Diarization speaker labels are arbitrary identifiers — `SPEAKER_00` from one
+ * tool is not meant to equal `SPEAKER_00` from another. The only honest
+ * agreement score is invariant under any bijection candidate-label →
+ * reference-label, so brute-force every relabeling and take the best (speaker
+ * counts are tiny — ≤3 in practice; cap at 7 to keep n! bounded). This is the
+ * standard DER-style optimal label assignment.
+ */
+function bestSpeakerAgreement(pairs: Array<{ cand: string; ref: string }>): number {
+    if (pairs.length === 0) {
+        return 1;
+    }
+
+    const candSpk = [...new Set(pairs.map((p) => p.cand))];
+    const refSpk = [...new Set(pairs.map((p) => p.ref))];
+
+    if (candSpk.length > 7 || refSpk.length > 7) {
+        const direct = pairs.filter((p) => p.cand === p.ref).length;
+
+        return direct / pairs.length;
+    }
+
+    // Explore ALL injective relabelings regardless of cardinality: permute
+    // the larger label set and zip it against the smaller one. (Permuting
+    // only `refSpk` and prefix-mapping `candSpk` missed optimal assignments
+    // when the candidate has more speakers than the reference — e.g. an
+    // over-split local diarization vs a 2-speaker reference.)
+    const candBigger = candSpk.length > refSpk.length;
+    const smaller = candBigger ? refSpk : candSpk;
+    const larger = candBigger ? candSpk : refSpk;
+
+    let best = 0;
+
+    for (const perm of permutations(larger)) {
+        const candToRef = new Map<string, string>();
+        smaller.forEach((s, i) => {
+            const l = perm[i];
+
+            if (candBigger) {
+                candToRef.set(l, s); // l = candidate label, s = reference label
+            } else {
+                candToRef.set(s, l); // s = candidate label, l = reference label
+            }
+        });
+
+        let matched = 0;
+
+        for (const p of pairs) {
+            if (candToRef.get(p.cand) === p.ref) {
+                matched++;
+            }
+        }
+
+        if (matched > best) {
+            best = matched;
+        }
+    }
+
+    return best / pairs.length;
+}
+
+export function scoreAgainstReference(candSrt: string, refSrt: string): { werProxy: number; speakerAgreement: number } {
+    const cand = parseSrt(candSrt);
+    const ref = parseSrt(refSrt);
+
+    // Each candidate cue → the reference cue it overlaps most (pure
+    // max-overlap, NO start-distance gate: reference cues are long/
+    // utterance-level, candidate cues short/segment-level; a start gate would
+    // drop most candidates and skew the metric).
+    const grouped = new Map<number, Cue[]>();
+    const pairs: Array<{ cand: string; ref: string }> = [];
+
+    for (const c of cand) {
+        let bestIdx = -1;
+        let bestOv = 0;
+
+        for (let ri = 0; ri < ref.length; ri++) {
+            const ov = overlap(c, ref[ri]);
+
+            if (ov > bestOv) {
+                bestOv = ov;
+                bestIdx = ri;
+            }
+        }
+
+        if (bestIdx < 0 || bestOv <= 0) {
+            continue;
+        }
+
+        const list = grouped.get(bestIdx) ?? [];
+        list.push(c);
+        grouped.set(bestIdx, list);
+
+        const r = ref[bestIdx];
+
+        if (c.speaker && r.speaker) {
+            pairs.push({ cand: c.speaker, ref: r.speaker });
+        }
+    }
+
+    // WER-proxy aggregated PER REFERENCE CUE, not per candidate cue: collect
+    // every candidate cue that matched this ref cue, concatenate in time
+    // order, score the concatenation against the ref text. This decouples the
+    // score from candidate cue granularity — one long cue and five short cues
+    // over the same span with the same words now score identically.
+    let werSum = 0;
+    let werN = 0;
+
+    for (const [refIdx, list] of grouped) {
+        const r = ref[refIdx];
+        const concat = list
+            .slice()
+            .sort((a, b) => a.start - b.start)
+            .map((x) => x.text)
+            .join(" ")
+            .trim();
+        werSum += lev(concat, r.text) / Math.max(1, r.text.length);
+        werN++;
+    }
+
+    return {
+        werProxy: werN ? werSum / werN : 1,
+        speakerAgreement: bestSpeakerAgreement(pairs),
+    };
+}
+
+// CLI: bun tests/transcribe/verify-against-reference.ts <candidate.srt> <reference.srt>
+if (import.meta.main) {
+    const [cand, ref] = process.argv.slice(2);
+
+    if (!cand || !ref) {
+        console.error("Usage: bun tests/transcribe/verify-against-reference.ts <candidate.srt> <reference.srt>");
+        process.exit(1);
+    }
+
+    for (const f of [cand, ref]) {
+        if (!existsSync(f)) {
+            console.error(`File not found: ${f}`);
+            process.exit(1);
+        }
+    }
+
+    const s = scoreAgainstReference(await Bun.file(cand).text(), await Bun.file(ref).text());
+    console.log(
+        `${basename(cand)}: WER-proxy ${s.werProxy.toFixed(3)}, speaker-agreement ${s.speakerAgreement.toFixed(2)}`
+    );
+}


### PR DESCRIPTION
## Transcribe — repetition cleanup + speaker diarization

Implements `.claude/plans/2026-05-17-TranscribeDiarizationAndRepetitionCleanup.super.md` end-to-end (TDD, bisectable commits).

> **PR scope:** the transcription effort is the **24 commits `12b1205b..HEAD`** (from `fix(transcribe): Czech language drop…` onward). This branch was forked from `feat/dev-dashboard` (commit `2b66d3cb`), so the diff vs `master` also contains ~23 pre-existing dev-dashboard/usage commits that are **not** part of this work and are reviewed separately. Reviewers should focus on `src/utils/ai/**`, `src/transcribe/**`, `src/utils/audio/**`, `tests/transcribe/**`.

### What this delivers
- **Repetition cleanup (always-on, `--no-clean`/`--raw`):** consecutive-run collapse, Czech-diacritic-insensitive, cross-segment dedup, zlib flag-only, idempotent. Kills `whisper-1` ∞-loops on Czech; preserves legit scattered repeats.
- **Deepgram native diarization (production path):** `diarize+utterances`, typed raw-utterance parse (no `any`), speaker-aware SRT/VTT/text rendering, `--diarize`/`--speakers`, split-bypass (one global label space).
- **Local no-Python diarization:** `sherpa-onnx-node` (prebuilt darwin-arm64), pyannote-seg-3.0 + WeSpeaker, whisperX max-overlap alignment, graceful degradation, designed-out cross-chunk-remap invariant.
- **Corrected convergence metric:** permutation-invariant speaker agreement (label numbering is arbitrary) + ref-cue-grouped WER (granularity-invariant).
- **Phase D:** `AudioProcessor` ffprobe/split/convert moved to `src/utils/audio/{probe,split,converter}.ts`; class is a thin delegating shim (no behavior change).

### Results (corrected metric; 1,2.srt↔gth · 5.srt↔xyf)
| Path | gth WER | gth spk | xyf WER | xyf spk |
|---|---|---|---|---|
| Baseline non-diarized | 0.147 | — | 0.209 | — |
| **Deepgram `--diarize` (production)** | **0.213** | **1.00** | **0.209** | **0.97** |
| whisper-1 + local sherpa (segment) | 0.290 | 0.56 | 0.218 | 0.51 |

Speaker attribution is near-perfect on the Deepgram path (1.00 / 0.97) where the baseline had none. The gth diarized WER +0.066 is a representation property (utterance-segmented text under ref-cue grouping), not a words regression — the non-diarized default path is unchanged at 0.147 (`--diarize` is opt-in). Word-level alignment (Phase B3) was implemented then **reverted via its metric gate** (no agreement gain, xyf WER regressed) — a valid plan outcome. Local-embedding Czech accuracy ceiling is a documented out-of-scope follow-up; Deepgram is the production path.

### Verification
- `tsgo --noEmit`: **0 errors** (whole project)
- `bun test` (ai + audio + transcribe + tests/transcribe + ask): **250 pass / 0 fail / 26 skip** (276 tests)
- Per-task TDD; functional E2E on the 3 real recordings scored vs `~/Downloads/{1,2,5}.srt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end speaker diarization (local offline option), speaker-aware transcripts/subtitles, MP3 transcoding and automatic audio-format detection, size-based audio chunking, repetition-cleanup post-processing, non‑TTY quiet spinner, and CLI flags for diarization, speaker count, and no-clean/raw mode.
* **Tests**
  * Added coverage for diarization, speaker alignment/labels, repetition cleanup, subtitle rendering/scoring, and format detection.
* **Documentation**
  * Expanded utility guidance and “Audio transcription gotchas”.
* **Chores**
  * Added runtime support for Deepgram and native diarization tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->