### PR TITLE
feat: tools task orchestration + Q&A dev-dashboard

### DIFF
--- a/src/dev-dashboard/lib/obsidian-save.test.ts
+++ b/src/dev-dashboard/lib/obsidian-save.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveToObsidianUnique } from "./obsidian-save";
+
+describe("saveToObsidianUnique", () => {
+    let vaultRoot = "";
+
+    afterEach(async () => {
+        if (vaultRoot) {
+            await rm(vaultRoot, { recursive: true, force: true });
+            vaultRoot = "";
+        }
+    });
+
+    test("creates unique suffix when file exists", async () => {
+        vaultRoot = await mkdtemp(join(tmpdir(), "vault-"));
+        const dir = "notes";
+
+        await saveToObsidianUnique({
+            vaultRoot,
+            relativeDir: dir,
+            baseName: "test-note",
+            content: "first",
+            mode: "create",
+            createDir: true,
+        });
+
+        const second = await saveToObsidianUnique({
+            vaultRoot,
+            relativeDir: dir,
+            baseName: "test-note",
+            content: "second",
+            mode: "create",
+            createDir: true,
+        });
+
+        expect(second.path).toContain("test-note-2.md");
+        const body = await readFile(second.path, "utf8");
+        expect(body).toBe("second");
+    });
+
+    test("rejects directory traversal", async () => {
+        vaultRoot = await mkdtemp(join(tmpdir(), "vault-"));
+
+        await expect(
+            saveToObsidianUnique({
+                vaultRoot,
+                relativeDir: "../outside",
+                baseName: "note",
+                content: "nope",
+                mode: "create",
+                createDir: true,
+            })
+        ).rejects.toThrow(/escapes vault/);
+    });
+
+    test("rejects baseName with path separators", async () => {
+        vaultRoot = await mkdtemp(join(tmpdir(), "vault-"));
+
+        await expect(
+            saveToObsidianUnique({
+                vaultRoot,
+                relativeDir: "inbox",
+                baseName: "foo/bar",
+                content: "nope",
+                mode: "create",
+                createDir: true,
+            })
+        ).rejects.toThrow(/path separators/);
+    });
+
+    test("rejects filename traversal", async () => {
+        vaultRoot = await mkdtemp(join(tmpdir(), "vault-"));
+
+        await expect(
+            saveToObsidianUnique({
+                vaultRoot,
+                relativeDir: "inbox",
+                baseName: "../../etc/passwd",
+                content: "nope",
+                mode: "create",
+                createDir: true,
+            })
+        ).rejects.toThrow(/path separators/);
+    });
+
+    test("appends to existing file", async () => {
+        vaultRoot = await mkdtemp(join(tmpdir(), "vault-"));
+        const first = await saveToObsidianUnique({
+            vaultRoot,
+            relativeDir: "inbox",
+            baseName: "append-me",
+            content: "line one",
+            mode: "create",
+            createDir: true,
+        });
+
+        await saveToObsidianUnique({
+            vaultRoot,
+            relativeDir: "inbox",
+            baseName: "append-me",
+            content: "line two",
+            mode: "append",
+            createDir: true,
+        });
+
+        const body = await readFile(first.path, "utf8");
+        expect(body).toContain("line one");
+        expect(body).toContain("line two");
+    });
+});

--- a/src/dev-dashboard/lib/obsidian-save.ts
+++ b/src/dev-dashboard/lib/obsidian-save.ts
@@ -1,0 +1,92 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+
+function resolveUnderVault(vaultRoot: string, ...segments: string[]): string {
+    const root = resolve(vaultRoot);
+    const target = resolve(root, ...segments);
+
+    if (target !== root && !target.startsWith(`${root}${sep}`)) {
+        throw new Error(`path escapes vault: ${segments.join("/")}`);
+    }
+
+    return target;
+}
+
+function assertSafeBaseName(baseName: string): void {
+    if (baseName.includes("/") || baseName.includes("\\") || baseName.includes("..")) {
+        throw new Error("baseName must not contain path separators");
+    }
+}
+
+function resolveFileInDir(dir: string, fileName: string): string {
+    const target = resolve(dir, fileName);
+
+    if (target !== dir && !target.startsWith(`${dir}${sep}`)) {
+        throw new Error(`file escapes directory: ${fileName}`);
+    }
+
+    return target;
+}
+
+async function readExistingMarkdown(path: string): Promise<string> {
+    try {
+        return await readFile(path, "utf8");
+    } catch (err: unknown) {
+        if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+            return "";
+        }
+
+        throw err;
+    }
+}
+
+export async function saveToObsidianUnique(opts: {
+    vaultRoot: string;
+    relativeDir: string;
+    baseName: string;
+    content: string;
+    mode: "create" | "append";
+    createDir?: boolean;
+}): Promise<{ path: string }> {
+    assertSafeBaseName(opts.baseName);
+    const dir = resolveUnderVault(opts.vaultRoot, opts.relativeDir);
+
+    if (opts.createDir) {
+        await mkdir(dir, { recursive: true });
+    } else {
+        const dirStat = await stat(dir).catch(() => null);
+
+        if (!dirStat?.isDirectory()) {
+            throw new Error(`directory does not exist: ${opts.relativeDir}`);
+        }
+    }
+
+    if (opts.mode === "append") {
+        const path = resolveFileInDir(dir, `${opts.baseName}.md`);
+        const existing = await readExistingMarkdown(path);
+        const sep = existing && !existing.endsWith("\n") ? "\n\n" : existing ? "\n" : "";
+
+        await writeFile(path, existing + sep + opts.content);
+
+        return { path };
+    }
+
+    for (let n = 1; n <= 999; n++) {
+        const candidate = n === 1 ? `${opts.baseName}.md` : `${opts.baseName}-${n}.md`;
+        const path = resolveFileInDir(dir, candidate);
+
+        try {
+            await writeFile(path, opts.content, { flag: "wx" });
+
+            return { path };
+        } catch (err: unknown) {
+            if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
+                continue;
+            }
+
+            throw err;
+        }
+    }
+
+    throw new Error("too many duplicates");
+}

--- a/src/dev-dashboard/lib/obsidian/reader.ts
+++ b/src/dev-dashboard/lib/obsidian/reader.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import type { VaultEntry } from "@app/dev-dashboard/lib/obsidian/types";
 
@@ -47,6 +47,11 @@ export async function listVault(vaultRoot: string): Promise<VaultEntry[]> {
     }
 
     return walk(vaultRoot);
+}
+
+export async function mkdirInVault(vaultRoot: string, relativeDir: string): Promise<void> {
+    const full = assertInsideVault(vaultRoot, relativeDir);
+    await mkdir(full, { recursive: true });
 }
 
 export async function readNote(vaultRoot: string, relativePath: string): Promise<string> {

--- a/src/dev-dashboard/lib/qa-clipboard.ts
+++ b/src/dev-dashboard/lib/qa-clipboard.ts
@@ -1,0 +1,55 @@
+import { renderQaAnswerHtml, renderQaQuestionHtml } from "@app/dev-dashboard/lib/qa-render";
+import type { QaRow } from "./qa-types";
+
+function frontmatter(entry: QaRow): string {
+    return [
+        "---",
+        `id: ${entry.id}`,
+        `ts: ${new Date(entry.ts).toISOString()}`,
+        `tag: ${entry.tag}`,
+        entry.project ? `project: ${entry.project}` : "",
+        entry.branch ? `branch: ${entry.branch}` : "",
+        "---",
+    ]
+        .filter(Boolean)
+        .join("\n");
+}
+
+export function suggestObsidianFilename(question: string): string {
+    return (
+        question
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, "")
+            .trim()
+            .split(/\s+/)
+            .slice(0, 8)
+            .join("-")
+            .slice(0, 60) || "question"
+    );
+}
+
+export function formatQaAsMarkdown(entry: QaRow, opts?: { includeFrontmatter?: boolean; includeQuestion?: boolean }): string {
+    const includeFrontmatter = opts?.includeFrontmatter !== false;
+    const includeQuestion = opts?.includeQuestion !== false;
+    const refs =
+        entry.refs.length > 0
+            ? `\n\n**Refs:** ${entry.refs.map((r) => `${r.type}:${r.value}`).join(", ")}`
+            : "";
+    const fm = includeFrontmatter ? `${frontmatter(entry)}\n\n` : "";
+    const question = includeQuestion ? `## Question\n\n${entry.question}\n\n` : "";
+
+    return `${fm}${question}## Answer\n\n${entry.answerMd}${refs}\n`;
+}
+
+export function formatQaAsHtml(entry: QaRow, opts?: { includeQuestion?: boolean }): string {
+    const includeQuestion = opts?.includeQuestion !== false;
+    const refs =
+        entry.refs.length > 0
+            ? `<p><strong>Refs:</strong> ${entry.refs.map((r) => `${r.type}:${r.value}`).join(", ")}</p>`
+            : "";
+    const question = includeQuestion
+        ? `<h2>Question</h2>\n${renderQaQuestionHtml(entry.question)}\n`
+        : "";
+
+    return `<article>\n${question}<h2>Answer</h2>\n${renderQaAnswerHtml(entry.answerMd)}\n${refs}\n</article>`;
+}

--- a/src/dev-dashboard/lib/qa-render.test.ts
+++ b/src/dev-dashboard/lib/qa-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { enrichQaEntry, renderQaAnswerHtml } from "@app/dev-dashboard/lib/qa-render";
+import { enrichQaEntry, renderQaAnswerHtml, renderQaQuestionHtml } from "@app/dev-dashboard/lib/qa-render";
 import type { QaEntry } from "@app/question/lib/types";
 
 const baseEntry: QaEntry = {
@@ -42,6 +42,15 @@ export function Widget({ title }: { title: string }) {
     });
 });
 
