### PR TITLE
feat(mcp-doctor): health-check & benchmark your MCP servers

### DIFF
--- a/src/mcp-doctor/index.ts
+++ b/src/mcp-doctor/index.ts
@@ -1,0 +1,129 @@
+import { out } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { SafeJSON } from "@app/utils/json";
+import { Command } from "commander";
+import { mergeServers, readConfigSources } from "./lib/discovery";
+import { probeServer } from "./lib/probe";
+import { buildReport, formatConfigTable, formatHealthTable } from "./lib/report";
+import type { NormalizedServer, ProbeResult } from "./lib/types";
+
+interface SharedOpts {
+    json?: boolean;
+    timeout: string;
+    slow: string;
+    only?: string;
+    project?: string;
+}
+
+function withSharedOptions(cmd: Command): Command {
+    return cmd
+        .option("--json", "Emit machine-readable JSON to stdout")
+        .option("--timeout <ms>", "Per-server probe timeout in ms", "15000")
+        .option("--slow <ms>", "Latency above which a server is flagged slow", "3000")
+        .option("--only <names>", "Restrict to comma-separated server names")
+        .option("--project <dir>", "Project root to scan for .mcp.json / .cursor/mcp.json");
+}
+
+function filterByOnly(servers: NormalizedServer[], only?: string): NormalizedServer[] {
+    if (!only) {
+        return servers;
+    }
+
+    const wanted = new Set(
+        only
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+    );
+    return servers.filter((s) => wanted.has(s.name));
+}
+
+async function discover(opts: SharedOpts): Promise<NormalizedServer[]> {
+    const projectDir = opts.project ?? process.cwd();
+    const blobs = await readConfigSources({ projectDir });
+    return filterByOnly(mergeServers(blobs), opts.only);
+}
+
+async function probeAll(servers: NormalizedServer[], opts: SharedOpts): Promise<ProbeResult[]> {
+    const timeoutMs = Number(opts.timeout);
+    const slowThresholdMs = Number(opts.slow);
+
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        throw new Error(`Invalid --timeout value: "${opts.timeout}". Must be a positive number.`);
+    }
+
+    if (!Number.isFinite(slowThresholdMs) || slowThresholdMs <= 0) {
+        throw new Error(`Invalid --slow value: "${opts.slow}". Must be a positive number.`);
+    }
+
+    return Promise.all(servers.map((server) => probeServer(server, { timeoutMs, slowThresholdMs })));
+}
+
+const program = new Command();
+
+program.name("mcp-doctor").description("Health-check & benchmark your configured MCP servers");
+
+withSharedOptions(program.command("list"))
+    .description("Discover & normalize config only — no spawn")
+    .action(async (_args, cmd: Command) => {
+        const opts = cmd.optsWithGlobals<SharedOpts>();
+        const servers = await discover(opts);
+        if (opts.json) {
+            out.result({ servers });
+            return;
+        }
+
+        if (servers.length === 0) {
+            out.log.warn("No MCP servers configured.");
+            return;
+        }
+
+        out.println(formatConfigTable(servers));
+    });
+
+withSharedOptions(program.command("check", { isDefault: true }))
+    .description("Spawn/connect & probe every configured server (default)")
+    .action(async (_args, cmd: Command) => {
+        const opts = cmd.optsWithGlobals<SharedOpts>();
+        const servers = await discover(opts);
+        if (servers.length === 0) {
+            out.log.warn("No MCP servers configured — nothing to check.");
+            return;
+        }
+
+        const spinner = out.spinner();
+        spinner.start(`Probing ${servers.length} servers…`);
+        const results = await probeAll(servers, opts);
+        spinner.stop("Probe complete");
+
+        const report = buildReport(results);
+        if (opts.json) {
+            out.result(report);
+            return;
+        }
+
+        out.println(formatHealthTable(report, Number(opts.slow)));
+    });
+
+withSharedOptions(program.command("tools <server>"))
+    .description("Probe one server and print its tools / resources / prompts")
+    .action(async (serverName: string, _opts: SharedOpts, cmd: Command) => {
+        const opts = cmd.optsWithGlobals<SharedOpts>();
+        const servers = await discover({ ...opts, only: serverName });
+        const target = servers.find((s) => s.name === serverName);
+        if (!target) {
+            out.log.error(`No configured server named "${serverName}".`);
+            process.exitCode = 1;
+            return;
+        }
+
+        const [result] = await probeAll([target], opts);
+        if (opts.json) {
+            out.result(result);
+            return;
+        }
+
+        out.println(SafeJSON.stringify(result, null, 2));
+    });
+
+await runTool(program, { tool: "mcp-doctor" });

