### PR TITLE
feat(repo-map): token-efficient repo symbol map for agents

### DIFF
--- a/src/repo-map/index.ts
+++ b/src/repo-map/index.ts
@@ -1,0 +1,140 @@
+import { resolve } from "node:path";
+import { logger, out } from "@app/logger";
+import { runTool, suggestCommand } from "@app/utils/cli";
+import clipboardy from "clipboardy";
+import { Command } from "commander";
+import { packByBudget } from "./lib/pack";
+import { rankFiles } from "./lib/rank";
+import { type IncludedFile, renderJson, renderTree } from "./lib/render";
+import { type ScannedFileWithTokens, scanRepo } from "./lib/scanner";
+
+interface Options {
+    maxTokens: string;
+    lang?: string[];
+    json?: boolean;
+    filesOnly?: boolean;
+    clipboard?: boolean;
+}
+
+const LANG_ALIAS: Record<string, string> = {
+    ts: "typescript",
+    tsx: "tsx",
+    js: "javascript",
+    jsx: "jsx",
+    py: "python",
+    python: "python",
+    go: "go",
+    rs: "rust",
+    rust: "rust",
+    typescript: "typescript",
+    javascript: "javascript",
+};
+
+/** Normalize --lang values (comma-separated and/or repeated) to a set of names. */
+function parseLanguages(values: string[] | undefined): Set<string> | null {
+    if (!values || values.length === 0) {
+        return null;
+    }
+
+    const set = new Set<string>();
+
+    for (const raw of values) {
+        for (const part of raw.split(",")) {
+            const key = part.trim().toLowerCase();
+
+            if (key && LANG_ALIAS[key]) {
+                set.add(LANG_ALIAS[key]);
+            }
+        }
+    }
+
+    return set.size > 0 ? set : null;
+}
+
+async function main(dirArg: string | undefined, options: Options): Promise<void> {
+    const dir = resolve(process.cwd(), dirArg ?? ".");
+    const budget = Number.parseInt(options.maxTokens, 10);
+
+    if (!Number.isFinite(budget) || budget <= 0) {
+        logger.error(`Invalid --max-tokens: ${options.maxTokens}`);
+        logger.info(suggestCommand("tools repo-map", { add: ["--max-tokens", "8000"] }));
+        process.exitCode = 1;
+        return;
+    }
+
+    const languages = parseLanguages(options.lang);
+    const scan = await scanRepo({ dir, languages });
+
+    if (scan.files.length === 0) {
+        out.log.warn("No supported source files found.");
+        out.result(options.json ? { root: scan.root, files: [], elided: [] } : "");
+        return;
+    }
+
+    const ranked = rankFiles({
+        files: scan.files.map((f) => ({
+            path: f.path,
+            size: f.size,
+            fanIn: scan.fanIn[f.path] ?? 0,
+            mtimeMs: f.mtimeMs,
+        })),
+        now: Date.now(),
+    });
+
+    const byPath = new Map<string, ScannedFileWithTokens>(scan.files.map((f) => [f.path, f]));
+    const packInput = ranked.map((r) => ({ path: r.path, rank: r.rank, tokens: byPath.get(r.path)?.tokens ?? 0 }));
+    const packed = packByBudget({ files: packInput, budget });
+
+    const included: IncludedFile[] = packed.included
+        .map((p) => byPath.get(p.path))
+        .filter((f): f is ScannedFileWithTokens => Boolean(f))
+        .map((file) => ({ file, tokens: file.tokens }));
+    const elided = packed.elided.map((p) => byPath.get(p.path)).filter((f): f is ScannedFileWithTokens => Boolean(f));
+
+    const summary = {
+        root: scan.root,
+        budget,
+        usedTokens: packed.usedTokens,
+        filesIncluded: included.length,
+        filesTotal: scan.files.length,
+    };
+
+    if (options.json) {
+        if (options.clipboard) {
+            out.log.warn("--clipboard ignored with --json (structured output goes to stdout).");
+        }
+
+        out.result(renderJson({ ...summary, included, elided }));
+        return;
+    }
+
+    const text = renderTree({ ...summary, included, elided, filesOnly: Boolean(options.filesOnly) });
+
+    if (options.clipboard) {
+        await clipboardy.write(text);
+        out.log.success(`Copied repo map to clipboard (${included.length} files, ${packed.usedTokens} tok).`);
+        return;
+    }
+
+    out.result(text);
+}
+
+const program = new Command()
+    .name("repo-map")
+    .description("Token-efficient repo symbol map for agents (aider-style)")
+    .argument("[dir]", "Directory to map", ".")
+    .option("--max-tokens <n>", "Token budget for the rendered map", "8000")
+    .option(
+        "--lang <list>",
+        "Restrict to languages (comma-separated, repeatable)",
+        (v, prev: string[]) => [...prev, v],
+        []
+    )
+    .option("--json", "Emit structured JSON instead of a tree")
+    .option("--files-only", "List ranked files without per-file symbols")
+    .option("--clipboard", "Copy the rendered map to the clipboard")
+    .action(async (dirArg: string | undefined, options: Options) => {
+        await main(dirArg, options);
+    });
+
+await runTool(program, { tool: "repo-map" });

