### PR TITLE
feat(question): colorize tools question log digest

### DIFF
--- a/src/dev-dashboard/ui/vite-middleware.ts
+++ b/src/dev-dashboard/ui/vite-middleware.ts
@@ -29,14 +29,14 @@ import { listVault, readNote } from "@app/dev-dashboard/lib/obsidian/reader";
 import { renderSharePage } from "@app/dev-dashboard/lib/obsidian/share-template";
 import { createQaStream, todayLogFile } from "@app/dev-dashboard/lib/qa-sse";
 import { configureRetention, getCachedPulse, getSeries, startPulsePolling } from "@app/dev-dashboard/lib/system/poller";
-import { getAudioLibrary } from "@app/utils/audio/library";
-import { resolveSoundBuffer } from "@app/utils/audio/runner.server";
 import { addTodo, completeTodo, deleteTodo, listTodos } from "@app/dev-dashboard/lib/todos/service";
 import { killTtyd, listTtyd, renameTtyd, spawnTtyd } from "@app/dev-dashboard/lib/ttyd/manager";
 import { fetchWeather } from "@app/dev-dashboard/lib/weather/client";
 import logger from "@app/logger";
 import { defaultDbPath } from "@app/question/commands/log";
 import { openReadModel, queryEntries } from "@app/question/lib/read-model";
+import { getAudioLibrary } from "@app/utils/audio/library";
+import { resolveSoundBuffer } from "@app/utils/audio/runner.server";
 import { SafeJSON } from "@app/utils/json";
 import type { Connect } from "vite";
 

--- a/src/question/commands/config.ts
+++ b/src/question/commands/config.ts
@@ -55,11 +55,21 @@ export function registerConfigCommand(program: Command): void {
                     next = saveConfig({ soundVolume: Math.max(0, Math.min(1, o.soundVolume)) });
                 }
 