+describe("renderQaQuestionHtml", () => {
+    test("renders markdown bold and code", () => {
+        const html = renderQaQuestionHtml("Why **bold** and `code`?");
+
+        expect(html).toContain("<strong>bold</strong>");
+        expect(html).toContain("code");
+    });
+});
+
 describe("enrichQaEntry", () => {
     test("builds preview html for answers over the line limit", () => {
         const lines = Array.from({ length: 52 }, (_, i) => `line ${i + 1}`);
@@ -53,5 +62,6 @@ describe("enrichQaEntry", () => {
         expect(entry.answerHtml).toContain("line 52");
         expect(entry.answerHtmlPreview).toContain("line 50");
         expect(entry.answerHtmlPreview).not.toContain("line 51");
+        expect(entry.questionHtml).toContain("How does");
     });
 });

--- a/src/dev-dashboard/lib/qa-render.ts
+++ b/src/dev-dashboard/lib/qa-render.ts
@@ -14,22 +14,28 @@ export function renderQaAnswerHtml(answerMd: string): string {
     return renderMarkdown(answerMd, noopWikilink).html;
 }
 
+export function renderQaQuestionHtml(questionMd: string): string {
+    return renderMarkdown(questionMd, noopWikilink).html;
+}
+
 export type EnrichedQaEntry = QaEntry & {
     answerHtml: string;
     answerHtmlPreview: string;
+    questionHtml: string;
 };
 
 export function enrichQaEntry(entry: QaEntry): EnrichedQaEntry {
     const lines = entry.answerMd.split("\n");
     const answerHtml = renderQaAnswerHtml(entry.answerMd);
+    const questionHtml = renderQaQuestionHtml(entry.question);
     const truncated = isQaAnswerTruncated(entry.answerMd);
 
     if (!truncated) {
-        return { ...entry, answerHtml, answerHtmlPreview: answerHtml };
+        return { ...entry, answerHtml, answerHtmlPreview: answerHtml, questionHtml };
     }
 
     const previewMd = `${lines.slice(0, QA_ANSWER_PREVIEW_LINES).join("\n")}\n…`;
     const answerHtmlPreview = renderQaAnswerHtml(previewMd);
 
-    return { ...entry, answerHtml, answerHtmlPreview };
+    return { ...entry, answerHtml, answerHtmlPreview, questionHtml };
 }

--- a/src/dev-dashboard/lib/qa-search.test.ts
+++ b/src/dev-dashboard/lib/qa-search.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { searchQa } from "./qa-search";
+import type { QaRow } from "./qa-types";
+
+function row(over: Partial<QaRow> & { id: string }): QaRow {
+    return {
+        id: over.id,
+        ts: Date.now(),
+        sessionId: "s",
+        sessionTitle: null,
+        project: "P",
+        repoRoot: "/r",
+        cwd: "/r",
+        branch: null,
+        commitSha: null,
+        isWorktree: false,
+        worktreePath: null,
+        aiAgent: null,
+        agentLabel: null,
+        tag: "question",
+        question: over.question ?? "q",
+        answerMd: over.answerMd ?? "a",
+        refs: [],
+        source: "cli",
+        turnUuid: null,
+        answerHtml: "<p>a</p>",
+        answerHtmlPreview: "<p>a</p>",
+        questionHtml: "<p>q</p>",
+        supersededBy: null,
+        readAt: null,
+        ...over,
+    };
+}
+
+describe("searchQa", () => {
+    test("empty query returns all rows", () => {
+        const rows = [row({ id: "1" }), row({ id: "2" })];
+        expect(searchQa(rows, "").entries).toHaveLength(2);
+    });
+
+    test("filters by tokenized query", () => {
+        const rows = [
+            row({ id: "1", question: "metro bundler setup" }),
+            row({ id: "2", question: "unrelated topic" }),
+        ];
+        const { entries } = searchQa(rows, "metro");
+
+        expect(entries.map((e) => e.id)).toEqual(["1"]);
+    });
+});

--- a/src/dev-dashboard/lib/qa-search.ts
+++ b/src/dev-dashboard/lib/qa-search.ts
@@ -1,0 +1,36 @@
+import { scoreEntry, tokenizeSearch } from "@app/utils/fuzzy-tokens";
+import type { QaRow } from "./qa-types";
+
+export interface SearchResult {
+    entries: QaRow[];
+    tokens: string[];
+}
+
+function entryHaystack(row: QaRow): string {
+    return [
+        row.question,
+        row.answerMd,
+        row.tag,
+        row.project ?? "",
+        row.branch ?? "",
+        row.commitSha ?? "",
+        row.agentLabel ?? "",
+        row.refs.map((x) => `${x.type}:${x.value}`).join(" "),
+    ].join(" ");
+}
+
+export function searchQa(rows: QaRow[], query: string): SearchResult {
+    const tokens = tokenizeSearch(query);
+
+    if (tokens.length === 0) {
+        return { entries: rows, tokens: [] };
+    }
+
+    const entries = rows
+        .map((entry) => ({ entry, score: scoreEntry(entryHaystack(entry), tokens) }))
+        .filter((x) => x.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map((x) => x.entry);
+
+    return { entries, tokens };
+}

--- a/src/dev-dashboard/lib/qa-types.ts
+++ b/src/dev-dashboard/lib/qa-types.ts
@@ -1,0 +1,7 @@
+import type { EnrichedQaEntry } from "@app/dev-dashboard/lib/qa-render";
+import type { QaEntry } from "@app/question/lib/types";
+
+export interface QaRow extends QaEntry, EnrichedQaEntry {
+    supersededBy: string | null;
+    readAt: number | null;
+}

--- a/src/dev-dashboard/ui/src/components/ObsidianTree.tsx
+++ b/src/dev-dashboard/ui/src/components/ObsidianTree.tsx
@@ -1,12 +1,17 @@
 import type { VaultEntry } from "@app/dev-dashboard/lib/obsidian/types";
+import { SafeJSON } from "@app/utils/json";
+import { Button } from "@ui/components/button";
 import { Input } from "@ui/components/input";
-import { ChevronDown, ChevronRight, FileText, Folder } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, Folder, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 interface Props {
     entries: VaultEntry[];
     onSelect: (relativePath: string) => void;
     selected: string | null;
+    selectDirectories?: boolean;
+    allowAddDir?: boolean;
+    onTreeChange?: () => void;
 }
 
 function filterEntries(entries: VaultEntry[], query: string): VaultEntry[] {
@@ -34,30 +39,53 @@ function Node({
     onSelect,
     selected,
     forceOpen,
+    selectDirectories,
 }: {
     entry: VaultEntry;
     onSelect: Props["onSelect"];
     selected: string | null;
     forceOpen: boolean;
+    selectDirectories?: boolean;
 }) {
     const [open, setOpen] = useState(false);
 
     if (entry.isDirectory) {
         const expanded = forceOpen || open;
+        const isActive = selectDirectories && selected === entry.relativePath;
 
         return (
             <li>
-                <button
-                    type="button"
-                    className="flex w-full items-center gap-1 px-1 text-left font-mono text-[11px] text-[var(--dd-text-secondary)] hover:text-[var(--dd-text-primary)]"
-                    onClick={() => setOpen((value) => !value)}
-                >
-                    {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    <Folder size={12} />
-                    <span className="truncate">{entry.name}</span>
-                </button>
+                <div className="flex w-full items-center gap-0.5">
+                    <button
+                        type="button"
+                        className="shrink-0 px-0.5 text-[var(--dd-text-secondary)]"
+                        aria-label={expanded ? "Collapse folder" : "Expand folder"}
+                        onClick={() => setOpen((value) => !value)}
+                    >
+                        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    </button>
+                    <button
+                        type="button"
+                        className="flex min-w-0 flex-1 items-center gap-1 rounded px-1 text-left font-mono text-[11px]"
+                        style={
+                            isActive
+                                ? { background: "var(--dd-accent-gradient)", color: "#0c0e10" }
+                                : { color: "var(--dd-text-secondary)" }
+                        }
+                        onClick={() => {
+                            if (selectDirectories) {
+                                onSelect(entry.relativePath);
+                            } else {
+                                setOpen((value) => !value);
+                            }
+                        }}
+                    >
+                        <Folder size={12} />
+                        <span className="truncate">{entry.name}</span>
+                    </button>
+                </div>
                 {expanded ? (
-                    <ul className="ml-3 mt-0.5 border-l border-[var(--dd-border)] pl-2">
+                    <ul className="mt-0.5 ml-3 border-l border-[var(--dd-border)] pl-2">
                         {(entry.children ?? []).map((child) => (
                             <Node
                                 key={child.relativePath}
@@ -65,12 +93,17 @@ function Node({
                                 onSelect={onSelect}
                                 selected={selected}
                                 forceOpen={forceOpen}
+                                selectDirectories={selectDirectories}
                             />
                         ))}
                     </ul>
                 ) : null}
             </li>
         );
+    }
+
+    if (selectDirectories) {
+        return null;
     }
 
     const isActive = selected === entry.relativePath;
@@ -94,20 +127,61 @@ function Node({
     );
 }
 
-export function ObsidianTree({ entries, onSelect, selected }: Props) {
+export function ObsidianTree({
+    entries,
+    onSelect,
+    selected,
+    selectDirectories,
+    allowAddDir,
+    onTreeChange,
+}: Props) {
     const [query, setQuery] = useState("");
     const normalizedQuery = query.trim().toLowerCase();
     const filtered = useMemo(() => filterEntries(entries, normalizedQuery), [entries, normalizedQuery]);
 
+    const addDir = async (): Promise<void> => {
+        const parent = selected && selectDirectories ? selected : "";
+        const name = window.prompt("New folder name");
+
+        if (!name?.trim()) {
+            return;
+        }
+
+        const relativeDir = parent ? `${parent}/${name.trim()}` : name.trim();
+
+        const res = await fetch("/api/obsidian/mkdir", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: SafeJSON.stringify({ relativeDir }),
+        });
+
+        if (!res.ok) {
+            const err = (await res.json().catch(() => ({ error: "Unknown error" }))) as { error?: string };
+            window.alert(`Failed to create folder: ${err.error ?? "Unknown error"}`);
+
+            return;
+        }
+
+        onSelect(relativeDir);
+        onTreeChange?.();
+    };
+
     return (
         <div className="space-y-2">
-            <Input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search notes"
-                className="h-8 border-[var(--dd-border)] bg-black/20 text-xs"
-            />
-            <ul className="space-y-0.5">
+            <div className="flex gap-2">
+                <Input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search notes"
+                    className="h-8 flex-1 border-[var(--dd-border)] bg-black/20 text-xs"
+                />
+                {allowAddDir ? (
+                    <Button type="button" size="icon" variant="outline" className="h-8 w-8 shrink-0" onClick={() => void addDir()} title="Add folder">
+                        <Plus className="h-3.5 w-3.5" />
+                    </Button>
+                ) : null}
+            </div>
+            <ul className="max-h-48 space-y-0.5 overflow-y-auto">
                 {filtered.map((entry) => (
                     <Node
                         key={entry.relativePath}
@@ -115,6 +189,7 @@ export function ObsidianTree({ entries, onSelect, selected }: Props) {
                         onSelect={onSelect}
                         selected={selected}
                         forceOpen={normalizedQuery.length > 0}
+                        selectDirectories={selectDirectories}
                     />
                 ))}
             </ul>

--- a/src/dev-dashboard/ui/src/components/QaCopyButtons.tsx
+++ b/src/dev-dashboard/ui/src/components/QaCopyButtons.tsx
@@ -1,0 +1,66 @@
+import { formatQaAsHtml, formatQaAsMarkdown } from "@app/dev-dashboard/lib/qa-clipboard";
+import type { QaRow } from "@app/dev-dashboard/lib/qa-types";
+import { Button } from "@ui/components/button";
+import { FileText, FileType2, NotebookPen } from "lucide-react";
+import { useState } from "react";
+
+export function QaCopyButtons({
+    entry,
+    onSaveToObsidian,
+}: {
+    entry: QaRow;
+    onSaveToObsidian: () => void;
+}) {
+    const [copied, setCopied] = useState<"md" | "html" | null>(null);
+
+    const copy = async (kind: "md" | "html"): Promise<void> => {
+        if (kind === "md") {
+            await navigator.clipboard.writeText(formatQaAsMarkdown(entry));
+        } else {
+            const html = formatQaAsHtml(entry);
+            const md = formatQaAsMarkdown(entry);
+
+            await navigator.clipboard.write([
+                new ClipboardItem({
+                    "text/html": new Blob([html], { type: "text/html" }),
+                    "text/plain": new Blob([md], { type: "text/plain" }),
+                }),
+            ]);
+        }
+
+        setCopied(kind);
+        setTimeout(() => setCopied(null), 1200);
+    };
+
+    return (
+        <div className="inline-flex items-center gap-1">
+            <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Copy as Markdown"
+                title="Copy as Markdown"
+                onClick={() => void copy("md")}
+            >
+                {copied === "md" ? <span className="text-xs">✓</span> : <FileText className="h-3.5 w-3.5" />}
+            </Button>
+            <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Copy as formatted"
+                title="Copy as formatted (rich text)"
+                onClick={() => void copy("html")}
+            >
+                {copied === "html" ? <span className="text-xs">✓</span> : <FileType2 className="h-3.5 w-3.5" />}
+            </Button>
+            <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Save to Obsidian"
+                title="Save to Obsidian"
+                onClick={onSaveToObsidian}
+            >
+                <NotebookPen className="h-3.5 w-3.5" />
+            </Button>
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/QaCopyButtons.tsx
+++ b/src/dev-dashboard/ui/src/components/QaCopyButtons.tsx
@@ -4,31 +4,31 @@ import { Button } from "@ui/components/button";
 import { FileText, FileType2, NotebookPen } from "lucide-react";
 import { useState } from "react";
 
-export function QaCopyButtons({
-    entry,
-    onSaveToObsidian,
-}: {
-    entry: QaRow;
-    onSaveToObsidian: () => void;
-}) {
-    const [copied, setCopied] = useState<"md" | "html" | null>(null);
+export function QaCopyButtons({ entry, onSaveToObsidian }: { entry: QaRow; onSaveToObsidian: () => void }) {
+    const [copied, setCopied] = useState<"md" | "html" | "error" | null>(null);
 
     const copy = async (kind: "md" | "html"): Promise<void> => {
-        if (kind === "md") {
-            await navigator.clipboard.writeText(formatQaAsMarkdown(entry));
-        } else {
-            const html = formatQaAsHtml(entry);
-            const md = formatQaAsMarkdown(entry);
+        try {
+            if (kind === "md") {
+                await navigator.clipboard.writeText(formatQaAsMarkdown(entry));
+            } else {
+                const html = formatQaAsHtml(entry);
+                const md = formatQaAsMarkdown(entry);
 
-            await navigator.clipboard.write([
-                new ClipboardItem({
-                    "text/html": new Blob([html], { type: "text/html" }),
-                    "text/plain": new Blob([md], { type: "text/plain" }),
-                }),
-            ]);
+                await navigator.clipboard.write([
+                    new ClipboardItem({
+                        "text/html": new Blob([html], { type: "text/html" }),
+                        "text/plain": new Blob([md], { type: "text/plain" }),
+                    }),
+                ]);
+            }
+
+            setCopied(kind);
+        } catch {
+            // navigator.clipboard rejects on permission denial or insecure context.
+            setCopied("error");
         }
 
-        setCopied(kind);
         setTimeout(() => setCopied(null), 1200);
     };
 
@@ -41,7 +41,13 @@ export function QaCopyButtons({
                 title="Copy as Markdown"
                 onClick={() => void copy("md")}
             >
-                {copied === "md" ? <span className="text-xs">✓</span> : <FileText className="h-3.5 w-3.5" />}
+                {copied === "md" ? (
+                    <span className="text-xs">✓</span>
+                ) : copied === "error" ? (
+                    <span className="text-xs text-[var(--dd-danger)]">!</span>
+                ) : (
+                    <FileText className="h-3.5 w-3.5" />
+                )}
             </Button>
             <Button
                 size="icon"
@@ -50,7 +56,13 @@ export function QaCopyButtons({
                 title="Copy as formatted (rich text)"
                 onClick={() => void copy("html")}
             >
-                {copied === "html" ? <span className="text-xs">✓</span> : <FileType2 className="h-3.5 w-3.5" />}
+                {copied === "html" ? (
+                    <span className="text-xs">✓</span>
+                ) : copied === "error" ? (
+                    <span className="text-xs text-[var(--dd-danger)]">!</span>
+                ) : (
+                    <FileType2 className="h-3.5 w-3.5" />
+                )}
             </Button>
             <Button
                 size="icon"

--- a/src/dev-dashboard/ui/src/components/QaSaveToObsidianDialog.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSaveToObsidianDialog.tsx
@@ -1,0 +1,162 @@
+import { suggestObsidianFilename } from "@app/dev-dashboard/lib/qa-clipboard";
+import type { QaRow } from "@app/dev-dashboard/lib/qa-types";
+import { SafeJSON } from "@app/utils/json";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@ui/components/button";
+import { Checkbox } from "@ui/components/checkbox";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@ui/components/dialog";
+import { Input } from "@ui/components/input";
+import { Label } from "@ui/components/label";
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/toggle-group";
+import { useState } from "react";
+import { ObsidianTree } from "./ObsidianTree";
+
+export function QaSaveToObsidianDialog({
+    entry,
+    open,
+    onOpenChange,
+}: {
+    entry: QaRow;
+    open: boolean;
+    onOpenChange: (b: boolean) => void;
+}) {
+    const queryClient = useQueryClient();
+    const treeQuery = useQuery({
+        queryKey: ["obsidian-tree"],
+        queryFn: async () => {
+            const r = await fetch("/api/obsidian/tree");
+
+            if (!r.ok) {
+                throw new Error(`tree: ${r.status}`);
+            }
+
+            return SafeJSON.parse(await r.text()) as {
+                entries: import("@app/dev-dashboard/lib/obsidian/types").VaultEntry[];
+            };
+        },
+        enabled: open,
+    });
+    const [dir, setDir] = useState<string>("Inbox/qa-test");
+    const [name, setName] = useState<string>(() => suggestObsidianFilename(entry.question));
+    const [mode, setMode] = useState<"create" | "append">("create");
+    const [createDir, setCreateDir] = useState(true);
+    const [includeFrontmatter, setIncludeFrontmatter] = useState(true);
+    const [includeQuestion, setIncludeQuestion] = useState(true);
+
+    const save = useMutation({
+        mutationFn: async () => {
+            const r = await fetch("/api/qa/save-to-obsidian", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify({
+                    entryId: entry.id,
+                    relativeDir: dir,
+                    baseName: name,
+                    mode,
+                    createDir,
+                    includeFrontmatter,
+                    includeQuestion,
+                }),
+            });
+
+            if (!r.ok) {
+                throw new Error(await r.text());
+            }
+
+            return SafeJSON.parse(await r.text()) as { path: string };
+        },
+        onSuccess: () => {
+            setTimeout(() => onOpenChange(false), 1500);
+        },
+    });
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>Save to Obsidian</DialogTitle>
+                </DialogHeader>
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                        <Label>Folder</Label>
+                        {treeQuery.data ? (
+                            <ObsidianTree
+                                entries={treeQuery.data.entries}
+                                selected={dir}
+                                onSelect={setDir}
+                                selectDirectories
+                                allowAddDir
+                                onTreeChange={() => void queryClient.invalidateQueries({ queryKey: ["obsidian-tree"] })}
+                            />
+                        ) : (
+                            <p className="text-xs text-[var(--dd-text-muted)]">Loading vault…</p>
+                        )}
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                id="create-dir"
+                                checked={createDir}
+                                onCheckedChange={(v) => setCreateDir(!!v)}
+                            />
+                            <Label htmlFor="create-dir">Create directory if missing</Label>
+                        </div>
+                    </div>
+                    <div className="flex flex-col gap-3">
+                        <div>
+                            <Label htmlFor="name">Filename (no .md)</Label>
+                            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+                            <p className="mt-1 text-xs text-[var(--dd-text-muted)]">
+                                Server appends -2, -3… if name exists.
+                            </p>
+                        </div>
+                        <div className="space-y-1">
+                            <Label>Mode</Label>
+                            <ToggleGroup
+                                type="single"
+                                size="sm"
+                                value={mode}
+                                onValueChange={(v) => {
+                                    if (v === "create" || v === "append") {
+                                        setMode(v);
+                                    }
+                                }}
+                            >
+                                <ToggleGroupItem value="create">Save as new</ToggleGroupItem>
+                                <ToggleGroupItem value="append">Append</ToggleGroupItem>
+                            </ToggleGroup>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                id="fm"
+                                checked={includeFrontmatter}
+                                onCheckedChange={(v) => setIncludeFrontmatter(!!v)}
+                            />
+                            <Label htmlFor="fm">Include frontmatter</Label>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                id="q"
+                                checked={includeQuestion}
+                                onCheckedChange={(v) => setIncludeQuestion(!!v)}
+                            />
+                            <Label htmlFor="q">Include question</Label>
+                        </div>
+                    </div>
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button onClick={() => save.mutate()} disabled={save.isPending || !name.trim()}>
+                        {save.isPending ? "Saving…" : mode === "append" ? "Append" : "Save"}
+                    </Button>
+                </DialogFooter>
+                {save.isError ? (
+                    <p className="text-xs text-[var(--dd-danger)]">{String(save.error)}</p>
+                ) : null}
+                {save.isSuccess ? (
+                    <p className="text-xs text-emerald-400">Saved to {save.data?.path}</p>
+                ) : null}
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/QaSaveToObsidianDialog.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSaveToObsidianDialog.tsx
@@ -88,15 +88,20 @@ export function QaSaveToObsidianDialog({
                                 allowAddDir
                                 onTreeChange={() => void queryClient.invalidateQueries({ queryKey: ["obsidian-tree"] })}
                             />
+                        ) : treeQuery.isError ? (
+                            <div className="space-y-1">
+                                <p className="text-xs text-[var(--dd-danger)]">
+                                    Failed to load vault: {String(treeQuery.error)}
+                                </p>
+                                <Button size="sm" variant="outline" onClick={() => void treeQuery.refetch()}>
+                                    Retry
+                                </Button>
+                            </div>
                         ) : (
                             <p className="text-xs text-[var(--dd-text-muted)]">Loading vault…</p>
                         )}
                         <div className="flex items-center gap-2">
-                            <Checkbox
-                                id="create-dir"
-                                checked={createDir}
-                                onCheckedChange={(v) => setCreateDir(!!v)}
-                            />
+                            <Checkbox id="create-dir" checked={createDir} onCheckedChange={(v) => setCreateDir(!!v)} />
                             <Label htmlFor="create-dir">Create directory if missing</Label>
                         </div>
                     </div>
@@ -150,12 +155,8 @@ export function QaSaveToObsidianDialog({
                         {save.isPending ? "Saving…" : mode === "append" ? "Append" : "Save"}
                     </Button>
                 </DialogFooter>
-                {save.isError ? (
-                    <p className="text-xs text-[var(--dd-danger)]">{String(save.error)}</p>
-                ) : null}
-                {save.isSuccess ? (
-                    <p className="text-xs text-emerald-400">Saved to {save.data?.path}</p>
-                ) : null}
+                {save.isError ? <p className="text-xs text-[var(--dd-danger)]">{String(save.error)}</p> : null}
+                {save.isSuccess ? <p className="text-xs text-emerald-400">Saved to {save.data?.path}</p> : null}
             </DialogContent>
         </Dialog>
     );

--- a/src/dev-dashboard/ui/src/components/QaScrollNav.tsx
+++ b/src/dev-dashboard/ui/src/components/QaScrollNav.tsx
@@ -1,0 +1,68 @@
+import type { QaRow } from "@app/dev-dashboard/lib/qa-types";
+import { resolveQaRecency } from "@app/utils/ui/helpers/qa-recency";
+import { ScrollArea } from "@ui/components/scroll-area";
+
+const TAG_DOT: Record<string, string> = {
+    action: "bg-[#a3e635]",
+    directive: "bg-[#c792ea]",
+    question: "bg-[var(--dd-text-secondary)]",
+};
+
+export const QA_SCROLL_NAV_OFFSET_PX = 400;
+
+export function QaScrollNav({
+    entries,
+    seenIds,
+    visible,
+}: {
+    entries: QaRow[];
+    seenIds: Set<string>;
+    visible: boolean;
+}) {
+    if (!visible) {
+        return null;
+    }
+
+    const jumpTo = (id: string): void => {
+        document.querySelector(`[data-qa-id="${CSS.escape(id)}"]`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    return (
+        <aside className="dd-panel fixed top-20 right-2 z-20 w-64 max-h-[calc(100vh-6rem)]">
+            <div className="border-b border-[var(--dd-border)] px-3 py-2 text-xs tracking-wider text-[var(--dd-text-muted)] uppercase">
+                Navigate ({entries.length})
+            </div>
+            <ScrollArea className="max-h-[calc(100vh-9rem)]">
+                <ul className="flex flex-col">
+                    {entries.map((e) => {
+                        const unread = !seenIds.has(e.id);
+                        const { relative } = resolveQaRecency(e.ts, Date.now());
+
+                        return (
+                            <li key={e.id}>
+                                <button
+                                    type="button"
+                                    onClick={() => jumpTo(e.id)}
+                                    className="flex w-full items-start gap-2 border-b border-[var(--dd-border)]/50 px-3 py-1.5 text-left text-xs hover:bg-white/5"
+                                >
+                                    <span
+                                        className={`mt-1 h-1.5 w-1.5 shrink-0 rounded-full ${TAG_DOT[e.tag] ?? TAG_DOT.question} ${unread ? "ring-2 ring-emerald-400/60" : ""}`}
+                                        aria-hidden
+                                    />
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block truncate text-[var(--dd-text-primary)]">
+                                            {e.question.slice(0, 60)}
+                                        </span>
+                                        <span className="block font-mono text-[var(--dd-text-muted)] tabular-nums">
+                                            {relative}
+                                        </span>
+                                    </span>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </ScrollArea>
+        </aside>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/QaSearchBox.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSearchBox.tsx
@@ -1,0 +1,17 @@
+import { Input } from "@ui/components/input";
+import { Search } from "lucide-react";
+
+export function QaSearchBox({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+    return (
+        <div className="relative min-w-0 w-full">
+            <Search className="absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-[var(--dd-text-muted)]" />
+            <Input
+                type="search"
+                placeholder="Search Q&A — any field, fuzzy (commit-1c0, file:foo.ts, etc.)"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="w-full pl-8"
+            />
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/QaSoundWrench.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSoundWrench.tsx
@@ -1,8 +1,8 @@
 import { playDingInBrowser } from "@app/utils/audio/runner.client";
 import { SafeJSON } from "@app/utils/json";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@ui/components/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@ui/components/popover";
-import { useQuery } from "@tanstack/react-query";
 import { Wrench } from "lucide-react";
 import { useState } from "react";
 
@@ -33,7 +33,15 @@ function previewSound(id: string, vol: number): void {
 export function QaSoundWrench() {
     const { data: lib } = useQuery<AudioLib>({
         queryKey: ["qa-audio-library"],
-        queryFn: async () => (await fetch("/api/qa/audio-library")).json() as Promise<AudioLib>,
+        queryFn: async () => {
+            const r = await fetch("/api/qa/audio-library");
+
+            if (!r.ok) {
+                throw new Error(`audio-library: ${r.status}`);
+            }
+
+            return r.json() as Promise<AudioLib>;
+        },
     });
     const [id, setId] = useState<string | null>(null);
     const [vol, setVol] = useState(0.6);
@@ -67,9 +75,7 @@ export function QaSoundWrench() {
                 </Button>
             </PopoverTrigger>
             <PopoverContent align="end" className="flex w-80 flex-col gap-3">
-                <div className="text-xs uppercase tracking-wider text-[var(--dd-text-muted)]">
-                    Notification sound
-                </div>
+                <div className="text-xs uppercase tracking-wider text-[var(--dd-text-muted)]">Notification sound</div>
                 <select
                     className="rounded border border-[var(--dd-border)] bg-transparent px-2 py-1 text-sm text-[var(--dd-text-secondary)]"
                     value={selected}
@@ -108,7 +114,12 @@ export function QaSoundWrench() {
                     <span className="w-10 text-right font-mono text-xs tabular-nums">{Math.round(vol * 100)}%</span>
                 </div>
                 <div className="flex justify-end gap-2">
-                    <Button size="sm" variant="outline" disabled={!selected} onClick={() => previewSound(selected, vol)}>
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!selected}
+                        onClick={() => previewSound(selected, vol)}
+                    >
                         Test
                     </Button>
                     <Button size="sm" disabled={!selected} onClick={apply}>

--- a/src/dev-dashboard/ui/src/components/QaSoundWrench.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSoundWrench.tsx
@@ -1,0 +1,121 @@
+import { playDingInBrowser } from "@app/utils/audio/runner.client";
+import { SafeJSON } from "@app/utils/json";
+import { Button } from "@ui/components/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@ui/components/popover";
+import { useQuery } from "@tanstack/react-query";
+import { Wrench } from "lucide-react";
+import { useState } from "react";
+
+interface AudioEntry {
+    id: string;
+    label: string;
+    kind: "bundled" | "synth";
+    isDefault: boolean;
+}
+
+interface AudioLib {
+    bundled: AudioEntry[];
+    synth: AudioEntry[];
+    default: AudioEntry;
+}
+
+function previewSound(id: string, vol: number): void {
+    if (id.startsWith("synth:")) {
+        playDingInBrowser(id.slice("synth:".length), vol);
+        return;
+    }
+
+    const audio = new Audio(`/api/qa/sound?id=${encodeURIComponent(id)}`);
+    audio.volume = Math.max(0, Math.min(1, vol));
+    void audio.play();
+}
+
+export function QaSoundWrench() {
+    const { data: lib } = useQuery<AudioLib>({
+        queryKey: ["qa-audio-library"],
+        queryFn: async () => (await fetch("/api/qa/audio-library")).json() as Promise<AudioLib>,
+    });
+    const [id, setId] = useState<string | null>(null);
+    const [vol, setVol] = useState(0.6);
+    const [saved, setSaved] = useState(false);
+    const selected = id ?? lib?.default.id ?? "";
+
+    const apply = async (): Promise<void> => {
+        try {
+            const res = await fetch("/api/qa/config", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify({ sound: selected, soundVolume: vol }),
+            });
+
+            if (!res.ok) {
+                return;
+            }
+
+            setSaved(true);
+            setTimeout(() => setSaved(false), 1500);
+        } catch {
+            return;
+        }
+    };
+
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Audio settings">
+                    <Wrench className="h-4 w-4" />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="flex w-80 flex-col gap-3">
+                <div className="text-xs uppercase tracking-wider text-[var(--dd-text-muted)]">
+                    Notification sound
+                </div>
+                <select
+                    className="rounded border border-[var(--dd-border)] bg-transparent px-2 py-1 text-sm text-[var(--dd-text-secondary)]"
+                    value={selected}
+                    onChange={(e) => setId(e.target.value)}
+                >
+                    {lib && (
+                        <>
+                            <optgroup label="Bundled (Kenney CC0)">
+                                {lib.bundled.map((e) => (
+                                    <option key={e.id} value={e.id}>
+                                        {e.label}
+                                        {e.isDefault ? " (default)" : ""}
+                                    </option>
+                                ))}
+                            </optgroup>
+                            <optgroup label="Synth presets">
+                                {lib.synth.map((e) => (
+                                    <option key={e.id} value={e.id}>
+                                        {e.label}
+                                    </option>
+                                ))}
+                            </optgroup>
+                        </>
+                    )}
+                </select>
+                <div className="flex items-center gap-2">
+                    <input
+                        type="range"
+                        min={0}
+                        max={1}
+                        step={0.05}
+                        value={vol}
+                        onChange={(e) => setVol(Number.parseFloat(e.target.value))}
+                        className="flex-1 accent-cyan-400"
+                    />
+                    <span className="w-10 text-right font-mono text-xs tabular-nums">{Math.round(vol * 100)}%</span>
+                </div>
+                <div className="flex justify-end gap-2">
+                    <Button size="sm" variant="outline" disabled={!selected} onClick={() => previewSound(selected, vol)}>
+                        Test
+                    </Button>
+                    <Button size="sm" disabled={!selected} onClick={apply}>
+                        {saved ? "Saved ✓" : "Apply"}
+                    </Button>
+                </div>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/QaSourceToggle.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSourceToggle.tsx
@@ -1,0 +1,32 @@
+import { ToggleGroup, ToggleGroupItem } from "@ui/components/toggle-group";
+import { BookOpen, FileCode } from "lucide-react";
+
+export type QaViewMode = "reading" | "source";
+
+export function QaSourceToggle({
+    mode,
+    onChange,
+}: {
+    mode: QaViewMode;
+    onChange: (m: QaViewMode) => void;
+}) {
+    return (
+        <ToggleGroup
+            type="single"
+            size="sm"
+            value={mode}
+            onValueChange={(v) => {
+                if (v) {
+                    onChange(v as QaViewMode);
+                }
+            }}
+        >
+            <ToggleGroupItem value="reading" aria-label="Reading mode">
+                <BookOpen className="h-4 w-4" />
+            </ToggleGroupItem>
+            <ToggleGroupItem value="source" aria-label="Source mode">
+                <FileCode className="h-4 w-4" />
+            </ToggleGroupItem>
+        </ToggleGroup>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/QaSourceToggle.tsx
+++ b/src/dev-dashboard/ui/src/components/QaSourceToggle.tsx
@@ -3,21 +3,15 @@ import { BookOpen, FileCode } from "lucide-react";
 
 export type QaViewMode = "reading" | "source";
 
-export function QaSourceToggle({
-    mode,
-    onChange,
-}: {
-    mode: QaViewMode;
-    onChange: (m: QaViewMode) => void;
-}) {
+export function QaSourceToggle({ mode, onChange }: { mode: QaViewMode; onChange: (m: QaViewMode) => void }) {
     return (
         <ToggleGroup
             type="single"
             size="sm"
             value={mode}
             onValueChange={(v) => {
-                if (v) {
-                    onChange(v as QaViewMode);
+                if (v === "reading" || v === "source") {
+                    onChange(v);
                 }
             }}
         >

--- a/src/dev-dashboard/ui/src/components/QaTopBar.tsx
+++ b/src/dev-dashboard/ui/src/components/QaTopBar.tsx
@@ -1,0 +1,32 @@
+import { useScrollProgress } from "@app/utils/ui/hooks/useScrollProgress.client";
+import type { ReactNode } from "react";
+import { LiveSseIndicator } from "./LiveSseIndicator";
+import { QaSoundWrench } from "./QaSoundWrench";
+
+interface QaTopBarProps {
+    live: boolean;
+    count: number;
+    search: ReactNode;
+    viewToggle: ReactNode;
+}
+
+export function QaTopBar({ live, count, search, viewToggle }: QaTopBarProps) {
+    const { y } = useScrollProgress();
+    const opacity = Math.min(1, 0.55 + y / 240);
+
+    return (
+        <header
+            className="dd-qa-topbar sticky top-0 z-30 backdrop-blur-sm"
+            style={{ ["--dd-topbar-opacity" as never]: opacity }}
+        >
+            <div className="flex flex-wrap items-center gap-3 px-4 py-2">
+                <div className="flex items-center gap-3">
+                    {viewToggle}
+                    <LiveSseIndicator live={live} count={count} />
+                </div>
+                <div className="min-w-0 flex-1">{search}</div>
+                <QaSoundWrench />
+            </div>
+        </header>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/Sidebar.tsx
+++ b/src/dev-dashboard/ui/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ export function Sidebar() {
     const { pathname } = useLocation();
 
     return (
-        <nav className="flex flex-col items-center gap-3 pt-4">
+        <nav className="sticky top-0 flex h-screen flex-col items-center gap-3 overflow-y-auto pt-4">
             <div
                 className="flex h-[30px] w-[30px] items-center justify-center rounded-[9px]"
                 style={{ background: "var(--dd-accent-gradient)", boxShadow: "0 0 14px rgba(52,211,153,0.35)" }}

--- a/src/dev-dashboard/ui/src/routes/qa.tsx
+++ b/src/dev-dashboard/ui/src/routes/qa.tsx
@@ -1,127 +1,33 @@
-import { type EnrichedQaEntry, isQaAnswerTruncated } from "@app/dev-dashboard/lib/qa-render";
-import type { QaEntry } from "@app/question/lib/types";
-import { playDingInBrowser } from "@app/utils/audio/runner.client";
+import { searchQa } from "@app/dev-dashboard/lib/qa-search";
+import { isQaAnswerTruncated } from "@app/dev-dashboard/lib/qa-render";
+import type { QaRow } from "@app/dev-dashboard/lib/qa-types";
+import { highlightMatchesInHtml } from "@app/utils/ui/helpers/highlight-matches.client";
+import { hasNonEmptySelection } from "@app/utils/ui/hooks/useSelectionAware.client";
+import { useScrollProgress } from "@app/utils/ui/hooks/useScrollProgress.client";
 import { SafeJSON } from "@app/utils/json";
 import { useQuery } from "@tanstack/react-query";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { LiveSseIndicator } from "@/components/LiveSseIndicator";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { QaClockProvider } from "@/components/QaClockProvider";
+import { QaCopyButtons } from "@/components/QaCopyButtons";
 import { QaRecencyTime } from "@/components/QaRecencyTime";
+import { QaSaveToObsidianDialog } from "@/components/QaSaveToObsidianDialog";
+import { QA_SCROLL_NAV_OFFSET_PX, QaScrollNav } from "@/components/QaScrollNav";
+import { QaSearchBox } from "@/components/QaSearchBox";
 import { QaSectionHeading } from "@/components/QaSectionHeading";
+import { QaSourceToggle, type QaViewMode } from "@/components/QaSourceToggle";
+import { QaTopBar } from "@/components/QaTopBar";
 
 const READ_PERSIST_DEBOUNCE_MS = 400;
 
-interface AudioEntry {
-    id: string;
-    label: string;
-    kind: "bundled" | "synth";
-    isDefault: boolean;
-}
-interface AudioLib {
-    bundled: AudioEntry[];
-    synth: AudioEntry[];
-    default: AudioEntry;
-}
-
-function previewSound(id: string, vol: number): void {
-    if (id.startsWith("synth:")) {
-        playDingInBrowser(id.slice("synth:".length), vol);
-        return;
-    }
-
-    const audio = new Audio(`/api/qa/sound?id=${encodeURIComponent(id)}`);
-    audio.volume = Math.max(0, Math.min(1, vol));
-    void audio.play();
-}
-
-function SoundControl() {
-    const { data: lib } = useQuery<AudioLib>({
-        queryKey: ["qa-audio-library"],
-        queryFn: async () => {
-            const r = await fetch("/api/qa/audio-library");
-            return (await r.json()) as AudioLib;
-        },
-    });
-    const [id, setId] = useState<string | null>(null);
-    const [vol, setVol] = useState(0.6);
-    const [saved, setSaved] = useState(false);
-
-    const selected = id ?? lib?.default.id ?? "";
-
-    const apply = async (): Promise<void> => {
-        await fetch("/api/qa/config", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: SafeJSON.stringify({ sound: selected, soundVolume: vol }),
-        });
-        setSaved(true);
-        setTimeout(() => setSaved(false), 1500);
-    };
-
-    return (
-        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--dd-text-muted)]">
-            <span>🔔 sound</span>
-            <select
-                className="rounded border border-[#2a3445] bg-transparent px-2 py-1 text-[var(--dd-text-secondary)]"
-                value={selected}
-                onChange={(e) => setId(e.target.value)}
-            >
-                {lib && (
-                    <>
-                        <optgroup label="Bundled (Kenney CC0)">
-                            {lib.bundled.map((e) => (
-                                <option key={e.id} value={e.id}>
-                                    {e.label}
-                                    {e.isDefault ? " (default)" : ""}
-                                </option>
-                            ))}
-                        </optgroup>
-                        <optgroup label="Synth presets">
-                            {lib.synth.map((e) => (
-                                <option key={e.id} value={e.id}>
-                                    {e.label}
-                                </option>
-                            ))}
-                        </optgroup>
-                    </>
-                )}
-            </select>
-            <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.05}
-                value={vol}
-                onChange={(e) => setVol(Number.parseFloat(e.target.value))}
-            />
-            <span>{Math.round(vol * 100)}%</span>
-            <button
-                type="button"
-                className="dd-accent-text"
-                disabled={!selected}
-                onClick={() => previewSound(selected, vol)}
-            >
-                ▶ test
-            </button>
-            <button type="button" className="dd-accent-text" disabled={!selected} onClick={apply}>
-                {saved ? "saved ✓" : "apply"}
-            </button>
-        </div>
-    );
-}
-
-interface QaRow extends QaEntry, EnrichedQaEntry {
-    supersededBy: string | null;
-    readAt: number | null;
-}
-
 async function fetchQaLog(): Promise<QaRow[]> {
     const res = await fetch("/api/qa/log?limit=100");
+
     if (!res.ok) {
         throw new Error(`Failed to load Q&A: ${res.status}`);
     }
 
     const body = SafeJSON.parse(await res.text(), { strict: true }) as { entries: QaRow[] };
+
     return body.entries;
 }
 
@@ -134,77 +40,160 @@ function tagClass(tag: string): string {
         return "border-[#4a3a5e] text-[#c792ea]";
     }
 
-    return "border-[#2a3445] text-[var(--dd-text-secondary)]";
+    return "border-[var(--dd-border)] text-[var(--dd-text-secondary)]";
 }
 
 const QaCard = memo(function QaCard({
     entry,
     unread,
+    wasReadOnLoad,
+    viewMode,
+    highlightTokens,
     onSeen,
+    onUnseen,
 }: {
     entry: QaRow;
     unread: boolean;
+    wasReadOnLoad: boolean;
+    viewMode: QaViewMode;
+    highlightTokens: string[];
     onSeen: (id: string) => void;
+    onUnseen: (id: string) => void;
 }) {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(!wasReadOnLoad);
+    const [saveDialogOpen, setSaveDialogOpen] = useState(false);
     const truncated = isQaAnswerTruncated(entry.answerMd);
-    const answerHtml = open || !truncated ? entry.answerHtml : entry.answerHtmlPreview;
+    const answerBase = open || !truncated ? entry.answerHtml : entry.answerHtmlPreview;
 
-    const handleMarkRead = useCallback(() => {
-        if (!unread) {
+    const questionHtml = useMemo(() => {
+        if (viewMode === "source") {
+            return "";
+        }
+
+        const html = entry.questionHtml;
+
+        if (highlightTokens.length === 0) {
+            return html;
+        }
+
+        return highlightMatchesInHtml(html, highlightTokens);
+    }, [entry.questionHtml, highlightTokens, viewMode]);
+
+    const answerHtml = useMemo(() => {
+        if (viewMode === "source") {
+            return "";
+        }
+
+        if (highlightTokens.length === 0) {
+            return answerBase;
+        }
+
+        return highlightMatchesInHtml(answerBase, highlightTokens);
+    }, [answerBase, highlightTokens, viewMode]);
+
+    const handleCardMouseUp = useCallback((ev: MouseEvent) => {
+        const target = ev.target as HTMLElement;
+
+        if (target.closest("button") || target.closest("a")) {
             return;
         }
 
-        onSeen(entry.id);
-    }, [entry.id, onSeen, unread]);
+        const nestedButton = target.closest("[role='button']");
+
+        if (nestedButton && nestedButton !== ev.currentTarget) {
+            return;
+        }
+
+        if (hasNonEmptySelection()) {
+            return;
+        }
+
+        setTimeout(() => {
+            if (hasNonEmptySelection()) {
+                return;
+            }
+
+            if (unread) {
+                onSeen(entry.id);
+            } else {
+                onUnseen(entry.id);
+            }
+        }, 0);
+    }, [entry.id, onSeen, onUnseen, unread]);
+
+    const openSave = (): void => setSaveDialogOpen(true);
 
     return (
-        <div
-            role={unread ? "button" : undefined}
-            tabIndex={unread ? 0 : undefined}
-            className={`dd-panel flex flex-col gap-3 p-4${unread ? " dd-qa-card--unread dd-qa-card--clickable" : ""}`}
-            data-qa-id={entry.id}
-            data-qa-unread={unread ? "1" : "0"}
-            onClick={handleMarkRead}
-            onKeyDown={(ev) => {
-                if (!unread) {
-                    return;
-                }
+        <>
+            <div
+                role="button"
+                tabIndex={0}
+                className={`dd-panel flex flex-col gap-3 p-4${unread ? " dd-qa-card--unread dd-qa-card--clickable" : " dd-qa-card--clickable"}`}
+                data-qa-id={entry.id}
+                data-qa-unread={unread ? "1" : "0"}
+                onMouseUp={handleCardMouseUp}
+                onKeyDown={(ev) => {
+                    if (ev.key === "Enter" || ev.key === " ") {
+                        ev.preventDefault();
 
-                if (ev.key === "Enter" || ev.key === " ") {
-                    ev.preventDefault();
-                    onSeen(entry.id);
-                }
-            }}
-        >
-            <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--dd-text-muted)]">
-                <span className="dd-qa-unread-badge">new</span>
-                <span className="text-[var(--dd-text-secondary)]">{entry.project}</span>
-                <span>·</span>
-                <span>{entry.branch ?? "-"}</span>
-                <span className={`rounded-full border px-2 py-[1px] ${tagClass(entry.tag)}`}>{entry.tag}</span>
-                <QaRecencyTime ts={entry.ts} />
-            </div>
-            <QaSectionHeading label="Question" />
-            <div className="dd-qa-section-body text-[var(--dd-text-primary)] font-medium leading-relaxed">
-                {entry.question}
-            </div>
-            <QaSectionHeading label="Answer" />
-            <article
-                className="dd-qa-section-body dd-markdown text-sm"
-                dangerouslySetInnerHTML={{ __html: answerHtml }}
-            />
-            {truncated ? (
-                <button type="button" className="dd-accent-text self-start text-xs" onClick={() => setOpen((v) => !v)}>
-                    {open ? "▴ collapse" : "▾ expand full answer (rationale · refs · links)"}
-                </button>
-            ) : null}
-            {entry.refs.length > 0 ? (
-                <div className="text-xs text-[var(--dd-text-muted)]">
-                    refs: {entry.refs.map((r) => `${r.type}:${r.value}`).join(" · ")}
+                        if (unread) {
+                            onSeen(entry.id);
+                        } else {
+                            onUnseen(entry.id);
+                        }
+                    }
+                }}
+            >
+                <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--dd-text-muted)]">
+                    {unread ? <span className="dd-qa-unread-badge">new</span> : null}
+                    <span className="text-[var(--dd-text-secondary)]">{entry.project}</span>
+                    <span>·</span>
+                    <span>{entry.branch ?? "-"}</span>
+                    <span className={`rounded-full border px-2 py-[1px] ${tagClass(entry.tag)}`}>{entry.tag}</span>
+                    <QaCopyButtons entry={entry} onSaveToObsidian={openSave} />
+                    <QaRecencyTime ts={entry.ts} />
                 </div>
-            ) : null}
-        </div>
+                <QaSectionHeading label="Question" />
+                {viewMode === "reading" ? (
+                    <article
+                        className="dd-qa-section-body dd-markdown font-medium leading-relaxed text-[var(--dd-text-primary)]"
+                        dangerouslySetInnerHTML={{ __html: questionHtml }}
+                    />
+                ) : (
+                    <pre className="dd-qa-section-body text-xs whitespace-pre-wrap">{entry.question}</pre>
+                )}
+                <QaSectionHeading label="Answer" />
+                {viewMode === "reading" ? (
+                    <article
+                        className="dd-qa-section-body dd-markdown text-sm"
+                        dangerouslySetInnerHTML={{ __html: answerHtml }}
+                    />
+                ) : (
+                    <pre className="dd-qa-section-body text-xs whitespace-pre-wrap">{entry.answerMd}</pre>
+                )}
+                {truncated ? (
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            className="dd-accent-text self-start text-xs"
+                            onClick={(ev) => {
+                                ev.stopPropagation();
+                                setOpen((v) => !v);
+                            }}
+                        >
+                            {open ? "▴ collapse" : "▾ expand full answer (rationale · refs · links)"}
+                        </button>
+                        <QaCopyButtons entry={entry} onSaveToObsidian={openSave} />
+                    </div>
+                ) : null}
+                {entry.refs.length > 0 ? (
+                    <div className="text-xs text-[var(--dd-text-muted)]">
+                        refs: {entry.refs.map((r) => `${r.type}:${r.value}`).join(" · ")}
+                    </div>
+                ) : null}
+            </div>
+            <QaSaveToObsidianDialog entry={entry} open={saveDialogOpen} onOpenChange={setSaveDialogOpen} />
+        </>
     );
 });
 
@@ -213,41 +202,68 @@ export function QaRoute() {
     const [live, setLive] = useState<QaRow[]>([]);
     const [sseDown, setSseDown] = useState(false);
     const [seenIds, setSeenIds] = useState<Set<string>>(() => new Set());
+    const [viewMode, setViewMode] = useState<QaViewMode>("reading");
+    const [query, setQuery] = useState("");
+    const initialReadIds = useRef<Set<string> | null>(null);
     const seen = useRef<Set<string>>(new Set());
     const markedReadRef = useRef<Set<string>>(new Set());
     const pendingReadIds = useRef<Set<string>>(new Set());
+    const pendingUnreadIds = useRef<Set<string>>(new Set());
     const readFlushTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     const readApiDisabledRef = useRef(false);
+    const { y: scrollY } = useScrollProgress();
+
+    useEffect(() => {
+        if (initialReadIds.current === null && logQuery.data) {
+            initialReadIds.current = new Set(logQuery.data.filter((r) => r.readAt != null).map((r) => r.id));
+        }
+    }, [logQuery.data]);
 
     const flushReadIds = useCallback(() => {
         readFlushTimer.current = undefined;
 
         if (readApiDisabledRef.current) {
             pendingReadIds.current.clear();
+            pendingUnreadIds.current.clear();
             return;
         }
 
-        const ids = [...pendingReadIds.current];
+        const readIds = [...pendingReadIds.current];
+        const unreadIds = [...pendingUnreadIds.current];
         pendingReadIds.current.clear();
+        pendingUnreadIds.current.clear();
 
-        if (ids.length === 0) {
+        const post = (ids: string[], unread: boolean): void => {
+            if (ids.length === 0) {
+                return;
+            }
+
+            void fetch("/api/qa/read", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify({ ids, unread: unread || undefined }),
+            })
+                .then((res) => {
+                    if (res.status === 404) {
+                        readApiDisabledRef.current = true;
+                    }
+                })
+                .catch(() => {
+                    /* best-effort */
+                });
+        };
+
+        post(readIds, false);
+        post(unreadIds, true);
+    }, []);
+
+    const scheduleFlush = useCallback(() => {
+        if (readFlushTimer.current) {
             return;
         }
 
-        void fetch("/api/qa/read", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: SafeJSON.stringify({ ids }),
-        })
-            .then((res) => {
-                if (res.status === 404) {
-                    readApiDisabledRef.current = true;
-                }
-            })
-            .catch(() => {
-                /* best-effort — unread styling is client-side until next load */
-            });
-    }, []);
+        readFlushTimer.current = setTimeout(flushReadIds, READ_PERSIST_DEBOUNCE_MS);
+    }, [flushReadIds]);
 
     const markSeen = useCallback(
         (id: string) => {
@@ -256,6 +272,7 @@ export function QaRoute() {
             }
 
             markedReadRef.current.add(id);
+            pendingUnreadIds.current.delete(id);
             setSeenIds((prev) => {
                 if (prev.has(id)) {
                     return prev;
@@ -266,14 +283,28 @@ export function QaRoute() {
                 return next;
             });
             pendingReadIds.current.add(id);
-
-            if (readFlushTimer.current) {
-                return;
-            }
-
-            readFlushTimer.current = setTimeout(flushReadIds, READ_PERSIST_DEBOUNCE_MS);
+            scheduleFlush();
         },
-        [flushReadIds]
+        [scheduleFlush]
+    );
+
+    const markUnseen = useCallback(
+        (id: string) => {
+            markedReadRef.current.delete(id);
+            pendingReadIds.current.delete(id);
+            setSeenIds((prev) => {
+                if (!prev.has(id)) {
+                    return prev;
+                }
+
+                const next = new Set(prev);
+                next.delete(id);
+                return next;
+            });
+            pendingUnreadIds.current.add(id);
+            scheduleFlush();
+        },
+        [scheduleFlush]
     );
 
     useEffect(() => {
@@ -315,8 +346,10 @@ export function QaRoute() {
         es.onopen = () => setSseDown(false);
         es.onmessage = (ev) => {
             setSseDown(false);
+
             try {
                 const entry = SafeJSON.parse(ev.data, { strict: true }) as QaRow;
+
                 if (seen.current.has(entry.id)) {
                     return;
                 }
@@ -328,19 +361,18 @@ export function QaRoute() {
             }
         };
         es.onerror = () => {
-            // EventSource auto-reconnects while CONNECTING — only show disconnected when
-            // the browser has given up (CLOSED). Avoid flicker on transient proxy blips.
             if (es.readyState === EventSource.CLOSED) {
                 setSseDown(true);
             }
         };
+
         return () => es.close();
     }, []);
 
     if (logQuery.isError) {
         return (
             <div className="dd-panel flex h-[calc(100vh-2rem)] flex-col items-center justify-center gap-2 text-center">
-                <p className="text-lg font-bold text-[#f87171]">Failed to load Q&A</p>
+                <p className="text-lg font-bold text-[#f87171]">Failed to load Q&amp;A</p>
                 <p className="max-w-sm text-sm text-[var(--dd-text-secondary)]">
                     {logQuery.error instanceof Error ? logQuery.error.message : String(logQuery.error)}
                 </p>
@@ -350,28 +382,43 @@ export function QaRoute() {
 
     const persisted = (logQuery.data ?? []).filter((r) => !seen.current.has(r.id));
     const all = [...live, ...persisted];
+    const { entries: filtered, tokens: highlightTokens } = searchQa(all, query);
+    const showScrollNav = scrollY >= QA_SCROLL_NAV_OFFSET_PX && filtered.length > 0;
 
     return (
-        <div className="flex flex-col gap-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="dd-accent-text text-xl font-bold">Q&amp;A</h2>
-                <SoundControl />
-                <LiveSseIndicator live={!sseDown} count={all.length} />
-            </div>
+        <div className="relative flex flex-col gap-4">
+            <QaTopBar
+                live={!sseDown}
+                count={all.length}
+                search={<QaSearchBox value={query} onChange={setQuery} />}
+                viewToggle={<QaSourceToggle mode={viewMode} onChange={setViewMode} />}
+            />
 
             {logQuery.isLoading ? (
                 <div className="dd-panel py-8 text-center text-sm text-[var(--dd-text-muted)]">Loading Q&amp;A…</div>
-            ) : all.length === 0 ? (
+            ) : filtered.length === 0 ? (
                 <div className="dd-panel py-8 text-center text-sm text-[var(--dd-text-muted)]">
-                    No questions recorded yet.
+                    {all.length === 0 ? "No questions recorded yet." : "No matches for your search."}
                 </div>
             ) : (
                 <QaClockProvider>
-                    <div className="flex flex-col gap-3">
-                        {all.map((entry) => (
-                            <QaCard key={entry.id} entry={entry} unread={!seenIds.has(entry.id)} onSeen={markSeen} />
+                    <div
+                        className={`flex flex-col gap-3${showScrollNav ? " pr-0 lg:pr-68" : ""}`}
+                    >
+                        {filtered.map((entry) => (
+                            <QaCard
+                                key={entry.id}
+                                entry={entry}
+                                unread={!seenIds.has(entry.id)}
+                                wasReadOnLoad={initialReadIds.current?.has(entry.id) ?? false}
+                                viewMode={viewMode}
+                                highlightTokens={highlightTokens}
+                                onSeen={markSeen}
+                                onUnseen={markUnseen}
+                            />
                         ))}
                     </div>
+                    <QaScrollNav entries={filtered} seenIds={seenIds} visible={showScrollNav} />
                 </QaClockProvider>
             )}
         </div>

--- a/src/dev-dashboard/ui/src/slate-grid.css
+++ b/src/dev-dashboard/ui/src/slate-grid.css
@@ -52,6 +52,7 @@
     margin-left: 0.625rem;
     padding-left: 0.75rem;
     border-left: 1px solid var(--dd-border);
+    overflow-wrap: anywhere;
 }
 
 .dd-qa-card--unread {

--- a/src/dev-dashboard/ui/src/styles.css
+++ b/src/dev-dashboard/ui/src/styles.css
@@ -8,6 +8,11 @@
 
 @custom-variant dark (&:is(.dark *));
 
+html {
+    /* Keep viewport width stable when filtering shortens the page and the scrollbar disappears. */
+    scrollbar-gutter: stable;
+}
+
 body {
     font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -21,4 +26,18 @@ code,
 pre,
 .font-mono {
     font-family: "JetBrains Mono", source-code-pro, Menlo, Monaco, Consolas, monospace;
+}
+
+.dd-qa-topbar {
+    background: color-mix(in srgb, var(--dd-bg-panel) calc(var(--dd-topbar-opacity, 0.8) * 100%), transparent);
+    transition: background 200ms linear;
+    border-bottom: 1px solid
+        color-mix(in srgb, var(--dd-border) calc(var(--dd-topbar-opacity, 0.8) * 100%), transparent);
+}
+
+.dd-qa-mark {
+    background: color-mix(in srgb, var(--dd-accent-from) 35%, transparent);
+    color: inherit;
+    border-radius: 2px;
+    padding: 0 1px;
 }

--- a/src/dev-dashboard/ui/vite-middleware.ts
+++ b/src/dev-dashboard/ui/vite-middleware.ts
@@ -25,10 +25,10 @@ import {
     publishNote,
     unpublishNote,
 } from "@app/dev-dashboard/lib/obsidian/publish";
+import { listVault, mkdirInVault, readNote } from "@app/dev-dashboard/lib/obsidian/reader";
+import { renderSharePage } from "@app/dev-dashboard/lib/obsidian/share-template";
 import { saveToObsidianUnique } from "@app/dev-dashboard/lib/obsidian-save";
 import { formatQaAsMarkdown } from "@app/dev-dashboard/lib/qa-clipboard";
-import { mkdirInVault, listVault, readNote } from "@app/dev-dashboard/lib/obsidian/reader";
-import { renderSharePage } from "@app/dev-dashboard/lib/obsidian/share-template";
 import { enrichQaEntry } from "@app/dev-dashboard/lib/qa-render";
 import { createQaStream, todayLogFile } from "@app/dev-dashboard/lib/qa-sse";
 import { configureRetention, getCachedPulse, getSeries, startPulsePolling } from "@app/dev-dashboard/lib/system/poller";
@@ -37,7 +37,13 @@ import { killTtyd, listTtyd, renameTtyd, spawnTtyd } from "@app/dev-dashboard/li
 import { fetchWeather } from "@app/dev-dashboard/lib/weather/client";
 import { logger } from "@app/logger";
 import { defaultDbPath } from "@app/question/commands/log";
-import { markEntriesRead, markEntriesUnread, openReadModel, queryEntries } from "@app/question/lib/read-model";
+import {
+    getEntryById,
+    markEntriesRead,
+    markEntriesUnread,
+    openReadModel,
+    queryEntries,
+} from "@app/question/lib/read-model";
 import { getAudioLibrary } from "@app/utils/audio/library";
 import { resolveSoundBuffer } from "@app/utils/audio/runner.server";
 import { SafeJSON } from "@app/utils/json";
@@ -545,8 +551,7 @@ export function attachDevDashboardMiddleware(middlewares: Connect.Server): void 
                 }
 
                 db = openReadModel(defaultDbPath());
-                const rows = queryEntries(db, { limit: 500 });
-                const row = rows.find((r) => r.id === entryId);
+                const row = getEntryById(db, entryId);
 
                 if (!row) {
                     sendJson(res, 404, { error: `unknown entry: ${entryId}` });

--- a/src/dev-dashboard/ui/vite-middleware.ts
+++ b/src/dev-dashboard/ui/vite-middleware.ts
@@ -25,7 +25,9 @@ import {
     publishNote,
     unpublishNote,
 } from "@app/dev-dashboard/lib/obsidian/publish";
-import { listVault, readNote } from "@app/dev-dashboard/lib/obsidian/reader";
+import { saveToObsidianUnique } from "@app/dev-dashboard/lib/obsidian-save";
+import { formatQaAsMarkdown } from "@app/dev-dashboard/lib/qa-clipboard";
+import { mkdirInVault, listVault, readNote } from "@app/dev-dashboard/lib/obsidian/reader";
 import { renderSharePage } from "@app/dev-dashboard/lib/obsidian/share-template";
 import { enrichQaEntry } from "@app/dev-dashboard/lib/qa-render";
 import { createQaStream, todayLogFile } from "@app/dev-dashboard/lib/qa-sse";
@@ -35,7 +37,7 @@ import { killTtyd, listTtyd, renameTtyd, spawnTtyd } from "@app/dev-dashboard/li
 import { fetchWeather } from "@app/dev-dashboard/lib/weather/client";
 import { logger } from "@app/logger";
 import { defaultDbPath } from "@app/question/commands/log";
-import { markEntriesRead, openReadModel, queryEntries } from "@app/question/lib/read-model";
+import { markEntriesRead, markEntriesUnread, openReadModel, queryEntries } from "@app/question/lib/read-model";
 import { getAudioLibrary } from "@app/utils/audio/library";
 import { resolveSoundBuffer } from "@app/utils/audio/runner.server";
 import { SafeJSON } from "@app/utils/json";
@@ -367,10 +369,10 @@ export function attachDevDashboardMiddleware(middlewares: Connect.Server): void 
         if (req.method === "POST" && url.pathname === "/api/qa/read") {
             let db: ReturnType<typeof openReadModel> | undefined;
             try {
-                const body = await readJson<{ ids?: string[] }>(req);
+                const body = await readJson<{ ids?: string[]; unread?: boolean }>(req);
                 const ids = body.ids?.filter((id) => typeof id === "string" && id.length > 0) ?? [];
                 db = openReadModel(defaultDbPath());
-                const updated = markEntriesRead(db, ids);
+                const updated = body.unread ? markEntriesUnread(db, ids) : markEntriesRead(db, ids);
                 sendJson(res, 200, { ok: true, updated });
             } catch (err) {
                 sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -521,11 +523,99 @@ export function attachDevDashboardMiddleware(middlewares: Connect.Server): void 
             return;
         }
 
+        if (req.method === "POST" && url.pathname === "/api/qa/save-to-obsidian") {
+            let db: ReturnType<typeof openReadModel> | undefined;
+            try {
+                const body = await readJson<{
+                    entryId?: string;
+                    relativeDir?: string;
+                    baseName?: string;
+                    mode?: "create" | "append";
+                    createDir?: boolean;
+                    includeFrontmatter?: boolean;
+                    includeQuestion?: boolean;
+                }>(req);
+                const entryId = body.entryId ?? "";
+                const relativeDir = body.relativeDir ?? "";
+                const baseName = (body.baseName ?? "").replace(/\.md$/i, "").trim();
+
+                if (!entryId || !relativeDir || !baseName) {
+                    sendJson(res, 400, { error: "entryId, relativeDir, and baseName required" });
+                    return;
+                }
+
+                db = openReadModel(defaultDbPath());
+                const rows = queryEntries(db, { limit: 500 });
+                const row = rows.find((r) => r.id === entryId);
+
+                if (!row) {
+                    sendJson(res, 404, { error: `unknown entry: ${entryId}` });
+                    return;
+                }
+
+                const enriched = enrichQaEntry(row);
+                const content = formatQaAsMarkdown(
+                    { ...enriched, supersededBy: row.supersededBy, readAt: row.readAt },
+                    {
+                        includeFrontmatter: body.includeFrontmatter !== false,
+                        includeQuestion: body.includeQuestion !== false,
+                    }
+                );
+                const { obsidianVault } = await getConfig();
+
+                if (!obsidianVault) {
+                    sendJson(res, 500, { error: "obsidian vault not configured" });
+                    return;
+                }
+
+                const result = await saveToObsidianUnique({
+                    vaultRoot: obsidianVault,
+                    relativeDir,
+                    baseName,
+                    content,
+                    mode: body.mode === "append" ? "append" : "create",
+                    createDir: body.createDir === true,
+                });
+                sendJson(res, 200, result);
+            } catch (err) {
+                sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+            } finally {
+                db?.close();
+            }
+
+            return;
+        }
+
         if (req.method === "GET" && url.pathname === "/api/obsidian/tree") {
             try {
                 const { obsidianVault } = await getConfig();
                 const entries = await listVault(obsidianVault);
                 sendJson(res, 200, { entries });
+            } catch (err) {
+                sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+            }
+
+            return;
+        }
+
+        if (req.method === "POST" && url.pathname === "/api/obsidian/mkdir") {
+            try {
+                const { relativeDir } = await readJson<{ relativeDir?: string }>(req);
+
+                if (!relativeDir?.trim()) {
+                    sendJson(res, 400, { error: "relativeDir required" });
+                    return;
+                }
+
+                const { obsidianVault } = await getConfig();
+
+                if (!obsidianVault) {
+                    sendJson(res, 500, { error: "obsidian vault not configured" });
+                    return;
+                }
+
+                await mkdirInVault(obsidianVault, relativeDir.trim());
+                sendJson(res, 200, { ok: true, relativeDir: relativeDir.trim() });
             } catch (err) {
                 sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
             }

--- a/src/question/lib/read-model.test.ts
+++ b/src/question/lib/read-model.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { appendEntry } from "./log-store";
-import { markEntriesRead, openReadModel, queryEntries } from "./read-model";
+import { markEntriesRead, markEntriesUnread, openReadModel, queryEntries } from "./read-model";
 import type { QaEntry } from "./types";
 
 function e(id: string, over: Partial<QaEntry> = {}): QaEntry {
@@ -66,5 +66,18 @@ describe("read-model", () => {
         expect(markEntriesRead(db, ["r1", "r2"], { logBase })).toBe(2);
         expect(queryEntries(db, { logBase, unread: true }).length).toBe(0);
         expect(markEntriesRead(db, ["r1"], { logBase })).toBe(0);
+    });
+
+    it("marks entries unread", () => {
+        const logBase = mkdtempSync(join(tmpdir(), "qa-log-"));
+        const dbPath = join(mkdtempSync(join(tmpdir(), "qa-db-")), "qa.db");
+        appendEntry(e("u1"), logBase);
+        const db = openReadModel(dbPath);
+        queryEntries(db, { logBase });
+
+        markEntriesRead(db, ["u1"], { logBase });
+        expect(queryEntries(db, { logBase, unread: true }).length).toBe(0);
+        expect(markEntriesUnread(db, ["u1"], { logBase })).toBe(1);
+        expect(queryEntries(db, { logBase, unread: true }).length).toBe(1);
     });
 });

--- a/src/question/lib/read-model.ts
+++ b/src/question/lib/read-model.ts
@@ -164,6 +164,21 @@ export function queryEntries(db: Database, opts: QueryOpts = {}): QaRow[] {
     }));
 }
 
+export function markEntriesUnread(db: Database, ids: string[], opts: Pick<QueryOpts, "logBase"> = {}): number {
+    if (ids.length === 0) {
+        return 0;
+    }
+
+    catchUp(db, opts.logBase);
+    const placeholders = ids.map(() => "?").join(",");
+    const result = db.run(
+        `UPDATE entries SET read_at = NULL WHERE id IN (${placeholders}) AND read_at IS NOT NULL`,
+        ids
+    );
+
+    return result.changes;
+}
+
 export function markEntriesRead(db: Database, ids: string[], opts: Pick<QueryOpts, "logBase"> = {}): number {
     if (ids.length === 0) {
         return 0;

--- a/src/question/lib/read-model.ts
+++ b/src/question/lib/read-model.ts
@@ -119,27 +119,8 @@ export interface QaRow extends QaEntry {
     readAt: number | null;
 }
 
-export function queryEntries(db: Database, opts: QueryOpts = {}): QaRow[] {
-    catchUp(db, opts.logBase);
-    const where: string[] = ["superseded_by IS NULL"];
-    const params: (string | number)[] = [];
-    if (opts.project) {
-        where.push("project = ?");
-        params.push(opts.project);
-    }
-
-    if (opts.tag) {
-        where.push("tag = ?");
-        params.push(opts.tag);
-    }
-
-    if (opts.unread) {
-        where.push("read_at IS NULL");
-    }
-
-    const sql = `SELECT * FROM entries WHERE ${where.join(" AND ")} ORDER BY ts DESC LIMIT ?`;
-    params.push(opts.limit ?? 50);
-    return (db.query(sql).all(...params) as Record<string, unknown>[]).map((r) => ({
+function rowToQaRow(r: Record<string, unknown>): QaRow {
+    return {
         id: r.id as string,
         ts: r.ts as number,
         sessionId: r.session_id as string,
@@ -161,7 +142,36 @@ export function queryEntries(db: Database, opts: QueryOpts = {}): QaRow[] {
         turnUuid: r.turn_uuid as string | null,
         supersededBy: r.superseded_by as string | null,
         readAt: r.read_at as number | null,
-    }));
+    };
+}
+
+export function queryEntries(db: Database, opts: QueryOpts = {}): QaRow[] {
+    catchUp(db, opts.logBase);
+    const where: string[] = ["superseded_by IS NULL"];
+    const params: (string | number)[] = [];
+    if (opts.project) {
+        where.push("project = ?");
+        params.push(opts.project);
+    }
+
+    if (opts.tag) {
+        where.push("tag = ?");
+        params.push(opts.tag);
+    }
+
+    if (opts.unread) {
+        where.push("read_at IS NULL");
+    }
+
+    const sql = `SELECT * FROM entries WHERE ${where.join(" AND ")} ORDER BY ts DESC LIMIT ?`;
+    params.push(opts.limit ?? 50);
+    return (db.query(sql).all(...params) as Record<string, unknown>[]).map(rowToQaRow);
+}
+
+export function getEntryById(db: Database, id: string, opts: Pick<QueryOpts, "logBase"> = {}): QaRow | null {
+    catchUp(db, opts.logBase);
+    const row = db.query("SELECT * FROM entries WHERE id = ? LIMIT 1").get(id) as Record<string, unknown> | null;
+    return row ? rowToQaRow(row) : null;
 }
 
 export function markEntriesUnread(db: Database, ids: string[], opts: Pick<QueryOpts, "logBase"> = {}): number {

--- a/src/task/README.md
+++ b/src/task/README.md
@@ -16,7 +16,7 @@ tools task run --session metro -- npx react-native start
 tools task get --session metro
 
 # Read last 100 lines
-tools task logs --session metro --lines 100
+tools task logs --session metro --tail 100
 
 # Live follow
 tools task tail --session metro --follow
@@ -43,7 +43,7 @@ tools task logs --session metro --raw | grep BUNDLE
 tools task logs --session metro --jsonl | rg '"text".*error'
 tools task logs --session metro --stderr --raw | grep -i warning
 tools task tail --session metro --follow
-tools task logs --session metro --tail --follow
+tools task logs --session metro --tail 100 --follow
 ```
 
 ## On-disk files
@@ -57,16 +57,27 @@ tools task logs --session metro --tail --follow
 
 ## Session names
 
-Reusing a name that already has a `.jsonl` on disk **does not wipe** the old session. The run is assigned a suffixed id such as `metro-2026-05-26_14-30-22`, printed immediately on stderr before the banner:
+A session name is the file stem under `~/.genesis-tools/task/sessions/`. There are two distinct reuse paths:
+
+**1. Implicit reuse (no `--session` flag).** When you previously ran `tools task run -- npx react-native start` with no `--session`, `tools task get` / `logs` / `tail` will fuzzy-resolve to the most recent matching session. If no exact match, the run is assigned a timestamp-suffixed id (`metro-2026-05-26_14-30-22`) printed on stderr before the banner:
 
 ```text
 note: session "metro" already exists — using "metro-2026-05-26_14-30-22"
 task-session-id: metro-2026-05-26_14-30-22
 ```
 
-Use `tools task get --session <full-id>` or pick the suffixed name from `tools task sessions` (see **Related:** in `get`).
+**2. Explicit reuse (you passed `--session foo` and `foo` already exists).** This is **append mode**: the new run continues writing into the existing `.jsonl` and `.log` files, with `seq` continuing from the prior last value. You'll see:
 
-When **`--session` is omitted**, `get` / `logs` / `tail` auto-resolve: explicit `--session` flag → fuzzy match → sole active session → error if ambiguous. Use `tools task sessions` to list all.
+```text
+warn: reusing existing session "foo" (append mode)
+info: last seq 1234; new lines continue from 1235
+info: tail live output: tools task tail --session foo --follow
+info: clear older lines: tools task get --session foo --clear-older-than-seq 1234
+```
+
+Append mode is useful when re-running the same logical task (e.g. `lint`, `tsc`) and you want one rolling log per check-name. Use `--clear-older-than-seq N` on `get` to drop the prior run's lines if you want a clean slate without renaming the session.
+
+When **`--session` is omitted**, `get` / `logs` / `tail` auto-resolve: explicit flag → fuzzy match → sole active session → error if ambiguous. Use `tools task sessions` to list all.
 
 ## Run modes
 
@@ -85,12 +96,55 @@ For Metro/Vite/interactive dev servers, prefer **PTY mode** (default when stdin 
 
 ## Log window defaults
 
-`logs` defaults to the **last 50 lines**; `tail` shows the last 10 before follow. Use `--all` to dump the full session, `--from-seq 1` for seq-based windows, or `--lines N` for a custom tail count.
+`logs` defaults to the **last 50 lines** in a TTY; `tail` shows the last 10 before follow. When stdout is **not** a TTY (pipes, agents), both default to **`--all`** so nothing is silently truncated.
+
+Use `--head N` / `--tail N` for windows, `--head X --tail Y` for first+last with an elision marker, or `--all` for the full session. `--grep PAT` implies `--all` unless you also pass `--head` / `--tail`.
 
 ```bash
 tools task logs --session metro --all --raw | grep TOKEN
 tools task logs --session metro --from-seq 1 --jsonl | rg error
+tools task logs --session metro --head 5 --tail 5 --raw
 ```
+
+## Dashboard auto-start
+
+The dashboard at `http://localhost:7243` is **NOT** automatically started by `tools task run`. To launch it:
+
+```bash
+tools task dashboard up         # foreground (Ctrl+C to stop)
+tools task dashboard open       # open in browser (starts if not running)
+```
+
+If you see :7243 listening when you did not start it, another GenesisTools dashboard is sharing the port — see `src/utils/ui/dashboards.ts` for the canonical registry.
+
+## Wait for a session
+
+Block on session completion or a pattern. Replaces the `until grep -qE …; sleep 5; done` polling idiom.
+
+```bash
+# Wait for dev server "ready" sentinel, max 60s
+tools task wait --session metro --exit-on-match "Bundled" --timeout 60
+
+# Wait for session to exit, propagate exit code
+tools task wait --session jest --propagate-exit
+
+# Or follow live and exit with the child's code when the session ends
+tools task tail --session jest --follow --propagate-exit
+```
+
+Exit codes: 0 on match or normal exit (without `--propagate-exit`), child's code with `--propagate-exit`, 124 on timeout.
+
+## Retention
+
+Sessions older than `sessionRetentionDays` (default **30**) are GC'd on the next `tools task run` when `gcOnRunStart` is true (default). Configure interactively or via flags:
+
+```bash
+tools task config                              # print current config (JSON)
+tools task config --session-retention-days 14  # example: shorter retention
+tools task config --gc-on-run-start off        # disable opportunistic GC
+```
+
+Config file (same values): `~/.genesis-tools/task/config.json`. Manually: `tools task clean --all`, or `tools task clean --session <name>`.
 
 ## vs shell `tee`
 

--- a/src/task/commands/clean.ts
+++ b/src/task/commands/clean.ts
@@ -7,9 +7,10 @@ import { TaskSessionStore } from "@app/task/lib/session-store";
 export function registerCleanCommand(program: Command): void {
     program
         .command("clean")
-        .description("Remove session log files")
+        .description("Remove session log files (--session <name> for one, --all for all)")
+        .option("--session <name>", "Remove a single session by name (fuzzy-matched)")
         .option("--all", "Remove all sessions")
-        .action(async (opts: { all?: boolean }) => {
+        .action(async (opts: { all?: boolean; session?: string }) => {
             const globalOpts = program.opts<{ session?: string }>();
             const store = new TaskSessionStore();
 
@@ -40,7 +41,7 @@ export function registerCleanCommand(program: Command): void {
                 return;
             }
 
-            let session = globalOpts.session;
+            let session = opts.session ?? globalOpts.session;
             if (!session) {
                 if (!isInteractive()) {
                     out.printlnErr("error: --session or --all required in non-interactive mode.");

--- a/src/task/commands/config.ts
+++ b/src/task/commands/config.ts
@@ -1,0 +1,36 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { loadTaskToolConfig, saveTaskToolConfig } from "@app/task/lib/config";
+
+export function registerConfigCommand(program: Command): void {
+    program
+        .command("config")
+        .description("Read/update task retention and GC settings")
+        .option("--session-retention-days <n>", "Delete sessions older than N days on GC")
+        .option("--gc-on-run-start <onoff>", "Run GC at the start of each tools task run (on|off)")
+        .action((opts: { sessionRetentionDays?: string; gcOnRunStart?: string }) => {
+            let next = loadTaskToolConfig();
+
+            if (opts.sessionRetentionDays !== undefined) {
+                const days = Number.parseInt(opts.sessionRetentionDays, 10);
+                if (Number.isNaN(days) || days < 0) {
+                    out.printlnErr("error: --session-retention-days requires a non-negative number");
+                    process.exit(1);
+                }
+
+                next = saveTaskToolConfig({ sessionRetentionDays: days });
+            }
+
+            if (opts.gcOnRunStart !== undefined) {
+                if (opts.gcOnRunStart !== "on" && opts.gcOnRunStart !== "off") {
+                    out.printlnErr("error: --gc-on-run-start expects on|off");
+                    process.exit(1);
+                }
+
+                next = saveTaskToolConfig({ gcOnRunStart: opts.gcOnRunStart === "on" });
+            }
+
+            out.result(SafeJSON.stringify(next, null, 2));
+        });
+}

--- a/src/task/commands/dashboard.ts
+++ b/src/task/commands/dashboard.ts
@@ -20,9 +20,10 @@ export function registerDashboardCommand(program: Command): void {
     dashboard
         .command("open")
         .description("Ensure the log server is up, print URL + QR, and open in the browser")
+        .option("--session <name>", "Session name (fuzzy-matched; inherits global if unset)")
         .option("--port <n>", "Port the dashboard server is on", String(logDashboardApp.port))
         .option("--no-qr", "Skip the phone-scan QR code")
-        .action(async (opts: { port: string; qr?: boolean }) => {
+        .action(async (opts: { port: string; qr?: boolean; session?: string }) => {
             const port = Number.parseInt(opts.port, 10);
             const globalOpts = program.opts<{ session?: string }>();
             // Fuzzy-resolve via the session store so prefix/abbrev matches
@@ -31,7 +32,7 @@ export function registerDashboardCommand(program: Command): void {
             // is passed through verbatim and a 404 lands on App.refreshSessions
             // which falls back to the first session in the list — silently
             // opening a different one than the user typed.
-            const rawSession = globalOpts.session;
+            const rawSession = opts.session ?? globalOpts.session;
             let session: string | undefined;
             if (rawSession) {
                 try {

--- a/src/task/commands/get.ts
+++ b/src/task/commands/get.ts
@@ -8,11 +8,13 @@ export function registerGetCommand(program: Command): void {
     program
         .command("get")
         .description("Show session info panel (state, files, flags cheat sheet)")
+        .option("--session <name>", "Session name (fuzzy-matched; inherits global if unset)")
         .option("--clear-older-than-seq <n>", "Remove log lines with seq <= N before showing info")
-        .action(async (opts: { clearOlderThanSeq?: string }) => {
+        .action(async (opts: { session?: string; clearOlderThanSeq?: string }) => {
             const globalOpts = program.opts<{ session?: string }>();
+            const sessionFlag = opts.session ?? globalOpts.session;
 
-            await withResolvedSession(globalOpts.session, async (session) => {
+            await withResolvedSession(sessionFlag, async (session) => {
                 if (opts.clearOlderThanSeq !== undefined) {
                     const seq = Number.parseInt(opts.clearOlderThanSeq, 10);
 

--- a/src/task/commands/logs.ts
+++ b/src/task/commands/logs.ts
@@ -1,13 +1,17 @@
 import type { Command } from "commander";
 import { buildLogQueryOpts, tailOrQuery } from "@app/task/lib/build-log-query-opts";
+import { applyGrepImpliesAll, applyLogWindowDefaults } from "@app/task/lib/log-window";
 import { withResolvedSession } from "@app/task/lib/with-resolved-session";
+import type { LogCliOpts } from "@app/task/types";
 
 export function registerLogsCommand(program: Command): void {
     program
         .command("logs")
-        .description("Read session log content (snapshot or live with --tail/--follow)")
-        .option("-n, --lines <count>", "Last N lines", "50")
-        .option("--all", "Return all matching lines (ignore --lines default)")
+        .description("Read session log content (snapshot or live with --follow)")
+        .option("--session <name>", "Session name (fuzzy-matched; inherits global if unset)")
+        .option("-H, --head <count>", "Show first N lines")
+        .option("-t, --tail <count>", "Show last N lines")
+        .option("--all", "Dump every line — overrides --head/--tail")
         .option("--from-seq <n>", "Start at seq N (inclusive)")
         .option("--to-seq <n>", "End at seq N (inclusive)")
         .option("--grep <pat>", "Filter lines matching pattern")
@@ -15,14 +19,16 @@ export function registerLogsCommand(program: Command): void {
         .option("--raw", "Plain text on stdout (grep-safe)")
         .option("--stdout", "Stdout stream only")
         .option("--stderr", "Stderr stream only")
-        .option("--tail", "Follow live (same as task tail)")
-        .option("-f, --follow", "Alias for --tail")
-        .action(async (opts) => {
+        .option("-f, --follow", "Follow live")
+        .action(async (opts: LogCliOpts) => {
             const globalOpts = program.opts<{ session?: string }>();
+            const sessionFlag = opts.session ?? globalOpts.session;
+            let resolvedOpts = applyGrepImpliesAll(opts);
+            resolvedOpts = applyLogWindowDefaults(resolvedOpts, { ttyTail: "50" });
 
-            await withResolvedSession(globalOpts.session, async (session) => {
-                const queryOpts = buildLogQueryOpts(session, opts);
-                await tailOrQuery(queryOpts, Boolean(opts.tail || opts.follow));
+            await withResolvedSession(sessionFlag, async (session) => {
+                const queryOpts = buildLogQueryOpts(session, resolvedOpts);
+                await tailOrQuery(queryOpts, Boolean(opts.follow));
             });
         });
 }

--- a/src/task/commands/run.ts
+++ b/src/task/commands/run.ts
@@ -5,6 +5,10 @@ import type { Command } from "commander";
 import pc from "picocolors";
 import { printRunBanner, printRunExitSummary } from "@app/task/lib/banner";
 import { resolveRunSession } from "@app/task/lib/resolve-run-session";
+import { pollSessionExitCode, shouldSuperviseDetachedRun, spawnDetachedRunWorker } from "@app/task/lib/detached-run";
+import { loadTaskToolConfig } from "@app/task/lib/config";
+import { runSessionGc } from "@app/task/lib/gc";
+import { logger } from "@app/logger";
 import { resolveRunMode } from "@app/task/lib/run-mode";
 import { runTask } from "@app/task/lib/runner";
 import { suggestClearOlderThanSeq, suggestTail } from "@app/task/lib/suggest-flags";
@@ -85,6 +89,15 @@ export function registerRunCommand(program: Command): void {
 
             const mode = resolveRunMode({ tty: opts.tty });
 
+            const taskConfig = loadTaskToolConfig();
+            if (taskConfig.gcOnRunStart) {
+                try {
+                    await runSessionGc({ retentionDays: taskConfig.sessionRetentionDays });
+                } catch (err) {
+                    logger.warn({ err }, "gc: failed");
+                }
+            }
+
             const store = new TaskSessionStore();
             const resolved = await resolveRunSession(store, session, {
                 explicitSessionFlag,
@@ -107,6 +120,27 @@ export function registerRunCommand(program: Command): void {
             }
 
             printRunBanner({ session: resolved.session, command, mode });
+
+            if (shouldSuperviseDetachedRun()) {
+                const toolsEntry = process.argv[1] ?? "tools";
+                const worker = spawnDetachedRunWorker({
+                    toolsEntry,
+                    session: resolved.session,
+                    command,
+                    mode,
+                    forceTty: opts.tty === true,
+                    forceNoTty: opts.tty === false,
+                });
+                worker.unref();
+
+                const exitCode = await pollSessionExitCode(resolved.session);
+                printRunExitSummary({
+                    session: resolved.session,
+                    exitCode,
+                    durationMs: 0,
+                });
+                process.exit(exitCode);
+            }
 
             const result = await runTask({
                 session: resolved.session,

--- a/src/task/commands/sessions.ts
+++ b/src/task/commands/sessions.ts
@@ -1,6 +1,8 @@
 import { out } from "@app/logger";
 import { formatBytes } from "@app/utils/format";
+import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
+import { formatSessionsJson } from "@app/task/lib/format-sessions-json";
 import { formatSessionState } from "@app/task/lib/format-session-state";
 import { sessionFilePaths } from "@app/task/lib/paths";
 import { TaskSessionStore } from "@app/task/lib/session-store";
@@ -9,7 +11,14 @@ export function registerSessionsCommand(program: Command): void {
     program
         .command("sessions")
         .description("List task sessions")
-        .action(async () => {
+        .option("--json", "Emit machine-readable JSON array on stdout")
+        .action(async (opts: { json?: boolean }) => {
+            if (opts.json) {
+                const data = await formatSessionsJson();
+                out.print(`${SafeJSON.stringify(data, null, 2)}\n`);
+                return;
+            }
+
             const store = new TaskSessionStore();
             const names = await store.listSessionNames();
 

--- a/src/task/commands/sessions.ts
+++ b/src/task/commands/sessions.ts
@@ -1,11 +1,11 @@
 import { out } from "@app/logger";
+import { formatSessionState } from "@app/task/lib/format-session-state";
+import { formatSessionsJson } from "@app/task/lib/format-sessions-json";
+import { sessionFilePaths } from "@app/task/lib/paths";
+import { TaskSessionStore } from "@app/task/lib/session-store";
 import { formatBytes } from "@app/utils/format";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
-import { formatSessionsJson } from "@app/task/lib/format-sessions-json";
-import { formatSessionState } from "@app/task/lib/format-session-state";
-import { sessionFilePaths } from "@app/task/lib/paths";
-import { TaskSessionStore } from "@app/task/lib/session-store";
 
 export function registerSessionsCommand(program: Command): void {
     program
@@ -15,7 +15,7 @@ export function registerSessionsCommand(program: Command): void {
         .action(async (opts: { json?: boolean }) => {
             if (opts.json) {
                 const data = await formatSessionsJson();
-                out.print(`${SafeJSON.stringify(data, null, 2)}\n`);
+                out.result(SafeJSON.stringify(data, null, 2));
                 return;
             }
 

--- a/src/task/commands/tail.ts
+++ b/src/task/commands/tail.ts
@@ -1,13 +1,19 @@
+import { out } from "@app/logger";
 import type { Command } from "commander";
 import { buildLogQueryOpts, tailOrQuery } from "@app/task/lib/build-log-query-opts";
+import { applyGrepImpliesAll, applyLogWindowDefaults } from "@app/task/lib/log-window";
+import { waitForSession } from "@app/task/lib/wait-for-session";
 import { withResolvedSession } from "@app/task/lib/with-resolved-session";
+import type { LogCliOpts } from "@app/task/types";
 
 export function registerTailCommand(program: Command): void {
     program
         .command("tail")
-        .description("Follow session logs live (same as logs --tail)")
-        .option("-n, --lines <count>", "Show last N existing lines before follow", "10")
-        .option("--all", "Return all matching lines (ignore --lines default)")
+        .description("Follow session logs live (same as logs --follow)")
+        .option("--session <name>", "Session name (fuzzy-matched; inherits global if unset)")
+        .option("-H, --head <count>", "Show first N existing lines before follow")
+        .option("-t, --tail <count>", "Show last N existing lines before follow")
+        .option("--all", "Show all existing lines before follow — overrides --head/--tail")
         .option("--from-seq <n>", "Start at seq N (inclusive)")
         .option("--to-seq <n>", "End at seq N (inclusive)")
         .option("--grep <pat>", "Filter lines matching pattern")
@@ -16,12 +22,41 @@ export function registerTailCommand(program: Command): void {
         .option("--stdout", "Stdout stream only")
         .option("--stderr", "Stderr stream only")
         .option("-f, --follow", "Follow live (default for tail)")
-        .action(async (opts) => {
+        .option("--exit-on-match <pat>", "Exit 0 as soon as PATTERN appears (regex)")
+        .option("--propagate-exit", "Exit with the session's exit code when it ends")
+        .action(async (opts: LogCliOpts & { exitOnMatch?: string; propagateExit?: boolean }) => {
             const globalOpts = program.opts<{ session?: string }>();
+            const sessionFlag = opts.session ?? globalOpts.session;
+            let resolvedOpts = applyGrepImpliesAll(opts);
+            resolvedOpts = applyLogWindowDefaults(resolvedOpts, { ttyTail: "10" });
 
-            await withResolvedSession(globalOpts.session, async (session) => {
-                const queryOpts = buildLogQueryOpts(session, opts);
-                await tailOrQuery(queryOpts, true);
+            await withResolvedSession(sessionFlag, async (session) => {
+                if (opts.exitOnMatch) {
+                    const result = await waitForSession({
+                        session,
+                        exitOnMatch: new RegExp(opts.exitOnMatch),
+                        waitForExit: true,
+                    });
+
+                    if (result.reason === "match") {
+                        if (result.matchedLine) {
+                            out.result(result.matchedLine);
+                        }
+
+                        process.exit(0);
+                    }
+
+                    process.exit(1);
+                }
+
+                const queryOpts = buildLogQueryOpts(session, resolvedOpts);
+                const sessionExitCode = await tailOrQuery(queryOpts, true, {
+                    propagateExit: Boolean(opts.propagateExit),
+                });
+
+                if (opts.propagateExit && typeof sessionExitCode === "number") {
+                    process.exit(sessionExitCode);
+                }
             });
         });
 }

--- a/src/task/commands/tail.ts
+++ b/src/task/commands/tail.ts
@@ -1,10 +1,10 @@
 import { out } from "@app/logger";
-import type { Command } from "commander";
 import { buildLogQueryOpts, tailOrQuery } from "@app/task/lib/build-log-query-opts";
 import { applyGrepImpliesAll, applyLogWindowDefaults } from "@app/task/lib/log-window";
 import { waitForSession } from "@app/task/lib/wait-for-session";
 import { withResolvedSession } from "@app/task/lib/with-resolved-session";
 import type { LogCliOpts } from "@app/task/types";
+import type { Command } from "commander";
 
 export function registerTailCommand(program: Command): void {
     program
@@ -30,11 +30,23 @@ export function registerTailCommand(program: Command): void {
             let resolvedOpts = applyGrepImpliesAll(opts);
             resolvedOpts = applyLogWindowDefaults(resolvedOpts, { ttyTail: "10" });
 
+            let exitOnMatchRegex: RegExp | undefined;
+            if (opts.exitOnMatch) {
+                try {
+                    exitOnMatchRegex = new RegExp(opts.exitOnMatch);
+                } catch (err) {
+                    out.printlnErr(
+                        `error: --exit-on-match requires a valid regex (${err instanceof Error ? err.message : String(err)})`
+                    );
+                    process.exit(1);
+                }
+            }
+
             await withResolvedSession(sessionFlag, async (session) => {
-                if (opts.exitOnMatch) {
+                if (exitOnMatchRegex) {
                     const result = await waitForSession({
                         session,
-                        exitOnMatch: new RegExp(opts.exitOnMatch),
+                        exitOnMatch: exitOnMatchRegex,
                         waitForExit: true,
                     });
 

--- a/src/task/commands/wait.ts
+++ b/src/task/commands/wait.ts
@@ -1,9 +1,9 @@
 import { out } from "@app/logger";
-import type { Command } from "commander";
 import { sessionFilePaths } from "@app/task/lib/paths";
 import { waitForSession } from "@app/task/lib/wait-for-session";
 import { withResolvedSession } from "@app/task/lib/with-resolved-session";
 import { filterLineRecords, lastNLines, readJsonlFile } from "@app/utils/log-session/jsonl-reader";
+import type { Command } from "commander";
 
 export function registerWaitCommand(program: Command): void {
     program
@@ -36,10 +36,22 @@ export function registerWaitCommand(program: Command): void {
                     }
                 }
 
+                let exitOnMatchRegex: RegExp | undefined;
+                if (opts.exitOnMatch) {
+                    try {
+                        exitOnMatchRegex = new RegExp(opts.exitOnMatch);
+                    } catch (err) {
+                        out.printlnErr(
+                            `error: --exit-on-match requires a valid regex (${err instanceof Error ? err.message : String(err)})`
+                        );
+                        process.exit(1);
+                    }
+                }
+
                 await withResolvedSession(sessionFlag, async (resolved) => {
                     const result = await waitForSession({
                         session: resolved,
-                        exitOnMatch: opts.exitOnMatch ? new RegExp(opts.exitOnMatch) : undefined,
+                        exitOnMatch: exitOnMatchRegex,
                         timeoutMs: opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined,
                         waitForExit: !opts.exitOnMatch,
                     });
@@ -49,7 +61,7 @@ export function registerWaitCommand(program: Command): void {
                         const records = await readJsonlFile(sessionFilePaths(resolved).jsonl);
                         const tail = lastNLines(filterLineRecords(records), printN);
                         for (const line of tail) {
-                            process.stdout.write(`${line.text}\n`);
+                            out.result(line.text);
                         }
                     }
 

--- a/src/task/commands/wait.ts
+++ b/src/task/commands/wait.ts
@@ -1,0 +1,77 @@
+import { out } from "@app/logger";
+import type { Command } from "commander";
+import { sessionFilePaths } from "@app/task/lib/paths";
+import { waitForSession } from "@app/task/lib/wait-for-session";
+import { withResolvedSession } from "@app/task/lib/with-resolved-session";
+import { filterLineRecords, lastNLines, readJsonlFile } from "@app/utils/log-session/jsonl-reader";
+
+export function registerWaitCommand(program: Command): void {
+    program
+        .command("wait")
+        .description("Block until session exits or PATTERN appears in stream")
+        .option("--session <name>", "Session name (fuzzy-matched)")
+        .option("--exit-on-match <pat>", "Exit when PATTERN matches (regex); else wait for session exit")
+        .option("--timeout <seconds>", "Deadline before non-zero exit")
+        .option("--print-tail <n>", "Print last N lines before exiting", "0")
+        .option("--print-exit", "Print 'Session exited (code N)' on exit-path")
+        .option("--propagate-exit", "Use child's exit code instead of 0 (only with no --exit-on-match)")
+        .action(
+            async (opts: {
+                session?: string;
+                exitOnMatch?: string;
+                timeout?: string;
+                printTail?: string;
+                printExit?: boolean;
+                propagateExit?: boolean;
+            }) => {
+                const globalOpts = program.opts<{ session?: string }>();
+                const sessionFlag = opts.session ?? globalOpts.session;
+
+                if (opts.timeout !== undefined) {
+                    const seconds = Number.parseInt(opts.timeout, 10);
+
+                    if (Number.isNaN(seconds) || seconds <= 0) {
+                        out.printlnErr("error: --timeout requires a positive number of seconds");
+                        process.exit(1);
+                    }
+                }
+
+                await withResolvedSession(sessionFlag, async (resolved) => {
+                    const result = await waitForSession({
+                        session: resolved,
+                        exitOnMatch: opts.exitOnMatch ? new RegExp(opts.exitOnMatch) : undefined,
+                        timeoutMs: opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined,
+                        waitForExit: !opts.exitOnMatch,
+                    });
+
+                    const printN = Number.parseInt(opts.printTail ?? "0", 10);
+                    if (printN > 0) {
+                        const records = await readJsonlFile(sessionFilePaths(resolved).jsonl);
+                        const tail = lastNLines(filterLineRecords(records), printN);
+                        for (const line of tail) {
+                            process.stdout.write(`${line.text}\n`);
+                        }
+                    }
+
+                    if (result.reason === "match") {
+                        if (opts.printExit) {
+                            out.printlnErr(`Matched: ${result.matchedLine}`);
+                        }
+
+                        process.exit(0);
+                    }
+
+                    if (result.reason === "session-exit") {
+                        if (opts.printExit) {
+                            out.printlnErr(`Session exited (code ${result.sessionExitCode ?? "?"}).`);
+                        }
+
+                        process.exit(opts.propagateExit ? (result.sessionExitCode ?? 0) : 0);
+                    }
+
+                    out.printlnErr(`Timeout after ${opts.timeout}s.`);
+                    process.exit(124);
+                });
+            }
+        );
+}

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -9,6 +9,8 @@ import { registerLogsCommand } from "@app/task/commands/logs";
 import { registerRunCommand } from "@app/task/commands/run";
 import { registerSessionsCommand } from "@app/task/commands/sessions";
 import { registerTailCommand } from "@app/task/commands/tail";
+import { registerConfigCommand } from "@app/task/commands/config";
+import { registerWaitCommand } from "@app/task/commands/wait";
 
 const program = new Command();
 
@@ -22,6 +24,8 @@ registerRunCommand(program);
 registerGetCommand(program);
 registerLogsCommand(program);
 registerTailCommand(program);
+registerWaitCommand(program);
+registerConfigCommand(program);
 registerSessionsCommand(program);
 registerCleanCommand(program);
 registerDashboardCommand(program);

--- a/src/task/lib/banner.ts
+++ b/src/task/lib/banner.ts
@@ -23,7 +23,7 @@ export function printRunBanner({ session, command, mode }: RunBannerInput): void
     out.printlnErr(`│           ${paths.stderr}`);
     out.printlnErr("│");
     out.printlnErr(`│ Session info:  ${suggestGet(session)}`);
-    out.printlnErr(`│ Read logs:     ${suggestLogs(session, ["--lines", "100"])}`);
+    out.printlnErr(`│ Read logs:     ${suggestLogs(session, ["--tail", "100"])}`);
     out.printlnErr(`│ Live follow:   ${suggestTail(session)}`);
     out.printlnErr(`│ Same as above: ${suggestLogsFollow(session)}`);
     out.printlnErr(`│ Grep-safe:     ${suggestLogs(session, ["--raw"])} | grep PATTERN`);

--- a/src/task/lib/build-log-query-opts.test.ts
+++ b/src/task/lib/build-log-query-opts.test.ts
@@ -2,27 +2,32 @@ import { describe, expect, it } from "bun:test";
 import { buildLogQueryOpts } from "@app/task/lib/build-log-query-opts";
 
 describe("buildLogQueryOpts", () => {
-    it("defaults to 50 lines when --all is not set (eval2 bug #7 baseline)", () => {
+    it("defaults head/tail unset when --all is not set", () => {
         const opts = buildLogQueryOpts("metro", {});
 
-        expect(opts.lines).toBe(50);
+        expect(opts.head).toBeUndefined();
+        expect(opts.tail).toBeUndefined();
+        expect(opts.all).toBe(false);
     });
 
-    it("passes lines undefined when --all is set (eval2 bug #7)", () => {
+    it("passes all true when --all is set", () => {
         const opts = buildLogQueryOpts("metro", { all: true });
 
-        expect(opts.lines).toBeUndefined();
+        expect(opts.all).toBe(true);
+        expect(opts.head).toBeUndefined();
+        expect(opts.tail).toBeUndefined();
     });
 
-    it("respects explicit --lines over default", () => {
-        const opts = buildLogQueryOpts("metro", { lines: "200" });
+    it("parses --head and --tail", () => {
+        const opts = buildLogQueryOpts("metro", { head: "5", tail: "10" });
 
-        expect(opts.lines).toBe(200);
+        expect(opts.head).toBe(5);
+        expect(opts.tail).toBe(10);
     });
 
-    it("prefers --all over explicit --lines", () => {
-        const opts = buildLogQueryOpts("metro", { all: true, lines: "200" });
+    it("prefers --all over explicit --head/--tail", () => {
+        const opts = buildLogQueryOpts("metro", { all: true, head: "5", tail: "10" });
 
-        expect(opts.lines).toBeUndefined();
+        expect(opts.all).toBe(true);
     });
 });

--- a/src/task/lib/build-log-query-opts.ts
+++ b/src/task/lib/build-log-query-opts.ts
@@ -1,28 +1,15 @@
 import { resolveStreamFilter } from "@app/task/lib/stream-filter";
 import { tailOrQuery } from "@app/task/lib/tail-session";
-import type { LogOutputFormat, LogQueryOpts } from "@app/task/types";
+import type { LogCliOpts, LogOutputFormat, LogQueryOpts } from "@app/task/types";
 
-export function buildLogQueryOpts(
-    session: string,
-    opts: {
-        lines?: string;
-        fromSeq?: string;
-        toSeq?: string;
-        grep?: string;
-        jsonl?: boolean;
-        raw?: boolean;
-        stdout?: boolean;
-        stderr?: boolean;
-        tail?: boolean;
-        follow?: boolean;
-        all?: boolean;
-    }
-): LogQueryOpts {
+export function buildLogQueryOpts(session: string, opts: LogCliOpts): LogQueryOpts {
     const format: LogOutputFormat = opts.jsonl ? "jsonl" : opts.raw ? "raw" : "human";
 
     return {
         session,
-        lines: opts.all ? undefined : opts.lines ? Number.parseInt(opts.lines, 10) : 50,
+        head: opts.head ? Number.parseInt(opts.head, 10) : undefined,
+        tail: opts.tail ? Number.parseInt(opts.tail, 10) : undefined,
+        all: Boolean(opts.all),
         fromSeq: opts.fromSeq ? Number.parseInt(opts.fromSeq, 10) : undefined,
         toSeq: opts.toSeq ? Number.parseInt(opts.toSeq, 10) : undefined,
         grep: opts.grep,

--- a/src/task/lib/config.ts
+++ b/src/task/lib/config.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { logger } from "@app/logger";
+import { taskConfigPath } from "@app/task/lib/paths";
+import { SafeJSON } from "@app/utils/json";
+
+export interface TaskToolConfig {
+    sessionRetentionDays: number;
+    gcOnRunStart: boolean;
+}
+
+const DEFAULT: TaskToolConfig = {
+    sessionRetentionDays: 30,
+    gcOnRunStart: true,
+};
+
+export function configPath(): string {
+    return taskConfigPath();
+}
+
+function normalizeTaskToolConfig(input: unknown): Partial<TaskToolConfig> {
+    if (!input || typeof input !== "object") {
+        return {};
+    }
+
+    const obj = input as Record<string, unknown>;
+    const out: Partial<TaskToolConfig> = {};
+
+    if (
+        typeof obj.sessionRetentionDays === "number" &&
+        Number.isFinite(obj.sessionRetentionDays) &&
+        obj.sessionRetentionDays >= 0
+    ) {
+        out.sessionRetentionDays = obj.sessionRetentionDays;
+    }
+
+    if (typeof obj.gcOnRunStart === "boolean") {
+        out.gcOnRunStart = obj.gcOnRunStart;
+    }
+
+    return out;
+}
+
+export function loadTaskToolConfig(path = configPath()): TaskToolConfig {
+    if (!existsSync(path)) {
+        return DEFAULT;
+    }
+
+    try {
+        return { ...DEFAULT, ...normalizeTaskToolConfig(SafeJSON.parse(readFileSync(path, "utf8"))) };
+    } catch (err) {
+        logger.warn({ err, path }, "task config: failed to load; falling back to defaults");
+
+        return DEFAULT;
+    }
+}
+
+export function saveTaskToolConfig(patch: Partial<TaskToolConfig>, path = configPath()): TaskToolConfig {
+    const next = { ...loadTaskToolConfig(path), ...patch };
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, SafeJSON.stringify(next, null, 2));
+
+    return next;
+}

--- a/src/task/lib/detached-run.ts
+++ b/src/task/lib/detached-run.ts
@@ -1,0 +1,78 @@
+import { openSync } from "node:fs";
+import { readJsonlFile } from "@app/utils/log-session/jsonl-reader";
+import type { JsonlExitRecord } from "@app/utils/log-session/types";
+import { jsonlPath, stdoutLogPath } from "@app/task/lib/paths";
+import type { TaskRunMode } from "@app/task/types";
+
+const WORKER_ENV = "TASK_RUN_WORKER";
+
+export function isDetachedRunWorker(): boolean {
+    return process.env[WORKER_ENV] === "1";
+}
+
+export function shouldSuperviseDetachedRun(): boolean {
+    // Foreground CI/agents: stdin may be piped but stdout is still a TTY — run
+    // in-process so output streams through. Background `tools task run &` with
+    // redirects typically has neither stdin nor stdout attached to a TTY.
+    return !process.stdin.isTTY && !process.stdout.isTTY && !isDetachedRunWorker();
+}
+
+function findExitRecord(records: Awaited<ReturnType<typeof readJsonlFile>>): JsonlExitRecord | undefined {
+    return records.find(
+        (record): record is JsonlExitRecord =>
+            record.type === "exit" && typeof (record as JsonlExitRecord).code === "number"
+    );
+}
+
+export async function pollSessionExitCode(session: string, pollMs = 50): Promise<number> {
+    const path = jsonlPath(session);
+
+    for (;;) {
+        const records = await readJsonlFile(path);
+        const exit = findExitRecord(records);
+        if (exit) {
+            return exit.code;
+        }
+
+        await Bun.sleep(pollMs);
+    }
+}
+
+function buildWorkerCmdPrefix(toolsEntry: string): string[] {
+    if (/[/\\]task[/\\]index\.tsx?$/i.test(toolsEntry)) {
+        return [process.execPath, toolsEntry];
+    }
+
+    return [process.execPath, toolsEntry, "task"];
+}
+
+export function spawnDetachedRunWorker(opts: {
+    toolsEntry: string;
+    session: string;
+    command: string[];
+    mode: TaskRunMode;
+    forceTty?: boolean;
+    forceNoTty?: boolean;
+}): ReturnType<typeof Bun.spawn> {
+    const cmd = [...buildWorkerCmdPrefix(opts.toolsEntry), "run", "--session", opts.session];
+
+    if (opts.forceTty) {
+        cmd.push("--tty");
+    } else if (opts.forceNoTty || opts.mode === "pipe") {
+        cmd.push("--no-tty");
+    }
+
+    cmd.push("--", ...opts.command);
+
+    const logFd = openSync(stdoutLogPath(opts.session), "a");
+
+    return Bun.spawn({
+        cmd,
+        env: { ...process.env, [WORKER_ENV]: "1" },
+        cwd: process.cwd(),
+        stdin: "ignore",
+        stdout: logFd,
+        stderr: logFd,
+        detached: true,
+    });
+}

--- a/src/task/lib/format-sessions-json.ts
+++ b/src/task/lib/format-sessions-json.ts
@@ -1,0 +1,49 @@
+import { formatSessionState } from "@app/task/lib/format-session-state";
+import { sessionFilePaths } from "@app/task/lib/paths";
+import { TaskSessionStore } from "@app/task/lib/session-store";
+import { filterLineRecords, readJsonlFile } from "@app/utils/log-session/jsonl-reader";
+
+export interface SessionSummary {
+    name: string;
+    state: string;
+    command: string | null;
+    cwd: string | null;
+    mode: string | null;
+    pid: number | null;
+    jsonlSizeBytes: number;
+    stdoutSizeBytes: number;
+    stderrSizeBytes: number;
+    firstSeq: number;
+    lastSeq: number;
+    jsonlPath: string;
+}
+
+export async function formatSessionsJson(): Promise<SessionSummary[]> {
+    const store = new TaskSessionStore();
+    const names = await store.listSessionNames();
+    const out: SessionSummary[] = [];
+
+    for (const name of names.sort()) {
+        const meta = await store.reconcileSessionState(name);
+        const paths = sessionFilePaths(name);
+        const records = await readJsonlFile(paths.jsonl);
+        const lines = filterLineRecords(records);
+
+        out.push({
+            name,
+            state: formatSessionState(meta),
+            command: meta?.command ?? null,
+            cwd: meta?.cwd ?? null,
+            mode: meta?.mode ?? null,
+            pid: meta?.pid ?? null,
+            jsonlSizeBytes: await store.getSessionFileSize(paths.jsonl),
+            stdoutSizeBytes: await store.getSessionFileSize(paths.stdout),
+            stderrSizeBytes: await store.getSessionFileSize(paths.stderr),
+            firstSeq: lines[0]?.seq ?? 0,
+            lastSeq: lines.length > 0 ? lines[lines.length - 1].seq : 0,
+            jsonlPath: paths.jsonl,
+        });
+    }
+
+    return out;
+}

--- a/src/task/lib/gc.ts
+++ b/src/task/lib/gc.ts
@@ -1,0 +1,47 @@
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { getTaskSessionsDir } from "@app/task/lib/paths";
+import { TaskSessionStore } from "@app/task/lib/session-store";
+import { isProcessAlive } from "@app/task/lib/process-alive";
+
+export async function runSessionGc(opts: { retentionDays: number }): Promise<{ removed: number }> {
+    const cutoffMs = Date.now() - opts.retentionDays * 24 * 3600 * 1000;
+    const dir = getTaskSessionsDir();
+    let names: string[];
+
+    try {
+        names = (await readdir(dir)).filter((n) => n.endsWith(".jsonl") && !n.endsWith(".ui.jsonl"));
+    } catch (err) {
+        logger.warn({ err, dir }, "gc: failed to read sessions directory");
+
+        return { removed: 0 };
+    }
+
+    let removed = 0;
+    const store = new TaskSessionStore();
+
+    for (const file of names) {
+        const session = file.replace(/\.jsonl$/, "");
+
+        try {
+            const st = await stat(join(dir, file));
+            if (st.mtimeMs >= cutoffMs) {
+                continue;
+            }
+
+            const meta = await store.reconcileSessionState(session);
+            if (meta?.exitCode === undefined && meta?.pid !== undefined && isProcessAlive(meta.pid)) {
+                continue;
+            }
+
+            await store.deleteSession(session);
+            removed++;
+            logger.debug({ session, age: Date.now() - st.mtimeMs }, "gc: removed session");
+        } catch (err) {
+            logger.warn({ err, session }, "gc: failed to evaluate session");
+        }
+    }
+
+    return { removed };
+}

--- a/src/task/lib/get-session-info.ts
+++ b/src/task/lib/get-session-info.ts
@@ -4,7 +4,13 @@ import { filterByStream, filterLineRecords, lastNLines, readJsonlFile } from "@a
 import { formatSessionState } from "@app/task/lib/format-session-state";
 import { sessionFilePaths } from "@app/task/lib/paths";
 import { TaskSessionStore } from "@app/task/lib/session-store";
-import { suggestDashboard, suggestLogs, suggestLogsFollow, suggestTail } from "@app/task/lib/suggest-flags";
+import {
+    suggestDashboard,
+    suggestLogs,
+    suggestLogsAllGrep,
+    suggestLogsFollow,
+    suggestTail,
+} from "@app/task/lib/suggest-flags";
 
 export async function getSessionInfo(session: string): Promise<void> {
     const store = new TaskSessionStore();
@@ -85,27 +91,30 @@ export async function getSessionInfo(session: string): Promise<void> {
 
     out.printlnErr("║");
     out.printlnErr("║ WHAT TO RUN NEXT (copy-paste)");
-    out.printlnErr(`║   Read last 100    ${suggestLogs(session, ["--lines", "100"])}`);
+    out.printlnErr(`║   Read last 100    ${suggestLogs(session, ["--tail", "100"])}`);
     out.printlnErr(`║   All lines        ${suggestLogs(session, ["--all", "--raw"])}`);
     out.printlnErr(`║   Live follow      ${suggestTail(session)}`);
     out.printlnErr(`║   Same as above    ${suggestLogsFollow(session)}`);
     out.printlnErr(`║   Stderr only      ${suggestLogs(session, ["--stderr", "--raw"])}`);
-    out.printlnErr(`║   Grep stdout      ${suggestLogs(session, ["--raw"])} | grep PATTERN`);
+    out.printlnErr(`║   Grep stdout      ${suggestLogsAllGrep(session)}`);
     out.printlnErr(`║   JSONL + rg       ${suggestLogs(session, ["--jsonl"])} | rg error`);
     out.printlnErr(`║   Dashboard        ${suggestDashboard(session)}`);
+    out.printlnErr("║   Clean all        tools task clean --all");
     out.printlnErr("║");
     out.printlnErr("║ FLAGS (logs + tail — short forms also work but mean the same)");
-    out.printlnErr("║   --follow       Stream live until Ctrl+C (alias: -f)");
-    out.printlnErr("║   --tail         On logs only — same as --follow");
-    out.printlnErr("║   --lines N      Last N lines by seq (alias: -n; default: logs=50, tail=10)");
-    out.printlnErr("║   --all          Full session (ignore --lines default)");
-    out.printlnErr("║   --from-seq N   Include from seq N onward");
-    out.printlnErr("║   --to-seq N     Include up to seq N");
-    out.printlnErr("║   --stdout       Stdout lines only (default: both streams)");
-    out.printlnErr("║   --stderr       Stderr lines only");
-    out.printlnErr("║   --raw          Plain text on stdout → safe for | grep");
-    out.printlnErr("║   --jsonl        JSON lines on stdout → safe for | rg");
-    out.printlnErr("║   --grep PAT     Filter before printing");
+    out.printlnErr("║   -f, --follow  Stream live until Ctrl+C");
+    out.printlnErr("║   -H, --head N  First N lines");
+    out.printlnErr("║   -t, --tail N  Last N lines (default: logs=50, tail=10)");
+    out.printlnErr("║   --head X --tail Y   First X + last Y, with elision marker between");
+    out.printlnErr("║   --all         Full session (no slicing)");
+    out.printlnErr("║                 (non-TTY default: --all, so | grep sees everything)");
+    out.printlnErr("║   --from-seq N  Include from seq N onward");
+    out.printlnErr("║   --to-seq N    Include up to seq N");
+    out.printlnErr("║   --stdout      Stdout lines only (default: both streams)");
+    out.printlnErr("║   --stderr      Stderr lines only");
+    out.printlnErr("║   --raw         Plain text on stdout → safe for | grep");
+    out.printlnErr("║   --jsonl       JSON lines on stdout → safe for | rg");
+    out.printlnErr("║   --grep PAT    Filter before printing (implies --all unless --head/--tail given)");
     out.printlnErr("║");
     out.printlnErr("║ I/O CONTRACT");
     out.printlnErr("║   this panel (get)     → stderr — don't pipe");

--- a/src/task/lib/log-hints.ts
+++ b/src/task/lib/log-hints.ts
@@ -6,10 +6,10 @@ export function printLogNavigationHints(opts: {
     session: string;
     lines: JsonlLineRecord[];
     totalLines: number;
-    linesRequested?: number;
+    windowLabel: string;
     streams: Set<"stdout" | "stderr">;
 }): void {
-    const { session, lines, totalLines, linesRequested, streams } = opts;
+    const { session, lines, totalLines, windowLabel, streams } = opts;
 
     if (lines.length === 0) {
         out.printlnErr(`── session ${session} ── no matching lines`);
@@ -21,21 +21,20 @@ export function printLogNavigationHints(opts: {
     const firstSeq = lines[0].seq;
     const lastSeq = lines[lines.length - 1].seq;
     const streamLabel = streams.size === 2 ? "stdout+stderr" : streams.has("stdout") ? "stdout" : "stderr";
-    const linesLabel = linesRequested ? `--lines ${linesRequested}` : "all";
 
     out.printlnErr(`── session ${session} ${"─".repeat(Math.max(0, 40 - session.length))}`);
     out.printlnErr(
-        `  Showing seq ${firstSeq}–${lastSeq} of ${totalLines.toLocaleString()} lines (${linesLabel}, streams: ${streamLabel})`
+        `  Showing seq ${firstSeq}–${lastSeq} of ${totalLines.toLocaleString()} lines (${windowLabel}, streams: ${streamLabel})`
     );
     out.printlnErr("");
     out.printlnErr("  Navigate:");
 
     if (firstSeq > 1) {
-        out.printlnErr(`    earlier  → ${suggestLogs(session, ["--to-seq", String(firstSeq - 1), "--lines", "50"])}`);
+        out.printlnErr(`    earlier  → ${suggestLogs(session, ["--to-seq", String(firstSeq - 1), "--tail", "50"])}`);
     }
 
     if (lastSeq < totalLines) {
-        out.printlnErr(`    later    → ${suggestLogs(session, ["--from-seq", String(lastSeq + 1), "--lines", "50"])}`);
+        out.printlnErr(`    later    → ${suggestLogs(session, ["--from-seq", String(lastSeq + 1), "--tail", "50"])}`);
     }
 
     out.printlnErr(`    live     → ${suggestTail(session)}`);

--- a/src/task/lib/log-query.ts
+++ b/src/task/lib/log-query.ts
@@ -5,13 +5,48 @@ import {
     filterFromSeq,
     filterLineRecords,
     filterToSeq,
-    lastNLines,
     readJsonlFile,
 } from "@app/utils/log-session/jsonl-reader";
 import type { JsonlLineRecord } from "@app/utils/log-session/types";
 import type { LogQueryOpts } from "@app/task/types";
 import { printLogNavigationHints } from "@app/task/lib/log-hints";
 import { jsonlPath } from "@app/task/lib/paths";
+
+export interface SliceResult<T> {
+    lines: T[];
+    elidedCount: number;
+    headCount: number;
+}
+
+export function sliceLogLines<T>(lines: T[], opts: Pick<LogQueryOpts, "head" | "tail" | "all">): SliceResult<T> {
+    if (opts.all || lines.length === 0) {
+        return { lines, elidedCount: 0, headCount: 0 };
+    }
+
+    if (opts.head === undefined && opts.tail === undefined) {
+        return { lines, elidedCount: 0, headCount: 0 };
+    }
+
+    const h = opts.head ?? 0;
+    const t = opts.tail ?? 0;
+
+    if (h === 0 && t === 0) {
+        return { lines: [], elidedCount: 0, headCount: 0 };
+    }
+
+    if (h + t >= lines.length) {
+        return { lines, elidedCount: 0, headCount: 0 };
+    }
+
+    const headSlice = h > 0 ? lines.slice(0, h) : [];
+    const tailSlice = t > 0 ? lines.slice(-t) : [];
+
+    return {
+        lines: [...headSlice, ...tailSlice],
+        elidedCount: lines.length - headSlice.length - tailSlice.length,
+        headCount: headSlice.length,
+    };
+}
 
 function applyGrep(lines: JsonlLineRecord[], pattern?: string): JsonlLineRecord[] {
     if (!pattern) {
@@ -29,7 +64,7 @@ function applyGrep(lines: JsonlLineRecord[], pattern?: string): JsonlLineRecord[
     return lines.filter((l) => re.test(l.text));
 }
 
-function selectLines(allLines: JsonlLineRecord[], opts: LogQueryOpts): JsonlLineRecord[] {
+function selectLines(allLines: JsonlLineRecord[], opts: LogQueryOpts): SliceResult<JsonlLineRecord> {
     let lines = [...allLines];
 
     if (opts.fromSeq !== undefined) {
@@ -43,22 +78,20 @@ function selectLines(allLines: JsonlLineRecord[], opts: LogQueryOpts): JsonlLine
     lines = filterByStream(lines, opts.streams);
     lines = applyGrep(lines, opts.grep);
 
-    if (opts.fromSeq === undefined && opts.toSeq === undefined && opts.lines !== undefined) {
-        lines = lastNLines(lines, opts.lines);
+    if (opts.fromSeq !== undefined || opts.toSeq !== undefined) {
+        return { lines, elidedCount: 0, headCount: 0 };
     }
 
-    return lines;
+    return sliceLogLines(lines, opts);
 }
 
-function formatHuman(lines: JsonlLineRecord[]): void {
-    // A "block" is a maximal contiguous run of lines from the same stream.
-    // Headers are emitted as `=== [stream] seq A-B ===` where A and B are
-    // the first and LAST seq in the block. The previous implementation set
-    // rangeEnd to the current line's seq inline, so the displayed header
-    // was always degenerate (`seq A`); compute the block boundaries up
-    // front by scanning forward to the next stream change.
+function formatHuman(lines: JsonlLineRecord[], elision?: { count: number; afterIndex: number }): void {
     let i = 0;
     while (i < lines.length) {
+        if (elision && i === elision.afterIndex) {
+            out.print(`... ${elision.count} lines elided ...\n`);
+        }
+
         const blockStart = i;
         const blockStream = lines[i].out;
         let blockEnd = i;
@@ -66,7 +99,7 @@ function formatHuman(lines: JsonlLineRecord[]): void {
             blockEnd += 1;
         }
 
-        if (blockStart > 0) {
+        if (blockStart > 0 && !(elision && blockStart === elision.afterIndex)) {
             out.print(`\n`);
         }
 
@@ -83,29 +116,41 @@ function formatHuman(lines: JsonlLineRecord[]): void {
     }
 }
 
-function formatRaw(lines: JsonlLineRecord[]): void {
-    for (const line of lines) {
-        out.print(`${line.text}\n`);
+function formatRaw(lines: JsonlLineRecord[], elision?: { count: number; afterIndex: number }): void {
+    for (let i = 0; i < lines.length; i++) {
+        if (elision && i === elision.afterIndex) {
+            out.print(`... ${elision.count} lines elided ...\n`);
+        }
+
+        out.print(`${lines[i].text}\n`);
     }
 }
 
-function formatJsonl(lines: JsonlLineRecord[]): void {
-    for (const line of lines) {
-        out.print(`${SafeJSON.stringify(line, { jsonl: true })}\n`);
+function formatJsonl(lines: JsonlLineRecord[], elision?: { count: number; afterIndex: number }): void {
+    for (let i = 0; i < lines.length; i++) {
+        if (elision && i === elision.afterIndex) {
+            out.print(`${SafeJSON.stringify({ type: "elision", count: elision.count }, { jsonl: true })}\n`);
+        }
+
+        out.print(`${SafeJSON.stringify(lines[i], { jsonl: true })}\n`);
     }
 }
 
 export async function queryLogs(opts: LogQueryOpts): Promise<void> {
     const records = await readJsonlFile(jsonlPath(opts.session));
     const allLines = filterLineRecords(records);
-    const lines = selectLines(allLines, opts);
+    const { lines, elidedCount, headCount } = selectLines(allLines, opts);
+    const elision =
+        elidedCount > 0 && (opts.head ?? 0) > 0 && (opts.tail ?? 0) > 0
+            ? { count: elidedCount, afterIndex: headCount }
+            : undefined;
 
     if (opts.format === "raw") {
-        formatRaw(lines);
+        formatRaw(lines, elision);
     } else if (opts.format === "jsonl") {
-        formatJsonl(lines);
+        formatJsonl(lines, elision);
     } else {
-        formatHuman(lines);
+        formatHuman(lines, elision);
     }
 
     if (opts.format === "human") {
@@ -113,10 +158,27 @@ export async function queryLogs(opts: LogQueryOpts): Promise<void> {
             session: opts.session,
             lines,
             totalLines: allLines.length,
-            linesRequested: opts.lines,
+            windowLabel: windowLabel(opts),
             streams: opts.streams,
         });
     }
+}
+
+function windowLabel(opts: LogQueryOpts): string {
+    if (opts.all) {
+        return "all";
+    }
+
+    const parts: string[] = [];
+    if (opts.head) {
+        parts.push(`--head ${opts.head}`);
+    }
+
+    if (opts.tail) {
+        parts.push(`--tail ${opts.tail}`);
+    }
+
+    return parts.length > 0 ? parts.join(" ") : "default";
 }
 
 export async function loadSessionLines(session: string): Promise<JsonlLineRecord[]> {

--- a/src/task/lib/log-window.ts
+++ b/src/task/lib/log-window.ts
@@ -1,0 +1,23 @@
+import type { LogCliOpts } from "@app/task/types";
+
+export function applyLogWindowDefaults(opts: LogCliOpts, defaults: { ttyTail: string }): LogCliOpts {
+    const noExplicit = !opts.head && !opts.tail && !opts.all && !opts.fromSeq && !opts.toSeq;
+
+    if (noExplicit) {
+        if (process.stdout.isTTY) {
+            return { ...opts, tail: defaults.ttyTail };
+        }
+
+        return { ...opts, all: true };
+    }
+
+    return opts;
+}
+
+export function applyGrepImpliesAll(opts: LogCliOpts): LogCliOpts {
+    if (opts.grep && !opts.head && !opts.tail && !opts.all) {
+        return { ...opts, all: true };
+    }
+
+    return opts;
+}

--- a/src/task/lib/paths.ts
+++ b/src/task/lib/paths.ts
@@ -9,6 +9,10 @@ export function getTaskSessionsDir(): string {
     return resolve(genesisToolsRoot(), ".genesis-tools", "task", "sessions");
 }
 
+export function taskConfigPath(): string {
+    return process.env.TASK_CONFIG_PATH ?? resolve(genesisToolsRoot(), ".genesis-tools", "task", "config.json");
+}
+
 function safeSessionPath(session: string, suffix: string): string {
     const sessionsDir = getTaskSessionsDir();
     const candidate = resolve(sessionsDir, `${session}${suffix}`);

--- a/src/task/lib/runner.ts
+++ b/src/task/lib/runner.ts
@@ -99,12 +99,14 @@ async function multiplexPipeStreams(
 }
 
 async function runPipeMode(opts: RunTaskOptions, writer: OrderedCaptureWriter): Promise<number> {
+    const detachChild = !process.stdin.isTTY;
     const proc = Bun.spawn(opts.command, {
         cwd: opts.cwd,
         stdout: "pipe",
         stderr: "pipe",
         stdin: "inherit",
         env: process.env,
+        detached: detachChild,
     });
 
     const store = new TaskSessionStore();
@@ -127,7 +129,9 @@ async function runPipeMode(opts: RunTaskOptions, writer: OrderedCaptureWriter): 
         }
     };
 
-    process.on("SIGINT", onSigInt);
+    if (process.stdin.isTTY) {
+        process.on("SIGINT", onSigInt);
+    }
 
     let exitCode = 1;
 
@@ -136,7 +140,9 @@ async function runPipeMode(opts: RunTaskOptions, writer: OrderedCaptureWriter): 
         await streamsDone;
         await writer.flush();
     } finally {
-        process.off("SIGINT", onSigInt);
+        if (process.stdin.isTTY) {
+            process.off("SIGINT", onSigInt);
+        }
     }
 
     return exitCode;

--- a/src/task/lib/suggest-flags.ts
+++ b/src/task/lib/suggest-flags.ts
@@ -30,7 +30,14 @@ export function suggestDashboard(session: string): string {
 
 export function suggestLogsFollow(session: string): string {
     return suggestCommand("tools task", {
-        replaceCommand: ["logs", "--session", session, "--tail", "--follow"],
+        replaceCommand: ["logs", "--session", session, "--follow"],
+        keepFlags: [],
+    });
+}
+
+export function suggestLogsAllGrep(session: string): string {
+    return suggestCommand("tools task", {
+        replaceCommand: ["logs", "--session", session, "--grep", "PATTERN"],
         keepFlags: [],
     });
 }

--- a/src/task/lib/tail-session.ts
+++ b/src/task/lib/tail-session.ts
@@ -5,7 +5,7 @@ import { filterLineRecords, readJsonlFile } from "@app/utils/log-session/jsonl-r
 import type { JsonlExitRecord, JsonlLineRecord, JsonlRecord } from "@app/utils/log-session/types";
 import type { LogQueryOpts } from "@app/task/types";
 import { printTailStatus } from "@app/task/lib/log-hints";
-import { queryLogs } from "@app/task/lib/log-query";
+import { queryLogs, sliceLogLines } from "@app/task/lib/log-query";
 import { jsonlPath } from "@app/task/lib/paths";
 
 function matchesFilters(
@@ -75,38 +75,49 @@ function findExitRecord(records: JsonlRecord[]): JsonlExitRecord | undefined {
     );
 }
 
-export async function tailSession(opts: LogQueryOpts & { follow: true }): Promise<void> {
+function filterExistingLines(records: JsonlLineRecord[], opts: LogQueryOpts, grepRe: RegExp | null): JsonlLineRecord[] {
+    const seenSeq = new Set<number>();
+    const matched: JsonlLineRecord[] = [];
+
+    for (const line of records) {
+        if (matchesFilters(line, opts, seenSeq, grepRe)) {
+            seenSeq.add(line.seq);
+            matched.push(line);
+        }
+    }
+
+    if (opts.fromSeq !== undefined || opts.toSeq !== undefined) {
+        return matched;
+    }
+
+    return sliceLogLines(matched, opts).lines;
+}
+
+export async function tailSession(
+    opts: LogQueryOpts & { follow: true },
+    tailOpts?: { propagateExit?: boolean }
+): Promise<number | undefined> {
     const path = jsonlPath(opts.session);
     const seenSeq = new Set<number>();
-    // Compile once at the entry — a bad pattern fails up-front (loud and
-    // recoverable) instead of throwing per-line inside the live tailer's
-    // onLine callback where the error is swallowed and the tail dies silent.
     const grepRe = compileGrep(opts.grep);
 
     const records = await readJsonlFile(path);
     const existingExit = findExitRecord(records);
     const existing = filterLineRecords(records);
-    // `opts.lines ?? 10` lets `--lines 0` mean "show no backlog, just stream
-    // new lines" (rather than the default 10). slice(-0) === slice(0) returns
-    // the WHOLE array, so guard the zero case explicitly.
-    const tailCount = opts.lines ?? 10;
-    const initial = tailCount > 0 ? existing.slice(-tailCount) : [];
+    const initial = filterExistingLines(existing, opts, grepRe);
 
     for (const line of initial) {
-        if (matchesFilters(line, opts, seenSeq, grepRe)) {
-            seenSeq.add(line.seq);
-            emitLine(line, opts.format);
-        }
+        emitLine(line, opts.format);
     }
 
     if (existingExit) {
         out.printlnErr(`Session exited (code ${existingExit.code}).`);
-        return;
+        return tailOpts?.propagateExit ? existingExit.code : undefined;
     }
 
     printTailStatus(opts.session);
 
-    let resolveFollow: (() => void) | undefined;
+    let resolveFollow: ((code?: number) => void) | undefined;
     let onSigint: (() => void) | undefined;
 
     const tailer = new FileTailer<JsonlRecord>(path, {
@@ -120,7 +131,7 @@ export async function tailSession(opts: LogQueryOpts & { follow: true }): Promis
                 }
 
                 out.printlnErr(`\nSession exited (code ${exit.code}).`);
-                resolveFollow?.();
+                resolveFollow?.(exit.code);
                 return;
             }
 
@@ -138,34 +149,34 @@ export async function tailSession(opts: LogQueryOpts & { follow: true }): Promis
 
     tailer.start();
 
-    await new Promise<void>((resolve) => {
-        resolveFollow = resolve;
+    return new Promise<number | undefined>((resolve) => {
+        resolveFollow = (code?: number) => {
+            resolve(code);
+        };
 
         onSigint = (): void => {
-            // Detach ourselves so we don't leak the listener — a subsequent
-            // tailSession() call in the same process (tests, repeated CLI use,
-            // long-lived MCP) would otherwise stack handlers and a single
-            // Ctrl+C would resolve multiple promises out of order. The exit-
-            // record branch above already calls process.off; do the same here
-            // for the explicit-cancel branch.
             if (onSigint) {
                 process.off("SIGINT", onSigint);
             }
 
             tailer.stop();
             out.printlnErr("\nStopped tailing.");
-            resolve();
+            resolve(undefined);
         };
 
         process.on("SIGINT", onSigint);
     });
 }
 
-export async function tailOrQuery(opts: LogQueryOpts, follow: boolean): Promise<void> {
+export async function tailOrQuery(
+    opts: LogQueryOpts,
+    follow: boolean,
+    tailOpts?: { propagateExit?: boolean }
+): Promise<number | undefined> {
     if (follow) {
-        await tailSession({ ...opts, follow: true });
-        return;
+        return tailSession({ ...opts, follow: true }, tailOpts);
     }
 
     await queryLogs(opts);
+    return undefined;
 }

--- a/src/task/lib/wait-for-session.ts
+++ b/src/task/lib/wait-for-session.ts
@@ -1,0 +1,83 @@
+import { FileTailer } from "@app/utils/fs/file-tailer";
+import { filterLineRecords, readJsonlFile } from "@app/utils/log-session/jsonl-reader";
+import type { JsonlExitRecord, JsonlLineRecord, JsonlRecord } from "@app/utils/log-session/types";
+import { jsonlPath } from "@app/task/lib/paths";
+
+export interface WaitOptions {
+    session: string;
+    exitOnMatch?: RegExp;
+    timeoutMs?: number;
+    waitForExit?: boolean;
+}
+
+export interface WaitResult {
+    reason: "match" | "session-exit" | "timeout";
+    matchedLine?: string;
+    sessionExitCode?: number;
+}
+
+export async function waitForSession(opts: WaitOptions): Promise<WaitResult> {
+    const path = jsonlPath(opts.session);
+
+    const existing = await readJsonlFile(path);
+    if (opts.exitOnMatch) {
+        for (const rec of filterLineRecords(existing)) {
+            if (opts.exitOnMatch.test(rec.text)) {
+                return { reason: "match", matchedLine: rec.text };
+            }
+        }
+    }
+
+    if (opts.waitForExit) {
+        const exit = existing.find((r): r is JsonlExitRecord => r.type === "exit");
+        if (exit) {
+            return { reason: "session-exit", sessionExitCode: exit.code };
+        }
+    }
+
+    return new Promise<WaitResult>((resolve) => {
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+
+        const settle = (result: WaitResult): void => {
+            if (settled) {
+                return;
+            }
+
+            settled = true;
+            tailer.stop();
+
+            if (timer) {
+                clearTimeout(timer);
+            }
+
+            resolve(result);
+        };
+
+        const tailer = new FileTailer<JsonlRecord>(path, {
+            onLine: (entry) => {
+                if (opts.exitOnMatch && entry.type === "line") {
+                    const line = entry as JsonlLineRecord;
+                    if (opts.exitOnMatch.test(line.text)) {
+                        settle({ reason: "match", matchedLine: line.text });
+
+                        return;
+                    }
+                }
+
+                if (opts.waitForExit && entry.type === "exit") {
+                    const exit = entry as JsonlExitRecord;
+                    settle({ reason: "session-exit", sessionExitCode: exit.code });
+                }
+            },
+        });
+
+        if (opts.timeoutMs !== undefined) {
+            timer = setTimeout(() => {
+                settle({ reason: "timeout" });
+            }, opts.timeoutMs);
+        }
+
+        tailer.start();
+    });
+}

--- a/src/task/lib/wait-for-session.ts
+++ b/src/task/lib/wait-for-session.ts
@@ -1,7 +1,7 @@
+import { jsonlPath } from "@app/task/lib/paths";
 import { FileTailer } from "@app/utils/fs/file-tailer";
 import { filterLineRecords, readJsonlFile } from "@app/utils/log-session/jsonl-reader";
 import type { JsonlExitRecord, JsonlLineRecord, JsonlRecord } from "@app/utils/log-session/types";
-import { jsonlPath } from "@app/task/lib/paths";
 
 export interface WaitOptions {
     session: string;

--- a/src/task/tests/clean-session.integration.test.ts
+++ b/src/task/tests/clean-session.integration.test.ts
@@ -17,7 +17,7 @@ test("clean --session removes ONE session, leaves others (B5)", async () => {
         expect(cleanResult.code).toBe(0);
 
         const list = env.task(["sessions", "--json"]);
-        const names = (SafeJSON.parse(list.stdout) as Array<{ name: string }>).map((s) => s.name);
+        const names = (SafeJSON.parse(list.stdout, { strict: true }) as Array<{ name: string }>).map((s) => s.name);
         expect(names).not.toContain(A);
         expect(names).toContain(B);
     });

--- a/src/task/tests/clean-session.integration.test.ts
+++ b/src/task/tests/clean-session.integration.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
+import { setupTaskIntegrationHome, withTaskSession } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+
+test("clean --session removes ONE session, leaves others (B5)", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const A = `clean-a-${suffix}`;
+    const B = `clean-b-${suffix}`;
+
+    await withTaskSession(env, B, async () => {
+        env.task(["run", "--session", A, "--no-tty", "--", "bash", "-c", "echo a"]);
+        env.task(["run", "--session", B, "--no-tty", "--", "bash", "-c", "echo b"]);
+
+        const cleanResult = env.task(["clean", "--session", A]);
+        expect(cleanResult.code).toBe(0);
+
+        const list = env.task(["sessions", "--json"]);
+        const names = (SafeJSON.parse(list.stdout) as Array<{ name: string }>).map((s) => s.name);
+        expect(names).not.toContain(A);
+        expect(names).toContain(B);
+    });
+});

--- a/src/task/tests/detach-signal.integration.test.ts
+++ b/src/task/tests/detach-signal.integration.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { setupTaskIntegrationHome, withTaskSession } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+const TASK_TOOL = resolve(import.meta.dir, "../../../tools");
+
+test("tools task run survives parent-shell exit (B8)", async () => {
+    const S = `detach-${Date.now()}`;
+
+    await withTaskSession(env, S, async () => {
+        spawnSync(
+            "bash",
+            [
+                "-c",
+                `
+        export GENESIS_TOOLS_HOME="${env.homeDir}"
+        ${TASK_TOOL} task run --session ${S} --no-tty -- bash -c 'for i in $(seq 1 5); do echo tick $i; sleep 0.4; done' </dev/null >/dev/null 2>&1 &
+        disown
+    `,
+            ],
+            { encoding: "utf-8", env: { ...process.env, GENESIS_TOOLS_HOME: env.homeDir } }
+        );
+
+        await new Promise((r) => setTimeout(r, 4000));
+
+        const get = env.task(["get", "--session", S]);
+        const combined = get.stdout + get.stderr;
+        expect(combined).toMatch(/Lines:\s+5/);
+        expect(combined).toMatch(/exited \(code 0/);
+    });
+}, 30_000);

--- a/src/task/tests/eval2-fixes.integration.test.ts
+++ b/src/task/tests/eval2-fixes.integration.test.ts
@@ -103,7 +103,7 @@ describe("eval2 bug fixes integration", () => {
         expect(stderr).toContain("Streams:   merged");
     }, 30_000);
 
-    it("logs --all returns full session beyond default 50-line window (bug #7)", async () => {
+    it("logs default (non-TTY) returns full session; --tail caps window (bug #7 + B2)", async () => {
         const homeDir = setupHome();
         const session = `all-lines-${Date.now()}`;
 
@@ -120,11 +120,12 @@ describe("eval2 bug fixes integration", () => {
         writeFileSync(sessionJsonlPath(homeDir, session), `${lines}\n`);
 
         const defaultWindow = await runTaskCli(["logs", "--session", session, "--raw"], { homeDir });
-        expect(defaultWindow.stdout).not.toContain("EVAL2_EARLY_MARKER");
+        expect(defaultWindow.stdout).toContain("EVAL2_EARLY_MARKER");
+        expect(defaultWindow.stdout.split("\n").filter(Boolean).length).toBe(100);
 
-        const allLines = await runTaskCli(["logs", "--session", session, "--raw", "--all"], { homeDir });
-        expect(allLines.stdout).toContain("EVAL2_EARLY_MARKER");
-        expect(allLines.stdout.split("\n").filter(Boolean).length).toBe(100);
+        const tailWindow = await runTaskCli(["logs", "--session", session, "--raw", "--tail", "50"], { homeDir });
+        expect(tailWindow.stdout).not.toContain("EVAL2_EARLY_MARKER");
+        expect(tailWindow.stdout.split("\n").filter(Boolean).length).toBe(50);
     }, 30_000);
 
     it("tail --follow exits when session already ended (bug #5 CLI)", async () => {

--- a/src/task/tests/exit-on-match.integration.test.ts
+++ b/src/task/tests/exit-on-match.integration.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { setupTaskIntegrationHome, withTaskSession } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+
+test("tail --follow --exit-on-match PATTERN exits on first match (F2)", async () => {
+    const SESSION = `exit-match-${Date.now()}`;
+
+    await withTaskSession(env, SESSION, async () => {
+        env
+            .taskSpawn(
+                [
+                    "run",
+                    "--session",
+                    SESSION,
+                    "--no-tty",
+                    "--",
+                    "bash",
+                    "-c",
+                    "echo noise1; sleep 0.5; echo SENTINEL_FOUND; sleep 2; echo more",
+                ],
+                { detached: true, stdio: "ignore" }
+            )
+            .unref();
+
+        await new Promise((r) => setTimeout(r, 800));
+
+        const waitStart = Date.now();
+        const watcher = env.task(
+            ["tail", "--session", SESSION, "--follow", "--raw", "--exit-on-match", "SENTINEL_FOUND"],
+            { timeout: 5000 }
+        );
+        const elapsed = Date.now() - waitStart;
+
+        expect(watcher.code).toBe(0);
+        expect(elapsed).toBeLessThan(2000);
+        expect(watcher.stdout).toContain("SENTINEL_FOUND");
+    });
+});
+
+test("tail --follow --propagate-exit propagates session exit code (F3)", async () => {
+    const SESSION = `prop-exit-${Date.now()}`;
+
+    await withTaskSession(env, SESSION, async () => {
+        env
+            .taskSpawn(
+                [
+                    "run",
+                    "--session",
+                    SESSION,
+                    "--no-tty",
+                    "--",
+                    "bash",
+                    "-c",
+                    "echo working; sleep 0.3; exit 42",
+                ],
+                { detached: true, stdio: "ignore" }
+            )
+            .unref();
+
+        await new Promise((r) => setTimeout(r, 800));
+
+        const watcher = env.task(["tail", "--session", SESSION, "--follow", "--propagate-exit"], { timeout: 5000 });
+
+        expect(watcher.code).toBe(42);
+    });
+});

--- a/src/task/tests/gc.integration.test.ts
+++ b/src/task/tests/gc.integration.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { setupTaskIntegrationHome, withTaskSession } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+
+test("GC removes sessions older than retention window (F6)", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const oldName = `gc-old-fixture-${suffix}`;
+    const triggerName = `gc-trigger-${suffix}`;
+    const dir = env.sessionsDir();
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${oldName}.jsonl`);
+    writeFileSync(path, '{"type":"line","seq":1,"out":"stdout","text":"old","ts":1}\n');
+    const past = new Date(Date.now() - 31 * 24 * 3600 * 1000);
+    utimesSync(path, past, past);
+
+    await withTaskSession(env, triggerName, () => {
+        env.task(["run", "--session", triggerName, "--no-tty", "--", "bash", "-c", "echo trigger"]);
+        expect(existsSync(path)).toBe(false);
+    });
+});

--- a/src/task/tests/grep-implies-all.test.ts
+++ b/src/task/tests/grep-implies-all.test.ts
@@ -1,0 +1,35 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { setupTaskIntegrationHome } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+const SESSION = `grep-implies-all-fixture-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+beforeAll(() => {
+    env.clean(SESSION);
+    env.task([
+        "run",
+        "--session",
+        SESSION,
+        "--no-tty",
+        "--",
+        "bash",
+        "-c",
+        "for i in $(seq 1 100); do echo line $i; done",
+    ]);
+});
+
+afterAll(() => {
+    env.clean(SESSION);
+});
+
+test("--grep returns ALL matches, not last-50 of matches (F5)", () => {
+    const r = env.task(["logs", "--session", SESSION, "--grep", "^line ", "--raw"]);
+    const matches = r.stdout.trim().split("\n").filter((l) => /^line /.test(l));
+    expect(matches).toHaveLength(100);
+});
+
+test("--grep + explicit --tail 5 honors the explicit window (F5)", () => {
+    const r = env.task(["logs", "--session", SESSION, "--grep", "^line ", "--tail", "5", "--raw"]);
+    const matches = r.stdout.trim().split("\n").filter((l) => /^line /.test(l));
+    expect(matches).toHaveLength(5);
+});

--- a/src/task/tests/head-tail-flags.integration.test.ts
+++ b/src/task/tests/head-tail-flags.integration.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { setupTaskIntegrationHome } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+const SESSION = `head-tail-fixture-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+beforeAll(() => {
+    env.clean(SESSION);
+    env.task([
+        "run",
+        "--session",
+        SESSION,
+        "--no-tty",
+        "--",
+        "bash",
+        "-c",
+        "for i in $(seq 1 100); do echo line $i; done",
+    ]);
+});
+
+afterAll(() => {
+    env.clean(SESSION);
+});
+
+test("--head 5 returns first 5 lines (F7)", () => {
+    const r = env.task(["logs", "--session", SESSION, "--head", "5", "--raw"]);
+    const lines = r.stdout.trim().split("\n");
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toBe("line 1");
+    expect(lines[4]).toBe("line 5");
+});
+
+test("--tail 5 returns last 5 lines (F7)", () => {
+    const r = env.task(["logs", "--session", SESSION, "--tail", "5", "--raw"]);
+    const lines = r.stdout.trim().split("\n");
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toBe("line 96");
+    expect(lines[4]).toBe("line 100");
+});
+
+test("--head 5 --tail 5 returns 10 lines with elision marker (F7)", () => {
+    const r = env.task(["logs", "--session", SESSION, "--head", "5", "--tail", "5", "--raw"]);
+    const lines = r.stdout.trim().split("\n");
+    expect(lines.filter((l) => l.startsWith("line "))).toHaveLength(10);
+    const elision = lines.find((l) => /elided/i.test(l)) ?? r.stderr;
+    expect(elision).toMatch(/90 lines elided/);
+});
+
+test("--all dumps every line, overrides --head/--tail (F7)", () => {
+    const r = env.task(["logs", "--session", SESSION, "--all", "--raw"]);
+    const lines = r.stdout.trim().split("\n").filter((l) => l.startsWith("line "));
+    expect(lines).toHaveLength(100);
+});
+
+test("B1 repro — tail --all returns ALL lines, not just last 10", () => {
+    const r = env.task(["tail", "--session", SESSION, "--all", "--raw"]);
+    const matchingLines = r.stdout.trim().split("\n").filter((l) => l.startsWith("line "));
+    expect(matchingLines).toHaveLength(100);
+});
+
+test("B1 repro — tail --all --grep returns ALL matching lines", () => {
+    const r = env.task(["tail", "--session", SESSION, "--all", "--grep", "^line ", "--raw"]);
+    const matchingLines = r.stdout.trim().split("\n").filter((l) => /^line /.test(l));
+    expect(matchingLines).toHaveLength(100);
+});

--- a/src/task/tests/sessions-json.integration.test.ts
+++ b/src/task/tests/sessions-json.integration.test.ts
@@ -1,0 +1,26 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
+import { setupTaskIntegrationHome } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+const FIXTURE = `json-test-fixture-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+beforeAll(() => {
+    env.task(["run", "--session", FIXTURE, "--no-tty", "--", "bash", "-c", "echo hi"]);
+});
+
+afterAll(() => {
+    env.clean(FIXTURE);
+});
+
+test("tools task sessions --json emits parseable JSON array (F4)", () => {
+    const r = env.task(["sessions", "--json"]);
+    expect(r.code).toBe(0);
+    const parsed = SafeJSON.parse(r.stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    const fixture = (parsed as Array<{ name: string }>).find((s) => s.name === FIXTURE);
+    expect(fixture).toBeDefined();
+    expect(fixture).toHaveProperty("state");
+    expect(fixture).toHaveProperty("jsonlSizeBytes");
+    expect(fixture).toHaveProperty("lastSeq");
+});

--- a/src/task/tests/sessions-json.integration.test.ts
+++ b/src/task/tests/sessions-json.integration.test.ts
@@ -16,7 +16,7 @@ afterAll(() => {
 test("tools task sessions --json emits parseable JSON array (F4)", () => {
     const r = env.task(["sessions", "--json"]);
     expect(r.code).toBe(0);
-    const parsed = SafeJSON.parse(r.stdout);
+    const parsed = SafeJSON.parse(r.stdout, { strict: true });
     expect(Array.isArray(parsed)).toBe(true);
     const fixture = (parsed as Array<{ name: string }>).find((s) => s.name === FIXTURE);
     expect(fixture).toBeDefined();

--- a/src/task/tests/show-help-after-error.integration.test.ts
+++ b/src/task/tests/show-help-after-error.integration.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const TASK_TOOL = resolve(import.meta.dir, "../../../tools");
+
+test("tools task <unknown> prints usage after error (B3)", () => {
+    const result = spawnSync("bun", [TASK_TOOL, "task", "definitely-not-a-real-subcommand"], {
+        encoding: "utf-8",
+    });
+    expect(result.status).not.toBe(0);
+    const combined = (result.stdout ?? "") + (result.stderr ?? "");
+    expect(combined).toContain("Usage:");
+    expect(combined.toLowerCase()).toContain("definitely-not-a-real-subcommand");
+});
+
+test("tools question <unknown> prints usage after error (B3 — cross-tool)", () => {
+    const result = spawnSync("bun", [TASK_TOOL, "question", "definitely-not-a-real-subcommand"], {
+        encoding: "utf-8",
+    });
+    expect(result.status).not.toBe(0);
+    const combined = (result.stdout ?? "") + (result.stderr ?? "");
+    expect(combined).toContain("Usage:");
+});

--- a/src/task/tests/subcommand-session-flag.test.ts
+++ b/src/task/tests/subcommand-session-flag.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const TASK_TOOL = resolve(import.meta.dir, "../../../tools");
+
+function help(subcommand: string): string {
+    const r = spawnSync("bun", [TASK_TOOL, "task", subcommand, "--help"], { encoding: "utf-8" });
+    return (r.stdout ?? "") + (r.stderr ?? "");
+}
+
+test.each(["get", "logs", "tail", "clean", "wait"])("--session listed in 'tools task %s --help' (B4)", (sub) => {
+    expect(help(sub)).toContain("--session");
+});

--- a/src/task/tests/task-integration-env.ts
+++ b/src/task/tests/task-integration-env.ts
@@ -1,0 +1,72 @@
+import { afterAll } from "bun:test";
+import { spawn, spawnSync, type SpawnOptions } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const TASK_TOOL = resolve(import.meta.dir, "../../../tools");
+
+export interface TaskRunResult {
+    code: number;
+    stdout: string;
+    stderr: string;
+}
+
+export interface TaskIntegrationEnv {
+    homeDir: string;
+    task: (args: string[], opts?: { timeout?: number }) => TaskRunResult;
+    taskSpawn: (args: string[], opts?: SpawnOptions) => ReturnType<typeof spawn>;
+    sessionsDir: () => string;
+    clean: (session: string) => void;
+}
+
+export function setupTaskIntegrationHome(): TaskIntegrationEnv {
+    const homeDir = mkdtempSync(join(tmpdir(), "gt-task-int-"));
+    const childEnv = { ...process.env, GENESIS_TOOLS_HOME: homeDir };
+
+    afterAll(() => {
+        rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    const clean = (session: string) => {
+        spawnSync("bun", [TASK_TOOL, "task", "clean", "--session", session], {
+            env: childEnv,
+            stdio: "ignore",
+        });
+    };
+
+    return {
+        homeDir,
+        task(args, opts) {
+            const r = spawnSync("bun", [TASK_TOOL, "task", ...args], {
+                encoding: "utf-8",
+                env: childEnv,
+                timeout: opts?.timeout,
+            });
+
+            return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+        },
+        taskSpawn(args, opts) {
+            return spawn("bun", [TASK_TOOL, "task", ...args], {
+                ...opts,
+                env: { ...childEnv, ...opts?.env },
+            });
+        },
+        sessionsDir: () => join(homeDir, ".genesis-tools", "task", "sessions"),
+        clean,
+    };
+}
+
+export async function withTaskSession(
+    env: TaskIntegrationEnv,
+    session: string,
+    fn: () => void | Promise<void>
+): Promise<void> {
+    env.clean(session);
+
+    try {
+        await fn();
+    } finally {
+        env.clean(session);
+    }
+}

--- a/src/task/tests/wait.integration.test.ts
+++ b/src/task/tests/wait.integration.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { setupTaskIntegrationHome, withTaskSession } from "./task-integration-env";
+
+const env = setupTaskIntegrationHome();
+
+test("wait --exit-on-match exits 0 on first pattern match (F1)", async () => {
+    const S = `wait-match-${Date.now()}`;
+
+    await withTaskSession(env, S, async () => {
+        env
+            .taskSpawn(
+                [
+                    "run",
+                    "--session",
+                    S,
+                    "--no-tty",
+                    "--",
+                    "bash",
+                    "-c",
+                    "echo a; sleep 0.5; echo Bundled in 234ms; sleep 5",
+                ],
+                { detached: true, stdio: "ignore" }
+            )
+            .unref();
+
+        await new Promise((r) => setTimeout(r, 800));
+
+        const start = Date.now();
+        const r = env.task(["wait", "--session", S, "--exit-on-match", "Bundled", "--timeout", "10"], {
+            timeout: 12000,
+        });
+        const elapsed = Date.now() - start;
+
+        expect(r.code).toBe(0);
+        expect(elapsed).toBeLessThan(3000);
+    });
+});
+
+test("wait --timeout exits non-zero on deadline (F1)", async () => {
+    const S = `wait-timeout-${Date.now()}`;
+
+    await withTaskSession(env, S, async () => {
+        env.taskSpawn(["run", "--session", S, "--no-tty", "--", "bash", "-c", "sleep 30"], {
+            detached: true,
+            stdio: "ignore",
+        }).unref();
+
+        await new Promise((r) => setTimeout(r, 800));
+
+        const r = env.task(["wait", "--session", S, "--exit-on-match", "NEVER_APPEARS", "--timeout", "2"], {
+            timeout: 5000,
+        });
+
+        expect(r.code).not.toBe(0);
+    });
+});
+
+test("wait without --exit-on-match waits for session exit + --propagate-exit (F1)", async () => {
+    const S = `wait-exit-${Date.now()}`;
+
+    await withTaskSession(env, S, async () => {
+        env.taskSpawn(["run", "--session", S, "--no-tty", "--", "bash", "-c", "sleep 0.5; exit 17"], {
+            detached: true,
+            stdio: "ignore",
+        }).unref();
+
+        await new Promise((r) => setTimeout(r, 800));
+
+        const r = env.task(["wait", "--session", S, "--timeout", "10", "--propagate-exit"], { timeout: 12000 });
+
+        expect(r.code).toBe(17);
+    });
+});

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -35,12 +35,29 @@ export type LogOutputFormat = "human" | "raw" | "jsonl";
 
 export interface LogQueryOpts {
     session: string;
-    lines?: number;
+    head?: number;
+    tail?: number;
+    all?: boolean;
     fromSeq?: number;
     toSeq?: number;
     grep?: string;
     format: LogOutputFormat;
     streams: Set<"stdout" | "stderr">;
+}
+
+export interface LogCliOpts {
+    session?: string;
+    head?: string;
+    tail?: string;
+    all?: boolean;
+    fromSeq?: string;
+    toSeq?: string;
+    grep?: string;
+    jsonl?: boolean;
+    raw?: boolean;
+    stdout?: boolean;
+    stderr?: boolean;
+    follow?: boolean;
 }
 
 export interface PrepareSessionInput {

--- a/src/utils/cli/commander.ts
+++ b/src/utils/cli/commander.ts
@@ -185,6 +185,8 @@ export async function runTool(
         addGlobalVerboseOption(program, { trace: opts.trace === true });
     }
 
+    program.showHelpAfterError(true);
+
     if (opts.enhanceHelp) {
         enhanceHelp(program);
     }

--- a/src/utils/fuzzy-tokens.test.ts
+++ b/src/utils/fuzzy-tokens.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { findTokenMatches, scoreEntry, tokenizeSearch } from "./fuzzy-tokens";
+
+describe("fuzzy-tokens", () => {
+    test("tokenizes on common separators", () => {
+        expect(tokenizeSearch("commit-1c0 file:foo.ts")).toEqual(["commit", "1c0", "file", "foo", "ts"]);
+    });
+
+    test("matches across separator variations", () => {
+        const tokens = tokenizeSearch("commit-1c0");
+
+        for (const h of ["commit:1c0", "commit-1c0", "commit 1c0", "the commit 1c0 was bad"]) {
+            const m = findTokenMatches(h, tokens);
+            expect(m.length).toBeGreaterThanOrEqual(2);
+        }
+    });
+
+    test("multi-token query finds discrete spans", () => {
+        const tokens = tokenizeSearch("commit:1 commit:2");
+        const matches = findTokenMatches("see commit 1 and later commit 2", tokens);
+
+        expect(matches.length).toBeGreaterThanOrEqual(4);
+    });
+
+    test("scoreEntry requires all tokens", () => {
+        expect(scoreEntry("commit 1c0 only", tokenizeSearch("commit 1c0"))).toBe(1);
+        expect(scoreEntry("commit only", tokenizeSearch("commit 1c0"))).toBeLessThan(1);
+    });
+});

--- a/src/utils/fuzzy-tokens.test.ts
+++ b/src/utils/fuzzy-tokens.test.ts
@@ -26,4 +26,15 @@ describe("fuzzy-tokens", () => {
         expect(scoreEntry("commit 1c0 only", tokenizeSearch("commit 1c0"))).toBe(1);
         expect(scoreEntry("commit only", tokenizeSearch("commit 1c0"))).toBeLessThan(1);
     });
+
+    test("tokenizes Windows-style path separators", () => {
+        expect(tokenizeSearch("src\\foo\\bar.ts")).toEqual(["src", "foo", "bar", "ts"]);
+        const tokens = tokenizeSearch("foo bar");
+        const matches = findTokenMatches("C:\\Users\\me\\foo\\bar.ts", tokens);
+        expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("duplicate query tokens do not reduce full-match score", () => {
+        expect(scoreEntry("commit message", tokenizeSearch("commit commit"))).toBe(1);
+    });
 });

--- a/src/utils/fuzzy-tokens.ts
+++ b/src/utils/fuzzy-tokens.ts
@@ -20,11 +20,11 @@ export function findTokenMatches(haystack: string, tokens: string[], threshold =
     const spans: TokenMatch[] = [];
 
     for (const token of tokens) {
-        let idx = 0;
+        let idx = lower.indexOf(token);
 
-        while ((idx = lower.indexOf(token, idx)) !== -1) {
+        while (idx !== -1) {
             spans.push({ token, start: idx, end: idx + token.length });
-            idx += token.length;
+            idx = lower.indexOf(token, idx + token.length);
         }
 
         if (spans.some((s) => s.token === token)) {
@@ -69,8 +69,9 @@ export function scoreEntry(haystack: string, tokens: string[]): number {
         return 1;
     }
 
-    const matches = findTokenMatches(haystack, tokens);
+    const uniqueTokens = [...new Set(tokens)];
+    const matches = findTokenMatches(haystack, uniqueTokens);
     const distinctTokensMatched = new Set(matches.map((m) => m.token)).size;
 
-    return distinctTokensMatched / tokens.length;
+    return distinctTokensMatched / uniqueTokens.length;
 }

--- a/src/utils/fuzzy-tokens.ts
+++ b/src/utils/fuzzy-tokens.ts
@@ -1,0 +1,76 @@
+import { similarityScore } from "./fuzzy-match";
+
+const SEP = /[\\\s\-:/,.;_]+/;
+
+export function tokenizeSearch(input: string): string[] {
+    return input
+        .split(SEP)
+        .map((t) => t.trim().toLowerCase())
+        .filter((t) => t.length > 0);
+}
+
+export interface TokenMatch {
+    token: string;
+    start: number;
+    end: number;
+}
+
+export function findTokenMatches(haystack: string, tokens: string[], threshold = 0.7): TokenMatch[] {
+    const lower = haystack.toLowerCase();
+    const spans: TokenMatch[] = [];
+
+    for (const token of tokens) {
+        let idx = 0;
+
+        while ((idx = lower.indexOf(token, idx)) !== -1) {
+            spans.push({ token, start: idx, end: idx + token.length });
+            idx += token.length;
+        }
+
+        if (spans.some((s) => s.token === token)) {
+            continue;
+        }
+
+        for (const m of lower.matchAll(/[^\\\s\-:/,.;_]+/g)) {
+            if (m.index === undefined) {
+                continue;
+            }
+
+            const word = m[0];
+
+            if (Math.abs(word.length - token.length) > 3) {
+                continue;
+            }
+
+            if (similarityScore(word, token) >= threshold) {
+                spans.push({ token, start: m.index, end: m.index + word.length });
+            }
+        }
+    }
+
+    spans.sort((a, b) => a.start - b.start);
+    const merged: TokenMatch[] = [];
+
+    for (const s of spans) {
+        const last = merged[merged.length - 1];
+
+        if (last && s.start < last.end) {
+            last.end = Math.max(last.end, s.end);
+        } else {
+            merged.push({ ...s });
+        }
+    }
+
+    return merged;
+}
+
+export function scoreEntry(haystack: string, tokens: string[]): number {
+    if (tokens.length === 0) {
+        return 1;
+    }
+
+    const matches = findTokenMatches(haystack, tokens);
+    const distinctTokensMatched = new Set(matches.map((m) => m.token)).size;
+
+    return distinctTokensMatched / tokens.length;
+}

--- a/src/utils/log-viewer/task-session-listing-meta.test.ts
+++ b/src/utils/log-viewer/task-session-listing-meta.test.ts
@@ -1,17 +1,26 @@
-import { describe, expect, it } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
 import { TaskSessionStore } from "@app/task/lib/session-store";
 import { resolveTaskSessionListingMeta } from "./task-session-listing-meta";
 
 describe("resolveTaskSessionListingMeta", () => {
+    let scratchDir: string | undefined;
+
+    afterEach(() => {
+        if (scratchDir) {
+            rmSync(scratchDir, { recursive: true, force: true });
+            scratchDir = undefined;
+        }
+    });
+
     it("falls back to jsonl meta line when meta file is missing", async () => {
-        const dir = join(import.meta.dir, ".tmp-task-listing-meta");
-        mkdirSync(dir, { recursive: true });
+        scratchDir = mkdtempSync(join(tmpdir(), "gt-task-listing-meta-"));
 
         const name = `jsonl-only-${Date.now()}`;
-        const jsonlPath = join(dir, `${name}.jsonl`);
+        const jsonlPath = join(scratchDir, `${name}.jsonl`);
 
         writeFileSync(
             jsonlPath,

--- a/src/utils/ui/helpers/highlight-matches.client.ts
+++ b/src/utils/ui/helpers/highlight-matches.client.ts
@@ -1,0 +1,65 @@
+import { findTokenMatches } from "@app/utils/fuzzy-tokens";
+
+const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "PRE", "CODE"]);
+
+export function highlightMatchesInHtml(html: string, tokens: string[]): string {
+    if (tokens.length === 0) {
+        return html;
+    }
+
+    if (typeof window === "undefined") {
+        return html;
+    }
+
+    const tpl = document.createElement("template");
+    tpl.innerHTML = html;
+    walk(tpl.content, tokens);
+
+    return tpl.innerHTML;
+}
+
+function walk(node: Node, tokens: string[]): void {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as Element;
+
+        if (SKIP_TAGS.has(el.tagName)) {
+            return;
+        }
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent ?? "";
+        const matches = findTokenMatches(text, tokens);
+
+        if (matches.length === 0) {
+            return;
+        }
+
+        const frag = document.createDocumentFragment();
+        let cursor = 0;
+
+        for (const m of matches) {
+            if (m.start > cursor) {
+                frag.appendChild(document.createTextNode(text.slice(cursor, m.start)));
+            }
+
+            const mark = document.createElement("mark");
+            mark.className = "dd-qa-mark";
+            mark.textContent = text.slice(m.start, m.end);
+            frag.appendChild(mark);
+            cursor = m.end;
+        }
+
+        if (cursor < text.length) {
+            frag.appendChild(document.createTextNode(text.slice(cursor)));
+        }
+
+        node.parentNode?.replaceChild(frag, node);
+
+        return;
+    }
+
+    for (const child of Array.from(node.childNodes)) {
+        walk(child, tokens);
+    }
+}

--- a/src/utils/ui/helpers/qa-recency.test.ts
+++ b/src/utils/ui/helpers/qa-recency.test.ts
@@ -1,32 +1,29 @@
 import { describe, expect, test } from "bun:test";
 import { resolveQaRecency } from "./qa-recency";
 
-const now = Date.parse("2026-05-20T12:00:00.000Z");
+const now = 1_700_000_000_000;
 
 describe("resolveQaRecency", () => {
-    test("uses hot tier under 10 seconds", () => {
-        expect(resolveQaRecency(now - 4_000, now)).toEqual({
-            tier: "hot",
-            relative: "4s ago",
-            ageMs: 4_000,
-        });
+    test("just-now under 5 seconds", () => {
+        expect(resolveQaRecency(now - 2_000, now).relative).toBe("just now");
     });
 
-    test("uses fresh tier from 10s to under 30s", () => {
-        expect(resolveQaRecency(now - 18_000, now).tier).toBe("fresh");
-        expect(resolveQaRecency(now - 18_000, now).relative).toBe("18s ago");
+    test("under 60s shows Ns ago", () => {
+        expect(resolveQaRecency(now - 30_000, now).relative).toBe("30s ago");
     });
 
-    test("uses recent tier from 30s to under 1 minute", () => {
-        expect(resolveQaRecency(now - 45_000, now).tier).toBe("recent");
+    test("under 60min shows Nm Ks ago", () => {
+        expect(resolveQaRecency(now - 312_000, now).relative).toBe("5m 12s ago");
     });
 
-    test("uses warm tier from 1 to under 5 minutes", () => {
-        expect(resolveQaRecency(now - 3 * 60_000, now).tier).toBe("warm");
+    test("uses fresh tier under 5 minutes", () => {
+        expect(resolveQaRecency(now - 3 * 60_000, now).tier).toBe("fresh");
         expect(resolveQaRecency(now - 3 * 60_000, now).relative).toBe("3m ago");
     });
 
-    test("cools down after 15 minutes", () => {
-        expect(resolveQaRecency(now - 20 * 60_000, now).tier).toBe("cool");
+    test("uses muted tier for hours", () => {
+        expect(resolveQaRecency(now - 2 * HOUR, now).tier).toBe("muted");
     });
 });
+
+const HOUR = 60 * 60_000;

--- a/src/utils/ui/helpers/qa-recency.ts
+++ b/src/utils/ui/helpers/qa-recency.ts
@@ -13,39 +13,27 @@ const DAY = 24 * HOUR;
 
 export function resolveQaRecency(ts: number, now = Date.now()): QaRecency {
     const ageMs = Math.max(0, now - ts);
-    const ageSec = Math.floor(ageMs / SECOND);
+    const secs = Math.floor(ageMs / SECOND);
 
-    if (ageSec < 10) {
-        return {
-            tier: "hot",
-            relative: ageSec < 1 ? "just now" : `${ageSec}s ago`,
-            ageMs,
-        };
+    if (secs < 5) {
+        return { tier: "hot", relative: "just now", ageMs };
     }
 
-    if (ageSec < 30) {
-        return { tier: "fresh", relative: `${ageSec}s ago`, ageMs };
+    if (secs < 60) {
+        return { tier: "hot", relative: `${secs}s ago`, ageMs };
     }
 
-    if (ageSec < 60) {
-        return { tier: "recent", relative: `${ageSec}s ago`, ageMs };
-    }
+    const mins = Math.floor(secs / 60);
+    const remainderSecs = secs - mins * 60;
 
-    const ageMin = Math.floor(ageMs / MINUTE);
+    if (mins < 60) {
+        const tier: QaRecencyTier = mins < 5 ? "fresh" : mins < 30 ? "recent" : "warm";
+        const relative = remainderSecs === 0 ? `${mins}m ago` : `${mins}m ${remainderSecs}s ago`;
 
-    if (ageMin < 5) {
-        return { tier: "warm", relative: `${ageMin}m ago`, ageMs };
-    }
-
-    if (ageMin < 15) {
-        return { tier: "cool", relative: `${ageMin}m ago`, ageMs };
+        return { tier, relative, ageMs };
     }
 
     const ageHours = Math.floor(ageMs / HOUR);
-
-    if (ageHours < 1) {
-        return { tier: "cool", relative: `${ageMin}m ago`, ageMs };
-    }
 
     if (ageHours < 24) {
         return { tier: "muted", relative: `${ageHours}h ago`, ageMs };
@@ -53,5 +41,13 @@ export function resolveQaRecency(ts: number, now = Date.now()): QaRecency {
 
     const ageDays = Math.floor(ageMs / DAY);
 
-    return { tier: "stale", relative: `${ageDays}d ago`, ageMs };
+    if (ageDays < 7) {
+        return { tier: "cool", relative: `${ageDays}d ago`, ageMs };
+    }
+
+    if (ageDays < 30) {
+        return { tier: "stale", relative: `${ageDays}d ago`, ageMs };
+    }
+
+    return { tier: "stale", relative: `${Math.floor(ageDays / 7)}w ago`, ageMs };
 }

--- a/src/utils/ui/hooks/useScrollProgress.client.ts
+++ b/src/utils/ui/hooks/useScrollProgress.client.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+export interface ScrollProgress {
+    y: number;
+    ratio: number;
+}
+
+export function useScrollProgress(container?: HTMLElement | null): ScrollProgress {
+    const [state, setState] = useState<ScrollProgress>({ y: 0, ratio: 0 });
+
+    useEffect(() => {
+        const target = container ?? window;
+
+        const read = (): void => {
+            const y = container ? container.scrollTop : window.scrollY;
+            const max = container
+                ? container.scrollHeight - container.clientHeight
+                : document.documentElement.scrollHeight - window.innerHeight;
+
+            setState({ y, ratio: max > 0 ? y / max : 0 });
+        };
+
+        read();
+        target.addEventListener("scroll", read, { passive: true });
+        return () => target.removeEventListener("scroll", read);
+    }, [container]);
+
+    return state;
+}

--- a/src/utils/ui/hooks/useSelectionAware.client.ts
+++ b/src/utils/ui/hooks/useSelectionAware.client.ts
@@ -1,0 +1,9 @@
+export function hasNonEmptySelection(): boolean {
+    if (typeof window === "undefined") {
+        return false;
+    }
+
+    const sel = window.getSelection();
+
+    return sel !== null && sel.toString().trim().length > 0;
+}


### PR DESCRIPTION
## Summary

- **Part 1 — `tools task`:** Session-scoped subcommands (`--session`), `sessions --json`, `clean --session`, `--head`/`--tail`, grep→all behavior, `tail --exit-on-match` / `--propagate-exit`, `wait` subcommand, detached background runs (B8), 30-day GC + `tools task config`, global `showHelpAfterError`, integration tests isolated via `GENESIS_TOOLS_HOME` temp dirs.
- **Part 2 — dev-dashboard `/qa`:** Sticky topbar + sidebar, wrench audio popover, reading/source toggle, question markdown, recency min/sec, collapse + read↔unread, selection-aware mark-read, copy MD/HTML, Obsidian save dialog, fuzzy search + highlights, scroll-nav, layout width stability on filter.

## Test plan

- [x] `bun test src/task/tests/` (42 pass)
- [x] `bun test` on fuzzy-tokens, qa-search, obsidian-save, qa-render, qa-recency
- [x] Playwright MCP sweep on `http://localhost:3042/qa` (UI items 1–12, 16–20; vault write 13–15 manual/sandbox)
- [ ] Smoke `tools task run` / `tail` / `wait` / `clean` against a throwaway session
- [ ] Optional: Obsidian save E2E into `Inbox/qa-test/` then `mv` sandbox cleanup per part2 plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QA fuzzy search, highlighting, and search box
  * Save-to-Obsidian flow: dialog, filename suggestions, create/append options, and folder creation
  * QA copy buttons (MD/HTML) and scroll navigation UI
  * New QA top bar, view-mode toggle, sound settings, and expanded sidebar behavior
  * New task commands: config and wait; JSON output for sessions

* **Improvements**
  * Log CLI: explicit head/tail/all windowing, new exit-on-match/propagate-exit behaviors
  * Session GC and detached-run support
* **Tests**
  * Extensive new and updated tests and integrations for QA, Obsidian, and task flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genesiscz/GenesisTools/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->