### PR TITLE
feat(regret-grep): warn when a diff repeats a bug you already fixed

### DIFF
--- a/src/regret-grep/index.ts
+++ b/src/regret-grep/index.ts
@@ -1,0 +1,141 @@
+import { out } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { Command } from "commander";
+import { isGitRepo, readStagedDiff, readWorkingDiff, repoToplevel } from "./lib/git";
+import { scoreQuery } from "./lib/similarity";
+import { buildIndex, loadIndex } from "./lib/store";
+import type { RegretIndex } from "./lib/types";
+
+/** Default cosine-similarity floor below which a match is not reported. */
+const DEFAULT_THRESHOLD = 0.15;
+
+interface IndexOptions {
+    since?: string;
+}
+
+interface CheckOptions {
+    diff?: string;
+    staged?: boolean;
+    threshold: string;
+    top: string;
+}
+
+async function resolveRepo(): Promise<string | null> {
+    const cwd = process.cwd();
+    if (!(await isGitRepo(cwd))) {
+        return null;
+    }
+
+    return repoToplevel(cwd);
+}
+
+async function runIndex(options: IndexOptions): Promise<void> {
+    const repo = await resolveRepo();
+    if (!repo) {
+        out.log.error("Not inside a git repository.");
+        process.exit(1);
+    }
+
+    const spin = out.spinner();
+    spin.start("Indexing bug-fix commits");
+    const index = await buildIndex({ repo, since: options.since });
+    spin.stop(`Indexed ${index.entries.length} bug-fix commit(s) from ${repo}`);
+
+    out.result({ repo, entries: index.entries.length, builtAt: index.builtAt });
+}
+
+async function loadQueryDiff(repo: string, options: CheckOptions): Promise<string> {
+    if (options.diff) {
+        return Bun.file(options.diff).text();
+    }
+
+    if (options.staged) {
+        return readStagedDiff(repo);
+    }
+
+    return readWorkingDiff(repo);
+}
+
+async function ensureIndex(repo: string): Promise<RegretIndex | null> {
+    const index = await loadIndex(repo);
+    if (index && index.entries.length > 0) {
+        return index;
+    }
+
+    return null;
+}
+
+async function runCheck(options: CheckOptions): Promise<void> {
+    const repo = await resolveRepo();
+    if (!repo) {
+        out.log.error("Not inside a git repository.");
+        process.exit(1);
+    }
+
+    const index = await ensureIndex(repo);
+    if (!index) {
+        out.log.warn("No regret-grep index found (or it is empty). Run `tools regret-grep index` first.");
+        out.result({ repo, matches: [] });
+        return;
+    }
+
+    const queryText = await loadQueryDiff(repo, options);
+    if (!queryText.trim()) {
+        out.log.info("No diff to check (working tree clean or empty input).");
+        out.result({ repo, matches: [] });
+        return;
+    }
+
+    const threshold = Number.parseFloat(options.threshold);
+    const topN = Math.max(1, Number.parseInt(options.top, 10) || 5);
+    const scored = scoreQuery(queryText, index, topN).filter((m) => m.score >= threshold);
+
+    if (scored.length === 0) {
+        out.log.success("No similar past bug-fixes found above threshold.");
+        out.result({ repo, matches: [] });
+        return;
+    }
+
+    out.log.warn(`You fixed something like this before (${scored.length} match(es)):`);
+    for (const match of scored) {
+        const pct = (match.score * 100).toFixed(0);
+        const overlap = match.overlap.length > 0 ? ` [${match.overlap.join(", ")}]` : "";
+        out.log.message(`  ${match.entry.hash} (${match.entry.date}): ${match.entry.subject} — ${pct}%${overlap}`);
+    }
+
+    out.result({
+        repo,
+        matches: scored.map((m) => ({
+            hash: m.entry.hash,
+            date: m.entry.date,
+            subject: m.entry.subject,
+            score: m.score,
+            overlap: m.overlap,
+        })),
+    });
+}
+
+const program = new Command();
+
+program.name("regret-grep").description("Warn when the current diff repeats a bug you already fixed.");
+
+program
+    .command("index")
+    .description("Build/update the local index of past bug-fix commits.")
+    .option("--since <when>", "Only index commits since this git date (e.g. '6 months ago').")
+    .action(async (options: IndexOptions) => {
+        await runIndex(options);
+    });
+
+program
+    .command("check")
+    .description("Score the current diff against past bug-fixes and warn on repeats.")
+    .option("--diff <file>", "Score this unified-diff file instead of the working tree.")
+    .option("--staged", "Score the staged diff (git diff --cached) instead of the working tree.")
+    .option("--threshold <n>", "Minimum cosine similarity to report (0-1).", String(DEFAULT_THRESHOLD))
+    .option("--top <n>", "Maximum number of matches to report.", "5")
+    .action(async (options: CheckOptions) => {
+        await runCheck(options);
+    });
+
+await runTool(program, { tool: "regret-grep" });