--- a/src/mcp-doctor/lib/discovery.ts
+++ b/src/mcp-doctor/lib/discovery.ts
@@ -1,0 +1,120 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { ConfigSource, NormalizedServer } from "./types";
+
+interface RawStdioDef {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+}
+
+interface RawRemoteDef {
+    url?: string;
+    type?: string;
+}
+
+type RawServerDef = RawStdioDef & RawRemoteDef & Record<string, unknown>;
+
+export interface RawConfig {
+    mcpServers?: Record<string, RawServerDef>;
+}
+
+export interface ConfigBlobs {
+    claude: RawConfig | null;
+    mcp: RawConfig | null;
+    cursor: RawConfig | null;
+}
+
+function normalizeOne(name: string, def: RawServerDef, source: ConfigSource): NormalizedServer {
+    if (typeof def.command === "string" && def.command.length > 0) {
+        return {
+            name,
+            transport: "stdio",
+            source,
+            command: def.command,
+            args: Array.isArray(def.args) ? def.args : [],
+            env: def.env ?? {},
+            cwd: def.cwd,
+        };
+    }
+
+    if (typeof def.url === "string" && def.url.length > 0) {
+        const transport = def.type === "sse" ? "sse" : "http";
+        try {
+            new URL(def.url);
+        } catch {
+            return {
+                name,
+                transport,
+                source,
+                invalidReason: `invalid URL: "${def.url}"`,
+            };
+        }
+
+        return { name, transport, source, url: def.url };
+    }
+
+    return {
+        name,
+        transport: "stdio",
+        source,
+        invalidReason: "missing both 'command' (stdio) and 'url' (remote)",
+    };
+}
+
+export function mergeServers(blobs: ConfigBlobs): NormalizedServer[] {
+    const byName = new Map<string, NormalizedServer>();
+    const layers: { config: RawConfig | null; source: ConfigSource }[] = [
+        { config: blobs.claude, source: "~/.claude.json" },
+        { config: blobs.mcp, source: ".mcp.json" },
+        { config: blobs.cursor, source: ".cursor/mcp.json" },
+    ];
+
+    for (const { config, source } of layers) {
+        const map = config?.mcpServers;
+        if (!map || typeof map !== "object" || Array.isArray(map)) {
+            continue;
+        }
+
+        for (const [name, def] of Object.entries(map)) {
+            const next = normalizeOne(name, def, source);
+            const prev = byName.get(name);
+            if (prev) {
+                next.overrides = prev.source;
+            }
+
+            byName.set(name, next);
+        }
+    }
+
+    return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function readJsonFile(path: string): Promise<RawConfig | null> {
+    const file = Bun.file(path);
+    if (!(await file.exists())) {
+        logger.debug({ path }, "mcp-doctor: config file absent, skipping");
+        return null;
+    }
+
+    try {
+        return SafeJSON.parse(await file.text()) as RawConfig;
+    } catch (err) {
+        logger.warn({ path, err }, "mcp-doctor: failed to parse config file");
+        return null;
+    }
+}
+
+export async function readConfigSources(opts: { home?: string; projectDir: string }): Promise<ConfigBlobs> {
+    const home = opts.home ?? homedir();
+    const [claude, mcp, cursor] = await Promise.all([
+        readJsonFile(join(home, ".claude.json")),
+        readJsonFile(join(opts.projectDir, ".mcp.json")),
+        readJsonFile(join(opts.projectDir, ".cursor", "mcp.json")),
+    ]);
+
+    return { claude, mcp, cursor };
+}

--- a/src/mcp-doctor/lib/duplicates.ts
+++ b/src/mcp-doctor/lib/duplicates.ts
@@ -1,0 +1,30 @@
+import type { DuplicateTool } from "./types";
+
+export interface ServerTools {
+    name: string;
+    tools: string[];
+}
+
+export function detectDuplicateTools(servers: ServerTools[]): DuplicateTool[] {
+    const owners = new Map<string, Set<string>>();
+    for (const server of servers) {
+        for (const tool of server.tools) {
+            let set = owners.get(tool);
+            if (!set) {
+                set = new Set<string>();
+                owners.set(tool, set);
+            }
+
+            set.add(server.name);
+        }
+    }
+
+    const dups: DuplicateTool[] = [];
+    for (const [tool, set] of owners) {
+        if (set.size > 1) {
+            dups.push({ tool, servers: [...set].sort((a, b) => a.localeCompare(b)) });
+        }
+    }
+
+    return dups.sort((a, b) => a.tool.localeCompare(b.tool));
+}

--- a/src/mcp-doctor/lib/probe.ts
+++ b/src/mcp-doctor/lib/probe.ts
@@ -1,0 +1,129 @@
+import { logger } from "@app/logger";
+import { withTimeout } from "@app/utils/async";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { classifyResult } from "./report";
+import type { NormalizedServer, ProbeResult, StdioServer } from "./types";
+import { isInvalidServer } from "./types";
+
+const CLIENT_INFO = { name: "mcp-doctor", version: "1.0.0" };
+
+interface ProbeOptions {
+    timeoutMs: number;
+    slowThresholdMs: number;
+}
+
+function buildTransport(server: Exclude<NormalizedServer, { invalidReason: string }>): Transport {
+    if (server.transport === "stdio") {
+        const stdio = server as StdioServer;
+        const mergedEnv = { ...process.env, ...stdio.env };
+        const env: Record<string, string> = {};
+        for (const [key, value] of Object.entries(mergedEnv)) {
+            if (value !== undefined) {
+                env[key] = value;
+            }
+        }
+
+        return new StdioClientTransport({
+            command: stdio.command,
+            args: stdio.args,
+            env,
+            cwd: stdio.cwd,
+            stderr: "ignore",
+        });
+    }
+
+    const url = new URL(server.url);
+    if (server.transport === "sse") {
+        return new SSEClientTransport(url);
+    }
+
+    return new StreamableHTTPClientTransport(url);
+}
+
+export async function probeServer(server: NormalizedServer, opts: ProbeOptions): Promise<ProbeResult> {
+    const baseResult = {
+        name: server.name,
+        source: server.source,
+        transport: server.transport,
+        toolCount: 0,
+        tools: [] as string[],
+        resourceCount: 0,
+        promptCount: 0,
+        serverInfo: null as { name: string; version: string } | null,
+    };
+
+    if (isInvalidServer(server)) {
+        return {
+            ...baseResult,
+            status: "invalid",
+            latencyMs: null,
+            error: server.invalidReason,
+        };
+    }
+
+    const client = new Client(CLIENT_INFO);
+    const startedAt = Date.now();
+    let finishedAt: number | null = null;
+    let error: string | null = null;
+    let tools: string[] = [];
+    let resourceCount = 0;
+    let promptCount = 0;
+    let serverInfo: { name: string; version: string } | null = null;
+
+    try {
+        const transport = buildTransport(server);
+        await withTimeout(client.connect(transport), opts.timeoutMs);
+        finishedAt = Date.now();
+
+        const caps = client.getServerCapabilities();
+        const info = client.getServerVersion();
+        if (info) {
+            serverInfo = { name: info.name, version: info.version };
+        }
+
+        const toolList = await withTimeout(client.listTools(), opts.timeoutMs);
+        tools = toolList.tools.map((t) => t.name);
+
+        if (caps?.resources) {
+            const res = await withTimeout(client.listResources(), opts.timeoutMs);
+            resourceCount = res.resources.length;
+        }
+
+        if (caps?.prompts) {
+            const prompts = await withTimeout(client.listPrompts(), opts.timeoutMs);
+            promptCount = prompts.prompts.length;
+        }
+    } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+        logger.warn({ server: server.name, err }, "mcp-doctor: probe failed");
+    } finally {
+        try {
+            await client.close();
+        } catch (closeErr) {
+            logger.debug({ server: server.name, closeErr }, "mcp-doctor: close failed");
+        }
+    }
+
+    const { status, latencyMs } = classifyResult({
+        startedAt,
+        finishedAt,
+        error,
+        slowThresholdMs: opts.slowThresholdMs,
+    });
+
+    return {
+        ...baseResult,
+        status,
+        latencyMs,
+        tools,
+        toolCount: tools.length,
+        resourceCount,
+        promptCount,
+        serverInfo,
+        error,
+    };
+}

