### PR TITLE
feat(hash): compute & verify file checksums

### DIFF
--- a/src/hash/hash.test.ts
+++ b/src/hash/hash.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ALGOS, createHasher, type HashAlgo } from "./lib/algorithms";
+import {
+    type ChecksumEntry,
+    formatChecksumLine,
+    parseChecksumFile,
+    summarizeVerify,
+    type VerifyResult,
+} from "./lib/checksum-file";
+import { hashBuffer, hashChunks } from "./lib/hash-stream";
+
+describe("algorithms", () => {
+    it("ALGOS lists exactly the five supported algorithms", () => {
+        expect([...ALGOS]).toEqual(["md5", "sha1", "sha256", "sha512", "blake3"]);
+    });
+
+    it("createHasher returns a usable hasher for each algo", async () => {
+        for (const algo of ALGOS) {
+            const hasher = await createHasher(algo);
+            hasher.init();
+            hasher.update("abc");
+            const hex = hasher.digest("hex");
+            expect(typeof hex).toBe("string");
+            expect(hex.length).toBeGreaterThan(0);
+        }
+    });
+});
+
+const KNOWN_ABC: Record<HashAlgo, string> = {
+    md5: "900150983cd24fb0d6963f7d28e17f72",
+    sha1: "a9993e364706816aba3e25717850c26c9cd0d89d",
+    sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    sha512:
+        "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a" +
+        "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+    blake3: "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85",
+};
+
+describe("hashBuffer (known vectors for 'abc')", () => {
+    for (const [algo, expected] of Object.entries(KNOWN_ABC)) {
+        it(`${algo}("abc") matches the published digest`, async () => {
+            const hex = await hashBuffer(algo as HashAlgo, new TextEncoder().encode("abc"));
+            expect(hex).toBe(expected);
+        });
+    }
+});
+
+describe("hashChunks streaming", () => {
+    it("produces the same digest whether fed in one chunk or many", async () => {
+        const data = new TextEncoder().encode("the quick brown fox jumps over the lazy dog");
+        const oneShot = await hashChunks({ algo: "sha256", chunks: [data] });
+
+        const small: Uint8Array[] = [];
+        for (let i = 0; i < data.length; i += 3) {
+            small.push(data.subarray(i, i + 3));
+        }
+        const chunked = await hashChunks({ algo: "sha256", chunks: small });
+
+        expect(chunked).toBe(oneShot);
+    });
+
+    it("hashes an empty stream to the algorithm's empty-input digest", async () => {
+        const empty = await hashChunks({ algo: "sha256", chunks: [] });
+        expect(empty).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    });
+
+    it("accepts an async iterable of chunks", async () => {
+        async function* gen(): AsyncGenerator<Uint8Array> {
+            yield new TextEncoder().encode("ab");
+            yield new TextEncoder().encode("c");
+        }
+
+        const hex = await hashChunks({ algo: "sha256", chunks: gen() });
+        expect(hex).toBe(KNOWN_ABC.sha256);
+    });
+});
+
+describe("formatChecksumLine", () => {
+    it("emits coreutils '<hex>  <path>' with exactly two spaces", () => {
+        expect(formatChecksumLine("deadbeef", "a.txt")).toBe("deadbeef  a.txt");
+    });
+});
+
+describe("parseChecksumFile", () => {
+    it("parses standard two-space lines", () => {
+        const entries = parseChecksumFile("deadbeef  a.txt\ncafef00d  sub/b.txt\n");
+        expect(entries).toEqual([
+            { hex: "deadbeef", path: "a.txt" },
+            { hex: "cafef00d", path: "sub/b.txt" },
+        ]);
+    });
+
+    it("skips blank lines and '#' comments", () => {
+        const entries = parseChecksumFile("# header\n\ndeadbeef  a.txt\n\n");
+        expect(entries).toEqual([{ hex: "deadbeef", path: "a.txt" }]);
+    });
+
+    it("tolerates a single space and the GNU '*' binary marker", () => {
+        const entries = parseChecksumFile("deadbeef a.txt\ncafef00d *bin.dat\n");
+        expect(entries).toEqual([
+            { hex: "deadbeef", path: "a.txt" },
+            { hex: "cafef00d", path: "bin.dat" },
+        ]);
+    });
+
+    it("preserves spaces inside the path", () => {
+        const entries = parseChecksumFile("deadbeef  my file.txt\n");
+        expect(entries).toEqual([{ hex: "deadbeef", path: "my file.txt" }]);
+    });
+
+    it("lowercases uppercase hex", () => {
+        const entries = parseChecksumFile("DEADBEEF  a.txt\n");
+        expect(entries).toEqual([{ hex: "deadbeef", path: "a.txt" }]);
+    });
+});
+
+describe("summarizeVerify", () => {
+    it("counts total and failed", () => {
+        const results: VerifyResult[] = [
+            { path: "a", ok: true },
+            { path: "b", ok: false },
+            { path: "c", ok: false, unreadable: true },
+        ];
+        expect(summarizeVerify(results)).toEqual({ total: 3, failed: 2 });
+    });
+});
+
+async function verifyEntries(dir: string, algo: HashAlgo, entries: ChecksumEntry[]): Promise<VerifyResult[]> {
+    const results: VerifyResult[] = [];
+    for (const entry of entries) {
+        try {
+            const bytes = new Uint8Array(await Bun.file(join(dir, entry.path)).arrayBuffer());
+            const actual = await hashBuffer(algo, bytes);
+            results.push({ path: entry.path, ok: actual === entry.hex });
+        } catch {
+            results.push({ path: entry.path, ok: false, unreadable: true });
+        }
+    }
+
+    return results;
+}
+
+describe("end-to-end verify against tmp files", () => {
+    it("reports OK for matching files and FAILED for tampered/missing ones", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "gt-hash-"));
+        try {
+            writeFileSync(join(dir, "a.txt"), "alpha");
+            writeFileSync(join(dir, "b.txt"), "bravo");
+
+            const hexA = await hashBuffer("sha256", new TextEncoder().encode("alpha"));
+            const hexB = await hashBuffer("sha256", new TextEncoder().encode("bravo"));
+
+            const checksumText =
+                `${formatChecksumLine(hexA, "a.txt")}\n` +
+                `${formatChecksumLine("0".repeat(hexB.length), "b.txt")}\n` +
+                `${formatChecksumLine(hexA, "c.txt")}\n`;
+
+            const entries = parseChecksumFile(checksumText);
+            const results = await verifyEntries(dir, "sha256", entries);
+
+            expect(results.find((r) => r.path === "a.txt")?.ok).toBe(true);
+            expect(results.find((r) => r.path === "b.txt")?.ok).toBe(false);
+            const cResult = results.find((r) => r.path === "c.txt");
+            expect(cResult?.ok).toBe(false);
+            expect(cResult?.unreadable).toBe(true);
+
+            const summary = summarizeVerify(results);
+            expect(summary).toEqual({ total: 3, failed: 2 });
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/hash/index.ts
+++ b/src/hash/index.ts
@@ -144,7 +144,7 @@ program
     .action(async (files: string[], options: Options) => {
         if (!isHashAlgo(options.algo)) {
             out.error(`Unknown algorithm: ${options.algo}`);
-            await exitWith(1);
+            return await exitWith(1);
         }
 
         const algo = options.algo;
@@ -152,11 +152,11 @@ program
         if (options.check) {
             if (files.length > 0) {
                 out.error("Cannot pass files together with --check.");
-                await exitWith(1);
+                return await exitWith(1);
             }
 
             const code = await runCheck(algo, options.check, options.quiet ?? false);
-            await exitWith(code);
+            return await exitWith(code);
         }
 
         if (files.length === 0) {
@@ -165,11 +165,11 @@ program
                 out.log.info(suggestCommand("tools hash", { add: ["<file>", "--algo", "sha256"] }));
             }
 
-            await exitWith(1);
+            return await exitWith(1);
         }
 
         const code = await runCompute(algo, files);
-        await exitWith(code);
+        return await exitWith(code);
     });
 
 await runTool(program, { tool: "hash" });

--- a/src/hash/index.ts
+++ b/src/hash/index.ts
@@ -1,0 +1,175 @@
+import { logger, out } from "@app/logger";
+import { isInteractive, runTool, suggestCommand } from "@app/utils/cli";
+import { Command, Option } from "commander";
+import { glob } from "glob";
+import { ALGOS, type HashAlgo, isHashAlgo } from "./lib/algorithms";
+import {
+    type ChecksumEntry,
+    formatChecksumLine,
+    parseChecksumFile,
+    summarizeVerify,
+    type VerifyResult,
+} from "./lib/checksum-file";
+import { hashChunks } from "./lib/hash-stream";
+
+interface Options {
+    algo: string;
+    check?: string;
+    quiet?: boolean;
+}
+
+async function* fileChunks(path: string): AsyncGenerator<Uint8Array> {
+    const stream = Bun.file(path).stream();
+    for await (const chunk of stream) {
+        yield chunk;
+    }
+}
+
+async function hashFile(algo: HashAlgo, path: string): Promise<string> {
+    return hashChunks({ algo, chunks: fileChunks(path) });
+}
+
+async function expandGlobs(patterns: string[]): Promise<string[]> {
+    const seen = new Set<string>();
+    const result: string[] = [];
+
+    for (const pattern of patterns) {
+        const matches = await glob(pattern, { nodir: true });
+        matches.sort();
+        for (const match of matches) {
+            if (!seen.has(match)) {
+                seen.add(match);
+                result.push(match);
+            }
+        }
+    }
+
+    return result;
+}
+
+async function runCompute(algo: HashAlgo, patterns: string[]): Promise<number> {
+    const files = await expandGlobs(patterns);
+
+    if (files.length === 0) {
+        out.error("No files matched.");
+        logger.warn({ patterns }, "hash: zero files matched");
+        return 1;
+    }
+
+    let failures = 0;
+    for (const file of files) {
+        try {
+            const hex = await hashFile(algo, file);
+            out.println(formatChecksumLine(hex, file));
+        } catch (error) {
+            failures++;
+            out.error(`hash: ${file}: could not read`);
+            logger.warn({ file, error }, "hash: failed to read file");
+        }
+    }
+
+    return failures > 0 ? 1 : 0;
+}
+
+async function verifyEntries(algo: HashAlgo, entries: ChecksumEntry[]): Promise<VerifyResult[]> {
+    const results: VerifyResult[] = [];
+
+    for (const entry of entries) {
+        try {
+            const actual = await hashFile(algo, entry.path);
+            results.push({ path: entry.path, ok: actual === entry.hex });
+        } catch (error) {
+            logger.debug({ path: entry.path, error }, "hash: verify read failed");
+            results.push({ path: entry.path, ok: false, unreadable: true });
+        }
+    }
+
+    return results;
+}
+
+async function runCheck(algo: HashAlgo, checkFile: string, quiet: boolean): Promise<number> {
+    let text: string;
+    try {
+        text = await Bun.file(checkFile).text();
+    } catch (error) {
+        out.error(`hash: cannot open checksum file: ${checkFile}`);
+        logger.error({ checkFile, error }, "hash: failed to read checksum file");
+        return 1;
+    }
+
+    const entries = parseChecksumFile(text);
+    if (entries.length === 0) {
+        out.error(`hash: no checksum entries found in ${checkFile}`);
+        return 1;
+    }
+
+    const results = await verifyEntries(algo, entries);
+
+    for (const result of results) {
+        if (result.ok) {
+            if (!quiet) {
+                out.println(`${result.path}: OK`);
+            }
+        } else if (result.unreadable) {
+            out.println(`${result.path}: FAILED (could not read)`);
+        } else {
+            out.println(`${result.path}: FAILED`);
+        }
+    }
+
+    const summary = summarizeVerify(results);
+    if (summary.failed > 0) {
+        out.error(`hash: ${summary.failed} of ${summary.total} computed checksums did NOT match`);
+        return 1;
+    }
+
+    out.log.success(`hash: all ${summary.total} checksums OK`);
+    return 0;
+}
+
+async function exitWith(code: number): Promise<never> {
+    await out.flush();
+    process.exit(code);
+}
+
+const program = new Command();
+
+program
+    .name("hash")
+    .description("Compute & verify file checksums (md5/sha1/sha256/sha512/blake3). Coreutils-compatible.")
+    .argument("[files...]", "Files or glob patterns to hash (quote globs)")
+    .addOption(new Option("-a, --algo <algo>", "Hash algorithm").choices([...ALGOS]).default("sha256"))
+    .option("-c, --check <file>", "Verify the checksum file at <file> instead of computing")
+    .option("--quiet", "In --check mode, print only FAILED lines")
+    .action(async (files: string[], options: Options) => {
+        if (!isHashAlgo(options.algo)) {
+            out.error(`Unknown algorithm: ${options.algo}`);
+            await exitWith(1);
+        }
+
+        const algo = options.algo;
+
+        if (options.check) {
+            if (files.length > 0) {
+                out.error("Cannot pass files together with --check.");
+                await exitWith(1);
+            }
+
+            const code = await runCheck(algo, options.check, options.quiet ?? false);
+            await exitWith(code);
+        }
+
+        if (files.length === 0) {
+            out.error("No files given.");
+            if (!isInteractive()) {
+                out.log.info(suggestCommand("tools hash", { add: ["<file>", "--algo", "sha256"] }));
+            }
+
+            await exitWith(1);
+        }
+
+        const code = await runCompute(algo, files);
+        await exitWith(code);
+    });
+
+await runTool(program, { tool: "hash" });

--- a/src/hash/index.ts
+++ b/src/hash/index.ts
@@ -29,11 +29,24 @@ async function hashFile(algo: HashAlgo, path: string): Promise<string> {
     return hashChunks({ algo, chunks: fileChunks(path) });
 }
 
+function hasGlobMagic(pattern: string): boolean {
+    return /[*?[\]{}]/.test(pattern);
+}
+
 async function expandGlobs(patterns: string[]): Promise<string[]> {
     const seen = new Set<string>();
     const result: string[] = [];
 
     for (const pattern of patterns) {
+        if (!hasGlobMagic(pattern)) {
+            if (!seen.has(pattern)) {
+                seen.add(pattern);
+                result.push(pattern);
+            }
+
+            continue;
+        }
+
         const matches = await glob(pattern, { nodir: true });
         matches.sort();
         for (const match of matches) {
@@ -100,6 +113,13 @@ async function runCheck(algo: HashAlgo, checkFile: string, quiet: boolean): Prom
     const entries = parseChecksumFile(text);
     if (entries.length === 0) {
         out.error(`hash: no checksum entries found in ${checkFile}`);
+        return 1;
+    }
+
+    const expectedLength = algo === "md5" ? 32 : algo === "sha1" ? 40 : algo === "sha512" ? 128 : 64;
+    if (entries.some((e) => e.hex.length !== expectedLength)) {
+        out.error(`hash: checksum hash length does not match the selected algorithm (${algo})`);
+        logger.warn({ algo, expectedLength, checkFile }, "hash: algorithm/length mismatch in checksum file");
         return 1;
     }
 

--- a/src/hash/lib/algorithms.ts
+++ b/src/hash/lib/algorithms.ts
@@ -1,0 +1,22 @@
+import { createBLAKE3, createMD5, createSHA1, createSHA256, createSHA512, type IHasher } from "hash-wasm";
+
+export const ALGOS = ["md5", "sha1", "sha256", "sha512", "blake3"] as const;
+
+export type HashAlgo = (typeof ALGOS)[number];
+
+const FACTORIES: Record<HashAlgo, () => Promise<IHasher>> = {
+    md5: createMD5,
+    sha1: createSHA1,
+    sha256: createSHA256,
+    sha512: createSHA512,
+    blake3: () => createBLAKE3(),
+};
+
+export function isHashAlgo(value: string): value is HashAlgo {
+    return (ALGOS as readonly string[]).includes(value);
+}
+
+export async function createHasher(algo: HashAlgo): Promise<IHasher> {
+    const factory = FACTORIES[algo];
+    return factory();
+}

--- a/src/hash/lib/checksum-file.ts
+++ b/src/hash/lib/checksum-file.ts
@@ -1,0 +1,44 @@
+export interface ChecksumEntry {
+    hex: string;
+    path: string;
+}
+
+export interface VerifyResult {
+    path: string;
+    ok: boolean;
+    unreadable?: boolean;
+}
+
+export interface VerifySummary {
+    total: number;
+    failed: number;
+}
+
+export function formatChecksumLine(hex: string, path: string): string {
+    return `${hex}  ${path}`;
+}
+
+export function parseChecksumFile(text: string): ChecksumEntry[] {
+    const entries: ChecksumEntry[] = [];
+
+    for (const rawLine of text.split("\n")) {
+        const line = rawLine.trimEnd();
+        if (line.length === 0 || line.startsWith("#")) {
+            continue;
+        }
+
+        const match = line.match(/^([0-9a-fA-F]+)\s+\*?(.+)$/);
+        if (!match) {
+            continue;
+        }
+
+        entries.push({ hex: match[1].toLowerCase(), path: match[2] });
+    }
+
+    return entries;
+}
+
+export function summarizeVerify(results: VerifyResult[]): VerifySummary {
+    const failed = results.filter((r) => !r.ok).length;
+    return { total: results.length, failed };
+}

--- a/src/hash/lib/hash-stream.ts
+++ b/src/hash/lib/hash-stream.ts
@@ -1,0 +1,21 @@
+import { createHasher, type HashAlgo } from "./algorithms";
+
+export interface HashChunksArgs {
+    algo: HashAlgo;
+    chunks: Iterable<Uint8Array> | AsyncIterable<Uint8Array>;
+}
+
+export async function hashChunks({ algo, chunks }: HashChunksArgs): Promise<string> {
+    const hasher = await createHasher(algo);
+    hasher.init();
+
+    for await (const chunk of chunks) {
+        hasher.update(chunk);
+    }
+
+    return hasher.digest("hex");
+}
+
+export async function hashBuffer(algo: HashAlgo, data: Uint8Array): Promise<string> {
+    return hashChunks({ algo, chunks: [data] });
+}


### PR DESCRIPTION
## What

`tools hash` — a cross-platform CLI to compute and verify file checksums, backed by the already-installed `hash-wasm` dependency. One command replaces the per-platform mix of `shasum`, `md5sum`, and `b3sum` (blake3 isn't available by default on macOS).

## CLI surface

```
tools hash [options] <files...>          # compute mode (default)
tools hash --check <file> [options]      # verify mode
```

- `-a, --algo <md5|sha1|sha256|sha512|blake3>` — algorithm (default `sha256`, validated via commander `.choices`).
- `-c, --check <file>` — verify a checksum file instead of computing (mutually exclusive with positional files).
- `--quiet` — in `--check` mode, print only `FAILED` lines.

`<files...>` are paths or glob patterns (quote globs; expanded via the `glob` dep with `nodir: true`, de-duped, deterministic order).

## Behavior

- **Streaming**: files are read via `Bun.file(path).stream()` and fed to `hash-wasm`'s `IHasher` chunk-by-chunk (`init` → `update` → `digest`). The whole file is never buffered, so multi-GB files work.
- **Coreutils-compatible output**: `<lowercase-hex><two spaces><path>` — byte-identical to `shasum`/`md5sum`/`b3sum`, so output feeds straight back into `--check` (and vice-versa). Verified against system `shasum -a 256`.
- **`--check`**: tolerant parser (skips blank/`#` lines, accepts 1+ spaces and the GNU `*` binary marker, lowercases hex), recomputes each entry, prints `<path>: OK` / `<path>: FAILED` / `<path>: FAILED (could not read)`, with a summary to stderr.
- **Exit codes**: 0 only when every operation succeeds; 1 on any mismatch, unreadable file, or zero glob matches.
- **Output discipline**: results via `out.println` (stdout only); status/errors/summaries via `out.error` / `out.log.*` / `logger` (stderr). `await out.flush()` precedes every `process.exit()` so redirected output (`> sums.sha256`) is never truncated mid-drain.

## Structure

- Pure, testable lib in `src/hash/lib/` — `algorithms.ts` (registry + `createHasher`), `hash-stream.ts` (`hashChunks`/`hashBuffer`), `checksum-file.ts` (format/parse/summarize). No commander, `out`, `process.exit`, or clock reads.
- Thin commander entrypoint in `src/hash/index.ts`, ending in `await runTool(program, { tool: "hash" })`.
- Hermetic `bun:test` in `src/hash/hash.test.ts` — known-vector digests per algo, chunked==one-shot equality, async-iterable feed, tolerant-parser cases, and an end-to-end verify over `os.tmpdir()` files (no network, no clipboard, no live-repo state).

## Verification (local)

- `bunx biome check src/hash` — exit 0.
- `bun test src/hash` — 18 pass / 0 fail.
- `./tools hash --help` — exit 0.
- Compute matches `shasum -a 256`; redirect round-trip + verify/tamper/quiet/glob/no-match all behave per spec.

No new npm dependencies; no `console.log`; no `JSON.*`; no `any`; no hardcoded user paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `hash` command for computing and verifying file checksums
  * Supports multiple hashing algorithms (MD5, SHA1, SHA256, SHA512, BLAKE3)
  * Verification mode to validate checksums against a checksum file
  * Glob pattern support for processing multiple files
  * Quiet mode to show only verification failures

* **Tests**
  * Added comprehensive test suite for hashing and verification functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->