### PR TITLE
feat(ai-spend): Claude Code token & cost analytics

### DIFF
--- a/src/ai-spend/ai-spend.test.ts
+++ b/src/ai-spend/ai-spend.test.ts
@@ -58,6 +58,10 @@ describe("parseTranscriptLine", () => {
         expect(parseTranscriptLine("{not json")).toBeNull();
         expect(parseTranscriptLine("")).toBeNull();
     });
+
+    it("returns null for a bare null line instead of throwing", () => {
+        expect(parseTranscriptLine("null")).toBeNull();
+    });
 });
 
 describe("pricing", () => {
@@ -98,6 +102,11 @@ describe("resolveSince", () => {
 
     it("defaults nonsense to undefined (caller applies its own default)", () => {
         expect(resolveSince("garbage", now)).toBeUndefined();
+    });
+
+    it("rejects shape-valid but impossible dates", () => {
+        expect(resolveSince("2026-02-30", now)).toBeUndefined();
+        expect(resolveSince("2026-13-01", now)).toBeUndefined();
     });
 });
 

--- a/src/ai-spend/ai-spend.test.ts
+++ b/src/ai-spend/ai-spend.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { Storage } from "@app/utils/storage/storage";
+import { aggregate } from "./lib/aggregate";
+import { loadPricing } from "./lib/config";
+import { findTranscriptFiles, readEvents } from "./lib/discover";
+import { parseTranscriptLine } from "./lib/parse";
+import { costOf, DEFAULT_PRICING, priceFor } from "./lib/pricing";
+import { renderSummary } from "./lib/render";
+import { resolveSince } from "./lib/since";
+import type { UsageEvent } from "./lib/types";
+
+describe("parseTranscriptLine", () => {
+    const assistantLine = SafeJSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-01T09:52:38.815Z",
+        cwd: "/Users/x/Projects/Foo",
+        sessionId: "sess-1",
+        message: {
+            id: "msg_abc",
+            model: "claude-opus-4-8",
+            usage: {
+                input_tokens: 100,
+                output_tokens: 20,
+                cache_creation_input_tokens: 300,
+                cache_read_input_tokens: 4000,
+                iterations: [{ input_tokens: 100, output_tokens: 20 }],
+            },
+        },
+    });
+
+    it("extracts a UsageEvent from an assistant line", () => {
+        const ev = parseTranscriptLine(assistantLine);
+        expect(ev).not.toBeNull();
+        expect(ev?.messageId).toBe("msg_abc");
+        expect(ev?.model).toBe("claude-opus-4-8");
+        expect(ev?.project).toBe("/Users/x/Projects/Foo");
+        expect(ev?.inputTokens).toBe(100);
+        expect(ev?.outputTokens).toBe(20);
+        expect(ev?.cacheCreationTokens).toBe(300);
+        expect(ev?.cacheReadTokens).toBe(4000);
+    });
+
+    it("returns null for non-assistant lines", () => {
+        expect(parseTranscriptLine(SafeJSON.stringify({ type: "user", message: {} }))).toBeNull();
+    });
+
+    it("returns null for assistant lines without usage", () => {
+        expect(
+            parseTranscriptLine(SafeJSON.stringify({ type: "assistant", message: { id: "m", model: "x" } }))
+        ).toBeNull();
+    });
+
+    it("returns null for malformed JSON", () => {
+        expect(parseTranscriptLine("{not json")).toBeNull();
+        expect(parseTranscriptLine("")).toBeNull();
+    });
+});
+
+describe("pricing", () => {
+    it("prices the four token classes separately", () => {
+        const price = { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 };
+        const cost = costOf(
+            { input: 1_000_000, output: 1_000_000, cacheWrite: 1_000_000, cacheRead: 1_000_000 },
+            price
+        );
+        expect(cost).toBeCloseTo(15 + 75 + 18.75 + 1.5, 6);
+    });
+
+    it("knows the canonical Claude models", () => {
+        expect(priceFor("claude-opus-4-8", DEFAULT_PRICING)).not.toBeNull();
+        expect(priceFor("claude-sonnet-4-6", DEFAULT_PRICING)).not.toBeNull();
+    });
+
+    it("matches by longest known prefix so versioned ids resolve", () => {
+        expect(priceFor("claude-opus-4-8-20260101", DEFAULT_PRICING)).not.toBeNull();
+    });
+
+    it("returns null for genuinely unknown models", () => {
+        expect(priceFor("glm-4.6", DEFAULT_PRICING)).toBeNull();
+    });
+});
+
+describe("resolveSince", () => {
+    const now = new Date("2026-06-02T12:00:00.000Z");
+
+    it("parses Nd as N days back (UTC day)", () => {
+        expect(resolveSince("7d", now)).toBe("2026-05-26");
+        expect(resolveSince("0d", now)).toBe("2026-06-02");
+    });
+
+    it("passes through a YYYY-MM-DD literal", () => {
+        expect(resolveSince("2026-05-01", now)).toBe("2026-05-01");
+    });
+
+    it("defaults nonsense to undefined (caller applies its own default)", () => {
+        expect(resolveSince("garbage", now)).toBeUndefined();
+    });
+});
+
+function ev(over: Partial<UsageEvent>): UsageEvent {
+    return {
+        messageId: "m",
+        model: "claude-opus-4-8",
+        timestamp: "2026-06-01T10:00:00.000Z",
+        project: "/p/Foo",
+        sessionId: "s1",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        ...over,
+    };
+}
+
+describe("aggregate", () => {
+    const now = new Date("2026-06-02T00:00:00.000Z");
+
+    it("dedups by messageId — identical triplicate events count once", () => {
+        const dup = ev({ messageId: "dup", inputTokens: 100, outputTokens: 10 });
+        const report = aggregate({ events: [dup, { ...dup }, { ...dup }], pricing: DEFAULT_PRICING, now });
+        expect(report.total.tokens.input).toBe(100);
+        expect(report.total.tokens.output).toBe(10);
+    });
+
+    it("computes four-component cost against hand numbers (two models, two days)", () => {
+        const events: UsageEvent[] = [
+            ev({
+                messageId: "a",
+                model: "claude-opus-4-8",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                inputTokens: 1_000_000,
+                outputTokens: 1_000_000,
+                cacheCreationTokens: 1_000_000,
+                cacheReadTokens: 1_000_000,
+            }),
+            ev({
+                messageId: "b",
+                model: "claude-sonnet-4-6",
+                timestamp: "2026-06-02T10:00:00.000Z",
+                inputTokens: 1_000_000,
+                outputTokens: 0,
+                cacheCreationTokens: 0,
+                cacheReadTokens: 0,
+            }),
+        ];
+        const report = aggregate({ events, pricing: DEFAULT_PRICING, now });
+        // opus: 15+75+18.75+1.5 = 110.25 ; sonnet: 3 ; total 113.25
+        expect(report.total.cost).toBeCloseTo(113.25, 6);
+        expect(report.days.map((d) => d.day)).toEqual(["2026-06-01", "2026-06-02"]);
+        expect(report.models.find((m) => m.model === "claude-opus-4-8")?.cost).toBeCloseTo(110.25, 6);
+    });
+
+    it("computes cache-hit rate = cacheRead / (input + cacheRead)", () => {
+        const report = aggregate({
+            events: [ev({ messageId: "c", inputTokens: 100, cacheReadTokens: 900 })],
+            pricing: DEFAULT_PRICING,
+            now,
+        });
+        expect(report.total.cacheHitRate).toBeCloseTo(0.9, 6);
+    });
+
+    it("counts tokens but $0 for an unpriced model, marked priced=false", () => {
+        const report = aggregate({
+            events: [ev({ messageId: "u", model: "glm-4.6", inputTokens: 5000 })],
+            pricing: DEFAULT_PRICING,
+            now,
+        });
+        const m = report.models.find((x) => x.model === "glm-4.6");
+        expect(m?.priced).toBe(false);
+        expect(m?.tokens.input).toBe(5000);
+        expect(m?.cost).toBe(0);
+        expect(report.total.cost).toBe(0);
+    });
+
+    it("applies since/model/project filters in-core", () => {
+        const events: UsageEvent[] = [
+            ev({ messageId: "old", timestamp: "2026-05-01T10:00:00.000Z", inputTokens: 1 }),
+            ev({ messageId: "new", timestamp: "2026-06-01T10:00:00.000Z", inputTokens: 2 }),
+            ev({ messageId: "other-proj", project: "/p/Bar", inputTokens: 4 }),
+            ev({ messageId: "sonnet", model: "claude-sonnet-4-6", inputTokens: 8 }),
+        ];
+        const r = aggregate({
+            events,
+            pricing: DEFAULT_PRICING,
+            now,
+            sinceDay: "2026-05-15",
+            project: "foo",
+            model: "opus",
+        });
+        // keeps only events on/after 2026-05-15, project contains "foo", model contains "opus"
+        expect(r.total.tokens.input).toBe(2);
+    });
+
+    it("UTC day keys are TZ-independent", () => {
+        const prev = process.env.TZ;
+        process.env.TZ = "Pacific/Kiritimati"; // UTC+14
+        try {
+            const r = aggregate({
+                events: [ev({ messageId: "tz", timestamp: "2026-06-01T23:30:00.000Z", inputTokens: 1 })],
+                pricing: DEFAULT_PRICING,
+                now,
+            });
+            expect(r.days[0].day).toBe("2026-06-01");
+        } finally {
+            process.env.TZ = prev;
+        }
+    });
+});
+
+describe("discover + readEvents", () => {
+    it("finds *.jsonl under <home>/.claude/projects and parses events", () => {
+        const home = mkdtempSync(join(tmpdir(), "ai-spend-home-"));
+        const projDir = join(home, ".claude", "projects", "-Users-x-Foo");
+        mkdirSync(projDir, { recursive: true });
+        const line = SafeJSON.stringify({
+            type: "assistant",
+            timestamp: "2026-06-01T10:00:00.000Z",
+            cwd: "/Users/x/Foo",
+            sessionId: "s1",
+            message: { id: "m1", model: "claude-opus-4-8", usage: { input_tokens: 10, output_tokens: 2 } },
+        });
+        writeFileSync(join(projDir, "sess.jsonl"), `${line}\n{garbage}\n\n`);
+
+        const files = findTranscriptFiles(home);
+        expect(files.length).toBe(1);
+
+        const events = readEvents(files);
+        expect(events.length).toBe(1);
+        expect(events[0].messageId).toBe("m1");
+    });
+
+    it("returns [] when the projects dir is absent", () => {
+        const home = mkdtempSync(join(tmpdir(), "ai-spend-empty-"));
+        expect(findTranscriptFiles(home)).toEqual([]);
+    });
+});
+
+describe("loadPricing", () => {
+    it("merges user config pricing over defaults", async () => {
+        const home = mkdtempSync(join(tmpdir(), "ai-spend-cfg-"));
+        const prev = process.env.GENESIS_TOOLS_HOME;
+        process.env.GENESIS_TOOLS_HOME = home;
+        try {
+            const storage = new Storage("ai-spend");
+            await storage.setConfigValue("pricing", {
+                "glm-4.6": { input: 1, output: 2, cacheWrite: 1, cacheRead: 0.1 },
+            });
+            const pricing = await loadPricing(storage);
+            expect(pricing["glm-4.6"]).toEqual({ input: 1, output: 2, cacheWrite: 1, cacheRead: 0.1 });
+            expect(pricing["claude-opus-4"]).toBeDefined();
+        } finally {
+            process.env.GENESIS_TOOLS_HOME = prev;
+        }
+    });
+});
+
+describe("renderSummary", () => {
+    it("renders totals, model and project sections from a Report", () => {
+        const report = aggregate({
+            events: [
+                ev({ messageId: "r1", model: "claude-opus-4-8", inputTokens: 1_000_000, outputTokens: 1_000_000 }),
+                ev({ messageId: "r2", model: "glm-4.6", project: "/p/Bar", inputTokens: 1000 }),
+            ],
+            pricing: DEFAULT_PRICING,
+            now: new Date("2026-06-02T00:00:00.000Z"),
+        });
+        const text = renderSummary(report);
+        expect(text).toContain("TOTAL");
+        expect(text).toContain("claude-opus-4-8");
+        expect(text).toContain("(unpriced)");
+    });
+});

