### PR TITLE
feat(qr): terminal QR codes for url/text/wifi

### DIFF
--- a/src/qr/index.ts
+++ b/src/qr/index.ts
@@ -1,0 +1,85 @@
+import { logger, out } from "@app/logger";
+import { runTool, suggestCommand } from "@app/utils/cli";
+import { renderQr } from "@app/utils/qr";
+import { Command } from "commander";
+import { buildTextPayload, buildWifiPayload, normalizeSecurity } from "./lib/payload";
+
+interface TextOptions {
+    small?: boolean;
+}
+
+interface WifiOptions {
+    ssid?: string;
+    pass?: string;
+    security: string;
+    hidden?: boolean;
+    small?: boolean;
+}
+
+const program = new Command();
+
+program
+    .name("qr")
+    .description("Render QR codes in the terminal for a URL/text or a WiFi network.")
+    .argument("[text]", "URL or text to encode")
+    .option("--small", "Compact rendering (half-height blocks)")
+    .action(async (text: string | undefined, options: TextOptions) => {
+        if (!text) {
+            out.log.error("No text provided.");
+            out.printlnErr(suggestCommand("tools qr", { add: ["<text>"] }));
+            await out.flush();
+            process.exit(1);
+        }
+
+        const payload = buildTextPayload(text);
+        logger.debug({ payload }, "qr: rendering text payload");
+        const matrix = renderQr(payload, { small: options.small });
+        out.log.step(`QR for: ${text}`);
+        out.print(matrix);
+    });
+
+program
+    .command("wifi")
+    .description("Render a QR for a WiFi network (phones can scan to join).")
+    .requiredOption("--ssid <ssid>", "Network name (SSID)")
+    .option("--pass <password>", "Network password (required unless --security nopass)")
+    .option("--security <type>", "WPA | WEP | nopass", "WPA")
+    .option("--hidden", "Mark the network as hidden (H:true)")
+    .option("--small", "Compact rendering (half-height blocks)")
+    .action(async (options: WifiOptions) => {
+        let security: ReturnType<typeof normalizeSecurity>;
+        try {
+            security = normalizeSecurity(options.security);
+        } catch (err) {
+            out.log.error(err instanceof Error ? err.message : String(err));
+            await out.flush();
+            process.exit(1);
+        }
+
+        if (security !== "nopass" && !options.pass) {
+            out.log.error(`--pass is required for ${security} networks (or use --security nopass).`);
+            await out.flush();
+            process.exit(1);
+        }
+
+        const ssid = options.ssid;
+        if (!ssid) {
+            out.log.error("--ssid is required.");
+            await out.flush();
+            process.exit(1);
+        }
+
+        const payload = buildWifiPayload({
+            ssid,
+            password: options.pass,
+            security,
+            hidden: options.hidden ?? false,
+        });
+
+        logger.debug({ payload }, "qr: rendering wifi payload");
+        const matrix = renderQr(payload, { small: options.small });
+        out.log.step(`WIFI payload: ${payload}`);
+        out.print(matrix);
+    });
+
+await runTool(program, { tool: "qr" });

--- a/src/qr/index.ts
+++ b/src/qr/index.ts
@@ -76,9 +76,9 @@ program
             hidden: options.hidden ?? false,
         });
 
-        logger.debug({ payload }, "qr: rendering wifi payload");
+        logger.debug({ ssid, security, hidden: options.hidden ?? false }, "qr: rendering wifi payload");
         const matrix = renderQr(payload, { small: options.small ?? false });
-        out.log.step(`WIFI payload: ${payload}`);
+        out.log.step(`QR for WiFi network: ${ssid}`);
         out.print(matrix);
     });
 

--- a/src/qr/index.ts
+++ b/src/qr/index.ts
@@ -33,7 +33,7 @@ program
 
         const payload = buildTextPayload(text);
         logger.debug({ payload }, "qr: rendering text payload");
-        const matrix = renderQr(payload, { small: options.small });
+        const matrix = renderQr(payload, { small: options.small ?? false });
         out.log.step(`QR for: ${text}`);
         out.print(matrix);
     });
@@ -77,7 +77,7 @@ program
         });
 
         logger.debug({ payload }, "qr: rendering wifi payload");
-        const matrix = renderQr(payload, { small: options.small });
+        const matrix = renderQr(payload, { small: options.small ?? false });
         out.log.step(`WIFI payload: ${payload}`);
         out.print(matrix);
     });

