### PR TITLE
fix: tool reliability sweep — cmux, wakeful polling, debugging-master, timelog

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,9 @@
 preload = ["./src/utils/bun/preload-solid-scoped.ts", "./src/utils/search/stores/sqlite-vec-preload.ts"]
 
+[install]
+# Supply-chain delay: refuse package versions younger than 7 days (604800s)
+minimumReleaseAge = 604800
+
 [test]
 preload = [
     "./src/utils/bun/preload-test-process-exit.ts",

--- a/docs/plans/2026-06-23-extra-usage-notify-unified.md
+++ b/docs/plans/2026-06-23-extra-usage-notify-unified.md
@@ -1,0 +1,61 @@
+# Extra Usage Notifications — Unified Architecture
+
+> **Status:** Implemented (2026-06-23)
+
+**Goal:** Any consumer that triggers a live Anthropic usage fetch (daemon, TUI `r`, watch, one-shot CLI) must be the single notifier for extra-usage transitions — without duplicate trackers or missed enable/disable banners.
+
+**Architecture:** `getSharedAccountsUsage()` owns the notification pass. On every **fresh** fetch (inside the existing file lock, after cache write + history record), it calls `processExtraUsageNotifications()`. That function atomically updates `notificationPollTracker.extraUsageTrackers` in `~/.genesis-tools/claude-usage/config.json` **before** dispatching macOS notifications. Session/weekly alerts remain in `NotificationManager` (daemon + TUI).
+
+**Root cause fixed:** Extra-usage lived only in poll-daemon with a separate in-memory tracker. TUI `r` refreshed shared cache but never notified. Worse: tracker state was saved *after* `dispatchNotification`, so a slow/hung dispatch left `lastKnownEnabled: true` and the daemon re-fired `EXTRA_DISABLED` every minute without ever persisting `false` or reliably showing the banner.
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `src/claude/lib/usage/extra-usage-notify.ts` | **New.** Single owner: load trackers → detect transition → persist → dispatch |
+| `src/claude/lib/usage/shared-cache.ts` | Calls `processExtraUsageNotifications` on live fetch only |
+| `src/claude/lib/usage/notification-manager.ts` | Session/weekly only; preserves `extraUsageTrackers` on save |
+| `src/claude/lib/usage/poll-daemon.ts` | Removed duplicate extra-usage path; top-level `await main()` |
+| `src/claude/lib/usage/watch.ts` | Removed ephemeral extra-usage tracker (shared-cache handles it) |
+
+## Config
+
+- Toggle: `notifications.extraUsage` in `~/.genesis-tools/claude/config.json` (hidden JSON, default off)
+- Tracker state: `notificationPollTracker.extraUsageTrackers` in `~/.genesis-tools/claude-usage/config.json`
+
+## Notification rules (unchanged)
+
+- `EXTRA_ENABLED` — first observation or `false → true`
+- `EXTRA_DISABLED` — `true → false` (balance from last-known snapshot when API nulls fields)
+- `EXTRA_SPEND` — every €5 spent while enabled
+- Group: `claude-extra-usage` (separate macOS thread from session alerts)
+- No `ignoreDnD`
+
+## Verify
+
+```bash
+# Reset tracker to simulate "was enabled"
+bun -e "
+import { Storage } from './src/utils/storage/storage.ts';
+const s = new Storage('claude-usage');
+await s.atomicConfigUpdate((c) => {
+  c.notificationPollTracker.extraUsageTrackers['reservine:extra_usage'].lastKnownEnabled = true;
+});
+"
+
+# Live poll — should log EXTRA_DISABLED once + dispatched + daemon poll completed
+bun run src/claude/lib/usage/poll-daemon.ts
+
+# Second poll — no extra-usage log lines
+bun run src/claude/lib/usage/poll-daemon.ts
+
+# Tests
+bun test src/claude/lib/usage/extra-usage-notify.test.ts src/claude/lib/usage/shared-cache.test.ts
+```
+
+## Future (out of scope)
+
+- Unify session/weekly notifications into shared-cache the same way (TUI still has a separate `NotificationManager` without persisted state)
+- Dedupe session/weekly notification flood when multiple accounts cross thresholds in one poll

--- a/plugins/genesis-tools/commands/timelog.md
+++ b/plugins/genesis-tools/commands/timelog.md
@@ -153,10 +153,12 @@ tools azure-devops timelog import .genesis-tools/azure-devops/cache/prepare-impo
 
 This workflow:
 - Validates each entry as it's added (Zod schema + workitem type precheck)
+- Backfills `workItemTitle` via precheck — do not guess titles in `--entry` JSON
 - Allows user to review before committing
 - Generates a name automatically from date range (e.g., `2026-02-01.2026-02-08`)
 - Entries can be removed or modified before import
-- Import supports `--dry-run` for final verification
+- Import `--dry-run` validates and writes backfilled titles to the file
+- Run from the repo with `.claude/azure/config.json` (e.g. `col-fe/`)
 
 ### Step 8: Execute Approved Entries (Alternative for Single Entries)
 
@@ -312,9 +314,11 @@ Fields:
 - `minutes` (optional): Additional minutes (use instead of decimal hours if preferred)
 - `comment` (optional): Description of work done
 
+`workItemTitle` is **not** an input field — precheck adds it on `prepare-import add` / `list` or `import --dry-run`. Do not invent titles when authoring JSON.
+
 Commands:
 ```bash
-# Validate without creating entries
+# Validate and backfill workItemTitle (run from project with .claude/azure/config.json)
 tools azure-devops timelog import <file.json> --dry-run
 
 # Actually import

--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -474,6 +474,8 @@ tools azure-devops timelog prepare-import clear --name 2026-02-01.2026-02-08
 
 The name is auto-generated from `--from` and `--to` as `<from>.<to>` (e.g., `2026-02-01.2026-02-08`). Each entry is validated with Zod schema and runs workitem type precheck before being added.
 
+Do **not** include `workItemTitle` in staged `--entry` JSON unless you already have the exact ADO title. Precheck backfills it on `prepare-import add`; `prepare-import list` and `import --dry-run` fill any still-missing titles. Run from the project directory that has `.claude/azure/config.json` (e.g. `col-fe/`).
+
 ### Import Time Logs
 
 ```bash
@@ -483,9 +485,11 @@ tools azure-devops timelog import .genesis-tools/azure-devops/cache/prepare-impo
 # Or import from custom JSON file
 tools azure-devops timelog import entries.json
 
-# Dry run to validate without creating entries
+# Dry run — validates, backfills workItemTitle into the file, does not create entries
 tools azure-devops timelog import entries.json --dry-run
 ```
+
+Omit `workItemTitle` when authoring import JSON. Precheck resolves titles (single ADO fetch per work item) and `--dry-run` writes them back to the source file.
 
 The import command runs workitem type precheck for each entry before creating it. After import, the command shows a precheck summary with counts of passed/redirected/failed entries. The cache is automatically evicted after successful imports.
 

--- a/plugins/genesis-tools/skills/debugging-master/SKILL.md
+++ b/plugins/genesis-tools/skills/debugging-master/SKILL.md
@@ -7,9 +7,10 @@ description: Hypothesis-driven runtime debugging with temporary, auto-cleanable 
 
 Runtime data beats static analysis. Instead of guessing, instrument code with targeted logging, reproduce the bug, and analyze real runtime data.
 
-## Critical Rule
+## Critical Rules
 
-**NEVER guess at runtime values or execution flow.** Instrument, reproduce, analyze. One `dbg.dump()` is worth a hundred lines of static reasoning.
+1. **NEVER guess at runtime values or execution flow.** Instrument, reproduce, analyze. One `dbg.dump()` is worth a hundred lines of static reasoning.
+2. **EVERY ingest call MUST be wrapped in `// #region @dbg` / `// #endregion @dbg` markers — no exceptions.** This is what makes cleanup and the git-stash-and-reapply workflow work. A bare `dbg.info(...)` / `LlmLog::info(...)` / `fetch('http://.../log/...')` outside markers is a bug: cleanup cannot find it, cannot stash it, cannot remove it, and it WILL get committed by accident. Wrap **every single ingest line** (imports, requires, fetch posts, every `dbg.*` / `LlmLog::*` call) in its own region block. Use `tools debugging-master snippet <type> <label>` to generate ready-to-paste, correctly wrapped blocks instead of hand-writing them.
 
 ## Quick Reference
 
@@ -55,19 +56,19 @@ The `start` command:
 
 ### Rules
 
-1. **Always wrap in region markers** - enables automated cleanup:
+1. **MANDATORY: every ingest call MUST be wrapped in `// #region @dbg` / `// #endregion @dbg` markers.** No exceptions — not for imports, not for one-liners, not for `fetch('/log/...')` HTTP posts, not even for "I'll remove it manually in a second" debug lines. The stash and cleanup tooling is ONLY able to see / move / restore lines that live inside these markers. An un-wrapped ingest line is a leak waiting to be committed.
    ```ts
    // #region @dbg
    import { dbg } from '../utils/llm-log';
    // #endregion @dbg
    ```
-2. **Every debug line gets its own region block** - granular removal:
+2. **Every debug line gets its OWN region block** — granular stash + removal, and so a partial cleanup can drop one call without disturbing the others:
    ```ts
    // #region @dbg
    dbg.dump('userData', userData);
    // #endregion @dbg
    ```
-3. Use `tools debugging-master snippet <type> <label>` to generate ready-to-paste blocks with correct imports and markers.
+3. **Prefer `tools debugging-master snippet <type> <label>`** to generate blocks — it always emits the markers correctly so you cannot forget them. Hand-written ingest calls are the #1 source of orphan logs that survive cleanup.
 
 ### API Methods
 
@@ -400,31 +401,59 @@ PHP HTTP mode auto-detects Guzzle. If installed, uses Guzzle; otherwise falls ba
 
 ## Cleanup Checklist
 
-Always clean up after debugging is resolved:
+Cleanup is **opt-in** — `tools debugging-master cleanup` with no flags just prints help and exits. You MUST pick an action:
 
 ```bash
-# 1. Remove all @dbg blocks from project files, archive logs to /tmp
-tools debugging-master cleanup
+# Remove @dbg blocks (stashes them into git first, so you can re-apply later)
+tools debugging-master cleanup --blocks
 
-# 2. If cleanup reports formatting-only diffs, fix them:
-tools debugging-master cleanup --repair-formatting
+# Archive session logs out of the sessions dir (moves to /tmp by default)
+tools debugging-master cleanup --clean-logs
 
-# 3. If you want to keep logs permanently:
-tools debugging-master cleanup --keep-logs ./debug-logs/
+# Do both in one shot — the typical "I'm done debugging" command
+tools debugging-master cleanup --blocks --clean-logs
+
+# Block removal + skip the git stash (rare; means you really want them gone)
+tools debugging-master cleanup --blocks --no-stash
+
+# Block removal + custom stash message (default is auto-timestamped)
+tools debugging-master cleanup --blocks --stash-message "auth bug investigation"
+
+# Archive logs to a permanent path instead of /tmp
+tools debugging-master cleanup --clean-logs ./debug-logs/
+
+# Fix formatting-only diffs left by block removal
+tools debugging-master cleanup --blocks --repair-formatting
 ```
 
-What cleanup does:
-- Scans all project files for `// #region @dbg` ... `// #endregion @dbg` blocks
-- Removes those blocks
-- Archives session logs to `/tmp/<datetime>-llmlog-<session>.jsonl`
-- Reports files with formatting-only diffs (blank lines left by block removal)
-- `--repair-formatting` runs `git checkout` on files with only whitespace diffs
-- `--keep-logs <path>` moves archived logs to a permanent location
+What `--blocks` does:
+- Scans all project files for `// #region @dbg` ... `// #endregion @dbg` blocks (this is why **every** ingest line MUST be wrapped — see Critical Rules)
+- **Stashes** the @dbg blocks + the `llm-log.{ts,php}` snippet into git first (default; `--no-stash` to skip)
+- Removes the blocks from working tree
+- Reports any formatting-only diffs; `--repair-formatting` `git checkout`s those files
+- `--stash-message <msg>` attaches a custom note to the stash entry
+
+What `--clean-logs` does:
+- Moves the active session jsonl + meta out of `~/.genesis-tools/debugging-master/sessions/`
+- Default destination is `/tmp/<datetime>-llmlog-<session>.jsonl` (cleared on reboot)
+- Pass a path to keep them permanently: `--clean-logs ./debug-logs/`
+
+### Re-applying a stash
+
+The stash is the recovery mechanism. Recommend `apply` (NOT `pop`) so the stash sticks around for repeated re-application:
+
+```bash
+git stash list                    # find the stash index
+git stash apply stash@{0}         # re-insert @dbg blocks + snippet
+git stash show -p stash@{0}       # preview the diff
+git stash drop stash@{0}          # discard when truly done
+```
 
 What cleanup does NOT do:
-- Delete sessions from config
-- Permanently delete log data (always archives first)
+- Delete sessions from config (use the sessions CLI for that)
+- Permanently delete log data — `--clean-logs` archives, never `rm`
 - Touch files with non-debug changes
+- Find or stash any ingest line that's missing its `// #region @dbg` markers (this is the failure mode the wrap-mandate prevents)
 
 ## Token Efficiency Tips
 

--- a/plugins/genesis-tools/skills/debugging-master/SKILL.md
+++ b/plugins/genesis-tools/skills/debugging-master/SKILL.md
@@ -452,7 +452,7 @@ git stash drop stash@{0}          # discard when truly done
 What cleanup does NOT do:
 - Delete sessions from config (use the sessions CLI for that)
 - Permanently delete log data — `--clean-logs` archives, never `rm`
-- Touch files with non-debug changes
+- Leave unrelated edits untouched in files that contain `@dbg` blocks — note that `--blocks` stashes whole files, so any non-debug edits in those files move into the stash too
 - Find or stash any ingest line that's missing its `// #region @dbg` markers (this is the failure mode the wrap-mandate prevents)
 
 ## Token Efficiency Tips

--- a/src/azure-devops/commands/timelog/import.ts
+++ b/src/azure-devops/commands/timelog/import.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { Api } from "@app/azure-devops/api";
 import { AzureDevOpsCacheManager } from "@app/azure-devops/cache-manager";
+import { buildAllowedTypeConfig } from "@app/azure-devops/lib/timelog/allowed-type-config";
 import {
     normalizeTimelogEntries,
     readEntryWorkItemTitle,
@@ -8,10 +9,11 @@ import {
 } from "@app/azure-devops/lib/timelog/entry-fields";
 import { convertToMinutes, formatMinutes, TimeLogApi } from "@app/azure-devops/timelog-api";
 import { updateWorkItemEffort } from "@app/azure-devops/timelog-effort";
-import type { AllowedTypeConfig, TimeLogImportFile } from "@app/azure-devops/types";
+import type { TimeLogImportFile } from "@app/azure-devops/types";
 import { requireTimeLogConfig, requireTimeLogUser } from "@app/azure-devops/utils";
 import { precheckWorkItem } from "@app/azure-devops/workitem-precheck";
 import { logger, out } from "@app/logger";
+import { concurrentMap } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
 import pc from "picocolors";
@@ -114,12 +116,6 @@ export function registerImportSubcommand(parent: Command): void {
 
             const workitemTitles = new Map<number, string>();
 
-            for (const entry of validEntries) {
-                if (entry.workItemTitle) {
-                    workitemTitles.set(entry.workItemId, entry.workItemTitle);
-                }
-            }
-
             // Report validation errors
             if (errors.length > 0) {
                 out.error("Validation errors:");
@@ -136,14 +132,7 @@ export function registerImportSubcommand(parent: Command): void {
             }
 
             // ---- Precheck phase: validate work item types ----
-            const allowedTypeConfig: AllowedTypeConfig | undefined = config.timelog?.allowedWorkItemTypes?.length
-                ? {
-                      allowedWorkItemTypes: config.timelog?.allowedWorkItemTypes,
-                      allowedStatesPerType: config.timelog?.allowedStatesPerType,
-                      deprioritizedStates: config.timelog?.deprioritizedStates,
-                      defaultUserName: config.timelog?.defaultUser?.userName,
-                  }
-                : undefined;
+            const allowedTypeConfig = buildAllowedTypeConfig(config);
 
             let precheckPassed: typeof validEntries = [];
             const precheckRedirected: Array<{
@@ -162,17 +151,22 @@ export function registerImportSubcommand(parent: Command): void {
                     pc.yellow("Note: allowedWorkItemTypes not configured — skipping work item type precheck.\n")
                 );
                 precheckPassed = validEntries;
+
+                for (const entry of validEntries) {
+                    if (entry.workItemTitle) {
+                        workitemTitles.set(entry.workItemId, entry.workItemTitle);
+                    }
+                }
             } else {
                 out.println("Pre-checking work item types...");
 
                 // Deduplicate work item IDs to avoid redundant API calls
                 const uniqueWorkItemIds = [...new Set(validEntries.map((e) => e.workItemId))];
-                const precheckResults = new Map<number, Awaited<ReturnType<typeof precheckWorkItem>>>();
-
-                for (const workItemId of uniqueWorkItemIds) {
-                    const result = await precheckWorkItem(workItemId, config.org, allowedTypeConfig);
-                    precheckResults.set(workItemId, result);
-                }
+                const precheckResults = await concurrentMap({
+                    items: uniqueWorkItemIds,
+                    fn: (workItemId) => precheckWorkItem(workItemId, config.org, allowedTypeConfig),
+                    concurrency: 5,
+                });
 
                 for (const entry of validEntries) {
                     const result = precheckResults.get(entry.workItemId)!;

--- a/src/azure-devops/commands/timelog/import.ts
+++ b/src/azure-devops/commands/timelog/import.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { Api } from "@app/azure-devops/api";
 import { AzureDevOpsCacheManager } from "@app/azure-devops/cache-manager";
+import {
+    normalizeTimelogEntries,
+    readEntryWorkItemTitle,
+    setEntryWorkItemTitle,
+} from "@app/azure-devops/lib/timelog/entry-fields";
 import { convertToMinutes, formatMinutes, TimeLogApi } from "@app/azure-devops/timelog-api";
 import { updateWorkItemEffort } from "@app/azure-devops/timelog-effort";
 import type { AllowedTypeConfig, TimeLogImportFile } from "@app/azure-devops/types";
@@ -50,6 +55,7 @@ export function registerImportSubcommand(parent: Command): void {
             const errors: string[] = [];
             const validEntries: Array<{
                 workItemId: number;
+                workItemTitle?: string;
                 minutes: number;
                 timeType: string;
                 date: string;
@@ -98,11 +104,20 @@ export function registerImportSubcommand(parent: Command): void {
 
                 validEntries.push({
                     workItemId: entry.workItemId,
+                    workItemTitle: readEntryWorkItemTitle(entry),
                     minutes,
                     timeType: exactType!.description,
                     date: entry.date,
                     comment: entry.comment || "",
                 });
+            }
+
+            const workitemTitles = new Map<number, string>();
+
+            for (const entry of validEntries) {
+                if (entry.workItemTitle) {
+                    workitemTitles.set(entry.workItemId, entry.workItemTitle);
+                }
             }
 
             // Report validation errors
@@ -131,7 +146,6 @@ export function registerImportSubcommand(parent: Command): void {
                 : undefined;
 
             let precheckPassed: typeof validEntries = [];
-            const workitemTitles = new Map<number, string>();
             const precheckRedirected: Array<{
                 original: number;
                 originalTitle: string;
@@ -228,6 +242,25 @@ export function registerImportSubcommand(parent: Command): void {
             }
 
             if (options.dryRun) {
+                const serializedBefore = SafeJSON.stringify(data.entries, null, 2);
+                data.entries = normalizeTimelogEntries(
+                    data.entries.map((entry) => {
+                        const title = workitemTitles.get(entry.workItemId) ?? readEntryWorkItemTitle(entry);
+
+                        if (title) {
+                            return setEntryWorkItemTitle(entry, title);
+                        }
+
+                        return entry;
+                    })
+                );
+                const serializedAfter = SafeJSON.stringify(data.entries, null, 2);
+
+                if (serializedBefore !== serializedAfter) {
+                    await Bun.write(file, `${serializedAfter}\n`);
+                    out.println(pc.dim(`Updated ${file} with resolved workItemTitle values.\n`));
+                }
+
                 out.println("\u2714 Dry run complete. Valid entries:");
 
                 for (const e of precheckPassed) {

--- a/src/azure-devops/commands/timelog/prepare-import.ts
+++ b/src/azure-devops/commands/timelog/prepare-import.ts
@@ -1,3 +1,9 @@
+import {
+    normalizeTimelogEntries,
+    readEntryWorkItemTitle,
+    setEntryWorkItemTitle,
+    workItemTitleFromPrecheck,
+} from "@app/azure-devops/lib/timelog/entry-fields";
 import { convertToMinutes, formatMinutes } from "@app/azure-devops/timelog-api";
 import type { AllowedTypeConfig } from "@app/azure-devops/types";
 import { requireTimeLogConfig } from "@app/azure-devops/utils";
@@ -13,6 +19,8 @@ import { z } from "zod";
 const TimelogEntrySchema = z
     .object({
         workItemId: z.number().int().positive(),
+        workItemTitle: z.string().optional(),
+        workItemName: z.string().optional(),
         date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
         hours: z.number().min(0).optional(),
         minutes: z.number().int().min(0).optional(),
@@ -28,8 +36,10 @@ type TimelogEntryInput = z.infer<typeof TimelogEntrySchema>;
 interface StoredEntry {
     _id: string;
     _status: "pending";
-    _workitemTitle?: string;
     workItemId: number;
+    workItemTitle: string;
+    workItemName?: string;
+    _workitemTitle?: string;
     date: string;
     hours?: number;
     minutes?: number;
@@ -90,9 +100,65 @@ function computeTotalMinutes(entry: StoredEntry): number {
     return h * 60 + m;
 }
 
+async function backfillMissingWorkItemTitles(
+    entries: StoredEntry[],
+    org: string,
+    allowedTypeConfig: AllowedTypeConfig | undefined
+): Promise<boolean> {
+    let mutated = false;
+
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const existing = readEntryWorkItemTitle(entry);
+
+        if (!existing) {
+            continue;
+        }
+
+        if (!entry.workItemTitle || entry.workItemName || entry._workitemTitle) {
+            entries[i] = setEntryWorkItemTitle(entry, existing);
+            mutated = true;
+        }
+    }
+
+    const idsMissingTitle = [...new Set(entries.filter((e) => !readEntryWorkItemTitle(e)).map((e) => e.workItemId))];
+
+    if (idsMissingTitle.length === 0 || !allowedTypeConfig) {
+        return mutated;
+    }
+
+    for (const id of idsMissingTitle) {
+        const result = await precheckWorkItem(id, org, allowedTypeConfig);
+        const title = workItemTitleFromPrecheck(result);
+
+        if (!title) {
+            continue;
+        }
+
+        for (let i = 0; i < entries.length; i++) {
+            const entry = entries[i];
+
+            if (entry.workItemId === id && !readEntryWorkItemTitle(entry)) {
+                entries[i] = setEntryWorkItemTitle(entry, title);
+                mutated = true;
+            }
+        }
+    }
+
+    const before = SafeJSON.stringify(entries);
+    entries.splice(0, entries.length, ...normalizeTimelogEntries(entries));
+
+    if (!mutated && SafeJSON.stringify(entries) !== before) {
+        mutated = true;
+    }
+
+    return mutated;
+}
+
 function printEntry(entry: StoredEntry): void {
     const totalMin = computeTotalMinutes(entry);
-    const wiLabel = entry._workitemTitle ? `#${entry.workItemId} ${entry._workitemTitle}` : `#${entry.workItemId}`;
+    const title = readEntryWorkItemTitle(entry);
+    const wiLabel = title ? `#${entry.workItemId} ${title}` : `#${entry.workItemId}`;
     const parts = [wiLabel, formatMinutes(totalMin), entry.timeType, entry.date];
 
     if (entry.comment) {
@@ -103,12 +169,24 @@ function printEntry(entry: StoredEntry): void {
     out.println(`  ${parts.join(" | ")}`);
 }
 
+function buildAllowedTypeConfig(config: ReturnType<typeof requireTimeLogConfig>): AllowedTypeConfig | undefined {
+    if (!config.timelog?.allowedWorkItemTypes?.length) {
+        return undefined;
+    }
+
+    return {
+        allowedWorkItemTypes: config.timelog.allowedWorkItemTypes,
+        allowedStatesPerType: config.timelog.allowedStatesPerType,
+        deprioritizedStates: config.timelog.deprioritizedStates,
+        defaultUserName: config.timelog.defaultUser?.userName,
+    };
+}
+
 // ============= Subcommand Actions =============
 
 async function handleAdd(options: TimelogAddOptions): Promise<void> {
     const fileName = resolveFileName(options);
 
-    // Parse and validate entry JSON
     let rawEntry: unknown;
 
     try {
@@ -132,7 +210,6 @@ async function handleAdd(options: TimelogAddOptions): Promise<void> {
 
     const validated: TimelogEntryInput = parseResult.data;
 
-    // Validate time converts properly
     try {
         convertToMinutes(validated.hours, validated.minutes);
     } catch (e) {
@@ -140,17 +217,8 @@ async function handleAdd(options: TimelogAddOptions): Promise<void> {
         process.exit(1);
     }
 
-    // Precheck work item
     const config = requireTimeLogConfig();
-    const allowedTypeConfig: AllowedTypeConfig | undefined = config.timelog?.allowedWorkItemTypes?.length
-        ? {
-              allowedWorkItemTypes: config.timelog.allowedWorkItemTypes,
-              allowedStatesPerType: config.timelog.allowedStatesPerType,
-              deprioritizedStates: config.timelog.deprioritizedStates,
-              defaultUserName: config.timelog.defaultUser?.userName,
-          }
-        : undefined;
-
+    const allowedTypeConfig = buildAllowedTypeConfig(config);
     const precheck = await precheckWorkItem(validated.workItemId, config.org, allowedTypeConfig);
 
     let effectiveWorkItemId = validated.workItemId;
@@ -174,17 +242,13 @@ async function handleAdd(options: TimelogAddOptions): Promise<void> {
         effectiveWorkItemId = precheck.redirectId!;
     }
 
-    const workitemTitle =
-        precheck.status === "redirect"
-            ? (precheck.redirectTitle ?? `${precheck.originalTitle} (redirected → #${precheck.redirectId})`)
-            : precheck.originalTitle;
+    const resolvedWorkItemTitle = readEntryWorkItemTitle(validated) || workItemTitleFromPrecheck(precheck) || "";
 
-    // Build stored entry
     const storedEntry: StoredEntry = {
         _id: crypto.randomUUID(),
         _status: "pending",
-        _workitemTitle: workitemTitle,
         workItemId: effectiveWorkItemId,
+        workItemTitle: resolvedWorkItemTitle,
         date: validated.date,
         hours: validated.hours,
         minutes: validated.minutes,
@@ -192,7 +256,6 @@ async function handleAdd(options: TimelogAddOptions): Promise<void> {
         comment: validated.comment ?? "",
     };
 
-    // Atomic append
     await storage.atomicUpdate<PrepareImportFile>(cacheKey(fileName), (current) => {
         if (current) {
             return { ...current, entries: [...current.entries, storedEntry] };
@@ -238,12 +301,18 @@ async function handleList(options: TimelogListOptions): Promise<void> {
         process.exit(1);
     }
 
+    const config = requireTimeLogConfig();
+    const backfilled = await backfillMissingWorkItemTitles(data.entries, config.org, buildAllowedTypeConfig(config));
+
+    if (backfilled) {
+        await storage.atomicUpdate<PrepareImportFile>(key, () => data);
+    }
+
     if (options.format === "json") {
         out.println(SafeJSON.stringify(data, null, 2));
         return;
     }
 
-    // Table format (default)
     out.println(`Prepare-import: ${data.name}`);
     out.println(`Created: ${data.createdAt}`);
     out.println(`Entries: ${data.entries.length}\n`);
@@ -253,12 +322,10 @@ async function handleList(options: TimelogListOptions): Promise<void> {
         return;
     }
 
-    // Print entries
     for (const entry of data.entries) {
         printEntry(entry);
     }
 
-    // Totals per day
     const dailyTotals = new Map<string, number>();
     const workitemTotals = new Map<number, number>();
 
@@ -278,19 +345,21 @@ async function handleList(options: TimelogListOptions): Promise<void> {
 
     out.println("\nTotals per work item:");
 
-    const workitemNames = new Map<number, string>();
+    const workitemTitles = new Map<number, string>();
 
     for (const entry of data.entries) {
-        if (entry._workitemTitle) {
-            workitemNames.set(entry.workItemId, entry._workitemTitle);
+        const title = readEntryWorkItemTitle(entry);
+
+        if (title) {
+            workitemTitles.set(entry.workItemId, title);
         }
     }
 
     const sortedItems = [...workitemTotals.entries()].sort(([a], [b]) => a - b);
 
     for (const [id, mins] of sortedItems) {
-        const name = workitemNames.get(id);
-        const label = name ? `#${id} ${name}` : `#${id}`;
+        const title = workitemTitles.get(id);
+        const label = title ? `#${id} ${title}` : `#${id}`;
         out.println(`  ${label}: ${formatMinutes(mins)}`);
     }
 

--- a/src/azure-devops/commands/timelog/prepare-import.ts
+++ b/src/azure-devops/commands/timelog/prepare-import.ts
@@ -1,3 +1,4 @@
+import { buildAllowedTypeConfig } from "@app/azure-devops/lib/timelog/allowed-type-config";
 import {
     normalizeTimelogEntries,
     readEntryWorkItemTitle,
@@ -9,6 +10,7 @@ import type { AllowedTypeConfig } from "@app/azure-devops/types";
 import { requireTimeLogConfig } from "@app/azure-devops/utils";
 import { precheckWorkItem } from "@app/azure-devops/workitem-precheck";
 import { out } from "@app/logger";
+import { concurrentMap } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 import { Storage } from "@app/utils/storage";
 import type { Command } from "commander";
@@ -127,8 +129,13 @@ async function backfillMissingWorkItemTitles(
         return mutated;
     }
 
-    for (const id of idsMissingTitle) {
-        const result = await precheckWorkItem(id, org, allowedTypeConfig);
+    const precheckById = await concurrentMap({
+        items: idsMissingTitle,
+        fn: (id) => precheckWorkItem(id, org, allowedTypeConfig),
+        concurrency: 5,
+    });
+
+    for (const [id, result] of precheckById) {
         const title = workItemTitleFromPrecheck(result);
 
         if (!title) {
@@ -167,19 +174,6 @@ function printEntry(entry: StoredEntry): void {
 
     parts.push(`[${entry._id.substring(0, 8)}]`);
     out.println(`  ${parts.join(" | ")}`);
-}
-
-function buildAllowedTypeConfig(config: ReturnType<typeof requireTimeLogConfig>): AllowedTypeConfig | undefined {
-    if (!config.timelog?.allowedWorkItemTypes?.length) {
-        return undefined;
-    }
-
-    return {
-        allowedWorkItemTypes: config.timelog.allowedWorkItemTypes,
-        allowedStatesPerType: config.timelog.allowedStatesPerType,
-        deprioritizedStates: config.timelog.deprioritizedStates,
-        defaultUserName: config.timelog.defaultUser?.userName,
-    };
 }
 
 // ============= Subcommand Actions =============

--- a/src/azure-devops/lib/timelog/allowed-type-config.ts
+++ b/src/azure-devops/lib/timelog/allowed-type-config.ts
@@ -1,0 +1,14 @@
+import type { AllowedTypeConfig, AzureConfigWithTimeLog } from "@app/azure-devops/types";
+
+export function buildAllowedTypeConfig(config: AzureConfigWithTimeLog): AllowedTypeConfig | undefined {
+    if (!config.timelog?.allowedWorkItemTypes?.length) {
+        return undefined;
+    }
+
+    return {
+        allowedWorkItemTypes: config.timelog.allowedWorkItemTypes,
+        allowedStatesPerType: config.timelog.allowedStatesPerType,
+        deprioritizedStates: config.timelog.deprioritizedStates,
+        defaultUserName: config.timelog.defaultUser?.userName,
+    };
+}

--- a/src/azure-devops/lib/timelog/entry-fields.ts
+++ b/src/azure-devops/lib/timelog/entry-fields.ts
@@ -20,8 +20,25 @@ const PREPARE_IMPORT_ENTRY_ORDER = [
 
 const IMPORT_ENTRY_ORDER = ["workItemId", "workItemTitle", "date", "hours", "minutes", "timeType", "comment"] as const;
 
+function normalizeTitleField(value: unknown): string | undefined {
+    if (typeof value !== "string") {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        return undefined;
+    }
+
+    return trimmed;
+}
+
 export function readEntryWorkItemTitle(entry: TimelogEntryTitleFields): string | undefined {
-    const title = entry.workItemTitle?.trim() || entry.workItemName?.trim() || entry._workitemTitle?.trim();
+    const title =
+        normalizeTitleField(entry.workItemTitle) ??
+        normalizeTitleField(entry.workItemName) ??
+        normalizeTitleField(entry._workitemTitle);
 
     if (!title) {
         return undefined;

--- a/src/azure-devops/lib/timelog/entry-fields.ts
+++ b/src/azure-devops/lib/timelog/entry-fields.ts
@@ -1,0 +1,81 @@
+import type { PrecheckResult } from "@app/azure-devops/workitem-precheck";
+
+export interface TimelogEntryTitleFields {
+    workItemTitle?: string;
+    workItemName?: string;
+    _workitemTitle?: string;
+}
+
+const PREPARE_IMPORT_ENTRY_ORDER = [
+    "_id",
+    "_status",
+    "workItemId",
+    "workItemTitle",
+    "date",
+    "hours",
+    "minutes",
+    "timeType",
+    "comment",
+] as const;
+
+const IMPORT_ENTRY_ORDER = ["workItemId", "workItemTitle", "date", "hours", "minutes", "timeType", "comment"] as const;
+
+export function readEntryWorkItemTitle(entry: TimelogEntryTitleFields): string | undefined {
+    const title = entry.workItemTitle?.trim() || entry.workItemName?.trim() || entry._workitemTitle?.trim();
+
+    if (!title) {
+        return undefined;
+    }
+
+    return title;
+}
+
+export function workItemTitleFromPrecheck(result: PrecheckResult): string | undefined {
+    if (result.status === "redirect") {
+        return result.redirectTitle ?? result.originalTitle;
+    }
+
+    return result.originalTitle || undefined;
+}
+
+export function normalizeTimelogEntryKeys<T extends object>(entry: T): T {
+    const record = entry as Record<string, unknown>;
+    const order = "_id" in record ? PREPARE_IMPORT_ENTRY_ORDER : IMPORT_ENTRY_ORDER;
+    const normalized: Record<string, unknown> = {};
+    const used = new Set<string>();
+
+    for (const key of order) {
+        if (key in record) {
+            normalized[key] = record[key];
+            used.add(key);
+        }
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+        if (!used.has(key) && key !== "workItemName" && key !== "_workitemTitle") {
+            normalized[key] = value;
+        }
+    }
+
+    return normalized as T;
+}
+
+export function normalizeTimelogEntries<T extends object>(entries: T[]): T[] {
+    return entries.map((entry) => normalizeTimelogEntryKeys(entry));
+}
+
+export function setEntryWorkItemTitle<T extends TimelogEntryTitleFields>(entry: T, title: string): T {
+    const {
+        workItemName: _workItemName,
+        _workitemTitle,
+        ...rest
+    } = entry as T & {
+        workItemName?: string;
+        _workitemTitle?: string;
+    };
+
+    return normalizeTimelogEntryKeys({
+        ...rest,
+        workItemTitle: title,
+    }) as T;
+}

--- a/src/azure-devops/types.ts
+++ b/src/azure-devops/types.ts
@@ -475,6 +475,7 @@ export interface TimeLogListOptions {
 export interface TimeLogImportFile {
     entries: Array<{
         workItemId: number;
+        workItemTitle?: string;
         hours?: number;
         minutes?: number;
         timeType: string;

--- a/src/claude/commands/usage/app.tsx
+++ b/src/claude/commands/usage/app.tsx
@@ -87,7 +87,7 @@ function Dashboard({ config, accountFilter }: DashboardProps) {
         // abandons in-place erasing for clear-terminal-and-rewrite (ink.js
         // onRender), which scrolls overflow into scrollback and duplicates
         // stale frames on every refresh. The active view clips instead.
-        <Box flexDirection="column" height={Math.max(1, Math.min(rows - 1, 4))}>
+        <Box flexDirection="column" height={Math.max(1, rows - 1)} overflow="hidden">
             <TabBar tabs={tabs} activeIndex={activeIndex} />
             <Box flexDirection="column" flexGrow={1} overflowY="hidden">
                 {activeTab === "overview" && <OverviewView results={results} config={config} />}

--- a/src/claude/commands/usage/components/alert-banner.tsx
+++ b/src/claude/commands/usage/components/alert-banner.tsx
@@ -42,7 +42,7 @@ export function AlertBanner({ alerts, onDismiss }: AlertBannerProps) {
     }
 
     return (
-        <Box flexDirection="column" paddingX={1}>
+        <Box flexDirection="column" flexShrink={0} paddingX={1}>
             {alerts.map((alert, i) => {
                 const bgColor = alert.severity === "critical" ? "red" : "yellow";
                 const isLast = i === alerts.length - 1;

--- a/src/claude/commands/usage/components/overview/account-section.tsx
+++ b/src/claude/commands/usage/components/overview/account-section.tsx
@@ -1,5 +1,6 @@
-import type { AccountUsage, UsageBucket } from "@app/claude/lib/usage/api";
+import type { AccountUsage, ExtraUsageBucket, UsageBucket } from "@app/claude/lib/usage/api";
 import { BUCKET_LABELS, BUCKET_PERIODS_MS, colorForPct } from "@app/claude/lib/usage/constants";
+import { resolveExtraUsageOverview } from "@app/claude/lib/usage/extra-usage-tracker";
 import { useTerminalSize } from "@app/utils/ink/hooks/use-terminal-size";
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
@@ -114,6 +115,41 @@ function BucketRow({ bucketKey, bucket, barWidth }: BucketRowProps) {
     );
 }
 
+interface ExtraUsageRowProps {
+    bucket: ExtraUsageBucket;
+    barWidth: number;
+}
+
+function ExtraUsageRow({ bucket, barWidth }: ExtraUsageRowProps) {
+    const overview = resolveExtraUsageOverview(bucket);
+    const label = BUCKET_LABELS.extra_usage;
+
+    if (!overview.enabled) {
+        return (
+            <Box flexDirection="column">
+                <Box>
+                    <Text>{label.padEnd(NAME_WIDTH)}</Text>
+                    <Text dimColor>{"off"}</Text>
+                </Box>
+            </Box>
+        );
+    }
+
+    const pct = Math.round(Math.max(0, Math.min(overview.utilization, 100)));
+
+    return (
+        <Box flexDirection="column">
+            <Box>
+                <Text>{label.padEnd(NAME_WIDTH)}</Text>
+                <UsageBar utilization={overview.utilization} width={barWidth} />
+                <Text bold>{`${pct}%`.padStart(PCT_WIDTH)}</Text>
+                <Text>{" ".repeat(PROJ_WIDTH)}</Text>
+            </Box>
+            {overview.balance ? <Text dimColor>{`${" ".repeat(NAME_WIDTH)}${overview.balance}`}</Text> : null}
+        </Box>
+    );
+}
+
 interface AccountSectionProps {
     account: AccountUsage;
     prominentBuckets: string[];
@@ -143,9 +179,15 @@ export function AccountSection({ account, prominentBuckets }: AccountSectionProp
         );
     }
 
-    const allEntries = Object.entries(account.usage).filter(
-        ([, v]) => v && typeof v === "object" && "utilization" in v
-    ) as Array<[string, UsageBucket]>;
+    const extraUsage = account.usage.extra_usage ?? null;
+
+    const allEntries = Object.entries(account.usage).filter(([key, v]) => {
+        if (key === "extra_usage") {
+            return false;
+        }
+
+        return v && typeof v === "object" && "utilization" in v;
+    }) as Array<[string, UsageBucket]>;
 
     const sessionAt100 = allEntries.some(([k, b]) => k === "five_hour" && b.utilization >= 100);
     const weeklyAt100 = allEntries.some(([k, b]) => k === "seven_day" && b.utilization >= 100);
@@ -167,6 +209,7 @@ export function AccountSection({ account, prominentBuckets }: AccountSectionProp
             {entries.map(([key, bucket]) => (
                 <BucketRow key={key} bucketKey={key} bucket={bucket} barWidth={barWidth} />
             ))}
+            {extraUsage ? <ExtraUsageRow bucket={extraUsage} barWidth={barWidth} /> : null}
         </Box>
     );
 }

--- a/src/claude/commands/usage/components/overview/overview-view.tsx
+++ b/src/claude/commands/usage/components/overview/overview-view.tsx
@@ -37,7 +37,7 @@ export function OverviewView({ results, config }: OverviewViewProps) {
     }
 
     return (
-        <Box flexDirection="column" paddingX={1} paddingY={1}>
+        <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
             {results.accounts.map((account) => (
                 <AccountSection
                     key={account.accountName}

--- a/src/claude/commands/usage/components/status-bar.tsx
+++ b/src/claude/commands/usage/components/status-bar.tsx
@@ -31,6 +31,7 @@ export function StatusBar({ lastRefresh, nextRefresh, paused, pollingLabel, poll
     return (
         <Box
             flexDirection="column"
+            flexShrink={0}
             borderStyle="single"
             borderTop
             borderBottom={false}

--- a/src/claude/commands/usage/components/tab-bar.tsx
+++ b/src/claude/commands/usage/components/tab-bar.tsx
@@ -9,7 +9,7 @@ interface TabBarProps {
 
 export function TabBar({ tabs, activeIndex }: TabBarProps) {
     return (
-        <Box>
+        <Box flexShrink={0}>
             <Text dimColor>{"← "}</Text>
             {tabs.map((tab, i) => (
                 <Fragment key={tab.id}>

--- a/src/claude/commands/usage/hooks/use-usage-poller.ts
+++ b/src/claude/commands/usage/hooks/use-usage-poller.ts
@@ -1,5 +1,6 @@
 import { refreshAccountLabels } from "@app/claude/lib/config";
 import type { AccountUsage } from "@app/claude/lib/usage/api";
+import { isUsageBucket } from "@app/claude/lib/usage/api";
 import type { UsageDashboardConfig } from "@app/claude/lib/usage/dashboard-config";
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { NotificationManager } from "@app/claude/lib/usage/notification-manager";
@@ -62,7 +63,7 @@ export function useUsagePoller({ config, accountFilter, paused, pollIntervalSeco
                 }
 
                 for (const [bucket, data] of Object.entries(account.usage)) {
-                    if (!data || typeof data !== "object" || !("utilization" in data)) {
+                    if (!isUsageBucket(data)) {
                         continue;
                     }
 

--- a/src/claude/lib/config/index.ts
+++ b/src/claude/lib/config/index.ts
@@ -24,6 +24,8 @@ export interface NotificationConfig {
     weeklyThresholds: number[];
     channels: NotificationChannels;
     watchInterval: number;
+    /** Hidden JSON-only toggle — alerts when extra usage enables and every +5%. Default off. */
+    extraUsage?: boolean;
 }
 
 export interface WarmupSchedule {

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -19,13 +19,24 @@ export interface UsageBucket {
     resets_at: string | null;
 }
 
+export interface ExtraUsageBucket {
+    is_enabled: boolean;
+    monthly_limit: number | null;
+    used_credits: number | null;
+    utilization: number | null;
+    currency?: string | null;
+    decimal_places?: number | null;
+    disabled_reason?: string | null;
+}
+
 export interface UsageResponse {
     five_hour: UsageBucket;
     seven_day: UsageBucket;
     seven_day_opus?: UsageBucket | null;
     seven_day_sonnet?: UsageBucket | null;
     seven_day_oauth_apps?: UsageBucket | null;
-    [key: string]: UsageBucket | null | undefined;
+    extra_usage?: ExtraUsageBucket | null;
+    [key: string]: UsageBucket | ExtraUsageBucket | null | undefined;
 }
 
 export interface AccountUsage {
@@ -33,6 +44,14 @@ export interface AccountUsage {
     label?: string;
     usage?: UsageResponse;
     error?: string;
+}
+
+export function isUsageBucket(value: UsageBucket | ExtraUsageBucket | null | undefined): value is UsageBucket {
+    if (value === null || value === undefined) {
+        return false;
+    }
+
+    return "resets_at" in value;
 }
 
 const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";

--- a/src/claude/lib/usage/constants.ts
+++ b/src/claude/lib/usage/constants.ts
@@ -4,6 +4,7 @@ export const BUCKET_LABELS: Record<string, string> = {
     seven_day_opus: "Weekly (Opus)",
     seven_day_sonnet: "Weekly (Sonnet)",
     seven_day_oauth_apps: "Weekly (OAuth)",
+    extra_usage: "Extra usage",
 };
 
 export const BUCKET_PERIODS_MS: Record<string, number> = {

--- a/src/claude/lib/usage/display.ts
+++ b/src/claude/lib/usage/display.ts
@@ -1,6 +1,8 @@
 import { formatDateTime } from "@app/utils/date";
 import pc from "picocolors";
 import type { AccountUsage } from "./api";
+import { isUsageBucket } from "./api";
+import { resolveExtraUsageOverview } from "./extra-usage-tracker";
 
 const BAR_WIDTH = 40;
 const BLOCK_FULL = "\u2588"; // █
@@ -40,6 +42,7 @@ const BUCKET_LABELS: Record<string, string> = {
     seven_day_opus: "Current week (Opus only)",
     seven_day_sonnet: "Current week (Sonnet only)",
     seven_day_oauth_apps: "Current week (OAuth apps)",
+    extra_usage: "Extra usage",
 };
 
 function bucketLabel(key: string): string {
@@ -123,9 +126,14 @@ export function renderAccountUsage(account: AccountUsage): string {
     }
 
     for (const [key, bucket] of Object.entries(account.usage)) {
-        if (!bucket || typeof bucket !== "object" || !("utilization" in bucket)) {
+        if (key === "extra_usage" || !isUsageBucket(bucket)) {
             continue;
         }
+
+        if (bucket.utilization === null || bucket.utilization === undefined) {
+            continue;
+        }
+
         lines.push(`${bucketLabel(key)}`);
         lines.push(renderBar(bucket.utilization));
 
@@ -143,6 +151,23 @@ export function renderAccountUsage(account: AccountUsage): string {
         if (parts.length > 0) {
             lines.push(pc.dim(parts[0]) + (parts[1] ? `  ${parts[1]}` : ""));
         }
+        lines.push("");
+    }
+
+    if (account.usage.extra_usage) {
+        const overview = resolveExtraUsageOverview(account.usage.extra_usage);
+        lines.push(bucketLabel("extra_usage"));
+
+        if (!overview.enabled) {
+            lines.push(pc.dim("  off"));
+        } else {
+            lines.push(renderBar(overview.utilization));
+
+            if (overview.balance) {
+                lines.push(pc.dim(`  ${overview.balance}`));
+            }
+        }
+
         lines.push("");
     }
 

--- a/src/claude/lib/usage/extra-usage-notify.test.ts
+++ b/src/claude/lib/usage/extra-usage-notify.test.ts
@@ -1,0 +1,75 @@
+import { setupStorageSandbox } from "@app/utils/storage/test-sandbox";
+
+setupStorageSandbox();
+
+import { describe, expect, test } from "bun:test";
+import { Storage } from "@app/utils/storage/storage";
+import type { AccountUsage, ExtraUsageBucket } from "./api";
+import { __makeExtraUsageNotifier } from "./extra-usage-notify";
+import { formatExtraUsageMessage } from "./extra-usage-tracker";
+
+function makeAccount(name: string, extra: ExtraUsageBucket): AccountUsage {
+    return {
+        accountName: name,
+        label: name,
+        usage: {
+            five_hour: { utilization: 0, resets_at: null },
+            seven_day: { utilization: 0, resets_at: null },
+            extra_usage: extra,
+        },
+    };
+}
+
+describe("processExtraUsageNotifications", () => {
+    test("persists disabled state before returning so repeat polls do not re-fire", async () => {
+        const storage = new Storage("claude-usage");
+        const dispatched: string[] = [];
+        const run = __makeExtraUsageNotifier({
+            extraUsageEnabled: () => true,
+            storage,
+            dispatch: async (accountName, event) => {
+                dispatched.push(formatExtraUsageMessage({ accountName, event }));
+            },
+        });
+
+        await run([
+            makeAccount("reservine", {
+                is_enabled: true,
+                used_credits: 1834,
+                monthly_limit: 10_000,
+                utilization: 18.34,
+                currency: "EUR",
+                decimal_places: 2,
+            }),
+        ]);
+
+        expect(dispatched).toHaveLength(1);
+
+        dispatched.length = 0;
+
+        await run([
+            makeAccount("reservine", {
+                is_enabled: false,
+                monthly_limit: null,
+                used_credits: null,
+                utilization: null,
+            }),
+        ]);
+
+        expect(dispatched).toHaveLength(1);
+        expect(dispatched[0]).toContain("disabled");
+
+        dispatched.length = 0;
+
+        await run([
+            makeAccount("reservine", {
+                is_enabled: false,
+                monthly_limit: null,
+                used_credits: null,
+                utilization: null,
+            }),
+        ]);
+
+        expect(dispatched).toHaveLength(0);
+    });
+});

--- a/src/claude/lib/usage/extra-usage-notify.ts
+++ b/src/claude/lib/usage/extra-usage-notify.ts
@@ -1,0 +1,149 @@
+import { loadConfig } from "@app/claude/lib/config";
+import { logger } from "@app/logger";
+import { dispatchNotification } from "@app/utils/notifications";
+import type { Storage } from "@app/utils/storage/storage";
+import type { AccountUsage } from "./api";
+import {
+    EXTRA_USAGE_BUCKET,
+    EXTRA_USAGE_NOTIFICATION_GROUP,
+    ExtraUsageBucketTracker,
+    type ExtraUsageNotifyEvent,
+    type ExtraUsageTrackerState,
+    formatExtraUsageMessage,
+} from "./extra-usage-tracker";
+import { getClaudeUsageStorage } from "./storage";
+
+const TRACKER_CONFIG_KEY = "notificationPollTracker";
+
+interface PendingExtraUsageNotification {
+    accountName: string;
+    event: ExtraUsageNotifyEvent;
+}
+
+function trackerKey(accountName: string): string {
+    return `${accountName}:${EXTRA_USAGE_BUCKET}`;
+}
+
+function loadTrackers(saved: Record<string, unknown> | null | undefined): Map<string, ExtraUsageBucketTracker> {
+    const trackers = new Map<string, ExtraUsageBucketTracker>();
+    const raw = saved?.[TRACKER_CONFIG_KEY] as
+        | { extraUsageTrackers?: Record<string, ExtraUsageTrackerState> }
+        | undefined;
+    const byKey = raw?.extraUsageTrackers ?? {};
+
+    for (const [key, state] of Object.entries(byKey)) {
+        const tracker = new ExtraUsageBucketTracker();
+        tracker.restoreState(state);
+        trackers.set(key, tracker);
+    }
+
+    return trackers;
+}
+
+function snapshotTrackers(trackers: Map<string, ExtraUsageBucketTracker>): Record<string, ExtraUsageTrackerState> {
+    return Object.fromEntries([...trackers.entries()].map(([key, tracker]) => [key, tracker.getState()]));
+}
+
+interface ExtraUsageNotifyDeps {
+    extraUsageEnabled: () => boolean | Promise<boolean>;
+    storage: Storage;
+    dispatch: (accountName: string, event: ExtraUsageNotifyEvent) => Promise<void>;
+}
+
+export function __makeExtraUsageNotifier(deps: ExtraUsageNotifyDeps) {
+    return async function processExtraUsageNotifications(accounts: AccountUsage[]): Promise<void> {
+        if (!(await deps.extraUsageEnabled())) {
+            return;
+        }
+
+        await deps.storage.ensureDirs();
+
+        const pending: PendingExtraUsageNotification[] = [];
+
+        await deps.storage.atomicConfigUpdate<Record<string, unknown>>((config) => {
+            const trackers = loadTrackers(config);
+
+            for (const account of accounts) {
+                const extraUsage = account.usage?.extra_usage;
+
+                if (!extraUsage) {
+                    continue;
+                }
+
+                const key = trackerKey(account.accountName);
+                let tracker = trackers.get(key);
+
+                if (!tracker) {
+                    tracker = new ExtraUsageBucketTracker();
+                    trackers.set(key, tracker);
+                }
+
+                const event = tracker.shouldNotify(extraUsage);
+
+                if (event) {
+                    pending.push({ accountName: account.accountName, event });
+                }
+            }
+
+            const prev = config[TRACKER_CONFIG_KEY] as Record<string, unknown> | undefined;
+
+            config[TRACKER_CONFIG_KEY] = {
+                ...(typeof prev === "object" && prev !== null ? prev : {}),
+                extraUsageTrackers: snapshotTrackers(trackers),
+                savedAt: new Date().toISOString(),
+            };
+        });
+
+        for (const { accountName, event } of pending) {
+            await deps.dispatch(accountName, event);
+        }
+    };
+}
+
+const processExtraUsageNotifications = __makeExtraUsageNotifier({
+    extraUsageEnabled: async () => (await loadConfig()).notifications.extraUsage ?? false,
+    storage: getClaudeUsageStorage(),
+    dispatch: dispatchExtraUsageNotification,
+});
+
+export { processExtraUsageNotifications };
+
+async function dispatchExtraUsageNotification(accountName: string, notifyEvent: ExtraUsageNotifyEvent): Promise<void> {
+    const message = formatExtraUsageMessage({ accountName, event: notifyEvent });
+
+    const titleByReason: Record<typeof notifyEvent.reason, string> = {
+        EXTRA_ENABLED: "Claude Extra Usage Enabled",
+        EXTRA_DISABLED: "Claude Extra Usage Disabled",
+        EXTRA_SPEND: "Claude Extra Usage Alert",
+    };
+
+    logger.info(
+        {
+            accountName,
+            reason: notifyEvent.reason,
+            fromSpent: notifyEvent.fromSpent,
+            toSpent: notifyEvent.toSpent,
+            limit: notifyEvent.limit,
+            currency: notifyEvent.currency,
+            elapsedMs: notifyEvent.elapsedMs,
+        },
+        "[claude-usage] extra usage notification"
+    );
+
+    try {
+        await dispatchNotification({
+            app: "claude",
+            title: titleByReason[notifyEvent.reason],
+            message,
+            group: EXTRA_USAGE_NOTIFICATION_GROUP,
+            sound: "Hero",
+        });
+
+        logger.info(
+            { accountName, reason: notifyEvent.reason, message },
+            "[claude-usage] extra usage notification dispatched"
+        );
+    } catch (err) {
+        logger.warn({ err, accountName, reason: notifyEvent.reason }, "[claude-usage] extra usage notification failed");
+    }
+}

--- a/src/claude/lib/usage/extra-usage-tracker.test.ts
+++ b/src/claude/lib/usage/extra-usage-tracker.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import {
+    type ExtraUsageBucket,
+    ExtraUsageBucketTracker,
+    formatExtraUsageMessage,
+    toMajorAmount,
+} from "./extra-usage-tracker";
+
+function extra(overrides: Partial<ExtraUsageBucket> = {}): ExtraUsageBucket {
+    return {
+        is_enabled: false,
+        monthly_limit: 10_000,
+        used_credits: null,
+        utilization: null,
+        currency: "EUR",
+        decimal_places: 2,
+        ...overrides,
+    };
+}
+
+describe("toMajorAmount", () => {
+    test("converts API minor units to major currency", () => {
+        expect(toMajorAmount(1834, 2)).toBe(18.34);
+        expect(toMajorAmount(10_000, 2)).toBe(100);
+    });
+});
+
+describe("ExtraUsageBucketTracker", () => {
+    test("notifies on first observation when already enabled", () => {
+        const tracker = new ExtraUsageBucketTracker();
+
+        expect(tracker.shouldNotify(extra({ is_enabled: true, used_credits: 1834 }), 1_000)).toEqual({
+            reason: "EXTRA_ENABLED",
+            fromSpent: null,
+            toSpent: 18.34,
+            limit: 100,
+            currency: "EUR",
+            decimalPlaces: 2,
+            elapsedMs: null,
+        });
+    });
+
+    test("notifies on disabled -> enabled transition", () => {
+        const tracker = new ExtraUsageBucketTracker();
+
+        tracker.shouldNotify(extra({ is_enabled: false }), 0);
+
+        expect(tracker.shouldNotify(extra({ is_enabled: true, used_credits: 350 }), 1_000)).toEqual({
+            reason: "EXTRA_ENABLED",
+            fromSpent: null,
+            toSpent: 3.5,
+            limit: 100,
+            currency: "EUR",
+            decimalPlaces: 2,
+            elapsedMs: null,
+        });
+    });
+
+    test("disabled notification keeps last known balance when API clears fields", () => {
+        const tracker = new ExtraUsageBucketTracker();
+
+        tracker.shouldNotify(extra({ is_enabled: true, used_credits: 1834, monthly_limit: 10_000 }), 0);
+
+        expect(tracker.shouldNotify(extra({ is_enabled: false }), 1_000)).toEqual({
+            reason: "EXTRA_DISABLED",
+            fromSpent: 18.34,
+            toSpent: 18.34,
+            limit: 100,
+            currency: "EUR",
+            decimalPlaces: 2,
+            elapsedMs: null,
+        });
+    });
+
+    test("notifies every 5 EUR spent while enabled", () => {
+        const tracker = new ExtraUsageBucketTracker();
+
+        tracker.shouldNotify(extra({ is_enabled: false }), 0);
+        tracker.shouldNotify(extra({ is_enabled: true, used_credits: 800 }), 1_000);
+
+        expect(tracker.shouldNotify(extra({ is_enabled: true, used_credits: 1200 }), 60_000)).toBeNull();
+        expect(tracker.shouldNotify(extra({ is_enabled: true, used_credits: 1350 }), 3_600_000)).toEqual({
+            reason: "EXTRA_SPEND",
+            fromSpent: 8,
+            toSpent: 13.5,
+            limit: 100,
+            currency: "EUR",
+            decimalPlaces: 2,
+            elapsedMs: 3_599_000,
+        });
+    });
+});
+
+describe("formatExtraUsageMessage", () => {
+    test("formats live reservine-style values", () => {
+        const message = formatExtraUsageMessage({
+            accountName: "reservine",
+            event: {
+                reason: "EXTRA_ENABLED",
+                fromSpent: null,
+                toSpent: 18.34,
+                limit: 100,
+                currency: "EUR",
+                decimalPlaces: 2,
+                elapsedMs: null,
+            },
+        });
+
+        expect(message).toBe("reservine: Extra usage enabled — €18.34/€100.00");
+    });
+});

--- a/src/claude/lib/usage/extra-usage-tracker.ts
+++ b/src/claude/lib/usage/extra-usage-tracker.ts
@@ -1,0 +1,324 @@
+import { formatDuration } from "@app/utils/format";
+import type { ExtraUsageBucket } from "./api";
+
+export type { ExtraUsageBucket };
+
+export const EXTRA_USAGE_BUCKET = "extra_usage";
+export const EXTRA_USAGE_NOTIFICATION_GROUP = "claude-extra-usage";
+export const EXTRA_USAGE_SPEND_INCREMENT = 5;
+
+export type ExtraUsageNotifyReason = "EXTRA_ENABLED" | "EXTRA_DISABLED" | "EXTRA_SPEND";
+
+export interface ExtraUsageTrackerState {
+    lastKnownEnabled: boolean | null;
+    lastKnownSpent: number | null;
+    lastKnownLimit: number | null;
+    lastKnownCurrency: string | null;
+    lastKnownDecimalPlaces: number | null;
+    lastNotifiedSpent: number | null;
+    lastNotifiedAt: number | null;
+}
+
+export interface ExtraUsageNotifyEvent {
+    reason: ExtraUsageNotifyReason;
+    fromSpent: number | null;
+    toSpent: number | null;
+    limit: number | null;
+    currency: string | null;
+    decimalPlaces: number;
+    elapsedMs: number | null;
+}
+
+/** API amounts are minor units (e.g. cents); normalize to major for tracking/display. */
+export function toMajorAmount(amount: number | null, decimalPlaces: number): number | null {
+    if (amount === null) {
+        return null;
+    }
+
+    return amount / 10 ** decimalPlaces;
+}
+
+export function formatExtraUsageMoney(amount: number | null, currency: string | null, decimalPlaces: number): string {
+    if (amount === null) {
+        return "?";
+    }
+
+    const symbol = currencySymbol(currency);
+    return `${symbol}${amount.toFixed(decimalPlaces)}`;
+}
+
+export function resolveExtraUsageOverview(bucket: ExtraUsageBucket): {
+    enabled: boolean;
+    utilization: number;
+    balance: string | null;
+    spentMajor: number | null;
+    limitMajor: number | null;
+} {
+    const decimalPlaces = bucket.decimal_places ?? 2;
+    const spentMajor = toMajorAmount(bucket.used_credits, decimalPlaces);
+    const limitMajor = toMajorAmount(bucket.monthly_limit, decimalPlaces);
+    const currency = bucket.currency ?? null;
+
+    if (!bucket.is_enabled) {
+        return {
+            enabled: false,
+            utilization: 0,
+            balance: null,
+            spentMajor,
+            limitMajor,
+        };
+    }
+
+    const utilization =
+        bucket.utilization ??
+        (spentMajor !== null && limitMajor !== null && limitMajor > 0 ? (spentMajor / limitMajor) * 100 : 0);
+
+    const balance =
+        spentMajor !== null || limitMajor !== null
+            ? formatExtraUsageBalance({
+                  spent: spentMajor,
+                  limit: limitMajor,
+                  currency,
+                  decimalPlaces,
+              })
+            : null;
+
+    return {
+        enabled: true,
+        utilization,
+        balance,
+        spentMajor,
+        limitMajor,
+    };
+}
+
+export function formatExtraUsageBalance({
+    spent,
+    limit,
+    currency,
+    decimalPlaces,
+}: {
+    spent: number | null;
+    limit: number | null;
+    currency: string | null;
+    decimalPlaces: number;
+}): string {
+    const spentLabel = formatExtraUsageMoney(spent, currency, decimalPlaces);
+    const limitLabel = formatExtraUsageMoney(limit, currency, decimalPlaces);
+
+    return `${spentLabel}/${limitLabel}`;
+}
+
+function currencySymbol(currency: string | null): string {
+    if (!currency) {
+        return "€";
+    }
+
+    const code = currency.toUpperCase();
+
+    if (code === "EUR") {
+        return "€";
+    }
+
+    if (code === "USD") {
+        return "$";
+    }
+
+    if (code === "GBP") {
+        return "£";
+    }
+
+    return `${code} `;
+}
+
+function buildMeta(bucket: ExtraUsageBucket): {
+    limit: number | null;
+    currency: string | null;
+    decimalPlaces: number;
+    spentMajor: number | null;
+    limitMajor: number | null;
+} {
+    const decimalPlaces = bucket.decimal_places ?? 2;
+    const spentMajor = toMajorAmount(bucket.used_credits, decimalPlaces);
+    const limitMajor = toMajorAmount(bucket.monthly_limit, decimalPlaces);
+
+    return {
+        limit: limitMajor,
+        currency: bucket.currency ?? null,
+        decimalPlaces,
+        spentMajor,
+        limitMajor,
+    };
+}
+
+export function formatExtraUsageMessage({
+    accountName,
+    event,
+}: {
+    accountName: string;
+    event: ExtraUsageNotifyEvent;
+}): string {
+    const balance = formatExtraUsageBalance({
+        spent: event.toSpent,
+        limit: event.limit,
+        currency: event.currency,
+        decimalPlaces: event.decimalPlaces,
+    });
+
+    if (event.reason === "EXTRA_ENABLED") {
+        return `${accountName}: Extra usage enabled — ${balance}`;
+    }
+
+    if (event.reason === "EXTRA_DISABLED") {
+        return `${accountName}: Extra usage disabled — ${balance}`;
+    }
+
+    const fromLabel = formatExtraUsageMoney(event.fromSpent, event.currency, event.decimalPlaces);
+    const toLabel = formatExtraUsageMoney(event.toSpent, event.currency, event.decimalPlaces);
+    const limitLabel = formatExtraUsageMoney(event.limit, event.currency, event.decimalPlaces);
+    const elapsed =
+        event.elapsedMs !== null && event.elapsedMs > 0
+            ? ` (in ${formatDuration(event.elapsedMs, "ms", "hm-smart")})`
+            : "";
+
+    return `${accountName}: Extra usage ${fromLabel} -> ${toLabel}/${limitLabel}${elapsed}`;
+}
+
+export class ExtraUsageBucketTracker {
+    private lastKnownEnabled: boolean | null = null;
+    private lastKnownSpent: number | null = null;
+    private lastKnownLimit: number | null = null;
+    private lastKnownCurrency: string | null = null;
+    private lastKnownDecimalPlaces: number | null = null;
+    private lastNotifiedSpent: number | null = null;
+    private lastNotifiedAt: number | null = null;
+
+    private rememberActiveSnapshot(
+        spentMajor: number | null,
+        limitMajor: number | null,
+        currency: string | null,
+        decimalPlaces: number
+    ): void {
+        this.lastKnownSpent = spentMajor;
+        this.lastKnownLimit = limitMajor;
+        this.lastKnownCurrency = currency;
+        this.lastKnownDecimalPlaces = decimalPlaces;
+    }
+
+    shouldNotify(bucket: ExtraUsageBucket, now = Date.now()): ExtraUsageNotifyEvent | null {
+        const enabled = bucket.is_enabled;
+        const { spentMajor, limitMajor, currency, decimalPlaces } = buildMeta(bucket);
+
+        const prevEnabled = this.lastKnownEnabled;
+
+        if (prevEnabled === true && !enabled) {
+            const event: ExtraUsageNotifyEvent = {
+                reason: "EXTRA_DISABLED",
+                fromSpent: this.lastKnownSpent,
+                toSpent: spentMajor ?? this.lastKnownSpent,
+                limit: limitMajor ?? this.lastKnownLimit,
+                currency: currency ?? this.lastKnownCurrency,
+                decimalPlaces: decimalPlaces ?? this.lastKnownDecimalPlaces ?? 2,
+                elapsedMs: null,
+            };
+            this.lastKnownEnabled = false;
+            this.lastNotifiedSpent = null;
+            this.lastNotifiedAt = null;
+            return event;
+        }
+
+        if (prevEnabled === false && enabled) {
+            this.lastKnownEnabled = true;
+            this.rememberActiveSnapshot(spentMajor, limitMajor, currency, decimalPlaces);
+            this.lastNotifiedSpent = spentMajor ?? 0;
+            this.lastNotifiedAt = now;
+
+            return {
+                reason: "EXTRA_ENABLED",
+                fromSpent: null,
+                toSpent: spentMajor,
+                limit: limitMajor,
+                currency,
+                decimalPlaces,
+                elapsedMs: null,
+            };
+        }
+
+        if (prevEnabled === null) {
+            this.lastKnownEnabled = enabled;
+
+            if (enabled) {
+                this.rememberActiveSnapshot(spentMajor, limitMajor, currency, decimalPlaces);
+                this.lastNotifiedSpent = spentMajor ?? 0;
+                this.lastNotifiedAt = now;
+
+                return {
+                    reason: "EXTRA_ENABLED",
+                    fromSpent: null,
+                    toSpent: spentMajor,
+                    limit: limitMajor,
+                    currency,
+                    decimalPlaces,
+                    elapsedMs: null,
+                };
+            }
+
+            return null;
+        }
+
+        if (!enabled) {
+            return null;
+        }
+
+        if (spentMajor === null) {
+            return null;
+        }
+
+        this.rememberActiveSnapshot(spentMajor, limitMajor, currency, decimalPlaces);
+
+        if (this.lastNotifiedSpent === null) {
+            this.lastNotifiedSpent = spentMajor;
+            this.lastNotifiedAt = now;
+            return null;
+        }
+
+        if (spentMajor >= this.lastNotifiedSpent + EXTRA_USAGE_SPEND_INCREMENT) {
+            const event: ExtraUsageNotifyEvent = {
+                reason: "EXTRA_SPEND",
+                fromSpent: this.lastNotifiedSpent,
+                toSpent: spentMajor,
+                limit: limitMajor,
+                currency,
+                decimalPlaces,
+                elapsedMs: this.lastNotifiedAt !== null ? now - this.lastNotifiedAt : null,
+            };
+            this.lastNotifiedSpent = spentMajor;
+            this.lastNotifiedAt = now;
+            return event;
+        }
+
+        return null;
+    }
+
+    restoreState(state: ExtraUsageTrackerState & { lastNotifiedPct?: number | null }): void {
+        this.lastKnownEnabled = state.lastKnownEnabled ?? null;
+        this.lastKnownSpent = state.lastKnownSpent ?? null;
+        this.lastKnownLimit = state.lastKnownLimit ?? null;
+        this.lastKnownCurrency = state.lastKnownCurrency ?? null;
+        this.lastKnownDecimalPlaces = state.lastKnownDecimalPlaces ?? null;
+        this.lastNotifiedSpent = state.lastNotifiedSpent ?? null;
+        this.lastNotifiedAt = state.lastNotifiedAt ?? null;
+    }
+
+    getState(): ExtraUsageTrackerState {
+        return {
+            lastKnownEnabled: this.lastKnownEnabled,
+            lastKnownSpent: this.lastKnownSpent,
+            lastKnownLimit: this.lastKnownLimit,
+            lastKnownCurrency: this.lastKnownCurrency,
+            lastKnownDecimalPlaces: this.lastKnownDecimalPlaces,
+            lastNotifiedSpent: this.lastNotifiedSpent,
+            lastNotifiedAt: this.lastNotifiedAt,
+        };
+    }
+}

--- a/src/claude/lib/usage/notification-manager.ts
+++ b/src/claude/lib/usage/notification-manager.ts
@@ -2,6 +2,7 @@ import { dispatchNotification } from "@app/utils/notifications";
 import type { Storage } from "@app/utils/storage/storage";
 import { BUCKET_LABELS, BUCKET_THRESHOLD_MAP } from "./constants";
 import type { UsageDashboardConfig } from "./dashboard-config";
+import type { ExtraUsageTrackerState } from "./extra-usage-tracker";
 
 const NOTIFICATION_POLL_TRACKER_CONFIG_KEY = "notificationPollTracker";
 
@@ -12,6 +13,7 @@ interface TrackerState {
 
 interface PersistedState {
     trackers: Record<string, TrackerState>;
+    extraUsageTrackers?: Record<string, ExtraUsageTrackerState>;
     savedAt: string;
 }
 
@@ -104,7 +106,12 @@ export class NotificationManager {
         return this._alerts.filter((a) => !a.dismissed);
     }
 
-    processUsage(accountName: string, bucket: string, utilization: number, resetsAt: string | null): void {
+    async processUsage(
+        accountName: string,
+        bucket: string,
+        utilization: number,
+        resetsAt: string | null
+    ): Promise<void> {
         if (!this.config.enabled) {
             return;
         }
@@ -143,10 +150,11 @@ export class NotificationManager {
                 });
             }
 
-            dispatchNotification({
+            await dispatchNotification({
                 app: "claude",
                 title: "Claude Usage Alert",
                 message,
+                group: "claude-usage",
             });
         }
     }
@@ -189,7 +197,13 @@ export class NotificationManager {
 
         const snapshot = Object.fromEntries([...this.trackers.entries()].map(([k, t]) => [k, t.getState()]));
         await storage.atomicConfigUpdate<Record<string, unknown>>((c) => {
-            c[NOTIFICATION_POLL_TRACKER_CONFIG_KEY] = { trackers: snapshot, savedAt: new Date().toISOString() };
+            const prev = c[NOTIFICATION_POLL_TRACKER_CONFIG_KEY] as PersistedState | undefined;
+
+            c[NOTIFICATION_POLL_TRACKER_CONFIG_KEY] = {
+                trackers: snapshot,
+                extraUsageTrackers: prev?.extraUsageTrackers,
+                savedAt: new Date().toISOString(),
+            };
         });
         this.dirty = false;
     }

--- a/src/claude/lib/usage/poll-daemon.ts
+++ b/src/claude/lib/usage/poll-daemon.ts
@@ -1,3 +1,4 @@
+import { isUsageBucket } from "@app/claude/lib/usage/api";
 import { loadDashboardConfig } from "@app/claude/lib/usage/dashboard-config";
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { NotificationManager } from "@app/claude/lib/usage/notification-manager";
@@ -36,7 +37,7 @@ async function main(): Promise<void> {
             }
 
             for (const [bucket, data] of Object.entries(account.usage)) {
-                if (!data || typeof data !== "object" || !("utilization" in data)) {
+                if (!isUsageBucket(data)) {
                     continue;
                 }
 
@@ -45,9 +46,12 @@ async function main(): Promise<void> {
                 }
 
                 try {
-                    notifManager.processUsage(account.accountName, bucket, data.utilization, data.resets_at);
-                } catch {
-                    // Notification failure should not interrupt polling
+                    await notifManager.processUsage(account.accountName, bucket, data.utilization, data.resets_at);
+                } catch (err) {
+                    logger.warn(
+                        { err, account: account.accountName, bucket },
+                        "[claude-usage] usage notification failed"
+                    );
                 }
             }
         }
@@ -85,11 +89,12 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-    main()
-        .then(() => process.exit(0))
-        .catch((err) => {
-            logger.error({ error: err }, "[claude-usage] daemon poll failed");
-            out.error(err);
-            process.exit(1);
-        });
+    try {
+        await main();
+        process.exit(0);
+    } catch (err) {
+        logger.error({ error: err }, "[claude-usage] daemon poll failed");
+        out.error(err);
+        process.exit(1);
+    }
 }

--- a/src/claude/lib/usage/shared-cache.test.ts
+++ b/src/claude/lib/usage/shared-cache.test.ts
@@ -82,6 +82,29 @@ describe("getSharedAccountsUsage", () => {
         expect(fetches).toBe(1);
     });
 
+    test("invokes extra-usage notify only on a live fetch", async () => {
+        let notifyCalls = 0;
+        const store: CacheStore = new Map();
+        store.set("usage-shared", { fetchedAt: Date.now() - 5_000, accounts: [acct("a", 11)] });
+        const get = __makeSharedUsage({
+            fetchAll: async () => [acct("a", 42)],
+            getCache: (k) => store.get(k) ?? null,
+            putCache: (k, v) => void store.set(k, v),
+            withLock: async (_k, fn) => fn(),
+            record: () => {},
+            notifyExtraUsage: async () => {
+                notifyCalls++;
+            },
+        });
+
+        await get({});
+        expect(notifyCalls).toBe(0);
+
+        store.set("usage-shared", { fetchedAt: Date.now() - 60_000, accounts: [acct("a", 11)] });
+        await get({});
+        expect(notifyCalls).toBe(1);
+    });
+
     test("accountFilter narrows the returned set", async () => {
         const store: CacheStore = new Map();
         store.set("usage-shared", { fetchedAt: Date.now(), accounts: [acct("a", 1), acct("b", 2)] });

--- a/src/claude/lib/usage/shared-cache.ts
+++ b/src/claude/lib/usage/shared-cache.ts
@@ -1,9 +1,10 @@
 import { join } from "node:path";
+import { processExtraUsageNotifications } from "@app/claude/lib/usage/extra-usage-notify";
 import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { getClaudeUsageStorage } from "@app/claude/lib/usage/storage";
 import { logger } from "@app/logger";
 import type { AccountUsage } from "./api";
-import { fetchAllAccountsUsage } from "./api";
+import { fetchAllAccountsUsage, isUsageBucket } from "./api";
 
 export const DB_FRESH_MS = 10_000;
 export const API_MIN_INTERVAL_MS = 30_000;
@@ -22,6 +23,7 @@ interface Deps {
     putCache: (key: string, value: Cached) => void | Promise<void>;
     withLock: <T>(key: string, fn: () => Promise<T>) => Promise<T>;
     record: (accounts: AccountUsage[]) => void;
+    notifyExtraUsage?: (accounts: AccountUsage[]) => void | Promise<void>;
 }
 
 export interface SharedUsageOpts {
@@ -49,7 +51,7 @@ function recordAll(accounts: AccountUsage[]): void {
         }
 
         for (const [bucket, data] of Object.entries(account.usage)) {
-            if (data && typeof data.utilization === "number") {
+            if (isUsageBucket(data) && typeof data.utilization === "number") {
                 db.recordIfChanged(account.accountName, bucket, data.utilization, data.resets_at ?? null);
             }
         }
@@ -82,6 +84,14 @@ export function __makeSharedUsage(deps: Deps) {
                 logger.warn({ err }, "usage history record failed; returning fetched usage anyway");
             }
 
+            if (deps.notifyExtraUsage) {
+                try {
+                    await deps.notifyExtraUsage(fresh);
+                } catch (err) {
+                    logger.warn({ err }, "extra usage notification pass failed; returning fetched usage anyway");
+                }
+            }
+
             return filterAccounts(fresh, opts.accountFilter);
         });
     };
@@ -102,6 +112,7 @@ const realGetShared = __makeSharedUsage({
             timeout: 10_000,
         }),
     record: recordAll,
+    notifyExtraUsage: processExtraUsageNotifications,
 });
 
 export function getSharedAccountsUsage(opts: SharedUsageOpts = {}): Promise<AccountUsage[]> {

--- a/src/claude/lib/usage/watch.ts
+++ b/src/claude/lib/usage/watch.ts
@@ -2,6 +2,7 @@ import type { NotificationConfig } from "@app/claude/lib/config";
 import { out } from "@app/logger";
 import { dispatchNotification } from "@app/utils/notifications";
 import type { AccountUsage } from "./api";
+import { isUsageBucket } from "./api";
 import { renderAllAccounts } from "./display";
 import { getSharedAccountsUsage } from "./shared-cache";
 
@@ -107,8 +108,8 @@ class UsageWatcher {
     /**
      * Process usage results and return notifications to send
      */
-    processResults(results: AccountUsage[]): Array<{ message: string; reason: string }> {
-        const notifications: Array<{ message: string; reason: string }> = [];
+    processResults(results: AccountUsage[]): Array<{ message: string; reason: string; title: string }> {
+        const notifications: Array<{ message: string; reason: string; title: string }> = [];
 
         for (const account of results) {
             if (!account.usage) {
@@ -116,9 +117,10 @@ class UsageWatcher {
             }
 
             for (const [bucket, data] of Object.entries(account.usage)) {
-                if (!data || typeof data !== "object" || !("utilization" in data)) {
+                if (!isUsageBucket(data)) {
                     continue;
                 }
+
                 if (data.utilization === null || data.utilization === undefined) {
                     continue;
                 }
@@ -144,6 +146,7 @@ class UsageWatcher {
                     notifications.push({
                         message: `${account.accountName}: ${tracker.label} ${Math.round(data.utilization)}%`,
                         reason,
+                        title: "Claude Usage Alert",
                     });
                 }
             }
@@ -193,11 +196,10 @@ export async function watchUsage(accountFilter?: string, notifications?: Notific
         if (pending.length > 0) {
             const initNotifs = pending.filter((n) => n.reason === "INIT");
             const increaseNotifs = pending.filter((n) => n.reason === "+5%");
-
             for (const notif of initNotifs) {
                 dispatchNotification({
                     app: "claude",
-                    title: "Claude Usage Alert",
+                    title: notif.title,
                     message: `[INIT] ${notif.message}`,
                 });
             }
@@ -206,7 +208,7 @@ export async function watchUsage(accountFilter?: string, notifications?: Notific
                 const first = increaseNotifs[0];
                 dispatchNotification({
                     app: "claude",
-                    title: "Claude Usage Alert",
+                    title: first.title,
                     message:
                         increaseNotifs.length > 1
                             ? `[+5%] ${first.message} (+${increaseNotifs.length - 1} more)`

--- a/src/cmux/docs/Cmux.md
+++ b/src/cmux/docs/Cmux.md
@@ -165,8 +165,8 @@ print(json.loads(buf.decode())["result"]["windows"][0])'
 
 | Operation | CLI | Raw RPC | Notes |
 |-----------|-----|---------|-------|
-| List in current window | `cmux list-workspaces` | `workspace.list` | Without `--params.window`, returns only the focused window's workspaces. |
-| List in specific window | n/a | `workspace.list {"window":"window:N"}` | Use this for multi-window snapshots. |
+| List in current window | `cmux list-workspaces` | `workspace.list` | Without `window_id`, returns only the focused window's workspaces. |
+| List in specific window | n/a | `workspace.list {"window_id":"window:N"}` | Use this for multi-window snapshots. |
 | New | `cmux new-workspace [--name X] [--cwd PATH] [--command CMD]` returns `OK <ref>` (plain text) | `workspace.create` returns `{workspace_ref, workspace_id, window_ref, window_id}` | The `name` arg is **best-effort** — cmux frequently overrides it with an auto-generated `user@host:cwd` title. Always follow up with `rename-workspace`. |
 | Rename | `cmux rename-workspace [--workspace <ref>] "<title>"` | `workspace.rename` | Sticks. Use this. |
 | Select (focus) | `cmux select-workspace --workspace <ref>` | `workspace.select` | **Steals user focus**. The 400 ms after the call is when geometry settles. |
@@ -485,7 +485,7 @@ cmux --version                                  # for cmux_version field
 # Discover (raw socket — CLI strips refs from list-windows)
 RPC window.list                                 # → [{ref, id, index, ...}]
 for each window:
-  RPC workspace.list { window: <ref> }          # → workspaces with current_directory
+  RPC workspace.list { window_id: <ref> }          # → workspaces with current_directory
 
 # Per workspace (sequential):
   cmux select-workspace --workspace <ref>       # FOCUS FLICKER (~400ms)

--- a/src/cmux/lib/socket.test.ts
+++ b/src/cmux/lib/socket.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as socket from "@app/cmux/lib/socket";
+
+describe("cmux socket RPC params", () => {
+    afterEach(() => {
+        socket.resetSocketPathCache();
+    });
+
+    test("workspaceList passes window_id not window", async () => {
+        const rpcSpy = spyOn(socket, "rpc").mockResolvedValue({
+            window_ref: "window:1",
+            window_id: "abc",
+            workspaces: [],
+        });
+
+        await socket.workspaceList("window:1");
+
+        expect(rpcSpy).toHaveBeenCalledWith("workspace.list", { window_id: "window:1" });
+
+        rpcSpy.mockRestore();
+    });
+
+    test("workspaceCreate passes window_id not window", async () => {
+        const rpcSpy = spyOn(socket, "rpc").mockResolvedValue({
+            workspace_ref: "workspace:1",
+            workspace_id: "ws",
+            window_ref: "window:1",
+            window_id: "abc",
+        });
+
+        await socket.workspaceCreate({ window: "window:1", name: "test" });
+
+        expect(rpcSpy).toHaveBeenCalledWith("workspace.create", { name: "test", window_id: "window:1" });
+
+        rpcSpy.mockRestore();
+    });
+});

--- a/src/cmux/lib/socket.ts
+++ b/src/cmux/lib/socket.ts
@@ -162,10 +162,10 @@ export interface WorkspaceListResponse {
     workspaces: WorkspaceEntry[];
 }
 
-export async function workspaceList(windowRef?: string): Promise<WorkspaceListResponse> {
+export async function workspaceList(windowId?: string): Promise<WorkspaceListResponse> {
     const params: Record<string, unknown> = {};
-    if (windowRef) {
-        params.window = windowRef;
+    if (windowId) {
+        params.window_id = windowId;
     }
     return rpc<WorkspaceListResponse>("workspace.list", params);
 }
@@ -194,7 +194,7 @@ export async function workspaceCreate(
         params.command = opts.command;
     }
     if (opts.window) {
-        params.window = opts.window;
+        params.window_id = opts.window;
     }
     return rpc<WorkspaceCreateResult>("workspace.create", params);
 }

--- a/src/daemon/lib/scheduler.ts
+++ b/src/daemon/lib/scheduler.ts
@@ -1,6 +1,6 @@
 import { logger as appLogger, createLogger } from "@app/logger";
+import { wakefulSleep } from "@app/utils/async";
 import { dispatchNotification } from "@app/utils/notifications";
-import { wakefulSleep } from "@app/utils/wakeful";
 import { loadConfig } from "./config";
 import { computeNextRunAt, parseInterval } from "./interval";
 import { listRunsForTask } from "./log-reader";

--- a/src/daemon/lib/scheduler.ts
+++ b/src/daemon/lib/scheduler.ts
@@ -1,5 +1,6 @@
 import { logger as appLogger, createLogger } from "@app/logger";
 import { dispatchNotification } from "@app/utils/notifications";
+import { wakefulSleep } from "@app/utils/wakeful";
 import { loadConfig } from "./config";
 import { computeNextRunAt, parseInterval } from "./interval";
 import { listRunsForTask } from "./log-reader";
@@ -69,7 +70,15 @@ export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
 
         const sleepMs = getNextWakeupMs(taskStates, config.tasks);
         log.debug({ sleepMs, activeTasks: activeRuns.size }, "Sleeping");
-        await Bun.sleep(sleepMs);
+        await wakefulSleep(sleepMs, {
+            shouldAbort: () => !running,
+            onWallClockJump: ({ elapsedMs, expectedMs }) => {
+                appLogger.info(
+                    { elapsedMs, expectedMs },
+                    "[daemon] wall-clock jumped (likely wake from sleep/hibernate); resuming scheduler"
+                );
+            },
+        });
     }
 
     if (activeRuns.size > 0) {

--- a/src/debugging-master/commands/cleanup.ts
+++ b/src/debugging-master/commands/cleanup.ts
@@ -80,6 +80,24 @@ async function checkGitDiff(filePath: string): Promise<{ hasOnlyWhitespace: bool
     return { hasOnlyWhitespace, diff };
 }
 
+async function stashInstrumentation(files: string[], message: string, projectPath: string): Promise<boolean> {
+    // `-u` includes untracked files (e.g. freshly-copied llm-log.ts).
+    // Don't combine with `git add -N` — intent-to-add entries make `stash -u` fail with
+    // "Entry 'X' not uptodate. Cannot merge."
+    const stashProc = Bun.spawn(["git", "stash", "push", "-u", "-m", message, "--", ...files], {
+        cwd: projectPath,
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const stderr = await new Response(stashProc.stderr).text();
+    const exitCode = await stashProc.exited;
+    if (exitCode !== 0) {
+        throw new Error(`git stash failed (exit ${exitCode}): ${stderr.trim()}`);
+    }
+    const stdout = await new Response(stashProc.stdout).text();
+    return /Saved working directory|Created stash/i.test(stdout);
+}
+
 async function repairFile(filePath: string): Promise<void> {
     const proc = Bun.spawn(["git", "checkout", filePath], {
         stdout: "pipe",
@@ -95,152 +113,272 @@ async function repairFile(filePath: string): Promise<void> {
 export function registerCleanupCommand(program: Command): void {
     program
         .command("cleanup")
-        .description("Remove debug instrumentation and archive logs")
-        .option("--repair-formatting", "Auto-fix formatting-only diffs after block removal")
-        .option("--keep-logs [path]", "Keep logs at specified path instead of /tmp")
-        .action(async (opts: { repairFormatting?: boolean; keepLogs?: string | true }) => {
-            const globalOpts = program.opts<{ session?: string }>();
-            const sm = new SessionManager();
-            const projectPath = process.cwd();
+        .description(
+            "Remove debug instrumentation and/or archive session logs (opt-in: pick --blocks, --clean-logs, or both)"
+        )
+        .option("--blocks", "Remove @dbg instrumentation blocks from source files")
+        .option(
+            "--clean-logs [path]",
+            "Archive the active session jsonl + meta out of the sessions dir (default destination: /tmp; pass a path to keep them permanently)"
+        )
+        .option("--repair-formatting", "Auto-fix formatting-only diffs after block removal (implies --blocks)")
+        .option(
+            "--no-stash",
+            "Skip stashing @dbg blocks into git before removing them (stash is on by default with --blocks)"
+        )
+        .option(
+            "--stash-message <msg>",
+            "Custom message to attach to the git stash (default: auto-generated timestamp)"
+        )
+        .action(
+            async (
+                opts: {
+                    blocks?: boolean;
+                    cleanLogs?: string | boolean;
+                    repairFormatting?: boolean;
+                    stash?: boolean;
+                    stashMessage?: string;
+                },
+                cmd: Command
+            ) => {
+                // Modifier flags imply their owning action so old muscle-memory keeps working.
+                const removeBlocksRequested = opts.blocks === true || opts.repairFormatting === true;
+                const cleanLogsRequested = opts.cleanLogs !== undefined && opts.cleanLogs !== false;
+                const cleanLogsPath = typeof opts.cleanLogs === "string" ? opts.cleanLogs : undefined;
 
-            // --- A. Scan for @dbg blocks ---
-            const patterns = ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.php"];
-            const ignore = ["**/node_modules/**", "**/vendor/**", "**/.git/**", "**/dist/**", "**/build/**"];
-
-            const files = await glob(patterns, { cwd: projectPath, ignore, absolute: true });
-
-            const fileBlockMap = new Map<string, BlockRange[]>();
-            let totalBlocks = 0;
-            const allWarnings: { file: string; warning: string }[] = [];
-
-            for (const file of files) {
-                const content = readFileSync(file, "utf-8");
-                const { blocks, warnings } = findBlocks(content);
-
-                for (const w of warnings) {
-                    allWarnings.push({ file, warning: w });
+                if (!removeBlocksRequested && !cleanLogsRequested) {
+                    cmd.help();
+                    return;
                 }
 
-                if (blocks.length === 0) {
-                    continue;
+                const globalOpts = program.opts<{ session?: string }>();
+                const sm = new SessionManager();
+                const projectPath = process.cwd();
+                const ignore = ["**/node_modules/**", "**/vendor/**", "**/.git/**", "**/dist/**", "**/build/**"];
+
+                // ─── BLOCK REMOVAL (gated on --blocks / --repair-formatting) ───────────────
+                if (removeBlocksRequested) {
+                    await runBlockRemoval({ projectPath, ignore, opts });
                 }
 
+                // ─── LOG ARCHIVE (gated on --clean-logs) ───────────────────────────────────
+                if (cleanLogsRequested) {
+                    await runLogArchive({ sm, sessionOverride: globalOpts.session, keepPath: cleanLogsPath });
+                }
+            }
+        );
+}
+
+interface BlockRemovalArgs {
+    projectPath: string;
+    ignore: string[];
+    opts: { repairFormatting?: boolean; stash?: boolean; stashMessage?: string };
+}
+
+async function runBlockRemoval({ projectPath, ignore, opts }: BlockRemovalArgs): Promise<void> {
+    // --- A. Scan for @dbg blocks ---
+    const patterns = ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.php"];
+    const files = await glob(patterns, { cwd: projectPath, ignore, absolute: true });
+
+    const fileBlockMap = new Map<string, BlockRange[]>();
+    let totalBlocks = 0;
+    const allWarnings: { file: string; warning: string }[] = [];
+
+    for (const file of files) {
+        const content = readFileSync(file, "utf-8");
+        const { blocks, warnings } = findBlocks(content);
+
+        for (const w of warnings) {
+            allWarnings.push({ file, warning: w });
+        }
+
+        if (blocks.length === 0) {
+            continue;
+        }
+
+        fileBlockMap.set(file, blocks);
+        totalBlocks += blocks.length;
+    }
+
+    if (allWarnings.length > 0) {
+        out.println(pc.yellow(`\n${allWarnings.length} unclosed/orphan @dbg region(s) found:`));
+        for (const { file, warning } of allWarnings) {
+            out.println(`  ${pc.dim(relative(projectPath, file))}: ${warning}`);
+        }
+        out.println(pc.dim("\nThese regions were skipped. Fix the markers manually, then re-run cleanup."));
+    }
+
+    // --- B.0 Stash (default-on; runs BEFORE block removal so the stash captures @dbg blocks) ---
+    if (opts.stash !== false) {
+        const snippetFiles = await glob(["**/llm-log.ts", "**/llm-log.php"], {
+            cwd: projectPath,
+            ignore,
+            absolute: true,
+        });
+        const stashTargets = Array.from(new Set([...fileBlockMap.keys(), ...snippetFiles]));
+
+        if (stashTargets.length === 0) {
+            out.println(pc.dim("\nNothing to stash (no @dbg blocks and no llm-log snippet found)."));
+        } else {
+            const note = opts.stashMessage ?? "";
+            const ts = new Date().toISOString().slice(0, 16).replace("T", " ");
+            const message = note ? `@dbg instrumentation: ${note} (${ts})` : `@dbg instrumentation (${ts})`;
+
+            try {
+                const stashed = await stashInstrumentation(stashTargets, message, projectPath);
+                if (stashed) {
+                    out.println(pc.green(`\nStashed @dbg instrumentation across ${stashTargets.length} file(s):`));
+                    out.println(`  ${pc.dim("message:")} ${message}`);
+                    out.println("");
+                    out.println(pc.bold("To re-apply later (recommend apply, NOT pop — keeps the stash):"));
+                    out.println(
+                        `  ${pc.cyan("git stash list")}                    ${pc.dim("# find the stash index")}`
+                    );
+                    out.println(
+                        `  ${pc.cyan("git stash apply stash@{0}")}         ${pc.dim("# re-insert @dbg blocks + snippet")}`
+                    );
+                    out.println(`  ${pc.cyan("git stash show -p stash@{0}")}       ${pc.dim("# preview the diff")}`);
+                    out.println(`  ${pc.cyan("git stash drop stash@{0}")}          ${pc.dim("# discard when done")}`);
+                    out.println("");
+                } else {
+                    out.println(
+                        pc.yellow("\nNo changes to stash — files already match HEAD (nothing to re-apply later).")
+                    );
+                }
+            } catch (err) {
+                out.println(pc.red(`\nStash failed: ${(err as Error).message}`));
+                out.println(pc.dim("Skipping removal — re-run without --stash if you want to proceed."));
+                return;
+            }
+        }
+
+        // Re-scan after stash: working tree may have reverted to HEAD; any remaining @dbg
+        // blocks (e.g. committed instrumentation) still need removal below.
+        fileBlockMap.clear();
+        totalBlocks = 0;
+        for (const file of files) {
+            if (!existsSync(file)) {
+                continue;
+            }
+            const { blocks } = findBlocks(readFileSync(file, "utf-8"));
+            if (blocks.length > 0) {
                 fileBlockMap.set(file, blocks);
                 totalBlocks += blocks.length;
             }
+        }
+    }
 
-            if (allWarnings.length > 0) {
-                out.println(pc.yellow(`\n${allWarnings.length} unclosed/orphan @dbg region(s) found:`));
-                for (const { file, warning } of allWarnings) {
-                    out.println(`  ${pc.dim(relative(projectPath, file))}: ${warning}`);
-                }
-                out.println(pc.dim("\nThese regions were skipped. Fix the markers manually, then re-run cleanup."));
+    // --- B. Remove blocks ---
+    const modifiedFiles: string[] = [];
+
+    for (const [file, blocks] of fileBlockMap) {
+        const content = readFileSync(file, "utf-8");
+        const cleaned = removeBlocks(content, blocks);
+        writeFileSync(file, cleaned);
+        modifiedFiles.push(file);
+    }
+
+    if (totalBlocks > 0) {
+        out.println(pc.green(`Removed ${totalBlocks} @dbg block(s) from ${modifiedFiles.length} file(s):`));
+        for (const file of modifiedFiles) {
+            const blocks = fileBlockMap.get(file)!;
+            out.println(
+                `  ${pc.dim(relative(projectPath, file))} (${blocks.length} block${blocks.length > 1 ? "s" : ""})`
+            );
+        }
+    } else {
+        out.println(pc.dim("No @dbg blocks found."));
+    }
+
+    // --- C. Git diff check ---
+    if (modifiedFiles.length > 0) {
+        const formatOnlyFiles: string[] = [];
+        const realDiffFiles: { file: string; diff: string }[] = [];
+
+        for (const file of modifiedFiles) {
+            const { hasOnlyWhitespace, diff } = await checkGitDiff(file);
+            if (hasOnlyWhitespace && diff) {
+                formatOnlyFiles.push(file);
+            } else if (diff) {
+                realDiffFiles.push({ file, diff });
             }
+        }
 
-            // --- B. Remove blocks ---
-            const modifiedFiles: string[] = [];
-
-            for (const [file, blocks] of fileBlockMap) {
-                const content = readFileSync(file, "utf-8");
-                const cleaned = removeBlocks(content, blocks);
-                writeFileSync(file, cleaned);
-                modifiedFiles.push(file);
+        if (realDiffFiles.length > 0) {
+            out.println(`\n${pc.yellow(`${realDiffFiles.length} file(s) have real diffs remaining:`)}`);
+            for (const { file } of realDiffFiles) {
+                out.println(`  ${relative(projectPath, file)}`);
             }
+        }
 
-            if (totalBlocks > 0) {
-                out.println(pc.green(`Removed ${totalBlocks} @dbg block(s) from ${modifiedFiles.length} file(s):`));
-                for (const file of modifiedFiles) {
-                    const blocks = fileBlockMap.get(file)!;
-                    out.println(
-                        `  ${pc.dim(relative(projectPath, file))} (${blocks.length} block${blocks.length > 1 ? "s" : ""})`
-                    );
+        if (formatOnlyFiles.length > 0) {
+            if (opts.repairFormatting) {
+                for (const file of formatOnlyFiles) {
+                    await repairFile(file);
                 }
+                out.println(pc.green(`\nRepaired formatting in ${formatOnlyFiles.length} file(s).`));
             } else {
-                out.println(pc.dim("No @dbg blocks found."));
-            }
-
-            // --- C. Git diff check ---
-            if (modifiedFiles.length > 0) {
-                const formatOnlyFiles: string[] = [];
-                const realDiffFiles: { file: string; diff: string }[] = [];
-
-                for (const file of modifiedFiles) {
-                    const { hasOnlyWhitespace, diff } = await checkGitDiff(file);
-                    if (hasOnlyWhitespace && diff) {
-                        formatOnlyFiles.push(file);
-                    } else if (diff) {
-                        realDiffFiles.push({ file, diff });
-                    }
+                out.println(`\n${pc.yellow(`${formatOnlyFiles.length} file(s) have formatting-only diffs:`)}`);
+                for (const file of formatOnlyFiles) {
+                    out.println(`  ${pc.dim(relative(projectPath, file))}`);
                 }
-
-                if (realDiffFiles.length > 0) {
-                    out.println(`\n${pc.yellow(`${realDiffFiles.length} file(s) have real diffs remaining:`)}`);
-                    for (const { file } of realDiffFiles) {
-                        out.println(`  ${relative(projectPath, file)}`);
-                    }
-                }
-
-                if (formatOnlyFiles.length > 0) {
-                    if (opts.repairFormatting) {
-                        for (const file of formatOnlyFiles) {
-                            await repairFile(file);
-                        }
-                        out.println(pc.green(`\nRepaired formatting in ${formatOnlyFiles.length} file(s).`));
-                    } else {
-                        out.println(`\n${pc.yellow(`${formatOnlyFiles.length} file(s) have formatting-only diffs:`)}`);
-                        for (const file of formatOnlyFiles) {
-                            out.println(`  ${pc.dim(relative(projectPath, file))}`);
-                        }
-                        out.println(`\n${pc.dim("Tip:")} ${suggestCommand(TOOL, { add: ["--repair-formatting"] })}`);
-                    }
-                }
+                out.println(`\n${pc.dim("Tip:")} ${suggestCommand(TOOL, { add: ["--repair-formatting"] })}`);
             }
+        }
+    }
+}
 
-            // --- D. Archive logs ---
-            let sessionName: string | undefined;
-            try {
-                sessionName = await sm.resolveSession(globalOpts.session);
-            } catch {
-                // No active session to archive
-            }
+interface LogArchiveArgs {
+    sm: SessionManager;
+    sessionOverride: string | undefined;
+    /** Destination directory. `undefined` → archive to /tmp (cleared on reboot). */
+    keepPath: string | undefined;
+}
 
-            if (sessionName) {
-                const sessionPath = await sm.getSessionPath(sessionName);
-                const metaPath = sessionPath.replace(".jsonl", ".meta.json");
-                const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+async function runLogArchive({ sm, sessionOverride, keepPath }: LogArchiveArgs): Promise<void> {
+    let sessionName: string | undefined;
+    try {
+        sessionName = await sm.resolveSession(sessionOverride);
+    } catch {
+        // No active session to archive
+    }
 
-                if (existsSync(sessionPath)) {
-                    let archivePath: string;
+    if (!sessionName) {
+        out.println(pc.dim("\nNo active session found — skipping log archival."));
+        return;
+    }
 
-                    if (opts.keepLogs) {
-                        const keepDir =
-                            typeof opts.keepLogs === "string" ? resolve(opts.keepLogs) : resolve("debug-logs");
-                        if (!existsSync(keepDir)) {
-                            mkdirSync(keepDir, { recursive: true });
-                        }
-                        archivePath = join(keepDir, `${timestamp}-llmlog-${sessionName}.jsonl`);
-                        copyFileSync(sessionPath, archivePath);
-                        unlinkSync(sessionPath);
-                    } else {
-                        archivePath = join(tmpdir(), `${timestamp}-llmlog-${sessionName}.jsonl`);
-                        renameSync(sessionPath, archivePath);
-                    }
+    const sessionPath = await sm.getSessionPath(sessionName);
+    const metaPath = sessionPath.replace(".jsonl", ".meta.json");
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
 
-                    if (existsSync(metaPath)) {
-                        unlinkSync(metaPath);
-                    }
+    if (!existsSync(sessionPath)) {
+        out.println(pc.dim("\nNo session log file to archive."));
+        return;
+    }
 
-                    out.println(`\n${pc.green("Logs archived to:")} ${archivePath}`);
-                    if (!opts.keepLogs) {
-                        out.println(
-                            `${pc.dim("Tip: Keep logs permanently →")} ${suggestCommand(TOOL, { add: ["--keep-logs", "./debug-logs/"] })}`
-                        );
-                    }
-                } else {
-                    out.println(pc.dim("\nNo session log file to archive."));
-                }
-            } else {
-                out.println(pc.dim("\nNo active session found — skipping log archival."));
-            }
-        });
+    let archivePath: string;
+    if (keepPath) {
+        const keepDir = resolve(keepPath);
+        if (!existsSync(keepDir)) {
+            mkdirSync(keepDir, { recursive: true });
+        }
+        archivePath = join(keepDir, `${timestamp}-llmlog-${sessionName}.jsonl`);
+        copyFileSync(sessionPath, archivePath);
+        unlinkSync(sessionPath);
+    } else {
+        archivePath = join(tmpdir(), `${timestamp}-llmlog-${sessionName}.jsonl`);
+        renameSync(sessionPath, archivePath);
+    }
+
+    if (existsSync(metaPath)) {
+        unlinkSync(metaPath);
+    }
+
+    out.println(`\n${pc.green("Logs archived to:")} ${archivePath}`);
+    if (!keepPath) {
+        out.println(
+            `${pc.dim("Tip: Keep logs permanently →")} ${suggestCommand(TOOL, { add: ["cleanup", "--clean-logs", "./debug-logs/"] })}`
+        );
+    }
 }

--- a/src/debugging-master/commands/cleanup.ts
+++ b/src/debugging-master/commands/cleanup.ts
@@ -295,8 +295,14 @@ async function runBlockRemoval({ projectPath, ignore, opts }: BlockRemovalArgs):
         const formatOnlyFiles: string[] = [];
         const realDiffFiles: { file: string; diff: string }[] = [];
 
-        for (const file of modifiedFiles) {
-            const { hasOnlyWhitespace, diff } = await checkGitDiff(file);
+        const diffResults = await Promise.all(
+            modifiedFiles.map(async (file) => ({
+                file,
+                ...(await checkGitDiff(file)),
+            }))
+        );
+
+        for (const { file, hasOnlyWhitespace, diff } of diffResults) {
             if (hasOnlyWhitespace && diff) {
                 formatOnlyFiles.push(file);
             } else if (diff) {

--- a/src/debugging-master/commands/cleanup.ts
+++ b/src/debugging-master/commands/cleanup.ts
@@ -370,15 +370,22 @@ async function runLogArchive({ sm, sessionOverride, keepPath }: LogArchiveArgs):
             mkdirSync(keepDir, { recursive: true });
         }
         archivePath = join(keepDir, `${timestamp}-llmlog-${sessionName}.jsonl`);
+        const archiveMetaPath = join(keepDir, `${timestamp}-llmlog-${sessionName}.meta.json`);
         copyFileSync(sessionPath, archivePath);
         unlinkSync(sessionPath);
+
+        if (existsSync(metaPath)) {
+            copyFileSync(metaPath, archiveMetaPath);
+            unlinkSync(metaPath);
+        }
     } else {
         archivePath = join(tmpdir(), `${timestamp}-llmlog-${sessionName}.jsonl`);
+        const archiveMetaPath = join(tmpdir(), `${timestamp}-llmlog-${sessionName}.meta.json`);
         renameSync(sessionPath, archivePath);
-    }
 
-    if (existsSync(metaPath)) {
-        unlinkSync(metaPath);
+        if (existsSync(metaPath)) {
+            renameSync(metaPath, archiveMetaPath);
+        }
     }
 
     out.println(`\n${pc.green("Logs archived to:")} ${archivePath}`);

--- a/src/debugging-master/commands/start.ts
+++ b/src/debugging-master/commands/start.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
 import { ensureDashboardBuilt } from "@app/debugging-master/commands/dashboard";
 import { startServer } from "@app/debugging-master/core/http-server";
@@ -125,6 +125,15 @@ export function registerStartCommand(program: Command): void {
             }
 
             copyFileSync(snippetSrc, snippetDest);
+
+            // Substitute __LAN_IP__ placeholder so cross-device logging works out of the box.
+            const lanIp = getLocalIpv4();
+            if (lanIp) {
+                const snippetContent = readFileSync(snippetDest, "utf-8");
+                if (snippetContent.includes("__LAN_IP__")) {
+                    writeFileSync(snippetDest, snippetContent.replaceAll("__LAN_IP__", lanIp));
+                }
+            }
 
             // --- Create session ---
             const sm = new SessionManager();

--- a/src/debugging-master/commands/start.ts
+++ b/src/debugging-master/commands/start.ts
@@ -126,13 +126,15 @@ export function registerStartCommand(program: Command): void {
 
             copyFileSync(snippetSrc, snippetDest);
 
-            // Substitute __LAN_IP__ placeholder so cross-device logging works out of the box.
-            const lanIp = getLocalIpv4();
-            if (lanIp) {
-                const snippetContent = readFileSync(snippetDest, "utf-8");
-                if (snippetContent.includes("__LAN_IP__")) {
-                    writeFileSync(snippetDest, snippetContent.replaceAll("__LAN_IP__", lanIp));
-                }
+            const lanIp = getLocalIpv4() ?? "__LAN_IP__";
+            const snippetContent = readFileSync(snippetDest, "utf-8");
+            const rewrittenSnippetContent = snippetContent
+                .replaceAll("__LAN_IP__", lanIp)
+                .replace("const PORT = 7243;", `const PORT = ${port};`)
+                .replace("private const PORT = 7243;", `private const PORT = ${port};`);
+
+            if (rewrittenSnippetContent !== snippetContent) {
+                writeFileSync(snippetDest, rewrittenSnippetContent);
             }
 
             // --- Create session ---

--- a/src/debugging-master/core/http-server.ts
+++ b/src/debugging-master/core/http-server.ts
@@ -60,7 +60,9 @@ export function startServer(port: number = 7243): { server: ReturnType<typeof Bu
     const corsHeaders: Record<string, string> = {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Headers": "*",
+        "Access-Control-Expose-Headers": "*",
+        "Access-Control-Max-Age": "86400",
     };
 
     const server = Bun.serve({

--- a/src/debugging-master/core/sse-broadcaster.ts
+++ b/src/debugging-master/core/sse-broadcaster.ts
@@ -1,4 +1,5 @@
 import type { LogEntry } from "@app/debugging-master/types";
+import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 import type { LogSourceId } from "@app/utils/log-viewer/log-source";
 import { parseSessionKey } from "@app/utils/log-viewer/session-key";
@@ -29,7 +30,7 @@ export class SSEBroadcaster {
     private multiplexSubscribers = new Set<MultiplexSubscriber>();
     private tailers = new Map<string, ReturnType<typeof createSourceTailer>>();
     private nextId = 1;
-    private heartbeat: ReturnType<typeof setInterval> | null = null;
+    private heartbeat: WakefulInterval | null = null;
 
     subscribe(
         source: LogSourceId,
@@ -238,7 +239,7 @@ export class SSEBroadcaster {
         }
         this.tailers.clear();
         if (this.heartbeat) {
-            clearInterval(this.heartbeat);
+            this.heartbeat.stop();
             this.heartbeat = null;
         }
     }
@@ -325,7 +326,7 @@ export class SSEBroadcaster {
         }
 
         if (this.subscribers.size === 0 && this.multiplexSubscribers.size === 0 && this.heartbeat) {
-            clearInterval(this.heartbeat);
+            this.heartbeat.stop();
             this.heartbeat = null;
         }
     }
@@ -343,7 +344,7 @@ export class SSEBroadcaster {
         }
 
         if (this.subscribers.size === 0 && this.multiplexSubscribers.size === 0 && this.heartbeat) {
-            clearInterval(this.heartbeat);
+            this.heartbeat.stop();
             this.heartbeat = null;
         }
     }
@@ -385,27 +386,30 @@ export class SSEBroadcaster {
             return;
         }
 
-        this.heartbeat = setInterval(() => {
-            const ping = encoder.encode(`: ping\n\n`);
-            for (const bucket of this.subscribers.values()) {
-                for (const sub of [...bucket]) {
+        this.heartbeat = startWakefulInterval(
+            HEARTBEAT_INTERVAL_MS,
+            () => {
+                const ping = encoder.encode(`: ping\n\n`);
+                for (const bucket of this.subscribers.values()) {
+                    for (const sub of [...bucket]) {
+                        try {
+                            sub.controller.enqueue(ping);
+                        } catch {
+                            this.removeSubscriber(sub);
+                        }
+                    }
+                }
+
+                for (const sub of [...this.multiplexSubscribers]) {
                     try {
                         sub.controller.enqueue(ping);
                     } catch {
-                        this.removeSubscriber(sub);
+                        this.removeMultiplexSubscriber(sub);
                     }
                 }
-            }
-
-            for (const sub of [...this.multiplexSubscribers]) {
-                try {
-                    sub.controller.enqueue(ping);
-                } catch {
-                    this.removeMultiplexSubscriber(sub);
-                }
-            }
-        }, HEARTBEAT_INTERVAL_MS);
-        this.heartbeat.unref?.();
+            },
+            { leading: false }
+        );
     }
 }
 

--- a/src/debugging-master/core/sse-broadcaster.ts
+++ b/src/debugging-master/core/sse-broadcaster.ts
@@ -1,4 +1,5 @@
 import type { LogEntry } from "@app/debugging-master/types";
+import { logger } from "@app/logger";
 import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 import type { LogSourceId } from "@app/utils/log-viewer/log-source";
@@ -372,7 +373,11 @@ export class SSEBroadcaster {
                     for (const sub of [...bucket]) {
                         try {
                             sub.controller.enqueue(ping);
-                        } catch {
+                        } catch (err) {
+                            logger.debug(
+                                { error: err, subId: sub.id, key: sub.key },
+                                "SSE heartbeat enqueue failed; removing subscriber"
+                            );
                             this.removeSubscriber(sub);
                         }
                     }
@@ -381,12 +386,16 @@ export class SSEBroadcaster {
                 for (const sub of [...this.multiplexSubscribers]) {
                     try {
                         sub.controller.enqueue(ping);
-                    } catch {
+                    } catch (err) {
+                        logger.debug(
+                            { error: err, subId: sub.id, keyCount: sub.keys.size },
+                            "SSE heartbeat enqueue failed; removing multiplex subscriber"
+                        );
                         this.removeMultiplexSubscriber(sub);
                     }
                 }
             },
-            { leading: false }
+            { leading: false, unref: true }
         );
     }
 }

--- a/src/debugging-master/core/sse-broadcaster.ts
+++ b/src/debugging-master/core/sse-broadcaster.ts
@@ -119,28 +119,7 @@ export class SSEBroadcaster {
         const payload = SafeJSON.stringify({ source, session: sessionName });
         const frame = encoder.encode(`event: removed\ndata: ${payload}\n\n`);
 
-        const bucket = this.subscribers.get(key);
-        if (bucket) {
-            for (const sub of [...bucket]) {
-                try {
-                    sub.controller.enqueue(frame);
-                } catch {
-                    this.removeSubscriber(sub);
-                }
-            }
-        }
-
-        for (const sub of [...this.multiplexSubscribers]) {
-            if (!sub.keys.has(key)) {
-                continue;
-            }
-
-            try {
-                sub.controller.enqueue(frame);
-            } catch {
-                this.removeMultiplexSubscriber(sub);
-            }
-        }
+        this.broadcastFrame(key, frame);
 
         const tailer = this.tailers.get(key);
         if (tailer) {
@@ -179,28 +158,7 @@ export class SSEBroadcaster {
         const payload = SafeJSON.stringify({ source, session: sessionName });
         const frame = encoder.encode(`event: cleared\ndata: ${payload}\n\n`);
 
-        const bucket = this.subscribers.get(key);
-        if (bucket) {
-            for (const sub of [...bucket]) {
-                try {
-                    sub.controller.enqueue(frame);
-                } catch {
-                    this.removeSubscriber(sub);
-                }
-            }
-        }
-
-        for (const sub of [...this.multiplexSubscribers]) {
-            if (!sub.keys.has(key)) {
-                continue;
-            }
-
-            try {
-                sub.controller.enqueue(frame);
-            } catch {
-                this.removeMultiplexSubscriber(sub);
-            }
-        }
+        this.broadcastFrame(key, frame);
     }
 
     subscriberCount(key?: string): number {
@@ -274,6 +232,16 @@ export class SSEBroadcaster {
             const payload = SafeJSON.stringify({ ...entry, index: entryIndex });
             const frame = encoder.encode(`event: entry\ndata: ${payload}\n\n`);
 
+            this.broadcastFrame(key, frame);
+        }
+
+        this.fanOutMultiplex(key, entry, entryIndex);
+    }
+
+    private broadcastFrame(key: string, frame: Uint8Array): void {
+        const bucket = this.subscribers.get(key);
+
+        if (bucket) {
             for (const sub of [...bucket]) {
                 try {
                     sub.controller.enqueue(frame);
@@ -283,7 +251,17 @@ export class SSEBroadcaster {
             }
         }
 
-        this.fanOutMultiplex(key, entry, entryIndex);
+        for (const sub of [...this.multiplexSubscribers]) {
+            if (!sub.keys.has(key)) {
+                continue;
+            }
+
+            try {
+                sub.controller.enqueue(frame);
+            } catch {
+                this.removeMultiplexSubscriber(sub);
+            }
+        }
     }
 
     private fanOutMultiplex(key: string, entry: LogEntry, entryIndex: number): void {

--- a/src/debugging-master/dashboard/App.tsx
+++ b/src/debugging-master/dashboard/App.tsx
@@ -24,7 +24,7 @@ import { SessionDeleteConfirmProvider } from "@/lib/ui/SessionDeleteConfirm";
 import { resetLogSearchState, useLogSearchDisplay } from "@/lib/use-log-search-display";
 
 const FRESH_TTL_MS = 1500;
-const SESSIONS_REFRESH_MS = 5_000;
+const SESSIONS_REFRESH_MS = 10_000;
 
 type AppView = "home" | "detail";
 
@@ -79,6 +79,8 @@ export function App(): React.ReactElement {
     const [activeSession, setActiveSession] = useState<string | null>(initial.session);
     const [entries, setEntries] = useState<IndexedLogEntry[]>([]);
     const [status, setStatus] = useState<ConnectionStatus>("connecting");
+    const [serverReachable, setServerReachable] = useState<boolean | null>(null);
+    const [refreshing, setRefreshing] = useState(false);
     const [filterState, setFilterState] = useState<FilterState>(defaultFilterState);
     const [paused, setPaused] = useState(false);
     const [sortDir, setSortDir] = useState<SortDir>(() => {
@@ -130,9 +132,16 @@ export function App(): React.ReactElement {
         }
 
         const run = async (): Promise<void> => {
+            setRefreshing(true);
+
             try {
                 const { sessions: list } = await api.listSessions();
                 setSessions(sortSessionsByRecency(list));
+                setServerReachable(true);
+
+                if (activeRef.current.view === "home") {
+                    setStatus("live");
+                }
 
                 const { view: currentView, source, session } = activeRef.current;
 
@@ -156,8 +165,13 @@ export function App(): React.ReactElement {
 
                 goHome();
             } catch {
-                setStatus("down");
+                setServerReachable(false);
+
+                if (activeRef.current.view === "home") {
+                    setStatus("reconnecting");
+                }
             } finally {
+                setRefreshing(false);
                 refreshInFlightRef.current = null;
             }
         };
@@ -407,6 +421,9 @@ export function App(): React.ReactElement {
 
     const sessionDirSources = useMemo(() => collectSessionCwds(sessions), [sessions]);
 
+    const homeConnectionStatus: ConnectionStatus =
+        serverReachable === null ? "connecting" : serverReachable ? "live" : "reconnecting";
+
     return (
         <DisplaySettingsProvider>
             <SessionPoolSettingsProvider>
@@ -417,7 +434,8 @@ export function App(): React.ReactElement {
                                 <div className="h-full min-h-0 flex flex-col">
                                     <SessionsHome
                                         sessions={sessions}
-                                        status={status}
+                                        status={homeConnectionStatus}
+                                        refreshing={refreshing}
                                         onRefresh={refreshSessions}
                                         onOpenSession={openSession}
                                         onStatus={setStatus}
@@ -441,6 +459,7 @@ export function App(): React.ReactElement {
                                                     }
                                                 }}
                                                 status={status}
+                                                refreshing={refreshing}
                                                 entryCount={entries.length}
                                                 onClear={onClear}
                                                 onRefresh={() => {

--- a/src/debugging-master/dashboard/components/Header.tsx
+++ b/src/debugging-master/dashboard/components/Header.tsx
@@ -19,6 +19,7 @@ interface Props {
     activeSession: string | null;
     onSelectSession: (source: string, name: string) => void;
     status: ConnectionStatus;
+    refreshing?: boolean;
     entryCount: number;
     onClear: () => void;
     onRefresh: () => void;
@@ -44,6 +45,7 @@ export function Header({
     activeSession,
     onSelectSession,
     status,
+    refreshing = false,
     entryCount,
     onClear,
     onRefresh,
@@ -77,7 +79,7 @@ export function Header({
                         ← sessions
                     </button>
                     <span className="brand-title">▓▓▓ LOG VIEWER</span>
-                    <StatusPill status={status} />
+                    <StatusPill status={status} refreshing={refreshing} />
                 </div>
 
                 <div className="flex flex-1 min-w-0 items-center gap-3">

--- a/src/debugging-master/dashboard/components/SessionPoolSettingsButton.tsx
+++ b/src/debugging-master/dashboard/components/SessionPoolSettingsButton.tsx
@@ -1,7 +1,11 @@
 import { IconPopover } from "@ui/components/icon-button";
 import { Wrench } from "lucide-react";
 import type { ReactElement } from "react";
-import { MAX_ACTIVE_SESSION_LIMIT_MINUTES, MIN_ACTIVE_SESSION_LIMIT_MINUTES } from "@/lib/session-pool-settings";
+import {
+    formatActiveSessionLimit,
+    MAX_ACTIVE_SESSION_LIMIT_SECONDS,
+    MIN_ACTIVE_SESSION_LIMIT_SECONDS,
+} from "@/lib/session-pool-settings";
 import { useSessionPoolSettings } from "./SessionPoolSettingsProvider";
 
 export function SessionPoolSettingsButton(): ReactElement {
@@ -32,17 +36,17 @@ export function SessionPoolSettingsButton(): ReactElement {
                 <div className="flex items-center gap-2">
                     <input
                         type="range"
-                        min={MIN_ACTIVE_SESSION_LIMIT_MINUTES}
-                        max={MAX_ACTIVE_SESSION_LIMIT_MINUTES}
-                        step={5}
-                        value={settings.activeSessionLimitMinutes}
+                        min={MIN_ACTIVE_SESSION_LIMIT_SECONDS}
+                        max={MAX_ACTIVE_SESSION_LIMIT_SECONDS}
+                        step={1}
+                        value={settings.activeSessionLimitSeconds}
                         onChange={(event) => {
-                            updateSettings({ activeSessionLimitMinutes: Number(event.target.value) });
+                            updateSettings({ activeSessionLimitSeconds: Number(event.target.value) });
                         }}
                         className="flex-1 accent-cyan-400"
                     />
-                    <span className="dbg-ui-text-sm text-white/70 w-14 text-right tabular-nums">
-                        {settings.activeSessionLimitMinutes}m
+                    <span className="dbg-ui-text-sm text-white/70 w-20 text-right tabular-nums shrink-0">
+                        {formatActiveSessionLimit(settings.activeSessionLimitSeconds)}
                     </span>
                 </div>
                 <p className="dbg-ui-text-xs text-white/35 leading-relaxed">

--- a/src/debugging-master/dashboard/components/SessionsHome.tsx
+++ b/src/debugging-master/dashboard/components/SessionsHome.tsx
@@ -74,6 +74,7 @@ function mergePreviewLines(
 interface Props {
     sessions: DashboardSession[];
     status: ConnectionStatus;
+    refreshing?: boolean;
     onRefresh: () => Promise<void>;
     onOpenSession: (source: LogSourceId, name: string) => void;
     onStatus: (status: ConnectionStatus) => void;
@@ -310,14 +311,21 @@ function ActiveSessionMosaicPane({
     );
 }
 
-export function SessionsHome({ sessions, status, onRefresh, onOpenSession, onStatus }: Props): React.ReactElement {
+export function SessionsHome({
+    sessions,
+    status,
+    refreshing = false,
+    onRefresh,
+    onOpenSession,
+    onStatus,
+}: Props): React.ReactElement {
     const { settings } = useDisplaySettings();
     const { settings: poolSettings } = useSessionPoolSettings();
     const pathPrefix = useDirPathPrefix();
     const now = useNowTick(1000);
     const activeRetentionMs = useMemo(
         () => activeSessionRetentionMs(poolSettings),
-        [poolSettings.activeSessionLimitMinutes]
+        [poolSettings.activeSessionLimitSeconds]
     );
     const maxMosaicTiles = poolSettings.keepAllAlive ? Number.MAX_SAFE_INTEGER : MAX_ACTIVE_TILES;
     const [liveLines, setLiveLines] = useState<Map<string, MultiplexLogEntry[]>>(new Map());
@@ -520,13 +528,8 @@ export function SessionsHome({ sessions, status, onRefresh, onOpenSession, onSta
     }, [mosaicEntryCountsSig, prefetchSessionTail]);
 
     useEffect(() => {
-        // Re-open the multiplex SSE whenever the SET of active pool keys changes
-        // (not just mosaic tiles). subscribeActive snapshots server targets once
-        // at connect time; mosaic-only deps left new actives without live tail.
-        if (allActiveKeys.length === 0) {
-            return;
-        }
-
+        // Multiplex SSE for live tail — keep open even with zero active sessions so
+        // the home view still shows "connected" when the server is reachable.
         const dispose = connectActiveStream({
             onStatus: onStatus,
             onEntry: (entry) => {
@@ -565,7 +568,6 @@ export function SessionsHome({ sessions, status, onRefresh, onOpenSession, onSta
         });
 
         return dispose;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [onStatus, allActiveKeysSig]);
 
     const toggleArchiveRow = useCallback(
@@ -637,7 +639,7 @@ export function SessionsHome({ sessions, status, onRefresh, onOpenSession, onSta
                 <div className="px-3 sm:px-5 py-2.5 flex flex-wrap items-center gap-3">
                     <div className="flex items-center gap-3 mr-auto">
                         <span className="brand-title">▓▓▓ SESSIONS</span>
-                        <StatusPill status={status} />
+                        <StatusPill status={status} refreshing={refreshing} />
                         <span className="dbg-ui-text-sm text-emerald-400/70">
                             {allActiveSessions.length} live
                             {hiddenActiveCount > 0 ? ` · ${mosaicActiveKeys.length} in mosaic` : ""}

--- a/src/debugging-master/dashboard/components/StatusPill.tsx
+++ b/src/debugging-master/dashboard/components/StatusPill.tsx
@@ -2,8 +2,8 @@ import type { ConnectionStatus } from "@/lib/sse";
 
 const LABELS: Record<ConnectionStatus, string> = {
     connecting: "connecting",
-    live: "live",
-    reconnecting: "reconnecting",
+    live: "connected",
+    reconnecting: "offline · retrying",
     down: "offline",
 };
 
@@ -16,13 +16,20 @@ const DOT_CLASS: Record<ConnectionStatus, string> = {
 
 interface Props {
     status: ConnectionStatus;
+    refreshing?: boolean;
 }
 
-export function StatusPill({ status }: Props): React.ReactElement {
+export function StatusPill({ status, refreshing = false }: Props): React.ReactElement {
+    let label = LABELS[status];
+
+    if (refreshing && status === "live") {
+        label = "connected · refreshing";
+    }
+
     return (
         <span className="dbg-ui-text-sm inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-white/8 bg-white/[0.02] uppercase tracking-wider">
             <span className={DOT_CLASS[status]} />
-            <span className="text-white/70">{LABELS[status]}</span>
+            <span className="text-white/70">{label}</span>
         </span>
     );
 }

--- a/src/debugging-master/dashboard/lib/session-pool-settings.test.ts
+++ b/src/debugging-master/dashboard/lib/session-pool-settings.test.ts
@@ -1,13 +1,36 @@
 import { describe, expect, it } from "bun:test";
-import { activeSessionRetentionMs, DEFAULT_SESSION_POOL_SETTINGS } from "./session-pool-settings";
+import {
+    activeSessionRetentionMs,
+    DEFAULT_SESSION_POOL_SETTINGS,
+    formatActiveSessionLimit,
+    parseSessionPoolSettings,
+} from "./session-pool-settings";
 
 describe("session-pool-settings", () => {
-    it("converts minutes to retention ms", () => {
-        expect(activeSessionRetentionMs({ activeSessionLimitMinutes: 60, keepAllAlive: true })).toBe(3_600_000);
+    it("converts seconds to retention ms", () => {
+        expect(activeSessionRetentionMs({ activeSessionLimitSeconds: 3600, keepAllAlive: true })).toBe(3_600_000);
     });
 
-    it("defaults to 60 minutes and keep all alive", () => {
-        expect(DEFAULT_SESSION_POOL_SETTINGS.activeSessionLimitMinutes).toBe(60);
+    it("defaults to 1 hour and keep all alive", () => {
+        expect(DEFAULT_SESSION_POOL_SETTINGS.activeSessionLimitSeconds).toBe(3600);
         expect(DEFAULT_SESSION_POOL_SETTINGS.keepAllAlive).toBe(true);
+    });
+
+    it("migrates legacy minute-based settings", () => {
+        const parsed = parseSessionPoolSettings({ activeSessionLimitMinutes: 30, keepAllAlive: false });
+
+        expect(parsed.activeSessionLimitSeconds).toBe(1800);
+        expect(parsed.keepAllAlive).toBe(false);
+    });
+
+    it("formats sub-minute limits in seconds", () => {
+        expect(formatActiveSessionLimit(1)).toBe("1s");
+        expect(formatActiveSessionLimit(45)).toBe("45s");
+    });
+
+    it("formats hour-scale limits compactly", () => {
+        expect(formatActiveSessionLimit(3600)).toBe("1h");
+        expect(formatActiveSessionLimit(14_400)).toBe("4h");
+        expect(formatActiveSessionLimit(3661)).toBe("1h 1m 1s");
     });
 });

--- a/src/debugging-master/dashboard/lib/session-pool-settings.ts
+++ b/src/debugging-master/dashboard/lib/session-pool-settings.ts
@@ -2,13 +2,13 @@ import { loadPersistedSettings, savePersistedSettings } from "@ui/settings";
 
 export interface SessionPoolSettings {
     /** How long after exit a session stays in the live / mosaic pool. */
-    activeSessionLimitMinutes: number;
+    activeSessionLimitSeconds: number;
     /** When true, show every live-pool session in the mosaic (no tile cap). */
     keepAllAlive: boolean;
 }
 
 export const DEFAULT_SESSION_POOL_SETTINGS: SessionPoolSettings = {
-    activeSessionLimitMinutes: 60,
+    activeSessionLimitSeconds: 60 * 60,
     keepAllAlive: true,
 };
 
@@ -20,18 +20,59 @@ const persistOptions = {
     parse: parseSessionPoolSettings,
 };
 
-const MIN_ACTIVE_SESSION_LIMIT_MINUTES = 5;
-const MAX_ACTIVE_SESSION_LIMIT_MINUTES = 24 * 60;
+const MIN_ACTIVE_SESSION_LIMIT_SECONDS = 1;
+const MAX_ACTIVE_SESSION_LIMIT_SECONDS = 4 * 60 * 60;
 
 export function activeSessionRetentionMs(settings: SessionPoolSettings): number {
-    return settings.activeSessionLimitMinutes * 60 * 1000;
+    return settings.activeSessionLimitSeconds * 1000;
 }
 
+export function formatActiveSessionLimit(seconds: number): string {
+    const clamped = clampActiveSessionLimitSeconds(seconds);
+
+    if (clamped < 60) {
+        return `${clamped}s`;
+    }
+
+    const minutes = Math.floor(clamped / 60);
+    const remainderSeconds = clamped % 60;
+
+    if (clamped < 3600) {
+        if (remainderSeconds === 0) {
+            return `${minutes}m`;
+        }
+
+        return `${minutes}m ${remainderSeconds}s`;
+    }
+
+    const hours = Math.floor(clamped / 3600);
+    const remainderMinutes = Math.floor((clamped % 3600) / 60);
+    const tailSeconds = clamped % 60;
+
+    if (remainderMinutes === 0 && tailSeconds === 0) {
+        return `${hours}h`;
+    }
+
+    if (tailSeconds === 0) {
+        return `${hours}h ${remainderMinutes}m`;
+    }
+
+    if (remainderMinutes === 0) {
+        return `${hours}h ${tailSeconds}s`;
+    }
+
+    return `${hours}h ${remainderMinutes}m ${tailSeconds}s`;
+}
+
+type PersistedSessionPoolSettings = Partial<SessionPoolSettings> & {
+    activeSessionLimitMinutes?: number;
+};
+
 export function parseSessionPoolSettings(raw: unknown): SessionPoolSettings {
-    const parsed = (raw ?? {}) as Partial<SessionPoolSettings>;
+    const parsed = (raw ?? {}) as PersistedSessionPoolSettings;
 
     return {
-        activeSessionLimitMinutes: clampActiveSessionLimitMinutes(parsed.activeSessionLimitMinutes),
+        activeSessionLimitSeconds: resolveActiveSessionLimitSeconds(parsed),
         keepAllAlive: parsed.keepAllAlive !== false,
     };
 }
@@ -44,12 +85,24 @@ export function saveSessionPoolSettings(settings: SessionPoolSettings): void {
     savePersistedSettings(persistOptions, settings);
 }
 
-function clampActiveSessionLimitMinutes(value: unknown): number {
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-        return DEFAULT_SESSION_POOL_SETTINGS.activeSessionLimitMinutes;
+function resolveActiveSessionLimitSeconds(parsed: PersistedSessionPoolSettings): number {
+    if (typeof parsed.activeSessionLimitSeconds === "number") {
+        return clampActiveSessionLimitSeconds(parsed.activeSessionLimitSeconds);
     }
 
-    return Math.min(MAX_ACTIVE_SESSION_LIMIT_MINUTES, Math.max(MIN_ACTIVE_SESSION_LIMIT_MINUTES, Math.round(value)));
+    if (typeof parsed.activeSessionLimitMinutes === "number") {
+        return clampActiveSessionLimitSeconds(parsed.activeSessionLimitMinutes * 60);
+    }
+
+    return DEFAULT_SESSION_POOL_SETTINGS.activeSessionLimitSeconds;
 }
 
-export { MAX_ACTIVE_SESSION_LIMIT_MINUTES, MIN_ACTIVE_SESSION_LIMIT_MINUTES };
+function clampActiveSessionLimitSeconds(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return DEFAULT_SESSION_POOL_SETTINGS.activeSessionLimitSeconds;
+    }
+
+    return Math.min(MAX_ACTIVE_SESSION_LIMIT_SECONDS, Math.max(MIN_ACTIVE_SESSION_LIMIT_SECONDS, Math.round(value)));
+}
+
+export { MAX_ACTIVE_SESSION_LIMIT_SECONDS, MIN_ACTIVE_SESSION_LIMIT_SECONDS };

--- a/src/debugging-master/dashboard/lib/sse.ts
+++ b/src/debugging-master/dashboard/lib/sse.ts
@@ -25,6 +25,7 @@ export interface ActiveStreamHandlers {
 
 const RECONNECT_DELAY_MS = 1500;
 const MAX_RECONNECT_DELAY_MS = 15_000;
+const OFFLINE_RETRY_MS = 10_000;
 
 export function connectStream(source: LogSourceId, sessionName: string, handlers: SseHandlers): () => void {
     let es: EventSource | null = null;
@@ -65,12 +66,15 @@ export function connectStream(source: LogSourceId, sessionName: string, handlers
             es?.close();
             es = null;
             attempt++;
-            handlers.onStatus(attempt > 4 ? "down" : "reconnecting");
+            handlers.onStatus("reconnecting");
             if (reconnectTimer) {
                 clearTimeout(reconnectTimer);
                 reconnectTimer = null;
             }
-            const delay = Math.min(MAX_RECONNECT_DELAY_MS, RECONNECT_DELAY_MS * 2 ** Math.min(attempt - 1, 4));
+            const delay =
+                attempt > 4
+                    ? OFFLINE_RETRY_MS
+                    : Math.min(MAX_RECONNECT_DELAY_MS, RECONNECT_DELAY_MS * 2 ** Math.min(attempt - 1, 4));
             reconnectTimer = setTimeout(() => {
                 reconnectTimer = null;
                 open();
@@ -86,7 +90,6 @@ export function connectStream(source: LogSourceId, sessionName: string, handlers
             clearTimeout(reconnectTimer);
         }
         es?.close();
-        handlers.onStatus("down");
     };
 }
 
@@ -143,12 +146,15 @@ export function connectActiveStream(handlers: ActiveStreamHandlers): () => void 
             es?.close();
             es = null;
             attempt++;
-            handlers.onStatus(attempt > 4 ? "down" : "reconnecting");
+            handlers.onStatus("reconnecting");
             if (reconnectTimer) {
                 clearTimeout(reconnectTimer);
                 reconnectTimer = null;
             }
-            const delay = Math.min(MAX_RECONNECT_DELAY_MS, RECONNECT_DELAY_MS * 2 ** Math.min(attempt - 1, 4));
+            const delay =
+                attempt > 4
+                    ? OFFLINE_RETRY_MS
+                    : Math.min(MAX_RECONNECT_DELAY_MS, RECONNECT_DELAY_MS * 2 ** Math.min(attempt - 1, 4));
             reconnectTimer = setTimeout(() => {
                 reconnectTimer = null;
                 open();
@@ -164,6 +170,5 @@ export function connectActiveStream(handlers: ActiveStreamHandlers): () => void 
             clearTimeout(reconnectTimer);
         }
         es?.close();
-        handlers.onStatus("down");
     };
 }

--- a/src/dev-dashboard/lib/cmux/poller.ts
+++ b/src/dev-dashboard/lib/cmux/poller.ts
@@ -1,9 +1,10 @@
 import { fetchSnapshot } from "@app/dev-dashboard/lib/cmux/client";
 import type { CmuxSnapshot } from "@app/dev-dashboard/lib/cmux/types";
 import { logger } from "@app/logger";
+import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 
 let cached: CmuxSnapshot | null = null;
-let timer: ReturnType<typeof setInterval> | null = null;
+let handle: WakefulInterval | null = null;
 
 export function getCachedSnapshot(): CmuxSnapshot {
     if (cached) {
@@ -24,22 +25,20 @@ export function startPolling(intervalMs: number): void {
         return;
     }
 
-    if (timer) {
+    if (handle) {
         return;
     }
 
-    timer = setInterval(() => {
-        refreshOnce().catch((err) => logger.debug({ err }, "cmux poll failed"));
-    }, intervalMs);
-
-    refreshOnce().catch((err) => logger.debug({ err }, "cmux initial poll failed"));
+    handle = startWakefulInterval(intervalMs, async () => {
+        await refreshOnce();
+    });
 }
 
 export function stopPolling(): void {
-    if (!timer) {
+    if (!handle) {
         return;
     }
 
-    clearInterval(timer);
-    timer = null;
+    handle.stop();
+    handle = null;
 }

--- a/src/dev-dashboard/lib/system/poller.ts
+++ b/src/dev-dashboard/lib/system/poller.ts
@@ -95,6 +95,11 @@ async function tick(): Promise<void> {
 }
 
 export function startPulsePolling(intervalMs: number): void {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        logger.warn({ intervalMs }, "pulse polling not started: invalid interval");
+        return;
+    }
+
     if (handle) {
         return;
     }

--- a/src/dev-dashboard/lib/system/poller.ts
+++ b/src/dev-dashboard/lib/system/poller.ts
@@ -1,4 +1,5 @@
 import { logger } from "@app/logger";
+import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 import { collectPulse } from "./collector";
 import { PulseHistoryDb } from "./history-db";
@@ -11,7 +12,7 @@ interface IpifyResponse {
     ip?: string;
 }
 
-let timer: ReturnType<typeof setInterval> | null = null;
+let handle: WakefulInterval | null = null;
 let polling = false;
 let db: PulseHistoryDb | null = null;
 let lastSnapshot: PulseSnapshot | null = null;
@@ -94,14 +95,20 @@ async function tick(): Promise<void> {
 }
 
 export function startPulsePolling(intervalMs: number): void {
-    if (timer) {
+    if (handle) {
         return;
     }
 
-    void tick();
-    timer = setInterval(() => {
-        void tick();
-    }, intervalMs);
+    handle = startWakefulInterval(intervalMs, () => tick());
+}
+
+export function stopPulsePolling(): void {
+    if (!handle) {
+        return;
+    }
+
+    handle.stop();
+    handle = null;
 }
 
 export function configureRetention(hours: number): void {

--- a/src/indexer/lib/indexer.ts
+++ b/src/indexer/lib/indexer.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { logger } from "@app/logger";
 import { findModel } from "@app/utils/ai/ModelRegistry";
 import type { Embedder } from "@app/utils/ai/tasks/Embedder";
+import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 import type { WatcherSubscription } from "@app/utils/fs/watcher";
 import { Stopwatch } from "@app/utils/Stopwatch";
 import type { SearchOptions, SearchResult } from "@app/utils/search/types";
@@ -78,7 +79,7 @@ export class Indexer extends IndexerEventEmitter {
     private config: IndexConfig;
     private source: IndexerSource;
     private embedder: Embedder | null = null;
-    private watchTimer: ReturnType<typeof setInterval> | null = null;
+    private watchTimer: WakefulInterval | null = null;
     private watchSubscription: WatcherSubscription | null = null;
     private isSyncing = false;
     private cancellationRequested = false;
@@ -406,21 +407,25 @@ export class Indexer extends IndexerEventEmitter {
     private startPollingWatch(callbacks?: IndexerCallbacks): void {
         const interval = this.config.watch?.interval ?? DEFAULT_WATCH_INTERVAL_MS;
 
-        this.watchTimer = setInterval(async () => {
-            if (this.isSyncing) {
-                return;
-            }
+        this.watchTimer = startWakefulInterval(
+            interval,
+            async () => {
+                if (this.isSyncing) {
+                    return;
+                }
 
-            this.isSyncing = true;
+                this.isSyncing = true;
 
-            try {
-                await this.sync(callbacks);
-            } catch {
-                // Watch sync errors are non-fatal
-            } finally {
-                this.isSyncing = false;
-            }
-        }, interval);
+                try {
+                    await this.sync(callbacks);
+                } catch {
+                    // Watch sync errors are non-fatal
+                } finally {
+                    this.isSyncing = false;
+                }
+            },
+            { leading: false }
+        );
     }
 
     async stopWatch(): Promise<void> {
@@ -430,7 +435,7 @@ export class Indexer extends IndexerEventEmitter {
         }
 
         if (this.watchTimer) {
-            clearInterval(this.watchTimer);
+            this.watchTimer.stop();
             this.watchTimer = null;
         }
 

--- a/src/indexer/lib/indexer.ts
+++ b/src/indexer/lib/indexer.ts
@@ -407,6 +407,18 @@ export class Indexer extends IndexerEventEmitter {
     private startPollingWatch(callbacks?: IndexerCallbacks): void {
         const interval = this.config.watch?.interval ?? DEFAULT_WATCH_INTERVAL_MS;
 
+        if (!Number.isFinite(interval) || interval <= 0) {
+            this.emitAndDispatch(
+                "sync:error",
+                {
+                    indexName: this.config.name,
+                    error: `Invalid watch interval: ${String(interval)}`,
+                },
+                callbacks
+            );
+            return;
+        }
+
         this.watchTimer = startWakefulInterval(
             interval,
             async () => {
@@ -418,8 +430,8 @@ export class Indexer extends IndexerEventEmitter {
 
                 try {
                     await this.sync(callbacks);
-                } catch {
-                    // Watch sync errors are non-fatal
+                } catch (err) {
+                    logger.debug({ error: err, indexName: this.config.name }, "polling watch sync failed");
                 } finally {
                     this.isSyncing = false;
                 }

--- a/src/npm-package-diff/index.ts
+++ b/src/npm-package-diff/index.ts
@@ -8,6 +8,7 @@ import { resolvePathWithTilde } from "@app/utils";
 import { isVerbose, runTool } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import { handleReadmeFlag } from "@app/utils/readme";
+import * as TOML from "@iarna/toml";
 import boxen from "boxen";
 import chalk from "chalk";
 import chokidar, { type FSWatcher } from "chokidar";
@@ -95,6 +96,83 @@ const loadConfig = (configPath?: string): Record<string, unknown> => {
         }
     }
     return {};
+};
+
+// Walk up from startDir to the filesystem root, returning the first existing file
+// among `names`. Mirrors how npm/pnpm/yarn/bun discover project config — the temp
+// install dir lives in os.tmpdir() with no such ancestry, so we re-create it.
+const findNearestConfig = (startDir: string, names: string[]): string | null => {
+    let dir = startDir;
+    while (true) {
+        for (const name of names) {
+            const candidate = path.join(dir, name);
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
+        }
+
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return null;
+        }
+
+        dir = parent;
+    }
+};
+
+// Resolve relative cafile/certfile/keyfile values against the config's own
+// directory. Once copied into os.tmpdir(), a "./certs/ca.pem" would otherwise
+// resolve against the temp dir and fail with a confusing cert error.
+const PATH_VALUED_KEYS = ["cafile", "certfile", "keyfile"];
+
+const resolveConfigPath = (value: string, sourceDir: string): string => {
+    if (!value || path.isAbsolute(value) || value.startsWith("~") || /^[a-z]+:\/\//i.test(value)) {
+        return value;
+    }
+    return path.resolve(sourceDir, value);
+};
+
+const rewriteNpmrcPaths = (content: string, sourceDir: string): string => {
+    const keys = PATH_VALUED_KEYS.join("|");
+    const re = new RegExp(`^(\\s*(?:${keys})\\s*=\\s*)(.+)$`, "gim");
+    return content.replace(re, (_full, prefix: string, rawValue: string) => {
+        return `${prefix}${resolveConfigPath(rawValue.trim(), sourceDir)}`;
+    });
+};
+
+// Build the bunfig.toml for the temp install dir by mirroring the nearest project
+// bunfig (so corp cafile / linker / scopes carry over), but always forcing
+// minimumReleaseAge = 0 — diffing targets brand-new releases that the project's
+// supply-chain age gate would otherwise refuse to resolve.
+const buildTempBunfig = (cwd: string): string => {
+    const source = findNearestConfig(cwd, ["bunfig.toml", ".bunfig.toml"]);
+    if (source) {
+        try {
+            const parsed = TOML.parse(fs.readFileSync(source, "utf8"));
+            const install: TOML.JsonMap =
+                parsed.install && typeof parsed.install === "object" ? (parsed.install as TOML.JsonMap) : {};
+
+            const sourceDir = path.dirname(source);
+            for (const key of PATH_VALUED_KEYS) {
+                const v = install[key];
+                if (typeof v === "string") {
+                    install[key] = resolveConfigPath(v, sourceDir);
+                }
+            }
+
+            install.minimumReleaseAge = 0;
+            delete install.minimumReleaseAgeExcludes;
+            logger.debug(`Mirrored bunfig [install] from ${source} (minimumReleaseAge forced to 0)`);
+
+            // Only the [install] table is relevant; preload/test/run paths reference
+            // files that don't exist in the temp dir.
+            return TOML.stringify({ install });
+        } catch (error) {
+            logger.warn(`Failed to parse bunfig at ${source}, using minimal config: ${error}`);
+        }
+    }
+
+    return "[install]\nminimumReleaseAge = 0\n";
 };
 
 const program = new Command()
@@ -274,7 +352,9 @@ interface FileMetadata {
 
 interface DiffResult {
     file: string;
-    status: "added" | "removed" | "modified" | "identical";
+    status: "added" | "removed" | "modified" | "identical" | "renamed";
+    oldPath?: string;
+    newPath?: string;
     oldSize?: number;
     newSize?: number;
     additions?: number;
@@ -297,6 +377,7 @@ class EnhancedPackageComparison {
     private packageManager: PackageManager;
     private pagerProcess?: ReturnType<typeof spawn>;
     private outputBuffer: string[] = [];
+    private tempBunfigContent?: string;
 
     constructor(
         private packageName: string,
@@ -371,21 +452,33 @@ class EnhancedPackageComparison {
         fs.mkdirSync(this.dir1, { recursive: true });
         fs.mkdirSync(this.dir2, { recursive: true });
 
-        // Copy .npmrc if specified
+        // Mirror the nearest .npmrc into both temp dirs so private-scope registries
+        // and auth tokens resolve exactly as they would in the user's project.
+        // Explicit --npmrc wins; otherwise walk up from cwd. ~/.npmrc is already read
+        // globally by every package manager, so only the project-local one is missing.
+        let npmrcSource: string | null = null;
         if (this.options.npmrc) {
-            const npmrcPath = resolvePathWithTilde(this.options.npmrc);
-
-            if (fs.existsSync(npmrcPath)) {
-                try {
-                    const npmrcContent = fs.readFileSync(npmrcPath, "utf8");
-                    fs.writeFileSync(path.join(this.dir1, ".npmrc"), npmrcContent);
-                    fs.writeFileSync(path.join(this.dir2, ".npmrc"), npmrcContent);
-                    logger.debug(`\nCopied .npmrc from ${npmrcPath}`);
-                } catch (error) {
-                    logger.error(`\nError copying .npmrc from ${npmrcPath}: ${error}`);
-                }
+            const explicit = resolvePathWithTilde(this.options.npmrc);
+            if (fs.existsSync(explicit)) {
+                npmrcSource = explicit;
             } else {
-                logger.warn(`\nSpecified .npmrc file not found: ${npmrcPath}`);
+                logger.warn(`\nSpecified .npmrc file not found: ${explicit}`);
+            }
+        } else {
+            npmrcSource = findNearestConfig(process.cwd(), [".npmrc"]);
+        }
+
+        if (npmrcSource) {
+            try {
+                const content = rewriteNpmrcPaths(fs.readFileSync(npmrcSource, "utf8"), path.dirname(npmrcSource));
+                fs.writeFileSync(path.join(this.dir1, ".npmrc"), content);
+                fs.writeFileSync(path.join(this.dir2, ".npmrc"), content);
+                logger.debug(`Mirrored .npmrc from ${npmrcSource}`);
+                if (this.options.keep) {
+                    logger.warn(`--keep leaves a copy of ${npmrcSource} (incl. any auth tokens) in ${this.tempDir}`);
+                }
+            } catch (error) {
+                logger.error(`Error copying .npmrc from ${npmrcSource}: ${error}`);
             }
         }
 
@@ -458,6 +551,13 @@ class EnhancedPackageComparison {
         await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
+    private getTempBunfig(): string {
+        if (this.tempBunfigContent === undefined) {
+            this.tempBunfigContent = buildTempBunfig(process.cwd());
+        }
+        return this.tempBunfigContent;
+    }
+
     private async installPackageInDirectory(pkg: string, version: string, dir: string): Promise<void> {
         logger.debug(`Installing ${pkg}@${version} in ${dir} using ${this.packageManager}`);
 
@@ -478,35 +578,56 @@ class EnhancedPackageComparison {
 
         fs.writeFileSync(path.join(dir, "package.json"), SafeJSON.stringify(packageJson, null, 2));
 
+        // Diffing often targets brand-new releases. Mirror the nearest project
+        // bunfig (corp cafile / linker / scopes) but force minimumReleaseAge = 0 so
+        // the age gate never blocks the requested version. Falls back to a minimal
+        // config when no project bunfig exists.
+        if (this.packageManager === "bun") {
+            fs.writeFileSync(path.join(dir, "bunfig.toml"), this.getTempBunfig());
+        }
+
         // Prepare install command based on package manager
         let installCmd: string;
         let installArgs: string[];
 
+        // --ignore-scripts on every manager: we install arbitrary, untrusted
+        // package versions purely to read their files. No pre/post/install
+        // lifecycle script may ever execute in the temp dir.
         switch (this.packageManager) {
             case "bun":
                 installCmd = "bun";
-                installArgs = ["install"];
+                installArgs = ["install", "--ignore-scripts"];
                 break;
             case "pnpm":
                 installCmd = "pnpm";
-                installArgs = ["install", "--no-lockfile"];
+                installArgs = ["install", "--no-lockfile", "--ignore-scripts"];
                 break;
             case "yarn":
                 installCmd = "yarn";
-                installArgs = ["install", "--no-lockfile"];
+                installArgs = ["install", "--no-lockfile", "--ignore-scripts"];
                 break;
             default:
                 installCmd = "npm";
-                installArgs = ["install", "--no-package-lock"];
+                installArgs = ["install", "--no-package-lock", "--ignore-scripts"];
                 break;
         }
 
         // Run install with timeout
         return new Promise((resolve, reject) => {
+            const verbose = isVerbose();
             const installProcess = spawn(installCmd, installArgs, {
                 cwd: dir,
-                stdio: isVerbose() ? "inherit" : "pipe",
+                stdio: verbose ? "inherit" : "pipe",
             });
+
+            // When not verbose the streams are piped (and would otherwise be silently
+            // discarded). Capture them so a non-zero exit can report WHY it failed
+            // (404 / auth / cert) instead of an opaque "failed with code 1".
+            const captured: string[] = [];
+            if (!verbose) {
+                installProcess.stdout?.on("data", (d: Buffer) => captured.push(d.toString()));
+                installProcess.stderr?.on("data", (d: Buffer) => captured.push(d.toString()));
+            }
 
             let timedOut = false;
             const timeout = setTimeout(() => {
@@ -525,7 +646,21 @@ class EnhancedPackageComparison {
                     logger.debug(`Successfully installed ${pkg}@${version} to ${dir}`);
                     resolve();
                 } else {
-                    reject(new Error(`${this.packageManager} install failed with code ${code} for ${pkg}@${version}`));
+                    const detail = captured.join("").trim();
+                    const tail = detail.length > 1600 ? `…${detail.slice(-1600)}` : detail;
+                    const needsAuth = /E404|404|ENEEDAUTH|E401|401|403|no permission|not found|authenticate/i.test(
+                        detail
+                    );
+                    const hint = needsAuth
+                        ? "\n  Hint: looks like a private/authenticated package. npm-package-diff mirrors the nearest .npmrc/bunfig.toml from your cwd — run it from inside the project tree (and on VPN if the registry is internal), or pass --npmrc <path>."
+                        : "";
+                    reject(
+                        new Error(
+                            `${this.packageManager} install failed with code ${code} for ${pkg}@${version}${
+                                tail ? `\n${tail}` : ""
+                            }${hint}`
+                        )
+                    );
                 }
             });
 
@@ -577,101 +712,223 @@ class EnhancedPackageComparison {
         const files1Map = new Map(filteredFiles1.map((f) => [f.relativePath, f]));
         const files2Map = new Map(filteredFiles2.map((f) => [f.relativePath, f]));
 
-        // Get all unique file paths
-        const allPaths = new Set([...files1Map.keys(), ...files2Map.keys()]);
+        // Partition into common / only-in-v1 / only-in-v2.
+        const inBoth: string[] = [];
+        const onlyIn1: string[] = [];
+        const onlyIn2: string[] = [];
+        for (const filePath of new Set([...files1Map.keys(), ...files2Map.keys()])) {
+            const in1 = files1Map.has(filePath);
+            const in2 = files2Map.has(filePath);
+            if (in1 && in2) {
+                inBoth.push(filePath);
+            } else if (in1) {
+                onlyIn1.push(filePath);
+            } else {
+                onlyIn2.push(filePath);
+            }
+        }
 
-        for (const filePath of Array.from(allPaths).sort()) {
+        // Pair relocated files (e.g. apis/X.d.ts -> dist/apis/X.d.ts) so they
+        // render as a rename WITH a side-by-side diff instead of an unrelated
+        // delete + add pair.
+        const { pairs, removed, added } = this.detectRenames(onlyIn1, onlyIn2);
+
+        for (const filePath of inBoth.sort()) {
             const file1 = files1Map.get(filePath);
             const file2 = files2Map.get(filePath);
-
             if (file1 && file2) {
                 await this.compareTwoFiles(file1, file2);
-            } else if (file1 && !file2) {
-                // For removed files, read the content and create a diff showing all lines as deletions
-                try {
-                    const content1 = fs.readFileSync(file1.absolutePath, "utf8");
-                    const lines = content1.split("\n");
-                    // Remove last empty line if present
-                    if (lines[lines.length - 1] === "") {
-                        lines.pop();
-                    }
-                    const lineCount = lines.length;
+            }
+        }
 
-                    const changes = [{ removed: true, added: false, value: content1, count: lineCount }];
+        for (const [oldPath, newPath] of pairs) {
+            const file1 = files1Map.get(oldPath);
+            const file2 = files2Map.get(newPath);
+            if (file1 && file2) {
+                this.emitRenamedFile(file1, file2, oldPath, newPath);
+            }
+        }
 
-                    // Generate patch for removed file
-                    const patch = diff.createTwoFilesPatch(
-                        filePath,
-                        filePath,
-                        content1,
-                        "",
-                        `v${this.version1}`,
-                        `v${this.version2}`,
-                        { context: this.options.context }
-                    );
+        for (const filePath of removed.sort()) {
+            const file1 = files1Map.get(filePath);
+            if (file1) {
+                this.emitRemovedFile(file1, filePath);
+            }
+        }
 
-                    this.results.push({
-                        file: filePath,
-                        status: "removed",
-                        oldSize: file1.size,
-                        additions: 0,
-                        deletions: lineCount,
-                        changes,
-                        patch,
-                    });
-                } catch (error) {
-                    logger.error(`Error reading removed file ${filePath}: ${error}`);
-                    this.results.push({
-                        file: filePath,
-                        status: "removed",
-                        oldSize: file1.size,
-                    });
-                }
-            } else if (!file1 && file2) {
-                // For added files, read the content and create a diff showing all lines as additions
-                try {
-                    const content2 = fs.readFileSync(file2.absolutePath, "utf8");
-                    const lines = content2.split("\n");
-                    // Remove last empty line if present
-                    if (lines[lines.length - 1] === "") {
-                        lines.pop();
-                    }
-                    const lineCount = lines.length;
-
-                    const changes = [{ added: true, removed: false, value: content2, count: lineCount }];
-
-                    // Generate patch for added file
-                    const patch = diff.createTwoFilesPatch(
-                        filePath,
-                        filePath,
-                        "",
-                        content2,
-                        `v${this.version1}`,
-                        `v${this.version2}`,
-                        { context: this.options.context }
-                    );
-
-                    this.results.push({
-                        file: filePath,
-                        status: "added",
-                        newSize: file2.size,
-                        additions: lineCount,
-                        deletions: 0,
-                        changes,
-                        patch,
-                    });
-                } catch (error) {
-                    logger.error(`Error reading added file ${filePath}: ${error}`);
-                    this.results.push({
-                        file: filePath,
-                        status: "added",
-                        newSize: file2.size,
-                    });
-                }
+        for (const filePath of added.sort()) {
+            const file2 = files2Map.get(filePath);
+            if (file2) {
+                this.emitAddedFile(file2, filePath);
             }
         }
 
         this.spinner?.succeed(`Comparison complete`);
+    }
+
+    // Trailing path segments two paths share, e.g. apis/X.d.ts vs dist/apis/X.d.ts → 2.
+    private commonSuffixSegments(a: string[], b: string[]): number {
+        let n = 0;
+        let i = a.length - 1;
+        let j = b.length - 1;
+        while (i >= 0 && j >= 0 && a[i] === b[j]) {
+            n++;
+            i--;
+            j--;
+        }
+        return n;
+    }
+
+    private detectRenames(
+        onlyIn1: string[],
+        onlyIn2: string[]
+    ): { pairs: [string, string][]; removed: string[]; added: string[] } {
+        const pairs: [string, string][] = [];
+        const usedAdded = new Set<string>();
+        const usedRemoved = new Set<string>();
+
+        // Longest paths first so the most specific removed file claims its match
+        // before a shorter, more ambiguous one does.
+        for (const removed of [...onlyIn1].sort((a, b) => b.length - a.length)) {
+            const rSeg = removed.split("/");
+            let best: string | null = null;
+            let bestLen = 0;
+            let ambiguous = false;
+
+            for (const added of onlyIn2) {
+                if (usedAdded.has(added)) {
+                    continue;
+                }
+
+                const len = this.commonSuffixSegments(rSeg, added.split("/"));
+                if (len === 0) {
+                    continue;
+                }
+
+                if (len > bestLen) {
+                    bestLen = len;
+                    best = added;
+                    ambiguous = false;
+                } else if (len === bestLen) {
+                    ambiguous = true;
+                }
+            }
+
+            // Require a basename match (bestLen >= 1) that is unambiguously the closest.
+            if (!best || ambiguous) {
+                continue;
+            }
+
+            pairs.push([removed, best]);
+            usedAdded.add(best);
+            usedRemoved.add(removed);
+            logger.debug(`Detected rename: ${removed} -> ${best} (common suffix ${bestLen})`);
+        }
+
+        return {
+            pairs,
+            removed: onlyIn1.filter((p) => !usedRemoved.has(p)),
+            added: onlyIn2.filter((p) => !usedAdded.has(p)),
+        };
+    }
+
+    private emitRenamedFile(file1: FileMetadata, file2: FileMetadata, oldPath: string, newPath: string): void {
+        try {
+            const content1 = fs.readFileSync(file1.absolutePath, "utf8");
+            const content2 = fs.readFileSync(file2.absolutePath, "utf8");
+
+            const changes = this.options.wordDiff
+                ? diff.diffWords(content1, content2)
+                : diff.diffLines(content1, content2, { ignoreWhitespace: false, newlineIsToken: true });
+
+            let additions = 0;
+            let deletions = 0;
+            changes.forEach((change) => {
+                if (change.added) {
+                    additions += change.count || 0;
+                } else if (change.removed) {
+                    deletions += change.count || 0;
+                }
+            });
+
+            // Different old/new paths + real hunks → diff2html renders a rename with diff.
+            const patch = diff.createTwoFilesPatch(oldPath, newPath, content1, content2, undefined, undefined, {
+                context: this.options.context,
+            });
+
+            this.results.push({
+                file: `${oldPath} → ${newPath}`,
+                status: "renamed",
+                oldPath,
+                newPath,
+                oldSize: file1.size,
+                newSize: file2.size,
+                additions,
+                deletions,
+                changes,
+                patch,
+            });
+        } catch (error) {
+            logger.error(`Error comparing renamed files ${oldPath} -> ${newPath}: ${error}`);
+        }
+    }
+
+    private emitRemovedFile(file1: FileMetadata, filePath: string): void {
+        try {
+            const content1 = fs.readFileSync(file1.absolutePath, "utf8");
+            const lines = content1.split("\n");
+            if (lines[lines.length - 1] === "") {
+                lines.pop();
+            }
+
+            const lineCount = lines.length;
+            const changes = [{ removed: true, added: false, value: content1, count: lineCount }];
+            const patch = diff.createTwoFilesPatch(filePath, filePath, content1, "", undefined, undefined, {
+                context: this.options.context,
+            });
+
+            this.results.push({
+                file: filePath,
+                status: "removed",
+                oldSize: file1.size,
+                additions: 0,
+                deletions: lineCount,
+                changes,
+                patch,
+            });
+        } catch (error) {
+            logger.error(`Error reading removed file ${filePath}: ${error}`);
+            this.results.push({ file: filePath, status: "removed", oldSize: file1.size });
+        }
+    }
+
+    private emitAddedFile(file2: FileMetadata, filePath: string): void {
+        try {
+            const content2 = fs.readFileSync(file2.absolutePath, "utf8");
+            const lines = content2.split("\n");
+            if (lines[lines.length - 1] === "") {
+                lines.pop();
+            }
+
+            const lineCount = lines.length;
+            const changes = [{ added: true, removed: false, value: content2, count: lineCount }];
+            const patch = diff.createTwoFilesPatch(filePath, filePath, "", content2, undefined, undefined, {
+                context: this.options.context,
+            });
+
+            this.results.push({
+                file: filePath,
+                status: "added",
+                newSize: file2.size,
+                additions: lineCount,
+                deletions: 0,
+                changes,
+                patch,
+            });
+        } catch (error) {
+            logger.error(`Error reading added file ${filePath}: ${error}`);
+            this.results.push({ file: filePath, status: "added", newSize: file2.size });
+        }
     }
 
     private async compareTwoFiles(file1: FileMetadata, file2: FileMetadata): Promise<void> {
@@ -708,15 +965,18 @@ class EnhancedPackageComparison {
                 }
             });
 
-            // Generate patch if needed
+            // No version header: it leaks into the diff2html filename and makes
+            // same-path modifications render as bogus "renames". Version is in the title.
             const patch = diff.createTwoFilesPatch(
                 file1.relativePath,
                 file2.relativePath,
                 content1,
                 content2,
-                `v${this.version1}`,
-                `v${this.version2}`,
-                { context: this.options.context }
+                undefined,
+                undefined,
+                {
+                    context: this.options.context,
+                }
             );
 
             this.results.push({
@@ -803,6 +1063,12 @@ class EnhancedPackageComparison {
             this.write(chalk.green(`   Status: Added (${filesize(result.newSize || 0)})`));
         } else if (result.status === "removed") {
             this.write(chalk.red(`   Status: Removed (${filesize(result.oldSize || 0)})`));
+        } else if (result.status === "renamed") {
+            this.write(chalk.magenta(`   Status: Renamed (${result.oldPath} → ${result.newPath})`));
+            this.write(chalk.gray(`   Size: ${filesize(result.oldSize || 0)} → ${filesize(result.newSize || 0)}`));
+            this.write(
+                `${chalk.green(`   +${result.additions} additions`)} ${chalk.red(`-${result.deletions} deletions`)}`
+            );
         } else if (result.status === "modified") {
             this.write(chalk.yellow(`   Status: Modified`));
             this.write(chalk.gray(`   Size: ${filesize(result.oldSize || 0)} → ${filesize(result.newSize || 0)}`));
@@ -814,7 +1080,10 @@ class EnhancedPackageComparison {
 
         if (
             result.changes &&
-            (result.status === "modified" || result.status === "added" || result.status === "removed")
+            (result.status === "modified" ||
+                result.status === "added" ||
+                result.status === "removed" ||
+                result.status === "renamed")
         ) {
             if (this.options.format === "side-by-side") {
                 this.outputSideBySideDiff(result);
@@ -1221,6 +1490,7 @@ class EnhancedPackageComparison {
                 total: this.results.length,
                 added: this.results.filter((r) => r.status === "added").length,
                 removed: this.results.filter((r) => r.status === "removed").length,
+                renamed: this.results.filter((r) => r.status === "renamed").length,
                 modified: this.results.filter((r) => r.status === "modified").length,
                 identical: this.results.filter((r) => r.status === "identical").length,
             },
@@ -1299,6 +1569,7 @@ class EnhancedPackageComparison {
             total: this.results.length,
             added: this.results.filter((r) => r.status === "added").length,
             removed: this.results.filter((r) => r.status === "removed").length,
+            renamed: this.results.filter((r) => r.status === "renamed").length,
             modified: this.results.filter((r) => r.status === "modified").length,
             identical: this.results.filter((r) => r.status === "identical").length,
         };
@@ -1308,6 +1579,7 @@ class EnhancedPackageComparison {
                 `Total files analyzed: ${chalk.cyan(stats.total)}\n` +
                 `Files added: ${chalk.green(`+${stats.added}`)}\n` +
                 `Files removed: ${chalk.red(`-${stats.removed}`)}\n` +
+                `Files renamed: ${chalk.magenta(`→${stats.renamed}`)}\n` +
                 `Files modified: ${chalk.yellow(`~${stats.modified}`)}\n` +
                 `Files unchanged: ${chalk.gray(stats.identical)}`,
             {
@@ -1341,6 +1613,7 @@ class EnhancedPackageComparison {
                 const status = {
                     added: chalk.green("Added"),
                     removed: chalk.red("Removed"),
+                    renamed: chalk.magenta("Renamed"),
                     modified: chalk.yellow("Modified"),
                     identical: chalk.gray("Identical"),
                 }[result.status];

--- a/src/port/index.ts
+++ b/src/port/index.ts
@@ -276,7 +276,7 @@ async function watchPortActivity(options: { all?: boolean; interval?: string }):
 
     await new Promise<void>((resolve) => {
         process.on("SIGINT", () => {
-            clearInterval(timer);
+            timer.stop();
             out.println();
             p.outro(pc.dim("Stopped watching."));
             resolve();

--- a/src/port/lib/scanner.ts
+++ b/src/port/lib/scanner.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
+import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 import type { KillResult, PortProcess, PortSnapshot, ProcessSnapshot, ProcessStatus } from "./types";
 
@@ -1215,7 +1216,7 @@ function killProcessesWindows(pids: number[]): Promise<KillResult[]> {
 export function watchPorts(
     callback: (event: "new" | "removed", snapshot: PortSnapshot) => void,
     options?: { includeSystem?: boolean; intervalMs?: number }
-): ReturnType<typeof setInterval> {
+): WakefulInterval {
     const includeSystem = options?.includeSystem ?? false;
     const intervalMs = options?.intervalMs ?? DEFAULT_WATCH_INTERVAL_MS;
     let previous = new Map<number, PortSnapshot>();
@@ -1247,6 +1248,5 @@ export function watchPorts(
         previous = current;
     };
 
-    collect();
-    return setInterval(collect, intervalMs);
+    return startWakefulInterval(intervalMs, collect);
 }

--- a/src/shops/lib/live-events-source.ts
+++ b/src/shops/lib/live-events-source.ts
@@ -3,6 +3,7 @@ import type { ShopsDatabase } from "@app/shops/db/ShopsDatabase";
 import { getShopsDatabase } from "@app/shops/db/ShopsDatabase";
 import { sseBroadcaster } from "@app/shops/lib/sse-broadcaster";
 import type { LiveCrawlProgressEvent, LiveHttpRequestEvent } from "@app/shops/types";
+import { startWakefulInterval } from "@app/utils/async";
 
 const POLL_INTERVAL_MS = 2_000;
 const HTTP_BACKFILL_LIMIT = 100;
@@ -231,15 +232,17 @@ export function ensureLiveEventPoller(db: ShopsDatabase = getShopsDatabase()): v
         }
     })();
 
-    const interval = setInterval(() => {
-        if (sseBroadcaster.subscriberCount() === 0) {
-            return;
-        }
+    startWakefulInterval(
+        POLL_INTERVAL_MS,
+        () => {
+            if (sseBroadcaster.subscriberCount() === 0) {
+                return;
+            }
 
-        void pollOnce(db).catch((err) => log.warn({ err }, "live-events poll error"));
-    }, POLL_INTERVAL_MS);
-
-    interval.unref?.();
+            void pollOnce(db).catch((err) => log.warn({ err }, "live-events poll error"));
+        },
+        { leading: false }
+    );
 }
 
 /**

--- a/src/shops/lib/live-events-source.ts
+++ b/src/shops/lib/live-events-source.ts
@@ -239,9 +239,9 @@ export function ensureLiveEventPoller(db: ShopsDatabase = getShopsDatabase()): v
                 return;
             }
 
-            void pollOnce(db).catch((err) => log.warn({ err }, "live-events poll error"));
+            return pollOnce(db).catch((err) => log.warn({ err }, "live-events poll error"));
         },
-        { leading: false }
+        { leading: false, unref: true }
     );
 }
 

--- a/src/shops/lib/sse-broadcaster.ts
+++ b/src/shops/lib/sse-broadcaster.ts
@@ -112,12 +112,13 @@ export class SseBroadcaster {
                 for (const sub of [...this.subscribers]) {
                     try {
                         sub.controller.enqueue(ping);
-                    } catch {
+                    } catch (err) {
+                        log.debug({ subId: sub.id, error: err }, "heartbeat ping failed; removing subscriber");
                         this.removeSubscriber(sub);
                     }
                 }
             },
-            { leading: false }
+            { leading: false, unref: true }
         );
     }
 }

--- a/src/shops/lib/sse-broadcaster.ts
+++ b/src/shops/lib/sse-broadcaster.ts
@@ -1,4 +1,5 @@
 import { logger } from "@app/logger";
+import { startWakefulInterval, type WakefulInterval } from "@app/utils/async";
 import { SafeJSON } from "@app/utils/json";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
@@ -13,7 +14,7 @@ interface Subscriber {
 export class SseBroadcaster {
     private subscribers = new Set<Subscriber>();
     private nextId = 1;
-    private heartbeat: ReturnType<typeof setInterval> | null = null;
+    private heartbeat: WakefulInterval | null = null;
 
     subscribe(opts?: { initialEvents?: ReadonlyArray<{ event: string; data: unknown }> }): {
         stream: ReadableStream<Uint8Array>;
@@ -86,7 +87,7 @@ export class SseBroadcaster {
         }
         this.subscribers.clear();
         if (this.heartbeat) {
-            clearInterval(this.heartbeat);
+            this.heartbeat.stop();
             this.heartbeat = null;
         }
     }
@@ -94,7 +95,7 @@ export class SseBroadcaster {
     private removeSubscriber(sub: Subscriber): void {
         this.subscribers.delete(sub);
         if (this.subscribers.size === 0 && this.heartbeat) {
-            clearInterval(this.heartbeat);
+            this.heartbeat.stop();
             this.heartbeat = null;
         }
     }
@@ -104,17 +105,20 @@ export class SseBroadcaster {
             return;
         }
 
-        this.heartbeat = setInterval(() => {
-            const ping = encoder.encode(`: ping\n\n`);
-            for (const sub of [...this.subscribers]) {
-                try {
-                    sub.controller.enqueue(ping);
-                } catch {
-                    this.removeSubscriber(sub);
+        this.heartbeat = startWakefulInterval(
+            HEARTBEAT_INTERVAL_MS,
+            () => {
+                const ping = encoder.encode(`: ping\n\n`);
+                for (const sub of [...this.subscribers]) {
+                    try {
+                        sub.controller.enqueue(ping);
+                    } catch {
+                        this.removeSubscriber(sub);
+                    }
                 }
-            }
-        }, HEARTBEAT_INTERVAL_MS);
-        this.heartbeat.unref?.();
+            },
+            { leading: false }
+        );
     }
 }
 

--- a/src/task/lib/session-store.ts
+++ b/src/task/lib/session-store.ts
@@ -98,14 +98,46 @@ export class TaskSessionStore {
     }
 
     async getLastLineSeq(name: string): Promise<number> {
-        const records = await readJsonlFile(jsonlPath(name));
-        const lines = filterLineRecords(records);
+        const path = jsonlPath(name);
 
-        if (lines.length === 0) {
+        if (!existsSync(path)) {
             return 0;
         }
 
-        return Math.max(...lines.map((line) => line.seq));
+        // Read just the tail. The writer appends line records with monotonic
+        // seq, so the last line in the file carries the max. Reading the whole
+        // file would be O(file size) — Metro/Vite sessions can be gigabytes.
+        const file = Bun.file(path);
+        const tailStart = Math.max(0, file.size - 64 * 1024);
+        const tail = await file.slice(tailStart).text();
+        const lines = tail.split("\n");
+
+        // If we sliced mid-file, the first line is likely a partial JSON
+        // object — drop it before parsing.
+        if (tailStart > 0) {
+            lines.shift();
+        }
+
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const line = lines[i].trim();
+
+            if (!line) {
+                continue;
+            }
+
+            try {
+                const record = SafeJSON.parse(line, { strict: true }) as JsonlLineRecord | null;
+
+                if (record?.type === "line" && typeof record.seq === "number") {
+                    return record.seq;
+                }
+            } catch {
+                // Last line of a crashed writer may be a partial JSON object —
+                // skip and keep walking backwards.
+            }
+        }
+
+        return 0;
     }
 
     async clearSessionLogs(name: string): Promise<void> {

--- a/src/task/lib/session-store.ts
+++ b/src/task/lib/session-store.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { logger } from "@app/logger";
 import {
     getTaskSessionsDir,
     jsonlPath,
@@ -112,10 +113,13 @@ export class TaskSessionStore {
         const tail = await file.slice(tailStart).text();
         const lines = tail.split("\n");
 
-        // If we sliced mid-file, the first line is likely a partial JSON
-        // object — drop it before parsing.
+        // Drop first row only when slice truly starts mid-line.
         if (tailStart > 0) {
-            lines.shift();
+            const prevChar = await file.slice(tailStart - 1, tailStart).text();
+
+            if (prevChar !== "\n") {
+                lines.shift();
+            }
         }
 
         for (let i = lines.length - 1; i >= 0; i--) {
@@ -131,9 +135,21 @@ export class TaskSessionStore {
                 if (record?.type === "line" && typeof record.seq === "number") {
                     return record.seq;
                 }
-            } catch {
-                // Last line of a crashed writer may be a partial JSON object —
-                // skip and keep walking backwards.
+            } catch (err) {
+                logger.debug(
+                    { err, path, tailStart, lineIndex: i },
+                    "TaskSessionStore.getLastLineSeq skipped unparsable JSONL tail line"
+                );
+            }
+        }
+
+        const records = await readJsonlFile(path);
+
+        for (let i = records.length - 1; i >= 0; i--) {
+            const record = records[i];
+
+            if (record.type === "line" && typeof (record as JsonlLineRecord).seq === "number") {
+                return (record as JsonlLineRecord).seq;
             }
         }
 

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -192,6 +192,16 @@ export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> 
     });
 }
 
+export {
+    startWakefulInterval,
+    WAKEFUL_JUMP_THRESHOLD_MS,
+    WAKEFUL_TICK_MS,
+    type WakefulInterval,
+    type WakefulIntervalOptions,
+    type WakefulSleepOptions,
+    wakefulSleep,
+} from "./wakeful";
+
 // ============= AsyncOpQueue =============
 
 /**

--- a/src/utils/cmux/layout.ts
+++ b/src/utils/cmux/layout.ts
@@ -168,7 +168,7 @@ export async function fetchCmuxFullLayout(options: FetchCmuxLayoutOptions = {}):
             windows.map(async (window) => {
                 const wsResponse = await rpc<{
                     workspaces?: WorkspaceEntry[];
-                }>("workspace.list", { window: window.ref });
+                }>("workspace.list", { window_id: window.ref });
 
                 const workspaces: CmuxLayoutWorkspace[] = await Promise.all(
                     (wsResponse.workspaces ?? []).map(async (workspace) => ({

--- a/src/utils/cmux/layout.ts
+++ b/src/utils/cmux/layout.ts
@@ -1,6 +1,6 @@
 import { runCmuxJSON } from "@app/cmux/lib/cli";
 import { redactTerminalPreview } from "@app/cmux/lib/live-snapshot";
-import { rpc, type WorkspaceEntry, windowList } from "@app/cmux/lib/socket";
+import { type WorkspaceEntry, windowList, workspaceList } from "@app/cmux/lib/socket";
 import { logger } from "@app/logger";
 import type {
     CmuxLayoutPane,
@@ -166,9 +166,7 @@ export async function fetchCmuxFullLayout(options: FetchCmuxLayoutOptions = {}):
 
         const layoutWindows: CmuxLayoutWindow[] = await Promise.all(
             windows.map(async (window) => {
-                const wsResponse = await rpc<{
-                    workspaces?: WorkspaceEntry[];
-                }>("workspace.list", { window_id: window.ref });
+                const wsResponse = await workspaceList(window.ref);
 
                 const workspaces: CmuxLayoutWorkspace[] = await Promise.all(
                     (wsResponse.workspaces ?? []).map(async (workspace) => ({

--- a/src/utils/debugging-master/llm-log.php
+++ b/src/utils/debugging-master/llm-log.php
@@ -1,77 +1,127 @@
 <?php
 /**
- * LLM-assisted debugging instrumentation snippet.
+ * LLM-assisted debugging instrumentation snippet — network mode.
  *
- * This file is **self-contained** — copy it into any PHP project.
- * It has zero external dependencies (only PHP builtins).
+ * Self-contained — uses only ext-curl (curl_multi for parallel probe).
+ * Fire-and-forget: every log call posts JSON to the dashboard with short
+ * timeouts and never blocks the caller materially. Targets are probed in
+ * parallel on the first call; first 200 wins and is reused thereafter.
+ *
+ * Edit HOSTS to point at the dashboard. The `tools debugging-master start`
+ * command auto-substitutes `__LAN_IP__` with the detected local IP.
  *
  * Usage:
  *   require_once __DIR__ . '/llm-log.php';
  *   LlmLog::session('my-feature');
  *   LlmLog::info('request received', ['url' => $_SERVER['REQUEST_URI']]);
- *   LlmLog::dump('response', $data);
- *   LlmLog::timerStart('db-query');
- *   // ... do work ...
- *   LlmLog::timerEnd('db-query');
- *   LlmLog::snapshot('state', ['user' => $user, 'cart' => $cart]);
- *
- * Every entry captures the full call stack by default (callers up the chain).
- * To opt out per-call:           LlmLog::info('msg', null, ['stack' => false])
- * To opt out globally (one-time): LlmLog::configure(['captureStackByDefault' => false])
- *
- * Every method accepts a final `$opts` argument — an associative array with
- * optional keys: `h` (string, hypothesis tag) and `stack` (false to skip,
- * string to override). For backwards compatibility, methods that previously
- * accepted `?string $h` still accept a string in that position.
- *
- * Logs are written as JSONL to:
- *   ~/.genesis-tools/debugging-master/sessions/<session>.jsonl
  */
 
 class LlmLog
 {
+	// ─── Config ──────────────────────────────────────────────────────────
+	private const HOSTS = ['__LAN_IP__', '127.0.0.1', 'localhost'];
+	private const PORT = 7243;
+	private const TIMEOUT_MS = 2000;
+	// ─────────────────────────────────────────────────────────────────────
+
 	/** @var array<string, float> */
 	private static array $timers = [];
 	private static string $currentSession = 'default';
-	private static string $sessionPath = '';
-	private static bool $dirEnsured = false;
 	private static bool $captureStackByDefault = true;
+	private static ?string $resolvedBase = null;
+	private static bool $probed = false;
+	private static bool $reportedUnreachable = false;
 
-	private static function sessionsDir(): string
+	private static function resolveBase(): ?string
 	{
-		return ($_SERVER['HOME'] ?? $_ENV['HOME'] ?? getenv('HOME') ?: '/tmp')
-			. '/.genesis-tools/debugging-master/sessions';
-	}
+		if (self::$resolvedBase !== null) return self::$resolvedBase;
+		if (self::$probed) return null;
+		self::$probed = true;
 
-	private static function getSessionPath(): string
-	{
-		if (self::$sessionPath === '') {
-			self::$sessionPath = self::sessionsDir() . '/' . self::$currentSession . '.jsonl';
+		$candidates = array_values(array_filter(self::HOSTS, fn($h) => $h !== '' && !str_starts_with($h, '__')));
+		$mh = curl_multi_init();
+		/** @var array<int, array{ch: \CurlHandle, base: string}> $entries */
+		$entries = [];
+		foreach ($candidates as $host) {
+			$base = "http://$host:" . self::PORT;
+			$ch = curl_init("$base/health");
+			curl_setopt_array($ch, [
+				CURLOPT_NOBODY => true,
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_TIMEOUT_MS => self::TIMEOUT_MS,
+				CURLOPT_CONNECTTIMEOUT_MS => self::TIMEOUT_MS,
+				CURLOPT_NOSIGNAL => true,
+			]);
+			curl_multi_add_handle($mh, $ch);
+			$entries[spl_object_id($ch)] = ['ch' => $ch, 'base' => $base];
 		}
-		return self::$sessionPath;
-	}
 
-	private static function ensureDir(): void
-	{
-		if (self::$dirEnsured) return;
-		$dir = self::sessionsDir();
-		if (!is_dir($dir)) {
-			mkdir($dir, 0755, true);
+		$winner = null;
+		$running = null;
+		do {
+			curl_multi_exec($mh, $running);
+			while ($info = curl_multi_info_read($mh)) {
+				$id = spl_object_id($info['handle']);
+				if ($winner === null
+					&& $info['result'] === CURLE_OK
+					&& curl_getinfo($info['handle'], CURLINFO_HTTP_CODE) === 200
+				) {
+					$winner = $entries[$id]['base'] ?? null;
+				}
+			}
+			if ($winner !== null) break;
+			if ($running) curl_multi_select($mh, 0.1);
+		} while ($running > 0);
+
+		foreach ($entries as $e) {
+			curl_multi_remove_handle($mh, $e['ch']);
 		}
-		self::$dirEnsured = true;
+		curl_multi_close($mh);
+
+		if ($winner === null) {
+			fwrite(STDERR, "[dbg] ingest unreachable on " . implode(', ', $candidates) . ":" . self::PORT . "\n");
+			return null;
+		}
+		return self::$resolvedBase = $winner;
 	}
 
-	/** Render a full backtrace as a multiline string, skipping LlmLog internals. */
+	private static function send(array $entry): void
+	{
+		$base = self::resolveBase();
+		if ($base === null) return;
+		$url = $base . '/log/' . rawurlencode(self::$currentSession);
+		try {
+			$json = json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+		} catch (\Throwable $e) {
+			$json = json_encode(['level' => 'error', 'msg' => 'serialize_failed: ' . $e->getMessage()]);
+		}
+
+		$ch = curl_init($url);
+		curl_setopt_array($ch, [
+			CURLOPT_POST => true,
+			CURLOPT_POSTFIELDS => $json,
+			CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+			CURLOPT_TIMEOUT_MS => self::TIMEOUT_MS,
+			CURLOPT_CONNECTTIMEOUT_MS => self::TIMEOUT_MS,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_NOSIGNAL => true,
+		]);
+		curl_exec($ch);
+		if (curl_errno($ch) && !self::$reportedUnreachable) {
+			self::$reportedUnreachable = true;
+			fwrite(STDERR, "[dbg] ingest failed: " . curl_error($ch) . "\n");
+		}
+	}
+
 	private static function captureStack(): string
 	{
 		$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 		$lines = [];
 		foreach ($trace as $frame) {
-			$cls = $frame['class'] ?? '';
-			if ($cls === self::class) continue;
+			if (($frame['class'] ?? '') === self::class) continue;
 			$file = $frame['file'] ?? 'unknown';
 			$line = $frame['line'] ?? 0;
-			$fn = ($cls !== '' ? $cls . ($frame['type'] ?? '::') : '') . ($frame['function'] ?? '?');
+			$fn = (($frame['class'] ?? '') !== '' ? $frame['class'] . ($frame['type'] ?? '::') : '') . ($frame['function'] ?? '?');
 			$lines[] = "  at $fn ($file:$line)";
 		}
 		return implode("\n", $lines);
@@ -80,26 +130,14 @@ class LlmLog
 	/** @return array{file: string, line: int} */
 	private static function getCallerLocation(): array
 	{
-		$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-		// Walk past LlmLog frames to find the real caller.
-		foreach ($trace as $frame) {
-			$cls = $frame['class'] ?? '';
-			if ($cls === self::class) continue;
-			return [
-				'file' => $frame['file'] ?? 'unknown',
-				'line' => $frame['line'] ?? 0,
-			];
+		foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+			if (($frame['class'] ?? '') === self::class) continue;
+			return ['file' => $frame['file'] ?? 'unknown', 'line' => $frame['line'] ?? 0];
 		}
 		return ['file' => 'unknown', 'line' => 0];
 	}
 
-	/**
-	 * Normalize backwards-compatible $opts. Methods used to accept `?string $h`
-	 * as the last arg; that's still allowed and is mapped to ['h' => <string>].
-	 *
-	 * @param string|array<string, mixed>|null $opts
-	 * @return array<string, mixed>
-	 */
+	/** @param string|array<string, mixed>|null $opts */
 	private static function normalizeOpts(string|array|null $opts): array
 	{
 		if ($opts === null) return [];
@@ -111,9 +149,8 @@ class LlmLog
 	 * @param array<string, mixed> $entry
 	 * @param array<string, mixed> $opts
 	 */
-	private static function write(array $entry, array $opts = []): void
+	private static function emit(array $entry, array $opts = []): void
 	{
-		self::ensureDir();
 		$caller = self::getCallerLocation();
 		$entry['ts'] = (int)(microtime(true) * 1000);
 		$entry['file'] = $caller['file'];
@@ -123,40 +160,24 @@ class LlmLog
 			$entry['h'] = $opts['h'];
 		}
 
-		$includeStack = self::$captureStackByDefault;
+		$wantStack = self::$captureStackByDefault;
 		if (array_key_exists('stack', $opts)) {
-			$includeStack = $opts['stack'] !== false;
+			$wantStack = $opts['stack'] !== false;
 		}
-
 		if (!isset($entry['stack'])) {
 			if (is_string($opts['stack'] ?? null)) {
 				$entry['stack'] = $opts['stack'];
-			} elseif ($includeStack) {
+			} elseif ($wantStack) {
 				$entry['stack'] = self::captureStack();
 			}
 		}
 
-		try {
-			$json = json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
-		} catch (\Throwable $e) {
-			$json = json_encode([
-				'level' => $entry['level'] ?? 'unknown',
-				'ts' => $entry['ts'] ?? 0,
-				'error' => 'serialize_failed: ' . $e->getMessage(),
-			]);
-		}
-		file_put_contents(
-			self::getSessionPath(),
-			$json . "\n",
-			FILE_APPEND | LOCK_EX
-		);
+		self::send($entry);
 	}
 
 	public static function session(string $name): void
 	{
 		self::$currentSession = $name;
-		self::$sessionPath = self::sessionsDir() . '/' . $name . '.jsonl';
-		self::$dirEnsured = false;
 	}
 
 	/** @param array{captureStackByDefault?: bool} $opts */
@@ -170,7 +191,7 @@ class LlmLog
 	/** @param string|array<string, mixed>|null $opts */
 	public static function dump(string $label, mixed $data, string|array|null $opts = null): void
 	{
-		self::write(['level' => 'dump', 'label' => $label, 'data' => $data], self::normalizeOpts($opts));
+		self::emit(['level' => 'dump', 'label' => $label, 'data' => $data], self::normalizeOpts($opts));
 	}
 
 	/** @param string|array<string, mixed>|null $opts */
@@ -178,7 +199,7 @@ class LlmLog
 	{
 		$entry = ['level' => 'info', 'msg' => $msg];
 		if ($data !== null) $entry['data'] = $data;
-		self::write($entry, self::normalizeOpts($opts));
+		self::emit($entry, self::normalizeOpts($opts));
 	}
 
 	/** @param string|array<string, mixed>|null $opts */
@@ -186,7 +207,7 @@ class LlmLog
 	{
 		$entry = ['level' => 'warn', 'msg' => $msg];
 		if ($data !== null) $entry['data'] = $data;
-		self::write($entry, self::normalizeOpts($opts));
+		self::emit($entry, self::normalizeOpts($opts));
 	}
 
 	/** @param string|array<string, mixed>|null $opts */
@@ -201,14 +222,14 @@ class LlmLog
 				'code' => $err->getCode(),
 			];
 		}
-		self::write($entry, self::normalizeOpts($opts));
+		self::emit($entry, self::normalizeOpts($opts));
 	}
 
 	/** @param array<string, mixed>|null $opts */
 	public static function timerStart(string $label, ?array $opts = null): void
 	{
 		self::$timers[$label] = microtime(true) * 1000;
-		self::write(['level' => 'timer-start', 'label' => $label], self::normalizeOpts($opts));
+		self::emit(['level' => 'timer-start', 'label' => $label], self::normalizeOpts($opts));
 	}
 
 	/** @param array<string, mixed>|null $opts */
@@ -219,13 +240,13 @@ class LlmLog
 			$entry['durationMs'] = (int)(microtime(true) * 1000 - self::$timers[$label]);
 			unset(self::$timers[$label]);
 		}
-		self::write($entry, self::normalizeOpts($opts));
+		self::emit($entry, self::normalizeOpts($opts));
 	}
 
 	/** @param array<string, mixed>|null $opts */
 	public static function checkpoint(string $label, ?array $opts = null): void
 	{
-		self::write(['level' => 'checkpoint', 'label' => $label], self::normalizeOpts($opts));
+		self::emit(['level' => 'checkpoint', 'label' => $label], self::normalizeOpts($opts));
 	}
 
 	/** @param array<string, mixed>|null $opts */
@@ -233,13 +254,13 @@ class LlmLog
 	{
 		$entry = ['level' => 'assert', 'label' => $label, 'passed' => $condition];
 		if ($ctx !== null) $entry['ctx'] = $ctx;
-		self::write($entry, self::normalizeOpts($opts));
+		self::emit($entry, self::normalizeOpts($opts));
 	}
 
 	/** @param string|array<string, mixed>|null $opts */
 	public static function snapshot(string $label, array $vars, string|array|null $opts = null): void
 	{
-		self::write(['level' => 'snapshot', 'label' => $label, 'vars' => $vars], self::normalizeOpts($opts));
+		self::emit(['level' => 'snapshot', 'label' => $label, 'vars' => $vars], self::normalizeOpts($opts));
 	}
 
 	/** @param string|array<string, mixed>|null $opts */
@@ -247,6 +268,6 @@ class LlmLog
 	{
 		$entry = ['level' => 'trace', 'label' => $label];
 		if ($data !== null) $entry['data'] = $data;
-		self::write($entry, self::normalizeOpts($opts));
+		self::emit($entry, self::normalizeOpts($opts));
 	}
 }

--- a/src/utils/debugging-master/llm-log.php
+++ b/src/utils/debugging-master/llm-log.php
@@ -46,7 +46,7 @@ class LlmLog
 			$base = "http://$host:" . self::PORT;
 			$ch = curl_init("$base/health");
 			curl_setopt_array($ch, [
-				CURLOPT_NOBODY => true,
+				CURLOPT_HTTPGET => true,
 				CURLOPT_RETURNTRANSFER => true,
 				CURLOPT_TIMEOUT_MS => self::TIMEOUT_MS,
 				CURLOPT_CONNECTTIMEOUT_MS => self::TIMEOUT_MS,
@@ -79,6 +79,7 @@ class LlmLog
 		curl_multi_close($mh);
 
 		if ($winner === null) {
+			self::$probed = false;
 			fwrite(STDERR, "[dbg] ingest unreachable on " . implode(', ', $candidates) . ":" . self::PORT . "\n");
 			return null;
 		}

--- a/src/utils/debugging-master/llm-log.ts
+++ b/src/utils/debugging-master/llm-log.ts
@@ -1,62 +1,93 @@
 /**
- * LLM-assisted debugging instrumentation snippet.
+ * LLM-assisted debugging instrumentation snippet — network mode.
  *
- * This file is **self-contained** — copy it into any TypeScript/JS project.
- * It has zero external dependencies (only node: builtins).
+ * Self-contained — zero deps (web/node-18+ fetch + AbortSignal.timeout).
+ * Fire-and-forget: every log call posts JSON to the dashboard and never
+ * blocks the caller. Targets are probed in parallel on the first call;
+ * the first successful host wins and is reused for every subsequent call.
+ *
+ * Edit HOSTS to point at the dashboard. The `tools debugging-master start`
+ * command auto-substitutes `__LAN_IP__` with the detected local IP.
  *
  * Usage:
  *   import { dbg } from './llm-log';
  *   dbg.session('my-feature');
  *   dbg.info('request received', { url: req.url });
  *   dbg.dump('response', data);
- *   dbg.timerStart('db-query');
- *   // ... do work ...
- *   dbg.timerEnd('db-query');
- *   dbg.snapshot('state', { user, cart, flags });
- *
- * Every entry captures the full call stack by default (callers up the chain).
- * To opt out per-call:           dbg.info('msg', undefined, { stack: false });
- * To opt out globally (one-time): dbg.configure({ captureStackByDefault: false });
- *
- * Every method accepts a final `opts` argument with `{ h?, stack? }`:
- *   - `h`     — hypothesis tag to filter by in the dashboard
- *   - `stack` — false to skip stack capture for this call; string to override
- *
- * Logs are written as JSONL to:
- *   ~/.genesis-tools/debugging-master/sessions/<session>.jsonl
  */
 
-import { appendFileSync, existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+// ─── Config ──────────────────────────────────────────────────────────────────
+const HOSTS = ["__LAN_IP__", "127.0.0.1", "localhost"];
+const PORT = 7243;
+const TIMEOUT_MS = 2000;
+// ─────────────────────────────────────────────────────────────────────────────
 
 interface LogOpts {
     h?: string;
-    /** false = skip stack capture, string = use this stack verbatim. Default: capture full stack. */
+    /** false = skip stack capture, string = use this stack verbatim. */
     stack?: boolean | string;
 }
 
-const SESSIONS_DIR = join(homedir(), ".genesis-tools", "debugging-master", "sessions");
 const timers: Record<string, number> = {};
+const config = { captureStackByDefault: true };
 let currentSession = "default";
-let sessionPath = join(SESSIONS_DIR, `${currentSession}.jsonl`);
-let dirEnsured = false;
 
-const config = {
-    captureStackByDefault: true,
-};
+let resolvedBase: string | null = null;
+let probing: Promise<string> | null = null;
+let reportedUnreachable = false;
 
-function ensureDir(): void {
-    if (dirEnsured) {
-        return;
+async function probeHost(host: string): Promise<string> {
+    const base = `http://${host}:${PORT}`;
+    const res = await fetch(`${base}/health`, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
     }
-    if (!existsSync(SESSIONS_DIR)) {
-        mkdirSync(SESSIONS_DIR, { recursive: true });
-    }
-    dirEnsured = true;
+    return base;
 }
 
-/** Capture a full call stack, stripped of llm-log internal frames. */
+function getBase(): Promise<string> {
+    if (resolvedBase) {
+        return Promise.resolve(resolvedBase);
+    }
+    if (!probing) {
+        const candidates = HOSTS.filter((h) => h && !h.startsWith("__"));
+        probing = Promise.any(candidates.map(probeHost))
+            .then((b) => {
+                resolvedBase = b;
+                reportedUnreachable = false;
+                return b;
+            })
+            .catch(() => {
+                probing = null;
+                throw new Error(`no dbg ingest reachable on ${candidates.join(", ")}:${PORT}`);
+            });
+    }
+    return probing;
+}
+
+function send(entry: Record<string, unknown>): void {
+    getBase()
+        .then((base) =>
+            fetch(`${base}/log/${encodeURIComponent(currentSession)}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                // biome-ignore lint/style/noRestrictedGlobals: self-contained file — no external deps
+                body: JSON.stringify(entry),
+                signal: AbortSignal.timeout(TIMEOUT_MS),
+            }).then((r) => {
+                if (!r.ok) {
+                    throw new Error(`HTTP ${r.status}`);
+                }
+            })
+        )
+        .catch((err) => {
+            if (!reportedUnreachable) {
+                reportedUnreachable = true;
+                console.error("[dbg] ingest failed:", (err as Error).message);
+            }
+        });
+}
+
 function captureStack(): string {
     const raw = new Error().stack;
     if (!raw) {
@@ -68,9 +99,7 @@ function captureStack(): string {
     for (let i = 1; i < lines.length; i++) {
         const frame = lines[i];
         if (frame.includes("llm-log")) {
-            // skip llm-log internals (write, captureStack, getCaller, dbg.* method bodies)
             if (seenExternal) {
-                // edge case: re-entry through llm-log — treat as boundary
                 break;
             }
             continue;
@@ -82,54 +111,30 @@ function captureStack(): string {
 }
 
 function getCallerLocation(stack: string): { file: string; line: number } {
-    if (!stack) {
-        return { file: "unknown", line: 0 };
-    }
-    const firstFrame = stack.split("\n")[0];
-    const match = firstFrame?.match(/(?:at\s+.*?\s+\(|at\s+)(.+?):(\d+):\d+\)?/);
-    if (match) {
-        return { file: match[1], line: parseInt(match[2], 10) };
-    }
-    return { file: "unknown", line: 0 };
+    const first = stack.split("\n")[0] ?? "";
+    const m = first.match(/(?:at\s+.*?\s+\(|at\s+)(.+?):(\d+):\d+\)?/);
+    return m ? { file: m[1], line: Number.parseInt(m[2], 10) } : { file: "unknown", line: 0 };
 }
 
-function shouldIncludeStack(opts?: LogOpts): boolean {
-    if (opts?.stack === false) {
-        return false;
-    }
-    if (opts?.stack === true) {
-        return true;
-    }
-    if (typeof opts?.stack === "string") {
-        // explicit override — always include
-        return true;
-    }
-    return config.captureStackByDefault;
-}
-
-function write(entry: Record<string, unknown>, opts?: LogOpts): void {
-    ensureDir();
-    const stack = typeof opts?.stack === "string" ? opts.stack : captureStack();
+function emit(entry: Record<string, unknown>, opts?: LogOpts): void {
+    const wantStack = opts?.stack === false ? false : opts?.stack !== undefined || config.captureStackByDefault;
+    const stack = typeof opts?.stack === "string" ? opts.stack : wantStack ? captureStack() : "";
     const { file, line } = getCallerLocation(stack);
-    const full: Record<string, unknown> = { ...entry, ts: entry.ts ?? Date.now(), file, line };
+    const full: Record<string, unknown> = { ts: Date.now(), file, line, ...entry };
     if (opts?.h && full.h === undefined) {
         full.h = opts.h;
     }
-    if (shouldIncludeStack(opts) && stack && full.stack === undefined) {
+    if (stack && wantStack && full.stack === undefined) {
         full.stack = stack;
     }
-    // biome-ignore lint/style/noRestrictedGlobals: self-contained file — no external deps
-    appendFileSync(sessionPath, `${JSON.stringify(full)}\n`);
+    send(full);
 }
 
 export const dbg = {
     session(name: string): void {
         currentSession = name;
-        sessionPath = join(SESSIONS_DIR, `${currentSession}.jsonl`);
-        dirEnsured = false;
     },
 
-    /** Adjust global behavior (e.g. disable default stack capture). */
     configure(opts: { captureStackByDefault?: boolean }): void {
         if (opts.captureStackByDefault !== undefined) {
             config.captureStackByDefault = opts.captureStackByDefault;
@@ -137,32 +142,31 @@ export const dbg = {
     },
 
     dump(label: string, data: unknown, opts?: LogOpts): void {
-        write({ level: "dump", label, data }, opts);
+        emit({ level: "dump", label, data }, opts);
     },
 
     info(msg: string, data?: unknown, opts?: LogOpts): void {
-        write({ level: "info", msg, ...(data !== undefined && { data }) }, opts);
+        emit({ level: "info", msg, ...(data !== undefined && { data }) }, opts);
     },
 
     warn(msg: string, data?: unknown, opts?: LogOpts): void {
-        write({ level: "warn", msg, ...(data !== undefined && { data }) }, opts);
+        emit({ level: "warn", msg, ...(data !== undefined && { data }) }, opts);
     },
 
     error(msg: string, err?: Error | unknown, opts?: LogOpts): void {
         const entry: Record<string, unknown> = { level: "error", msg };
         if (err instanceof Error) {
-            // explicit Error stack wins over auto-captured caller stack
             entry.stack = err.stack;
             entry.data = { message: err.message, class: err.name, code: (err as { code?: unknown }).code };
         } else if (err !== undefined) {
             entry.data = err;
         }
-        write(entry, opts);
+        emit(entry, opts);
     },
 
     timerStart(label: string, opts?: LogOpts): void {
         timers[label] = Date.now();
-        write({ level: "timer-start", label }, opts);
+        emit({ level: "timer-start", label }, opts);
     },
 
     timerEnd(label: string, opts?: LogOpts): void {
@@ -172,22 +176,22 @@ export const dbg = {
             entry.durationMs = Date.now() - start;
             delete timers[label];
         }
-        write(entry, opts);
+        emit(entry, opts);
     },
 
     checkpoint(label: string, opts?: LogOpts): void {
-        write({ level: "checkpoint", label }, opts);
+        emit({ level: "checkpoint", label }, opts);
     },
 
     assert(condition: boolean, label: string, ctx?: unknown, opts?: LogOpts): void {
-        write({ level: "assert", label, passed: condition, ...(ctx !== undefined && { ctx }) }, opts);
+        emit({ level: "assert", label, passed: condition, ...(ctx !== undefined && { ctx }) }, opts);
     },
 
     snapshot(label: string, vars: Record<string, unknown>, opts?: LogOpts): void {
-        write({ level: "snapshot", label, vars }, opts);
+        emit({ level: "snapshot", label, vars }, opts);
     },
 
     trace(label: string, data?: unknown, opts?: LogOpts): void {
-        write({ level: "trace", label, ...(data !== undefined && { data }) }, opts);
+        emit({ level: "trace", label, ...(data !== undefined && { data }) }, opts);
     },
 };

--- a/src/utils/debugging-master/llm-log.ts
+++ b/src/utils/debugging-master/llm-log.ts
@@ -66,9 +66,11 @@ function getBase(): Promise<string> {
 }
 
 function send(entry: Record<string, unknown>): void {
+    const sessionName = currentSession;
+
     getBase()
         .then((base) =>
-            fetch(`${base}/log/${encodeURIComponent(currentSession)}`, {
+            fetch(`${base}/log/${encodeURIComponent(sessionName)}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 // biome-ignore lint/style/noRestrictedGlobals: self-contained file — no external deps

--- a/src/utils/paths.client.test.ts
+++ b/src/utils/paths.client.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { collapsePathForDisplay, longestCommonPathPrefix, shortenPathWithPrefix, toPosixPath } from "./paths.client";
+import {
+    collapsePathForDisplay,
+    longestCommonPathPrefix,
+    resolveDirPathDisplayPrefix,
+    shortenPathWithPrefix,
+    toPosixPath,
+} from "./paths.client";
 
 describe("paths.client", () => {
     it("normalizes backslashes", () => {
@@ -42,5 +48,25 @@ describe("paths.client", () => {
         expect(shortenPathWithPrefix("~/Tresors/Projects/CEZ/col-fe/col-mobile", prefix)).toBe("CEZ/col-fe/col-mobile");
         expect(shortenPathWithPrefix("~/Tresors/Projects/GenesisTools", prefix)).toBe("GenesisTools");
         expect(shortenPathWithPrefix("~/Tresors/Projects", prefix)).toBe(".");
+    });
+
+    it("keeps worktree folders visible when siblings share a repo", () => {
+        const paths = [
+            "~/Tresors/Projects/CEZ/col-fe/.claude/worktrees/wt-a",
+            "~/Tresors/Projects/CEZ/col-fe/.claude/worktrees/wt-b",
+        ];
+        const prefix = resolveDirPathDisplayPrefix(paths);
+
+        expect(prefix).toBe("~/Tresors/Projects");
+        expect(shortenPathWithPrefix(paths[0], prefix)).toBe("CEZ/col-fe/.claude/worktrees/wt-a");
+        expect(shortenPathWithPrefix(paths[1], prefix)).toBe("CEZ/col-fe/.claude/worktrees/wt-b");
+    });
+
+    it("supports .worktrees/ sibling paths", () => {
+        const paths = ["~/Projects/app/.worktrees/feature-a", "~/Projects/app/.worktrees/feature-b"];
+        const prefix = resolveDirPathDisplayPrefix(paths);
+
+        expect(prefix).toBe("~/Projects");
+        expect(shortenPathWithPrefix(paths[0], prefix)).toBe("app/.worktrees/feature-a");
     });
 });

--- a/src/utils/paths.client.ts
+++ b/src/utils/paths.client.ts
@@ -28,6 +28,10 @@ export function collapsePathForDisplay(p: string): string {
     return normalized;
 }
 
+function normalizePathsForDisplay(paths: readonly string[]): string[] {
+    return [...new Set(paths.map((path) => collapsePathForDisplay(toPosixPath(path.trim()))).filter(Boolean))];
+}
+
 function splitPathSegments(path: string): string[] {
     const normalized = collapsePathForDisplay(toPosixPath(path.trim()));
 
@@ -95,8 +99,9 @@ function truncatePrefixBeforeWorktreeMarker(prefix: string): string {
         return normalized;
     }
 
-    for (const marker of ["/.claude/worktrees", "/.worktrees"]) {
-        const idx = normalized.indexOf(marker);
+    for (const marker of WORKTREE_MARKERS) {
+        const bare = marker.slice(0, -1);
+        const idx = normalized.indexOf(bare);
 
         if (idx !== -1) {
             return normalized.slice(0, idx);
@@ -120,9 +125,7 @@ function shallowerPathPrefix(a: string, b: string): string {
 
 /** Longest shared directory prefix across paths (collapsed, no trailing slash). Empty when not shared. */
 export function longestCommonPathPrefix(paths: readonly string[]): string {
-    const normalized = [
-        ...new Set(paths.map((path) => collapsePathForDisplay(toPosixPath(path.trim()))).filter(Boolean)),
-    ];
+    const normalized = normalizePathsForDisplay(paths);
 
     if (normalized.length < 2) {
         return "";
@@ -184,9 +187,7 @@ function resolveSameRepoWorktreePrefix(repoRoot: string, normalized: readonly st
  * so siblings stay distinguishable (e.g. `CEZ/col-fe/.claude/worktrees/wt-a`).
  */
 export function resolveDirPathDisplayPrefix(paths: readonly string[]): string {
-    const normalized = [
-        ...new Set(paths.map((path) => collapsePathForDisplay(toPosixPath(path.trim()))).filter(Boolean)),
-    ];
+    const normalized = normalizePathsForDisplay(paths);
 
     if (normalized.length < 2) {
         return "";

--- a/src/utils/paths.client.ts
+++ b/src/utils/paths.client.ts
@@ -66,6 +66,58 @@ function joinPathSegments(segments: string[]): string {
     return `/${segments.join("/")}`;
 }
 
+const WORKTREE_MARKERS = ["/.claude/worktrees/", "/.worktrees/"] as const;
+
+function pathContainsWorktree(path: string): boolean {
+    const normalized = collapsePathForDisplay(toPosixPath(path.trim()));
+
+    return WORKTREE_MARKERS.some((marker) => normalized.includes(marker));
+}
+
+function worktreeRepoRoot(path: string): string | null {
+    const normalized = collapsePathForDisplay(toPosixPath(path.trim()));
+
+    for (const marker of WORKTREE_MARKERS) {
+        const idx = normalized.indexOf(marker);
+
+        if (idx !== -1) {
+            return normalized.slice(0, idx);
+        }
+    }
+
+    return null;
+}
+
+function truncatePrefixBeforeWorktreeMarker(prefix: string): string {
+    const normalized = collapsePathForDisplay(toPosixPath(prefix.trim()));
+
+    if (!normalized) {
+        return normalized;
+    }
+
+    for (const marker of ["/.claude/worktrees", "/.worktrees"]) {
+        const idx = normalized.indexOf(marker);
+
+        if (idx !== -1) {
+            return normalized.slice(0, idx);
+        }
+    }
+
+    return normalized;
+}
+
+function shallowerPathPrefix(a: string, b: string): string {
+    if (!a) {
+        return b;
+    }
+
+    if (!b) {
+        return a;
+    }
+
+    return splitPathSegments(a).length <= splitPathSegments(b).length ? a : b;
+}
+
 /** Longest shared directory prefix across paths (collapsed, no trailing slash). Empty when not shared. */
 export function longestCommonPathPrefix(paths: readonly string[]): string {
     const normalized = [
@@ -99,6 +151,67 @@ export function longestCommonPathPrefix(paths: readonly string[]): string {
     }
 
     return joinPathSegments(first.slice(0, sharedSegmentCount));
+}
+
+function resolveSameRepoWorktreePrefix(repoRoot: string, normalized: readonly string[]): string | null {
+    const segments = splitPathSegments(repoRoot);
+
+    if (segments.length < 2) {
+        return null;
+    }
+
+    const dropParents = normalized.some((path) => path.includes("/.claude/worktrees/")) ? 2 : 1;
+    const len = Math.max(2, segments.length - dropParents);
+    const ancestor = joinPathSegments(segments.slice(0, len));
+    const tails = new Set(normalized.map((path) => shortenPathWithPrefix(path, ancestor)));
+
+    if (tails.size !== normalized.length) {
+        return null;
+    }
+
+    const sample = shortenPathWithPrefix(normalized[0], ancestor);
+
+    if (sample.startsWith(".claude") || sample.startsWith(".worktrees")) {
+        return null;
+    }
+
+    return ancestor;
+}
+
+/**
+ * Prefix for dashboard cwd display. When paths sit under `.claude/worktrees/`
+ * or `.worktrees/`, avoid absorbing the worktree folder into the shared prefix
+ * so siblings stay distinguishable (e.g. `CEZ/col-fe/.claude/worktrees/wt-a`).
+ */
+export function resolveDirPathDisplayPrefix(paths: readonly string[]): string {
+    const normalized = [
+        ...new Set(paths.map((path) => collapsePathForDisplay(toPosixPath(path.trim()))).filter(Boolean)),
+    ];
+
+    if (normalized.length < 2) {
+        return "";
+    }
+
+    const standard = longestCommonPathPrefix(normalized);
+
+    if (!normalized.some(pathContainsWorktree)) {
+        return standard;
+    }
+
+    const capped = truncatePrefixBeforeWorktreeMarker(standard);
+    const repoRoots = [...new Set(normalized.map(worktreeRepoRoot).filter((root): root is string => Boolean(root)))];
+
+    if (repoRoots.length === 1) {
+        const sameRepoPrefix = resolveSameRepoWorktreePrefix(repoRoots[0], normalized);
+
+        if (sameRepoPrefix) {
+            return sameRepoPrefix;
+        }
+    }
+
+    const anchoredPrefix = longestCommonPathPrefix(normalized.map((path) => worktreeRepoRoot(path) ?? path));
+
+    return shallowerPathPrefix(capped, anchoredPrefix);
 }
 
 export function shortenPathWithPrefix(path: string, prefix: string): string {

--- a/src/utils/ui/components/DirPath.tsx
+++ b/src/utils/ui/components/DirPath.tsx
@@ -1,4 +1,4 @@
-import { formatPathForDisplay, longestCommonPathPrefix } from "@app/utils/paths.client";
+import { formatPathForDisplay, resolveDirPathDisplayPrefix } from "@app/utils/paths.client";
 import { createContext, type ReactElement, type ReactNode, useContext, useMemo } from "react";
 
 const DirPathPrefixContext = createContext<string>("");
@@ -9,7 +9,7 @@ interface DirPathPrefixProviderProps {
 }
 
 export function DirPathPrefixProvider({ paths, children }: DirPathPrefixProviderProps): ReactElement {
-    const prefix = useMemo(() => longestCommonPathPrefix(paths), [paths]);
+    const prefix = useMemo(() => resolveDirPathDisplayPrefix(paths), [paths]);
 
     return <DirPathPrefixContext.Provider value={prefix}>{children}</DirPathPrefixContext.Provider>;
 }

--- a/src/utils/wakeful.test.ts
+++ b/src/utils/wakeful.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { startWakefulInterval, wakefulSleep } from "./wakeful";
+
+describe("wakeful", () => {
+    afterEach(() => {
+        Bun.sleepSync(0);
+    });
+
+    test("wakefulSleep resolves after the requested delay", async () => {
+        const started = Date.now();
+        await wakefulSleep(50);
+        expect(Date.now() - started).toBeGreaterThanOrEqual(40);
+    });
+
+    test("wakefulSleep aborts when shouldAbort returns true", async () => {
+        let aborted = false;
+
+        const sleepPromise = wakefulSleep(5_000, {
+            shouldAbort: () => aborted,
+        });
+
+        aborted = true;
+        await sleepPromise;
+    });
+
+    test("startWakefulInterval fires tick and can be stopped", async () => {
+        let ticks = 0;
+        const handle = startWakefulInterval(30, () => {
+            ticks++;
+        });
+
+        await Bun.sleep(80);
+        handle.stop();
+        await Bun.sleep(40);
+
+        expect(ticks).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/src/utils/wakeful.ts
+++ b/src/utils/wakeful.ts
@@ -1,0 +1,104 @@
+import { logger } from "@app/logger";
+
+export const WAKEFUL_TICK_MS = 2_000;
+export const WAKEFUL_JUMP_THRESHOLD_MS = WAKEFUL_TICK_MS * 5;
+
+export interface WakefulSleepOptions {
+    shouldAbort?: () => boolean;
+    onWallClockJump?: (ctx: { elapsedMs: number; expectedMs: number }) => void;
+}
+
+/**
+ * One-shot sleep that survives macOS Low Power Sleep / hibernate. Long `Bun.sleep`
+ * calls can wedge on a dropped kqueue timer; short ticks self-heal after wake.
+ */
+export async function wakefulSleep(totalMs: number, options: WakefulSleepOptions = {}): Promise<void> {
+    const shouldAbort = options.shouldAbort ?? (() => false);
+    const deadline = Date.now() + totalMs;
+    let lastTickAt = Date.now();
+
+    while (!shouldAbort()) {
+        const remaining = deadline - Date.now();
+
+        if (remaining <= 0) {
+            return;
+        }
+
+        await Bun.sleep(Math.min(WAKEFUL_TICK_MS, remaining));
+
+        const now = Date.now();
+        const elapsed = now - lastTickAt;
+
+        if (elapsed > WAKEFUL_JUMP_THRESHOLD_MS) {
+            const ctx = { elapsedMs: elapsed, expectedMs: WAKEFUL_TICK_MS };
+
+            if (options.onWallClockJump) {
+                options.onWallClockJump(ctx);
+            } else {
+                logger.info(ctx, "wakeful sleep: wall-clock jumped (likely wake from sleep); resuming");
+            }
+        }
+
+        lastTickAt = now;
+    }
+}
+
+export interface WakefulInterval {
+    stop: () => void;
+}
+
+export interface WakefulIntervalOptions {
+    /**
+     * If true (default), fire `tick` once immediately on start, then repeat.
+     * If false, wait `intervalMs` before the first fire — matches raw
+     * `setInterval(fn, ms)` semantics.
+     */
+    leading?: boolean;
+    onWallClockJump?: WakefulSleepOptions["onWallClockJump"];
+}
+
+/**
+ * Drop-in replacement for `setInterval(tick, ms)` that survives macOS sleep.
+ * Errors thrown by `tick` are logged at debug level; the loop never dies.
+ */
+export function startWakefulInterval(
+    intervalMs: number,
+    tick: () => Promise<void> | void,
+    options: WakefulIntervalOptions = {}
+): WakefulInterval {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        throw new Error(`startWakefulInterval: intervalMs must be a positive finite number, got ${intervalMs}`);
+    }
+
+    const leading = options.leading ?? true;
+    let running = true;
+
+    const waitInterval = async (): Promise<void> => {
+        await wakefulSleep(intervalMs, {
+            shouldAbort: () => !running,
+            onWallClockJump: options.onWallClockJump,
+        });
+    };
+
+    (async () => {
+        if (!leading) {
+            await waitInterval();
+        }
+
+        while (running) {
+            try {
+                await tick();
+            } catch (err) {
+                logger.debug({ err }, "wakeful interval tick failed");
+            }
+
+            await waitInterval();
+        }
+    })().catch((err) => logger.error({ err }, "wakeful interval loop died"));
+
+    return {
+        stop: () => {
+            running = false;
+        },
+    };
+}

--- a/src/utils/wakeful.ts
+++ b/src/utils/wakeful.ts
@@ -6,6 +6,18 @@ export const WAKEFUL_JUMP_THRESHOLD_MS = WAKEFUL_TICK_MS * 5;
 export interface WakefulSleepOptions {
     shouldAbort?: () => boolean;
     onWallClockJump?: (ctx: { elapsedMs: number; expectedMs: number }) => void;
+    /** When true, timers do not keep the process alive (matches `setInterval().unref()`). */
+    unref?: boolean;
+}
+
+function delayMs(ms: number, unref: boolean): Promise<void> {
+    return new Promise((resolve) => {
+        const timer = setTimeout(resolve, ms);
+
+        if (unref) {
+            timer.unref();
+        }
+    });
 }
 
 /**
@@ -14,6 +26,7 @@ export interface WakefulSleepOptions {
  */
 export async function wakefulSleep(totalMs: number, options: WakefulSleepOptions = {}): Promise<void> {
     const shouldAbort = options.shouldAbort ?? (() => false);
+    const unref = options.unref ?? false;
     const deadline = Date.now() + totalMs;
     let lastTickAt = Date.now();
 
@@ -24,7 +37,13 @@ export async function wakefulSleep(totalMs: number, options: WakefulSleepOptions
             return;
         }
 
-        await Bun.sleep(Math.min(WAKEFUL_TICK_MS, remaining));
+        const tickMs = Math.min(WAKEFUL_TICK_MS, remaining);
+
+        if (unref) {
+            await delayMs(tickMs, true);
+        } else {
+            await Bun.sleep(tickMs);
+        }
 
         const now = Date.now();
         const elapsed = now - lastTickAt;
@@ -55,6 +74,8 @@ export interface WakefulIntervalOptions {
      */
     leading?: boolean;
     onWallClockJump?: WakefulSleepOptions["onWallClockJump"];
+    /** When true, the interval does not keep the process alive. */
+    unref?: boolean;
 }
 
 /**
@@ -77,6 +98,7 @@ export function startWakefulInterval(
         await wakefulSleep(intervalMs, {
             shouldAbort: () => !running,
             onWallClockJump: options.onWallClockJump,
+            unref: options.unref,
         });
     };
 


### PR DESCRIPTION
## Summary

Cross-cutting reliability and UX fixes across several tools (18 commits, 45 files).

### cmux
- Reject legacy `window` param on `workspace.list` / `workspace.create`; require `window_id`
- Fixes dev-dashboard "Port tmux session" layout load and other per-window workspace enumeration paths
- Regression tests for socket RPC param mapping

### Wakeful intervals (macOS hibernate)
- Add `startWakefulInterval()` in `src/utils/async.ts` — short `Bun.sleep` ticks instead of a single long `setInterval` timer that the kernel can drop across Low Power Sleep
- Apply to dev-dashboard cmux/pulse pollers, daemon scheduler sleep, indexer FS sync, `tools port` watch, shops live-events poll, and shared SSE broadcaster heartbeats

### debugging-master
- `llm-log.ts` / `llm-log.php` post over HTTP with parallel host probe (LAN IP / 127.0.0.1 / localhost); first 200 wins
- `start` substitutes `__LAN_IP__` in the copied snippet for cross-device logging
- `cleanup` is opt-in (`--blocks`, `--clean-logs`, or both); `--blocks` stashes instrumentation into git before removal (default-on; `--no-stash` to skip)
- Fix stash: drop `git add -N` before `stash push -u` (intent-to-add broke untracked snippet files)
- Dashboard: `refreshing` status badge during session-list fetch; SSE never reaches terminal "down" (keeps retrying); session-pool limit input in seconds

### azure-devops / timelog
- `prepare-import` and `import --dry-run` enrich entries with `workItemTitle` (after `workItemId` in JSON)
- Shared helpers in `entry-fields.ts`; plugin skill/command docs updated (agents omit `workItemTitle` from authored JSON)

### Other
- `npm-package-diff`: mirror project install config in tmp installs, detect renamed files, verbose errors
- `utils/paths`: worktree-aware shared prefix for `DirPath` display (keeps `.worktrees/` siblings distinguishable)
- `claude usage`: remove height cap clipping; `flexShrink` on chrome so tabs/status aren't squeezed
- `task`: O(1) `getLastLineSeq` tail parse
- `bunfig.toml`: `minimumReleaseAge = 7d` supply-chain delay for project installs (diff tools bypass in their own tmp installs)

## Test plan
- [x] `bun test src/cmux/lib/socket.test.ts src/utils/cmux/layout.test.ts src/dev-dashboard/lib/cmux/`
- [x] `bun test src/utils/paths.client.test.ts src/debugging-master/dashboard/lib/session-pool-settings.test.ts`
- [x] Live verify: cmux `workspaceList`, `fetchCmuxFullLayout`, `fetchCmuxLiveSnapshot`, `createWorkspaceWithName`
- [x] debugging-master cleanup stash/re-apply on scratch repo (untracked snippet + mixed edits)
- [x] dev-dashboard pulse graphs resume after simulated hibernate / long sleep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cmux workspace listing/creation to use the correct per-window `window_id` RPC parameter.
  * Improved dashboard connectivity/retry behavior and live refresh status; enhanced SSE reconnect handling.
  * Robustified scheduler/polling timing for sleep/hibernate; improved session last-line detection.
  * Made dashboard CWD/path display work correctly with worktrees.
* **New Features**
  * Updated session-pool retention controls/UI to use seconds-based limits.
  * Expanded npm package diff to detect and report renamed files.
  * Debug logging now streams to the dashboard ingest endpoint.
* **Documentation**
  * Refreshed cmux and timelog/debugging-master documentation for `window_id` and `workItemTitle` behavior.
* **Tests**
  * Added/updated coverage for RPC parameter mapping, session-pool settings, and path-prefix display.
* **Performance / Config**
  * Faster tail-based session parsing; hardened temp installs with stricter bun install configuration and safer install behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->