--- a/src/ai-spend/index.ts
+++ b/src/ai-spend/index.ts
@@ -35,7 +35,8 @@ async function buildReport(opts: SharedOpts, view: View): Promise<Report> {
         sinceDay = resolveSince(opts.since ?? DEFAULT_SINCE, now) ?? resolveSince(DEFAULT_SINCE, now);
     }
 
-    const top = opts.top ? Number.parseInt(opts.top, 10) : 10;
+    const parsedTop = opts.top ? Number.parseInt(opts.top, 10) : 10;
+    const top = Number.isInteger(parsedTop) && parsedTop > 0 ? parsedTop : 10;
     return aggregate({ events, pricing, now, sinceDay, model: opts.model, project: opts.project, top });
 }
 

--- a/src/ai-spend/index.ts
+++ b/src/ai-spend/index.ts
@@ -1,105 +1,11 @@
-import { homedir } from "node:os";
-import { out } from "@app/logger";
 import { runTool } from "@app/utils/cli";
-import { Storage } from "@app/utils/storage/storage";
 import { Command } from "commander";
-import { aggregate } from "./lib/aggregate";
-import { loadPricing } from "./lib/config";
-import { findTranscriptFiles, readEvents } from "./lib/discover";
-import { renderSessions, renderSummary, renderToday } from "./lib/render";
-import { resolveSince } from "./lib/since";
-import type { Report } from "./lib/types";
-
-interface SharedOpts {
-    since?: string;
-    model?: string;
-    project?: string;
-    top?: string;
-    json?: boolean;
-}
-
-type View = "summary" | "sessions" | "today";
-
-const DEFAULT_SINCE = "30d";
-
-async function buildReport(opts: SharedOpts, view: View): Promise<Report> {
-    const now = new Date();
-    const storage = new Storage("ai-spend");
-    const pricing = await loadPricing(storage);
-    const events = readEvents(findTranscriptFiles(homedir()));
-
-    let sinceDay: string | undefined;
-    if (view === "today") {
-        sinceDay = now.toISOString().slice(0, 10);
-    } else {
-        sinceDay = resolveSince(opts.since ?? DEFAULT_SINCE, now) ?? resolveSince(DEFAULT_SINCE, now);
-    }
-
-    const parsedTop = opts.top ? Number.parseInt(opts.top, 10) : 10;
-    const top = Number.isInteger(parsedTop) && parsedTop > 0 ? parsedTop : 10;
-    return aggregate({ events, pricing, now, sinceDay, model: opts.model, project: opts.project, top });
-}
-
-function emit(report: Report, opts: SharedOpts, view: View): void {
-    if (opts.json) {
-        out.result(report);
-        return;
-    }
-
-    if (view === "sessions") {
-        out.println(renderSessions(report));
-        return;
-    }
-
-    if (view === "today") {
-        out.println(renderToday(report));
-        return;
-    }
-
-    out.println(renderSummary(report));
-}
-
-function addSharedOptions(cmd: Command): Command {
-    return cmd
-        .option("--since <when>", 'Include events on/after "Nd" or YYYY-MM-DD', DEFAULT_SINCE)
-        .option("--model <substr>", "Filter to models containing this substring")
-        .option("--project <substr>", "Filter to projects (cwd) containing this substring")
-        .option("--top <n>", "Leaderboard length", "10")
-        .option("--json", "Emit the Report as JSON to stdout");
-}
-
-async function run(cmd: Command, view: View): Promise<void> {
-    // Shared options live on BOTH the root program and each subcommand, so
-    // commander treats them as global. The action's plain opts arg therefore
-    // omits flags resolved onto the parent — optsWithGlobals() merges them back.
-    const opts = cmd.optsWithGlobals() as SharedOpts;
-    emit(await buildReport(opts, view), opts, view);
-}
+import { registerSpendCommand } from "./lib/register";
 
 const program = new Command();
 
 program.name("ai-spend").description("Claude Code token & cost analytics across all local sessions");
 