--- a/src/qr/lib/payload.ts
+++ b/src/qr/lib/payload.ts
@@ -1,0 +1,63 @@
+export type WifiSecurity = "WPA" | "WEP" | "nopass";
+
+export interface WifiPayloadInput {
+    ssid: string;
+    password?: string;
+    security: WifiSecurity;
+    hidden: boolean;
+}
+
+const CANONICAL_SECURITY: Record<string, WifiSecurity> = {
+    wpa: "WPA",
+    wep: "WEP",
+    nopass: "nopass",
+};
+
+/**
+ * Normalize a user-supplied security value to the canonical WIFI casing.
+ * Accepts case-insensitive input; throws on anything outside WPA|WEP|nopass.
+ */
+export function normalizeSecurity(value: string): WifiSecurity {
+    const canonical = CANONICAL_SECURITY[value.toLowerCase()];
+    if (!canonical) {
+        throw new Error(`Invalid --security "${value}". Must be one of: WPA, WEP, nopass.`);
+    }
+
+    return canonical;
+}
+
+/**
+ * Escape the five MECARD-reserved characters in a WIFI field by prefixing
+ * each with a backslash: \ ; , : "
+ * The backslash itself is escaped FIRST so already-present backslashes are
+ * not double-processed by the later replacements.
+ */
+export function escapeWifiField(value: string): string {
+    return value
+        .replace(/\\/g, "\\\\")
+        .replace(/;/g, "\\;")
+        .replace(/,/g, "\\,")
+        .replace(/:/g, "\\:")
+        .replace(/"/g, '\\"');
+}
+
+/**
+ * Build a standard WIFI:...;; payload with correctly-escaped SSID/password.
+ * Shape: WIFI:T:<security>;S:<ssid>;P:<password>;H:<hidden>;;
+ * For security "nopass", P: is emitted empty and password is ignored.
+ */
+export function buildWifiPayload(input: WifiPayloadInput): string {
+    const ssid = escapeWifiField(input.ssid);
+    const password = input.security === "nopass" ? "" : escapeWifiField(input.password ?? "");
+    const hidden = input.hidden ? "true" : "false";
+
+    return `WIFI:T:${input.security};S:${ssid};P:${password};H:${hidden};;`;
+}
+
+/**
+ * URL/text passthrough — the input is returned verbatim, no transformation
+ * and no auto-prefixing of a scheme.
+ */
+export function buildTextPayload(text: string): string {
+    return text;
+}

--- a/src/qr/qr.test.ts
+++ b/src/qr/qr.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { buildTextPayload, buildWifiPayload, escapeWifiField, normalizeSecurity } from "./lib/payload";
+
+describe("buildTextPayload", () => {
+    test("passes URLs through verbatim", () => {
+        expect(buildTextPayload("https://x.test?a=1&b=2")).toBe("https://x.test?a=1&b=2");
+    });
+
+    test("passes arbitrary text through unchanged", () => {
+        expect(buildTextPayload("Hello, world")).toBe("Hello, world");
+    });
+
+    test("does not auto-prefix a scheme", () => {
+        expect(buildTextPayload("example.com")).toBe("example.com");
+    });
+
+    test("preserves the empty string", () => {
+        expect(buildTextPayload("")).toBe("");
+    });
+});
+
+describe("escapeWifiField", () => {
+    test("escapes each of the five reserved characters", () => {
+        expect(escapeWifiField(";")).toBe("\\;");
+        expect(escapeWifiField(",")).toBe("\\,");
+        expect(escapeWifiField(":")).toBe("\\:");
+        expect(escapeWifiField('"')).toBe('\\"');
+        expect(escapeWifiField("\\")).toBe("\\\\");
+    });
+
+    test("escapes the backslash first so it is not double-processed", () => {
+        // Input \; must become \\\; (backslash escaped, then the semicolon
+        // escaped), NOT \\\\; (which would happen if ; were escaped first and
+        // its new backslash then re-escaped).
+        expect(escapeWifiField("\\;")).toBe("\\\\\\;");
+    });
+
+    test("leaves unreserved characters untouched", () => {
+        expect(escapeWifiField("Plain Text 123")).toBe("Plain Text 123");
+    });
+});
+
+describe("buildWifiPayload", () => {
+    test("builds a plain WPA payload", () => {
+        expect(buildWifiPayload({ ssid: "Foo", password: "bar", security: "WPA", hidden: false })).toBe(
+            "WIFI:T:WPA;S:Foo;P:bar;H:false;;"
+        );
+    });
+
+    test("escapes all reserved chars in ssid and password", () => {
+        expect(buildWifiPayload({ ssid: 'a;b,c:d\\e"f', password: "x", security: "WPA", hidden: false })).toBe(
+            'WIFI:T:WPA;S:a\\;b\\,c\\:d\\\\e\\"f;P:x;H:false;;'
+        );
+    });
+
+    test("nopass emits an empty P field and ignores the password", () => {
+        expect(buildWifiPayload({ ssid: "Foo", security: "nopass", hidden: false })).toBe(
+            "WIFI:T:nopass;S:Foo;P:;H:false;;"
+        );
+        expect(buildWifiPayload({ ssid: "Foo", password: "ignored", security: "nopass", hidden: false })).toBe(
+            "WIFI:T:nopass;S:Foo;P:;H:false;;"
+        );
+    });
+
+    test("--hidden flips H to true; default is false", () => {
+        expect(buildWifiPayload({ ssid: "Foo", password: "bar", security: "WPA", hidden: true })).toBe(
+            "WIFI:T:WPA;S:Foo;P:bar;H:true;;"
+        );
+        expect(buildWifiPayload({ ssid: "Foo", password: "bar", security: "WPA", hidden: false })).toBe(
+            "WIFI:T:WPA;S:Foo;P:bar;H:false;;"
+        );
+    });
+
+    test("WEP security is carried into the T field", () => {
+        expect(buildWifiPayload({ ssid: "HiddenNet", password: "secret", security: "WEP", hidden: true })).toBe(
+            "WIFI:T:WEP;S:HiddenNet;P:secret;H:true;;"
+        );
+    });
+
+    test("missing password on a non-nopass network yields an empty P (caller enforces requiredness)", () => {
+        expect(buildWifiPayload({ ssid: "Foo", security: "WPA", hidden: false })).toBe("WIFI:T:WPA;S:Foo;P:;H:false;;");
+    });
+});
+
+describe("normalizeSecurity", () => {
+    test("accepts canonical casing", () => {
+        expect(normalizeSecurity("WPA")).toBe("WPA");
+        expect(normalizeSecurity("WEP")).toBe("WEP");
+        expect(normalizeSecurity("nopass")).toBe("nopass");
+    });
+
+    test("normalizes case-insensitive input to canonical casing", () => {
+        expect(normalizeSecurity("wpa")).toBe("WPA");
+        expect(normalizeSecurity("Wep")).toBe("WEP");
+        expect(normalizeSecurity("NOPASS")).toBe("nopass");
+    });
+
+    test("throws on an unknown security type", () => {
+        expect(() => normalizeSecurity("bogus")).toThrow(/Invalid --security/);
+        expect(() => normalizeSecurity("")).toThrow(/Invalid --security/);
+    });
+});


### PR DESCRIPTION
## Summary

Adds `tools qr` — a terminal QR code renderer for a URL/text string, or a WiFi network via a `wifi` subcommand that builds the standard `WIFI:...;;` payload with correctly-escaped reserved characters.

The genuinely regression-prone part is **payload construction** (WiFi MECARD escaping + URL/text passthrough). That logic lives in pure, unit-tested functions in `src/qr/lib/payload.ts`; the visual render is a thin wrapper around the existing shared util `@app/utils/qr` (`renderQr`) — `qrcode-terminal` is not imported directly.

## CLI surface

```
tools qr <text>                              Render a QR for a URL or arbitrary text.
tools qr wifi --ssid <ssid> --pass <p>       Render a QR for a WiFi network.

  --small                  Compact rendering (half-height blocks).

wifi flags:
  --ssid <ssid>            Network name (SSID). Required.
  --pass <password>        Required unless --security nopass.
  --security <type>        WPA | WEP | nopass   (default: WPA, case-insensitive)
  --hidden                 Mark the network as hidden (H:true). Default: false.
```

## Behavior / contract

- **Output split:** the rendered QR matrix is the only thing on **stdout** (`out.print`), so `tools qr <url> > file.txt` captures just the matrix. Captions/diagnostics go to **stderr** (`out.log.*`). Never `console.log`.
- **WiFi escaping:** SSID and password escape the five MECARD-reserved chars `\ ; , : "`, backslash first so it isn't double-escaped. e.g. `--ssid 'My;Net' --pass 'p:w'` → `WIFI:T:WPA;S:My\;Net;P:p\:w;H:false;;`.
- **nopass:** `T:nopass`, empty `P:`, `--pass` not required.
- **Validation:** unknown `--security` exits non-zero with a clear message; missing `--ssid` (or missing `--pass` on a non-nopass network) errors and exits non-zero rather than rendering a garbage QR.

## Files

- `src/qr/index.ts` — commander program, ends in `runTool(program, { tool: "qr" })`.
- `src/qr/lib/payload.ts` — pure builders: `buildTextPayload`, `buildWifiPayload`, `escapeWifiField`, `normalizeSecurity`.
- `src/qr/qr.test.ts` — hermetic `bun:test` over the pure builders (no network/fs/clock/clipboard).

No new dependencies; all changes confined to `src/qr/`.

## Verification

- `bunx biome check src/qr` → exit 0.
- `bun test src/qr` → 16 pass, 27 assertions.
- `./tools qr --help` → exit 0, shows `wifi` + shared flags.
- Functional smoke: stdout-only matrix on redirect; reserved-char escaping correct; bogus `--security` and missing `--ssid` both exit non-zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a QR code CLI command to generate QR codes for plain text/URLs (default) and WiFi networks (WiFi subcommand).
  * WiFi generation supports selectable security modes, password handling, and hidden-network output.
  * Added input validation and improved WiFi field handling to ensure characters are encoded correctly.
  * Supports an optional compact rendering mode for smaller QR output.

* **Tests**
  * Added comprehensive automated coverage for QR payload building and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->