### PR TITLE
feat(mcp-manager): TRUE global disable + remove command; logger console-noise fix, mail index cleanup & --format support

### DIFF
--- a/src/azure-devops/commands/query.ts
+++ b/src/azure-devops/commands/query.ts
@@ -192,7 +192,8 @@ export type WorkItemHandler = (
     queryMetadata?: Map<number, QueryItemMetadata>,
     fetchOptions?: { comments?: boolean; updates?: boolean },
     attachmentFilter?: AttachmentFilter,
-    downloadImages?: boolean
+    downloadImages?: boolean,
+    full?: boolean
 ) => Promise<void>;
 
 let workItemHandler: WorkItemHandler | null = null;

--- a/src/azure-devops/commands/workitem.ts
+++ b/src/azure-devops/commands/workitem.ts
@@ -35,6 +35,7 @@ import {
     requireConfig,
 } from "@app/azure-devops/utils";
 import { logger, out } from "@app/logger";
+import { suggestCommand } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
 
@@ -48,13 +49,19 @@ const log = (msg: string) => {
 
 // ============= Output Formatters =============
 
+interface FormatAIResult {
+    text: string;
+    truncated: boolean;
+}
+
 function formatWorkItemAI(
     item: WorkItemFull,
     taskPath: string,
     cacheTime?: Date,
     downloadedAttachments?: AttachmentInfo[],
-    inlineImages?: Map<string, string>
-): string {
+    inlineImages?: Map<string, string>,
+    full?: boolean
+): FormatAIResult {
     const lines: string[] = [];
 
     lines.push(`# Work Item #${item.id}`);
@@ -75,21 +82,41 @@ function formatWorkItemAI(
     lines.push(`- Created: ${item.created} by ${item.createdBy}`);
     lines.push(`- Last Changed: ${item.changed}`);
 
+    let truncated = false;
+
     if (item.description) {
         lines.push("");
         lines.push("## Description");
         const mdDesc = htmlToMarkdown(item.description);
-        lines.push(mdDesc.slice(0, 500) + (mdDesc.length > 500 ? "..." : ""));
+
+        if (full || mdDesc.length <= 500) {
+            lines.push(mdDesc);
+        } else {
+            lines.push(`${mdDesc.slice(0, 500)}...`);
+            truncated = true;
+        }
     }
 
     if (item.comments.length > 0) {
         lines.push("");
+        const shownComments = full ? item.comments : item.comments.slice(-5);
+
+        if (!full && item.comments.length > 5) {
+            truncated = true;
+        }
+
         lines.push(`## Comments (${item.comments.length})`);
-        for (const comment of item.comments.slice(-5)) {
+        for (const comment of shownComments) {
             lines.push("");
             lines.push(`**${comment.author}** (${new Date(comment.date).toLocaleDateString()}):`);
             const mdComment = htmlToMarkdown(comment.text);
-            lines.push(mdComment.slice(0, 300) + (mdComment.length > 300 ? "..." : ""));
+
+            if (full || mdComment.length <= 300) {
+                lines.push(mdComment);
+            } else {
+                lines.push(`${mdComment.slice(0, 300)}...`);
+                truncated = true;
+            }
         }
     }
 
@@ -152,7 +179,7 @@ function formatWorkItemAI(
         }
     }
 
-    return lines.join("\n");
+    return { text: lines.join("\n"), truncated };
 }
 
 function generateWorkItemMarkdown(item: WorkItemFull, imageMap?: Map<string, string>): string {
@@ -247,7 +274,8 @@ export async function handleWorkItem(
     queryMetadata?: Map<number, QueryItemMetadata>,
     fetchOptions?: { comments?: boolean; updates?: boolean },
     attachmentFilter?: AttachmentFilter,
-    downloadImages?: boolean
+    downloadImages?: boolean,
+    full?: boolean
 ): Promise<void> {
     silentMode = format === "json";
     logger.debug(
@@ -491,6 +519,8 @@ export async function handleWorkItem(
     }
 
     // Output
+    let anyTruncated = false;
+
     for (let i = 0; i < results.length; i++) {
         const item = results[i];
         const settings = settingsMap.get(item.id);
@@ -504,17 +534,23 @@ export async function handleWorkItem(
         }
 
         switch (format) {
-            case "ai":
-                out.println(
-                    formatWorkItemAI(
-                        item,
-                        taskPath,
-                        cacheTime,
-                        attachmentsMap.get(item.id),
-                        inlineImageMaps.get(item.id)
-                    )
+            case "ai": {
+                const result = formatWorkItemAI(
+                    item,
+                    taskPath,
+                    cacheTime,
+                    attachmentsMap.get(item.id),
+                    inlineImageMaps.get(item.id),
+                    full
                 );
+                out.println(result.text);
+
+                if (result.truncated) {
+                    anyTruncated = true;
+                }
+
                 break;
+            }
             case "md":
                 out.println(
                     `# ${item.title}\n\n${item.description || "No description"}\n\n## Comments\n${item.comments.map((c) => `- **${c.author}**: ${c.text}`).join("\n")}`
@@ -524,6 +560,11 @@ export async function handleWorkItem(
                 out.println(formatJSON(item));
                 break;
         }
+    }
+
+    if (anyTruncated) {
+        out.println("");
+        out.println(suggestCommand("tools azure-devops workitem", { add: ["--full"] }));
     }
 }
 
@@ -547,6 +588,7 @@ export function registerWorkitemCommand(program: Command): void {
         .option("--attachments-suffix <suffix>", "Only attachments ending with this (e.g. .har)")
         .option("--output-dir <path>", "Custom directory for downloaded attachments")
         .option("--images", "Download inline images from description and comments")
+        .option("--full", "Show full description and comments without truncation")
         .action(
             async (
                 input: string,
@@ -561,6 +603,7 @@ export function registerWorkitemCommand(program: Command): void {
                     attachmentsSuffix?: string;
                     outputDir?: string;
                     images?: boolean;
+                    full?: boolean;
                 }
             ) => {
                 const hasAttachmentFilter =
@@ -600,7 +643,8 @@ export function registerWorkitemCommand(program: Command): void {
                     undefined,
                     undefined,
                     attachmentFilter,
-                    options.images
+                    options.images,
+                    options.full
                 );
             }
         );

--- a/src/claude/commands/usage/app.tsx
+++ b/src/claude/commands/usage/app.tsx
@@ -40,7 +40,7 @@ interface DashboardProps {
 }
 
 function Dashboard({ config, accountFilter }: DashboardProps) {
-    useTerminalSize({ clearOnResize: true });
+    const { rows } = useTerminalSize({ clearOnResize: true });
     const { activeTab, tabs, activeIndex } = useTabNavigation(config.defaultTab);
 
     const [pollInterval, setPollInterval] = useState<PollInterval>(
@@ -83,13 +83,19 @@ function Dashboard({ config, accountFilter }: DashboardProps) {
     }
 
     return (
-        <Box flexDirection="column">
+        // Clamp the frame STRICTLY below the viewport height: at >= rows Ink
+        // abandons in-place erasing for clear-terminal-and-rewrite (ink.js
+        // onRender), which scrolls overflow into scrollback and duplicates
+        // stale frames on every refresh. The active view clips instead.
+        <Box flexDirection="column" height={Math.max(4, rows - 1)}>
             <TabBar tabs={tabs} activeIndex={activeIndex} />
-            {activeTab === "overview" && <OverviewView results={results} config={config} />}
-            {activeTab === "timeline" && <TimelineView db={db} results={results} config={config} />}
-            {activeTab === "rates" && <RatesView db={db} results={results} dbVersion={dbVersion} />}
-            {activeTab === "history" && <HistoryView db={db} dbVersion={dbVersion} />}
-            {activeTab === "sessions" && <SessionsView notifications={notifications} />}
+            <Box flexDirection="column" flexGrow={1} overflowY="hidden">
+                {activeTab === "overview" && <OverviewView results={results} config={config} />}
+                {activeTab === "timeline" && <TimelineView db={db} results={results} config={config} />}
+                {activeTab === "rates" && <RatesView db={db} results={results} dbVersion={dbVersion} />}
+                {activeTab === "history" && <HistoryView db={db} dbVersion={dbVersion} />}
+                {activeTab === "sessions" && <SessionsView notifications={notifications} />}
+            </Box>
             <AlertBanner
                 alerts={notifications?.alerts ?? []}
                 onDismiss={() => {

--- a/src/claude/commands/usage/app.tsx
+++ b/src/claude/commands/usage/app.tsx
@@ -87,7 +87,7 @@ function Dashboard({ config, accountFilter }: DashboardProps) {
         // abandons in-place erasing for clear-terminal-and-rewrite (ink.js
         // onRender), which scrolls overflow into scrollback and duplicates
         // stale frames on every refresh. The active view clips instead.
-        <Box flexDirection="column" height={Math.max(4, rows - 1)}>
+        <Box flexDirection="column" height={Math.max(1, Math.min(rows - 1, 4))}>
             <TabBar tabs={tabs} activeIndex={activeIndex} />
             <Box flexDirection="column" flexGrow={1} overflowY="hidden">
                 {activeTab === "overview" && <OverviewView results={results} config={config} />}

--- a/src/claude/commands/usage/index.tsx
+++ b/src/claude/commands/usage/index.tsx
@@ -1,7 +1,7 @@
 import { logger, out } from "@app/logger";
+import { renderFullScreen } from "@app/utils/ink";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
-import { render } from "ink";
 import { App } from "./app";
 
 export function registerUsageCommand(program: Command): void {
@@ -67,7 +67,6 @@ export function registerUsageCommand(program: Command): void {
                 return;
             }
 
-            const { waitUntilExit } = render(<App accountFilter={accountFilter} />);
-            await waitUntilExit();
+            await renderFullScreen(<App accountFilter={accountFilter} />);
         });
 }

--- a/src/claude/lib/memory.ts
+++ b/src/claude/lib/memory.ts
@@ -43,6 +43,7 @@ export function appendMemory(entry: string, cwd?: string): string {
     }
 
     const line = entry.startsWith("- ") ? entry : `- ${entry}`;
-    appendFileSync(path, `\n${line}\n`);
+    const prefix = existsSync(path) && !readFileSync(path, "utf-8").endsWith("\n") ? "\n" : "";
+    appendFileSync(path, `${prefix}${line}\n`);
     return path;
 }

--- a/src/debugging-master/dashboard/styles.css
+++ b/src/debugging-master/dashboard/styles.css
@@ -184,7 +184,6 @@ body {
 .dbg-log-wrap {
     white-space: pre-wrap;
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 .dbg-log-line__id-rail .dbg-log-line__id-btn {

--- a/src/dev-dashboard/contract/auth-header.ts
+++ b/src/dev-dashboard/contract/auth-header.ts
@@ -3,6 +3,8 @@
 // (scrypt/hmac/timing-safe compare) stay in `lib/auth.ts`; only the encode/parse
 // pair lives here because the mobile client must build the `Authorization` header.
 
+import { logger } from "@app/logger";
+
 export interface BasicAuthInput {
     username: string;
     password: string;
@@ -48,7 +50,8 @@ export function parseBasicAuthHeader(header: string | null): BasicAuthInput | nu
     let decoded: string;
     try {
         decoded = fromBase64Utf8(encoded);
-    } catch {
+    } catch (err) {
+        logger.warn({ error: err, encoded, header }, "Failed to decode Basic auth header");
         return null;
     }
     const separatorIndex = decoded.indexOf(":");

--- a/src/dev-dashboard/contract/auth-header.ts
+++ b/src/dev-dashboard/contract/auth-header.ts
@@ -45,7 +45,12 @@ export function parseBasicAuthHeader(header: string | null): BasicAuthInput | nu
     }
 
     const encoded = header.replace(/^basic\s+/i, "").trim();
-    const decoded = fromBase64Utf8(encoded);
+    let decoded: string;
+    try {
+        decoded = fromBase64Utf8(encoded);
+    } catch {
+        return null;
+    }
     const separatorIndex = decoded.indexOf(":");
 
     if (separatorIndex < 1) {

--- a/src/dev-dashboard/contract/e2e-request.ts
+++ b/src/dev-dashboard/contract/e2e-request.ts
@@ -29,7 +29,11 @@ export function encodeE2eRequest(req: E2eRequest): string {
 export function decodeE2eRequest(raw: string): E2eRequest {
     const req = SafeJSON.parse(raw, { strict: true }) as E2eRequest;
 
-    if (typeof req.method !== "string" || typeof req.path !== "string" || (req.body !== undefined && typeof req.body !== "string")) {
+    if (
+        typeof req.method !== "string" ||
+        typeof req.path !== "string" ||
+        (req.body !== undefined && typeof req.body !== "string")
+    ) {
         throw new Error("invalid E2eRequest");
     }
 
@@ -43,7 +47,11 @@ export function encodeE2eResponse(res: E2eResponse): string {
 export function decodeE2eResponse(raw: string): E2eResponse {
     const res = SafeJSON.parse(raw, { strict: true }) as E2eResponse;
 
-    if (typeof res.status !== "number" || typeof res.body !== "string" || (res.contentType !== undefined && typeof res.contentType !== "string")) {
+    if (
+        typeof res.status !== "number" ||
+        typeof res.body !== "string" ||
+        (res.contentType !== undefined && typeof res.contentType !== "string")
+    ) {
         throw new Error("invalid E2eResponse");
     }
 

--- a/src/dev-dashboard/index.ts
+++ b/src/dev-dashboard/index.ts
@@ -22,7 +22,7 @@ import { Command } from "commander";
 
 const program = new Command()
     .name("dev-dashboard")
-    .description("Personal dev dashboard (ttyd, cmux, obsidian) at mac.foltyn.dev")
+    .description("Personal dev dashboard (ttyd, cmux, obsidian)")
     .version("0.1.0");
 
 async function runUiServer(): Promise<void> {

--- a/src/dev-dashboard/lib/allowed-hosts.test.ts
+++ b/src/dev-dashboard/lib/allowed-hosts.test.ts
@@ -3,8 +3,8 @@ import { formatHostsList, parseHostsList } from "./allowed-hosts";
 
 describe("parseHostsList", () => {
     it("splits comma-delimited input, trims, dedupes, and drops empty strings", () => {
-        expect(parseHostsList(" mac.foltyn.dev , mac.foltyn.dev , localhost ")).toEqual([
-            "mac.foltyn.dev",
+        expect(parseHostsList(" myhost.example.com , myhost.example.com , localhost ")).toEqual([
+            "myhost.example.com",
             "localhost",
         ]);
     });
@@ -16,6 +16,6 @@ describe("parseHostsList", () => {
 
 describe("formatHostsList", () => {
     it("joins hosts for display", () => {
-        expect(formatHostsList(["mac.foltyn.dev", "localhost"])).toBe("mac.foltyn.dev, localhost");
+        expect(formatHostsList(["myhost.example.com", "localhost"])).toBe("myhost.example.com, localhost");
     });
 });

--- a/src/dev-dashboard/lib/front-proxy.test.ts
+++ b/src/dev-dashboard/lib/front-proxy.test.ts
@@ -40,7 +40,7 @@ describe("isLoopbackOnlyOrigin — locality comes from socket + Host only", () =
     });
 
     test("non-localhost Host from loopback (tunnel/LAN names) is not local", () => {
-        expect(isLoopbackOnlyOrigin(reqWith({ host: "mac.foltyn.dev" }), "127.0.0.1")).toBe(false);
+        expect(isLoopbackOnlyOrigin(reqWith({ host: "myhost.example.com" }), "127.0.0.1")).toBe(false);
         expect(isLoopbackOnlyOrigin(reqWith({ host: "192.168.0.15:3042" }), "127.0.0.1")).toBe(false);
         expect(isLoopbackOnlyOrigin(reqWith({ host: "evil.example" }), "127.0.0.1")).toBe(false);
     });

--- a/src/dev-dashboard/lib/qa-deep-link.ts
+++ b/src/dev-dashboard/lib/qa-deep-link.ts
@@ -3,6 +3,7 @@ import { getConfig } from "@app/dev-dashboard/config";
 export async function buildQaDeepLink(entryId: string): Promise<string> {
     const config = await getConfig();
     const host = config.allowedHosts[0] ?? "localhost";
+    const needsPort = host === "localhost" || host === "127.0.0.1";
 
-    return `http://${host}:${config.port}/qa?id=${encodeURIComponent(entryId)}`;
+    return `http://${host}${needsPort ? `:${config.port}` : ""}/qa?id=${encodeURIComponent(entryId)}`;
 }

--- a/src/dev-dashboard/server/router.ts
+++ b/src/dev-dashboard/server/router.ts
@@ -59,9 +59,13 @@ export class Router {
             }
 
             const params: Record<string, string> = {};
-            route.paramNames.forEach((name, i) => {
-                params[name] = decodeURIComponent(m[i + 1] ?? "");
-            });
+            try {
+                route.paramNames.forEach((name, i) => {
+                    params[name] = decodeURIComponent(m[i + 1] ?? "");
+                });
+            } catch {
+                return null;
+            }
 
             return { def: route.def, params };
         }

--- a/src/dev-dashboard/ui/src/lib/iframe-keys.ts
+++ b/src/dev-dashboard/ui/src/lib/iframe-keys.ts
@@ -125,7 +125,7 @@ export function pasteTextToIframe(iframe: HTMLIFrameElement | null, text: string
 
         // The ttyd frame is served same-origin under the dashboard's reverse
         // proxy. A scoped targetOrigin broke the cloudflared-proxied mobile path
-        // (mac.foltyn.dev), so post with "*" — the front proxy already auth-gates
+        // (LAN hostname), so post with "*" — the front proxy already auth-gates
         // every /ttyd/ request, so an untrusted embedder can't load this frame.
         contentWindow.postMessage({ type: "dd-ttyd-paste", text }, "*");
         return true;

--- a/src/dev-dashboard/ui/src/routes/port-killer.tsx
+++ b/src/dev-dashboard/ui/src/routes/port-killer.tsx
@@ -31,7 +31,7 @@ export function PortKillerRoute() {
                 <PortsTable
                     result={data}
                     onKill={handleKill}
-                    killingPid={killMutation.isPending ? killMutation.variables?.pid ?? null : null}
+                    killingPid={killMutation.isPending ? (killMutation.variables?.pid ?? null) : null}
                 />
             ) : (
                 <div className="dd-panel flex h-full items-center justify-center text-[var(--dd-text-muted)]">

--- a/src/dev-dashboard/ui/src/routes/qa.tsx
+++ b/src/dev-dashboard/ui/src/routes/qa.tsx
@@ -238,6 +238,7 @@ const QaCard = memo(function QaCard({
             className={`dd-panel flex flex-col gap-3 p-4${unread ? " dd-qa-card--unread dd-qa-card--clickable" : " dd-qa-card--clickable"}`}
             data-qa-id={entry.id}
             data-qa-unread={unread ? "1" : "0"}
+            style={{ scrollMarginTop: "5rem" }}
             onMouseUp={handleCardMouseUp}
             onKeyDown={(ev) => {
                 if (ev.key === "Enter" || ev.key === " ") {
@@ -313,7 +314,7 @@ const QaCard = memo(function QaCard({
     return (
         <>
             {pinned ? (
-                <BlinkingBox active variant="accent-glow" iterations={5} durationMs={700}>
+                <BlinkingBox active variant="accent-glow" iterations={5} durationMs={700} className="rounded-lg">
                     {card}
                 </BlinkingBox>
             ) : (

--- a/src/indexer/lib/indexer.ts
+++ b/src/indexer/lib/indexer.ts
@@ -241,13 +241,21 @@ export class Indexer extends IndexerEventEmitter {
                 await this.store.removeChunks(staleIds);
                 chunksPruned = staleIds.length;
             }
+        } else {
+            logger.debug(`[cleanup] ${this.config.name}: source has no pruneStale — skipping prune phase`);
         }
 
         const { removed: vectorsHealed } = await this.store.removeOrphanVectors();
+        const shouldVacuum = opts?.vacuum === true && (chunksPruned > 0 || vectorsHealed > 0);
 
-        if (opts?.vacuum && (chunksPruned > 0 || vectorsHealed > 0)) {
+        if (shouldVacuum) {
             this.store.getDb().exec("VACUUM");
         }
+
+        logger.debug(
+            `[cleanup] ${this.config.name}: pruned ${chunksPruned} stale chunks, ` +
+                `healed ${vectorsHealed} orphan vectors${shouldVacuum ? ", vacuumed" : ""}`
+        );
 
         return { chunksPruned, vectorsHealed };
     }

--- a/src/indexer/lib/indexer.ts
+++ b/src/indexer/lib/indexer.ts
@@ -223,6 +223,35 @@ export class Indexer extends IndexerEventEmitter {
         return this.embedUnembeddedChunks(callbacks);
     }
 
+    /**
+     * Maintenance-only pass: prune chunks whose backing source row no longer
+     * exists (for mail, messages deleted from the Envelope Index) and sweep
+     * orphan vectors — the same phases sync() runs, without the scan/embed
+     * work. Writes ONLY to the index store; the source DB stays read-only.
+     * With `vacuum`, compacts the index DB afterwards when anything was removed.
+     */
+    async cleanup(opts?: { vacuum?: boolean }): Promise<{ chunksPruned: number; vectorsHealed: number }> {
+        const tableName = sanitizeName(this.config.name);
+        let chunksPruned = 0;
+
+        if (typeof this.source.pruneStale === "function") {
+            const staleIds = await this.source.pruneStale(this.store.getDb(), tableName);
+
+            if (staleIds.length > 0) {
+                await this.store.removeChunks(staleIds);
+                chunksPruned = staleIds.length;
+            }
+        }
+
+        const { removed: vectorsHealed } = await this.store.removeOrphanVectors();
+
+        if (opts?.vacuum && (chunksPruned > 0 || vectorsHealed > 0)) {
+            this.store.getDb().exec("VACUUM");
+        }
+
+        return { chunksPruned, vectorsHealed };
+    }
+
     async search(
         query: string,
         opts?: Partial<SearchOptions> & { callbacks?: IndexerCallbacks }

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -107,7 +107,9 @@ describe("scoped out + log.out/log.tee double-mirror rule", () => {
     //    `logger.scoped(component)` (a DIFFERENT child instance), so that
     //    spy would capture nothing. The real, render-verified discriminator
     //    is the component-tagged pino debug line: clack's step render does
-    //    NOT carry `component: "<name>"`; the single mirror debug line does.
+    //    NOT carry the inlined `[<component>]` tag; the single mirror debug
+    //    line does (component renders inline via messageFormat — the raw
+    //    `component: "x"` field line is console-ignored).
     //    Exactly-one occurrence == the no-double-mirror invariant.
     it("log.out.log.* emits EXACTLY ONE component-tagged debug line (mirrorToLogger=true)", async () => {
         const mod = await import("./logger");
@@ -125,7 +127,8 @@ describe("scoped out + log.out/log.tee double-mirror rule", () => {
         await Bun.sleep(20);
         process.stderr.write = oe;
         const stderr = chunks.join("");
-        expect((stderr.match(/component: "shops:crawler"/g) ?? []).length).toBe(1);
+        expect((stderr.match(/\[shops:crawler\]/g) ?? []).length).toBe(1);
+        expect(stderr).not.toContain('component: "shops:crawler"');
         expect(stderr).toContain("Crawling");
     });
 
@@ -142,7 +145,7 @@ describe("scoped out + log.out/log.tee double-mirror rule", () => {
 // Advisor-mandated (the plan's Task 13 test only exercises runTool's surface;
 // without these the eff()/setBaseBinding refactor ships untested).
 describe("setBaseBinding + eff() — Task 13", () => {
-    it("logger.info after setBaseBinding({tool}) renders the tool binding on stderr", async () => {
+    it("logger.info after setBaseBinding({tool}) carries the binding but does NOT echo it on console", async () => {
         const mod = await import("./logger");
         mod.setConsoleLevel("info");
         mod.setBaseBinding({ tool: "loggertest" });
@@ -156,11 +159,15 @@ describe("setBaseBinding + eff() — Task 13", () => {
         await Bun.sleep(20);
         process.stderr.write = oe;
         const stderr = chunks.join("");
-        expect(stderr).toContain('tool: "loggertest"');
+        // Binding is in the chain (file log gets it) — verified via child bindings.
+        expect(mod.logger.child({}).bindings()).toMatchObject({ tool: "loggertest" });
+        // Console must NOT echo ambient bindings as field lines (the
+        // `tool: "macos"` garbage-line bug when output is piped).
+        expect(stderr).not.toContain('tool: "loggertest"');
         expect(stderr).toContain("base-bound line");
     });
 
-    it("scoped() flows through eff() — renders BOTH tool and component", async () => {
+    it("scoped() flows through eff() — component inlined as [tag], tool suppressed", async () => {
         const mod = await import("./logger");
         mod.setConsoleLevel("debug");
         mod.setBaseBinding({ tool: "loggertest" });
@@ -175,7 +182,9 @@ describe("setBaseBinding + eff() — Task 13", () => {
         await Bun.sleep(20);
         process.stderr.write = oe;
         const stderr = chunks.join("");
-        expect(stderr).toContain('tool: "loggertest"');
-        expect(stderr).toContain('component: "scopecomp"');
+        expect(log.bindings()).toMatchObject({ tool: "loggertest", component: "scopecomp" });
+        expect(stderr).toContain("[scopecomp] scoped base-bound line");
+        expect(stderr).not.toContain('tool: "loggertest"');
+        expect(stderr).not.toContain('component: "scopecomp"');
     });
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -131,7 +131,12 @@ export const createLogger = (options: LoggerOptions = {}): pino.Logger => {
             sync: true,
             colorize: process.stderr.isTTY === true,
             translateTime: timestampFormat,
-            ignore: showPid ? "hostname" : "pid,hostname",
+            // Ambient bindings (tool from runTool's setBaseBinding, component
+            // from scoped()) are file-log context, not console content —
+            // without ignoring them every console line echoes `tool: "x"` as
+            // an indented field line. component stays visible inline instead.
+            messageFormat: "{if component}[{component}] {end}{msg}",
+            ignore: showPid ? "hostname,tool,component" : "pid,hostname,tool,component",
         };
 
         // minimalLevels: hide level for info/debug/trace, colored WARN:/ERROR:.

--- a/src/macos/commands/mail/accounts.ts
+++ b/src/macos/commands/mail/accounts.ts
@@ -1,4 +1,5 @@
 import { out } from "@app/logger";
+import { isStructuredFormat, printStructured } from "@app/macos/lib/mail/command-helpers";
 import { isQuietOutput } from "@app/utils/cli";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import { formatTable } from "@app/utils/table";
@@ -9,11 +10,18 @@ export function registerAccountsCommand(program: Command): void {
     program
         .command("accounts")
         .description("List configured mail accounts")
-        .action(async () => {
+        .option("-f, --format <type>", "Output format: table, json, toon", "table")
+        .action(async (options: { format?: string }) => {
             const db = new MailDatabase();
+            const format = options.format ?? "table";
 
             try {
                 const accounts = await db.listAccounts();
+
+                if (isStructuredFormat(format)) {
+                    await printStructured(accounts, format);
+                    return;
+                }
 
                 if (accounts.length === 0) {
                     out.println("No mail accounts found.");

--- a/src/macos/commands/mail/index-cmd.ts
+++ b/src/macos/commands/mail/index-cmd.ts
@@ -251,7 +251,8 @@ async function runCleanup(): Promise<void> {
 
         if (!meta) {
             p.log.error("Mail index not found. Run `tools macos mail index` first.");
-            process.exit(1);
+            process.exitCode = 1;
+            return;
         }
 
         const sizeBefore = meta.stats.dbSizeBytes;
@@ -290,7 +291,8 @@ async function runCleanup(): Promise<void> {
         } catch (err) {
             spinner.stop("Cleanup failed");
             p.log.error(err instanceof Error ? err.message : String(err));
-            process.exit(1);
+            process.exitCode = 1;
+            return;
         }
 
         p.outro("Done");

--- a/src/macos/commands/mail/index-cmd.ts
+++ b/src/macos/commands/mail/index-cmd.ts
@@ -33,7 +33,7 @@ function parseDate(str: string | undefined, label: string, endOfDay = false): Da
 }
 
 export function registerIndexCommand(program: Command): void {
-    program
+    const indexCmd = program
         .command("index")
         .description("Build/update a searchable index of your emails")
         .option("--model [id]", "Embedding model ID — omit value for interactive selection")
@@ -232,6 +232,71 @@ export function registerIndexCommand(program: Command): void {
                 p.outro("Done");
             }
         );
+
+    indexCmd
+        .command("cleanup")
+        .description(
+            "Prune index entries for messages deleted from Mail.app — writes ONLY to the GenesisTools index DB"
+        )
+        .action(runCleanup);
+}
+
+async function runCleanup(): Promise<void> {
+    p.intro(pc.bgCyan(pc.white(" mail index cleanup ")));
+
+    const manager = await IndexerManager.load();
+
+    try {
+        const meta = manager.listIndexes().find((m) => m.name === MAIL_INDEX_NAME);
+
+        if (!meta) {
+            p.log.error("Mail index not found. Run `tools macos mail index` first.");
+            process.exit(1);
+        }
+
+        const sizeBefore = meta.stats.dbSizeBytes;
+        p.log.info(
+            `Index: ${pc.bold(MAIL_INDEX_NAME)} — ${meta.stats.totalChunks.toLocaleString()} chunks, ` +
+                `${formatBytes(sizeBefore)}`
+        );
+        p.log.info("Mail.app's Envelope Index is opened read-only; cleanup never writes to it.");
+
+        const spinner = p.spinner();
+        spinner.start("Pruning chunks whose messages no longer exist in Mail.app...");
+
+        try {
+            const indexer = await manager.getIndex(MAIL_INDEX_NAME);
+            const result = await indexer.cleanup({ vacuum: true });
+            const sizeAfter = indexer.stats.dbSizeBytes;
+            spinner.stop("Cleanup complete");
+
+            if (result.chunksPruned === 0 && result.vectorsHealed === 0) {
+                p.log.info("Nothing to clean — the index matches Mail.app.");
+            } else {
+                if (result.chunksPruned > 0) {
+                    p.log.success(
+                        `Pruned ${pc.red(`-${result.chunksPruned.toLocaleString()}`)} chunks of deleted messages`
+                    );
+                }
+
+                if (result.vectorsHealed > 0) {
+                    p.log.success(`Healed ${pc.red(`-${result.vectorsHealed.toLocaleString()}`)} orphan vectors`);
+                }
+
+                if (sizeAfter < sizeBefore) {
+                    p.log.info(`DB size: ${formatBytes(sizeBefore)} → ${formatBytes(sizeAfter)} (vacuumed)`);
+                }
+            }
+        } catch (err) {
+            spinner.stop("Cleanup failed");
+            p.log.error(err instanceof Error ? err.message : String(err));
+            process.exit(1);
+        }
+
+        p.outro("Done");
+    } finally {
+        await manager.close();
+    }
 }
 
 const VALID_EMBEDDING_PROVIDERS: ReadonlySet<string> = getEmbeddingProviderTypes();

--- a/src/macos/commands/mail/list.ts
+++ b/src/macos/commands/mail/list.ts
@@ -1,6 +1,7 @@
 import { ALL_COLUMN_KEYS } from "@app/macos/lib/mail/columns";
 import {
     enrichWithBodies,
+    isStructuredFormat,
     needsRecipients,
     outputFormattedResults,
     resolveColumnsFromFlag,
@@ -8,6 +9,8 @@ import {
 import { MailStorage } from "@app/macos/lib/mail/mail-storage";
 import { rowToMessage } from "@app/macos/lib/mail/transform";
 import type { MailMessage } from "@app/macos/lib/mail/types";
+import { isQuietOutput } from "@app/utils/cli/output-mode";
+import { createQuietSpinner } from "@app/utils/cli/quiet-spinner";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
@@ -40,7 +43,10 @@ export function registerListCommand(program: Command): void {
                     return;
                 }
 
-                const spinner = p.spinner();
+                const format = options.format ?? "table";
+                // Clack renders on stdout — a real spinner would corrupt
+                // structured/piped output.
+                const spinner = isQuietOutput(options.format) ? createQuietSpinner() : p.spinner();
                 spinner.start(`Fetching latest ${limit} emails from ${targetMailbox}...`);
 
                 let rows = await db.listMessages(targetMailbox, limit);
@@ -56,6 +62,11 @@ export function registerListCommand(program: Command): void {
 
                 if (rows.length === 0) {
                     spinner.stop(`No messages found in ${targetMailbox}.`);
+
+                    if (isStructuredFormat(format)) {
+                        await outputFormattedResults({ messages: [], columns, format });
+                    }
+
                     return;
                 }
 
@@ -83,7 +94,7 @@ export function registerListCommand(program: Command): void {
                 await outputFormattedResults({
                     messages,
                     columns,
-                    format: options.format ?? "table",
+                    format,
                 });
             } catch (error) {
                 p.log.error(error instanceof Error ? error.message : String(error));

--- a/src/macos/commands/mail/list.ts
+++ b/src/macos/commands/mail/list.ts
@@ -46,7 +46,7 @@ export function registerListCommand(program: Command): void {
                 const format = options.format ?? "table";
                 // Clack renders on stdout — a real spinner would corrupt
                 // structured/piped output.
-                const spinner = isQuietOutput(options.format) ? createQuietSpinner() : p.spinner();
+                const spinner = isQuietOutput(format) ? createQuietSpinner() : p.spinner();
                 spinner.start(`Fetching latest ${limit} emails from ${targetMailbox}...`);
 
                 let rows = await db.listMessages(targetMailbox, limit);

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -5,11 +5,13 @@ import {
     needsRecipients,
     outputFormattedResults,
     parseMailDate,
+    printStructured,
     resolveColumnsFromFlag,
 } from "@app/macos/lib/mail/command-helpers";
 import { resolveMailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
 import type { SearchOptions } from "@app/macos/lib/mail/types";
 import { isQuietOutput } from "@app/utils/cli/output-mode";
+import { createQuietSpinner } from "@app/utils/cli/quiet-spinner";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
@@ -66,18 +68,6 @@ function buildSearchColumns({
     return result;
 }
 
-interface QuietSpinner {
-    start: (msg: string) => void;
-    stop: (msg: string) => void;
-}
-
-function createQuietSpinner(): QuietSpinner {
-    return {
-        start: (): void => {},
-        stop: (): void => {},
-    };
-}
-
 export function registerSearchCommand(program: Command): void {
     program
         .command("search <query>")
@@ -113,6 +103,12 @@ export function registerSearchCommand(program: Command): void {
             try {
                 if (options.helpReceivers) {
                     const receivers = await db.listReceivers();
+
+                    if (isStructuredOutput) {
+                        await printStructured(receivers, options.format ?? "json");
+                        return;
+                    }
+
                     announce("\nReceiver addresses (by message count):\n");
 
                     for (const r of receivers) {
@@ -162,6 +158,15 @@ export function registerSearchCommand(program: Command): void {
 
                 if (messages.length === 0) {
                     announce("No messages found matching your query.");
+
+                    if (isStructuredOutput) {
+                        await outputFormattedResults({
+                            messages: [],
+                            columns: baseColumns,
+                            format: options.format ?? "table",
+                        });
+                    }
+
                     return;
                 }
 

--- a/src/macos/commands/mail/show.ts
+++ b/src/macos/commands/mail/show.ts
@@ -1,9 +1,9 @@
 import { out } from "@app/logger";
+import { isStructuredFormat, printStructured } from "@app/macos/lib/mail/command-helpers";
 import { EmlxBodyExtractor } from "@app/macos/lib/mail/emlx";
 import { rowToMessage, truncateBody } from "@app/macos/lib/mail/transform";
 import { printLn } from "@app/utils/cli";
 import { formatBytes } from "@app/utils/format";
-import { SafeJSON } from "@app/utils/json";
 import { MailDatabase } from "@app/utils/macos/MailDatabase";
 import chalk from "chalk";
 import type { Command } from "commander";
@@ -13,6 +13,7 @@ type BodyFormat = "text" | "markdown" | "html" | "raw";
 interface ShowOptions {
     maxChars?: string;
     json?: boolean;
+    format?: string;
     bodyFormat?: BodyFormat;
 }
 
@@ -53,7 +54,8 @@ export function registerShowCommand(program: Command): void {
         .description("Show full email details including body")
         .option("--max-chars <n>", "Truncate body to N characters")
         .option("--body-format <format>", "Body format for human output: text, markdown, html, raw", "text")
-        .option("--json", "Output as JSON")
+        .option("-f, --format <type>", "Output format: text, json, toon", "text")
+        .option("--json", "Output as JSON (alias for --format json)")
         .action(async (messageIdArg: string, options: ShowOptions) => {
             const db = new MailDatabase();
 
@@ -97,20 +99,19 @@ export function registerShowCommand(program: Command): void {
                 msg.bodyMarkdown = bodyMarkdown;
                 msg.bodyRaw = bodyRaw;
 
-                if (options.json) {
-                    await printLn(
-                        SafeJSON.stringify(
-                            {
-                                ...msg,
-                                body: bodyText,
-                                bodyText,
-                                bodyHtml,
-                                bodyMarkdown,
-                                bodyRaw,
-                            },
-                            null,
-                            2
-                        )
+                const format = options.json ? "json" : (options.format ?? "text");
+
+                if (isStructuredFormat(format)) {
+                    await printStructured(
+                        {
+                            ...msg,
+                            body: bodyText,
+                            bodyText,
+                            bodyHtml,
+                            bodyMarkdown,
+                            bodyRaw,
+                        },
+                        format
                     );
                     return;
                 }

--- a/src/macos/lib/mail/command-helpers.ts
+++ b/src/macos/lib/mail/command-helpers.ts
@@ -164,22 +164,15 @@ export function formatJsonOutput(messages: MailMessage[], columns: MailColumnKey
     return SafeJSON.stringify(data, null, 2);
 }
 
-export async function outputFormattedResults({
-    messages,
-    columns,
-    format,
-}: {
-    messages: MailMessage[];
-    columns: MailColumnKey[];
-    format: string;
-}): Promise<void> {
-    if (format === "json") {
-        await printLn(formatJsonOutput(messages, columns));
-        return;
-    }
+export function isStructuredFormat(format: string | undefined): boolean {
+    return format === "json" || format === "toon";
+}
+
+/** Print structured result data to stdout: as JSON, or as TOON via `tools json`. */
+export async function printStructured(data: unknown, format: string): Promise<void> {
+    const jsonStr = typeof data === "string" ? data : SafeJSON.stringify(data, null, 2);
 
     if (format === "toon") {
-        const jsonStr = formatJsonOutput(messages, columns);
         const proc = Bun.spawn(["tools", "json"], {
             stdin: new Blob([jsonStr]),
             stdout: "inherit",
@@ -192,6 +185,23 @@ export async function outputFormattedResults({
             await printLn(jsonStr);
         }
 
+        return;
+    }
+
+    await printLn(jsonStr);
+}
+
+export async function outputFormattedResults({
+    messages,
+    columns,
+    format,
+}: {
+    messages: MailMessage[];
+    columns: MailColumnKey[];
+    format: string;
+}): Promise<void> {
+    if (isStructuredFormat(format)) {
+        await printStructured(formatJsonOutput(messages, columns), format);
         return;
     }
 

--- a/src/mcp-manager/README.md
+++ b/src/mcp-manager/README.md
@@ -38,6 +38,12 @@ tools mcp-manager enable github
 # Disable a server in a provider
 tools mcp-manager disable github
 
+# Re-enable a globally-disabled server for ONE claude project (override)
+tools mcp-manager enable github -p claude --project /abs/path/to/project
+
+# Completely REMOVE server(s) everywhere (permanent — disable is reversible)
+tools mcp-manager remove github,old-server -y
+
 # Install a server from unified config to a provider
 tools mcp-manager install github
 
@@ -54,8 +60,9 @@ tools mcp-manager show github
 | `sync`                | Sync MCP servers from unified config to providers        |
 | `sync-from-providers` | Sync servers FROM providers TO unified config            |
 | `list`                | List all MCP servers across all providers                |
-| `enable`              | Enable an MCP server in a provider                       |
-| `disable`             | Disable an MCP server in a provider                      |
+| `enable`              | Enable an MCP server in a provider (`--project` for per-project) |
+| `disable`             | Disable an MCP server in a provider (`--project` for per-project) |
+| `remove` (`purge`)    | PERMANENTLY remove server(s) from unified config + all provider configs |
 | `install`             | Install/add an MCP server to a provider                  |
 | `show`                | Show full configuration of an MCP server                 |
 | `backup-all`          | Backup all configs for all providers                     |
@@ -177,6 +184,50 @@ mcp-manager therefore implements a TRUE global disable for Claude:
 -   **`sync-from-providers`** does not interpret the absence of a
     globally-disabled server as "user deleted it" — the unified config entry
     and its `_meta.enabled.claude = false` flag are preserved.
+
+#### Per-project enable override (claude)
+
+A global disable can be overridden for individual projects:
+
+```bash
+tools mcp-manager enable <server> -p claude --project /abs/path [--project /other] [-y]
+```
+
+-   Installs the server's claude-format config into
+    `.projects[<path>].mcpServers.<name>` in `~/.claude.json` — Claude Code
+    DOES honor project-scope entries there (it's the same storage
+    `claude mcp add -s local` uses) — and removes the name from that project's
+    `disabledMcpServers` list.
+-   The global state stays disabled: the server remains absent from the global
+    `mcpServers` and `_meta.enabled.claude` stays `false`. The override is
+    tracked solely by the presence of the project-scope entry — no extra
+    metadata.
+-   **Override-awareness:** the per-project sweep (global disable) and `sync`
+    SKIP projects that have a project-scope entry for that server — they never
+    re-add the name to that project's `disabledMcpServers` and never delete
+    the entry (its config is refreshed from the unified config on sync).
+    `sync-from-providers` keeps `_meta.enabled.claude === false` even though
+    the override projects report the server as enabled.
+-   `list` shows such servers as `disabled globally, enabled in N project(s)`.
+-   Undo with `tools mcp-manager disable <server> -p claude --project <path>` —
+    removes the project-scope entry and puts the name back on that project's
+    disabled list.
+-   `--project` is repeatable and accepts comma-separated paths; `-p all` is
+    also accepted for enable/disable and expands to all providers with configs.
+
+#### `remove` vs `disable`
+
+`disable` is reversible: the full server config stays in the unified config
+and `enable` can restore it anywhere. `remove` (alias `purge`) is PERMANENT:
+it deletes the server from the unified config (`mcpServers.<name>` and the
+`enabledMcpServers.<name>` mirror) and from every selected provider config —
+claude `~/.claude.json` `mcpServers` (global + project-scope entries; the
+per-project `disabledMcpServers` history lists are left as harmless
+leftovers), cursor `~/.cursor/mcp.json`, gemini `~/.gemini/settings.json`
+(`mcpServers` + `mcp.excluded`), and codex `~/.codex/config.toml`
+(`[mcp_servers.<name>]` including nested `.env`/`.http_headers` subsections,
+leaving `[projects.*]`/`[notice]` untouched). Each write shows the standard
+diff + confirmation and goes through the backup path; `-y` auto-confirms.
 
 ### Gemini Code Assist (`~/.gemini/settings.json`)
 

--- a/src/mcp-manager/README.md
+++ b/src/mcp-manager/README.md
@@ -142,8 +142,41 @@ The tool uses a unified configuration file at `~/.genesis-tools/mcp-manager/conf
 ### Claude Desktop (`~/.claude.json`)
 
 -   Supports global and project-specific server configurations
--   Uses `disabledMcpServers` array for disable state
 -   Supports stdio, SSE, and HTTP transports
+-   **Global disable = removal from `mcpServers`** (see below)
+
+#### Claude enable/disable semantics
+
+Verified against the Claude Code binary: Claude Code reads `disabledMcpServers`
+**only** from per-project entries (`.projects[<cwd>].disabledMcpServers`). The
+**top-level `disabledMcpServers` key is never read by Claude Code** — it is an
+mcp-manager-only marker. A per-project sweep covers only projects registered at
+sweep time; a project registered later would load the server again. The only
+mechanism Claude Code honors globally (including future projects) is the server
+**not existing in `mcpServers` at all**.
+
+mcp-manager therefore implements a TRUE global disable for Claude:
+
+-   **Global disable** (`tools mcp-manager disable <server> --provider claude`):
+    1. Preserves the server's full config in the unified config with
+       `_meta.enabled.claude = false` (imports it there first if missing —
+       the entry is never removed unless it is safely preserved).
+    2. Keeps the top-level marker + per-project sweep for back-compat.
+    3. **Removes the entry from `mcpServers`** in `~/.claude.json`.
+-   **Global enable** restores the entry into `mcpServers` from the unified
+    config and cleans the top-level + all per-project disabled lists.
+-   **Per-project disable** is unchanged: the entry stays in `mcpServers` and
+    the project's `disabledMcpServers` list is updated (this is the mechanism
+    Claude Code actually reads).
+-   **`list`** shows globally-disabled servers (absent from `~/.claude.json`)
+    as `disabled` for claude — sourced from the unified config — instead of
+    "not installed".
+-   **`sync`** treats `_meta.enabled.claude === false` as disabled-by-absence:
+    such servers are never (re)installed into `mcpServers`, and drifted
+    entries are removed.
+-   **`sync-from-providers`** does not interpret the absence of a
+    globally-disabled server as "user deleted it" — the unified config entry
+    and its `_meta.enabled.claude = false` flag are preserved.
 
 ### Gemini Code Assist (`~/.gemini/settings.json`)
 

--- a/src/mcp-manager/commands/__tests__/claude-global-disable.test.ts
+++ b/src/mcp-manager/commands/__tests__/claude-global-disable.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setupStorageSandbox } from "@app/utils/storage/test-sandbox";
+import { setupInquirerMock } from "./inquirer-mock.js";
+
+// Setup prompt mock + storage sandbox BEFORE importing modules under test
+setupInquirerMock();
+setupStorageSandbox();
+
+const { ClaudeProvider } = await import("@app/mcp-manager/utils/providers/claude.js");
+const { syncServers } = await import("../sync.js");
+const { syncFromProviders } = await import("../sync-from-providers.js");
+const { renameServer } = await import("../rename.js");
+const { disableServer: disableCommand } = await import("../disable.js");
+const { enableServer: enableCommand } = await import("../enable.js");
+
+import { logger } from "@app/logger";
+import * as configUtils from "@app/mcp-manager/utils/config.utils.js";
+import { setGlobalOptions } from "@app/mcp-manager/utils/config.utils.js";
+import type { ClaudeGenericConfig } from "@app/mcp-manager/utils/providers/claude.types.js";
+import type { UnifiedMCPConfig, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
+import { SafeJSON } from "@app/utils/json";
+import { Storage } from "@app/utils/storage";
+
+/**
+ * Fixture tests for the TRUE global-disable scheme of the Claude provider.
+ *
+ * All writes go to a temp HOME (~/.claude.json fixture) and the sandboxed
+ * Storage (unified config) — the real ~/.claude.json is never touched.
+ */
+
+const SERENA: UnifiedMCPServerConfig = { type: "stdio", command: "uvx", args: ["serena"] };
+const GITHUB: UnifiedMCPServerConfig = { type: "stdio", command: "bunx", args: ["github-mcp"] };
+
+function claudeFixture(): Record<string, unknown> {
+    return {
+        numStartups: 5, // unrelated precious state — must survive writes
+        mcpServers: { serena: { ...SERENA }, github: { ...GITHUB } },
+        disabledMcpServers: [],
+        projects: {
+            "/proj/a": { mcpServers: {}, disabledMcpServers: [], history: ["precious"] },
+            "/proj/b": { mcpServers: {}, disabledMcpServers: [] },
+        },
+    };
+}
+
+function unifiedFixture(): UnifiedMCPConfig {
+    return {
+        mcpServers: {
+            serena: { ...SERENA, _meta: { enabled: { claude: true } } },
+            github: { ...GITHUB, _meta: { enabled: { claude: true } } },
+        },
+    };
+}
+
+describe("claude provider TRUE global disable", () => {
+    let homeDir: string;
+    let prevHome: string | undefined;
+
+    const claudeJsonPath = () => join(homeDir, ".claude.json");
+
+    const writeClaudeJson = (config: Record<string, unknown>) => {
+        writeFileSync(claudeJsonPath(), SafeJSON.stringify(config, null, 2));
+    };
+
+    const readClaudeJson = (): ClaudeGenericConfig & Record<string, unknown> => {
+        return SafeJSON.parse(readFileSync(claudeJsonPath(), "utf-8")) as ClaudeGenericConfig & Record<string, unknown>;
+    };
+
+    const writeUnified = async (config: UnifiedMCPConfig) => {
+        const storage = new Storage("mcp-manager");
+        await storage.ensureDirs();
+        await storage.setConfig(config);
+    };
+
+    const readUnified = async (): Promise<UnifiedMCPConfig> => {
+        const storage = new Storage("mcp-manager");
+        return (await storage.getConfig<UnifiedMCPConfig>()) ?? { mcpServers: {} };
+    };
+
+    beforeEach(() => {
+        // Other mcp-manager test files spy on configUtils (readUnifiedConfig/
+        // writeUnifiedConfig) without restoring; bun runs all files in one
+        // process, so restore everything BEFORE installing our own spies.
+        mock.restore();
+        prevHome = process.env.HOME;
+        homeDir = mkdtempSync(join(tmpdir(), "mcp-claude-global-"));
+        process.env.HOME = homeDir;
+        setGlobalOptions({ yes: true });
+        spyOn(logger, "info").mockImplementation(() => {});
+        spyOn(logger, "warn").mockImplementation(() => {});
+        spyOn(logger, "error").mockImplementation(() => {});
+        spyOn(logger, "debug").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        mock.restore();
+        process.env.HOME = prevHome;
+        setGlobalOptions({});
+        rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    describe("disableServer(name, null) — global", () => {
+        it("removes the entry from mcpServers, keeps markers, preserves unknown keys", async () => {
+            writeClaudeJson(claudeFixture());
+            await writeUnified(unifiedFixture());
+
+            const provider = new ClaudeProvider();
+            await provider.disableServer("serena", null);
+
+            const claude = readClaudeJson();
+            expect(claude.mcpServers?.serena).toBeUndefined(); // TRUE global disable
+            expect(claude.mcpServers?.github).toBeDefined(); // untouched sibling
+            expect(claude.disabledMcpServers).toContain("serena"); // legacy marker
+            expect(claude.projects?.["/proj/a"].disabledMcpServers).toContain("serena"); // sweep
+            expect(claude.projects?.["/proj/b"].disabledMcpServers).toContain("serena");
+            // Unrelated state preserved (read-modify-write)
+            expect(claude.numStartups).toBe(5);
+            expect((claude.projects?.["/proj/a"] as Record<string, unknown>).history).toEqual(["precious"]);
+
+            // Full config preserved in unified config with claude disabled
+            const unified = await readUnified();
+            expect(unified.mcpServers.serena.command).toBe("uvx");
+            expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(false);
+        });
+
+        it("imports the server into the unified config when it is missing there", async () => {
+            writeClaudeJson(claudeFixture());
+            await writeUnified({ mcpServers: {} });
+
+            const provider = new ClaudeProvider();
+            await provider.disableServer("serena", null);
+
+            const unified = await readUnified();
+            expect(unified.mcpServers.serena).toBeDefined();
+            expect(unified.mcpServers.serena.command).toBe("uvx");
+            expect(unified.mcpServers.serena.args).toEqual(["serena"]);
+            expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(false);
+
+            expect(readClaudeJson().mcpServers?.serena).toBeUndefined();
+        });
+
+        it("does NOT remove the entry when it cannot be preserved in the unified config", async () => {
+            writeClaudeJson(claudeFixture());
+            await writeUnified({ mcpServers: {} });
+
+            // Simulate rejected/failed unified-config write during import
+            spyOn(configUtils, "writeUnifiedConfig").mockResolvedValue(false);
+
+            const provider = new ClaudeProvider();
+            await provider.disableServer("serena", null);
+
+            const claude = readClaudeJson();
+            expect(claude.mcpServers?.serena).toBeDefined(); // kept — no data loss
+            expect(claude.disabledMcpServers).toContain("serena"); // markers still applied
+            expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("NOT removed"));
+        });
+    });
+
+    describe("disableServer(name, '/project') — per-project unchanged", () => {
+        it("keeps the entry in mcpServers and only updates the project's disabled list", async () => {
+            writeClaudeJson(claudeFixture());
+            await writeUnified(unifiedFixture());
+
+            const provider = new ClaudeProvider();
+            await provider.disableServer("serena", "/proj/a");
+
+            const claude = readClaudeJson();
+            expect(claude.mcpServers?.serena).toBeDefined(); // still installed
+            expect(claude.disabledMcpServers).toEqual([]); // top-level untouched
+            expect(claude.projects?.["/proj/a"].disabledMcpServers).toContain("serena");
+            expect(claude.projects?.["/proj/b"].disabledMcpServers).toEqual([]);
+
+            const unified = await readUnified();
+            expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(true); // untouched
+        });
+    });
+
+    describe("enableServer(name, null) — global", () => {
+        it("restores the entry from the unified config and cleans all disabled lists", async () => {
+            const claude = claudeFixture();
+            delete (claude.mcpServers as Record<string, unknown>).serena; // globally disabled = absent
+            claude.disabledMcpServers = ["serena"];
+            (claude.projects as Record<string, { disabledMcpServers: string[] }>)["/proj/a"].disabledMcpServers = [
+                "serena",
+            ];
+            writeClaudeJson(claude);
+
+            const unified = unifiedFixture();
+            unified.mcpServers.serena._meta = { enabled: { claude: false } };
+            await writeUnified(unified);
+
+            const provider = new ClaudeProvider();
+            await provider.enableServer("serena", null);
+
+            const result = readClaudeJson();
+            expect(result.mcpServers?.serena).toBeDefined(); // restored
+            expect(result.mcpServers?.serena.command).toBe("uvx");
+            expect((result.mcpServers?.serena as Record<string, unknown>)._meta).toBeUndefined(); // no _meta leak
+            expect(result.disabledMcpServers).not.toContain("serena");
+            expect(result.projects?.["/proj/a"].disabledMcpServers).not.toContain("serena");
+        });
+    });
+
+    describe("listServers", () => {
+        it("reports a globally-disabled (absent) server as disabled, not missing", async () => {
+            const claude = claudeFixture();
+            delete (claude.mcpServers as Record<string, unknown>).serena;
+            writeClaudeJson(claude);
+
+            const unified = unifiedFixture();
+            unified.mcpServers.serena._meta = { enabled: { claude: false } };
+            await writeUnified(unified);
+
+            const provider = new ClaudeProvider();
+            const servers = await provider.listServers();
+
+            const serena = servers.find((s) => s.name === "serena");
+            expect(serena).toBeDefined();
+            expect(serena?.enabled).toBe(false);
+            expect(serena?.provider).toBe("claude");
+            expect(serena?.config._meta).toBeUndefined(); // _meta stays in unified config
+        });
+    });
+
+    describe("syncServers (provider)", () => {
+        it("removes globally-disabled servers from mcpServers and keeps enabled ones", async () => {
+            writeClaudeJson(claudeFixture()); // serena still installed (drift)
+            const unified = unifiedFixture();
+            unified.mcpServers.serena._meta = { enabled: { claude: false } };
+            await writeUnified(unified);
+
+            const provider = new ClaudeProvider();
+            await provider.syncServers(unified.mcpServers);
+
+            const claude = readClaudeJson();
+            expect(claude.mcpServers?.serena).toBeUndefined(); // drift corrected
+            expect(claude.mcpServers?.github).toBeDefined();
+            expect(claude.disabledMcpServers).toContain("serena");
+            expect(claude.disabledMcpServers).not.toContain("github");
+        });
+    });
+
+    describe("sync command", () => {
+        it("does not (re)install globally-disabled servers", async () => {
+            writeClaudeJson({
+                numStartups: 5,
+                mcpServers: {},
+                disabledMcpServers: [],
+                projects: {},
+            });
+            const unified = unifiedFixture();
+            unified.mcpServers.serena._meta = { enabled: { claude: false } };
+            await writeUnified(unified);
+
+            const provider = new ClaudeProvider();
+            await syncServers([provider], { provider: "claude" });
+
+            const claude = readClaudeJson();
+            expect(claude.mcpServers?.github).toBeDefined(); // enabled → installed
+            expect(claude.mcpServers?.serena).toBeUndefined(); // disabled → stays absent
+        });
+    });
+
+    describe("sync-from-providers command", () => {
+        it("does not drop or re-enable a globally-disabled server that is absent from ~/.claude.json", async () => {
+            const claude = claudeFixture();
+            delete (claude.mcpServers as Record<string, unknown>).serena; // absent = globally disabled
+            writeClaudeJson(claude);
+
+            const unified = unifiedFixture();
+            unified.mcpServers.serena._meta = { enabled: { claude: false } };
+            await writeUnified(unified);
+
+            const provider = new ClaudeProvider();
+            await syncFromProviders([provider], { provider: "claude" });
+
+            const result = await readUnified();
+            expect(result.mcpServers.serena).toBeDefined(); // not interpreted as "user deleted it"
+            expect(result.mcpServers.serena.command).toBe("uvx");
+            expect(result.mcpServers.serena._meta?.enabled?.claude).toBe(false); // flag not flipped
+        });
+    });
+
+    describe("rename command", () => {
+        it("renames a globally-disabled server in the unified config without installing it in claude", async () => {
+            writeClaudeJson({
+                mcpServers: {},
+                disabledMcpServers: ["serena"],
+                projects: { "/proj/a": { mcpServers: {}, disabledMcpServers: ["serena"] } },
+            });
+
+            await writeUnified({
+                mcpServers: { serena: { ...SERENA, _meta: { enabled: { claude: false } } } },
+            });
+
+            const provider = new ClaudeProvider();
+            await renameServer("serena", "serena-x", [provider]);
+
+            const unified = await readUnified();
+            expect(unified.mcpServers["serena-x"]).toBeDefined();
+            expect(unified.mcpServers["serena-x"]._meta?.enabled?.claude).toBe(false);
+            expect(unified.mcpServers.serena).toBeUndefined();
+
+            const claude = readClaudeJson();
+            expect(claude.mcpServers?.["serena-x"]).toBeUndefined(); // still globally disabled = absent
+            expect(claude.mcpServers?.serena).toBeUndefined();
+        });
+    });
+
+    describe("disable/enable commands end-to-end (toggle flow)", () => {
+        it("disable --provider claude removes the entry and flips _meta to false", async () => {
+            writeClaudeJson(claudeFixture());
+            await writeUnified(unifiedFixture());
+
+            const provider = new ClaudeProvider();
+            await disableCommand("serena", [provider], { provider: "claude" });
+
+            expect(readClaudeJson().mcpServers?.serena).toBeUndefined();
+            const unified = await readUnified();
+            expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(false);
+            expect(unified.mcpServers.serena.command).toBe("uvx");
+        });
+
+        it("enable --provider claude reinstalls the entry and flips _meta to true", async () => {
+            const claude = claudeFixture();
+            delete (claude.mcpServers as Record<string, unknown>).serena;
+            claude.disabledMcpServers = ["serena"];
+            writeClaudeJson(claude);
+
+            const unified = unifiedFixture();
+            unified.mcpServers.serena._meta = { enabled: { claude: false } };
+            await writeUnified(unified);
+
+            const provider = new ClaudeProvider();
+            await enableCommand("serena", [provider], { provider: "claude" });
+
+            const result = readClaudeJson();
+            expect(result.mcpServers?.serena).toBeDefined();
+            expect(result.disabledMcpServers).not.toContain("serena");
+
+            const unifiedAfter = await readUnified();
+            expect(unifiedAfter.mcpServers.serena._meta?.enabled?.claude).toBe(true);
+        });
+    });
+});

--- a/src/mcp-manager/commands/__tests__/claude-project-override.test.ts
+++ b/src/mcp-manager/commands/__tests__/claude-project-override.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setupStorageSandbox } from "@app/utils/storage/test-sandbox";
+import { setupInquirerMock } from "./inquirer-mock.js";
+
+// Setup prompt mock + storage sandbox BEFORE importing modules under test
+setupInquirerMock();
+setupStorageSandbox();
+
+const { ClaudeProvider } = await import("@app/mcp-manager/utils/providers/claude.js");
+const { syncServers } = await import("../sync.js");
+const { syncFromProviders } = await import("../sync-from-providers.js");
+const { disableServer: disableCommand } = await import("../disable.js");
+const { enableServer: enableCommand } = await import("../enable.js");
+
+import { logger } from "@app/logger";
+import { setGlobalOptions } from "@app/mcp-manager/utils/config.utils.js";
+import type { ClaudeGenericConfig } from "@app/mcp-manager/utils/providers/claude.types.js";
+import type { UnifiedMCPConfig, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
+import { SafeJSON } from "@app/utils/json";
+import { Storage } from "@app/utils/storage";
+
+/**
+ * Fixture tests for the per-project ENABLE OVERRIDE of a globally-disabled
+ * server (claude): `enable <server> -p claude --project <path>` installs a
+ * project-scope entry at `.projects[<path>].mcpServers.<name>` (which Claude
+ * Code honors — same storage as `claude mcp add -s local`) while the global
+ * state stays disabled (`_meta.enabled.claude === false`, absent from global
+ * mcpServers). The override must survive global-disable sweeps and `sync`.
+ */
+
+const SERENA: UnifiedMCPServerConfig = { type: "stdio", command: "uvx", args: ["serena"] };
+const GITHUB: UnifiedMCPServerConfig = { type: "stdio", command: "bunx", args: ["github-mcp"] };
+
+describe("claude per-project enable override for globally-disabled servers", () => {
+    let homeDir: string;
+    let prevHome: string | undefined;
+
+    const claudeJsonPath = () => join(homeDir, ".claude.json");
+
+    const writeClaudeJson = (config: Record<string, unknown>) => {
+        writeFileSync(claudeJsonPath(), SafeJSON.stringify(config, null, 2));
+    };
+
+    const readClaudeJson = (): ClaudeGenericConfig & Record<string, unknown> => {
+        return SafeJSON.parse(readFileSync(claudeJsonPath(), "utf-8")) as ClaudeGenericConfig & Record<string, unknown>;
+    };
+
+    const writeUnified = async (config: UnifiedMCPConfig) => {
+        const storage = new Storage("mcp-manager");
+        await storage.ensureDirs();
+        await storage.setConfig(config);
+    };
+
+    const readUnified = async (): Promise<UnifiedMCPConfig> => {
+        const storage = new Storage("mcp-manager");
+        return (await storage.getConfig<UnifiedMCPConfig>()) ?? { mcpServers: {} };
+    };
+
+    /** serena globally disabled (absent + swept), github installed/enabled */
+    const globallyDisabledFixture = () => ({
+        mcpServers: { github: { ...GITHUB } },
+        disabledMcpServers: ["serena"],
+        projects: {
+            "/proj/a": { mcpServers: {}, disabledMcpServers: ["serena"] },
+            "/proj/b": { mcpServers: {}, disabledMcpServers: ["serena"] },
+        },
+    });
+
+    const unifiedFixture = (): UnifiedMCPConfig => ({
+        mcpServers: {
+            serena: { ...SERENA, _meta: { enabled: { claude: false } } },
+            github: { ...GITHUB, _meta: { enabled: { claude: true } } },
+        },
+    });
+
+    /** Install the serena override into /proj/a via the enable command */
+    const installOverride = async (provider: InstanceType<typeof ClaudeProvider>) => {
+        await enableCommand("serena", [provider], { provider: "claude", project: ["/proj/a"] });
+    };
+
+    beforeEach(() => {
+        mock.restore(); // clear spies leaked from other test files (single bun process)
+        prevHome = process.env.HOME;
+        homeDir = mkdtempSync(join(tmpdir(), "mcp-claude-override-"));
+        process.env.HOME = homeDir;
+        setGlobalOptions({ yes: true });
+        spyOn(logger, "info").mockImplementation(() => {});
+        spyOn(logger, "warn").mockImplementation(() => {});
+        spyOn(logger, "error").mockImplementation(() => {});
+        spyOn(logger, "debug").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        mock.restore();
+        process.env.HOME = prevHome;
+        setGlobalOptions({});
+        rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it("enable --project installs a project-scope entry and keeps the global disable", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await installOverride(provider);
+
+        const claude = readClaudeJson();
+        // Override installed where Claude Code reads it
+        expect(claude.projects?.["/proj/a"].mcpServers?.serena).toBeDefined();
+        expect(claude.projects?.["/proj/a"].mcpServers?.serena.command).toBe("uvx");
+        // Name removed from THAT project's disabled list (it would defeat the entry)
+        expect(claude.projects?.["/proj/a"].disabledMcpServers).not.toContain("serena");
+        // Other project + global state untouched
+        expect(claude.projects?.["/proj/b"].disabledMcpServers).toContain("serena");
+        expect(claude.mcpServers?.serena).toBeUndefined(); // NOT reinstalled globally
+
+        // Global state in the unified config stays disabled — the override is
+        // tracked solely by the project-scope entry
+        const unified = await readUnified();
+        expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(false);
+    });
+
+    it("regular per-project enable of a globally-installed server does NOT create an override entry", async () => {
+        writeClaudeJson({
+            mcpServers: { github: { ...GITHUB } },
+            disabledMcpServers: [],
+            projects: { "/proj/a": { mcpServers: {}, disabledMcpServers: ["github"] } },
+        });
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await enableCommand("github", [provider], { provider: "claude", project: ["/proj/a"] });
+
+        const claude = readClaudeJson();
+        expect(claude.projects?.["/proj/a"].disabledMcpServers).not.toContain("github");
+        expect(claude.projects?.["/proj/a"].mcpServers?.github).toBeUndefined(); // no project-scope copy
+        expect(claude.mcpServers?.github).toBeDefined();
+    });
+
+    it("a later global disable sweep SKIPS projects with an override entry", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await installOverride(provider);
+
+        // Re-run the global disable — the sweep must not clobber the override
+        await provider.disableServer("serena", null);
+
+        const claude = readClaudeJson();
+        expect(claude.projects?.["/proj/a"].mcpServers?.serena).toBeDefined(); // entry kept
+        expect(claude.projects?.["/proj/a"].disabledMcpServers).not.toContain("serena"); // not re-added
+        expect(claude.projects?.["/proj/b"].disabledMcpServers).toContain("serena"); // sweep still works elsewhere
+    });
+
+    it("CRITICAL INVARIANT: the override survives `sync`", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await installOverride(provider);
+
+        await syncServers([provider], { provider: "claude" });
+
+        const claude = readClaudeJson();
+        // Override entry kept (config refreshed from unified config)
+        expect(claude.projects?.["/proj/a"].mcpServers?.serena).toBeDefined();
+        expect(claude.projects?.["/proj/a"].mcpServers?.serena.command).toBe("uvx");
+        // Name NOT re-added to the override project's disabled list
+        expect(claude.projects?.["/proj/a"].disabledMcpServers).not.toContain("serena");
+        // Global disable still enforced
+        expect(claude.mcpServers?.serena).toBeUndefined();
+        expect(claude.projects?.["/proj/b"].disabledMcpServers).toContain("serena");
+        // Enabled sibling unaffected
+        expect(claude.mcpServers?.github).toBeDefined();
+    });
+
+    it("sync-from-providers keeps _meta.enabled.claude === false despite the override", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await installOverride(provider);
+
+        await syncFromProviders([provider], { provider: "claude" });
+
+        const unified = await readUnified();
+        expect(unified.mcpServers.serena).toBeDefined();
+        expect(unified.mcpServers.serena.command).toBe("uvx");
+        // Must stay boolean false — NOT flip to a per-project object, which
+        // would make the next sync reinstall the server globally
+        expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(false);
+    });
+
+    it("disable --project removes the override entry again", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await installOverride(provider);
+
+        await disableCommand("serena", [provider], { provider: "claude", project: ["/proj/a"] });
+
+        const claude = readClaudeJson();
+        expect(claude.projects?.["/proj/a"].mcpServers?.serena).toBeUndefined(); // override gone
+        expect(claude.projects?.["/proj/a"].disabledMcpServers).toContain("serena"); // back on the list
+
+        const unified = await readUnified();
+        expect(unified.mcpServers.serena._meta?.enabled?.claude).toBe(false); // global state untouched
+    });
+
+    it("listServers reports the global disable AND the per-project override", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await installOverride(provider);
+
+        const servers = await provider.listServers();
+        const serenaRows = servers.filter((s) => s.name === "serena");
+
+        const globalRow = serenaRows.find((s) => s.provider === "claude");
+        expect(globalRow).toBeDefined();
+        expect(globalRow?.enabled).toBe(false); // disabled globally
+
+        const overrideRow = serenaRows.find((s) => s.provider === "claude:/proj/a");
+        expect(overrideRow).toBeDefined();
+        expect(overrideRow?.enabled).toBe(true); // enabled in 1 project
+    });
+
+    it("-p all expands to all providers with configs (bonus fix)", async () => {
+        writeClaudeJson(globallyDisabledFixture());
+        await writeUnified(unifiedFixture());
+
+        const provider = new ClaudeProvider();
+        await disableCommand("github", [provider], { provider: "all" });
+
+        const claude = readClaudeJson();
+        expect(claude.mcpServers?.github).toBeUndefined(); // globally disabled = removed
+
+        const unified = await readUnified();
+        expect(unified.mcpServers.github._meta?.enabled?.claude).toBe(false);
+    });
+});

--- a/src/mcp-manager/commands/__tests__/claude-project-override.test.ts
+++ b/src/mcp-manager/commands/__tests__/claude-project-override.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setupStorageSandbox } from "@app/utils/storage/test-sandbox";
@@ -10,6 +10,7 @@ setupInquirerMock();
 setupStorageSandbox();
 
 const { ClaudeProvider } = await import("@app/mcp-manager/utils/providers/claude.js");
+const { CursorProvider } = await import("@app/mcp-manager/utils/providers/cursor.js");
 const { syncServers } = await import("../sync.js");
 const { syncFromProviders } = await import("../sync-from-providers.js");
 const { disableServer: disableCommand } = await import("../disable.js");
@@ -235,13 +236,28 @@ describe("claude per-project enable override for globally-disabled servers", () 
         writeClaudeJson(globallyDisabledFixture());
         await writeUnified(unifiedFixture());
 
+        // Second provider with a config in the sandbox HOME, so "all" has to
+        // expand beyond claude (a single-provider array can't prove expansion).
+        mkdirSync(join(homeDir, ".cursor"), { recursive: true });
+        writeFileSync(
+            join(homeDir, ".cursor", "mcp.json"),
+            SafeJSON.stringify({ mcpServers: { github: { command: "bunx", args: ["github-mcp"] } } }, null, 2)
+        );
+
         const provider = new ClaudeProvider();
-        await disableCommand("github", [provider], { provider: "all" });
+        const cursorProvider = new CursorProvider();
+        await disableCommand("github", [provider, cursorProvider], { provider: "all" });
 
         const claude = readClaudeJson();
         expect(claude.mcpServers?.github).toBeUndefined(); // globally disabled = removed
 
+        const cursor = SafeJSON.parse(readFileSync(join(homeDir, ".cursor", "mcp.json"), "utf-8")) as {
+            mcpServers?: Record<string, unknown>;
+        };
+        expect(cursor.mcpServers?.github).toBeUndefined(); // cursor disable = entry removed
+
         const unified = await readUnified();
         expect(unified.mcpServers.github._meta?.enabled?.claude).toBe(false);
+        expect(unified.mcpServers.github._meta?.enabled?.cursor).toBe(false);
     });
 });

--- a/src/mcp-manager/commands/__tests__/remove.test.ts
+++ b/src/mcp-manager/commands/__tests__/remove.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setupStorageSandbox } from "@app/utils/storage/test-sandbox";
+import { setupInquirerMock } from "./inquirer-mock.js";
+
+// Setup prompt mock + storage sandbox BEFORE importing modules under test
+setupInquirerMock();
+setupStorageSandbox();
+
+const { ClaudeProvider } = await import("@app/mcp-manager/utils/providers/claude.js");
+const { CursorProvider } = await import("@app/mcp-manager/utils/providers/cursor.js");
+const { GeminiProvider } = await import("@app/mcp-manager/utils/providers/gemini.js");
+const { CodexProvider } = await import("@app/mcp-manager/utils/providers/codex.js");
+const { removeServers } = await import("../remove.js");
+
+import { logger } from "@app/logger";
+import { setGlobalOptions } from "@app/mcp-manager/utils/config.utils.js";
+import { SafeJSON } from "@app/utils/json";
+import { Storage } from "@app/utils/storage";
+import * as TOML from "@iarna/toml";
+
+/**
+ * Fixture tests for the `remove` (purge) command: servers are removed
+ * ENTIRELY — from every provider config and from the unified config.
+ * All writes go to a temp HOME + sandboxed Storage; live configs are never
+ * touched.
+ */
+
+const CODEX_TOML = `[notice]
+seen = true
+
+[projects."/Users/x/proj"]
+trust_level = "trusted"
+
+[mcp_servers.serena]
+command = "uvx"
+args = ["serena"]
+
+[mcp_servers.serena.env]
+FOO = "bar"
+
+[mcp_servers.serena.http_headers]
+Authorization = "Bearer x"
+
+[mcp_servers.github]
+command = "bunx"
+args = ["github-mcp"]
+`;
+
+const UNIFIED_JSONC = `{
+    "mcpServers": {
+        "serena": {
+            "type": "stdio",
+            "command": "uvx",
+            "args": ["serena"],
+            "_meta": { "enabled": { "claude": false } }
+        },
+        // keep-me: precious user comment about github
+        "github": {
+            "type": "stdio",
+            "command": "bunx",
+            "args": ["github-mcp"],
+            "_meta": { "enabled": { "claude": true } }
+        }
+    },
+    "enabledMcpServers": {
+        "serena": { "claude": false },
+        "github": { "claude": true }
+    }
+}
+`;
+
+describe("remove command (permanent purge)", () => {
+    let homeDir: string;
+    let prevHome: string | undefined;
+
+    const readJson = (path: string): Record<string, unknown> =>
+        SafeJSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+
+    const writeFixtures = () => {
+        // ~/.claude.json
+        writeFileSync(
+            join(homeDir, ".claude.json"),
+            SafeJSON.stringify(
+                {
+                    numStartups: 7,
+                    mcpServers: {
+                        serena: { type: "stdio", command: "uvx", args: ["serena"] },
+                        github: { type: "stdio", command: "bunx", args: ["github-mcp"] },
+                    },
+                    disabledMcpServers: ["serena"],
+                    projects: {
+                        "/proj/a": {
+                            mcpServers: { serena: { type: "stdio", command: "uvx", args: ["serena"] } },
+                            disabledMcpServers: ["serena", "other-history"],
+                        },
+                    },
+                },
+                null,
+                2
+            )
+        );
+
+        // ~/.cursor/mcp.json
+        mkdirSync(join(homeDir, ".cursor"), { recursive: true });
+        writeFileSync(
+            join(homeDir, ".cursor", "mcp.json"),
+            SafeJSON.stringify(
+                {
+                    mcpServers: {
+                        serena: { command: "uvx", args: ["serena"] },
+                        github: { command: "bunx", args: ["github-mcp"] },
+                    },
+                },
+                null,
+                2
+            )
+        );
+
+        // ~/.gemini/settings.json
+        mkdirSync(join(homeDir, ".gemini"), { recursive: true });
+        writeFileSync(
+            join(homeDir, ".gemini", "settings.json"),
+            SafeJSON.stringify(
+                {
+                    theme: "dark",
+                    mcpServers: {
+                        serena: { command: "uvx", args: ["serena"] },
+                        github: { command: "bunx", args: ["github-mcp"] },
+                    },
+                    mcp: { excluded: ["serena"] },
+                },
+                null,
+                2
+            )
+        );
+
+        // ~/.codex/config.toml
+        mkdirSync(join(homeDir, ".codex"), { recursive: true });
+        writeFileSync(join(homeDir, ".codex", "config.toml"), CODEX_TOML);
+
+        // Unified config (raw JSONC with a user comment)
+        const storage = new Storage("mcp-manager");
+        mkdirSync(join(storage.getConfigPath(), ".."), { recursive: true });
+        writeFileSync(storage.getConfigPath(), UNIFIED_JSONC);
+    };
+
+    beforeEach(() => {
+        mock.restore(); // clear spies leaked from other test files (single bun process)
+        prevHome = process.env.HOME;
+        homeDir = mkdtempSync(join(tmpdir(), "mcp-remove-"));
+        process.env.HOME = homeDir;
+        setGlobalOptions({ yes: true });
+        spyOn(logger, "info").mockImplementation(() => {});
+        spyOn(logger, "warn").mockImplementation(() => {});
+        spyOn(logger, "error").mockImplementation(() => {});
+        spyOn(logger, "debug").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        mock.restore();
+        process.env.HOME = prevHome;
+        setGlobalOptions({});
+        rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it("removes the server from all provider configs and the unified config", async () => {
+        writeFixtures();
+        const providers = [new ClaudeProvider(), new GeminiProvider(), new CodexProvider(), new CursorProvider()];
+
+        await removeServers("serena", providers, {});
+
+        // claude: global entry + top-level marker + project-scope entry gone;
+        // per-project disabledMcpServers history lists untouched
+        const claude = readJson(join(homeDir, ".claude.json")) as {
+            numStartups: number;
+            mcpServers: Record<string, unknown>;
+            disabledMcpServers: string[];
+            projects: Record<string, { mcpServers?: Record<string, unknown>; disabledMcpServers?: string[] }>;
+        };
+        expect(claude.mcpServers.serena).toBeUndefined();
+        expect(claude.mcpServers.github).toBeDefined();
+        expect(claude.disabledMcpServers).not.toContain("serena");
+        expect(claude.projects["/proj/a"].mcpServers?.serena).toBeUndefined();
+        expect(claude.projects["/proj/a"].disabledMcpServers).toEqual(["serena", "other-history"]); // untouched
+        expect(claude.numStartups).toBe(7); // unrelated state preserved
+
+        // cursor
+        const cursor = readJson(join(homeDir, ".cursor", "mcp.json")) as { mcpServers: Record<string, unknown> };
+        expect(cursor.mcpServers.serena).toBeUndefined();
+        expect(cursor.mcpServers.github).toBeDefined();
+
+        // gemini: mcpServers + mcp.excluded
+        const gemini = readJson(join(homeDir, ".gemini", "settings.json")) as {
+            theme: string;
+            mcpServers: Record<string, unknown>;
+            mcp: { excluded: string[] };
+        };
+        expect(gemini.mcpServers.serena).toBeUndefined();
+        expect(gemini.mcpServers.github).toBeDefined();
+        expect(gemini.mcp.excluded).not.toContain("serena");
+        expect(gemini.theme).toBe("dark"); // unrelated state preserved
+
+        // codex: [mcp_servers.serena] incl. nested .env/.http_headers gone;
+        // [projects.*] and [notice] untouched
+        const codex = TOML.parse(readFileSync(join(homeDir, ".codex", "config.toml"), "utf-8")) as {
+            notice?: { seen?: boolean };
+            projects?: Record<string, { trust_level?: string }>;
+            mcp_servers?: Record<string, unknown>;
+        };
+        expect(codex.mcp_servers?.serena).toBeUndefined();
+        expect(codex.mcp_servers?.github).toBeDefined();
+        expect(codex.notice?.seen).toBe(true);
+        expect(codex.projects?.["/Users/x/proj"]?.trust_level).toBe("trusted");
+
+        // unified config: mcpServers block + enabledMcpServers mirror gone,
+        // user comments preserved through the write
+        const storage = new Storage("mcp-manager");
+        const rawUnified = readFileSync(storage.getConfigPath(), "utf-8");
+        expect(rawUnified).toContain("keep-me: precious user comment about github");
+        expect(rawUnified).not.toContain('"serena"');
+        const unified = SafeJSON.parse(rawUnified) as {
+            mcpServers: Record<string, unknown>;
+            enabledMcpServers?: Record<string, unknown>;
+        };
+        expect(unified.mcpServers.serena).toBeUndefined();
+        expect(unified.mcpServers.github).toBeDefined();
+        expect(unified.enabledMcpServers?.serena).toBeUndefined();
+        expect(unified.enabledMcpServers?.github).toBeDefined();
+    });
+
+    it("prints the reversible-alternative hint", async () => {
+        writeFixtures();
+        const providers = [new ClaudeProvider()];
+
+        await removeServers("serena", providers, {});
+
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("disable"));
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("PERMANENTLY"));
+    });
+
+    it("rejects unknown server names without touching any config", async () => {
+        writeFixtures();
+        const providers = [new ClaudeProvider()];
+        const before = readFileSync(join(homeDir, ".claude.json"), "utf-8");
+
+        await removeServers("does-not-exist", providers, {});
+
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("not found"));
+        expect(readFileSync(join(homeDir, ".claude.json"), "utf-8")).toBe(before);
+    });
+
+    it("skips providers whose config does not exist", async () => {
+        writeFixtures();
+        rmSync(join(homeDir, ".cursor"), { recursive: true, force: true });
+        const providers = [new ClaudeProvider(), new CursorProvider()];
+
+        await removeServers("serena", providers, {});
+
+        const claude = readJson(join(homeDir, ".claude.json")) as { mcpServers: Record<string, unknown> };
+        expect(claude.mcpServers.serena).toBeUndefined();
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+});

--- a/src/mcp-manager/commands/__tests__/test-utils.ts
+++ b/src/mcp-manager/commands/__tests__/test-utils.ts
@@ -19,6 +19,7 @@ export class MockMCPProvider extends MCPProvider {
     public enableServersCalls: Array<{ serverNames: string[]; projectPath?: string | null }> = [];
     public disableServersCalls: Array<{ serverNames: string[]; projectPath?: string | null }> = [];
     public installServerCalls: Array<{ serverName: string; config: UnifiedMCPServerConfig }> = [];
+    public removeServersCalls: Array<{ serverNames: string[] }> = [];
     public syncServersCalls: Array<{ servers: Record<string, UnifiedMCPServerConfig> }> = [];
     public writeConfigCalls: unknown[] = [];
     public errors: Map<string, Error> = new Map();
@@ -118,6 +119,14 @@ export class MockMCPProvider extends MCPProvider {
         return WriteResult.Applied;
     }
 
+    async removeServers(serverNames: string[]): Promise<WriteResult> {
+        if (this.errors.has("removeServers")) {
+            throw this.errors.get("removeServers")!;
+        }
+        this.removeServersCalls.push({ serverNames });
+        return WriteResult.Applied;
+    }
+
     async syncServers(servers: Record<string, UnifiedMCPServerConfig>): Promise<WriteResult> {
         if (this.errors.has("syncServers")) {
             throw this.errors.get("syncServers")!;
@@ -160,6 +169,7 @@ export class MockMCPProvider extends MCPProvider {
         this.enableServersCalls = [];
         this.disableServersCalls = [];
         this.installServerCalls = [];
+        this.removeServersCalls = [];
         this.syncServersCalls = [];
         this.writeConfigCalls = [];
         this.errors.clear();

--- a/src/mcp-manager/commands/__tests__/test-utils.ts
+++ b/src/mcp-manager/commands/__tests__/test-utils.ts
@@ -123,7 +123,9 @@ export class MockMCPProvider extends MCPProvider {
         if (this.errors.has("removeServers")) {
             throw this.errors.get("removeServers")!;
         }
-        this.removeServersCalls.push({ serverNames });
+        // Copy — capturing the live reference would let later caller-side
+        // mutation rewrite recorded history.
+        this.removeServersCalls.push({ serverNames: [...serverNames] });
         return WriteResult.Applied;
     }
 

--- a/src/mcp-manager/commands/index.ts
+++ b/src/mcp-manager/commands/index.ts
@@ -9,6 +9,7 @@ export { disableServer } from "./disable.js";
 export { enableServer } from "./enable.js";
 export { installServer } from "./install.js";
 export { listServers } from "./list.js";
+export { removeServers } from "./remove.js";
 export { renameServer } from "./rename.js";
 export { showServerConfig } from "./show.js";
 export { syncServers } from "./sync.js";

--- a/src/mcp-manager/commands/list.ts
+++ b/src/mcp-manager/commands/list.ts
@@ -44,7 +44,17 @@ export async function listServers(providers: MCPProvider[]): Promise<void> {
 
         logger.info(`${status} ${chalk.bold(name)} (${statusText} in ${instances.length} provider(s))`);
         for (const instance of instances) {
-            const providerStatus = instance.enabled ? chalk.green("enabled") : chalk.red("disabled");
+            let providerStatus = instance.enabled ? chalk.green("enabled") : chalk.red("disabled");
+
+            // Claude: a globally-disabled server can be re-enabled per project
+            // via a project-scope override entry — surface that on the global row.
+            if (!instance.enabled && instance.provider === "claude") {
+                const overrideCount = instances.filter((s) => s.provider.startsWith("claude:") && s.enabled).length;
+                if (overrideCount > 0) {
+                    providerStatus = chalk.yellow(`disabled globally, enabled in ${overrideCount} project(s)`);
+                }
+            }
+
             logger.info(`  └─ ${instance.provider}: ${providerStatus}`);
         }
         logger.info("");

--- a/src/mcp-manager/commands/remove.ts
+++ b/src/mcp-manager/commands/remove.ts
@@ -1,7 +1,7 @@
 import { logger } from "@app/logger";
 import { getServerNames } from "@app/mcp-manager/utils/command.utils.js";
 import { readUnifiedConfig, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
-import type { MCPProvider } from "@app/mcp-manager/utils/providers/types.js";
+import type { MCPProvider, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
 import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
 import chalk from "chalk";
 
@@ -47,6 +47,7 @@ export async function removeServers(
 
     // 1. Remove from every selected provider that has a config file
     let providersNotRemoved = 0;
+    const providersSuccess = new Map<string, UnifiedMCPServerConfig[]>();
 
     for (const provider of providers) {
         const providerName = provider.getName();
@@ -58,6 +59,15 @@ export async function removeServers(
             const result = await provider.removeServers(serverNames);
             if (result === WriteResult.Applied) {
                 logger.info(`✓ Removed from ${providerName}`);
+                // Track successful removal with configs for potential rollback
+                const removedConfigs: UnifiedMCPServerConfig[] = [];
+                for (const serverName of serverNames) {
+                    const serverConfig = config.mcpServers[serverName];
+                    if (serverConfig) {
+                        removedConfigs.push(serverConfig);
+                    }
+                }
+                providersSuccess.set(providerName, removedConfigs);
             } else if (result === WriteResult.Rejected) {
                 providersNotRemoved++;
                 logger.info(`Skipped ${providerName} - user rejected confirmation`);
@@ -85,15 +95,48 @@ export async function removeServers(
 
     // 2. Remove from the unified config (mcpServers + enabledMcpServers mirror;
     //    writeUnifiedConfig also rebuilds the mirror from the remaining _meta)
+    const originalConfigs = new Map<string, UnifiedMCPServerConfig>();
     for (const serverName of serverNames) {
+        originalConfigs.set(serverName, config.mcpServers[serverName]);
         delete config.mcpServers[serverName];
         if (config.enabledMcpServers?.[serverName]) {
             delete config.enabledMcpServers[serverName];
         }
     }
 
-    const written = await writeUnifiedConfig(config);
-    if (written) {
-        logger.info(chalk.green(`✓ Removed ${serverNames.length} server(s) from unified config`));
+    let written: boolean;
+    try {
+        written = await writeUnifiedConfig(config);
+    } catch (error) {
+        logger.error({ error }, "Failed to write unified config - rolling back provider changes");
+        written = false;
     }
+
+    if (!written) {
+        // Rollback: restore servers to providers that successfully removed them
+        logger.warn(chalk.yellow("Rolling back provider changes..."));
+        for (const [providerName, removedConfigs] of providersSuccess.entries()) {
+            const provider = providers.find((p) => p.getName() === providerName);
+            if (!provider) {
+                continue;
+            }
+            try {
+                for (let i = 0; i < serverNames.length; i++) {
+                    const serverName = serverNames[i];
+                    const serverConfig = removedConfigs[i];
+                    if (serverConfig) {
+                        await provider.installServer(serverName, serverConfig);
+                    }
+                }
+                logger.info(`✓ Rolled back ${providerName}`);
+            } catch (error) {
+                providersNotRemoved++;
+                logger.error({ providerName, error }, `✗ Failed to rollback ${providerName}`);
+            }
+        }
+        logger.error(chalk.red("Failed to remove servers from unified config - all changes rolled back"));
+        return;
+    }
+
+    logger.info(chalk.green(`✓ Removed ${serverNames.length} server(s) from unified config`));
 }

--- a/src/mcp-manager/commands/remove.ts
+++ b/src/mcp-manager/commands/remove.ts
@@ -46,6 +46,8 @@ export async function removeServers(
     );
 
     // 1. Remove from every selected provider that has a config file
+    let providersNotRemoved = 0;
+
     for (const provider of providers) {
         const providerName = provider.getName();
         try {
@@ -57,15 +59,28 @@ export async function removeServers(
             if (result === WriteResult.Applied) {
                 logger.info(`✓ Removed from ${providerName}`);
             } else if (result === WriteResult.Rejected) {
+                providersNotRemoved++;
                 logger.info(`Skipped ${providerName} - user rejected confirmation`);
             } else {
                 logger.info(`→ Nothing to remove in ${providerName}`);
             }
         } catch (error) {
-            logger.error(
-                `✗ Failed to remove from ${providerName}: ${error instanceof Error ? error.message : String(error)}`
-            );
+            providersNotRemoved++;
+            logger.error({ providerName, error }, `✗ Failed to remove from ${providerName}`);
         }
+    }
+
+    // Keep the unified entries while any provider still holds the server —
+    // deleting them here would orphan the provider config (no unified record
+    // to retry/disable against) and break the "remove everywhere" contract.
+    if (providersNotRemoved > 0) {
+        logger.warn(
+            chalk.yellow(
+                `Keeping ${serverNames.length} server(s) in the unified config — ` +
+                    `${providersNotRemoved} provider(s) failed or were rejected. Re-run remove to retry.`
+            )
+        );
+        return;
     }
 
     // 2. Remove from the unified config (mcpServers + enabledMcpServers mirror;

--- a/src/mcp-manager/commands/remove.ts
+++ b/src/mcp-manager/commands/remove.ts
@@ -1,0 +1,84 @@
+import { logger } from "@app/logger";
+import { getServerNames } from "@app/mcp-manager/utils/command.utils.js";
+import { readUnifiedConfig, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
+import type { MCPProvider } from "@app/mcp-manager/utils/providers/types.js";
+import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
+import chalk from "chalk";
+
+export interface RemoveOptions {
+    provider?: string; // Provider name(s) for non-interactive mode (already pre-filtered by parseProviderArg)
+}
+
+/**
+ * Completely REMOVE server(s):
+ * - from every selected provider's config (claude mcpServers incl.
+ *   project-scope entries, cursor mcpServers, gemini mcpServers +
+ *   mcp.excluded, codex [mcp_servers.<name>] incl. nested subsections),
+ * - from the unified config (`mcpServers.<name>` and the
+ *   `enabledMcpServers.<name>` mirror).
+ *
+ * Unlike `disable`, this is PERMANENT — the server config is no longer kept
+ * anywhere, so it cannot be restored by `enable` or `sync`.
+ */
+export async function removeServers(
+    serverNamesArg: string | undefined,
+    providers: MCPProvider[],
+    _options: RemoveOptions = {}
+): Promise<void> {
+    const config = await readUnifiedConfig();
+
+    if (Object.keys(config.mcpServers).length === 0) {
+        logger.warn("No servers found in unified config. Run 'tools mcp-manager config' to add servers.");
+        return;
+    }
+
+    const serverNames = await getServerNames(serverNamesArg, config, "Select servers to REMOVE (permanent):");
+    if (!serverNames || serverNames.length === 0) {
+        logger.info("No servers selected.");
+        return;
+    }
+
+    logger.info(
+        chalk.yellow(
+            `Removing ${serverNames.length} server(s) PERMANENTLY: ${serverNames.join(", ")}\n` +
+                `  (hint: 'tools mcp-manager disable' is the reversible alternative — it keeps the config in the unified config)`
+        )
+    );
+
+    // 1. Remove from every selected provider that has a config file
+    for (const provider of providers) {
+        const providerName = provider.getName();
+        try {
+            if (!(await provider.configExists())) {
+                continue;
+            }
+
+            const result = await provider.removeServers(serverNames);
+            if (result === WriteResult.Applied) {
+                logger.info(`✓ Removed from ${providerName}`);
+            } else if (result === WriteResult.Rejected) {
+                logger.info(`Skipped ${providerName} - user rejected confirmation`);
+            } else {
+                logger.info(`→ Nothing to remove in ${providerName}`);
+            }
+        } catch (error) {
+            logger.error(
+                `✗ Failed to remove from ${providerName}: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+    }
+
+    // 2. Remove from the unified config (mcpServers + enabledMcpServers mirror;
+    //    writeUnifiedConfig also rebuilds the mirror from the remaining _meta)
+    for (const serverName of serverNames) {
+        delete config.mcpServers[serverName];
+        if (config.enabledMcpServers?.[serverName]) {
+            delete config.enabledMcpServers[serverName];
+        }
+    }
+
+    const written = await writeUnifiedConfig(config);
+    if (written) {
+        logger.info(chalk.green(`✓ Removed ${serverNames.length} server(s) from unified config`));
+    }
+}

--- a/src/mcp-manager/commands/sync-from-providers.ts
+++ b/src/mcp-manager/commands/sync-from-providers.ts
@@ -178,6 +178,18 @@ export async function syncFromProviders(providers: MCPProvider[], options: SyncF
                     enabledState = serverEnabledStates.get(serverName) ?? false;
                 }
 
+                // Guard: a globally-disabled server (unified _meta === false,
+                // provider still reports the global state as disabled) must
+                // STAY globally disabled. Its per-project override entries
+                // (e.g. Claude's .projects[<path>].mcpServers) live in the
+                // provider config itself and must not flip _meta to a
+                // per-project object — that would make the next sync reinstall
+                // the server globally.
+                const existingProviderState = existingConfig?._meta?.enabled?.[providerName as MCPProviderName];
+                if (existingProviderState === false && serverEnabledStates.get(serverName) === false) {
+                    enabledState = false;
+                }
+
                 if (existingConfig) {
                     // Preserve _meta from existing config
                     const preservedMeta = existingConfig._meta || { enabled: {} };

--- a/src/mcp-manager/commands/sync.ts
+++ b/src/mcp-manager/commands/sync.ts
@@ -75,12 +75,12 @@ export async function syncServers(providers: MCPProvider[], options: SyncOptions
             for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
                 const existingServerConfig = await provider.getServerConfig(serverName);
                 if (!existingServerConfig) {
-                    // For providers without native disable (Cursor/Codex), only install if enabled
-                    if (!provider.supportsDisabledState()) {
-                        const isEnabled = provider.isServerEnabledInMeta(serverConfig);
-                        if (!isEnabled) {
-                            continue; // Skip - will be handled (deleted) by syncServers
-                        }
+                    // Skip servers that must stay absent from this provider's
+                    // config: Cursor/Codex have no disabled state (presence =
+                    // enabled), and Claude's only TRUE global disable is
+                    // absence from ~/.claude.json mcpServers.
+                    if (!provider.shouldBeInstalled(serverConfig)) {
+                        continue; // Skip - will be handled (deleted) by syncServers
                     }
                     logger.info(`  Installing '${serverName}' in ${providerName}...`);
                     const configToInstall = stripMeta(serverConfig);

--- a/src/mcp-manager/commands/toggle-server.ts
+++ b/src/mcp-manager/commands/toggle-server.ts
@@ -6,7 +6,8 @@ import { WriteResult } from "@app/mcp-manager/utils/providers/types.js";
 import type { MCPProviderName, PerProjectEnabledState } from "@app/mcp-manager/utils/types.js";
 
 export interface ToggleOptions {
-    provider?: string; // Provider name for non-interactive mode
+    provider?: string; // Provider name(s) for non-interactive mode ("all" or comma-separated)
+    project?: string[]; // Project path(s) for per-project enable/disable (providers with project support)
 }
 
 /**
@@ -51,15 +52,24 @@ export async function toggleServer(
 
     let selectedProviderNames: string[] | null;
     if (options.provider) {
-        // Filter to the specified provider
-        const matchedProvider = availableProviders.find(
-            (p) => p.getName().toLowerCase() === options.provider?.toLowerCase()
-        );
-        if (!matchedProvider) {
+        // Filter to the specified provider(s); supports "all" and comma-separated names
+        const requested = options.provider
+            .split(",")
+            .map((name) => name.trim().toLowerCase())
+            .filter(Boolean);
+
+        if (requested.includes("all")) {
+            selectedProviderNames = availableProviders.map((p) => p.getName());
+        } else {
+            selectedProviderNames = availableProviders
+                .filter((p) => requested.includes(p.getName().toLowerCase()))
+                .map((p) => p.getName());
+        }
+
+        if (selectedProviderNames.length === 0) {
             logger.warn(`Provider '${options.provider}' not found or has no config file.`);
             return;
         }
-        selectedProviderNames = [matchedProvider.getName()];
     } else {
         selectedProviderNames = await promptForProviders(
             availableProviders,
@@ -88,8 +98,16 @@ export async function toggleServer(
 
         if (projects.length > 0) {
             if (isNonInteractive) {
-                // Non-interactive: apply globally to all projects
-                projectChoices = [{ projectPath: null, displayName: "Global (all projects)" }];
+                if (options.project && options.project.length > 0) {
+                    // Non-interactive with explicit --project path(s)
+                    projectChoices = options.project.map((projectPath) => ({
+                        projectPath,
+                        displayName: projectPath,
+                    }));
+                } else {
+                    // Non-interactive: apply globally to all projects
+                    projectChoices = [{ projectPath: null, displayName: "Global (all projects)" }];
+                }
             } else {
                 // Interactive: prompt for selection
                 projectChoices = await promptForProjects(
@@ -102,7 +120,13 @@ export async function toggleServer(
                     continue;
                 }
             }
+        } else if (isNonInteractive && options.project && options.project.length > 0) {
+            logger.warn(`--project is not supported by ${providerName} — applying globally.`);
         }
+
+        // Pure per-project operation (no "Global" choice among the selections)
+        const isPerProjectOp =
+            !!projectChoices && projectChoices.length > 0 && projectChoices.every((c) => c.projectPath !== null);
 
         // Collect servers to toggle
         const serversToToggle: string[] = [];
@@ -134,8 +158,16 @@ export async function toggleServer(
                 continue;
             }
 
+            // A per-project operation on a globally-disabled server is an
+            // OVERRIDE: the provider manages a project-scope entry itself.
+            // Do NOT reinstall the server globally and leave _meta.enabled at
+            // `false` — the override is tracked solely by the presence of the
+            // project-scope entry in the provider config.
+            const isGlobalDisableOverride =
+                isPerProjectOp && serverConfig!._meta?.enabled?.[providerName as MCPProviderName] === false;
+
             try {
-                if (enabled) {
+                if (enabled && !isGlobalDisableOverride) {
                     // Strip _meta before syncing to provider
                     const configToSync = stripMeta(serverConfig!);
 
@@ -169,7 +201,11 @@ export async function toggleServer(
                 const isGlobalEnablement =
                     projectChoices && projectChoices.length === 1 && projectChoices[0].projectPath === null;
 
-                if (projects.length > 0 && !isGlobalEnablement) {
+                if (isGlobalDisableOverride) {
+                    // Keep _meta.enabled[provider] === false: the global state
+                    // stays "disabled"; the per-project override lives only in
+                    // the provider config (.projects[<path>].mcpServers).
+                } else if (projects.length > 0 && !isGlobalEnablement) {
                     // Provider supports projects and we have specific project selections - use project objects
                     const perProjectState: PerProjectEnabledState =
                         typeof enabledState === "object" && enabledState !== null && !Array.isArray(enabledState)

--- a/src/mcp-manager/index.ts
+++ b/src/mcp-manager/index.ts
@@ -27,12 +27,26 @@ import {
     installServer,
     listServers,
     openConfig,
+    removeServers,
     renameServer,
     showServerConfig,
     syncFromProviders,
     syncServers,
 } from "./commands/index.js";
 import { setGlobalOptions } from "./utils/config.utils.js";
+
+/**
+ * Collect --project values: repeatable flag, each value may be comma-separated
+ */
+function collectProjects(value: string, previous: string[]): string[] {
+    return [
+        ...previous,
+        ...value
+            .split(",")
+            .map((p) => p.trim())
+            .filter(Boolean),
+    ];
+}
 
 // Include timestamps in console output. The console stream is now always
 // sync (pino-pretty sync:true in createLogger), so logs reliably appear
@@ -152,20 +166,51 @@ program
 program
     .command("enable [servers]")
     .description("Enable MCP server(s) in provider(s)")
-    .action(async (servers) => {
+    .option(
+        "--project <path>",
+        "Project path(s) for per-project enable (claude; repeatable or comma-separated). Overrides a global disable for that project.",
+        collectProjects,
+        []
+    )
+    .action(async (servers, cmdOptions) => {
         const opts = program.opts();
         const providers = parseProviderArg(opts.provider, getProviders());
-        await enableServer(servers, providers, { provider: opts.provider });
+        await enableServer(servers, providers, {
+            provider: opts.provider,
+            project: cmdOptions.project?.length > 0 ? cmdOptions.project : undefined,
+        });
     });
 
 // disable command
 program
     .command("disable [servers]")
     .description("Disable MCP server(s) in provider(s)")
+    .option(
+        "--project <path>",
+        "Project path(s) for per-project disable (claude; repeatable or comma-separated). Removes a per-project override.",
+        collectProjects,
+        []
+    )
+    .action(async (servers, cmdOptions) => {
+        const opts = program.opts();
+        const providers = parseProviderArg(opts.provider, getProviders());
+        await disableServer(servers, providers, {
+            provider: opts.provider,
+            project: cmdOptions.project?.length > 0 ? cmdOptions.project : undefined,
+        });
+    });
+
+// remove command (a.k.a. purge) — permanent, unlike disable
+program
+    .command("remove [servers]")
+    .alias("purge")
+    .description(
+        "Completely REMOVE MCP server(s) from the unified config and provider configs (permanent; 'disable' is the reversible alternative)"
+    )
     .action(async (servers) => {
         const opts = program.opts();
         const providers = parseProviderArg(opts.provider, getProviders());
-        await disableServer(servers, providers, { provider: opts.provider });
+        await removeServers(servers, providers, { provider: opts.provider });
     });
 
 // install command
@@ -266,6 +311,7 @@ program.action(async () => {
             { value: "enable", label: "Enable servers" },
             { value: "disable", label: "Disable servers" },
             { value: "install", label: "Install a server" },
+            { value: "remove", label: "Remove a server (permanent)" },
             { value: "show", label: "Show server configuration" },
             { value: "backupAll", label: "Backup all configs" },
             { value: "rename", label: "Rename a server" },
@@ -293,6 +339,9 @@ program.action(async () => {
             break;
         case "install":
             await installServer(undefined, undefined, providers);
+            break;
+        case "remove":
+            await removeServers(undefined, providers);
             break;
         case "show": {
             const serverName = (await p.text({

--- a/src/mcp-manager/utils/providers/claude.ts
+++ b/src/mcp-manager/utils/providers/claude.ts
@@ -82,11 +82,13 @@ export class ClaudeProvider extends MCPProvider {
     async listServers(): Promise<MCPServerInfo[]> {
         const config = await this.readConfig();
         const servers: MCPServerInfo[] = [];
+        const globalNames = new Set<string>();
 
         // Global servers
         if (config.mcpServers) {
             const disabledServers = new Set(config.disabledMcpServers || []);
             for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
+                globalNames.add(name);
                 servers.push({
                     name,
                     config: this.claudeToUnified(serverConfig),
@@ -96,14 +98,16 @@ export class ClaudeProvider extends MCPProvider {
             }
         }
 
-        // Project-specific servers
+        // Project-scope servers (this is where per-project overrides of
+        // globally-disabled servers live — one row per project so callers can
+        // see/count every override).
         if (config.projects) {
             for (const [projectPath, projectConfig] of Object.entries(config.projects)) {
                 if (projectConfig.mcpServers) {
                     const projectDisabled = new Set(projectConfig.disabledMcpServers || []);
                     for (const [name, serverConfig] of Object.entries(projectConfig.mcpServers)) {
                         // Only add if not already in global list
-                        if (!servers.find((s) => s.name === name)) {
+                        if (!globalNames.has(name)) {
                             servers.push({
                                 name,
                                 config: this.claudeToUnified(serverConfig),
@@ -124,7 +128,7 @@ export class ClaudeProvider extends MCPProvider {
             if (entry._meta?.enabled?.claude !== false) {
                 continue;
             }
-            if (servers.find((s) => s.name === name)) {
+            if (globalNames.has(name)) {
                 continue;
             }
             servers.push({
@@ -218,14 +222,7 @@ export class ClaudeProvider extends MCPProvider {
             // Global enable (no project specified = global)
             await this.applyGlobalEnable([serverName], config);
         } else {
-            // Enable for specific project
-            if (config.projects?.[projectPath]) {
-                if (config.projects[projectPath].disabledMcpServers) {
-                    config.projects[projectPath].disabledMcpServers = config.projects[
-                        projectPath
-                    ].disabledMcpServers?.filter((name) => name !== serverName);
-                }
-            }
+            await this.applyProjectEnable([serverName], projectPath, config);
         }
 
         await this.writeConfig(config);
@@ -238,15 +235,7 @@ export class ClaudeProvider extends MCPProvider {
             // Global disable (no project specified = global)
             await this.applyGlobalDisable([serverName], config);
         } else {
-            // Disable for specific project
-            if (config.projects?.[projectPath]) {
-                if (!config.projects[projectPath].disabledMcpServers) {
-                    config.projects[projectPath].disabledMcpServers = [];
-                }
-                if (!config.projects[projectPath].disabledMcpServers?.includes(serverName)) {
-                    config.projects[projectPath].disabledMcpServers?.push(serverName);
-                }
-            }
+            this.applyProjectDisable([serverName], projectPath, config);
         }
 
         await this.writeConfig(config);
@@ -266,13 +255,7 @@ export class ClaudeProvider extends MCPProvider {
         if (projectPath === null || projectPath === undefined) {
             await this.applyGlobalEnable(serverNames, config);
         } else {
-            for (const serverName of serverNames) {
-                if (config.projects?.[projectPath]?.disabledMcpServers) {
-                    config.projects[projectPath].disabledMcpServers = config.projects[
-                        projectPath
-                    ].disabledMcpServers?.filter((name) => name !== serverName);
-                }
-            }
+            await this.applyProjectEnable(serverNames, projectPath, config);
         }
 
         return this.writeConfig(config);
@@ -284,19 +267,89 @@ export class ClaudeProvider extends MCPProvider {
         if (projectPath === null || projectPath === undefined) {
             await this.applyGlobalDisable(serverNames, config);
         } else {
-            for (const serverName of serverNames) {
-                if (config.projects?.[projectPath]) {
-                    if (!config.projects[projectPath].disabledMcpServers) {
-                        config.projects[projectPath].disabledMcpServers = [];
-                    }
-                    if (!config.projects[projectPath].disabledMcpServers?.includes(serverName)) {
-                        config.projects[projectPath].disabledMcpServers?.push(serverName);
-                    }
-                }
-            }
+            this.applyProjectDisable(serverNames, projectPath, config);
         }
 
         return this.writeConfig(config);
+    }
+
+    /**
+     * Per-project enable. Removes the server names from the project's
+     * `disabledMcpServers` list. For servers that are globally disabled
+     * (absent from the global `mcpServers`), additionally installs a
+     * project-scope entry at `.projects[<path>].mcpServers.<name>` from the
+     * unified config — Claude Code DOES honor project-scope entries (it's the
+     * same storage `claude mcp add -s local` uses), so this overrides the
+     * global disable for that one project. The global state in the unified
+     * config (`_meta.enabled.claude = false`) is intentionally left untouched;
+     * the override is tracked solely by the presence of the project entry.
+     */
+    private async applyProjectEnable(
+        serverNames: string[],
+        projectPath: string,
+        config: ClaudeGenericConfig
+    ): Promise<void> {
+        const existingProject = config.projects?.[projectPath];
+
+        // Remove from the project's disabled list (Claude Code reads this list,
+        // so an override entry only works when the name is NOT in it)
+        if (existingProject?.disabledMcpServers) {
+            existingProject.disabledMcpServers = existingProject.disabledMcpServers.filter(
+                (name) => !serverNames.includes(name)
+            );
+        }
+
+        // Install project-scope override entries for globally-disabled servers
+        const needsOverride = serverNames.filter(
+            (name) => !config.mcpServers?.[name] && !existingProject?.mcpServers?.[name]
+        );
+        if (needsOverride.length === 0) {
+            return;
+        }
+
+        const unified = await readUnifiedConfig();
+        const installable = needsOverride.filter((name) => unified.mcpServers[name]);
+        if (installable.length === 0) {
+            return;
+        }
+
+        if (!config.projects) {
+            config.projects = {};
+        }
+        if (!config.projects[projectPath]) {
+            config.projects[projectPath] = {};
+        }
+        const projectConfig = config.projects[projectPath];
+        if (!projectConfig.mcpServers) {
+            projectConfig.mcpServers = {};
+        }
+        for (const name of installable) {
+            projectConfig.mcpServers[name] = this.unifiedToClaude(stripMeta(unified.mcpServers[name]));
+        }
+    }
+
+    /**
+     * Per-project disable. Removes a project-scope override entry if present
+     * (undoing an `enable --project` override) and adds the name to the
+     * project's `disabledMcpServers` list.
+     */
+    private applyProjectDisable(serverNames: string[], projectPath: string, config: ClaudeGenericConfig): void {
+        const projectConfig = config.projects?.[projectPath];
+        if (!projectConfig) {
+            return;
+        }
+
+        if (!projectConfig.disabledMcpServers) {
+            projectConfig.disabledMcpServers = [];
+        }
+        for (const serverName of serverNames) {
+            if (projectConfig.mcpServers?.[serverName]) {
+                delete projectConfig.mcpServers[serverName];
+            }
+            if (!projectConfig.disabledMcpServers.includes(serverName)) {
+                projectConfig.disabledMcpServers.push(serverName);
+            }
+        }
     }
 
     /**
@@ -323,9 +376,15 @@ export class ClaudeProvider extends MCPProvider {
                 config.disabledMcpServers.push(serverName);
             }
 
-            // Per-project sweep (covers existing projects, kept for back-compat)
+            // Per-project sweep (covers existing projects, kept for back-compat).
+            // Projects with a project-scope override entry for this server are
+            // SKIPPED — the override (enable --project) wins over the global
+            // disable and must never be clobbered.
             if (config.projects) {
                 for (const projectConfig of Object.values(config.projects)) {
+                    if (projectConfig.mcpServers?.[serverName]) {
+                        continue;
+                    }
                     if (!projectConfig.disabledMcpServers) {
                         projectConfig.disabledMcpServers = [];
                     }
@@ -472,6 +531,34 @@ export class ClaudeProvider extends MCPProvider {
         return this.writeConfig(claudeConfig);
     }
 
+    async removeServers(serverNames: string[]): Promise<WriteResult> {
+        const config = await this.readConfig();
+
+        for (const serverName of serverNames) {
+            // Global entry
+            if (config.mcpServers?.[serverName]) {
+                delete config.mcpServers[serverName];
+            }
+            // Top-level marker (mcp-manager-only)
+            if (config.disabledMcpServers) {
+                config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
+            }
+            // Project-scope entries (incl. per-project overrides). The
+            // per-project disabledMcpServers lists are intentionally left
+            // untouched — harmless leftovers, and scrubbing them would churn
+            // dozens of project entries for no behavioral gain.
+            if (config.projects) {
+                for (const projectConfig of Object.values(config.projects)) {
+                    if (projectConfig.mcpServers?.[serverName]) {
+                        delete projectConfig.mcpServers[serverName];
+                    }
+                }
+            }
+        }
+
+        return this.writeConfig(config);
+    }
+
     async syncServers(servers: Record<string, UnifiedMCPServerConfig>): Promise<WriteResult> {
         const config = await this.readConfig();
 
@@ -506,6 +593,16 @@ export class ClaudeProvider extends MCPProvider {
 
             if (config.projects) {
                 for (const [projectPath, projectConfig] of Object.entries(config.projects)) {
+                    // Per-project override entry (.projects[<path>].mcpServers.<name>)
+                    // wins over the global/meta state: refresh its config from
+                    // the unified config, but NEVER delete it and NEVER (re-)add
+                    // the name to the project's disabled list — otherwise the
+                    // next sync would clobber an `enable --project` override.
+                    if (projectConfig.mcpServers?.[name]) {
+                        projectConfig.mcpServers[name] = this.unifiedToClaude(cleanConfig);
+                        continue;
+                    }
+
                     if (!projectConfig.disabledMcpServers) {
                         projectConfig.disabledMcpServers = [];
                     }
@@ -514,16 +611,8 @@ export class ClaudeProvider extends MCPProvider {
 
                     if (isEnabledForProject) {
                         projectConfig.disabledMcpServers = projectConfig.disabledMcpServers.filter((n) => n !== name);
-                        if (projectConfig.mcpServers?.[name]) {
-                            projectConfig.mcpServers[name] = this.unifiedToClaude(cleanConfig);
-                        }
-                    } else {
-                        if (!projectConfig.disabledMcpServers.includes(name)) {
-                            projectConfig.disabledMcpServers.push(name);
-                        }
-                        if (projectConfig.mcpServers?.[name]) {
-                            delete projectConfig.mcpServers[name];
-                        }
+                    } else if (!projectConfig.disabledMcpServers.includes(name)) {
+                        projectConfig.disabledMcpServers.push(name);
                     }
                 }
             }

--- a/src/mcp-manager/utils/providers/claude.ts
+++ b/src/mcp-manager/utils/providers/claude.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { logger } from "@app/logger";
-import { stripMeta } from "@app/mcp-manager/utils/config.utils.js";
+import { readUnifiedConfig, stripMeta, writeUnifiedConfig } from "@app/mcp-manager/utils/config.utils.js";
 import { SafeJSON } from "@app/utils/json";
 import chalk from "chalk";
 import type { ClaudeGenericConfig, ClaudeMCPServerConfig } from "./claude.types.js";
@@ -12,6 +12,16 @@ import { MCPProvider, WriteResult } from "./types.js";
 /**
  * Claude Desktop MCP provider.
  * Manages MCP servers in ~/.claude.json
+ *
+ * IMPORTANT (verified against the Claude Code binary): Claude Code reads
+ * `disabledMcpServers` ONLY from per-project entries
+ * (`.projects[<cwd>].disabledMcpServers`). The TOP-LEVEL `disabledMcpServers`
+ * key is NEVER read by Claude Code — it is an mcp-manager-only marker. A
+ * per-project sweep covers only projects that exist at sweep time; projects
+ * registered later load the server again. The only mechanism Claude Code
+ * honors globally (including future projects) is the server NOT existing in
+ * `mcpServers` — so a TRUE global disable removes the entry (after preserving
+ * its full config in the unified config with `_meta.enabled.claude = false`).
  */
 export class ClaudeProvider extends MCPProvider {
     constructor() {
@@ -25,6 +35,14 @@ export class ClaudeProvider extends MCPProvider {
 
     supportsDisabledState(): boolean {
         return true; // Claude has disabledMcpServers list
+    }
+
+    shouldBeInstalled(serverConfig: UnifiedMCPServerConfig): boolean {
+        // A globally-disabled server (_meta.enabled.claude === false) must be
+        // ABSENT from ~/.claude.json — absence is the only global disable
+        // Claude Code honors. Everything else (enabled, per-project, unset)
+        // stays installed.
+        return serverConfig._meta?.enabled?.claude !== false;
     }
 
     async readConfig(): Promise<ClaudeGenericConfig> {
@@ -96,6 +114,25 @@ export class ClaudeProvider extends MCPProvider {
                     }
                 }
             }
+        }
+
+        // Globally-disabled servers are absent from ~/.claude.json entirely
+        // (absence is the only global disable Claude Code honors). Surface them
+        // from the unified config as disabled so they don't look "not installed".
+        const unified = await readUnifiedConfig();
+        for (const [name, entry] of Object.entries(unified.mcpServers)) {
+            if (entry._meta?.enabled?.claude !== false) {
+                continue;
+            }
+            if (servers.find((s) => s.name === name)) {
+                continue;
+            }
+            servers.push({
+                name,
+                config: stripMeta(entry),
+                enabled: false,
+                provider: this.providerName,
+            });
         }
 
         return servers;
@@ -177,23 +214,10 @@ export class ClaudeProvider extends MCPProvider {
     async enableServer(serverName: string, projectPath?: string | null): Promise<void> {
         const config = await this.readConfig();
 
-        if (projectPath === null) {
-            // Enable globally (all projects)
-            if (config.disabledMcpServers) {
-                config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
-            }
-
-            // Also remove from all project-specific disabled lists
-            if (config.projects) {
-                for (const projectConfig of Object.values(config.projects)) {
-                    if (projectConfig.disabledMcpServers) {
-                        projectConfig.disabledMcpServers = projectConfig.disabledMcpServers.filter(
-                            (name) => name !== serverName
-                        );
-                    }
-                }
-            }
-        } else if (projectPath !== undefined) {
+        if (projectPath === null || projectPath === undefined) {
+            // Global enable (no project specified = global)
+            await this.applyGlobalEnable([serverName], config);
+        } else {
             // Enable for specific project
             if (config.projects?.[projectPath]) {
                 if (config.projects[projectPath].disabledMcpServers) {
@@ -201,11 +225,6 @@ export class ClaudeProvider extends MCPProvider {
                         projectPath
                     ].disabledMcpServers?.filter((name) => name !== serverName);
                 }
-            }
-        } else {
-            // No project specified - enable globally only
-            if (config.disabledMcpServers) {
-                config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
             }
         }
 
@@ -215,27 +234,10 @@ export class ClaudeProvider extends MCPProvider {
     async disableServer(serverName: string, projectPath?: string | null): Promise<void> {
         const config = await this.readConfig();
 
-        if (projectPath === null) {
-            // Disable globally (all projects)
-            if (!config.disabledMcpServers) {
-                config.disabledMcpServers = [];
-            }
-            if (!config.disabledMcpServers.includes(serverName)) {
-                config.disabledMcpServers.push(serverName);
-            }
-
-            // Also disable in all project-specific lists
-            if (config.projects) {
-                for (const projectConfig of Object.values(config.projects)) {
-                    if (!projectConfig.disabledMcpServers) {
-                        projectConfig.disabledMcpServers = [];
-                    }
-                    if (!projectConfig.disabledMcpServers.includes(serverName)) {
-                        projectConfig.disabledMcpServers.push(serverName);
-                    }
-                }
-            }
-        } else if (projectPath !== undefined) {
+        if (projectPath === null || projectPath === undefined) {
+            // Global disable (no project specified = global)
+            await this.applyGlobalDisable([serverName], config);
+        } else {
             // Disable for specific project
             if (config.projects?.[projectPath]) {
                 if (!config.projects[projectPath].disabledMcpServers) {
@@ -245,93 +247,30 @@ export class ClaudeProvider extends MCPProvider {
                     config.projects[projectPath].disabledMcpServers?.push(serverName);
                 }
             }
-        } else {
-            // No project specified - disable globally only
-            if (!config.disabledMcpServers) {
-                config.disabledMcpServers = [];
-            }
-            if (!config.disabledMcpServers.includes(serverName)) {
-                config.disabledMcpServers.push(serverName);
-            }
         }
 
         await this.writeConfig(config);
     }
 
     async enableServerForAllProjects(serverName: string): Promise<void> {
-        const config = await this.readConfig();
-
-        // Enable globally
-        if (config.disabledMcpServers) {
-            config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
-        }
-
-        // Also enable in all projects
-        if (config.projects) {
-            for (const projectConfig of Object.values(config.projects)) {
-                if (projectConfig.disabledMcpServers) {
-                    projectConfig.disabledMcpServers = projectConfig.disabledMcpServers.filter(
-                        (name) => name !== serverName
-                    );
-                }
-            }
-        }
-
-        await this.writeConfig(config);
+        await this.enableServer(serverName, null);
     }
 
     async disableServerForAllProjects(serverName: string): Promise<void> {
-        const config = await this.readConfig();
-
-        // Disable globally
-        if (!config.disabledMcpServers) {
-            config.disabledMcpServers = [];
-        }
-        if (!config.disabledMcpServers.includes(serverName)) {
-            config.disabledMcpServers.push(serverName);
-        }
-
-        // Also disable in all projects
-        if (config.projects) {
-            for (const projectConfig of Object.values(config.projects)) {
-                if (!projectConfig.disabledMcpServers) {
-                    projectConfig.disabledMcpServers = [];
-                }
-                if (!projectConfig.disabledMcpServers.includes(serverName)) {
-                    projectConfig.disabledMcpServers.push(serverName);
-                }
-            }
-        }
-
-        await this.writeConfig(config);
+        await this.disableServer(serverName, null);
     }
 
     async enableServers(serverNames: string[], projectPath?: string | null): Promise<WriteResult> {
         const config = await this.readConfig();
 
-        for (const serverName of serverNames) {
-            if (projectPath === null) {
-                if (config.disabledMcpServers) {
-                    config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
-                }
-                if (config.projects) {
-                    for (const projectConfig of Object.values(config.projects)) {
-                        if (projectConfig.disabledMcpServers) {
-                            projectConfig.disabledMcpServers = projectConfig.disabledMcpServers.filter(
-                                (name) => name !== serverName
-                            );
-                        }
-                    }
-                }
-            } else if (projectPath !== undefined) {
+        if (projectPath === null || projectPath === undefined) {
+            await this.applyGlobalEnable(serverNames, config);
+        } else {
+            for (const serverName of serverNames) {
                 if (config.projects?.[projectPath]?.disabledMcpServers) {
                     config.projects[projectPath].disabledMcpServers = config.projects[
                         projectPath
                     ].disabledMcpServers?.filter((name) => name !== serverName);
-                }
-            } else {
-                if (config.disabledMcpServers) {
-                    config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
                 }
             }
         }
@@ -342,26 +281,10 @@ export class ClaudeProvider extends MCPProvider {
     async disableServers(serverNames: string[], projectPath?: string | null): Promise<WriteResult> {
         const config = await this.readConfig();
 
-        if (!config.disabledMcpServers) {
-            config.disabledMcpServers = [];
-        }
-
-        for (const serverName of serverNames) {
-            if (projectPath === null) {
-                if (!config.disabledMcpServers.includes(serverName)) {
-                    config.disabledMcpServers.push(serverName);
-                }
-                if (config.projects) {
-                    for (const projectConfig of Object.values(config.projects)) {
-                        if (!projectConfig.disabledMcpServers) {
-                            projectConfig.disabledMcpServers = [];
-                        }
-                        if (!projectConfig.disabledMcpServers.includes(serverName)) {
-                            projectConfig.disabledMcpServers.push(serverName);
-                        }
-                    }
-                }
-            } else if (projectPath !== undefined) {
+        if (projectPath === null || projectPath === undefined) {
+            await this.applyGlobalDisable(serverNames, config);
+        } else {
+            for (const serverName of serverNames) {
                 if (config.projects?.[projectPath]) {
                     if (!config.projects[projectPath].disabledMcpServers) {
                         config.projects[projectPath].disabledMcpServers = [];
@@ -370,14 +293,153 @@ export class ClaudeProvider extends MCPProvider {
                         config.projects[projectPath].disabledMcpServers?.push(serverName);
                     }
                 }
-            } else {
-                if (!config.disabledMcpServers.includes(serverName)) {
-                    config.disabledMcpServers.push(serverName);
-                }
             }
         }
 
         return this.writeConfig(config);
+    }
+
+    /**
+     * Apply a TRUE global disable to the in-memory Claude config:
+     * 1. Preserve each server's full config in the unified config with
+     *    `_meta.enabled.claude = false` (import it there if missing).
+     * 2. Keep the top-level marker + per-project sweep for back-compat
+     *    (Claude Code ignores the top-level key; the sweep covers only
+     *    currently-registered projects).
+     * 3. Remove the entry from `mcpServers` — the only mechanism Claude Code
+     *    honors globally, including projects registered in the future.
+     * Entries that could not be preserved are NOT removed (no data loss).
+     */
+    private async applyGlobalDisable(serverNames: string[], config: ClaudeGenericConfig): Promise<void> {
+        if (!config.disabledMcpServers) {
+            config.disabledMcpServers = [];
+        }
+
+        const safeToRemove = await this.preserveServersInUnifiedConfig(serverNames, config);
+
+        for (const serverName of serverNames) {
+            // Top-level marker (ignored by Claude Code, kept for back-compat)
+            if (!config.disabledMcpServers.includes(serverName)) {
+                config.disabledMcpServers.push(serverName);
+            }
+
+            // Per-project sweep (covers existing projects, kept for back-compat)
+            if (config.projects) {
+                for (const projectConfig of Object.values(config.projects)) {
+                    if (!projectConfig.disabledMcpServers) {
+                        projectConfig.disabledMcpServers = [];
+                    }
+                    if (!projectConfig.disabledMcpServers.includes(serverName)) {
+                        projectConfig.disabledMcpServers.push(serverName);
+                    }
+                }
+            }
+
+            // TRUE global disable: remove the entry from mcpServers
+            if (config.mcpServers?.[serverName]) {
+                if (safeToRemove.has(serverName)) {
+                    delete config.mcpServers[serverName];
+                } else {
+                    logger.warn(
+                        chalk.yellow(
+                            `⚠ '${serverName}' was NOT removed from mcpServers in ${this.configPath} because its config could not be preserved in the unified config — the disable will not cover projects registered later.`
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Apply a global enable to the in-memory Claude config: restore the entry
+     * into `mcpServers` from the unified config (a TRUE global disable removed
+     * it) and clean the top-level + all per-project disabled lists.
+     */
+    private async applyGlobalEnable(serverNames: string[], config: ClaudeGenericConfig): Promise<void> {
+        await this.restoreServersFromUnifiedConfig(serverNames, config);
+
+        for (const serverName of serverNames) {
+            if (config.disabledMcpServers) {
+                config.disabledMcpServers = config.disabledMcpServers.filter((name) => name !== serverName);
+            }
+            if (config.projects) {
+                for (const projectConfig of Object.values(config.projects)) {
+                    if (projectConfig.disabledMcpServers) {
+                        projectConfig.disabledMcpServers = projectConfig.disabledMcpServers.filter(
+                            (name) => name !== serverName
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Ensure full server configs are preserved in the unified config with
+     * `_meta.enabled.claude = false` BEFORE they are removed from
+     * ~/.claude.json. Returns the set of server names whose config body is
+     * safely stored in the unified config (pre-existing or successfully
+     * imported) — only those may be removed without data loss.
+     */
+    private async preserveServersInUnifiedConfig(
+        serverNames: string[],
+        claudeConfig: ClaudeGenericConfig
+    ): Promise<Set<string>> {
+        const unified = await readUnifiedConfig();
+        const preExisting = new Set<string>();
+        const imported = new Set<string>();
+
+        for (const serverName of serverNames) {
+            let entry = unified.mcpServers[serverName];
+            if (entry) {
+                preExisting.add(serverName);
+            } else {
+                const providerEntry = claudeConfig.mcpServers?.[serverName];
+                if (!providerEntry) {
+                    continue; // Not installed — nothing to preserve or remove
+                }
+                entry = this.claudeToUnified(providerEntry);
+                unified.mcpServers[serverName] = entry;
+                imported.add(serverName);
+            }
+
+            if (!entry._meta) {
+                entry._meta = { enabled: {} };
+            }
+            if (!entry._meta.enabled) {
+                entry._meta.enabled = {};
+            }
+            entry._meta.enabled.claude = false;
+        }
+
+        // writeUnifiedConfig no-ops (returns false) when nothing changed; with
+        // pending imports a `false` means the write was rejected — those
+        // entries are NOT preserved and must not be removed.
+        const written = await writeUnifiedConfig(unified);
+        return written ? new Set([...preExisting, ...imported]) : preExisting;
+    }
+
+    /**
+     * Restore entries removed by a TRUE global disable: copy the server config
+     * back into `mcpServers` from the unified config (where it was preserved).
+     */
+    private async restoreServersFromUnifiedConfig(serverNames: string[], config: ClaudeGenericConfig): Promise<void> {
+        const missing = serverNames.filter((name) => !config.mcpServers?.[name]);
+        if (missing.length === 0) {
+            return;
+        }
+
+        const unified = await readUnifiedConfig();
+        for (const name of missing) {
+            const entry = unified.mcpServers[name];
+            if (!entry) {
+                continue; // Not in unified config — nothing to restore
+            }
+            if (!config.mcpServers) {
+                config.mcpServers = {};
+            }
+            config.mcpServers[name] = this.unifiedToClaude(stripMeta(entry));
+        }
     }
 
     async installServer(serverName: string, config: UnifiedMCPServerConfig): Promise<WriteResult> {
@@ -422,10 +484,19 @@ export class ClaudeProvider extends MCPProvider {
 
         for (const [name, serverConfig] of Object.entries(servers)) {
             const cleanConfig = stripMeta(serverConfig);
-            config.mcpServers[name] = this.unifiedToClaude(cleanConfig);
 
             const enabledState = serverConfig._meta?.enabled?.claude;
-            const isGloballyEnabled = typeof enabledState === "boolean" && enabledState === true;
+            const isGloballyEnabled = enabledState === true;
+            const isGloballyDisabled = enabledState === false;
+
+            if (isGloballyDisabled) {
+                // TRUE global disable = absent from mcpServers (Claude Code
+                // never reads the top-level disabledMcpServers key, and the
+                // per-project sweep misses projects registered later).
+                delete config.mcpServers[name];
+            } else {
+                config.mcpServers[name] = this.unifiedToClaude(cleanConfig);
+            }
 
             if (isGloballyEnabled) {
                 config.disabledMcpServers = config.disabledMcpServers.filter((n) => n !== name);

--- a/src/mcp-manager/utils/providers/claude.ts
+++ b/src/mcp-manager/utils/providers/claude.ts
@@ -334,10 +334,13 @@ export class ClaudeProvider extends MCPProvider {
      * project's `disabledMcpServers` list.
      */
     private applyProjectDisable(serverNames: string[], projectPath: string, config: ClaudeGenericConfig): void {
-        const projectConfig = config.projects?.[projectPath];
-        if (!projectConfig) {
-            return;
+        if (!config.projects) {
+            config.projects = {};
         }
+        if (!config.projects[projectPath]) {
+            config.projects[projectPath] = {};
+        }
+        const projectConfig = config.projects[projectPath];
 
         if (!projectConfig.disabledMcpServers) {
             projectConfig.disabledMcpServers = [];

--- a/src/mcp-manager/utils/providers/codex.ts
+++ b/src/mcp-manager/utils/providers/codex.ts
@@ -163,6 +163,23 @@ export class CodexProvider extends MCPProvider {
         return this.writeConfig(codexConfig);
     }
 
+    async removeServers(serverNames: string[]): Promise<WriteResult> {
+        const config = await this.readConfig();
+
+        for (const serverName of serverNames) {
+            if (config.mcp_servers?.[serverName]) {
+                // Deleting the parsed key drops the whole [mcp_servers.<name>]
+                // section including nested subsections ([...env],
+                // [...http_headers]); unrelated content like [projects.*] and
+                // [notice] is part of the same parsed object and survives the
+                // re-serialization untouched.
+                delete config.mcp_servers[serverName];
+            }
+        }
+
+        return this.writeConfig(config);
+    }
+
     async syncServers(servers: Record<string, UnifiedMCPServerConfig>): Promise<WriteResult> {
         const config = await this.readConfig();
 

--- a/src/mcp-manager/utils/providers/codex.ts
+++ b/src/mcp-manager/utils/providers/codex.ts
@@ -165,6 +165,7 @@ export class CodexProvider extends MCPProvider {
 
     async removeServers(serverNames: string[]): Promise<WriteResult> {
         const config = await this.readConfig();
+        let changed = false;
 
         for (const serverName of serverNames) {
             if (config.mcp_servers?.[serverName]) {
@@ -174,7 +175,12 @@ export class CodexProvider extends MCPProvider {
                 // [notice] is part of the same parsed object and survives the
                 // re-serialization untouched.
                 delete config.mcp_servers[serverName];
+                changed = true;
             }
+        }
+
+        if (!changed) {
+            return WriteResult.NoChanges;
         }
 
         return this.writeConfig(config);

--- a/src/mcp-manager/utils/providers/cursor.ts
+++ b/src/mcp-manager/utils/providers/cursor.ts
@@ -158,11 +158,17 @@ export class CursorProvider extends MCPProvider {
 
     async removeServers(serverNames: string[]): Promise<WriteResult> {
         const config = await this.readConfig();
+        let changed = false;
 
         for (const serverName of serverNames) {
             if (config.mcpServers?.[serverName]) {
                 delete config.mcpServers[serverName];
+                changed = true;
             }
+        }
+
+        if (!changed) {
+            return WriteResult.NoChanges;
         }
 
         return this.writeConfig(config);

--- a/src/mcp-manager/utils/providers/cursor.ts
+++ b/src/mcp-manager/utils/providers/cursor.ts
@@ -156,6 +156,18 @@ export class CursorProvider extends MCPProvider {
         return this.writeConfig(cursorConfig);
     }
 
+    async removeServers(serverNames: string[]): Promise<WriteResult> {
+        const config = await this.readConfig();
+
+        for (const serverName of serverNames) {
+            if (config.mcpServers?.[serverName]) {
+                delete config.mcpServers[serverName];
+            }
+        }
+
+        return this.writeConfig(config);
+    }
+
     async syncServers(servers: Record<string, UnifiedMCPServerConfig>): Promise<WriteResult> {
         const config = await this.readConfig();
 

--- a/src/mcp-manager/utils/providers/gemini.ts
+++ b/src/mcp-manager/utils/providers/gemini.ts
@@ -168,6 +168,21 @@ export class GeminiProvider extends MCPProvider {
         return this.writeConfig(geminiConfig);
     }
 
+    async removeServers(serverNames: string[]): Promise<WriteResult> {
+        const config = await this.readConfig();
+
+        for (const serverName of serverNames) {
+            if (config.mcpServers?.[serverName]) {
+                delete config.mcpServers[serverName];
+            }
+            if (config.mcp?.excluded) {
+                config.mcp.excluded = config.mcp.excluded.filter((name) => name !== serverName);
+            }
+        }
+
+        return this.writeConfig(config);
+    }
+
     async syncServers(servers: Record<string, UnifiedMCPServerConfig>): Promise<WriteResult> {
         const config = await this.readConfig();
 

--- a/src/mcp-manager/utils/providers/gemini.ts
+++ b/src/mcp-manager/utils/providers/gemini.ts
@@ -170,14 +170,25 @@ export class GeminiProvider extends MCPProvider {
 
     async removeServers(serverNames: string[]): Promise<WriteResult> {
         const config = await this.readConfig();
+        let changed = false;
 
         for (const serverName of serverNames) {
             if (config.mcpServers?.[serverName]) {
                 delete config.mcpServers[serverName];
+                changed = true;
             }
             if (config.mcp?.excluded) {
-                config.mcp.excluded = config.mcp.excluded.filter((name) => name !== serverName);
+                const filtered = config.mcp.excluded.filter((name) => name !== serverName);
+
+                if (filtered.length !== config.mcp.excluded.length) {
+                    config.mcp.excluded = filtered;
+                    changed = true;
+                }
             }
+        }
+
+        if (!changed) {
+            return WriteResult.NoChanges;
         }
 
         return this.writeConfig(config);

--- a/src/mcp-manager/utils/providers/types.ts
+++ b/src/mcp-manager/utils/providers/types.ts
@@ -197,6 +197,14 @@ export abstract class MCPProvider {
     abstract installServer(serverName: string, config: UnifiedMCPServerConfig): Promise<WriteResult>;
 
     /**
+     * Completely REMOVE servers from this provider's config. Unlike disable,
+     * this is permanent — the entries are gone from the provider config (and,
+     * when driven by the `remove` command, from the unified config too).
+     * @returns WriteResult indicating whether changes were applied, no changes needed, or rejected
+     */
+    abstract removeServers(serverNames: string[]): Promise<WriteResult>;
+
+    /**
      * Check if this provider supports a "disabled" state for servers.
      * - Claude/Gemini: true (have disabledMcpServers/mcp.excluded lists)
      * - Cursor/Codex: false (presence in config = enabled, no separate disabled state)

--- a/src/mcp-manager/utils/providers/types.ts
+++ b/src/mcp-manager/utils/providers/types.ts
@@ -204,6 +204,20 @@ export abstract class MCPProvider {
     abstract supportsDisabledState(): boolean;
 
     /**
+     * Whether a server should be present (installed) in this provider's config
+     * given its _meta.enabled state.
+     * - Providers WITH a native disabled state (e.g. Gemini) keep disabled
+     *   servers installed and mark them disabled.
+     * - Providers WITHOUT one (Cursor/Codex) only install enabled servers.
+     * - Claude overrides this: a globally-disabled server
+     *   (`_meta.enabled.claude === false`) must be ABSENT from ~/.claude.json,
+     *   because absence is the only global disable Claude Code honors.
+     */
+    shouldBeInstalled(serverConfig: UnifiedMCPServerConfig): boolean {
+        return this.supportsDisabledState() || this.isServerEnabledInMeta(serverConfig);
+    }
+
+    /**
      * Check if a server is enabled for this provider based on _meta.enabled state.
      * For providers with project support, checks if enabled globally or for a specific project.
      * @param serverConfig - Server configuration with _meta

--- a/src/question/lib/sinks/notification.test.ts
+++ b/src/question/lib/sinks/notification.test.ts
@@ -9,7 +9,7 @@ mock.module("@app/utils/notifications", () => ({
 }));
 
 mock.module("@app/dev-dashboard/lib/qa-deep-link", () => ({
-    buildQaDeepLink: async (id: string) => `http://mac.foltyn.dev:3042/qa?id=${encodeURIComponent(id)}`,
+    buildQaDeepLink: async (id: string) => `http://myhost.example.com/qa?id=${encodeURIComponent(id)}`,
 }));
 
 import type { QuestionConfig } from "../config";
@@ -56,7 +56,7 @@ describe("notificationSink", () => {
         expect(f.title).toContain("GenesisTools");
         expect(f.message).toContain("why X?");
         expect(f.message).toContain("Because Y.");
-        expect(f.open).toBe("http://mac.foltyn.dev:3042/qa?id=abc-entry");
+        expect(f.open).toBe("http://myhost.example.com/qa?id=abc-entry");
 
         dispatched.length = 0;
         await notificationSink.emit(e, { ...baseCfg, sinks: { obsidian: true, sound: false, notify: true } });
@@ -64,6 +64,6 @@ describe("notificationSink", () => {
         expect(dispatched[0].app).toBe("question");
         expect(dispatched[0].title).toContain("GenesisTools");
         expect(dispatched[0].message).toContain("Because Y.");
-        expect(dispatched[0].open).toBe("http://mac.foltyn.dev:3042/qa?id=abc-entry");
+        expect(dispatched[0].open).toBe("http://myhost.example.com/qa?id=abc-entry");
     });
 });

--- a/src/tmux/commands/presets/delete.ts
+++ b/src/tmux/commands/presets/delete.ts
@@ -38,9 +38,7 @@ export async function runDeletePreset(name: string, flags: DeleteFlags): Promise
             return;
         }
 
-        const proceed = await withCancel(
-            p.confirm({ message: `Delete preset "${name}"?`, initialValue: false })
-        );
+        const proceed = await withCancel(p.confirm({ message: `Delete preset "${name}"?`, initialValue: false }));
 
         if (!proceed) {
             p.cancel("Aborted.");

--- a/src/todo/lib/store.ts
+++ b/src/todo/lib/store.ts
@@ -145,8 +145,8 @@ export class TodoStore {
 
         const todos = await this.readTodos();
         todos.push(todo);
-        await this.writeTodos(todos);
-        await this.writeMeta(todos);
+        this.writeTodos(todos);
+        this.writeMeta(todos);
 
         return todo;
     }
@@ -187,8 +187,8 @@ export class TodoStore {
         };
 
         todos[index] = updated;
-        await this.writeTodos(todos);
-        await this.writeMeta(todos);
+        this.writeTodos(todos);
+        this.writeMeta(todos);
 
         return updated;
     }
@@ -207,8 +207,8 @@ export class TodoStore {
             rmSync(todoAttachDir, { recursive: true, force: true });
         }
 
-        await this.writeTodos(filtered);
-        await this.writeMeta(filtered);
+        this.writeTodos(filtered);
+        this.writeMeta(filtered);
 
         return true;
     }
@@ -236,8 +236,8 @@ export class TodoStore {
         }
 
         todos.push(...toImport);
-        await this.writeTodos(todos);
-        await this.writeMeta(todos);
+        this.writeTodos(todos);
+        this.writeMeta(todos);
         return toImport.length;
     }
 

--- a/src/tradingview/commands/indicator.ts
+++ b/src/tradingview/commands/indicator.ts
@@ -124,7 +124,9 @@ async function runIndicatorInner(
 
         for (const layoutStudy of layoutStudies) {
             if (pendingStudies.length >= MAX_CHART_STUDIES) {
-                out.warn(`Layout has ${layoutStudies.length} studies; attaching the first ${MAX_CHART_STUDIES} that translate.`);
+                out.warn(
+                    `Layout has ${layoutStudies.length} studies; attaching the first ${MAX_CHART_STUDIES} that translate.`
+                );
                 break;
             }
 

--- a/src/tradingview/lib/format.ts
+++ b/src/tradingview/lib/format.ts
@@ -50,9 +50,7 @@ export function formatAlertRow(alert: Alert): string {
 export function formatAlertFire(fire: AlertFire): string {
     const sym = parseProSymbol(fire.symbol);
     const parsed = new Date(fire.fire_time);
-    const time = Number.isNaN(parsed.getTime())
-        ? "—"
-        : parsed.toLocaleTimeString("en-US", { hour12: false });
+    const time = Number.isNaN(parsed.getTime()) ? "—" : parsed.toLocaleTimeString("en-US", { hour12: false });
     const head = pc.bgYellow(pc.black(" ALERT "));
     return `${head} ${pc.dim(time)}  ${pc.bold(pc.yellow(sym))}  ${fire.message}`;
 }

--- a/src/utils/ink/hooks/use-terminal-size.ts
+++ b/src/utils/ink/hooks/use-terminal-size.ts
@@ -1,5 +1,5 @@
 import { useStdout } from "ink";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 export interface TerminalSize {
     columns: number;
@@ -10,11 +10,12 @@ const DEFAULT_SIZE: TerminalSize = { columns: 80, rows: 24 };
 
 export function useTerminalSize({ clearOnResize = false } = {}): TerminalSize {
     const { stdout } = useStdout();
-    const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    // `||` not `??`: degenerate PTYs (script/CI) report 0×0, which must fall
+    // back to the default size too — a 0-row clamp breaks Ink's repaint math.
     const [size, setSize] = useState<TerminalSize>(() => ({
-        columns: stdout?.columns ?? DEFAULT_SIZE.columns,
-        rows: stdout?.rows ?? DEFAULT_SIZE.rows,
+        columns: stdout?.columns || DEFAULT_SIZE.columns,
+        rows: stdout?.rows || DEFAULT_SIZE.rows,
     }));
 
     useEffect(() => {
@@ -23,29 +24,26 @@ export function useTerminalSize({ clearOnResize = false } = {}): TerminalSize {
         }
 
         const onResize = () => {
-            setSize({
-                columns: stdout.columns ?? DEFAULT_SIZE.columns,
-                rows: stdout.rows ?? DEFAULT_SIZE.rows,
-            });
-
+            // Clear BEFORE the size state propagates: Ink's own resize
+            // listener has already repainted with mismatched erase counts
+            // (re-wrapped lines), so blank the screen and home the cursor
+            // now — the state update below triggers a clean full repaint
+            // from the top. Intended for full-screen apps whose frame
+            // starts at the top-left. (A deferred clear here used to run
+            // AFTER the repaint, leaving stale frames behind.)
             if (clearOnResize) {
-                if (clearTimerRef.current) {
-                    clearTimeout(clearTimerRef.current);
-                }
-
-                clearTimerRef.current = setTimeout(() => {
-                    stdout.write("\x1b[2J\x1b[H");
-                }, 500);
+                stdout.write("\x1b[2J\x1b[H");
             }
+
+            setSize({
+                columns: stdout.columns || DEFAULT_SIZE.columns,
+                rows: stdout.rows || DEFAULT_SIZE.rows,
+            });
         };
 
         stdout.on("resize", onResize);
         return () => {
             stdout.off("resize", onResize);
-
-            if (clearTimerRef.current) {
-                clearTimeout(clearTimerRef.current);
-            }
         };
     }, [stdout, clearOnResize]);
 

--- a/src/utils/ink/index.ts
+++ b/src/utils/ink/index.ts
@@ -22,5 +22,8 @@ export { useElapsedTimer } from "./hooks/use-elapsed-timer.js";
 export { useOperation } from "./hooks/use-operation.js";
 export { useTerminalSize } from "./hooks/use-terminal-size.js";
 
+// Lib
+export { renderFullScreen } from "./lib/fullscreen.js";
+
 // Theme
 export { colors, symbols } from "./lib/theme.js";

--- a/src/utils/ink/lib/fullscreen.ts
+++ b/src/utils/ink/lib/fullscreen.ts
@@ -1,0 +1,42 @@
+import { type RenderOptions, render } from "ink";
+import type { ReactNode } from "react";
+
+const ENTER_ALT_SCREEN = "\x1b[?1049h\x1b[H";
+const LEAVE_ALT_SCREEN = "\x1b[?1049l";
+
+/**
+ * Render an Ink tree inside the terminal's alternate screen buffer.
+ *
+ * Full-screen dashboards must not paint into the primary buffer: Ink frames
+ * that reach the viewport height scroll into scrollback, where neither
+ * eraseLines nor clearTerminal can reach them — every refresh then leaves a
+ * stale duplicate frame behind (and `\x1b[3J` wipes the user's shell
+ * scrollback on terminals that honor it). The alternate buffer has no
+ * scrollback, so duplicates cannot accumulate, and on exit the user's shell
+ * is restored exactly as it was.
+ *
+ * Falls back to a plain render when stdout is not a TTY.
+ */
+export async function renderFullScreen(node: ReactNode, options?: RenderOptions): Promise<void> {
+    const stdout = options?.stdout ?? process.stdout;
+
+    if (!stdout.isTTY) {
+        await render(node, options).waitUntilExit();
+        return;
+    }
+
+    const leaveAltScreen = (): void => {
+        stdout.write(LEAVE_ALT_SCREEN);
+    };
+
+    stdout.write(ENTER_ALT_SCREEN);
+    // Restore the primary buffer even on hard exits (uncaught throw, signals).
+    process.once("exit", leaveAltScreen);
+
+    try {
+        await render(node, options).waitUntilExit();
+    } finally {
+        process.off("exit", leaveAltScreen);
+        leaveAltScreen();
+    }
+}

--- a/src/utils/macos/MailDatabase.ts
+++ b/src/utils/macos/MailDatabase.ts
@@ -365,9 +365,13 @@ export class MailDatabase extends MacDatabase {
     }
 
     async listReceivers(): Promise<ReceiverInfo[]> {
+        // The Envelope Index never garbage-collects recipients/addresses rows
+        // after message deletion, so without the messages join this counts
+        // ghosts (~93% of recipients rows can be orphans).
         const rows = await this.k()
             .selectFrom("recipients as r")
             .innerJoin("addresses as a", "a.ROWID", "r.address")
+            .innerJoin("messages as m", "m.ROWID", "r.message")
             .select([
                 sql<string>`a.address`.as("address"),
                 sql<string | null>`a.comment`.as("name"),


### PR DESCRIPTION
# Summary

This branch bundles the mcp-manager global-disable feature line with a round of CLI output-hygiene and mail-tooling fixes. (Rebased onto master — the dev-dashboard/tmux ancestry it was originally branched from lives in its own PR.)

## mcp-manager: TRUE global disable for the claude provider

Claude Code reads `disabledMcpServers` only from per-project entries — the top-level key is never read, and per-project sweeps miss projects registered later. The only global disable Claude Code honors is the server **not existing** in `mcpServers`.

- `disable` (global): preserve full config in the unified config with `_meta.enabled.claude=false`, then remove the entry from `~/.claude.json` `mcpServers`; `enable` restores it and cleans disabled lists
- `listServers` surfaces globally-disabled (absent) servers as disabled instead of "not installed"
- `syncServers` keeps drift corrected via new `MCPProvider.shouldBeInstalled()`; sync-from-providers no longer flips/drops unified entries for absent disabled servers
- Fixture tests against temp HOME + sandboxed storage — live configs never touched

## mcp-manager: remove (purge) command + per-project enable override

- `remove`/`purge`: permanently deletes server(s) from the unified config and every selected provider config (claude/cursor/gemini/codex), with diff + confirmation + backup
- `enable <s> -p claude --project <path>`: per-project override for a globally-disabled server via `.projects[<path>].mcpServers.<name>`; override-aware sweeps/sync never re-disable or delete it
- `-p all` and comma-separated provider lists in enable/disable/toggle-server
- 12 new fixture tests incl. the override-survives-sync invariant

## Logger: no more `tool: "..."` garbage lines (systemic)

pino-pretty echoed ambient bindings (`tool` from `runTool`, `component` from `scoped()`) as indented field lines under every console message — polluting piped output for **every** tool. They are now console-ignored (file log unchanged); `component` renders inline as a `[component]` message prefix.

## macos mail: orphan-aware receivers, index cleanup, --format everywhere

- `listReceivers()` now inner-joins `messages` — Mail's Envelope Index never garbage-collects `recipients`/`addresses` rows, so `--help-receivers` previously reported ghost addresses with six-figure counts (e.g. 294k deleted GitHub notification emails)
- New `tools macos mail index cleanup`: prunes stale chunks + orphan vectors from the GenesisTools index DB (`Indexer.cleanup()`, vacuum when dirty). Writes **only** to our DB — Apple's Envelope Index stays read-only
- `--format json/toon` honored across subcommands: `search --help-receivers`, `accounts` and `show` gained the flag (`--json` stays as alias), `list` no longer leaks clack spinner frames into structured stdout, empty results emit `[]`
- Shared `printStructured()`/`isStructuredFormat()` helpers replace per-command json/toon plumbing; search's local quiet-spinner copy (missing `.message()`) replaced with the shared util

## claude usage TUI: no more duplicated frames

`tools claude usage` duplicated all stats into scrollback on refresh/resize. Root cause: Ink frames at viewport height switch to clear-terminal-and-rewrite, scrolling overflow into scrollback where no escape sequence can erase it; the deferred resize-clear also ran after Ink's mismatched repaint.

- New shared `renderFullScreen()` (`src/utils/ink`): renders inside the alternate screen buffer — no scrollback to pollute, shell restored on exit
- Dashboard layout clamped to `rows - 1` with `overflowY="hidden"` so Ink always repaints in place
- `useTerminalSize` clears immediately on resize (was debounced 500ms, post-repaint) and guards degenerate 0×0 PTYs

## Misc

- `style:` commit applying biome formatting to 3 files that arrived unformatted from master (unblocks CI shard 4 / pre-push hook)

## Test plan

- `bun test src/logger.test.ts src/logger/out.test.ts src/logger/client.test.ts src/logger/client-isolation.test.ts src/macos/commands/mail/search.e2e.test.ts` — 38 pass
- mcp-manager fixture suites (12 + 12 new tests) — temp HOME, live configs untouched
- `tsgo --noEmit` clean, biome clean, `scripts/ci/logging-guard.sh` OK
- Live verification sweep: 23 checks across all `macos mail` subcommands (table/json/toon, piped purity, download/search-download artifacts, idempotent `index cleanup`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mail index cleanup command (prunes chunks, heals vectors, optional VACUUM)
  * Permanent remove/purge command for MCP servers; per-project enable/disable overrides
  * Full-screen TUI rendering for the usage dashboard

* **Improvements**
  * Structured output support (json/"toon") across mail commands; format flags added
  * Cleaner console log formatting (component inlined, fewer echoed fields)
  * Quiet spinner to avoid stdout corruption for structured/piped output
  * MCP sync/enable/disable behavior tightened to preserve global-disable semantics

* **Documentation**
  * Expanded MCP manager README clarifying lifecycle and remove semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->