### PR TITLE
fix(notify+ai): stop leaking darwinkit Swift child per CLI invocation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@clack/prompts": "^1.0.0",
         "@crawlee/utils": "^3.16.0",
-        "@genesiscz/darwinkit": "0.7.4",
+        "@genesiscz/darwinkit": "0.7.5",
         "@gitbeaker/rest": "^43.5.0",
         "@hlidac-shopu/actors-common": "^3.2.5",
         "@hlidac-shopu/lib": "^1.5.3",
@@ -478,7 +478,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
-    "@genesiscz/darwinkit": ["@genesiscz/darwinkit@0.7.4", "", { "dependencies": { "tar": "^7.0.0" } }, "sha512-yfzSIsJjH5AOF+LKz4/YXPXD8u8xT9U4tfjdbSUMXVTXmVOyEeYhBFfTsAwmbdYtL8m2sNmgi4uwXGQH18boDg=="],
+    "@genesiscz/darwinkit": ["@genesiscz/darwinkit@0.7.5", "", { "dependencies": { "tar": "^7.0.0" } }, "sha512-2bMDALD7rbq8onG+1B66jHK8SgB4fYCpt7+QQYJa5rljzhRkXZ1PLRSdiNlk98soVwvwnmgNzssyKUni6ck5Tw=="],
 
     "@gitbeaker/core": ["@gitbeaker/core@43.5.0", "", { "dependencies": { "@gitbeaker/requester-utils": "^43.5.0", "qs": "^6.14.0", "xcase": "^2.0.1" } }, "sha512-Lfsl6DE/2RkFvpSEhMEnN6sNuY0IeR68UEQq2qzR0MkUF1RMCmOFlD3OydnT9yY+fkWjB4FPSG4SA/oBVZYTFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@clack/prompts": "^1.0.0",
         "@crawlee/utils": "^3.16.0",
-        "@genesiscz/darwinkit": "0.7.4",
+        "@genesiscz/darwinkit": "0.7.5",
         "@gitbeaker/rest": "^43.5.0",
         "@hlidac-shopu/actors-common": "^3.2.5",
         "@hlidac-shopu/lib": "^1.5.3",

--- a/src/dev-dashboard/ui/src/routes/claude.tsx
+++ b/src/dev-dashboard/ui/src/routes/claude.tsx
@@ -22,10 +22,7 @@ export function ClaudeRoute() {
     // One window end shared by every chart so their time axes align exactly.
     // Recomputed on each poll tick and on range change, not per chart render
     // (per-render Date.now() would drift the two charts apart again).
-    const rangeEndMs = useMemo(
-        () => Date.now(),
-        [rangeMinutes, usageQuery.dataUpdatedAt]
-    );
+    const rangeEndMs = useMemo(() => Date.now(), [rangeMinutes, usageQuery.dataUpdatedAt]);
 
     const accounts = usageQuery.data ?? [];
 

--- a/src/macos/lib/clones/orchestrator.ts
+++ b/src/macos/lib/clones/orchestrator.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { basename, dirname, relative, resolve } from "node:path";
 import logger from "@app/logger";
 import { formatBytes } from "@app/utils/format";
-import { type DiskUsage, freeDiskSpace, walkFiles, type WalkError } from "@app/utils/fs/disk-usage";
+import { type DiskUsage, freeDiskSpace, type WalkError, walkFiles } from "@app/utils/fs/disk-usage";
 import { getCloneId, getPrivateSize } from "@app/utils/macos/apfs";
 import { Stopwatch } from "@app/utils/Stopwatch";
 import { passesGlobs } from "./filters";
@@ -569,12 +569,11 @@ export function buildMeasureReport(args: BuildMeasureArgs): MeasureReport {
             continue;
         }
 
-        const { tree: rootMut, aggregate: u, privateUnknown: rootPrivateUnknown } = walkRoot(
-            root,
-            rootRecs,
-            args,
-            crossTree.sharedByPath
-        );
+        const {
+            tree: rootMut,
+            aggregate: u,
+            privateUnknown: rootPrivateUnknown,
+        } = walkRoot(root, rootRecs, args, crossTree.sharedByPath);
         totalsAgg.logical += u.logical;
         totalsAgg.allocated += u.allocated;
         totalsAgg.fileCount += u.fileCount;

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -311,6 +311,21 @@ async function main(): Promise<void> {
         const message = error instanceof Error ? error.message : String(error);
         p.log.error(message);
         process.exit(1);
+    } finally {
+        // sendViaDarwinKit() spawns a long-lived Swift child via the
+        // module-level singleton in @app/utils/macos/darwinkit. Without
+        // closeDarwinKit() here, the child's stdio pipes keep Node's event
+        // loop alive forever — a single `tools notify` invocation leaks
+        // both processes. Defense in depth alongside the SDK's unref() +
+        // exit reaper.
+        try {
+            const { closeDarwinKit, hasDarwinKit } = await import("@app/utils/macos");
+            if (hasDarwinKit()) {
+                closeDarwinKit();
+            }
+        } catch {
+            // DarwinKit not used in this invocation; ignore
+        }
     }
 }
 

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import logger from "@app/logger";
 import { isInteractive, suggestCommand } from "@app/utils/cli";
 import type { ChannelConfigs } from "@app/utils/notifications";
 import { dispatchNotification, notificationsConfig } from "@app/utils/notifications";
@@ -310,7 +311,10 @@ async function main(): Promise<void> {
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         p.log.error(message);
-        process.exit(1);
+        // Use exitCode rather than process.exit() so the finally block below
+        // runs and closes the DarwinKit child. process.exit() terminates
+        // synchronously and would skip finally — defeating the whole point.
+        process.exitCode = 1;
     } finally {
         // sendViaDarwinKit() spawns a long-lived Swift child via the
         // module-level singleton in @app/utils/macos/darwinkit. Without
@@ -323,8 +327,10 @@ async function main(): Promise<void> {
             if (hasDarwinKit()) {
                 closeDarwinKit();
             }
-        } catch {
-            // DarwinKit not used in this invocation; ignore
+        } catch (error) {
+            // Cleanup is best-effort; log so a real failure (e.g. SDK API
+            // change) is visible in debug output without breaking the CLI.
+            logger.debug(`DarwinKit cleanup skipped: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 }

--- a/src/utils/ai/LanguageDetector.ts
+++ b/src/utils/ai/LanguageDetector.ts
@@ -358,13 +358,12 @@ export class DarwinKitTextDriver implements TextLanguageDetectionDriver {
     readonly name = "darwinkit";
 
     async isAvailable(): Promise<boolean> {
-        try {
-            const { getDarwinKit } = await import("@app/utils/macos/darwinkit");
-            const dk = getDarwinKit();
-            return dk !== null;
-        } catch {
-            return false;
-        }
+        // Cheap, no-spawn availability check. The real DarwinKit handle is
+        // created lazily in detectFromText() via getDarwinKit(). Spawning a
+        // child here used to leak a darwinkit serve process every time the
+        // provider registry probed for available drivers — a common path
+        // for short-lived CLIs that never reached an actual detection call.
+        return process.platform === "darwin";
     }
 
     async detectFromText(text: string): Promise<LanguageDetectionResult> {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -90,7 +90,10 @@ export function formatDuration(value: number, unit: DurationUnit = "ms", style: 
         }
 
         default: {
-            const _exhaustive: never = style;
+            // Exhaustiveness check — if a new `style` is added without a case
+            // arm, `satisfies never` becomes a compile error here. No variable
+            // is allocated (dashboard tsconfig has noUnusedLocals: true).
+            style satisfies never;
             return `${ms}ms`;
         }
     }


### PR DESCRIPTION
## Summary

Stops `tools notify` / `tools say` (and any other consumer that uses `@app/utils/macos/darwinkit`) from leaking a stuck `bun` + `darwinkit serve` zombie pair on every invocation. Companion to https://github.com/genesiscz/darwinkit-swift/pull/17.

**Root cause on this side:** `src/notify/index.ts` calls `sendNotification` → `sendViaDarwinKit` → `getDarwinKit()` which spawns the Swift child via the module-level singleton, and `main()` returns without calling `closeDarwinKit()`. Combined with the SDK bug being fixed in PR #17 (no `unref()`), this left both the parent Node and the Swift child alive forever — accumulating dozens of zombies over a multi-day Claude Code session and ultimately triggering the macOS "Your system has run out of application memory" dialog.

## Changes

- `src/notify/index.ts` — `main()` `finally` block calls `closeDarwinKit()` if `hasDarwinKit()` (`d458019b7`)
- `src/utils/ai/LanguageDetector.ts` — `DarwinKitTextDriver.isAvailable()` returns `process.platform === "darwin"` instead of calling `getDarwinKit()`. The probe used to spawn a Swift child every time the provider registry checked availability, leaking even when the consumer never reached `detectFromText()`. Real spawn still happens lazily on first detection call. (`5f1a4b988`)

Plus two unrelated chores to keep CI green:
- `chore: biome safe-fix pre-existing format/import-sort lint errors` (`dd58ca411`) — two pre-existing biome violations on master that pre-push hook gates on
- `fix(utils/format): replace _exhaustive var with satisfies-never` (`c9af236e7`) — pre-existing TS6133 from `noUnusedLocals: true` under the dashboard tsconfig; `satisfies never` is the modern idiomatic exhaustiveness check

## Verification

Tested end-to-end with the SDK fix from genesiscz/darwinkit-swift#17 installed in `node_modules`:

| SDK | Consumer | Result |
|---|---|---|
| broken 0.7.4 | broken (master) | `bun notify "test"` hangs ≥ 8 s, leaks parent + child |
| **fixed (from PR #17)** | broken | exits ≤ 1 s, zero leak |
| **fixed** | **fixed (this PR)** | exits ≤ 1 s, zero leak (belt + suspenders) |

The SDK fix alone closes the leak. This PR is defense in depth and removes a redundant spawn in `LanguageDetector` that was leaking even on the new SDK if Node managed to exit before the unref'd handle was cleaned up.

## Test plan

- [x] `bun src/notify/index.ts "manual test" --title T` 5x in a row — zero accumulated `darwinkit serve` after 5s
- [x] `bun test src/utils/ai/LanguageDetector.test.ts` — 9 pass, 6 skip, 0 fail
- [x] `bun run typecheck:all` — clean
- [x] `bunx biome check .` — clean
- [ ] CI green
- [ ] After PR #17 ships as 0.7.5: bump `@genesiscz/darwinkit` dependency to 0.7.5 in a follow-up PR

## Notes

- Depends on https://github.com/genesiscz/darwinkit-swift/pull/17 landing first for the **full** fix, but the `closeDarwinKit()` change here is correct against the current 0.7.4 SDK as well.
- The two chore commits could be split into their own PR if you'd prefer; happy to do that. They were necessary to satisfy the pre-push hook on the current master state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary chart redraws by stabilizing time-axis recalculation.
  * Improved CLI shutdown to ensure cleanup runs and exit code is set reliably.

* **Chores**
  * Minor refactors and formatting improvements across macOS and utility code.
  * Simplified macOS availability checks to reduce startup overhead.
  * Bumped darwinkit dependency to v0.7.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->