### PR TITLE
feat(time-machine): auto-bisect a failing command across git history

### DIFF
--- a/src/time-machine/index.ts
+++ b/src/time-machine/index.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env bun
+
+/**
+ * tools time-machine — auto-bisect a failing command across git history.
+ *
+ * Runs `<cmd...>` against the current working tree. If it passes, there is
+ * nothing to bisect. If it fails, we walk back through git history checking
+ * out each candidate commit IN A THROWAWAY WORKTREE (never the user tree) and
+ * re-running the command, binary-searching for the FIRST commit that fails —
+ * the one that introduced the failure. We then report that commit's metadata
+ * and its diff.
+ *
+ * SAFETY: every probe runs in a detached worktree under the OS temp dir. The
+ * user's working tree, branch, and index are never modified. The temp worktree
+ * is always cleaned up (even on error / interrupt).
+ *
+ * Usage:
+ *   tools time-machine -- <cmd...>
+ *   tools time-machine --depth 50 -- npm test
+ *   tools time-machine --good v1.2.0 -- ./run-checks.sh
+ */
+
+import { logger, out } from "@app/logger";
+import { runTool } from "@app/utils/cli";
+import { Command } from "commander";
+import { findFirstBad } from "./lib/bisect";
+import {
+    type CommitInfo,
+    checkoutInWorktree,
+    createTempWorktree,
+    getCommitDiff,
+    getCommitInfo,
+    isGitRepo,
+    listCommits,
+    resolveRef,
+    runCommandInDir,
+} from "./lib/git";
+
+const DEFAULT_DEPTH = 30;
+
+interface TimeMachineOptions {
+    depth: number;
+    good?: string | null;
+    cwd: string;
+}
+
+export interface TimeMachineReport {
+    /** Outcome of the run. */
+    status: "no-commits" | "already-green" | "found" | "predates-range" | "not-in-history";
+    /** The first failing commit, when status === "found". */
+    firstBad?: CommitInfo;
+    /** The last green commit (parent of firstBad), when known. */
+    lastGood?: CommitInfo | null;
+    /** Full `git show` diff of firstBad, when status === "found". */
+    diff?: string;
+    /** Number of commits considered in the search window. */
+    candidates: number;
+    /** Number of command runs spent probing history (excludes the HEAD probe). */
+    probes: number;
+}
+
+/**
+ * Drive the bisect end-to-end against a real git repo. Returns a structured
+ * report; the caller decides how to render it. This is the orchestration seam
+ * the integration test exercises — keep it free of process.exit / printing.
+ */
+export async function runTimeMachine(command: string[], options: TimeMachineOptions): Promise<TimeMachineReport> {
+    const { depth, good, cwd } = options;
+
+    // 1. Probe the CURRENT working tree. If the command already passes there is
+    //    nothing to blame — short-circuit before touching history.
+    out.log.step(`Running command in current tree: ${command.join(" ")}`);
+    const headRun = await runCommandInDir({ command, cwd, captureOutput: true });
+    logger.debug({ exitCode: headRun.exitCode }, "time-machine: head probe");
+
+    if (headRun.exitCode === 0) {
+        return { status: "already-green", candidates: 0, probes: 0 };
+    }
+
+    out.log.warn(`Command fails at HEAD (exit ${headRun.exitCode}). Walking back through history…`);
+
+    // 2. Resolve the optional --good lower bound.
+    let goodSha: string | null = null;
+    if (good) {
+        goodSha = await resolveRef(good, cwd);
+        if (!goodSha) {
+            throw new Error(`--good ref "${good}" could not be resolved to a commit.`);
+        }
+
+        out.log.info(`Seeded known-good lower bound: ${good} (${goodSha.slice(0, 7)})`);
+    }
+
+    // 3. List candidate commits. listCommits returns NEWEST → OLDEST; the
+    //    bisect core needs OLDEST → NEWEST (index 0 = oldest = lower bound),
+    //    so we reverse. Without this the search blames HEAD every time.
+    const newestFirst = await listCommits({ cwd, startRef: "HEAD", depth, goodRef: goodSha });
+    const commits = [...newestFirst].reverse(); // oldest → newest
+
+    if (commits.length === 0) {
+        return { status: "no-commits", candidates: 0, probes: 0 };
+    }
+
+    out.log.info(`Searching ${commits.length} commit(s) for the one that introduced the failure…`);
+
+    // 4. One reusable throwaway worktree for all probes (pay `worktree add`
+    //    once). ALWAYS cleaned up, even if a probe throws.
+    const headSha = newestFirst[0]?.sha ?? commits[commits.length - 1].sha;
+    const worktree = await createTempWorktree({ repoCwd: cwd, sha: headSha });
+
+    try {
+        const result = await findFirstBad(commits, async (index) => {
+            const commit = commits[index];
+            await checkoutInWorktree(commit.sha, worktree.path);
+            const run = await runCommandInDir({ command, cwd: worktree.path, captureOutput: true });
+            const verdict = run.exitCode === 0 ? "pass" : "fail";
+            out.log.step(`  ${commit.shortSha} ${commit.subject} → ${verdict} (exit ${run.exitCode})`);
+            return verdict;
+        });
+
+        const probes = result.probes;
+
+        if (result.firstBad === null) {
+            // Every commit in the window passed even though HEAD failed in step
+            // 1 — the failure comes from UNCOMMITTED working-tree changes or the
+            // environment, not from any committed snapshot. Nothing to blame.
+            return { status: "not-in-history", candidates: commits.length, probes };
+        }
+
+        if (result.lastGood === null) {
+            const diff = await getCommitDiff(result.firstBad.sha, cwd);
+
+            // When --good seeded a trusted lower bound, the oldest searched
+            // commit failing is the EXPECTED success path: the seeded good ref
+            // is the last green parent (it lives just below the window, excluded
+            // by the good..HEAD range). Report a confirmed "found".
+            if (goodSha) {
+                const goodInfo = await getCommitInfo(goodSha, cwd);
+                return {
+                    status: "found",
+                    firstBad: result.firstBad,
+                    lastGood: goodInfo,
+                    diff,
+                    candidates: commits.length,
+                    probes,
+                };
+            }
+
+            // No --good: even the OLDEST commit in the window fails, so the
+            // failure predates the searched range. Widen --depth or seed --good.
+            return {
+                status: "predates-range",
+                firstBad: result.firstBad,
+                lastGood: null,
+                diff,
+                candidates: commits.length,
+                probes,
+            };
+        }
+
+        const diff = await getCommitDiff(result.firstBad.sha, cwd);
+        return {
+            status: "found",
+            firstBad: result.firstBad,
+            lastGood: result.lastGood,
+            diff,
+            candidates: commits.length,
+            probes,
+        };
+    } finally {
+        await worktree.cleanup();
+    }
+}
+
+function renderCommit(commit: CommitInfo): string {
+    return [
+        `  commit  ${commit.sha}`,
+        `  author  ${commit.author} <${commit.authorEmail}>`,
+        `  date    ${commit.date}`,
+        `  subject ${commit.subject}`,
+    ].join("\n");
+}
+
+async function main(): Promise<void> {
+    const program = new Command()
+        .name("time-machine")
+        .description("Auto-bisect a failing command across git history (rewind to the last green commit).")
+        .option("--depth <n>", "How many commits back to search", String(DEFAULT_DEPTH))
+        .option("--good <ref>", "Known-good lower bound (branch/tag/sha); limits the search to good..HEAD")
+        .argument("[command...]", "The command to run (everything after `--`)");
+
+    const { command } = await runTool(program, { tool: "time-machine" });
+
+    const commandArgs = command.args;
+    if (commandArgs.length === 0) {
+        out.log.error("No command given. Usage: tools time-machine -- <cmd...>");
+        out.log.info("Example: tools time-machine --depth 50 -- npm test");
+        process.exit(1);
+    }
+
+    const opts = program.opts();
+    const depth = Number.parseInt(opts.depth, 10);
+    if (!Number.isInteger(depth) || depth < 1) {
+        out.log.error(`--depth must be a positive integer (got "${opts.depth}").`);
+        process.exit(1);
+    }
+
+    const cwd = process.cwd();
+    if (!(await isGitRepo(cwd))) {
+        out.log.error(`Not inside a git work tree: ${cwd}`);
+        process.exit(1);
+    }
+
+    let report: TimeMachineReport;
+    try {
+        report = await runTimeMachine(commandArgs, { depth, good: opts.good ?? null, cwd });
+    } catch (err) {
+        out.log.error(`time-machine failed: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error({ err }, "time-machine: run failed");
+        process.exit(1);
+    }
+
+    switch (report.status) {
+        case "already-green": {
+            out.log.success("Command already passes at HEAD — nothing to bisect.");
+            process.exit(0);
+            break;
+        }
+        case "no-commits": {
+            out.log.warn("No commits found in the search window. Try a larger --depth or remove --good.");
+            process.exit(1);
+            break;
+        }
+        case "not-in-history": {
+            out.log.warn(
+                `Command fails at HEAD but PASSES at all ${report.candidates} searched commit(s) — the failure is from uncommitted working-tree changes or the environment, not a committed change.`
+            );
+            out.log.info("Check `git status` / `git diff` for uncommitted changes, or environment differences.");
+            process.exit(1);
+            break;
+        }
+        case "predates-range": {
+            out.log.warn(
+                `The failure was not isolated within the last ${report.candidates} commit(s) — every searched commit failed.`
+            );
+            out.log.info("Widen the window with --depth, or seed a known-good ref with --good.");
+            if (report.firstBad && report.diff) {
+                out.print(`\nOldest searched (still failing) commit:\n${renderCommit(report.firstBad)}\n\n`);
+                out.result(report.diff);
+            }
+
+            process.exit(1);
+            break;
+        }
+        case "found": {
+            if (!report.firstBad || !report.diff) {
+                out.log.error("Internal error: 'found' report missing commit/diff.");
+                process.exit(1);
+                break;
+            }
+
+            out.log.success(`Found the commit that introduced the failure (after ${report.probes} probe(s)):`);
+            if (report.lastGood) {
+                out.printErr(`\nLast green commit:\n${renderCommit(report.lastGood)}\n`);
+            }
+
+            out.printErr(`\nFirst BAD commit (introduced the failure):\n${renderCommit(report.firstBad)}\n`);
+            out.printErr("\n--- diff (git show) ---\n");
+            await out.flush();
+            out.result(report.diff);
+            process.exit(0);
+            break;
+        }
+    }
+}
+
+// Only run the CLI when executed directly (`bun src/time-machine/index.ts`),
+// not when imported (e.g. by the test, which calls runTimeMachine directly).
+if (import.meta.main) {
+    main().catch((err) => {
+        logger.error({ err }, "time-machine: unexpected error");
+        process.exit(1);
+    });
+}

--- a/src/time-machine/index.ts
+++ b/src/time-machine/index.ts
@@ -167,7 +167,11 @@ export async function runTimeMachine(command: string[], options: TimeMachineOpti
             probes,
         };
     } finally {
-        await worktree.cleanup();
+        try {
+            await worktree.cleanup();
+        } catch (err) {
+            logger.warn({ err }, "time-machine: failed to clean up temporary worktree");
+        }
     }
 }
 

--- a/src/time-machine/index.ts
+++ b/src/time-machine/index.ts
@@ -62,15 +62,20 @@ export interface TimeMachineReport {
 /**
  * Drive the bisect end-to-end against a real git repo. Returns a structured
  * report; the caller decides how to render it. This is the orchestration seam
- * the integration test exercises — keep it free of process.exit / printing.
+ * the integration test exercises — keep it free of process.exit (it does emit
+ * progress via out.log, but callers/tests should assert on the returned
+ * report, not on exit behavior).
  */
 export async function runTimeMachine(command: string[], options: TimeMachineOptions): Promise<TimeMachineReport> {
     const { depth, good, cwd } = options;
 
     // 1. Probe the CURRENT working tree. If the command already passes there is
-    //    nothing to blame — short-circuit before touching history.
+    //    nothing to blame — short-circuit before touching history. Inherit
+    //    stdio so the user sees exactly why it fails before we start bisecting
+    //    (captured output was otherwise discarded, wasting memory on chatty
+    //    commands like test runners).
     out.log.step(`Running command in current tree: ${command.join(" ")}`);
-    const headRun = await runCommandInDir({ command, cwd, captureOutput: true });
+    const headRun = await runCommandInDir({ command, cwd, captureOutput: false });
     logger.debug({ exitCode: headRun.exitCode }, "time-machine: head probe");
 
     if (headRun.exitCode === 0) {
@@ -90,9 +95,16 @@ export async function runTimeMachine(command: string[], options: TimeMachineOpti
         out.log.info(`Seeded known-good lower bound: ${good} (${goodSha.slice(0, 7)})`);
     }
 
-    // 3. List candidate commits. listCommits returns NEWEST → OLDEST; the
-    //    bisect core needs OLDEST → NEWEST (index 0 = oldest = lower bound),
-    //    so we reverse. Without this the search blames HEAD every time.
+    // 3. Guard against an unborn HEAD (freshly `git init`ed repo with zero
+    //    commits) — `git log HEAD` throws on an unresolvable ref, so resolve
+    //    it first and short-circuit to the "no-commits" report instead of
+    //    letting the error propagate. Otherwise list candidate commits:
+    //    listCommits returns NEWEST → OLDEST; the bisect core needs
+    //    OLDEST → NEWEST (index 0 = oldest = lower bound), so we reverse.
+    if (!(await resolveRef("HEAD", cwd))) {
+        return { status: "no-commits", candidates: 0, probes: 0 };
+    }
+
     const newestFirst = await listCommits({ cwd, startRef: "HEAD", depth, goodRef: goodSha });
     const commits = [...newestFirst].reverse(); // oldest → newest
 

--- a/src/time-machine/lib/bisect.ts
+++ b/src/time-machine/lib/bisect.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure bisect core for `tools time-machine`.
+ *
+ * Given an ordered list of commits (oldest → newest) and an async predicate
+ * that reports whether the command PASSES at a given commit, find the FIRST
+ * commit that FAILS — i.e. the commit that introduced the failure.
+ *
+ * The list MUST be monotonic for the binary search to be correct: every
+ * commit at or before the transition point passes, every commit at or after
+ * it fails. This is the same assumption `git bisect` makes. Real-world
+ * histories that flap (pass → fail → pass) violate it; we surface that as a
+ * caveat in the CLI but the algorithm still returns a defensible answer.
+ */
+
+export type CommitStatus = "pass" | "fail";
+
+export type BisectPredicate = (index: number) => Promise<CommitStatus> | CommitStatus;
+
+export interface BisectResult<T> {
+    /**
+     * The first failing commit (the one that introduced the failure), or
+     * `null` when every commit passes (nothing to blame).
+     */
+    firstBad: T | null;
+    /** Index of `firstBad` in the input list, or -1 when none failed. */
+    firstBadIndex: number;
+    /**
+     * The last passing commit (the green parent of `firstBad`), or `null`
+     * when even the oldest commit already fails (the failure predates the
+     * searched range — widen with --depth or seed --good).
+     */
+    lastGood: T | null;
+    /** Index of `lastGood`, or -1 when no commit passed. */
+    lastGoodIndex: number;
+    /** Number of predicate evaluations performed (for reporting / tests). */
+    probes: number;
+}
+
+/**
+ * Binary search for the first failing commit in a monotonic pass→fail list.
+ *
+ * @param commits Ordered oldest → newest. Index 0 is the oldest / lower bound.
+ * @param predicate Resolves "pass"/"fail" for `commits[index]`.
+ *
+ * Results are cached per index so a probe is never repeated (checkouts are
+ * expensive). The returned `probes` count reflects unique evaluations.
+ */
+export async function findFirstBad<T>(commits: readonly T[], predicate: BisectPredicate): Promise<BisectResult<T>> {
+    const cache = new Map<number, CommitStatus>();
+    let probes = 0;
+
+    const evaluate = async (index: number): Promise<CommitStatus> => {
+        const cached = cache.get(index);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const status = await predicate(index);
+        cache.set(index, status);
+        probes += 1;
+        return status;
+    };
+
+    const empty: BisectResult<T> = {
+        firstBad: null,
+        firstBadIndex: -1,
+        lastGood: null,
+        lastGoodIndex: -1,
+        probes: 0,
+    };
+
+    if (commits.length === 0) {
+        return empty;
+    }
+
+    // Classic lower-bound binary search: find the smallest index whose status
+    // is "fail". Everything strictly below it is assumed to pass.
+    let lo = 0;
+    let hi = commits.length; // exclusive; `hi` == length means "no fail found yet".
+
+    while (lo < hi) {
+        const mid = lo + Math.floor((hi - lo) / 2);
+        const status = await evaluate(mid);
+
+        if (status === "fail") {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+
+    const firstBadIndex = lo < commits.length ? lo : -1;
+
+    if (firstBadIndex === -1) {
+        // Every probed commit passed — nothing to blame.
+        return {
+            firstBad: null,
+            firstBadIndex: -1,
+            lastGood: commits[commits.length - 1] ?? null,
+            lastGoodIndex: commits.length - 1,
+            probes,
+        };
+    }
+
+    const lastGoodIndex = firstBadIndex - 1;
+
+    return {
+        firstBad: commits[firstBadIndex],
+        firstBadIndex,
+        lastGood: lastGoodIndex >= 0 ? commits[lastGoodIndex] : null,
+        lastGoodIndex,
+        probes,
+    };
+}

--- a/src/time-machine/lib/git.ts
+++ b/src/time-machine/lib/git.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { logger } from "@app/logger";
 
 export interface CommitInfo {
     sha: string;
@@ -129,6 +130,10 @@ export async function getCommitInfo(sha: string, cwd: string): Promise<CommitInf
  */
 export async function getCommitDiff(sha: string, cwd: string): Promise<string> {
     const result = await runGit(["show", "--no-color", sha], cwd);
+    if (result.exitCode !== 0) {
+        throw new Error(`git show ${sha} failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`);
+    }
+
     return result.stdout;
 }
 
@@ -155,10 +160,19 @@ export async function createTempWorktree(opts: {
     }
 
     const cleanup = async (): Promise<void> => {
-        // Best-effort: remove the registration first so git forgets it, then
-        // delete the temp dir even if the registration removal failed.
-        await runGit(["worktree", "remove", "--force", worktreePath], repoCwd);
-        await rm(base, { recursive: true, force: true });
+        // Best-effort, independent steps: a failure removing the registration
+        // must not prevent deleting the temp dir, and vice-versa.
+        try {
+            await runGit(["worktree", "remove", "--force", worktreePath], repoCwd);
+        } catch (err) {
+            logger.debug({ err, worktreePath }, "time-machine: worktree remove failed during cleanup");
+        }
+
+        try {
+            await rm(base, { recursive: true, force: true });
+        } catch (err) {
+            logger.debug({ err, base }, "time-machine: temp dir removal failed during cleanup");
+        }
     };
 
     return { path: worktreePath, cleanup };
@@ -174,6 +188,15 @@ export async function checkoutInWorktree(sha: string, worktreePath: string): Pro
     const result = await runGit(["checkout", "--detach", "--force", "--quiet", sha], worktreePath);
     if (result.exitCode !== 0) {
         throw new Error(`git checkout ${sha} failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`);
+    }
+
+    // Remove untracked files/dirs (incl. gitignored build output such as
+    // node_modules / coverage) left behind by the previous probe so each probe
+    // sees a pristine tree. The verdict is the command's exit code, so stray
+    // artifacts could otherwise flip it.
+    const clean = await runGit(["clean", "-fdx"], worktreePath);
+    if (clean.exitCode !== 0) {
+        throw new Error(`git clean failed: ${clean.stderr.trim() || `exit ${clean.exitCode}`}`);
     }
 }
 

--- a/src/time-machine/lib/git.ts
+++ b/src/time-machine/lib/git.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface CommitInfo {
+    sha: string;
+    shortSha: string;
+    author: string;
+    authorEmail: string;
+    date: string;
+    subject: string;
+}
+
+export interface RunResult {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Field-separated `git log` so we can parse commit metadata without choking on
+ * subjects that contain newlines or our separators. `%x1f` is the ASCII unit
+ * separator (0x1F) between fields, `%x1e` the record separator (0x1E) between
+ * commits — neither appears in normal commit text.
+ */
+const LOG_FORMAT = "%H%x1f%h%x1f%an%x1f%ae%x1f%aI%x1f%s%x1e";
+
+async function runGit(args: string[], cwd: string): Promise<RunResult> {
+    const proc = Bun.spawn(["git", ...args], {
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+
+    return { exitCode, stdout, stderr };
+}
+
+export async function isGitRepo(cwd: string): Promise<boolean> {
+    const result = await runGit(["rev-parse", "--is-inside-work-tree"], cwd);
+    return result.exitCode === 0 && result.stdout.trim() === "true";
+}
+
+/**
+ * Resolve a ref (branch / tag / sha / HEAD~N) to a full commit sha. Returns
+ * null when the ref cannot be resolved.
+ */
+export async function resolveRef(ref: string, cwd: string): Promise<string | null> {
+    const result = await runGit(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], cwd);
+    if (result.exitCode !== 0) {
+        return null;
+    }
+
+    const sha = result.stdout.trim();
+    return sha.length > 0 ? sha : null;
+}
+
+function parseLog(stdout: string): CommitInfo[] {
+    const commits: CommitInfo[] = [];
+
+    for (const record of stdout.split("\x1e")) {
+        const trimmed = record.replace(/^\n+/, "");
+        if (trimmed.length === 0) {
+            continue;
+        }
+
+        const [sha, shortSha, author, authorEmail, date, subject] = trimmed.split("\x1f");
+        if (!sha) {
+            continue;
+        }
+
+        commits.push({
+            sha,
+            shortSha: shortSha ?? sha.slice(0, 7),
+            author: author ?? "",
+            authorEmail: authorEmail ?? "",
+            date: date ?? "",
+            subject: subject ?? "",
+        });
+    }
+
+    return commits;
+}
+
+/**
+ * List commits reachable from `startRef` (default HEAD), newest first, capped
+ * at `depth`. When `goodRef` is provided, the range is limited to
+ * `good..start` so commits at or before the known-good lower bound are
+ * excluded.
+ *
+ * Returned order is newest → oldest (git's native order).
+ */
+export async function listCommits(opts: {
+    cwd: string;
+    startRef: string;
+    depth: number;
+    goodRef?: string | null;
+}): Promise<CommitInfo[]> {
+    const { cwd, startRef, depth, goodRef } = opts;
+    const range = goodRef ? `${goodRef}..${startRef}` : startRef;
+    const args = ["log", `--max-count=${depth}`, `--format=${LOG_FORMAT}`, range];
+    const result = await runGit(args, cwd);
+
+    if (result.exitCode !== 0) {
+        throw new Error(`git log failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`);
+    }
+
+    return parseLog(result.stdout);
+}
+
+export async function getCommitInfo(sha: string, cwd: string): Promise<CommitInfo | null> {
+    const result = await runGit(["show", "--no-patch", `--format=${LOG_FORMAT}`, sha], cwd);
+    if (result.exitCode !== 0) {
+        return null;
+    }
+
+    const commits = parseLog(result.stdout);
+    return commits[0] ?? null;
+}
+
+/**
+ * `git show <sha>` (full patch). Caller decides how much to print.
+ */
+export async function getCommitDiff(sha: string, cwd: string): Promise<string> {
+    const result = await runGit(["show", "--no-color", sha], cwd);
+    return result.stdout;
+}
+
+/**
+ * Create a throwaway worktree under the OS temp dir checked out at `sha`. The
+ * USER'S working tree and branch are never touched. The returned `cleanup`
+ * removes the worktree registration and deletes the temp directory.
+ *
+ * `--detach` so we never create or move a branch; the worktree is a detached
+ * HEAD at the given commit.
+ */
+export async function createTempWorktree(opts: {
+    repoCwd: string;
+    sha: string;
+}): Promise<{ path: string; cleanup: () => Promise<void> }> {
+    const { repoCwd, sha } = opts;
+    const base = await mkdtemp(join(tmpdir(), "time-machine-"));
+    const worktreePath = join(base, "wt");
+
+    const add = await runGit(["worktree", "add", "--detach", "--quiet", worktreePath, sha], repoCwd);
+    if (add.exitCode !== 0) {
+        await rm(base, { recursive: true, force: true });
+        throw new Error(`git worktree add failed: ${add.stderr.trim() || `exit ${add.exitCode}`}`);
+    }
+
+    const cleanup = async (): Promise<void> => {
+        // Best-effort: remove the registration first so git forgets it, then
+        // delete the temp dir even if the registration removal failed.
+        await runGit(["worktree", "remove", "--force", worktreePath], repoCwd);
+        await rm(base, { recursive: true, force: true });
+    };
+
+    return { path: worktreePath, cleanup };
+}
+
+/**
+ * Check out `sha` (detached) inside an EXISTING worktree, reusing it across
+ * probes so we pay the `worktree add` cost only once.
+ */
+export async function checkoutInWorktree(sha: string, worktreePath: string): Promise<void> {
+    // `-f` so a probe that dirtied tracked files doesn't wedge the next
+    // checkout. The worktree is throwaway, so discarding its state is safe.
+    const result = await runGit(["checkout", "--detach", "--force", "--quiet", sha], worktreePath);
+    if (result.exitCode !== 0) {
+        throw new Error(`git checkout ${sha} failed: ${result.stderr.trim() || `exit ${result.exitCode}`}`);
+    }
+}
+
+/**
+ * Run an arbitrary command (argv form) in `cwd`. Used both to probe the
+ * current working tree and to probe each checked-out commit. The exit code is
+ * the verdict: 0 = pass, anything else = fail.
+ */
+export async function runCommandInDir(opts: {
+    command: string[];
+    cwd: string;
+    captureOutput: boolean;
+}): Promise<RunResult> {
+    const { command, cwd, captureOutput } = opts;
+    const proc = Bun.spawn(command, {
+        cwd,
+        stdout: captureOutput ? "pipe" : "inherit",
+        stderr: captureOutput ? "pipe" : "inherit",
+    });
+
+    if (!captureOutput) {
+        const exitCode = await proc.exited;
+        return { exitCode, stdout: "", stderr: "" };
+    }
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+
+    return { exitCode, stdout, stderr };
+}

--- a/src/time-machine/lib/git.ts
+++ b/src/time-machine/lib/git.ts
@@ -161,11 +161,14 @@ export async function createTempWorktree(opts: {
 
     const cleanup = async (): Promise<void> => {
         // Best-effort, independent steps: a failure removing the registration
-        // must not prevent deleting the temp dir, and vice-versa.
-        try {
-            await runGit(["worktree", "remove", "--force", worktreePath], repoCwd);
-        } catch (err) {
-            logger.debug({ err, worktreePath }, "time-machine: worktree remove failed during cleanup");
+        // must not prevent deleting the temp dir, and vice-versa. `runGit`
+        // resolves a RunResult instead of throwing, so inspect the exit code.
+        const remove = await runGit(["worktree", "remove", "--force", worktreePath], repoCwd);
+        if (remove.exitCode !== 0) {
+            logger.debug(
+                { worktreePath, exitCode: remove.exitCode, stderr: remove.stderr },
+                "time-machine: worktree remove failed during cleanup"
+            );
         }
 
         try {

--- a/src/time-machine/time-machine.test.ts
+++ b/src/time-machine/time-machine.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runTimeMachine } from "./index";
+import { type BisectPredicate, type CommitStatus, findFirstBad } from "./lib/bisect";
+
+describe("findFirstBad (pure algorithm)", () => {
+    const fromStatuses = (statuses: CommitStatus[]): BisectPredicate => {
+        return (index) => statuses[index];
+    };
+
+    it("returns null firstBad when every commit passes", async () => {
+        const commits = ["a", "b", "c", "d"];
+        const result = await findFirstBad(commits, fromStatuses(["pass", "pass", "pass", "pass"]));
+
+        expect(result.firstBad).toBeNull();
+        expect(result.firstBadIndex).toBe(-1);
+        expect(result.lastGood).toBe("d");
+        expect(result.lastGoodIndex).toBe(3);
+    });
+
+    it("blames index 0 when every commit fails (no green parent)", async () => {
+        const commits = ["a", "b", "c", "d"];
+        const result = await findFirstBad(commits, fromStatuses(["fail", "fail", "fail", "fail"]));
+
+        expect(result.firstBad).toBe("a");
+        expect(result.firstBadIndex).toBe(0);
+        expect(result.lastGood).toBeNull();
+        expect(result.lastGoodIndex).toBe(-1);
+    });
+
+    it("finds the first failing commit at a mid-list transition", async () => {
+        // oldest → newest: pass pass pass FAIL fail fail
+        const commits = ["c0", "c1", "c2", "c3", "c4", "c5"];
+        const result = await findFirstBad(commits, fromStatuses(["pass", "pass", "pass", "fail", "fail", "fail"]));
+
+        expect(result.firstBad).toBe("c3");
+        expect(result.firstBadIndex).toBe(3);
+        expect(result.lastGood).toBe("c2");
+        expect(result.lastGoodIndex).toBe(2);
+    });
+
+    it("performs at most ceil(log2(n))+1 probes (binary, not linear)", async () => {
+        const n = 64;
+        const commits = Array.from({ length: n }, (_, i) => `c${i}`);
+        const transition = 40;
+        const statuses: CommitStatus[] = commits.map((_, i) => (i < transition ? "pass" : "fail"));
+        const result = await findFirstBad(commits, fromStatuses(statuses));
+
+        expect(result.firstBadIndex).toBe(transition);
+        // log2(64) = 6; allow a small slack for the lower-bound search shape.
+        expect(result.probes).toBeLessThanOrEqual(8);
+    });
+
+    it("handles the empty commit list", async () => {
+        const result = await findFirstBad([], () => "fail");
+        expect(result.firstBad).toBeNull();
+        expect(result.probes).toBe(0);
+    });
+});
+
+describe("runTimeMachine (integration, tmp git repo)", () => {
+    let repos: string[] = [];
+
+    afterEach(async () => {
+        await Promise.all(repos.map((dir) => rm(dir, { recursive: true, force: true })));
+        repos = [];
+    });
+
+    /**
+     * Build a deterministic, hermetic tmp git repo. Each commit either writes
+     * "ok" or "broken" into marker.txt; the predicate command (a portable
+     * `grep -q ok marker.txt`) passes only on commits whose marker says "ok".
+     * Fixed author identity + dates so no host git config is required and the
+     * run is reproducible.
+     */
+    async function makeRepo(markers: string[]): Promise<{ dir: string; shas: string[] }> {
+        const dir = await mkdtemp(join(tmpdir(), "tm-test-"));
+        repos.push(dir);
+
+        const baseDate = "2026-01-01T00:00:00Z";
+        const env = {
+            ...process.env,
+            GIT_AUTHOR_NAME: "TM Test",
+            GIT_AUTHOR_EMAIL: "tm@test.local",
+            GIT_COMMITTER_NAME: "TM Test",
+            GIT_COMMITTER_EMAIL: "tm@test.local",
+            GIT_AUTHOR_DATE: baseDate,
+            GIT_COMMITTER_DATE: baseDate,
+        };
+
+        const git = async (args: string[]): Promise<void> => {
+            const proc = Bun.spawn(["git", ...args], { cwd: dir, env, stdout: "pipe", stderr: "pipe" });
+            const exitCode = await proc.exited;
+            if (exitCode !== 0) {
+                const stderr = await new Response(proc.stderr).text();
+                throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+            }
+        };
+
+        await git(["init", "-q", "-b", "main"]);
+        await git(["config", "commit.gpgsign", "false"]);
+
+        const shas: string[] = [];
+        for (let i = 0; i < markers.length; i++) {
+            // Include the index so consecutive same-marker commits still produce
+            // a real diff (git refuses an empty commit). The predicate only
+            // looks at the `marker:` line, so the index line is inert.
+            await writeFile(join(dir, "marker.txt"), `seq:${i}\nmarker:${markers[i]}\n`);
+            await git(["add", "marker.txt"]);
+            await git(["commit", "-q", "-m", `commit ${i}: ${markers[i]}`]);
+
+            const proc = Bun.spawn(["git", "rev-parse", "HEAD"], { cwd: dir, env, stdout: "pipe", stderr: "pipe" });
+            const sha = (await new Response(proc.stdout).text()).trim();
+            await proc.exited;
+            shas.push(sha);
+        }
+
+        return { dir, shas };
+    }
+
+    const PREDICATE = ["sh", "-c", "grep -q '^marker:ok$' marker.txt"];
+
+    it("finds the exact commit that introduced the failure", async () => {
+        // History (oldest → newest): ok, ok, broken, broken, broken.
+        // Commit index 2 is the first BAD one; index 1 is the last good.
+        const { dir, shas } = await makeRepo(["ok", "ok", "broken", "broken", "broken"]);
+
+        const report = await runTimeMachine(PREDICATE, { depth: 30, good: null, cwd: dir });
+
+        expect(report.status).toBe("found");
+        expect(report.firstBad?.sha).toBe(shas[2]);
+        expect(report.lastGood?.sha).toBe(shas[1]);
+        expect(report.diff).toContain("marker.txt");
+        expect(report.diff).toContain("broken");
+    });
+
+    it("reports already-green when the command passes at HEAD", async () => {
+        const { dir } = await makeRepo(["ok", "ok", "ok"]);
+
+        const report = await runTimeMachine(PREDICATE, { depth: 30, good: null, cwd: dir });
+
+        expect(report.status).toBe("already-green");
+        expect(report.firstBad).toBeUndefined();
+    });
+
+    it("reports predates-range when even the oldest searched commit fails", async () => {
+        // Every commit is broken → no green parent within the window.
+        const { dir } = await makeRepo(["broken", "broken", "broken"]);
+
+        const report = await runTimeMachine(PREDICATE, { depth: 30, good: null, cwd: dir });
+
+        expect(report.status).toBe("predates-range");
+        expect(report.lastGood ?? null).toBeNull();
+    });
+
+    it("honors --good to narrow the search window", async () => {
+        // oldest → newest: ok, ok, broken, broken. Seed good = shas[1] so the
+        // window is shas[2..3]; the first bad is still shas[2].
+        const { dir, shas } = await makeRepo(["ok", "ok", "broken", "broken"]);
+
+        const report = await runTimeMachine(PREDICATE, { depth: 30, good: shas[1], cwd: dir });
+
+        expect(report.status).toBe("found");
+        expect(report.firstBad?.sha).toBe(shas[2]);
+        // Only two commits should be in the window (shas[2], shas[3]).
+        expect(report.candidates).toBe(2);
+    });
+});

--- a/src/time-machine/time-machine.test.ts
+++ b/src/time-machine/time-machine.test.ts
@@ -113,7 +113,12 @@ describe("runTimeMachine (integration, tmp git repo)", () => {
 
             const proc = Bun.spawn(["git", "rev-parse", "HEAD"], { cwd: dir, env, stdout: "pipe", stderr: "pipe" });
             const sha = (await new Response(proc.stdout).text()).trim();
-            await proc.exited;
+            const exitCode = await proc.exited;
+            if (exitCode !== 0) {
+                const stderr = await new Response(proc.stderr).text();
+                throw new Error(`git rev-parse HEAD failed: ${stderr}`);
+            }
+
             shas.push(sha);
         }
 


### PR DESCRIPTION
## Summary

`tools time-machine -- <cmd...>` auto-bisects a failing command across git history — a "rewind to the last green commit" for any command whose exit code is the verdict (tests, build, lint, a script).

It runs the command against the current working tree. If it already passes, there's nothing to blame. If it fails, it binary-searches back through history, checking out each candidate commit **in a throwaway detached worktree** and re-running the command, to pin the **first BAD commit** (the one that introduced the failure). It reports that commit's metadata (sha, author, date, subject), its last green parent, and the full `git show` diff.

## Safety

Every probe runs in a detached worktree under the OS temp dir (`git worktree add --detach`). The user's working tree, branch, and index are **never** modified. The worktree is always cleaned up (even on error, via `finally`).

## Usage

```
tools time-machine -- npm test
tools time-machine --depth 50 -- ./run-checks.sh
tools time-machine --good v1.2.0 -- bun test
```

- `--depth N` (default 30): how many commits back to search.
- `--good <ref>`: seed a known-good lower bound; limits the search to `good..HEAD` and treats the seeded ref as the last green parent.

## Design

- **Pure, testable core** (`lib/bisect.ts`): `findFirstBad(commits, predicate)` — a lower-bound binary search over a monotonic pass→fail list, with per-index memoization so a probe is never repeated. Returns `firstBad` / `lastGood` plus a `probes` count.
- **Git I/O** (`lib/git.ts`): commit listing with unit/record-separator log parsing, ref resolution, temp-worktree lifecycle, and command execution (exit code = verdict).
- **Orchestration** (`index.ts`): `runTimeMachine()` is a printing-free seam returning a structured `TimeMachineReport`; the CLI renders it. Distinct outcomes: `already-green`, `found`, `predates-range` (oldest searched commit still fails — widen `--depth`/seed `--good`), and `not-in-history` (HEAD fails but every committed snapshot passes → uncommitted/environment cause).

## Tests (hermetic, `bun:test`)

- Pure algorithm: all-pass, all-fail, mid-list transition, log2-bounded probe count, empty list.
- Integration: builds throwaway tmp git repos with fixed author identity/dates (no host git config, deterministic) and asserts the exact first-bad commit is found, plus `already-green`, `predates-range`, and `--good` window-narrowing.

9 tests pass. `biome check src/time-machine` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `time-machine` CLI tool to automatically bisect a failing command across git history and identify the first bad commit
  * Uses efficient binary search to minimize command re-runs
  * Supports `--depth` to limit history and `--good` to optionally narrow the candidate range
  * Produces detailed status output including commit metadata and diffs when a failure is found
* **Tests**
  * Added unit and integration coverage for both the bisect logic and CLI behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->