### PR TITLE
fix(dev-dashboard): keep tmux sessions alive across ui restart + restart diagnostics

### DIFF
--- a/src/dev-dashboard/lib/restart-diag.ts
+++ b/src/dev-dashboard/lib/restart-diag.ts
@@ -1,0 +1,57 @@
+import { logger } from "@app/logger";
+import { resolveTmuxBin } from "@app/utils/tmux/bin";
+import { buildTmuxSpawnEnv } from "@app/utils/tmux/sessions";
+
+/**
+ * Snapshot ttyd + tmux state for restart diagnostics, logged at dev-dashboard
+ * startup. Two consecutive instances' snapshots reveal exactly what a `ui
+ * restart` did to the sessions:
+ *   - if `tmuxServerPid` changes (or sessions vanish) across a restart, the tmux
+ *     server died/self-exited — taking its sessions with it;
+ *   - if it's stable, the sessions survived (merely detached).
+ * `exitEmpty` is the smoking gun: a server with `exit-empty on` self-destructs
+ * the instant it reaches zero sessions, so a dashboard-bootstrapped server with
+ * that flag will wipe every session at once. Read-only; never throws.
+ */
+export function logTtydTmuxSnapshot(phase: string): void {
+    try {
+        const tmuxBin = resolveTmuxBin();
+        const env = buildTmuxSpawnEnv();
+
+        const tmux = (args: string[]): string => {
+            const result = Bun.spawnSync([tmuxBin, ...args], { env, stdio: ["ignore", "pipe", "pipe"] });
+            return result.stdout.toString().trim();
+        };
+
+        const serverPid = tmux(["display-message", "-p", "#{pid}"]);
+        const exitEmpty = tmux(["show-options", "-s", "exit-empty"]);
+        const sessionsRaw = tmux([
+            "list-sessions",
+            "-F",
+            "#{session_name} attached=#{session_attached} windows=#{session_windows}",
+        ]);
+        const sessions = sessionsRaw ? sessionsRaw.split("\n") : [];
+
+        const ttydProcs = Bun.spawnSync(["/bin/ps", "-axo", "pid,ppid,pgid,command"], {
+            stdio: ["ignore", "pipe", "ignore"],
+        })
+            .stdout.toString()
+            .split("\n")
+            .filter((line) => line.includes("ttyd -i 127"))
+            .map((line) => line.trim());
+
+        logger.info(
+            {
+                phase,
+                tmuxServerPid: serverPid || null,
+                exitEmpty: exitEmpty || null,
+                sessionCount: sessions.length,
+                sessions,
+                ttydProcs,
+            },
+            "dev-dashboard ttyd/tmux snapshot"
+        );
+    } catch (error) {
+        logger.debug({ error, phase }, "logTtydTmuxSnapshot failed");
+    }
+}

