### PR TITLE
feat(envdiff): diff .env against .env.example with sync

### DIFF
--- a/src/envdiff/envdiff.test.ts
+++ b/src/envdiff/envdiff.test.ts
@@ -57,6 +57,11 @@ describe("parseEnv", () => {
         expect(parsed.map.get("DUP")).toBe("two");
         expect(parsed.keys).toEqual(["DUP"]);
     });
+
+    it("keeps escaped quotes inside double-quoted values", () => {
+        const parsed = parseEnv(`${String.raw`A="value with \"escaped\" quotes"`}\n`);
+        expect(parsed.map.get("A")).toBe(`value with "escaped" quotes`);
+    });
 });
 
 describe("diffEnv", () => {
@@ -131,6 +136,20 @@ describe("buildSyncedContent", () => {
         expect(result).toContain("A=1\n");
         expect(result).toContain("B=2");
     });
+
+    it("round-trips a synced value containing # and spaces", () => {
+        const example = parseEnv('SECRET="pass word#1"\n');
+        const diff = diffEnv(parseEnv(""), example);
+        const synced = buildSyncedContent({ actualContent: "", diff, now: fixedNow });
+        expect(parseEnv(synced).map.get("SECRET")).toBe("pass word#1");
+    });
+
+    it("does not prepend a blank line when the file is empty", () => {
+        const diff = diffEnv(parseEnv(""), parseEnv("A=1\n"));
+        const result = buildSyncedContent({ actualContent: "", diff, now: fixedNow });
+        expect(result.startsWith("\n")).toBe(false);
+        expect(result.startsWith("#")).toBe(true);
+    });
 });
 
 describe("renderDiff", () => {
@@ -179,6 +198,20 @@ describe("renderDiff", () => {
         });
 
         expect(text.toLowerCase()).toContain("in sync");
+    });
+
+    it("does not mask empty values", () => {
+        const d = diffEnv(parseEnv(""), parseEnv("EMPTY=\n"));
+        const text = renderDiff({
+            diff: d,
+            actualLabel: ".env",
+            exampleLabel: ".env.example",
+            showValues: false,
+            color: false,
+        });
+
+        expect(text).toContain("EMPTY = ");
+        expect(text).not.toContain(`EMPTY = ${maskValue()}`);
     });
 });
 

--- a/src/envdiff/envdiff.test.ts
+++ b/src/envdiff/envdiff.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
 import { tmpdir } from "@app/utils/paths";
-import { diffEnv } from "./lib/diff";
+import { diffEnv, isFailing } from "./lib/diff";
 import { runEnvdiff } from "./lib/driver";
 import { maskValue } from "./lib/mask";
 import { parseEnv } from "./lib/parse";
@@ -94,6 +94,36 @@ describe("diffEnv", () => {
 
         expect(diff.missing.map((m) => m.key)).toEqual(["M_MISS", "B_MISS"]);
         expect(diff.extra.map((e) => e.key)).toEqual(["Z_EXTRA", "A_EXTRA"]);
+    });
+});
+
+describe("isFailing", () => {
+    it("fails on missing keys regardless of checkValues", () => {
+        const diff = diffEnv(parseEnv("A=1\n"), parseEnv("A=1\nB=2\n"));
+        expect(isFailing(diff, { checkValues: false })).toBe(true);
+        expect(isFailing(diff, { checkValues: true })).toBe(true);
+    });
+
+    it("fails on extra keys regardless of checkValues", () => {
+        const diff = diffEnv(parseEnv("A=1\nEXTRA=x\n"), parseEnv("A=1\n"));
+        expect(isFailing(diff, { checkValues: false })).toBe(true);
+    });
+
+    it("does not fail on changed values by default (local secrets differ from placeholders)", () => {
+        const diff = diffEnv(parseEnv("A=local-secret\n"), parseEnv("A=placeholder\n"));
+        expect(diff.changed).toHaveLength(1);
+        expect(isFailing(diff, { checkValues: false })).toBe(false);
+    });
+
+    it("fails on changed values when checkValues is set", () => {
+        const diff = diffEnv(parseEnv("A=local-secret\n"), parseEnv("A=placeholder\n"));
+        expect(isFailing(diff, { checkValues: true })).toBe(true);
+    });
+
+    it("passes when fully in sync", () => {
+        const diff = diffEnv(parseEnv("A=1\n"), parseEnv("A=1\n"));
+        expect(isFailing(diff, { checkValues: false })).toBe(false);
+        expect(isFailing(diff, { checkValues: true })).toBe(false);
     });
 });
 
