### PR TITLE
feat(agent-watch): notify when background agents finish, stall, or need you

### DIFF
--- a/scripts/apply-patches.ts
+++ b/scripts/apply-patches.ts
@@ -11,7 +11,7 @@
  * interop guard is redundant under a correctly-resolved string-width@4, and
  * the @opentui/solid patch is types-only).
  */
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { logger } from "@genesiscz/utils/logger";
 
 const PATCHES: Array<{ pkg: string; patch: string }> = [
@@ -25,11 +25,15 @@ async function gitApply(args: string[]): Promise<number> {
 }
 
 let failed = false;
-for (const { pkg, patch } of PATCHES) {
-    if (!existsSync(pkg)) {
-        logger.debug({ pkg }, "apply-patches: package not installed, skipping");
+for (const { pkg: pkgPath, patch } of PATCHES) {
+    if (!existsSync(pkgPath)) {
+        logger.debug({ pkg: pkgPath }, "apply-patches: package not installed, skipping");
         continue;
     }
+
+    // git apply refuses paths "beyond a symbolic link" (worktrees often symlink
+    // node_modules to the main checkout) — resolve to the real directory first.
+    const pkg = realpathSync(pkgPath);
 
     if ((await gitApply(["--reverse", "--check", `--directory=${pkg}`, "--unsafe-paths", patch])) === 0) {
         continue;

--- a/src/agent-watch/README.md
+++ b/src/agent-watch/README.md
@@ -1,0 +1,44 @@
+# agent-watch
+
+Notify when background AI agents **finish**, **stall**, or **need your input** — instead of you tabbing back to check on them.
+
+```bash
+tools agent-watch                 # live watch (default), notify via terminal
+tools agent-watch status          # one-shot table of every tracked agent
+tools agent-watch list            # discovered agents (id + source)
+```
+
+## What it watches
+
+| Source | Files | Finish detection | Input detection |
+|---|---|---|---|
+| `task` | `~/.genesis-tools/task/sessions/*.jsonl` (+ `*.meta.json` sidecar) | trailing `exit` line, sidecar `exitCode`, or dead pid | — |
+| `claude` | `~/.claude/projects/*/*.jsonl` transcripts | trailing `result` record | trailing `AskUserQuestion` tool use, or an ended turn (`stop_reason: end_turn`) |
+| `workflows` | `~/.claude/projects/**/subagents/workflows/**` | — (mtime only, v1) | — |
+
+States: `RUNNING`, `FINISHED`, `STALLED` (no output past `--stall-timeout`), `AWAITING-INPUT`.
+
+## Notifications
+
+Fires only on a **state transition** into a notable state (`FINISHED` / `STALLED` / `AWAITING-INPUT`). In continuous mode the first sweep just seeds the baseline silently — states that were already notable before you started never replay as a storm. With `--once` (cron mode) currently-notable agents inside the active window DO fire; that is the point of a single shot.
+
+Channels ride the existing `notify` stack (`dispatchNotification`, app `agent-watch`): `--notify terminal,say,telegram` or `none`. Channel *configuration* (telegram token, voice) lives in the shared notify config — a channel disabled there stays silent even when requested here.
+
+## Flags
+
+- `--stall-timeout <seconds>` — silence before `STALLED` (default 120)
+- `--sources <names>` — `task,claude,workflows` (default all)
+- `--active <minutes>` — ignore agents whose last activity is older (watch default **60**; status/list default 0 = show all)
+- `--poll <seconds>` — re-sweep cadence; the poll is load-bearing, a stall produces no fs events (default 5)
+- `--once` — single pass then exit (cron-friendly)
+- `--json` — machine output on stdout (status snapshot / one event per notification)
+
+## Design
+
+Two pure, injected-time cores carry the logic — `classifyAgentState` (exit → question → dead-pid → stale → running) and `shouldNotify` (transition gate) — everything else is thin glue: source adapters, a chokidar tail + poll re-sweep watcher, three commands. Tests are hermetic (temp dirs, stubbed notifier, injected clocks).
+
+## Caveats
+
+- Claude "ended turn" = `AWAITING-INPUT`: an interactive session you simply walked away from counts as waiting for you — that is the intended semantic, scoped by `--active`.
+- Workflow dirs have no finish detection in v1: an untouched dir past the timeout reads `STALLED`; completed workflows age out of the active window.
+- Permission prompts that never reach the transcript (OS dialogs) are invisible to the `claude` source.

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { classifyAgentState } from "./classify";
+import { readClaudeSnapshots } from "./sources/claude";
+import { collectSnapshots } from "./sources/index";
+import { readTaskSnapshots } from "./sources/task";
+import { readWorkflowSnapshots } from "./sources/workflows";
+import { NOTABLE_STATES, shouldNotify, transitionMessage } from "./transitions";
+import type { AgentEvent, AgentSnapshot, AgentState, Notifier } from "./types";
+import { decideAndNotify } from "./watcher";
+
+const T0 = 1_000_000_000_000; // fixed injected baseline (epoch ms)
+
+function ev(kind: AgentEvent["kind"], ts: number, extra: Partial<AgentEvent> = {}): AgentEvent {
+    return { kind, ts, ...extra };
+}
+
+describe("classifyAgentState", () => {
+    it("returns FINISHED when the latest event is an exit", () => {
+        const events = [ev("start", T0), ev("output", T0 + 100), ev("exit", T0 + 200, { exitCode: 0 })];
+        const state = classifyAgentState({ events, lastModified: T0 + 200, now: T0 + 5_000, stallTimeoutMs: 120_000 });
+        expect(state).toBe("FINISHED");
+    });
+
+    it("returns AWAITING-INPUT when the latest event is a question", () => {
+        const events = [ev("output", T0), ev("question", T0 + 50, { text: "May I edit? (y/n)" })];
+        const state = classifyAgentState({ events, lastModified: T0 + 50, now: T0 + 60, stallTimeoutMs: 120_000 });
+        expect(state).toBe("AWAITING-INPUT");
+    });
+
+    it("returns STALLED when alive and no output past the timeout", () => {
+        const events = [ev("output", T0)];
+        const state = classifyAgentState({
+            events,
+            lastModified: T0,
+            now: T0 + 200_000,
+            stallTimeoutMs: 120_000,
+            pidAlive: true,
+        });
+        expect(state).toBe("STALLED");
+    });
+
+    it("returns RUNNING when recent output and within the timeout", () => {
+        const events = [ev("output", T0)];
+        const state = classifyAgentState({ events, lastModified: T0, now: T0 + 5_000, stallTimeoutMs: 120_000 });
+        expect(state).toBe("RUNNING");
+    });
+
+    it("reclassifies a dead-pid RUNNING agent as FINISHED", () => {
+        const events = [ev("output", T0)];
+        const state = classifyAgentState({
+            events,
+            lastModified: T0,
+            now: T0 + 5_000,
+            stallTimeoutMs: 120_000,
+            pidAlive: false,
+        });
+        expect(state).toBe("FINISHED");
+    });
+
+    it("prefers an explicit exit event over a dead-pid hint (still FINISHED)", () => {
+        const events = [ev("exit", T0, { exitCode: 1 })];
+        const state = classifyAgentState({
+            events,
+            lastModified: T0,
+            now: T0 + 5_000,
+            stallTimeoutMs: 120_000,
+            pidAlive: false,
+        });
+        expect(state).toBe("FINISHED");
+    });
+
+    it("question wins over stall (awaiting input is not a stall)", () => {
+        const events = [ev("question", T0)];
+        const state = classifyAgentState({
+            events,
+            lastModified: T0,
+            now: T0 + 999_999,
+            stallTimeoutMs: 120_000,
+            pidAlive: true,
+        });
+        expect(state).toBe("AWAITING-INPUT");
+    });
+
+    it("treats an agent with no events as RUNNING when fresh, STALLED when stale+alive", () => {
+        expect(classifyAgentState({ events: [], lastModified: T0, now: T0 + 1_000, stallTimeoutMs: 120_000 })).toBe(
+            "RUNNING"
+        );
+        expect(
+            classifyAgentState({
+                events: [],
+                lastModified: T0,
+                now: T0 + 200_000,
+                stallTimeoutMs: 120_000,
+                pidAlive: true,
+            })
+        ).toBe("STALLED");
+    });
+});
+
+describe("shouldNotify", () => {
+    it("notifies on transition into a notable state from a different state", () => {
+        expect(shouldNotify("RUNNING", "FINISHED")).toBe(true);
+        expect(shouldNotify("RUNNING", "STALLED")).toBe(true);
+        expect(shouldNotify("RUNNING", "AWAITING-INPUT")).toBe(true);
+    });
+
+    it("notifies on first sighting that is already notable (prev undefined)", () => {
+        expect(shouldNotify(undefined, "FINISHED")).toBe(true);
+        expect(shouldNotify(undefined, "AWAITING-INPUT")).toBe(true);
+    });
+
+    it("does NOT notify for a first sighting of RUNNING", () => {
+        expect(shouldNotify(undefined, "RUNNING")).toBe(false);
+    });
+
+    it("does NOT notify when state is unchanged", () => {
+        expect(shouldNotify("RUNNING", "RUNNING")).toBe(false);
+        expect(shouldNotify("STALLED", "STALLED")).toBe(false);
+        expect(shouldNotify("FINISHED", "FINISHED")).toBe(false);
+    });
+
+    it("does NOT notify when leaving a notable state into RUNNING (recovery is quiet)", () => {
+        expect(shouldNotify("STALLED", "RUNNING")).toBe(false);
+        expect(shouldNotify("AWAITING-INPUT", "RUNNING")).toBe(false);
+    });
+
+    it("notifies when moving between two different notable states", () => {
+        expect(shouldNotify("STALLED", "FINISHED")).toBe(true);
+        expect(shouldNotify("AWAITING-INPUT", "FINISHED")).toBe(true);
+    });
+});
+
+describe("transitionMessage", () => {
+    const base: AgentSnapshot = {
+        id: "task:checks-6984",
+        name: "checks-6984",
+        source: "task",
+        state: "FINISHED",
+        lastOutputAt: 1,
+        ageMs: 0,
+        exitCode: 0,
+        lastLine: "===== ALL STEPS DONE =====",
+    };
+
+    it("includes the agent name and the new state", () => {
+        const msg = transitionMessage(base);
+        expect(msg.title).toContain("checks-6984");
+        expect(msg.message).toContain("finished");
+    });
+
+    it("surfaces a non-zero exit code on FINISHED", () => {
+        const msg = transitionMessage({ ...base, exitCode: 2 });
+        expect(msg.message).toContain("2");
+    });
+
+    it("NOTABLE_STATES excludes RUNNING", () => {
+        expect(NOTABLE_STATES.has("RUNNING")).toBe(false);
+        expect(NOTABLE_STATES.has("FINISHED")).toBe(true);
+    });
+});
+
+describe("readTaskSnapshots", () => {
+    function makeSessionDir(): string {
+        const dir = mkdtempSync(join(tmpdir(), "agent-watch-task-"));
+        const finished = [
+            { type: "meta", session: "checks-1", command: "bash run.sh", startedAt: "2026-06-02T01:34:49.745Z" },
+            { type: "line", seq: 1, out: "stdout", level: "info", ts: T0 + 10, text: "starting" },
+            { type: "line", seq: 2, out: "stdout", level: "info", ts: T0 + 20, text: "===== DONE =====" },
+            { type: "exit", code: 0, durationMs: 100, ts: "2026-06-02T01:35:45.927Z" },
+        ];
+        writeFileSync(join(dir, "checks-1.jsonl"), `${finished.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+        writeFileSync(
+            join(dir, "checks-1.meta.json"),
+            SafeJSON.stringify({ name: "checks-1", pid: 4242, exitCode: 0, lastActivityAt: T0 + 20 })
+        );
+        const running = [
+            { type: "meta", session: "dev-2", command: "vite", startedAt: "2026-06-02T01:40:00.000Z" },
+            { type: "line", seq: 1, out: "stdout", level: "info", ts: T0 + 50, text: "VITE ready" },
+        ];
+        writeFileSync(join(dir, "dev-2.jsonl"), `${running.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+        writeFileSync(
+            join(dir, "dev-2.meta.json"),
+            SafeJSON.stringify({ name: "dev-2", pid: 1, lastActivityAt: T0 + 50 })
+        );
+        return dir;
+    }
+
+    it("reads finished and running sessions from a session dir", async () => {
+        const dir = makeSessionDir();
+
+        try {
+            const snaps = await readTaskSnapshots({ dir, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            const byName = new Map(snaps.map((s) => [s.name, s]));
+
+            expect(byName.get("checks-1")?.state).toBe("FINISHED");
+            expect(byName.get("checks-1")?.exitCode).toBe(0);
+            expect(byName.get("checks-1")?.lastLine).toBe("===== DONE =====");
+            expect(byName.get("checks-1")?.id).toBe("task:checks-1");
+
+            // pid 1 (launchd/init) is alive but not ours; events are recent → RUNNING
+            expect(byName.get("dev-2")?.state).toBe("RUNNING");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("returns [] for a non-existent dir without throwing", async () => {
+        const snaps = await readTaskSnapshots({
+            dir: join(tmpdir(), "agent-watch-does-not-exist-xyz"),
+            now: T0,
+            stallTimeoutMs: 120_000,
+        });
+        expect(snaps).toEqual([]);
+    });
+});
+
+describe("claude/workflows adapters tolerate a missing root", () => {
+    it("return [] when their root does not exist", async () => {
+        const missing = join(tmpdir(), "agent-watch-missing-root-abc");
+        expect(await readClaudeSnapshots({ root: missing, now: T0, stallTimeoutMs: 120_000 })).toEqual([]);
+        expect(await readWorkflowSnapshots({ root: missing, now: T0, stallTimeoutMs: 120_000 })).toEqual([]);
+    });
+});
+
+describe("collectSnapshots", () => {
+    it("honors the sources filter and returns [] for empty injected roots (hermetic)", async () => {
+        const empty = mkdtempSync(join(tmpdir(), "agent-watch-empty-"));
+
+        try {
+            const snaps = await collectSnapshots({
+                sources: ["task", "claude", "workflows"],
+                now: T0,
+                stallTimeoutMs: 120_000,
+                roots: { task: empty, claude: empty, workflow: empty },
+            });
+            expect(snaps).toEqual([]);
+        } finally {
+            rmSync(empty, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("decideAndNotify (notify decision against a stub)", () => {
+    function stubNotifier(): { notifier: Notifier; calls: { title: string; message: string }[] } {
+        const calls: { title: string; message: string }[] = [];
+        const notifier: Notifier = {
+            notify: async ({ title, message }) => {
+                calls.push({ title, message });
+            },
+        };
+        return { notifier, calls };
+    }
+
+    it("fires once on RUNNING→FINISHED and not again while it stays FINISHED", async () => {
+        const { notifier, calls } = stubNotifier();
+        const prev = new Map<string, AgentState>();
+        prev.set("task:a", "RUNNING");
+
+        const finished: AgentSnapshot = {
+            id: "task:a",
+            name: "a",
+            source: "task",
+            state: "FINISHED",
+            lastOutputAt: 1,
+            ageMs: 0,
+            exitCode: 0,
+        };
+
+        await decideAndNotify({ snapshots: [finished], prevStates: prev, notifier });
+        await decideAndNotify({ snapshots: [finished], prevStates: prev, notifier });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].message).toContain("finished");
+        expect(prev.get("task:a")).toBe("FINISHED");
+    });
+
+    it("does NOT fire for a first-sighting RUNNING agent", async () => {
+        const { notifier, calls } = stubNotifier();
+        const prev = new Map<string, AgentState>();
+        const running: AgentSnapshot = {
+            id: "task:b",
+            name: "b",
+            source: "task",
+            state: "RUNNING",
+            lastOutputAt: 1,
+            ageMs: 0,
+        };
+
+        await decideAndNotify({ snapshots: [running], prevStates: prev, notifier });
+
+        expect(calls).toHaveLength(0);
+    });
+});

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -209,8 +209,11 @@ describe("readTaskSnapshots", () => {
     });
 
     it("returns [] for a non-existent dir without throwing", async () => {
+        const missingTaskRoot = join(tmpdir(), `agent-watch-missing-${process.pid}-${Date.now()}-task`);
+        rmSync(missingTaskRoot, { recursive: true, force: true });
+
         const snaps = await readTaskSnapshots({
-            dir: join(tmpdir(), "agent-watch-does-not-exist-xyz"),
+            dir: missingTaskRoot,
             now: T0,
             stallTimeoutMs: 120_000,
         });
@@ -220,7 +223,8 @@ describe("readTaskSnapshots", () => {
 
 describe("claude/workflows adapters tolerate a missing root", () => {
     it("return [] when their root does not exist", async () => {
-        const missing = join(tmpdir(), "agent-watch-missing-root-abc");
+        const missing = join(tmpdir(), `agent-watch-missing-${process.pid}-${Date.now()}-root`);
+        rmSync(missing, { recursive: true, force: true });
         expect(await readClaudeSnapshots({ root: missing, now: T0, stallTimeoutMs: 120_000 })).toEqual([]);
         expect(await readWorkflowSnapshots({ root: missing, now: T0, stallTimeoutMs: 120_000 })).toEqual([]);
     });

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -415,6 +415,9 @@ describe("collectSnapshots active window", () => {
             const fresh = [{ type: "line", seq: 1, out: "stdout", level: "info", ts: T0 - 1_000, text: "recent" }];
             writeFileSync(join(dir, "ancient.jsonl"), `${old.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
             writeFileSync(join(dir, "recent.jsonl"), `${fresh.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+            // lastOutputAt = max(event ts, mtime) — age the mtimes to match the fixture clock.
+            utimesSync(join(dir, "ancient.jsonl"), (T0 - 10_000_000) / 1000, (T0 - 10_000_000) / 1000);
+            utimesSync(join(dir, "recent.jsonl"), (T0 - 1_000) / 1000, (T0 - 1_000) / 1000);
 
             const all = await collectSnapshots({ sources: ["task"], now: T0, stallTimeoutMs: 120_000, roots: { task: dir } });
             const windowed = await collectSnapshots({

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -395,7 +395,10 @@ describe("readTaskSnapshots meta sidecar", () => {
                 { type: "line", seq: 1, out: "stdout", level: "info", ts: T0 + 10, text: "boom" },
             ];
             writeFileSync(join(dir, "crashy.jsonl"), `${lines.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
-            writeFileSync(join(dir, "crashy.meta.json"), SafeJSON.stringify({ name: "crashy", pid: 999999, exitCode: 137 }));
+            writeFileSync(
+                join(dir, "crashy.meta.json"),
+                SafeJSON.stringify({ name: "crashy", pid: 999999, exitCode: 137 })
+            );
 
             const snaps = await readTaskSnapshots({ dir, now: T0 + 1_000, stallTimeoutMs: 120_000 });
             expect(snaps[0]?.state).toBe("FINISHED");
@@ -419,7 +422,12 @@ describe("collectSnapshots active window", () => {
             utimesSync(join(dir, "ancient.jsonl"), (T0 - 10_000_000) / 1000, (T0 - 10_000_000) / 1000);
             utimesSync(join(dir, "recent.jsonl"), (T0 - 1_000) / 1000, (T0 - 1_000) / 1000);
 
-            const all = await collectSnapshots({ sources: ["task"], now: T0, stallTimeoutMs: 120_000, roots: { task: dir } });
+            const all = await collectSnapshots({
+                sources: ["task"],
+                now: T0,
+                stallTimeoutMs: 120_000,
+                roots: { task: dir },
+            });
             const windowed = await collectSnapshots({
                 sources: ["task"],
                 now: T0,
@@ -456,13 +464,23 @@ describe("sweep seed silence (continuous watch baseline)", () => {
             const prev = new Map<string, AgentState>();
 
             // Hermetic: same decide flow the watcher's seed pass runs, silent notifier.
-            const seedSnaps = await collectSnapshots({ sources: ["task"], now: T0, stallTimeoutMs: 120_000, roots: { task: dir } });
+            const seedSnaps = await collectSnapshots({
+                sources: ["task"],
+                now: T0,
+                stallTimeoutMs: 120_000,
+                roots: { task: dir },
+            });
             await decideAndNotify({ snapshots: seedSnaps, prevStates: prev, notifier: { notify: async () => {} } });
             expect(calls).toHaveLength(0);
             expect(prev.get("task:old-done")).toBe("FINISHED");
 
             // Second pass with the REAL notifier: state unchanged → still quiet.
-            const again = await collectSnapshots({ sources: ["task"], now: T0 + 1_000, stallTimeoutMs: 120_000, roots: { task: dir } });
+            const again = await collectSnapshots({
+                sources: ["task"],
+                now: T0 + 1_000,
+                stallTimeoutMs: 120_000,
+                roots: { task: dir },
+            });
             await decideAndNotify({ snapshots: again, prevStates: prev, notifier });
             expect(calls).toHaveLength(0);
         } finally {

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SafeJSON } from "@app/utils/json";
+import { SafeJSON } from "@genesiscz/utils/json";
 import { classifyAgentState } from "./classify";
 import { readClaudeSnapshots } from "./sources/claude";
 import { collectSnapshots } from "./sources/index";

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -464,6 +464,30 @@ describe("sweep seed silence (continuous watch baseline)", () => {
             expect(calls).toHaveLength(0);
         } finally {
             rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("readWorkflowSnapshots activity detection", () => {
+    it("uses newest contained-file mtime, not the stale dir mtime (append-only writes)", async () => {
+        const root = mkdtempSync(join(tmpdir(), "agent-watch-wf-"));
+
+        try {
+            const leaf = join(root, "proj", "sess", "subagents", "workflows", "wf-1");
+            mkdirSync(leaf, { recursive: true });
+            const transcript = join(leaf, "agent-1.jsonl");
+            writeFileSync(transcript, "{}\n");
+
+            // Age the DIRECTORY far past the stall timeout; keep the FILE fresh.
+            const oldSec = (T0 - 10_000_000) / 1000;
+            utimesSync(leaf, oldSec, oldSec);
+            utimesSync(transcript, T0 / 1000, T0 / 1000);
+
+            const snaps = await readWorkflowSnapshots({ root, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            expect(snaps[0]?.state).toBe("RUNNING");
+            expect(snaps[0]?.lastOutputAt).toBe(T0);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
         }
     });
 });

--- a/src/agent-watch/agent-watch.test.ts
+++ b/src/agent-watch/agent-watch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -297,5 +297,173 @@ describe("decideAndNotify (notify decision against a stub)", () => {
         await decideAndNotify({ snapshots: [running], prevStates: prev, notifier });
 
         expect(calls).toHaveLength(0);
+    });
+});
+
+describe("readClaudeSnapshots (event mapping)", () => {
+    function writeSession(dir: string, name: string, records: object[]): void {
+        writeFileSync(join(dir, "proj", `${name}.jsonl`), `${records.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+    }
+
+    function makeClaudeRoot(): string {
+        const root = mkdtempSync(join(tmpdir(), "agent-watch-claude-"));
+        mkdirSync(join(root, "proj"));
+        return root;
+    }
+
+    const iso = (offset: number): string => new Date(T0 + offset).toISOString();
+
+    it("does NOT treat a leading summary (compacted session) as FINISHED", async () => {
+        const root = makeClaudeRoot();
+
+        try {
+            writeSession(root, "compacted", [
+                { type: "summary", summary: "earlier context", leafUuid: "x" },
+                { type: "user", timestamp: iso(10) },
+                { type: "assistant", timestamp: iso(20), message: { stop_reason: "tool_use", content: [] } },
+            ]);
+            const snaps = await readClaudeSnapshots({ root, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            expect(snaps[0]?.state).toBe("RUNNING");
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("treats only a TRAILING result record as FINISHED", async () => {
+        const root = makeClaudeRoot();
+
+        try {
+            writeSession(root, "done", [
+                { type: "user", timestamp: iso(10) },
+                { type: "result", timestamp: iso(500) },
+            ]);
+            writeSession(root, "mid-result", [
+                { type: "result", timestamp: iso(10) },
+                { type: "assistant", timestamp: iso(500), message: { stop_reason: "tool_use", content: [] } },
+            ]);
+            const snaps = await readClaudeSnapshots({ root, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            const byName = new Map(snaps.map((s) => [s.name, s]));
+            expect(byName.get("done")?.state).toBe("FINISHED");
+            expect(byName.get("mid-result")?.state).toBe("RUNNING");
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("classifies an ended turn (stop_reason end_turn) as AWAITING-INPUT", async () => {
+        const root = makeClaudeRoot();
+
+        try {
+            writeSession(root, "idle-at-prompt", [
+                { type: "user", timestamp: iso(10) },
+                { type: "assistant", timestamp: iso(400), message: { stop_reason: "end_turn", content: [] } },
+            ]);
+            const snaps = await readClaudeSnapshots({ root, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            expect(snaps[0]?.state).toBe("AWAITING-INPUT");
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("classifies a trailing AskUserQuestion tool_use as AWAITING-INPUT even mid-turn", async () => {
+        const root = makeClaudeRoot();
+
+        try {
+            writeSession(root, "asking", [
+                { type: "user", timestamp: iso(10) },
+                {
+                    type: "assistant",
+                    timestamp: iso(400),
+                    message: { stop_reason: "tool_use", content: [{ type: "tool_use", name: "AskUserQuestion" }] },
+                },
+            ]);
+            const snaps = await readClaudeSnapshots({ root, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            expect(snaps[0]?.state).toBe("AWAITING-INPUT");
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("readTaskSnapshots meta sidecar", () => {
+    it("marks a session FINISHED via meta.exitCode even without a jsonl exit line", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "agent-watch-task-meta-"));
+
+        try {
+            const lines = [
+                { type: "meta", session: "crashy", command: "bash x.sh", startedAt: "2026-06-02T01:34:49.745Z" },
+                { type: "line", seq: 1, out: "stdout", level: "info", ts: T0 + 10, text: "boom" },
+            ];
+            writeFileSync(join(dir, "crashy.jsonl"), `${lines.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+            writeFileSync(join(dir, "crashy.meta.json"), SafeJSON.stringify({ name: "crashy", pid: 999999, exitCode: 137 }));
+
+            const snaps = await readTaskSnapshots({ dir, now: T0 + 1_000, stallTimeoutMs: 120_000 });
+            expect(snaps[0]?.state).toBe("FINISHED");
+            expect(snaps[0]?.exitCode).toBe(137);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("collectSnapshots active window", () => {
+    it("drops agents whose last activity is outside activeWindowMs", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "agent-watch-window-"));
+
+        try {
+            const old = [{ type: "line", seq: 1, out: "stdout", level: "info", ts: T0 - 10_000_000, text: "ancient" }];
+            const fresh = [{ type: "line", seq: 1, out: "stdout", level: "info", ts: T0 - 1_000, text: "recent" }];
+            writeFileSync(join(dir, "ancient.jsonl"), `${old.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+            writeFileSync(join(dir, "recent.jsonl"), `${fresh.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+
+            const all = await collectSnapshots({ sources: ["task"], now: T0, stallTimeoutMs: 120_000, roots: { task: dir } });
+            const windowed = await collectSnapshots({
+                sources: ["task"],
+                now: T0,
+                stallTimeoutMs: 120_000,
+                activeWindowMs: 60_000,
+                roots: { task: dir },
+            });
+
+            expect(all.map((s) => s.name).sort()).toEqual(["ancient", "recent"]);
+            expect(windowed.map((s) => s.name)).toEqual(["recent"]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("sweep seed silence (continuous watch baseline)", () => {
+    it("notify:false populates prevStates without calling the notifier; next sweep only fires real transitions", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "agent-watch-seed-"));
+
+        try {
+            const finished = [
+                { type: "line", seq: 1, out: "stdout", level: "info", ts: T0 - 500, text: "done long ago" },
+                { type: "exit", code: 0, durationMs: 10, ts: T0 - 400 },
+            ];
+            writeFileSync(join(dir, "old-done.jsonl"), `${finished.map((o) => SafeJSON.stringify(o)).join("\n")}\n`);
+
+            const calls: string[] = [];
+            const notifier: Notifier = {
+                notify: async ({ message }) => {
+                    calls.push(message);
+                },
+            };
+            const prev = new Map<string, AgentState>();
+
+            // Hermetic: same decide flow the watcher's seed pass runs, silent notifier.
+            const seedSnaps = await collectSnapshots({ sources: ["task"], now: T0, stallTimeoutMs: 120_000, roots: { task: dir } });
+            await decideAndNotify({ snapshots: seedSnaps, prevStates: prev, notifier: { notify: async () => {} } });
+            expect(calls).toHaveLength(0);
+            expect(prev.get("task:old-done")).toBe("FINISHED");
+
+            // Second pass with the REAL notifier: state unchanged → still quiet.
+            const again = await collectSnapshots({ sources: ["task"], now: T0 + 1_000, stallTimeoutMs: 120_000, roots: { task: dir } });
+            await decideAndNotify({ snapshots: again, prevStates: prev, notifier });
+            expect(calls).toHaveLength(0);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
     });
 });

--- a/src/agent-watch/classify.ts
+++ b/src/agent-watch/classify.ts
@@ -1,0 +1,42 @@
+import type { AgentEvent, AgentState, ClassifyInput } from "./types";
+
+function latestEvent(events: AgentEvent[]): AgentEvent | undefined {
+    if (events.length === 0) {
+        return undefined;
+    }
+
+    return events[events.length - 1];
+}
+
+/**
+ * PURE state classifier. Reads no clock and no filesystem — `now`, `lastModified`,
+ * and `pidAlive` are injected. Decision order matters:
+ *   1. exit event present  → FINISHED   (terminal; outranks everything)
+ *   2. latest is question  → AWAITING-INPUT (a prompt is not a stall)
+ *   3. pid confirmed dead  → FINISHED   (process gone without an exit line)
+ *   4. stale past timeout  → STALLED
+ *   5. otherwise           → RUNNING
+ */
+export function classifyAgentState(input: ClassifyInput): AgentState {
+    const { events, lastModified, now, stallTimeoutMs, pidAlive } = input;
+    const last = latestEvent(events);
+
+    if (events.some((e) => e.kind === "exit")) {
+        return "FINISHED";
+    }
+
+    if (last?.kind === "question") {
+        return "AWAITING-INPUT";
+    }
+
+    if (pidAlive === false) {
+        return "FINISHED";
+    }
+
+    const lastActivity = last ? Math.max(last.ts, lastModified) : lastModified;
+    if (now - lastActivity > stallTimeoutMs) {
+        return "STALLED";
+    }
+
+    return "RUNNING";
+}

--- a/src/agent-watch/commands/list.ts
+++ b/src/agent-watch/commands/list.ts
@@ -1,0 +1,26 @@
+import { out } from "@app/logger";
+import type { Command } from "commander";
+import { collectSnapshots } from "../sources/index";
+import { parseSharedOptions } from "./shared";
+
+export function registerListCommand(program: Command): void {
+    program
+        .command("list")
+        .description("List discovered agents (id + source), no state classification")
+        .option("--sources <names>", "Comma list: task,claude,workflows", "task,claude,workflows")
+        .option("--json", "Emit JSON to stdout", false)
+        .action(async (opts: { sources: string; json: boolean }) => {
+            const { sources } = parseSharedOptions({ ...opts, stallTimeout: "120" });
+            const snapshots = await collectSnapshots({ sources, now: Date.now(), stallTimeoutMs: 120_000 });
+            const rows = snapshots.map((s) => ({ id: s.id, name: s.name, source: s.source }));
+
+            if (opts.json) {
+                out.result(rows);
+                return;
+            }
+
+            for (const r of rows) {
+                out.println(`${r.source.padEnd(10)} ${r.id}`);
+            }
+        });
+}

--- a/src/agent-watch/commands/list.ts
+++ b/src/agent-watch/commands/list.ts
@@ -20,7 +20,7 @@ export function registerListCommand(program: Command): void {
             }
 
             for (const r of rows) {
-                out.println(`${r.source.padEnd(10)} ${r.id}`);
+                out.printlnErr(`${r.source.padEnd(10)} ${r.id}`);
             }
 
             await out.flush();

--- a/src/agent-watch/commands/list.ts
+++ b/src/agent-watch/commands/list.ts
@@ -22,5 +22,7 @@ export function registerListCommand(program: Command): void {
             for (const r of rows) {
                 out.println(`${r.source.padEnd(10)} ${r.id}`);
             }
+
+            await out.flush();
         });
 }

--- a/src/agent-watch/commands/list.ts
+++ b/src/agent-watch/commands/list.ts
@@ -8,10 +8,16 @@ export function registerListCommand(program: Command): void {
         .command("list")
         .description("List discovered agents (id + source), no state classification")
         .option("--sources <names>", "Comma list: task,claude,workflows", "task,claude,workflows")
+        .option("--active <minutes>", "Only list agents active within this window (0 = all)", "0")
         .option("--json", "Emit JSON to stdout", false)
-        .action(async (opts: { sources: string; json: boolean }) => {
-            const { sources } = parseSharedOptions({ ...opts, stallTimeout: "120" });
-            const snapshots = await collectSnapshots({ sources, now: Date.now(), stallTimeoutMs: 120_000 });
+        .action(async (opts: { sources: string; active: string; json: boolean }) => {
+            const { sources, activeWindowMs } = parseSharedOptions({ ...opts, stallTimeout: "120" });
+            const snapshots = await collectSnapshots({
+                sources,
+                now: Date.now(),
+                stallTimeoutMs: 120_000,
+                activeWindowMs,
+            });
             const rows = snapshots.map((s) => ({ id: s.id, name: s.name, source: s.source }));
 
             if (opts.json) {

--- a/src/agent-watch/commands/list.ts
+++ b/src/agent-watch/commands/list.ts
@@ -1,4 +1,4 @@
-import { out } from "@genesiscz/utils/logger";
+import { logger, out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { collectSnapshots } from "../sources/index";
 import { parseSharedOptions } from "./shared";
@@ -12,6 +12,7 @@ export function registerListCommand(program: Command): void {
         .option("--json", "Emit JSON to stdout", false)
         .action(async (opts: { sources: string; active: string; json: boolean }) => {
             const { sources, activeWindowMs } = parseSharedOptions({ ...opts, stallTimeout: "120" });
+            logger.debug({ sources, activeWindowMs }, "agent-watch list: collecting");
             const snapshots = await collectSnapshots({
                 sources,
                 now: Date.now(),
@@ -19,9 +20,11 @@ export function registerListCommand(program: Command): void {
                 activeWindowMs,
             });
             const rows = snapshots.map((s) => ({ id: s.id, name: s.name, source: s.source }));
+            logger.debug({ count: rows.length }, "agent-watch list: collected");
 
             if (opts.json) {
                 out.result(rows);
+                await out.flush();
                 return;
             }
 

--- a/src/agent-watch/commands/list.ts
+++ b/src/agent-watch/commands/list.ts
@@ -1,4 +1,4 @@
-import { out } from "@app/logger";
+import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { collectSnapshots } from "../sources/index";
 import { parseSharedOptions } from "./shared";

--- a/src/agent-watch/commands/shared.ts
+++ b/src/agent-watch/commands/shared.ts
@@ -1,0 +1,26 @@
+import type { WatchSourceName } from "../types";
+
+const VALID_SOURCES: ReadonlySet<WatchSourceName> = new Set<WatchSourceName>(["task", "claude", "workflows"]);
+
+export function parseSources(raw: string): WatchSourceName[] {
+    const sources: WatchSourceName[] = [];
+
+    for (const part of raw.split(",")) {
+        const s = part.trim();
+
+        if (VALID_SOURCES.has(s as WatchSourceName)) {
+            sources.push(s as WatchSourceName);
+        }
+    }
+
+    return sources.length > 0 ? sources : ["task", "claude", "workflows"];
+}
+
+export function parseSharedOptions(opts: { stallTimeout: string; sources: string }): {
+    stallTimeoutMs: number;
+    sources: WatchSourceName[];
+} {
+    const seconds = Number.parseInt(opts.stallTimeout, 10);
+    const stallTimeoutMs = (Number.isFinite(seconds) && seconds > 0 ? seconds : 120) * 1000;
+    return { stallTimeoutMs, sources: parseSources(opts.sources) };
+}

--- a/src/agent-watch/commands/shared.ts
+++ b/src/agent-watch/commands/shared.ts
@@ -16,11 +16,14 @@ export function parseSources(raw: string): WatchSourceName[] {
     return sources.length > 0 ? sources : ["task", "claude", "workflows"];
 }
 
-export function parseSharedOptions(opts: { stallTimeout: string; sources: string }): {
+export function parseSharedOptions(opts: { stallTimeout: string; sources: string; active?: string }): {
     stallTimeoutMs: number;
     sources: WatchSourceName[];
+    activeWindowMs: number;
 } {
     const seconds = Number.parseInt(opts.stallTimeout, 10);
     const stallTimeoutMs = (Number.isFinite(seconds) && seconds > 0 ? seconds : 120) * 1000;
-    return { stallTimeoutMs, sources: parseSources(opts.sources) };
+    const activeMinutes = Number.parseInt(opts.active ?? "0", 10);
+    const activeWindowMs = (Number.isFinite(activeMinutes) && activeMinutes > 0 ? activeMinutes : 0) * 60_000;
+    return { stallTimeoutMs, sources: parseSources(opts.sources), activeWindowMs };
 }

--- a/src/agent-watch/commands/shared.ts
+++ b/src/agent-watch/commands/shared.ts
@@ -4,16 +4,38 @@ const VALID_SOURCES: ReadonlySet<WatchSourceName> = new Set<WatchSourceName>(["t
 
 export function parseSources(raw: string): WatchSourceName[] {
     const sources: WatchSourceName[] = [];
+    const unknown: string[] = [];
 
     for (const part of raw.split(",")) {
         const s = part.trim();
 
+        if (!s) {
+            continue;
+        }
+
         if (VALID_SOURCES.has(s as WatchSourceName)) {
             sources.push(s as WatchSourceName);
+        } else {
+            unknown.push(s);
         }
     }
 
+    if (unknown.length > 0) {
+        throw new Error(`Unknown source(s): ${unknown.join(", ")}. Valid: ${[...VALID_SOURCES].join(", ")}`);
+    }
+
     return sources.length > 0 ? sources : ["task", "claude", "workflows"];
+}
+
+/** Strict non-negative integer parse — rejects "120abc" instead of truncating it. */
+export function parseNonNegativeInt(raw: string, flag: string): number {
+    const trimmed = raw.trim();
+
+    if (!/^\d+$/.test(trimmed)) {
+        throw new Error(`Invalid ${flag} value "${raw}" — expected a non-negative integer`);
+    }
+
+    return Number.parseInt(trimmed, 10);
 }
 
 export function parseSharedOptions(opts: { stallTimeout: string; sources: string; active?: string }): {
@@ -21,9 +43,9 @@ export function parseSharedOptions(opts: { stallTimeout: string; sources: string
     sources: WatchSourceName[];
     activeWindowMs: number;
 } {
-    const seconds = Number.parseInt(opts.stallTimeout, 10);
-    const stallTimeoutMs = (Number.isFinite(seconds) && seconds > 0 ? seconds : 120) * 1000;
-    const activeMinutes = Number.parseInt(opts.active ?? "0", 10);
-    const activeWindowMs = (Number.isFinite(activeMinutes) && activeMinutes > 0 ? activeMinutes : 0) * 60_000;
+    const seconds = parseNonNegativeInt(opts.stallTimeout, "--stall-timeout");
+    const stallTimeoutMs = (seconds > 0 ? seconds : 120) * 1000;
+    const activeMinutes = parseNonNegativeInt(opts.active ?? "0", "--active");
+    const activeWindowMs = activeMinutes * 60_000;
     return { stallTimeoutMs, sources: parseSources(opts.sources), activeWindowMs };
 }

--- a/src/agent-watch/commands/status.ts
+++ b/src/agent-watch/commands/status.ts
@@ -1,0 +1,28 @@
+import { out } from "@app/logger";
+import type { Command } from "commander";
+import { renderStatusTable, toJsonSnapshot } from "../render";
+import { collectSnapshots } from "../sources/index";
+import { parseSharedOptions } from "./shared";
+
+export function registerStatusCommand(program: Command): void {
+    program
+        .command("status")
+        .description("One-shot snapshot table of every tracked agent and its state")
+        .option("--stall-timeout <seconds>", "Seconds without output before STALLED", "120")
+        .option("--sources <names>", "Comma list: task,claude,workflows", "task,claude,workflows")
+        .option("--json", "Emit a JSON snapshot to stdout", false)
+        .action(async (opts: { stallTimeout: string; sources: string; json: boolean }) => {
+            const { stallTimeoutMs, sources } = parseSharedOptions(opts);
+            const now = Date.now();
+            const snapshots = await collectSnapshots({ sources, now, stallTimeoutMs });
+
+            if (opts.json) {
+                out.result(toJsonSnapshot(snapshots, now));
+                return;
+            }
+
+            out.printlnErr(`${snapshots.length} agent(s) tracked`);
+            out.printlnErr(renderStatusTable(snapshots));
+            await out.flush();
+        });
+}

--- a/src/agent-watch/commands/status.ts
+++ b/src/agent-watch/commands/status.ts
@@ -1,4 +1,4 @@
-import { out } from "@app/logger";
+import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { renderStatusTable, toJsonSnapshot } from "../render";
 import { collectSnapshots } from "../sources/index";

--- a/src/agent-watch/commands/status.ts
+++ b/src/agent-watch/commands/status.ts
@@ -1,4 +1,4 @@
-import { out } from "@genesiscz/utils/logger";
+import { logger, out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { renderStatusTable, toJsonSnapshot } from "../render";
 import { collectSnapshots } from "../sources/index";
@@ -14,11 +14,14 @@ export function registerStatusCommand(program: Command): void {
         .option("--json", "Emit a JSON snapshot to stdout", false)
         .action(async (opts: { stallTimeout: string; sources: string; active: string; json: boolean }) => {
             const { stallTimeoutMs, sources, activeWindowMs } = parseSharedOptions(opts);
+            logger.debug({ sources, stallTimeoutMs, activeWindowMs }, "agent-watch status: collecting");
             const now = Date.now();
             const snapshots = await collectSnapshots({ sources, now, stallTimeoutMs, activeWindowMs });
+            logger.debug({ count: snapshots.length }, "agent-watch status: collected");
 
             if (opts.json) {
                 out.result(toJsonSnapshot(snapshots, now));
+                await out.flush();
                 return;
             }
 

--- a/src/agent-watch/commands/status.ts
+++ b/src/agent-watch/commands/status.ts
@@ -10,11 +10,12 @@ export function registerStatusCommand(program: Command): void {
         .description("One-shot snapshot table of every tracked agent and its state")
         .option("--stall-timeout <seconds>", "Seconds without output before STALLED", "120")
         .option("--sources <names>", "Comma list: task,claude,workflows", "task,claude,workflows")
+        .option("--active <minutes>", "Only show agents active within this window (0 = all)", "0")
         .option("--json", "Emit a JSON snapshot to stdout", false)
-        .action(async (opts: { stallTimeout: string; sources: string; json: boolean }) => {
-            const { stallTimeoutMs, sources } = parseSharedOptions(opts);
+        .action(async (opts: { stallTimeout: string; sources: string; active: string; json: boolean }) => {
+            const { stallTimeoutMs, sources, activeWindowMs } = parseSharedOptions(opts);
             const now = Date.now();
-            const snapshots = await collectSnapshots({ sources, now, stallTimeoutMs });
+            const snapshots = await collectSnapshots({ sources, now, stallTimeoutMs, activeWindowMs });
 
             if (opts.json) {
                 out.result(toJsonSnapshot(snapshots, now));

--- a/src/agent-watch/commands/watch.ts
+++ b/src/agent-watch/commands/watch.ts
@@ -1,0 +1,38 @@
+import { out } from "@app/logger";
+import type { Command } from "commander";
+import { createNotifier, parseChannels } from "../notify";
+import { runWatch } from "../watcher";
+import { parseSharedOptions } from "./shared";
+
+interface WatchOpts {
+    stallTimeout: string;
+    sources: string;
+    notify: string;
+    json: boolean;
+    once: boolean;
+    poll: string;
+}
+
+export function registerWatchCommand(program: Command): Command {
+    return program
+        .command("watch", { isDefault: true })
+        .description("Live-watch agents and notify on finish/stall/awaiting-input transitions")
+        .option("--stall-timeout <seconds>", "Seconds without output before STALLED", "120")
+        .option("--sources <names>", "Comma list: task,claude,workflows", "task,claude,workflows")
+        .option("--notify <channels>", "Comma list: terminal,say,telegram | none", "terminal")
+        .option("--poll <seconds>", "Re-sweep cadence (catches stalls)", "5")
+        .option("--json", "Emit a JSON event per notification to stdout", false)
+        .option("--once", "Single pass then exit (cron-friendly)", false)
+        .action(async (opts: WatchOpts) => {
+            const { stallTimeoutMs, sources } = parseSharedOptions(opts);
+            const channels = parseChannels(opts.notify);
+            const pollMs = Math.max(1, Number.parseInt(opts.poll, 10) || 5) * 1000;
+            const notifier = createNotifier(channels);
+
+            out.log.info(
+                `agent-watch · sources: ${sources.join(",")} · notify: ${channels.join(",") || "none"} · stall ${stallTimeoutMs / 1000}s`
+            );
+
+            await runWatch({ sources, stallTimeoutMs, pollMs, notifier, json: opts.json, once: opts.once });
+        });
+}

--- a/src/agent-watch/commands/watch.ts
+++ b/src/agent-watch/commands/watch.ts
@@ -1,4 +1,4 @@
-import { out } from "@app/logger";
+import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { createNotifier, parseChannels } from "../notify";
 import { runWatch } from "../watcher";

--- a/src/agent-watch/commands/watch.ts
+++ b/src/agent-watch/commands/watch.ts
@@ -11,6 +11,7 @@ interface WatchOpts {
     json: boolean;
     once: boolean;
     poll: string;
+    active: string;
 }
 
 export function registerWatchCommand(program: Command): Command {
@@ -21,18 +22,27 @@ export function registerWatchCommand(program: Command): Command {
         .option("--sources <names>", "Comma list: task,claude,workflows", "task,claude,workflows")
         .option("--notify <channels>", "Comma list: terminal,say,telegram | none", "terminal")
         .option("--poll <seconds>", "Re-sweep cadence (catches stalls)", "5")
+        .option("--active <minutes>", "Only consider agents active within this window (0 = all)", "60")
         .option("--json", "Emit a JSON event per notification to stdout", false)
         .option("--once", "Single pass then exit (cron-friendly)", false)
         .action(async (opts: WatchOpts) => {
-            const { stallTimeoutMs, sources } = parseSharedOptions(opts);
+            const { stallTimeoutMs, sources, activeWindowMs } = parseSharedOptions(opts);
             const channels = parseChannels(opts.notify);
             const pollMs = Math.max(1, Number.parseInt(opts.poll, 10) || 5) * 1000;
             const notifier = createNotifier(channels);
 
             out.log.info(
-                `agent-watch · sources: ${sources.join(",")} · notify: ${channels.join(",") || "none"} · stall ${stallTimeoutMs / 1000}s`
+                `agent-watch · sources: ${sources.join(",")} · notify: ${channels.join(",") || "none"} · stall ${stallTimeoutMs / 1000}s · active ${activeWindowMs ? `${activeWindowMs / 60_000}m` : "all"}`
             );
 
-            await runWatch({ sources, stallTimeoutMs, pollMs, notifier, json: opts.json, once: opts.once });
+            await runWatch({
+                sources,
+                stallTimeoutMs,
+                pollMs,
+                notifier,
+                json: opts.json,
+                once: opts.once,
+                activeWindowMs,
+            });
         });
 }

--- a/src/agent-watch/commands/watch.ts
+++ b/src/agent-watch/commands/watch.ts
@@ -2,7 +2,7 @@ import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { createNotifier, parseChannels } from "../notify";
 import { runWatch } from "../watcher";
-import { parseSharedOptions } from "./shared";
+import { parseNonNegativeInt, parseSharedOptions } from "./shared";
 
 interface WatchOpts {
     stallTimeout: string;
@@ -28,7 +28,8 @@ export function registerWatchCommand(program: Command): Command {
         .action(async (opts: WatchOpts) => {
             const { stallTimeoutMs, sources, activeWindowMs } = parseSharedOptions(opts);
             const channels = parseChannels(opts.notify);
-            const pollMs = Math.max(1, Number.parseInt(opts.poll, 10) || 5) * 1000;
+            const pollSeconds = parseNonNegativeInt(opts.poll, "--poll");
+            const pollMs = Math.max(1, pollSeconds > 0 ? pollSeconds : 5) * 1000;
             const notifier = createNotifier(channels);
 
             out.log.info(

--- a/src/agent-watch/index.ts
+++ b/src/agent-watch/index.ts
@@ -28,12 +28,12 @@ async function main(): Promise<void> {
             process.exit(0);
         }
 
-        logger.error(`Error: ${message}`);
+        logger.error({ error, tool: "agent-watch" }, "agent-watch failed");
         process.exit(1);
     }
 }
 
-main().catch((err) => {
-    logger.error(`Unexpected error: ${err}`);
+main().catch((error) => {
+    logger.error({ error, tool: "agent-watch" }, "agent-watch crashed unexpectedly");
     process.exit(1);
 });

--- a/src/agent-watch/index.ts
+++ b/src/agent-watch/index.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+import { logger } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { Command } from "commander";
+import { registerListCommand } from "./commands/list";
+import { registerStatusCommand } from "./commands/status";
+import { registerWatchCommand } from "./commands/watch";
+
+const program = new Command();
+
+program
+    .name("agent-watch")
+    .description("Notify when background agents finish, stall, or need you")
+    .version("1.0.0")
+    .showHelpAfterError(true);
+
+registerWatchCommand(program);
+registerStatusCommand(program);
+registerListCommand(program);
+
+async function main(): Promise<void> {
+    try {
+        await runTool(program, { tool: "agent-watch" });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        if (message.includes("ExitPromptError") || message === "Cancelled") {
+            process.exit(0);
+        }
+
+        logger.error(`Error: ${message}`);
+        process.exit(1);
+    }
+}
+
+main().catch((err) => {
+    logger.error(`Unexpected error: ${err}`);
+    process.exit(1);
+});

--- a/src/agent-watch/index.ts
+++ b/src/agent-watch/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
-import { logger } from "@app/logger";
-import { runTool } from "@app/utils/cli";
+import { runTool } from "@genesiscz/utils/cli";
+import { logger } from "@genesiscz/utils/logger";
 import { Command } from "commander";
 import { registerListCommand } from "./commands/list";
 import { registerStatusCommand } from "./commands/status";

--- a/src/agent-watch/notify.ts
+++ b/src/agent-watch/notify.ts
@@ -1,0 +1,57 @@
+import { logger } from "@app/logger";
+import { dispatchNotification } from "@app/utils/notifications";
+import type { Notifier } from "./types";
+
+export type NotifyChannel = "terminal" | "say" | "telegram";
+
+const VALID_CHANNELS: ReadonlySet<NotifyChannel> = new Set<NotifyChannel>(["terminal", "say", "telegram"]);
+
+export function parseChannels(raw: string): NotifyChannel[] {
+    const trimmed = raw.trim().toLowerCase();
+
+    if (trimmed === "none" || trimmed === "") {
+        return [];
+    }
+
+    const channels: NotifyChannel[] = [];
+
+    for (const part of trimmed.split(",")) {
+        const ch = part.trim();
+
+        if (VALID_CHANNELS.has(ch as NotifyChannel)) {
+            channels.push(ch as NotifyChannel);
+        } else if (ch) {
+            logger.warn({ ch }, "ignoring unknown notify channel");
+        }
+    }
+
+    return channels;
+}
+
+/**
+ * Production notifier. `dispatchNotification` reads channel *config* from the
+ * shared `notify` store; the `channels` filter here decides which channels we
+ * actually want for THIS run. "terminal" maps to the system channel.
+ * NOTE: channels disabled in `notify` config still won't fire even if requested —
+ * the user must enable telegram/say there once. terminal (system) is on by default.
+ */
+export function createNotifier(channels: NotifyChannel[]): Notifier {
+    const wantSystem = channels.includes("terminal");
+    const wantSay = channels.includes("say");
+    const wantTelegram = channels.includes("telegram");
+
+    return {
+        notify: async ({ title, message, subtitle }) => {
+            if (!wantSystem && !wantSay && !wantTelegram) {
+                return;
+            }
+
+            await dispatchNotification({
+                app: "agent-watch",
+                title,
+                message,
+                subtitle,
+            });
+        },
+    };
+}

--- a/src/agent-watch/notify.ts
+++ b/src/agent-watch/notify.ts
@@ -1,4 +1,5 @@
 import { logger } from "@app/logger";
+import type { ChannelName } from "@app/utils/notifications";
 import { dispatchNotification } from "@app/utils/notifications";
 import type { Notifier } from "./types";
 
@@ -28,21 +29,27 @@ export function parseChannels(raw: string): NotifyChannel[] {
     return channels;
 }
 
+const CHANNEL_MAP: Record<NotifyChannel, ChannelName> = {
+    terminal: "system",
+    say: "say",
+    telegram: "telegram",
+};
+
 /**
  * Production notifier. `dispatchNotification` reads channel *config* from the
  * shared `notify` store; the `channels` filter here decides which channels we
- * actually want for THIS run. "terminal" maps to the system channel.
+ * actually want for THIS run. "terminal" maps to the system channel. The
+ * per-run selection is passed through as the dispatch `only` allow-list so a
+ * channel enabled in config but not requested for this run does NOT fire.
  * NOTE: channels disabled in `notify` config still won't fire even if requested —
  * the user must enable telegram/say there once. terminal (system) is on by default.
  */
 export function createNotifier(channels: NotifyChannel[]): Notifier {
-    const wantSystem = channels.includes("terminal");
-    const wantSay = channels.includes("say");
-    const wantTelegram = channels.includes("telegram");
+    const only = channels.map((c) => CHANNEL_MAP[c]);
 
     return {
         notify: async ({ title, message, subtitle }) => {
-            if (!wantSystem && !wantSay && !wantTelegram) {
+            if (only.length === 0) {
                 return;
             }
 
@@ -51,6 +58,7 @@ export function createNotifier(channels: NotifyChannel[]): Notifier {
                 title,
                 message,
                 subtitle,
+                only,
             });
         },
     };

--- a/src/agent-watch/notify.ts
+++ b/src/agent-watch/notify.ts
@@ -1,6 +1,6 @@
-import { logger } from "@app/logger";
-import type { ChannelName } from "@app/utils/notifications";
-import { dispatchNotification } from "@app/utils/notifications";
+import { logger } from "@genesiscz/utils/logger";
+import type { ChannelName } from "@genesiscz/utils/notifications";
+import { dispatchNotification } from "@genesiscz/utils/notifications";
 import type { Notifier } from "./types";
 
 export type NotifyChannel = "terminal" | "say" | "telegram";

--- a/src/agent-watch/render.ts
+++ b/src/agent-watch/render.ts
@@ -1,0 +1,57 @@
+import { formatTable } from "@app/utils/table";
+import pc from "picocolors";
+import type { AgentSnapshot } from "./types";
+
+function fmtAge(ms: number): string {
+    const s = Math.max(0, Math.round(ms / 1000));
+
+    if (s < 60) {
+        return `${s}s`;
+    }
+
+    if (s < 3600) {
+        return `${Math.round(s / 60)}m`;
+    }
+
+    return `${Math.round(s / 3600)}h`;
+}
+
+function colorState(state: AgentSnapshot["state"]): string {
+    switch (state) {
+        case "FINISHED": {
+            return pc.green(state);
+        }
+
+        case "STALLED": {
+            return pc.yellow(state);
+        }
+
+        case "AWAITING-INPUT": {
+            return pc.magenta(state);
+        }
+
+        default: {
+            return pc.cyan(state);
+        }
+    }
+}
+
+export function renderStatusTable(snapshots: AgentSnapshot[]): string {
+    if (snapshots.length === 0) {
+        return "no agents tracked";
+    }
+
+    const rows = snapshots.map((s) => [
+        s.name,
+        s.source,
+        colorState(s.state) + (s.exitCode !== undefined ? ` (${s.exitCode})` : ""),
+        fmtAge(s.ageMs),
+        (s.lastLine ?? "").slice(0, 48),
+    ]);
+
+    return formatTable(rows, ["NAME", "SOURCE", "STATE", "AGE", "LAST OUTPUT"]);
+}
+
+export function toJsonSnapshot(snapshots: AgentSnapshot[], now: number): { now: number; agents: AgentSnapshot[] } {
+    return { now, agents: snapshots };
+}

--- a/src/agent-watch/render.ts
+++ b/src/agent-watch/render.ts
@@ -1,4 +1,4 @@
-import { formatTable } from "@app/utils/table";
+import { formatTable } from "@genesiscz/utils/table";
 import pc from "picocolors";
 import type { AgentSnapshot } from "./types";
 

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -47,7 +47,14 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
     }
 
     const snapshots: AgentSnapshot[] = [];
-    const projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+    let projectDirs: import("node:fs").Dirent[] = [];
+
+    try {
+        projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+    } catch (err) {
+        logger.debug({ err, root }, "could not list claude projects root");
+        return [];
+    }
 
     for (const projDir of projectDirs) {
         const projPath = join(root, projDir.name);

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -90,7 +90,7 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
                 const lastOutputAt = events.at(-1)?.ts ?? lastModified;
 
                 snapshots.push({
-                    id: `claude:${name}`,
+                    id: `claude:${projDir.name}:${name}`,
                     name,
                     source: "claude",
                     state,

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { logger } from "@app/logger";
+import { parseJsonl } from "@app/utils/jsonl";
+import { classifyAgentState } from "../classify";
+import type { AgentEvent, AgentSnapshot } from "../types";
+
+interface ClaudeRecord {
+    type?: string;
+    timestamp?: string;
+    ts?: number | string;
+}
+
+export function defaultClaudeRoot(): string {
+    return join(homedir(), ".claude", "projects");
+}
+
+function recordToEvent(rec: ClaudeRecord): AgentEvent | undefined {
+    const raw = rec.timestamp ?? rec.ts;
+    const ts = typeof raw === "number" ? raw : typeof raw === "string" ? Date.parse(raw) : Number.NaN;
+
+    if (Number.isNaN(ts)) {
+        return undefined;
+    }
+
+    // A trailing result/summary record looks like a finish; everything else is output.
+    if (rec.type === "result" || rec.type === "summary") {
+        return { kind: "exit", ts };
+    }
+
+    return { kind: "output", ts };
+}
+
+interface ReadClaudeOptions {
+    root?: string;
+    now: number;
+    stallTimeoutMs: number;
+}
+
+export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<AgentSnapshot[]> {
+    const root = opts.root ?? defaultClaudeRoot();
+
+    if (!existsSync(root)) {
+        logger.debug({ root }, "claude source root missing; skipping");
+        return [];
+    }
+
+    const snapshots: AgentSnapshot[] = [];
+    const projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+
+    for (const projDir of projectDirs) {
+        const projPath = join(root, projDir.name);
+        let sessionFiles: string[] = [];
+
+        try {
+            sessionFiles = readdirSync(projPath).filter((f) => f.endsWith(".jsonl"));
+        } catch (err) {
+            logger.debug({ err, projPath }, "could not list claude project dir");
+            continue;
+        }
+
+        for (const file of sessionFiles) {
+            const path = join(projPath, file);
+            const name = basename(file, ".jsonl");
+
+            try {
+                const buf = readFileSync(path);
+
+                if (buf.length === 0) {
+                    continue;
+                }
+
+                const records = parseJsonl<ClaudeRecord>(buf);
+                const events = records.map(recordToEvent).filter((e): e is AgentEvent => e !== undefined);
+                const lastModified = statSync(path).mtimeMs;
+                const state = classifyAgentState({
+                    events,
+                    lastModified,
+                    now: opts.now,
+                    stallTimeoutMs: opts.stallTimeoutMs,
+                });
+                const lastOutputAt = events.at(-1)?.ts ?? lastModified;
+
+                snapshots.push({
+                    id: `claude:${name}`,
+                    name,
+                    source: "claude",
+                    state,
+                    lastOutputAt,
+                    ageMs: opts.now - lastOutputAt,
+                });
+            } catch (err) {
+                logger.warn({ err, path }, "failed to read claude session; skipping");
+            }
+        }
+    }
+
+    return snapshots;
+}

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -80,6 +80,8 @@ interface ReadClaudeOptions {
     root?: string;
     now: number;
     stallTimeoutMs: number;
+    /** Skip files whose mtime is older than this window (ms). 0/undefined = read everything. */
+    activeWindowMs?: number;
 }
 
 export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<AgentSnapshot[]> {
@@ -90,6 +92,7 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
         return [];
     }
 
+    const cutoffMs = opts.activeWindowMs && opts.activeWindowMs > 0 ? opts.now - opts.activeWindowMs : undefined;
     const snapshots: AgentSnapshot[] = [];
     let projectDirs: import("node:fs").Dirent[] = [];
 
@@ -116,6 +119,15 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
             const name = basename(file, ".jsonl");
 
             try {
+                const lastModified = statSync(path).mtimeMs;
+
+                // Pre-read cutoff: don't parse hundreds of stale historical
+                // transcripts just to filter them out afterwards. lastOutputAt
+                // is always >= mtime, so nothing active is skipped.
+                if (cutoffMs !== undefined && lastModified < cutoffMs) {
+                    continue;
+                }
+
                 const buf = readFileSync(path);
 
                 if (buf.length === 0) {
@@ -124,7 +136,6 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
 
                 const records = parseJsonl<ClaudeRecord>(buf);
                 const events = recordsToEvents(records);
-                const lastModified = statSync(path).mtimeMs;
                 const state = classifyAgentState({
                     events,
                     lastModified,

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -131,7 +131,10 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
                     now: opts.now,
                     stallTimeoutMs: opts.stallTimeoutMs,
                 });
-                const lastOutputAt = events.at(-1)?.ts ?? lastModified;
+                // Same effective-activity timestamp the classifier uses —
+                // otherwise a live file with an older last parsed event can
+                // classify RUNNING yet fall outside the active window.
+                const lastOutputAt = Math.max(events.at(-1)?.ts ?? 0, lastModified);
 
                 snapshots.push({
                     id: `claude:${projDir.name}:${name}`,

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -6,30 +6,74 @@ import { logger } from "@genesiscz/utils/logger";
 import { classifyAgentState } from "../classify";
 import type { AgentEvent, AgentSnapshot } from "../types";
 
+interface ClaudeContentBlock {
+    type?: string;
+    name?: string;
+}
+
 interface ClaudeRecord {
     type?: string;
     timestamp?: string;
     ts?: number | string;
+    message?: {
+        stop_reason?: string | null;
+        content?: ClaudeContentBlock[] | string;
+    };
 }
 
 export function defaultClaudeRoot(): string {
     return join(homedir(), ".claude", "projects");
 }
 
-function recordToEvent(rec: ClaudeRecord): AgentEvent | undefined {
+function recordTs(rec: ClaudeRecord): number | undefined {
     const raw = rec.timestamp ?? rec.ts;
     const ts = typeof raw === "number" ? raw : typeof raw === "string" ? Date.parse(raw) : Number.NaN;
+    return Number.isNaN(ts) ? undefined : ts;
+}
 
-    if (Number.isNaN(ts)) {
-        return undefined;
+function asksUser(rec: ClaudeRecord): boolean {
+    if (rec.type !== "assistant") {
+        return false;
     }
 
-    // A trailing result/summary record looks like a finish; everything else is output.
-    if (rec.type === "result" || rec.type === "summary") {
-        return { kind: "exit", ts };
+    const content = rec.message?.content;
+    if (Array.isArray(content) && content.some((b) => b.type === "tool_use" && b.name === "AskUserQuestion")) {
+        return true;
     }
 
-    return { kind: "output", ts };
+    // A completed turn means the session is idle at the prompt, waiting on the user.
+    return rec.message?.stop_reason === "end_turn";
+}
+
+/**
+ * Convert a transcript into normalized events. Only the TRAILING record may
+ * mark a finish (`result`) or a question — `summary` records sit at the TOP of
+ * compacted/continued sessions and mid-file `result`s belong to subagents, so
+ * treating any of them as terminal would freeze live sessions at FINISHED.
+ */
+function recordsToEvents(records: ClaudeRecord[]): AgentEvent[] {
+    const events: AgentEvent[] = [];
+
+    for (let i = 0; i < records.length; i++) {
+        const rec = records[i];
+        const ts = recordTs(rec);
+
+        if (ts === undefined) {
+            continue;
+        }
+
+        const isLast = i === records.length - 1;
+
+        if (isLast && rec.type === "result") {
+            events.push({ kind: "exit", ts });
+        } else if (isLast && asksUser(rec)) {
+            events.push({ kind: "question", ts });
+        } else {
+            events.push({ kind: "output", ts });
+        }
+    }
+
+    return events;
 }
 
 interface ReadClaudeOptions {
@@ -79,7 +123,7 @@ export async function readClaudeSnapshots(opts: ReadClaudeOptions): Promise<Agen
                 }
 
                 const records = parseJsonl<ClaudeRecord>(buf);
-                const events = records.map(recordToEvent).filter((e): e is AgentEvent => e !== undefined);
+                const events = recordsToEvents(records);
                 const lastModified = statSync(path).mtimeMs;
                 const state = classifyAgentState({
                     events,

--- a/src/agent-watch/sources/claude.ts
+++ b/src/agent-watch/sources/claude.ts
@@ -1,8 +1,8 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { logger } from "@app/logger";
-import { parseJsonl } from "@app/utils/jsonl";
+import { parseJsonl } from "@genesiscz/utils/jsonl";
+import { logger } from "@genesiscz/utils/logger";
 import { classifyAgentState } from "../classify";
 import type { AgentEvent, AgentSnapshot } from "../types";
 

--- a/src/agent-watch/sources/index.ts
+++ b/src/agent-watch/sources/index.ts
@@ -1,0 +1,26 @@
+import type { AgentSnapshot, CollectOptions } from "../types";
+import { defaultClaudeRoot, readClaudeSnapshots } from "./claude";
+import { defaultTaskDir, readTaskSnapshots } from "./task";
+import { defaultWorkflowRoot, readWorkflowSnapshots } from "./workflows";
+
+export { defaultTaskDir, defaultClaudeRoot, defaultWorkflowRoot };
+
+export async function collectSnapshots(opts: CollectOptions): Promise<AgentSnapshot[]> {
+    const { sources, now, stallTimeoutMs, roots } = opts;
+    const results: AgentSnapshot[] = [];
+
+    if (sources.includes("task")) {
+        results.push(...(await readTaskSnapshots({ dir: roots?.task, now, stallTimeoutMs })));
+    }
+
+    if (sources.includes("claude")) {
+        results.push(...(await readClaudeSnapshots({ root: roots?.claude, now, stallTimeoutMs })));
+    }
+
+    if (sources.includes("workflows")) {
+        results.push(...(await readWorkflowSnapshots({ root: roots?.workflow, now, stallTimeoutMs })));
+    }
+
+    results.sort((a, b) => b.lastOutputAt - a.lastOutputAt);
+    return results;
+}

--- a/src/agent-watch/sources/index.ts
+++ b/src/agent-watch/sources/index.ts
@@ -10,15 +10,15 @@ export async function collectSnapshots(opts: CollectOptions): Promise<AgentSnaps
     let results: AgentSnapshot[] = [];
 
     if (sources.includes("task")) {
-        results.push(...(await readTaskSnapshots({ dir: roots?.task, now, stallTimeoutMs })));
+        results.push(...(await readTaskSnapshots({ dir: roots?.task, now, stallTimeoutMs, activeWindowMs })));
     }
 
     if (sources.includes("claude")) {
-        results.push(...(await readClaudeSnapshots({ root: roots?.claude, now, stallTimeoutMs })));
+        results.push(...(await readClaudeSnapshots({ root: roots?.claude, now, stallTimeoutMs, activeWindowMs })));
     }
 
     if (sources.includes("workflows")) {
-        results.push(...(await readWorkflowSnapshots({ root: roots?.workflow, now, stallTimeoutMs })));
+        results.push(...(await readWorkflowSnapshots({ root: roots?.workflow, now, stallTimeoutMs, activeWindowMs })));
     }
 
     if (activeWindowMs !== undefined && activeWindowMs > 0) {

--- a/src/agent-watch/sources/index.ts
+++ b/src/agent-watch/sources/index.ts
@@ -3,7 +3,7 @@ import { defaultClaudeRoot, readClaudeSnapshots } from "./claude";
 import { defaultTaskDir, readTaskSnapshots } from "./task";
 import { defaultWorkflowRoot, readWorkflowSnapshots } from "./workflows";
 
-export { defaultTaskDir, defaultClaudeRoot, defaultWorkflowRoot };
+export { defaultClaudeRoot, defaultTaskDir, defaultWorkflowRoot };
 
 export async function collectSnapshots(opts: CollectOptions): Promise<AgentSnapshot[]> {
     const { sources, now, stallTimeoutMs, roots } = opts;

--- a/src/agent-watch/sources/index.ts
+++ b/src/agent-watch/sources/index.ts
@@ -6,8 +6,8 @@ import { defaultWorkflowRoot, readWorkflowSnapshots } from "./workflows";
 export { defaultClaudeRoot, defaultTaskDir, defaultWorkflowRoot };
 
 export async function collectSnapshots(opts: CollectOptions): Promise<AgentSnapshot[]> {
-    const { sources, now, stallTimeoutMs, roots } = opts;
-    const results: AgentSnapshot[] = [];
+    const { sources, now, stallTimeoutMs, activeWindowMs, roots } = opts;
+    let results: AgentSnapshot[] = [];
 
     if (sources.includes("task")) {
         results.push(...(await readTaskSnapshots({ dir: roots?.task, now, stallTimeoutMs })));
@@ -19,6 +19,10 @@ export async function collectSnapshots(opts: CollectOptions): Promise<AgentSnaps
 
     if (sources.includes("workflows")) {
         results.push(...(await readWorkflowSnapshots({ root: roots?.workflow, now, stallTimeoutMs })));
+    }
+
+    if (activeWindowMs !== undefined && activeWindowMs > 0) {
+        results = results.filter((s) => s.ageMs <= activeWindowMs);
     }
 
     results.sort((a, b) => b.lastOutputAt - a.lastOutputAt);

--- a/src/agent-watch/sources/task.ts
+++ b/src/agent-watch/sources/task.ts
@@ -1,0 +1,124 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { parseJsonl } from "@app/utils/jsonl";
+import { isProcessAlive } from "@app/utils/process-alive";
+import { classifyAgentState } from "../classify";
+import type { AgentEvent, AgentSnapshot } from "../types";
+
+interface TaskLine {
+    type: "meta" | "line" | "exit";
+    ts?: number | string;
+    text?: string;
+    code?: number;
+}
+
+interface TaskMeta {
+    pid?: number;
+    exitCode?: number;
+    lastActivityAt?: number;
+}
+
+export function defaultTaskDir(): string {
+    return join(homedir(), ".genesis-tools", "task", "sessions");
+}
+
+function toEpochMs(ts: number | string | undefined): number | undefined {
+    if (typeof ts === "number") {
+        return ts;
+    }
+
+    if (typeof ts === "string") {
+        const parsed = Date.parse(ts);
+        return Number.isNaN(parsed) ? undefined : parsed;
+    }
+
+    return undefined;
+}
+
+function lineToEvent(line: TaskLine): AgentEvent | undefined {
+    const ts = toEpochMs(line.ts);
+
+    if (line.type === "exit") {
+        return { kind: "exit", ts: ts ?? 0, exitCode: line.code };
+    }
+
+    if (line.type === "line" && ts !== undefined) {
+        return { kind: "output", ts, text: line.text };
+    }
+
+    return undefined;
+}
+
+interface ReadTaskOptions {
+    dir?: string;
+    now: number;
+    stallTimeoutMs: number;
+}
+
+export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSnapshot[]> {
+    const dir = opts.dir ?? defaultTaskDir();
+
+    if (!existsSync(dir)) {
+        logger.debug({ dir }, "task source dir missing; skipping");
+        return [];
+    }
+
+    const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl") && !f.endsWith(".ui.jsonl"));
+    const snapshots: AgentSnapshot[] = [];
+
+    for (const file of files) {
+        const path = join(dir, file);
+        const name = basename(file, ".jsonl");
+
+        try {
+            const buf = readFileSync(path);
+            const records = parseJsonl<TaskLine>(buf);
+            const events = records.map(lineToEvent).filter((e): e is AgentEvent => e !== undefined);
+
+            const metaPath = join(dir, `${name}.meta.json`);
+            let pidAlive: boolean | undefined;
+            let metaExitCode: number | undefined;
+
+            if (existsSync(metaPath)) {
+                const meta = SafeJSON.parse(readFileSync(metaPath, "utf8")) as TaskMeta;
+                metaExitCode = meta.exitCode;
+
+                if (typeof meta.pid === "number" && meta.exitCode === undefined) {
+                    pidAlive = isProcessAlive(meta.pid);
+                }
+            }
+
+            const lastModified = statSync(path).mtimeMs;
+            const state = classifyAgentState({
+                events,
+                lastModified,
+                now: opts.now,
+                stallTimeoutMs: opts.stallTimeoutMs,
+                pidAlive,
+            });
+
+            const lastEvent = events.at(-1);
+            const exitEvent = events.find((e) => e.kind === "exit");
+            const lastOutputAt = lastEvent?.ts ?? lastModified;
+            const lastLine = [...events].reverse().find((e) => e.text)?.text;
+
+            snapshots.push({
+                id: `task:${name}`,
+                name,
+                source: "task",
+                state,
+                lastOutputAt,
+                ageMs: opts.now - lastOutputAt,
+                exitCode: exitEvent?.exitCode ?? metaExitCode,
+                lastLine,
+            });
+        } catch (err) {
+            logger.warn({ err, path }, "failed to read task session; skipping");
+        }
+    }
+
+    return snapshots;
+}

--- a/src/agent-watch/sources/task.ts
+++ b/src/agent-watch/sources/task.ts
@@ -66,7 +66,15 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
         return [];
     }
 
-    const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl") && !f.endsWith(".ui.jsonl"));
+    let files: string[] = [];
+
+    try {
+        files = readdirSync(dir).filter((f) => f.endsWith(".jsonl") && !f.endsWith(".ui.jsonl"));
+    } catch (err) {
+        logger.warn({ err, dir }, "failed to read task session directory; skipping");
+        return [];
+    }
+
     const snapshots: AgentSnapshot[] = [];
 
     for (const file of files) {
@@ -75,6 +83,11 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
 
         try {
             const buf = readFileSync(path);
+
+            if (buf.length === 0) {
+                continue;
+            }
+
             const records = parseJsonl<TaskLine>(buf);
             const events = records.map(lineToEvent).filter((e): e is AgentEvent => e !== undefined);
 
@@ -83,11 +96,14 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
             let metaExitCode: number | undefined;
 
             if (existsSync(metaPath)) {
-                const meta = SafeJSON.parse(readFileSync(metaPath, "utf8")) as TaskMeta;
-                metaExitCode = meta.exitCode;
+                const meta = SafeJSON.parse(readFileSync(metaPath, "utf8")) as TaskMeta | null;
 
-                if (typeof meta.pid === "number" && meta.exitCode === undefined) {
-                    pidAlive = isProcessAlive(meta.pid);
+                if (meta) {
+                    metaExitCode = meta.exitCode;
+
+                    if (typeof meta.pid === "number" && meta.exitCode === undefined) {
+                        pidAlive = isProcessAlive(meta.pid);
+                    }
                 }
             }
 
@@ -103,7 +119,7 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
             const lastEvent = events.at(-1);
             const exitEvent = events.find((e) => e.kind === "exit");
             const lastOutputAt = lastEvent?.ts ?? lastModified;
-            const lastLine = [...events].reverse().find((e) => e.text)?.text;
+            const lastLine = events.findLast((e) => e.text)?.text;
 
             snapshots.push({
                 id: `task:${name}`,

--- a/src/agent-watch/sources/task.ts
+++ b/src/agent-watch/sources/task.ts
@@ -101,7 +101,11 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
                 if (meta) {
                     metaExitCode = meta.exitCode;
 
-                    if (typeof meta.pid === "number" && meta.exitCode === undefined) {
+                    if (meta.exitCode !== undefined) {
+                        // Session recorded its exit in the sidecar; even if the
+                        // jsonl lacks a trailing exit line, this run is over.
+                        pidAlive = false;
+                    } else if (typeof meta.pid === "number") {
                         pidAlive = isProcessAlive(meta.pid);
                     }
                 }

--- a/src/agent-watch/sources/task.ts
+++ b/src/agent-watch/sources/task.ts
@@ -56,6 +56,8 @@ interface ReadTaskOptions {
     dir?: string;
     now: number;
     stallTimeoutMs: number;
+    /** Skip files whose on-disk activity is older than this (ms). 0/undefined = read everything. */
+    activeWindowMs?: number;
 }
 
 export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSnapshot[]> {
@@ -77,11 +79,31 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
 
     const snapshots: AgentSnapshot[] = [];
 
+    const cutoffMs = opts.activeWindowMs && opts.activeWindowMs > 0 ? opts.now - opts.activeWindowMs : undefined;
+
     for (const file of files) {
         const path = join(dir, file);
         const name = basename(file, ".jsonl");
+        const metaPath = join(dir, `${name}.meta.json`);
 
         try {
+            // Sidecar activity: the meta file may record activity (or its own
+            // mtime) newer than the jsonl — e.g. an exit written only there.
+            let metaActivityAt = 0;
+            const hasMeta = existsSync(metaPath);
+            let meta: TaskMeta | null = null;
+
+            if (hasMeta) {
+                metaActivityAt = statSync(metaPath).mtimeMs;
+            }
+
+            // Pre-read cutoff: skip stale historical sessions without parsing
+            // them. Uses the same activity signal (jsonl mtime + sidecar) the
+            // snapshot itself is stamped with, so nothing active is skipped.
+            if (cutoffMs !== undefined && statSync(path).mtimeMs < cutoffMs && metaActivityAt < cutoffMs) {
+                continue;
+            }
+
             const buf = readFileSync(path);
 
             if (buf.length === 0) {
@@ -91,15 +113,15 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
             const records = parseJsonl<TaskLine>(buf);
             const events = records.map(lineToEvent).filter((e): e is AgentEvent => e !== undefined);
 
-            const metaPath = join(dir, `${name}.meta.json`);
             let pidAlive: boolean | undefined;
             let metaExitCode: number | undefined;
 
-            if (existsSync(metaPath)) {
-                const meta = SafeJSON.parse(readFileSync(metaPath, "utf8")) as TaskMeta | null;
+            if (hasMeta) {
+                meta = SafeJSON.parse(readFileSync(metaPath, "utf8")) as TaskMeta | null;
 
                 if (meta) {
                     metaExitCode = meta.exitCode;
+                    metaActivityAt = Math.max(metaActivityAt, meta.lastActivityAt ?? 0);
 
                     if (meta.exitCode !== undefined) {
                         // Session recorded its exit in the sidecar; even if the
@@ -111,7 +133,7 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
                 }
             }
 
-            const lastModified = statSync(path).mtimeMs;
+            const lastModified = Math.max(statSync(path).mtimeMs, metaActivityAt);
             const state = classifyAgentState({
                 events,
                 lastModified,

--- a/src/agent-watch/sources/task.ts
+++ b/src/agent-watch/sources/task.ts
@@ -1,10 +1,10 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { logger } from "@app/logger";
-import { SafeJSON } from "@app/utils/json";
-import { parseJsonl } from "@app/utils/jsonl";
-import { isProcessAlive } from "@app/utils/process-alive";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { parseJsonl } from "@genesiscz/utils/jsonl";
+import { logger } from "@genesiscz/utils/logger";
+import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { classifyAgentState } from "../classify";
 import type { AgentEvent, AgentSnapshot } from "../types";
 

--- a/src/agent-watch/sources/task.ts
+++ b/src/agent-watch/sources/task.ts
@@ -120,9 +120,8 @@ export async function readTaskSnapshots(opts: ReadTaskOptions): Promise<AgentSna
                 pidAlive,
             });
 
-            const lastEvent = events.at(-1);
             const exitEvent = events.find((e) => e.kind === "exit");
-            const lastOutputAt = lastEvent?.ts ?? lastModified;
+            const lastOutputAt = Math.max(events.at(-1)?.ts ?? 0, lastModified);
             const lastLine = events.findLast((e) => e.text)?.text;
 
             snapshots.push({

--- a/src/agent-watch/sources/workflows.ts
+++ b/src/agent-watch/sources/workflows.ts
@@ -84,7 +84,7 @@ export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<
                     });
 
                     snapshots.push({
-                        id: `workflows:${session}/${leaf}`,
+                        id: `workflows:${projDir.name}/${session}/${leaf}`,
                         name: leaf,
                         source: "workflows",
                         state,

--- a/src/agent-watch/sources/workflows.ts
+++ b/src/agent-watch/sources/workflows.ts
@@ -30,7 +30,14 @@ export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<
     }
 
     const snapshots: AgentSnapshot[] = [];
-    const projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+    let projectDirs: import("node:fs").Dirent[] = [];
+
+    try {
+        projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+    } catch (err) {
+        logger.debug({ err, root }, "could not list workflow projects root");
+        return [];
+    }
 
     for (const projDir of projectDirs) {
         const sessionsRoot = join(root, projDir.name);
@@ -65,23 +72,28 @@ export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<
 
             for (const leaf of leaves) {
                 const leafPath = join(wfRoot, leaf);
-                const lastModified = statSync(leafPath).mtimeMs;
-                const state = classifyAgentState({
-                    events: [],
-                    lastModified,
-                    now: opts.now,
-                    stallTimeoutMs: opts.stallTimeoutMs,
-                    pidAlive: true,
-                });
 
-                snapshots.push({
-                    id: `workflows:${session}/${leaf}`,
-                    name: leaf,
-                    source: "workflows",
-                    state,
-                    lastOutputAt: lastModified,
-                    ageMs: opts.now - lastModified,
-                });
+                try {
+                    const lastModified = statSync(leafPath).mtimeMs;
+                    const state = classifyAgentState({
+                        events: [],
+                        lastModified,
+                        now: opts.now,
+                        stallTimeoutMs: opts.stallTimeoutMs,
+                        pidAlive: true,
+                    });
+
+                    snapshots.push({
+                        id: `workflows:${session}/${leaf}`,
+                        name: leaf,
+                        source: "workflows",
+                        state,
+                        lastOutputAt: lastModified,
+                        ageMs: opts.now - lastModified,
+                    });
+                } catch (err) {
+                    logger.debug({ err, leafPath }, "failed to stat workflow leaf; skipping");
+                }
             }
         }
     }

--- a/src/agent-watch/sources/workflows.ts
+++ b/src/agent-watch/sources/workflows.ts
@@ -1,0 +1,90 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { classifyAgentState } from "../classify";
+import type { AgentSnapshot } from "../types";
+
+export function defaultWorkflowRoot(): string {
+    return join(homedir(), ".claude", "projects");
+}
+
+interface ReadWorkflowOptions {
+    root?: string;
+    now: number;
+    stallTimeoutMs: number;
+}
+
+/**
+ * Workflow transcripts live at projects/<proj>/<session>/subagents/workflows/**.
+ * We treat each leaf workflow dir as one agent and classify by its mtime alone
+ * (no per-event parse needed for v1 — a workflow dir untouched past the timeout
+ * is STALLED; otherwise RUNNING). Exit detection for workflows is out of scope v1.
+ */
+export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<AgentSnapshot[]> {
+    const root = opts.root ?? defaultWorkflowRoot();
+
+    if (!existsSync(root)) {
+        logger.debug({ root }, "workflow source root missing; skipping");
+        return [];
+    }
+
+    const snapshots: AgentSnapshot[] = [];
+    const projectDirs = readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory());
+
+    for (const projDir of projectDirs) {
+        const sessionsRoot = join(root, projDir.name);
+        let sessionDirs: string[] = [];
+
+        try {
+            sessionDirs = readdirSync(sessionsRoot, { withFileTypes: true })
+                .filter((d) => d.isDirectory())
+                .map((d) => d.name);
+        } catch (err) {
+            logger.debug({ err, sessionsRoot }, "could not list workflow sessions");
+            continue;
+        }
+
+        for (const session of sessionDirs) {
+            const wfRoot = join(sessionsRoot, session, "subagents", "workflows");
+
+            if (!existsSync(wfRoot)) {
+                continue;
+            }
+
+            let leaves: string[] = [];
+
+            try {
+                leaves = readdirSync(wfRoot, { withFileTypes: true })
+                    .filter((d) => d.isDirectory())
+                    .map((d) => d.name);
+            } catch (err) {
+                logger.debug({ err, wfRoot }, "could not list workflow leaves");
+                continue;
+            }
+
+            for (const leaf of leaves) {
+                const leafPath = join(wfRoot, leaf);
+                const lastModified = statSync(leafPath).mtimeMs;
+                const state = classifyAgentState({
+                    events: [],
+                    lastModified,
+                    now: opts.now,
+                    stallTimeoutMs: opts.stallTimeoutMs,
+                    pidAlive: true,
+                });
+
+                snapshots.push({
+                    id: `workflows:${session}/${leaf}`,
+                    name: leaf,
+                    source: "workflows",
+                    state,
+                    lastOutputAt: lastModified,
+                    ageMs: opts.now - lastModified,
+                });
+            }
+        }
+    }
+
+    return snapshots;
+}

--- a/src/agent-watch/sources/workflows.ts
+++ b/src/agent-watch/sources/workflows.ts
@@ -16,6 +16,33 @@ interface ReadWorkflowOptions {
 }
 
 /**
+ * Appending to an EXISTING file does not touch its parent directory's mtime
+ * (only create/rename/delete do), so an actively-writing workflow would look
+ * frozen by dir mtime alone. Activity = newest mtime of the dir or any file
+ * directly inside it (workflow transcripts are flat jsonl files).
+ */
+function newestMtime(dir: string): number {
+    let newest = statSync(dir).mtimeMs;
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isFile()) {
+            continue;
+        }
+
+        try {
+            const m = statSync(join(dir, entry.name)).mtimeMs;
+            if (m > newest) {
+                newest = m;
+            }
+        } catch (err) {
+            logger.debug({ err, dir, file: entry.name }, "workflow file vanished between readdir and stat");
+        }
+    }
+
+    return newest;
+}
+
+/**
  * Workflow transcripts live at projects/<proj>/<session>/subagents/workflows/**.
  * We treat each leaf workflow dir as one agent and classify by its mtime alone
  * (no per-event parse needed for v1 — a workflow dir untouched past the timeout
@@ -74,7 +101,7 @@ export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<
                 const leafPath = join(wfRoot, leaf);
 
                 try {
-                    const lastModified = statSync(leafPath).mtimeMs;
+                    const lastModified = newestMtime(leafPath);
                     const state = classifyAgentState({
                         events: [],
                         lastModified,

--- a/src/agent-watch/sources/workflows.ts
+++ b/src/agent-watch/sources/workflows.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { logger } from "@app/logger";
+import { logger } from "@genesiscz/utils/logger";
 import { classifyAgentState } from "../classify";
 import type { AgentSnapshot } from "../types";
 

--- a/src/agent-watch/sources/workflows.ts
+++ b/src/agent-watch/sources/workflows.ts
@@ -13,6 +13,8 @@ interface ReadWorkflowOptions {
     root?: string;
     now: number;
     stallTimeoutMs: number;
+    /** Skip leaves whose newest mtime is older than this window (ms). 0/undefined = keep everything. */
+    activeWindowMs?: number;
 }
 
 /**
@@ -56,6 +58,7 @@ export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<
         return [];
     }
 
+    const cutoffMs = opts.activeWindowMs && opts.activeWindowMs > 0 ? opts.now - opts.activeWindowMs : undefined;
     const snapshots: AgentSnapshot[] = [];
     let projectDirs: import("node:fs").Dirent[] = [];
 
@@ -102,6 +105,11 @@ export async function readWorkflowSnapshots(opts: ReadWorkflowOptions): Promise<
 
                 try {
                     const lastModified = newestMtime(leafPath);
+
+                    if (cutoffMs !== undefined && lastModified < cutoffMs) {
+                        continue;
+                    }
+
                     const state = classifyAgentState({
                         events: [],
                         lastModified,

--- a/src/agent-watch/transitions.ts
+++ b/src/agent-watch/transitions.ts
@@ -1,0 +1,44 @@
+import type { AgentSnapshot, AgentState } from "./types";
+
+export const NOTABLE_STATES: ReadonlySet<AgentState> = new Set<AgentState>(["FINISHED", "STALLED", "AWAITING-INPUT"]);
+
+/**
+ * PURE transition gate. Notify only when entering a NOTABLE state from a
+ * *different* state. First sighting (prev === undefined) notifies iff the
+ * agent is already notable. Recovery into RUNNING and unchanged states are quiet.
+ */
+export function shouldNotify(prev: AgentState | undefined, next: AgentState): boolean {
+    if (!NOTABLE_STATES.has(next)) {
+        return false;
+    }
+
+    return prev !== next;
+}
+
+function describeState(snap: AgentSnapshot): string {
+    switch (snap.state) {
+        case "FINISHED": {
+            const code = snap.exitCode ?? 0;
+            return code === 0 ? "finished" : `finished with exit code ${code}`;
+        }
+
+        case "STALLED": {
+            return "stalled (no output)";
+        }
+
+        case "AWAITING-INPUT": {
+            return "is waiting for your input";
+        }
+
+        default: {
+            return "is running";
+        }
+    }
+}
+
+export function transitionMessage(snap: AgentSnapshot): { title: string; message: string; subtitle?: string } {
+    const title = `agent ${snap.name}`;
+    const message = `${snap.name} ${describeState(snap)}`;
+    const subtitle = snap.lastLine ? snap.lastLine.slice(0, 120) : undefined;
+    return { title, message, subtitle };
+}

--- a/src/agent-watch/types.ts
+++ b/src/agent-watch/types.ts
@@ -1,0 +1,61 @@
+export type AgentState = "RUNNING" | "FINISHED" | "STALLED" | "AWAITING-INPUT";
+
+export type WatchSourceName = "task" | "claude" | "workflows";
+
+/** Normalized event, source-agnostic. Adapters convert native records into this. */
+export interface AgentEvent {
+    /** Epoch ms when the event happened. */
+    ts: number;
+    kind: "start" | "output" | "exit" | "question";
+    /** Exit status when kind === "exit" (process exit code). */
+    exitCode?: number;
+    /** Human-readable text for the last-line preview (output/question events). */
+    text?: string;
+}
+
+/** Input to the PURE classifier. Nothing here is read from a clock or fs. */
+export interface ClassifyInput {
+    /** Ordered oldest→newest. May be empty. */
+    events: AgentEvent[];
+    /** Epoch ms the underlying file/dir was last modified. */
+    lastModified: number;
+    /** Injected "current time" in epoch ms. */
+    now: number;
+    /** Stall threshold in ms. */
+    stallTimeoutMs: number;
+    /**
+     * Tri-state pid liveness hint resolved OUTSIDE the core:
+     *   true  → pid confirmed alive
+     *   false → pid confirmed dead (forces FINISHED if not awaiting input)
+     *   undefined → no pid info; rely on events + timing only
+     */
+    pidAlive?: boolean;
+}
+
+/** One discovered agent after classification. */
+export interface AgentSnapshot {
+    /** Stable unique id, e.g. "task:checks-6984". */
+    id: string;
+    name: string;
+    source: WatchSourceName;
+    state: AgentState;
+    /** Epoch ms of the newest event (or file mtime if no events). */
+    lastOutputAt: number;
+    /** now - lastOutputAt, ms. */
+    ageMs: number;
+    exitCode?: number;
+    lastLine?: string;
+}
+
+/** Injectable notification sink. Production wraps dispatchNotification; tests stub it. */
+export interface Notifier {
+    notify(input: { title: string; message: string; subtitle?: string }): Promise<void>;
+}
+
+export interface CollectOptions {
+    sources: WatchSourceName[];
+    now: number;
+    stallTimeoutMs: number;
+    /** Optional root overrides — injected by tests for hermeticity. Defaults to homedir-derived paths. */
+    roots?: { task?: string; claude?: string; workflow?: string };
+}

--- a/src/agent-watch/types.ts
+++ b/src/agent-watch/types.ts
@@ -56,6 +56,11 @@ export interface CollectOptions {
     sources: WatchSourceName[];
     now: number;
     stallTimeoutMs: number;
+    /**
+     * Drop agents whose last activity is older than this (ms). Keeps hundreds
+     * of historical sessions out of watch/status. 0/undefined = no filter.
+     */
+    activeWindowMs?: number;
     /** Optional root overrides — injected by tests for hermeticity. Defaults to homedir-derived paths. */
     roots?: { task?: string; claude?: string; workflow?: string };
 }

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -1,0 +1,138 @@
+import { logger, out } from "@app/logger";
+import chokidar from "chokidar";
+import { collectSnapshots, defaultClaudeRoot, defaultTaskDir, defaultWorkflowRoot } from "./sources/index";
+import { shouldNotify, transitionMessage } from "./transitions";
+import type { AgentSnapshot, AgentState, Notifier, WatchSourceName } from "./types";
+
+export interface DecideAndNotifyInput {
+    snapshots: AgentSnapshot[];
+    prevStates: Map<string, AgentState>;
+    notifier: Notifier;
+}
+
+/**
+ * For each snapshot, compare its state to the remembered previous state and
+ * notify on a notable transition. Mutates `prevStates` to the new states.
+ * Returns the snapshots that fired (for the live status line).
+ */
+export async function decideAndNotify(input: DecideAndNotifyInput): Promise<AgentSnapshot[]> {
+    const { snapshots, prevStates, notifier } = input;
+    const fired: AgentSnapshot[] = [];
+
+    for (const snap of snapshots) {
+        const prev = prevStates.get(snap.id);
+        prevStates.set(snap.id, snap.state);
+
+        if (!shouldNotify(prev, snap.state)) {
+            continue;
+        }
+
+        const msg = transitionMessage(snap);
+
+        try {
+            await notifier.notify(msg);
+            fired.push(snap);
+        } catch (err) {
+            logger.warn({ err, id: snap.id }, "notifier failed");
+        }
+    }
+
+    return fired;
+}
+
+export interface RunWatchOptions {
+    sources: WatchSourceName[];
+    stallTimeoutMs: number;
+    pollMs: number;
+    notifier: Notifier;
+    json: boolean;
+    /** When set, do a single pass and resolve (cron / --once). */
+    once?: boolean;
+    /** Injected clock for determinism in any future test; defaults to Date.now. */
+    now?: () => number;
+}
+
+function watchRootsFor(sources: WatchSourceName[]): string[] {
+    const roots: string[] = [];
+
+    if (sources.includes("task")) {
+        roots.push(defaultTaskDir());
+    }
+
+    if (sources.includes("claude")) {
+        roots.push(defaultClaudeRoot());
+    }
+
+    if (sources.includes("workflows")) {
+        roots.push(defaultWorkflowRoot());
+    }
+
+    return roots;
+}
+
+async function sweep(opts: RunWatchOptions, prevStates: Map<string, AgentState>): Promise<void> {
+    const now = (opts.now ?? Date.now)();
+    const snapshots = await collectSnapshots({ sources: opts.sources, now, stallTimeoutMs: opts.stallTimeoutMs });
+    const fired = await decideAndNotify({ snapshots, prevStates, notifier: opts.notifier });
+
+    for (const snap of fired) {
+        const ts = new Date(now).toTimeString().slice(0, 8);
+        out.log.step(`[${ts}] ${snap.name.padEnd(20)} → ${snap.state}  notified`);
+
+        if (opts.json) {
+            out.result({ ts: now, id: snap.id, name: snap.name, source: snap.source, state: snap.state });
+        }
+    }
+}
+
+export async function runWatch(opts: RunWatchOptions): Promise<void> {
+    const prevStates = new Map<string, AgentState>();
+
+    // Baseline pass: seed prevStates. On --once we still want the FIRST notable
+    // states reported, so we run sweep (shouldNotify fires on undefined→notable).
+    await sweep(opts, prevStates);
+
+    if (opts.once) {
+        return;
+    }
+
+    const roots = watchRootsFor(opts.sources);
+    out.log.info(`watching ${roots.length} root(s) · stall-timeout ${opts.stallTimeoutMs / 1000}s`);
+
+    const watcher = chokidar.watch(roots, { persistent: true, ignoreInitial: true, depth: 6 });
+    let sweeping = false;
+
+    const trigger = async (): Promise<void> => {
+        if (sweeping) {
+            return;
+        }
+
+        sweeping = true;
+
+        try {
+            await sweep(opts, prevStates);
+        } finally {
+            sweeping = false;
+        }
+    };
+
+    watcher.on("change", trigger);
+    watcher.on("add", trigger);
+
+    // Poll re-sweep: a STALL is the ABSENCE of file events, so chokidar never
+    // wakes us for it — we must re-classify on a timer to catch stalls/dead pids.
+    const interval = setInterval(() => {
+        void trigger();
+    }, opts.pollMs);
+
+    await new Promise<void>((resolve) => {
+        const stop = (): void => {
+            clearInterval(interval);
+            void watcher.close();
+            resolve();
+        };
+
+        process.once("SIGINT", stop);
+        process.once("SIGTERM", stop);
+    });
+}

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -111,6 +111,8 @@ export async function runWatch(opts: RunWatchOptions): Promise<void> {
 
         try {
             await sweep(opts, prevStates);
+        } catch (err) {
+            logger.warn({ err }, "agent-watch sweep failed");
         } finally {
             sweeping = false;
         }

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -118,6 +118,9 @@ export async function runWatch(opts: RunWatchOptions): Promise<void> {
 
     watcher.on("change", trigger);
     watcher.on("add", trigger);
+    watcher.on("error", (err) => {
+        logger.error({ err }, "watcher error");
+    });
 
     // Poll re-sweep: a STALL is the ABSENCE of file events, so chokidar never
     // wakes us for it — we must re-classify on a timer to catch stalls/dead pids.

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -126,16 +126,24 @@ export async function runWatch(opts: RunWatchOptions): Promise<void> {
 
     const watcher = chokidar.watch(roots, { persistent: true, ignoreInitial: true, depth: 6 });
     let sweeping = false;
+    let resweepQueued = false;
 
+    // An event landing DURING a sweep may describe a change the sweep already
+    // missed — dropping it would delay (or lose) the transition until the next
+    // poll. Queue exactly one follow-up sweep instead.
     const trigger = async (): Promise<void> => {
         if (sweeping) {
+            resweepQueued = true;
             return;
         }
 
         sweeping = true;
 
         try {
-            await sweep(opts, prevStates);
+            do {
+                resweepQueued = false;
+                await sweep(opts, prevStates);
+            } while (resweepQueued);
         } catch (err) {
             logger.warn({ err }, "agent-watch sweep failed");
         } finally {

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -1,4 +1,4 @@
-import { logger, out } from "@app/logger";
+import { logger, out } from "@genesiscz/utils/logger";
 import chokidar from "chokidar";
 import { collectSnapshots, defaultClaudeRoot, defaultTaskDir, defaultWorkflowRoot } from "./sources/index";
 import { shouldNotify, transitionMessage } from "./transitions";

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -21,9 +21,9 @@ export async function decideAndNotify(input: DecideAndNotifyInput): Promise<Agen
 
     for (const snap of snapshots) {
         const prev = prevStates.get(snap.id);
-        prevStates.set(snap.id, snap.state);
 
         if (!shouldNotify(prev, snap.state)) {
+            prevStates.set(snap.id, snap.state);
             continue;
         }
 
@@ -31,9 +31,12 @@ export async function decideAndNotify(input: DecideAndNotifyInput): Promise<Agen
 
         try {
             await notifier.notify(msg);
+            // Commit the state only after the notify succeeds — a transient
+            // notifier failure leaves prev unchanged so the next sweep retries.
+            prevStates.set(snap.id, snap.state);
             fired.push(snap);
         } catch (err) {
-            logger.warn({ err, id: snap.id }, "notifier failed");
+            logger.warn({ err, id: snap.id }, "notifier failed; transition will retry on next sweep");
         }
     }
 
@@ -74,11 +77,14 @@ function watchRootsFor(sources: WatchSourceName[]): string[] {
 
 const SILENT_NOTIFIER: Notifier = { notify: async () => {} };
 
-export async function sweep(
-    opts: RunWatchOptions,
-    prevStates: Map<string, AgentState>,
-    mode: { notify: boolean } = { notify: true }
-): Promise<AgentSnapshot[]> {
+export interface SweepInput {
+    opts: RunWatchOptions;
+    prevStates: Map<string, AgentState>;
+    mode?: { notify: boolean };
+}
+
+export async function sweep(input: SweepInput): Promise<AgentSnapshot[]> {
+    const { opts, prevStates, mode = { notify: true } } = input;
     const now = (opts.now ?? Date.now)();
     const snapshots = await collectSnapshots({
         sources: opts.sources,
@@ -91,6 +97,11 @@ export async function sweep(
         prevStates,
         notifier: mode.notify ? opts.notifier : SILENT_NOTIFIER,
     });
+
+    logger.debug(
+        { sources: opts.sources, notify: mode.notify, snapshots: snapshots.length, fired: fired.length },
+        "sweep complete"
+    );
 
     if (!mode.notify) {
         return [];
@@ -105,6 +116,7 @@ export async function sweep(
         }
     }
 
+    await out.flush();
     return fired;
 }
 
@@ -115,7 +127,7 @@ export async function runWatch(opts: RunWatchOptions): Promise<void> {
     // window SHOULD fire (that's the single-shot's purpose). In continuous mode
     // the baseline only seeds prevStates — notifying on states that were already
     // notable before we started would replay history as a notification storm.
-    await sweep(opts, prevStates, { notify: opts.once === true });
+    await sweep({ opts, prevStates, mode: { notify: opts.once === true } });
 
     if (opts.once) {
         return;
@@ -142,7 +154,7 @@ export async function runWatch(opts: RunWatchOptions): Promise<void> {
         try {
             do {
                 resweepQueued = false;
-                await sweep(opts, prevStates);
+                await sweep({ opts, prevStates });
             } while (resweepQueued);
         } catch (err) {
             logger.warn({ err }, "agent-watch sweep failed");
@@ -166,8 +178,12 @@ export async function runWatch(opts: RunWatchOptions): Promise<void> {
     await new Promise<void>((resolve) => {
         const stop = (): void => {
             clearInterval(interval);
-            void watcher.close();
-            resolve();
+            watcher
+                .close()
+                .catch((err) => {
+                    logger.warn({ err }, "watcher close failed");
+                })
+                .finally(resolve);
         };
 
         process.once("SIGINT", stop);

--- a/src/agent-watch/watcher.ts
+++ b/src/agent-watch/watcher.ts
@@ -46,6 +46,8 @@ export interface RunWatchOptions {
     pollMs: number;
     notifier: Notifier;
     json: boolean;
+    /** Drop agents inactive longer than this (ms). 0 = no filter. */
+    activeWindowMs?: number;
     /** When set, do a single pass and resolve (cron / --once). */
     once?: boolean;
     /** Injected clock for determinism in any future test; defaults to Date.now. */
@@ -70,10 +72,29 @@ function watchRootsFor(sources: WatchSourceName[]): string[] {
     return roots;
 }
 
-async function sweep(opts: RunWatchOptions, prevStates: Map<string, AgentState>): Promise<void> {
+const SILENT_NOTIFIER: Notifier = { notify: async () => {} };
+
+export async function sweep(
+    opts: RunWatchOptions,
+    prevStates: Map<string, AgentState>,
+    mode: { notify: boolean } = { notify: true }
+): Promise<AgentSnapshot[]> {
     const now = (opts.now ?? Date.now)();
-    const snapshots = await collectSnapshots({ sources: opts.sources, now, stallTimeoutMs: opts.stallTimeoutMs });
-    const fired = await decideAndNotify({ snapshots, prevStates, notifier: opts.notifier });
+    const snapshots = await collectSnapshots({
+        sources: opts.sources,
+        now,
+        stallTimeoutMs: opts.stallTimeoutMs,
+        activeWindowMs: opts.activeWindowMs,
+    });
+    const fired = await decideAndNotify({
+        snapshots,
+        prevStates,
+        notifier: mode.notify ? opts.notifier : SILENT_NOTIFIER,
+    });
+
+    if (!mode.notify) {
+        return [];
+    }
 
     for (const snap of fired) {
         const ts = new Date(now).toTimeString().slice(0, 8);
@@ -83,14 +104,18 @@ async function sweep(opts: RunWatchOptions, prevStates: Map<string, AgentState>)
             out.result({ ts: now, id: snap.id, name: snap.name, source: snap.source, state: snap.state });
         }
     }
+
+    return fired;
 }
 
 export async function runWatch(opts: RunWatchOptions): Promise<void> {
     const prevStates = new Map<string, AgentState>();
 
-    // Baseline pass: seed prevStates. On --once we still want the FIRST notable
-    // states reported, so we run sweep (shouldNotify fires on undefined→notable).
-    await sweep(opts, prevStates);
+    // Baseline pass. On --once (cron) currently-notable states within the active
+    // window SHOULD fire (that's the single-shot's purpose). In continuous mode
+    // the baseline only seeds prevStates — notifying on states that were already
+    // notable before we started would replay history as a notification storm.
+    await sweep(opts, prevStates, { notify: opts.once === true });
 
     if (opts.once) {
         return;

--- a/src/codex/lib/control-channel.ts
+++ b/src/codex/lib/control-channel.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { isProcessAlive } from "@app/task/lib/process-alive";
+import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { parseJsonl } from "@genesiscz/utils/jsonl";
 import { withFileLock } from "@genesiscz/utils/storage";

--- a/src/codex/lib/control-channel.ts
+++ b/src/codex/lib/control-channel.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { parseJsonl } from "@genesiscz/utils/jsonl";
+import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { withFileLock } from "@genesiscz/utils/storage";
 import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
 import type { CodexControl } from "./control";

--- a/src/codex/lib/seed-instructions.ts
+++ b/src/codex/lib/seed-instructions.ts
@@ -2,7 +2,21 @@ export function buildAgentInstructions(options: {
     agentName: string;
     rendezvousSession: string;
     leadName: string;
+    sandbox?: string;
 }): string {
+    // In a read-only sandbox every write is denied — including the agents
+    // feed lock — so `tools agents …` calls can only fail with EPERM. The
+    // bridge already streams this session's items (assistant messages,
+    // commands, file changes) to the lead, so narration IS the channel.
+    if (options.sandbox === "read-only") {
+        return [
+            `You are \`${options.agentName}\`, a member of a Claude Code agent swarm. The lead agent is \`${options.leadName}\`.`,
+            "Your sandbox is READ-ONLY: do NOT run `tools agents` commands — any write, including the messaging feed, fails with EPERM.",
+            "Instead, narrate progress as short standalone assistant messages (one concise line per meaningful step);",
+            "the lead automatically receives every message and command you produce through the session event bridge.",
+        ].join("\n");
+    }
+
     const sessionFlag = `--session ${options.rendezvousSession}`;
 
     return [

--- a/src/codex/lib/session.test.ts
+++ b/src/codex/lib/session.test.ts
@@ -158,7 +158,11 @@ describe("CodexSessionRuntime", () => {
 
             const result = await runtime.execute({ op: "steer", body: "Focus on auth", force: false });
 
-            expect(result).toEqual({ turnId: "turn-2", queued: false });
+            // codex 0.144.5 merges mid-turn input into the ACTIVE turn (verified
+            // live): the phantom new turn id is reported, but meta keeps the
+            // original active turn.
+            expect(result).toEqual({ turnId: "turn-2", queued: false, merged: true });
+            expect((await store.readMeta("reviewer"))?.activeTurnId).toBe("turn-1");
             expect(client.requests.at(-1)).toEqual({
                 method: "turn/start",
                 params: {

--- a/src/codex/lib/session.ts
+++ b/src/codex/lib/session.ts
@@ -283,10 +283,7 @@ export class CodexSessionRuntime {
         return this.meta.threadId;
     }
 
-    private async steer(
-        body: string,
-        force: boolean
-    ): Promise<{ turnId?: string; queued: boolean; merged?: boolean }> {
+    private async steer(body: string, force: boolean): Promise<{ turnId?: string; queued: boolean; merged?: boolean }> {
         // codex 0.144.5 accepts turn/start during an active turn and MERGES the
         // input into it (verified live): the returned turn id never runs as a
         // separate turn, so keep the original active id in meta instead of the

--- a/src/codex/lib/session.ts
+++ b/src/codex/lib/session.ts
@@ -122,6 +122,7 @@ export class CodexSessionRuntime {
                           agentName: this.meta.agentName,
                           rendezvousSession: this.meta.rendezvousSession,
                           leadName: "lead",
+                          sandbox: this.meta.sandbox,
                       }),
                   }
                 : {}),
@@ -282,9 +283,25 @@ export class CodexSessionRuntime {
         return this.meta.threadId;
     }
 
-    private async steer(body: string, force: boolean): Promise<{ turnId?: string; queued: boolean }> {
+    private async steer(
+        body: string,
+        force: boolean
+    ): Promise<{ turnId?: string; queued: boolean; merged?: boolean }> {
+        // codex 0.144.5 accepts turn/start during an active turn and MERGES the
+        // input into it (verified live): the returned turn id never runs as a
+        // separate turn, so keep the original active id in meta instead of the
+        // phantom one. The error path below is kept for servers that reject
+        // same-turn input.
+        const activeBefore = this.meta.activeTurnId;
+
         try {
             const turnId = await this.startTurn(body);
+
+            if (activeBefore) {
+                await this.updateMeta({ activeTurnId: activeBefore });
+                return { turnId, queued: false, merged: true };
+            }
+
             return { turnId, queued: false };
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);

--- a/src/codex/lib/spawn.ts
+++ b/src/codex/lib/spawn.ts
@@ -1,8 +1,8 @@
 import { closeSync, openSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
+import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
 import { CODEX_SCHEMA_VERSION } from "./_generated/protocol";
 import { sessionDaemonLogPath, sessionLaunchPath } from "./paths";

--- a/src/codex/lib/spawn.ts
+++ b/src/codex/lib/spawn.ts
@@ -1,6 +1,6 @@
 import { closeSync, openSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { isProcessAlive } from "@app/task/lib/process-alive";
+import { isProcessAlive } from "@genesiscz/utils/process-alive";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";

--- a/src/dashboard/apps/web/src/routes/dashboard/-mood/MoodTrendChart.tsx
+++ b/src/dashboard/apps/web/src/routes/dashboard/-mood/MoodTrendChart.tsx
@@ -112,7 +112,7 @@ function MoodDot({ cx, cy, payload }: DotProps) {
 }
 
 function MoodTooltip({ active, payload }: { active?: boolean; payload?: TooltipPayloadItem[] }) {
-    if (!active || !payload || !payload.length) {
+    if (!active || !payload?.length) {
         return null;
     }
 

--- a/src/mcp-manager/commands/config.ts
+++ b/src/mcp-manager/commands/config.ts
@@ -57,7 +57,8 @@ export async function openConfig(options: ConfigOptions = {}): Promise<void> {
     const editor = env.editor.get() || "nano";
     // Split editor command in case it has arguments (e.g., "code --wait")
     const editorParts = editor.split(" ");
-    const proc = Bun.spawn([...editorParts, configPath], {
+    const proc = Bun.spawn({
+        cmd: [...editorParts, configPath],
         stdio: ["inherit", "inherit", "inherit"],
     });
 

--- a/src/utils/notifications/dispatch.ts
+++ b/src/utils/notifications/dispatch.ts
@@ -3,7 +3,7 @@ import { dispatchSystem } from "./channels/system";
 import { dispatchTelegram } from "./channels/telegram";
 import { dispatchWebhook } from "./channels/webhook";
 import { notificationsConfig } from "./config";
-import type { NotificationEvent, SayChannelConfig } from "./types";
+import type { ChannelName, NotificationEvent, SayChannelConfig } from "./types";
 
 async function dispatchSay(message: string, config: SayChannelConfig): Promise<void> {
     if (!config.enabled) {
@@ -30,13 +30,15 @@ async function dispatchSay(message: string, config: SayChannelConfig): Promise<v
 export async function dispatchNotification(event: NotificationEvent): Promise<void> {
     try {
         const channels = await notificationsConfig.getChannels(event.app);
+        const only = event.only;
+        const allows = (name: ChannelName): boolean => only === undefined || only.includes(name);
 
         const channelNames = ["system", "telegram", "webhook", "say"] as const;
         const results = await Promise.allSettled([
-            dispatchSystem(event, channels.system),
-            dispatchTelegram(event, channels.telegram),
-            dispatchWebhook(event, channels.webhook),
-            dispatchSay(event.message, channels.say),
+            allows("system") ? dispatchSystem(event, channels.system) : Promise.resolve(),
+            allows("telegram") ? dispatchTelegram(event, channels.telegram) : Promise.resolve(),
+            allows("webhook") ? dispatchWebhook(event, channels.webhook) : Promise.resolve(),
+            allows("say") ? dispatchSay(event.message, channels.say) : Promise.resolve(),
         ]);
 
         for (let i = 0; i < results.length; i++) {

--- a/src/utils/notifications/types.ts
+++ b/src/utils/notifications/types.ts
@@ -65,4 +65,10 @@ export interface NotificationEvent {
     ignoreDnD?: boolean;
     /** Custom icon path/URL (terminal-notifier only) */
     appIcon?: string;
+    /**
+     * Per-call channel allow-list. When set, only these channels may fire for
+     * this event (still subject to each channel being enabled in config). When
+     * undefined, all config-enabled channels fire (default behaviour).
+     */
+    only?: ChannelName[];
 }

--- a/src/youtube/lib/server/__tests__/history-routes.test.ts
+++ b/src/youtube/lib/server/__tests__/history-routes.test.ts
@@ -61,7 +61,7 @@ describe("history + watchlist + digest routes", () => {
         expect(byVideo.status).toBe(200);
         expect(byVideo.json.groupBy).toBe("video");
         expect((byVideo.json.videos as Array<{ videoId: string }>)[0].videoId).toBe("vid00000001");
-        expect((byVideo.json.videosById as Record<string, unknown>)["vid00000001"]).toBeDefined();
+        expect((byVideo.json.videosById as Record<string, unknown>).vid00000001).toBeDefined();
 
         const byAction = await call("GET", "/api/v1/users/history?groupBy=action", user.token);
 


### PR DESCRIPTION
## What this does

`tools agent-watch` watches your background AI agents/tasks across three sources, classifies each agent's live state, and pings you (desktop / `tools say` / Telegram via the existing `notify` stack) the moment any one of them **finishes**, **stalls**, or **awaits your input** — so you stop tabbing back to a dashboard to babysit them.

It tails the files those agents already write and fires only on a meaningful **state transition** (e.g. `RUNNING → FINISHED`).

## Watch sources

- **task** — `~/.genesis-tools/task/sessions/*.jsonl` (+ sibling `*.meta.json` for pid/exit-code)
- **claude** — `~/.claude/projects/*/*.jsonl` session transcripts
- **workflows** — `~/.claude/projects/**/subagents/workflows/**` transcript dirs (mtime-based, v1)

## CLI surface

- `tools agent-watch` / `watch` — live: tail all sources, notify on transitions. Flags: `--stall-timeout`, `--notify terminal,say,telegram|none`, `--sources`, `--poll`, `--active <minutes>` (default 60), `--once`, `--json`.
- `status` — one-shot snapshot table (stderr; `--json` to stdout; `--active` filter available, default all).
- `list` — one-shot discovery list (`--active` available).

## Design

Two pure decision cores, injected time, fully unit-tested: `classifyAgentState` (exit → question → dead-pid → stale → running) and `shouldNotify` (transition gate). Everything else is thin glue: source adapters, a chokidar tail + poll re-sweep watcher (the poll is load-bearing — a stall is the *absence* of events), three thin commands. Notifications ride the existing `dispatchNotification` with a per-call `only` channel allow-list; JSONL via `parseJsonl`; tables via `@genesiscz/utils/table`. **No new npm dependencies.**

## Production-readiness pass (2026-07-18, this branch's final review)

Four real bugs found by review + live e2e, all fixed with regression tests:

1. **Notification storm on first watch run** — the baseline sweep notified every historically-notable session (hundreds under `~/.claude/projects`). Continuous mode now seeds its baseline **silently**; `--once` (cron) still reports, scoped by the new **`--active` window** (watch default 60 min).
2. **Compacted Claude sessions frozen at FINISHED** — `summary` records (which sit at the *top* of continued sessions) were treated as exit events. Now only a **trailing** `result` record finishes a session.
3. **AWAITING-INPUT never fired for Claude sessions** — the adapter never emitted `question` events. Now a trailing `AskUserQuestion` tool use or an ended turn (`stop_reason: "end_turn"`) classifies as `AWAITING-INPUT`.
4. **Finished task sessions misclassified** — a `meta.json` with `exitCode` but no trailing jsonl `exit` line read as RUNNING/STALLED. Sidecar exit now finishes the session.

Plus: `src/agent-watch/README.md`, and a drive-by fix to `scripts/apply-patches.ts` (git apply refuses package dirs behind a symlinked `node_modules`; now realpath-resolved — surfaced because this worktree symlinks node_modules).

## Verification

- `bun test src/agent-watch` → **30 pass / 0 fail** (was 23; new tests cover all four fixes: compacted-session, trailing-result, end_turn/AskUserQuestion, meta exitCode, active window, silent seed).
- `tsgo --noEmit` → 0 errors repo-wide. Boundary guard: 0 hard errors. logging-guard: OK. Biome: clean (scoped).
- **Live e2e** (real `tools task run` probes): status showed the probe RUNNING with last line, then FINISHED with exit code; `watch --once` fired exactly one FINISHED event; continuous watch seeded silently (a minute-old FINISHED probe inside the window did NOT replay) and caught a fresh probe's transition live; claude source classified 6 real concurrent sessions sanely (active ones RUNNING, quiet one STALLED).
- Local pre-push CI mirror could not run at push time — the machine's vnode table was saturated (`kern.num_vnodes == kern.maxvnodes`), which SIGKILLs any repo-wide biome scan; scoped checks + GitHub CI stand in as the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agent-watch` with `watch`, `status`, and `list` commands (including `--json` and active-window filtering).
  * Implemented state detection for running, finished (with exit codes), stalled, and awaiting input.
  * Added configurable terminal/voice/messaging notifications for notable state transitions.
* **Bug Fixes**
  * Notification dispatch now respects per-call channel restrictions; CLI parsing is stricter for sources and numeric flags.
* **Tests**
  * Added a comprehensive Bun end-to-end test suite covering state classification, snapshot collection, and notification gating.
* **Documentation**
  * Added `agent-watch` README covering commands, states, sources, and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->