-addSharedOptions(program).action(async (_opts: SharedOpts, cmd: Command) => {
-    await run(cmd, "summary");
-});
-
-addSharedOptions(program.command("summary").description("Spend summary for the window (default)")).action(
-    async (_opts: SharedOpts, cmd: Command) => {
-        await run(cmd, "summary");
-    }
-);
-
-addSharedOptions(program.command("sessions").description("Most expensive sessions leaderboard")).action(
-    async (_opts: SharedOpts, cmd: Command) => {
-        await run(cmd, "sessions");
-    }
-);
-
-addSharedOptions(program.command("today").description("Today's spend (UTC day)")).action(
-    async (_opts: SharedOpts, cmd: Command) => {
-        await run(cmd, "today");
-    }
-);
+registerSpendCommand(program);
 
 await runTool(program, { tool: "ai-spend" });

--- a/src/ai-spend/index.ts
+++ b/src/ai-spend/index.ts
@@ -1,0 +1,104 @@
+import { homedir } from "node:os";
+import { out } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { Storage } from "@app/utils/storage/storage";
+import { Command } from "commander";
+import { aggregate } from "./lib/aggregate";
+import { loadPricing } from "./lib/config";
+import { findTranscriptFiles, readEvents } from "./lib/discover";
+import { renderSessions, renderSummary, renderToday } from "./lib/render";
+import { resolveSince } from "./lib/since";
+import type { Report } from "./lib/types";
+
+interface SharedOpts {
+    since?: string;
+    model?: string;
+    project?: string;
+    top?: string;
+    json?: boolean;
+}
+
+type View = "summary" | "sessions" | "today";
+
+const DEFAULT_SINCE = "30d";
+
+async function buildReport(opts: SharedOpts, view: View): Promise<Report> {
+    const now = new Date();
+    const storage = new Storage("ai-spend");
+    const pricing = await loadPricing(storage);
+    const events = readEvents(findTranscriptFiles(homedir()));
+
+    let sinceDay: string | undefined;
+    if (view === "today") {
+        sinceDay = now.toISOString().slice(0, 10);
+    } else {
+        sinceDay = resolveSince(opts.since ?? DEFAULT_SINCE, now) ?? resolveSince(DEFAULT_SINCE, now);
+    }
+
+    const top = opts.top ? Number.parseInt(opts.top, 10) : 10;
+    return aggregate({ events, pricing, now, sinceDay, model: opts.model, project: opts.project, top });
+}
+
+function emit(report: Report, opts: SharedOpts, view: View): void {
+    if (opts.json) {
+        out.result(report);
+        return;
+    }
+
+    if (view === "sessions") {
+        out.println(renderSessions(report));
+        return;
+    }
+
+    if (view === "today") {
+        out.println(renderToday(report));
+        return;
+    }
+
+    out.println(renderSummary(report));
+}
+
+function addSharedOptions(cmd: Command): Command {
+    return cmd
+        .option("--since <when>", 'Include events on/after "Nd" or YYYY-MM-DD', DEFAULT_SINCE)
+        .option("--model <substr>", "Filter to models containing this substring")
+        .option("--project <substr>", "Filter to projects (cwd) containing this substring")
+        .option("--top <n>", "Leaderboard length", "10")
+        .option("--json", "Emit the Report as JSON to stdout");
+}
+
+async function run(cmd: Command, view: View): Promise<void> {
+    // Shared options live on BOTH the root program and each subcommand, so
+    // commander treats them as global. The action's plain opts arg therefore
+    // omits flags resolved onto the parent — optsWithGlobals() merges them back.
+    const opts = cmd.optsWithGlobals() as SharedOpts;
+    emit(await buildReport(opts, view), opts, view);
+}
+
+const program = new Command();
+
+program.name("ai-spend").description("Claude Code token & cost analytics across all local sessions");
+
+addSharedOptions(program).action(async (_opts: SharedOpts, cmd: Command) => {
+    await run(cmd, "summary");
+});
+
+addSharedOptions(program.command("summary").description("Spend summary for the window (default)")).action(
+    async (_opts: SharedOpts, cmd: Command) => {
+        await run(cmd, "summary");
+    }
+);
+
+addSharedOptions(program.command("sessions").description("Most expensive sessions leaderboard")).action(
+    async (_opts: SharedOpts, cmd: Command) => {
+        await run(cmd, "sessions");
+    }
+);
+
+addSharedOptions(program.command("today").description("Today's spend (UTC day)")).action(
+    async (_opts: SharedOpts, cmd: Command) => {
+        await run(cmd, "today");
+    }
+);
+
+await runTool(program, { tool: "ai-spend" });