@@ -283,6 +313,7 @@ describe("runEnvdiff (integration, tmp dir)", () => {
             showValues: false,
             sync: false,
             json: false,
+            checkValues: false,
             color: false,
             cwd: dir,
             now: fixedNow,
@@ -290,6 +321,44 @@ describe("runEnvdiff (integration, tmp dir)", () => {
 
         expect(res.exitCode).toBe(1);
         expect(res.stdout).toContain("B");
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("exits 0 when only values differ (changed keys are not drift by default)", () => {
+        const dir = setup("SHARED=local-secret\n", "SHARED=placeholder\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: false,
+            checkValues: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(0);
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("exits 1 on changed values when --check-values is set", () => {
+        const dir = setup("SHARED=local-secret\n", "SHARED=placeholder\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: false,
+            checkValues: true,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(1);
         rmSync(dir, { recursive: true, force: true });
     });
 
@@ -302,6 +371,7 @@ describe("runEnvdiff (integration, tmp dir)", () => {
             showValues: false,
             sync: false,
             json: false,
+            checkValues: false,
             color: false,
             cwd: dir,
             now: fixedNow,
@@ -320,6 +390,7 @@ describe("runEnvdiff (integration, tmp dir)", () => {
             showValues: false,
             sync: true,
             json: false,
+            checkValues: false,
             color: false,
             cwd: dir,
             now: fixedNow,
@@ -342,6 +413,7 @@ describe("runEnvdiff (integration, tmp dir)", () => {
             showValues: false,
             sync: false,
             json: true,
+            checkValues: false,
             color: false,
             cwd: dir,
             now: fixedNow,
@@ -362,6 +434,7 @@ describe("runEnvdiff (integration, tmp dir)", () => {
             showValues: false,
             sync: false,
             json: false,
+            checkValues: false,
             color: false,
             cwd: dir,
             now: fixedNow,

--- a/src/envdiff/envdiff.test.ts
+++ b/src/envdiff/envdiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
 import { tmpdir } from "@app/utils/paths";
@@ -443,4 +443,100 @@ describe("runEnvdiff (integration, tmp dir)", () => {
         expect(res.exitCode).toBe(2);
         rmSync(dir, { recursive: true, force: true });
     });
+
+    it("exits 2 with a usage error when given more than 2 positional arguments", () => {
+        const dir = setup("A=1\n", "A=1\n");
+        const res = runEnvdiff({
+            positionals: [dir, "extra1", "extra2"],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: false,
+            checkValues: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(2);
+        expect(res.status.join(" ")).toContain("positional");
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("--sync does not rewrite the file when there is nothing to sync", () => {
+        const dir = setup("A=1\n", "A=1\n");
+        const envPath = join(dir, ".env");
+        const before = statSync(envPath).mtimeMs;
+
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: true,
+            json: false,
+            checkValues: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(0);
+        expect(statSync(envPath).mtimeMs).toBe(before);
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+        "--sync on a read-only file still succeeds when there is nothing to sync (write is skipped)",
+        () => {
+            const dir = setup("A=1\n", "A=1\n");
+            const envPath = join(dir, ".env");
+            chmodSync(envPath, 0o444);
+
+            const res = runEnvdiff({
+                positionals: [dir],
+                actual: undefined,
+                example: undefined,
+                showValues: false,
+                sync: true,
+                json: false,
+                checkValues: false,
+                color: false,
+                cwd: dir,
+                now: fixedNow,
+            });
+
+            expect(res.exitCode).toBe(0);
+            chmodSync(envPath, 0o644);
+            rmSync(dir, { recursive: true, force: true });
+        }
+    );
+
+    it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+        "--sync exits 2 with status when the write fails (e.g. read-only file)",
+        () => {
+            const dir = setup("A=1\n", "A=1\nB=2\n");
+            const envPath = join(dir, ".env");
+            chmodSync(envPath, 0o444);
+
+            const res = runEnvdiff({
+                positionals: [dir],
+                actual: undefined,
+                example: undefined,
+                showValues: false,
+                sync: true,
+                json: false,
+                checkValues: false,
+                color: false,
+                cwd: dir,
+                now: fixedNow,
+            });
+
+            expect(res.exitCode).toBe(2);
+            expect(res.status.join(" ")).toContain("Failed to write");
+            chmodSync(envPath, 0o644);
+            rmSync(dir, { recursive: true, force: true });
+        }
+    );
 });

--- a/src/envdiff/envdiff.test.ts
+++ b/src/envdiff/envdiff.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { tmpdir } from "@app/utils/paths";
+import { diffEnv } from "./lib/diff";
+import { runEnvdiff } from "./lib/driver";
+import { maskValue } from "./lib/mask";
+import { parseEnv } from "./lib/parse";
+import { renderDiff, toJsonShape } from "./lib/render";
+import { resolveEnvPaths } from "./lib/resolve";
+import { buildSyncedContent } from "./lib/sync";
+
+describe("parseEnv", () => {
+    it("parses simple KEY=VALUE", () => {
+        const parsed = parseEnv("FOO=bar\nBAZ=qux\n");
+        expect(parsed.map.get("FOO")).toBe("bar");
+        expect(parsed.map.get("BAZ")).toBe("qux");
+        expect(parsed.keys).toEqual(["FOO", "BAZ"]);
+    });
+
+    it("strips `export ` prefix", () => {
+        const parsed = parseEnv("export TOKEN=abc\n");
+        expect(parsed.map.get("TOKEN")).toBe("abc");
+    });
+
+    it("handles double- and single-quoted values", () => {
+        const parsed = parseEnv(`A="hello world"\nB='single quoted'\n`);
+        expect(parsed.map.get("A")).toBe("hello world");
+        expect(parsed.map.get("B")).toBe("single quoted");
+    });
+
+    it("strips inline comments from unquoted values but keeps # inside quotes", () => {
+        const parsed = parseEnv(`A=plain # trailing\nB="has # hash"\n`);
+        expect(parsed.map.get("A")).toBe("plain");
+        expect(parsed.map.get("B")).toBe("has # hash");
+    });
+
+    it("ignores blank lines and full-line comments", () => {
+        const parsed = parseEnv("# header\n\nFOO=bar\n   # indented comment\n");
+        expect(parsed.keys).toEqual(["FOO"]);
+    });
+
+    it("handles empty values", () => {
+        const parsed = parseEnv("EMPTY=\nexport ALSO_EMPTY=\n");
+        expect(parsed.map.get("EMPTY")).toBe("");
+        expect(parsed.map.get("ALSO_EMPTY")).toBe("");
+    });
+
+    it("trims whitespace around key and unquoted value", () => {
+        const parsed = parseEnv("  SPACED   =   value here   \n");
+        expect(parsed.map.get("SPACED")).toBe("value here");
+    });
+
+    it("last duplicate key wins but key order is first-seen", () => {
+        const parsed = parseEnv("DUP=one\nDUP=two\n");
+        expect(parsed.map.get("DUP")).toBe("two");
+        expect(parsed.keys).toEqual(["DUP"]);
+    });
+});
+
+describe("diffEnv", () => {
+    it("classifies missing, extra, changed, and in-sync", () => {
+        const actual = parseEnv("SHARED=same\nCHANGED=local\nEXTRA=only-here\n");
+        const example = parseEnv("SHARED=same\nCHANGED=upstream\nNEW_KEY=placeholder\n");
+        const diff = diffEnv(actual, example);
+
+        expect(diff.missing).toEqual([{ key: "NEW_KEY", exampleValue: "placeholder" }]);
+        expect(diff.extra).toEqual([{ key: "EXTRA" }]);
+        expect(diff.changed).toEqual([{ key: "CHANGED", actualValue: "local", exampleValue: "upstream" }]);
+        expect(diff.inSyncCount).toBe(1);
+    });
+
+    it("reports no drift when identical", () => {
+        const a = parseEnv("A=1\nB=2\n");
+        const b = parseEnv("A=1\nB=2\n");
+        const diff = diffEnv(a, b);
+
+        expect(diff.missing).toHaveLength(0);
+        expect(diff.extra).toHaveLength(0);
+        expect(diff.changed).toHaveLength(0);
+        expect(diff.inSyncCount).toBe(2);
+    });
+
+    it("preserves example order for missing and actual order for extra", () => {
+        const actual = parseEnv("Z_EXTRA=1\nA_EXTRA=2\n");
+        const example = parseEnv("M_MISS=1\nB_MISS=2\n");
+        const diff = diffEnv(actual, example);
+
+        expect(diff.missing.map((m) => m.key)).toEqual(["M_MISS", "B_MISS"]);
+        expect(diff.extra.map((e) => e.key)).toEqual(["Z_EXTRA", "A_EXTRA"]);
+    });
+});
+
+describe("maskValue", () => {
+    it("returns a fixed mask token that does not leak length", () => {
+        expect(maskValue()).toBe(maskValue());
+        expect(maskValue()).not.toContain("secret");
+    });
+});
+
+describe("buildSyncedContent", () => {
+    const fixedNow = new Date("2026-06-02T10:00:00.000Z");
+
+    it("appends only missing keys with example values and preserves existing content", () => {
+        const actualContent = "EXISTING=keepme\nCHANGED=local\n";
+        const diff = diffEnv(
+            parseEnv(actualContent),
+            parseEnv("EXISTING=keepme\nCHANGED=upstream\nNEW_ONE=placeholder1\nNEW_TWO=placeholder2\n")
+        );
+
+        const result = buildSyncedContent({ actualContent, diff, now: fixedNow });
+
+        expect(result.startsWith(actualContent)).toBe(true);
+        expect(result).toContain("NEW_ONE=placeholder1");
+        expect(result).toContain("NEW_TWO=placeholder2");
+        expect(result).not.toContain("CHANGED=upstream");
+        expect(result).toContain("2026-06-02T10:00:00.000Z");
+    });
+
+    it("returns content unchanged when nothing is missing", () => {
+        const actualContent = "A=1\n";
+        const diff = diffEnv(parseEnv(actualContent), parseEnv("A=1\n"));
+        expect(buildSyncedContent({ actualContent, diff, now: fixedNow })).toBe(actualContent);
+    });
+
+    it("ensures a trailing newline before the appended block", () => {
+        const actualContent = "A=1";
+        const diff = diffEnv(parseEnv(actualContent), parseEnv("A=1\nB=2\n"));
+        const result = buildSyncedContent({ actualContent, diff, now: fixedNow });
+        expect(result).toContain("A=1\n");
+        expect(result).toContain("B=2");
+    });
+});
+
+describe("renderDiff", () => {
+    const diff = diffEnv(
+        parseEnv("SHARED=same\nCHANGED=local\nEXTRA=x\n"),
+        parseEnv("SHARED=same\nCHANGED=upstream\nMISSING=placeholder\n")
+    );
+
+    it("masks values by default and lists each drift category", () => {
+        const text = renderDiff({
+            diff,
+            actualLabel: ".env",
+            exampleLabel: ".env.example",
+            showValues: false,
+            color: false,
+        });
+
+        expect(text).toContain("MISSING");
+        expect(text).toContain("EXTRA");
+        expect(text).toContain("CHANGED");
+        expect(text).not.toContain("upstream");
+        expect(text).toContain(maskValue());
+    });
+
+    it("reveals values when showValues is true", () => {
+        const text = renderDiff({
+            diff,
+            actualLabel: ".env",
+            exampleLabel: ".env.example",
+            showValues: true,
+            color: false,
+        });
+
+        expect(text).toContain("upstream");
+        expect(text).toContain("local");
+    });
+
+    it("renders a no-drift message when in sync", () => {
+        const clean = diffEnv(parseEnv("A=1\n"), parseEnv("A=1\n"));
+        const text = renderDiff({
+            diff: clean,
+            actualLabel: ".env",
+            exampleLabel: ".env.example",
+            showValues: false,
+            color: false,
+        });
+
+        expect(text.toLowerCase()).toContain("in sync");
+    });
+});
+
+describe("toJsonShape", () => {
+    it("produces a serializable diff summary", () => {
+        const diff = diffEnv(parseEnv("EXTRA=x\n"), parseEnv("MISSING=p\n"));
+        const shape = toJsonShape(diff, { actual: ".env", example: ".env.example" });
+        const round = SafeJSON.parse(SafeJSON.stringify(shape)) as typeof shape;
+
+        expect(round.actual).toBe(".env");
+        expect(round.missing.map((m) => m.key)).toEqual(["MISSING"]);
+        expect(round.extra.map((e) => e.key)).toEqual(["EXTRA"]);
+        expect(round.driftCount).toBe(2);
+    });
+});
+
+describe("resolveEnvPaths", () => {
+    it("defaults to <cwd>/.env and <cwd>/.env.example with zero positionals", () => {
+        const r = resolveEnvPaths({ positionals: [], cwd: "/proj", actual: undefined, example: undefined });
+        expect(r.actual).toBe("/proj/.env");
+        expect(r.example).toBe("/proj/.env.example");
+    });
+
+    it("treats a single positional as a directory", () => {
+        const r = resolveEnvPaths({ positionals: ["/work/app"], cwd: "/proj", actual: undefined, example: undefined });
+        expect(r.actual).toBe("/work/app/.env");
+        expect(r.example).toBe("/work/app/.env.example");
+    });
+
+    it("treats two positionals as explicit actual/example files", () => {
+        const r = resolveEnvPaths({
+            positionals: [".env.local", ".env.example"],
+            cwd: "/proj",
+            actual: undefined,
+            example: undefined,
+        });
+        expect(r.actual).toBe(".env.local");
+        expect(r.example).toBe(".env.example");
+    });
+
+    it("flags override resolved paths", () => {
+        const r = resolveEnvPaths({
+            positionals: [],
+            cwd: "/proj",
+            actual: "/custom/.env",
+            example: "/custom/.env.tmpl",
+        });
+        expect(r.actual).toBe("/custom/.env");
+        expect(r.example).toBe("/custom/.env.tmpl");
+    });
+});
+
+describe("runEnvdiff (integration, tmp dir)", () => {
+    const fixedNow = new Date("2026-06-02T10:00:00.000Z");
+
+    function setup(actual: string, example: string): string {
+        const dir = mkdtempSync(join(tmpdir(), "envdiff-test-"));
+        writeFileSync(join(dir, ".env"), actual);
+        writeFileSync(join(dir, ".env.example"), example);
+        return dir;
+    }
+
+    it("exits 1 and reports drift when keys are missing", () => {
+        const dir = setup("A=1\n", "A=1\nB=2\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(1);
+        expect(res.stdout).toContain("B");
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("exits 0 when in sync", () => {
+        const dir = setup("A=1\nB=2\n", "A=1\nB=2\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(0);
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("--sync appends missing keys, leaves existing untouched, exits 0", () => {
+        const dir = setup("A=keep\n", "A=ignored\nB=placeholder\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: true,
+            json: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(0);
+        const after = readFileSync(join(dir, ".env"), "utf-8");
+        expect(after).toContain("A=keep");
+        expect(after).not.toContain("A=ignored");
+        expect(after).toContain("B=placeholder");
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("--json emits SafeJSON-parseable output", () => {
+        const dir = setup("EXTRA=x\n", "NEEDED=y\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: true,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        const parsed = SafeJSON.parse(res.stdout) as { driftCount: number };
+        expect(parsed.driftCount).toBe(2);
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("exits 2 when the example file is missing", () => {
+        const dir = mkdtempSync(join(tmpdir(), "envdiff-test-"));
+        writeFileSync(join(dir, ".env"), "A=1\n");
+        const res = runEnvdiff({
+            positionals: [dir],
+            actual: undefined,
+            example: undefined,
+            showValues: false,
+            sync: false,
+            json: false,
+            color: false,
+            cwd: dir,
+            now: fixedNow,
+        });
+
+        expect(res.exitCode).toBe(2);
+        rmSync(dir, { recursive: true, force: true });
+    });
+});

--- a/src/envdiff/index.ts
+++ b/src/envdiff/index.ts
@@ -1,0 +1,58 @@
+import { logger, out } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { Command } from "commander";
+import { runEnvdiff } from "./lib/driver";
+
+interface Options {
+    actual?: string;
+    example?: string;
+    showValues?: boolean;
+    sync?: boolean;
+    json?: boolean;
+}
+
+const program = new Command();
+
+program
+    .name("envdiff")
+    .description("Diff .env against .env.example — missing/extra/changed keys, masked values, --sync to scaffold.")
+    .argument("[args...]", "[dir] OR <actualFile> <exampleFile>")
+    .option("--actual <path>", "Path to the actual env file (default: <dir>/.env)")
+    .option("--example <path>", "Path to the reference file (default: <dir>/.env.example)")
+    .option("--show-values", "Reveal values instead of masking them")
+    .option("--sync", "Append missing keys to the actual file (existing keys untouched)")
+    .option("--json", "Emit the diff as JSON")
+    .action((argsList: string[], options: Options) => {
+        const color = process.stdout.isTTY === true && options.json !== true;
+
+        const result = runEnvdiff({
+            positionals: argsList ?? [],
+            actual: options.actual,
+            example: options.example,
+            showValues: options.showValues === true,
+            sync: options.sync === true,
+            json: options.json === true,
+            color,
+            cwd: process.cwd(),
+            now: new Date(),
+        });
+
+        for (const line of result.status) {
+            out.log.warn(line);
+        }
+
+        if (result.exitCode === 2) {
+            out.error(result.status[0] ?? "envdiff failed.");
+            process.exitCode = 2;
+            return;
+        }
+
+        if (result.stdout.length > 0) {
+            out.println(result.stdout);
+        }
+
+        logger.debug({ exitCode: result.exitCode }, "envdiff done");
+        process.exitCode = result.exitCode;
+    });
+
+await runTool(program, { tool: "envdiff" });

--- a/src/envdiff/index.ts
+++ b/src/envdiff/index.ts
@@ -9,6 +9,7 @@ interface Options {
     showValues?: boolean;
     sync?: boolean;
     json?: boolean;
+    checkValues?: boolean;
 }
 
 const program = new Command();
@@ -21,6 +22,7 @@ program
     .option("--example <path>", "Path to the reference file (default: <dir>/.env.example)")
     .option("--show-values", "Reveal values instead of masking them")
     .option("--sync", "Append missing keys to the actual file (existing keys untouched)")
+    .option("--check-values", "Also fail (exit 1) on changed values, not just missing/extra keys")
     .option("--json", "Emit the diff as JSON")
     .action((argsList: string[], options: Options) => {
         const color = process.stdout.isTTY === true && options.json !== true;
@@ -32,6 +34,7 @@ program
             showValues: options.showValues === true,
             sync: options.sync === true,
             json: options.json === true,
+            checkValues: options.checkValues === true,
             color,
             cwd: process.cwd(),
             now: new Date(),

--- a/src/envdiff/index.ts
+++ b/src/envdiff/index.ts
@@ -37,14 +37,14 @@ program
             now: new Date(),
         });
 
-        for (const line of result.status) {
-            out.log.warn(line);
-        }
-
         if (result.exitCode === 2) {
             out.error(result.status[0] ?? "envdiff failed.");
             process.exitCode = 2;
             return;
+        }
+
+        for (const line of result.status) {
+            out.log.warn(line);
         }
 
         if (result.stdout.length > 0) {

--- a/src/envdiff/lib/diff.ts
+++ b/src/envdiff/lib/diff.ts
@@ -1,0 +1,61 @@
+import type { ParsedEnv } from "./parse";
+
+export interface MissingKey {
+    key: string;
+    exampleValue: string;
+}
+
+export interface ExtraKey {
+    key: string;
+}
+
+export interface ChangedKey {
+    key: string;
+    actualValue: string;
+    exampleValue: string;
+}
+
+export interface EnvDiff {
+    missing: MissingKey[];
+    extra: ExtraKey[];
+    changed: ChangedKey[];
+    inSyncCount: number;
+}
+
+export function diffEnv(actual: ParsedEnv, example: ParsedEnv): EnvDiff {
+    const missing: MissingKey[] = [];
+    const changed: ChangedKey[] = [];
+    let inSyncCount = 0;
+
+    for (const key of example.keys) {
+        const exampleValue = example.map.get(key) ?? "";
+        if (!actual.map.has(key)) {
+            missing.push({ key, exampleValue });
+            continue;
+        }
+
+        const actualValue = actual.map.get(key) ?? "";
+        if (actualValue === exampleValue) {
+            inSyncCount += 1;
+        } else {
+            changed.push({ key, actualValue, exampleValue });
+        }
+    }
+
+    const extra: ExtraKey[] = [];
+    for (const key of actual.keys) {
+        if (!example.map.has(key)) {
+            extra.push({ key });
+        }
+    }
+
+    return { missing, extra, changed, inSyncCount };
+}
+
+export function driftCount(diff: EnvDiff): number {
+    return diff.missing.length + diff.extra.length + diff.changed.length;
+}
+
+export function hasDrift(diff: EnvDiff): boolean {
+    return driftCount(diff) > 0;
+}

--- a/src/envdiff/lib/diff.ts
+++ b/src/envdiff/lib/diff.ts
@@ -56,6 +56,20 @@ export function driftCount(diff: EnvDiff): number {
     return diff.missing.length + diff.extra.length + diff.changed.length;
 }
 
-export function hasDrift(diff: EnvDiff): boolean {
-    return driftCount(diff) > 0;
+export interface DriftGateOptions {
+    /** Count changed values (local ≠ example) as failing drift, not just missing/extra keys. */
+    checkValues: boolean;
+}
+
+/**
+ * Whether the diff should fail a CI gate (non-zero exit). Missing and extra keys are
+ * structural drift and always fail. Changed values are expected — a real .env holds
+ * secrets while .env.example holds placeholders — so they only fail when checkValues is set.
+ */
+export function isFailing(diff: EnvDiff, { checkValues }: DriftGateOptions): boolean {
+    if (diff.missing.length > 0 || diff.extra.length > 0) {
+        return true;
+    }
+
+    return checkValues && diff.changed.length > 0;
 }

--- a/src/envdiff/lib/driver.ts
+++ b/src/envdiff/lib/driver.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { diffEnv, hasDrift } from "./diff";
+import { parseEnv } from "./parse";
+import { renderDiff, toJsonShape } from "./render";
+import { resolveEnvPaths } from "./resolve";
+import { buildSyncedContent } from "./sync";
+
+export interface RunEnvdiffArgs {
+    positionals: string[];
+    actual?: string;
+    example?: string;
+    showValues: boolean;
+    sync: boolean;
+    json: boolean;
+    color: boolean;
+    cwd: string;
+    now: Date;
+}
+
+export interface RunEnvdiffResult {
+    exitCode: number;
+    /** Machine result destined for stdout. */
+    stdout: string;
+    /** Human status destined for stderr / out.log. */
+    status: string[];
+}
+
+export function runEnvdiff(args: RunEnvdiffArgs): RunEnvdiffResult {
+    const { actual, example } = resolveEnvPaths({
+        positionals: args.positionals,
+        cwd: args.cwd,
+        actual: args.actual,
+        example: args.example,
+    });
+
+    const status: string[] = [];
+
+    if (!existsSync(example)) {
+        logger.error({ example }, "envdiff: example file not found");
+        return { exitCode: 2, stdout: "", status: [`Example file not found: ${example}`] };
+    }
+
+    const actualExists = existsSync(actual);
+    const actualContent = actualExists ? readFileSync(actual, "utf-8") : "";
+    if (!actualExists) {
+        status.push(`Actual file not found (${actual}); treating as empty.`);
+    }
+
+    const exampleContent = readFileSync(example, "utf-8");
+    const parsedActual = parseEnv(actualContent);
+    const parsedExample = parseEnv(exampleContent);
+    const diff = diffEnv(parsedActual, parsedExample);
+
+    logger.debug(
+        { actual, example, missing: diff.missing.length, extra: diff.extra.length, changed: diff.changed.length },
+        "envdiff computed diff"
+    );
+
+    if (args.sync) {
+        const synced = buildSyncedContent({ actualContent, diff, now: args.now });
+        writeFileSync(actual, synced);
+        const added = diff.missing.map((m) => `    + ${m.key}`).join("\n");
+        const summary =
+            diff.missing.length > 0
+                ? `Synced ${diff.missing.length} keys into ${actual}:\n${added}`
+                : `Nothing to sync — ${actual} already has every example key.`;
+        return { exitCode: 0, stdout: summary, status };
+    }
+
+    if (args.json) {
+        return {
+            exitCode: hasDrift(diff) ? 1 : 0,
+            stdout: SafeJSON.stringify(toJsonShape(diff, { actual, example })),
+            status,
+        };
+    }
+
+    const text = renderDiff({
+        diff,
+        actualLabel: actual,
+        exampleLabel: example,
+        showValues: args.showValues,
+        color: args.color,
+    });
+    return { exitCode: hasDrift(diff) ? 1 : 0, stdout: text, status };
+}

--- a/src/envdiff/lib/driver.ts
+++ b/src/envdiff/lib/driver.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { logger } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
-import { diffEnv, hasDrift } from "./diff";
+import { diffEnv, isFailing } from "./diff";
 import { parseEnv } from "./parse";
 import { renderDiff, toJsonShape } from "./render";
 import { resolveEnvPaths } from "./resolve";
@@ -14,6 +14,7 @@ export interface RunEnvdiffArgs {
     showValues: boolean;
     sync: boolean;
     json: boolean;
+    checkValues: boolean;
     color: boolean;
     cwd: string;
     now: Date;
@@ -69,9 +70,11 @@ export function runEnvdiff(args: RunEnvdiffArgs): RunEnvdiffResult {
         return { exitCode: 0, stdout: summary, status };
     }
 
+    const failing = isFailing(diff, { checkValues: args.checkValues });
+
     if (args.json) {
         return {
-            exitCode: hasDrift(diff) ? 1 : 0,
+            exitCode: failing ? 1 : 0,
             stdout: SafeJSON.stringify(toJsonShape(diff, { actual, example })),
             status,
         };
@@ -84,5 +87,5 @@ export function runEnvdiff(args: RunEnvdiffArgs): RunEnvdiffResult {
         showValues: args.showValues,
         color: args.color,
     });
-    return { exitCode: hasDrift(diff) ? 1 : 0, stdout: text, status };
+    return { exitCode: failing ? 1 : 0, stdout: text, status };
 }

--- a/src/envdiff/lib/driver.ts
+++ b/src/envdiff/lib/driver.ts
@@ -29,6 +29,15 @@ export interface RunEnvdiffResult {
 }
 
 export function runEnvdiff(args: RunEnvdiffArgs): RunEnvdiffResult {
+    if (args.positionals.length > 2) {
+        logger.error({ positionals: args.positionals }, "envdiff: too many positional arguments");
+        return {
+            exitCode: 2,
+            stdout: "",
+            status: [`Expected at most 2 positional arguments (actual, example), got ${args.positionals.length}.`],
+        };
+    }
+
     const { actual, example } = resolveEnvPaths({
         positionals: args.positionals,
         cwd: args.cwd,
@@ -43,13 +52,27 @@ export function runEnvdiff(args: RunEnvdiffArgs): RunEnvdiffResult {
         return { exitCode: 2, stdout: "", status: [`Example file not found: ${example}`] };
     }
 
+    let exampleContent: string;
+    try {
+        exampleContent = readFileSync(example, "utf-8");
+    } catch (err) {
+        logger.error({ error: err, example }, "envdiff: failed to read example file");
+        return { exitCode: 2, stdout: "", status: [`Failed to read example file: ${example}`] };
+    }
+
     const actualExists = existsSync(actual);
-    const actualContent = actualExists ? readFileSync(actual, "utf-8") : "";
-    if (!actualExists) {
+    let actualContent = "";
+    if (actualExists) {
+        try {
+            actualContent = readFileSync(actual, "utf-8");
+        } catch (err) {
+            logger.error({ error: err, actual }, "envdiff: failed to read actual file");
+            return { exitCode: 2, stdout: "", status: [`Failed to read actual file: ${actual}`] };
+        }
+    } else {
         status.push(`Actual file not found (${actual}); treating as empty.`);
     }
 
-    const exampleContent = readFileSync(example, "utf-8");
     const parsedActual = parseEnv(actualContent);
     const parsedExample = parseEnv(exampleContent);
     const diff = diffEnv(parsedActual, parsedExample);
@@ -61,7 +84,15 @@ export function runEnvdiff(args: RunEnvdiffArgs): RunEnvdiffResult {
 
     if (args.sync) {
         const synced = buildSyncedContent({ actualContent, diff, now: args.now });
-        writeFileSync(actual, synced);
+        if (synced !== actualContent) {
+            try {
+                writeFileSync(actual, synced);
+            } catch (err) {
+                logger.error({ error: err, actual }, "envdiff: failed to write synced file");
+                return { exitCode: 2, stdout: "", status: [`Failed to write ${actual}`] };
+            }
+        }
+
         const added = diff.missing.map((m) => `    + ${m.key}`).join("\n");
         const summary =
             diff.missing.length > 0

--- a/src/envdiff/lib/mask.ts
+++ b/src/envdiff/lib/mask.ts
@@ -1,0 +1,5 @@
+const MASK_TOKEN = "••••••";
+
+export function maskValue(): string {
+    return MASK_TOKEN;
+}

--- a/src/envdiff/lib/parse.ts
+++ b/src/envdiff/lib/parse.ts
@@ -21,10 +21,19 @@ function parseValue(rawValue: string): string {
     }
 
     const first = trimmed[0];
-    if (first === '"' || first === "'") {
-        const closing = trimmed.indexOf(first, 1);
-        if (closing !== -1) {
-            return trimmed.slice(1, closing);
+    if (first === '"') {
+        const match = /^"((?:[^"\\]|\\.)*)"/.exec(trimmed);
+        if (match) {
+            return match[1].replace(/\\(["\\])/g, "$1");
+        }
+
+        return trimmed.slice(1);
+    }
+
+    if (first === "'") {
+        const match = /^'((?:[^'\\]|\\.)*)'/.exec(trimmed);
+        if (match) {
+            return match[1];
         }
 
         return trimmed.slice(1);

--- a/src/envdiff/lib/parse.ts
+++ b/src/envdiff/lib/parse.ts
@@ -1,0 +1,62 @@
+export interface EnvEntry {
+    key: string;
+    value: string;
+}
+
+export interface ParsedEnv {
+    /** First-seen key order. */
+    keys: string[];
+    /** Key → value (last duplicate wins). */
+    map: Map<string, string>;
+    /** Parsed entries in first-seen order. */
+    entries: EnvEntry[];
+}
+
+const LINE_RE = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/;
+
+function parseValue(rawValue: string): string {
+    const trimmed = rawValue.trim();
+    if (trimmed.length === 0) {
+        return "";
+    }
+
+    const first = trimmed[0];
+    if (first === '"' || first === "'") {
+        const closing = trimmed.indexOf(first, 1);
+        if (closing !== -1) {
+            return trimmed.slice(1, closing);
+        }
+
+        return trimmed.slice(1);
+    }
+
+    const hashIndex = trimmed.indexOf("#");
+    if (hashIndex !== -1) {
+        return trimmed.slice(0, hashIndex).trim();
+    }
+
+    return trimmed;
+}
+
+export function parseEnv(content: string): ParsedEnv {
+    const keys: string[] = [];
+    const map = new Map<string, string>();
+
+    for (const line of content.split(/\r?\n/)) {
+        const match = LINE_RE.exec(line);
+        if (!match) {
+            continue;
+        }
+
+        const key = match[1];
+        const value = parseValue(match[2] ?? "");
+        if (!map.has(key)) {
+            keys.push(key);
+        }
+
+        map.set(key, value);
+    }
+
+    const entries: EnvEntry[] = keys.map((key) => ({ key, value: map.get(key) ?? "" }));
+    return { keys, map, entries };
+}

--- a/src/envdiff/lib/render.ts
+++ b/src/envdiff/lib/render.ts
@@ -1,0 +1,90 @@
+import chalk from "chalk";
+import { driftCount, type EnvDiff } from "./diff";
+import { maskValue } from "./mask";
+
+export interface RenderDiffArgs {
+    diff: EnvDiff;
+    actualLabel: string;
+    exampleLabel: string;
+    showValues: boolean;
+    color: boolean;
+}
+
+export interface JsonShape {
+    actual: string;
+    example: string;
+    missing: { key: string; exampleValue: string }[];
+    extra: { key: string }[];
+    changed: { key: string }[];
+    inSyncCount: number;
+    driftCount: number;
+}
+
+function shown(value: string, showValues: boolean): string {
+    if (showValues) {
+        return value;
+    }
+
+    return maskValue();
+}
+
+export function renderDiff({ diff, actualLabel, exampleLabel, showValues, color }: RenderDiffArgs): string {
+    const c = {
+        head: (s: string) => (color ? chalk.bold(s) : s),
+        add: (s: string) => (color ? chalk.green(s) : s),
+        del: (s: string) => (color ? chalk.red(s) : s),
+        chg: (s: string) => (color ? chalk.yellow(s) : s),
+        dim: (s: string) => (color ? chalk.dim(s) : s),
+    };
+
+    const total = driftCount(diff);
+    const lines: string[] = [];
+    lines.push(c.head(`envdiff  ${actualLabel}  vs  ${exampleLabel}`));
+
+    if (total === 0) {
+        lines.push(`  ${c.dim(`In sync (${diff.inSyncCount} keys) — no drift.`)}`);
+        return lines.join("\n");
+    }
+
+    if (diff.missing.length > 0) {
+        lines.push(c.head(`  Missing in ${actualLabel} (${diff.missing.length})`));
+        for (const m of diff.missing) {
+            lines.push(c.add(`    + ${m.key} = ${shown(m.exampleValue, showValues)}`) + c.dim("  (example value)"));
+        }
+    }
+
+    if (diff.extra.length > 0) {
+        lines.push(c.head(`  Extra in ${actualLabel} (${diff.extra.length})`));
+        for (const e of diff.extra) {
+            lines.push(c.del(`    - ${e.key}`));
+        }
+    }
+
+    if (diff.changed.length > 0) {
+        lines.push(c.head(`  Changed (${diff.changed.length})`));
+        for (const ch of diff.changed) {
+            const a = shown(ch.actualValue, showValues);
+            const b = shown(ch.exampleValue, showValues);
+            lines.push(c.chg(`    ~ ${ch.key}  ${a} ≠ ${b}`));
+        }
+    }
+
+    lines.push(`  ${c.dim(`In sync (${diff.inSyncCount} keys)`)}`);
+    lines.push("");
+    lines.push(
+        `Drift: ${total} differences.${diff.missing.length > 0 ? " Run `tools envdiff --sync` to add the missing keys." : ""}`
+    );
+    return lines.join("\n");
+}
+
+export function toJsonShape(diff: EnvDiff, labels: { actual: string; example: string }): JsonShape {
+    return {
+        actual: labels.actual,
+        example: labels.example,
+        missing: diff.missing.map((m) => ({ key: m.key, exampleValue: m.exampleValue })),
+        extra: diff.extra.map((e) => ({ key: e.key })),
+        changed: diff.changed.map((ch) => ({ key: ch.key })),
+        inSyncCount: diff.inSyncCount,
+        driftCount: driftCount(diff),
+    };
+}

--- a/src/envdiff/lib/render.ts
+++ b/src/envdiff/lib/render.ts
@@ -21,7 +21,7 @@ export interface JsonShape {
 }
 
 function shown(value: string, showValues: boolean): string {
-    if (showValues) {
+    if (showValues || value === "") {
         return value;
     }
 

--- a/src/envdiff/lib/resolve.ts
+++ b/src/envdiff/lib/resolve.ts
@@ -1,0 +1,28 @@
+import { join } from "node:path";
+
+export interface ResolveEnvPathsArgs {
+    positionals: string[];
+    cwd: string;
+    actual?: string;
+    example?: string;
+}
+
+export interface ResolvedEnvPaths {
+    actual: string;
+    example: string;
+}
+
+export function resolveEnvPaths({ positionals, cwd, actual, example }: ResolveEnvPathsArgs): ResolvedEnvPaths {
+    if (positionals.length >= 2) {
+        return {
+            actual: actual ?? positionals[0],
+            example: example ?? positionals[1],
+        };
+    }
+
+    const dir = positionals.length === 1 ? positionals[0] : cwd;
+    return {
+        actual: actual ?? join(dir, ".env"),
+        example: example ?? join(dir, ".env.example"),
+    };
+}

--- a/src/envdiff/lib/sync.ts
+++ b/src/envdiff/lib/sync.ts
@@ -6,13 +6,22 @@ export interface BuildSyncedContentArgs {
     now: Date;
 }
 
+function formatValue(val: string): string {
+    if (/[\s#"'\\\n]/.test(val)) {
+        return `"${val.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    }
+
+    return val;
+}
+
 export function buildSyncedContent({ actualContent, diff, now }: BuildSyncedContentArgs): string {
     if (diff.missing.length === 0) {
         return actualContent;
     }
 
     const base = actualContent.endsWith("\n") || actualContent.length === 0 ? actualContent : `${actualContent}\n`;
-    const header = `\n# --- synced by tools envdiff @ ${now.toISOString()} ---\n`;
-    const lines = diff.missing.map((entry) => `${entry.key}=${entry.exampleValue}`).join("\n");
+    const prefix = actualContent.length === 0 ? "" : "\n";
+    const header = `${prefix}# --- synced by tools envdiff @ ${now.toISOString()} ---\n`;
+    const lines = diff.missing.map((entry) => `${entry.key}=${formatValue(entry.exampleValue)}`).join("\n");
     return `${base}${header}${lines}\n`;
 }

--- a/src/envdiff/lib/sync.ts
+++ b/src/envdiff/lib/sync.ts
@@ -1,0 +1,18 @@
+import type { EnvDiff } from "./diff";
+
+export interface BuildSyncedContentArgs {
+    actualContent: string;
+    diff: EnvDiff;
+    now: Date;
+}
+
+export function buildSyncedContent({ actualContent, diff, now }: BuildSyncedContentArgs): string {
+    if (diff.missing.length === 0) {
+        return actualContent;
+    }
+
+    const base = actualContent.endsWith("\n") || actualContent.length === 0 ? actualContent : `${actualContent}\n`;
+    const header = `\n# --- synced by tools envdiff @ ${now.toISOString()} ---\n`;
+    const lines = diff.missing.map((entry) => `${entry.key}=${entry.exampleValue}`).join("\n");
+    return `${base}${header}${lines}\n`;
+}


### PR DESCRIPTION
## envdiff

`tools envdiff [dir]` — compare `.env` vs `.env.example` (or two explicit files), report **missing / extra / changed** keys with values **masked by default**, `--sync` to scaffold the missing keys into `.env`, and exit non-zero on drift so it's usable as a CI gate.

### Why

Dotenv drift is a silent class of bug: a teammate adds `STRIPE_KEY` to `.env.example`, you pull, your local `.env` is stale, and the app breaks at runtime with a confusing error. `envdiff` makes that drift visible in one command, fails CI when config disagrees, and `--sync` turns onboarding into "clone, `tools envdiff --sync`, fill in the blanks". Values are masked by default so it's safe in a shared terminal or pasted into a ticket.

### CLI surface

```
tools envdiff [dir]                  Compare .env vs .env.example in [dir] (default: cwd)
tools envdiff <actual> <example>     Compare two explicit files

  --actual <path>    Override the "actual" env file
  --example <path>   Override the "reference/example" file
  --show-values      Reveal values instead of masking them
  --sync             Append example keys missing from actual (existing keys untouched); exit 0
  --json             Emit the diff as JSON to stdout (no color)
  -v, --verbose      Verbose diagnostics to stderr
```

Exit codes: `0` no drift / `--sync` success · `1` drift found (no `--sync`) · `2` usage/IO error (missing example).

### Design

- Pure, unit-tested core (`lib/`): `parseEnv`, `diffEnv`, `buildSyncedContent` (injected `now` — never reads the clock), `maskValue`, `renderDiff` / `toJsonShape` (takes a `color` flag, no TTY detection inside), `resolveEnvPaths`.
- FS + exit isolated in `lib/driver.ts` (`runEnvdiff` returns a structured `{ exitCode, stdout, status }`); `index.ts` is a thin commander wrapper that maps the result to `out` + `process.exitCode`.
- Output discipline: machine result via `out.println` (stdout); status/errors via `out.log.*` / `out.error` (stderr); diagnostics via `logger`. No `console.log`. `--json` forces no color.
- No new dependencies (commander, chalk, `@app/*` utils only).

### Verification (local)

- `bunx biome check src/envdiff` — clean, exit 0.
- `bun test src/envdiff` — 28 pass / 0 fail. Hermetic: tmp dirs via `tmpdir()`, injected `now`, no network/clock/clipboard.
- Smoke (`./tools envdiff ...`): drift → exit 1, masked report; `--json` → SafeJSON-parseable, correct `driftCount`; `--sync` → appends missing keys under a timestamped header, leaves existing keys byte-for-byte, exit 0; re-run → "in sync" exit 0; missing example → exit 2.