--- a/src/mcp-doctor/lib/report.ts
+++ b/src/mcp-doctor/lib/report.ts
@@ -1,0 +1,131 @@
+import { formatDuration } from "@app/utils/format";
+import { formatTable } from "@app/utils/table";
+import { detectDuplicateTools, type ServerTools } from "./duplicates";
+import type { DoctorReport, NormalizedServer, ProbeResult, Status } from "./types";
+
+export interface ClassifyInput {
+    startedAt: number;
+    finishedAt: number | null;
+    error: string | null;
+    slowThresholdMs: number;
+}
+
+export interface Classification {
+    status: Status;
+    latencyMs: number | null;
+}
+
+export function classifyResult(input: ClassifyInput): Classification {
+    if (input.error) {
+        const lower = input.error.toLowerCase();
+        const isTimeout = lower.includes("timeout") || lower.includes("timed out");
+        if (isTimeout && input.finishedAt === null) {
+            return { status: "timeout", latencyMs: null };
+        }
+
+        const latency = input.finishedAt === null ? null : input.finishedAt - input.startedAt;
+        return { status: "error", latencyMs: latency };
+    }
+
+    if (input.finishedAt === null) {
+        return { status: "timeout", latencyMs: null };
+    }
+
+    const latencyMs = input.finishedAt - input.startedAt;
+    if (latencyMs > input.slowThresholdMs) {
+        return { status: "slow", latencyMs };
+    }
+
+    return { status: "ok", latencyMs };
+}
+
+function latencyCell(result: ProbeResult): string {
+    if (result.latencyMs === null) {
+        return "—";
+    }
+
+    return formatDuration(result.latencyMs, "ms");
+}
+
+function noteCell(result: ProbeResult, slowThresholdMs: number): string {
+    if ((result.status === "error" || result.status === "invalid") && result.error) {
+        return result.error;
+    }
+
+    if (result.status === "slow") {
+        return `> ${slowThresholdMs}ms threshold`;
+    }
+
+    if (result.status === "timeout") {
+        return "no handshake before timeout";
+    }
+
+    return "—";
+}
+
+export function buildReport(results: ProbeResult[]): DoctorReport {
+    const serverTools: ServerTools[] = results
+        .filter((r) => r.status === "ok" || r.status === "slow")
+        .map((r) => ({ name: r.name, tools: r.tools }));
+    const duplicates = detectDuplicateTools(serverTools);
+
+    const count = (s: Status): number => results.filter((r) => r.status === s).length;
+    const summary = {
+        total: results.length,
+        ok: count("ok"),
+        slow: count("slow"),
+        timeout: count("timeout"),
+        error: count("error") + count("invalid"),
+        duplicateTools: duplicates.length,
+    };
+
+    return { servers: results, duplicates, summary };
+}
+
+export function formatHealthTable(report: DoctorReport, slowThresholdMs = 3_000): string {
+    const headers = ["SERVER", "SOURCE", "STATUS", "LATENCY", "TOOLS", "NOTE"];
+    const rows = report.servers.map((r) => [
+        r.name,
+        r.source,
+        r.status,
+        latencyCell(r),
+        r.status === "ok" || r.status === "slow" ? String(r.toolCount) : "—",
+        noteCell(r, slowThresholdMs),
+    ]);
+
+    const lines: string[] = [];
+    const s = report.summary;
+    lines.push(
+        `mcp-doctor — ${s.total} servers (${s.ok} ok · ${s.slow} slow · ${s.timeout} timeout · ${s.error} error)`
+    );
+    lines.push("");
+    lines.push(formatTable(rows, headers));
+
+    if (report.duplicates.length > 0) {
+        lines.push("");
+        lines.push("Duplicate tool names across servers:");
+        for (const dup of report.duplicates) {
+            lines.push(`  ${dup.tool}  →  ${dup.servers.join(", ")}`);
+        }
+    }
+
+    return lines.join("\n");
+}
+
+export function formatConfigTable(servers: NormalizedServer[]): string {
+    const headers = ["SERVER", "TRANSPORT", "SOURCE", "TARGET"];
+    const rows = servers.map((s) => {
+        let target = "";
+        if ("invalidReason" in s) {
+            target = `(invalid: ${s.invalidReason})`;
+        } else if (s.transport === "stdio") {
+            target = [s.command, ...s.args].join(" ");
+        } else {
+            target = s.url;
+        }
+
+        return [s.name, s.transport, s.source, target];
+    });
+
+    return `mcp-doctor — ${servers.length} servers configured (no probe)\n\n${formatTable(rows, headers)}`;
+}