--- a/src/regret-grep/index.ts
+++ b/src/regret-grep/index.ts
@@ -46,7 +46,13 @@ async function runIndex(options: IndexOptions): Promise<void> {
 
 async function loadQueryDiff(repo: string, options: CheckOptions): Promise<string> {
     if (options.diff) {
-        return Bun.file(options.diff).text();
+        const file = Bun.file(options.diff);
+        if (!(await file.exists())) {
+            out.log.error(`Diff file not found: ${options.diff}`);
+            process.exit(1);
+        }
+
+        return file.text();
     }
 
     if (options.staged) {
@@ -87,6 +93,11 @@ async function runCheck(options: CheckOptions): Promise<void> {
     }
 
     const threshold = Number.parseFloat(options.threshold);
+    if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+        out.log.error(`Invalid --threshold value: ${options.threshold} (expected a number 0-1).`);
+        process.exit(1);
+    }
+
     const topN = Math.max(1, Number.parseInt(options.top, 10) || 5);
     const scored = scoreQuery(queryText, index, topN).filter((m) => m.score >= threshold);
 

--- a/src/regret-grep/lib/entry.ts
+++ b/src/regret-grep/lib/entry.ts
@@ -1,0 +1,57 @@
+import { fileTypeToken, tokenize } from "./tokenize";
+import type { RawCommit, RegretEntry } from "./types";
+
+/**
+ * Cap on tokens stored per entry. Keeps the index small and stops one huge
+ * commit from dominating the corpus. Subject tokens are always kept; diff
+ * tokens fill the remaining budget by frequency.
+ */
+const MAX_TOKENS_PER_ENTRY = 60;
+
+/**
+ * Distill a raw bug-fix commit into the lexical {@link RegretEntry} we score
+ * against. Pure and deterministic.
+ *
+ * Subject tokens are weighted by including them twice (the subject is the
+ * highest-signal description of the bug). Diff tokens are deduplicated by
+ * frequency and truncated to fit the per-entry budget.
+ */
+export function distillEntry(commit: RawCommit): RegretEntry {
+    const subjectTokens = tokenize(commit.subject);
+
+    const diffFreq = new Map<string, number>();
+    for (const line of commit.diffLines) {
+        for (const token of tokenize(line)) {
+            diffFreq.set(token, (diffFreq.get(token) ?? 0) + 1);
+        }
+    }
+
+    // Subject tokens counted twice for emphasis.
+    const tokens: string[] = [...subjectTokens, ...subjectTokens];
+
+    const budget = MAX_TOKENS_PER_ENTRY - tokens.length;
+    if (budget > 0) {
+        const rankedDiff = [...diffFreq.entries()]
+            .sort((a, b) => {
+                if (b[1] !== a[1]) {
+                    return b[1] - a[1];
+                }
+
+                return a[0].localeCompare(b[0]);
+            })
+            .slice(0, budget)
+            .map(([token]) => token);
+        tokens.push(...rankedDiff);
+    }
+
+    const fileTypes = [...new Set(commit.files.map(fileTypeToken))].sort();
+
+    return {
+        hash: commit.hash,
+        subject: commit.subject,
+        date: commit.date,
+        timestamp: commit.timestamp,
+        fileTypes,
+        tokens,
+    };
+}

--- a/src/regret-grep/lib/git.ts
+++ b/src/regret-grep/lib/git.ts
@@ -1,4 +1,5 @@
 import { logger } from "@app/logger";
+import { createGit } from "@app/utils/git";
 import { isBugFixSubject } from "./tokenize";
 import type { RawCommit } from "./types";
 
@@ -6,18 +7,20 @@ import type { RawCommit } from "./types";
 const FIELD_SEP = "\x1f";
 const RECORD_SEP = "\x1e";
 
+/**
+ * Run a git command in {@link cwd} via the shared git executor.
+ *
+ * Returns the trimmed stdout and an `ok` flag derived from the exit code
+ * (the shared executor exposes `success`/`exitCode`; we map `ok = success`).
+ */
 async function runGit(args: string[], cwd: string): Promise<{ stdout: string; ok: boolean }> {
-    const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-        proc.exited,
-    ]);
-    if (exitCode !== 0) {
-        logger.debug(`git ${args.join(" ")} exited ${exitCode}: ${stderr.trim()}`);
+    const git = createGit({ cwd });
+    const result = await git.executor.exec(args);
+    if (!result.success) {
+        logger.debug(`git ${args.join(" ")} exited ${result.exitCode}: ${result.stderr}`);
     }
 
-    return { stdout, ok: exitCode === 0 };
+    return { stdout: result.stdout, ok: result.success };
 }
 
 /** True when {@link cwd} is inside a git work tree. */

--- a/src/regret-grep/lib/git.ts
+++ b/src/regret-grep/lib/git.ts
@@ -1,0 +1,145 @@
+import { logger } from "@app/logger";
+import { isBugFixSubject } from "./tokenize";
+import type { RawCommit } from "./types";
+
+/** Field/record separators unlikely to appear in commit metadata. */
+const FIELD_SEP = "\x1f";
+const RECORD_SEP = "\x1e";
+
+async function runGit(args: string[], cwd: string): Promise<{ stdout: string; ok: boolean }> {
+    const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        logger.debug(`git ${args.join(" ")} exited ${exitCode}: ${stderr.trim()}`);
+    }
+
+    return { stdout, ok: exitCode === 0 };
+}
+
+/** True when {@link cwd} is inside a git work tree. */
+export async function isGitRepo(cwd: string): Promise<boolean> {
+    const { stdout, ok } = await runGit(["rev-parse", "--is-inside-work-tree"], cwd);
+    return ok && stdout.trim() === "true";
+}
+
+/**
+ * Pull bug-fix commits from git history.
+ *
+ * Subjects are classified with {@link isBugFixSubject}, so we over-fetch the
+ * raw log and filter in-process (one deterministic classifier, reused by the
+ * tests). For each surviving commit we fetch its name-only file list and a
+ * size-bounded diff body.
+ */
+export async function collectBugFixCommits(opts: {
+    cwd: string;
+    since?: string;
+    maxCommits: number;
+    maxDiffBytesPerCommit: number;
+}): Promise<RawCommit[]> {
+    const { cwd, since, maxCommits, maxDiffBytesPerCommit } = opts;
+
+    const logArgs = ["log", `--pretty=format:%h${FIELD_SEP}%s${FIELD_SEP}%aI${FIELD_SEP}%at${RECORD_SEP}`];
+    if (since) {
+        logArgs.push(`--since=${since}`);
+    }
+
+    const { stdout, ok } = await runGit(logArgs, cwd);
+    if (!ok) {
+        return [];
+    }
+
+    const records = stdout
+        .split(RECORD_SEP)
+        .map((r) => r.trim())
+        .filter(Boolean);
+
+    const bugFixes: RawCommit[] = [];
+    for (const record of records) {
+        const [hash, subject, date, atRaw] = record.split(FIELD_SEP);
+        if (!hash || !subject) {
+            continue;
+        }
+
+        if (!isBugFixSubject(subject)) {
+            continue;
+        }
+
+        const timestamp = Number.parseInt(atRaw ?? "0", 10) || 0;
+        bugFixes.push({ hash, subject, date: date ?? "", timestamp, files: [], diffLines: [] });
+
+        if (bugFixes.length >= maxCommits) {
+            break;
+        }
+    }
+
+    for (const commit of bugFixes) {
+        commit.files = await fetchChangedFiles(commit.hash, cwd);
+        commit.diffLines = await fetchDiffLines(commit.hash, cwd, maxDiffBytesPerCommit);
+    }
+
+    logger.debug(`collected ${bugFixes.length} bug-fix commits from ${cwd}`);
+    return bugFixes;
+}
+
+async function fetchChangedFiles(hash: string, cwd: string): Promise<string[]> {
+    const { stdout, ok } = await runGit(["show", "--no-color", "--name-only", "--pretty=format:", hash], cwd);
+    if (!ok) {
+        return [];
+    }
+
+    return stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+}
+
+async function fetchDiffLines(hash: string, cwd: string, maxBytes: number): Promise<string[]> {
+    const { stdout, ok } = await runGit(["show", "--no-color", "--unified=0", "--pretty=format:", hash], cwd);
+    if (!ok) {
+        return [];
+    }
+
+    return extractDiffContentLines(stdout.slice(0, maxBytes));
+}
+
+/**
+ * Keep only added/removed content lines from a unified diff, stripping the
+ * leading `+`/`-`, and dropping the `+++`/`---` file headers and `@@` hunk
+ * markers. Exported for unit testing.
+ */
+export function extractDiffContentLines(diff: string): string[] {
+    const lines: string[] = [];
+    for (const raw of diff.split("\n")) {
+        if (raw.startsWith("+++") || raw.startsWith("---")) {
+            continue;
+        }
+
+        if (raw.startsWith("+") || raw.startsWith("-")) {
+            const content = raw.slice(1).trim();
+            if (content) {
+                lines.push(content);
+            }
+        }
+    }
+
+    return lines;
+}
+
+/** Read the staged diff (`git diff --cached`). */
+export async function readStagedDiff(cwd: string): Promise<string> {
+    const { stdout } = await runGit(["diff", "--cached", "--no-color"], cwd);
+    return stdout;
+}
+
+/** Read the unstaged working-tree diff (`git diff`). */
+export async function readWorkingDiff(cwd: string): Promise<string> {
+    const { stdout } = await runGit(["diff", "--no-color"], cwd);
+    return stdout;
+}
+
+/** Resolve the absolute top level of the repo containing {@link cwd}. */
+export async function repoToplevel(cwd: string): Promise<string> {
+    const { stdout, ok } = await runGit(["rev-parse", "--show-toplevel"], cwd);
+    return ok ? stdout.trim() : cwd;
+}

