### PR TITLE
feat(jwt): decode & inspect a JWT (offline)

### DIFF
--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -1,0 +1,120 @@
+import { logger, out } from "@app/logger";
+import { isInteractive, runTool, suggestCommand } from "@app/utils/cli";
+import { SafeJSON } from "@app/utils/json";
+import { Command } from "commander";
+import { decodeJwt, describeClaimTime, type JwtObject, type TimeClaim } from "./lib/jwt-core";
+
+const TIME_CLAIMS: TimeClaim[] = ["exp", "iat", "nbf"];
+
+function pad(value: number, width = 2): string {
+    return String(value).padStart(width, "0");
+}
+
+// Local YYYY-MM-DD HH:MM:SS — matches the spec's example output. `formatTimestamp`
+// from @app/utils/format is time-only (HH:MM:SS.mmm), which drops the date.
+function formatLocalDateTime(date: Date): string {
+    const ymd = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+    const hms = `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+    return `${ymd} ${hms}`;
+}
+
+function renderValue(value: unknown): string {
+    if (typeof value === "string") {
+        return value;
+    }
+
+    if (typeof value === "number" || typeof value === "boolean" || value === null) {
+        return String(value);
+    }
+
+    return SafeJSON.stringify(value);
+}
+
+function describeIfTimeClaim(key: string, value: unknown, nowMs: number): string | null {
+    if (!TIME_CLAIMS.includes(key as TimeClaim) || typeof value !== "number") {
+        return null;
+    }
+
+    const claim = key as TimeClaim;
+    const verb = claim === "exp" ? "expires" : "issued";
+    const local = formatLocalDateTime(new Date(value * 1000));
+    return `${verb} ${local} — ${describeClaimTime(claim, value, nowMs)}`;
+}
+
+function printHumanized(header: JwtObject, payload: JwtObject, nowMs: number): void {
+    out.println("Header");
+    out.println(`  alg  ${renderValue(header.alg ?? "(none)")}`);
+    out.println(`  typ  ${renderValue(header.typ ?? "(none)")}`);
+    out.println("");
+    out.println("Claims");
+
+    for (const [key, value] of Object.entries(payload)) {
+        const annotation = describeIfTimeClaim(key, value, nowMs);
+        const base = `  ${key}  ${renderValue(value)}`;
+        out.println(annotation ? `${base}   (${annotation})` : base);
+    }
+
+    out.println("");
+    out.println("Signature  not verified (offline decode only)");
+}
+
+async function readToken(argToken: string | undefined): Promise<string | undefined> {
+    if (argToken && argToken.trim().length > 0) {
+        return argToken.trim();
+    }
+
+    if (isInteractive()) {
+        return undefined;
+    }
+
+    const piped = (await Bun.stdin.text()).trim();
+    return piped.length > 0 ? piped : undefined;
+}
+
+async function main(): Promise<void> {
+    const program = new Command()
+        .name("jwt")
+        .description(
+            "Decode & inspect a JWT (offline). Base64url-decodes the header and payload and humanizes " +
+                "exp/iat/nbf into local + relative time. Offline; does not verify signatures."
+        )
+        .argument("[token]", "JWT to decode (omit to read from stdin)")
+        .option("--json", "Print raw decoded { header, payload } as pretty JSON")
+        .option("-v, --verbose", "Verbose diagnostics on stderr (never includes the token)");
+
+    await runTool(program, { tool: "jwt" });
+
+    const options = program.opts<{ json?: boolean; verbose?: boolean }>();
+    const token = await readToken(program.args[0]);
+
+    if (!token) {
+        out.error("Error: no token provided.");
+        out.error(suggestCommand("tools jwt", { add: ["<token>"] }));
+        out.error('Or pipe one:  echo "<token>" | tools jwt');
+        await out.flush();
+        process.exit(1);
+    }
+
+    const result = decodeJwt(token);
+
+    if (!result.ok) {
+        out.error(`Error: ${result.error}`);
+        await out.flush();
+        process.exit(1);
+    }
+
+    // Diagnostics only — NEVER the token or claim values (Requirement 9).
+    logger.debug({ alg: renderValue(result.header.alg ?? "none"), segments: 3 }, "jwt decoded");
+
+    if (options.json) {
+        out.result(SafeJSON.stringify({ header: result.header, payload: result.payload }, null, 2));
+        return;
+    }
+
+    printHumanized(result.header, result.payload, Date.now());
+}
+
+main().catch((error) => {
+    out.error(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+});

--- a/src/jwt/index.ts
+++ b/src/jwt/index.ts
@@ -31,12 +31,12 @@ function renderValue(value: unknown): string {
 }
 
 function describeIfTimeClaim(key: string, value: unknown, nowMs: number): string | null {
-    if (!TIME_CLAIMS.includes(key as TimeClaim) || typeof value !== "number") {
+    if (!TIME_CLAIMS.includes(key as TimeClaim) || typeof value !== "number" || !Number.isFinite(value)) {
         return null;
     }
 
     const claim = key as TimeClaim;
-    const verb = claim === "exp" ? "expires" : "issued";
+    const verb = claim === "exp" ? "expires" : claim === "iat" ? "issued" : "valid from";
     const local = formatLocalDateTime(new Date(value * 1000));
     return `${verb} ${local} — ${describeClaimTime(claim, value, nowMs)}`;
 }
@@ -114,7 +114,8 @@ async function main(): Promise<void> {
     printHumanized(result.header, result.payload, Date.now());
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
     out.error(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    await out.flush();
     process.exit(1);
 });

--- a/src/jwt/jwt.test.ts
+++ b/src/jwt/jwt.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { decodeJwt, describeClaimTime, humanizeDelta } from "./lib/jwt-core";
+
+// Public jwt.io sample token (HS256). Decoding needs no secret.
+const SAMPLE =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+    ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ" +
+    ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+describe("decodeJwt", () => {
+    it("decodes header and payload of a valid token", () => {
+        const result = decodeJwt(SAMPLE);
+        expect(result.ok).toBe(true);
+        if (!result.ok) {
+            throw new Error("expected ok");
+        }
+
+        expect(result.header).toEqual({ alg: "HS256", typ: "JWT" });
+        expect(result.payload).toEqual({ sub: "1234567890", name: "John Doe", iat: 1516239022 });
+        expect(result.signature).toBe("SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+    });
+
+    it("rejects a token without exactly three segments", () => {
+        const result = decodeJwt("aaa.bbb");
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+            throw new Error("expected error");
+        }
+
+        expect(result.error).toContain("3 dot-separated segments");
+        expect(result.error).toContain("got 2");
+    });
+
+    it("rejects an empty segment", () => {
+        const result = decodeJwt("aaa..ccc");
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+            throw new Error("expected error");
+        }
+
+        expect(result.error).toContain("3 dot-separated segments");
+    });
+
+    it("rejects a segment that is not valid JSON", () => {
+        // "###" is not valid base64url → decodes to garbage that is not JSON.
+        const result = decodeJwt("###.###.sig");
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+            throw new Error("expected error");
+        }
+
+        expect(result.error.toLowerCase()).toContain("header");
+    });
+});
+
+const NOW_MS = 1_700_000_000_000; // fixed injected "now"
+
+describe("humanizeDelta", () => {
+    it("formats the largest non-zero unit, floored", () => {
+        expect(humanizeDelta(23 * 60_000)).toBe("23m");
+        expect(humanizeDelta(2 * 3_600_000)).toBe("2h");
+        expect(humanizeDelta(90_000)).toBe("1m");
+        expect(humanizeDelta(45_000)).toBe("45s");
+        expect(humanizeDelta(3 * 86_400_000)).toBe("3d");
+        expect(humanizeDelta(0)).toBe("0s");
+    });
+});
+
+describe("describeClaimTime", () => {
+    it("describes a future exp as 'expires in <Δ>'", () => {
+        const expSeconds = (NOW_MS + 23 * 60_000) / 1000;
+        expect(describeClaimTime("exp", expSeconds, NOW_MS)).toBe("expires in 23m");
+    });
+
+    it("describes a past exp as 'EXPIRED <Δ> ago'", () => {
+        const expSeconds = (NOW_MS - 2 * 3_600_000) / 1000;
+        expect(describeClaimTime("exp", expSeconds, NOW_MS)).toBe("EXPIRED 2h ago");
+    });
+
+    it("describes a past iat as '<Δ> ago'", () => {
+        const iatSeconds = (NOW_MS - 5 * 60_000) / 1000;
+        expect(describeClaimTime("iat", iatSeconds, NOW_MS)).toBe("5m ago");
+    });
+
+    it("describes a future nbf as 'in <Δ>'", () => {
+        const nbfSeconds = (NOW_MS + 10 * 60_000) / 1000;
+        expect(describeClaimTime("nbf", nbfSeconds, NOW_MS)).toBe("in 10m");
+    });
+});

--- a/src/jwt/lib/jwt-core.ts
+++ b/src/jwt/lib/jwt-core.ts
@@ -1,3 +1,4 @@
+import { logger } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 
 export type JwtObject = Record<string, unknown>;
@@ -10,14 +11,16 @@ function decodeSegment(segment: string, label: "header" | "payload"): JwtObject 
     let decoded: string;
     try {
         decoded = Buffer.from(segment, "base64url").toString("utf-8");
-    } catch {
+    } catch (err) {
+        logger.debug({ err, label }, "jwt: base64url decode failed");
         return { error: `failed to base64url-decode the ${label} segment.` };
     }
 
     let parsed: unknown;
     try {
-        parsed = SafeJSON.parse(decoded);
-    } catch {
+        parsed = SafeJSON.parse(decoded, { strict: true });
+    } catch (err) {
+        logger.debug({ err, label }, "jwt: JSON parse failed");
         return { error: `the ${label} segment is not valid JSON.` };
     }
 
@@ -26,6 +29,10 @@ function decodeSegment(segment: string, label: "header" | "payload"): JwtObject 
     }
 
     return parsed as JwtObject;
+}
+
+function isErrorResult(result: JwtObject | { error: string }): result is { error: string } {
+    return typeof (result as { error?: unknown }).error === "string";
 }
 
 export function decodeJwt(token: string): DecodeResult {
@@ -41,12 +48,12 @@ export function decodeJwt(token: string): DecodeResult {
     const [headerSeg, payloadSeg, signature] = segments;
 
     const header = decodeSegment(headerSeg, "header");
-    if ("error" in header) {
+    if (isErrorResult(header)) {
         return { ok: false, error: header.error };
     }
 
     const payload = decodeSegment(payloadSeg, "payload");
-    if ("error" in payload) {
+    if (isErrorResult(payload)) {
         return { ok: false, error: payload.error };
     }
 

--- a/src/jwt/lib/jwt-core.ts
+++ b/src/jwt/lib/jwt-core.ts
@@ -1,0 +1,90 @@
+import { SafeJSON } from "@app/utils/json";
+
+export type JwtObject = Record<string, unknown>;
+
+export type DecodeResult =
+    | { ok: true; header: JwtObject; payload: JwtObject; signature: string }
+    | { ok: false; error: string };
+
+function decodeSegment(segment: string, label: "header" | "payload"): JwtObject | { error: string } {
+    let decoded: string;
+    try {
+        decoded = Buffer.from(segment, "base64url").toString("utf-8");
+    } catch {
+        return { error: `failed to base64url-decode the ${label} segment.` };
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = SafeJSON.parse(decoded);
+    } catch {
+        return { error: `the ${label} segment is not valid JSON.` };
+    }
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return { error: `the ${label} segment is not a JSON object.` };
+    }
+
+    return parsed as JwtObject;
+}
+
+export function decodeJwt(token: string): DecodeResult {
+    const segments = token.trim().split(".");
+
+    if (segments.length !== 3 || segments.some((s) => s.length === 0)) {
+        return {
+            ok: false,
+            error: `not a valid JWT — expected 3 dot-separated segments, got ${segments.length}.`,
+        };
+    }
+
+    const [headerSeg, payloadSeg, signature] = segments;
+
+    const header = decodeSegment(headerSeg, "header");
+    if ("error" in header) {
+        return { ok: false, error: header.error };
+    }
+
+    const payload = decodeSegment(payloadSeg, "payload");
+    if ("error" in payload) {
+        return { ok: false, error: payload.error };
+    }
+
+    return { ok: true, header, payload, signature };
+}
+
+export type TimeClaim = "exp" | "iat" | "nbf";
+
+export function humanizeDelta(absMs: number): string {
+    const seconds = Math.floor(absMs / 1000);
+    if (seconds < 60) {
+        return `${seconds}s`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+        return `${minutes}m`;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        return `${hours}h`;
+    }
+
+    const days = Math.floor(hours / 24);
+    return `${days}d`;
+}
+
+// NumericDate claims are unix SECONDS → ×1000 to compare against nowMs.
+export function describeClaimTime(claim: TimeClaim, valueSeconds: number, nowMs: number): string {
+    const targetMs = valueSeconds * 1000;
+    const deltaMs = targetMs - nowMs;
+    const isPast = deltaMs < 0;
+    const phrase = humanizeDelta(Math.abs(deltaMs));
+
+    if (claim === "exp") {
+        return isPast ? `EXPIRED ${phrase} ago` : `expires in ${phrase}`;
+    }
+
+    return isPast ? `${phrase} ago` : `in ${phrase}`;
+}


### PR DESCRIPTION
## What

Adds `tools jwt <token>` — an offline JWT decoder & inspector. It base64url-decodes a JWT's header and payload, pretty-prints them, and humanizes the registered NumericDate claims (`exp` / `iat` / `nbf`) into local date+time plus a relative phrase like `expires in 23m` or `EXPIRED 2h ago`.

The whole point: answer "what's in this token, and is it expired?" without pasting a (often production) credential into jwt.io. It is **decode-only by design** — no secret, no network, no signature verification — so it is safe on any token and never leaks it off the machine. It also never writes the token (or any claim value) to the day-stamped log file.

## CLI surface

```bash
tools jwt <token>              # humanized Header / Claims / Signature view
echo "<token>" | tools jwt    # stdin (e.g. straight out of curl / pbpaste)
tools jwt <token> --json      # pretty { header, payload } JSON, machine-readable
tools jwt --help              # states clearly it does NOT verify signatures
```

Input precedence: positional `<token>` wins; else stdin; else (interactive TTY, no token) it errors with a `suggestCommand` hint rather than hanging or prompting.

## Concept / design

- **Pure, deterministic core** in `src/jwt/lib/jwt-core.ts`: `decodeJwt` (split + structure-validate + base64url-decode + `SafeJSON.parse`), `humanizeDelta`, and `describeClaimTime`. The time humanizer takes `nowMs` as a parameter and never reads the system clock, so relative-time output is unit-testable and TZ-independent.
- **Thin entrypoint** in `src/jwt/index.ts`: arg/stdin I/O, TTY guard, and presentation only. `Date.now()` lives here, not in the core.
- **base64url** via `Buffer.from(seg, "base64url")` — no new dependency, no hand-rolled alphabet.
- **Never logs the token**: token + claim values flow only through `out.println` / `out.result` (pure stdout, no logger mirror). The single `logger.debug` call passes only `{ alg, segments }`.

## Notes for the reviewer

- The spec's Requirement 6 suggested `formatTimestamp` for the absolute time, but that util is time-only (`HH:MM:SS.mmm`) and drops the date. The spec's *example output* clearly wants a full local datetime (`2018-01-18 02:30:22`), so the entrypoint uses a small local `formatLocalDateTime` (`YYYY-MM-DD HH:MM:SS`) instead. This is display-only, kept out of the asserted pure core.
- Relative phrasing floors to the largest defined unit (`s`/`m`/`h`/`d`); there is no "years" unit, so a very old `iat` shows e.g. `3057d ago` — matches the spec's compact `<Δ>` design.

## Verification (local)

- `bunx biome check src/jwt` -> exit 0 (clean).
- `bun test src/jwt` -> 9 pass / 0 fail (decode + structure errors + relative-time with injected `nowMs`).
- Smoke: `--help` (offline notice present), arg decode, `--json` (valid pretty JSON), stdin parity, malformed 2-segment token -> clear `Error:` + exit 1, future-`exp` token -> `expires in <Δ>`.
- No new npm dependency added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a JWT decoder command-line tool that works offline, decoding tokens from command-line arguments, interactive input, or piped stdin.
  * Displays decoded JWT headers and claims in human-readable format with relative time descriptions for expiration and time-based claims.
  * Includes a notice that signature verification is not performed (offline decode only).

* **Tests**
  * Added comprehensive test suite for JWT decoding and time claim formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->