### PR TITLE
feat(loc): count lines of code by language

### DIFF
--- a/src/loc/index.ts
+++ b/src/loc/index.ts
@@ -29,7 +29,14 @@ program
     .action(async (dir: string, options: Options) => {
         const root = resolve(dir);
 
-        if (!existsSync(root) || !statSync(root).isDirectory()) {
+        let isDirectory = false;
+        try {
+            isDirectory = existsSync(root) && statSync(root).isDirectory();
+        } catch (err) {
+            logger.debug({ root, error: err }, "loc: failed to stat target path");
+        }
+
+        if (!isDirectory) {
             out.error(`Not a directory: ${root}`);
             process.exit(1);
         }
@@ -58,8 +65,13 @@ function parseTop(value: string | undefined): number | undefined {
         return undefined;
     }
 
-    const n = Number.parseInt(value, 10);
-    if (Number.isNaN(n) || n < 1) {
+    if (!/^\d+$/.test(value)) {
+        out.error(`--top must be a positive integer, got: ${value}`);
+        process.exit(1);
+    }
+
+    const n = Number(value);
+    if (n < 1) {
         out.error(`--top must be a positive integer, got: ${value}`);
         process.exit(1);
     }

--- a/src/loc/index.ts
+++ b/src/loc/index.ts
@@ -1,0 +1,70 @@
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { logger, out } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { Command, Option } from "commander";
+import { buildReport, type GroupBy } from "./lib/aggregate";
+import { renderTable } from "./lib/render";
+import { scanDirectory } from "./lib/walk";
+
+interface Options {
+    top?: string;
+    by: GroupBy;
+    json?: boolean;
+    gitignore: boolean;
+    includeHidden?: boolean;
+}
+
+const program = new Command();
+
+program
+    .name("loc")
+    .description("Count files, code/blank/comment lines by language in a directory, respecting .gitignore.")
+    .argument("[dir]", "Directory to scan", ".")
+    .option("--top <n>", "Show only the top N rows by code lines")
+    .addOption(new Option("--by <key>", "Group rows by language or extension").choices(["lang", "ext"]).default("lang"))
+    .option("--json", "Emit the report as JSON instead of a table")
+    .option("--no-gitignore", "Do not honour .gitignore (still skips .git/node_modules/dotfiles)")
+    .option("--include-hidden", "Include dotfiles and dot-directories")
+    .action(async (dir: string, options: Options) => {
+        const root = resolve(dir);
+
+        if (!existsSync(root) || !statSync(root).isDirectory()) {
+            out.error(`Not a directory: ${root}`);
+            process.exit(1);
+        }
+
+        const top = parseTop(options.top);
+        logger.debug({ root, by: options.by, gitignore: options.gitignore, top }, "loc: scanning");
+
+        const files = await scanDirectory({
+            root,
+            gitignore: options.gitignore,
+            includeHidden: Boolean(options.includeHidden),
+        });
+
+        const report = buildReport({ root, by: options.by, files, now: new Date(), top });
+
+        if (options.json) {
+            out.result(report);
+            return;
+        }
+
+        out.println(renderTable(report));
+    });
+
+function parseTop(value: string | undefined): number | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    const n = Number.parseInt(value, 10);
+    if (Number.isNaN(n) || n < 1) {
+        out.error(`--top must be a positive integer, got: ${value}`);
+        process.exit(1);
+    }
+
+    return n;
+}
+
+await runTool(program, { tool: "loc" });

--- a/src/loc/lib/aggregate.ts
+++ b/src/loc/lib/aggregate.ts
@@ -1,0 +1,76 @@
+import type { LineCounts } from "./classify";
+
+export type GroupBy = "lang" | "ext";
+
+export interface FileResult {
+    ext: string;
+    language: string;
+    counts: LineCounts;
+}
+
+export interface Row {
+    name: string;
+    files: number;
+    lines: number;
+    code: number;
+    comment: number;
+    blank: number;
+}
+
+export type Totals = Omit<Row, "name">;
+
+export interface Report {
+    root: string;
+    by: GroupBy;
+    generatedAt: string;
+    rows: Row[];
+    total: Totals;
+}
+
+export interface BuildReportInput {
+    root: string;
+    by: GroupBy;
+    files: FileResult[];
+    now: Date;
+    top?: number;
+}
+
+export function buildReport({ root, by, files, now, top }: BuildReportInput): Report {
+    const groups = new Map<string, Row>();
+    const total: Totals = { files: 0, lines: 0, code: 0, comment: 0, blank: 0 };
+
+    for (const file of files) {
+        const key = by === "ext" ? file.ext : file.language;
+        const lines = file.counts.code + file.counts.comment + file.counts.blank;
+        const row = groups.get(key) ?? { name: key, files: 0, lines: 0, code: 0, comment: 0, blank: 0 };
+
+        row.files += 1;
+        row.lines += lines;
+        row.code += file.counts.code;
+        row.comment += file.counts.comment;
+        row.blank += file.counts.blank;
+        groups.set(key, row);
+
+        total.files += 1;
+        total.lines += lines;
+        total.code += file.counts.code;
+        total.comment += file.counts.comment;
+        total.blank += file.counts.blank;
+    }
+
+    const sorted = [...groups.values()].sort((a, b) => {
+        if (b.code !== a.code) {
+            return b.code - a.code;
+        }
+
+        if (b.lines !== a.lines) {
+            return b.lines - a.lines;
+        }
+
+        return a.name.localeCompare(b.name);
+    });
+
+    const rows = typeof top === "number" ? sorted.slice(0, top) : sorted;
+
+    return { root, by, generatedAt: now.toISOString(), rows, total };
+}

--- a/src/loc/lib/aggregate.ts
+++ b/src/loc/lib/aggregate.ts
@@ -40,7 +40,7 @@ export function buildReport({ root, by, files, now, top }: BuildReportInput): Re
     const total: Totals = { files: 0, lines: 0, code: 0, comment: 0, blank: 0 };
 
     for (const file of files) {
-        const key = by === "ext" ? file.ext : file.language;
+        const key = by === "ext" ? file.ext || "(no ext)" : file.language;
         const lines = file.counts.code + file.counts.comment + file.counts.blank;
         const row = groups.get(key) ?? { name: key, files: 0, lines: 0, code: 0, comment: 0, blank: 0 };
 

--- a/src/loc/lib/classify.ts
+++ b/src/loc/lib/classify.ts
@@ -1,0 +1,112 @@
+import { commentSyntaxForExt } from "./languages";
+
+export interface ClassifyInput {
+    content: string;
+    ext: string;
+}
+
+export interface LineCounts {
+    code: number;
+    comment: number;
+    blank: number;
+}
+
+export function classifyFile({ content, ext }: ClassifyInput): LineCounts {
+    const counts: LineCounts = { code: 0, comment: 0, blank: 0 };
+
+    if (content.length === 0) {
+        return counts;
+    }
+
+    const { line: linePrefixes, block } = commentSyntaxForExt(ext);
+    const normalized = content.endsWith("\n") ? content.slice(0, -1) : content;
+    const lines = normalized.split("\n");
+    let activeBlock: { close: string } | null = null;
+
+    for (const raw of lines) {
+        const trimmed = raw.trim();
+
+        if (trimmed.length === 0) {
+            counts.blank += 1;
+            continue;
+        }
+
+        const result = classifyLine({ trimmed, linePrefixes, block, activeBlock });
+        activeBlock = result.activeBlock;
+
+        if (result.kind === "comment") {
+            counts.comment += 1;
+        } else {
+            counts.code += 1;
+        }
+    }
+
+    return counts;
+}
+
+interface ClassifyLineInput {
+    trimmed: string;
+    linePrefixes: string[];
+    block: { open: string; close: string }[];
+    activeBlock: { close: string } | null;
+}
+
+interface ClassifyLineResult {
+    kind: "code" | "comment";
+    activeBlock: { close: string } | null;
+}
+
+function classifyLine({ trimmed, linePrefixes, block, activeBlock }: ClassifyLineInput): ClassifyLineResult {
+    let cursor = 0;
+    let sawCode = false;
+    let sawComment = false;
+    let open = activeBlock;
+
+    while (cursor < trimmed.length) {
+        if (open) {
+            const closeIdx = trimmed.indexOf(open.close, cursor);
+            if (closeIdx === -1) {
+                sawComment = true;
+                return { kind: sawCode ? "code" : "comment", activeBlock: open };
+            }
+
+            sawComment = true;
+            cursor = closeIdx + open.close.length;
+            open = null;
+            continue;
+        }
+
+        const rest = trimmed.slice(cursor);
+
+        if (rest.trim().length === 0) {
+            break;
+        }
+
+        const linePrefix = linePrefixes.find((p) => rest.startsWith(p));
+        if (linePrefix) {
+            sawComment = true;
+            break;
+        }
+
+        const blockStart = block.find((b) => rest.startsWith(b.open));
+        if (blockStart) {
+            sawComment = true;
+            open = { close: blockStart.close };
+            cursor += blockStart.open.length;
+            continue;
+        }
+
+        sawCode = true;
+        cursor += 1;
+    }
+
+    if (sawCode) {
+        return { kind: "code", activeBlock: open };
+    }
+
+    if (sawComment) {
+        return { kind: "comment", activeBlock: open };
+    }
+
+    return { kind: "code", activeBlock: open };
+}

--- a/src/loc/lib/classify.ts
+++ b/src/loc/lib/classify.ts
@@ -76,19 +76,19 @@ function classifyLine({ trimmed, linePrefixes, block, activeBlock }: ClassifyLin
             continue;
         }
 
-        const rest = trimmed.slice(cursor);
-
-        if (rest.trim().length === 0) {
-            break;
+        const char = trimmed[cursor];
+        if (char === " " || char === "\t" || char === "\r" || char === "\n") {
+            cursor += 1;
+            continue;
         }
 
-        const linePrefix = linePrefixes.find((p) => rest.startsWith(p));
+        const linePrefix = linePrefixes.find((p) => trimmed.startsWith(p, cursor));
         if (linePrefix) {
             sawComment = true;
             break;
         }
 
-        const blockStart = block.find((b) => rest.startsWith(b.open));
+        const blockStart = block.find((b) => trimmed.startsWith(b.open, cursor));
         if (blockStart) {
             sawComment = true;
             open = { close: blockStart.close };

--- a/src/loc/lib/languages.ts
+++ b/src/loc/lib/languages.ts
@@ -1,0 +1,122 @@
+export interface BlockComment {
+    open: string;
+    close: string;
+}
+
+export interface CommentSyntax {
+    line: string[];
+    block: BlockComment[];
+}
+
+const SLASH_STAR: BlockComment = { open: "/*", close: "*/" };
+const HTML_BLOCK: BlockComment = { open: "<!--", close: "-->" };
+
+const EXT_TO_LANGUAGE: Record<string, string> = {
+    ts: "TypeScript",
+    tsx: "TypeScript",
+    js: "JavaScript",
+    jsx: "JavaScript",
+    mjs: "JavaScript",
+    cjs: "JavaScript",
+    py: "Python",
+    go: "Go",
+    rs: "Rust",
+    java: "Java",
+    kt: "Kotlin",
+    rb: "Ruby",
+    php: "PHP",
+    c: "C",
+    h: "C",
+    cpp: "C++",
+    cc: "C++",
+    hpp: "C++",
+    cs: "C#",
+    swift: "Swift",
+    css: "CSS",
+    scss: "SCSS",
+    sass: "Sass",
+    less: "Less",
+    html: "HTML",
+    htm: "HTML",
+    vue: "Vue",
+    svelte: "Svelte",
+    md: "Markdown",
+    json: "JSON",
+    jsonc: "JSON",
+    yaml: "YAML",
+    yml: "YAML",
+    toml: "TOML",
+    sh: "Shell",
+    bash: "Shell",
+    zsh: "Shell",
+    sql: "SQL",
+    lua: "Lua",
+};
+
+const C_LIKE = new Set([
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "mjs",
+    "cjs",
+    "go",
+    "rs",
+    "java",
+    "kt",
+    "c",
+    "h",
+    "cpp",
+    "cc",
+    "hpp",
+    "cs",
+    "swift",
+    "php",
+    "scss",
+    "sass",
+    "less",
+    "vue",
+    "svelte",
+]);
+
+const HASH_LINE = new Set(["py", "rb", "sh", "bash", "zsh", "yaml", "yml", "toml"]);
+const DASH_LINE = new Set(["sql", "lua"]);
+const HTML_LIKE = new Set(["html", "htm", "md", "vue", "svelte"]);
+
+function normalizeExt(ext: string): string {
+    return ext.replace(/^\./, "").toLowerCase();
+}
+
+export function resolveLanguage(ext: string): string {
+    const key = normalizeExt(ext);
+    return EXT_TO_LANGUAGE[key] ?? "Other";
+}
+
+export function commentSyntaxForExt(ext: string): CommentSyntax {
+    const key = normalizeExt(ext);
+    const line: string[] = [];
+    const block: BlockComment[] = [];
+
+    if (C_LIKE.has(key)) {
+        line.push("//");
+        block.push(SLASH_STAR);
+    }
+
+    if (HASH_LINE.has(key)) {
+        line.push("#");
+    }
+
+    if (DASH_LINE.has(key)) {
+        line.push("--");
+    }
+
+    if (key === "css") {
+        block.push(SLASH_STAR);
+    }
+
+    if (HTML_LIKE.has(key)) {
+        block.push(HTML_BLOCK);
+    }
+
+    return { line, block };
+}

--- a/src/loc/lib/languages.ts
+++ b/src/loc/lib/languages.ts
@@ -60,6 +60,7 @@ const C_LIKE = new Set([
     "jsx",
     "mjs",
     "cjs",
+    "jsonc",
     "go",
     "rs",
     "java",

--- a/src/loc/lib/render.ts
+++ b/src/loc/lib/render.ts
@@ -1,0 +1,29 @@
+import { formatNumber } from "@app/utils/format";
+import { formatTable } from "@app/utils/table";
+import type { Report } from "./aggregate";
+
+export function renderTable(report: Report): string {
+    const nameHeader = report.by === "ext" ? "Ext" : "Language";
+    const headers = [nameHeader, "Files", "Lines", "Code", "Comment", "Blank"];
+
+    const rows = report.rows.map((r) => [
+        r.name,
+        formatNumber(r.files),
+        formatNumber(r.lines),
+        formatNumber(r.code),
+        formatNumber(r.comment),
+        formatNumber(r.blank),
+    ]);
+
+    const total = report.total;
+    rows.push([
+        "Total",
+        formatNumber(total.files),
+        formatNumber(total.lines),
+        formatNumber(total.code),
+        formatNumber(total.comment),
+        formatNumber(total.blank),
+    ]);
+
+    return formatTable(rows, headers, { alignRight: [1, 2, 3, 4, 5] });
+}

--- a/src/loc/lib/walk.ts
+++ b/src/loc/lib/walk.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import { logger } from "@app/logger";
+import { concurrentMap } from "@app/utils/async";
+import ignore, { type Ignore } from "ignore";
+import type { FileResult } from "./aggregate";
+import { classifyFile } from "./classify";
+import { resolveLanguage } from "./languages";
+
+export interface ScanInput {
+    root: string;
+    gitignore: boolean;
+    includeHidden: boolean;
+}
+
+const ALWAYS_SKIP = new Set([".git", "node_modules"]);
+
+function toPosix(p: string): string {
+    return p.split(sep).join("/");
+}
+
+function loadGitignore(root: string): Ignore | null {
+    const gitignorePath = join(root, ".gitignore");
+
+    if (!existsSync(gitignorePath)) {
+        return null;
+    }
+
+    return ignore().add(readFileSync(gitignorePath, "utf-8"));
+}
+
+async function collectFiles(input: ScanInput): Promise<string[]> {
+    const { root, gitignore, includeHidden } = input;
+    const ig = gitignore ? loadGitignore(root) : null;
+    const files: string[] = [];
+
+    async function walk(dir: string): Promise<void> {
+        const entries = await readdir(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const name = entry.name;
+
+            if (ALWAYS_SKIP.has(name)) {
+                continue;
+            }
+
+            if (!includeHidden && name.startsWith(".")) {
+                continue;
+            }
+
+            const abs = join(dir, name);
+            const rel = toPosix(relative(root, abs));
+
+            if (ig && rel.length > 0) {
+                const probe = entry.isDirectory() ? `${rel}/` : rel;
+                if (ig.ignores(probe)) {
+                    continue;
+                }
+            }
+
+            if (entry.isDirectory()) {
+                await walk(abs);
+            } else if (entry.isFile()) {
+                files.push(abs);
+            }
+        }
+    }
+
+    await walk(root);
+    return files;
+}
+
+function extOf(filePath: string): string {
+    const base = filePath.split(sep).pop() ?? filePath;
+    const dot = base.lastIndexOf(".");
+    if (dot <= 0) {
+        return "";
+    }
+
+    return base.slice(dot + 1).toLowerCase();
+}
+
+export async function scanDirectory(input: ScanInput): Promise<FileResult[]> {
+    const filePaths = await collectFiles(input);
+    logger.debug({ root: input.root, count: filePaths.length }, "loc: collected files");
+
+    const read = await concurrentMap({
+        items: filePaths,
+        concurrency: 50,
+        fn: async (filePath): Promise<FileResult | null> => {
+            const ext = extOf(filePath);
+            try {
+                const content = await Bun.file(filePath).text();
+                return { ext, language: resolveLanguage(ext), counts: classifyFile({ content, ext }) };
+            } catch (err) {
+                logger.debug({ filePath, error: err }, "loc: skipped unreadable file");
+                return null;
+            }
+        },
+    });
+
+    const results: FileResult[] = [];
+    for (const [, value] of read) {
+        if (value) {
+            results.push(value);
+        }
+    }
+
+    return results;
+}

--- a/src/loc/lib/walk.ts
+++ b/src/loc/lib/walk.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { type Dirent, existsSync, readFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { logger } from "@app/logger";
@@ -23,11 +23,15 @@ function toPosix(p: string): string {
 function loadGitignore(root: string): Ignore | null {
     const gitignorePath = join(root, ".gitignore");
 
-    if (!existsSync(gitignorePath)) {
-        return null;
+    try {
+        if (existsSync(gitignorePath)) {
+            return ignore().add(readFileSync(gitignorePath, "utf-8"));
+        }
+    } catch (err) {
+        logger.warn({ gitignorePath, error: err }, "loc: failed to read .gitignore");
     }
 
-    return ignore().add(readFileSync(gitignorePath, "utf-8"));
+    return null;
 }
 
 async function collectFiles(input: ScanInput): Promise<string[]> {
@@ -36,7 +40,13 @@ async function collectFiles(input: ScanInput): Promise<string[]> {
     const files: string[] = [];
 
     async function walk(dir: string): Promise<void> {
-        const entries = await readdir(dir, { withFileTypes: true });
+        let entries: Dirent[];
+        try {
+            entries = await readdir(dir, { withFileTypes: true });
+        } catch (err) {
+            logger.debug({ dir, error: err }, "loc: skipped unreadable directory");
+            return;
+        }
 
         for (const entry of entries) {
             const name = entry.name;

--- a/src/loc/loc.test.ts
+++ b/src/loc/loc.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildReport, type FileResult } from "./lib/aggregate";
+import { classifyFile } from "./lib/classify";
+import { commentSyntaxForExt, resolveLanguage } from "./lib/languages";
+import { renderTable } from "./lib/render";
+import { scanDirectory } from "./lib/walk";
+
+describe("resolveLanguage", () => {
+    it("maps known extensions to language names", () => {
+        expect(resolveLanguage("ts")).toBe("TypeScript");
+        expect(resolveLanguage("tsx")).toBe("TypeScript");
+        expect(resolveLanguage("py")).toBe("Python");
+        expect(resolveLanguage("go")).toBe("Go");
+        expect(resolveLanguage("sql")).toBe("SQL");
+    });
+
+    it("is case-insensitive and tolerates a leading dot", () => {
+        expect(resolveLanguage(".TS")).toBe("TypeScript");
+        expect(resolveLanguage("JSON")).toBe("JSON");
+    });
+
+    it("falls back to Other for unknown extensions", () => {
+        expect(resolveLanguage("xyz")).toBe("Other");
+        expect(resolveLanguage("")).toBe("Other");
+    });
+});
+
+describe("commentSyntaxForExt", () => {
+    it("returns slash line + slash-star block for C-likes", () => {
+        const syntax = commentSyntaxForExt("ts");
+        expect(syntax.line).toContain("//");
+        expect(syntax.block).toEqual([{ open: "/*", close: "*/" }]);
+    });
+
+    it("returns hash line comments for Python and shell", () => {
+        expect(commentSyntaxForExt("py").line).toEqual(["#"]);
+        expect(commentSyntaxForExt("sh").line).toEqual(["#"]);
+    });
+
+    it("returns html block comments for markdown and html", () => {
+        expect(commentSyntaxForExt("md").block).toEqual([{ open: "<!--", close: "-->" }]);
+        expect(commentSyntaxForExt("html").block).toEqual([{ open: "<!--", close: "-->" }]);
+    });
+
+    it("returns no comment syntax for json", () => {
+        const syntax = commentSyntaxForExt("json");
+        expect(syntax.line).toEqual([]);
+        expect(syntax.block).toEqual([]);
+    });
+});
+
+describe("classifyFile", () => {
+    it("counts blank, code and line comments for TypeScript", () => {
+        const content = ["// a comment", "const x = 1;", "", "   ", "let y = 2; // trailing"].join("\n");
+        expect(classifyFile({ content, ext: "ts" })).toEqual({ code: 2, comment: 1, blank: 2 });
+    });
+
+    it("handles block comments spanning multiple lines (C-like)", () => {
+        const content = ["/* start", " * middle", " end */", "doThing();"].join("\n");
+        expect(classifyFile({ content, ext: "ts" })).toEqual({ code: 1, comment: 3, blank: 0 });
+    });
+
+    it("treats code before a block-open and after a block-close as code", () => {
+        const content = ["foo(); /* note", "still comment */ bar();"].join("\n");
+        expect(classifyFile({ content, ext: "ts" })).toEqual({ code: 2, comment: 0, blank: 0 });
+    });
+
+    it("counts hash comments for Python", () => {
+        const content = ["# header", "x = 1", "", "y = 2  # inline"].join("\n");
+        expect(classifyFile({ content, ext: "py" })).toEqual({ code: 2, comment: 1, blank: 1 });
+    });
+
+    it("counts html block comments in markdown", () => {
+        const content = ["# Title", "<!-- hidden -->", "text"].join("\n");
+        expect(classifyFile({ content, ext: "md" })).toEqual({ code: 2, comment: 1, blank: 0 });
+    });
+
+    it("reports zero comments for json", () => {
+        const content = ['{ "a": 1 }', "", '{ "b": 2 }'].join("\n");
+        expect(classifyFile({ content, ext: "json" })).toEqual({ code: 2, comment: 0, blank: 1 });
+    });
+
+    it("counts an empty file as zero lines", () => {
+        expect(classifyFile({ content: "", ext: "ts" })).toEqual({ code: 0, comment: 0, blank: 0 });
+    });
+});
+
+const sample: FileResult[] = [
+    { ext: "ts", language: "TypeScript", counts: { code: 100, comment: 10, blank: 5 } },
+    { ext: "ts", language: "TypeScript", counts: { code: 50, comment: 5, blank: 2 } },
+    { ext: "py", language: "Python", counts: { code: 200, comment: 20, blank: 8 } },
+    { ext: "json", language: "JSON", counts: { code: 30, comment: 0, blank: 0 } },
+];
+
+const fakeRoot = join(tmpdir(), "loc-fake-root");
+
+describe("buildReport", () => {
+    const now = new Date("2026-06-02T00:52:00.000Z");
+
+    it("groups by language, sorts by code desc, and totals everything", () => {
+        const report = buildReport({ root: fakeRoot, by: "lang", files: sample, now });
+
+        expect(report.by).toBe("lang");
+        expect(report.root).toBe(fakeRoot);
+        expect(report.generatedAt).toBe("2026-06-02T00:52:00.000Z");
+        expect(report.rows.map((r) => r.name)).toEqual(["Python", "TypeScript", "JSON"]);
+        expect(report.rows[1]).toEqual({ name: "TypeScript", files: 2, lines: 172, code: 150, comment: 15, blank: 7 });
+        expect(report.total).toEqual({ files: 4, lines: 430, code: 380, comment: 35, blank: 15 });
+    });
+
+    it("groups by ext when by=ext", () => {
+        const report = buildReport({ root: fakeRoot, by: "ext", files: sample, now });
+        expect(report.rows.map((r) => r.name)).toEqual(["py", "ts", "json"]);
+    });
+
+    it("truncates rows with top but keeps the full total", () => {
+        const report = buildReport({ root: fakeRoot, by: "lang", files: sample, now, top: 1 });
+        expect(report.rows.map((r) => r.name)).toEqual(["Python"]);
+        expect(report.total.code).toBe(380);
+    });
+
+    it("returns an empty report for no files", () => {
+        const report = buildReport({ root: fakeRoot, by: "lang", files: [], now });
+        expect(report.rows).toEqual([]);
+        expect(report.total).toEqual({ files: 0, lines: 0, code: 0, comment: 0, blank: 0 });
+    });
+});
+
+describe("renderTable", () => {
+    const now = new Date("2026-06-02T00:52:00.000Z");
+
+    it("renders a header, data rows, and a Total row", () => {
+        const report = buildReport({ root: fakeRoot, by: "lang", files: sample, now });
+        const text = renderTable(report);
+        expect(text).toContain("Language");
+        expect(text).toContain("Python");
+        expect(text).toContain("Total");
+        expect(text).toContain("430");
+    });
+
+    it("labels the name column Ext when grouping by ext", () => {
+        const report = buildReport({ root: fakeRoot, by: "ext", files: sample, now });
+        const text = renderTable(report);
+        expect(text).toContain("Ext");
+    });
+});
+
+describe("scanDirectory", () => {
+    function makeRepo(): string {
+        const root = mkdtempSync(join(tmpdir(), "loc-test-"));
+        writeFileSync(join(root, "a.ts"), "const x = 1;\n// note\n\n");
+        writeFileSync(join(root, "b.py"), "x = 1\n# c\n");
+        writeFileSync(join(root, ".gitignore"), "ignored.ts\nbuild/\n");
+        writeFileSync(join(root, "ignored.ts"), "const skip = 1;\n");
+        mkdirSync(join(root, "build"));
+        writeFileSync(join(root, "build", "out.js"), "console.log(1);\n");
+        mkdirSync(join(root, "node_modules"));
+        writeFileSync(join(root, "node_modules", "dep.js"), "module.exports = {};\n");
+        mkdirSync(join(root, "nested"));
+        writeFileSync(join(root, "nested", "c.ts"), "export const y = 2;\n");
+        return root;
+    }
+
+    it("honours .gitignore and always skips node_modules", async () => {
+        const root = makeRepo();
+        const results = await scanDirectory({ root, gitignore: true, includeHidden: false });
+        const exts = results.map((r) => r.ext).sort();
+        expect(exts).toEqual(["py", "ts", "ts"]);
+
+        const ts = results.find((r) => r.language === "TypeScript" && r.counts.comment === 1);
+        expect(ts?.counts).toEqual({ code: 1, comment: 1, blank: 1 });
+    });
+
+    it("includes gitignored files when gitignore is disabled but still skips node_modules", async () => {
+        const root = makeRepo();
+        const results = await scanDirectory({ root, gitignore: false, includeHidden: false });
+        const names = results.map((r) => r.ext).sort();
+        expect(names).toEqual(["js", "py", "ts", "ts", "ts"]);
+    });
+});


### PR DESCRIPTION
## Summary

Adds `tools loc [dir]` — a dependency-free "how big is this codebase, and in what?" counter. It walks a directory (respecting the root `.gitignore` via the already-installed `ignore` dep) and reports, per programming language, the number of files plus total / code / blank / comment lines, sorted by code lines descending with a totals row. Runs on Bun directly — no shelling out to an external `cloc`/`tokei` binary.

## CLI surface

```
tools loc [dir]

Arguments:
  dir                Directory to scan (default: current working directory)

Options:
  --top <n>          Show only the top N rows by code lines (totals row always shown)
  --by <key>         Group by "lang" (default) or "ext"
  --json             Emit the report as JSON to stdout instead of a table
  --no-gitignore     Do not honour .gitignore (still skips .git/, node_modules/, dotfiles)
  --include-hidden   Include dotfiles and dot-directories (off by default)
```

## Concept / design

- **Auto-discovered tool.** Lives at `src/loc/index.ts`; no registry edit.
- **Layered, commands-thin.** The entrypoint parses args and emits output; logic lives in `src/loc/lib/`. Two PURE, unit-tested cores: the **classifier** (string + ext to `{ code, comment, blank }`) and the **aggregator** (per-file results + an injected `now: Date` to a deterministic report). The **walker** is the only impure module (disk + `ignore`).
- **Determinism.** `buildReport` never reads the clock — the caller injects `now`, which becomes `report.generatedAt`, so tests assert an exact timestamp.
- **Comment detection is pragmatic** (documented non-goal to match `cloc`/`tokei` exactly): line-comment prefixes (`//`, `#`, `--`), block comments (`/* */`, `<!-- -->`), code-before-open / code-after-close counts as code, no string-literal awareness, Python docstrings count as code.
- **Output discipline.** `out.result(report)` is the only JSON-to-stdout path; `out.println(table)` for the human table; `out.error` + `process.exit(1)` for a missing/non-directory `dir`. Never `console.log`; `SafeJSON` only.

## Files

- `src/loc/index.ts` — commander entrypoint, ends in `runTool(program, { tool: "loc" })`.
- `src/loc/lib/languages.ts` — extension to language map + per-language comment syntax.
- `src/loc/lib/classify.ts` — pure per-file line classifier with a block-comment state machine.
- `src/loc/lib/aggregate.ts` — pure report aggregator (group, sort, totals, `--top` truncation, injected clock).
- `src/loc/lib/walk.ts` — directory walker honouring the root `.gitignore`, always skipping `.git/` and `node_modules/`.
- `src/loc/lib/render.ts` — pure table renderer using `formatTable` + `formatNumber`.
- `src/loc/loc.test.ts` — hermetic `bun:test` suite (tmp dirs, no network/clock dependence).

## Checks (run locally in the worktree)

- `bunx biome check src/loc` — exits 0, no diagnostics.
- `bun test src/loc` — 22 pass / 0 fail, 43 real assertions.
- `./tools loc --help` — exits 0, shows usage with all flags.
- Smoke: table, `--json` (valid SafeJSON), `--top`, `--by ext`, and the bad-dir error path all verified by hand.

## Notes

- No new dependencies; only `commander`, `ignore`, and `@app/*` utils.
- `formatNumber` (reused per spec) abbreviates large counts (`8.2K`), which differs cosmetically from the comma-grouped numbers in the spec's illustrative example — this is the spec-mandated util.
- Two classifier fixes were made beyond the plan's draft so its own test expectations pass: a single trailing newline no longer counts as an extra blank line, and a block comment opened after code on the same line keeps the line classified as code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `loc` CLI command to analyze project files and count code, comment, and blank lines.
  * Supports grouping by language or file extension.
  * Added `--top` to limit displayed groups (overall totals are still included).
  * Honors `.gitignore`, with optional inclusion of hidden files (while skipping common internal folders).
  * Detects comment styles across multiple languages and formats (including block and inline comments).
  * Outputs JSON via `--json` or a readable table by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->