--- a/src/ai-spend/lib/aggregate.ts
+++ b/src/ai-spend/lib/aggregate.ts
@@ -1,0 +1,194 @@
+import { costOf, priceFor } from "./pricing";
+import type {
+    DayBreakdown,
+    Filters,
+    ModelBreakdown,
+    PricingTable,
+    ProjectBreakdown,
+    Report,
+    SessionBreakdown,
+    TokenTotals,
+    UsageEvent,
+} from "./types";
+
+interface AggregateArgs extends Filters {
+    events: UsageEvent[];
+    pricing: PricingTable;
+    /** injected — the pure core never reads the system clock */
+    now: Date;
+}
+
+function emptyTotals(): TokenTotals {
+    return { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 };
+}
+
+function addTokens(into: TokenTotals, ev: UsageEvent): void {
+    into.input += ev.inputTokens;
+    into.output += ev.outputTokens;
+    into.cacheWrite += ev.cacheCreationTokens;
+    into.cacheRead += ev.cacheReadTokens;
+}
+
+function sumTokens(t: TokenTotals): number {
+    return t.input + t.output + t.cacheWrite + t.cacheRead;
+}
+
+function dayOf(timestamp: string): string {
+    return timestamp.slice(0, 10);
+}
+
+function passesFilters(ev: UsageEvent, f: Filters): boolean {
+    if (f.sinceDay && dayOf(ev.timestamp) < f.sinceDay) {
+        return false;
+    }
+
+    if (f.model && !ev.model.toLowerCase().includes(f.model.toLowerCase())) {
+        return false;
+    }
+
+    if (f.project && !ev.project.toLowerCase().includes(f.project.toLowerCase())) {
+        return false;
+    }
+
+    return true;
+}
+
+function eventsCost(events: UsageEvent[], pricing: PricingTable): number {
+    let cost = 0;
+    for (const ev of events) {
+        const price = priceFor(ev.model, pricing);
+        if (!price) {
+            continue;
+        }
+
+        cost +=
+            (ev.inputTokens * price.input +
+                ev.outputTokens * price.output +
+                ev.cacheCreationTokens * price.cacheWrite +
+                ev.cacheReadTokens * price.cacheRead) /
+            1_000_000;
+    }
+
+    return cost;
+}
+
+function dayCost(events: UsageEvent[], day: string, pricing: PricingTable): number {
+    return eventsCost(
+        events.filter((e) => dayOf(e.timestamp) === day),
+        pricing
+    );
+}
+
+export function aggregate(args: AggregateArgs): Report {
+    const { events, pricing, now } = args;
+    const top = args.top ?? 10;
+
+    const seen = new Set<string>();
+    const kept: UsageEvent[] = [];
+    for (const ev of events) {
+        if (seen.has(ev.messageId)) {
+            continue;
+        }
+
+        seen.add(ev.messageId);
+        if (passesFilters(ev, args)) {
+            kept.push(ev);
+        }
+    }
+
+    const totalTokens = emptyTotals();
+    const byModel = new Map<string, { tokens: TokenTotals; priced: boolean }>();
+    const byDay = new Map<string, TokenTotals>();
+    const byProject = new Map<string, { tokens: TokenTotals; sessions: Set<string> }>();
+    const bySession = new Map<string, { tokens: TokenTotals; project: string; lastDay: string }>();
+
+    for (const ev of kept) {
+        addTokens(totalTokens, ev);
+
+        const model = byModel.get(ev.model) ?? { tokens: emptyTotals(), priced: priceFor(ev.model, pricing) !== null };
+        addTokens(model.tokens, ev);
+        byModel.set(ev.model, model);
+
+        const day = dayOf(ev.timestamp);
+        const dayTok = byDay.get(day) ?? emptyTotals();
+        addTokens(dayTok, ev);
+        byDay.set(day, dayTok);
+
+        const proj = byProject.get(ev.project) ?? { tokens: emptyTotals(), sessions: new Set<string>() };
+        addTokens(proj.tokens, ev);
+        proj.sessions.add(ev.sessionId);
+        byProject.set(ev.project, proj);
+
+        const sess = bySession.get(ev.sessionId) ?? { tokens: emptyTotals(), project: ev.project, lastDay: day };
+        addTokens(sess.tokens, ev);
+        if (day > sess.lastDay) {
+            sess.lastDay = day;
+        }
+
+        bySession.set(ev.sessionId, sess);
+    }
+
+    const models: ModelBreakdown[] = [...byModel.entries()]
+        .map(([model, v]) => {
+            const price = priceFor(model, pricing);
+            return {
+                model,
+                priced: v.priced,
+                tokens: v.tokens,
+                totalTokens: sumTokens(v.tokens),
+                cost: price ? costOf(v.tokens, price) : 0,
+            };
+        })
+        .sort((a, b) => b.cost - a.cost || b.totalTokens - a.totalTokens);
+
+    const days: DayBreakdown[] = [...byDay.entries()]
+        .map(([day, tokens]) => ({ day, totalTokens: sumTokens(tokens), cost: dayCost(kept, day, pricing) }))
+        .sort((a, b) => a.day.localeCompare(b.day));
+
+    const projects: ProjectBreakdown[] = [...byProject.entries()]
+        .map(([project, v]) => ({
+            project,
+            sessions: v.sessions.size,
+            totalTokens: sumTokens(v.tokens),
+            cost: eventsCost(
+                kept.filter((e) => e.project === project),
+                pricing
+            ),
+        }))
+        .sort((a, b) => b.cost - a.cost || b.totalTokens - a.totalTokens)
+        .slice(0, top);
+
+    const sessions: SessionBreakdown[] = [...bySession.entries()]
+        .map(([sessionId, v]) => ({
+            sessionId,
+            project: v.project,
+            lastDay: v.lastDay,
+            totalTokens: sumTokens(v.tokens),
+            cost: eventsCost(
+                kept.filter((e) => e.sessionId === sessionId),
+                pricing
+            ),
+        }))
+        .sort((a, b) => b.cost - a.cost || b.totalTokens - a.totalTokens)
+        .slice(0, top);
+
+    const allDays = [...byDay.keys()].sort();
+    const cacheHitDenom = totalTokens.input + totalTokens.cacheRead;
+
+    return {
+        windowStartDay: args.sinceDay ?? allDays[0] ?? dayOf(now.toISOString()),
+        windowEndDay: allDays.at(-1) ?? dayOf(now.toISOString()),
+        projectCount: byProject.size,
+        sessionCount: bySession.size,
+        total: {
+            tokens: totalTokens,
+            totalTokens: sumTokens(totalTokens),
+            cost: eventsCost(kept, pricing),
+            cacheHitRate: cacheHitDenom === 0 ? 0 : totalTokens.cacheRead / cacheHitDenom,
+        },
+        days,
+        models: models.slice(0, top),
+        projects,
+        sessions,
+    };
+}