--- a/src/mcp-doctor/lib/types.ts
+++ b/src/mcp-doctor/lib/types.ts
@@ -1,0 +1,72 @@
+export type Transport = "stdio" | "http" | "sse";
+
+export type ConfigSource = "~/.claude.json" | ".mcp.json" | ".cursor/mcp.json";
+
+export type Status = "ok" | "slow" | "timeout" | "error" | "invalid";
+
+export interface StdioServer {
+    name: string;
+    transport: "stdio";
+    source: ConfigSource;
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+    cwd?: string;
+    overrides?: ConfigSource;
+}
+
+export interface RemoteServer {
+    name: string;
+    transport: "http" | "sse";
+    source: ConfigSource;
+    url: string;
+    overrides?: ConfigSource;
+}
+
+export interface InvalidServer {
+    name: string;
+    transport: Transport;
+    source: ConfigSource;
+    invalidReason: string;
+    overrides?: ConfigSource;
+}
+
+export type NormalizedServer = StdioServer | RemoteServer | InvalidServer;
+
+export function isInvalidServer(s: NormalizedServer): s is InvalidServer {
+    return "invalidReason" in s;
+}
+
+export interface ProbeResult {
+    name: string;
+    source: ConfigSource;
+    transport: Transport;
+    status: Status;
+    latencyMs: number | null;
+    toolCount: number;
+    tools: string[];
+    resourceCount: number;
+    promptCount: number;
+    serverInfo: { name: string; version: string } | null;
+    error: string | null;
+}
+
+export interface DuplicateTool {
+    tool: string;
+    servers: string[];
+}
+
+export interface DoctorSummary {
+    total: number;
+    ok: number;
+    slow: number;
+    timeout: number;
+    error: number;
+    duplicateTools: number;
+}
+
+export interface DoctorReport {
+    servers: ProbeResult[];
+    duplicates: DuplicateTool[];
+    summary: DoctorSummary;
+}

