### PR TITLE
feat(git): tools git commits — branch attribution, rebase dedup, markdown

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -4,7 +4,7 @@
 
 > **Git analysis for commits, authors, and workitem ID extraction.**
 
-Queries commits across a date range, extracts workitem IDs from commit messages via configurable regex patterns, and maintains a list of author identities so you can slice history cleanly across name/email changes.
+Queries commits across a date range, extracts workitem IDs from commit messages via configurable regex patterns, attributes branches, classifies rebased commits, and maintains a list of author identities so you can slice history cleanly across name/email changes.
 
 This is complementary to `git-commit` (which *creates* commits) and `git-last-commits-diff` (which *renders* diffs). `tools git commits` is the reporting layer.
 
@@ -19,8 +19,11 @@ tools git commits --from 2026-04-13 --to 2026-04-20
 # Include line-change stats and filter by author
 tools git commits --from 2026-04-01 --to 2026-04-30 --stat --author "Martin"
 
-# Emit JSON for piping / dashboards
-tools git commits --from 2026-04-01 --to 2026-04-30 --format json
+# Group by branch, include workitem titles from Azure DevOps cache
+tools git commits --from 2026-05-01 --to 2026-05-15 --group-by branch --with-workitem-title
+
+# Markdown for standup / Clarity paste
+tools git commits --from 2026-05-14 --to 2026-05-27 --markdown --clipboard
 
 # Configure authors interactively (pick from git history)
 tools git configure-authors
@@ -42,7 +45,7 @@ tools git configure-workitem-patterns --add 'col-(\d+)'
 
 ### `commits`
 
-Query commits by date range with optional workitem extraction.
+Query commits by date range with optional workitem extraction, branch attribution, and rebase handling.
 
 | Option | Description |
 |--------|-------------|
@@ -52,6 +55,21 @@ Query commits by date range with optional workitem extraction.
 | `--with-author <name>` | Append to configured authors (repeatable) |
 | `--format <json\|table>` | Output format (default: table) |
 | `--stat` | Include line-change stats |
+| `--group-by <day\|branch\|workitem\|none>` | Group main listing (default: `day`) |
+| `--without-branch` | Hide inline `[branch]` column (shown by default) |
+| `--without-workitem-id` | Hide inline `[#id]` column (shown by default) |
+| `--with-workitem-title` | Append Azure DevOps title after `#id` (cache-first) |
+| `--without-stashes` | Exclude `WIP on` / `index on` stash commits |
+| `--without-merges` | Exclude merge commits |
+| `--workitem <id>` | Filter to commits referencing workitem ID (repeatable, OR) |
+| `--include-rebases` | Expand rebased-into-range commits inline |
+| `--date <author\|commit\|true-first>` | Date used for grouping (default: `author`) |
+| `--markdown` | Markdown output (day headers, bullet list) |
+| `--clipboard` | Copy output to clipboard (`--markdown` recommended) |
+
+**Rebase behaviour:** `git log --after`/`--before` still filter by committer date. Commits authored before `--from` but committed inside the range appear in a compressed “rebased into this range” footer (or inline with `--include-rebases`). Patch-id dedup collapses cherry-pick/rebase duplicates (keeps newest committer date).
+
+**Default inline columns:** each row shows `[branch]` and `[#workitem]` when known. Trunk-only attribution is labelled `[trunk: develop]`.
 
 ### `configure-authors`
 
@@ -82,3 +100,19 @@ Manage regex patterns that extract workitem IDs (e.g. `DEV-1234`, `FEAT-42`) fro
 ## Storage
 
 Configuration lives at `~/.genesis-tools/git/config.json`.
+
+Example with branch attribution:
+
+```json
+{
+  "authors": ["you@example.com"],
+  "workitemPatterns": [ ... ],
+  "branchAttribution": {
+    "excludeTrunks": ["develop", "main", "master"]
+  }
+}
+```
+
+`branchAttribution.excludeTrunks` is optional; defaults to `develop`, `main`, and `master`. Names matching these (including `origin/<name>`) are skipped during branch resolution unless no other branch exists — then the trunk is shown as `[trunk: <name>]`.
+
+Workitem pattern tightening (e.g. `col-(\d{5,6})` instead of `col-(\d+)`) is per-user via `configure-workitem-patterns` or direct config edit; code defaults remain loose for other projects.

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -22,7 +22,7 @@ tools git commits --from 2026-04-01 --to 2026-04-30 --stat --author "Martin"
 # Group by branch, include workitem titles from Azure DevOps cache
 tools git commits --from 2026-05-01 --to 2026-05-15 --group-by branch --with-workitem-title
 
-# Markdown for standup / Clarity paste
+# markdown for standup / Clarity paste
 tools git commits --from 2026-05-14 --to 2026-05-27 --markdown --clipboard
 
 # Configure authors interactively (pick from git history)
@@ -64,7 +64,7 @@ Query commits by date range with optional workitem extraction, branch attributio
 | `--workitem <id>` | Filter to commits referencing workitem ID (repeatable, OR) |
 | `--include-rebases` | Expand rebased-into-range commits inline |
 | `--date <author\|commit\|true-first>` | Date used for grouping (default: `author`) |
-| `--markdown` | Markdown output (day headers, bullet list) |
+| `--markdown` | markdown output (day headers, bullet list) |
 | `--clipboard` | Copy output to clipboard (`--markdown` recommended) |
 
 **Rebase behaviour:** `git log --after`/`--before` still filter by committer date. Commits authored before `--from` but committed inside the range appear in a compressed “rebased into this range” footer (or inline with `--include-rebases`). Patch-id dedup collapses cherry-pick/rebase duplicates (keeps newest committer date).

--- a/src/git/commands/commits.ts
+++ b/src/git/commands/commits.ts
@@ -5,13 +5,9 @@
  * branch attribution, rebase classification, and optional line change stats.
  */
 
-import { enrichWorkItems } from "@app/azure-devops/lib/work-item-enrichment";
 import { loadConfig } from "@app/azure-devops/config";
-import {
-    formatBranchTag,
-    resolveBranchForCommits,
-    type BranchAttribution,
-} from "@app/git/lib/branch-attribution";
+import { enrichWorkItems } from "@app/azure-devops/lib/work-item-enrichment";
+import { type BranchAttribution, formatBranchTag, resolveBranchForCommits } from "@app/git/lib/branch-attribution";
 import { showItems } from "@app/git/lib/format";
 import { renderMarkdown } from "@app/git/lib/markdown-render";
 import { computePatchIds, dedupByPatchId } from "@app/git/lib/patch-id-dedup";
@@ -21,8 +17,8 @@ import {
     formatClusterTimestamp,
     formatYmd,
     isLikelyResetAuthor,
-    rangeBoundsMs,
     type RebaseCluster,
+    rangeBoundsMs,
 } from "@app/git/lib/rebase-classifier";
 import { extractFromMessage, loadWorkitemPatternsAsync } from "@app/git/workitem-patterns";
 import { out } from "@app/logger";
@@ -94,7 +90,12 @@ async function loadStashHashes(cwd: string): Promise<Set<string>> {
         return new Set();
     }
 