--- a/src/ai-spend/lib/aggregate.ts
+++ b/src/ai-spend/lib/aggregate.ts
@@ -1,4 +1,4 @@
-import { costOf, priceFor } from "./pricing";
+import { priceFor } from "./pricing";
 import type {
     DayBreakdown,
     Filters,
@@ -53,29 +53,18 @@ function passesFilters(ev: UsageEvent, f: Filters): boolean {
     return true;
 }
 
-function eventsCost(events: UsageEvent[], pricing: PricingTable): number {
-    let cost = 0;
-    for (const ev of events) {
-        const price = priceFor(ev.model, pricing);
-        if (!price) {
-            continue;
-        }
-
-        cost +=
-            (ev.inputTokens * price.input +
-                ev.outputTokens * price.output +
-                ev.cacheCreationTokens * price.cacheWrite +
-                ev.cacheReadTokens * price.cacheRead) /
-            1_000_000;
+function eventCost(ev: UsageEvent, pricing: PricingTable): number {
+    const price = priceFor(ev.model, pricing);
+    if (!price) {
+        return 0;
     }
 
-    return cost;
-}
-
-function dayCost(events: UsageEvent[], day: string, pricing: PricingTable): number {
-    return eventsCost(
-        events.filter((e) => dayOf(e.timestamp) === day),
-        pricing
+    return (
+        (ev.inputTokens * price.input +
+            ev.outputTokens * price.output +
+            ev.cacheCreationTokens * price.cacheWrite +
+            ev.cacheReadTokens * price.cacheRead) /
+        1_000_000
     );
 }
 
@@ -97,30 +86,46 @@ export function aggregate(args: AggregateArgs): Report {
     }
 
     const totalTokens = emptyTotals();
-    const byModel = new Map<string, { tokens: TokenTotals; priced: boolean }>();
-    const byDay = new Map<string, TokenTotals>();
-    const byProject = new Map<string, { tokens: TokenTotals; sessions: Set<string> }>();
-    const bySession = new Map<string, { tokens: TokenTotals; project: string; lastDay: string }>();
+    let totalCost = 0;
+    const byModel = new Map<string, { tokens: TokenTotals; cost: number; priced: boolean }>();
+    const byDay = new Map<string, { tokens: TokenTotals; cost: number }>();
+    const byProject = new Map<string, { tokens: TokenTotals; cost: number; sessions: Set<string> }>();
+    const bySession = new Map<string, { tokens: TokenTotals; cost: number; project: string; lastDay: string }>();
 
     for (const ev of kept) {
+        const evCost = eventCost(ev, pricing);
+        totalCost += evCost;
         addTokens(totalTokens, ev);
 
-        const model = byModel.get(ev.model) ?? { tokens: emptyTotals(), priced: priceFor(ev.model, pricing) !== null };
+        const model = byModel.get(ev.model) ?? {
+            tokens: emptyTotals(),
+            cost: 0,
+            priced: priceFor(ev.model, pricing) !== null,
+        };
         addTokens(model.tokens, ev);
+        model.cost += evCost;
         byModel.set(ev.model, model);
 
         const day = dayOf(ev.timestamp);
-        const dayTok = byDay.get(day) ?? emptyTotals();
-        addTokens(dayTok, ev);
-        byDay.set(day, dayTok);
+        const dayAgg = byDay.get(day) ?? { tokens: emptyTotals(), cost: 0 };
+        addTokens(dayAgg.tokens, ev);
+        dayAgg.cost += evCost;
+        byDay.set(day, dayAgg);
 
-        const proj = byProject.get(ev.project) ?? { tokens: emptyTotals(), sessions: new Set<string>() };
+        const proj = byProject.get(ev.project) ?? { tokens: emptyTotals(), cost: 0, sessions: new Set<string>() };
         addTokens(proj.tokens, ev);
+        proj.cost += evCost;
         proj.sessions.add(ev.sessionId);
         byProject.set(ev.project, proj);
 
-        const sess = bySession.get(ev.sessionId) ?? { tokens: emptyTotals(), project: ev.project, lastDay: day };
+        const sess = bySession.get(ev.sessionId) ?? {
+            tokens: emptyTotals(),
+            cost: 0,
+            project: ev.project,
+            lastDay: day,
+        };
         addTokens(sess.tokens, ev);
+        sess.cost += evCost;
         if (day > sess.lastDay) {
             sess.lastDay = day;
         }
@@ -129,20 +134,17 @@ export function aggregate(args: AggregateArgs): Report {
     }
 
     const models: ModelBreakdown[] = [...byModel.entries()]
-        .map(([model, v]) => {
-            const price = priceFor(model, pricing);
-            return {
-                model,
-                priced: v.priced,
-                tokens: v.tokens,
-                totalTokens: sumTokens(v.tokens),
-                cost: price ? costOf(v.tokens, price) : 0,
-            };
-        })
+        .map(([model, v]) => ({
+            model,
+            priced: v.priced,
+            tokens: v.tokens,
+            totalTokens: sumTokens(v.tokens),
+            cost: v.cost,
+        }))
         .sort((a, b) => b.cost - a.cost || b.totalTokens - a.totalTokens);
 
     const days: DayBreakdown[] = [...byDay.entries()]
-        .map(([day, tokens]) => ({ day, totalTokens: sumTokens(tokens), cost: dayCost(kept, day, pricing) }))
+        .map(([day, v]) => ({ day, totalTokens: sumTokens(v.tokens), cost: v.cost }))
         .sort((a, b) => a.day.localeCompare(b.day));
 
     const projects: ProjectBreakdown[] = [...byProject.entries()]
@@ -150,10 +152,7 @@ export function aggregate(args: AggregateArgs): Report {
             project,
             sessions: v.sessions.size,
             totalTokens: sumTokens(v.tokens),
-            cost: eventsCost(
-                kept.filter((e) => e.project === project),
-                pricing
-            ),
+            cost: v.cost,
         }))
         .sort((a, b) => b.cost - a.cost || b.totalTokens - a.totalTokens)
         .slice(0, top);
@@ -164,10 +163,7 @@ export function aggregate(args: AggregateArgs): Report {
             project: v.project,
             lastDay: v.lastDay,
             totalTokens: sumTokens(v.tokens),
-            cost: eventsCost(
-                kept.filter((e) => e.sessionId === sessionId),
-                pricing
-            ),
+            cost: v.cost,
         }))
         .sort((a, b) => b.cost - a.cost || b.totalTokens - a.totalTokens)
         .slice(0, top);
@@ -183,7 +179,7 @@ export function aggregate(args: AggregateArgs): Report {
         total: {
             tokens: totalTokens,
             totalTokens: sumTokens(totalTokens),
-            cost: eventsCost(kept, pricing),
+            cost: totalCost,
             cacheHitRate: cacheHitDenom === 0 ? 0 : totalTokens.cacheRead / cacheHitDenom,
         },
         days,

--- a/src/ai-spend/lib/config.ts
+++ b/src/ai-spend/lib/config.ts
@@ -1,0 +1,18 @@
+import { logger } from "@app/logger";
+import type { Storage } from "@app/utils/storage/storage";
+import { DEFAULT_PRICING } from "./pricing";
+import type { PricingTable } from "./types";
+
+interface AiSpendConfig {
+    pricing?: PricingTable;
+}
+
+export async function loadPricing(storage: Storage): Promise<PricingTable> {
+    const config = await storage.getConfig<AiSpendConfig>();
+    if (!config?.pricing) {
+        return DEFAULT_PRICING;
+    }
+
+    logger.debug({ models: Object.keys(config.pricing) }, "ai-spend: merging user pricing overrides");
+    return { ...DEFAULT_PRICING, ...config.pricing };
+}

--- a/src/ai-spend/lib/config.ts
+++ b/src/ai-spend/lib/config.ts
@@ -14,5 +14,16 @@ export async function loadPricing(storage: Storage): Promise<PricingTable> {
     }
 
     logger.debug({ models: Object.keys(config.pricing) }, "ai-spend: merging user pricing overrides");
-    return { ...DEFAULT_PRICING, ...config.pricing };
+    const merged: PricingTable = { ...DEFAULT_PRICING };
+    for (const [model, override] of Object.entries(config.pricing)) {
+        const base = merged[model];
+        merged[model] = {
+            input: override.input ?? base?.input ?? 0,
+            output: override.output ?? base?.output ?? 0,
+            cacheWrite: override.cacheWrite ?? base?.cacheWrite ?? 0,
+            cacheRead: override.cacheRead ?? base?.cacheRead ?? 0,
+        };
+    }
+
+    return merged;
 }

--- a/src/ai-spend/lib/discover.ts
+++ b/src/ai-spend/lib/discover.ts
@@ -1,0 +1,53 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { parseTranscriptLine } from "./parse";
+import type { UsageEvent } from "./types";
+
+/** All *.jsonl files under <homeDir>/.claude/projects (one level of project dirs). */
+export function findTranscriptFiles(homeDir: string): string[] {
+    const root = join(homeDir, ".claude", "projects");
+    if (!existsSync(root)) {
+        logger.debug({ root }, "ai-spend: no Claude Code projects dir");
+        return [];
+    }
+
+    const out: string[] = [];
+    for (const entry of readdirSync(root)) {
+        const dir = join(root, entry);
+        if (!statSync(dir).isDirectory()) {
+            continue;
+        }
+
+        for (const file of readdirSync(dir)) {
+            if (file.endsWith(".jsonl")) {
+                out.push(join(dir, file));
+            }
+        }
+    }
+
+    logger.debug({ count: out.length }, "ai-spend: discovered transcript files");
+    return out;
+}
+
+export function readEvents(files: string[]): UsageEvent[] {
+    const events: UsageEvent[] = [];
+    for (const file of files) {
+        let content: string;
+        try {
+            content = readFileSync(file, "utf-8");
+        } catch (err) {
+            logger.warn({ err, file }, "ai-spend: failed to read transcript");
+            continue;
+        }
+
+        for (const line of content.split("\n")) {
+            const ev = parseTranscriptLine(line);
+            if (ev) {
+                events.push(ev);
+            }
+        }
+    }
+
+    return events;
+}

--- a/src/ai-spend/lib/discover.ts
+++ b/src/ai-spend/lib/discover.ts
@@ -12,14 +12,35 @@ export function findTranscriptFiles(homeDir: string): string[] {
         return [];
     }
 
+    let entries: string[];
+    try {
+        entries = readdirSync(root);
+    } catch (err) {
+        logger.warn({ err, root }, "ai-spend: failed to read Claude Code projects dir");
+        return [];
+    }
+
     const out: string[] = [];
-    for (const entry of readdirSync(root)) {
+    for (const entry of entries) {
         const dir = join(root, entry);
-        if (!statSync(dir).isDirectory()) {
+        try {
+            if (!statSync(dir).isDirectory()) {
+                continue;
+            }
+        } catch (err) {
+            logger.warn({ err, dir }, "ai-spend: failed to stat project entry");
             continue;
         }
 
-        for (const file of readdirSync(dir)) {
+        let files: string[];
+        try {
+            files = readdirSync(dir);
+        } catch (err) {
+            logger.warn({ err, dir }, "ai-spend: failed to read project dir");
+            continue;
+        }
+
+        for (const file of files) {
             if (file.endsWith(".jsonl")) {
                 out.push(join(dir, file));
             }

--- a/src/ai-spend/lib/parse.ts
+++ b/src/ai-spend/lib/parse.ts
@@ -1,0 +1,64 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { UsageEvent } from "./types";
+
+interface RawUsage {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+}
+
+interface RawMessage {
+    id?: string;
+    model?: string;
+    usage?: RawUsage;
+}
+
+interface RawLine {
+    type?: string;
+    timestamp?: string;
+    cwd?: string;
+    sessionId?: string;
+    message?: RawMessage;
+}
+
+function num(value: number | undefined): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function parseTranscriptLine(line: string): UsageEvent | null {
+    const trimmed = line.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    let raw: RawLine;
+    try {
+        raw = SafeJSON.parse(trimmed) as RawLine;
+    } catch (err) {
+        logger.debug({ err }, "ai-spend: skipping malformed transcript line");
+        return null;
+    }
+
+    if (raw.type !== "assistant") {
+        return null;
+    }
+
+    const message = raw.message;
+    if (!message?.usage || !message.id) {
+        return null;
+    }
+
+    return {
+        messageId: message.id,
+        model: message.model ?? "unknown",
+        timestamp: raw.timestamp ?? "",
+        project: raw.cwd ?? "",
+        sessionId: raw.sessionId ?? "",
+        inputTokens: num(message.usage.input_tokens),
+        outputTokens: num(message.usage.output_tokens),
+        cacheCreationTokens: num(message.usage.cache_creation_input_tokens),
+        cacheReadTokens: num(message.usage.cache_read_input_tokens),
+    };
+}

--- a/src/ai-spend/lib/parse.ts
+++ b/src/ai-spend/lib/parse.ts
@@ -27,20 +27,29 @@ function num(value: number | undefined): number {
     return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
+function isRawLine(value: unknown): value is RawLine {
+    return typeof value === "object" && value !== null;
+}
+
 export function parseTranscriptLine(line: string): UsageEvent | null {
     const trimmed = line.trim();
     if (!trimmed) {
         return null;
     }
 
-    let raw: RawLine;
+    let rawUnknown: unknown;
     try {
-        raw = SafeJSON.parse(trimmed) as RawLine;
+        rawUnknown = SafeJSON.parse(trimmed, { strict: true });
     } catch (err) {
         logger.debug({ err }, "ai-spend: skipping malformed transcript line");
         return null;
     }
 
+    if (!isRawLine(rawUnknown)) {
+        return null;
+    }
+
+    const raw = rawUnknown;
     if (raw.type !== "assistant") {
         return null;
     }

--- a/src/ai-spend/lib/pricing.ts
+++ b/src/ai-spend/lib/pricing.ts
@@ -1,0 +1,40 @@
+import type { ModelPrice, PricingTable, TokenTotals } from "./types";
+
+/**
+ * $/Mtok. cacheWrite ≈ 1.25× input, cacheRead ≈ 0.1× input (Anthropic public ratios).
+ * Keys are model-id prefixes; priceFor() resolves by longest matching prefix so
+ * versioned ids (claude-opus-4-8-20260101) hit the family entry.
+ */
+export const DEFAULT_PRICING: PricingTable = {
+    "claude-opus-4": { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 },
+    "claude-sonnet-4": { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
+    "claude-haiku-3-5": { input: 0.8, output: 4, cacheWrite: 1.0, cacheRead: 0.08 },
+    "claude-3-5-haiku": { input: 0.8, output: 4, cacheWrite: 1.0, cacheRead: 0.08 },
+};
+
+export function priceFor(model: string, pricing: PricingTable): ModelPrice | null {
+    if (pricing[model]) {
+        return pricing[model];
+    }
+
+    let best: ModelPrice | null = null;
+    let bestLen = -1;
+    for (const [prefix, price] of Object.entries(pricing)) {
+        if (model.startsWith(prefix) && prefix.length > bestLen) {
+            best = price;
+            bestLen = prefix.length;
+        }
+    }
+
+    return best;
+}
+
+export function costOf(tokens: TokenTotals, price: ModelPrice): number {
+    return (
+        (tokens.input * price.input +
+            tokens.output * price.output +
+            tokens.cacheWrite * price.cacheWrite +
+            tokens.cacheRead * price.cacheRead) /
+        1_000_000
+    );
+}

--- a/src/ai-spend/lib/register.ts
+++ b/src/ai-spend/lib/register.ts
@@ -1,0 +1,102 @@
+import { homedir } from "node:os";
+import { out } from "@app/logger";
+import { Storage } from "@app/utils/storage/storage";
+import type { Command } from "commander";
+import { aggregate } from "./aggregate";
+import { loadPricing } from "./config";
+import { findTranscriptFiles, readEvents } from "./discover";
+import { renderSessions, renderSummary, renderToday } from "./render";
+import { resolveSince } from "./since";
+import type { Report } from "./types";
+
+export interface SpendOpts {
+    since?: string;
+    model?: string;
+    project?: string;
+    top?: string;
+    json?: boolean;
+}
+
+export type SpendView = "summary" | "sessions" | "today";
+
+const DEFAULT_SINCE = "30d";
+
+async function buildReport(opts: SpendOpts, view: SpendView): Promise<Report> {
+    const now = new Date();
+    const storage = new Storage("ai-spend");
+    const pricing = await loadPricing(storage);
+    const events = readEvents(findTranscriptFiles(homedir()));
+
+    let sinceDay: string | undefined;
+    if (view === "today") {
+        sinceDay = now.toISOString().slice(0, 10);
+    } else {
+        sinceDay = resolveSince(opts.since ?? DEFAULT_SINCE, now) ?? resolveSince(DEFAULT_SINCE, now);
+    }
+
+    const parsedTop = opts.top ? Number.parseInt(opts.top, 10) : 10;
+    const top = Number.isInteger(parsedTop) && parsedTop > 0 ? parsedTop : 10;
+    return aggregate({ events, pricing, now, sinceDay, model: opts.model, project: opts.project, top });
+}
+
+function emit(report: Report, opts: SpendOpts, view: SpendView): void {
+    if (opts.json) {
+        out.result(report);
+        return;
+    }
+
+    if (view === "sessions") {
+        out.println(renderSessions(report));
+        return;
+    }
+
+    if (view === "today") {
+        out.println(renderToday(report));
+        return;
+    }
+
+    out.println(renderSummary(report));
+}
+
+export function addSpendOptions(cmd: Command): Command {
+    return cmd
+        .option("--since <when>", 'Include events on/after "Nd" or YYYY-MM-DD', DEFAULT_SINCE)
+        .option("--model <substr>", "Filter to models containing this substring")
+        .option("--project <substr>", "Filter to projects (cwd) containing this substring")
+        .option("--top <n>", "Leaderboard length", "10")
+        .option("--json", "Emit the Report as JSON to stdout");
+}
+
+export async function runSpend(cmd: Command, view: SpendView): Promise<void> {
+    // Shared options live on BOTH the root program and each subcommand, so
+    // commander treats them as global. The action's plain opts arg therefore
+    // omits flags resolved onto the parent — optsWithGlobals() merges them back.
+    const opts = cmd.optsWithGlobals() as SpendOpts;
+    emit(await buildReport(opts, view), opts, view);
+}
+
+export function registerSpendCommand(program: Command): Command {
+    addSpendOptions(program).action(async (_opts: SpendOpts, cmd: Command) => {
+        await runSpend(cmd, "summary");
+    });
+
+    addSpendOptions(program.command("summary").description("Spend summary for the window (default)")).action(
+        async (_opts: SpendOpts, cmd: Command) => {
+            await runSpend(cmd, "summary");
+        }
+    );
+
+    addSpendOptions(program.command("sessions").description("Most expensive sessions leaderboard")).action(
+        async (_opts: SpendOpts, cmd: Command) => {
+            await runSpend(cmd, "sessions");
+        }
+    );
+
+    addSpendOptions(program.command("today").description("Today's spend (UTC day)")).action(
+        async (_opts: SpendOpts, cmd: Command) => {
+            await runSpend(cmd, "today");
+        }
+    );
+
+    return program;
+}

--- a/src/ai-spend/lib/render.ts
+++ b/src/ai-spend/lib/render.ts
@@ -1,0 +1,104 @@
+import { formatCost, formatTokens } from "@app/utils/format";
+import { formatTable } from "@app/utils/table";
+import asciichart from "asciichart";
+import pc from "picocolors";
+import type { Report } from "./types";
+
+function pct(n: number): string {
+    return `${(n * 100).toFixed(1)}%`;
+}
+
+function modelLabel(model: string, priced: boolean): string {
+    return priced ? model : `${model} ${pc.dim("(unpriced)")}`;
+}
+
+function trend(report: Report): string {
+    const series = report.days.map((d) => d.cost);
+    if (series.length < 2) {
+        return "";
+    }
+
+    // padding must be wide enough for the longest left-axis label or asciichart
+    // slices leading digits (a $1358 day would render as "358"). format keeps
+    // the axis to 2 decimals and a fixed width.
+    const chart = asciichart.plot(series, {
+        height: 6,
+        padding: "         ",
+        format: (v: number) => `$${v.toFixed(2)}`.padStart(9),
+    });
+    return `\nDAILY TREND (spend $)\n${chart}\n  ${report.days.map((d) => d.day.slice(5)).join("  ")}`;
+}
+
+export function renderSummary(report: Report): string {
+    const t = report.total;
+    const header = [
+        pc.bold("ai-spend — Claude Code token & cost analytics"),
+        pc.dim(
+            `window: ${report.windowStartDay} → ${report.windowEndDay} (UTC)  •  ${report.projectCount} projects  •  ${report.sessionCount} sessions`
+        ),
+        "",
+        "TOTAL",
+        `  spend          ${formatCost(t.cost)}`,
+        `  tokens         ${formatTokens(t.totalTokens)}  (in ${formatTokens(t.tokens.input)} · out ${formatTokens(
+            t.tokens.output
+        )} · cache-write ${formatTokens(t.tokens.cacheWrite)} · cache-read ${formatTokens(t.tokens.cacheRead)})`,
+        `  cache-hit rate ${pct(t.cacheHitRate)}`,
+    ].join("\n");
+
+    const modelTable = formatTable(
+        report.models.map((m) => [
+            modelLabel(m.model, m.priced),
+            formatCost(m.cost),
+            `${formatTokens(m.totalTokens)} tok`,
+        ]),
+        ["MODEL", "COST", "TOKENS"]
+    );
+
+    const projectTable = formatTable(
+        report.projects.map((p) => [p.project, formatCost(p.cost), `${p.sessions} sessions`]),
+        ["PROJECT", "COST", "SESSIONS"]
+    );
+
+    const sessionTable = formatTable(
+        report.sessions.map((s) => [
+            s.sessionId.slice(0, 8),
+            s.project,
+            formatCost(s.cost),
+            `${formatTokens(s.totalTokens)} tok`,
+            s.lastDay,
+        ]),
+        ["SESSION", "PROJECT", "COST", "TOKENS", "DAY"]
+    );
+
+    return [
+        header,
+        trend(report),
+        `\nBY MODEL\n${modelTable}`,
+        `\nTOP PROJECTS\n${projectTable}`,
+        `\nTOP SESSIONS\n${sessionTable}`,
+    ].join("\n");
+}
+
+export function renderSessions(report: Report): string {
+    const table = formatTable(
+        report.sessions.map((s) => [
+            s.sessionId.slice(0, 8),
+            s.project,
+            formatCost(s.cost),
+            `${formatTokens(s.totalTokens)} tok`,
+            s.lastDay,
+        ]),
+        ["SESSION", "PROJECT", "COST", "TOKENS", "DAY"]
+    );
+    return `Most expensive sessions (${report.windowStartDay} → ${report.windowEndDay} UTC)\n${table}`;
+}
+
+export function renderToday(report: Report): string {
+    const t = report.total;
+    return [
+        pc.bold(`Today (${report.windowEndDay} UTC)`),
+        `  spend          ${formatCost(t.cost)}`,
+        `  tokens         ${formatTokens(t.totalTokens)}`,
+        `  cache-hit rate ${pct(t.cacheHitRate)}`,
+    ].join("\n");
+}

--- a/src/ai-spend/lib/since.ts
+++ b/src/ai-spend/lib/since.ts
@@ -1,0 +1,20 @@
+const DAYS_PATTERN = /^(\d+)d$/;
+const ISO_DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Resolve a --since value to an inclusive UTC day key (YYYY-MM-DD), or undefined if unparseable. */
+export function resolveSince(input: string, now: Date): string | undefined {
+    const trimmed = input.trim();
+
+    const days = trimmed.match(DAYS_PATTERN);
+    if (days) {
+        const back = Number.parseInt(days[1], 10);
+        const d = new Date(now.getTime() - back * 24 * 60 * 60 * 1000);
+        return d.toISOString().slice(0, 10);
+    }
+
+    if (ISO_DAY_PATTERN.test(trimmed)) {
+        return trimmed;
+    }
+
+    return undefined;
+}

--- a/src/ai-spend/lib/since.ts
+++ b/src/ai-spend/lib/since.ts
@@ -13,7 +13,12 @@ export function resolveSince(input: string, now: Date): string | undefined {
     }
 
     if (ISO_DAY_PATTERN.test(trimmed)) {
-        return trimmed;
+        const parsed = new Date(`${trimmed}T00:00:00.000Z`);
+        if (!Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === trimmed) {
+            return trimmed;
+        }
+
+        return undefined;
     }
 
     return undefined;

--- a/src/ai-spend/lib/types.ts
+++ b/src/ai-spend/lib/types.ts
@@ -1,0 +1,88 @@
+export interface UsageEvent {
+    messageId: string;
+    model: string;
+    /** ISO-8601 UTC timestamp, e.g. "2026-06-01T09:52:38.815Z" */
+    timestamp: string;
+    /** Project = the cwd recorded on the event. "" when absent. */
+    project: string;
+    sessionId: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+}
+
+export interface ModelPrice {
+    /** $/Mtok */
+    input: number;
+    output: number;
+    cacheWrite: number;
+    cacheRead: number;
+}
+
+export type PricingTable = Record<string, ModelPrice>;
+
+export interface TokenTotals {
+    input: number;
+    output: number;
+    cacheWrite: number;
+    cacheRead: number;
+}
+
+export interface ModelBreakdown {
+    model: string;
+    priced: boolean;
+    tokens: TokenTotals;
+    totalTokens: number;
+    cost: number;
+}
+
+export interface ProjectBreakdown {
+    project: string;
+    sessions: number;
+    totalTokens: number;
+    cost: number;
+}
+
+export interface SessionBreakdown {
+    sessionId: string;
+    project: string;
+    /** UTC day (YYYY-MM-DD) of the session's last event in-window */
+    lastDay: string;
+    totalTokens: number;
+    cost: number;
+}
+
+export interface DayBreakdown {
+    day: string;
+    totalTokens: number;
+    cost: number;
+}
+
+export interface Report {
+    windowStartDay: string;
+    windowEndDay: string;
+    projectCount: number;
+    sessionCount: number;
+    total: {
+        tokens: TokenTotals;
+        totalTokens: number;
+        cost: number;
+        cacheHitRate: number;
+    };
+    days: DayBreakdown[];
+    models: ModelBreakdown[];
+    projects: ProjectBreakdown[];
+    sessions: SessionBreakdown[];
+}
+
+export interface Filters {
+    /** ISO day (YYYY-MM-DD) inclusive lower bound. */
+    sinceDay?: string;
+    /** case-insensitive substring on model id */
+    model?: string;
+    /** case-insensitive substring on project path */
+    project?: string;
+    /** leaderboard length cap (models/projects/sessions). Default 10 applied by caller. */
+    top?: number;
+}

--- a/src/claude/commands/spending.ts
+++ b/src/claude/commands/spending.ts
@@ -1,0 +1,9 @@
+import { registerSpendCommand } from "@app/ai-spend/lib/register";
+import type { Command } from "commander";
+
+export function registerSpendingCommand(program: Command): void {
+    const spending = program
+        .command("spending")
+        .description("Claude Code token & cost analytics across all local sessions (alias of `tools ai-spend`)");
+    registerSpendCommand(spending);
+}

--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -18,6 +18,7 @@ import { registerMcpCommand } from "./commands/mcp";
 import { registerMemoryCommand } from "./commands/memory";
 import { registerMigrateCommand } from "./commands/migrate";
 import { registerResumeCommand } from "./commands/resume";
+import { registerSpendingCommand } from "./commands/spending";
 import { registerSummarizeCommand } from "./commands/summarize";
 import { registerTailCommand } from "./commands/tail";
 import { registerUsageCommand } from "./commands/usage";
@@ -44,6 +45,7 @@ registerDaemonCommand(program);
 registerMigrateCommand(program);
 registerWarmupCommand(program);
 registerMcpCommand(program);
+registerSpendingCommand(program);
 
 addGlobalVerboseOption(program);
 


### PR DESCRIPTION
## What

`tools ai-spend` — Claude Code token & cost analytics. Scans local Claude Code session transcripts (`~/.claude/projects/**/*.jsonl`) and reports where your tokens and dollars go — per day, session, model, and project — with cache-hit rate, top burners, and a daily spend sparkline. Fully local, offline, read-only. No API, no upload, no account.

## CLI surface

```
tools ai-spend [summary]   # default — full window summary (TOTAL, DAILY TREND, BY MODEL, TOP PROJECTS, TOP SESSIONS)
tools ai-spend sessions    # most-expensive-sessions leaderboard
tools ai-spend today       # just today's spend (UTC day)
```

Shared flags (work on every subcommand AND on the bare invocation):

- `--since <when>` — `Nd` (N days back) or `YYYY-MM-DD`. Default `30d`.
- `--model <substr>` — case-insensitive substring filter on model id.
- `--project <substr>` — case-insensitive substring filter on project (cwd) path.
- `--top <n>` — leaderboard length. Default `10`.
- `--json` — emit the machine-readable Report as a single JSON object on stdout (suppresses tables).

## Correctness highlights

- **Dedup by `message.id` (critical).** A single API request emits multiple assistant JSONL events that each carry the identical `usage` object; summing every line would double/triple-count. The pure core keeps only the first event seen per `message.id` before aggregating. Asserted by a test (3 identical events counted once).
- **Four-component cost.** Cache is priced as two distinct rates (write != read != input): `cost = (in*input + out*output + cacheWrite*cw + cacheRead*cr) / 1e6`. Asserted against hand-computed numbers (opus 110.25 + sonnet 3 = 113.25 for a two-model, two-day fixture).
- **Cache-hit rate** = `cacheRead / (input + cacheRead)`, `0` when the denominator is `0`. Tested.
- **Unknown models never crash** — tokens still aggregate, cost contribution is `0`, rendered with an `(unpriced)` marker. Tested.
- **UTC, deterministic day bucketing** — day key is `timestamp.slice(0,10)`, no local-`Date` construction, so output is TZ-independent (test pins `TZ=Pacific/Kiritimati`). The pure core takes an injected `now` and reads no clock and no filesystem.
- **Pricing override** — a default pricing table ships in code; users may override/extend it via `~/.genesis-tools/ai-spend/config.json` (`pricing` key) through the Storage util. Tested (merge over defaults).
- **Robustness** — missing dir, empty files, malformed JSON lines, lines without usage, and missing optional fields all degrade gracefully (skip + log at debug), never crash.

## Architecture

Pure deterministic core (`lib/aggregate.ts`, `pricing.ts`, `since.ts`) takes parsed events + pricing + injected `now` and returns a `Report`. Thin IO layer (`discover.ts`, `parse.ts`) resolves `~/.claude` via `os.homedir()` and parses line-by-line. `render.ts` turns a Report into TTY text; stdout only via `out.result`/`out.println`, diagnostics via `logger`. The three subcommands are thin views over the same `Report`.

## Verification (local)

- `bunx biome check src/ai-spend` — exit 0.
- `bun test src/ai-spend` — 21 pass, 0 fail (hermetic: temp dirs + `GENESIS_TOOLS_HOME`, no network, no live `~/.claude` dependency).
- Smoke: `--help`, bare `ai-spend`, `--since 7d`, `today --json` (single JSON object on stdout, nothing else), `sessions --top 3` — all exit 0 against real transcripts.

## Notable fix during impl

Shared options declared on both the root program and each subcommand are treated as global by commander, so a subcommand action's plain opts arg omitted flags resolved onto the parent (`today --json` printed the table; `sessions --top 3` ignored the cap). Fixed by reading `cmd.optsWithGlobals()` in each action. Verified `--json` and value flags (`--top`/`--since`) now resolve correctly on subcommands.

## v1 non-goals

- No `~/.genesis-tools/claude-code/sessions/*.json` ingestion (the JSONL transcripts already carry every needed field).
- No live Anthropic billing API, no network, no auth.
- No 1h-vs-5m cache-creation tier split — v1 prices all cache-creation at one `cacheWrite` rate.
- Read-only; no transcript mutation, no clipboard, no interactive wizard.

## Known cosmetic limitation

The DAILY TREND sparkline uses `asciichart`; on very-high-spend days the left y-axis labels are padded/`format`-fixed to keep leading digits (a $1358 day rendered as "358" before the fix). Padding is now widened and a `format` callback fixes the axis to a `$X.XX` 9-char width.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ai-spend` command to track and analyze AI API usage costs with support for custom pricing configuration.
  * Supports multiple output modes: summary report, sessions leaderboard, and today's totals.
  * Filtering options for date range, model, project, and top-N results with JSON export.

* **Tests**
  * Added comprehensive test suite for ai-spend functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->