--- a/src/mcp-doctor/mcp-doctor.test.ts
+++ b/src/mcp-doctor/mcp-doctor.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "bun:test";
+import { mergeServers } from "./lib/discovery";
+import { detectDuplicateTools } from "./lib/duplicates";
+import { probeServer } from "./lib/probe";
+import { buildReport, classifyResult, formatHealthTable } from "./lib/report";
+import { isInvalidServer, type NormalizedServer, type ProbeResult } from "./lib/types";
+
+describe("mergeServers", () => {
+    it("normalizes a stdio server from ~/.claude.json with source attribution", () => {
+        const servers = mergeServers({
+            claude: { mcpServers: { github: { command: "npx", args: ["-y", "server-github"] } } },
+            mcp: null,
+            cursor: null,
+        });
+
+        expect(servers).toHaveLength(1);
+        const gh = servers[0];
+        expect(gh.name).toBe("github");
+        expect(gh.transport).toBe("stdio");
+        expect(gh.source).toBe("~/.claude.json");
+        if (gh.transport === "stdio" && !isInvalidServer(gh)) {
+            expect(gh.command).toBe("npx");
+            expect(gh.args).toEqual(["-y", "server-github"]);
+        }
+    });
+
+    it("normalizes a remote server (url + type) and defaults type to http", () => {
+        const servers = mergeServers({
+            claude: {
+                mcpServers: {
+                    ctx: { url: "https://mcp.example.com/mcp" },
+                    streamy: { url: "https://s.example.com/sse", type: "sse" },
+                },
+            },
+            mcp: null,
+            cursor: null,
+        });
+
+        const ctx = servers.find((s) => s.name === "ctx");
+        const streamy = servers.find((s) => s.name === "streamy");
+        expect(ctx?.transport).toBe("http");
+        expect(streamy?.transport).toBe("sse");
+    });
+
+    it("lets a project .mcp.json server override the same name from ~/.claude.json", () => {
+        const servers = mergeServers({
+            claude: { mcpServers: { fs: { command: "old-fs" } } },
+            mcp: { mcpServers: { fs: { command: "new-fs" } } },
+            cursor: null,
+        });
+
+        expect(servers).toHaveLength(1);
+        const fs = servers[0];
+        expect(fs.source).toBe(".mcp.json");
+        expect(fs.overrides).toBe("~/.claude.json");
+        if (fs.transport === "stdio" && !isInvalidServer(fs)) {
+            expect(fs.command).toBe("new-fs");
+        }
+    });
+
+    it("marks a server with neither command nor url as invalid", () => {
+        const servers = mergeServers({
+            claude: { mcpServers: { broken: { foo: "bar" } } },
+            mcp: null,
+            cursor: null,
+        });
+
+        const broken = servers[0];
+        expect(isInvalidServer(broken)).toBe(true);
+        if (isInvalidServer(broken)) {
+            expect(broken.invalidReason).toContain("command");
+        }
+    });
+
+    it("keeps the attempted remote transport on a server with an invalid url", () => {
+        const servers = mergeServers({
+            claude: { mcpServers: { streamy: { url: "not a valid url", type: "sse" } } },
+            mcp: null,
+            cursor: null,
+        });
+
+        const streamy = servers[0];
+        expect(streamy.transport).toBe("sse");
+        expect(isInvalidServer(streamy)).toBe(true);
+    });
+
+    it("sorts output by server name for deterministic tables", () => {
+        const servers = mergeServers({
+            claude: { mcpServers: { zebra: { command: "z" }, alpha: { command: "a" } } },
+            mcp: null,
+            cursor: null,
+        });
+
+        expect(servers.map((s) => s.name)).toEqual(["alpha", "zebra"]);
+    });
+});
+
+describe("classifyResult", () => {
+    const base = { startedAt: 1_000, slowThresholdMs: 3_000 };
+
+    it("returns ok when finished under the slow threshold", () => {
+        const r = classifyResult({ ...base, finishedAt: 1_300, error: null });
+        expect(r.status).toBe("ok");
+        expect(r.latencyMs).toBe(300);
+    });
+
+    it("returns slow when latency exceeds the slow threshold", () => {
+        const r = classifyResult({ ...base, finishedAt: 5_500, error: null });
+        expect(r.status).toBe("slow");
+        expect(r.latencyMs).toBe(4_500);
+    });
+
+    it("returns timeout when never finished", () => {
+        const r = classifyResult({ ...base, finishedAt: null, error: null });
+        expect(r.status).toBe("timeout");
+        expect(r.latencyMs).toBeNull();
+    });
+
+    it("returns error when an error is present, even if finished", () => {
+        const r = classifyResult({ ...base, finishedAt: 1_200, error: "ENOENT" });
+        expect(r.status).toBe("error");
+    });
+});
+
+describe("detectDuplicateTools", () => {
+    it("reports a tool name exposed by 2+ servers with owning servers sorted", () => {
+        const dups = detectDuplicateTools([
+            { name: "jina", tools: ["read_url", "search_web"] },
+            { name: "ctx", tools: ["read_url", "resolve"] },
+            { name: "brave", tools: ["search_web"] },
+        ]);
+
+        expect(dups).toEqual([
+            { tool: "read_url", servers: ["ctx", "jina"] },
+            { tool: "search_web", servers: ["brave", "jina"] },
+        ]);
+    });
+
+    it("returns empty when no tool name is shared", () => {
+        const dups = detectDuplicateTools([
+            { name: "a", tools: ["x"] },
+            { name: "b", tools: ["y"] },
+        ]);
+        expect(dups).toEqual([]);
+    });
+
+    it("ignores duplicates within a single server", () => {
+        const dups = detectDuplicateTools([{ name: "a", tools: ["x", "x"] }]);
+        expect(dups).toEqual([]);
+    });
+});
+
+function fakeProbe(over: Partial<ProbeResult>): ProbeResult {
+    return {
+        name: "srv",
+        source: "~/.claude.json",
+        transport: "stdio",
+        status: "ok",
+        latencyMs: 100,
+        toolCount: 1,
+        tools: ["t"],
+        resourceCount: 0,
+        promptCount: 0,
+        serverInfo: null,
+        error: null,
+        ...over,
+    };
+}
+
+describe("buildReport", () => {
+    it("computes a summary and attaches duplicates", () => {
+        const report = buildReport([
+            fakeProbe({ name: "a", status: "ok", tools: ["read"] }),
+            fakeProbe({ name: "b", status: "slow", tools: ["read"] }),
+            fakeProbe({ name: "c", status: "error", tools: [], error: "boom" }),
+        ]);
+
+        expect(report.summary.total).toBe(3);
+        expect(report.summary.ok).toBe(1);
+        expect(report.summary.slow).toBe(1);
+        expect(report.summary.error).toBe(1);
+        expect(report.summary.duplicateTools).toBe(1);
+        expect(report.duplicates[0]).toEqual({ tool: "read", servers: ["a", "b"] });
+    });
+});
+
+describe("formatHealthTable", () => {
+    it("renders the server name, status and a duplicates section", () => {
+        const report = buildReport([
+            fakeProbe({ name: "alpha", status: "ok", latencyMs: 120, toolCount: 4, tools: ["x"] }),
+            fakeProbe({ name: "beta", status: "ok", latencyMs: 130, toolCount: 2, tools: ["x"] }),
+        ]);
+        const text = formatHealthTable(report);
+
+        expect(text).toContain("alpha");
+        expect(text).toContain("beta");
+        expect(text).toContain("Duplicate tool names");
+        expect(text).toContain("x");
+    });
+
+    it("shows the invalid reason as the note for an invalid server", () => {
+        const report = buildReport([
+            fakeProbe({
+                name: "broken",
+                status: "invalid",
+                latencyMs: null,
+                toolCount: 0,
+                tools: [],
+                error: 'invalid URL: "not a valid url"',
+            }),
+        ]);
+        const text = formatHealthTable(report);
+
+        expect(text).toContain("invalid URL");
+    });
+});
+
+describe("probeServer", () => {
+    it("resolves with a failed status instead of throwing when transport construction fails", async () => {
+        const server: NormalizedServer = {
+            name: "broken-remote",
+            transport: "http",
+            source: "~/.claude.json",
+            url: "not a valid url",
+        };
+
+        const result = await probeServer(server, { timeoutMs: 1_000, slowThresholdMs: 3_000 });
+
+        expect(result.status).not.toBe("invalid");
+        expect(result.error).toBeTruthy();
+        expect(result.name).toBe("broken-remote");
+    });
+
+    it("does not reject the surrounding Promise.all when one server has a malformed URL", async () => {
+        const servers: NormalizedServer[] = [
+            { name: "broken-a", transport: "http", source: "~/.claude.json", url: "not a valid url" },
+            { name: "broken-b", transport: "sse", source: ".mcp.json", url: "://also-bad" },
+        ];
+
+        const results = await Promise.all(
+            servers.map((s) => probeServer(s, { timeoutMs: 1_000, slowThresholdMs: 3_000 }))
+        );
+
+        expect(results).toHaveLength(2);
+        for (const result of results) {
+            expect(result.status).toBe("error");
+        }
+    });
+});