--- a/src/regret-grep/lib/git.ts
+++ b/src/regret-grep/lib/git.ts
@@ -8,9 +8,12 @@ const RECORD_SEP = "\x1e";
 
 async function runGit(args: string[], cwd: string): Promise<{ stdout: string; ok: boolean }> {
     const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
-    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
     if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
         logger.debug(`git ${args.join(" ")} exited ${exitCode}: ${stderr.trim()}`);
     }
 

--- a/src/regret-grep/lib/similarity.ts
+++ b/src/regret-grep/lib/similarity.ts
@@ -1,0 +1,163 @@
+import { termFrequencies, tokenize } from "./tokenize";
+import type { RegretEntry, RegretIndex } from "./types";
+
+/**
+ * A scored match between the query diff and one indexed bug-fix commit.
+ */
+export interface ScoredMatch {
+    entry: RegretEntry;
+    /** Cosine similarity in [0, 1]. */
+    score: number;
+    /** Tokens shared by the query and the entry, ranked by combined weight. */
+    overlap: string[];
+}
+
+/**
+ * Compute inverse-document-frequency weights across all indexed entries.
+ *
+ * idf(t) = ln( (N + 1) / (df(t) + 1) ) + 1   (smoothed, always > 0)
+ */
+export function computeIdf(entries: RegretEntry[]): Map<string, number> {
+    const docCount = entries.length;
+    const docFrequency = new Map<string, number>();
+
+    for (const entry of entries) {
+        const seen = new Set(entry.tokens);
+        for (const token of seen) {
+            docFrequency.set(token, (docFrequency.get(token) ?? 0) + 1);
+        }
+    }
+
+    const idf = new Map<string, number>();
+    for (const [token, df] of docFrequency) {
+        idf.set(token, Math.log((docCount + 1) / (df + 1)) + 1);
+    }
+
+    return idf;
+}
+
+/**
+ * Build a TF-IDF vector (token -> weight) from a term-frequency map.
+ *
+ * Unknown tokens (absent from idf) still get a weight using the maximum
+ * possible idf for the corpus, so a brand-new salient token in the query is
+ * not silently zeroed out.
+ */
+function tfIdfVector(tf: Map<string, number>, idf: Map<string, number>, fallbackIdf: number): Map<string, number> {
+    const vector = new Map<string, number>();
+    for (const [token, freq] of tf) {
+        const weight = idf.get(token) ?? fallbackIdf;
+        vector.set(token, freq * weight);
+    }
+
+    return vector;
+}
+
+function l2norm(vector: Map<string, number>): number {
+    let sum = 0;
+    for (const value of vector.values()) {
+        sum += value * value;
+    }
+
+    return Math.sqrt(sum);
+}
+
+/**
+ * Cosine similarity between two sparse TF-IDF vectors. Returns 0 when either
+ * vector is empty.
+ */
+function cosine(a: Map<string, number>, b: Map<string, number>): number {
+    const normA = l2norm(a);
+    const normB = l2norm(b);
+    if (normA === 0 || normB === 0) {
+        return 0;
+    }
+
+    // Iterate the smaller vector for the dot product.
+    const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+    let dot = 0;
+    for (const [token, value] of small) {
+        const other = large.get(token);
+        if (other !== undefined) {
+            dot += value * other;
+        }
+    }
+
+    return dot / (normA * normB);
+}
+
+/**
+ * Score a query diff against every entry in the index using lexical TF-IDF
+ * cosine similarity. Results are sorted by descending score.
+ *
+ * Pure and deterministic: same index + same query text → same ranking.
+ */
+export function scoreQuery(queryText: string, index: RegretIndex, topN = 5): ScoredMatch[] {
+    if (index.entries.length === 0) {
+        return [];
+    }
+
+    const idf = computeIdf(index.entries);
+    let fallbackIdf = 1;
+    for (const value of idf.values()) {
+        if (value > fallbackIdf) {
+            fallbackIdf = value;
+        }
+    }
+
+    const queryTokens = tokenize(queryText);
+    const queryTf = termFrequencies(queryTokens);
+    const queryVec = tfIdfVector(queryTf, idf, fallbackIdf);
+
+    const matches: ScoredMatch[] = [];
+    for (const entry of index.entries) {
+        const entryTf = termFrequencies(entry.tokens);
+        const entryVec = tfIdfVector(entryTf, idf, fallbackIdf);
+        const score = cosine(queryVec, entryVec);
+        if (score <= 0) {
+            continue;
+        }
+
+        const overlap = rankedOverlap(queryVec, entryVec);
+        matches.push({ entry, score, overlap });
+    }
+
+    matches.sort((a, b) => {
+        if (b.score !== a.score) {
+            return b.score - a.score;
+        }
+
+        // Deterministic tie-break: newer commit first, then hash.
+        if (b.entry.timestamp !== a.entry.timestamp) {
+            return b.entry.timestamp - a.entry.timestamp;
+        }
+
+        return a.entry.hash.localeCompare(b.entry.hash);
+    });
+
+    return matches.slice(0, topN);
+}
+
+/**
+ * Tokens present in both vectors, ranked by the product of their two weights
+ * (the terms contributing most to the similarity), capped at 8.
+ */
+function rankedOverlap(queryVec: Map<string, number>, entryVec: Map<string, number>): string[] {
+    const shared: Array<{ token: string; weight: number }> = [];
+    for (const [token, qWeight] of queryVec) {
+        const eWeight = entryVec.get(token);
+        if (eWeight !== undefined) {
+            shared.push({ token, weight: qWeight * eWeight });
+        }
+    }
+
+    shared.sort((a, b) => {
+        if (b.weight !== a.weight) {
+            return b.weight - a.weight;
+        }
+
+        return a.token.localeCompare(b.token);
+    });
+
+    return shared.slice(0, 8).map((s) => s.token);
+}

