### PR TITLE
feat(port): see what's on a port and kill it

### DIFF
--- a/src/port/__tests__/display.test.ts
+++ b/src/port/__tests__/display.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { toPortJson, toProcessJson } from "../lib/display";
+import type { PortSnapshot, ProcessSnapshot } from "../lib/types";
+
+function makePortSnapshot(overrides: Partial<PortSnapshot> = {}): PortSnapshot {
+    return {
+        port: 3000,
+        pid: 123,
+        processName: "node",
+        command: "node server.js",
+        user: "alice",
+        state: "LISTEN",
+        name: "*:3000",
+        fd: "21u",
+        cwd: "/tmp/project",
+        projectName: "project",
+        framework: "Next.js",
+        uptime: "2h",
+        startTime: new Date("2026-06-02T08:30:00.000Z"),
+        memory: "120MB",
+        status: "healthy",
+        ...overrides,
+    };
+}
+
+function makeProcessSnapshot(overrides: Partial<ProcessSnapshot> = {}): ProcessSnapshot {
+    return {
+        pid: 456,
+        ppid: 1,
+        processName: "bun",
+        command: "bun run dev",
+        user: "bob",
+        cpu: 12.5,
+        memory: "80MB",
+        cwd: "/tmp/app",
+        projectName: "app",
+        framework: "Vite",
+        uptime: "10m",
+        startTime: new Date("2026-06-02T09:00:00.000Z"),
+        description: "dev server",
+        status: "healthy",
+        listeningPorts: [5173],
+        ...overrides,
+    };
+}
+
+describe("toPortJson", () => {
+    it("serializes Date startTime to a deterministic ISO string", () => {
+        const result = toPortJson([makePortSnapshot()]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].startTime).toBe("2026-06-02T08:30:00.000Z");
+        expect(result[0]).toMatchObject({
+            port: 3000,
+            pid: 123,
+            processName: "node",
+            user: "alice",
+            state: "LISTEN",
+            framework: "Next.js",
+            status: "healthy",
+        });
+    });
+
+    it("keeps a null startTime as null", () => {
+        const result = toPortJson([makePortSnapshot({ startTime: null, framework: null, cwd: null })]);
+
+        expect(result[0].startTime).toBeNull();
+        expect(result[0].framework).toBeNull();
+        expect(result[0].cwd).toBeNull();
+    });
+
+    it("preserves order and serializes every entry", () => {
+        const result = toPortJson([makePortSnapshot({ pid: 1, port: 3000 }), makePortSnapshot({ pid: 2, port: 3001 })]);
+
+        expect(result.map((entry) => entry.pid)).toEqual([1, 2]);
+        expect(result.map((entry) => entry.port)).toEqual([3000, 3001]);
+    });
+
+    it("returns an empty array for no snapshots", () => {
+        expect(toPortJson([])).toEqual([]);
+    });
+});
+
+describe("toProcessJson", () => {
+    it("serializes Date startTime to a deterministic ISO string and keeps listeningPorts", () => {
+        const result = toProcessJson([makeProcessSnapshot()]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].startTime).toBe("2026-06-02T09:00:00.000Z");
+        expect(result[0].listeningPorts).toEqual([5173]);
+        expect(result[0]).toMatchObject({
+            pid: 456,
+            ppid: 1,
+            processName: "bun",
+            cpu: 12.5,
+            framework: "Vite",
+        });
+    });
+
+    it("keeps a null startTime as null", () => {
+        const result = toProcessJson([makeProcessSnapshot({ startTime: null })]);
+
+        expect(result[0].startTime).toBeNull();
+    });
+});

--- a/src/port/index.ts
+++ b/src/port/index.ts
@@ -14,6 +14,8 @@ import {
     displayProcessTable,
     displayWatchEvent,
     displayWatchHeader,
+    toPortJson,
+    toProcessJson,
 } from "./lib/display";
 import {
     findOrphanedPorts,
@@ -31,6 +33,7 @@ interface RootOptions {
     all?: boolean;
     kill?: boolean;
     yes?: boolean;
+    json?: boolean;
 }
 
 type SelectionKind = "all" | "listeners" | "connections" | number;
@@ -173,16 +176,28 @@ async function maybeKillProcessesForPort(
     }
 }
 
-async function showPortOverview(includeSystem: boolean): Promise<void> {
+async function showPortOverview(includeSystem: boolean, json: boolean): Promise<void> {
     const ports = getListeningPorts().filter(
         (snapshot) => includeSystem || isLikelyDevProcess(snapshot.processName, snapshot.command)
     );
+
+    if (json) {
+        out.result(toPortJson(ports));
+        return;
+    }
+
     displayPortTable(ports, !includeSystem);
 }
 
 async function inspectPort(portArg: string, options: RootOptions): Promise<void> {
     const port = validatePort(portArg);
     const snapshots = getPortDetails(port);
+
+    if (options.json) {
+        out.result(toPortJson(snapshots));
+        return;
+    }
+
     const gitBranch = snapshots.length > 0 ? getGitBranch(snapshots[0].cwd) : null;
 
     displayPortDetail(port, snapshots, gitBranch);
@@ -199,10 +214,15 @@ async function inspectPort(portArg: string, options: RootOptions): Promise<void>
     }
 }
 
