### PR TITLE
aliases tool fixes + tools entrypoint drain + repo-wide lint cleanup

### DIFF
--- a/src/Internal/commands/reas/api/MfRentalClient.ts
+++ b/src/Internal/commands/reas/api/MfRentalClient.ts
@@ -128,7 +128,7 @@ export class MfRentalClient {
         const sheetName = workbook.SheetNames.find((name) => name.includes("Cenov")) ?? workbook.SheetNames[0];
         const sheet = workbook.Sheets[sheetName];
 
-        if (!sheet || !sheet["!ref"]) {
+        if (!sheet?.["!ref"]) {
             throw new Error(`MF XLSX: sheet "${sheetName}" is empty or missing`);
         }
 

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -689,4 +689,9 @@ async function main(): Promise<void> {
     }
 }
 
-main();
+try {
+    await main();
+} catch (err) {
+    out.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+}

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -693,5 +693,6 @@ try {
     await main();
 } catch (err) {
     out.error(err instanceof Error ? err.message : String(err));
+    await out.flush();
     process.exit(1);
 }

--- a/src/aliases/commands/analyze.ts
+++ b/src/aliases/commands/analyze.ts
@@ -1,5 +1,5 @@
 import { addScanFlags } from "@app/aliases/commands/shared";
-import { type AnalyzeFlags, parseParams, renderHuman, resolveHistoryFile, runAnalysis } from "@app/aliases/lib/myelin";
+import { type AnalyzeFlags, parseParams, renderHuman, resolveHistoryFile, runAnalysis } from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";

--- a/src/aliases/commands/analyze.ts
+++ b/src/aliases/commands/analyze.ts
@@ -1,5 +1,11 @@
 import { addScanFlags } from "@app/aliases/commands/shared";
-import { type AnalyzeFlags, parseParams, renderHuman, resolveHistoryFile, runAnalysis } from "@app/aliases/lib/analysis";
+import {
+    type AnalyzeFlags,
+    parseParams,
+    renderHuman,
+    resolveHistoryFile,
+    runAnalysis,
+} from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";

--- a/src/aliases/commands/apply.ts
+++ b/src/aliases/commands/apply.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { addScanFlags } from "@app/aliases/commands/shared";
-import { upsertManagedBlock } from "@app/aliases/lib/core";
+import { isWorthAliasing, upsertManagedBlock } from "@app/aliases/lib/core";
 import {
     type ApplyFlags,
     BLOCK_END,
@@ -10,7 +10,7 @@ import {
     parseParams,
     resolveHistoryFile,
     runAnalysis,
-} from "@app/aliases/lib/myelin";
+} from "@app/aliases/lib/analysis";
 import { logger, out } from "@app/logger";
 import type { Command } from "commander";
 
@@ -37,7 +37,9 @@ async function applyAction(flags: ApplyFlags): Promise<void> {
         now: Date.now(),
     });
 