--- a/src/regret-grep/lib/store.ts
+++ b/src/regret-grep/lib/store.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { Storage } from "@app/utils/storage/storage";
+import { distillEntry } from "./entry";
+import { collectBugFixCommits } from "./git";
+import { INDEX_VERSION, type RegretIndex } from "./types";
+
+/** Default ceiling on how many bug-fix commits we index per repo. */
+export const DEFAULT_MAX_COMMITS = 2000;
+
+/** Default per-commit diff byte budget before token distillation. */
+export const DEFAULT_MAX_DIFF_BYTES = 20_000;
+
+/**
+ * One index file per repo, named by a stable hash of the repo's absolute path.
+ * A single `~/.genesis-tools/regret-grep/indexes/` dir holds them all, so the
+ * per-PC layout stays flat (one tool dir, many repo files) rather than scattering
+ * caches per scan-root.
+ */
+function indexFilePath(repo: string): string {
+    const storage = new Storage("regret-grep");
+    const dir = join(storage.getBaseDir(), "indexes");
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    const key = createHash("sha1").update(repo).digest("hex").slice(0, 16);
+    return join(dir, `${key}.json`);
+}
+
+/**
+ * Build (or rebuild) the bug-fix index for {@link repo} and persist it.
+ *
+ * `now` is injected so the persisted `builtAt` is deterministic in tests. Pure
+ * distillation lives in {@link distillEntry}; this function only orchestrates
+ * git collection, distillation and the disk write.
+ */
+export async function buildIndex(opts: {
+    repo: string;
+    since?: string;
+    maxCommits?: number;
+    maxDiffBytesPerCommit?: number;
+    now?: Date;
+}): Promise<RegretIndex> {
+    const { repo, since } = opts;
+    const maxCommits = opts.maxCommits ?? DEFAULT_MAX_COMMITS;
+    const maxDiffBytesPerCommit = opts.maxDiffBytesPerCommit ?? DEFAULT_MAX_DIFF_BYTES;
+    const now = opts.now ?? new Date();
+
+    const commits = await collectBugFixCommits({ cwd: repo, since, maxCommits, maxDiffBytesPerCommit });
+    const entries = commits.map(distillEntry);
+
+    const index: RegretIndex = {
+        version: INDEX_VERSION,
+        repo,
+        builtAt: now.toISOString(),
+        entries,
+    };
+
+    const filePath = indexFilePath(repo);
+    await Bun.write(filePath, SafeJSON.stringify(index, null, 2));
+    logger.debug(`wrote regret-grep index for ${repo} (${entries.length} entries) to ${filePath}`);
+
+    return index;
+}
+
+/**
+ * Load the persisted index for {@link repo}, or null when none has been built
+ * (or the on-disk schema version no longer matches).
+ */
+export async function loadIndex(repo: string): Promise<RegretIndex | null> {
+    const filePath = indexFilePath(repo);
+    if (!existsSync(filePath)) {
+        return null;
+    }
+
+    try {
+        const raw = await Bun.file(filePath).text();
+        const parsed = SafeJSON.parse(raw) as RegretIndex;
+        if (parsed.version !== INDEX_VERSION) {
+            logger.debug(`regret-grep index at ${filePath} is version ${parsed.version}, expected ${INDEX_VERSION}`);
+            return null;
+        }
+
+        return parsed;
+    } catch (error) {
+        logger.warn(`failed to read regret-grep index at ${filePath}: ${error}`);
+        return null;
+    }
+}

