### PR TITLE
feat(dev-dashboard): restart detaches to background instead of holding the terminal

### DIFF
--- a/src/dev-dashboard/index.ts
+++ b/src/dev-dashboard/index.ts
@@ -8,6 +8,7 @@ import { startFrontProxy } from "@app/dev-dashboard/lib/front-proxy";
 import { findFreePort } from "@app/dev-dashboard/lib/ttyd/free-port";
 import logger from "@app/logger";
 import { PROJECT_ROOT } from "@app/utils/paths";
+import { stripAnsi } from "@app/utils/string";
 import { Command } from "commander";
 
 const program = new Command()
@@ -253,7 +254,12 @@ program
             shell: process.platform === "win32",
         });
 
-        const READY = /ready in \d+\s*ms|Local:\s+http|press h \+ enter/i;
+        // Match against ANSI-stripped, ACCUMULATED output: with FORCE_COLOR the
+        // banner is colored (`Local\x1b[22m:`) and arrives split across stdout
+        // chunks, so a per-raw-chunk test never matched and we always hit the
+        // 30s fallback. Accumulate + strip first.
+        const READY = /ready in \d+\s*m?s|Local:\s*http|localhost:\d+|press h \+ enter/i;
+        let acc = "";
         let settled = false;
 
         const finish = (note: string): void => {
@@ -274,7 +280,8 @@ program
         const onChunk = (buf: Buffer): void => {
             const text = buf.toString();
             process.stdout.write(text);
-            if (READY.test(text)) {
+            acc += stripAnsi(text);
+            if (READY.test(acc)) {
                 finish("✓ dev-dashboard is up.");
             }
         };

--- a/src/dev-dashboard/index.ts
+++ b/src/dev-dashboard/index.ts
@@ -119,10 +119,26 @@ async function runUiServer(): Promise<void> {
         killChild();
     });
 
-    setTimeout(() => {
+    // Open the browser only AFTER Vite is actually serving — the page load is
+    // what triggers /api/ttyd/spawn, so a blind 2s timer opened it before Vite
+    // was up and the proxy spammed ECONNREFUSED for Vite + the just-spawned
+    // ttyd. Poll the internal Vite port; ttyd is now effectively deferred until
+    // Vite is ready (no extra ttyd-lifecycle changes needed).
+    void (async () => {
+        const deadline = Date.now() + 20_000;
+        const internalUrl = `http://127.0.0.1:${internalPort}/`;
+        while (Date.now() < deadline) {
+            try {
+                await fetch(internalUrl, { signal: AbortSignal.timeout(1000) });
+                break; // any response (even 404) means Vite is listening
+            } catch {
+                await new Promise((r) => setTimeout(r, 250));
+            }
+        }
+
         // Best-effort browser open. Detached spawns have no "error" listener by
         // default; an unhandled "error" (opener binary missing) would crash the
-        // dashboard ~2s post-startup, so swallow it.
+        // dashboard, so swallow it.
         const [cmd, args] =
             process.platform === "darwin"
                 ? (["open", [url]] as const)
@@ -132,7 +148,7 @@ async function runUiServer(): Promise<void> {
         const opener = spawn(cmd, args, { stdio: "ignore", detached: true });
         opener.on("error", (err) => logger.debug({ err, cmd }, "failed to auto-open browser"));
         opener.unref();
-    }, 2000);
+    })();
 
     const exitCode: number = await new Promise((resolveExit) => {
         child.on("exit", (code) => resolveExit(code ?? 1));

--- a/src/dev-dashboard/index.ts
+++ b/src/dev-dashboard/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { closeSync, existsSync, mkdirSync, openSync, readSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { getConfig, saveConfig } from "@app/dev-dashboard/config";
 import { createBasicAuthCredentials } from "@app/dev-dashboard/lib/auth";
 import { startFrontProxy } from "@app/dev-dashboard/lib/front-proxy";
@@ -131,7 +132,8 @@ async function runUiServer(): Promise<void> {
             try {
                 await fetch(internalUrl, { signal: AbortSignal.timeout(1000) });
                 break; // any response (even 404) means Vite is listening
-            } catch {
+            } catch (err) {
+                logger.debug({ err, internalUrl }, "vite readiness probe retry (not up yet)");
                 await new Promise((r) => setTimeout(r, 250));
             }
         }
@@ -258,25 +260,31 @@ program
         await stopRunningDashboard(port);
 
         const url = `http://localhost:${port}`;
-        // Daemonize: the UI is Vite + an in-process front-proxy, so we can't
-        // just background Vite — we re-spawn the whole `dev-dashboard ui`
-        // command detached, echo its output until it's ready, then exit and
-        // leave it running (unlike `ui`, which stays foreground).
-        const child = spawn("tools", ["dev-dashboard", "ui"], {
+        const logFile = join(homedir(), ".genesis-tools", "logs", "dev-dashboard.bg.log");
+        mkdirSync(dirname(logFile), { recursive: true });
+        const logFd = openSync(logFile, "a");
+
+        // Daemonize: the UI is Vite + an in-process front-proxy. Re-invoke THIS
+        // script via process.execPath + argv[1] so it works even when `tools`
+        // isn't on PATH (t2). Child stdout/stderr go to a LOG FILE, not pipes —
+        // the inherited fd stays valid after we exit, so the backgrounded Vite
+        // never hits EPIPE/SIGPIPE on parent exit (t1). We tail the file for
+        // readiness; output to a file is also already ANSI-free.
+        const child = spawn(process.execPath, [process.argv[1], "ui"], {
             cwd: PROJECT_ROOT,
             detached: true,
-            stdio: ["ignore", "pipe", "pipe"],
-            env: { ...process.env, FORCE_COLOR: "1" },
-            shell: process.platform === "win32",
+            stdio: ["ignore", logFd, logFd],
+            env: process.env,
         });
+        closeSync(logFd); // the child holds its own dup'd fd now
 
-        // Match against ANSI-stripped, ACCUMULATED output: with FORCE_COLOR the
-        // banner is colored (`Local\x1b[22m:`) and arrives split across stdout
-        // chunks, so a per-raw-chunk test never matched and we always hit the
-        // 30s fallback. Accumulate + strip first.
         const READY = /ready in \d+\s*m?s|Local:\s*http|localhost:\d+|press h \+ enter/i;
-        let acc = "";
+        const isTty = Boolean(process.stdout.isTTY);
         let settled = false;
+        let pos = 0;
+        let acc = "";
+        let poll: ReturnType<typeof setInterval> | undefined;
+        let deadline: ReturnType<typeof setTimeout> | undefined;
 
         const finish = (note: string): void => {
             if (settled) {
@@ -284,40 +292,75 @@ program
             }
 
             settled = true;
+            if (poll) {
+                clearInterval(poll);
+            }
+
+            if (deadline) {
+                clearTimeout(deadline);
+            }
+
             console.log(`\n${note}`);
             console.log(`dev-dashboard running in background → ${url}  (pid ${child.pid})`);
-            console.log(`stop it with: tools dev-dashboard restart   (or kill ${child.pid})`);
-            child.stdout?.removeAllListeners();
-            child.stderr?.removeAllListeners();
+            console.log(`logs → ${logFile}`);
+            console.log(`stop it with: kill ${child.pid}  (\`tools dev-dashboard restart\` relaunches a new one)`);
             child.unref();
             process.exit(0);
         };
 
-        const onChunk = (buf: Buffer): void => {
-            const text = buf.toString();
-            process.stdout.write(text);
-            acc += stripAnsi(text);
-            if (READY.test(acc)) {
-                finish("✓ dev-dashboard is up.");
+        // Tail the child's log file; echo new bytes (strip ANSI when our stdout
+        // isn't a TTY — t6) and match the accumulated stripped text (t3).
+        const drain = (): void => {
+            let size: number;
+            try {
+                size = statSync(logFile).size;
+            } catch {
+                return;
+            }
+
+            if (size <= pos) {
+                return;
+            }
+
+            const fd = openSync(logFile, "r");
+            try {
+                const buf = Buffer.alloc(size - pos);
+                const read = readSync(fd, buf, 0, buf.length, pos);
+                pos += read;
+                const chunk = buf.subarray(0, read).toString();
+                process.stdout.write(isTty ? chunk : stripAnsi(chunk));
+                acc += stripAnsi(chunk);
+                if (acc.length > 4000) {
+                    acc = acc.slice(-2000);
+                }
+
+                if (READY.test(acc)) {
+                    finish("✓ dev-dashboard is up.");
+                }
+            } finally {
+                closeSync(fd);
             }
         };
 
-        child.stdout?.on("data", onChunk);
-        child.stderr?.on("data", onChunk);
         child.on("error", (err) => {
             console.error(`Failed to launch dev-dashboard: ${err.message}`);
             process.exit(1);
         });
         child.on("exit", (code) => {
             if (!settled) {
-                console.error(`dev-dashboard exited before becoming ready (code ${code ?? "?"})`);
+                drain();
+                console.error(`dev-dashboard exited before becoming ready (code ${code ?? "?"}) — see ${logFile}`);
                 process.exit(code ?? 1);
             }
         });
 
-        // Safety net: if the ready marker never matches, still detach and exit
+        poll = setInterval(drain, 150);
+        // Safety net: detach + exit even if the ready marker never matches,
         // rather than holding the terminal forever.
-        setTimeout(() => finish("⚠ ready marker not seen in 30s — detaching anyway; check the URL."), 30_000);
+        deadline = setTimeout(
+            () => finish("⚠ ready marker not seen in 30s — detaching anyway; check the URL."),
+            30_000
+        );
     });
 
 const auth = program.command("auth").description("Manage dev-dashboard Basic Auth");

--- a/src/dev-dashboard/index.ts
+++ b/src/dev-dashboard/index.ts
@@ -235,11 +235,66 @@ program.command("ui").alias("dashboard").description("Launch the dev-dashboard w
 
 program
     .command("restart")
-    .description("Stop any running dev-dashboard instance, then launch the UI (same as `ui`)")
+    .description("Stop any running dev-dashboard, relaunch it detached in the background, then exit")
     .action(async () => {
         const { port } = await getConfig();
         await stopRunningDashboard(port);
-        await runUiServer();
+
+        const url = `http://localhost:${port}`;
+        // Daemonize: the UI is Vite + an in-process front-proxy, so we can't
+        // just background Vite — we re-spawn the whole `dev-dashboard ui`
+        // command detached, echo its output until it's ready, then exit and
+        // leave it running (unlike `ui`, which stays foreground).
+        const child = spawn("tools", ["dev-dashboard", "ui"], {
+            cwd: PROJECT_ROOT,
+            detached: true,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: { ...process.env, FORCE_COLOR: "1" },
+            shell: process.platform === "win32",
+        });
+
+        const READY = /ready in \d+\s*ms|Local:\s+http|press h \+ enter/i;
+        let settled = false;
+
+        const finish = (note: string): void => {
+            if (settled) {
+                return;
+            }
+
+            settled = true;
+            console.log(`\n${note}`);
+            console.log(`dev-dashboard running in background → ${url}  (pid ${child.pid})`);
+            console.log(`stop it with: tools dev-dashboard restart   (or kill ${child.pid})`);
+            child.stdout?.removeAllListeners();
+            child.stderr?.removeAllListeners();
+            child.unref();
+            process.exit(0);
+        };
+
+        const onChunk = (buf: Buffer): void => {
+            const text = buf.toString();
+            process.stdout.write(text);
+            if (READY.test(text)) {
+                finish("✓ dev-dashboard is up.");
+            }
+        };
+
+        child.stdout?.on("data", onChunk);
+        child.stderr?.on("data", onChunk);
+        child.on("error", (err) => {
+            console.error(`Failed to launch dev-dashboard: ${err.message}`);
+            process.exit(1);
+        });
+        child.on("exit", (code) => {
+            if (!settled) {
+                console.error(`dev-dashboard exited before becoming ready (code ${code ?? "?"})`);
+                process.exit(code ?? 1);
+            }
+        });
+
+        // Safety net: if the ready marker never matches, still detach and exit
+        // rather than holding the terminal forever.
+        setTimeout(() => finish("⚠ ready marker not seen in 30s — detaching anyway; check the URL."), 30_000);
     });
 
 const auth = program.command("auth").description("Manage dev-dashboard Basic Auth");

--- a/src/dev-dashboard/lib/front-proxy.ts
+++ b/src/dev-dashboard/lib/front-proxy.ts
@@ -221,7 +221,13 @@ export function startFrontProxy(opts: { publicPort: number; internalPort: number
                     signal: AbortSignal.timeout(15_000),
                 });
             } catch (err) {
-                logger.warn({ err, httpTarget }, "front proxy: upstream fetch failed");
+                // A refused connection is almost always the benign startup race
+                // (upstream Vite/ttyd not listening yet) — log it at debug so it
+                // doesn't look like an error. A sustained real outage is still
+                // visible (the 502 below) and any non-refused failure stays warn.
+                const code = (err as { code?: string })?.code;
+                const refused = code === "ConnectionRefused" || code === "ECONNREFUSED";
+                logger[refused ? "debug" : "warn"]({ err, httpTarget }, "front proxy: upstream fetch failed");
                 return new Response("Bad Gateway: upstream unavailable", { status: 502 });
             }
 

--- a/src/dev-dashboard/ui/vite-middleware.ts
+++ b/src/dev-dashboard/ui/vite-middleware.ts
@@ -29,14 +29,14 @@ import { listVault, readNote } from "@app/dev-dashboard/lib/obsidian/reader";
 import { renderSharePage } from "@app/dev-dashboard/lib/obsidian/share-template";
 import { createQaStream, todayLogFile } from "@app/dev-dashboard/lib/qa-sse";
 import { configureRetention, getCachedPulse, getSeries, startPulsePolling } from "@app/dev-dashboard/lib/system/poller";
-import { getAudioLibrary } from "@app/utils/audio/library";
-import { resolveSoundBuffer } from "@app/utils/audio/runner.server";
 import { addTodo, completeTodo, deleteTodo, listTodos } from "@app/dev-dashboard/lib/todos/service";
 import { killTtyd, listTtyd, renameTtyd, spawnTtyd } from "@app/dev-dashboard/lib/ttyd/manager";
 import { fetchWeather } from "@app/dev-dashboard/lib/weather/client";
 import logger from "@app/logger";
 import { defaultDbPath } from "@app/question/commands/log";
 import { openReadModel, queryEntries } from "@app/question/lib/read-model";
+import { getAudioLibrary } from "@app/utils/audio/library";
+import { resolveSoundBuffer } from "@app/utils/audio/runner.server";
 import { SafeJSON } from "@app/utils/json";
 import type { Connect } from "vite";
 

--- a/src/utils/agent-runtime.ts
+++ b/src/utils/agent-runtime.ts
@@ -53,8 +53,7 @@ export function getAgentRuntimeContext(
         project: detectCurrentProject() ?? basename(repoRoot),
         repoRoot,
         cwd,
-        isWorktree:
-            gitDir != null && gitCommonDir != null && resolve(cwd, gitDir) !== resolve(cwd, gitCommonDir),
+        isWorktree: gitDir != null && gitCommonDir != null && resolve(cwd, gitDir) !== resolve(cwd, gitCommonDir),
         worktreePath: null,
         branch: gitSync(["rev-parse", "--abbrev-ref", "HEAD"], cwd),
         commitSha: gitSync(["rev-parse", "--short", "HEAD"], cwd),

--- a/src/utils/audio/library.ts
+++ b/src/utils/audio/library.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { type BundledSound, BUNDLED_SOUNDS } from "./assets/manifest";
+import { BUNDLED_SOUNDS, type BundledSound } from "./assets/manifest";
 import { DING_PRESETS } from "./ding-presets";
 import type { SoundChoice } from "./runner.server";
 
@@ -57,9 +57,7 @@ export function getAudioLibrary(): AudioLibrary {
     return { bundled, synth, default: def };
 }
 
-export type ParseSoundResult =
-    | { ok: true; sound?: SoundChoice; enabled: boolean }
-    | { ok: false; error: string };
+export type ParseSoundResult = { ok: true; sound?: SoundChoice; enabled: boolean } | { ok: false; error: string };
 
 /**
  * Parse a `--sound` / dashboard spec into a validated `SoundChoice`.
@@ -112,9 +110,7 @@ export function parseSoundSpec(spec: string): ParseSoundResult {
 /** Human-readable list of every available sound (for `--list-sounds` / errors). */
 export function formatAudioLibrary(): string {
     const lib = getAudioLibrary();
-    const bundled = lib.bundled
-        .map((e) => `  ${e.id}${e.isDefault ? "  (default)" : ""}  — ${e.label}`)
-        .join("\n");
+    const bundled = lib.bundled.map((e) => `  ${e.id}${e.isDefault ? "  (default)" : ""}  — ${e.label}`).join("\n");
     const synth = lib.synth.map((e) => `  ${e.id}  — ${e.label}`).join("\n");
     return `Available sounds:\n\nBundled (Kenney CC0):\n${bundled}\n\nSynth presets:\n${synth}\n\nAlso valid:  custom:/abs/path.wav  |  off`;
 }


### PR DESCRIPTION
## What
`tools dev-dashboard restart` now **detaches and exits**, leaving the server running in the background — instead of holding the terminal on the Vite ready banner forever.

## Why
`restart` called `runUiServer()` in the foreground (same as `ui`), so it never returned — you were stuck on:
```
  VITE v8.0.3  ready in 400 ms
  ➜  Local:   http://127.0.0.1:…/
```

## How
- Spawns `tools dev-dashboard ui` **detached** (the UI is Vite + an in-process front-proxy, so the whole command must daemonize, not just Vite)
- Pipes + echoes its output until the ready marker (`ready in Nms` / `Local:` / `press h + enter`), then prints URL + pid, `unref()`s, `exit(0)`
- 30s safety net: detaches anyway if the marker never matches (never holds the terminal)
- `error` / early-`exit` surfaced with proper codes; `ui` unchanged (stays foreground)

## Note
tsgo clean. Not live-run in review (it would kill+relaunch a running dashboard); behavior verified by construction — test with `tools dev-dashboard restart`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restart now fails fast if the UI process errors or exits before becoming ready.
  * Reduced noisy warnings for temporary upstream connection refusals (logged at lower verbosity).

* **New Features**
  * Restart relaunches the UI as a detached background process while streaming live startup output to the terminal.
  * UI readiness is actively polled (browser opens only once ready); if not ready within 30s it detaches with a timeout notice.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->