-async function showProcessOverview(includeSystem: boolean): Promise<void> {
+async function showProcessOverview(includeSystem: boolean, json: boolean): Promise<void> {
     const processes = getAllProcesses()
         .filter((processInfo) => includeSystem || isLikelyDevProcess(processInfo.processName, processInfo.command))
         .sort((left, right) => right.cpu - left.cpu || left.pid - right.pid);
+
+    if (json) {
+        out.result(toProcessJson(processes));
+        return;
+    }
 
     displayProcessTable(processes, !includeSystem);
 }
@@ -273,9 +293,10 @@ program
     .option("-a, --all", "Include system processes and listeners in list views")
     .option("-k, --kill", "Kill every PID found for the inspected port")
     .option("-y, --yes", "Skip confirmation prompts")
+    .option("-j, --json", "Emit machine-readable JSON instead of a table (read-only, never kills)")
     .action(async (portArg: string | undefined, options: RootOptions) => {
         if (!portArg) {
-            await showPortOverview(Boolean(options.all));
+            await showPortOverview(Boolean(options.all), Boolean(options.json));
             return;
         }
 
@@ -286,8 +307,9 @@ program
     .command("ps")
     .description("Show a colorful process listing focused on dev workflows")
     .option("-a, --all", "Include system processes")
-    .action(async (options: { all?: boolean }) => {
-        await showProcessOverview(Boolean(options.all));
+    .option("-j, --json", "Emit machine-readable JSON instead of a table")
+    .action(async (options: { all?: boolean; json?: boolean }) => {
+        await showProcessOverview(Boolean(options.all), Boolean(options.json));
     });
 
 program

--- a/src/port/lib/display.ts
+++ b/src/port/lib/display.ts
@@ -296,6 +296,28 @@ export function displayWatchHeader(includeSystem: boolean, intervalMs: number): 
     out.println(pc.dim("  Press Ctrl+C to stop.\n"));
 }
 
+export interface PortSnapshotJson extends Omit<PortSnapshot, "startTime"> {
+    startTime: string | null;
+}
+
+export interface ProcessSnapshotJson extends Omit<ProcessSnapshot, "startTime"> {
+    startTime: string | null;
+}
+
+export function toPortJson(snapshots: PortSnapshot[]): PortSnapshotJson[] {
+    return snapshots.map((snapshot) => ({
+        ...snapshot,
+        startTime: snapshot.startTime ? snapshot.startTime.toISOString() : null,
+    }));
+}
+
+export function toProcessJson(processes: ProcessSnapshot[]): ProcessSnapshotJson[] {
+    return processes.map((processInfo) => ({
+        ...processInfo,
+        startTime: processInfo.startTime ? processInfo.startTime.toISOString() : null,
+    }));
+}
+
 export function displayWatchEvent(event: "new" | "removed", snapshot: PortSnapshot): void {
     const timestamp = pc.dim(new Date().toLocaleTimeString());
 


### PR DESCRIPTION
## Summary

Adds `--json` machine-readable output to the `tools port` CLI. The base tool (port inspection, listing, `ps`, `clean`, `watch`, kill) already lives on `master`; this PR is the focused increment that makes the read-only views scriptable.

## What changed (all under `src/port/`)

- **`-j, --json` flag** on the root command (`tools port` / `tools port <number>`) and the `ps` subcommand. Emits a JSON array via `out.result()` (the only stdout writer) and returns early — JSON output is strictly read-only and never prompts or kills.
- **Serialization helpers** `toPortJson()` / `toProcessJson()` in `lib/display.ts`, with `PortSnapshotJson` / `ProcessSnapshotJson` types that convert the `Date startTime` field to a deterministic ISO string (or `null`).
- **Hermetic test** `__tests__/display.test.ts`: pure unit tests for the serializers with fixed dates and real assertions — no network, no clipboard, no `lsof`/`ps`/`kill`, no live-process dependency.

## Verification (in the worktree)

- `bunx biome check src/port` → exit 0 (no errors).
- `bun test src/port` → 11 pass / 0 fail, 22 assertions.
- `./tools port --help` → exit 0; `--json` listed on root and `ps`.
- `./tools port --json` → emits a valid JSON array to stdout, exit 0.

## Notes

- No dependencies added; no files touched outside `src/port/`.
- `--json` is intentionally inert with respect to side effects (no kill, no confirm) so it is safe in pipelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--json` / `-j` command-line option for generating machine-readable JSON output for port listing, port inspection, and process overview (read-only).

* **Tests**
  * Added coverage for deterministic JSON serialization, ensuring `startTime` is consistently formatted as ISO strings and that nullable fields (including `startTime`) are preserved as `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->