--- a/src/regret-grep/lib/tokenize.ts
+++ b/src/regret-grep/lib/tokenize.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure tokenization and bug-fix-commit classification.
+ *
+ * These functions are deterministic and side-effect free so they can be
+ * unit-tested without spawning git or touching disk.
+ */
+
+/** Keywords whose presence in a commit subject marks it as a bug-fix commit. */
+export const BUGFIX_KEYWORDS = ["fix", "fixes", "fixed", "bug", "bugfix", "revert", "hotfix", "patch", "regression"];
+
+/**
+ * Tokens shorter than this are dropped. Single/two-char fragments (`i`, `x`,
+ * `if`, `id`) are mostly noise for lexical similarity.
+ */
+const MIN_TOKEN_LENGTH = 2;
+
+/**
+ * Common English + diff-noise stop words. Kept small and deterministic — the
+ * goal is to stop the most frequent filler from dominating the cosine score,
+ * not to do real linguistic stemming.
+ */
+const STOP_WORDS = new Set<string>([
+    "the",
+    "and",
+    "for",
+    "this",
+    "that",
+    "with",
+    "from",
+    "into",
+    "are",
+    "was",
+    "were",
+    "but",
+    "not",
+    "you",
+    "your",
+    "they",
+    "their",
+    "have",
+    "has",
+    "had",
+    "will",
+    "would",
+    "should",
+    "could",
+    "can",
+    "all",
+    "any",
+    "out",
+    "use",
+    "get",
+    "set",
+    "var",
+    "let",
+    "const",
+    "return",
+    "import",
+    "export",
+    "function",
+    "diff",
+    "git",
+    "index",
+    "true",
+    "false",
+    "null",
+    "undefined",
+]);
+
+/**
+ * Split text into normalized lexical tokens.
+ *
+ * - lowercases everything
+ * - splits identifiers on camelCase / snake_case / kebab-case boundaries
+ * - splits on any non-alphanumeric run
+ * - drops stop words and tokens shorter than {@link MIN_TOKEN_LENGTH}
+ */
+export function tokenize(text: string): string[] {
+    if (!text) {
+        return [];
+    }
+
+    // Insert spaces at camelCase boundaries so `parseUserId` → `parse User Id`.
+    const camelSplit = text.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+
+    const rawTokens = camelSplit
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean);
+
+    const tokens: string[] = [];
+    for (const token of rawTokens) {
+        if (token.length < MIN_TOKEN_LENGTH) {
+            continue;
+        }
+
+        if (STOP_WORDS.has(token)) {
+            continue;
+        }
+
+        tokens.push(token);
+    }
+
+    return tokens;
+}
+
+/**
+ * Build a term-frequency map from a list of tokens.
+ */
+export function termFrequencies(tokens: string[]): Map<string, number> {
+    const tf = new Map<string, number>();
+    for (const token of tokens) {
+        tf.set(token, (tf.get(token) ?? 0) + 1);
+    }
+
+    return tf;
+}
+
+/**
+ * True when a commit subject looks like a bug fix / revert / hotfix.
+ *
+ * Matches whole words only, so `prefix` does not count as `fix` and
+ * `affixes` does not count as `fix`.
+ */
+export function isBugFixSubject(subject: string): boolean {
+    if (!subject) {
+        return false;
+    }
+
+    const words = new Set(tokenizeRaw(subject));
+    for (const keyword of BUGFIX_KEYWORDS) {
+        if (words.has(keyword)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Lowercased word split WITHOUT stop-word / length filtering. Used by the
+ * classifier so short keywords like `fix` survive.
+ */
+function tokenizeRaw(text: string): string[] {
+    return text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean);
+}
+
+/**
+ * Map a file path to a coarse "type" token (its lowercased extension, or
+ * `noext` when there is none). Used to weight same-file-type matches.
+ */
+export function fileTypeToken(filePath: string): string {
+    const base = filePath.split("/").pop() ?? filePath;
+    const dot = base.lastIndexOf(".");
+    if (dot <= 0) {
+        return "noext";
+    }
+
+    return base.slice(dot + 1).toLowerCase();
+}

--- a/src/regret-grep/lib/types.ts
+++ b/src/regret-grep/lib/types.ts
@@ -1,0 +1,46 @@
+/** Current on-disk index schema version. Bump when {@link RegretEntry} changes. */
+export const INDEX_VERSION = 1;
+
+/**
+ * One indexed bug-fix commit, reduced to the lexical signal we score against.
+ */
+export interface RegretEntry {
+    /** Abbreviated commit hash. */
+    hash: string;
+    /** Commit subject line. */
+    subject: string;
+    /** Author date (ISO 8601). */
+    date: string;
+    /** Author date as a unix-seconds timestamp (for deterministic tie-breaks). */
+    timestamp: number;
+    /** Distinct file-type tokens touched by the commit (e.g. `ts`, `tsx`). */
+    fileTypes: string[];
+    /** Salient lexical tokens distilled from subject + diff. */
+    tokens: string[];
+}
+
+/**
+ * The persisted index: a versioned bag of bug-fix entries.
+ */
+export interface RegretIndex {
+    version: number;
+    /** Absolute path of the repo this index was built from. */
+    repo: string;
+    /** When the index was last built (ISO 8601). */
+    builtAt: string;
+    entries: RegretEntry[];
+}
+
+/**
+ * A raw bug-fix commit pulled from git, before token distillation.
+ */
+export interface RawCommit {
+    hash: string;
+    subject: string;
+    date: string;
+    timestamp: number;
+    /** Files changed by the commit. */
+    files: string[];
+    /** Added/removed diff lines (content only, no `+++`/`---` headers). */
+    diffLines: string[];
+}

--- a/src/regret-grep/regret-grep.test.ts
+++ b/src/regret-grep/regret-grep.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { distillEntry } from "./lib/entry";
+import { collectBugFixCommits, extractDiffContentLines } from "./lib/git";
+import { scoreQuery } from "./lib/similarity";
+import { buildIndex, loadIndex } from "./lib/store";
+import { fileTypeToken, isBugFixSubject, tokenize } from "./lib/tokenize";
+import type { RawCommit } from "./lib/types";
+
+const FIXED_NOW = new Date("2026-06-02T12:00:00.000Z");
+
+async function git(args: string[], cwd: string): Promise<string> {
+    const proc = Bun.spawn(["git", ...args], {
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: "Test",
+            GIT_AUTHOR_EMAIL: "test@example.com",
+            GIT_COMMITTER_NAME: "Test",
+            GIT_COMMITTER_EMAIL: "test@example.com",
+            GIT_AUTHOR_DATE: "2026-01-01T00:00:00",
+            GIT_COMMITTER_DATE: "2026-01-01T00:00:00",
+        },
+    });
+
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(`git ${args.join(" ")} failed (${exitCode}): ${stderr}`);
+    }
+
+    return stdout;
+}
+
+async function writeAndCommit(repo: string, file: string, content: string, message: string): Promise<void> {
+    await Bun.write(join(repo, file), content);
+    await git(["add", file], repo);
+    await git(["commit", "--no-gpg-sign", "-m", message], repo);
+}
+
+describe("tokenize", () => {
+    test("splits camelCase and drops stop words / short tokens", () => {
+        const tokens = tokenize("Fix the parseUserId a b cancel");
+        expect(tokens).toContain("parse");
+        expect(tokens).toContain("user");
+        expect(tokens).toContain("cancel");
+        // stop word removed, single-char fragments removed
+        expect(tokens).not.toContain("the");
+        expect(tokens).not.toContain("a");
+        expect(tokens).not.toContain("b");
+        expect(tokens.every((t) => t.length >= 2)).toBe(true);
+    });
+
+    test("empty input yields no tokens", () => {
+        expect(tokenize("")).toEqual([]);
+    });
+});
+
+describe("isBugFixSubject classifier", () => {
+    test("matches bug-fix keywords as whole words", () => {
+        expect(isBugFixSubject("fix: null deref in parser")).toBe(true);
+        expect(isBugFixSubject("revert broken migration")).toBe(true);
+        expect(isBugFixSubject("hotfix login timeout")).toBe(true);
+        expect(isBugFixSubject("bug: off-by-one in pager")).toBe(true);
+    });
+
+    test("does not match substrings or non-fix subjects", () => {
+        expect(isBugFixSubject("add prefix to slug")).toBe(false);
+        expect(isBugFixSubject("affixes are formatted")).toBe(false);
+        expect(isBugFixSubject("feat: new dashboard")).toBe(false);
+        expect(isBugFixSubject("")).toBe(false);
+    });
+});
+
+describe("fileTypeToken", () => {
+    test("returns lowercased extension or noext", () => {
+        expect(fileTypeToken("src/foo/Bar.TSX")).toBe("tsx");
+        expect(fileTypeToken("Makefile")).toBe("noext");
+        expect(fileTypeToken(".gitignore")).toBe("noext");
+    });
+});
+
+describe("extractDiffContentLines", () => {
+    test("keeps +/- content, drops headers and hunk markers", () => {
+        const diff = [
+            "--- a/file.ts",
+            "+++ b/file.ts",
+            "@@ -1,2 +1,2 @@",
+            "-const x = 1;",
+            "+const x = 2;",
+            " unchanged",
+        ].join("\n");
+        const lines = extractDiffContentLines(diff);
+        expect(lines).toEqual(["const x = 1;", "const x = 2;"]);
+    });
+});
+
+describe("scoreQuery (pure lexical ranking)", () => {
+    test("ranks the obviously-similar past fix highest", () => {
+        const make = (hash: string, subject: string, timestamp: number): RawCommit => ({
+            hash,
+            subject,
+            date: new Date(timestamp * 1000).toISOString(),
+            timestamp,
+            files: ["src/auth/session.ts"],
+            diffLines: tokenize(subject),
+        });
+
+        const index = {
+            version: 1,
+            repo: "/tmp/fake",
+            builtAt: FIXED_NOW.toISOString(),
+            entries: [
+                distillEntry(make("aaa1111", "fix: refresh expired auth session token", 1000)),
+                distillEntry(make("bbb2222", "fix: dashboard chart color contrast", 2000)),
+                distillEntry(make("ccc3333", "fix: pagination off-by-one in results", 3000)),
+            ],
+        };
+
+        const query = "diff --git a/src/auth/session.ts\n+    refreshExpiredAuthSessionToken();";
+        const matches = scoreQuery(query, index, 5);
+
+        expect(matches.length).toBeGreaterThan(0);
+        expect(matches[0].entry.hash).toBe("aaa1111");
+        expect(matches[0].score).toBeGreaterThan(0);
+        // the auth-session entry must outrank the unrelated ones
+        const authScore = matches.find((m) => m.entry.hash === "aaa1111")?.score ?? 0;
+        const chartScore = matches.find((m) => m.entry.hash === "bbb2222")?.score ?? 0;
+        expect(authScore).toBeGreaterThan(chartScore);
+    });
+
+    test("empty index yields no matches", () => {
+        const empty = { version: 1, repo: "/tmp/fake", builtAt: FIXED_NOW.toISOString(), entries: [] };
+        expect(scoreQuery("anything", empty, 5)).toEqual([]);
+    });
+});
+
+describe("end-to-end index + check over a throwaway git repo", () => {
+    let home: string;
+    let repo: string;
+
+    beforeAll(async () => {
+        home = mkdtempSync(join(tmpdir(), "regret-home-"));
+        repo = mkdtempSync(join(tmpdir(), "regret-repo-"));
+        process.env.GENESIS_TOOLS_HOME = home;
+
+        await git(["init", "-q"], repo);
+        await git(["config", "commit.gpgsign", "false"], repo);
+
+        // a non-fix commit (should be ignored by the classifier)
+        await writeAndCommit(repo, "feature.ts", "export const dashboard = () => 1;\n", "feat: add dashboard");
+
+        // an obviously-similar past bug-fix
+        await writeAndCommit(
+            repo,
+            "session.ts",
+            "export function refreshExpiredAuthSessionToken() {\n    return true;\n}\n",
+            "fix: refresh expired auth session token on 401"
+        );
+
+        // an unrelated bug-fix
+        await writeAndCommit(
+            repo,
+            "pager.ts",
+            "export function paginateResults(page: number) {\n    return page - 1;\n}\n",
+            "fix: pagination off-by-one in results list"
+        );
+    });
+
+    afterAll(() => {
+        delete process.env.GENESIS_TOOLS_HOME;
+        rmSync(home, { recursive: true, force: true });
+        rmSync(repo, { recursive: true, force: true });
+    });
+
+    test("collectBugFixCommits picks only bug-fix commits", async () => {
+        const commits = await collectBugFixCommits({
+            cwd: repo,
+            maxCommits: 100,
+            maxDiffBytesPerCommit: 20_000,
+        });
+
+        expect(commits.length).toBe(2);
+        const subjects = commits.map((c) => c.subject);
+        expect(subjects.some((s) => s.includes("auth session"))).toBe(true);
+        expect(subjects.some((s) => s.includes("pagination"))).toBe(true);
+        expect(subjects.some((s) => s.includes("feat"))).toBe(false);
+    });
+
+    test("buildIndex persists, loadIndex round-trips, and check ranks the similar fix first", async () => {
+        const built = await buildIndex({ repo, now: FIXED_NOW });
+        expect(built.entries.length).toBe(2);
+        expect(built.builtAt).toBe(FIXED_NOW.toISOString());
+
+        const loaded = await loadIndex(repo);
+        expect(loaded).not.toBeNull();
+        expect(loaded?.entries.length).toBe(2);
+
+        // A new diff that re-introduces the auth-session bug pattern.
+        const query =
+            "diff --git a/session.ts b/session.ts\n" +
+            "+export function refreshExpiredAuthSessionToken() {\n" +
+            "+    return refreshAuthToken();\n" +
+            "+}\n";
+
+        const matches = scoreQuery(query, loaded!, 5);
+        expect(matches.length).toBeGreaterThan(0);
+        expect(matches[0].entry.subject).toContain("auth session");
+    });
+
+    test("loadIndex returns null for a never-indexed repo", async () => {
+        const other = mkdtempSync(join(tmpdir(), "regret-other-"));
+        try {
+            expect(await loadIndex(other)).toBeNull();
+        } finally {
+            rmSync(other, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/regret-grep/regret-grep.test.ts
+++ b/src/regret-grep/regret-grep.test.ts
@@ -142,10 +142,12 @@ describe("scoreQuery (pure lexical ranking)", () => {
 describe("end-to-end index + check over a throwaway git repo", () => {
     let home: string;
     let repo: string;
+    let previousGenesisToolsHome: string | undefined;
 
     beforeAll(async () => {
         home = mkdtempSync(join(tmpdir(), "regret-home-"));
         repo = mkdtempSync(join(tmpdir(), "regret-repo-"));
+        previousGenesisToolsHome = process.env.GENESIS_TOOLS_HOME;
         process.env.GENESIS_TOOLS_HOME = home;
 
         await git(["init", "-q"], repo);
@@ -172,7 +174,12 @@ describe("end-to-end index + check over a throwaway git repo", () => {
     });
 
     afterAll(() => {
-        delete process.env.GENESIS_TOOLS_HOME;
+        if (previousGenesisToolsHome === undefined) {
+            delete process.env.GENESIS_TOOLS_HOME;
+        } else {
+            process.env.GENESIS_TOOLS_HOME = previousGenesisToolsHome;
+        }
+
         rmSync(home, { recursive: true, force: true });
         rmSync(repo, { recursive: true, force: true });
     });


### PR DESCRIPTION
## regret-grep — warn when a diff repeats a bug you already fixed

`tools regret-grep` stops you repeating your own bugs. It builds a local index of
past **bug-fix commits** and scores your **current diff** against that index using
lexical similarity — **no model download, no network**.

### Subcommands

- `regret-grep index [--since <git-date>]` — build/update the per-repo index of
  bug-fix commits (classified by subject keyword: `fix|fixes|fixed|bug|bugfix|revert|hotfix|patch|regression`, whole-word). Stores subject, changed file-types, salient diff tokens.
- `regret-grep check [--diff <file>|--staged] [--threshold <n>] [--top <n>]` —
  score the current diff (working tree / staged / diff file) and print top matches:
  `You fixed something like this before: <commit> (<date>): <subject>`.

### How it scores (default, required to be offline)

Tokenize subject + diff lines (lowercase, camel/snake/kebab split, stop-words +
<2-char dropped) → per-entry token budget (subject ×2) → corpus IDF → TF-IDF
**cosine** similarity, deterministic with a newer-commit-then-hash tie-break. An
optional `--semantic` embedding path is out of scope for v1 (OFF by default, not
tested).

### Storage

`~/.genesis-tools/regret-grep/indexes/<sha1(repoPath)[..16]>.json` — one versioned
index per repo under one flat tool dir. Honors `GENESIS_TOOLS_HOME` so tests
sandbox to a tmp dir and never touch the real home.

### Files (all under `src/regret-grep/`)

- `index.ts` — commander program (`index` + `check`), ends in `runTool`.
- `lib/{types,tokenize,entry,git,similarity,store}.ts` — pure, testable cores +
  git collection + Storage-backed persistence.
- `regret-grep.test.ts` — hermetic `bun:test` (throwaway git repo in a tmp dir,
  sandboxed `GENESIS_TOOLS_HOME`, deterministic injected `now`; no network/model/clipboard).

### Verification

- `bunx biome check src/regret-grep` → exit 0.
- `bun test src/regret-grep` → **11 pass / 0 fail**.
- `./tools regret-grep --help` → exit 0.
- Live smoke against this repo: `index --since "3 months ago"` → 129 entries;
  `check --diff <synthetic>` surfaces past dashboard/session fixes with
  token-overlap explanations.

Spec + plan: `GenesisBrain/GenesisTools/2026-06-02-FunFeatures/Feature-regret-grep.{spec,plan}.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `regret-grep` CLI with subcommands to build/update a historical bug-fix index and to check the current diff for similar matches.
  * Supports `--since` indexing, staged vs working-tree diff selection, and providing a diff file.
  * Provides threshold- and top-N–based results with structured output including match scores and token overlap details.
* **Tests**
  * Added unit and end-to-end tests for tokenization, commit selection, diff parsing, index persistence, and similarity ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->