-    const chosen = report.paths.filter((p) => p.level >= minLevel);
+    const chosen = report.paths.filter(
+        (p) => p.level >= minLevel && isWorthAliasing({ commands: p.commands, aliasName: p.alias.name })
+    );
     const blockBody = chosen.map((p) => `alias ${p.alias.name}='${escapeForSingleQuote(p.alias.command)}'`).join("\n");
 
     if (flags.print) {
@@ -58,7 +60,7 @@ async function applyAction(flags: ApplyFlags): Promise<void> {
 export function registerApplyCommand(program: Command): void {
     addScanFlags(program.command("apply").description("Write suggested aliases into the managed rc block (or print)"))
         .option("--rc <file>", "Target rc file (default: auto-detect ~/.zshrc or ~/.bashrc)")
-        .option("--min-level <n>", "Only emit paths whose myelination level >= n", "2")
+        .option("--min-level <n>", "Only emit paths whose alias level >= n", "2")
         .option("--print", "Print the alias block to stdout instead of writing the rc")
         .action(applyAction);
 }

--- a/src/aliases/commands/apply.ts
+++ b/src/aliases/commands/apply.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import { addScanFlags } from "@app/aliases/commands/shared";
-import { isWorthAliasing, upsertManagedBlock } from "@app/aliases/lib/core";
 import {
     type ApplyFlags,
     BLOCK_END,
@@ -11,6 +10,7 @@ import {
     resolveHistoryFile,
     runAnalysis,
 } from "@app/aliases/lib/analysis";
+import { isWorthAliasing, upsertManagedBlock } from "@app/aliases/lib/core";
 import { logger, out } from "@app/logger";
 import type { Command } from "commander";
 

--- a/src/aliases/commands/decay.ts
+++ b/src/aliases/commands/decay.ts
@@ -1,5 +1,12 @@
+import {
+    type AliasState,
+    type DecayFlags,
+    daysSince,
+    emptyState,
+    STATE_FILE,
+    storage,
+} from "@app/aliases/lib/analysis";
 import { updateLevel } from "@app/aliases/lib/core";
-import { type DecayFlags, daysSince, emptyState, type AliasState, STATE_FILE, storage } from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";

--- a/src/aliases/commands/decay.ts
+++ b/src/aliases/commands/decay.ts
@@ -1,5 +1,5 @@
-import { updateMyelination } from "@app/aliases/lib/core";
-import { type DecayFlags, daysSince, emptyState, type MyelinState, STATE_FILE, storage } from "@app/aliases/lib/myelin";
+import { updateLevel } from "@app/aliases/lib/core";
+import { type DecayFlags, daysSince, emptyState, type AliasState, STATE_FILE, storage } from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 import type { Command } from "commander";
@@ -9,12 +9,12 @@ async function decayAction(flags: DecayFlags): Promise<void> {
     let decayed = 0;
     let pruned = 0;
 
-    const next = await storage.atomicUpdate<MyelinState>(STATE_FILE, (current) => {
-        const state: MyelinState = current?.paths ? current : emptyState();
+    const next = await storage.atomicUpdate<AliasState>(STATE_FILE, (current) => {
+        const state: AliasState = current?.paths ? current : emptyState();
         const result = emptyState();
 
         for (const [key, path] of Object.entries(state.paths)) {
-            const level = updateMyelination({
+            const level = updateLevel({
                 level: path.level,
                 reused: false,
                 daysSince: daysSince(path.lastSeen, now),

--- a/src/aliases/commands/reset.ts
+++ b/src/aliases/commands/reset.ts
@@ -1,4 +1,4 @@
-import { emptyState, type AliasState, STATE_FILE, storage } from "@app/aliases/lib/analysis";
+import { type AliasState, emptyState, STATE_FILE, storage } from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import type { Command } from "commander";
 

--- a/src/aliases/commands/reset.ts
+++ b/src/aliases/commands/reset.ts
@@ -1,12 +1,12 @@
-import { emptyState, type MyelinState, STATE_FILE, storage } from "@app/aliases/lib/myelin";
+import { emptyState, type AliasState, STATE_FILE, storage } from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import type { Command } from "commander";
 
 async function resetAction(): Promise<void> {
-    await storage.atomicUpdate<MyelinState>(STATE_FILE, () => emptyState());
-    out.log.success("Cleared myelination state.");
+    await storage.atomicUpdate<AliasState>(STATE_FILE, () => emptyState());
+    out.log.success("Cleared alias-level state.");
 }
 
 export function registerResetCommand(program: Command): void {
-    program.command("reset").description("Clear the persisted myelination state").action(resetAction);
+    program.command("reset").description("Clear the persisted alias-level state").action(resetAction);
 }

--- a/src/aliases/commands/shared.ts
+++ b/src/aliases/commands/shared.ts
@@ -3,10 +3,11 @@ import type { Command } from "commander";
 export function addScanFlags(cmd: Command): Command {
     return cmd
         .option("--history <file>", "Path to a history file (default: auto-detect zsh/bash)")
-        .option("--min-n <n>", "Minimum n-gram length", "2")
+        .option("--min-n <n>", "Minimum n-gram length", "1")
         .option("--max-n <n>", "Maximum n-gram length", "4")
-        .option("-t, --threshold <n>", "Minimum occurrences to be hot", "3")
+        .option("-t, --threshold <n>", "Minimum occurrences for a single command to be hot", "3")
+        .option("--chain-threshold <n>", "Minimum occurrences for a 2+ command chain to be hot", "2")
         .option("--top <n>", "Show at most N hot paths", "20")
-        .option("--no-state", "Pure scan: do not read/update myelination state")
+        .option("--no-state", "Pure scan: do not read/update alias-level state")
         .option("--json", "Emit the full report as JSON to stdout");
 }

--- a/src/aliases/commands/status.ts
+++ b/src/aliases/commands/status.ts
@@ -1,4 +1,4 @@
-import { bar, readState } from "@app/aliases/lib/myelin";
+import { bar, readState } from "@app/aliases/lib/analysis";
 import { out } from "@app/logger";
 import type { Command } from "commander";
 
@@ -7,7 +7,7 @@ async function statusAction(): Promise<void> {
     const entries = Object.values(state.paths).sort((a, b) => b.level - a.level);
 
     if (entries.length === 0) {
-        out.result("No myelination state yet. Run `tools aliases analyze` first.");
+        out.result("No alias-level state yet. Run `tools aliases analyze` first.");
         return;
     }
 
@@ -22,5 +22,5 @@ async function statusAction(): Promise<void> {
 }
 
 export function registerStatusCommand(program: Command): void {
-    program.command("status").description("Show the persisted myelination state, no scan").action(statusAction);
+    program.command("status").description("Show the persisted alias-level state, no scan").action(statusAction);
 }

--- a/src/aliases/index.ts
+++ b/src/aliases/index.ts
@@ -15,7 +15,7 @@ const program = new Command();
 program
     .name("aliases")
     .description(
-        "Use-dependent command-path compiler: mines shell history for hot command chains (activity-dependent myelination) and proposes compiled aliases."
+        "Mine shell history for hot command chains and single commands you reuse, and propose aliases for them."
     );
 
 registerAnalyzeCommand(program);

--- a/src/aliases/lib/aliases.test.ts
+++ b/src/aliases/lib/aliases.test.ts
@@ -32,16 +32,13 @@ describe("parseHistory", () => {
 
     test("merges zsh multi-line entries (trailing backslash is a continuation marker)", () => {
         const raw = [
-            ": 1700000000:0;php -r \"\\",
+            ': 1700000000:0;php -r "\\',
             "require 'vendor/autoload.php';\\",
             "echo 'ok';\\",
-            "\"",
+            '"',
             ": 1700000005:0;ls",
         ].join("\n");
-        expect(parseHistory(raw)).toEqual([
-            `php -r " require 'vendor/autoload.php'; echo 'ok'; "`,
-            "ls",
-        ]);
+        expect(parseHistory(raw)).toEqual([`php -r " require 'vendor/autoload.php'; echo 'ok'; "`, "ls"]);
     });
 
     test("a pasted multi-line block becomes ONE entry (not N continuation-line fakes)", () => {
@@ -107,18 +104,7 @@ describe("extractHotPaths", () => {
     test("applies separate threshold for single commands vs chains", () => {
         // `ccc` appears 6× — passes singles threshold (3). `ccc → resume` chain
         // appears only 2× — needs the chain threshold (2) to be admitted.
-        const commands = [
-            "ccc",
-            "ccc",
-            "ccc",
-            "ccc",
-            "ccc",
-            "ccc",
-            "z",
-            "ccc resume",
-            "z",
-            "ccc resume",
-        ];
+        const commands = ["ccc", "ccc", "ccc", "ccc", "ccc", "ccc", "z", "ccc resume", "z", "ccc resume"];
         const hot = extractHotPaths({ commands, minN: 1, maxN: 2, threshold: 3, chainThreshold: 2 });
         const keys = hot.map((h) => h.commands.join(" "));
         expect(keys).toContain("ccc");

--- a/src/aliases/lib/aliases.test.ts
+++ b/src/aliases/lib/aliases.test.ts
@@ -63,20 +63,19 @@ describe("parseHistory", () => {
         expect(parseHistory(raw)).toEqual(["echo a b"]);
     });
 
-    test("any trailing backslash is a continuation (regardless of how many)", () => {
+    test("any trailing backslash is a continuation (regardless of how many) — no stray \\ leaks through", () => {
         // zsh ext-history stores embedded newlines as `\\\n` (double backslash
         // + LF), so the parser must NOT use an odd-count check — even-count
         // trailing backslashes are the *normal* continuation case in this
-        // format. Pasted curl exports / jq chains rely on this.
-        const raw = [": 1700000000:0;curl -X GET \\\\", "-H 'foo: bar' \\\\", "-H 'baz: qux'", ": 1700000005:0;ls"].join(
-            "\n"
-        );
-        const parsed = parseHistory(raw);
-        expect(parsed).toHaveLength(2);
-        expect(parsed[0]).toContain("curl -X GET");
-        expect(parsed[0]).toContain("-H 'foo: bar'");
-        expect(parsed[0]).toContain("-H 'baz: qux'");
-        expect(parsed[1]).toBe("ls");
+        // format. Pasted curl exports / jq chains rely on this. Exact-equality
+        // assertion guarantees no stray backslash leaks through the join.
+        const raw = [
+            ": 1700000000:0;curl -X GET \\\\",
+            "-H 'foo: bar' \\\\",
+            "-H 'baz: qux'",
+            ": 1700000005:0;ls",
+        ].join("\n");
+        expect(parseHistory(raw)).toEqual(["curl -X GET -H 'foo: bar' -H 'baz: qux'", "ls"]);
     });
 });
 

--- a/src/aliases/lib/aliases.test.ts
+++ b/src/aliases/lib/aliases.test.ts
@@ -62,6 +62,22 @@ describe("parseHistory", () => {
         const raw = [": 1700000000:0;echo a\\", "b\\"].join("\n");
         expect(parseHistory(raw)).toEqual(["echo a b"]);
     });
+
+    test("any trailing backslash is a continuation (regardless of how many)", () => {
+        // zsh ext-history stores embedded newlines as `\\\n` (double backslash
+        // + LF), so the parser must NOT use an odd-count check — even-count
+        // trailing backslashes are the *normal* continuation case in this
+        // format. Pasted curl exports / jq chains rely on this.
+        const raw = [": 1700000000:0;curl -X GET \\\\", "-H 'foo: bar' \\\\", "-H 'baz: qux'", ": 1700000005:0;ls"].join(
+            "\n"
+        );
+        const parsed = parseHistory(raw);
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0]).toContain("curl -X GET");
+        expect(parsed[0]).toContain("-H 'foo: bar'");
+        expect(parsed[0]).toContain("-H 'baz: qux'");
+        expect(parsed[1]).toBe("ls");
+    });
 });
 
 describe("extractHotPaths", () => {

--- a/src/aliases/lib/aliases.test.ts
+++ b/src/aliases/lib/aliases.test.ts
@@ -7,9 +7,10 @@ import {
     BLOCK_END,
     BLOCK_START,
     extractHotPaths,
+    isWorthAliasing,
     parseHistory,
     suggestAlias,
-    updateMyelination,
+    updateLevel,
     upsertManagedBlock,
 } from "./core";
 
@@ -27,6 +28,42 @@ describe("parseHistory", () => {
     test("trims whitespace and keeps plain lines verbatim", () => {
         const raw = ["  ls -la  ", "cd /tmp"].join("\n");
         expect(parseHistory(raw)).toEqual(["ls -la", "cd /tmp"]);
+    });
+
+    test("merges zsh multi-line entries (trailing backslash is a continuation marker)", () => {
+        const raw = [
+            ": 1700000000:0;php -r \"\\",
+            "require 'vendor/autoload.php';\\",
+            "echo 'ok';\\",
+            "\"",
+            ": 1700000005:0;ls",
+        ].join("\n");
+        expect(parseHistory(raw)).toEqual([
+            `php -r " require 'vendor/autoload.php'; echo 'ok'; "`,
+            "ls",
+        ]);
+    });
+
+    test("a pasted multi-line block becomes ONE entry (not N continuation-line fakes)", () => {
+        // Regression: pasted crash traces used to be shredded into N separate
+        // "commands" whose stack-frame lines repeated across pastes and showed
+        // up as fake hot paths.
+        const crashEntry = [
+            ": 1700000000:0;0   libsystem_kernel.dylib  0x1979004f8 __psynch_cvwait + 8\\",
+            "1   libsystem_pthread.dylib 0x1979400dc _pthread_cond_wait + 984\\",
+            "2   forge                   0x10354ea8c 0x102388000 + 18639500",
+            ": 1700000005:0;ls",
+        ].join("\n");
+        const parsed = parseHistory(crashEntry);
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0]).toContain("libsystem_kernel.dylib");
+        expect(parsed[0]).toContain("forge");
+        expect(parsed[1]).toBe("ls");
+    });
+
+    test("handles a file that ends mid-continuation without losing the entry", () => {
+        const raw = [": 1700000000:0;echo a\\", "b\\"].join("\n");
+        expect(parseHistory(raw)).toEqual(["echo a b"]);
     });
 });
 
@@ -67,6 +104,30 @@ describe("extractHotPaths", () => {
         expect(keys).not.toContain("b c");
     });
 
+    test("applies separate threshold for single commands vs chains", () => {
+        // `ccc` appears 6× — passes singles threshold (3). `ccc → resume` chain
+        // appears only 2× — needs the chain threshold (2) to be admitted.
+        const commands = [
+            "ccc",
+            "ccc",
+            "ccc",
+            "ccc",
+            "ccc",
+            "ccc",
+            "z",
+            "ccc resume",
+            "z",
+            "ccc resume",
+        ];
+        const hot = extractHotPaths({ commands, minN: 1, maxN: 2, threshold: 3, chainThreshold: 2 });
+        const keys = hot.map((h) => h.commands.join(" "));
+        expect(keys).toContain("ccc");
+        expect(keys).toContain("z ccc resume");
+        // Without the lower chain threshold the chain would have been dropped.
+        const onlySingleThreshold = extractHotPaths({ commands, minN: 1, maxN: 2, threshold: 3 });
+        expect(onlySingleThreshold.map((h) => h.commands.join(" "))).not.toContain("z ccc resume");
+    });
+
     test("is deterministic across runs", () => {
         const commands = ["a", "b", "a", "b", "a", "b", "c", "d", "c", "d", "c", "d"];
         const first = extractHotPaths({ commands, minN: 2, maxN: 2, threshold: 3 });
@@ -75,22 +136,22 @@ describe("extractHotPaths", () => {
     });
 });
 
-describe("updateMyelination", () => {
+describe("updateLevel", () => {
     test("decays first then grows when reused, injected daysSince only", () => {
         // level 5, 3 idle days at 0.1/day -> 4.7, +1 growth -> 5.7
-        expect(updateMyelination({ level: 5, reused: true, daysSince: 3 })).toBeCloseTo(5.7, 5);
+        expect(updateLevel({ level: 5, reused: true, daysSince: 3 })).toBeCloseTo(5.7, 5);
     });
 
     test("pure decay when not reused, clamped at 0", () => {
         // level 1, 5 idle days at 0.1/day -> 0.5 (not yet dead).
-        expect(updateMyelination({ level: 1, reused: false, daysSince: 5 })).toBeCloseTo(0.5, 5);
+        expect(updateLevel({ level: 1, reused: false, daysSince: 5 })).toBeCloseTo(0.5, 5);
         // 15 idle days -> 1 - 1.5 clamps to 0.
-        expect(updateMyelination({ level: 1, reused: false, daysSince: 15 })).toBe(0);
-        expect(updateMyelination({ level: 0.5, reused: false, daysSince: 100 })).toBe(0);
+        expect(updateLevel({ level: 1, reused: false, daysSince: 15 })).toBe(0);
+        expect(updateLevel({ level: 0.5, reused: false, daysSince: 100 })).toBe(0);
     });
 
     test("clamps growth to max", () => {
-        expect(updateMyelination({ level: 10, reused: true, daysSince: 0, max: 10 })).toBe(10);
+        expect(updateLevel({ level: 10, reused: true, daysSince: 0, max: 10 })).toBe(10);
     });
 });
 
@@ -101,10 +162,15 @@ describe("suggestAlias", () => {
         expect(a.name).toBe("gagcgp");
     });
 
-    test("skips flag tokens starting with -", () => {
+    test("flag NAMES contribute their first alnum (so ccc --resume becomes cr, not just c)", () => {
+        const a = suggestAlias(["ccc --resume"]);
+        expect(a.name).toBe("cr");
+    });
+
+    test("short flag stems contribute (git add -A -> gaa)", () => {
         const a = suggestAlias(["git add -A", "git commit"]);
-        // tokens: git, add (skip -A), git, commit -> "gagc"
-        expect(a.name).toBe("gagc");
+        // tokens: git, add, -A (stem A), git, commit -> "gaagc"
+        expect(a.name).toBe("gaagc");
     });
 
     test("de-dupes against a taken set", () => {
@@ -112,6 +178,24 @@ describe("suggestAlias", () => {
         const a = suggestAlias(["git add .", "git commit", "git push"], taken);
         expect(a.name).toBe("gagcgp2");
         expect(taken.has("gagcgp2")).toBe(true);
+    });
+});
+
+describe("isWorthAliasing", () => {
+    test("always keeps multi-command chains", () => {
+        expect(isWorthAliasing({ commands: ["a", "b"], aliasName: "ab" })).toBe(true);
+        expect(isWorthAliasing({ commands: ["a", "b", "c"], aliasName: "abc" })).toBe(true);
+    });
+
+    test("requires real savings for single-command suggestions", () => {
+        // `cd ..` → alias `c..` saves 2 chars, original is 5 chars — not worth it.
+        expect(isWorthAliasing({ commands: ["cd .."], aliasName: "c.." })).toBe(false);
+        // `ccc` → alias `c` saves 2 chars on a 3-char original — not worth it.
+        expect(isWorthAliasing({ commands: ["ccc"], aliasName: "c" })).toBe(false);
+        // `tools claude usage` (18 chars) → `tcu` (3) saves 15 — worth it.
+        expect(isWorthAliasing({ commands: ["tools claude usage"], aliasName: "tcu" })).toBe(true);
+        // `ccc --resume` (12 chars) → `ccr` (3) saves 9 — worth it.
+        expect(isWorthAliasing({ commands: ["ccc --resume"], aliasName: "ccr" })).toBe(true);
     });
 });
 
@@ -182,7 +266,7 @@ describe("integration (hermetic state + rc round-trips)", () => {
     test("analyze persists levels; a second hot run raises level; decay lowers and prunes", async () => {
         const { Storage } = await import("@app/utils/storage/storage");
         const { extractHotPaths: extract } = await import("./core");
-        const { updateMyelination: update } = await import("./core");
+        const { updateLevel: update } = await import("./core");
 
         const storage = new Storage("aliases");
         const commands = parseHistory(synthHistory());
@@ -195,7 +279,7 @@ describe("integration (hermetic state + rc round-trips)", () => {
             lastSeen: string;
             count: number;
         }
-        interface MyelinState {
+        interface AliasState {
             paths: Record<string, PathState>;
         }
 
@@ -203,7 +287,7 @@ describe("integration (hermetic state + rc round-trips)", () => {
         const key = hot[0].commands.join(" ");
 
         // First analyze-like write: prior level 0, reused, daysSince 0 -> level 1.
-        await storage.atomicUpdate<MyelinState>("state.json", () => ({
+        await storage.atomicUpdate<AliasState>("state.json", () => ({
             paths: {
                 [key]: {
                     commands: hot[0].commands,
@@ -216,12 +300,12 @@ describe("integration (hermetic state + rc round-trips)", () => {
 
         const stateFile = join(storage.getCacheDir(), "state.json");
         expect(existsSync(stateFile)).toBe(true);
-        const first = SafeJSON.parse(readFileSync(stateFile, "utf8")) as MyelinState;
+        const first = SafeJSON.parse(readFileSync(stateFile, "utf8")) as AliasState;
         expect(first.paths[key].level).toBeCloseTo(1, 5);
 
         // Second hot run 2 days later: decay 0.2, +1 growth -> ~1.8.
         const t1 = t0 + 2 * 24 * 60 * 60 * 1000;
-        await storage.atomicUpdate<MyelinState>("state.json", (current) => {
+        await storage.atomicUpdate<AliasState>("state.json", (current) => {
             const prior = current?.paths[key];
             const daysSince = prior ? (t1 - Date.parse(prior.lastSeen)) / (24 * 60 * 60 * 1000) : 0;
             const next = current ?? { paths: {} };
@@ -233,13 +317,13 @@ describe("integration (hermetic state + rc round-trips)", () => {
             };
             return next;
         });
-        const second = SafeJSON.parse(readFileSync(stateFile, "utf8")) as MyelinState;
+        const second = SafeJSON.parse(readFileSync(stateFile, "utf8")) as AliasState;
         expect(second.paths[key].level).toBeCloseTo(1.8, 5);
 
         // Decay far into the future: level should hit 0 and be pruned.
         const tFar = t1 + 100 * 24 * 60 * 60 * 1000;
-        await storage.atomicUpdate<MyelinState>("state.json", (current) => {
-            const result: MyelinState = { paths: {} };
+        await storage.atomicUpdate<AliasState>("state.json", (current) => {
+            const result: AliasState = { paths: {} };
             for (const [k, path] of Object.entries(current?.paths ?? {})) {
                 const daysSince = (tFar - Date.parse(path.lastSeen)) / (24 * 60 * 60 * 1000);
                 const level = update({ level: path.level, reused: false, daysSince });
@@ -250,7 +334,7 @@ describe("integration (hermetic state + rc round-trips)", () => {
 
             return result;
         });
-        const third = SafeJSON.parse(readFileSync(stateFile, "utf8")) as MyelinState;
+        const third = SafeJSON.parse(readFileSync(stateFile, "utf8")) as AliasState;
         expect(Object.keys(third.paths)).toHaveLength(0);
     });
 

--- a/src/aliases/lib/analysis.ts
+++ b/src/aliases/lib/analysis.ts
@@ -303,19 +303,23 @@ export function renderHuman(report: AnalyzeReport, minLevel: number): string {
 }
 
 export function parseParams(flags: AnalyzeFlags): ScanParams {
-    const minN = flags.minN ? Number.parseInt(flags.minN, 10) : 1;
-    const maxN = flags.maxN ? Number.parseInt(flags.maxN, 10) : 4;
-    const threshold = flags.threshold ? Number.parseInt(flags.threshold, 10) : 3;
-    const chainThreshold = flags.chainThreshold ? Number.parseInt(flags.chainThreshold, 10) : 2;
-    const top = flags.top ? Number.parseInt(flags.top, 10) : 20;
+    // Mirror the clamping rules inside `extractHotPaths` so the report params
+    // describe what the scan ACTUALLY ran — without this, e.g. `--min-n 5
+    // --max-n 2` would be reported as `5..2` even though extraction silently
+    // executes 5..5.
+    const rawMinN = flags.minN ? Number.parseInt(flags.minN, 10) : 1;
+    const rawMaxN = flags.maxN ? Number.parseInt(flags.maxN, 10) : 4;
+    const rawThreshold = flags.threshold ? Number.parseInt(flags.threshold, 10) : 3;
+    const rawChainThreshold = flags.chainThreshold ? Number.parseInt(flags.chainThreshold, 10) : 2;
+    const rawTop = flags.top ? Number.parseInt(flags.top, 10) : 20;
 
-    return {
-        minN: Number.isNaN(minN) ? 1 : minN,
-        maxN: Number.isNaN(maxN) ? 4 : maxN,
-        threshold: Number.isNaN(threshold) ? 3 : threshold,
-        chainThreshold: Number.isNaN(chainThreshold) ? 2 : chainThreshold,
-        top: Number.isNaN(top) ? 20 : top,
-    };
+    const minN = Math.max(1, Number.isNaN(rawMinN) ? 1 : rawMinN);
+    const maxN = Math.max(minN, Number.isNaN(rawMaxN) ? 4 : rawMaxN);
+    const threshold = Math.max(1, Number.isNaN(rawThreshold) ? 3 : rawThreshold);
+    const chainThreshold = Math.max(1, Number.isNaN(rawChainThreshold) ? 2 : rawChainThreshold);
+    const top = Math.max(0, Number.isNaN(rawTop) ? 20 : rawTop);
+
+    return { minN, maxN, threshold, chainThreshold, top };
 }
 
 export function defaultRcFile(): string {

--- a/src/aliases/lib/analysis.ts
+++ b/src/aliases/lib/analysis.ts
@@ -6,9 +6,10 @@ import {
     BLOCK_START,
     extractHotPaths,
     type HotPath,
+    isWorthAliasing,
     parseHistory,
     suggestAlias,
-    updateMyelination,
+    updateLevel,
 } from "@app/aliases/lib/core";
 import { logger } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
@@ -24,7 +25,7 @@ export interface PathState {
     count: number;
 }
 
-export interface MyelinState {
+export interface AliasState {
     paths: Record<string, PathState>;
 }
 
@@ -32,6 +33,7 @@ export interface ScanParams {
     minN: number;
     maxN: number;
     threshold: number;
+    chainThreshold: number;
     top: number;
 }
 
@@ -57,6 +59,7 @@ export interface AnalyzeFlags {
     minN?: string;
     maxN?: string;
     threshold?: string;
+    chainThreshold?: string;
     top?: string;
     state?: boolean;
     json?: boolean;
@@ -78,11 +81,11 @@ function statePath(): string {
     return join(storage.getCacheDir(), STATE_FILE);
 }
 
-export function emptyState(): MyelinState {
+export function emptyState(): AliasState {
     return { paths: {} };
 }
 
-export async function readState(): Promise<MyelinState> {
+export async function readState(): Promise<AliasState> {
     const file = statePath();
     if (!existsSync(file)) {
         return emptyState();
@@ -90,7 +93,7 @@ export async function readState(): Promise<MyelinState> {
 
     try {
         const text = await Bun.file(file).text();
-        const parsed = SafeJSON.parse(text) as MyelinState;
+        const parsed = SafeJSON.parse(text) as AliasState;
         return parsed.paths ? parsed : emptyState();
     } catch (error) {
         logger.warn({ error, file }, "aliases: failed to read state, starting fresh");
@@ -139,7 +142,7 @@ export function escapeForSingleQuote(s: string): string {
 }
 
 /**
- * Mine history, extract hot paths, and update myelination state (unless
+ * Mine history, extract hot paths, and update alias-level state (unless
  * `noState`). Returns the report plus the raw command count.
  */
 export async function runAnalysis(opts: {
@@ -152,11 +155,17 @@ export async function runAnalysis(opts: {
     const commands = parseHistory(raw);
     logger.debug({ historyFile: opts.historyFile, commands: commands.length }, "aliases: parsed history");
 
+    // Single commands need to repeat more (default 3) to be worth aliasing,
+    // but chains are inherently rarer and a lower threshold (default 2)
+    // surfaces useful ones we'd otherwise miss. Single call so subsumption
+    // (drop `z genesistools` when `z genesistools && ccc` has the same count)
+    // still works.
     const hot = extractHotPaths({
         commands,
         minN: opts.params.minN,
         maxN: opts.params.maxN,
         threshold: opts.params.threshold,
+        chainThreshold: opts.params.chainThreshold,
         top: opts.params.top,
     });
 
@@ -168,7 +177,7 @@ export async function runAnalysis(opts: {
     if (opts.noState) {
         reportPaths = hot.map((path: HotPath) => {
             const key = path.commands.join(" ");
-            const level = updateMyelination({ level: 0, reused: true, daysSince: 0 });
+            const level = updateLevel({ level: 0, reused: true, daysSince: 0 });
             const alias = suggestAlias(path.commands, taken);
 
             return {
@@ -181,12 +190,12 @@ export async function runAnalysis(opts: {
             };
         });
     } else {
-        const nextState = await storage.atomicUpdate<MyelinState>(STATE_FILE, (current) => {
-            const next: MyelinState = current?.paths ? current : emptyState();
+        const nextState = await storage.atomicUpdate<AliasState>(STATE_FILE, (current) => {
+            const next: AliasState = current?.paths ? current : emptyState();
             for (const path of hot) {
                 const key = path.commands.join(" ");
                 const priorPath = next.paths[key];
-                const level = updateMyelination({
+                const level = updateLevel({
                     level: priorPath?.level ?? 0,
                     reused: true,
                     daysSince: priorPath ? daysSince(priorPath.lastSeen, opts.now) : 0,
@@ -244,48 +253,67 @@ export function renderHuman(report: AnalyzeReport, minLevel: number): string {
     lines.push(
         `aliases — ${report.history} (n=${report.params.minN}..${report.params.maxN}, threshold ${report.params.threshold})`
     );
-    lines.push("");
-    lines.push(`mined ${report.counts.lines} lines · ${report.counts.hot} hot paths`);
+    const worth = report.paths.filter((p) => isWorthAliasing({ commands: p.commands, aliasName: p.alias.name }));
+    const trivial = report.paths.length - worth.length;
+    const trivialNote = trivial > 0 ? ` (${trivial} skipped as too short to alias)` : "";
+    lines.push(`mined ${report.counts.lines.toLocaleString("en")} lines · ${worth.length} hot commands${trivialNote}`);
     lines.push("");
 
-    if (report.paths.length === 0) {
-        lines.push("No hot command sequences found above the threshold.");
+    if (worth.length === 0) {
+        lines.push("No hot command sequences worth aliasing.");
         return lines.join("\n");
     }
 
-    lines.push("HOT AXONS (ranked by activity score)");
-    for (const path of report.paths) {
-        const chain = path.commands.join("  →  ");
-        lines.push(
-            `  ${bar(path.level)}  ${chain}  ×${path.count}  level ${path.level.toFixed(1)}  alias: ${path.alias.name}`
-        );
+    const suggested = worth.filter((p) => p.level >= minLevel);
+
+    // Column widths from the worth-aliasing rows (which dominate the display).
+    const chainStrings = worth.map((p) => p.commands.join(" && "));
+    const maxChain = chainStrings.reduce((max, s) => Math.max(max, s.length), 0);
+    const maxCount = worth.reduce((max, p) => Math.max(max, String(p.count).length), 0);
+    const maxAlias = worth.reduce((max, p) => Math.max(max, p.alias.name.length), 0);
+
+    lines.push("HOT COMMANDS (sorted by reuse × chain length)");
+    for (const path of worth) {
+        const chain = path.commands.join(" && ").padEnd(maxChain);
+        const count = `×${String(path.count).padStart(maxCount)}`;
+        const level = `lvl ${path.level.toFixed(1)}`;
+        const alias = path.level >= minLevel ? `→ ${path.alias.name.padEnd(maxAlias)} ★` : `→ ${path.alias.name}`;
+        lines.push(`  ${bar(path.level)}  ${chain}  ${count}  ${level}  ${alias}`.trimEnd());
     }
 
-    const suggested = report.paths.filter((p) => p.level >= minLevel);
+    lines.push("");
+
     if (suggested.length > 0) {
-        lines.push("");
-        lines.push(`SUGGESTED ALIASES (level >= ${minLevel})`);
+        lines.push(`READY TO APPLY (level ≥ ${minLevel}, marked ★ above)`);
         for (const path of suggested) {
             lines.push(`  alias ${path.alias.name}='${escapeForSingleQuote(path.alias.command)}'`);
         }
 
         lines.push("");
-        lines.push(`Run \`tools aliases apply\` to write ${suggested.length} aliases to your rc (managed block).`);
+        lines.push(
+            `Run \`tools aliases apply\` to write ${suggested.length} alias${suggested.length === 1 ? "" : "es"} to your rc.`
+        );
+    } else if (worth.length > 0) {
+        lines.push(
+            `No aliases at level ≥ ${minLevel} yet — re-run \`tools aliases\` after using these more to raise levels.`
+        );
     }
 
     return lines.join("\n");
 }
 
 export function parseParams(flags: AnalyzeFlags): ScanParams {
-    const minN = flags.minN ? Number.parseInt(flags.minN, 10) : 2;
+    const minN = flags.minN ? Number.parseInt(flags.minN, 10) : 1;
     const maxN = flags.maxN ? Number.parseInt(flags.maxN, 10) : 4;
     const threshold = flags.threshold ? Number.parseInt(flags.threshold, 10) : 3;
+    const chainThreshold = flags.chainThreshold ? Number.parseInt(flags.chainThreshold, 10) : 2;
     const top = flags.top ? Number.parseInt(flags.top, 10) : 20;
 
     return {
-        minN: Number.isNaN(minN) ? 2 : minN,
+        minN: Number.isNaN(minN) ? 1 : minN,
         maxN: Number.isNaN(maxN) ? 4 : maxN,
         threshold: Number.isNaN(threshold) ? 3 : threshold,
+        chainThreshold: Number.isNaN(chainThreshold) ? 2 : chainThreshold,
         top: Number.isNaN(top) ? 20 : top,
     };
 }

--- a/src/aliases/lib/core.ts
+++ b/src/aliases/lib/core.ts
@@ -50,6 +50,14 @@ export function parseHistory(raw: string, _opts: { format?: HistoryFormat } = {}
     const merged: string[] = [];
     let buffer: string | null = null;
 
+    // NOTE: a "smart" odd-count-trailing-backslash check (so `echo \\` isn't
+    // treated as a continuation) was tried and reverted — zsh stores embedded
+    // newlines as `\\\n` (TWO backslashes + LF byte), so an even count of
+    // trailing backslashes is the normal continuation case in this file
+    // format, not the literal-backslash exception. Treating any trailing `\`
+    // as continuation is the empirically-correct rule for both zsh ext-history
+    // and the same-shape encoding bash uses.
+
     for (const rawLine of raw.split("\n")) {
         if (buffer !== null) {
             // We're inside a continuation. The previous buffer ends with `\`,
@@ -261,10 +269,10 @@ export function updateLevel(input: {
  * `command` joins the chain with ` && `. `name` is a short mnemonic built from
  * the first alnum of each token: for regular tokens we use the first alnum
  * directly; for flag tokens (`-x`, `--foo`) we use the first alnum of the flag
- * NAME (after the dashes) — so `ccc --resume` aliases to `ccr`, not just `c`.
- * Empty result falls back to `m<index>`. Uniqueness is enforced against the
- * optional `taken` set by appending an incrementing digit. Deterministic for
- * the same input.
+ * NAME (after the dashes) — so `ccc --resume` aliases to `cr` (not just `c`,
+ * which would happen if the flag were skipped). Empty result falls back to
+ * `m<index>`. Uniqueness is enforced against the optional `taken` set by
+ * appending an incrementing digit. Deterministic for the same input.
  */
 export function suggestAlias(commands: string[], taken?: Set<string>, index = 0): AliasSuggestion {
     const command = commands.join(" && ");

--- a/src/aliases/lib/core.ts
+++ b/src/aliases/lib/core.ts
@@ -1,6 +1,5 @@
 /**
- * Pure, testable cores for the `aliases` tool (the use-dependent
- * command-path compiler that models activity-dependent myelination).
+ * Pure, testable cores for the `aliases` tool.
  *
  * Everything in this file is a pure function: no filesystem, no clock, no
  * environment. The clock-dependent value (`daysSince`, `now`) is always
@@ -36,15 +35,48 @@ export const BLOCK_END = "# <<< aliases managed block <<<";
  *   without the prefix are kept verbatim.
  * - bash lines are one command per line; `HISTTIMEFORMAT` timestamp lines
  *   (a leading `#` followed by only digits) are dropped.
+ * - Multi-line zsh entries (a trailing `\` on a line is the continuation
+ *   marker; the next physical line is part of the same command) are coalesced
+ *   into a single entry. Each embedded newline is replaced with a space so the
+ *   result is a single command string. Without this, pasted multi-line content
+ *   (crash traces, heredocs, jq filter chains) gets shredded into fake
+ *   "commands" whose continuation lines repeat across pastes and pollute the
+ *   n-gram hot-path detection.
  * - Blank lines are skipped; leading/trailing whitespace is trimmed.
- * - Multi-line entries are out of scope: each physical line is one entry.
  *
  * Pure: does not read the filesystem or the clock.
  */
 export function parseHistory(raw: string, _opts: { format?: HistoryFormat } = {}): string[] {
-    const out: string[] = [];
+    const merged: string[] = [];
+    let buffer: string | null = null;
 
     for (const rawLine of raw.split("\n")) {
+        if (buffer !== null) {
+            // We're inside a continuation. The previous buffer ends with `\`,
+            // which encodes an embedded newline; drop it and join with a space
+            // so the result stays single-line.
+            buffer = `${buffer.slice(0, -1)} ${rawLine}`;
+        } else {
+            buffer = rawLine;
+        }
+
+        if (buffer.endsWith("\\")) {
+            continue;
+        }
+
+        merged.push(buffer);
+        buffer = null;
+    }
+
+    if (buffer !== null) {
+        // File ended mid-continuation; keep whatever we have without the
+        // dangling backslash.
+        merged.push(buffer.endsWith("\\") ? buffer.slice(0, -1) : buffer);
+    }
+
+    const out: string[] = [];
+
+    for (const rawLine of merged) {
         const line = rawLine.trim();
         if (line.length === 0) {
             continue;
@@ -102,7 +134,7 @@ function isContiguousSlice(outer: string[], inner: string[]): boolean {
 }
 
 /**
- * Extract frequently-repeated consecutive command n-grams ("hot axons").
+ * Extract frequently-repeated consecutive command n-grams ("hot commands").
  *
  * For every window length n in [minN, maxN], slide over the ordered command
  * array, count distinct consecutive n-grams, keep those with count >=
@@ -116,13 +148,17 @@ export function extractHotPaths(input: {
     commands: string[];
     minN?: number;
     maxN?: number;
+    /** Minimum count for single-command (n=1) candidates. */
     threshold?: number;
+    /** Minimum count for chain (n>=2) candidates. Defaults to `threshold`. */
+    chainThreshold?: number;
     top?: number;
 }): HotPath[] {
     const commands = input.commands;
     const minN = Math.max(1, input.minN ?? 2);
     const maxN = Math.max(minN, input.maxN ?? 4);
     const threshold = Math.max(1, input.threshold ?? 3);
+    const chainThreshold = Math.max(1, input.chainThreshold ?? threshold);
     const top = Math.max(0, input.top ?? 20);
 
     const counts = new Map<string, { commands: string[]; count: number }>();
@@ -146,7 +182,8 @@ export function extractHotPaths(input: {
 
     const hot: HotPath[] = [];
     for (const entry of counts.values()) {
-        if (entry.count >= threshold) {
+        const minCount = entry.commands.length === 1 ? threshold : chainThreshold;
+        if (entry.count >= minCount) {
             hot.push({
                 commands: entry.commands,
                 count: entry.count,
@@ -191,7 +228,7 @@ export function extractHotPaths(input: {
 }
 
 /**
- * Update a path's myelination level given whether it was reused this scan and
+ * Update a path's alias level given whether it was reused this scan and
  * how many days have passed since it was last seen.
  *
  * Decay for idle time is applied first, then growth (if reused). The level is
@@ -199,7 +236,7 @@ export function extractHotPaths(input: {
  * never reads the clock. A level decaying to 0 marks the path dead (the caller
  * decides whether to prune).
  */
-export function updateMyelination(input: {
+export function updateLevel(input: {
     level: number;
     reused: boolean;
     daysSince: number;
@@ -222,10 +259,12 @@ export function updateMyelination(input: {
  * Synthesize an alias for a chain of commands.
  *
  * `command` joins the chain with ` && `. `name` is a short mnemonic built from
- * the first letter of each significant token (flags starting with `-` skipped),
- * lowercased and alnum-only; empty falls back to `m<index>`. Uniqueness is
- * enforced against the optional `taken` set by appending an incrementing digit.
- * Deterministic for the same input.
+ * the first alnum of each token: for regular tokens we use the first alnum
+ * directly; for flag tokens (`-x`, `--foo`) we use the first alnum of the flag
+ * NAME (after the dashes) — so `ccc --resume` aliases to `ccr`, not just `c`.
+ * Empty result falls back to `m<index>`. Uniqueness is enforced against the
+ * optional `taken` set by appending an incrementing digit. Deterministic for
+ * the same input.
  */
 export function suggestAlias(commands: string[], taken?: Set<string>, index = 0): AliasSuggestion {
     const command = commands.join(" && ");
@@ -233,11 +272,13 @@ export function suggestAlias(commands: string[], taken?: Set<string>, index = 0)
     let base = "";
     for (const cmd of commands) {
         for (const token of cmd.split(/\s+/)) {
-            if (token.length === 0 || token.startsWith("-")) {
+            if (token.length === 0) {
                 continue;
             }
 
-            const firstAlnum = token.toLowerCase().replace(/[^a-z0-9]/g, "")[0];
+            // Strip leading dashes so flag NAMES contribute their first letter.
+            const stem = token.replace(/^-+/, "");
+            const firstAlnum = stem.toLowerCase().replace(/[^a-z0-9]/g, "")[0];
             if (firstAlnum) {
                 base += firstAlnum;
             }
@@ -260,6 +301,24 @@ export function suggestAlias(commands: string[], taken?: Set<string>, index = 0)
     }
 
     return { name, command };
+}
+
+/**
+ * Decide whether an alias is actually worth showing.
+ *
+ * Single-command suggestions are only useful if the alias saves real typing —
+ * skip the suggestion when the savings are trivial (e.g. `cd ..` → `c..` or
+ * `ccc` → `c`). For multi-command chains we always keep the suggestion because
+ * chaining commands is intrinsically worth aliasing.
+ */
+export function isWorthAliasing(input: { commands: string[]; aliasName: string }): boolean {
+    if (input.commands.length >= 2) {
+        return true;
+    }
+
+    const original = input.commands[0] ?? "";
+    const savings = original.length - input.aliasName.length;
+    return original.length >= 6 && savings >= 3;
 }
 
 /**

--- a/src/aliases/lib/core.ts
+++ b/src/aliases/lib/core.ts
@@ -60,10 +60,11 @@ export function parseHistory(raw: string, _opts: { format?: HistoryFormat } = {}
 
     for (const rawLine of raw.split("\n")) {
         if (buffer !== null) {
-            // We're inside a continuation. The previous buffer ends with `\`,
-            // which encodes an embedded newline; drop it and join with a space
-            // so the result stays single-line.
-            buffer = `${buffer.slice(0, -1)} ${rawLine}`;
+            // We're inside a continuation. The previous buffer ends in one or
+            // two trailing `\` (zsh encodes the embedded newline as `\\\n`,
+            // bash as `\\n`); strip ALL trailing backslashes and any leftover
+            // whitespace so the join doesn't leak stray `\` into the command.
+            buffer = `${buffer.replace(/\\+$/, "").trimEnd()} ${rawLine}`;
         } else {
             buffer = rawLine;
         }
@@ -78,8 +79,8 @@ export function parseHistory(raw: string, _opts: { format?: HistoryFormat } = {}
 
     if (buffer !== null) {
         // File ended mid-continuation; keep whatever we have without the
-        // dangling backslash.
-        merged.push(buffer.endsWith("\\") ? buffer.slice(0, -1) : buffer);
+        // dangling backslash(es).
+        merged.push(buffer.endsWith("\\") ? buffer.replace(/\\+$/, "").trimEnd() : buffer);
     }
 
     const out: string[] = [];

--- a/src/ask/providers/DynamicPricing.test.ts
+++ b/src/ask/providers/DynamicPricing.test.ts
@@ -1009,7 +1009,7 @@ describe("DynamicPricingManager", () => {
 
             for (const modelId of popularModelIds) {
                 const model = openRouterProvider?.models.find((m) => m.id === modelId);
-                if (!model || !model.pricing) {
+                if (!model?.pricing) {
                     _skippedCount++;
                     continue;
                 }

--- a/src/claude/commands/migrate.ts
+++ b/src/claude/commands/migrate.ts
@@ -633,7 +633,7 @@ async function promptRenamePath(targetPath: string): Promise<string | null> {
         placeholder: suggested,
         defaultValue: suggested,
         validate: (value) => {
-            if (!value || !value.trim()) {
+            if (!value?.trim()) {
                 return "Path is required";
             }
 

--- a/src/claude/commands/summarize.ts
+++ b/src/claude/commands/summarize.ts
@@ -199,7 +199,7 @@ async function runInteractiveFlow(session: ClaudeSession, opts: SummarizeCommand
             message: "Enter your custom summarization prompt:",
             placeholder: "e.g., Focus on the error handling patterns used...",
             validate: (val) => {
-                if (!val || !val.trim()) {
+                if (!val?.trim()) {
                     return "Prompt cannot be empty for custom mode.";
                 }
             },

--- a/src/cmux/commands/profiles/save.ts
+++ b/src/cmux/commands/profiles/save.ts
@@ -247,7 +247,7 @@ async function resolveName(rawName: string | undefined, scope: ProfileScope, int
             placeholder: defaultName(scope),
             defaultValue: defaultName(scope),
             validate: (input) => {
-                if (!input || !input.trim()) {
+                if (!input?.trim()) {
                     return "Name cannot be empty";
                 }
                 if (!NAME_PATTERN.test(input)) {

--- a/src/darwinkit/index.ts
+++ b/src/darwinkit/index.ts
@@ -160,7 +160,9 @@ async function handleCommandAction(cmd: CommandDef, sub: Command, actionArgs: un
 
     try {
         const result = await cmd.run(args);
-        out.println(formatOutput(result, format));
+        const output = formatOutput(result, format);
+        out.println(output);
+        await out.flush();
     } catch (error) {
         if (process.stdout.isTTY) {
             p.log.error(error instanceof Error ? error.message : String(error));
@@ -203,7 +205,9 @@ async function main(): Promise<void> {
     }
 }
 
-main().catch((err) => {
+try {
+    await main();
+} catch (err) {
     if (process.stdout.isTTY) {
         p.log.error(err instanceof Error ? err.message : String(err));
     } else {
@@ -212,4 +216,4 @@ main().catch((err) => {
 
     closeDarwinKit();
     process.exit(1);
-});
+}

--- a/src/dashboard/apps/web/src/lib/timer/hooks/useTimer.ts
+++ b/src/dashboard/apps/web/src/lib/timer/hooks/useTimer.ts
@@ -167,7 +167,7 @@ export function useTimer({ userId, timerId }: UseTimerOptions): UseTimerReturn {
     }
 
     function pause() {
-        if (!effectiveUserId || !timer || !timer.isRunning) {
+        if (!effectiveUserId || !timer?.isRunning) {
             return;
         }
 
@@ -191,7 +191,7 @@ export function useTimer({ userId, timerId }: UseTimerOptions): UseTimerReturn {
     }
 
     function addLap() {
-        if (!effectiveUserId || !timer || !timer.isRunning) {
+        if (!effectiveUserId || !timer?.isRunning) {
             return;
         }
 

--- a/src/dashboard/apps/web/src/routes/assistant/-components/analytics/CompletionTrend.tsx
+++ b/src/dashboard/apps/web/src/routes/assistant/-components/analytics/CompletionTrend.tsx
@@ -124,7 +124,7 @@ function CustomTooltip({
     payload?: Array<{ payload: TooltipPayload }>;
     label?: string;
 }) {
-    if (!active || !payload || !payload.length) {
+    if (!active || !payload?.length) {
         return null;
     }
 

--- a/src/dashboard/apps/web/src/routes/assistant/-components/analytics/DeadlinePerformance.tsx
+++ b/src/dashboard/apps/web/src/routes/assistant/-components/analytics/DeadlinePerformance.tsx
@@ -124,7 +124,7 @@ function CustomTooltip({
     payload?: Array<{ payload: TooltipPayload }>;
     total: number;
 }) {
-    if (!active || !payload || !payload.length) {
+    if (!active || !payload?.length) {
         return null;
     }
 

--- a/src/dashboard/apps/web/src/routes/assistant/-components/analytics/EnergyByDay.tsx
+++ b/src/dashboard/apps/web/src/routes/assistant/-components/analytics/EnergyByDay.tsx
@@ -121,7 +121,7 @@ interface TooltipPayload {
 }
 
 function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<{ payload: TooltipPayload }> }) {
-    if (!active || !payload || !payload.length) {
+    if (!active || !payload?.length) {
         return null;
     }
 

--- a/src/dashboard/apps/web/src/routes/assistant/-components/analytics/EnergyInsights.tsx
+++ b/src/dashboard/apps/web/src/routes/assistant/-components/analytics/EnergyInsights.tsx
@@ -42,7 +42,7 @@ function formatHourRange(hour: number): string {
  * Get peak focus time range description
  */
 function getPeakTimeDescription(data: EnergyHeatmapData | null): string {
-    if (!data || !data.peakTime) {
+    if (!data?.peakTime) {
         return "Not enough data";
     }
 
@@ -84,7 +84,7 @@ function getPeakTimeDescription(data: EnergyHeatmapData | null): string {
  * Get low energy time description
  */
 function getLowTimeDescription(data: EnergyHeatmapData | null): string {
-    if (!data || !data.lowTime) {
+    if (!data?.lowTime) {
         return "Not enough data";
     }
 

--- a/src/dev-dashboard/lib/system/history-db.ts
+++ b/src/dev-dashboard/lib/system/history-db.ts
@@ -86,7 +86,7 @@ export class PulseHistoryDb {
     getPublicIp(maxAgeMs: number): string | null {
         const row = this.db.prepare("SELECT v, updated_at FROM pulse_kv WHERE k = 'public_ip'").get() as KvRow | null;
 
-        if (!row || !row.v) {
+        if (!row?.v) {
             return null;
         }
 

--- a/src/macos/index.ts
+++ b/src/macos/index.ts
@@ -89,7 +89,9 @@ async function main(): Promise<void> {
     }
 }
 
-main().catch((err) => {
+try {
+    await main();
+} catch (err) {
     logger.error(`Unexpected error: ${err}`);
     process.exit(1);
-});
+}

--- a/src/mcp-tsc/LspWorker.ts
+++ b/src/mcp-tsc/LspWorker.ts
@@ -448,7 +448,7 @@ export class LspWorker {
         const content = readFileSync(file, "utf-8");
         const state = this.getFileState(uri);
 
-        if (!state || !state.isOpen) {
+        if (!state?.isOpen) {
             await this.openFile(file);
             return;
         }
@@ -476,7 +476,7 @@ export class LspWorker {
         const uri = `file://${file}`;
         const state = this.getFileState(uri);
 
-        if (!state || !state.isOpen) {
+        if (!state?.isOpen) {
             return true;
         }
 
@@ -571,7 +571,7 @@ export class LspWorker {
             for (const file of filesToProcess) {
                 const uri = `file://${file}`;
                 const state = this.getFileState(uri);
-                if (!state || !state.isOpen) {
+                if (!state?.isOpen) {
                     await this.openFile(file);
                 } else {
                     await this.updateFile(file);
@@ -785,7 +785,7 @@ export class LspWorker {
 
         // Ensure file is open
         const state = this.getFileState(uri);
-        if (!state || !state.isOpen) {
+        if (!state?.isOpen) {
             await this.openFile(file);
             // Give LSP a moment to process
             await new Promise((r) => setTimeout(r, 100));

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -335,4 +335,9 @@ async function main(): Promise<void> {
     }
 }
 
-main();
+try {
+    await main();
+} catch (err) {
+    logger.error(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+}

--- a/src/shops/api/shops/PilulkaClient.ts
+++ b/src/shops/api/shops/PilulkaClient.ts
@@ -190,7 +190,7 @@ function extractProductLinks(document: ReturnType<typeof parseHTML>["document"])
     const out: string[] = [];
     for (const item of Array.from(document.querySelectorAll(".product-list__item"))) {
         const href = item.querySelector("a")?.getAttribute("href");
-        if (!href || !href.startsWith("/")) {
+        if (!href?.startsWith("/")) {
             continue;
         }
 

--- a/src/telegram/runtime/shared/WatchSession.ts
+++ b/src/telegram/runtime/shared/WatchSession.ts
@@ -392,7 +392,7 @@ export class WatchSession {
         const mode = modelParts[0];
         const modelSpec = modelParts[1];
 
-        if (!modelSpec || !modelSpec.includes("/")) {
+        if (!modelSpec?.includes("/")) {
             return { handled: true, output: "Usage: /model <mode> <provider>/<model>" };
         }
 

--- a/src/transcribe/index.ts
+++ b/src/transcribe/index.ts
@@ -440,5 +440,6 @@ try {
     await main();
 } catch (err) {
     out.error(err instanceof Error ? err.message : String(err));
+    await out.flush();
     process.exit(1);
 }

--- a/src/transcribe/index.ts
+++ b/src/transcribe/index.ts
@@ -436,4 +436,9 @@ async function main(): Promise<void> {
     }
 }
 
-main();
+try {
+    await main();
+} catch (err) {
+    out.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+}

--- a/src/utils/macos/apple-calendar.ts
+++ b/src/utils/macos/apple-calendar.ts
@@ -132,7 +132,7 @@ export class MacCalendar {
         const dk = getDarwinKit();
         const existing = await dk.calendar.event({ identifier: eventId });
 
-        if (!existing || !existing.identifier) {
+        if (!existing?.identifier) {
             throw new Error(`Event not found: ${eventId}`);
         }
 

--- a/src/utils/macos/ocr.test.ts
+++ b/src/utils/macos/ocr.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { mergeTiledOcrResults } from "./ocr";
+
+describe("mergeTiledOcrResults", () => {
+    it("merges text and re-maps block y from tile-normalized to full-image coords", () => {
+        const merged = mergeTiledOcrResults(
+            [
+                {
+                    top: 0,
+                    tileHeight: 5000,
+                    result: {
+                        text: "top line",
+                        blocks: [
+                            {
+                                text: "top line",
+                                confidence: 1,
+                                bounds: { x: 0.1, y: 0.9, width: 0.2, height: 0.05 },
+                            },
+                        ],
+                    },
+                },
+                {
+                    top: 5000,
+                    tileHeight: 2562,
+                    result: {
+                        text: "bottom line",
+                        blocks: [
+                            {
+                                text: "bottom line",
+                                confidence: 1,
+                                bounds: { x: 0.1, y: 0.8, width: 0.2, height: 0.04 },
+                            },
+                        ],
+                    },
+                },
+            ],
+            12562
+        );
+
+        expect(merged.text).toBe("top line\nbottom line");
+        expect(merged.blocks).toHaveLength(2);
+
+        const topBlock = merged.blocks[0];
+        const bottomBlock = merged.blocks[1];
+
+        // bottom-left origin: top tile sits at the TOP of the image, so its
+        // base is high above the image bottom — block y must include that offset.
+        const topTileBottom = (12562 - 0 - 5000) / 12562;
+        expect(topBlock.bounds.y).toBeCloseTo(topTileBottom + 0.9 * (5000 / 12562), 5);
+        expect(topBlock.bounds.height).toBeCloseTo(0.05 * (5000 / 12562), 5);
+
+        const bottomTileBottom = (12562 - 5000 - 2562) / 12562;
+        expect(bottomBlock.bounds.y).toBeCloseTo(bottomTileBottom + 0.8 * (2562 / 12562), 5);
+        expect(bottomBlock.bounds.height).toBeCloseTo(0.04 * (2562 / 12562), 5);
+    });
+});

--- a/src/utils/macos/ocr.ts
+++ b/src/utils/macos/ocr.ts
@@ -1,14 +1,191 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { logger } from "@app/logger";
 import { getDarwinKit } from "./darwinkit";
-import type { OcrLevel, OcrResult } from "./types";
+import type { OcrBlock, OcrLevel, OcrResult } from "./types";
 
 export interface OcrOptions {
     /** BCP-47 language codes to use for recognition. Default: ["en-US"] */
     languages?: string[];
     /** "fast" for speed, "accurate" for quality. Default: "accurate" */
     level?: OcrLevel;
+}
+
+/** Vision accurate OCR returns empty results above ~6k px on one side (macOS 15). */
+const MAX_ACCURATE_DIMENSION = 6000;
+const TILE_HEIGHT = 5000;
+
+interface ImageDimensions {
+    width: number;
+    height: number;
+}
+
+interface TilePart {
+    result: OcrResult;
+    top: number;
+    tileHeight: number;
+}
+
+function isEmptyOcrResult(result: OcrResult): boolean {
+    if (result.text.trim().length > 0) {
+        return false;
+    }
+
+    return result.blocks.length === 0;
+}
+
+async function callVisionOcr(imagePath: string, languages: string[], level: OcrLevel): Promise<OcrResult> {
+    return getDarwinKit().vision.ocr({
+        path: imagePath,
+        languages,
+        level,
+    });
+}
+
+async function getImageDimensions(imagePath: string): Promise<ImageDimensions | null> {
+    const proc = Bun.spawn(["sips", "-g", "pixelWidth", "-g", "pixelHeight", imagePath], {
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+
+    if (exitCode !== 0) {
+        return null;
+    }
+
+    const widthMatch = stdout.match(/pixelWidth:\s*(\d+)/);
+    const heightMatch = stdout.match(/pixelHeight:\s*(\d+)/);
+
+    if (!widthMatch || !heightMatch) {
+        return null;
+    }
+
+    return {
+        width: Number(widthMatch[1]),
+        height: Number(heightMatch[1]),
+    };
+}
+
+async function cropImageTile(
+    sourcePath: string,
+    destPath: string,
+    opts: { top: number; height: number; width: number }
+): Promise<boolean> {
+    const proc = Bun.spawn(
+        [
+            "sips",
+            "-c",
+            String(opts.height),
+            String(opts.width),
+            "--cropOffset",
+            String(opts.top),
+            "0",
+            sourcePath,
+            "--out",
+            destPath,
+        ],
+        { stdout: "pipe", stderr: "pipe" }
+    );
+
+    const exitCode = await proc.exited;
+
+    return exitCode === 0;
+}
+
+function toNormalized(value: number | string): number {
+    return typeof value === "number" ? value : Number(value);
+}
+
+export function mergeTiledOcrResults(parts: TilePart[], fullHeight: number): OcrResult {
+    const blocks: OcrBlock[] = [];
+    const textParts: string[] = [];
+
+    for (const { result, top, tileHeight } of parts) {
+        if (result.text.trim().length > 0) {
+            textParts.push(result.text);
+        }
+
+        const tileBottomFromImageBottom = (fullHeight - top - tileHeight) / fullHeight;
+        const tileHeightNorm = tileHeight / fullHeight;
+
+        for (const block of result.blocks) {
+            const y = toNormalized(block.bounds.y);
+            const h = toNormalized(block.bounds.height);
+
+            blocks.push({
+                ...block,
+                bounds: {
+                    ...block.bounds,
+                    y: tileBottomFromImageBottom + y * tileHeightNorm,
+                    height: h * tileHeightNorm,
+                },
+            });
+        }
+    }
+
+    return {
+        text: textParts.join("\n"),
+        blocks,
+    };
+}
+
+function needsAccurateTiling(dims: ImageDimensions): boolean {
+    return dims.height > MAX_ACCURATE_DIMENSION || dims.width > MAX_ACCURATE_DIMENSION;
+}
+
+async function recognizeTextTiled(
+    imagePath: string,
+    dims: ImageDimensions,
+    languages: string[],
+    level: OcrLevel
+): Promise<OcrResult> {
+    const parts: TilePart[] = [];
+    const tempPaths: string[] = [];
+
+    try {
+        for (let top = 0; top < dims.height; top += TILE_HEIGHT) {
+            const tileHeight = Math.min(TILE_HEIGHT, dims.height - top);
+            const tempPath = join(tmpdir(), `darwin-ocr-tile-${Date.now()}-${top}.png`);
+            tempPaths.push(tempPath);
+
+            const cropped = await cropImageTile(imagePath, tempPath, {
+                top,
+                height: tileHeight,
+                width: dims.width,
+            });
+
+            if (!cropped) {
+                logger.warn({ imagePath, top, tileHeight }, "darwin-ocr: tile crop failed");
+                continue;
+            }
+
+            const result = await callVisionOcr(tempPath, languages, level);
+            parts.push({ result, top, tileHeight });
+        }
+    } finally {
+        for (const tempPath of tempPaths) {
+            if (existsSync(tempPath)) {
+                try {
+                    unlinkSync(tempPath);
+                } catch (err) {
+                    logger.debug({ err, tempPath }, "darwin-ocr: failed to remove tile temp file");
+                }
+            }
+        }
+    }
+
+    if (parts.length === 0) {
+        return { text: "", blocks: [] };
+    }
+
+    logger.debug(
+        { imagePath, tiles: parts.length, width: dims.width, height: dims.height },
+        "darwin-ocr: used vertical tiling for oversized image"
+    );
+
+    return mergeTiledOcrResults(parts, dims.height);
 }
 
 /**
@@ -18,11 +195,31 @@ export interface OcrOptions {
  * @param imagePath - Absolute path to the image file (JPEG, PNG, TIFF, HEIC, PDF)
  */
 export async function recognizeText(imagePath: string, options: OcrOptions = {}): Promise<OcrResult> {
-    return getDarwinKit().vision.ocr({
-        path: imagePath,
-        languages: options.languages ?? ["en-US"],
-        level: options.level ?? "accurate",
-    });
+    const level = options.level ?? "accurate";
+    const languages = options.languages ?? ["en-US"];
+
+    if (level === "accurate") {
+        const dims = await getImageDimensions(imagePath);
+
+        if (dims && needsAccurateTiling(dims)) {
+            const tiled = await recognizeTextTiled(imagePath, dims, languages, level);
+
+            if (!isEmptyOcrResult(tiled)) {
+                return tiled;
+            }
+
+            logger.debug({ imagePath, dims }, "darwin-ocr: tiled accurate empty, falling back to fast");
+        }
+    }
+
+    const result = await callVisionOcr(imagePath, languages, level);
+
+    if (level === "accurate" && isEmptyOcrResult(result)) {
+        logger.debug({ imagePath }, "darwin-ocr: accurate empty, falling back to fast");
+        return callVisionOcr(imagePath, languages, "fast");
+    }
+
+    return result;
 }
 
 /**
@@ -45,7 +242,9 @@ export async function recognizeTextFromBuffer(
         if (existsSync(tempPath)) {
             try {
                 unlinkSync(tempPath);
-            } catch {}
+            } catch (err) {
+                logger.debug({ err, tempPath }, "darwin-ocr: failed to remove buffer temp file");
+            }
         }
     }
 }

--- a/src/youtube/commands/transcribe.ts
+++ b/src/youtube/commands/transcribe.ts
@@ -156,7 +156,7 @@ async function resolveInput(
         message: "Enter YouTube URL or video ID:",
         placeholder: "https://www.youtube.com/watch?v=...",
         validate: (value) => {
-            if (!value || !value.trim()) {
+            if (!value?.trim()) {
                 return "URL is required";
             }
 

--- a/src/youtube/lib/yt-dlp.ts
+++ b/src/youtube/lib/yt-dlp.ts
@@ -343,7 +343,7 @@ function normalizeListedVideo(entry: RawListedVideo, tab: ChannelTab): ListedVid
 }
 
 function normalizeUploadDate(uploadDate?: string): string | null {
-    if (!uploadDate || uploadDate.length !== 8) {
+    if (uploadDate?.length !== 8) {
         return null;
     }
 


### PR DESCRIPTION
## Summary

Four small, independent commits — bundled because they all came out of the same shell-tool cleanup pass:

- **fix(aliases): merge zsh multi-line history + lower chain threshold** — `tools aliases` was producing pure garbage (stack-trace fragments, jq filter lines, php heredoc continuations) because `parseHistory` treated every physical line as a separate command, but zsh stores multi-line entries with `\`-escaped newlines. After coalescing continuations: 13278 mined lines → 9507 real entries, 20 hot paths → 7 actual useful ones. Also: surface single-command repeats (`--min-n=1`) with a higher bar (`--threshold=3`) while letting chains in at `--chain-threshold=2`; display chains with the actual `&&` shell operator; gate suggestions through a new `isWorthAliasing` check so trivial 5-char commands like `cd ..` don't get aliased to `c..`. Renamed `myelin.ts` → `analysis.ts` and dropped the biology metaphors.
- **chore(aliases): biome import-sort + format follow-up** — formatting the first commit's hook applied to the working tree but not the index.
- **fix(tools): use top-level await in entrypoints so piped stdout drains** — `main().catch(...)` at module top let Bun exit before the final `out.println` drained when the action held a loop-keeping resource (the DarwinKit IPC subprocess) that got killed in `finally`. Repro: `tools darwinkit ocr <img> --format raw | cat` returned empty / exit 0. Top-level await buys the extra tick the fire-and-forget writeStdout needs to settle. Same pattern fixed in `tools macos` (calendar/reminders), `transcribe`, `ai`, `notify`.
- **chore: biome useOptionalChain auto-fix across the repo** — mechanical `!x || !x.y` → `!x?.y` rewrite across 17 unrelated files that the pre-push lint flagged.

## Test plan

- [ ] `bun test src/aliases/lib/aliases.test.ts` passes (26 tests, including 4 new for the multi-line parser + 1 for dual thresholds + 2 for `isWorthAliasing`)
- [ ] `tsgo --noEmit` clean
- [ ] `bunx biome check .` clean (no `useOptionalChain` warnings left)
- [ ] Sanity-run `tools aliases` against your own `~/.zsh_history` and confirm the output looks sane (no stack frames, no `\` continuation crud, suggested aliases like `cr`, `tcu`, `sbbbd` make sense)
- [ ] Sanity-run `tools darwinkit ocr <image> --format raw | cat` and confirm output actually arrives (was silently empty before)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alias scanning now supports separate thresholds for single commands vs multi-command chains.
  * Alias mining now persists and reports **alias-level** state, including reset/decay/status updates.
  * OCR “accurate” mode now tiles large images and merges results into a single output.
* **Bug Fixes**
  * Improved unexpected-error handling in multiple CLI entrypoints (flush output and exit with error code).
  * More robust empty/missing-data checks across interactive prompts and dashboard tooltips.
  * Better handling of missing/empty spreadsheet sheet content during rental parsing.
* **Tests**
  * Expanded alias mining/history parsing and “worth it” logic coverage; added OCR merge coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->