--- a/src/dev-dashboard/lib/ttyd/manager.ts
+++ b/src/dev-dashboard/lib/ttyd/manager.ts
@@ -9,6 +9,7 @@ import { buildTerminalSpawnEnv } from "@app/utils/terminal/locale";
 import { resolveTmuxBin } from "@app/utils/tmux/bin";
 import {
     createTmuxSession,
+    ensureTmuxServerPersists,
     ensureTmuxSessionUtf8Locale,
     killTmuxSession,
     sessionExists,
@@ -175,6 +176,9 @@ export async function spawnTtyd(opts: SpawnOptions = {}): Promise<TtydSession> {
 
         tmuxSessionName = opts.attachTmuxSession;
         ensureTmuxSessionUtf8Locale(tmuxSessionName);
+        // Re-pin the server even when attaching to a pre-existing session — it may
+        // have been bootstrapped (by an older dashboard) with exit-empty on.
+        ensureTmuxServerPersists();
     } else {
         tmuxSessionName = makeTtydTmuxSessionName(id);
         createTmuxSession(tmuxSessionName, cwd, command);

--- a/src/dev-dashboard/ui/vite-middleware.ts
+++ b/src/dev-dashboard/ui/vite-middleware.ts
@@ -39,6 +39,7 @@ import { configureRetention, getCachedPulse, getSeries, startPulsePolling } from
 import { createStandaloneTmuxSession } from "@app/dev-dashboard/lib/tmux/create-session";
 import { enrichSessionsForHub } from "@app/dev-dashboard/lib/tmux/hub";
 import { renameTmuxSessionInHub } from "@app/dev-dashboard/lib/tmux/rename";
+import { logTtydTmuxSnapshot } from "@app/dev-dashboard/lib/restart-diag";
 import {
     addTodo,
     completeTodo,
@@ -88,6 +89,10 @@ getConfig()
         logger.warn({ err }, "dev-dashboard: pulse config load failed, polling with 5000ms default");
         startPulsePolling(5000);
     });
+
+// Restart diagnostics: snapshot ttyd/tmux state once at startup so two
+// consecutive instances reveal what a `ui restart` did to the sessions.
+logTtydTmuxSnapshot("startup");
 
 async function readJson<T>(req: IncomingMessage): Promise<T> {
     const chunks: Buffer[] = [];

--- a/src/utils/tmux/sessions.test.ts
+++ b/src/utils/tmux/sessions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { resetTmuxBinCache, setTmuxBinForTests } from "@app/utils/tmux/bin";
 import {
     buildTmuxSpawnEnv,
+    createTmuxSession,
     getTmuxScrollState,
     listTmuxSessions,
     renameTmuxSession,
@@ -107,6 +108,22 @@ describe("tmux sessions", () => {
         renameTmuxSession("foo", "bar");
 
         expect(calls.some((cmd) => cmd.includes("rename-session") && cmd.includes("bar"))).toBe(true);
+    });
+
+    test("createTmuxSession pins exit-empty off so the server keeps sessions across teardown", () => {
+        setTmuxBinForTests("/mock/tmux");
+        const calls: string[][] = [];
+        setTmuxSpawnSyncForTests((cmd) => {
+            calls.push(cmd);
+            return { exitCode: 0, stdout: "" };
+        });
+
+        createTmuxSession("foo", "/tmp", "/bin/zsh");
+
+        expect(calls.some((cmd) => cmd.includes("new-session") && cmd.includes("foo"))).toBe(true);
+        expect(
+            calls.some((cmd) => cmd.includes("set-option") && cmd.includes("exit-empty") && cmd.includes("off"))
+        ).toBe(true);
     });
 
     test("getTmuxScrollState parses display-message output", () => {

--- a/src/utils/tmux/sessions.ts
+++ b/src/utils/tmux/sessions.ts
@@ -131,6 +131,47 @@ export function createTmuxSession(sessionName: string, cwd: string, command: str
     if (result.exitCode !== 0) {
         throw new Error(`Failed to create tmux session ${sessionName}${tmuxErrorDetail(result.stderr)}`);
     }
+
+    // Pin the (possibly freshly-bootstrapped) server to keep sessions alive.
+    ensureTmuxServerPersists(tmuxBin);
+}
+
+/**
+ * Pin the tmux server so sessions survive detach/teardown instead of dying.
+ *
+ * tmux defaults to `exit-empty on`: the server process exits the instant it has
+ * zero sessions, taking every remaining session with it at once. A headless
+ * `new-session` (how the dashboard and cmux bootstrap the shared default server)
+ * inherits that stock default — unlike an interactive tmux, where tmux-continuum
+ * flips `exit-empty off`. So on the shared socket whether sessions survive a UI
+ * restart otherwise depends on who bootstrapped the server first. The dashboard
+ * uses tmux as a session daemon that must outlive restarts, so force the durable
+ * options on every time it touches the server. Both calls are idempotent and
+ * safe (turning these off can only make sessions more durable).
+ */
+export function ensureTmuxServerPersists(tmuxBin?: string): void {
+    let bin: string;
+
+    try {
+        bin = tmuxBin ?? resolveTmuxBin();
+    } catch (error) {
+        logger.debug({ error }, "ensureTmuxServerPersists: tmux binary not resolvable");
+        return;
+    }
+
+    for (const args of [
+        ["set-option", "-s", "exit-empty", "off"],
+        ["set-option", "-g", "destroy-unattached", "off"],
+    ]) {
+        const result = spawnSyncImpl([bin, ...args]);
+
+        if (result.exitCode !== 0) {
+            logger.debug(
+                { args, exitCode: result.exitCode, detail: tmuxErrorDetail(result.stderr) },
+                "ensureTmuxServerPersists: tmux set-option failed"
+            );
+        }
+    }
 }
 
 export function killTmuxSession(sessionName: string): void {


### PR DESCRIPTION
## What

Fixes `tools dev-dashboard ui restart` **destroying** the tmux sessions that back the dashboard's ttyd terminals (and cmux sessions) instead of leaving them detached. Stacked on top of `feat/tmux-cmux-dev-dashboard` (PR #188).

## Root cause

The dashboard uses tmux on the **shared default socket** (no `-L`/`-S`) as a session daemon that must outlive UI restarts. But a headless `tmux new-session` — how the dashboard bootstraps the server — inherits tmux's stock **`exit-empty on`**, which makes the server process **self-exit the instant it reaches zero sessions, taking every session with it at once**. An interactively-bootstrapped server (where tmux-continuum sets `exit-empty off`) survives — so whether sessions survived a restart depended on *who bootstrapped the socket first*.

This was confirmed two ways: two independent Explore agents converged on the facts (ttyd is correctly `setsid`'d and survives; the tmux server is daemonized; no `killpg`/`kill-session`/ttyd-cleanup exists in the restart path; `AbandonProcessGroup` is a red herring), and a disposable-socket experiment reproduced the smoking gun — a dashboard-style `new-session` comes up `exit-empty on`, while the live interactively-bootstrapped server is `exit-empty off`. The reported survivor pattern fits exactly: the session with a live foreground process kept the server non-empty; a post-restart session landed on a fresh server.

## Commits (kept separate so the fix is independently revertable)

1. **`feat(dev-dashboard): log ttyd/tmux snapshot at startup`** — zero-risk diagnostics. Logs the tmux server pid + `exit-empty` + session list + ttyd procs once at startup, so two consecutive instances' snapshots show exactly what a restart did (server pid stable → survived; changed/sessions gone → server self-exited).
2. **`fix(dev-dashboard): keep tmux sessions alive across ui restart (exit-empty off)`** — pins `exit-empty off` (+ `destroy-unattached off`) whenever the dashboard touches the server: in `createTmuxSession` (covers ttyd/cmux/dashboard creates) and on the ttyd attach path. Idempotent and safe — turning these off can only make sessions more durable. **Revert just this commit if it misbehaves; commit 1 (logging) stays.**

Kept the shared socket (so the dashboard still sees your cmux/interactive sessions); did **not** switch to a dedicated `-L` socket, which would have hidden those.

## Test plan

- `bun test src/utils/tmux/sessions.test.ts` (incl. new assertion that `createTmuxSession` pins `exit-empty off`) — 11 pass.
- tsgo clean; CI mirror green.
- Empirically verified the `exit-empty on` hazard on a disposable `-L` socket.
- **Needs live confirmation:** after this ships, the startup-snapshot log on the next `ui restart` should show the tmux server pid stable and sessions preserved.
