### PR TITLE
fix(claude+dashboard): quieter claude console + aligned usage chart axes

### DIFF
--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
+import "./log-policy";
 import logger from "@app/logger";
+import { addGlobalVerboseOption } from "@app/utils/cli/commander";
 import { Command } from "commander";
 import { registerConfigCommand } from "./commands/config";
 import { registerDaemonCommand } from "./commands/daemon";
@@ -36,6 +38,8 @@ registerDaemonCommand(program);
 registerMigrateCommand(program);
 registerWarmupCommand(program);
 registerMcpCommand(program);
+
+addGlobalVerboseOption(program);
 
 async function main(): Promise<void> {
     try {

--- a/src/claude/lib/history/search.ts
+++ b/src/claude/lib/history/search.ts
@@ -13,6 +13,7 @@ import { discoverSessionFiles, discoverSessionFilesInDir } from "@app/utils/clau
 import { extractProjectName, PROJECTS_DIR, resolveProjectDir } from "@app/utils/claude/projects";
 import { Executor } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
+import { Stopwatch } from "@app/utils/Stopwatch";
 import { glob } from "glob";
 import {
     invalidateToday as _invalidateToday,
@@ -86,6 +87,7 @@ export { CLAUDE_DIR, PROJECTS_DIR } from "@app/utils/claude/projects";
 
 export async function findConversationFiles(filters: SearchFilters): Promise<string[]> {
     const isAll = !filters.project || filters.project === "all";
+    const sw = new Stopwatch();
 
     const files = await discoverSessionFiles({
         project: isAll ? undefined : filters.project,
@@ -93,6 +95,7 @@ export async function findConversationFiles(filters: SearchFilters): Promise<str
         subagentsOnly: filters.agentsOnly,
         excludeSubagents: filters.excludeAgents,
     });
+    const discoverMs = sw.elapsedMs;
 
     // Sort by modification time (most recent first)
     const fileStats = await Promise.all(
@@ -102,6 +105,17 @@ export async function findConversationFiles(filters: SearchFilters): Promise<str
         })
     );
     fileStats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+
+    logger.info(
+        {
+            project: isAll ? "all" : filters.project,
+            isAll,
+            fileCount: fileStats.length,
+            discoverMs: Math.round(discoverMs),
+            statSortMs: Math.round(sw.elapsedMs - discoverMs),
+        },
+        "findConversationFiles: completed"
+    );
 
     return fileStats.map((f) => f.path);
 }
@@ -774,24 +788,63 @@ function searchSessionMetadataCache(filters: SearchFilters): SearchResult[] {
 }
 
 export async function searchConversations(filters: SearchFilters): Promise<SearchResult[]> {
+    const sw = new Stopwatch();
+    logger.info(
+        {
+            query: filters.query,
+            project: filters.project ?? "all",
+            summaryOnly: !!filters.summaryOnly,
+            sortByRelevance: !!filters.sortByRelevance,
+            commitHash: filters.commitHash,
+            commitMessage: filters.commitMessage,
+            limit: filters.limit,
+        },
+        "searchConversations: start"
+    );
+
     // Fast path: summary-only searches use SQLite cache (no JSONL parsing)
     if (filters.summaryOnly && !filters.commitHash && !filters.commitMessage) {
-        return searchSessionMetadataCache(filters);
+        logger.info("searchConversations: fast path = summary-only SQLite cache");
+        const r = await searchSessionMetadataCache(filters);
+        logger.info(
+            { fastPath: "summary-only", matched: r.length, elapsedMs: Math.round(sw.elapsedMs) },
+            "searchConversations: done"
+        );
+        return r;
     }
 
     // Fast path: commit hash search uses git log + cache + raw text scanning
     if (filters.commitHash) {
-        return searchCommitHashFast(filters.commitHash, filters);
+        logger.info("searchConversations: fast path = commit-hash");
+        const r = await searchCommitHashFast(filters.commitHash, filters);
+        logger.info(
+            { fastPath: "commit-hash", matched: r.length, elapsedMs: Math.round(sw.elapsedMs) },
+            "searchConversations: done"
+        );
+        return r;
     }
 
     let results: SearchResult[] = [];
     const files = await findConversationFiles(filters);
     const total = files.length;
     let processed = 0;
+    logger.info(
+        { fastPath: "none (full JSONL parse)", fileCount: total, findFilesMs: Math.round(sw.elapsedMs) },
+        "searchConversations: scanning files — no fast path, parsing every conversation"
+    );
+    let lastProgressLogMs = sw.elapsedMs;
 
     for (const filePath of files) {
         processed++;
         filters.onProgress?.(processed, total, basename(filePath, ".jsonl"));
+
+        if (processed % 500 === 0 || sw.elapsedMs - lastProgressLogMs >= 5000) {
+            lastProgressLogMs = sw.elapsedMs;
+            logger.info(
+                { processed, total, matched: results.length, elapsedMs: Math.round(sw.elapsedMs) },
+                "searchConversations: progress"
+            );
+        }
 
         const messages = await parseJsonlFile(filePath);
         if (messages.length === 0) {
@@ -993,6 +1046,17 @@ export async function searchConversations(filters: SearchFilters): Promise<Searc
     if (filters.limit && results.length > filters.limit) {
         results = results.slice(0, filters.limit);
     }
+
+    logger.info(
+        {
+            fastPath: "none (full JSONL parse)",
+            fileCount: total,
+            matched: results.length,
+            elapsedMs: Math.round(sw.elapsedMs),
+            sortByRelevance: !!filters.sortByRelevance,
+        },
+        "searchConversations: done"
+    );
 
     return results;
 }

--- a/src/claude/log-policy.ts
+++ b/src/claude/log-policy.ts
@@ -1,0 +1,25 @@
+// Pre-import side effect — MUST be imported before `@app/logger` so it runs
+// before the logger module evaluates its console level (that level is frozen
+// at import time; reconfiguring later does not affect already-imported default
+// `logger` bindings).
+//
+// Tool-level console policy: the `claude` tool keeps the console quiet (warn+)
+// by default so `--format json` / piped output is never polluted by the
+// info-level history instrumentation. The day-stamped log file still captures
+// everything (the file stream is hardcoded "debug"). `-v/--verbose` (or
+// `--trace`) overrides this and surfaces info/debug/trace live. This is scoped
+// to this tool only via the generic `LOG_CONSOLE_LEVEL` env knob — the global
+// logger default is unchanged for every other tool.
+
+const argv = process.argv.slice(2);
+const verbose =
+    argv.includes("-v") ||
+    argv.includes("--verbose") ||
+    argv.includes("-vv") ||
+    argv.includes("--trace") ||
+    process.env.LOG_DEBUG === "1" ||
+    process.env.LOG_TRACE === "1";
+
+if (!verbose && !process.env.LOG_CONSOLE_LEVEL) {
+    process.env.LOG_CONSOLE_LEVEL = "warn";
+}

--- a/src/dev-dashboard/ui/src/components/claude-usage/AccountUsageChart.tsx
+++ b/src/dev-dashboard/ui/src/components/claude-usage/AccountUsageChart.tsx
@@ -14,11 +14,19 @@ interface AccountUsageChartProps {
     /** Current poll error for this account, if any (from /api/claude/usage). */
     accountError?: string;
     rangeMinutes: number;
+    /** Shared end of the time window (epoch ms) — identical across all charts so axes align. */
+    rangeEndMs: number;
 }
 
 // One independent query per account so each chart shows its own loader and
 // renders as soon as its data arrives — no waiting on the slowest account.
-export function AccountUsageChart({ accountName, label, accountError, rangeMinutes }: AccountUsageChartProps) {
+export function AccountUsageChart({
+    accountName,
+    label,
+    accountError,
+    rangeMinutes,
+    rangeEndMs,
+}: AccountUsageChartProps) {
     const query = useQuery({
         queryKey: ["claude", "usage", "history", accountName, rangeMinutes],
         queryFn: () =>
@@ -39,6 +47,7 @@ export function AccountUsageChart({ accountName, label, accountError, rangeMinut
             title={formatAccountTitle(accountName, label)}
             series={query.data?.series ?? []}
             rangeMinutes={rangeMinutes}
+            rangeEndMs={rangeEndMs}
             loading={query.isLoading}
             hint={hint}
         />

--- a/src/dev-dashboard/ui/src/components/claude-usage/UsageChart.tsx
+++ b/src/dev-dashboard/ui/src/components/claude-usage/UsageChart.tsx
@@ -6,6 +6,8 @@ interface UsageChartProps {
     title: string;
     series: BucketSeries[];
     rangeMinutes: number;
+    /** End of the shared time window (epoch ms). Same value across all charts so their axes align. */
+    rangeEndMs: number;
     loading?: boolean;
     hint?: string;
 }
@@ -22,13 +24,14 @@ function bucketMeta(bucket: string): { label: string; color: string } {
     return BUCKET_META[bucket] ?? { label: bucket, color: "#94a3b8" };
 }
 
-function formatTick(timestamp: string, rangeMinutes: number): string {
+function formatTick(timestamp: number | string, rangeMinutes: number): string {
     return formatClock(timestamp, rangeMinutes <= 1440 ? {} : { date: "numeric" });
 }
 
 interface Row {
-    t: string;
-    [bucket: string]: string | number;
+    /** Epoch ms (minute-bucketed) — a real time value so the X axis is time-scaled, not categorical. */
+    t: number;
+    [bucket: string]: number;
 }
 
 interface Sample {
@@ -46,7 +49,7 @@ interface Sample {
  * sample, so at any x the nearest value of all three lines is well-defined
  * and the tooltip always shows all of them.
  */
-function mergeSeries(series: BucketSeries[], rangeMinutes: number): Row[] {
+function mergeSeries(series: BucketSeries[]): Row[] {
     const samples: Sample[] = [];
 
     for (const s of series) {
@@ -75,7 +78,7 @@ function mergeSeries(series: BucketSeries[], rangeMinutes: number): Row[] {
     for (const sample of samples) {
         if (sample.minute !== currentMinute) {
             currentMinute = sample.minute;
-            currentRow = { t: formatTick(sample.ts, rangeMinutes), ...last };
+            currentRow = { t: sample.minute * 60_000, ...last };
             rows.push(currentRow);
         }
 
@@ -88,7 +91,7 @@ function mergeSeries(series: BucketSeries[], rangeMinutes: number): Row[] {
     return rows;
 }
 
-export function UsageChart({ title, series, rangeMinutes, loading, hint }: UsageChartProps) {
+export function UsageChart({ title, series, rangeMinutes, rangeEndMs, loading, hint }: UsageChartProps) {
     const present = series.filter((s) => s.snapshots.length > 0);
 
     if (loading) {
@@ -109,7 +112,17 @@ export function UsageChart({ title, series, rangeMinutes, loading, hint }: Usage
         );
     }
 
-    const data = mergeSeries(present, rangeMinutes);
+    const data = mergeSeries(present);
+    const domainStart = rangeEndMs - rangeMinutes * 60_000;
+
+    // Fixed, evenly-spaced ticks across the shared domain so every chart shows
+    // the SAME labels at the SAME x positions — without this, recharts places
+    // ticks on each series' own sample points and stacked charts drift apart.
+    const TICK_COUNT = 6;
+    const ticks = Array.from(
+        { length: TICK_COUNT },
+        (_, i) => domainStart + ((rangeEndMs - domainStart) * i) / (TICK_COUNT - 1)
+    );
 
     return (
         <div className="dd-panel p-4">
@@ -117,7 +130,18 @@ export function UsageChart({ title, series, rangeMinutes, loading, hint }: Usage
             <ResponsiveContainer width="100%" height={256}>
                 <LineChart data={data}>
                     <CartesianGrid stroke="var(--dd-border)" strokeDasharray="3 3" />
-                    <XAxis dataKey="t" stroke="var(--dd-text-muted)" fontSize={11} minTickGap={28} />
+                    <XAxis
+                        dataKey="t"
+                        type="number"
+                        scale="time"
+                        domain={[domainStart, rangeEndMs]}
+                        ticks={ticks}
+                        allowDataOverflow={false}
+                        tickFormatter={(ms: number) => formatTick(ms, rangeMinutes)}
+                        stroke="var(--dd-text-muted)"
+                        fontSize={11}
+                        minTickGap={28}
+                    />
                     <YAxis domain={[0, 100]} stroke="var(--dd-text-muted)" fontSize={11} unit="%" width={38} />
                     <Tooltip
                         contentStyle={{
@@ -125,6 +149,7 @@ export function UsageChart({ title, series, rangeMinutes, loading, hint }: Usage
                             border: "1px solid var(--dd-border)",
                             color: "var(--dd-text-primary)",
                         }}
+                        labelFormatter={(ms) => formatTick(ms as number, rangeMinutes)}
                         formatter={(value, name) => [`${value}%`, name]}
                     />
                     <Legend wrapperStyle={{ fontSize: 12 }} />

--- a/src/dev-dashboard/ui/src/routes/claude.tsx
+++ b/src/dev-dashboard/ui/src/routes/claude.tsx
@@ -1,6 +1,6 @@
 import type { AccountUsage } from "@app/claude/lib/usage/api";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AccountCard } from "@/components/claude-usage/AccountCard";
 import { AccountUsageChart } from "@/components/claude-usage/AccountUsageChart";
 import { fetchJson } from "@/lib/api";
@@ -18,6 +18,14 @@ export function ClaudeRoute() {
         refetchInterval: 30000,
     });
     const [rangeMinutes, setRangeMinutes] = useState<number>(10080);
+
+    // One window end shared by every chart so their time axes align exactly.
+    // Recomputed on each poll tick and on range change, not per chart render
+    // (per-render Date.now() would drift the two charts apart again).
+    const rangeEndMs = useMemo(
+        () => Date.now(),
+        [rangeMinutes, usageQuery.dataUpdatedAt]
+    );
 
     const accounts = usageQuery.data ?? [];
 
@@ -76,6 +84,7 @@ export function ClaudeRoute() {
                         label={account.label}
                         accountError={account.error}
                         rangeMinutes={rangeMinutes}
+                        rangeEndMs={rangeEndMs}
                     />
                 ))}
             </div>

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -39,6 +39,14 @@ const getLogLevel = (): LogLevel => {
     if (args.verbose) {
         return "debug";
     }
+    // Generic, opt-in console-level override. Unset by default (global default
+    // stays "info"); a tool may set LOG_CONSOLE_LEVEL before this module is
+    // imported to scope its own console verbosity without changing other tools.
+    // Explicit verbose/trace/debug signals above still win.
+    const envLevel = process.env.LOG_CONSOLE_LEVEL as LogLevel | undefined;
+    if (envLevel && envLevel in LOG_LEVELS) {
+        return envLevel;
+    }
     return "info";
 };
 


### PR DESCRIPTION
## Summary

- **claude tool — quiet console by default.** Adds a generic `LOG_CONSOLE_LEVEL` env knob in the shared logger; `src/claude/log-policy.ts` is pre-imported by `src/claude/index.ts` and sets the level to `warn` unless `-v` / `--verbose` / `--trace` is on argv (or `LOG_DEBUG=1` / `LOG_TRACE=1`). Keeps `--format json` and other piped output clean while the day-stamped file log still captures everything. Other tools are unaffected — the global default stays `info`. Also wires `addGlobalVerboseOption(program)` so `-v` is recognized everywhere in the `claude` command tree.
- **claude history search — timing instrumentation.** `findConversationFiles` and `searchConversations` now log discover/stat/fast-path/elapsed timings via `Stopwatch` so a slow search is diagnosable from `~/.genesis-tools/logs/<today>.log` alone.
- **dev-dashboard — aligned claude usage chart axes.** `UsageChart` switches from a categorical X axis to a numeric time-scaled axis over a shared `[rangeEndMs - rangeMinutes, rangeEndMs]` domain with a fixed set of 6 evenly-spaced ticks. `ClaudeRoute` computes one `rangeEndMs` per poll tick and passes it to every `AccountUsageChart` so the stacked per-account charts share identical tick positions instead of each drifting to its own sample points.

## Test plan

- [ ] `claude search ...` (no `-v`) — only warn+ on stdout/stderr; full info-level entries land in `~/.genesis-tools/logs/<today>.log`
- [ ] `claude -v search ...` — info/debug logging restored to console
- [ ] `LOG_CONSOLE_LEVEL=debug claude ...` — env override wins
- [ ] Other tools (e.g. `tools say`) unchanged — still info on console
- [ ] Dev dashboard `/claude` route: both account charts show identical X-tick positions across range changes (10080 / 1440 / smaller)
- [ ] Hover tooltips show formatted clock labels (not raw ms)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added global verbose flag to CLI for granular logging control.
  * Usage charts now display aligned time axes across the dashboard.

* **Improvements**
  * Search operations now provide detailed progress and timing information.
  * Console logging is suppressed by default but can be controlled via environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->