-    return new Set(res.stdout.split("\n").map((line) => line.trim()).filter(Boolean));
+    return new Set(
+        res.stdout
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean)
+    );
 }
 
 async function loadExcludeTrunks(storage: Storage): Promise<string[]> {
@@ -238,10 +239,7 @@ function groupingDateFor(commit: CommitWithStats, dateMode: DateMode, resetMarke
     return commit.date;
 }
 
-function workitemTag(
-    commit: CommitWithStats,
-    showWorkitemId: boolean
-): string {
+function workitemTag(commit: CommitWithStats, showWorkitemId: boolean): string {
     if (!showWorkitemId || commit.workitemIds.length === 0) {
         return "";
     }
@@ -271,9 +269,7 @@ function formatCommitRow(
 ): string {
     const marker = commit.resetAuthorMarker ? chalk.dim(" (?)") : "";
     const branch =
-        opts.showBranch && commit.branchAttribution
-            ? chalk.dim(` ${formatBranchTag(commit.branchAttribution)}`)
-            : "";
+        opts.showBranch && commit.branchAttribution ? chalk.dim(` ${formatBranchTag(commit.branchAttribution)}`) : "";
     const stat =
         opts.includeStat && (commit.insertions > 0 || commit.deletions > 0)
             ? chalk.dim(` (${commit.filesChanged} files, +${commit.insertions}/-${commit.deletions})`)
@@ -286,12 +282,9 @@ function formatCommitRow(
 
 function buildWorkitemSummary(
     commits: CommitWithStats[],
-    includeStat: boolean
+    _includeStat: boolean
 ): Map<number, { commits: number; totalInsertions: number; totalDeletions: number }> {
-    const workitemMap = new Map<
-        number,
-        { commits: number; totalInsertions: number; totalDeletions: number }
-    >();
+    const workitemMap = new Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>();
 
     for (const commit of commits) {
         for (const wid of commit.workitemIds) {
@@ -354,10 +347,7 @@ function renderTableMain(
             out.println(chalk.dim("─".repeat(80)));
 
             for (const commit of group) {
-                const dateSuffix =
-                    opts.dateMode !== "author"
-                        ? chalk.dim(` (${commit.date.split("T")[0]})`)
-                        : "";
+                const dateSuffix = opts.dateMode !== "author" ? chalk.dim(` (${commit.date.split("T")[0]})`) : "";
                 out.println(`${formatCommitRow(commit, opts)}${dateSuffix}`);
             }
         }
@@ -418,9 +408,7 @@ function renderRebasedCompressed(clusters: RebaseCluster<CommitWithStats>[]): vo
         out.println(
             `  ${chalk.cyan("▸")} ${cluster.commits.length} commits rebased ${landed}, authored ${from} – ${to}`
         );
-        out.println(
-            `    [${showItems(cluster.commits, (c) => c.shortHash)}]`
-        );
+        out.println(`    [${showItems(cluster.commits, (c) => c.shortHash)}]`);
     }
 }
 
@@ -433,7 +421,7 @@ function renderRebasedExpanded(
         showAuthor: boolean;
     }
 ): void {
-    out.println(`\n${chalk.bold("── Rebased into range (" + rebased.length + " commits) ──")}`);
+    out.println(`\n${chalk.bold(`── Rebased into range (${rebased.length} commits) ──`)}`);
 
     const groups = new Map<string, CommitWithStats[]>();
 
@@ -452,8 +440,7 @@ function renderRebasedExpanded(
         for (const commit of dayCommits) {
             const authoredDay = commit.date.split("T")[0];
             const landedDay = commit.commitDate.split("T")[0];
-            const authoredAnnotation =
-                authoredDay !== landedDay ? `[authored ${authoredDay}]` : undefined;
+            const authoredAnnotation = authoredDay !== landedDay ? `[authored ${authoredDay}]` : undefined;
 
             out.println(
                 formatCommitRow(commit, {
@@ -465,14 +452,14 @@ function renderRebasedExpanded(
     }
 }
 
-function outputJson(payload: {
+function buildCommitsJson(payload: {
     from: string;
     to: string;
     authors: string[];
     commits: CommitWithStats[];
     rebasedCommits: CommitWithStats[];
     workitemSummary: Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>;
-}): void {
+}): string {
     const workitemSummary: Record<string, { commits: number; totalInsertions: number; totalDeletions: number }> = {};
 
     for (const [id, stats] of payload.workitemSummary) {
@@ -495,20 +482,29 @@ function outputJson(payload: {
         resetAuthorMarker: c.resetAuthorMarker ?? false,
     });
 
-    out.println(
-        SafeJSON.stringify(
-            {
-                from: payload.from,
-                to: payload.to,
-                authors: payload.authors,
-                commits: payload.commits.map(mapCommit),
-                rebasedCommits: payload.rebasedCommits.map(mapCommit),
-                workitemSummary,
-            },
-            null,
-            2
-        )
+    return SafeJSON.stringify(
+        {
+            from: payload.from,
+            to: payload.to,
+            authors: payload.authors,
+            commits: payload.commits.map(mapCommit),
+            rebasedCommits: payload.rebasedCommits.map(mapCommit),
+            workitemSummary,
+        },
+        null,
+        2
     );
+}
+
+function outputJson(payload: {
+    from: string;
+    to: string;
+    authors: string[];
+    commits: CommitWithStats[];
+    rebasedCommits: CommitWithStats[];
+    workitemSummary: Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>;
+}): void {
+    out.println(buildCommitsJson(payload));
 }
 
 async function handleCommits(options: CommitsOptions): Promise<void> {
@@ -542,13 +538,7 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
         out.println(chalk.bold(`Finding git commits from ${options.from} until ${options.to} from ${authorDisplay}`));
     }
 
-    let commits = await getCommitsByDate(
-        options.from,
-        options.to,
-        authors,
-        !!options.stat,
-        !!options.withoutMerges
-    );
+    let commits = await getCommitsByDate(options.from, options.to, authors, !!options.stat, !!options.withoutMerges);
 
     if (options.withoutStashes) {
         const stashHashes = await loadStashHashes(process.cwd());
@@ -600,10 +590,11 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
         workitemBySha.set(commit.hash, commit.workitemIds);
     }
 
-    const branchMap = await resolveBranchForCommits(
-        [...workitemBySha.keys()],
-        { excludeTrunks, workitemBySha, cwd: process.cwd() }
-    );
+    const branchMap = await resolveBranchForCommits([...workitemBySha.keys()], {
+        excludeTrunks,
+        workitemBySha,
+        cwd: process.cwd(),
+    });
 
     for (const commit of [...authoredInRange, ...rebasedInRange]) {
         commit.branchAttribution = branchMap.get(commit.hash);
@@ -613,11 +604,7 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
         const azureConfig = loadConfig();
 
         if (azureConfig) {
-            const allIds = [
-                ...new Set(
-                    [...authoredInRange, ...rebasedInRange].flatMap((c) => c.workitemIds)
-                ),
-            ];
+            const allIds = [...new Set([...authoredInRange, ...rebasedInRange].flatMap((c) => c.workitemIds))];
             const enriched = await enrichWorkItems(azureConfig, allIds);
 
             for (const commit of [...authoredInRange, ...rebasedInRange]) {
@@ -651,6 +638,23 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
     const rebasedClusters = clusterRebasedByCI(rebased);
 
     if (authored.length === 0 && rebased.length === 0) {
+        if (options.format === "json") {
+            outputJson({
+                from: options.from,
+                to: options.to,
+                authors,
+                commits: [],
+                rebasedCommits: [],
+                workitemSummary: new Map(),
+            });
+            return;
+        }
+
+        if (options.markdown) {
+            out.println("");
+            return;
+        }
+
         out.println(chalk.yellow("\nNo commits found for the specified criteria."));
         return;
     }
@@ -685,8 +689,7 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
             showWorkitemId,
             includeStat: !!options.stat,
             groupBy,
-            groupingDate: (c) =>
-                groupingDateFor(c, dateMode, resetAuthorByHash.get(c.hash) ?? false),
+            groupingDate: (c) => groupingDateFor(c, dateMode, resetAuthorByHash.get(c.hash) ?? false),
             workitemSummary: workitemMap,
             rebasedClusters,
             includeRebasesExpanded: !!options.includeRebases,
@@ -709,9 +712,7 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
             out.println(`\n${chalk.bold("Workitem Summary:")}`);
 
             for (const [id, stats] of [...workitemMap.entries()].sort((a, b) => a[0] - b[0])) {
-                const statPart = options.stat
-                    ? chalk.dim(` (+${stats.totalInsertions}/-${stats.totalDeletions})`)
-                    : "";
+                const statPart = options.stat ? chalk.dim(` (+${stats.totalInsertions}/-${stats.totalDeletions})`) : "";
                 out.println(`  ${chalk.yellow(`#${id}`)} - ${stats.commits} commit(s)${statPart}`);
             }
         }
@@ -730,18 +731,17 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
             await copyToClipboard(outputText);
         } else if (options.format === "json") {
             await copyToClipboard(
-                SafeJSON.stringify(
-                    {
-                        from: options.from,
-                        to: options.to,
-                        authors,
-                        commits: authored,
-                        rebasedCommits: rebased,
-                    },
-                    null,
-                    2
-                )
+                buildCommitsJson({
+                    from: options.from,
+                    to: options.to,
+                    authors,
+                    commits: authored,
+                    rebasedCommits: rebased,
+                    workitemSummary: workitemMap,
+                })
             );
+        } else {
+            out.println(chalk.yellow("\nWarning: Clipboard copy is only supported with --markdown or --format json."));
         }
     }
 }

--- a/src/git/commands/commits.ts
+++ b/src/git/commands/commits.ts
@@ -2,21 +2,41 @@
  * Git Commits Command
  *
  * Query commits by date range with author filtering, workitem ID extraction,
- * and optional line change stats.
- *
- * Usage:
- *   tools git commits --from 2026-02-01 --to 2026-02-08 [--author <name>] [--with-author <name>] [--format json|table] [--stat]
+ * branch attribution, rebase classification, and optional line change stats.
  */
 
+import { enrichWorkItems } from "@app/azure-devops/lib/work-item-enrichment";
+import { loadConfig } from "@app/azure-devops/config";
+import {
+    formatBranchTag,
+    resolveBranchForCommits,
+    type BranchAttribution,
+} from "@app/git/lib/branch-attribution";
+import { showItems } from "@app/git/lib/format";
+import { renderMarkdown } from "@app/git/lib/markdown-render";
+import { computePatchIds, dedupByPatchId } from "@app/git/lib/patch-id-dedup";
+import {
+    classifyCommit,
+    clusterRebasedByCI,
+    formatClusterTimestamp,
+    formatYmd,
+    isLikelyResetAuthor,
+    rangeBoundsMs,
+    type RebaseCluster,
+} from "@app/git/lib/rebase-classifier";
 import { extractFromMessage, loadWorkitemPatternsAsync } from "@app/git/workitem-patterns";
 import { out } from "@app/logger";
 import { Executor } from "@app/utils/cli";
+import { copyToClipboard } from "@app/utils/clipboard";
 import { formatDateTime } from "@app/utils/date";
 import type { DetailedCommitInfo } from "@app/utils/git";
 import { SafeJSON } from "@app/utils/json";
 import { Storage } from "@app/utils/storage";
 import chalk from "chalk";
 import type { Command } from "commander";
+
+type GroupBy = "day" | "branch" | "workitem" | "none";
+type DateMode = "author" | "commit" | "true-first";
 
 interface CommitsOptions {
     from: string;
@@ -25,14 +45,32 @@ interface CommitsOptions {
     withAuthor?: string[];
     format: "json" | "table";
     stat?: boolean;
+    groupBy?: GroupBy;
+    withoutBranch?: boolean;
+    withoutWorkitemId?: boolean;
+    withWorkitemTitle?: boolean;
+    withoutStashes?: boolean;
+    withoutMerges?: boolean;
+    workitem?: number[];
+    includeRebases?: boolean;
+    date?: DateMode;
+    markdown?: boolean;
+    clipboard?: boolean;
 }
 
 interface CommitWithStats extends DetailedCommitInfo {
+    commitDate: string;
     filesChanged: number;
     insertions: number;
     deletions: number;
     workitemIds: number[];
+    parentCount: number;
+    branchAttribution?: BranchAttribution;
+    workitemTitles?: Map<number, string>;
+    resetAuthorMarker?: boolean;
 }
+
+const DEFAULT_EXCLUDE_TRUNKS = ["develop", "main", "master"];
 
 function addOneDay(dateStr: string): string {
     const d = new Date(dateStr);
@@ -44,14 +82,39 @@ function formatDateForDisplay(dateStr: string): string {
     return formatDateTime(dateStr, { absolute: "date-long" });
 }
 
+function isStashSubject(message: string): boolean {
+    return message.startsWith("WIP on ") || message.startsWith("index on ");
+}
+
+async function loadStashHashes(cwd: string): Promise<Set<string>> {
+    const executor = new Executor({ prefix: "git", verbose: false, cwd });
+    const res = await executor.exec(["stash", "list", "--format=%H"]);
+
+    if (!res.success || !res.stdout.trim()) {
+        return new Set();
+    }
+
+    return new Set(res.stdout.split("\n").map((line) => line.trim()).filter(Boolean));
+}
+
+async function loadExcludeTrunks(storage: Storage): Promise<string[]> {
+    const configured = await storage.getConfigValue<{ excludeTrunks?: string[] }>("branchAttribution");
+
+    if (configured?.excludeTrunks && configured.excludeTrunks.length > 0) {
+        return configured.excludeTrunks;
+    }
+
+    return DEFAULT_EXCLUDE_TRUNKS;
+}
+
 async function getCommitsByDate(
     from: string,
     to: string,
     authors: string[],
-    includeStat: boolean
+    includeStat: boolean,
+    withoutMerges: boolean
 ): Promise<CommitWithStats[]> {
     const executor = new Executor({ prefix: "git", verbose: false });
-
     const toExclusive = addOneDay(to);
 
     const args = [
@@ -59,8 +122,12 @@ async function getCommitsByDate(
         `--after=${from}`,
         `--before=${toExclusive}`,
         "--all",
-        "--pretty=format:%H%x00%h%x00%an%x00%aI%x00%s",
+        "--pretty=format:%H%x00%h%x00%an%x00%aI%x00%cI%x00%s%x00%P",
     ];
+
+    if (withoutMerges) {
+        args.push("--no-merges");
+    }
 
     if (includeStat) {
         args.push("--numstat");
@@ -80,6 +147,7 @@ async function getCommitsByDate(
     const lines = result.stdout.split("\n");
 
     let i = 0;
+
     while (i < lines.length) {
         const line = lines[i].trim();
 
@@ -88,7 +156,6 @@ async function getCommitsByDate(
             continue;
         }
 
-        // Check if this is a commit line (contains null bytes)
         if (!line.includes("\0")) {
             i++;
             continue;
@@ -96,21 +163,21 @@ async function getCommitsByDate(
 
         const parts = line.split("\0");
 
-        if (parts.length < 5) {
+        if (parts.length < 7) {
             i++;
             continue;
         }
 
-        const [hash, shortHash, author, date, ...rest] = parts;
-        const message = rest.join("\0");
+        const [hash, shortHash, author, date, commitDate, message, parentPart] = parts;
+        const parentCount = parentPart.trim() ? parentPart.trim().split(/\s+/).length : 0;
 
         let filesChanged = 0;
         let insertions = 0;
         let deletions = 0;
 
         if (includeStat) {
-            // Parse numstat lines that follow the commit
             i++;
+
             while (i < lines.length) {
                 const statLine = lines[i].trim();
 
@@ -146,144 +213,85 @@ async function getCommitsByDate(
             shortHash,
             author,
             date,
+            commitDate,
             message,
             filesChanged,
             insertions,
             deletions,
             workitemIds: [],
+            parentCount,
         });
     }
 
     return commits;
 }
 
-function groupByDay(commits: CommitWithStats[]): Map<string, CommitWithStats[]> {
-    const groups = new Map<string, CommitWithStats[]>();
-
-    for (const commit of commits) {
-        const day = commit.date.split("T")[0];
-        const existing = groups.get(day) ?? [];
-        existing.push(commit);
-        groups.set(day, existing);
+function groupingDateFor(commit: CommitWithStats, dateMode: DateMode, resetMarked: boolean): string {
+    if (dateMode === "commit") {
+        return commit.commitDate;
     }
 
-    return groups;
+    if (dateMode === "true-first" && resetMarked) {
+        return commit.commitDate;
+    }
+
+    return commit.date;
 }
 
-function outputTable(
-    commits: CommitWithStats[],
-    _from: string,
-    _to: string,
-    authors: string[],
-    includeStat: boolean,
-    workitemMap: Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>
-): void {
-    const grouped = groupByDay(commits);
-    const sortedDays = [...grouped.keys()].sort();
+function workitemTag(
+    commit: CommitWithStats,
+    showWorkitemId: boolean
+): string {
+    if (!showWorkitemId || commit.workitemIds.length === 0) {
+        return "";
+    }
 
-    for (const day of sortedDays) {
-        const dayCommits = grouped.get(day)!;
-        out.println(`\n${chalk.bold.cyan(formatDateForDisplay(day))} ${chalk.dim(`(${dayCommits.length} commits)`)}`);
-        out.println(chalk.dim("─".repeat(80)));
+    const parts = commit.workitemIds.map((id) => {
+        const title = commit.workitemTitles?.get(id);
 
-        for (const commit of dayCommits) {
-            const workitemTag =
-                commit.workitemIds.length > 0
-                    ? chalk.yellow(` [${commit.workitemIds.map((id) => `#${id}`).join(", ")}]`)
-                    : "";
-
-            const statTag =
-                includeStat && (commit.insertions > 0 || commit.deletions > 0)
-                    ? chalk.dim(` (${commit.filesChanged} files, +${commit.insertions}/-${commit.deletions})`)
-                    : "";
-
-            const authorTag = authors.length !== 1 ? chalk.dim(` (${commit.author})`) : "";
-
-            out.println(`  ${chalk.dim(commit.shortHash)} ${commit.message}${workitemTag}${statTag}${authorTag}`);
+        if (title) {
+            return chalk.yellow(` [#${id} — ${title}]`);
         }
-    }
 
-    // Workitem summary
-    if (workitemMap.size > 0) {
-        out.println(`\n${chalk.bold("Workitem Summary:")}`);
-        for (const [id, stats] of workitemMap) {
-            const statPart = includeStat ? chalk.dim(` (+${stats.totalInsertions}/-${stats.totalDeletions})`) : "";
-            out.println(`  ${chalk.yellow(`#${id}`)} - ${stats.commits} commit(s)${statPart}`);
-        }
-    }
+        return chalk.yellow(` [#${id}]`);
+    });
 
-    out.println(`\n${chalk.dim(`Total: ${commits.length} commits`)}`);
+    return parts.join("");
 }
 
-function outputJson(
+function formatCommitRow(
+    commit: CommitWithStats,
+    opts: {
+        showBranch: boolean;
+        showWorkitemId: boolean;
+        includeStat: boolean;
+        showAuthor: boolean;
+        authoredAnnotation?: string;
+    }
+): string {
+    const marker = commit.resetAuthorMarker ? chalk.dim(" (?)") : "";
+    const branch =
+        opts.showBranch && commit.branchAttribution
+            ? chalk.dim(` ${formatBranchTag(commit.branchAttribution)}`)
+            : "";
+    const stat =
+        opts.includeStat && (commit.insertions > 0 || commit.deletions > 0)
+            ? chalk.dim(` (${commit.filesChanged} files, +${commit.insertions}/-${commit.deletions})`)
+            : "";
+    const author = opts.showAuthor ? chalk.dim(` (${commit.author})`) : "";
+    const authored = opts.authoredAnnotation ? chalk.dim(` ${opts.authoredAnnotation}`) : "";
+
+    return `  ${chalk.dim(commit.shortHash)}${marker} ${commit.message}${branch}${workitemTag(commit, opts.showWorkitemId)}${stat}${authored}${author}`;
+}
+
+function buildWorkitemSummary(
     commits: CommitWithStats[],
-    from: string,
-    to: string,
-    authors: string[],
-    workitemMap: Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>
-): void {
-    const workitemSummary: Record<string, { commits: number; totalInsertions: number; totalDeletions: number }> = {};
-
-    for (const [id, stats] of workitemMap) {
-        workitemSummary[String(id)] = stats;
-    }
-
-    const output = {
-        from,
-        to,
-        authors,
-        commits: commits.map((c) => ({
-            hash: c.shortHash,
-            date: c.date,
-            message: c.message,
-            author: c.author,
-            filesChanged: c.filesChanged,
-            insertions: c.insertions,
-            deletions: c.deletions,
-            workitemIds: c.workitemIds,
-        })),
-        workitemSummary,
-    };
-
-    out.println(SafeJSON.stringify(output, null, 2));
-}
-
-async function handleCommits(options: CommitsOptions): Promise<void> {
-    const storage = new Storage("git");
-    const configAuthors = (await storage.getConfigValue<string[]>("authors")) ?? [];
-    const patterns = await loadWorkitemPatternsAsync();
-
-    let authors: string[] = [];
-
-    if (options.author && options.author.length > 0) {
-        authors = options.author;
-    } else if (options.withAuthor && options.withAuthor.length > 0) {
-        authors = [...configAuthors, ...options.withAuthor];
-    } else {
-        authors = configAuthors;
-    }
-
-    if (authors.length === 0) {
-        out.println(chalk.dim("Note: No authors configured. Showing all commits."));
-        out.println(chalk.dim('To pre-configure: tools git configure-authors --add "Your Name"'));
-        out.println();
-    }
-
-    if (options.format !== "json") {
-        const authorDisplay = authors.length > 0 ? authors.join(", ") : "all authors";
-        out.println(chalk.bold(`Finding git commits from ${options.from} until ${options.to} from ${authorDisplay}`));
-    }
-
-    const commits = await getCommitsByDate(options.from, options.to, authors, !!options.stat);
-
-    // Extract workitem IDs
-    for (const commit of commits) {
-        const refs = extractFromMessage(commit.message, patterns);
-        commit.workitemIds = [...new Set(refs.map((r) => r.id))];
-    }
-
-    // Build workitem summary
-    const workitemMap = new Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>();
+    includeStat: boolean
+): Map<number, { commits: number; totalInsertions: number; totalDeletions: number }> {
+    const workitemMap = new Map<
+        number,
+        { commits: number; totalInsertions: number; totalDeletions: number }
+    >();
 
     for (const commit of commits) {
         for (const wid of commit.workitemIds) {
@@ -295,15 +303,446 @@ async function handleCommits(options: CommitsOptions): Promise<void> {
         }
     }
 
-    if (commits.length === 0) {
+    return workitemMap;
+}
+
+function matchesWorkitemFilter(commit: CommitWithStats, filter: number[] | undefined): boolean {
+    if (!filter || filter.length === 0) {
+        return true;
+    }
+
+    return commit.workitemIds.some((id) => filter.includes(id));
+}
+
+function renderTableMain(
+    commits: CommitWithStats[],
+    opts: {
+        groupBy: GroupBy;
+        dateMode: DateMode;
+        showBranch: boolean;
+        showWorkitemId: boolean;
+        includeStat: boolean;
+        showAuthor: boolean;
+        resetAuthorByHash: Map<string, boolean>;
+    }
+): void {
+    const dateFn = (c: CommitWithStats) =>
+        groupingDateFor(c, opts.dateMode, opts.resetAuthorByHash.get(c.hash) ?? false);
+
+    if (opts.groupBy === "none") {
+        const sorted = [...commits].sort((a, b) => dateFn(b).localeCompare(dateFn(a)));
+
+        for (const commit of sorted) {
+            out.println(formatCommitRow(commit, opts));
+        }
+
+        return;
+    }
+
+    if (opts.groupBy === "branch") {
+        const groups = new Map<string, CommitWithStats[]>();
+
+        for (const commit of commits) {
+            const key = commit.branchAttribution?.branch ?? "(detached)";
+            const list = groups.get(key) ?? [];
+            list.push(commit);
+            groups.set(key, list);
+        }
+
+        for (const [branch, group] of [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+            out.println(`\n${chalk.bold.cyan(`[${branch}]`)} ${chalk.dim(`(${group.length} commits)`)}`);
+            out.println(chalk.dim("─".repeat(80)));
+
+            for (const commit of group) {
+                const dateSuffix =
+                    opts.dateMode !== "author"
+                        ? chalk.dim(` (${commit.date.split("T")[0]})`)
+                        : "";
+                out.println(`${formatCommitRow(commit, opts)}${dateSuffix}`);
+            }
+        }
+
+        return;
+    }
+
+    if (opts.groupBy === "workitem") {
+        const groups = new Map<string, CommitWithStats[]>();
+
+        for (const commit of commits) {
+            const key = commit.workitemIds.length > 0 ? `#${commit.workitemIds[0]}` : "[no-workitem]";
+            const list = groups.get(key) ?? [];
+            list.push(commit);
+            groups.set(key, list);
+        }
+
+        for (const [key, group] of [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+            out.println(`\n${chalk.bold.cyan(`[${key}]`)} ${chalk.dim(`(${group.length} commits)`)}`);
+            out.println(chalk.dim("─".repeat(80)));
+
+            for (const commit of group) {
+                out.println(formatCommitRow(commit, opts));
+            }
+        }
+
+        return;
+    }
+
+    const groups = new Map<string, CommitWithStats[]>();
+
+    for (const commit of commits) {
+        const day = dateFn(commit).split("T")[0];
+        const list = groups.get(day) ?? [];
+        list.push(commit);
+        groups.set(day, list);
+    }
+
+    for (const day of [...groups.keys()].sort()) {
+        const dayCommits = groups.get(day)!;
+        out.println(`\n${chalk.bold.cyan(formatDateForDisplay(day))} ${chalk.dim(`(${dayCommits.length} commits)`)}`);
+        out.println(chalk.dim("─".repeat(80)));
+
+        for (const commit of dayCommits) {
+            out.println(formatCommitRow(commit, opts));
+        }
+    }
+}
+
+function renderRebasedCompressed(clusters: RebaseCluster<CommitWithStats>[]): void {
+    const total = clusters.reduce((sum, c) => sum + c.commits.length, 0);
+    out.println(`\n${chalk.dim(`… and ${total} commits rebased into this range (use --include-rebases):`)}`);
+
+    for (const cluster of clusters) {
+        const landed = formatClusterTimestamp(cluster.landedAt);
+        const from = formatYmd(cluster.authorDateRange[0]);
+        const to = formatYmd(cluster.authorDateRange[1]);
+        out.println(
+            `  ${chalk.cyan("▸")} ${cluster.commits.length} commits rebased ${landed}, authored ${from} – ${to}`
+        );
+        out.println(
+            `    [${showItems(cluster.commits, (c) => c.shortHash)}]`
+        );
+    }
+}
+
+function renderRebasedExpanded(
+    rebased: CommitWithStats[],
+    opts: {
+        showBranch: boolean;
+        showWorkitemId: boolean;
+        includeStat: boolean;
+        showAuthor: boolean;
+    }
+): void {
+    out.println(`\n${chalk.bold("── Rebased into range (" + rebased.length + " commits) ──")}`);
+
+    const groups = new Map<string, CommitWithStats[]>();
+
+    for (const commit of rebased) {
+        const day = commit.commitDate.split("T")[0];
+        const list = groups.get(day) ?? [];
+        list.push(commit);
+        groups.set(day, list);
+    }
+
+    for (const day of [...groups.keys()].sort()) {
+        const dayCommits = groups.get(day)!;
+        out.println(`\n${chalk.bold.cyan(formatDateForDisplay(day))} ${chalk.dim(`(${dayCommits.length} commits)`)}`);
+        out.println(chalk.dim("─".repeat(80)));
+
+        for (const commit of dayCommits) {
+            const authoredDay = commit.date.split("T")[0];
+            const landedDay = commit.commitDate.split("T")[0];
+            const authoredAnnotation =
+                authoredDay !== landedDay ? `[authored ${authoredDay}]` : undefined;
+
+            out.println(
+                formatCommitRow(commit, {
+                    ...opts,
+                    authoredAnnotation,
+                })
+            );
+        }
+    }
+}
+
+function outputJson(payload: {
+    from: string;
+    to: string;
+    authors: string[];
+    commits: CommitWithStats[];
+    rebasedCommits: CommitWithStats[];
+    workitemSummary: Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>;
+}): void {
+    const workitemSummary: Record<string, { commits: number; totalInsertions: number; totalDeletions: number }> = {};
+
+    for (const [id, stats] of payload.workitemSummary) {
+        workitemSummary[String(id)] = stats;
+    }
+
+    const mapCommit = (c: CommitWithStats) => ({
+        hash: c.shortHash,
+        fullHash: c.hash,
+        date: c.date,
+        commitDate: c.commitDate,
+        message: c.message,
+        author: c.author,
+        branch: c.branchAttribution?.branch ?? null,
+        trunkFallback: c.branchAttribution?.trunkFallback ?? false,
+        filesChanged: c.filesChanged,
+        insertions: c.insertions,
+        deletions: c.deletions,
+        workitemIds: c.workitemIds,
+        resetAuthorMarker: c.resetAuthorMarker ?? false,
+    });
+
+    out.println(
+        SafeJSON.stringify(
+            {
+                from: payload.from,
+                to: payload.to,
+                authors: payload.authors,
+                commits: payload.commits.map(mapCommit),
+                rebasedCommits: payload.rebasedCommits.map(mapCommit),
+                workitemSummary,
+            },
+            null,
+            2
+        )
+    );
+}
+
+async function handleCommits(options: CommitsOptions): Promise<void> {
+    const storage = new Storage("git");
+    const configAuthors = (await storage.getConfigValue<string[]>("authors")) ?? [];
+    const patterns = await loadWorkitemPatternsAsync();
+    const excludeTrunks = await loadExcludeTrunks(storage);
+    const groupBy = options.groupBy ?? "day";
+    const dateMode = options.date ?? "author";
+    const showBranch = !options.withoutBranch;
+    const showWorkitemId = !options.withoutWorkitemId;
+
+    let authors: string[] = [];
+
+    if (options.author && options.author.length > 0) {
+        authors = options.author;
+    } else if (options.withAuthor && options.withAuthor.length > 0) {
+        authors = [...configAuthors, ...options.withAuthor];
+    } else {
+        authors = configAuthors;
+    }
+
+    if (authors.length === 0 && options.format !== "json" && !options.markdown) {
+        out.println(chalk.dim("Note: No authors configured. Showing all commits."));
+        out.println(chalk.dim('To pre-configure: tools git configure-authors --add "Your Name"'));
+        out.println();
+    }
+
+    if (options.format !== "json" && !options.markdown) {
+        const authorDisplay = authors.length > 0 ? authors.join(", ") : "all authors";
+        out.println(chalk.bold(`Finding git commits from ${options.from} until ${options.to} from ${authorDisplay}`));
+    }
+
+    let commits = await getCommitsByDate(
+        options.from,
+        options.to,
+        authors,
+        !!options.stat,
+        !!options.withoutMerges
+    );
+
+    if (options.withoutStashes) {
+        const stashHashes = await loadStashHashes(process.cwd());
+
+        commits = commits.filter(
+            (c) => !isStashSubject(c.message) && !stashHashes.has(c.hash) && !stashHashes.has(c.shortHash)
+        );
+    }
+
+    for (const commit of commits) {
+        const refs = extractFromMessage(commit.message, patterns);
+        commit.workitemIds = [...new Set(refs.map((r) => r.id))];
+    }
+
+    const patchIds = await computePatchIds(
+        commits.map((c) => c.hash),
+        process.cwd()
+    );
+    commits = dedupByPatchId(commits, patchIds);
+
+    const bounds = rangeBoundsMs(options.from, options.to);
+    const allForReset = commits;
+    const authoredInRange: CommitWithStats[] = [];
+    const rebasedInRange: CommitWithStats[] = [];
+
+    for (const commit of commits) {
+        const kind = classifyCommit(commit, bounds);
+
+        if (kind === "authored") {
+            authoredInRange.push(commit);
+        } else if (kind === "rebased") {
+            rebasedInRange.push(commit);
+        }
+    }
+
+    const resetAuthorByHash = new Map<string, boolean>();
+
+    for (const commit of allForReset) {
+        resetAuthorByHash.set(commit.hash, isLikelyResetAuthor(commit, allForReset));
+    }
+
+    for (const commit of [...authoredInRange, ...rebasedInRange]) {
+        commit.resetAuthorMarker = resetAuthorByHash.get(commit.hash) ?? false;
+    }
+
+    const workitemBySha = new Map<string, number[]>();
+
+    for (const commit of [...authoredInRange, ...rebasedInRange]) {
+        workitemBySha.set(commit.hash, commit.workitemIds);
+    }
+
+    const branchMap = await resolveBranchForCommits(
+        [...workitemBySha.keys()],
+        { excludeTrunks, workitemBySha, cwd: process.cwd() }
+    );
+
+    for (const commit of [...authoredInRange, ...rebasedInRange]) {
+        commit.branchAttribution = branchMap.get(commit.hash);
+    }
+
+    if (options.withWorkitemTitle) {
+        const azureConfig = loadConfig();
+
+        if (azureConfig) {
+            const allIds = [
+                ...new Set(
+                    [...authoredInRange, ...rebasedInRange].flatMap((c) => c.workitemIds)
+                ),
+            ];
+            const enriched = await enrichWorkItems(azureConfig, allIds);
+
+            for (const commit of [...authoredInRange, ...rebasedInRange]) {
+                const titles = new Map<number, string>();
+
+                for (const id of commit.workitemIds) {
+                    const item = enriched.get(id);
+
+                    if (item?.title) {
+                        titles.set(id, item.title);
+                    }
+                }
+
+                if (titles.size > 0) {
+                    commit.workitemTitles = titles;
+                }
+            }
+        }
+    }
+
+    let authored = authoredInRange;
+    let rebased = rebasedInRange;
+
+    if (options.workitem && options.workitem.length > 0) {
+        authored = authored.filter((c) => matchesWorkitemFilter(c, options.workitem));
+        rebased = rebased.filter((c) => matchesWorkitemFilter(c, options.workitem));
+    }
+
+    const summaryCommits = [...authored, ...rebased];
+    const workitemMap = buildWorkitemSummary(summaryCommits, !!options.stat);
+    const rebasedClusters = clusterRebasedByCI(rebased);
+
+    if (authored.length === 0 && rebased.length === 0) {
         out.println(chalk.yellow("\nNo commits found for the specified criteria."));
         return;
     }
 
+    const showAuthor = authors.length !== 1;
+    const renderOpts = {
+        showBranch,
+        showWorkitemId,
+        includeStat: !!options.stat,
+        showAuthor,
+        resetAuthorByHash,
+        dateMode,
+        groupBy,
+    };
+
+    let outputText = "";
+
     if (options.format === "json") {
-        outputJson(commits, options.from, options.to, authors, workitemMap);
+        outputJson({
+            from: options.from,
+            to: options.to,
+            authors,
+            commits: authored,
+            rebasedCommits: rebased,
+            workitemSummary: workitemMap,
+        });
+    } else if (options.markdown) {
+        outputText = renderMarkdown(authored, {
+            from: options.from,
+            to: options.to,
+            showBranch,
+            showWorkitemId,
+            includeStat: !!options.stat,
+            groupBy,
+            groupingDate: (c) =>
+                groupingDateFor(c, dateMode, resetAuthorByHash.get(c.hash) ?? false),
+            workitemSummary: workitemMap,
+            rebasedClusters,
+            includeRebasesExpanded: !!options.includeRebases,
+            rebasedExpanded: rebased,
+        });
+
+        out.println(outputText);
     } else {
-        outputTable(commits, options.from, options.to, authors, !!options.stat, workitemMap);
+        renderTableMain(authored, {
+            groupBy,
+            dateMode,
+            showBranch,
+            showWorkitemId,
+            includeStat: !!options.stat,
+            showAuthor,
+            resetAuthorByHash,
+        });
+
+        if (workitemMap.size > 0) {
+            out.println(`\n${chalk.bold("Workitem Summary:")}`);
+
+            for (const [id, stats] of [...workitemMap.entries()].sort((a, b) => a[0] - b[0])) {
+                const statPart = options.stat
+                    ? chalk.dim(` (+${stats.totalInsertions}/-${stats.totalDeletions})`)
+                    : "";
+                out.println(`  ${chalk.yellow(`#${id}`)} - ${stats.commits} commit(s)${statPart}`);
+            }
+        }
+
+        if (options.includeRebases) {
+            renderRebasedExpanded(rebased, renderOpts);
+        } else if (rebased.length > 0) {
+            renderRebasedCompressed(rebasedClusters);
+        }
+
+        out.println(`\n${chalk.dim(`Total: ${authored.length} commits`)}`);
+    }
+
+    if (options.clipboard) {
+        if (options.markdown && outputText) {
+            await copyToClipboard(outputText);
+        } else if (options.format === "json") {
+            await copyToClipboard(
+                SafeJSON.stringify(
+                    {
+                        from: options.from,
+                        to: options.to,
+                        authors,
+                        commits: authored,
+                        rebasedCommits: rebased,
+                    },
+                    null,
+                    2
+                )
+            );
+        }
     }
 }
 
@@ -317,6 +756,25 @@ export function registerCommitsCommand(parent: Command, _storage: Storage): void
         .option("--with-author <name...>", "Append to configured authors (repeatable)")
         .option("--format <format>", "Output format: json or table", "table")
         .option("--stat", "Include line change stats (files changed, insertions, deletions)")
+        .option("--group-by <mode>", "Group commits: day, branch, workitem, or none", "day")
+        .option("--without-branch", "Hide inline branch column")
+        .option("--without-workitem-id", "Hide inline #workitem column")
+        .option("--with-workitem-title", "Resolve workitem titles from Azure DevOps cache")
+        .option("--without-stashes", "Exclude stash commits (WIP on / index on)")
+        .option("--without-merges", "Exclude merge commits")
+        .option(
+            "--workitem <id>",
+            "Filter to commits referencing workitem ID (repeatable)",
+            (v: string, prev: number[] = []) => {
+                const parsed = parseInt(v, 10);
+                return [...prev, parsed];
+            },
+            [] as number[]
+        )
+        .option("--include-rebases", "Expand rebased-into-range commits inline")
+        .option("--date <mode>", "Grouping date: author, commit, or true-first", "author")
+        .option("--markdown", "Markdown output for standup / time-log paste")
+        .option("--clipboard", "Copy output to clipboard")
         .action(async (options: CommitsOptions) => {
             await handleCommits(options);
         });

--- a/src/git/lib/branch-attribution.ts
+++ b/src/git/lib/branch-attribution.ts
@@ -1,0 +1,303 @@
+import { Executor } from "@app/utils/cli";
+
+export interface BranchAttribution {
+    branch: string;
+    trunkFallback: boolean;
+}
+
+export interface ResolveBranchOptions {
+    excludeTrunks: string[];
+    workitemBySha: Map<string, number[]>;
+    cwd?: string;
+}
+
+const DETACHED = "(detached)";
+
+function normalizeRefName(raw: string): string {
+    let name = raw.trim();
+
+    name = name.replace(/^remotes\/origin\//, "");
+    name = name.replace(/^origin\//, "");
+    name = name.replace(/~\d+$/, "");
+    name = name.replace(/\^\d+$/, "");
+
+    return name;
+}
+
+function trunkBaseName(name: string): string {
+    const parts = name.split("/");
+
+    return parts[parts.length - 1] ?? name;
+}
+
+function isTrunk(name: string, excludeTrunks: string[]): boolean {
+    const base = trunkBaseName(name);
+
+    for (const trunk of excludeTrunks) {
+        if (name === trunk || base === trunk || name === `origin/${trunk}`) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function isShaLike(value: string): boolean {
+    return /^[0-9a-f]{7,40}$/i.test(value);
+}
+
+function pickBranchFromContains(
+    branches: string[],
+    excludeTrunks: string[],
+    workitemIds: number[]
+): string | null {
+    const filtered = branches
+        .map(normalizeRefName)
+        .filter((b) => b && !b.includes("HEAD detached") && !isTrunk(b, excludeTrunks));
+
+    if (filtered.length === 0) {
+        return null;
+    }
+
+    if (filtered.length === 1) {
+        return filtered[0];
+    }
+
+    for (const id of workitemIds) {
+        const idStr = String(id);
+
+        for (const branch of filtered) {
+            if (branch.toLowerCase().includes(idStr) || branch.toUpperCase().includes(`COL-${idStr}`)) {
+                return branch;
+            }
+        }
+    }
+
+    return [...filtered].sort((a, b) => a.localeCompare(b))[0];
+}
+
+async function nameRevBatch(shas: string[], cwd: string): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+
+    if (shas.length === 0) {
+        return result;
+    }
+
+    const input = `${shas.join("\n")}\n`;
+    const proc = Bun.spawn(
+        [
+            "git",
+            "name-rev",
+            "--name-only",
+            "--refs=refs/heads/*",
+            "--refs=refs/remotes/*",
+            "--annotate-stdin",
+        ],
+        {
+            cwd,
+            stdin: new Blob([input]),
+            stdout: "pipe",
+            stderr: "pipe",
+        }
+    );
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        return result;
+    }
+
+    const lines = stdout.trim().split("\n").filter(Boolean);
+
+    for (let i = 0; i < shas.length && i < lines.length; i++) {
+        const line = lines[i].trim();
+        const parts = line.split(/\s+/);
+        const ref = parts.length > 1 ? parts.slice(1).join(" ") : parts[0];
+        const normalized = normalizeRefName(ref);
+
+        if (isShaLike(normalized)) {
+            continue;
+        }
+
+        result.set(shas[i], normalized);
+    }
+
+    return result;
+}
+
+async function branchesContaining(sha: string, cwd: string): Promise<string[]> {
+    const executor = new Executor({ prefix: "git", verbose: false, cwd });
+    const res = await executor.exec(["branch", "-a", "--contains", sha]);
+
+    if (!res.success || !res.stdout.trim()) {
+        return [];
+    }
+
+    return res.stdout
+        .split("\n")
+        .map((line) => line.trim().replace(/^\*\s+/, ""))
+        .filter(Boolean);
+}
+
+async function buildReflogMap(cwd: string): Promise<Map<string, string>> {
+    const map = new Map<string, string>();
+    const executor = new Executor({ prefix: "git", verbose: false, cwd });
+    const res = await executor.exec(["reflog", "show", "--all", "--date=iso"]);
+
+    if (!res.success) {
+        return map;
+    }
+
+    for (const line of res.stdout.split("\n")) {
+        const match = line.match(/^([0-9a-f]{7,40})\s+(refs\/\S+?)@\{/i);
+
+        if (!match) {
+            continue;
+        }
+
+        const sha = match[1];
+        const ref = match[2];
+        const existing = map.get(sha);
+
+        if (!existing) {
+            map.set(sha, ref);
+            continue;
+        }
+
+        if (ref.startsWith("refs/heads/") && !existing.startsWith("refs/heads/")) {
+            map.set(sha, ref);
+        }
+    }
+
+    return map;
+}
+
+function lookupReflogRef(sha: string, reflogMap: Map<string, string>): string | undefined {
+    const direct = reflogMap.get(sha);
+
+    if (direct) {
+        return direct;
+    }
+
+    for (const [key, ref] of reflogMap) {
+        if (sha.startsWith(key) || key.startsWith(sha)) {
+            return ref;
+        }
+    }
+
+    return undefined;
+}
+
+function reflogBranchName(ref: string): string {
+    if (ref.startsWith("refs/heads/")) {
+        return normalizeRefName(ref.replace(/^refs\/heads\//, ""));
+    }
+
+    const worktreeHead = ref.match(/^worktrees\/[^/]+\/HEAD$/);
+
+    if (worktreeHead) {
+        return "";
+    }
+
+    return normalizeRefName(ref);
+}
+
+export async function resolveBranchForCommits(
+    shas: string[],
+    opts: ResolveBranchOptions
+): Promise<Map<string, BranchAttribution>> {
+    const cwd = opts.cwd ?? process.cwd();
+    const result = new Map<string, BranchAttribution>();
+    const excludeTrunks = opts.excludeTrunks;
+    const reflogMap = await buildReflogMap(cwd);
+    const nameRev = await nameRevBatch(shas, cwd);
+
+    const needsFallback: string[] = [];
+
+    for (const sha of shas) {
+        const fromNameRev = nameRev.get(sha);
+
+        if (fromNameRev && !isTrunk(fromNameRev, excludeTrunks)) {
+            result.set(sha, { branch: fromNameRev, trunkFallback: false });
+            continue;
+        }
+
+        needsFallback.push(sha);
+    }
+
+    const stillUnmapped: string[] = [];
+
+    for (const sha of needsFallback) {
+        const contains = await branchesContaining(sha, cwd);
+        const picked = pickBranchFromContains(contains, excludeTrunks, opts.workitemBySha.get(sha) ?? []);
+
+        if (picked) {
+            result.set(sha, { branch: picked, trunkFallback: false });
+            continue;
+        }
+
+        stillUnmapped.push(sha);
+    }
+
+    for (const sha of stillUnmapped) {
+        const reflogRef = lookupReflogRef(sha, reflogMap);
+
+        if (reflogRef) {
+            const branch = reflogBranchName(reflogRef);
+
+            if (branch && !isTrunk(branch, excludeTrunks)) {
+                result.set(sha, { branch, trunkFallback: false });
+                continue;
+            }
+        }
+
+        const fromNameRev = nameRev.get(sha);
+        const contains = await branchesContaining(sha, cwd);
+        const trunkCandidates = new Set<string>();
+
+        if (fromNameRev && isTrunk(fromNameRev, excludeTrunks)) {
+            trunkCandidates.add(fromNameRev);
+        }
+
+        for (const b of contains.map(normalizeRefName)) {
+            if (isTrunk(b, excludeTrunks)) {
+                trunkCandidates.add(b);
+            }
+        }
+
+        if (reflogRef) {
+            const rb = reflogBranchName(reflogRef);
+
+            if (rb && isTrunk(rb, excludeTrunks)) {
+                trunkCandidates.add(rb);
+            }
+        }
+
+        if (trunkCandidates.size > 0) {
+            const trunk = [...trunkCandidates].sort((a, b) => a.localeCompare(b))[0];
+            result.set(sha, { branch: trunkBaseName(trunk), trunkFallback: true });
+            continue;
+        }
+
+        result.set(sha, { branch: DETACHED, trunkFallback: false });
+    }
+
+    return result;
+}
+
+export function formatBranchTag(attribution: BranchAttribution | undefined): string {
+    if (!attribution) {
+        return "";
+    }
+
+    if (attribution.branch === DETACHED) {
+        return `(${DETACHED})`;
+    }
+
+    if (attribution.trunkFallback) {
+        return `[trunk: ${attribution.branch}]`;
+    }
+
+    return `[${attribution.branch}]`;
+}

--- a/src/git/lib/branch-attribution.ts
+++ b/src/git/lib/branch-attribution.ts
@@ -46,11 +46,7 @@ function isShaLike(value: string): boolean {
     return /^[0-9a-f]{7,40}$/i.test(value);
 }
 
-function pickBranchFromContains(
-    branches: string[],
-    excludeTrunks: string[],
-    workitemIds: number[]
-): string | null {
+function pickBranchFromContains(branches: string[], excludeTrunks: string[], workitemIds: number[]): string | null {
     const filtered = branches
         .map(normalizeRefName)
         .filter((b) => b && !b.includes("HEAD detached") && !isTrunk(b, excludeTrunks));
@@ -85,19 +81,12 @@ async function nameRevBatch(shas: string[], cwd: string): Promise<Map<string, st
 
     const input = `${shas.join("\n")}\n`;
     const proc = Bun.spawn(
-        [
-            "git",
-            "name-rev",
-            "--name-only",
-            "--refs=refs/heads/*",
-            "--refs=refs/remotes/*",
-            "--annotate-stdin",
-        ],
+        ["git", "name-rev", "--name-only", "--refs=refs/heads/*", "--refs=refs/remotes/*", "--annotate-stdin"],
         {
             cwd,
             stdin: new Blob([input]),
             stdout: "pipe",
-            stderr: "pipe",
+            stderr: "ignore",
         }
     );
 
@@ -143,7 +132,7 @@ async function branchesContaining(sha: string, cwd: string): Promise<string[]> {
 async function buildReflogMap(cwd: string): Promise<Map<string, string>> {
     const map = new Map<string, string>();
     const executor = new Executor({ prefix: "git", verbose: false, cwd });
-    const res = await executor.exec(["reflog", "show", "--all", "--date=iso"]);
+    const res = await executor.exec(["reflog", "show", "--all", "-n", "10000", "--date=iso"]);
 
     if (!res.success) {
         return map;
@@ -156,7 +145,7 @@ async function buildReflogMap(cwd: string): Promise<Map<string, string>> {
             continue;
         }
 
-        const sha = match[1];
+        const sha = match[1].toLowerCase();
         const ref = match[2];
         const existing = map.get(sha);
 
@@ -174,14 +163,15 @@ async function buildReflogMap(cwd: string): Promise<Map<string, string>> {
 }
 
 function lookupReflogRef(sha: string, reflogMap: Map<string, string>): string | undefined {
-    const direct = reflogMap.get(sha);
+    const normalized = sha.toLowerCase();
+    const direct = reflogMap.get(normalized);
 
     if (direct) {
         return direct;
     }
 
     for (const [key, ref] of reflogMap) {
-        if (sha.startsWith(key) || key.startsWith(sha)) {
+        if (normalized.startsWith(key) || key.startsWith(normalized)) {
             return ref;
         }
     }
@@ -292,7 +282,7 @@ export function formatBranchTag(attribution: BranchAttribution | undefined): str
     }
 
     if (attribution.branch === DETACHED) {
-        return `(${DETACHED})`;
+        return DETACHED;
     }
 
     if (attribution.trunkFallback) {

--- a/src/git/lib/format.ts
+++ b/src/git/lib/format.ts
@@ -1,0 +1,13 @@
+export function showItems<T>(items: T[], render: (item: T) => string): string {
+    const n = items.length;
+
+    if (n <= 6) {
+        return items.map(render).join(", ");
+    }
+
+    if (n === 7) {
+        return `${items.slice(0, 5).map(render).join(", ")}, … +2 more`;
+    }
+
+    return `${items.slice(0, 6).map(render).join(", ")}, … +${n - 6} more`;
+}

--- a/src/git/lib/markdown-render.ts
+++ b/src/git/lib/markdown-render.ts
@@ -1,0 +1,211 @@
+import { formatDateTime } from "@app/utils/date";
+import type { BranchAttribution } from "@app/git/lib/branch-attribution";
+import { formatBranchTag } from "@app/git/lib/branch-attribution";
+import { showItems } from "@app/git/lib/format";
+import type { RebaseCluster } from "@app/git/lib/rebase-classifier";
+import { formatClusterTimestamp, formatYmd } from "@app/git/lib/rebase-classifier";
+
+export interface MarkdownCommit {
+    hash: string;
+    shortHash: string;
+    message: string;
+    date: string;
+    commitDate: string;
+    author: string;
+    workitemIds: number[];
+    insertions?: number;
+    deletions?: number;
+    branchAttribution?: BranchAttribution;
+    workitemTitles?: Map<number, string>;
+    resetAuthorMarker?: boolean;
+}
+
+export interface MarkdownRenderOptions<T extends MarkdownCommit = MarkdownCommit> {
+    from: string;
+    to: string;
+    showBranch: boolean;
+    showWorkitemId: boolean;
+    includeStat: boolean;
+    groupBy: "day" | "branch" | "workitem" | "none";
+    groupingDate: (c: T) => string;
+    workitemSummary: Map<number, { commits: number; totalInsertions: number; totalDeletions: number }>;
+    rebasedClusters: RebaseCluster<T>[];
+    includeRebasesExpanded: boolean;
+    rebasedExpanded: T[];
+}
+
+function workitemTag(
+    ids: number[],
+    titles: Map<number, string> | undefined,
+    show: boolean
+): string {
+    if (!show || ids.length === 0) {
+        return "";
+    }
+
+    const parts = ids.map((id) => {
+        const title = titles?.get(id);
+
+        if (title) {
+            return `**[#${id} — ${title}]**`;
+        }
+
+        return `**[#${id}]**`;
+    });
+
+    return ` ${parts.join(" ")}`;
+}
+
+function branchTag(attribution: BranchAttribution | undefined, show: boolean): string {
+    if (!show || !attribution) {
+        return "";
+    }
+
+    const tag = formatBranchTag(attribution);
+
+    if (!tag) {
+        return "";
+    }
+
+    return ` _${tag}_`;
+}
+
+function formatDayHeader(day: string, count: number): string {
+    return `## ${formatDateTime(day, { absolute: "date-long" })} (${count} commits)`;
+}
+
+function renderCommitLine<T extends MarkdownCommit>(commit: T, opts: MarkdownRenderOptions<T>): string {
+    const marker = commit.resetAuthorMarker ? " (?)" : "";
+    const stat =
+        opts.includeStat && commit.insertions !== undefined
+            ? ` (+${commit.insertions}/-${commit.deletions})`
+            : "";
+
+    return `- \`${commit.shortHash}\`${marker} ${commit.message}${branchTag(commit.branchAttribution, opts.showBranch)}${workitemTag(commit.workitemIds, commit.workitemTitles, opts.showWorkitemId)}${stat}`;
+}
+
+export function renderMarkdown<T extends MarkdownCommit>(
+    commits: T[],
+    options: MarkdownRenderOptions<T>
+): string {
+    const lines: string[] = [];
+
+    if (options.groupBy === "none") {
+        const sorted = [...commits].sort((a, b) => options.groupingDate(b).localeCompare(options.groupingDate(a)));
+
+        for (const commit of sorted) {
+            lines.push(renderCommitLine(commit, options));
+        }
+    } else if (options.groupBy === "branch") {
+        const groups = groupByKey(commits, (c) => c.branchAttribution?.branch ?? "(detached)");
+
+        for (const [branch, group] of [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+            lines.push(`## [${branch}] (${group.length} commits)`);
+            lines.push("");
+
+            for (const commit of group) {
+                lines.push(renderCommitLine(commit, options));
+            }
+
+            lines.push("");
+        }
+    } else if (options.groupBy === "workitem") {
+        const groups = groupByKey(commits, (c) =>
+            c.workitemIds.length > 0 ? `#${c.workitemIds[0]}` : "[no-workitem]"
+        );
+
+        for (const [key, group] of [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+            lines.push(`## [${key}] (${group.length} commits)`);
+            lines.push("");
+
+            for (const commit of group) {
+                lines.push(renderCommitLine(commit, options));
+            }
+
+            lines.push("");
+        }
+    } else {
+        const groups = groupByKey(commits, (c) => options.groupingDate(c).split("T")[0]);
+        const sortedDays = [...groups.keys()].sort();
+
+        for (const day of sortedDays) {
+            const group = groups.get(day)!;
+            lines.push(formatDayHeader(day, group.length));
+            lines.push("");
+
+            for (const commit of group) {
+                lines.push(renderCommitLine(commit, options));
+            }
+
+            lines.push("");
+        }
+    }
+
+    if (options.workitemSummary.size > 0) {
+        lines.push("### Workitem summary");
+        lines.push("");
+
+        for (const [id, stats] of [...options.workitemSummary.entries()].sort((a, b) => a[0] - b[0])) {
+            lines.push(`- **#${id}** — ${stats.commits} commit(s)`);
+        }
+
+        lines.push("");
+    }
+
+    if (options.includeRebasesExpanded && options.rebasedExpanded.length > 0) {
+        lines.push(`### Rebased into range (${options.rebasedExpanded.length})`);
+        lines.push("");
+
+        const byDay = groupByKey(options.rebasedExpanded, (c) => c.commitDate.split("T")[0]);
+
+        for (const day of [...byDay.keys()].sort()) {
+            lines.push(`#### ${formatDateTime(day, { absolute: "date-long" })}`);
+            lines.push("");
+
+            for (const commit of byDay.get(day)!) {
+                const authored =
+                    commit.date.split("T")[0] !== commit.commitDate.split("T")[0]
+                        ? ` [authored ${commit.date.split("T")[0]}]`
+                        : "";
+                lines.push(
+                    `${renderCommitLine(commit, options).replace(/^- /, "- ")}${authored}`
+                );
+            }
+
+            lines.push("");
+        }
+    } else if (options.rebasedClusters.length > 0) {
+        const total = options.rebasedClusters.reduce((n, c) => n + c.commits.length, 0);
+        lines.push(`### Rebased into range (${total})`);
+        lines.push("");
+        lines.push(`… and ${total} commits rebased into this range (use --include-rebases):`);
+        lines.push("");
+
+        for (const cluster of options.rebasedClusters) {
+            const landed = formatClusterTimestamp(cluster.landedAt);
+            const from = formatYmd(cluster.authorDateRange[0]);
+            const to = formatYmd(cluster.authorDateRange[1]);
+            lines.push(
+                `- ${cluster.commits.length} commits rebased ${landed}, authored ${from} – ${to}`
+            );
+            lines.push(
+                `  - ${showItems(cluster.commits, (c) => `\`${c.shortHash}\``)}`
+            );
+        }
+    }
+
+    return lines.join("\n").trimEnd();
+}
+
+function groupByKey<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
+    const map = new Map<string, T[]>();
+
+    for (const item of items) {
+        const key = keyFn(item);
+        const list = map.get(key) ?? [];
+        list.push(item);
+        map.set(key, list);
+    }
+
+    return map;
+}

--- a/src/git/lib/markdown-render.ts
+++ b/src/git/lib/markdown-render.ts
@@ -1,9 +1,9 @@
-import { formatDateTime } from "@app/utils/date";
 import type { BranchAttribution } from "@app/git/lib/branch-attribution";
 import { formatBranchTag } from "@app/git/lib/branch-attribution";
 import { showItems } from "@app/git/lib/format";
 import type { RebaseCluster } from "@app/git/lib/rebase-classifier";
 import { formatClusterTimestamp, formatYmd } from "@app/git/lib/rebase-classifier";
+import { formatDateTime } from "@app/utils/date";
 
 export interface MarkdownCommit {
     hash: string;
@@ -34,11 +34,7 @@ export interface MarkdownRenderOptions<T extends MarkdownCommit = MarkdownCommit
     rebasedExpanded: T[];
 }
 
-function workitemTag(
-    ids: number[],
-    titles: Map<number, string> | undefined,
-    show: boolean
-): string {
+function workitemTag(ids: number[], titles: Map<number, string> | undefined, show: boolean): string {
     if (!show || ids.length === 0) {
         return "";
     }
@@ -77,17 +73,12 @@ function formatDayHeader(day: string, count: number): string {
 function renderCommitLine<T extends MarkdownCommit>(commit: T, opts: MarkdownRenderOptions<T>): string {
     const marker = commit.resetAuthorMarker ? " (?)" : "";
     const stat =
-        opts.includeStat && commit.insertions !== undefined
-            ? ` (+${commit.insertions}/-${commit.deletions})`
-            : "";
+        opts.includeStat && commit.insertions !== undefined ? ` (+${commit.insertions}/-${commit.deletions})` : "";
 
     return `- \`${commit.shortHash}\`${marker} ${commit.message}${branchTag(commit.branchAttribution, opts.showBranch)}${workitemTag(commit.workitemIds, commit.workitemTitles, opts.showWorkitemId)}${stat}`;
 }
 
-export function renderMarkdown<T extends MarkdownCommit>(
-    commits: T[],
-    options: MarkdownRenderOptions<T>
-): string {
+export function renderMarkdown<T extends MarkdownCommit>(commits: T[], options: MarkdownRenderOptions<T>): string {
     const lines: string[] = [];
 
     if (options.groupBy === "none") {
@@ -167,9 +158,7 @@ export function renderMarkdown<T extends MarkdownCommit>(
                     commit.date.split("T")[0] !== commit.commitDate.split("T")[0]
                         ? ` [authored ${commit.date.split("T")[0]}]`
                         : "";
-                lines.push(
-                    `${renderCommitLine(commit, options).replace(/^- /, "- ")}${authored}`
-                );
+                lines.push(`${renderCommitLine(commit, options).replace(/^- /, "- ")}${authored}`);
             }
 
             lines.push("");
@@ -185,12 +174,8 @@ export function renderMarkdown<T extends MarkdownCommit>(
             const landed = formatClusterTimestamp(cluster.landedAt);
             const from = formatYmd(cluster.authorDateRange[0]);
             const to = formatYmd(cluster.authorDateRange[1]);
-            lines.push(
-                `- ${cluster.commits.length} commits rebased ${landed}, authored ${from} – ${to}`
-            );
-            lines.push(
-                `  - ${showItems(cluster.commits, (c) => `\`${c.shortHash}\``)}`
-            );
+            lines.push(`- ${cluster.commits.length} commits rebased ${landed}, authored ${from} – ${to}`);
+            lines.push(`  - ${showItems(cluster.commits, (c) => `\`${c.shortHash}\``)}`);
         }
     }
 

--- a/src/git/lib/patch-id-dedup.ts
+++ b/src/git/lib/patch-id-dedup.ts
@@ -3,11 +3,24 @@ export interface PatchIdCommit {
     commitDate: string;
 }
 
+function commitDateMs(commitDate: string): number {
+    const ms = new Date(commitDate).getTime();
+
+    return Number.isNaN(ms) ? 0 : ms;
+}
+
 export async function computePatchIds(shas: string[], cwd: string): Promise<Map<string, string>> {
     const result = new Map<string, string>();
 
-    for (const sha of shas) {
-        const showProc = Bun.spawn(["git", "show", "--no-color", sha], {
+    if (shas.length === 0) {
+        return result;
+    }
+
+    const batchSize = 100;
+
+    for (let i = 0; i < shas.length; i += batchSize) {
+        const batch = shas.slice(i, i + batchSize);
+        const showProc = Bun.spawn(["git", "show", "--no-color", ...batch], {
             cwd,
             stdout: "pipe",
             stderr: "ignore",
@@ -30,16 +43,24 @@ export async function computePatchIds(shas: string[], cwd: string): Promise<Map<
             continue;
         }
 
-        const line = stdout.trim().split("\n")[0];
+        for (const line of stdout.trim().split("\n")) {
+            const parts = line.trim().split(/\s+/);
 
-        if (!line) {
-            continue;
-        }
+            if (parts.length < 2) {
+                continue;
+            }
 
-        const patchId = line.split(/\s+/)[0];
+            const [patchId, sha] = parts;
+            result.set(sha.toLowerCase(), patchId);
 
-        if (patchId) {
-            result.set(sha, patchId);
+            for (const inputSha of batch) {
+                if (
+                    inputSha.toLowerCase().startsWith(sha.toLowerCase()) ||
+                    sha.toLowerCase().startsWith(inputSha.toLowerCase())
+                ) {
+                    result.set(inputSha, patchId);
+                }
+            }
         }
     }
 
@@ -74,7 +95,7 @@ export function dedupByPatchId<T extends PatchIdCommit>(commits: T[], patchIds: 
         let best = group[0];
 
         for (const candidate of group.slice(1)) {
-            if (candidate.commitDate > best.commitDate) {
+            if (commitDateMs(candidate.commitDate) > commitDateMs(best.commitDate)) {
                 best = candidate;
             }
         }

--- a/src/git/lib/patch-id-dedup.ts
+++ b/src/git/lib/patch-id-dedup.ts
@@ -1,0 +1,86 @@
+export interface PatchIdCommit {
+    hash: string;
+    commitDate: string;
+}
+
+export async function computePatchIds(shas: string[], cwd: string): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+
+    for (const sha of shas) {
+        const showProc = Bun.spawn(["git", "show", "--no-color", sha], {
+            cwd,
+            stdout: "pipe",
+            stderr: "ignore",
+        });
+
+        const patchProc = Bun.spawn(["git", "patch-id", "--stable"], {
+            cwd,
+            stdin: showProc.stdout,
+            stdout: "pipe",
+            stderr: "ignore",
+        });
+
+        const [showExit, patchExit, stdout] = await Promise.all([
+            showProc.exited,
+            patchProc.exited,
+            new Response(patchProc.stdout).text(),
+        ]);
+
+        if (showExit !== 0 || patchExit !== 0) {
+            continue;
+        }
+
+        const line = stdout.trim().split("\n")[0];
+
+        if (!line) {
+            continue;
+        }
+
+        const patchId = line.split(/\s+/)[0];
+
+        if (patchId) {
+            result.set(sha, patchId);
+        }
+    }
+
+    return result;
+}
+
+export function dedupByPatchId<T extends PatchIdCommit>(commits: T[], patchIds: Map<string, string>): T[] {
+    const groups = new Map<string, T[]>();
+    const noPatchId: T[] = [];
+
+    for (const commit of commits) {
+        const patchId = patchIds.get(commit.hash);
+
+        if (!patchId) {
+            noPatchId.push(commit);
+            continue;
+        }
+
+        const existing = groups.get(patchId) ?? [];
+        existing.push(commit);
+        groups.set(patchId, existing);
+    }
+
+    const kept: T[] = [...noPatchId];
+
+    for (const group of groups.values()) {
+        if (group.length === 1) {
+            kept.push(group[0]);
+            continue;
+        }
+
+        let best = group[0];
+
+        for (const candidate of group.slice(1)) {
+            if (candidate.commitDate > best.commitDate) {
+                best = candidate;
+            }
+        }
+
+        kept.push(best);
+    }
+
+    return kept;
+}

--- a/src/git/lib/rebase-classifier.ts
+++ b/src/git/lib/rebase-classifier.ts
@@ -67,17 +67,12 @@ export function isLikelyResetAuthor(
     return sameMinuteCount >= 2;
 }
 
-export function clusterRebasedByCI<T extends ClassifiableCommit>(
-    rebased: T[],
-    gapMs = 300_000
-): RebaseCluster<T>[] {
+export function clusterRebasedByCI<T extends ClassifiableCommit>(rebased: T[], gapMs = 300_000): RebaseCluster<T>[] {
     if (rebased.length === 0) {
         return [];
     }
 
-    const sorted = [...rebased].sort(
-        (a, b) => parseIsoMs(a.commitDate) - parseIsoMs(b.commitDate)
-    );
+    const sorted = [...rebased].sort((a, b) => parseIsoMs(a.commitDate) - parseIsoMs(b.commitDate));
 
     const clusters: RebaseCluster<T>[] = [];
     let current: T[] = [sorted[0]];

--- a/src/git/lib/rebase-classifier.ts
+++ b/src/git/lib/rebase-classifier.ts
@@ -1,0 +1,124 @@
+export interface ClassifiableCommit {
+    date: string;
+    commitDate: string;
+}
+
+export interface RebaseCluster<T extends ClassifiableCommit> {
+    landedAt: Date;
+    commits: T[];
+    authorDateRange: [Date, Date];
+}
+
+export function parseIsoMs(iso: string): number {
+    return new Date(iso).getTime();
+}
+
+export function rangeBoundsMs(from: string, to: string): { fromMs: number; toMs: number } {
+    const fromMs = new Date(`${from}T00:00:00.000Z`).getTime();
+    const toMs = new Date(`${to}T23:59:59.999Z`).getTime();
+
+    return { fromMs, toMs };
+}
+
+export function classifyCommit(
+    commit: ClassifiableCommit,
+    bounds: { fromMs: number; toMs: number }
+): "authored" | "rebased" | "skip" {
+    const aIMs = parseIsoMs(commit.date);
+    const cIMs = parseIsoMs(commit.commitDate);
+
+    if (aIMs >= bounds.fromMs && aIMs <= bounds.toMs) {
+        return "authored";
+    }
+
+    if (aIMs < bounds.fromMs && cIMs >= bounds.fromMs && cIMs <= bounds.toMs) {
+        return "rebased";
+    }
+
+    return "skip";
+}
+
+export function isLikelyResetAuthor(
+    commit: ClassifiableCommit,
+    allCommits: ClassifiableCommit[],
+    resetAuthorWindowMs = 60_000
+): boolean {
+    const gap = parseIsoMs(commit.commitDate) - parseIsoMs(commit.date);
+
+    if (gap >= resetAuthorWindowMs) {
+        return false;
+    }
+
+    const cMinute = commit.commitDate.slice(0, 16);
+    let sameMinuteCount = 0;
+
+    for (const other of allCommits) {
+        if (other.commitDate.slice(0, 16) !== cMinute) {
+            continue;
+        }
+
+        const otherGap = parseIsoMs(other.commitDate) - parseIsoMs(other.date);
+
+        if (otherGap < resetAuthorWindowMs) {
+            sameMinuteCount++;
+        }
+    }
+
+    return sameMinuteCount >= 2;
+}
+
+export function clusterRebasedByCI<T extends ClassifiableCommit>(
+    rebased: T[],
+    gapMs = 300_000
+): RebaseCluster<T>[] {
+    if (rebased.length === 0) {
+        return [];
+    }
+
+    const sorted = [...rebased].sort(
+        (a, b) => parseIsoMs(a.commitDate) - parseIsoMs(b.commitDate)
+    );
+
+    const clusters: RebaseCluster<T>[] = [];
+    let current: T[] = [sorted[0]];
+
+    for (let i = 1; i < sorted.length; i++) {
+        const prev = sorted[i - 1];
+        const cur = sorted[i];
+        const gap = parseIsoMs(cur.commitDate) - parseIsoMs(prev.commitDate);
+
+        if (gap > gapMs) {
+            clusters.push(buildCluster(current));
+            current = [cur];
+        } else {
+            current.push(cur);
+        }
+    }
+
+    clusters.push(buildCluster(current));
+
+    return clusters;
+}
+
+function buildCluster<T extends ClassifiableCommit>(commits: T[]): RebaseCluster<T> {
+    const authorTimes = commits.map((c) => parseIsoMs(c.date));
+    const landedAt = new Date(parseIsoMs(commits[0].commitDate));
+
+    return {
+        landedAt,
+        commits,
+        authorDateRange: [new Date(Math.min(...authorTimes)), new Date(Math.max(...authorTimes))],
+    };
+}
+
+export function formatYmd(d: Date): string {
+    return d.toISOString().slice(0, 10);
+}
+
+export function formatClusterTimestamp(d: Date): string {
+    const iso = d.toISOString();
+    const date = iso.slice(0, 10);
+    const time = iso.slice(11, 16);
+
+    return `${date} ${time}`;
+}


### PR DESCRIPTION
## Summary

Redesigns `tools git commits` to fix four reported issues and add standup-friendly output:

1. **Workitem IDs** — No repo change to default patterns; per-user `~/.genesis-tools/git/config.json` tightened to `\d{5,6}` (backup at `config.json.bak`). Footer no longer lists 1–4 digit phantom IDs.
2. **Branch attribution** — Cascade: `name-rev` → trunk filter → `branch --contains` (workitem-aware) → reflog rescue → trunk-only `[trunk: …]` fallback → `(detached)`.
3. **Rebase / dates** — Patch-id dedup (newest committer wins), authored vs rebased-into-range split, compressed cluster footer (B.0 truncation, never `+1 more`), optional `--include-rebases` with `[authored …]` tags, `(?)` reset-author hint.
4. **Grouping & columns** — `--group-by day|branch|workitem|none`, inline `[branch]` / `[#id]` by default, `--markdown` / `--clipboard`, `--with-workitem-title` via `enrichWorkItems`.

New modules under `src/git/lib/`: `format`, `branch-attribution`, `patch-id-dedup`, `rebase-classifier`, `markdown-render`.

## Verification (col-fe, worktree binary)

| Check | Result |
|-------|--------|
| C.1 config backup + tight patterns | Pass |
| C.1.3 no 1–4 digit workitem summary keys | Pass |
| C.2.1 fa9db75 → col-283375-search-partner-page | Pass (with CEZ author in log) |
| C.2.2 2f50166 → develop + trunk tag | Pass |
| C.2.3 e3896c7/32a3f66/7182379 → feat/col-mobile-testids-tests | Pass |
| C.3.1 no 2025 day headers in default run | Pass |
| C.3.4 no `+1 more` | Pass |
| C.3.5 c8a5b69+3e2c50e patch-id dedup → 1 row | Pass |
| C.3 rebase footer + clusters | Pass (11 @ 08:33 cluster, `+5 more`) |
| C.4 grouping / `--workitem 277298` | Pass |
| C.5 stashes / merges / markdown | Pass |
| `tsgo --noEmit` `src/git/` | Clean |

## Follow-up

**C.7 — `--author` over-match:** configured emails still substring-match other authors (555 vs 37 commits). Out of scope; track exact-email / `--author-partial` separately.

## Test plan

- [x] `tools git commits --from 2026-05-14 --to 2026-05-27` in col-fe (no 2025 day headers, rebased footer)
- [x] `--include-rebases` + JSON branch fields for quoted SHAs
- [x] `--markdown --clipboard` (optional manual `pbpaste`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group commits by branch, day, workitem ID, or none
  * Markdown output with clipboard copy and richer grouping
  * Fetch and include workitem titles; filter by workitem ID (repeatable)
  * Hide columns, exclude merges/stashes, inline/expanded rebased views
  * Patch-id deduplication and rebased/authored classification; branch attribution with trunk fallback

* **Documentation**
  * Expanded quick start, examples, and configuration guidance for branch/workitem behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->