-                if (o.notify === "on" || o.notify === "off") {
+                if (o.notify !== undefined) {
+                    if (o.notify !== "on" && o.notify !== "off") {
+                        process.stderr.write(`error: --notify expects on|off, got '${o.notify}'\n`);
+                        process.exit(1);
+                    }
+
                     next = saveConfig({ sinks: { ...next.sinks, notify: o.notify === "on" } });
                 }
 
-                if (o.obsidian === "on" || o.obsidian === "off") {
+                if (o.obsidian !== undefined) {
+                    if (o.obsidian !== "on" && o.obsidian !== "off") {
+                        process.stderr.write(`error: --obsidian expects on|off, got '${o.obsidian}'\n`);
+                        process.exit(1);
+                    }
+
                     next = saveConfig({ sinks: { ...next.sinks, obsidian: o.obsidian === "on" } });
                 }
 

--- a/src/question/commands/config.ts
+++ b/src/question/commands/config.ts
@@ -16,6 +16,7 @@ export function registerConfigCommand(program: Command): void {
         .option("--sound [spec]", "synth:<preset> | bundled:<file> | custom:<path> | off")
         .option("--sound-volume <n>", "0..1", (v) => Number.parseFloat(v))
         .option("--notify <onoff>", "on|off")
+        .option("--obsidian <onoff>", "on|off")
         .option("--obsidian-vault <path>", "set the Obsidian vault override")
         .option("--list-sounds", "list every available sound (bundled + synth) and exit")
         .action(
@@ -23,6 +24,7 @@ export function registerConfigCommand(program: Command): void {
                 sound?: string | boolean;
                 soundVolume?: number;
                 notify?: string;
+                obsidian?: string;
                 obsidianVault?: string;
                 listSounds?: boolean;
             }) => {
@@ -55,6 +57,10 @@ export function registerConfigCommand(program: Command): void {
 
                 if (o.notify === "on" || o.notify === "off") {
                     next = saveConfig({ sinks: { ...next.sinks, notify: o.notify === "on" } });
+                }
+
+                if (o.obsidian === "on" || o.obsidian === "off") {
+                    next = saveConfig({ sinks: { ...next.sinks, obsidian: o.obsidian === "on" } });
                 }
 
                 if (o.obsidianVault) {

--- a/src/question/commands/log.ts
+++ b/src/question/commands/log.ts
@@ -3,15 +3,8 @@ import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
 import chalk from "chalk";
 import type { Command } from "commander";
+import { formatQaEntry } from "../lib/format";
 import { openReadModel, type QueryOpts, queryEntries } from "../lib/read-model";
-
-// chalk auto-detects stdout: full color on a TTY, no-ops when piped/redirected,
-// so the digest is colorful in a terminal and clean ANSI-free for `| tools json` etc.
-const TAG_TINT: Record<string, (s: string) => string> = {
-    question: chalk.bold.blue,
-    action: chalk.bold.yellow,
-    directive: chalk.bold.green,
-};
 
 export function defaultDbPath(): string {
     return join(homedir(), ".genesis-tools", "question", "qa.db");
@@ -25,15 +18,7 @@ export function renderDigest(opts: QueryOpts & { dbPath: string }): string {
             return chalk.dim("No questions recorded.");
         }
 
-        return rows
-            .map((r) => {
-                const when = new Date(r.ts).toISOString().slice(0, 16).replace("T", " ");
-                const tint = TAG_TINT[r.tag] ?? chalk.bold.gray;
-                const head = `${chalk.dim(when)}  ${chalk.cyan.bold(r.project)} ${chalk.dim("·")} ${chalk.magenta(r.branch ?? "-")}  ${tint(`[${r.tag}]`)}`;
-                const preview = chalk.yellow(r.answerMd.split("\n").slice(0, 3).join("\n"));
-                return `${head}\n${chalk.green("❯")} ${chalk.bold(r.question)}\n${preview}\n`;
-            })
-            .join("\n");
+        return rows.map(formatQaEntry).join("\n");
     } finally {
         db.close();
     }

--- a/src/question/commands/log.ts
+++ b/src/question/commands/log.ts
@@ -1,8 +1,17 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
+import chalk from "chalk";
 import type { Command } from "commander";
 import { openReadModel, type QueryOpts, queryEntries } from "../lib/read-model";
+
+// chalk auto-detects stdout: full color on a TTY, no-ops when piped/redirected,
+// so the digest is colorful in a terminal and clean ANSI-free for `| tools json` etc.
+const TAG_TINT: Record<string, (s: string) => string> = {
+    question: chalk.bold.blue,
+    action: chalk.bold.yellow,
+    directive: chalk.bold.green,
+};
 
 export function defaultDbPath(): string {
     return join(homedir(), ".genesis-tools", "question", "qa.db");
@@ -13,15 +22,16 @@ export function renderDigest(opts: QueryOpts & { dbPath: string }): string {
     try {
         const rows = queryEntries(db, opts);
         if (rows.length === 0) {
-            return "No questions recorded.";
+            return chalk.dim("No questions recorded.");
         }
 
         return rows
             .map((r) => {
                 const when = new Date(r.ts).toISOString().slice(0, 16).replace("T", " ");
-                const head = `${when}  ${r.project} · ${r.branch ?? "-"}  [${r.tag}]`;
-                const preview = r.answerMd.split("\n").slice(0, 3).join("\n");
-                return `${head}\n❯ ${r.question}\n${preview}\n`;
+                const tint = TAG_TINT[r.tag] ?? chalk.bold.gray;
+                const head = `${chalk.dim(when)}  ${chalk.cyan.bold(r.project)} ${chalk.dim("·")} ${chalk.magenta(r.branch ?? "-")}  ${tint(`[${r.tag}]`)}`;
+                const preview = chalk.gray(r.answerMd.split("\n").slice(0, 3).join("\n"));
+                return `${head}\n${chalk.green("❯")} ${chalk.bold(r.question)}\n${preview}\n`;
             })
             .join("\n");
     } finally {

--- a/src/question/commands/log.ts
+++ b/src/question/commands/log.ts
@@ -30,7 +30,7 @@ export function renderDigest(opts: QueryOpts & { dbPath: string }): string {
                 const when = new Date(r.ts).toISOString().slice(0, 16).replace("T", " ");
                 const tint = TAG_TINT[r.tag] ?? chalk.bold.gray;
                 const head = `${chalk.dim(when)}  ${chalk.cyan.bold(r.project)} ${chalk.dim("·")} ${chalk.magenta(r.branch ?? "-")}  ${tint(`[${r.tag}]`)}`;
-                const preview = chalk.gray(r.answerMd.split("\n").slice(0, 3).join("\n"));
+                const preview = chalk.yellow(r.answerMd.split("\n").slice(0, 3).join("\n"));
                 return `${head}\n${chalk.green("❯")} ${chalk.bold(r.question)}\n${preview}\n`;
             })
             .join("\n");

--- a/src/question/commands/log.ts
+++ b/src/question/commands/log.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
-import chalk from "chalk";
+import pc from "picocolors";
 import type { Command } from "commander";
 import { formatQaEntry } from "../lib/format";
 import { openReadModel, type QueryOpts, queryEntries } from "../lib/read-model";
@@ -15,7 +15,7 @@ export function renderDigest(opts: QueryOpts & { dbPath: string }): string {
     try {
         const rows = queryEntries(db, opts);
         if (rows.length === 0) {
-            return chalk.dim("No questions recorded.");
+            return pc.dim("No questions recorded.");
         }
 
         return rows.map(formatQaEntry).join("\n");

--- a/src/question/commands/log.ts
+++ b/src/question/commands/log.ts
@@ -1,8 +1,8 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
-import pc from "picocolors";
 import type { Command } from "commander";
+import pc from "picocolors";
 import { formatQaEntry } from "../lib/format";
 import { openReadModel, type QueryOpts, queryEntries } from "../lib/read-model";
 

--- a/src/question/commands/tail.ts
+++ b/src/question/commands/tail.ts
@@ -1,19 +1,33 @@
 import { FileTailer } from "@app/utils/fs/file-tailer";
+import chalk from "chalk";
 import type { Command } from "commander";
+import { formatQaEntry } from "../lib/format";
 import { logFilePathFor } from "../lib/log-store";
+import { openReadModel, queryEntries } from "../lib/read-model";
 import type { QaEntry } from "../lib/types";
+import { defaultDbPath } from "./log";
 
-function watchToday(): void {
+function watchToday(opts: { lines?: number }): void {
+    const backlog = opts.lines ?? 10;
+
+    // Backlog: last N entries oldest→newest (chronological, like `tail -f`),
+    // rendered identically to `tools question log` via the shared formatter.
+    if (backlog > 0) {
+        const db = openReadModel(defaultDbPath());
+        try {
+            const rows = queryEntries(db, { limit: backlog });
+            if (rows.length > 0) {
+                process.stdout.write(`${[...rows].reverse().map(formatQaEntry).join("\n")}\n`);
+            }
+        } finally {
+            db.close();
+        }
+    }
+
     const file = logFilePathFor({ ts: Date.now() });
-    process.stdout.write(`tailing ${file} (Ctrl-C to stop)\n`);
+    process.stdout.write(chalk.dim(`\n— live: tailing ${file} (Ctrl-C to stop) —\n`));
     const t = new FileTailer<QaEntry>(file, {
-        onLine: (e) => {
-            const when = new Date(e.ts).toISOString().slice(11, 16);
-            const preview = e.answerMd.split("\n").slice(0, 3).join("\n");
-            process.stdout.write(
-                `\n${when} ${e.project} · ${e.branch ?? "-"} [${e.tag}]\n❯ ${e.question}\n${preview}\n`
-            );
-        },
+        onLine: (e) => process.stdout.write(`\n${formatQaEntry(e)}`),
     });
     t.start();
     process.on("SIGINT", () => {
@@ -23,5 +37,12 @@ function watchToday(): void {
 }
 
 export function registerTailCommand(program: Command): void {
-    program.command("tail").alias("answers").description("Live feed of Q→A as they are recorded").action(watchToday);
+    program
+        .command("tail")
+        .alias("answers")
+        .description("Live feed of Q→A as they are recorded (with last-N backlog)")
+        .option("-n, --lines <n>", "show the last N entries before tailing (0 = none)", (v) =>
+            Number.parseInt(v, 10)
+        )
+        .action((o: { lines?: number }) => watchToday(o));
 }

--- a/src/question/commands/tail.ts
+++ b/src/question/commands/tail.ts
@@ -1,6 +1,6 @@
 import { FileTailer } from "@app/utils/fs/file-tailer";
-import pc from "picocolors";
 import type { Command } from "commander";
+import pc from "picocolors";
 import { formatQaEntry } from "../lib/format";
 import { logFilePathFor } from "../lib/log-store";
 import { openReadModel, queryEntries } from "../lib/read-model";

--- a/src/question/commands/tail.ts
+++ b/src/question/commands/tail.ts
@@ -41,8 +41,6 @@ export function registerTailCommand(program: Command): void {
         .command("tail")
         .alias("answers")
         .description("Live feed of Q→A as they are recorded (with last-N backlog)")
-        .option("-n, --lines <n>", "show the last N entries before tailing (0 = none)", (v) =>
-            Number.parseInt(v, 10)
-        )
+        .option("-n, --lines <n>", "show the last N entries before tailing (0 = none)", (v) => Number.parseInt(v, 10))
         .action((o: { lines?: number }) => watchToday(o));
 }

--- a/src/question/commands/tail.ts
+++ b/src/question/commands/tail.ts
@@ -1,5 +1,5 @@
 import { FileTailer } from "@app/utils/fs/file-tailer";
-import chalk from "chalk";
+import pc from "picocolors";
 import type { Command } from "commander";
 import { formatQaEntry } from "../lib/format";
 import { logFilePathFor } from "../lib/log-store";
@@ -25,7 +25,7 @@ function watchToday(opts: { lines?: number }): void {
     }
 
     const file = logFilePathFor({ ts: Date.now() });
-    process.stdout.write(chalk.dim(`\n— live: tailing ${file} (Ctrl-C to stop) —\n`));
+    process.stdout.write(pc.dim(`\n— live: tailing ${file} (Ctrl-C to stop) —\n`));
     const t = new FileTailer<QaEntry>(file, {
         onLine: (e) => process.stdout.write(`\n${formatQaEntry(e)}`),
     });

--- a/src/question/lib/format.ts
+++ b/src/question/lib/format.ts
@@ -10,10 +10,7 @@ const TAG_TINT: Record<string, (s: string) => string> = {
     directive: (s) => pc.bold(pc.green(s)),
 };
 
-type FormattableEntry = Pick<
-    QaEntry,
-    "ts" | "project" | "branch" | "tag" | "question" | "answerMd" | "sessionId"
->;
+type FormattableEntry = Pick<QaEntry, "ts" | "project" | "branch" | "tag" | "question" | "answerMd" | "sessionId">;
 
 /**
  * Single source of truth for one Q→A entry's terminal rendering. Used by both

--- a/src/question/lib/format.ts
+++ b/src/question/lib/format.ts
@@ -1,12 +1,13 @@
-import chalk from "chalk";
+import pc from "picocolors";
 import type { QaEntry } from "./types";
 
-// chalk auto-detects stdout: full color on a TTY, no-ops when piped/redirected,
-// so digests are colorful in a terminal and clean ANSI-free for `| tools json`.
+// picocolors (the codebase convention over chalk) auto-detects stdout: full
+// color on a TTY, no-ops when piped/redirected — colorful in a terminal,
+// clean ANSI-free for `| tools json`.
 const TAG_TINT: Record<string, (s: string) => string> = {
-    question: chalk.bold.blue,
-    action: chalk.bold.yellow,
-    directive: chalk.bold.green,
+    question: (s) => pc.bold(pc.blue(s)),
+    action: (s) => pc.bold(pc.yellow(s)),
+    directive: (s) => pc.bold(pc.green(s)),
 };
 
 type FormattableEntry = Pick<
@@ -21,10 +22,10 @@ type FormattableEntry = Pick<
  */
 export function formatQaEntry(e: FormattableEntry): string {
     const when = new Date(e.ts).toISOString().slice(0, 16).replace("T", " ");
-    const tint = TAG_TINT[e.tag] ?? chalk.bold.gray;
-    const head = `${chalk.dim(when)}  ${chalk.cyan.bold(e.project)} ${chalk.dim("·")} ${chalk.magenta(e.branch ?? "-")}  ${tint(`[${e.tag}]`)}`;
-    const preview = chalk.yellow(e.answerMd.split("\n").slice(0, 3).join("\n"));
+    const tint = TAG_TINT[e.tag] ?? ((s: string) => pc.bold(pc.gray(s)));
+    const head = `${pc.dim(when)}  ${pc.bold(pc.cyan(e.project))} ${pc.dim("·")} ${pc.magenta(e.branch ?? "-")}  ${tint(`[${e.tag}]`)}`;
+    const preview = pc.yellow(e.answerMd.split("\n").slice(0, 3).join("\n"));
     const sid = e.sessionId && e.sessionId !== "unknown" ? e.sessionId.slice(0, 8) : null;
-    const resume = sid ? chalk.dim(`  ↩ ${sid} · tools claude resume ${sid}\n`) : "";
-    return `${head}\n${chalk.green("❯")} ${chalk.bold(e.question)}\n${preview}\n${resume}`;
+    const resume = sid ? pc.dim(`  ↩ ${sid} · tools claude resume ${sid}\n`) : "";
+    return `${head}\n${pc.green("❯")} ${pc.bold(e.question)}\n${preview}\n${resume}`;
 }

--- a/src/question/lib/format.ts
+++ b/src/question/lib/format.ts
@@ -9,7 +9,10 @@ const TAG_TINT: Record<string, (s: string) => string> = {
     directive: chalk.bold.green,
 };
 
-type FormattableEntry = Pick<QaEntry, "ts" | "project" | "branch" | "tag" | "question" | "answerMd">;
+type FormattableEntry = Pick<
+    QaEntry,
+    "ts" | "project" | "branch" | "tag" | "question" | "answerMd" | "sessionId"
+>;
 
 /**
  * Single source of truth for one Q→A entry's terminal rendering. Used by both
@@ -21,5 +24,7 @@ export function formatQaEntry(e: FormattableEntry): string {
     const tint = TAG_TINT[e.tag] ?? chalk.bold.gray;
     const head = `${chalk.dim(when)}  ${chalk.cyan.bold(e.project)} ${chalk.dim("·")} ${chalk.magenta(e.branch ?? "-")}  ${tint(`[${e.tag}]`)}`;
     const preview = chalk.yellow(e.answerMd.split("\n").slice(0, 3).join("\n"));
-    return `${head}\n${chalk.green("❯")} ${chalk.bold(e.question)}\n${preview}\n`;
+    const sid = e.sessionId && e.sessionId !== "unknown" ? e.sessionId.slice(0, 8) : null;
+    const resume = sid ? chalk.dim(`  ↩ ${sid} · tools claude resume ${sid}\n`) : "";
+    return `${head}\n${chalk.green("❯")} ${chalk.bold(e.question)}\n${preview}\n${resume}`;
 }

--- a/src/question/lib/format.ts
+++ b/src/question/lib/format.ts
@@ -1,0 +1,25 @@
+import chalk from "chalk";
+import type { QaEntry } from "./types";
+
+// chalk auto-detects stdout: full color on a TTY, no-ops when piped/redirected,
+// so digests are colorful in a terminal and clean ANSI-free for `| tools json`.
+const TAG_TINT: Record<string, (s: string) => string> = {
+    question: chalk.bold.blue,
+    action: chalk.bold.yellow,
+    directive: chalk.bold.green,
+};
+
+type FormattableEntry = Pick<QaEntry, "ts" | "project" | "branch" | "tag" | "question" | "answerMd">;
+
+/**
+ * Single source of truth for one Q→A entry's terminal rendering. Used by both
+ * `tools question log` (newest-first digest) and `tools question tail` (live
+ * feed) so they are visually identical per entry.
+ */
+export function formatQaEntry(e: FormattableEntry): string {
+    const when = new Date(e.ts).toISOString().slice(0, 16).replace("T", " ");
+    const tint = TAG_TINT[e.tag] ?? chalk.bold.gray;
+    const head = `${chalk.dim(when)}  ${chalk.cyan.bold(e.project)} ${chalk.dim("·")} ${chalk.magenta(e.branch ?? "-")}  ${tint(`[${e.tag}]`)}`;
+    const preview = chalk.yellow(e.answerMd.split("\n").slice(0, 3).join("\n"));
+    return `${head}\n${chalk.green("❯")} ${chalk.bold(e.question)}\n${preview}\n`;
+}

--- a/src/question/lib/sinks/notification.ts
+++ b/src/question/lib/sinks/notification.ts
@@ -4,13 +4,18 @@ import { registerSink, type Sink } from "./registry-exports";
 
 export function formatNotification(e: QaEntry): { title: string; message: string } {
     return {
-        title: `${e.project} · ${e.tag}`,
+        // Same header shape as `tools question log`/`tail`: project · branch [tag].
+        title: `${e.project} · ${e.branch ?? "-"} [${e.tag}]`,
         message: `❯ ${e.question}\n\n${e.answerMd}`,
     };
 }
 
 export const notificationSink: Sink = {
     name: "notification",
+    // Telegram = cold `await import(@app/telegram-bot)` + HTTP; the 2s default
+    // fan-out budget gets truncated by the CLI's process.exit(0) before the
+    // send completes (system banner is fast, telegram isn't). Give it room.
+    timeoutMs: 9000,
     isEnabled: (c) => c.sinks.notify,
     emit: async (entry) => {
         const { title, message } = formatNotification(entry);

--- a/src/question/lib/sinks/registry.ts
+++ b/src/question/lib/sinks/registry.ts
@@ -38,7 +38,7 @@ export async function runFanOut(
     });
     return Promise.all(
         enabled.map(async (s): Promise<SinkResult> => {
-            const t = timeout(timeoutMs);
+            const t = timeout(s.timeoutMs ?? timeoutMs);
             try {
                 await Promise.race([Promise.resolve(s.emit(entry, config)), t.promise]);
                 return { name: s.name, ok: true };

--- a/src/question/lib/sinks/types.ts
+++ b/src/question/lib/sinks/types.ts
@@ -15,6 +15,10 @@ export interface Sink {
     name: string;
     isEnabled(config: QuestionConfig): boolean;
     emit(entry: QaEntry, config: QuestionConfig): Promise<void> | void;
+    /** Optional per-sink fan-out budget (ms). Network sinks (Telegram does a
+     *  cold dynamic import + HTTP) need more than the 2s default or they get
+     *  cut off by process.exit(0) before delivery. */
+    timeoutMs?: number;
 }
 
 // SinkResult is defined once, canonically, in ../types (Task 2 — RecordResult.sinks uses it).

--- a/src/utils/agent-runtime.ts
+++ b/src/utils/agent-runtime.ts
@@ -53,8 +53,7 @@ export function getAgentRuntimeContext(
         project: detectCurrentProject() ?? basename(repoRoot),
         repoRoot,
         cwd,
-        isWorktree:
-            gitDir != null && gitCommonDir != null && resolve(cwd, gitDir) !== resolve(cwd, gitCommonDir),
+        isWorktree: gitDir != null && gitCommonDir != null && resolve(cwd, gitDir) !== resolve(cwd, gitCommonDir),
         worktreePath: null,
         branch: gitSync(["rev-parse", "--abbrev-ref", "HEAD"], cwd),
         commitSha: gitSync(["rev-parse", "--short", "HEAD"], cwd),

--- a/src/utils/audio/library.ts
+++ b/src/utils/audio/library.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { type BundledSound, BUNDLED_SOUNDS } from "./assets/manifest";
+import { BUNDLED_SOUNDS, type BundledSound } from "./assets/manifest";
 import { DING_PRESETS } from "./ding-presets";
 import type { SoundChoice } from "./runner.server";
 
@@ -57,9 +57,7 @@ export function getAudioLibrary(): AudioLibrary {
     return { bundled, synth, default: def };
 }
 
-export type ParseSoundResult =
-    | { ok: true; sound?: SoundChoice; enabled: boolean }
-    | { ok: false; error: string };
+export type ParseSoundResult = { ok: true; sound?: SoundChoice; enabled: boolean } | { ok: false; error: string };
 
 /**
  * Parse a `--sound` / dashboard spec into a validated `SoundChoice`.
@@ -112,9 +110,7 @@ export function parseSoundSpec(spec: string): ParseSoundResult {
 /** Human-readable list of every available sound (for `--list-sounds` / errors). */
 export function formatAudioLibrary(): string {
     const lib = getAudioLibrary();
-    const bundled = lib.bundled
-        .map((e) => `  ${e.id}${e.isDefault ? "  (default)" : ""}  — ${e.label}`)
-        .join("\n");
+    const bundled = lib.bundled.map((e) => `  ${e.id}${e.isDefault ? "  (default)" : ""}  — ${e.label}`).join("\n");
     const synth = lib.synth.map((e) => `  ${e.id}  — ${e.label}`).join("\n");
     return `Available sounds:\n\nBundled (Kenney CC0):\n${bundled}\n\nSynth presets:\n${synth}\n\nAlso valid:  custom:/abs/path.wav  |  off`;
 }


### PR DESCRIPTION
## What
Colorize the `tools question log` digest.

## Why
The 'colorful design' only ever applied to the dev-dashboard `/qa` web route. The CLI `renderDigest` shipped as plain text from day one — colorless in the terminal while the web view got all the styling. This closes that gap.

## How
- `chalk`: dim timestamp · cyan-bold project · magenta branch · tag chip tinted by type (question=blue, action=yellow, directive=green) · green `❯` · bold question · gray answer
- chalk auto-detects stdout → full color on a TTY, ANSI-free when piped (so `--format json`, `| tools json`, and the existing tests are unaffected)

## Verify
- tsgo clean; `bun test src/question/commands/log.test.ts` → 2 pass (chalk no-ops in non-TTY, plain-string assertions still hold)
- `FORCE_COLOR=3 tools question log` → ANSI confirmed present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared terminal formatter for consistent, colorful Q→A digests.

* **Enhancements**
  * Log and tail views use the shared formatter; empty-state shown in dim style.
  * Tail command accepts a backlog option to show last N entries before live tailing; live output prefaced with a dim "live" header.
  * JSON export unchanged.

* **Configuration**
  * Added an --obsidian on|off option to config command.

* **Notifications**
  * Notification titles now include project · branch [tag]; notification timeout increased and per-sink timeout support added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->