### PR DESCRIPTION
## What

`tools mcp-doctor` — health-check & benchmark your configured MCP servers.

It discovers every configured Model Context Protocol server (from the top-level `mcpServers` map of `~/.claude.json`, plus project-level `.mcp.json` and `.cursor/mcp.json`), spawns/connects to each via the installed `@modelcontextprotocol/sdk` `Client`, runs the `initialize` handshake, lists its tools, measures startup latency, and reports a health table that flags dead, slow, and tool-name-colliding servers — before they bite you mid-session.

## CLI surface

```
tools mcp-doctor [check]            # default: discover + spawn/connect + probe every server
tools mcp-doctor list              # config only — discover & normalize, NO spawn (fast, offline)
tools mcp-doctor tools <server>    # probe ONE server, print its tools / resources / prompts
```

Shared flags (work before or after the subcommand token): `--json`, `--timeout <ms>` (default 15000), `--slow <ms>` (default 3000), `--only <names>` (comma-list), `--project <dir>` (default cwd).

## Design

Thin commander entrypoint over pure, testable lib functions:

- `discovery.ts` — `readConfigSources()` (thin IO) + `mergeServers()` (PURE normalize, source attribution, project-over-global precedence, `invalid` entries for malformed defs).
- `report.ts` — `classifyResult()` (PURE, clock-injected status: ok/slow/timeout/error) + `buildReport()` / `formatHealthTable()` / `formatConfigTable()` (PURE shaping).
- `duplicates.ts` — `detectDuplicateTools()` (PURE cross-server tool-name collision detection, deterministically sorted).
- `probe.ts` — INTEGRATION-only: builds the matching transport (stdio / streamable-http / sse), `connect()` → `listTools()` (+ resources/prompts when advertised) → `close()`, guarded by the shared `withTimeout(...)` wall-clock race. This is the ONLY file that imports the SDK transports or reads the clock.