--- a/src/repo-map/index.ts
+++ b/src/repo-map/index.ts
@@ -111,9 +111,15 @@ async function main(dirArg: string | undefined, options: Options): Promise<void>
     const text = renderTree({ ...summary, included, elided, filesOnly: Boolean(options.filesOnly) });
 
     if (options.clipboard) {
-        await clipboardy.write(text);
-        out.log.success(`Copied repo map to clipboard (${included.length} files, ${packed.usedTokens} tok).`);
-        return;
+        try {
+            await clipboardy.write(text);
+            out.log.success(`Copied repo map to clipboard (${included.length} files, ${packed.usedTokens} tok).`);
+            return;
+        } catch (err) {
+            out.log.error(
+                `Failed to copy to clipboard, printing to stdout instead: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
     }
 
     out.result(text);

--- a/src/repo-map/index.ts
+++ b/src/repo-map/index.ts
@@ -31,24 +31,33 @@ const LANG_ALIAS: Record<string, string> = {
 };
 
 /** Normalize --lang values (comma-separated and/or repeated) to a set of names. */
-function parseLanguages(values: string[] | undefined): Set<string> | null {
+function parseLanguages(values: string[] | undefined): { languages: Set<string> | null; unknown: string[] } {
     if (!values || values.length === 0) {
-        return null;
+        return { languages: null, unknown: [] };
     }
 
     const set = new Set<string>();
+    const unknown = new Set<string>();
 
     for (const raw of values) {
         for (const part of raw.split(",")) {
             const key = part.trim().toLowerCase();
 
-            if (key && LANG_ALIAS[key]) {
-                set.add(LANG_ALIAS[key]);
+            if (!key) {
+                continue;
+            }
+
+            const mapped = LANG_ALIAS[key];
+
+            if (mapped) {
+                set.add(mapped);
+            } else {
+                unknown.add(key);
             }
         }
     }
 
-    return set.size > 0 ? set : null;
+    return { languages: set, unknown: [...unknown] };
 }
 
 async function main(dirArg: string | undefined, options: Options): Promise<void> {
@@ -62,12 +71,36 @@ async function main(dirArg: string | undefined, options: Options): Promise<void>
         return;
     }
 
-    const languages = parseLanguages(options.lang);
+    const { languages, unknown } = parseLanguages(options.lang);
+
+    if (unknown.length > 0) {
+        logger.error(`Unsupported --lang value(s): ${unknown.join(", ")}`);
+        logger.info(suggestCommand("tools repo-map", { add: ["--lang", "ts,py,go,rust"] }));
+        process.exitCode = 1;
+        return;
+    }
+
     const scan = await scanRepo({ dir, languages });
 
     if (scan.files.length === 0) {
         out.log.warn("No supported source files found.");
-        out.result(options.json ? { root: scan.root, files: [], elided: [] } : "");
+
+        if (options.json) {
+            out.result(
+                renderJson({
+                    root: scan.root,
+                    budget,
+                    usedTokens: 0,
+                    filesIncluded: 0,
+                    filesTotal: 0,
+                    included: [],
+                    elided: [],
+                })
+            );
+        } else {
+            out.result("");
+        }
+
         return;
     }
 

--- a/src/repo-map/lib/extract.ts
+++ b/src/repo-map/lib/extract.ts
@@ -13,6 +13,7 @@ const BUILTIN_LANG: Record<string, Lang> = {
 /** declaration.kind() → our SymbolKind. */
 const DECL_KIND_TO_SYMBOL: Record<string, SymbolKind> = {
     function_declaration: "function",
+    generator_function_declaration: "function",
     class_declaration: "class",
     interface_declaration: "interface",
     type_alias_declaration: "type",
@@ -39,7 +40,7 @@ function collapse(text: string): string {
 function findBodyNode(declNode: SgNode): SgNode | null {
     const kind = declNode.kind();
 
-    if (kind === "function_declaration") {
+    if (kind === "function_declaration" || kind === "generator_function_declaration") {
         return getNodeField(declNode, "body");
     }
 

--- a/src/repo-map/lib/extract.ts
+++ b/src/repo-map/lib/extract.ts
@@ -86,21 +86,20 @@ function signatureOf(exportNode: SgNode, declNode: SgNode): string {
     return collapse(head);
 }
 
-/** Resolve the exported name from a declaration node. */
-function nameOf(declNode: SgNode): string | undefined {
+/** Resolve the exported names from a declaration node (multiple for multi-declarator statements). */
+function namesOf(declNode: SgNode): string[] {
     const kind = declNode.kind();
 
     if (kind === "lexical_declaration" || kind === "variable_declaration") {
-        const declarator = declNode.children().find((c) => c.kind() === "variable_declarator");
-
-        if (declarator) {
-            return getNodeField(declarator, "name")?.text();
-        }
-
-        return undefined;
+        return declNode
+            .children()
+            .filter((c) => c.kind() === "variable_declarator")
+            .map((d) => getNodeField(d, "name")?.text())
+            .filter((n): n is string => Boolean(n));
     }
 
-    return getNodeField(declNode, "name")?.text();
+    const name = getNodeField(declNode, "name")?.text();
+    return name ? [name] : [];
 }
 
 /**
@@ -131,13 +130,17 @@ export function extractSymbols(source: string, language: string): ExtractedSymbo
             continue;
         }
 
-        const name = nameOf(decl);
+        const names = namesOf(decl);
 
-        if (!name) {
+        if (names.length === 0) {
             continue;
         }
 
-        out.push({ kind, name, signature: signatureOf(exportNode, decl) });
+        const signature = signatureOf(exportNode, decl);
+
+        for (const name of names) {
+            out.push({ kind, name, signature });
+        }
     }
 
     return out;

--- a/src/repo-map/lib/extract.ts
+++ b/src/repo-map/lib/extract.ts
@@ -1,0 +1,153 @@
+import { EXT_TO_LANG, EXT_TO_LANGUAGE_NAME } from "@app/indexer/lib/ast-languages";
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+import type { ExtractedSymbol, SymbolKind } from "./types";
+
+/** Language name → built-in ast-grep Lang (sync path; TS/TSX/JS only). */
+const BUILTIN_LANG: Record<string, Lang> = {
+    typescript: Lang.TypeScript,
+    tsx: Lang.Tsx,
+    javascript: Lang.JavaScript,
+    jsx: Lang.Tsx,
+};
+
+/** declaration.kind() → our SymbolKind. */
+const DECL_KIND_TO_SYMBOL: Record<string, SymbolKind> = {
+    function_declaration: "function",
+    class_declaration: "class",
+    interface_declaration: "interface",
+    type_alias_declaration: "type",
+    lexical_declaration: "const",
+    variable_declaration: "const",
+};
+
+/**
+ * Access a named field on an SgNode. ast-grep's field() signature is
+ * restrictive, so funnel all accesses through this cast wrapper
+ * (same approach as src/indexer/lib/chunker.ts).
+ */
+function getNodeField(node: SgNode, fieldName: string): SgNode | null {
+    type FieldAccessor = (name: string) => SgNode | null;
+    return (node.field as FieldAccessor)(fieldName);
+}
+
+/** Collapse all interior whitespace runs to single spaces and trim. */
+function collapse(text: string): string {
+    return text.replace(/\s+/g, " ").trim();
+}
+
+/** Locate the body block to strip for a given declaration node, if any. */
+function findBodyNode(declNode: SgNode): SgNode | null {
+    const kind = declNode.kind();
+
+    if (kind === "function_declaration") {
+        return getNodeField(declNode, "body");
+    }
+
+    if (kind === "class_declaration") {
+        return getNodeField(declNode, "body");
+    }
+
+    if (kind === "lexical_declaration" || kind === "variable_declaration") {
+        const declarator = declNode.children().find((c) => c.kind() === "variable_declarator");
+
+        if (!declarator) {
+            return null;
+        }
+
+        const value = getNodeField(declarator, "value");
+
+        if (value && value.kind() === "arrow_function") {
+            return getNodeField(value, "body");
+        }
+
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * Slice a declaration's source from its start up to (but excluding) its body
+ * block, yielding a body-free signature. Falls back to the full text when no
+ * body block exists (interfaces, type aliases).
+ */
+function signatureOf(exportNode: SgNode, declNode: SgNode): string {
+    const full = exportNode.text();
+    const bodyNode = findBodyNode(declNode);
+
+    if (!bodyNode) {
+        return collapse(full);
+    }
+
+    const exportStart = exportNode.range().start.index;
+    const bodyStart = bodyNode.range().start.index;
+    const head = full.slice(0, bodyStart - exportStart);
+    return collapse(head);
+}
+
+/** Resolve the exported name from a declaration node. */
+function nameOf(declNode: SgNode): string | undefined {
+    const kind = declNode.kind();
+
+    if (kind === "lexical_declaration" || kind === "variable_declaration") {
+        const declarator = declNode.children().find((c) => c.kind() === "variable_declarator");
+
+        if (declarator) {
+            return getNodeField(declarator, "name")?.text();
+        }
+
+        return undefined;
+    }
+
+    return getNodeField(declNode, "name")?.text();
+}
+
+/**
+ * Extract exported top-level symbols and their body-free signatures from a
+ * source string. PURE — no I/O, no clock. Built-in TS/TSX/JS use the
+ * synchronous Lang path; unknown languages return [].
+ */
+export function extractSymbols(source: string, language: string): ExtractedSymbol[] {
+    const lang = BUILTIN_LANG[language];
+
+    if (!lang) {
+        return [];
+    }
+
+    const root = parse(lang, source).root();
+    const out: ExtractedSymbol[] = [];
+
+    for (const exportNode of root.findAll({ rule: { kind: "export_statement" } })) {
+        const decl = getNodeField(exportNode, "declaration");
+
+        if (!decl) {
+            continue;
+        }
+
+        const kind = DECL_KIND_TO_SYMBOL[decl.kind()];
+
+        if (!kind) {
+            continue;
+        }
+
+        const name = nameOf(decl);
+
+        if (!name) {
+            continue;
+        }
+
+        out.push({ kind, name, signature: signatureOf(exportNode, decl) });
+    }
+
+    return out;
+}
+
+/** Resolve a filename's extension to a known language name (or null). */
+export function languageForFile(ext: string): string | null {
+    return EXT_TO_LANGUAGE_NAME[ext.toLowerCase()] ?? null;
+}
+
+/** True when the extension maps to a built-in (sync-parseable) language. */
+export function isBuiltinLanguage(ext: string): boolean {
+    return Boolean(EXT_TO_LANG[ext.toLowerCase()]);
+}

--- a/src/repo-map/lib/pack.ts
+++ b/src/repo-map/lib/pack.ts
@@ -1,0 +1,32 @@
+import type { PackInputFile, PackResult } from "./types";
+
+/**
+ * Greedily select files within a token budget. PURE — token counts are inputs;
+ * this core NEVER calls an encoder. Files are visited in descending rank; a
+ * file is included only if it fits the remaining budget (a too-large high-rank
+ * file is skipped so smaller lower-rank files can still fit). Input array is
+ * not mutated.
+ */
+export function packByBudget<T extends PackInputFile>({
+    files,
+    budget,
+}: {
+    files: T[];
+    budget: number;
+}): PackResult<T> {
+    const sorted = [...files].sort((a, b) => b.rank - a.rank);
+    const included: T[] = [];
+    const elided: T[] = [];
+    let used = 0;
+
+    for (const file of sorted) {
+        if (used + file.tokens <= budget) {
+            included.push(file);
+            used += file.tokens;
+        } else {
+            elided.push(file);
+        }
+    }
+
+    return { included, elided, usedTokens: used, budget };
+}

--- a/src/repo-map/lib/rank.ts
+++ b/src/repo-map/lib/rank.ts
@@ -1,0 +1,46 @@
+import type { RankedFile, RankInputFile } from "./types";
+
+const DAY_MS = 86_400_000;
+
+/** Normalize an array of raw values to 0..1 by max (0 when all zero). */
+function normalizeByMax(values: number[]): number[] {
+    const max = Math.max(0, ...values);
+
+    if (max === 0) {
+        return values.map(() => 0);
+    }
+
+    return values.map((v) => v / max);
+}
+
+/**
+ * Rank files by importance. PURE — `now` is injected; the core never reads the
+ * system clock. Score = weighted blend of normalized size, fan-in, and recency
+ * (exponential decay of age in days). Returns a new array sorted descending by
+ * rank (ties broken by path for stable ordering).
+ */
+export function rankFiles({ files, now }: { files: RankInputFile[]; now: number }): RankedFile[] {
+    const sizes = normalizeByMax(files.map((f) => f.size));
+    const fanIns = normalizeByMax(files.map((f) => f.fanIn));
+    const recency = files.map((f) => {
+        const ageDays = Math.max(0, (now - f.mtimeMs) / DAY_MS);
+        return 0.5 ** (ageDays / 14);
+    });
+
+    const W_SIZE = 0.2;
+    const W_FANIN = 0.5;
+    const W_RECENCY = 0.3;
+
+    const ranked: RankedFile[] = files.map((f, i) => ({
+        ...f,
+        rank: W_SIZE * sizes[i] + W_FANIN * fanIns[i] + W_RECENCY * recency[i],
+    }));
+
+    return ranked.sort((a, b) => {
+        if (b.rank !== a.rank) {
+            return b.rank - a.rank;
+        }
+
+        return a.path.localeCompare(b.path);
+    });
+}

--- a/src/repo-map/lib/render.ts
+++ b/src/repo-map/lib/render.ts
@@ -1,0 +1,99 @@
+import { formatTokens } from "@app/utils/format";
+import type { ScannedFile } from "./types";
+
+export interface IncludedFile {
+    file: ScannedFile;
+    tokens: number;
+}
+
+interface RenderSummary {
+    root: string;
+    budget: number;
+    usedTokens: number;
+    filesIncluded: number;
+    filesTotal: number;
+}
+
+interface RenderTreeArgs extends RenderSummary {
+    included: IncludedFile[];
+    elided: ScannedFile[];
+    filesOnly: boolean;
+}
+
+/** Render the human-readable map (tree or files-only) as a string. */
+export function renderTree(args: RenderTreeArgs): string {
+    const { root, budget, usedTokens, filesIncluded, filesTotal, included, elided, filesOnly } = args;
+    const lines: string[] = [];
+
+    lines.push(`repo-map: ${root}  (budget ${budget} tok, used ${usedTokens}, ${filesIncluded}/${filesTotal} files)`);
+    lines.push("");
+
+    for (const { file, tokens } of included) {
+        if (filesOnly) {
+            lines.push(`${file.path}\t${file.symbols.length} symbols\t~${formatTokens(tokens)}`);
+            continue;
+        }
+
+        lines.push(file.path);
+
+        for (const sym of file.symbols) {
+            lines.push(`  ${sym.signature}`);
+        }
+
+        lines.push("");
+    }
+
+    if (elided.length > 0) {
+        const noun = elided.length === 1 ? "file" : "files";
+        lines.push(`… ${elided.length} ${noun} elided to fit budget (raise --max-tokens or use --files-only)`);
+    }
+
+    return lines.join("\n");
+}
+
+interface JsonSymbol {
+    kind: string;
+    name: string;
+    signature: string;
+}
+
+interface JsonFile {
+    path: string;
+    language: string;
+    tokens: number;
+    included: boolean;
+    symbols: JsonSymbol[];
+}
+
+export interface RepoMapJson {
+    root: string;
+    budget: number;
+    usedTokens: number;
+    filesIncluded: number;
+    filesTotal: number;
+    files: JsonFile[];
+    elided: string[];
+}
+
+/** Build the structured JSON object for --json output. */
+export function renderJson(args: RenderSummary & { included: IncludedFile[]; elided: ScannedFile[] }): RepoMapJson {
+    const { root, budget, usedTokens, filesIncluded, filesTotal, included, elided } = args;
+
+    const files: JsonFile[] = included.map(({ file, tokens }) => ({
+        path: file.path,
+        language: file.language,
+        tokens,
+        included: true,
+        symbols: file.symbols.map((s) => ({ kind: s.kind, name: s.name, signature: s.signature })),
+    }));
+
+    return {
+        root,
+        budget,
+        usedTokens,
+        filesIncluded,
+        filesTotal,
+        files,
+        elided: elided.map((f) => f.path),
+    };
+}

--- a/src/repo-map/lib/scanner.ts
+++ b/src/repo-map/lib/scanner.ts
@@ -1,0 +1,168 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { extname, isAbsolute, join, resolve } from "node:path";
+import { EXT_TO_DYNAMIC_LANG } from "@app/indexer/lib/ast-languages";
+import { logger } from "@app/logger";
+import { countTokens } from "@app/utils/tokens";
+import { extractSymbols, isBuiltinLanguage, languageForFile } from "./extract";
+import type { ScannedFile } from "./types";
+
+export interface ScannedFileWithTokens extends ScannedFile {
+    tokens: number;
+}
+
+export interface ScanResult {
+    root: string;
+    files: ScannedFileWithTokens[];
+    /** repo-relative path → number of mapped files importing it. */
+    fanIn: Record<string, number>;
+}
+
+function toPosix(p: string): string {
+    return p.split("\\").join("/");
+}
+
+/** List candidate files via git (honors .gitignore) or null when not a git repo. */
+async function gitListFiles(dir: string): Promise<string[] | null> {
+    const proc = Bun.spawn(["git", "ls-files", "--cached", "--others", "--exclude-standard"], {
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "ignore",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+        return null;
+    }
+
+    return stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+}
+
+const SUPPORTED_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".py", ".go", ".rs"]);
+
+function isSupported(rel: string, languages: Set<string> | null): boolean {
+    const ext = extname(rel).toLowerCase();
+
+    if (!SUPPORTED_EXTS.has(ext)) {
+        return false;
+    }
+
+    if (!languages) {
+        return true;
+    }
+
+    const lang = languageForFile(ext);
+    return lang !== null && languages.has(lang);
+}
+
+/** Extract raw import module specifiers from TS/JS source (cheap regex). */
+function extractImports(source: string): string[] {
+    const out: string[] = [];
+    const re = /(?:import|export)[^"']*?from\s*["']([^"']+)["']|require\(\s*["']([^"']+)["']\s*\)/g;
+    let m: RegExpExecArray | null = re.exec(source);
+
+    while (m !== null) {
+        const spec = m[1] ?? m[2];
+
+        if (spec) {
+            out.push(spec);
+        }
+
+        m = re.exec(source);
+    }
+
+    return out;
+}
+
+/** Resolve a relative import specifier to a repo-relative path (best-effort). */
+function resolveImport(fromRel: string, spec: string, knownPaths: Set<string>): string | null {
+    if (!spec.startsWith(".")) {
+        return null;
+    }
+
+    const baseDir = toPosix(join(fromRel, ".."));
+    const target = toPosix(join(baseDir, spec));
+    const candidates = [target, ...[".ts", ".tsx", ".js", ".jsx"].map((e) => `${target}${e}`), `${target}/index.ts`];
+
+    for (const c of candidates) {
+        if (knownPaths.has(c)) {
+            return c;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Scan a directory into a structural map. IMPURE: touches fs/git and calls
+ * countTokens (the single token-counting site). `languages` is a set of
+ * language NAMES (e.g. "typescript") or null for all supported.
+ */
+export async function scanRepo({
+    dir,
+    languages,
+}: {
+    dir: string;
+    languages: Set<string> | null;
+}): Promise<ScanResult> {
+    const root = isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
+    const gitFiles = await gitListFiles(root);
+
+    if (gitFiles === null) {
+        logger.debug(
+            `repo-map: ${root} is not a git repo; no files discovered (manual ignore-walk fallback unimplemented)`
+        );
+    }
+
+    const rels = (gitFiles ?? []).filter((rel) => isSupported(rel, languages));
+    const built: ScannedFileWithTokens[] = [];
+
+    for (const rel of rels) {
+        const absPath = join(root, rel);
+
+        if (!existsSync(absPath)) {
+            continue;
+        }
+
+        const ext = extname(rel).toLowerCase();
+        const language = languageForFile(ext) ?? "unknown";
+        const source = readFileSync(absPath, "utf-8");
+        const stat = statSync(absPath);
+        const symbols = isBuiltinLanguage(ext) ? extractSymbols(source, language) : [];
+
+        if (!isBuiltinLanguage(ext) && EXT_TO_DYNAMIC_LANG[ext]) {
+            logger.debug(`repo-map: ${rel} is a dynamic-language file; symbol extraction is best-effort/skipped here`);
+        }
+
+        const signaturesText = symbols.map((s) => s.signature).join("\n");
+        built.push({
+            path: toPosix(rel),
+            absPath,
+            language,
+            size: stat.size,
+            mtimeMs: stat.mtimeMs,
+            imports: extractImports(source),
+            symbols,
+            tokens: countTokens(`${rel}\n${signaturesText}`),
+        });
+    }
+
+    const knownPaths = new Set(built.map((f) => f.path));
+    const fanIn: Record<string, number> = {};
+
+    for (const file of built) {
+        for (const spec of file.imports) {
+            const target = resolveImport(file.path, spec, knownPaths);
+
+            if (target) {
+                fanIn[target] = (fanIn[target] ?? 0) + 1;
+            }
+        }
+    }
+
+    return { root, files: built, fanIn };
+}

--- a/src/repo-map/lib/scanner.ts
+++ b/src/repo-map/lib/scanner.ts
@@ -4,7 +4,7 @@ import { EXT_TO_DYNAMIC_LANG } from "@app/indexer/lib/ast-languages";
 import { logger } from "@app/logger";
 import { countTokens } from "@app/utils/tokens";
 import { extractSymbols, isBuiltinLanguage, languageForFile } from "./extract";
-import type { ScannedFile } from "./types";
+import type { ExtractedSymbol, ScannedFile } from "./types";
 
 export interface ScannedFileWithTokens extends ScannedFile {
     tokens: number;
@@ -23,23 +23,30 @@ function toPosix(p: string): string {
 
 /** List candidate files via git (honors .gitignore) or null when not a git repo. */
 async function gitListFiles(dir: string): Promise<string[] | null> {
-    const proc = Bun.spawn(["git", "ls-files", "--cached", "--others", "--exclude-standard"], {
-        cwd: dir,
-        stdout: "pipe",
-        stderr: "ignore",
-    });
+    try {
+        const proc = Bun.spawn(["git", "ls-files", "--cached", "--others", "--exclude-standard"], {
+            cwd: dir,
+            stdout: "pipe",
+            stderr: "ignore",
+        });
 
-    const stdout = await new Response(proc.stdout).text();
-    await proc.exited;
+        const stdout = await new Response(proc.stdout).text();
+        await proc.exited;
 
-    if (proc.exitCode !== 0) {
+        if (proc.exitCode !== 0) {
+            return null;
+        }
+
+        return stdout
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l.length > 0);
+    } catch (err) {
+        logger.debug(
+            `repo-map: git ls-files failed (git missing or not a repo): ${err instanceof Error ? err.message : String(err)}`
+        );
         return null;
     }
-
-    return stdout
-        .split("\n")
-        .map((l) => l.trim())
-        .filter((l) => l.length > 0);
 }
 
 const SUPPORTED_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".py", ".go", ".rs"]);
@@ -62,7 +69,7 @@ function isSupported(rel: string, languages: Set<string> | null): boolean {
 /** Extract raw import module specifiers from TS/JS source (cheap regex). */
 function extractImports(source: string): string[] {
     const out: string[] = [];
-    const re = /(?:import|export)[^"']*?from\s*["']([^"']+)["']|require\(\s*["']([^"']+)["']\s*\)/g;
+    const re = /(?:import|export)[^"']*?from\s*["']([^"']+)["']|(?:require|import)\(\s*["']([^"']+)["']\s*\)/g;
     let m: RegExpExecArray | null = re.exec(source);
 
     while (m !== null) {
@@ -86,7 +93,12 @@ function resolveImport(fromRel: string, spec: string, knownPaths: Set<string>): 
 
     const baseDir = toPosix(join(fromRel, ".."));
     const target = toPosix(join(baseDir, spec));
-    const candidates = [target, ...[".ts", ".tsx", ".js", ".jsx"].map((e) => `${target}${e}`), `${target}/index.ts`];
+    const extensions = [".ts", ".tsx", ".js", ".jsx"];
+    const candidates = [
+        target,
+        ...extensions.map((e) => `${target}${e}`),
+        ...extensions.map((e) => `${target}/index${e}`),
+    ];
 
     for (const c of candidates) {
         if (knownPaths.has(c)) {
@@ -132,7 +144,15 @@ export async function scanRepo({
         const language = languageForFile(ext) ?? "unknown";
         const source = readFileSync(absPath, "utf-8");
         const stat = statSync(absPath);
-        const symbols = isBuiltinLanguage(ext) ? extractSymbols(source, language) : [];
+        let symbols: ExtractedSymbol[] = [];
+
+        if (isBuiltinLanguage(ext)) {
+            try {
+                symbols = extractSymbols(source, language);
+            } catch (err) {
+                logger.error({ rel, err }, "repo-map: failed to extract symbols");
+            }
+        }
 
         if (!isBuiltinLanguage(ext) && EXT_TO_DYNAMIC_LANG[ext]) {
             logger.debug(`repo-map: ${rel} is a dynamic-language file; symbol extraction is best-effort/skipped here`);

--- a/src/repo-map/lib/scanner.ts
+++ b/src/repo-map/lib/scanner.ts
@@ -93,7 +93,7 @@ function resolveImport(fromRel: string, spec: string, knownPaths: Set<string>): 
 
     const baseDir = toPosix(join(fromRel, ".."));
     const target = toPosix(join(baseDir, spec));
-    const extensions = [".ts", ".tsx", ".js", ".jsx"];
+    const extensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
     const candidates = [
         target,
         ...extensions.map((e) => `${target}${e}`),
@@ -175,12 +175,18 @@ export async function scanRepo({
     const fanIn: Record<string, number> = {};
 
     for (const file of built) {
+        const importedTargets = new Set<string>();
+
         for (const spec of file.imports) {
             const target = resolveImport(file.path, spec, knownPaths);
 
             if (target) {
-                fanIn[target] = (fanIn[target] ?? 0) + 1;
+                importedTargets.add(target);
             }
+        }
+
+        for (const target of importedTargets) {
+            fanIn[target] = (fanIn[target] ?? 0) + 1;
         }
     }
 

--- a/src/repo-map/lib/types.ts
+++ b/src/repo-map/lib/types.ts
@@ -1,0 +1,52 @@
+export type SymbolKind = "function" | "class" | "interface" | "type" | "const" | "method";
+
+export interface ExtractedSymbol {
+    kind: SymbolKind;
+    name: string;
+    /** Body-free signature, whitespace-collapsed. e.g. `export function foo(a: number): string` */
+    signature: string;
+}
+
+/** A file as produced by the scanner, before ranking. */
+export interface ScannedFile {
+    /** Repo-relative POSIX path, e.g. "src/utils/format.ts" */
+    path: string;
+    /** Absolute path on disk. */
+    absPath: string;
+    language: string;
+    /** Bytes of source. */
+    size: number;
+    /** File mtime in ms since epoch. */
+    mtimeMs: number;
+    symbols: ExtractedSymbol[];
+    /** Import sources this file references (raw module specifiers). */
+    imports: string[];
+}
+
+/** Input to the ranking core (numbers only — no fs, no clock). */
+export interface RankInputFile {
+    path: string;
+    size: number;
+    /** Number of other mapped files that import this file. */
+    fanIn: number;
+    mtimeMs: number;
+}
+
+export interface RankedFile extends RankInputFile {
+    /** Normalized 0..1 importance score (higher = more important). */
+    rank: number;
+}
+
+/** A file as fed to the packer: rank + total token cost already computed. */
+export interface PackInputFile {
+    path: string;
+    rank: number;
+    tokens: number;
+}
+
+export interface PackResult<T extends PackInputFile = PackInputFile> {
+    included: T[];
+    elided: T[];
+    usedTokens: number;
+    budget: number;
+}

--- a/src/repo-map/repo-map.test.ts
+++ b/src/repo-map/repo-map.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { extractSymbols } from "./lib/extract";
+import { packByBudget } from "./lib/pack";
+import { rankFiles } from "./lib/rank";
+import { renderJson, renderTree } from "./lib/render";
+import { scanRepo } from "./lib/scanner";
+import type { ScannedFile } from "./lib/types";
+
+const TS_SAMPLE = `import { x } from "./other";
+
+export function foo(a: number, b: string): string {
+    return b + a;
+}
+
+export const bar = (n: number): number => {
+    return n + 1;
+};
+
+export class Baz {
+    method(x: string): void {}
+}
+
+export interface Q {
+    a: number;
+}
+
+export type T = { a: number };
+
+function notExported() {
+    return 1;
+}
+`;
+
+describe("extractSymbols (typescript)", () => {
+    const syms = extractSymbols(TS_SAMPLE, "typescript");
+    const byName = (name: string) => syms.find((s) => s.name === name);
+
+    test("extracts exported function signature without body", () => {
+        expect(byName("foo")).toEqual({
+            kind: "function",
+            name: "foo",
+            signature: "export function foo(a: number, b: string): string",
+        });
+    });
+
+    test("extracts exported arrow-const signature without body", () => {
+        expect(byName("bar")).toEqual({
+            kind: "const",
+            name: "bar",
+            signature: "export const bar = (n: number): number =>",
+        });
+    });
+
+    test("extracts exported class signature without body", () => {
+        expect(byName("Baz")).toEqual({
+            kind: "class",
+            name: "Baz",
+            signature: "export class Baz",
+        });
+    });
+
+    test("extracts interface and type-alias signatures", () => {
+        expect(byName("Q")?.kind).toBe("interface");
+        expect(byName("Q")?.signature).toBe("export interface Q { a: number; }");
+        expect(byName("T")).toEqual({
+            kind: "type",
+            name: "T",
+            signature: "export type T = { a: number };",
+        });
+    });
+
+    test("ignores non-exported top-level declarations", () => {
+        expect(byName("notExported")).toBeUndefined();
+    });
+
+    test("returns [] for unsupported languages", () => {
+        expect(extractSymbols("def foo(): pass", "python")).toEqual([]);
+    });
+});
+
+describe("rankFiles (deterministic, injected now)", () => {
+    const now = 1_700_000_000_000;
+    const base = { size: 1000, mtimeMs: now - 86_400_000 };
+
+    test("higher fan-in ranks first when size+recency equal", () => {
+        const ranked = rankFiles({
+            files: [
+                { path: "a", fanIn: 0, ...base },
+                { path: "b", fanIn: 5, ...base },
+            ],
+            now,
+        });
+        expect(ranked[0].path).toBe("b");
+        expect(ranked[1].path).toBe("a");
+    });
+
+    test("more recent file ranks higher when size+fanIn equal", () => {
+        const ranked = rankFiles({
+            files: [
+                { path: "old", fanIn: 0, size: 1000, mtimeMs: now - 30 * 86_400_000 },
+                { path: "new", fanIn: 0, size: 1000, mtimeMs: now - 1 * 86_400_000 },
+            ],
+            now,
+        });
+        expect(ranked[0].path).toBe("new");
+    });
+
+    test("does not read the system clock (stable across calls)", () => {
+        const input = { files: [{ path: "a", fanIn: 1, ...base }], now };
+        expect(rankFiles(input)[0].rank).toBe(rankFiles(input)[0].rank);
+    });
+});
+
+describe("packByBudget (greedy, counts injected)", () => {
+    const files = [
+        { path: "a", rank: 0.9, tokens: 100 },
+        { path: "b", rank: 0.5, tokens: 100 },
+        { path: "c", rank: 0.1, tokens: 100 },
+    ];
+
+    test("includes files in rank order until budget exceeded", () => {
+        const res = packByBudget({ files, budget: 250 });
+        expect(res.included.map((f) => f.path)).toEqual(["a", "b"]);
+        expect(res.elided.map((f) => f.path)).toEqual(["c"]);
+    });
+
+    test("never exceeds the budget", () => {
+        const res = packByBudget({ files, budget: 250 });
+        const sum = res.included.reduce((acc, f) => acc + f.tokens, 0);
+        expect(sum).toBeLessThanOrEqual(250);
+        expect(res.usedTokens).toBe(sum);
+    });
+
+    test("skips an over-budget high-rank file but keeps fitting lower ones", () => {
+        const mixed = [
+            { path: "big", rank: 0.9, tokens: 500 },
+            { path: "small", rank: 0.5, tokens: 100 },
+        ];
+        const res = packByBudget({ files: mixed, budget: 200 });
+        expect(res.included.map((f) => f.path)).toEqual(["small"]);
+        expect(res.elided.map((f) => f.path)).toEqual(["big"]);
+    });
+
+    test("does not mutate input order", () => {
+        const input = [...files];
+        packByBudget({ files: input, budget: 100 });
+        expect(input.map((f) => f.path)).toEqual(["a", "b", "c"]);
+    });
+});
+
+function fakeScanned(path: string): ScannedFile {
+    return {
+        path,
+        absPath: join(tmpdir(), path),
+        language: "typescript",
+        size: 100,
+        mtimeMs: 0,
+        imports: [],
+        symbols: [{ kind: "function", name: "foo", signature: "export function foo(): void" }],
+    };
+}
+
+describe("render", () => {
+    const root = join(tmpdir(), "proj");
+    const included = [{ file: fakeScanned("a.ts"), tokens: 20 }];
+    const elided = [fakeScanned("b.ts")];
+    const summary = { root, budget: 8000, usedTokens: 20, filesIncluded: 1, filesTotal: 2 };
+
+    test("renderTree lists files, signatures, and an elision note", () => {
+        const text = renderTree({ ...summary, included, elided, filesOnly: false });
+        expect(text).toContain("a.ts");
+        expect(text).toContain("export function foo(): void");
+        expect(text).toContain("1 file");
+    });
+
+    test("renderTree files-only omits signatures", () => {
+        const text = renderTree({ ...summary, included, elided, filesOnly: true });
+        expect(text).not.toContain("export function foo(): void");
+        expect(text).toContain("a.ts");
+    });
+
+    test("renderJson produces a SafeJSON-parseable object with required keys", () => {
+        const obj = renderJson({ ...summary, included, elided });
+        const parsed = SafeJSON.parse(SafeJSON.stringify(obj));
+        expect(parsed.root).toBe(root);
+        expect(parsed.filesIncluded).toBe(1);
+        expect(parsed.files[0].path).toBe("a.ts");
+        expect(parsed.elided).toEqual(["b.ts"]);
+    });
+});
+
+async function makeTmpRepo(): Promise<string> {
+    const dir = mkdtempSync(join(tmpdir(), "repo-map-test-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "a.ts"), `export function aFn(): void {}\n`);
+    writeFileSync(join(dir, "src", "b.ts"), `import { aFn } from "./a";\nexport const bVal = (): number => 1;\n`);
+    writeFileSync(join(dir, "ignored.log"), "noise\n");
+    writeFileSync(join(dir, ".gitignore"), "*.log\n");
+    const git = (args: string[]) =>
+        Bun.spawn(["git", ...args], { cwd: dir, stdout: "ignore", stderr: "ignore" }).exited;
+    await git(["init"]);
+    await git(["add", "-A"]);
+    return dir;
+}
+
+describe("scanRepo (hermetic tmp git repo)", () => {
+    test("finds tracked source files, extracts symbols, computes fan-in, respects .gitignore", async () => {
+        const dir = await makeTmpRepo();
+        const result = await scanRepo({ dir, languages: null });
+        const paths = result.files.map((f) => f.path).sort();
+
+        expect(paths).toEqual(["src/a.ts", "src/b.ts"]);
+        const a = result.files.find((f) => f.path === "src/a.ts");
+        const b = result.files.find((f) => f.path === "src/b.ts");
+        expect(a?.symbols.some((s) => s.name === "aFn")).toBe(true);
+        expect(b?.symbols.some((s) => s.name === "bVal")).toBe(true);
+        expect(result.fanIn["src/a.ts"]).toBe(1);
+        expect(result.fanIn["src/b.ts"] ?? 0).toBe(0);
+        expect((a?.tokens ?? 0) > 0).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

`tools repo-map` — a token-efficient, aider-style structural map of a repo's files, exported symbols, and signatures (no bodies), built to feed a coding agent cheaply.

Hand an agent a fresh repo and the cheapest way to give it situational awareness is a compact map: which files exist and what each file exports (function/class/const/type/interface signatures only). A full file dump blows the context window; a bare `tree` says nothing about the API surface. This tool walks the repo (respecting `.gitignore` via `git ls-files`), extracts top-level exported symbols per file via `@ast-grep/napi`, ranks files by importance (size + import fan-in + mtime recency), and greedily packs as many symbols as fit into a token budget — emitting an aider-like map plus a note of what was elided. Fully offline (no model, no network), deterministic.

## CLI surface

```bash
tools repo-map                       # map cwd, 8000-tok budget, tree to stdout
tools repo-map ./src                 # map a specific dir
tools repo-map . --max-tokens 3000   # tighter budget; drops low-ranked files, notes elision
tools repo-map . --lang ts,tsx       # restrict languages (comma-separated and/or repeated)
tools repo-map . --json              # structured object via out.result
tools repo-map . --files-only        # ranked file list with symbol/token counts (cheapest overview)
tools repo-map . --clipboard         # copy the rendered map instead of printing
```

## Architecture

Three layers with strict separation so the cores are hermetically testable:

- **Pure cores** (no I/O, no clock, no encoder): `extractSymbols(source, language)` (ast-grep parse of a string to body-free signatures), `rankFiles({ files, now })` (deterministic score, `now` injected), `packByBudget({ files, budget })` (greedy selection over pre-computed token counts).
- **Impure orchestration** (`scanner.ts`): the only file touching fs/git and calling `countTokens` — walks files, extracts symbols and imports, computes fan-in, runs the token pre-pass, feeds numbers into the pure cores.
- **Rendering + entrypoint**: `render.ts` (tree / files-only / JSON), `index.ts` (thin commander wrapper ending in `runTool`).

## Reuse (no new deps)

- `EXT_TO_LANG` / `EXT_TO_LANGUAGE_NAME` / `EXT_TO_DYNAMIC_LANG` from `src/indexer/lib/ast-languages.ts`.
- `countTokens` from `@app/utils/tokens`; `formatTokens` from `@app/utils/format`; `SafeJSON`; `runTool` / `suggestCommand` from `@app/utils/cli`; `out` / `logger`; `clipboardy`; `commander`.

Built-in TS/TSX/JS use the synchronous ast-grep `Lang` path. Dynamic languages (python/go/rust) are best-effort and intentionally out of the must-pass suite.

## Verification (local)

- `bunx biome check src/repo-map` — exit 0.
- `bun test src/repo-map` — 17 tests pass (34 assertions). Hermetic: temp dirs via `os.tmpdir()`, a throwaway `git init` repo for the scanner, no network, no clipboard, no dependence on this repo's live state. Pure cores asserted with in-memory inputs; `rankFiles` gets a fixed injected `now`; `packByBudget` gets synthetic token counts. Exact-string assertions lock the body-free signature slicing for function/class/interface/type-alias/exported-const-arrow.
- `./tools repo-map --help` — exit 0, all flags listed. Smoke-tested tree, `--json`, `--files-only`, and tiny-budget elision against the tool's own dir.

## Notes

- Interface and type-alias signatures keep their full (whitespace-collapsed) declaration text since there is no body block to strip — this includes any inline JSDoc, which matches the spec.
- Non-git directories currently discover no files (manual ignore-walk fallback is stubbed/logged, not implemented in v1).
- All new code lives under `src/repo-map/` — no shared files touched, no new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `repo-map` CLI tool that scans a project directory for supported source files, extracts exported symbols, and generates a ranked repo map with token-budget aware inclusion.
  * Supports `--lang` filtering, `--max-tokens` limits, human-readable tree output (including `--files-only`) and structured JSON output (`--json`). Clipboard copying is available for tree output.
* **Bug Fixes**
  * Improved input validation for language values and token limits, with clearer error handling.
* **Tests**
  * Added comprehensive coverage for symbol extraction, deterministic ranking, budget packing, rendering, and end-to-end scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->