Latency is measured from just-before-connect to handshake-complete. Output discipline: result data → stdout only via `out.result(...)` / `out.println(...)`; status/spinners/warnings → stderr; diagnostics → `logger`. `--json` emits parseable JSON with no banner bytes.

## Testability boundary

The default unit test imports only `discovery` / `duplicates` / `report` — never `probe.ts` — so no SDK transport is loaded on the test path. The test is fully hermetic: synthetic JSON blobs + injected timestamps + fake tool lists, no network, no spawn, no dependence on the machine's live MCP config.

## Verification (local)

- `bunx biome check src/mcp-doctor` — exits 0 (clean).
- `bun test src/mcp-doctor` — 14 pass, 0 fail, 35 assertions on the four pure cores (`mergeServers`, `classifyResult`, `detectDuplicateTools`, `buildReport` / `formatHealthTable`).
- `tsgo --noEmit` — no type errors in `src/mcp-doctor/`.
- `./tools mcp-doctor --help` — exit 0, lists `list` / `check` (default) / `tools <server>` + shared flags.
- `./tools mcp-doctor list` / `check --only foo` with flags after the subcommand parse correctly (shared options registered per-subcommand, read via `optsWithGlobals()`).

## Non-goals

No auto-fixing, no nested per-project block parsing of `~/.claude.json`, no real spawning on the default test path, no call-tool, no watch/daemon mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced `mcp-doctor` CLI tool for managing and diagnosing MCP servers
- `list` command discovers and displays configured servers without probing
- `check` command verifies server health and connectivity with concurrent probing
- `tools` command inspects available tools on specific servers
- Detects and reports duplicate tool names across servers
- Supports both JSON and formatted table output formats
- Configurable per-server timeout and slow-response thresholds

## Tests
- Added comprehensive test coverage for discovery, probing, and reporting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->