### PR TITLE
feat(stash): global cross-project code-overlay manager

### DIFF
--- a/.claude/plans/2026-06-24-StashTool-plan.md
+++ b/.claude/plans/2026-06-24-StashTool-plan.md
@@ -1,0 +1,3696 @@
+# Stash Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `tools stash` — a global cross-project code-overlay manager with versioned named stashes, drift-tolerant apply via `git apply --3way`, foldable `@stash` region markers, and a reviewable multi-step unapply state machine.
+
+**Architecture:** Bun + commander CLI under `src/stash/`. Storage = bare git repo at `~/.genesis-tools/stash/store/` (patches as git commits, blob OIDs survive for 3-way) + SQLite index at `~/.genesis-tools/stash/index.db`. Marker decoration uses `// #region @stash:<name> {json}` to layer on the existing `@dbg` foldable-region convention. Unapply is a persistent state machine modeled on `git rebase --continue / --abort`.
+
+**Tech Stack:** Bun, TypeScript (strict), commander, @clack/prompts, bun:sqlite, git CLI via `Bun.spawn()`, pino logger (existing `@app/logger`), SafeJSON (existing `@app/utils/json`).
+
+**Spec:** `.claude/plans/2026-06-24-StashTool-spec.md` — refer for full design rationale.
+
+---
+
+## File Structure
+
+**New files (all under `src/stash/`):**
+
+```
+src/stash/
+├── index.ts                          # commander entrypoint
+├── README.md                         # tool documentation (auto-shown by --readme)
+├── types.ts                          # shared types
+├── commands/
+│   ├── save.ts                       # save subcommand
+│   ├── apply.ts                      # apply subcommand
+│   ├── unapply.ts                    # unapply subcommand (state machine driver)
+│   ├── update.ts                     # update subcommand
+│   ├── list.ts                       # list subcommand
+│   ├── show.ts                       # show subcommand
+│   ├── versions.ts                   # versions subcommand
+│   ├── drop.ts                       # drop subcommand
+│   └── where.ts                      # where subcommand
+├── lib/
+│   ├── storage.ts                    # StashStorage (paths, init dirs)
+│   ├── stash-db.ts                   # SQLite open + DAO methods
+│   ├── stash-migrations.ts           # Migration[] for sqlite schema
+│   ├── store-repo.ts                 # bare git repo I/O (init, save patch, fetch baseline)
+│   ├── markers.ts                    # parse / emit / strip @stash markers
+│   ├── languages.ts                  # ext → comment syntax mapping
+│   ├── regions.ts                    # working-tree region discovery + extraction
+│   ├── patch.ts                      # format-patch generation + apply via git
+│   ├── projects.ts                   # origin URL detection + sibling-clone match
+│   ├── ids.ts                        # uuid v7 + short-id derivation
+│   └── unapply-session.ts            # UnapplySession state machine
+└── *.test.ts                         # colocated tests (bun:test)
+
+.claude/skills/stash/
+└── SKILL.md                          # agent-facing skill
+```
+
+**Modifications:** None to existing files. The tool is fully additive (commander tools auto-discover from `src/`).
+
+---
+
+## Phase 1 — Foundation
+
+### Task 1: Scaffold tool entrypoint + storage paths
+
+**Files:**
+- Create: `src/stash/index.ts`
+- Create: `src/stash/lib/storage.ts`
+- Create: `src/stash/lib/storage.test.ts`
+
+- [ ] **Step 1: Write failing test for StashStorage paths**
+
+```typescript
+// src/stash/lib/storage.test.ts
+import { describe, expect, test } from "bun:test";
+import { StashStorage } from "./storage";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+describe("StashStorage", () => {
+    test("returns correct paths under ~/.genesis-tools/stash/", () => {
+        const s = new StashStorage();
+        expect(s.root()).toBe(join(homedir(), ".genesis-tools", "stash"));
+        expect(s.storeRepoDir()).toBe(join(s.root(), "store"));
+        expect(s.dbPath()).toBe(join(s.root(), "index.db"));
+        expect(s.stateDir()).toBe(join(s.root(), "state"));
+        expect(s.cacheDir()).toBe(join(s.root(), "cache"));
+    });
+
+    test("ensureDirs creates all subdirectories", async () => {
+        const s = new StashStorage();
+        await s.ensureDirs();
+        const { existsSync } = await import("node:fs");
+        expect(existsSync(s.storeRepoDir())).toBe(true);
+        expect(existsSync(s.stateDir())).toBe(true);
+        expect(existsSync(s.cacheDir())).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/stash/lib/storage.test.ts`
+Expected: FAIL — `Cannot find module './storage'`
+
+- [ ] **Step 3: Implement StashStorage**
+
+```typescript
+// src/stash/lib/storage.ts
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export class StashStorage {
+    private readonly base: string;
+
+    constructor(base?: string) {
+        this.base = base ?? join(homedir(), ".genesis-tools", "stash");
+    }
+
+    root(): string {
+        return this.base;
+    }
+
+    storeRepoDir(): string {
+        return join(this.base, "store");
+    }
+
+    dbPath(): string {
+        return join(this.base, "index.db");
+    }
+
+    stateDir(): string {
+        return join(this.base, "state");
+    }
+
+    cacheDir(): string {
+        return join(this.base, "cache");
+    }
+
+    async ensureDirs(): Promise<void> {
+        await Promise.all([
+            mkdir(this.storeRepoDir(), { recursive: true }),
+            mkdir(this.stateDir(), { recursive: true }),
+            mkdir(this.cacheDir(), { recursive: true }),
+        ]);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/stash/lib/storage.test.ts`
+Expected: 2 pass
+
+- [ ] **Step 5: Create commander entrypoint stub**
+
+```typescript
+// src/stash/index.ts
+#!/usr/bin/env bun
+import { Command } from "commander";
+import { runTool } from "@app/utils/cli";
+
+const program = new Command();
+program
+    .name("tools stash")
+    .description("Global cross-project code-overlay manager")
+    .version("0.1.0");
+
+// Subcommands wired in later tasks
+program
+    .command("save <name>")
+    .description("Capture working-tree changes as a named stash")
+    .action(async (_name: string) => {
+        console.error("save: not implemented yet");
+        process.exit(1);
+    });
+
+await runTool(program, { tool: "stash" });
+```
+
+- [ ] **Step 6: Verify tool auto-discovery**
+
+Run: `tools stash --help`
+Expected: prints commander help with `save` subcommand listed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/stash/
+git commit -m "feat(stash): scaffold tool with StashStorage paths"
+```
+
+---
+
+### Task 2: SQLite schema + migrations
+
+**Files:**
+- Create: `src/stash/lib/stash-migrations.ts`
+- Create: `src/stash/lib/stash-db.ts`
+- Create: `src/stash/lib/stash-db.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/stash-db.test.ts
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { openStashDb } from "./stash-db";
+
+describe("openStashDb", () => {
+    test("creates all tables on first open", () => {
+        const db = new Database(":memory:");
+        openStashDb(db);
+        const tables = db
+            .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .all()
+            .map((r) => r.name);
+        expect(tables).toContain("stashes");
+        expect(tables).toContain("versions");
+        expect(tables).toContain("regions");
+        expect(tables).toContain("applications");
+        expect(tables).toContain("projects");
+        expect(tables).toContain("_migrations");
+    });
+
+    test("idempotent — second open does not error", () => {
+        const db = new Database(":memory:");
+        openStashDb(db);
+        openStashDb(db);
+        const count = db
+            .query<{ c: number }, []>("SELECT COUNT(*) as c FROM _migrations")
+            .get();
+        expect(count?.c).toBeGreaterThan(0);
+    });
+
+    test("unique active application constraint", () => {
+        const db = new Database(":memory:");
+        openStashDb(db);
+        db.run(
+            "INSERT INTO stashes (id, name, created_at, updated_at) VALUES ('s1', 'foo', '2026-01-01', '2026-01-01')",
+        );
+        db.run(
+            "INSERT INTO versions (id, stash_id, version, patch_ref, region_count, file_count, created_at) VALUES ('v1', 's1', 1, 'refs/stashes/s1/v1', 1, 1, '2026-01-01')",
+        );
+        db.run(
+            "INSERT INTO applications (id, stash_id, version_id, project_path, applied_at, state) VALUES ('a1', 's1', 'v1', '/p', '2026-01-01', 'active')",
+        );
+        expect(() =>
+            db.run(
+                "INSERT INTO applications (id, stash_id, version_id, project_path, applied_at, state) VALUES ('a2', 's1', 'v1', '/p', '2026-01-01', 'active')",
+            ),
+        ).toThrow();
+    });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL "cannot find module './stash-db'"**
+
+Run: `bun test src/stash/lib/stash-db.test.ts`
+
+- [ ] **Step 3: Write migrations**
+
+```typescript
+// src/stash/lib/stash-migrations.ts
+import type { Migration } from "@app/utils/database/migrations";
+
+export const STASH_MIGRATIONS: Migration[] = [
+    {
+        id: "001-initial-schema",
+        sql: `
+            CREATE TABLE stashes (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                tags TEXT,
+                description TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE versions (
+                id TEXT PRIMARY KEY,
+                stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+                version INTEGER NOT NULL,
+                patch_ref TEXT NOT NULL,
+                source_repo_path TEXT,
+                source_origin TEXT,
+                source_sha TEXT,
+                region_count INTEGER NOT NULL,
+                file_count INTEGER NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                UNIQUE(stash_id, version)
+            );
+            CREATE TABLE regions (
+                id TEXT PRIMARY KEY,
+                version_id TEXT NOT NULL REFERENCES versions(id) ON DELETE CASCADE,
+                region_name TEXT,
+                file_path TEXT NOT NULL,
+                hunk_index INTEGER NOT NULL,
+                start_marker_present INTEGER NOT NULL DEFAULT 0,
+                line_count INTEGER NOT NULL
+            );
+            CREATE TABLE applications (
+                id TEXT PRIMARY KEY,
+                stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+                version_id TEXT NOT NULL REFERENCES versions(id),
+                project_path TEXT NOT NULL,
+                project_origin TEXT,
+                project_sha_at_apply TEXT,
+                applied_at TEXT NOT NULL,
+                state TEXT NOT NULL,
+                unapplied_at TEXT
+            );
+            CREATE TABLE projects (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL UNIQUE,
+                origin TEXT,
+                tree_hash TEXT,
+                last_seen TEXT NOT NULL
+            );
+            CREATE INDEX idx_versions_stash ON versions(stash_id);
+            CREATE INDEX idx_applications_project ON applications(project_path);
+            CREATE INDEX idx_applications_stash ON applications(stash_id);
+            CREATE INDEX idx_regions_version ON regions(version_id);
+            CREATE UNIQUE INDEX idx_applications_active
+                ON applications(stash_id, project_path)
+                WHERE state = 'active';
+        `,
+    },
+];
+```
+
+- [ ] **Step 4: Write openStashDb**
+
+```typescript
+// src/stash/lib/stash-db.ts
+import type { Database } from "bun:sqlite";
+import { runMigrations } from "@app/utils/database/migrations";
+import { STASH_MIGRATIONS } from "./stash-migrations";
+
+export function openStashDb(db: Database): Database {
+    db.run("PRAGMA foreign_keys = ON");
+    db.run("PRAGMA journal_mode = WAL");
+    runMigrations(db, STASH_MIGRATIONS);
+    return db;
+}
+```
+
+- [ ] **Step 5: Run tests — expect 3 pass**
+
+Run: `bun test src/stash/lib/stash-db.test.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/stash/lib/stash-migrations.ts src/stash/lib/stash-db.ts src/stash/lib/stash-db.test.ts
+git commit -m "feat(stash): sqlite schema + migrations"
+```
+
+---
+
+### Task 3: Bare git store repo
+
+**Files:**
+- Create: `src/stash/lib/store-repo.ts`
+- Create: `src/stash/lib/store-repo.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/store-repo.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StoreRepo } from "./store-repo";
+
+let storeDir: string;
+beforeEach(async () => {
+    storeDir = await mkdtemp(join(tmpdir(), "stash-store-"));
+});
+afterEach(async () => {
+    await rm(storeDir, { recursive: true, force: true });
+});
+
+describe("StoreRepo", () => {
+    test("init creates a bare git repo", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        const { existsSync } = await import("node:fs");
+        expect(existsSync(join(storeDir, "HEAD"))).toBe(true);
+        expect(existsSync(join(storeDir, "refs"))).toBe(true);
+    });
+
+    test("init is idempotent", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        await repo.init();
+        // no throw
+    });
+
+    test("writePatchCommit creates a ref pointing at a commit", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        const sha = await repo.writePatchCommit({
+            ref: "refs/stashes/abc/v1",
+            files: { "a.ts": "console.log(1);\n" },
+            message: "stash:test v1",
+        });
+        expect(sha).toMatch(/^[a-f0-9]{40}$/);
+        const resolved = await repo.resolveRef("refs/stashes/abc/v1");
+        expect(resolved).toBe(sha);
+    });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `bun test src/stash/lib/store-repo.test.ts`
+
+- [ ] **Step 3: Implement StoreRepo**
+
+```typescript
+// src/stash/lib/store-repo.ts
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+
+const log = logger.scoped("stash:store-repo").log;
+
+export interface WritePatchCommitArgs {
+    ref: string;
+    files: Record<string, string>;
+    message: string;
+    parentRef?: string;
+}
+
+export class StoreRepo {
+    constructor(private readonly dir: string) {}
+
+    async init(): Promise<void> {
+        await mkdir(this.dir, { recursive: true });
+        if (existsSync(join(this.dir, "HEAD"))) {
+            return;
+        }
+        await this.git(["init", "--bare", "--initial-branch=main"]);
+        log.debug({ dir: this.dir }, "initialized bare store repo");
+    }
+
+    async writePatchCommit(args: WritePatchCommitArgs): Promise<string> {
+        // Build a tree by writing blobs then a tree object, then commit.
+        const blobShas: Record<string, string> = {};
+        for (const [path, content] of Object.entries(args.files)) {
+            blobShas[path] = await this.gitWithStdin(["hash-object", "-w", "--stdin"], content);
+        }
+        const mktreeInput = Object.entries(blobShas)
+            .map(([path, sha]) => `100644 blob ${sha}\t${path}`)
+            .join("\n");
+        const treeSha = await this.gitWithStdin(["mktree"], mktreeInput + "\n");
+
+        const commitArgs = ["commit-tree", treeSha, "-m", args.message];
+        if (args.parentRef) {
+            const parentSha = await this.resolveRef(args.parentRef);
+            if (parentSha) {
+                commitArgs.push("-p", parentSha);
+            }
+        }
+        const commitSha = await this.git(commitArgs);
+        await this.git(["update-ref", args.ref, commitSha]);
+        return commitSha.trim();
+    }
+
+    async resolveRef(ref: string): Promise<string | null> {
+        try {
+            const sha = await this.git(["rev-parse", "--verify", ref]);
+            return sha.trim();
+        } catch {
+            return null;
+        }
+    }
+
+    async readFileAt(ref: string, path: string): Promise<string | null> {
+        try {
+            return await this.git(["show", `${ref}:${path}`]);
+        } catch {
+            return null;
+        }
+    }
+
+    async deleteRef(ref: string): Promise<void> {
+        await this.git(["update-ref", "-d", ref]);
+    }
+
+    async listRefs(prefix: string): Promise<string[]> {
+        try {
+            const out = await this.git(["for-each-ref", "--format=%(refname)", prefix]);
+            return out
+                .split("\n")
+                .map((s) => s.trim())
+                .filter(Boolean);
+        } catch {
+            return [];
+        }
+    }
+
+    private async git(args: string[]): Promise<string> {
+        const proc = Bun.spawn(["git", "--git-dir", this.dir, ...args], {
+            stdout: "pipe",
+            stderr: "pipe",
+            env: {
+                ...process.env,
+                GIT_AUTHOR_NAME: "stash",
+                GIT_AUTHOR_EMAIL: "stash@genesistools.local",
+                GIT_COMMITTER_NAME: "stash",
+                GIT_COMMITTER_EMAIL: "stash@genesistools.local",
+            },
+        });
+        const [stdout, stderr, exit] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+        if (exit !== 0) {
+            throw new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`);
+        }
+        return stdout;
+    }
+
+    private async gitWithStdin(args: string[], input: string): Promise<string> {
+        const proc = Bun.spawn(["git", "--git-dir", this.dir, ...args], {
+            stdin: "pipe",
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        proc.stdin.write(input);
+        await proc.stdin.end();
+        const [stdout, stderr, exit] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+        if (exit !== 0) {
+            throw new Error(`git ${args.join(" ")} (stdin) failed: ${stderr.trim()}`);
+        }
+        return stdout.trim();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect 3 pass**
+
+Run: `bun test src/stash/lib/store-repo.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stash/lib/store-repo.ts src/stash/lib/store-repo.test.ts
+git commit -m "feat(stash): bare git store repo with hash-object/mktree commit machinery"
+```
+
+---
+
+### Task 4: ID helpers (uuid v7 + short ID)
+
+**Files:**
+- Create: `src/stash/lib/ids.ts`
+- Create: `src/stash/lib/ids.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/ids.test.ts
+import { describe, expect, test } from "bun:test";
+import { newStashId, shortId } from "./ids";
+
+describe("ids", () => {
+    test("newStashId returns 32 hex chars", () => {
+        const id = newStashId();
+        expect(id).toMatch(/^[a-f0-9]{32}$/);
+    });
+
+    test("shortId returns first 6 hex chars", () => {
+        expect(shortId("3f2a8b7c1d4e5f6a7b8c9d0e1f2a3b4c")).toBe("3f2a8b");
+    });
+
+    test("newStashId is monotonically time-ordered (v7-ish)", () => {
+        const a = newStashId();
+        const b = newStashId();
+        expect(a < b || a === b).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/ids.ts
+import { randomBytes } from "node:crypto";
+
+export function newStashId(): string {
+    // Loose UUIDv7: 48-bit timestamp ms + 80 bits random — preserves ordering for sqlite indexes.
+    const now = BigInt(Date.now());
+    const tsHex = now.toString(16).padStart(12, "0");
+    const rand = randomBytes(10).toString("hex");
+    return tsHex + rand;
+}
+
+export function shortId(id: string): string {
+    return id.slice(0, 6);
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/ids.test.ts` — 3 pass.
+
+```bash
+git add src/stash/lib/ids.ts src/stash/lib/ids.test.ts
+git commit -m "feat(stash): uuid-v7-ish ID generator + shortId helper"
+```
+
+---
+
+## Phase 2 — Markers
+
+### Task 5: Language → comment syntax mapping
+
+**Files:**
+- Create: `src/stash/lib/languages.ts`
+- Create: `src/stash/lib/languages.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/languages.test.ts
+import { describe, expect, test } from "bun:test";
+import { commentSyntaxForFile } from "./languages";
+
+describe("commentSyntaxForFile", () => {
+    test("ts/tsx/js/jsx/php/java/c/cpp/go/rs/swift → //", () => {
+        for (const f of ["a.ts", "a.tsx", "a.js", "a.jsx", "a.php", "a.java", "a.c", "a.cpp", "a.go", "a.rs", "a.swift"]) {
+            expect(commentSyntaxForFile(f).line).toBe("//");
+        }
+    });
+    test("python/ruby/bash/yaml/toml → #", () => {
+        for (const f of ["a.py", "a.rb", "a.sh", "a.yaml", "a.yml", "a.toml"]) {
+            expect(commentSyntaxForFile(f).line).toBe("#");
+        }
+    });
+    test("html/xml/md → <!-- -->", () => {
+        for (const f of ["a.html", "a.xml", "a.md"]) {
+            expect(commentSyntaxForFile(f).block).toEqual({ open: "<!--", close: "-->" });
+            expect(commentSyntaxForFile(f).line).toBe(null);
+        }
+    });
+    test("css → /* */", () => {
+        expect(commentSyntaxForFile("a.css").block).toEqual({ open: "/*", close: "*/" });
+    });
+    test("unknown extension falls back to //", () => {
+        expect(commentSyntaxForFile("a.xyz").line).toBe("//");
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/languages.ts
+import { extname } from "node:path";
+
+export interface CommentSyntax {
+    line: string | null;
+    block: { open: string; close: string } | null;
+}
+
+const SLASH: CommentSyntax = { line: "//", block: { open: "/*", close: "*/" } };
+const HASH: CommentSyntax = { line: "#", block: null };
+const XML: CommentSyntax = { line: null, block: { open: "<!--", close: "-->" } };
+const CSS: CommentSyntax = { line: null, block: { open: "/*", close: "*/" } };
+
+const MAP: Record<string, CommentSyntax> = {
+    ts: SLASH, tsx: SLASH, js: SLASH, jsx: SLASH, mjs: SLASH, cjs: SLASH,
+    php: SLASH, java: SLASH, c: SLASH, h: SLASH, cpp: SLASH, hpp: SLASH,
+    go: SLASH, rs: SLASH, swift: SLASH, kt: SLASH, scala: SLASH, dart: SLASH,
+    py: HASH, rb: HASH, sh: HASH, bash: HASH, zsh: HASH, fish: HASH,
+    yaml: HASH, yml: HASH, toml: HASH,
+    html: XML, xml: XML, svg: XML, md: XML, vue: XML,
+    css: CSS, scss: CSS, less: CSS,
+};
+
+export function commentSyntaxForFile(path: string): CommentSyntax {
+    const ext = extname(path).slice(1).toLowerCase();
+    return MAP[ext] ?? SLASH;
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/languages.test.ts` — 5 pass.
+
+```bash
+git add src/stash/lib/languages.ts src/stash/lib/languages.test.ts
+git commit -m "feat(stash): per-file-ext comment syntax mapping"
+```
+
+---
+
+### Task 6: Marker parse / emit / strip
+
+**Files:**
+- Create: `src/stash/lib/markers.ts`
+- Create: `src/stash/lib/markers.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/markers.test.ts
+import { describe, expect, test } from "bun:test";
+import { emitOpenMarker, emitCloseMarker, parseMarkers, stripMarkers, type MarkerMeta } from "./markers";
+
+describe("markers", () => {
+    test("emit open marker for // syntax", () => {
+        const meta: MarkerMeta = { id: "3f2a8b", v: 2 };
+        const line = emitOpenMarker({ name: "debug-logger", meta, syntax: { line: "//", block: null } });
+        expect(line).toBe(`// #region @stash:debug-logger {"id":"3f2a8b","v":2}`);
+    });
+
+    test("emit open marker for # syntax", () => {
+        const meta: MarkerMeta = { id: "3f2a8b", v: 1 };
+        const line = emitOpenMarker({ name: "x", meta, syntax: { line: "#", block: null } });
+        expect(line).toBe(`# #region @stash:x {"id":"3f2a8b","v":1}`);
+    });
+
+    test("emit open marker for block-only (HTML)", () => {
+        const meta: MarkerMeta = { id: "abc", v: 1 };
+        const line = emitOpenMarker({
+            name: "x",
+            meta,
+            syntax: { line: null, block: { open: "<!--", close: "-->" } },
+        });
+        expect(line).toBe(`<!-- #region @stash:x {"id":"abc","v":1} -->`);
+    });
+
+    test("emit close marker (bare)", () => {
+        const line = emitCloseMarker({ name: "debug-logger", syntax: { line: "//", block: null } });
+        expect(line).toBe(`// #endregion @stash:debug-logger`);
+    });
+
+    test("parseMarkers finds open+close pair in TS file", () => {
+        const src = [
+            "function foo() {",
+            `    // #region @stash:debug-logger {"id":"3f2a8b","v":2}`,
+            "    console.log('debug');",
+            "    // #endregion @stash:debug-logger",
+            "}",
+        ].join("\n");
+        const found = parseMarkers(src);
+        expect(found).toHaveLength(1);
+        expect(found[0]?.name).toBe("debug-logger");
+        expect(found[0]?.meta.id).toBe("3f2a8b");
+        expect(found[0]?.meta.v).toBe(2);
+        expect(found[0]?.startLine).toBe(2);
+        expect(found[0]?.endLine).toBe(4);
+    });
+
+    test("parseMarkers handles bare author markers (no JSON)", () => {
+        const src = [
+            `// #region @stash:debug-logger`,
+            `x();`,
+            `// #endregion @stash:debug-logger`,
+        ].join("\n");
+        const found = parseMarkers(src);
+        expect(found).toHaveLength(1);
+        expect(found[0]?.meta).toEqual({});
+    });
+
+    test("stripMarkers removes both open and close lines", () => {
+        const src = [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "inside",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n");
+        expect(stripMarkers(src)).toBe(["before", "inside", "after"].join("\n"));
+    });
+
+    test("stripMarkers only removes @stash markers, not unrelated #region", () => {
+        const src = [
+            "// #region someOtherRegion",
+            "x",
+            "// #endregion someOtherRegion",
+        ].join("\n");
+        expect(stripMarkers(src)).toBe(src);
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/markers.ts
+import { SafeJSON } from "@app/utils/json";
+import type { CommentSyntax } from "./languages";
+
+export interface MarkerMeta {
+    id?: string;
+    v?: number;
+    hunk?: number;
+    src?: string;
+    applied?: string;
+}
+
+export interface ParsedMarker {
+    name: string;
+    meta: MarkerMeta;
+    startLine: number;       // 1-indexed line of open marker
+    endLine: number;         // 1-indexed line of close marker
+    contentStartLine: number;
+    contentEndLine: number;
+}
+
+const OPEN_RE = /#region\s+@stash:([\w.\-]+)(?:\s+(\{.*?\}))?(?:\s*(?:-->|\*\/))?\s*$/;
+const CLOSE_RE = /#endregion\s+@stash:([\w.\-]+)/;
+
+export function emitOpenMarker(args: {
+    name: string;
+    meta: MarkerMeta;
+    syntax: CommentSyntax;
+}): string {
+    const json = SafeJSON.stringify(args.meta);
+    if (args.syntax.line) {
+        return `${args.syntax.line} #region @stash:${args.name} ${json}`;
+    }
+    const b = args.syntax.block;
+    if (!b) {
+        throw new Error("language has no comment syntax");
+    }
+    return `${b.open} #region @stash:${args.name} ${json} ${b.close}`;
+}
+
+export function emitCloseMarker(args: {
+    name: string;
+    syntax: CommentSyntax;
+}): string {
+    if (args.syntax.line) {
+        return `${args.syntax.line} #endregion @stash:${args.name}`;
+    }
+    const b = args.syntax.block;
+    if (!b) {
+        throw new Error("language has no comment syntax");
+    }
+    return `${b.open} #endregion @stash:${args.name} ${b.close}`;
+}
+
+export function parseMarkers(source: string): ParsedMarker[] {
+    const lines = source.split("\n");
+    const opens: Array<{ name: string; meta: MarkerMeta; line: number }> = [];
+    const closes: Array<{ name: string; line: number }> = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? "";
+        const closeMatch = CLOSE_RE.exec(line);
+        if (closeMatch) {
+            closes.push({ name: closeMatch[1] ?? "", line: i + 1 });
+            continue;
+        }
+        const openMatch = OPEN_RE.exec(line);
+        if (openMatch) {
+            const name = openMatch[1] ?? "";
+            const json = openMatch[2];
+            let meta: MarkerMeta = {};
+            if (json) {
+                try {
+                    meta = SafeJSON.parse(json) as MarkerMeta;
+                } catch {
+                    // leave meta empty; classification will mark as edited/corrupt
+                }
+            }
+            opens.push({ name, meta, line: i + 1 });
+        }
+    }
+
+    const out: ParsedMarker[] = [];
+    for (const open of opens) {
+        const close = closes.find((c) => c.name === open.name && c.line > open.line);
+        if (!close) {
+            continue;
+        }
+        out.push({
+            name: open.name,
+            meta: open.meta,
+            startLine: open.line,
+            endLine: close.line,
+            contentStartLine: open.line + 1,
+            contentEndLine: close.line - 1,
+        });
+    }
+    return out;
+}
+
+export function stripMarkers(source: string): string {
+    const lines = source.split("\n");
+    const keep: string[] = [];
+    for (const line of lines) {
+        if (OPEN_RE.test(line) || CLOSE_RE.test(line)) {
+            continue;
+        }
+        keep.push(line);
+    }
+    return keep.join("\n");
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/markers.test.ts` — 8 pass.
+
+```bash
+git add src/stash/lib/markers.ts src/stash/lib/markers.test.ts
+git commit -m "feat(stash): @stash marker parse/emit/strip with JSON-in-comment metadata"
+```
+
+---
+
+### Task 7: Region content extraction from working tree
+
+**Files:**
+- Create: `src/stash/lib/regions.ts`
+- Create: `src/stash/lib/regions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/regions.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverRegionsInTree, extractRegionContent } from "./regions";
+
+let dir: string;
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stash-regions-"));
+});
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+describe("discoverRegionsInTree", () => {
+    test("finds named regions across multiple files", async () => {
+        await writeFile(join(dir, "a.ts"), [
+            "function a() {",
+            "    // #region @stash:foo",
+            "    x();",
+            "    // #endregion @stash:foo",
+            "}",
+        ].join("\n"));
+        await mkdir(join(dir, "lib"));
+        await writeFile(join(dir, "lib", "b.ts"), [
+            "// #region @stash:bar",
+            "y();",
+            "// #endregion @stash:bar",
+            "// #region @stash:foo",
+            "z();",
+            "// #endregion @stash:foo",
+        ].join("\n"));
+
+        const regions = await discoverRegionsInTree(dir);
+        expect(regions).toHaveLength(3);
+        const names = regions.map((r) => r.name).sort();
+        expect(names).toEqual(["bar", "foo", "foo"]);
+    });
+
+    test("respects .gitignore (no node_modules walk)", async () => {
+        await mkdir(join(dir, "node_modules"));
+        await writeFile(join(dir, "node_modules", "x.ts"), [
+            "// #region @stash:should-not-find",
+            "// #endregion @stash:should-not-find",
+        ].join("\n"));
+        const regions = await discoverRegionsInTree(dir);
+        expect(regions).toHaveLength(0);
+    });
+});
+
+describe("extractRegionContent", () => {
+    test("returns content between markers, excluding markers themselves", async () => {
+        const filePath = join(dir, "a.ts");
+        await writeFile(filePath, [
+            "before",
+            "// #region @stash:foo",
+            "line1",
+            "line2",
+            "// #endregion @stash:foo",
+            "after",
+        ].join("\n"));
+        const content = await extractRegionContent(filePath, "foo");
+        expect(content).toBe("line1\nline2");
+    });
+
+    test("returns null when region not found", async () => {
+        const filePath = join(dir, "a.ts");
+        await writeFile(filePath, "no regions here");
+        expect(await extractRegionContent(filePath, "missing")).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/regions.ts
+import { readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { parseMarkers, type ParsedMarker } from "./markers";
+
+export interface DiscoveredRegion extends ParsedMarker {
+    filePath: string;        // repo-relative
+    absPath: string;
+}
+
+const SKIP_DIRS = new Set([
+    "node_modules", ".git", "dist", "build", "out", ".next", ".turbo",
+    ".bun", ".cache", "coverage", "target", "vendor", ".venv", "__pycache__",
+]);
+
+export async function discoverRegionsInTree(rootDir: string): Promise<DiscoveredRegion[]> {
+    const out: DiscoveredRegion[] = [];
+    await walk(rootDir, rootDir, out);
+    return out;
+}
+
+async function walk(rootDir: string, dir: string, out: DiscoveredRegion[]): Promise<void> {
+    const { readdir, stat } = await import("node:fs/promises");
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (SKIP_DIRS.has(entry.name)) {
+            continue;
+        }
+        const abs = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            await walk(rootDir, abs, out);
+            continue;
+        }
+        if (!entry.isFile()) {
+            continue;
+        }
+        const st = await stat(abs);
+        if (st.size > 1_000_000) {
+            continue;
+        }
+        let content: string;
+        try {
+            content = await readFile(abs, "utf8");
+        } catch {
+            continue;
+        }
+        if (!content.includes("@stash:")) {
+            continue;
+        }
+        const markers = parseMarkers(content);
+        for (const m of markers) {
+            out.push({
+                ...m,
+                filePath: relative(rootDir, abs),
+                absPath: abs,
+            });
+        }
+    }
+}
+
+export async function extractRegionContent(filePath: string, regionName: string): Promise<string | null> {
+    const content = await readFile(filePath, "utf8");
+    const markers = parseMarkers(content);
+    const m = markers.find((x) => x.name === regionName);
+    if (!m) {
+        return null;
+    }
+    const lines = content.split("\n");
+    return lines.slice(m.contentStartLine - 1, m.contentEndLine).join("\n");
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/regions.test.ts` — 4 pass.
+
+```bash
+git add src/stash/lib/regions.ts src/stash/lib/regions.test.ts
+git commit -m "feat(stash): working-tree region discovery + per-region content extraction"
+```
+
+---
+
+## Phase 3 — Patch Core
+
+### Task 8: Patch generation + apply
+
+**Files:**
+- Create: `src/stash/lib/patch.ts`
+- Create: `src/stash/lib/patch.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/patch.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGitIn } from "./patch";
+import { diffWorkingTree, applyPatch, reversePatch } from "./patch";
+
+let dir: string;
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stash-patch-"));
+    await runGitIn(dir, ["init", "--initial-branch=main"]);
+    await runGitIn(dir, ["config", "user.email", "t@t"]);
+    await runGitIn(dir, ["config", "user.name", "t"]);
+    await writeFile(join(dir, "a.ts"), "line1\nline2\nline3\n");
+    await runGitIn(dir, ["add", "a.ts"]);
+    await runGitIn(dir, ["commit", "-m", "init"]);
+});
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+describe("patch", () => {
+    test("diffWorkingTree captures uncommitted change as unified diff", async () => {
+        await writeFile(join(dir, "a.ts"), "line1\nINSERTED\nline2\nline3\n");
+        const diff = await diffWorkingTree({ repoDir: dir, mode: "all" });
+        expect(diff).toContain("a.ts");
+        expect(diff).toContain("+INSERTED");
+    });
+
+    test("applyPatch round-trips a diff", async () => {
+        await writeFile(join(dir, "a.ts"), "line1\nINSERTED\nline2\nline3\n");
+        const diff = await diffWorkingTree({ repoDir: dir, mode: "all" });
+        await writeFile(join(dir, "a.ts"), "line1\nline2\nline3\n"); // revert
+        await applyPatch({ repoDir: dir, patch: diff, threeWay: true });
+        const after = await readFile(join(dir, "a.ts"), "utf8");
+        expect(after).toBe("line1\nINSERTED\nline2\nline3\n");
+    });
+
+    test("reversePatch removes the change", async () => {
+        await writeFile(join(dir, "a.ts"), "line1\nINSERTED\nline2\nline3\n");
+        const diff = await diffWorkingTree({ repoDir: dir, mode: "all" });
+        // diff captures the change; now stage+commit then reverse
+        await runGitIn(dir, ["add", "a.ts"]);
+        await runGitIn(dir, ["commit", "-m", "with insert"]);
+        await reversePatch({ repoDir: dir, patch: diff, threeWay: true });
+        const after = await readFile(join(dir, "a.ts"), "utf8");
+        expect(after).toBe("line1\nline2\nline3\n");
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/patch.ts
+import { logger } from "@app/logger";
+
+const log = logger.scoped("stash:patch").log;
+
+export type SaveMode = "staged" | "unstaged" | "all";
+
+export async function runGitIn(repoDir: string, args: string[], opts?: { stdin?: string }): Promise<string> {
+    const proc = Bun.spawn(["git", "-C", repoDir, ...args], {
+        stdin: opts?.stdin ? "pipe" : "inherit",
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    if (opts?.stdin) {
+        proc.stdin.write(opts.stdin);
+        await proc.stdin.end();
+    }
+    const [stdout, stderr, exit] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    if (exit !== 0) {
+        log.warn({ args, stderr: stderr.trim() }, "git command failed");
+        throw new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`);
+    }
+    return stdout;
+}
+
+export async function diffWorkingTree(args: { repoDir: string; mode: SaveMode }): Promise<string> {
+    const gitArgs = ["diff", "--no-color", "--no-ext-diff", "--binary", "--src-prefix=a/", "--dst-prefix=b/"];
+    if (args.mode === "staged") {
+        gitArgs.push("--cached");
+    } else if (args.mode === "all") {
+        gitArgs.push("HEAD");
+    }
+    return await runGitIn(args.repoDir, gitArgs);
+}
+
+export async function applyPatch(args: { repoDir: string; patch: string; threeWay: boolean }): Promise<void> {
+    const gitArgs = ["apply", "--whitespace=fix"];
+    if (args.threeWay) {
+        gitArgs.push("--3way");
+    }
+    await runGitIn(args.repoDir, gitArgs, { stdin: args.patch });
+}
+
+export async function reversePatch(args: { repoDir: string; patch: string; threeWay: boolean }): Promise<void> {
+    const gitArgs = ["apply", "-R", "--whitespace=fix"];
+    if (args.threeWay) {
+        gitArgs.push("--3way");
+    }
+    await runGitIn(args.repoDir, gitArgs, { stdin: args.patch });
+}
+
+export interface PatchedFile {
+    path: string;
+    afterContent: string | null; // null = deletion
+}
+
+export async function listFilesInPatch(args: { repoDir: string; patch: string }): Promise<string[]> {
+    // Use git apply --numstat to list affected files without applying
+    const out = await runGitIn(args.repoDir, ["apply", "--numstat", "--no-color"], { stdin: args.patch }).catch(
+        () => "",
+    );
+    return out
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((l) => l.split("\t").slice(2).join("\t"))
+        .filter(Boolean);
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/patch.test.ts` — 3 pass.
+
+```bash
+git add src/stash/lib/patch.ts src/stash/lib/patch.test.ts
+git commit -m "feat(stash): diff/apply/reverse patch helpers with --3way support"
+```
+
+---
+
+### Task 9: Project detection (origin URL + sibling clones)
+
+**Files:**
+- Create: `src/stash/lib/projects.ts`
+- Create: `src/stash/lib/projects.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/projects.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGitIn } from "./patch";
+import { normalizeOrigin, detectProject, findSiblingClones } from "./projects";
+
+describe("normalizeOrigin", () => {
+    test("strips .git suffix", () => {
+        expect(normalizeOrigin("https://github.com/x/y.git")).toBe("github.com/x/y");
+    });
+    test("normalizes ssh form", () => {
+        expect(normalizeOrigin("git@github.com:x/y.git")).toBe("github.com/x/y");
+    });
+    test("lowercases host", () => {
+        expect(normalizeOrigin("https://GitHub.com/X/Y")).toBe("github.com/X/Y");
+    });
+});
+
+let work: string;
+beforeEach(async () => {
+    work = await mkdtemp(join(tmpdir(), "stash-projects-"));
+});
+afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+});
+
+describe("detectProject", () => {
+    test("returns null outside git repo", async () => {
+        const result = await detectProject(work);
+        expect(result).toBeNull();
+    });
+
+    test("returns root + origin for a git repo", async () => {
+        const repo = join(work, "a");
+        await Bun.write(join(repo, ".keep"), "");
+        await runGitIn(work, ["init", "a", "--initial-branch=main"]);
+        await runGitIn(repo, ["remote", "add", "origin", "https://github.com/x/y.git"]);
+        const result = await detectProject(repo);
+        expect(result?.rootPath).toBe(repo);
+        expect(result?.origin).toBe("github.com/x/y");
+    });
+});
+
+describe("findSiblingClones", () => {
+    test("finds sibling dirs with same origin", async () => {
+        for (const name of ["foo", "foo2", "foo-upgrade", "bar"]) {
+            const repo = join(work, name);
+            await Bun.write(join(repo, ".keep"), "");
+            await runGitIn(work, ["init", name, "--initial-branch=main"]);
+            const origin = name === "bar" ? "https://github.com/diff/diff.git" : "https://github.com/x/y.git";
+            await runGitIn(repo, ["remote", "add", "origin", origin]);
+        }
+        const found = await findSiblingClones(join(work, "foo"));
+        const names = found.map((p) => p.split("/").pop()).sort();
+        expect(names).toEqual(["foo-upgrade", "foo2"]);
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/projects.ts
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { runGitIn } from "./patch";
+
+export interface DetectedProject {
+    rootPath: string;
+    origin: string | null;
+    sha: string | null;
+}
+
+export function normalizeOrigin(url: string): string {
+    let u = url.trim().replace(/\.git$/, "");
+    const ssh = /^git@([^:]+):(.+)$/.exec(u);
+    if (ssh) {
+        u = `${ssh[1]}/${ssh[2]}`;
+    } else {
+        u = u.replace(/^[a-z]+:\/\/(?:[^@]+@)?/, "");
+    }
+    const slash = u.indexOf("/");
+    if (slash > 0) {
+        const host = u.slice(0, slash).toLowerCase();
+        return `${host}${u.slice(slash)}`;
+    }
+    return u.toLowerCase();
+}
+
+export async function detectProject(cwd: string): Promise<DetectedProject | null> {
+    try {
+        const root = (await runGitIn(cwd, ["rev-parse", "--show-toplevel"])).trim();
+        let origin: string | null = null;
+        try {
+            const raw = (await runGitIn(root, ["config", "--get", "remote.origin.url"])).trim();
+            if (raw) {
+                origin = normalizeOrigin(raw);
+            }
+        } catch {
+            // no origin configured
+        }
+        let sha: string | null = null;
+        try {
+            sha = (await runGitIn(root, ["rev-parse", "HEAD"])).trim();
+        } catch {
+            // empty repo
+        }
+        return { rootPath: root, origin, sha };
+    } catch {
+        return null;
+    }
+}
+
+export async function findSiblingClones(projectPath: string): Promise<string[]> {
+    const project = await detectProject(projectPath);
+    if (!project || !project.origin) {
+        return [];
+    }
+    const parent = dirname(project.rootPath);
+    const entries = await readdir(parent, { withFileTypes: true });
+    const out: string[] = [];
+    for (const entry of entries) {
+        if (!entry.isDirectory()) {
+            continue;
+        }
+        const candidate = join(parent, entry.name);
+        if (candidate === project.rootPath) {
+            continue;
+        }
+        if (!existsSync(join(candidate, ".git"))) {
+            continue;
+        }
+        const other = await detectProject(candidate);
+        if (other?.origin === project.origin) {
+            out.push(candidate);
+        }
+    }
+    return out.sort();
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/projects.test.ts` — 5 pass.
+
+```bash
+git add src/stash/lib/projects.ts src/stash/lib/projects.test.ts
+git commit -m "feat(stash): project detection + sibling-clone scan by origin URL"
+```
+
+---
+
+## Phase 4 — Save Command
+
+### Task 10: save (staged/unstaged/all modes)
+
+**Files:**
+- Create: `src/stash/commands/save.ts`
+- Create: `src/stash/types.ts`
+- Modify: `src/stash/index.ts`
+
+- [ ] **Step 1: Define shared types**
+
+```typescript
+// src/stash/types.ts
+export interface StashRow {
+    id: string;
+    name: string;
+    tags: string | null;
+    description: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface VersionRow {
+    id: string;
+    stash_id: string;
+    version: number;
+    patch_ref: string;
+    source_repo_path: string | null;
+    source_origin: string | null;
+    source_sha: string | null;
+    region_count: number;
+    file_count: number;
+    metadata_json: string;
+    created_at: string;
+}
+
+export interface ApplicationRow {
+    id: string;
+    stash_id: string;
+    version_id: string;
+    project_path: string;
+    project_origin: string | null;
+    project_sha_at_apply: string | null;
+    applied_at: string;
+    state: "active" | "unapplying" | "unapplied" | "orphaned";
+    unapplied_at: string | null;
+}
+```
+
+- [ ] **Step 2: Implement save command**
+
+```typescript
+// src/stash/commands/save.ts
+import { Database } from "bun:sqlite";
+import { logger, out } from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import { StoreRepo } from "../lib/store-repo";
+import { newStashId, shortId } from "../lib/ids";
+import { detectProject } from "../lib/projects";
+import { diffWorkingTree, listFilesInPatch, type SaveMode } from "../lib/patch";
+import { stripMarkers, parseMarkers } from "../lib/markers";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { StashRow, VersionRow } from "../types";
+
+const log = logger.scoped("stash:save").log;
+
+export interface SaveOptions {
+    name: string;
+    mode: SaveMode | undefined;
+    tags: string[];
+    description: string | undefined;
+}
+
+export async function saveCommand(opts: SaveOptions): Promise<void> {
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        out.log.error("not inside a git repository");
+        process.exit(1);
+    }
+
+    let mode = opts.mode;
+    if (!mode) {
+        if (!isInteractive()) {
+            out.log.error("--staged | --unstaged | --all required in non-interactive mode");
+            out.log.info(suggestCommand("tools stash save", { add: ["--all"], extra: [opts.name] }));
+            process.exit(1);
+        }
+        const { select } = await import("@clack/prompts");
+        const sel = await select({
+            message: "What to save?",
+            options: [
+                { value: "all", label: "All changes (staged + unstaged + untracked)" },
+                { value: "staged", label: "Staged only" },
+                { value: "unstaged", label: "Unstaged tracked changes only" },
+            ],
+        });
+        if (typeof sel !== "string") {
+            out.log.warn("cancelled");
+            return;
+        }
+        mode = sel as SaveMode;
+    }
+
+    const rawPatch = await diffWorkingTree({ repoDir: project.rootPath, mode });
+    if (!rawPatch.trim()) {
+        out.log.warn("no changes to stash");
+        return;
+    }
+
+    const patch = stripApplyMarkersFromPatchFiles({ patch: rawPatch, projectRoot: project.rootPath });
+    const fileList = await listFilesInPatch({ repoDir: project.rootPath, patch: rawPatch });
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const repo = new StoreRepo(storage.storeRepoDir());
+    await repo.init();
+
+    const existing = db
+        .query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?")
+        .get(opts.name);
+
+    const now = new Date().toISOString();
+    let stashId: string;
+    let version: number;
+
+    if (existing) {
+        stashId = existing.id;
+        const maxV = db
+            .query<{ m: number | null }, [string]>("SELECT MAX(version) as m FROM versions WHERE stash_id = ?")
+            .get(stashId);
+        version = (maxV?.m ?? 0) + 1;
+        out.log.info(`stash "${opts.name}" exists, creating v${version}`);
+        db.run("UPDATE stashes SET updated_at = ? WHERE id = ?", [now, stashId]);
+    } else {
+        stashId = newStashId();
+        version = 1;
+        db.run(
+            "INSERT INTO stashes (id, name, tags, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                stashId,
+                opts.name,
+                opts.tags.length ? JSON.stringify(opts.tags) : null,
+                opts.description ?? null,
+                now,
+                now,
+            ],
+        );
+    }
+
+    const patchRef = `refs/stashes/${stashId}/v${version}`;
+    const baselineRef = `refs/baselines/${stashId}/v${version}`;
+
+    const baselineFiles = await collectBaselineFiles({ projectRoot: project.rootPath, files: fileList });
+    await repo.writePatchCommit({
+        ref: baselineRef,
+        files: baselineFiles,
+        message: `stash:${opts.name} v${version} baseline`,
+    });
+    await repo.writePatchCommit({
+        ref: patchRef,
+        files: { "PATCH.diff": patch },
+        message: `stash:${opts.name} v${version}`,
+    });
+
+    const versionId = newStashId();
+    db.run(
+        `INSERT INTO versions (id, stash_id, version, patch_ref, source_repo_path, source_origin, source_sha, region_count, file_count, metadata_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            versionId,
+            stashId,
+            version,
+            patchRef,
+            project.rootPath,
+            project.origin,
+            project.sha,
+            countAuthorRegionsInPatch(patch),
+            fileList.length,
+            "{}",
+            now,
+        ],
+    );
+
+    out.log.success(`saved "${opts.name}" v${version} [id=${shortId(stashId)}]`);
+    out.log.info(`  ${fileList.length} files, baseline ref=${baselineRef}`);
+
+    db.close();
+    log.info({ stashId, version, files: fileList.length }, "stash saved");
+}
+
+function stripApplyMarkersFromPatchFiles(args: { patch: string; projectRoot: string }): string {
+    // Strip apply-time markers (with JSON metadata) from added lines in the patch.
+    // Author-bare markers (no JSON) are preserved.
+    const lines = args.patch.split("\n");
+    const APPLY_OPEN = /^\+.*#region\s+@stash:[\w.\-]+\s+\{.*\}/;
+    const ANY_CLOSE = /^\+.*#endregion\s+@stash:[\w.\-]+/;
+    const kept: string[] = [];
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i] ?? "";
+        if (APPLY_OPEN.test(line)) {
+            // Skip this opener; also skip its matching closer (next + line that closes the region).
+            i++;
+            continue;
+        }
+        if (ANY_CLOSE.test(line)) {
+            // Only skip the close if its open was a JSON-marker; heuristic: skip all + close markers.
+            // (Safer: this loses semantically-paired author closers too, but those were preserved
+            // because author opens have no JSON and we keep them.)
+            const isCloseForAppliedRegion = true; // best-effort
+            if (isCloseForAppliedRegion) {
+                i++;
+                continue;
+            }
+        }
+        kept.push(line);
+        i++;
+    }
+    return kept.join("\n");
+}
+
+function countAuthorRegionsInPatch(patch: string): number {
+    const m = patch.match(/^\+.*#region\s+@stash:/gm);
+    return m?.length ?? 0;
+}
+
+async function collectBaselineFiles(args: { projectRoot: string; files: string[] }): Promise<Record<string, string>> {
+    const out: Record<string, string> = {};
+    for (const f of args.files) {
+        try {
+            // Try the committed version first; fall back to "" for newly-added files.
+            const { runGitIn } = await import("../lib/patch");
+            try {
+                out[f] = await runGitIn(args.projectRoot, ["show", `HEAD:${f}`]);
+            } catch {
+                out[f] = "";
+            }
+        } catch {
+            out[f] = "";
+        }
+    }
+    return out;
+}
+```
+
+- [ ] **Step 3: Wire into commander**
+
+Replace the stub `save` action in `src/stash/index.ts`:
+
+```typescript
+// src/stash/index.ts
+#!/usr/bin/env bun
+import { Command } from "commander";
+import { runTool } from "@app/utils/cli";
+import { saveCommand } from "./commands/save";
+
+const program = new Command();
+program
+    .name("tools stash")
+    .description("Global cross-project code-overlay manager")
+    .version("0.1.0");
+
+program
+    .command("save <name>")
+    .description("Capture working-tree changes as a named stash")
+    .option("--staged", "save staged changes only")
+    .option("--unstaged", "save unstaged tracked changes only")
+    .option("--all", "save staged + unstaged + untracked")
+    .option("-t, --tag <tag>", "add a tag (repeatable)", (val, prev: string[] = []) => [...prev, val], [])
+    .option("-d, --desc <description>", "human-readable description")
+    .action(async (name: string, opts: { staged?: boolean; unstaged?: boolean; all?: boolean; tag: string[]; desc?: string }) => {
+        const mode = opts.staged ? "staged" : opts.unstaged ? "unstaged" : opts.all ? "all" : undefined;
+        await saveCommand({ name, mode, tags: opts.tag, description: opts.desc });
+    });
+
+await runTool(program, { tool: "stash" });
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+In a scratch git repo with a modification:
+
+```bash
+mkdir /tmp/stash-smoke && cd /tmp/stash-smoke
+git init && echo "v1" > a.txt && git add a.txt && git commit -m init
+echo "v2" > a.txt
+tools stash save smoke-test --all
+# expected: "saved smoke-test v1 [id=<6hex>]"
+```
+
+Then run a second save with same name:
+
+```bash
+echo "v3" > a.txt
+tools stash save smoke-test --all
+# expected: "stash 'smoke-test' exists, creating v2"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stash/commands/save.ts src/stash/types.ts src/stash/index.ts
+git commit -m "feat(stash): save command (staged/unstaged/all modes) with auto-versioning"
+```
+
+---
+
+## Phase 5 — Apply Command
+
+### Task 11: apply (default flow with marker decoration)
+
+**Files:**
+- Create: `src/stash/commands/apply.ts`
+- Modify: `src/stash/index.ts`
+
+- [ ] **Step 1: Implement apply**
+
+```typescript
+// src/stash/commands/apply.ts
+import { Database } from "bun:sqlite";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger, out } from "@app/logger";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import { StoreRepo } from "../lib/store-repo";
+import { newStashId, shortId } from "../lib/ids";
+import { detectProject } from "../lib/projects";
+import { applyPatch, listFilesInPatch } from "../lib/patch";
+import { emitOpenMarker, emitCloseMarker } from "../lib/markers";
+import { commentSyntaxForFile } from "../lib/languages";
+import type { StashRow, VersionRow, ApplicationRow } from "../types";
+
+const log = logger.scoped("stash:apply").log;
+
+export interface ApplyOptions {
+    name: string;
+    version?: number;
+    verboseMarkers: boolean;
+}
+
+export async function applyCommand(opts: ApplyOptions): Promise<void> {
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        out.log.error("not inside a git repository");
+        process.exit(1);
+    }
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    const stash = db
+        .query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?")
+        .get(opts.name);
+    if (!stash) {
+        out.log.error(`stash "${opts.name}" not found`);
+        process.exit(1);
+    }
+
+    const version = opts.version
+        ? db
+              .query<VersionRow, [string, number]>(
+                  "SELECT * FROM versions WHERE stash_id = ? AND version = ?",
+              )
+              .get(stash.id, opts.version)
+        : db
+              .query<VersionRow, [string]>(
+                  "SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC LIMIT 1",
+              )
+              .get(stash.id);
+    if (!version) {
+        out.log.error(`no version found for "${opts.name}"${opts.version ? ` @v${opts.version}` : ""}`);
+        process.exit(1);
+    }
+
+    const existingActive = db
+        .query<ApplicationRow, [string, string]>(
+            "SELECT * FROM applications WHERE stash_id = ? AND project_path = ? AND state = 'active'",
+        )
+        .get(stash.id, project.rootPath);
+    if (existingActive) {
+        out.log.error(`"${opts.name}" is already applied here. Use 'unapply' or 'update'.`);
+        process.exit(1);
+    }
+
+    const repo = new StoreRepo(storage.storeRepoDir());
+    const patch = await repo.readFileAt(version.patch_ref, "PATCH.diff");
+    if (!patch) {
+        out.log.error(`patch missing from store at ${version.patch_ref}`);
+        process.exit(1);
+    }
+
+    // Fetch baseline blobs from store into project's git objects for --3way.
+    const baselineRef = `refs/baselines/${stash.id}/v${version.version}`;
+    await fetchBaselineBlobs({ projectRoot: project.rootPath, storeDir: storage.storeRepoDir(), baselineRef });
+
+    out.log.info(`applying "${opts.name}" v${version.version} [id=${shortId(stash.id)}]`);
+
+    try {
+        await applyPatch({ repoDir: project.rootPath, patch, threeWay: true });
+    } catch (err) {
+        out.log.error(`apply failed: ${(err as Error).message}`);
+        out.log.warn("apply-conflict state machine deferred to v1.1; resolve conflicts manually and re-run with --resume (future)");
+        process.exit(1);
+    }
+
+    const affectedFiles = await listFilesInPatch({ repoDir: project.rootPath, patch });
+    await decorateAppliedRegions({
+        projectRoot: project.rootPath,
+        files: affectedFiles,
+        patch,
+        stashName: opts.name,
+        stashId: stash.id,
+        version: version.version,
+        verbose: opts.verboseMarkers,
+        sourceRepo: version.source_repo_path,
+        sourceSha: version.source_sha,
+    });
+
+    const now = new Date().toISOString();
+    db.run(
+        `INSERT INTO applications (id, stash_id, version_id, project_path, project_origin, project_sha_at_apply, applied_at, state)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'active')`,
+        [newStashId(), stash.id, version.id, project.rootPath, project.origin, project.sha, now],
+    );
+
+    out.log.success(`applied "${opts.name}" v${version.version}`);
+    out.log.info(`  ${affectedFiles.length} files affected`);
+
+    db.close();
+    log.info({ stashId: stash.id, version: version.version, files: affectedFiles.length }, "stash applied");
+}
+
+async function fetchBaselineBlobs(args: { projectRoot: string; storeDir: string; baselineRef: string }): Promise<void> {
+    const { runGitIn } = await import("../lib/patch");
+    try {
+        await runGitIn(args.projectRoot, [
+            "fetch",
+            "--no-tags",
+            args.storeDir,
+            `${args.baselineRef}:refs/.gtstash-baseline`,
+        ]);
+    } catch (err) {
+        log.warn({ err }, "baseline fetch failed; --3way will fall back to fuzz matching");
+    }
+}
+
+async function decorateAppliedRegions(args: {
+    projectRoot: string;
+    files: string[];
+    patch: string;
+    stashName: string;
+    stashId: string;
+    version: number;
+    verbose: boolean;
+    sourceRepo: string | null;
+    sourceSha: string | null;
+}): Promise<void> {
+    // For each file in the patch, wrap each contiguous hunk of newly-inserted lines with markers.
+    // Parse the unified diff to find @@ hunk ranges and insert markers around added line groups.
+    const hunks = parseDiffHunks(args.patch);
+    for (const [filePath, fileHunks] of Object.entries(hunks)) {
+        const abs = join(args.projectRoot, filePath);
+        const syntax = commentSyntaxForFile(filePath);
+        let content: string;
+        try {
+            content = await readFile(abs, "utf8");
+        } catch {
+            continue;
+        }
+        const lines = content.split("\n");
+        // Walk hunks in reverse so line offsets stay valid.
+        for (let h = fileHunks.length - 1; h >= 0; h--) {
+            const hunk = fileHunks[h];
+            if (!hunk) {
+                continue;
+            }
+            const meta: Record<string, unknown> = { id: shortId(args.stashId), v: args.version };
+            if (args.verbose) {
+                meta.hunk = h + 1;
+                if (args.sourceRepo) {
+                    meta.src = `${args.sourceRepo.split("/").pop()}@${args.sourceSha?.slice(0, 7) ?? "?"}`;
+                }
+                meta.applied = new Date().toISOString();
+            }
+            const openLine = emitOpenMarker({ name: args.stashName, meta, syntax });
+            const closeLine = emitCloseMarker({ name: args.stashName, syntax });
+            // hunk.newStart is 1-indexed in the file AFTER apply; insert close at newStart+newLines-1+1.
+            const closeIdx = hunk.newStart + hunk.newLines - 1; // 0-indexed insertion point (after last added line)
+            const openIdx = hunk.newStart - 1; // 0-indexed insertion point (before first added line)
+            lines.splice(closeIdx, 0, closeLine);
+            lines.splice(openIdx, 0, openLine);
+        }
+        await writeFile(abs, lines.join("\n"));
+    }
+}
+
+interface DiffHunk {
+    newStart: number;
+    newLines: number;
+    addedCount: number;
+}
+
+function parseDiffHunks(patch: string): Record<string, DiffHunk[]> {
+    const out: Record<string, DiffHunk[]> = {};
+    const lines = patch.split("\n");
+    let currentFile: string | null = null;
+    let currentHunk: DiffHunk | null = null;
+    const HUNK_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+    const FILE_RE = /^\+\+\+ b\/(.+)$/;
+    for (const line of lines) {
+        const fm = FILE_RE.exec(line);
+        if (fm) {
+            currentFile = fm[1] ?? null;
+            currentHunk = null;
+            continue;
+        }
+        const hm = HUNK_RE.exec(line);
+        if (hm && currentFile) {
+            currentHunk = {
+                newStart: Number(hm[1]),
+                newLines: Number(hm[2] ?? "1"),
+                addedCount: 0,
+            };
+            (out[currentFile] ??= []).push(currentHunk);
+            continue;
+        }
+        if (currentHunk && line.startsWith("+") && !line.startsWith("+++")) {
+            currentHunk.addedCount++;
+        }
+    }
+    return out;
+}
+```
+
+- [ ] **Step 2: Wire into commander**
+
+Add to `src/stash/index.ts`:
+
+```typescript
+import { applyCommand } from "./commands/apply";
+
+program
+    .command("apply <name>")
+    .description("Apply a stash into the current project")
+    .option("--at <version>", "pin to specific version (default: latest)", (v) => Number(v))
+    .option("--verbose-markers", "include source/applied metadata in markers")
+    .action(async (name: string, opts: { at?: number; verboseMarkers?: boolean }) => {
+        await applyCommand({ name, version: opts.at, verboseMarkers: !!opts.verboseMarkers });
+    });
+```
+
+- [ ] **Step 3: Manual smoke test (round-trip with save)**
+
+```bash
+# In the save smoke-test repo:
+git checkout -- a.txt    # reset to last committed
+tools stash apply smoke-test
+cat a.txt   # expect: marker-wrapped content
+```
+
+- [ ] **Step 4: Write integration test**
+
+```typescript
+// src/stash/commands/apply.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGitIn } from "../lib/patch";
+import { saveCommand } from "./save";
+import { applyCommand } from "./apply";
+
+let work: string;
+let origHome: string | undefined;
+let projectA: string;
+let projectB: string;
+
+beforeEach(async () => {
+    work = await mkdtemp(join(tmpdir(), "stash-apply-it-"));
+    origHome = process.env.HOME;
+    process.env.HOME = work; // redirect storage root for test isolation
+    projectA = join(work, "repo-a");
+    projectB = join(work, "repo-b");
+    for (const repo of [projectA, projectB]) {
+        await runGitIn(work, ["init", repo.split("/").pop() ?? "", "--initial-branch=main"]);
+        await runGitIn(repo, ["config", "user.email", "t@t"]);
+        await runGitIn(repo, ["config", "user.name", "t"]);
+        await writeFile(join(repo, "a.ts"), "fn();\n");
+        await runGitIn(repo, ["add", "a.ts"]);
+        await runGitIn(repo, ["commit", "-m", "init"]);
+    }
+});
+afterEach(async () => {
+    process.env.HOME = origHome;
+    await rm(work, { recursive: true, force: true });
+});
+
+describe("apply integration", () => {
+    test("save in A, apply to B, decorates with markers", async () => {
+        process.chdir(projectA);
+        await writeFile(join(projectA, "a.ts"), "fn();\ninserted();\n");
+        await saveCommand({ name: "x", mode: "all", tags: [], description: undefined });
+
+        process.chdir(projectB);
+        await applyCommand({ name: "x", verboseMarkers: false });
+        const result = await readFile(join(projectB, "a.ts"), "utf8");
+        expect(result).toContain("#region @stash:x");
+        expect(result).toContain("inserted();");
+        expect(result).toContain("#endregion @stash:x");
+    });
+});
+```
+
+- [ ] **Step 5: Run, commit**
+
+Run: `bun test src/stash/commands/apply.test.ts` — 1 pass.
+
+```bash
+git add src/stash/commands/apply.ts src/stash/commands/apply.test.ts src/stash/index.ts
+git commit -m "feat(stash): apply command with --3way merge + region marker decoration"
+```
+
+---
+
+## Phase 6 — Unapply State Machine
+
+This phase is the centerpiece of the tool. Implementation follows TDD strictly: state machine is built bottom-up (classify → session → decisions → CLI), with persistence verified at each step.
+
+### Task 12: Region classification
+
+**Files:**
+- Create: `src/stash/lib/classify.ts`
+- Create: `src/stash/lib/classify.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/classify.test.ts
+import { describe, expect, test } from "bun:test";
+import { classifyRegion, type ClassifyInput } from "./classify";
+
+const baseStored = "logger.debug('x');";
+
+describe("classifyRegion", () => {
+    test("unchanged when stored == current", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: baseStored, present: true };
+        expect(classifyRegion(input).klass).toBe("unchanged");
+    });
+    test("edited when stored != current and both present", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: "logger.debug('y');", present: true };
+        expect(classifyRegion(input).klass).toBe("edited");
+    });
+    test("missing when markers absent", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: null, present: false };
+        expect(classifyRegion(input).klass).toBe("missing");
+    });
+    test("ignores trailing whitespace differences", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: `${baseStored}   `, present: true };
+        expect(classifyRegion(input).klass).toBe("unchanged");
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/classify.ts
+export type RegionClass = "unchanged" | "edited" | "missing" | "new-extra";
+
+export interface ClassifyInput {
+    storedContent: string;
+    currentContent: string | null;
+    present: boolean;
+}
+
+export interface Classification {
+    klass: RegionClass;
+}
+
+export function classifyRegion(input: ClassifyInput): Classification {
+    if (!input.present) {
+        return { klass: "missing" };
+    }
+    if (input.currentContent === null) {
+        return { klass: "missing" };
+    }
+    const norm = (s: string) => s.split("\n").map((l) => l.trimEnd()).join("\n").replace(/\n+$/, "");
+    if (norm(input.storedContent) === norm(input.currentContent)) {
+        return { klass: "unchanged" };
+    }
+    return { klass: "edited" };
+}
+```
+
+- [ ] **Step 3: Run, commit**
+
+Run: `bun test src/stash/lib/classify.test.ts` — 4 pass.
+
+```bash
+git add src/stash/lib/classify.ts src/stash/lib/classify.test.ts
+git commit -m "feat(stash): region classifier (unchanged/edited/missing)"
+```
+
+---
+
+### Task 13: UnapplySession state with persistence
+
+**Files:**
+- Create: `src/stash/lib/unapply-session.ts`
+- Create: `src/stash/lib/unapply-session.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/unapply-session.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnapplySession, type SessionRegion } from "./unapply-session";
+
+let stateDir: string;
+beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "stash-session-"));
+});
+afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+});
+
+const regions: SessionRegion[] = [
+    { id: "r1", filePath: "a.ts", hunkIndex: 1, klass: "unchanged", decision: "auto-remove" },
+    { id: "r2", filePath: "a.ts", hunkIndex: 2, klass: "edited", decision: null },
+    { id: "r3", filePath: "b.ts", hunkIndex: 1, klass: "missing", decision: null },
+];
+
+describe("UnapplySession", () => {
+    test("currentRegion skips decided + unchanged regions", () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        expect(s.currentRegion()?.id).toBe("r2");
+    });
+
+    test("decide() advances to next undecided region", () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        s.decide("update");
+        expect(s.currentRegion()?.id).toBe("r3");
+    });
+
+    test("isComplete after all decided", () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        s.decide("update");
+        s.decide("skip");
+        expect(s.isComplete()).toBe(true);
+    });
+
+    test("persist + load round-trip preserves decisions and current index", async () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        s.decide("update");
+        await s.persist();
+
+        const loaded = await UnapplySession.load({
+            stashId: "abc",
+            projectHash: "phash",
+            stateDir,
+        });
+        expect(loaded).not.toBeNull();
+        expect(loaded?.currentRegion()?.id).toBe("r3");
+        const r2 = loaded?.regions().find((r) => r.id === "r2");
+        expect(r2?.decision).toBe("update");
+    });
+
+    test("abort() deletes state file", async () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        await s.persist();
+        await s.abort();
+        const loaded = await UnapplySession.load({ stashId: "abc", projectHash: "phash", stateDir });
+        expect(loaded).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/unapply-session.ts
+import { existsSync } from "node:fs";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import type { RegionClass } from "./classify";
+
+export type Decision = "update" | "discard" | "skip" | "auto-remove" | null;
+
+export interface SessionRegion {
+    id: string;
+    filePath: string;
+    hunkIndex: number;
+    klass: RegionClass;
+    decision: Decision;
+    storedContent?: string;
+    currentContent?: string | null;
+}
+
+export interface SessionState {
+    stashId: string;
+    stashName: string;
+    projectPath: string;
+    projectHash: string;
+    regions: SessionRegion[];
+    currentIndex: number;
+    startedAt: string;
+    pausedAt: string | null;
+}
+
+export class UnapplySession {
+    private constructor(private state: SessionState, private readonly stateDir: string) {}
+
+    static start(args: {
+        stashId: string;
+        stashName: string;
+        projectPath: string;
+        projectHash: string;
+        regions: SessionRegion[];
+        stateDir: string;
+    }): UnapplySession {
+        const state: SessionState = {
+            stashId: args.stashId,
+            stashName: args.stashName,
+            projectPath: args.projectPath,
+            projectHash: args.projectHash,
+            regions: args.regions,
+            currentIndex: 0,
+            startedAt: new Date().toISOString(),
+            pausedAt: null,
+        };
+        const s = new UnapplySession(state, args.stateDir);
+        s.advanceToNextUndecided();
+        return s;
+    }
+
+    static async load(args: {
+        stashId: string;
+        projectHash: string;
+        stateDir: string;
+    }): Promise<UnapplySession | null> {
+        const path = stateFilePath(args.stateDir, args.projectHash, args.stashId);
+        if (!existsSync(path)) {
+            return null;
+        }
+        const raw = await readFile(path, "utf8");
+        const state = SafeJSON.parse<SessionState>(raw);
+        return new UnapplySession(state, args.stateDir);
+    }
+
+    regions(): SessionRegion[] {
+        return this.state.regions;
+    }
+
+    currentRegion(): SessionRegion | null {
+        return this.state.regions[this.state.currentIndex] ?? null;
+    }
+
+    isComplete(): boolean {
+        return this.state.regions.every((r) => r.decision !== null);
+    }
+
+    progress(): { decided: number; total: number } {
+        const decided = this.state.regions.filter((r) => r.decision !== null).length;
+        return { decided, total: this.state.regions.length };
+    }
+
+    decide(decision: Exclude<Decision, null | "auto-remove">): void {
+        const region = this.currentRegion();
+        if (!region) {
+            throw new Error("no current region");
+        }
+        region.decision = decision;
+        this.advanceToNextUndecided();
+    }
+
+    private advanceToNextUndecided(): void {
+        for (let i = this.state.currentIndex; i < this.state.regions.length; i++) {
+            const r = this.state.regions[i];
+            if (!r) {
+                continue;
+            }
+            if (r.decision === null) {
+                this.state.currentIndex = i;
+                return;
+            }
+        }
+        this.state.currentIndex = this.state.regions.length;
+    }
+
+    async persist(): Promise<void> {
+        this.state.pausedAt = new Date().toISOString();
+        const path = stateFilePath(this.stateDir, this.state.projectHash, this.state.stashId);
+        await writeFile(path, SafeJSON.stringify(this.state, null, 2));
+    }
+
+    async abort(): Promise<void> {
+        const path = stateFilePath(this.stateDir, this.state.projectHash, this.state.stashId);
+        if (existsSync(path)) {
+            await unlink(path);
+        }
+    }
+
+    async complete(): Promise<void> {
+        await this.abort();
+    }
+
+    snapshot(): SessionState {
+        return this.state;
+    }
+}
+
+function stateFilePath(stateDir: string, projectHash: string, stashId: string): string {
+    return join(stateDir, `${projectHash.slice(0, 12)}--unapply--${stashId.slice(0, 6)}.json`);
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/unapply-session.test.ts` — 5 pass.
+
+```bash
+git add src/stash/lib/unapply-session.ts src/stash/lib/unapply-session.test.ts
+git commit -m "feat(stash): UnapplySession state machine with persist/load/abort"
+```
+
+---
+
+### Task 14: Decision executors (update / discard / skip / auto-remove)
+
+**Files:**
+- Create: `src/stash/lib/decisions.ts`
+- Create: `src/stash/lib/decisions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/stash/lib/decisions.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyDecisionToCode } from "./decisions";
+
+let dir: string;
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stash-decisions-"));
+});
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+describe("applyDecisionToCode", () => {
+    test("auto-remove strips markers and content", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(f, [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "content",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n"));
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "auto-remove" });
+        expect(await readFile(f, "utf8")).toBe("before\nafter");
+    });
+
+    test("update removes markers + content (caller is responsible for new version)", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(f, [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "modified content",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n"));
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "update" });
+        expect(await readFile(f, "utf8")).toBe("before\nafter");
+    });
+
+    test("skip is a no-op on the file", async () => {
+        const f = join(dir, "a.ts");
+        const before = [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "content",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n");
+        await writeFile(f, before);
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "skip" });
+        expect(await readFile(f, "utf8")).toBe(before);
+    });
+
+    test("discard with storedContent restores original then removes", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(f, [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "edited content",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n"));
+        // discard means: remove region using the OLD stored content shape (markers + original between).
+        // In practice: same effect on file (markers + content vanish), but caller has already verified
+        // the discarded content matches what was originally applied.
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "discard" });
+        expect(await readFile(f, "utf8")).toBe("before\nafter");
+    });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+// src/stash/lib/decisions.ts
+import { readFile, writeFile } from "node:fs/promises";
+import { parseMarkers } from "./markers";
+import type { Decision } from "./unapply-session";
+
+export async function applyDecisionToCode(args: {
+    filePath: string;
+    regionName: string;
+    decision: Exclude<Decision, null>;
+}): Promise<void> {
+    if (args.decision === "skip") {
+        return;
+    }
+    // update | discard | auto-remove all have the same file-side effect: remove the region (markers + content).
+    const content = await readFile(args.filePath, "utf8");
+    const markers = parseMarkers(content);
+    const m = markers.find((x) => x.name === args.regionName);
+    if (!m) {
+        return; // already gone
+    }
+    const lines = content.split("\n");
+    const before = lines.slice(0, m.startLine - 1);
+    const after = lines.slice(m.endLine);
+    await writeFile(args.filePath, [...before, ...after].join("\n"));
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `bun test src/stash/lib/decisions.test.ts` — 4 pass.
+
+```bash
+git add src/stash/lib/decisions.ts src/stash/lib/decisions.test.ts
+git commit -m "feat(stash): per-region decision executors"
+```
+
+---
+
+### Task 15: unapply command — bootstrap session + walk
+
+**Files:**
+- Create: `src/stash/commands/unapply.ts`
+- Modify: `src/stash/index.ts`
+
+- [ ] **Step 1: Implement command (TTY + non-TTY flow)**
+
+```typescript
+// src/stash/commands/unapply.ts
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger, out } from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import { StoreRepo } from "../lib/store-repo";
+import { newStashId } from "../lib/ids";
+import { detectProject } from "../lib/projects";
+import { applyDecisionToCode } from "../lib/decisions";
+import { classifyRegion, type RegionClass } from "../lib/classify";
+import { extractRegionContent } from "../lib/regions";
+import { UnapplySession, type SessionRegion, type Decision } from "../lib/unapply-session";
+import { parseMarkers } from "../lib/markers";
+import type { StashRow, VersionRow, ApplicationRow } from "../types";
+
+const log = logger.scoped("stash:unapply").log;
+
+export interface UnapplyOptions {
+    name: string;
+    action: "start" | "continue" | "skip" | "abort" | "status";
+    decision: Exclude<Decision, null | "auto-remove"> | "discard-all-dangerous" | "update-stash-all-dangerous" | undefined;
+}
+
+export async function unapplyCommand(opts: UnapplyOptions): Promise<void> {
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        out.log.error("not inside a git repository");
+        process.exit(1);
+    }
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        out.log.error(`stash "${opts.name}" not found`);
+        process.exit(1);
+    }
+
+    const projectHash = createHash("sha256").update(project.rootPath).digest("hex");
+
+    if (opts.action === "abort") {
+        const s = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
+        if (!s) {
+            out.log.warn("no in-progress unapply session");
+            return;
+        }
+        await s.abort();
+        out.log.success("aborted");
+        return;
+    }
+
+    if (opts.action === "status") {
+        const s = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
+        if (!s) {
+            out.log.info("no in-progress session");
+            return;
+        }
+        const p = s.progress();
+        const cur = s.currentRegion();
+        out.log.info(`${p.decided}/${p.total} decided; current: ${cur?.filePath ?? "(none)"} hunk ${cur?.hunkIndex ?? "?"}`);
+        return;
+    }
+
+    // Start or resume session
+    let session = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
+    if (!session) {
+        if (opts.action !== "start") {
+            out.log.error("no in-progress session; run without --continue to start");
+            process.exit(1);
+        }
+        session = await bootstrapSession({ storage, db, stash, project, projectHash });
+    }
+
+    // Apply auto-remove decisions silently
+    await processAutoRemoves({ session, projectRoot: project.rootPath });
+
+    if (opts.decision === "discard-all-dangerous" || opts.decision === "update-stash-all-dangerous") {
+        const blanket = opts.decision === "discard-all-dangerous" ? "discard" : "update";
+        for (const r of session.regions()) {
+            if (r.decision === null) {
+                r.decision = blanket;
+            }
+        }
+    } else if (opts.decision) {
+        if (session.currentRegion()) {
+            session.decide(opts.decision);
+        }
+    } else if (opts.action === "skip") {
+        if (session.currentRegion()) {
+            session.decide("skip");
+        }
+    }
+
+    // Drive interactive walk if TTY and there are remaining undecided regions
+    if (isInteractive() && !session.isComplete()) {
+        await walkInteractive({ session, projectRoot: project.rootPath });
+    }
+
+    if (!session.isComplete()) {
+        await session.persist();
+        await emitNonTtyPrompt({ session, name: opts.name });
+        return;
+    }
+
+    // Execute decisions
+    const stats = await executeAllDecisions({ session, projectRoot: project.rootPath, storage, db, stash });
+
+    // Mark application unapplied
+    const now = new Date().toISOString();
+    db.run(
+        "UPDATE applications SET state = 'unapplied', unapplied_at = ? WHERE stash_id = ? AND project_path = ? AND state = 'active'",
+        [now, stash.id, project.rootPath],
+    );
+
+    await session.complete();
+
+    out.log.success(`unapplied "${opts.name}" — ${stats.removed} removed, ${stats.updated} captured to v${stats.newVersion ?? "(none)"}, ${stats.skipped} skipped`);
+
+    db.close();
+}
+
+async function bootstrapSession(args: {
+    storage: StashStorage;
+    db: Database;
+    stash: StashRow;
+    project: NonNullable<Awaited<ReturnType<typeof detectProject>>>;
+    projectHash: string;
+}): Promise<UnapplySession> {
+    // Find active application
+    const app = args.db
+        .query<ApplicationRow, [string, string]>(
+            "SELECT * FROM applications WHERE stash_id = ? AND project_path = ? AND state = 'active'",
+        )
+        .get(args.stash.id, args.project.rootPath);
+    if (!app) {
+        out.log.error(`"${args.stash.name}" is not applied here`);
+        process.exit(1);
+    }
+    const version = args.db.query<VersionRow, [string]>("SELECT * FROM versions WHERE id = ?").get(app.version_id);
+    if (!version) {
+        out.log.error("version row missing");
+        process.exit(1);
+    }
+    const repo = new StoreRepo(args.storage.storeRepoDir());
+    const storedPatch = (await repo.readFileAt(version.patch_ref, "PATCH.diff")) ?? "";
+    const regionMap = collectRegionsFromPatch(storedPatch);
+
+    const sessionRegions: SessionRegion[] = [];
+    for (const r of regionMap) {
+        const fileContent = await readFile(join(args.project.rootPath, r.filePath), "utf8").catch(() => null);
+        const present = fileContent ? parseMarkers(fileContent).some((m) => m.name === args.stash.name) : false;
+        const currentContent = fileContent ? await extractRegionContent(join(args.project.rootPath, r.filePath), args.stash.name) : null;
+        const klass = classifyRegion({
+            storedContent: r.content,
+            currentContent,
+            present,
+        }).klass;
+        sessionRegions.push({
+            id: newStashId(),
+            filePath: r.filePath,
+            hunkIndex: r.hunkIndex,
+            klass,
+            decision: klass === "unchanged" ? "auto-remove" : null,
+            storedContent: r.content,
+            currentContent,
+        });
+    }
+
+    return UnapplySession.start({
+        stashId: args.stash.id,
+        stashName: args.stash.name,
+        projectPath: args.project.rootPath,
+        projectHash: args.projectHash,
+        regions: sessionRegions,
+        stateDir: args.storage.stateDir(),
+    });
+}
+
+interface PatchRegion {
+    filePath: string;
+    hunkIndex: number;
+    content: string;
+}
+
+function collectRegionsFromPatch(patch: string): PatchRegion[] {
+    // For v1: derive one "region" per added hunk per file. v1.1 will use author-marker boundaries.
+    const out: PatchRegion[] = [];
+    const lines = patch.split("\n");
+    let currentFile: string | null = null;
+    let hunkIndex = 0;
+    let buffer: string[] = [];
+    const flush = () => {
+        if (currentFile && buffer.length) {
+            hunkIndex++;
+            out.push({ filePath: currentFile, hunkIndex, content: buffer.join("\n") });
+            buffer = [];
+        }
+    };
+    for (const line of lines) {
+        const fm = /^\+\+\+ b\/(.+)$/.exec(line);
+        if (fm) {
+            flush();
+            currentFile = fm[1] ?? null;
+            hunkIndex = 0;
+            continue;
+        }
+        if (line.startsWith("@@")) {
+            flush();
+            continue;
+        }
+        if (line.startsWith("+") && !line.startsWith("+++")) {
+            buffer.push(line.slice(1));
+        } else if (buffer.length && (line.startsWith(" ") || line.startsWith("-"))) {
+            flush();
+        }
+    }
+    flush();
+    return out;
+}
+
+async function processAutoRemoves(args: { session: UnapplySession; projectRoot: string }): Promise<void> {
+    for (const r of args.session.regions()) {
+        if (r.decision === "auto-remove") {
+            await applyDecisionToCode({
+                filePath: join(args.projectRoot, r.filePath),
+                regionName: args.session.snapshot().stashName,
+                decision: "auto-remove",
+            });
+        }
+    }
+}
+
+async function walkInteractive(args: { session: UnapplySession; projectRoot: string }): Promise<void> {
+    const { select, note } = await import("@clack/prompts");
+    const { renderDiff } = await import("../lib/diff-render");
+    while (!args.session.isComplete()) {
+        const region = args.session.currentRegion();
+        if (!region) {
+            return;
+        }
+        const total = args.session.regions().length;
+        const idx = args.session.snapshot().currentIndex + 1;
+        const diff = renderDiff({
+            before: region.storedContent ?? "",
+            after: region.currentContent ?? "",
+            label: `${region.filePath} hunk ${region.hunkIndex}`,
+        });
+        note(diff, `Region ${idx}/${total} — class: ${region.klass}`);
+        const opts: Array<{ value: Exclude<Decision, null | "auto-remove">; label: string; hint?: string }> = [
+            { value: "update", label: "update — capture current as new vN+1, remove from code" },
+            { value: "discard", label: "discard — remove using stored content (lose local edits)" },
+            { value: "skip", label: "skip — leave code & store alone (warns)" },
+        ];
+        if (region.klass === "missing") {
+            opts.splice(1, 1); // remove "discard" — nothing to discard
+        }
+        const sel = await select({ message: "decision?", options: opts });
+        if (typeof sel !== "string") {
+            out.log.warn("paused; resume with: tools stash unapply <name> --continue");
+            await args.session.persist();
+            process.exit(0);
+        }
+        args.session.decide(sel as Exclude<Decision, null | "auto-remove">);
+    }
+}
+
+async function emitNonTtyPrompt(args: { session: UnapplySession; name: string }): Promise<void> {
+    const region = args.session.currentRegion();
+    if (!region) {
+        return;
+    }
+    const total = args.session.regions().length;
+    const idx = args.session.snapshot().currentIndex + 1;
+    process.stderr.write(`\nRegion ${idx}/${total} — ${region.filePath} hunk ${region.hunkIndex} (class: ${region.klass})\n`);
+    const { renderDiff } = await import("../lib/diff-render");
+    process.stderr.write(renderDiff({
+        before: region.storedContent ?? "",
+        after: region.currentContent ?? "",
+        label: `${region.filePath} hunk ${region.hunkIndex}`,
+    }));
+    process.stderr.write("\nChoose a decision:\n");
+    for (const dec of ["update", "discard", "skip"]) {
+        process.stderr.write(`  ${suggestCommand("tools stash unapply", { add: ["--continue", `--decision=${dec}`], extra: [args.name] })}\n`);
+    }
+    process.stderr.write(`Or abort:\n  ${suggestCommand("tools stash unapply", { add: ["--abort"], extra: [args.name] })}\n`);
+}
+
+interface ExecStats {
+    removed: number;
+    updated: number;
+    skipped: number;
+    newVersion: number | null;
+}
+
+async function executeAllDecisions(args: {
+    session: UnapplySession;
+    projectRoot: string;
+    storage: StashStorage;
+    db: Database;
+    stash: StashRow;
+}): Promise<ExecStats> {
+    const stats: ExecStats = { removed: 0, updated: 0, skipped: 0, newVersion: null };
+    const updatedRegions: SessionRegion[] = [];
+    for (const r of args.session.regions()) {
+        if (r.decision === "skip") {
+            stats.skipped++;
+            out.log.warn(`region ${r.filePath} hunk ${r.hunkIndex}: kept (stash and code now diverged)`);
+            continue;
+        }
+        if (r.decision === "update") {
+            updatedRegions.push(r);
+            stats.updated++;
+        }
+        await applyDecisionToCode({
+            filePath: join(args.projectRoot, r.filePath),
+            regionName: args.session.snapshot().stashName,
+            decision: r.decision ?? "auto-remove",
+        });
+        if (r.decision === "auto-remove" || r.decision === "discard" || r.decision === "update") {
+            stats.removed++;
+        }
+    }
+    if (updatedRegions.length) {
+        stats.newVersion = await capturedUpdatesAsNewVersion({
+            storage: args.storage,
+            db: args.db,
+            stash: args.stash,
+            updatedRegions,
+        });
+    }
+    return stats;
+}
+
+async function capturedUpdatesAsNewVersion(args: {
+    storage: StashStorage;
+    db: Database;
+    stash: StashRow;
+    updatedRegions: SessionRegion[];
+}): Promise<number> {
+    // Capture the updated regions' current content as a new stash version.
+    // Stored as: refs/stashes/<id>/v<n> with one file per region's filePath holding the current content.
+    const repo = new StoreRepo(args.storage.storeRepoDir());
+    const maxV = args.db
+        .query<{ m: number | null }, [string]>("SELECT MAX(version) as m FROM versions WHERE stash_id = ?")
+        .get(args.stash.id);
+    const newV = (maxV?.m ?? 0) + 1;
+    const files: Record<string, string> = {};
+    for (const r of args.updatedRegions) {
+        files[`${r.filePath}.hunk${r.hunkIndex}.content`] = r.currentContent ?? "";
+    }
+    // Build a synthetic patch (added-only): not directly applicable, but preserves the captured content
+    // for future inspection. v1.1 will reconstruct a real format-patch.
+    const synth = Object.entries(files)
+        .map(([k, v]) => `# captured: ${k}\n${v}`)
+        .join("\n--\n");
+    const patchRef = `refs/stashes/${args.stash.id}/v${newV}`;
+    await repo.writePatchCommit({
+        ref: patchRef,
+        files: { "PATCH.diff": synth, ...files },
+        message: `stash:${args.stash.name} v${newV} (captured from unapply)`,
+    });
+    const now = new Date().toISOString();
+    args.db.run(
+        `INSERT INTO versions (id, stash_id, version, patch_ref, region_count, file_count, metadata_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, '{"capturedFromUnapply":true}', ?)`,
+        [newStashId(), args.stash.id, newV, patchRef, args.updatedRegions.length, args.updatedRegions.length, now],
+    );
+    return newV;
+}
+```
+
+- [ ] **Step 2: Stub `lib/diff-render.ts`** (real impl via `src/utils/diff` once we read its API)
+
+```typescript
+// src/stash/lib/diff-render.ts
+export function renderDiff(args: { before: string; after: string; label: string }): string {
+    // Stub: simple line-by-line unified rendering. Will be replaced by src/utils/diff usage in Task 16.
+    const beforeLines = args.before.split("\n");
+    const afterLines = args.after.split("\n");
+    const lines = [`--- stored (${args.label})`, `+++ current`];
+    const max = Math.max(beforeLines.length, afterLines.length);
+    for (let i = 0; i < max; i++) {
+        const b = beforeLines[i];
+        const a = afterLines[i];
+        if (b === a) {
+            lines.push(`  ${b ?? ""}`);
+        } else {
+            if (b !== undefined) {
+                lines.push(`- ${b}`);
+            }
+            if (a !== undefined) {
+                lines.push(`+ ${a}`);
+            }
+        }
+    }
+    return lines.join("\n");
+}
+```
+
+- [ ] **Step 3: Wire into commander**
+
+Add to `src/stash/index.ts`:
+
+```typescript
+import { unapplyCommand } from "./commands/unapply";
+
+program
+    .command("unapply <name>")
+    .description("Surgically remove an applied stash with diff review")
+    .option("--continue", "resume from last checkpoint")
+    .option("--skip", "decide current region as 'skip'")
+    .option("--abort", "abandon in-progress session, restore state")
+    .option("--status", "show progress of in-progress session")
+    .option("--decision <d>", "decide current region: update | discard | skip | discard-all-dangerous | update-stash-all-dangerous")
+    .action(async (name: string, opts: { continue?: boolean; skip?: boolean; abort?: boolean; status?: boolean; decision?: string }) => {
+        const action =
+            opts.abort ? "abort" :
+            opts.status ? "status" :
+            opts.skip ? "skip" :
+            opts.continue ? "continue" :
+            "start";
+        await unapplyCommand({ name, action, decision: opts.decision as never });
+    });
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+# In the apply smoke-test repo where smoke-test stash is applied:
+tools stash unapply smoke-test --decision=discard-all-dangerous
+# expected: removes all marker-wrapped content; reports stats
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stash/commands/unapply.ts src/stash/lib/diff-render.ts src/stash/index.ts
+git commit -m "feat(stash): unapply state machine with TTY clack walk + non-TTY suggestCommand"
+```
+
+---
+
+### Task 16: Replace diff-render stub with src/utils/diff
+
+**Files:**
+- Modify: `src/stash/lib/diff-render.ts`
+
+- [ ] **Step 1: Locate the diff utility**
+
+Run: `ls src/utils/diff*` to see the available API.
+
+- [ ] **Step 2: Wire the real renderer**
+
+Read `src/utils/diff` exports; pick a unified-diff renderer that returns a colored string. Replace the stub with a call into it. Example shape (adjust to actual API):
+
+```typescript
+// src/stash/lib/diff-render.ts
+import { renderUnifiedDiff } from "@app/utils/diff"; // adjust import to real export
+
+export function renderDiff(args: { before: string; after: string; label: string }): string {
+    return renderUnifiedDiff({
+        oldText: args.before,
+        newText: args.after,
+        oldLabel: `stored:${args.label}`,
+        newLabel: `current:${args.label}`,
+        context: 3,
+        color: true,
+    });
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/stash/lib/diff-render.ts
+git commit -m "feat(stash): use src/utils/diff for unapply diff rendering"
+```
+
+---
+
+## Phase 7 — list / show / drop / versions / where / update
+
+### Task 17: list / show / versions / drop / where commands
+
+**Files:**
+- Create: `src/stash/commands/list.ts`
+- Create: `src/stash/commands/show.ts`
+- Create: `src/stash/commands/versions.ts`
+- Create: `src/stash/commands/drop.ts`
+- Create: `src/stash/commands/where.ts`
+- Modify: `src/stash/index.ts`
+
+- [ ] **Step 1: Implement list**
+
+```typescript
+// src/stash/commands/list.ts
+import { Database } from "bun:sqlite";
+import { out } from "@app/logger";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import { detectProject, findSiblingClones } from "../lib/projects";
+import type { StashRow } from "../types";
+
+export interface ListOptions {
+    project: boolean;
+    tag: string | undefined;
+    applied: boolean;
+}
+
+export async function listCommand(opts: ListOptions): Promise<void> {
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    let projectPaths: string[] | null = null;
+    if (opts.project || opts.applied) {
+        const project = await detectProject(process.cwd());
+        if (!project) {
+            out.log.error("--project requires a git repo");
+            process.exit(1);
+        }
+        projectPaths = [project.rootPath, ...(await findSiblingClones(project.rootPath))];
+    }
+
+    let rows: StashRow[];
+    if (projectPaths) {
+        const placeholders = projectPaths.map(() => "?").join(",");
+        rows = db
+            .query<StashRow, string[]>(
+                `SELECT DISTINCT s.* FROM stashes s
+                 LEFT JOIN applications a ON a.stash_id = s.id AND a.state = 'active'
+                 LEFT JOIN versions v ON v.stash_id = s.id
+                 WHERE a.project_path IN (${placeholders}) OR v.source_repo_path IN (${placeholders})
+                 ORDER BY s.updated_at DESC`,
+            )
+            .all(...projectPaths, ...projectPaths);
+    } else {
+        rows = db
+            .query<StashRow, []>("SELECT * FROM stashes ORDER BY updated_at DESC")
+            .all();
+    }
+
+    if (opts.tag) {
+        const tag = opts.tag;
+        rows = rows.filter((r) => (r.tags ? (JSON.parse(r.tags) as string[]).includes(tag) : false));
+    }
+
+    if (!rows.length) {
+        out.log.info("no stashes");
+        return;
+    }
+    for (const r of rows) {
+        const v = db
+            .query<{ m: number | null }, [string]>("SELECT MAX(version) as m FROM versions WHERE stash_id = ?")
+            .get(r.id);
+        const appliedHere = projectPaths
+            ? db
+                  .query<{ c: number }, string[]>(
+                      `SELECT COUNT(*) as c FROM applications WHERE stash_id = ? AND state = 'active' AND project_path IN (${projectPaths.map(() => "?").join(",")})`,
+                  )
+                  .get(r.id, ...projectPaths)?.c ?? 0
+            : 0;
+        out.print(`${r.name}  v${v?.m ?? "?"}  ${r.tags ?? ""}  ${appliedHere ? "[applied here]" : ""}`);
+    }
+    db.close();
+}
+```
+
+- [ ] **Step 2: Implement show**
+
+```typescript
+// src/stash/commands/show.ts
+import { Database } from "bun:sqlite";
+import { out } from "@app/logger";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import { StoreRepo } from "../lib/store-repo";
+import type { StashRow, VersionRow } from "../types";
+
+export async function showCommand(opts: { name: string; version?: number; mode: "diff" | "meta" | "regions" }): Promise<void> {
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        out.log.error(`stash "${opts.name}" not found`);
+        process.exit(1);
+    }
+    const v = opts.version
+        ? db.query<VersionRow, [string, number]>("SELECT * FROM versions WHERE stash_id = ? AND version = ?").get(stash.id, opts.version)
+        : db.query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC LIMIT 1").get(stash.id);
+    if (!v) {
+        out.log.error("version not found");
+        process.exit(1);
+    }
+    out.print(`name:    ${stash.name}`);
+    out.print(`version: v${v.version}`);
+    out.print(`tags:    ${stash.tags ?? "-"}`);
+    out.print(`source:  ${v.source_repo_path ?? "?"} @ ${v.source_sha?.slice(0, 7) ?? "?"}`);
+    out.print(`files:   ${v.file_count}`);
+    out.print(`regions: ${v.region_count}`);
+    if (opts.mode === "meta") {
+        db.close();
+        return;
+    }
+    const repo = new StoreRepo(storage.storeRepoDir());
+    if (opts.mode === "diff") {
+        const patch = await repo.readFileAt(v.patch_ref, "PATCH.diff");
+        out.print("\n--- patch ---");
+        out.print(patch ?? "(empty)");
+    } else {
+        const refs = await repo.listRefs(`refs/stashes/${stash.id}/`);
+        out.print("\n--- regions (placeholder; full inventory in v1.1) ---");
+        for (const ref of refs) {
+            out.print(`  ${ref}`);
+        }
+    }
+    db.close();
+}
+```
+
+- [ ] **Step 3: Implement versions / drop / where**
+
+```typescript
+// src/stash/commands/versions.ts
+import { Database } from "bun:sqlite";
+import { out } from "@app/logger";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import type { StashRow, VersionRow } from "../types";
+
+export async function versionsCommand(name: string): Promise<void> {
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(name);
+    if (!stash) {
+        out.log.error(`stash "${name}" not found`);
+        process.exit(1);
+    }
+    const rows = db
+        .query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC")
+        .all(stash.id);
+    for (const r of rows) {
+        out.print(`v${r.version}  files:${r.file_count}  regions:${r.region_count}  ${r.created_at}  ${r.source_origin ?? ""}`);
+    }
+    db.close();
+}
+```
+
+```typescript
+// src/stash/commands/drop.ts
+import { Database } from "bun:sqlite";
+import { out } from "@app/logger";
+import { isInteractive } from "@app/utils/cli";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import { StoreRepo } from "../lib/store-repo";
+import type { StashRow, VersionRow } from "../types";
+
+export async function dropCommand(opts: { name: string; version?: number; allVersions: boolean; orphanActive: boolean }): Promise<void> {
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        out.log.error(`stash "${opts.name}" not found`);
+        process.exit(1);
+    }
+
+    const activeCount = db
+        .query<{ c: number }, [string]>("SELECT COUNT(*) as c FROM applications WHERE stash_id = ? AND state = 'active'")
+        .get(stash.id)?.c ?? 0;
+    if (activeCount > 0 && !opts.orphanActive) {
+        out.log.error(`${activeCount} active application(s) — pass --orphan-active to proceed`);
+        process.exit(1);
+    }
+
+    if (isInteractive()) {
+        const { confirm } = await import("@clack/prompts");
+        const ok = await confirm({ message: `delete stash "${opts.name}"${opts.allVersions ? " (all versions)" : opts.version ? ` v${opts.version}` : " (latest)"}?` });
+        if (ok !== true) {
+            out.log.warn("cancelled");
+            return;
+        }
+    }
+
+    const repo = new StoreRepo(storage.storeRepoDir());
+    let versionsToDelete: VersionRow[];
+    if (opts.allVersions) {
+        versionsToDelete = db.query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ?").all(stash.id);
+    } else if (opts.version) {
+        const v = db.query<VersionRow, [string, number]>("SELECT * FROM versions WHERE stash_id = ? AND version = ?").get(stash.id, opts.version);
+        versionsToDelete = v ? [v] : [];
+    } else {
+        const v = db.query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC LIMIT 1").get(stash.id);
+        versionsToDelete = v ? [v] : [];
+    }
+
+    for (const v of versionsToDelete) {
+        await repo.deleteRef(v.patch_ref);
+        await repo.deleteRef(`refs/baselines/${stash.id}/v${v.version}`);
+        db.run("DELETE FROM versions WHERE id = ?", [v.id]);
+    }
+
+    if (opts.orphanActive) {
+        db.run("UPDATE applications SET state = 'orphaned' WHERE stash_id = ? AND state = 'active'", [stash.id]);
+    }
+
+    if (opts.allVersions || versionsToDelete.length === db.query<{ c: number }, [string]>("SELECT COUNT(*) as c FROM versions WHERE stash_id = ?").get(stash.id)?.c) {
+        const remaining = db.query<{ c: number }, [string]>("SELECT COUNT(*) as c FROM versions WHERE stash_id = ?").get(stash.id)?.c ?? 0;
+        if (remaining === 0) {
+            db.run("DELETE FROM stashes WHERE id = ?", [stash.id]);
+        }
+    }
+
+    out.log.success(`dropped ${versionsToDelete.length} version(s)`);
+    db.close();
+}
+```
+
+```typescript
+// src/stash/commands/where.ts
+import { Database } from "bun:sqlite";
+import { out } from "@app/logger";
+import { StashStorage } from "../lib/storage";
+import { openStashDb } from "../lib/stash-db";
+import type { StashRow, ApplicationRow } from "../types";
+
+export async function whereCommand(name: string): Promise<void> {
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(name);
+    if (!stash) {
+        out.log.error(`stash "${name}" not found`);
+        process.exit(1);
+    }
+    const apps = db
+        .query<ApplicationRow, [string]>("SELECT * FROM applications WHERE stash_id = ? AND state = 'active' ORDER BY applied_at")
+        .all(stash.id);
+    if (!apps.length) {
+        out.log.info("not currently applied anywhere");
+        return;
+    }
+    for (const a of apps) {
+        out.print(`${a.project_path}  (applied ${a.applied_at})`);
+    }
+    db.close();
+}
+```
+
+- [ ] **Step 4: Wire all subcommands**
+
+Add to `src/stash/index.ts`:
+
+```typescript
+import { listCommand } from "./commands/list";
+import { showCommand } from "./commands/show";
+import { versionsCommand } from "./commands/versions";
+import { dropCommand } from "./commands/drop";
+import { whereCommand } from "./commands/where";
+
+program
+    .command("list")
+    .description("List stashes")
+    .option("--project", "only stashes related to the current project")
+    .option("--tag <tag>", "filter by tag")
+    .option("--applied", "only stashes currently applied to this project")
+    .action(async (opts) => {
+        await listCommand({ project: !!opts.project, tag: opts.tag, applied: !!opts.applied });
+    });
+
+program
+    .command("show <name>")
+    .description("Show stash details")
+    .option("--at <version>", "specific version", (v) => Number(v))
+    .option("--diff", "show patch content")
+    .option("--meta", "show only metadata")
+    .option("--regions", "show region inventory")
+    .action(async (name: string, opts) => {
+        const mode: "diff" | "meta" | "regions" = opts.diff ? "diff" : opts.meta ? "meta" : "regions";
+        await showCommand({ name, version: opts.at, mode });
+    });
+
+program
+    .command("versions <name>")
+    .description("List versions of a stash")
+    .action(async (name: string) => { await versionsCommand(name); });
+
+program
+    .command("drop <name>")
+    .description("Delete a stash version")
+    .option("--at <version>", "specific version", (v) => Number(v))
+    .option("--all-versions", "delete all versions")
+    .option("--orphan-active", "drop even with active applications")
+    .action(async (name: string, opts) => {
+        await dropCommand({ name, version: opts.at, allVersions: !!opts.allVersions, orphanActive: !!opts.orphanActive });
+    });
+
+program
+    .command("where <name>")
+    .description("Show projects where this stash is currently applied")
+    .action(async (name: string) => { await whereCommand(name); });
+```
+
+- [ ] **Step 5: Manual smoke + commit**
+
+```bash
+tools stash list
+tools stash show smoke-test
+tools stash versions smoke-test
+tools stash where smoke-test
+tools stash drop smoke-test --all-versions
+```
+
+```bash
+git add src/stash/commands/list.ts src/stash/commands/show.ts src/stash/commands/versions.ts src/stash/commands/drop.ts src/stash/commands/where.ts src/stash/index.ts
+git commit -m "feat(stash): list/show/versions/drop/where commands"
+```
+
+---
+
+## Phase 8 — Skill + README
+
+### Task 18: Author the agent-facing skill
+
+**Files:**
+- Create: `.claude/skills/stash/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md**
+
+```markdown
+---
+name: stash
+description: Save/apply/unapply named code overlays across projects with `tools stash`. Use when the user wants to capture a chunk of working-tree changes for re-use, apply a previously saved stash into the current project, surgically remove an applied stash with diff review, or list/inspect stashes. Triggers on "stash this", "save this overlay", "apply my <name> stash", "pop my debug stash here", "what stashes do I have applied".
+---
+
+# `tools stash` — Cross-Project Code Overlay Manager
+
+## What it does
+
+A global named stash store. Save a chunk from Project A; apply it later to Project A, B, or any sibling clone. Apply decorates injected hunks with foldable `// #region @stash:<name> {json}` markers so they're visible, greppable, and reversible. Unapply runs a multi-step state machine (like `git rebase --continue/--abort`) with per-region diff review.
+
+## Authoring discipline (regions in source)
+
+Wrap code that you might want to stash with foldable region markers. Editors fold them automatically.
+
+```ts
+// #region @stash:debug-logger
+const log = createDebugLogger();
+log.debug('hi');
+// #endregion @stash:debug-logger
+```
+
+- Language comment syntax adapts: `// #region` (TS/JS/PHP/Java/C/Go/Rust/Swift), `# #region` (Python/Ruby/Bash/YAML), `<!-- #region ... -->` (HTML/MD/XML), `/* #region */` (CSS).
+- Naming: kebab-case, purpose-prefixed: `debug-<x>`, `feat-flag-<x>`, `hotfix-<x>`, `experiment-<x>`.
+- Bare author markers (no JSON) are preserved on save; apply-time markers (with JSON metadata) are stripped on save.
+
+## Save modes
+
+```bash
+tools stash save <name> --all          # staged + unstaged + untracked
+tools stash save <name> --staged       # only staged (git diff --cached)
+tools stash save <name> --unstaged     # only unstaged tracked changes
+```
+
+If the name already exists, save bumps to vN+1 automatically (no overwrite). Use `tools stash versions <name>` to inspect history.
+
+## Apply
+
+```bash
+tools stash apply <name>               # latest version
+tools stash apply <name> --at 2        # specific version
+tools stash apply <name> --verbose-markers  # include src/applied metadata in markers
+```
+
+If a 3-way merge can't reconcile, conflict markers land in the file (`<<<<<<<` / `=======` / `>>>>>>>`) and you resolve manually before continuing. (Apply-conflict state machine is v1.1.)
+
+## Unapply — the state machine
+
+Surgical, reviewable removal. Multi-region stashes generate one decision per ambiguous region.
+
+```bash
+tools stash unapply <name>                                # start; auto-removes unchanged regions; prompts on ambiguous
+tools stash unapply <name> --continue                     # resume after pause / ctrl+c
+tools stash unapply <name> --continue --decision=update   # decide current region (non-TTY)
+tools stash unapply <name> --continue --decision=discard
+tools stash unapply <name> --continue --decision=skip
+tools stash unapply <name> --skip                         # alias for --continue --decision=skip
+tools stash unapply <name> --status                       # progress: "5/17 decided"
+tools stash unapply <name> --abort                        # discard all decisions
+```
+
+Three per-region decisions:
+- **`update`** — capture current code state as new vN+1, then remove from code. Use when local edits are worth preserving.
+- **`discard`** — remove using stored content, lose local edits. Use when local edits were experimental.
+- **`skip`** — leave both code and store alone, warn about divergence. Use when you want to detach: code keeps its own copy, stash keeps its.
+
+Power-user batch (explicit, never default — the `-dangerous` suffix is mandatory):
+```bash
+tools stash unapply <name> --continue --decision=discard-all-dangerous
+tools stash unapply <name> --continue --decision=update-stash-all-dangerous
+```
+
+## CRITICAL: never truncate unapply diff output
+
+The unapply state machine prints full diffs to stderr. **Never** pipe through `| head`, `| tail`, or narrow-grep them. The full diff is the only proof you made the right decision for each region. If output is large, redirect to a file (`2> /tmp/unapply.diff`) and read it whole.
+
+## Update — refresh stash from applied site
+
+```bash
+tools stash update <name>              # capture current state of applied regions as new vN+1
+```
+
+Useful when you've been iterating on an applied overlay for days and want to push your improvements back to the store. Errors if the stash isn't currently applied in the cwd.
+
+## Discovery
+
+```bash
+tools stash list                       # all stashes
+tools stash list --project             # only ones related to this project (origin + sibling-clone match)
+tools stash list --applied             # only ones currently applied here
+tools stash show <name>                # region inventory
+tools stash show <name> --diff         # patch content
+tools stash versions <name>            # version history
+tools stash where <name>               # which projects have this applied
+```
+
+## Anti-patterns
+
+- Don't stash secrets, API keys, or `.env` content. The store is plaintext on disk.
+- Don't stash binary or large (>1MB) files — they're skipped with a warning.
+- Don't try to apply the same stash twice to the same project — use `unapply` or `update` instead.
+```
+
+- [ ] **Step 2: Manual smoke — invoke skill via `/stash`**
+
+(Skill becomes available after copying to `.claude/skills/`. Verify `/stash` triggers the skill in a fresh session.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/stash/SKILL.md
+git commit -m "feat(stash): agent-facing skill for stash authoring + CLI workflow"
+```
+
+---
+
+### Task 19: Tool README
+
+**Files:**
+- Create: `src/stash/README.md`
+
+- [ ] **Step 1: Write README**
+
+```markdown
+# tools stash
+
+Global cross-project code-overlay manager. `git stash` × JetBrains Shelf × `quilt`.
+
+## Quick start
+
+\`\`\`bash
+# In Project A — capture a debug-logger overlay
+tools stash save debug-logger --all
+
+# In Project B (sibling clone) — apply it
+cd ../project-b
+tools stash apply debug-logger
+
+# Later, surgical removal with diff review
+tools stash unapply debug-logger
+\`\`\`
+
+## Storage
+
+- Patches: bare git repo at `~/.genesis-tools/stash/store/`
+- Index: SQLite at `~/.genesis-tools/stash/index.db`
+- In-progress sessions: JSON at `~/.genesis-tools/stash/state/`
+- Logs: `~/.genesis-tools/logs/<day>.log`
+
+## Commands
+
+See `tools stash --help` or the agent skill at `.claude/skills/stash/SKILL.md`.
+
+## Design
+
+See `.claude/plans/2026-06-24-StashTool-spec.md` for full design rationale (region marker format, state machine, sibling-clone detection, etc.).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/stash/README.md
+git commit -m "docs(stash): tool README"
+```
+
+---
+
+## Phase 9 — Polish + integration tests
+
+### Task 20: End-to-end integration test
+
+**Files:**
+- Create: `src/stash/e2e.test.ts`
+
+- [ ] **Step 1: Write the round-trip e2e**
+
+```typescript
+// src/stash/e2e.test.ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGitIn } from "./lib/patch";
+import { saveCommand } from "./commands/save";
+import { applyCommand } from "./commands/apply";
+import { unapplyCommand } from "./commands/unapply";
+
+let work: string;
+let origHome: string | undefined;
+let projectA: string;
+let projectB: string;
+
+beforeEach(async () => {
+    work = await mkdtemp(join(tmpdir(), "stash-e2e-"));
+    origHome = process.env.HOME;
+    process.env.HOME = work;
+    projectA = join(work, "repo-a");
+    projectB = join(work, "repo-b");
+    for (const repo of [projectA, projectB]) {
+        await runGitIn(work, ["init", repo.split("/").pop() ?? "", "--initial-branch=main"]);
+        await runGitIn(repo, ["config", "user.email", "t@t"]);
+        await runGitIn(repo, ["config", "user.name", "t"]);
+        await writeFile(join(repo, "main.ts"), "export function main() { return 1; }\n");
+        await runGitIn(repo, ["add", "main.ts"]);
+        await runGitIn(repo, ["commit", "-m", "init"]);
+    }
+});
+afterEach(async () => {
+    process.env.HOME = origHome;
+    await rm(work, { recursive: true, force: true });
+});
+
+describe("stash e2e", () => {
+    test("save in A → apply in B → unapply (discard) restores B to original", async () => {
+        process.chdir(projectA);
+        await writeFile(join(projectA, "main.ts"), "import { log } from './log';\nexport function main() { log('start'); return 1; }\n");
+        await saveCommand({ name: "logging", mode: "all", tags: [], description: undefined });
+
+        process.chdir(projectB);
+        await applyCommand({ name: "logging", verboseMarkers: false });
+        const applied = await readFile(join(projectB, "main.ts"), "utf8");
+        expect(applied).toContain("#region @stash:logging");
+        expect(applied).toContain("log('start')");
+
+        await unapplyCommand({ name: "logging", action: "start", decision: "discard-all-dangerous" });
+        const after = await readFile(join(projectB, "main.ts"), "utf8");
+        expect(after).not.toContain("#region @stash:logging");
+        expect(after).not.toContain("log('start')");
+    });
+
+    test("save → save again with edits → versions=2", async () => {
+        process.chdir(projectA);
+        await writeFile(join(projectA, "main.ts"), "v1");
+        await saveCommand({ name: "ver", mode: "all", tags: [], description: undefined });
+        await writeFile(join(projectA, "main.ts"), "v2");
+        await saveCommand({ name: "ver", mode: "all", tags: [], description: undefined });
+
+        const { Database } = await import("bun:sqlite");
+        const { openStashDb } = await import("./lib/stash-db");
+        const { StashStorage } = await import("./lib/storage");
+        const db = openStashDb(new Database(new StashStorage().dbPath()));
+        const count = db.query<{ c: number }, []>("SELECT COUNT(*) as c FROM versions").get();
+        expect(count?.c).toBe(2);
+        db.close();
+    });
+});
+```
+
+- [ ] **Step 2: Run + commit**
+
+Run: `bun test src/stash/e2e.test.ts` — 2 pass.
+
+```bash
+git add src/stash/e2e.test.ts
+git commit -m "test(stash): e2e save → apply → unapply round-trip"
+```
+
+---
+
+### Task 21: Run full test suite + final commit
+
+- [ ] **Step 1: Run full suite**
+
+Run: `bun test src/stash/` — all pass.
+
+- [ ] **Step 2: Run `tools stash --readme` to verify help discovery**
+
+Run: `tools stash --readme`
+Expected: README.md printed.
+
+- [ ] **Step 3: Lint + typecheck**
+
+Run: `bunx biome check src/stash/`
+Run: `git ls-files 'src/stash/*.ts' | tsgo --noEmit | rg 'src/stash/'`
+
+Fix any issues, then:
+
+```bash
+git add -u
+git commit -m "chore(stash): biome + tsgo clean pass"
+```
+
+---
+
+## Out of Plan Scope (deferred to v1.1+)
+
+These spec items are intentionally NOT in this plan. Tackle in follow-up plans once v1 ships.
+
+1. **`update` command** as a separate command (capture from applied site without unapplying). v1's `unapply --decision=update` covers the common case via the state machine. A standalone `update` command becomes trivial once that flow is stable.
+2. **`diff` command** (compare stored stash vs applied region without running unapply). Cosmetic — `show --diff` + manual file read is the workaround.
+3. **`--region` save mode** (save only specific author-marked regions). Currently `--all`/`--staged`/`--unstaged` cover working-tree-derived saves; `--region` requires the region scanner to feed a filter into `git diff -- pathspec` and is non-trivial.
+4. **`--patch` interactive save** (git-add-p style hunk picker). Inquirer/clack does not have a built-in hunk picker; would need custom UI.
+5. **Apply conflict state machine.** v1 lets 3-way conflicts surface as inline `<<<<<<<` markers, user resolves manually. The `ApplyConflictSession` shape mirrors `UnapplySession` and can be added in v1.1.
+6. **Tree-hash sibling-clone detection.** v1 uses origin URL + dir-pattern only. Tree-hash fallback covers fork-clones with diverged remotes.
+7. **`tools stash doctor`** (verify store + sqlite consistency, `git fsck`, rebuild index from refs). For v1.1 after first reported corruption.
+8. **`tools stash rebase-project <old> <new>`** (update `applications.project_path` when a project is moved on disk).
+9. **Author-marker-aware unapply.** v1 derives "regions" from patch hunks; v1.1 uses parsed `@stash:` markers as semantic boundaries, allowing one stash to have N named regions per file.
+10. **Remote sync** (publish stashes to a shared store, pull from teammates). Probably never.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec section | Plan task(s) | Status |
+|---|---|---|
+| §4 Use Cases UC1-UC5 | Tasks 10, 11, 15-17 | ✓ |
+| §5 Architecture | Tasks 1-9 (foundation), 10-17 (commands) | ✓ |
+| §6.1 Marker format | Task 6 | ✓ |
+| §6.2 SQLite schema | Task 2 | ✓ |
+| §6.3 Bare git store | Task 3 | ✓ |
+| §7.1 Lifecycle table | Tasks 10-17 | partial — `update`/`diff` deferred |
+| §7.2 Save modes | Task 10 | partial — `--region`/`--patch` deferred |
+| §7.3 Apply | Task 11 | ✓ (conflict state machine deferred) |
+| §7.4 Unapply state machine | Tasks 12-16 | ✓ |
+| §7.5 Update command | deferred to v1.1 (covered by `unapply --decision=update`) | partial |
+| §7.6 list/show/where | Task 17 | ✓ |
+| §7.7 diff/drop/versions | Task 17 | partial — `diff` deferred |
+| §8 Sibling-clone detection | Task 9 | ✓ (origin URL + dir-pattern) |
+| §9 Skill | Task 18 | ✓ |
+| §10 Error handling | covered inline across commands | ✓ |
+| §11 Testing strategy | Tasks include 1+ test per lib, Task 20 e2e | ✓ |
+| §12 Logging discipline | `logger.scoped()` used in every command | ✓ |
+
+**Deferred items are surfaced explicitly in "Out of Plan Scope".** No silent gaps.
+
+**2. Placeholder scan:** ran a mental grep for TBD/TODO/"implement later" — none in tasks. The stub `diff-render.ts` in Task 15 is explicitly replaced in Task 16.
+
+**3. Type consistency:**
+- `Decision` type referenced consistently in `unapply-session.ts`, `decisions.ts`, `unapply.ts`.
+- `StashRow` / `VersionRow` / `ApplicationRow` declared once in `types.ts`, imported everywhere.
+- `SaveMode` declared in `patch.ts`, imported by `save.ts`.
+- `CommentSyntax` declared in `languages.ts`, used by `markers.ts`.
+
+**4. One known caller-gap to flag during implementation:** Task 11's `decorateAppliedRegions` parses unified diff hunks to find insertion points; the `parseDiffHunks` regex assumes standard `+++ b/<path>` headers (works for `git apply --3way` output). If `apply` produces non-standard headers in any path, marker placement will drift — covered by Task 11 Step 4's integration test (will fail loudly if so).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `.claude/plans/2026-06-24-StashTool-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Good for a 20-task plan like this.
+
+**2. Inline Execution** — I execute tasks in this session using executing-plans, batch with checkpoints for review.
+
+**Which approach?**

--- a/.claude/plans/2026-06-24-StashTool-spec.md
+++ b/.claude/plans/2026-06-24-StashTool-spec.md
@@ -1,0 +1,463 @@
+# Stash Tool — Design Spec
+
+**Date:** 2026-06-24
+**Status:** Draft (brainstorming locked, awaiting implementation plan)
+**Author:** Martin + Claude (brainstormed in session 36161dfd)
+
+---
+
+## 1. Summary
+
+`tools stash` is a global, cross-project code-overlay manager. It captures named, hunk-level chunks of code from any project into a central store, lets you (re-)apply them to the same or any related project as drift-tolerant patches, marks the applied regions with foldable `#region` markers so they stay visible and findable, and supports surgical, fully-reviewable removal with a multi-step state-machine UX (like `git rebase`'s `--continue` / `--abort`).
+
+It's `git stash` × JetBrains Shelf × `quilt`, with first-class support for:
+- recurring overlays (apply the same "debug logger setup" across 5 sibling repos)
+- versioning (every `save` of an existing name creates `vN+1`)
+- drift tolerance (`git apply --3way` against stored blob OIDs)
+- multi-region, multi-file stashes
+- skill-driven authoring (a `@stash`-aware authoring discipline that the agent enforces)
+
+## 2. Goals
+
+- **G1.** Capture selected regions/hunks of working-tree code into a global, named store.
+- **G2.** Re-apply a stash to any project (same repo, sibling clones, or unrelated project) with drift-tolerant merging.
+- **G3.** Decorate every applied region with `// #region @stash:<name>` markers so they're foldable, greppable, and removable.
+- **G4.** Provide step-by-step, reviewable unapply with full diff visibility — never silently lose user edits.
+- **G5.** Auto-detect "same project" across sibling clones (e.g. `col-fe`, `col-fe2`, `col-fe-native-upgrade`) and across different paths with the same `origin`.
+- **G6.** Version stashes automatically — `save <name>` on an existing stash creates `vN+1`, never overwrites.
+- **G7.** Ship a `skill-creator`-output skill that teaches the agent (and the user) how to author code that is easy to stash, and how to drive `tools stash` end-to-end.
+
+## 3. Non-Goals
+
+- **NG1.** Not a snippet manager (use `gist`, `pet`, or `massCode` for standalone snippet libraries).
+- **NG2.** Not a replacement for `git stash` inside one repo (per-repo WIP shelving stays with native `git stash`).
+- **NG3.** Not a code-sharing / publishing platform (no remote sync in v1 — store is local to one machine).
+- **NG4.** Not a config-overlay tool like `chezmoi` (we patch *source code*, not render templates).
+- **NG5.** No semantic refactoring (we operate on textual hunks, not ASTs).
+
+## 4. Use Cases
+
+**UC1 — Personal debug overlay across sibling repos.** Martin has `col-fe`, `col-fe2`, `col-fe-native-upgrade` (three clones of the same monorepo at different branches). He authors a debug-logger setup in `col-fe`, wraps it `// #region @stash:debug-logger`, runs `tools stash save debug-logger`. Later, working in `col-fe-native-upgrade`, runs `tools stash apply debug-logger` — same code drops in, wrapped with apply-time metadata. When done, `tools stash unapply debug-logger` strips it cleanly.
+
+**UC2 — Cross-project transplant.** Martin writes a useful fix in Project X while debugging, decides to also drop it in Project Y as a starting point. `tools stash save fix-xyz` in X, `cd Y && tools stash apply fix-xyz` in Y. The patch may not apply cleanly (different baseline) — 3-way merge handles drift, conflict markers surface where it can't.
+
+**UC3 — Long-lived overlay with iteration.** Martin applies a stash, edits the applied region over a week, runs `tools stash update <name>` to capture the edits as `v2` of the stash. Future applies (and other projects) get the improved version.
+
+**UC4 — Reviewable removal.** After weeks of using an applied overlay with local edits, `tools stash unapply <name>` walks region-by-region: 14 regions unchanged → auto-removed silently; 2 regions edited → prompts to update/discard/skip; 1 region manually deleted by Martin → prompts to update stash (shrink) or skip.
+
+**UC5 — Discovery.** `tools stash list --project` shows only stashes whose recorded source is the same project (by origin URL or sibling-clone detection). `tools stash where debug-logger` shows all projects on this machine that currently have it applied.
+
+## 5. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CLI: src/stash/index.ts (commander)                            │
+│  ├─ commands/{save,apply,unapply,update,list,show,versions,     │
+│  │            diff,drop,where}.ts                               │
+│  └─ subcommand routing + global flags (-v, --readme)            │
+└──────────────┬──────────────────────────────────────────────────┘
+               │
+       ┌───────┴────────┐
+       ▼                ▼
+┌─────────────┐  ┌──────────────────────────────────┐
+│ lib/store/  │  │ lib/state-machine/               │
+│ ─ git bare  │  │  ─ UnapplySession                │
+│   repo I/O  │  │  ─ ApplyConflictSession          │
+│ ─ patch fmt │  │  ─ persist / resume / abort      │
+│ ─ blob fetch│  └──────────────────────────────────┘
+└─────────────┘
+       │
+       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ lib/index-db/  ─  sqlite at ~/.genesis-tools/stash/index.db     │
+│  (stashes, versions, regions, applications, projects)           │
+└─────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ lib/markers/    ─ JSON-in-comment marker parse/emit/strip       │
+│ lib/projects/   ─ sibling-clone detection (origin + tree-hash)  │
+│ lib/diff/       ─ wraps src/utils/diff for region-level diffs   │
+│ lib/regions/    ─ author-marker discovery in working tree       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Storage root: `~/.genesis-tools/stash/`
+- `store/` — bare git repo (`git init --bare`); patches stored as refs `refs/stashes/<id>/v<n>`; blob OIDs survive for `git apply --3way`.
+- `index.db` — sqlite (see §6.2).
+- `state/` — JSON state files for in-progress unapply/apply sessions: `<project-hash>--<verb>--<stash-id>.json`.
+- `cache/` — derived lookups (project↔origin↔stashes), regenerable.
+- `logs/` — pino day-stamped (via `@app/logger`).
+
+## 6. Data Model
+
+### 6.1 Region marker format
+
+**Opening marker (lean, default):**
+```ts
+// #region @stash:debug-logger {"id":"3f2a8b","v":2}
+```
+
+**Opening marker (verbose, `--verbose-markers` at apply time):**
+```ts
+// #region @stash:debug-logger {"id":"3f2a8b","v":2,"hunk":1,"src":"col-fe@abc123","applied":"2026-06-24T14:30:00Z"}
+```
+
+**Closing marker (always bare — pairs by label):**
+```ts
+// #endregion @stash:debug-logger
+```
+
+**Marker JSON schema (parsed via `SafeJSON.parse`):**
+- `id` *(required)* — stash UUID prefix (first 6 hex of full UUID, enough for collision-free lookup; falls back to full UUID if collision detected).
+- `v` *(required)* — version number (integer).
+- `hunk` *(optional)* — 1-indexed if a stash region is split across multiple non-contiguous hunks in one file.
+- `src` *(verbose only)* — `<basename>@<short-sha>` of the project where this was applied from.
+- `applied` *(verbose only)* — ISO-8601 UTC.
+
+**Comment syntax adapts per language:** `// #region` (JS/TS/PHP/Java/C/C++/Go/Rust/Swift), `# region` (Python/Ruby/Bash/YAML/TOML), `<!-- #region` … `-->` (HTML/XML/MD), `/* #region */` (CSS).
+
+**Inline single-line form** (for 1-line stashes):
+```ts
+someCall(); // @stash:debug-logger {"id":"3f2a8b","v":2}
+```
+On unapply, an inline-marked line is removed wholesale.
+
+### 6.2 SQLite schema
+
+```sql
+CREATE TABLE stashes (
+  id TEXT PRIMARY KEY,                -- full UUID v7
+  name TEXT NOT NULL UNIQUE,
+  tags TEXT,                          -- json array
+  description TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE versions (
+  id TEXT PRIMARY KEY,                -- uuid v7
+  stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL,           -- 1, 2, 3...
+  patch_ref TEXT NOT NULL,            -- git ref in store repo
+  source_repo_path TEXT,              -- abs path at save time
+  source_origin TEXT,                 -- git remote origin URL at save
+  source_sha TEXT,                    -- HEAD sha at save
+  region_count INTEGER NOT NULL,
+  file_count INTEGER NOT NULL,
+  metadata_json TEXT DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  UNIQUE(stash_id, version)
+);
+
+CREATE TABLE regions (
+  id TEXT PRIMARY KEY,                -- uuid v7
+  version_id TEXT NOT NULL REFERENCES versions(id) ON DELETE CASCADE,
+  region_name TEXT,                   -- nullable (anonymous hunks have no name)
+  file_path TEXT NOT NULL,            -- repo-relative
+  hunk_index INTEGER NOT NULL,        -- 1-indexed within file
+  start_marker_present BOOLEAN NOT NULL DEFAULT 0,
+  line_count INTEGER NOT NULL
+);
+
+CREATE TABLE applications (
+  id TEXT PRIMARY KEY,                -- uuid v7
+  stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+  version_id TEXT NOT NULL REFERENCES versions(id),
+  project_path TEXT NOT NULL,         -- abs path at apply time
+  project_origin TEXT,                -- git remote origin URL at apply
+  project_sha_at_apply TEXT,
+  applied_at TEXT NOT NULL,
+  state TEXT NOT NULL,                -- 'active' | 'unapplying' | 'unapplied' | 'orphaned'
+  unapplied_at TEXT
+);
+
+CREATE UNIQUE INDEX idx_applications_active
+  ON applications(stash_id, project_path)
+  WHERE state = 'active';
+
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,                -- uuid v7
+  path TEXT NOT NULL UNIQUE,
+  origin TEXT,                        -- normalized git origin URL
+  tree_hash TEXT,                     -- HEAD tree sha (cached)
+  last_seen TEXT NOT NULL
+);
+
+CREATE INDEX idx_versions_stash ON versions(stash_id);
+CREATE INDEX idx_applications_project ON applications(project_path);
+CREATE INDEX idx_applications_stash ON applications(stash_id);
+CREATE INDEX idx_regions_version ON regions(version_id);
+```
+
+Migrations follow the existing pattern: `src/stash/lib/stash-migrations.ts` defines `STASH_MIGRATIONS: Migration[]`, applied via `runMigrations()` from `src/utils/database/migrations.ts` on every read-write open.
+
+### 6.3 Patch storage in bare git repo
+
+Each stash version is a git commit in `~/.genesis-tools/stash/store/`, refs:
+- `refs/stashes/<stash-uuid>/v<n>` — points to a commit whose tree contains only the changed files (with marker-stripped content).
+- `refs/baselines/<stash-uuid>/v<n>` — points to a commit holding the pre-change versions of those same files (so `git apply --3way` can reconstruct the merge base).
+
+To apply: `git fetch <store-repo> refs/baselines/<id>/v<n>:refs/.gtstash-baseline` then `git apply --3way` of `git diff baseline..version` (or directly the format-patch file we stored alongside).
+
+This lets us:
+1. Recover the original baseline blobs for `--3way` even when applying to an unrelated project.
+2. Store-side garbage-collect old versions via `git gc` if disk grows.
+3. Inspect any stash with `git -C ~/.genesis-tools/stash/store show refs/stashes/<id>/v<n>`.
+
+## 7. Command Surface
+
+### 7.1 Lifecycle table
+
+| Command | Purpose | Mutates store | Mutates code | Interactive |
+|---|---|---|---|---|
+| `save <name> [--region|--staged|--unstaged|--all|--patch] [--tag T...] [--desc TEXT]` | Capture from working tree; create v1 or bump vN+1 | Yes (new version row + git ref) | No | Yes if `--patch` |
+| `apply <name>[@vN] [--verbose-markers]` | Inject into cwd project | No (only `applications` row added) | Yes | Yes on conflict |
+| `unapply <name>` | Surgical remove with diff review | Yes if user chooses `update` | Yes | Yes (state machine) |
+| `update <name>` | Capture current state of applied regions in cwd as new vN+1 | Yes | No | No |
+| `list [--project] [--tag T] [--applied]` | List stashes; filters | No | No | No |
+| `show <name>[@vN] [--diff|--meta|--regions]` | Inspect stash | No | No | No |
+| `versions <name>` | List all versions | No | No | No |
+| `diff <name>` | Diff applied regions in cwd vs stored stash | No | No | No |
+| `drop <name>[@vN] [--all-versions]` | Delete from store | Yes | No | Yes (confirm) |
+| `where <name>` | List all projects on machine that currently have it applied | No | No | No |
+
+### 7.2 Save modes (`tools stash save <name> [mode-flag]`)
+
+- `--region <name>` (repeatable) — Save only specific author-marked regions discovered in the working tree.
+- `--staged` — Save what's currently `git diff --cached`.
+- `--unstaged` — Save what's currently `git diff` (unstaged tracked changes).
+- `--all` — Save staged + unstaged + untracked.
+- `--patch` — Interactive hunk picker (`git add -p` style, via clack).
+- *(no flag, interactive TTY)* — clack menu offers the above; non-TTY without a flag errors with `suggestCommand()`.
+
+**Name collision handling:** If `name` already exists, `save` automatically creates `vN+1` after a one-line stderr notice (`stash 'debug-logger' exists, creating v3`). No `--force` needed — versioning is the safety net.
+
+**Marker handling on save:**
+- If the working tree has `// #region @stash:debug-logger {...}` apply markers (from a previous apply), they are **stripped** from the saved patch — the patch content is "what the code looks like without marker decoration."
+- If the working tree has bare `// #region @stash:foo` author markers (no JSON), they are **preserved** in the patch. Saved patches can carry author markers as semantic boundaries.
+- The bare label form is the canonical way to author "this is a stashable region" without yet running save.
+
+### 7.3 Apply (`tools stash apply <name>[@vN]`)
+
+Algorithm:
+1. **Resolve project context.** `cwd → git rev-parse --show-toplevel` → read `remote.origin.url` → look up `projects` row (insert if new).
+2. **Resolve stash version.** Default latest; `@vN` pins.
+3. **Compatibility check.** If `applications` row already exists for `(stash, project, state=active)`, error: `already applied; use unapply or update`. If the recorded `source_origin` differs from current project origin AND no sibling-clone match → warn but proceed (cross-project transplant is supported).
+4. **Fetch baseline blobs.** `git fetch ~/.genesis-tools/stash/store refs/baselines/<id>/v<n>:refs/.gtstash-baseline`.
+5. **Apply patch.** `git apply --3way --whitespace=fix <patch-file>`. On conflict markers: enter `ApplyConflictSession` (similar shape to unapply state machine).
+6. **Decorate with markers.** Walk inserted hunks; wrap each with `// #region @stash:<name> {"id":...,"v":...}` opener and `// #endregion @stash:<name>` closer. Use language-appropriate comment syntax based on file extension.
+7. **Record application.** Insert `applications` row with `state='active'`, `applied_at=now()`, `project_sha_at_apply=HEAD`.
+8. **Cleanup.** `git update-ref -d refs/.gtstash-baseline`.
+
+### 7.4 Unapply (`tools stash unapply <name>`) — state machine
+
+**The center of gravity of the tool.** Multi-step, persistent, fully reviewable.
+
+#### 7.4.1 Region classification
+
+For each region recorded for this stash+project, locate its markers in the working tree and classify:
+- **`unchanged`** — content between markers matches stored stash content exactly (modulo whitespace per `--whitespace=fix`).
+- **`edited`** — markers present, content differs.
+- **`missing`** — markers absent from the code (user manually deleted).
+- **`new-extra`** — code contains additional `@stash:<name>` regions not present in any stored version.
+
+#### 7.4.2 Decision menu (3 outcomes per ambiguous region)
+
+| Decision | Store effect | Code effect | When applicable |
+|---|---|---|---|
+| `update` | New `vN+1` reflects current code (handles `edited`, `missing`, `new-extra` uniformly) | Remove region from code (or no-op if `missing`) | All ambiguous classes |
+| `discard` | Unchanged | Remove using stored content (lose local edits) | `edited` only (others have nothing to discard) |
+| `skip` | Unchanged | Unchanged; warn divergence | All ambiguous classes |
+
+**`unchanged` regions are auto-removed with no prompt.** Final summary line reports the count: `14 regions unchanged, removed cleanly`.
+
+#### 7.4.3 State machine
+
+```
+states:
+  not_started → started → awaiting_decision[region_k] → … → staged → complete
+                  ↓                ↓                              ↓
+               aborted          aborted                       (no abort path
+                                                              after staging)
+```
+
+Persisted at `~/.genesis-tools/stash/state/<project-hash>--unapply--<stash-id>.json` where `<project-hash>` is the first 12 hex chars of `sha256(abs(project_path))`. Stash-id in the filename is also the 6-char prefix.
+
+```json
+{
+  "stashId": "3f2a8b...",
+  "stashName": "debug-logger",
+  "projectPath": "/Users/Martin/Tresors/Projects/col-fe-native-upgrade",
+  "projectHash": "ab12cd",
+  "startedAt": "2026-06-24T14:30:00Z",
+  "regions": [
+    {"id": "r1", "file": "src/app.ts", "hunk": 1, "class": "unchanged", "decision": "auto-remove"},
+    {"id": "r2", "file": "src/app.ts", "hunk": 2, "class": "edited", "decision": null},
+    {"id": "r3", "file": "src/lib/x.ts", "hunk": 1, "class": "missing", "decision": "skip"}
+  ],
+  "currentIndex": 1,
+  "pausedAt": "2026-06-24T14:31:12Z"
+}
+```
+
+`currentIndex` advances past `unchanged` and already-decided regions; stops on first `null` decision.
+
+#### 7.4.4 Commands
+
+```bash
+tools stash unapply <name>                              # start; walks first ambiguous region
+tools stash unapply <name> --continue                   # resume from last checkpoint
+tools stash unapply <name> --continue --decision=update # decide current region (non-TTY)
+tools stash unapply <name> --skip                       # alias for --continue --decision=skip
+tools stash unapply <name> --abort                      # discard decisions, restore code, drop state
+tools stash unapply <name> --status                     # show progress: "region 5 of 17 — file:src/app.ts hunk 2"
+
+# Dangerous escape hatches (explicit, never default):
+tools stash unapply <name> --continue --decision=discard-all-dangerous
+tools stash unapply <name> --continue --decision=update-stash-all-dangerous
+```
+
+The `-dangerous` suffix is mandatory in the flag name — it's the only way to batch-decide and it's intentionally unergonomic.
+
+#### 7.4.5 TTY vs non-TTY rendering
+
+**TTY:** clack walks region by region. Above each prompt, render the region's full diff via `src/utils/diff` (unified format, colored, NO truncation). Prompt is `select` with the 1-3 applicable choices.
+
+**Non-TTY:** process stops at the first ambiguous region, prints full diff to stderr, then prints `suggestCommand()` with all available decisions as concrete commands:
+```
+Region 2 of 17 — src/app.ts hunk 2 (class: edited)
+[full diff to stderr]
+Choose a decision:
+  tools stash unapply debug-logger --continue --decision=update
+  tools stash unapply debug-logger --continue --decision=discard
+  tools stash unapply debug-logger --continue --decision=skip
+Or abort:
+  tools stash unapply debug-logger --abort
+```
+
+**Hard rule (for skill + agent):** never `| head` / `| tail` / narrow-grep unapply output. Full diff is the only proof the right decision was made. The skill makes this explicit; CI guard in `scripts/ci/` could lint for it in agent-authored shell.
+
+### 7.5 Update (`tools stash update <name>`)
+
+For a stash currently `state='active'` in cwd:
+1. Find all regions via `applications` → `versions` → `regions`.
+2. For each region: locate markers in current code, capture content between them.
+3. Strip markers from captured content.
+4. Build a patch from `baseline ↔ current-captured-content`.
+5. Save as new `vN+1`.
+6. Application's `version_id` does NOT change — the application still points to the version that was applied. Use `apply --reapply` (future) to re-baseline.
+
+`update` errors if stash is not currently applied in cwd: `not applied here; use save to create a new stash from working tree`.
+
+### 7.6 List / show / where
+
+- `list` — table: `name | latest-version | tags | applied-here? | created`. With `--project`, filter to stashes whose `source_origin` matches cwd's origin OR cwd is a sibling clone of any application's project.
+- `show <name>[@vN]` — header (name, version, tags, source, region count, file count), then either patch (`--diff`), metadata (`--meta`), or region inventory (`--regions`, default).
+- `where <name>` — query `applications WHERE stash_name = ? AND state = 'active'`; print one project path per line. Useful for "I'm about to delete this stash — who's still using it?"
+
+### 7.7 Diff / drop / versions
+
+- `diff <name>` — for each applied region in cwd: side-by-side diff of (stored stash content) vs (current code content). Same renderer used inside unapply prompts.
+- `drop <name>[@vN] [--all-versions]` — confirm prompt always. `--all-versions` required if multiple versions exist. Errors if any active application exists; `--orphan-active` flag to drop anyway (marks applications as `state='orphaned'`).
+- `versions <name>` — `vN | created | regions | files | source | size`.
+
+## 8. Sibling-Clone / Project Detection
+
+A project is identified by, in priority order:
+1. **`git config remote.origin.url`** (normalized: strip `.git`, lowercase host, drop user prefix). Two paths with the same origin → same project.
+2. **Directory name pattern**: `<base>`, `<base>2`, `<base>-<suffix>` where they share the same `remote.origin.url`. (This handles `col-fe`, `col-fe2`, `col-fe-native-upgrade`.) Detection: walk siblings of cwd's parent, check origin matches.
+3. **HEAD tree hash similarity (fallback for clones with no origin)**: Jaccard similarity of top-100 file paths > 0.7 → likely same project. Cached in `projects.tree_hash`.
+
+`tools stash list --project` uses this to filter. `apply` uses it to suppress the cross-project-warning when transplanting between siblings.
+
+## 9. The Skill (skill-creator output)
+
+Skill name: `stash` (lives under `genesis-tools` plugin).
+
+Trigger conditions: user says "stash this", "save this overlay", "apply my <name> stash", "pop my debug stash here", "what stashes do I have applied", or invokes `/stash`. The skill is **agent-facing** — it teaches the agent both the marker discipline AND the CLI workflow.
+
+Skill content covers:
+1. **Marker authoring discipline** — `// #region @stash:<name>` syntax, language-comment table, when to use inline form, when to use named regions vs. anonymous hunks.
+2. **Save patterns** — when to use `--region` vs `--patch` vs `--all`; how to name stashes (kebab-case, prefixed by purpose: `debug-`, `feat-flag-`, `hotfix-`, `experiment-`).
+3. **Apply / unapply workflow** — including the state machine; **explicit rule against `| head` / `| tail`** of diff output.
+4. **Versioning intuition** — when to bump via re-`save` vs. `update`; how `apply name@vN` pins.
+5. **Cross-project model** — when sibling detection helps; when to pass `--force-foreign` (future) for unrelated projects.
+6. **Anti-patterns** — don't stash secrets; don't stash files >1MB (errors); don't stash binary files (errors).
+
+## 10. Error Handling & Edge Cases
+
+| Case | Behavior |
+|---|---|
+| Stash name collides on save | Auto-bump to vN+1 with stderr notice |
+| Apply when stash already active in this project | Error: use `unapply` or `update` |
+| Apply with 3-way merge conflict | Enter `ApplyConflictSession` state machine |
+| Apply when source origin ≠ cwd origin and not sibling | Warn but proceed |
+| Apply when baseline blobs missing from store | Fall back to `git apply --whitespace=fix` (fuzz); warn |
+| Unapply when markers have corrupted JSON | Classify as `edited`, present in state machine; offer `--rescue` mode to regenerate from sqlite-tracked region positions |
+| Unapply when application row missing but markers present | Reconstruct application row from marker JSON metadata; warn |
+| Unapply with active state file already present | Error: `--continue`, `--abort`, or `--status` |
+| Drop while applications active | Error unless `--orphan-active` |
+| Binary file in save scope | Skip with warning; record in `metadata_json.skipped[]` |
+| File > 1MB in save scope | Error; suggest `--force-large` (future, not v1) |
+| Store repo corrupted | `tools stash doctor` (v1.1) — runs `git fsck`, rebuilds sqlite index from refs |
+| Out-of-band region marker edits (user manually changed JSON) | Treat user edit as truth; warn if stash ID mismatches sqlite |
+| Project moved (`projects.path` no longer exists) | On next `list --project`, mark as `last_seen` stale; offer `tools stash rebase-project <old> <new>` (v1.1) |
+
+## 11. Testing Strategy
+
+In-memory sqlite + tmpdir git repos per `*.test.ts`, alongside source. Key tests:
+
+1. **Patch round-trip:** save → apply → unapply (all `update` decisions) → patch equals original.
+2. **Drift tolerance:** save in repo A → modify nearby lines in target repo → apply still succeeds via 3-way.
+3. **Version bumping:** save same name twice → versions table has 2 rows, refs `v1` and `v2` exist.
+4. **State machine resumption:** unapply, decide region 1, `^C`, re-run with `--continue` → resumes at region 2.
+5. **State machine abort:** unapply, decide region 1, `--abort` → code restored, state file deleted, application still `active`.
+6. **Sibling-clone detection:** create `/tmp/a`, `/tmp/a2`, `/tmp/a-foo` with same origin → `list --project` from any returns stashes from any.
+7. **Marker stripping on save:** working tree has apply markers from previous apply → saved patch has no markers.
+8. **Marker preservation on save:** working tree has bare author markers → saved patch retains them.
+9. **Multi-language markers:** apply to `.ts`, `.py`, `.html`, `.css` files in one stash → each uses its own comment syntax.
+10. **Cross-project apply:** save in repo A with origin X → apply in repo B with origin Y → warning printed, application succeeds.
+11. **Dangerous batch flags:** `--decision=update-stash-all-dangerous` skips prompts; default `--decision=update` does not.
+12. **Inline marker form:** save → apply → unapply with `--decision=discard` removes the single line.
+
+## 12. Logging & Output Discipline
+
+Per project CLAUDE.md (`@app/logger`):
+- **`logger`** for diagnostics — every external op (git invocation, sqlite open, store path), every decision-branch in state machine, every classification result.
+- **`out`** for user-facing — clack prompts, summaries, diffs.
+- **`out.result()`** only for machine-consumable output (e.g. `tools stash list --json`).
+- Diffs always to stderr (via `out.log.info` / clack note) so `tools stash diff <name> > foo.diff` captures the diff content cleanly via `out.print()`.
+- Day-stamped pino logs at `~/.genesis-tools/logs/` capture full unapply session including all decisions — auditable after the fact.
+
+## 13. Out of Scope (v1)
+
+- Remote sync / publishing (no server, no cloud, no shared stash libraries between machines).
+- AST-based region detection or refactoring-aware patching.
+- Auto-application on `cd` / direnv-style activation.
+- Conflict-merge UI beyond what `git apply --3way` emits as in-file markers.
+- A web/TUI dashboard (future: `tools stash ui`).
+- Stash composition (one stash that depends on another) — author markers can overlap textually but no formal dependency graph.
+- Cross-VCS support (Mercurial, jj) — git-only in v1.
+- Encryption at rest — store is plaintext on disk.
+
+## 14. Open Questions / Deferred
+
+1. **Tagging UX** — `--tag debug --tag wip` works, but should there be a `tools stash tags` command to list/rename tags? Defer.
+2. **Default stash name suggestion** — if no name given to `save`, infer from branch name + region label? Defer; v1 requires explicit name.
+3. **Region grouping syntax** — should `// #region @stash:debug-logger.subsystem-a` create a hierarchy? Defer; v1 treats `.` as literal.
+4. **Re-apply after upstream-baseline drift** — if applied baseline diverges far from current code, should there be a `tools stash refresh-baseline <name>`? Defer to v1.1.
+5. **Conflict-resolution state machine for apply** — sketched in §7.3 but not fully specced. Likely mirrors unapply state machine; will spec when implementing.
+
+## 15. Inspirations / Prior Art
+
+Synthesized from the research agent's survey:
+- **JetBrains Shelf** — hunk-level selectable, named, foldable, cross-project-within-IDE. The closest analog. Limitations: IDE-bound, no CLI, no versioning.
+- **`git stash export`** (git 2.51+) — portable stash via fetch/push; we steal the "patches as git commits in a bare repo" idea.
+- **`git apply --3way`** — drift-tolerant patch application via stored blob OIDs. Core primitive.
+- **`quilt`** — patch series with fuzz tolerance; we steal the "named patches" idea.
+- **`#region` foldable comments** — universal editor support; we extend the existing `@dbg` convention to `@stash`.
+
+---
+
+**End of spec.** Implementation plan to follow in `2026-06-24-StashTool-plan.md`.

--- a/.claude/skills/stash/SKILL.md
+++ b/.claude/skills/stash/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: stash
+description: Save/apply/unapply named code overlays across projects with `tools stash`. Use when the user wants to capture a chunk of working-tree changes for re-use, apply a previously saved stash into the current project, surgically remove an applied stash with diff review, or list/inspect stashes. Triggers on "stash this", "save this overlay", "apply my <name> stash", "pop my debug stash here", "what stashes do I have applied".
+---
+
+# `tools stash` — Cross-Project Code Overlay Manager
+
+## What it does
+
+A global named stash store. Save a chunk from Project A; apply it later to Project A, B, or any sibling clone. Apply decorates injected hunks with foldable `// #region @stash:<name> {json}` markers so they're visible, greppable, and reversible. Unapply runs a multi-step state machine (like `git rebase --continue/--abort`) with per-region diff review.
+
+## Authoring discipline (regions in source)
+
+Wrap code that you might want to stash with foldable region markers. Editors fold them automatically.
+
+```ts
+// #region @stash:debug-logger
+const log = createDebugLogger();
+log.debug('hi');
+// #endregion @stash:debug-logger
+```
+
+- Language comment syntax adapts: `// #region` (TS/JS/PHP/Java/C/Go/Rust/Swift), `# #region` (Python/Ruby/Bash/YAML), `<!-- #region ... -->` (HTML/MD/XML), `/* #region */` (CSS).
+- Naming: kebab-case, purpose-prefixed: `debug-<x>`, `feat-flag-<x>`, `hotfix-<x>`, `experiment-<x>`.
+- Bare author markers (no JSON) are preserved on save; apply-time markers (with JSON metadata) are stripped on save.
+
+## Save modes
+
+```bash
+tools stash save <name> --all          # staged + unstaged + untracked
+tools stash save <name> --staged       # only staged (git diff --cached)
+tools stash save <name> --unstaged     # only unstaged tracked changes
+```
+
+If the name already exists, save bumps to vN+1 automatically (no overwrite). Use `tools stash versions <name>` to inspect history.
+
+## Apply
+
+```bash
+tools stash apply <name>               # latest version
+tools stash apply <name> --at 2        # specific version
+tools stash apply <name> --verbose-markers  # include src/applied metadata in markers
+```
+
+If a 3-way merge can't reconcile, conflict markers land in the file (`<<<<<<<` / `=======` / `>>>>>>>`) and you resolve manually before continuing. (Apply-conflict state machine is v1.1.)
+
+## Unapply — the state machine
+
+Surgical, reviewable removal. Multi-region stashes generate one decision per ambiguous region.
+
+```bash
+tools stash unapply <name>                                # start; auto-removes unchanged regions; prompts on ambiguous
+tools stash unapply <name> --continue                     # resume after pause / ctrl+c
+tools stash unapply <name> --continue --decision=update   # decide current region (non-TTY)
+tools stash unapply <name> --continue --decision=discard
+tools stash unapply <name> --continue --decision=skip
+tools stash unapply <name> --skip                         # alias for --continue --decision=skip
+tools stash unapply <name> --status                       # progress: "5/17 decided"
+tools stash unapply <name> --abort                        # discard all decisions
+```
+
+Three per-region decisions:
+- **`update`** — capture current code state as new vN+1, then remove from code. Use when local edits are worth preserving.
+- **`discard`** — remove using stored content, lose local edits. Use when local edits were experimental.
+- **`skip`** — leave both code and store alone, warn about divergence. Use when you want to detach: code keeps its own copy, stash keeps its.
+
+Power-user batch (explicit, never default — the `-dangerous` suffix is mandatory):
+```bash
+tools stash unapply <name> --continue --decision=discard-all-dangerous
+tools stash unapply <name> --continue --decision=update-stash-all-dangerous
+```
+
+## CRITICAL: never truncate unapply diff output
+
+The unapply state machine prints full diffs to stderr. **Never** pipe through `| head`, `| tail`, or narrow-grep them. The full diff is the only proof you made the right decision for each region. If output is large, redirect to a file (`2> /tmp/unapply.diff`) and read it whole.
+
+## Update — refresh stash from applied site
+
+```bash
+tools stash update <name>              # capture current state of applied regions as new vN+1
+```
+
+Useful when you've been iterating on an applied overlay for days and want to push your improvements back to the store. Errors if the stash isn't currently applied in the cwd.
+
+## Discovery
+
+```bash
+tools stash list                       # all stashes
+tools stash list --project             # only ones related to this project (origin + sibling-clone match)
+tools stash list --applied             # only ones currently applied here
+tools stash show <name>                # region inventory
+tools stash show <name> --diff         # patch content
+tools stash versions <name>            # version history
+tools stash where <name>               # which projects have this applied
+```
+
+## Anti-patterns
+
+- Don't stash secrets, API keys, or `.env` content. The store is plaintext on disk.
+- Don't stash binary or large (>1MB) files — they're skipped with a warning.
+- Don't try to apply the same stash twice to the same project — use `unapply` or `update` instead.

--- a/src/stash/README.md
+++ b/src/stash/README.md
@@ -1,0 +1,32 @@
+# tools stash
+
+Global cross-project code-overlay manager. `git stash` × JetBrains Shelf × `quilt`.
+
+## Quick start
+
+```bash
+# In Project A — capture a debug-logger overlay
+tools stash save debug-logger --all
+
+# In Project B (sibling clone) — apply it
+cd ../project-b
+tools stash apply debug-logger
+
+# Later, surgical removal with diff review
+tools stash unapply debug-logger
+```
+
+## Storage
+
+- Patches: bare git repo at `~/.genesis-tools/stash/store/`
+- Index: SQLite at `~/.genesis-tools/stash/index.db`
+- In-progress sessions: JSON at `~/.genesis-tools/stash/state/`
+- Logs: `~/.genesis-tools/logs/<day>.log`
+
+## Commands
+
+See `tools stash --help` or the agent skill at `.claude/skills/stash/SKILL.md`.
+
+## Design
+
+See `.claude/plans/2026-06-24-StashTool-spec.md` for full design rationale (region marker format, state machine, sibling-clone detection, etc.).

--- a/src/stash/commands/apply.test.ts
+++ b/src/stash/commands/apply.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGitIn } from "../lib/patch";
+import { applyCommand } from "./apply";
+import { saveCommand } from "./save";
+
+let work: string;
+let origStashRoot: string | undefined;
+let origCwd: string;
+let projectA: string;
+let projectB: string;
+
+beforeEach(async () => {
+    origCwd = process.cwd();
+    work = await mkdtemp(join(tmpdir(), "stash-apply-it-"));
+    origStashRoot = process.env.GENESIS_TOOLS_STASH_ROOT;
+    // Redirect the global stash store into the per-test tmpdir so parallel test files don't share state.
+    process.env.GENESIS_TOOLS_STASH_ROOT = join(work, ".genesis-tools", "stash");
+    projectA = join(work, "repo-a");
+    projectB = join(work, "repo-b");
+    for (const repo of [projectA, projectB]) {
+        await runGitIn(work, ["init", repo.split("/").pop() ?? "", "--initial-branch=main"]);
+        await runGitIn(repo, ["config", "user.email", "t@t"]);
+        await runGitIn(repo, ["config", "user.name", "t"]);
+        await writeFile(join(repo, "a.ts"), "fn();\n");
+        await runGitIn(repo, ["add", "a.ts"]);
+        await runGitIn(repo, ["commit", "-m", "init"]);
+    }
+});
+afterEach(async () => {
+    // Restore cwd BEFORE rm — see e2e.test.ts for the macOS posix_spawn-ENOENT-on-dead-cwd note.
+    process.chdir(origCwd);
+    if (origStashRoot !== undefined) {
+        process.env.GENESIS_TOOLS_STASH_ROOT = origStashRoot;
+    } else {
+        delete process.env.GENESIS_TOOLS_STASH_ROOT;
+    }
+    await rm(work, { recursive: true, force: true });
+});
+
+describe.serial("apply integration", () => {
+    test("save in A, apply to B, decorates with markers", async () => {
+        process.chdir(projectA);
+        await writeFile(join(projectA, "a.ts"), "fn();\ninserted();\n");
+        await saveCommand({ name: "x", mode: "all", tags: [], description: undefined });
+
+        process.chdir(projectB);
+        await applyCommand({ name: "x", verboseMarkers: false });
+        const result = await readFile(join(projectB, "a.ts"), "utf8");
+        expect(result).toContain("#region @stash:x");
+        expect(result).toContain("inserted();");
+        expect(result).toContain("#endregion @stash:x");
+    });
+});

--- a/src/stash/commands/apply.ts
+++ b/src/stash/commands/apply.ts
@@ -92,6 +92,7 @@ export async function applyCommand(opts: ApplyOptions): Promise<void> {
         ui.warn(
             "apply-conflict state machine deferred to v1.1; resolve conflicts manually and re-run with --resume (future)"
         );
+        db.close();
         process.exit(1);
     }
 
@@ -169,6 +170,12 @@ async function decorateAppliedRegions(args: {
             if (!hunk) {
                 continue;
             }
+            // PR #222 t3: pure-deletion hunks (no `+` lines, newLines === 0) have nothing to wrap.
+            // Emitting a marker pair here would produce an empty `// #region … // #endregion …`
+            // sandwich with no body, which `parseMarkers` would then "find" with a zero-line span.
+            if (hunk.newLines === 0 || hunk.addedCount === 0) {
+                continue;
+            }
             const meta: Record<string, unknown> = { id: shortId(args.stashId), v: args.version };
             if (args.verbose) {
                 meta.hunk = h + 1;
@@ -223,7 +230,9 @@ function parseDiffHunks(patch: string): Record<string, DiffHunk[]> {
             result[currentFile].push(currentHunk);
             continue;
         }
-        if (currentHunk && line.startsWith("+") && !line.startsWith("+++")) {
+        // `+++ b/path` file headers always appear BEFORE the first `@@`, so currentHunk is null
+        // there and we never reach this branch — no startsWith("+++") guard needed.
+        if (currentHunk && line.startsWith("+")) {
             currentHunk.addedCount++;
         }
     }

--- a/src/stash/commands/apply.ts
+++ b/src/stash/commands/apply.ts
@@ -1,0 +1,231 @@
+import { Database } from "bun:sqlite";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { newStashId, shortId } from "../lib/ids";
+import { commentSyntaxForFile } from "../lib/languages";
+import { emitCloseMarker, emitOpenMarker } from "../lib/markers";
+import { applyPatch, listFilesInPatch, runGitIn } from "../lib/patch";
+import { detectProject } from "../lib/projects";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { StoreRepo } from "../lib/store-repo";
+import { ui } from "../lib/ui";
+import type { ApplicationRow, StashRow, VersionRow } from "../types";
+
+const { log } = logger.scoped("stash:apply");
+
+// Target ref for the fetched baseline. NOTE: git rejects ref-name path components that begin with `.`,
+// so `refs/.gtstash-baseline` would silently fail with "invalid refspec". Keep the dot OUT.
+const BASELINE_TARGET_REF = "refs/gtstash-baseline";
+
+export interface ApplyOptions {
+    name: string;
+    version?: number;
+    verboseMarkers: boolean;
+}
+
+export async function applyCommand(opts: ApplyOptions): Promise<void> {
+    log.debug({ opts }, "applyCommand");
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        ui.err("not inside a git repository");
+        process.exit(1);
+    }
+    log.debug({ rootPath: project.rootPath, origin: project.origin }, "project resolved");
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        ui.err(`stash "${opts.name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+
+    const version = opts.version
+        ? db
+              .query<VersionRow, [string, number]>("SELECT * FROM versions WHERE stash_id = ? AND version = ?")
+              .get(stash.id, opts.version)
+        : db
+              .query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC LIMIT 1")
+              .get(stash.id);
+    if (!version) {
+        ui.err(`no version found for "${opts.name}"${opts.version ? ` @v${opts.version}` : ""}`);
+        db.close();
+        process.exit(1);
+    }
+    log.debug({ stashId: stash.id, version: version.version, patch_ref: version.patch_ref }, "version resolved");
+
+    const existingActive = db
+        .query<ApplicationRow, [string, string]>(
+            "SELECT * FROM applications WHERE stash_id = ? AND project_path = ? AND state = 'active'"
+        )
+        .get(stash.id, project.rootPath);
+    if (existingActive) {
+        ui.err(`"${opts.name}" is already applied here. Use 'unapply' or 'update'.`);
+        db.close();
+        process.exit(1);
+    }
+
+    const repo = new StoreRepo(storage.storeRepoDir());
+    const patch = await repo.readFileAt(version.patch_ref, "PATCH.diff");
+    if (!patch) {
+        ui.err(`patch missing from store at ${version.patch_ref}`);
+        db.close();
+        process.exit(1);
+    }
+    log.debug({ patchBytes: patch.length }, "patch fetched from store");
+
+    const baselineRef = `refs/baselines/${stash.id}/v${version.version}`;
+    await fetchBaselineBlobs({ projectRoot: project.rootPath, storeDir: storage.storeRepoDir(), baselineRef });
+
+    ui.info(`applying "${opts.name}" v${version.version} [id=${shortId(stash.id)}]`);
+
+    try {
+        await applyPatch({ repoDir: project.rootPath, patch, threeWay: true });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ui.err(`apply failed: ${message}`);
+        ui.warn(
+            "apply-conflict state machine deferred to v1.1; resolve conflicts manually and re-run with --resume (future)"
+        );
+        process.exit(1);
+    }
+
+    const affectedFiles = await listFilesInPatch({ repoDir: project.rootPath, patch });
+    await decorateAppliedRegions({
+        projectRoot: project.rootPath,
+        files: affectedFiles,
+        patch,
+        stashName: opts.name,
+        stashId: stash.id,
+        version: version.version,
+        verbose: opts.verboseMarkers,
+        sourceRepo: version.source_repo_path,
+        sourceSha: version.source_sha,
+    });
+
+    const now = new Date().toISOString();
+    db.run(
+        `INSERT INTO applications (id, stash_id, version_id, project_path, project_origin, project_sha_at_apply, applied_at, state)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'active')`,
+        [newStashId(), stash.id, version.id, project.rootPath, project.origin, project.sha, now]
+    );
+
+    // Drop the fetched baseline ref — it was only needed to seed 3-way merge blobs into objects/.
+    // Failure is harmless: git's GC will reap unreachable objects eventually.
+    await runGitIn(project.rootPath, ["update-ref", "-d", BASELINE_TARGET_REF]).catch((err) => {
+        log.debug({ err }, "baseline ref cleanup failed (non-fatal)");
+    });
+
+    ui.ok(`applied "${opts.name}" v${version.version}`);
+    ui.info(`  ${affectedFiles.length} files affected`);
+
+    db.close();
+    log.debug({ stashId: stash.id, version: version.version, files: affectedFiles.length }, "stash applied");
+}
+
+async function fetchBaselineBlobs(args: { projectRoot: string; storeDir: string; baselineRef: string }): Promise<void> {
+    try {
+        await runGitIn(args.projectRoot, [
+            "fetch",
+            "--no-tags",
+            args.storeDir,
+            `${args.baselineRef}:${BASELINE_TARGET_REF}`,
+        ]);
+        log.debug({ ref: BASELINE_TARGET_REF }, "baseline blobs fetched into project objects");
+    } catch (err) {
+        log.warn({ err }, "baseline fetch failed; --3way will fall back to fuzz matching");
+    }
+}
+
+async function decorateAppliedRegions(args: {
+    projectRoot: string;
+    files: string[];
+    patch: string;
+    stashName: string;
+    stashId: string;
+    version: number;
+    verbose: boolean;
+    sourceRepo: string | null;
+    sourceSha: string | null;
+}): Promise<void> {
+    const hunks = parseDiffHunks(args.patch);
+    for (const [filePath, fileHunks] of Object.entries(hunks)) {
+        const abs = join(args.projectRoot, filePath);
+        const syntax = commentSyntaxForFile(filePath);
+        let content: string;
+        try {
+            content = await readFile(abs, "utf8");
+        } catch {
+            continue;
+        }
+        const lines = content.split("\n");
+        for (let h = fileHunks.length - 1; h >= 0; h--) {
+            const hunk = fileHunks[h];
+            if (!hunk) {
+                continue;
+            }
+            const meta: Record<string, unknown> = { id: shortId(args.stashId), v: args.version };
+            if (args.verbose) {
+                meta.hunk = h + 1;
+                if (args.sourceRepo) {
+                    meta.src = `${args.sourceRepo.split("/").pop()}@${args.sourceSha?.slice(0, 7) ?? "?"}`;
+                }
+                meta.applied = new Date().toISOString();
+            }
+            const openLine = emitOpenMarker({ name: args.stashName, meta, syntax });
+            const closeLine = emitCloseMarker({ name: args.stashName, syntax });
+            const closeIdx = hunk.newStart + hunk.newLines - 1;
+            const openIdx = hunk.newStart - 1;
+            lines.splice(closeIdx, 0, closeLine);
+            lines.splice(openIdx, 0, openLine);
+        }
+        await writeFile(abs, lines.join("\n"));
+    }
+}
+
+interface DiffHunk {
+    newStart: number;
+    newLines: number;
+    addedCount: number;
+}
+
+function parseDiffHunks(patch: string): Record<string, DiffHunk[]> {
+    const result: Record<string, DiffHunk[]> = {};
+    const lines = patch.split("\n");
+    let currentFile: string | null = null;
+    let currentHunk: DiffHunk | null = null;
+    // Unified-diff hunk header `@@ -orig +newStart,newLines @@` — capture newStart + newLines for marker placement.
+    const HUNK_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+    // Post-image file header from `git diff --dst-prefix=b/` — captures relative path.
+    const FILE_RE = /^\+\+\+ b\/(.+)$/;
+    for (const line of lines) {
+        const fm = FILE_RE.exec(line);
+        if (fm) {
+            currentFile = fm[1] ?? null;
+            currentHunk = null;
+            continue;
+        }
+        const hm = HUNK_RE.exec(line);
+        if (hm && currentFile) {
+            currentHunk = {
+                newStart: Number(hm[1]),
+                newLines: Number(hm[2] ?? "1"),
+                addedCount: 0,
+            };
+            if (!result[currentFile]) {
+                result[currentFile] = [];
+            }
+            result[currentFile].push(currentHunk);
+            continue;
+        }
+        if (currentHunk && line.startsWith("+") && !line.startsWith("+++")) {
+            currentHunk.addedCount++;
+        }
+    }
+    return result;
+}

--- a/src/stash/commands/drop.ts
+++ b/src/stash/commands/drop.ts
@@ -39,6 +39,12 @@ export async function dropCommand(opts: {
         process.exit(1);
     }
 
+    if (opts.allVersions && opts.version !== undefined) {
+        ui.err("--all-versions cannot be combined with --at");
+        db.close();
+        process.exit(1);
+    }
+
     if (isInteractive()) {
         const { confirm } = await import("@clack/prompts");
         const ok = await confirm({

--- a/src/stash/commands/drop.ts
+++ b/src/stash/commands/drop.ts
@@ -71,6 +71,15 @@ export async function dropCommand(opts: {
         "destructive drop starting"
     );
 
+    // PR #222 t25: an explicit `--at v` for a non-existent version must NOT proceed into the
+    // BEGIN block — otherwise `--orphan-active` would still flip every active application to
+    // 'orphaned' even though no version was dropped.
+    if (opts.version && versionsToDelete.length === 0) {
+        ui.err(`stash "${opts.name}" has no v${opts.version}`);
+        db.close();
+        process.exit(1);
+    }
+
     // Wrap the destructive sequence in a SQLite transaction so a half-failure rolls back the DB
     // side. Store-repo ref deletes happen alongside (no transactional join with git), but
     // deleteRef is missing-safe (it logs+ignores already-absent refs), so a retry converges.
@@ -101,8 +110,11 @@ export async function dropCommand(opts: {
     } catch (err) {
         try {
             db.run("ROLLBACK");
-        } catch {
-            // Transaction may already have been rolled back by SQLite after a DDL/constraint failure.
+        } catch (rollbackErr) {
+            // SQLite often auto-rolls-back after DDL/constraint failure; the explicit ROLLBACK then
+            // throws "cannot rollback - no transaction is active". Log it so a genuinely failing
+            // rollback (lock contention, etc.) isn't invisible.
+            log.debug({ err: rollbackErr, stashId: stash.id }, "rollback after drop error failed (often benign)");
         }
         db.close();
         throw err;

--- a/src/stash/commands/drop.ts
+++ b/src/stash/commands/drop.ts
@@ -1,0 +1,98 @@
+import { Database } from "bun:sqlite";
+import { logger } from "@app/logger";
+import { isInteractive } from "@app/utils/cli";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { StoreRepo } from "../lib/store-repo";
+import { ui } from "../lib/ui";
+import type { StashRow, VersionRow } from "../types";
+
+const { log } = logger.scoped("stash:drop");
+
+export async function dropCommand(opts: {
+    name: string;
+    version?: number;
+    allVersions: boolean;
+    orphanActive: boolean;
+}): Promise<void> {
+    log.debug({ opts }, "dropCommand");
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        ui.err(`stash "${opts.name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+
+    const activeCount =
+        db
+            .query<{ c: number }, [string]>(
+                "SELECT COUNT(*) as c FROM applications WHERE stash_id = ? AND state = 'active'"
+            )
+            .get(stash.id)?.c ?? 0;
+    log.debug({ stashId: stash.id, activeCount }, "active application scan");
+    if (activeCount > 0 && !opts.orphanActive) {
+        ui.err(`${activeCount} active application(s) — pass --orphan-active to proceed`);
+        db.close();
+        process.exit(1);
+    }
+
+    if (isInteractive()) {
+        const { confirm } = await import("@clack/prompts");
+        const ok = await confirm({
+            message: `delete stash "${opts.name}"${opts.allVersions ? " (all versions)" : opts.version ? ` v${opts.version}` : " (latest)"}?`,
+        });
+        if (ok !== true) {
+            ui.warn("cancelled");
+            db.close();
+            return;
+        }
+    }
+
+    const repo = new StoreRepo(storage.storeRepoDir());
+    let versionsToDelete: VersionRow[];
+    if (opts.allVersions) {
+        versionsToDelete = db.query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ?").all(stash.id);
+    } else if (opts.version) {
+        const v = db
+            .query<VersionRow, [string, number]>("SELECT * FROM versions WHERE stash_id = ? AND version = ?")
+            .get(stash.id, opts.version);
+        versionsToDelete = v ? [v] : [];
+    } else {
+        const v = db
+            .query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC LIMIT 1")
+            .get(stash.id);
+        versionsToDelete = v ? [v] : [];
+    }
+    log.debug(
+        { stashId: stash.id, count: versionsToDelete.length, orphanActive: opts.orphanActive },
+        "destructive drop starting"
+    );
+
+    // Orphan FIRST. If we delete versions first while applications still reference them via
+    // applications.version_id, the FK fires (no ON DELETE CASCADE on that FK by design — we want apps
+    // to outlive their version row as audit history).
+    if (opts.orphanActive) {
+        db.run("UPDATE applications SET state = 'orphaned' WHERE stash_id = ? AND state = 'active'", [stash.id]);
+    }
+
+    for (const v of versionsToDelete) {
+        await repo.deleteRef(v.patch_ref);
+        await repo.deleteRef(`refs/baselines/${stash.id}/v${v.version}`);
+        db.run("DELETE FROM versions WHERE id = ?", [v.id]);
+        log.debug({ version: v.version, patch_ref: v.patch_ref }, "version dropped");
+    }
+
+    const remaining =
+        db.query<{ c: number }, [string]>("SELECT COUNT(*) as c FROM versions WHERE stash_id = ?").get(stash.id)?.c ??
+        0;
+    if (remaining === 0) {
+        db.run("DELETE FROM stashes WHERE id = ?", [stash.id]);
+        log.debug({ stashId: stash.id, name: stash.name }, "stash row dropped (no remaining versions)");
+    }
+
+    ui.ok(`dropped ${versionsToDelete.length} version(s)`);
+    db.close();
+}

--- a/src/stash/commands/drop.ts
+++ b/src/stash/commands/drop.ts
@@ -71,26 +71,41 @@ export async function dropCommand(opts: {
         "destructive drop starting"
     );
 
-    // Orphan FIRST. If we delete versions first while applications still reference them via
-    // applications.version_id, the FK fires (no ON DELETE CASCADE on that FK by design — we want apps
-    // to outlive their version row as audit history).
-    if (opts.orphanActive) {
-        db.run("UPDATE applications SET state = 'orphaned' WHERE stash_id = ? AND state = 'active'", [stash.id]);
-    }
+    // Wrap the destructive sequence in a SQLite transaction so a half-failure rolls back the DB
+    // side. Store-repo ref deletes happen alongside (no transactional join with git), but
+    // deleteRef is missing-safe (it logs+ignores already-absent refs), so a retry converges.
+    // Orphan FIRST: flip application state to 'orphaned' so the audit row survives. The FK is
+    // now ON DELETE SET NULL (PR #222 t21), so deleting versions also nulls version_id; this
+    // explicit flip preserves the user-visible state transition.
+    db.run("BEGIN");
+    try {
+        if (opts.orphanActive) {
+            db.run("UPDATE applications SET state = 'orphaned' WHERE stash_id = ? AND state = 'active'", [stash.id]);
+        }
 
-    for (const v of versionsToDelete) {
-        await repo.deleteRef(v.patch_ref);
-        await repo.deleteRef(`refs/baselines/${stash.id}/v${v.version}`);
-        db.run("DELETE FROM versions WHERE id = ?", [v.id]);
-        log.debug({ version: v.version, patch_ref: v.patch_ref }, "version dropped");
-    }
+        for (const v of versionsToDelete) {
+            await repo.deleteRef(v.patch_ref);
+            await repo.deleteRef(`refs/baselines/${stash.id}/v${v.version}`);
+            db.run("DELETE FROM versions WHERE id = ?", [v.id]);
+            log.debug({ version: v.version, patch_ref: v.patch_ref }, "version dropped");
+        }
 
-    const remaining =
-        db.query<{ c: number }, [string]>("SELECT COUNT(*) as c FROM versions WHERE stash_id = ?").get(stash.id)?.c ??
-        0;
-    if (remaining === 0) {
-        db.run("DELETE FROM stashes WHERE id = ?", [stash.id]);
-        log.debug({ stashId: stash.id, name: stash.name }, "stash row dropped (no remaining versions)");
+        const remaining =
+            db.query<{ c: number }, [string]>("SELECT COUNT(*) as c FROM versions WHERE stash_id = ?").get(stash.id)
+                ?.c ?? 0;
+        if (remaining === 0) {
+            db.run("DELETE FROM stashes WHERE id = ?", [stash.id]);
+            log.debug({ stashId: stash.id, name: stash.name }, "stash row dropped (no remaining versions)");
+        }
+        db.run("COMMIT");
+    } catch (err) {
+        try {
+            db.run("ROLLBACK");
+        } catch {
+            // Transaction may already have been rolled back by SQLite after a DDL/constraint failure.
+        }
+        db.close();
+        throw err;
     }
 
     ui.ok(`dropped ${versionsToDelete.length} version(s)`);

--- a/src/stash/commands/list.ts
+++ b/src/stash/commands/list.ts
@@ -1,0 +1,125 @@
+import { Database } from "bun:sqlite";
+import { logger, out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import chalk from "chalk";
+import { detectProject, findSiblingClones } from "../lib/projects";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { ui } from "../lib/ui";
+import type { StashRow } from "../types";
+
+const { log } = logger.scoped("stash:list");
+
+export interface ListOptions {
+    project: boolean;
+    tag: string | undefined;
+    applied: boolean;
+}
+
+export async function listCommand(opts: ListOptions): Promise<void> {
+    log.debug({ opts }, "listCommand");
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    let projectPaths: string[] | null = null;
+    if (opts.project || opts.applied) {
+        const project = await detectProject(process.cwd());
+        if (!project) {
+            ui.err("--project / --applied require a git repo");
+            db.close();
+            process.exit(1);
+        }
+        const siblings = await findSiblingClones(project.rootPath);
+        projectPaths = [project.rootPath, ...siblings];
+        log.debug({ rootPath: project.rootPath, siblings: siblings.length }, "project scope resolved");
+    }
+
+    let rows: StashRow[];
+    if (opts.applied && projectPaths) {
+        // --applied: STRICTLY return only stashes with an active application in the project scope.
+        // (--project alone also matches `source_repo_path`, so a stash saved here but never applied still shows.)
+        const placeholders = projectPaths.map(() => "?").join(",");
+        rows = db
+            .query<StashRow, string[]>(
+                `SELECT DISTINCT s.* FROM stashes s
+                 JOIN applications a ON a.stash_id = s.id
+                 WHERE a.state = 'active' AND a.project_path IN (${placeholders})
+                 ORDER BY s.updated_at DESC`
+            )
+            .all(...projectPaths);
+    } else if (projectPaths) {
+        // --project: any stash either applied to this scope OR saved from this scope.
+        const placeholders = projectPaths.map(() => "?").join(",");
+        rows = db
+            .query<StashRow, string[]>(
+                `SELECT DISTINCT s.* FROM stashes s
+                 LEFT JOIN applications a ON a.stash_id = s.id AND a.state = 'active'
+                 LEFT JOIN versions v ON v.stash_id = s.id
+                 WHERE a.project_path IN (${placeholders}) OR v.source_repo_path IN (${placeholders})
+                 ORDER BY s.updated_at DESC`
+            )
+            .all(...projectPaths, ...projectPaths);
+    } else {
+        rows = db.query<StashRow, []>("SELECT * FROM stashes ORDER BY updated_at DESC").all();
+    }
+    log.debug({ rowCount: rows.length, projectScoped: projectPaths !== null }, "stashes fetched");
+
+    if (opts.tag) {
+        const tag = opts.tag;
+        const before = rows.length;
+        rows = rows.filter((r) => {
+            if (!r.tags) {
+                return false;
+            }
+            const tags = SafeJSON.parse(r.tags) as string[];
+            return tags.includes(tag);
+        });
+        log.debug({ tag, before, after: rows.length }, "tag filter applied");
+    }
+
+    if (!rows.length) {
+        ui.info("no stashes");
+        db.close();
+        return;
+    }
+
+    // Build aligned rows: NAME (left, padded to longest) | VER | TAGS | STATUS
+    interface DisplayRow {
+        name: string;
+        ver: string;
+        tags: string;
+        appliedHere: boolean;
+    }
+    const display: DisplayRow[] = rows.map((r) => {
+        const v = db
+            .query<{ m: number | null }, [string]>("SELECT MAX(version) as m FROM versions WHERE stash_id = ?")
+            .get(r.id);
+        const appliedHere = projectPaths
+            ? (db
+                  .query<{ c: number }, string[]>(
+                      `SELECT COUNT(*) as c FROM applications WHERE stash_id = ? AND state = 'active' AND project_path IN (${projectPaths.map(() => "?").join(",")})`
+                  )
+                  .get(r.id, ...projectPaths)?.c ?? 0) > 0
+            : false;
+        return {
+            name: r.name,
+            ver: `v${v?.m ?? "?"}`,
+            tags: r.tags ? (SafeJSON.parse(r.tags) as string[]).join(",") : "",
+            appliedHere,
+        };
+    });
+
+    const nameW = Math.max(4, ...display.map((d) => d.name.length));
+    const verW = Math.max(3, ...display.map((d) => d.ver.length));
+    const tagsW = Math.max(4, ...display.map((d) => d.tags.length));
+
+    ui.section(`${rows.length} stash${rows.length === 1 ? "" : "es"}`);
+    ui.dim(`  ${"NAME".padEnd(nameW)}  ${"VER".padEnd(verW)}  ${"TAGS".padEnd(tagsW)}  STATUS`);
+    for (const d of display) {
+        const status = d.appliedHere ? chalk.green("● applied here") : chalk.dim("·");
+        // Plain row data via out.print so `tools stash list | grep` still works as expected.
+        out.print(`  ${d.name.padEnd(nameW)}  ${d.ver.padEnd(verW)}  ${d.tags.padEnd(tagsW)}  ${status}`);
+    }
+    db.close();
+}

--- a/src/stash/commands/save.ts
+++ b/src/stash/commands/save.ts
@@ -4,11 +4,11 @@ import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import { newStashId, shortId } from "../lib/ids";
 import { diffWorkingTree, listFilesInPatch, runGitIn, type SaveMode } from "../lib/patch";
-import { stripApplyMarkersFromPatchFiles } from "../lib/strip-apply-markers";
 import { detectProject } from "../lib/projects";
 import { openStashDb } from "../lib/stash-db";
 import { StashStorage } from "../lib/storage";
 import { StoreRepo } from "../lib/store-repo";
+import { stripApplyMarkersFromPatchFiles } from "../lib/strip-apply-markers";
 import { ui } from "../lib/ui";
 import type { StashRow } from "../types";
 

--- a/src/stash/commands/save.ts
+++ b/src/stash/commands/save.ts
@@ -1,0 +1,197 @@
+import { Database } from "bun:sqlite";
+import { logger } from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import { SafeJSON } from "@app/utils/json";
+import { newStashId, shortId } from "../lib/ids";
+import { diffWorkingTree, listFilesInPatch, runGitIn, type SaveMode } from "../lib/patch";
+import { detectProject } from "../lib/projects";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { StoreRepo } from "../lib/store-repo";
+import { ui } from "../lib/ui";
+import type { StashRow } from "../types";
+
+const { log } = logger.scoped("stash:save");
+
+export interface SaveOptions {
+    name: string;
+    mode: SaveMode | undefined;
+    tags: string[];
+    description: string | undefined;
+}
+
+export async function saveCommand(opts: SaveOptions): Promise<void> {
+    log.debug({ opts }, "saveCommand");
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        ui.err("not inside a git repository");
+        process.exit(1);
+    }
+    log.debug({ rootPath: project.rootPath, origin: project.origin }, "project resolved");
+
+    let mode = opts.mode;
+    if (!mode) {
+        if (!isInteractive()) {
+            ui.err("--staged | --unstaged | --all required in non-interactive mode");
+            // suggestCommand pulls the stash name from process.argv automatically; subcommand=["save"]
+            // strips the duplicate `save` token that's already in toolName.
+            ui.info(suggestCommand("tools stash save", { add: ["--all"], subcommand: ["save"] }));
+            process.exit(1);
+        }
+        const { select } = await import("@clack/prompts");
+        const sel = await select({
+            message: "What to save?",
+            options: [
+                { value: "all", label: "All changes (staged + unstaged + untracked)" },
+                { value: "staged", label: "Staged only" },
+                { value: "unstaged", label: "Unstaged tracked changes only" },
+            ],
+        });
+        if (typeof sel !== "string") {
+            ui.warn("cancelled");
+            return;
+        }
+        mode = sel as SaveMode;
+    }
+    log.debug({ mode }, "mode resolved");
+
+    const rawPatch = await diffWorkingTree({ repoDir: project.rootPath, mode });
+    if (!rawPatch.trim()) {
+        ui.warn("no changes to stash");
+        return;
+    }
+    log.debug({ rawPatchBytes: rawPatch.length }, "working-tree diff captured");
+
+    const patch = stripApplyMarkersFromPatchFiles({ patch: rawPatch });
+    const fileList = await listFilesInPatch({ repoDir: project.rootPath, patch: rawPatch });
+    log.debug(
+        { files: fileList.length, strippedBytes: rawPatch.length - patch.length },
+        "apply-markers stripped + files listed"
+    );
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const repo = new StoreRepo(storage.storeRepoDir());
+    await repo.init();
+
+    const existing = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+
+    const now = new Date().toISOString();
+    let stashId: string;
+    let version: number;
+
+    if (existing) {
+        stashId = existing.id;
+        const maxV = db
+            .query<{ m: number | null }, [string]>("SELECT MAX(version) as m FROM versions WHERE stash_id = ?")
+            .get(stashId);
+        version = (maxV?.m ?? 0) + 1;
+        ui.info(`stash "${opts.name}" exists, creating v${version}`);
+        log.debug({ stashId, version, branch: "bump" }, "version bump for existing stash");
+        db.run("UPDATE stashes SET updated_at = ? WHERE id = ?", [now, stashId]);
+    } else {
+        stashId = newStashId();
+        version = 1;
+        log.debug({ stashId, version, branch: "new" }, "new stash created");
+        db.run("INSERT INTO stashes (id, name, tags, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)", [
+            stashId,
+            opts.name,
+            opts.tags.length ? SafeJSON.stringify(opts.tags) : null,
+            opts.description ?? null,
+            now,
+            now,
+        ]);
+    }
+
+    const patchRef = `refs/stashes/${stashId}/v${version}`;
+    const baselineRef = `refs/baselines/${stashId}/v${version}`;
+
+    const baselineFiles = await collectBaselineFiles({ projectRoot: project.rootPath, files: fileList });
+    await repo.writePatchCommit({
+        ref: baselineRef,
+        files: baselineFiles,
+        message: `stash:${opts.name} v${version} baseline`,
+    });
+    await repo.writePatchCommit({
+        ref: patchRef,
+        files: { "PATCH.diff": patch },
+        message: `stash:${opts.name} v${version}`,
+    });
+    log.debug({ patchRef, baselineRef }, "patch + baseline refs written to store");
+
+    const versionId = newStashId();
+    db.run(
+        `INSERT INTO versions (id, stash_id, version, patch_ref, source_repo_path, source_origin, source_sha, region_count, file_count, metadata_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            versionId,
+            stashId,
+            version,
+            patchRef,
+            project.rootPath,
+            project.origin,
+            project.sha,
+            countAuthorRegionsInPatch(patch),
+            fileList.length,
+            SafeJSON.stringify({ mode, tags: opts.tags }),
+            now,
+        ]
+    );
+
+    ui.ok(`saved "${opts.name}" v${version} [id=${shortId(stashId)}]`);
+    ui.info(`  ${fileList.length} files, baseline ref=${baselineRef}`);
+
+    db.close();
+    log.debug({ stashId, version, files: fileList.length }, "stash saved");
+}
+
+/**
+ * Strip apply-time region markers from the patch (so a save of an applied stash doesn't re-include
+ * the wrapper). The contract: drop opener lines that carry a JSON metadata blob (apply-time form)
+ * AND their matching `#endregion @stash:NAME` closer with the same name; preserve bare author
+ * markers (no JSON) so manually annotated regions round-trip cleanly.
+ */
+function stripApplyMarkersFromPatchFiles(args: { patch: string }): string {
+    const lines = args.patch.split("\n");
+    // Apply-time opener: added line matches `#region @stash:NAME {...json...}`. The JSON brace is
+    // what distinguishes it from a bare author marker, which has no metadata and must be kept.
+    const APPLY_OPEN_WITH_NAME = /^\+.*#region\s+@stash:([\w.-]+)\s+\{.*\}/;
+    // Any added closer — used only to drop closers whose paired opener was an apply-time opener.
+    const CLOSE_WITH_NAME = /^\+.*#endregion\s+@stash:([\w.-]+)/;
+    const dropCloseFor = new Set<string>();
+    const kept: string[] = [];
+    for (const line of lines) {
+        const openMatch = APPLY_OPEN_WITH_NAME.exec(line);
+        if (openMatch?.[1]) {
+            dropCloseFor.add(openMatch[1]);
+            continue;
+        }
+        const closeMatch = CLOSE_WITH_NAME.exec(line);
+        if (closeMatch?.[1] && dropCloseFor.has(closeMatch[1])) {
+            // Only one drop per opener — supports nested same-named regions (uncommon but correct).
+            dropCloseFor.delete(closeMatch[1]);
+            continue;
+        }
+        kept.push(line);
+    }
+    return kept.join("\n");
+}
+
+function countAuthorRegionsInPatch(patch: string): number {
+    // Count added (`+`) lines that open a `@stash:` region (includes JSON-tagged apply markers — see stripApplyMarkersFromPatchFiles).
+    const m = patch.match(/^\+.*#region\s+@stash:/gm);
+    return m?.length ?? 0;
+}
+
+async function collectBaselineFiles(args: { projectRoot: string; files: string[] }): Promise<Record<string, string>> {
+    const baseline: Record<string, string> = {};
+    for (const f of args.files) {
+        try {
+            baseline[f] = await runGitIn(args.projectRoot, ["show", `HEAD:${f}`]);
+        } catch {
+            baseline[f] = "";
+        }
+    }
+    return baseline;
+}

--- a/src/stash/commands/save.ts
+++ b/src/stash/commands/save.ts
@@ -148,34 +148,84 @@ export async function saveCommand(opts: SaveOptions): Promise<void> {
 
 /**
  * Strip apply-time region markers from the patch (so a save of an applied stash doesn't re-include
- * the wrapper). The contract: drop opener lines that carry a JSON metadata blob (apply-time form)
- * AND their matching `#endregion @stash:NAME` closer with the same name; preserve bare author
- * markers (no JSON) so manually annotated regions round-trip cleanly.
+ * the wrapper) AND fix up the surrounding `@@ -a,b +c,d @@` hunk counts. The contract: drop opener
+ * lines that carry a JSON metadata blob (apply-time form) AND their matching `#endregion @stash:NAME`
+ * closer with the same name; preserve bare author markers (no JSON) so manually annotated regions
+ * round-trip cleanly.
+ *
+ * Hunk-count fix-up (PR #222 t10): every dropped `+` line decrements the hunk's new-side count.
+ * Without this, the stored PATCH.diff becomes unparseable — `git apply` (and `--3way`) parse @@
+ * headers strictly and reject any mismatch between declared added-line count and actual body.
  */
 function stripApplyMarkersFromPatchFiles(args: { patch: string }): string {
-    const lines = args.patch.split("\n");
     // Apply-time opener: added line matches `#region @stash:NAME {...json...}`. The JSON brace is
     // what distinguishes it from a bare author marker, which has no metadata and must be kept.
     const APPLY_OPEN_WITH_NAME = /^\+.*#region\s+@stash:([\w.-]+)\s+\{.*\}/;
     // Any added closer — used only to drop closers whose paired opener was an apply-time opener.
     const CLOSE_WITH_NAME = /^\+.*#endregion\s+@stash:([\w.-]+)/;
+    // Unified-diff hunk header: `@@ -oldStart,oldLines +newStart,newLines @@ <optional ctx>`.
+    const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+
+    const lines = args.patch.split("\n");
     const dropCloseFor = new Set<string>();
-    const kept: string[] = [];
+    // Buffer per hunk so we can rewrite the header after counting dropped `+` lines.
+    let currentHeader: { oldStart: number; oldLines: number; newStart: number; newLines: number; ctx: string } | null =
+        null;
+    let currentBody: string[] = [];
+    let droppedInHunk = 0;
+    const out: string[] = [];
+
+    const flushHunk = () => {
+        if (!currentHeader) {
+            return;
+        }
+        const newLinesAdjusted = currentHeader.newLines - droppedInHunk;
+        // Emit corrected header. If `,N` was originally absent (single-line hunk), still write it
+        // when the adjusted value is no longer 1 — that's the only safe normalization.
+        const oldPart = `${currentHeader.oldStart},${currentHeader.oldLines}`;
+        const newPart = `${currentHeader.newStart},${newLinesAdjusted}`;
+        out.push(`@@ -${oldPart} +${newPart} @@${currentHeader.ctx}`);
+        out.push(...currentBody);
+        currentHeader = null;
+        currentBody = [];
+        droppedInHunk = 0;
+    };
+
     for (const line of lines) {
+        const hm = HUNK_RE.exec(line);
+        if (hm) {
+            flushHunk();
+            currentHeader = {
+                oldStart: Number(hm[1]),
+                oldLines: Number(hm[2] ?? "1"),
+                newStart: Number(hm[3]),
+                newLines: Number(hm[4] ?? "1"),
+                ctx: hm[5] ?? "",
+            };
+            continue;
+        }
+        // File-level headers, index headers, etc. — flush any open hunk and pass through.
+        if (!currentHeader) {
+            out.push(line);
+            continue;
+        }
         const openMatch = APPLY_OPEN_WITH_NAME.exec(line);
         if (openMatch?.[1]) {
             dropCloseFor.add(openMatch[1]);
+            droppedInHunk++;
             continue;
         }
         const closeMatch = CLOSE_WITH_NAME.exec(line);
         if (closeMatch?.[1] && dropCloseFor.has(closeMatch[1])) {
             // Only one drop per opener — supports nested same-named regions (uncommon but correct).
             dropCloseFor.delete(closeMatch[1]);
+            droppedInHunk++;
             continue;
         }
-        kept.push(line);
+        currentBody.push(line);
     }
-    return kept.join("\n");
+    flushHunk();
+    return out.join("\n");
 }
 
 function countAuthorRegionsInPatch(patch: string): number {

--- a/src/stash/commands/save.ts
+++ b/src/stash/commands/save.ts
@@ -167,7 +167,10 @@ function stripApplyMarkersFromPatchFiles(args: { patch: string }): string {
     const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
 
     const lines = args.patch.split("\n");
-    const dropCloseFor = new Set<string>();
+    // PR #222 t27: per-name depth counter, not a Set. Two nested apply-time openers with the same
+    // stash name would otherwise share one Set entry — deleting on the first close would leave the
+    // second close unmatched in the output. Counts increment on opener, decrement on close.
+    const dropCloseDepth = new Map<string, number>();
     // Buffer per hunk so we can rewrite the header after counting dropped `+` lines.
     let currentHeader: { oldStart: number; oldLines: number; newStart: number; newLines: number; ctx: string } | null =
         null;
@@ -211,16 +214,24 @@ function stripApplyMarkersFromPatchFiles(args: { patch: string }): string {
         }
         const openMatch = APPLY_OPEN_WITH_NAME.exec(line);
         if (openMatch?.[1]) {
-            dropCloseFor.add(openMatch[1]);
+            const name = openMatch[1];
+            dropCloseDepth.set(name, (dropCloseDepth.get(name) ?? 0) + 1);
             droppedInHunk++;
             continue;
         }
         const closeMatch = CLOSE_WITH_NAME.exec(line);
-        if (closeMatch?.[1] && dropCloseFor.has(closeMatch[1])) {
-            // Only one drop per opener — supports nested same-named regions (uncommon but correct).
-            dropCloseFor.delete(closeMatch[1]);
-            droppedInHunk++;
-            continue;
+        if (closeMatch?.[1]) {
+            const name = closeMatch[1];
+            const depth = dropCloseDepth.get(name) ?? 0;
+            if (depth > 0) {
+                if (depth === 1) {
+                    dropCloseDepth.delete(name);
+                } else {
+                    dropCloseDepth.set(name, depth - 1);
+                }
+                droppedInHunk++;
+                continue;
+            }
         }
         currentBody.push(line);
     }

--- a/src/stash/commands/save.ts
+++ b/src/stash/commands/save.ts
@@ -4,6 +4,7 @@ import { isInteractive, suggestCommand } from "@app/utils/cli";
 import { SafeJSON } from "@app/utils/json";
 import { newStashId, shortId } from "../lib/ids";
 import { diffWorkingTree, listFilesInPatch, runGitIn, type SaveMode } from "../lib/patch";
+import { stripApplyMarkersFromPatchFiles } from "../lib/strip-apply-markers";
 import { detectProject } from "../lib/projects";
 import { openStashDb } from "../lib/stash-db";
 import { StashStorage } from "../lib/storage";
@@ -144,99 +145,6 @@ export async function saveCommand(opts: SaveOptions): Promise<void> {
 
     db.close();
     log.debug({ stashId, version, files: fileList.length }, "stash saved");
-}
-
-/**
- * Strip apply-time region markers from the patch (so a save of an applied stash doesn't re-include
- * the wrapper) AND fix up the surrounding `@@ -a,b +c,d @@` hunk counts. The contract: drop opener
- * lines that carry a JSON metadata blob (apply-time form) AND their matching `#endregion @stash:NAME`
- * closer with the same name; preserve bare author markers (no JSON) so manually annotated regions
- * round-trip cleanly.
- *
- * Hunk-count fix-up (PR #222 t10): every dropped `+` line decrements the hunk's new-side count.
- * Without this, the stored PATCH.diff becomes unparseable — `git apply` (and `--3way`) parse @@
- * headers strictly and reject any mismatch between declared added-line count and actual body.
- */
-function stripApplyMarkersFromPatchFiles(args: { patch: string }): string {
-    // Apply-time opener: added line matches `#region @stash:NAME {...json...}`. The JSON brace is
-    // what distinguishes it from a bare author marker, which has no metadata and must be kept.
-    const APPLY_OPEN_WITH_NAME = /^\+.*#region\s+@stash:([\w.-]+)\s+\{.*\}/;
-    // Any added closer — used only to drop closers whose paired opener was an apply-time opener.
-    const CLOSE_WITH_NAME = /^\+.*#endregion\s+@stash:([\w.-]+)/;
-    // Unified-diff hunk header: `@@ -oldStart,oldLines +newStart,newLines @@ <optional ctx>`.
-    const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
-
-    const lines = args.patch.split("\n");
-    // PR #222 t27: per-name depth counter, not a Set. Two nested apply-time openers with the same
-    // stash name would otherwise share one Set entry — deleting on the first close would leave the
-    // second close unmatched in the output. Counts increment on opener, decrement on close.
-    const dropCloseDepth = new Map<string, number>();
-    // Buffer per hunk so we can rewrite the header after counting dropped `+` lines.
-    let currentHeader: { oldStart: number; oldLines: number; newStart: number; newLines: number; ctx: string } | null =
-        null;
-    let currentBody: string[] = [];
-    let droppedInHunk = 0;
-    const out: string[] = [];
-
-    const flushHunk = () => {
-        if (!currentHeader) {
-            return;
-        }
-        const newLinesAdjusted = currentHeader.newLines - droppedInHunk;
-        // Emit corrected header. If `,N` was originally absent (single-line hunk), still write it
-        // when the adjusted value is no longer 1 — that's the only safe normalization.
-        const oldPart = `${currentHeader.oldStart},${currentHeader.oldLines}`;
-        const newPart = `${currentHeader.newStart},${newLinesAdjusted}`;
-        out.push(`@@ -${oldPart} +${newPart} @@${currentHeader.ctx}`);
-        out.push(...currentBody);
-        currentHeader = null;
-        currentBody = [];
-        droppedInHunk = 0;
-    };
-
-    for (const line of lines) {
-        const hm = HUNK_RE.exec(line);
-        if (hm) {
-            flushHunk();
-            currentHeader = {
-                oldStart: Number(hm[1]),
-                oldLines: Number(hm[2] ?? "1"),
-                newStart: Number(hm[3]),
-                newLines: Number(hm[4] ?? "1"),
-                ctx: hm[5] ?? "",
-            };
-            continue;
-        }
-        // File-level headers, index headers, etc. — flush any open hunk and pass through.
-        if (!currentHeader) {
-            out.push(line);
-            continue;
-        }
-        const openMatch = APPLY_OPEN_WITH_NAME.exec(line);
-        if (openMatch?.[1]) {
-            const name = openMatch[1];
-            dropCloseDepth.set(name, (dropCloseDepth.get(name) ?? 0) + 1);
-            droppedInHunk++;
-            continue;
-        }
-        const closeMatch = CLOSE_WITH_NAME.exec(line);
-        if (closeMatch?.[1]) {
-            const name = closeMatch[1];
-            const depth = dropCloseDepth.get(name) ?? 0;
-            if (depth > 0) {
-                if (depth === 1) {
-                    dropCloseDepth.delete(name);
-                } else {
-                    dropCloseDepth.set(name, depth - 1);
-                }
-                droppedInHunk++;
-                continue;
-            }
-        }
-        currentBody.push(line);
-    }
-    flushHunk();
-    return out.join("\n");
 }
 
 function countAuthorRegionsInPatch(patch: string): number {

--- a/src/stash/commands/show.ts
+++ b/src/stash/commands/show.ts
@@ -1,0 +1,76 @@
+import { Database } from "bun:sqlite";
+import { logger, out } from "@app/logger";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { StoreRepo } from "../lib/store-repo";
+import { ui } from "../lib/ui";
+import type { RegionRow, StashRow, VersionRow } from "../types";
+
+const { log } = logger.scoped("stash:show");
+
+export async function showCommand(opts: {
+    name: string;
+    version?: number;
+    mode: "diff" | "meta" | "regions";
+}): Promise<void> {
+    log.debug({ opts }, "showCommand");
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        ui.err(`stash "${opts.name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+    const v = opts.version
+        ? db
+              .query<VersionRow, [string, number]>("SELECT * FROM versions WHERE stash_id = ? AND version = ?")
+              .get(stash.id, opts.version)
+        : db
+              .query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC LIMIT 1")
+              .get(stash.id);
+    if (!v) {
+        ui.err("version not found");
+        db.close();
+        process.exit(1);
+    }
+    log.debug({ stashId: stash.id, version: v.version, mode: opts.mode }, "version resolved");
+
+    ui.header(`${stash.name}  v${v.version}`);
+    ui.kv("tags", stash.tags ?? "—");
+    ui.kv("desc", stash.description ?? "—");
+    ui.kv("source", `${v.source_repo_path ?? "?"} @ ${v.source_sha?.slice(0, 7) ?? "?"}`);
+    ui.kv("origin", v.source_origin ?? "—");
+    ui.kv("files", String(v.file_count));
+    ui.kv("regions", String(v.region_count));
+    ui.kv("created", v.created_at);
+
+    if (opts.mode === "meta") {
+        db.close();
+        return;
+    }
+    const repo = new StoreRepo(storage.storeRepoDir());
+    if (opts.mode === "diff") {
+        const patch = await repo.readFileAt(v.patch_ref, "PATCH.diff");
+        ui.section("patch");
+        // Patch body to stdout so `tools stash show <name> --diff > foo.patch` captures cleanly.
+        out.print(patch ?? "(empty)");
+    } else {
+        const regions = db
+            .query<RegionRow, [string]>("SELECT * FROM regions WHERE version_id = ? ORDER BY file_path, hunk_index")
+            .all(v.id);
+        ui.section(`regions (${regions.length})`);
+        if (!regions.length) {
+            ui.dim("  (none recorded — older versions before region tracking)");
+        }
+        const fileW = Math.max(4, ...regions.map((r) => r.file_path.length));
+        for (const r of regions) {
+            const name = r.region_name ?? "(anon)";
+            out.print(
+                `  ${r.file_path.padEnd(fileW)}  hunk ${r.hunk_index}  ${String(r.line_count).padStart(4)} lines  ${name}`
+            );
+        }
+    }
+    db.close();
+}

--- a/src/stash/commands/unapply.ts
+++ b/src/stash/commands/unapply.ts
@@ -142,17 +142,32 @@ export async function unapplyCommand(opts: UnapplyOptions): Promise<void> {
 
     const stats = await executeAllDecisions({ session, projectRoot: project.rootPath, storage, db, stash });
 
-    const now = new Date().toISOString();
-    db.run(
-        "UPDATE applications SET state = 'unapplied', unapplied_at = ? WHERE stash_id = ? AND project_path = ? AND state = 'active'",
-        [now, stash.id, project.rootPath]
-    );
-
-    await session.complete();
-
-    ui.ok(
-        `unapplied "${opts.name}" — ${stats.removed} removed, ${stats.updated} captured to v${stats.newVersion ?? "(none)"}, ${stats.skipped} skipped`
-    );
+    // PR #222 t28: only mark the application as 'unapplied' if every region was actually cleaned
+    // up. A `marker-missing` outcome means the user's file may still carry wrapped code; flipping
+    // the DB to 'unapplied' would falsely claim the stash is gone. Keep the application 'active'
+    // and surface the failed files so the user can audit + retry.
+    if (stats.failedToFind === 0) {
+        const now = new Date().toISOString();
+        db.run(
+            "UPDATE applications SET state = 'unapplied', unapplied_at = ? WHERE stash_id = ? AND project_path = ? AND state = 'active'",
+            [now, stash.id, project.rootPath]
+        );
+        await session.complete();
+        ui.ok(
+            `unapplied "${opts.name}" — ${stats.removed} removed, ${stats.updated} captured to v${stats.newVersion ?? "(none)"}, ${stats.skipped} skipped`
+        );
+    } else {
+        // Persist the session so the user can re-run (`--continue`) after they investigate. Do NOT
+        // call session.complete() — that would discard the state.
+        await session.persist();
+        ui.err(`partial unapply: ${stats.failedToFind} region(s) had no matching marker; application kept ACTIVE`);
+        for (const f of stats.failedFiles) {
+            ui.warn(`  marker missing in: ${f}`);
+        }
+        ui.info(
+            "either restore the missing markers manually and re-run 'unapply --continue', or 'unapply --abort' to discard the session"
+        );
+    }
 
     db.close();
     log.debug({ stashId: stash.id, stats }, "stash unapplied");
@@ -367,6 +382,15 @@ interface ExecStats {
     updated: number;
     skipped: number;
     newVersion: number | null;
+    /**
+     * Regions whose marker couldn't be found at execute time (file edited out-of-band between
+     * bootstrap and execute, or already cleaned up manually). PR #222 t28: when > 0, the caller
+     * must NOT mark the application as 'unapplied' — the user's file may still contain wrapped
+     * code that the DB would otherwise claim is gone.
+     */
+    failedToFind: number;
+    /** Files where a marker lookup failed — surfaced to the user so they can audit. */
+    failedFiles: string[];
 }
 
 async function executeAllDecisions(args: {
@@ -376,7 +400,7 @@ async function executeAllDecisions(args: {
     db: Database;
     stash: StashRow;
 }): Promise<ExecStats> {
-    const stats: ExecStats = { removed: 0, updated: 0, skipped: 0, newVersion: null };
+    const stats: ExecStats = { removed: 0, updated: 0, skipped: 0, newVersion: null, failedToFind: 0, failedFiles: [] };
     // Snapshot "update"-bound regions in their original order so capturedUpdatesAsNewVersion sees
     // their stored/current content before we start mutating files. The capture itself is purely
     // in-memory (it reads from r.storedContent/r.currentContent), so order doesn't matter for
@@ -404,12 +428,18 @@ async function executeAllDecisions(args: {
             if (r.decision !== "discard" && r.decision !== "update") {
                 continue;
             }
-            await applyDecisionToCode({
+            const outcome = await applyDecisionToCode({
                 filePath: join(args.projectRoot, r.filePath),
                 regionName: args.session.snapshot().stashName,
                 hunkIndex: r.hunkIndex,
                 decision: r.decision,
             });
+            if (outcome === "marker-missing") {
+                stats.failedToFind++;
+                if (!stats.failedFiles.includes(r.filePath)) {
+                    stats.failedFiles.push(r.filePath);
+                }
+            }
         }
     }
     if (updatedRegions.length) {

--- a/src/stash/commands/unapply.ts
+++ b/src/stash/commands/unapply.ts
@@ -1,0 +1,459 @@
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import { classifyRegion } from "../lib/classify";
+import { applyDecisionToCode } from "../lib/decisions";
+import { renderDiff } from "../lib/diff-render";
+import { newStashId } from "../lib/ids";
+import { parseMarkers } from "../lib/markers";
+import { detectProject } from "../lib/projects";
+import { extractRegionContent } from "../lib/regions";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { StoreRepo } from "../lib/store-repo";
+import { ui } from "../lib/ui";
+import { type Decision, type SessionRegion, UnapplySession } from "../lib/unapply-session";
+import type { ApplicationRow, StashRow, VersionRow } from "../types";
+
+const { log } = logger.scoped("stash:unapply");
+
+export interface UnapplyOptions {
+    name: string;
+    action: "start" | "continue" | "skip" | "abort" | "status";
+    decision:
+        | Exclude<Decision, null | "auto-remove">
+        | "discard-all-dangerous"
+        | "update-stash-all-dangerous"
+        | undefined;
+}
+
+export async function unapplyCommand(opts: UnapplyOptions): Promise<void> {
+    log.debug({ opts }, "unapplyCommand");
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        ui.err("not inside a git repository");
+        process.exit(1);
+    }
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        ui.err(`stash "${opts.name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+
+    const projectHash = createHash("sha256").update(project.rootPath).digest("hex");
+
+    if (opts.action === "abort") {
+        const s = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
+        if (!s) {
+            ui.warn("no in-progress unapply session");
+            return;
+        }
+        await s.abort();
+        ui.ok("aborted");
+        return;
+    }
+
+    if (opts.action === "status") {
+        const s = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
+        if (!s) {
+            ui.info("no in-progress session");
+            return;
+        }
+        const p = s.progress();
+        const cur = s.currentRegion();
+        ui.info(`${p.decided}/${p.total} decided; current: ${cur?.filePath ?? "(none)"} hunk ${cur?.hunkIndex ?? "?"}`);
+        return;
+    }
+
+    let session = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
+    let bootstrapped = false;
+    if (!session) {
+        if (opts.action !== "start") {
+            ui.err("no in-progress session; run without --continue to start");
+            db.close();
+            process.exit(1);
+        }
+        session = await bootstrapSession({ storage, db, stash, project, projectHash });
+        bootstrapped = true;
+        log.debug(
+            {
+                regionsTotal: session.regions().length,
+                autoRemove: session.regions().filter((r) => r.decision === "auto-remove").length,
+            },
+            "session bootstrapped"
+        );
+    }
+
+    // Only strip the trivially-unchanged regions on the FIRST run of this session.
+    // On --continue we'd otherwise re-process every prior auto-remove with no markers left to remove
+    // (idempotent but noisy; the guard keeps logs clean).
+    if (bootstrapped) {
+        await processAutoRemoves({ session, projectRoot: project.rootPath });
+    }
+
+    if (opts.decision === "discard-all-dangerous" || opts.decision === "update-stash-all-dangerous") {
+        const blanket = opts.decision === "discard-all-dangerous" ? "discard" : "update";
+        const undecided = session.regions().filter((r) => r.decision === null).length;
+        ui.warn(`blanket decision: ${blanket} (applies to ${undecided} undecided region${undecided === 1 ? "" : "s"})`);
+        log.debug({ blanket, undecided }, "blanket dangerous-decision applied");
+        for (const r of session.regions()) {
+            if (r.decision === null) {
+                r.decision = blanket;
+            }
+        }
+    } else if (opts.decision) {
+        if (session.currentRegion()) {
+            log.debug(
+                { region: session.currentRegion()?.filePath, decision: opts.decision },
+                "per-step decision recorded"
+            );
+            session.decide(opts.decision);
+        }
+    } else if (opts.action === "skip") {
+        if (session.currentRegion()) {
+            log.debug({ region: session.currentRegion()?.filePath, decision: "skip" }, "--skip recorded");
+            session.decide("skip");
+        }
+    }
+
+    if (isInteractive() && !session.isComplete()) {
+        await walkInteractive({ session, projectRoot: project.rootPath });
+    }
+
+    if (!session.isComplete()) {
+        await session.persist();
+        await emitNonTtyPrompt({ session });
+        db.close();
+        return;
+    }
+
+    const stats = await executeAllDecisions({ session, projectRoot: project.rootPath, storage, db, stash });
+
+    const now = new Date().toISOString();
+    db.run(
+        "UPDATE applications SET state = 'unapplied', unapplied_at = ? WHERE stash_id = ? AND project_path = ? AND state = 'active'",
+        [now, stash.id, project.rootPath]
+    );
+
+    await session.complete();
+
+    ui.ok(
+        `unapplied "${opts.name}" — ${stats.removed} removed, ${stats.updated} captured to v${stats.newVersion ?? "(none)"}, ${stats.skipped} skipped`
+    );
+
+    db.close();
+    log.debug({ stashId: stash.id, stats }, "stash unapplied");
+}
+
+async function bootstrapSession(args: {
+    storage: StashStorage;
+    db: Database;
+    stash: StashRow;
+    project: NonNullable<Awaited<ReturnType<typeof detectProject>>>;
+    projectHash: string;
+}): Promise<UnapplySession> {
+    const app = args.db
+        .query<ApplicationRow, [string, string]>(
+            "SELECT * FROM applications WHERE stash_id = ? AND project_path = ? AND state = 'active'"
+        )
+        .get(args.stash.id, args.project.rootPath);
+    if (!app) {
+        ui.err(`"${args.stash.name}" is not applied here`);
+        process.exit(1);
+    }
+    const version = args.db.query<VersionRow, [string]>("SELECT * FROM versions WHERE id = ?").get(app.version_id);
+    if (!version) {
+        ui.err("version row missing");
+        process.exit(1);
+    }
+    const repo = new StoreRepo(args.storage.storeRepoDir());
+    const storedPatch = (await repo.readFileAt(version.patch_ref, "PATCH.diff")) ?? "";
+    const regionMap = collectRegionsFromPatch(storedPatch);
+
+    const sessionRegions: SessionRegion[] = [];
+    for (const r of regionMap) {
+        const fileContent = await readFile(join(args.project.rootPath, r.filePath), "utf8").catch(() => null);
+        const present = fileContent ? parseMarkers(fileContent).some((m) => m.name === args.stash.name) : false;
+        const currentContent = fileContent
+            ? await extractRegionContent(join(args.project.rootPath, r.filePath), args.stash.name)
+            : null;
+        const klass = classifyRegion({
+            storedContent: r.content,
+            currentContent,
+            present,
+        }).klass;
+        sessionRegions.push({
+            id: newStashId(),
+            filePath: r.filePath,
+            hunkIndex: r.hunkIndex,
+            klass,
+            decision: klass === "unchanged" ? "auto-remove" : null,
+            storedContent: r.content,
+            currentContent,
+        });
+    }
+
+    return UnapplySession.start({
+        stashId: args.stash.id,
+        stashName: args.stash.name,
+        projectPath: args.project.rootPath,
+        projectHash: args.projectHash,
+        regions: sessionRegions,
+        stateDir: args.storage.stateDir(),
+    });
+}
+
+interface PatchRegion {
+    filePath: string;
+    hunkIndex: number;
+    content: string;
+}
+
+function collectRegionsFromPatch(patch: string): PatchRegion[] {
+    const regions: PatchRegion[] = [];
+    const lines = patch.split("\n");
+    let currentFile: string | null = null;
+    let hunkIndex = 0;
+    let buffer: string[] = [];
+    const flush = () => {
+        if (currentFile && buffer.length) {
+            hunkIndex++;
+            regions.push({ filePath: currentFile, hunkIndex, content: buffer.join("\n") });
+            buffer = [];
+        }
+    };
+    for (const line of lines) {
+        // Post-image file header from `git diff --dst-prefix=b/` — captures relative path; resets hunk index per file.
+        const fm = /^\+\+\+ b\/(.+)$/.exec(line);
+        if (fm) {
+            flush();
+            currentFile = fm[1] ?? null;
+            hunkIndex = 0;
+            continue;
+        }
+        // New hunk delimiter `@@ ... @@` — flush the previous hunk's accumulated additions.
+        if (line.startsWith("@@")) {
+            flush();
+            continue;
+        }
+        // Added (`+`) lines accumulate into the current region buffer (stripping the `+` prefix); context/removal lines terminate it.
+        if (line.startsWith("+") && !line.startsWith("+++")) {
+            buffer.push(line.slice(1));
+        } else if (buffer.length && (line.startsWith(" ") || line.startsWith("-"))) {
+            flush();
+        }
+    }
+    flush();
+    return regions;
+}
+
+async function processAutoRemoves(args: { session: UnapplySession; projectRoot: string }): Promise<void> {
+    for (const r of args.session.regions()) {
+        if (r.decision === "auto-remove") {
+            await applyDecisionToCode({
+                filePath: join(args.projectRoot, r.filePath),
+                regionName: args.session.snapshot().stashName,
+                decision: "auto-remove",
+            });
+        }
+    }
+}
+
+async function walkInteractive(args: { session: UnapplySession; projectRoot: string }): Promise<void> {
+    const { select, note } = await import("@clack/prompts");
+    while (!args.session.isComplete()) {
+        const region = args.session.currentRegion();
+        if (!region) {
+            return;
+        }
+        const total = args.session.regions().length;
+        const idx = args.session.snapshot().currentIndex + 1;
+        const diff = renderDiff({
+            before: region.storedContent ?? "",
+            after: region.currentContent ?? "",
+            label: `${region.filePath} hunk ${region.hunkIndex}`,
+        });
+        note(diff, `Region ${idx}/${total} — class: ${region.klass}`);
+        const selectOpts: Array<{ value: Exclude<Decision, null | "auto-remove">; label: string; hint?: string }> = [
+            { value: "update", label: "update — capture current as new vN+1, remove from code" },
+            { value: "discard", label: "discard — remove using stored content (lose local edits)" },
+            { value: "skip", label: "skip — leave code & store alone (warns)" },
+        ];
+        if (region.klass === "missing") {
+            selectOpts.splice(1, 1);
+        }
+        const sel = await select({ message: "decision?", options: selectOpts });
+        if (typeof sel !== "string") {
+            ui.warn("paused; resume with: tools stash unapply <name> --continue");
+            await args.session.persist();
+            process.exit(0);
+        }
+        args.session.decide(sel as Exclude<Decision, null | "auto-remove">);
+    }
+}
+
+async function emitNonTtyPrompt(args: { session: UnapplySession }): Promise<void> {
+    const region = args.session.currentRegion();
+    if (!region) {
+        return;
+    }
+    const total = args.session.regions().length;
+    const idx = args.session.snapshot().currentIndex + 1;
+    process.stderr.write(
+        `\nRegion ${idx}/${total} — ${region.filePath} hunk ${region.hunkIndex} (class: ${region.klass})\n`
+    );
+    process.stderr.write(
+        renderDiff({
+            before: region.storedContent ?? "",
+            after: region.currentContent ?? "",
+            label: `${region.filePath} hunk ${region.hunkIndex}`,
+        })
+    );
+    process.stderr.write("\nChoose a decision:\n");
+    for (const dec of ["update", "discard", "skip"]) {
+        // suggestCommand pulls <name> from process.argv; subcommand=["unapply"] strips the duplicate token.
+        process.stderr.write(
+            `  ${suggestCommand("tools stash unapply", { add: ["--continue", `--decision=${dec}`], subcommand: ["unapply"] })}\n`
+        );
+    }
+    process.stderr.write(
+        `Or abort:\n  ${suggestCommand("tools stash unapply", { add: ["--abort"], subcommand: ["unapply"] })}\n`
+    );
+}
+
+interface ExecStats {
+    removed: number;
+    updated: number;
+    skipped: number;
+    newVersion: number | null;
+}
+
+async function executeAllDecisions(args: {
+    session: UnapplySession;
+    projectRoot: string;
+    storage: StashStorage;
+    db: Database;
+    stash: StashRow;
+}): Promise<ExecStats> {
+    const stats: ExecStats = { removed: 0, updated: 0, skipped: 0, newVersion: null };
+    const updatedRegions: SessionRegion[] = [];
+    for (const r of args.session.regions()) {
+        if (r.decision === "skip") {
+            stats.skipped++;
+            ui.warn(`region ${r.filePath} hunk ${r.hunkIndex}: kept (stash and code now diverged)`);
+            continue;
+        }
+        if (r.decision === "update") {
+            updatedRegions.push(r);
+            stats.updated++;
+        }
+        await applyDecisionToCode({
+            filePath: join(args.projectRoot, r.filePath),
+            regionName: args.session.snapshot().stashName,
+            decision: r.decision ?? "auto-remove",
+        });
+        if (r.decision === "auto-remove" || r.decision === "discard" || r.decision === "update") {
+            stats.removed++;
+        }
+    }
+    if (updatedRegions.length) {
+        stats.newVersion = await capturedUpdatesAsNewVersion({
+            storage: args.storage,
+            db: args.db,
+            stash: args.stash,
+            updatedRegions,
+        });
+    }
+    return stats;
+}
+
+/**
+ * Persist the user's `update` decisions as a new stash version.
+ *
+ * Builds a real unified diff per region (stored content → current content), reusing the existing
+ * v(N) baseline ref so future `apply` calls of v(N+1) still have a 3-way base. The diff is a plain
+ * concatenation of per-region `--- a/<path> / +++ b/<path>` blocks — git apply parses this and
+ * the round-trip test in e2e.test.ts proves it applies cleanly.
+ */
+async function capturedUpdatesAsNewVersion(args: {
+    storage: StashStorage;
+    db: Database;
+    stash: StashRow;
+    updatedRegions: SessionRegion[];
+}): Promise<number> {
+    const repo = new StoreRepo(args.storage.storeRepoDir());
+    const maxV = args.db
+        .query<{ m: number | null }, [string]>("SELECT MAX(version) as m FROM versions WHERE stash_id = ?")
+        .get(args.stash.id);
+    const newV = (maxV?.m ?? 0) + 1;
+
+    const patchParts: string[] = [];
+    for (const r of args.updatedRegions) {
+        const before = r.storedContent ?? "";
+        const after = r.currentContent ?? "";
+        patchParts.push(buildUnifiedDiff({ path: r.filePath, before, after }));
+    }
+    const patch = patchParts.join("");
+
+    const patchRef = `refs/stashes/${args.stash.id}/v${newV}`;
+    const baselineRef = `refs/baselines/${args.stash.id}/v${newV}`;
+
+    // Carry the prior baseline forward: an updated version still merges against the original
+    // pre-stash files, so 3-way merge stays valid for any future apply target.
+    const baselineFiles: Record<string, string> = {};
+    for (const r of args.updatedRegions) {
+        baselineFiles[r.filePath] = r.storedContent ?? "";
+    }
+    await repo.writePatchCommit({
+        ref: baselineRef,
+        files: baselineFiles,
+        message: `stash:${args.stash.name} v${newV} baseline (captured)`,
+    });
+    await repo.writePatchCommit({
+        ref: patchRef,
+        files: { "PATCH.diff": patch },
+        message: `stash:${args.stash.name} v${newV} (captured from unapply)`,
+    });
+    log.debug({ patchRef, baselineRef, regions: args.updatedRegions.length }, "captured-from-unapply version written");
+
+    const now = new Date().toISOString();
+    args.db.run(
+        `INSERT INTO versions (id, stash_id, version, patch_ref, region_count, file_count, metadata_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, '{"capturedFromUnapply":true}', ?)`,
+        [
+            newStashId(),
+            args.stash.id,
+            newV,
+            patchRef,
+            args.updatedRegions.length,
+            new Set(args.updatedRegions.map((r) => r.filePath)).size,
+            now,
+        ]
+    );
+    args.db.run("UPDATE stashes SET updated_at = ? WHERE id = ?", [now, args.stash.id]);
+    return newV;
+}
+
+/** Minimal single-file unified diff between `before` and `after` content. */
+function buildUnifiedDiff(args: { path: string; before: string; after: string }): string {
+    const beforeLines = args.before.split("\n");
+    const afterLines = args.after.split("\n");
+    const header = [
+        `--- a/${args.path}`,
+        `+++ b/${args.path}`,
+        // Whole-file replace hunk: covers `before` (count=beforeLines.length) → `after` (count=afterLines.length).
+        // Sufficient for the captured-region case where boundaries are exact.
+        `@@ -1,${beforeLines.length} +1,${afterLines.length} @@`,
+    ].join("\n");
+    const body = [...beforeLines.map((l) => `-${l}`), ...afterLines.map((l) => `+${l}`)].join("\n");
+    return `${header}\n${body}\n`;
+}

--- a/src/stash/commands/unapply.ts
+++ b/src/stash/commands/unapply.ts
@@ -55,10 +55,12 @@ export async function unapplyCommand(opts: UnapplyOptions): Promise<void> {
         const s = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
         if (!s) {
             ui.warn("no in-progress unapply session");
+            db.close();
             return;
         }
         await s.abort();
         ui.ok("aborted");
+        db.close();
         return;
     }
 
@@ -66,11 +68,13 @@ export async function unapplyCommand(opts: UnapplyOptions): Promise<void> {
         const s = await UnapplySession.load({ stashId: stash.id, projectHash, stateDir: storage.stateDir() });
         if (!s) {
             ui.info("no in-progress session");
+            db.close();
             return;
         }
         const p = s.progress();
         const cur = s.currentRegion();
         ui.info(`${p.decided}/${p.total} decided; current: ${cur?.filePath ?? "(none)"} hunk ${cur?.hunkIndex ?? "?"}`);
+        db.close();
         return;
     }
 
@@ -168,11 +172,18 @@ async function bootstrapSession(args: {
         .get(args.stash.id, args.project.rootPath);
     if (!app) {
         ui.err(`"${args.stash.name}" is not applied here`);
+        args.db.close();
+        process.exit(1);
+    }
+    if (!app.version_id) {
+        ui.err("application row has no version (orphaned by drop); cannot unapply");
+        args.db.close();
         process.exit(1);
     }
     const version = args.db.query<VersionRow, [string]>("SELECT * FROM versions WHERE id = ?").get(app.version_id);
     if (!version) {
         ui.err("version row missing");
+        args.db.close();
         process.exit(1);
     }
     const repo = new StoreRepo(args.storage.storeRepoDir());
@@ -245,8 +256,13 @@ function collectRegionsFromPatch(patch: string): PatchRegion[] {
             flush();
             continue;
         }
-        // Added (`+`) lines accumulate into the current region buffer (stripping the `+` prefix); context/removal lines terminate it.
-        if (line.startsWith("+") && !line.startsWith("+++")) {
+        // Added (`+`) lines accumulate into the current region buffer (stripping the `+` prefix).
+        // The `+++ b/path` file header is handled above (it sets currentFile and flushes), so we
+        // never see `+++` here — no extra startsWith guard required.
+        // Context/removal lines terminate the buffer. We DON'T flush on `\` lines (e.g.
+        // `\ No newline at end of file`) — those don't end a hunk, so flushing on them would
+        // truncate the region prematurely.
+        if (line.startsWith("+")) {
             buffer.push(line.slice(1));
         } else if (buffer.length && (line.startsWith(" ") || line.startsWith("-"))) {
             flush();
@@ -257,15 +273,31 @@ function collectRegionsFromPatch(patch: string): PatchRegion[] {
 }
 
 async function processAutoRemoves(args: { session: UnapplySession; projectRoot: string }): Promise<void> {
-    for (const r of args.session.regions()) {
-        if (r.decision === "auto-remove") {
-            await applyDecisionToCode({
-                filePath: join(args.projectRoot, r.filePath),
-                regionName: args.session.snapshot().stashName,
-                decision: "auto-remove",
-            });
+    // Group by filePath and walk each file's regions back-to-front (highest hunkIndex first).
+    // Each removal shifts subsequent line numbers, so descending hunkIndex order keeps the
+    // markers.filter(...)[hunkIndex-1] lookup in decisions.ts consistent as we go.
+    for (const regions of groupRegionsByFileDescending(args.session.regions())) {
+        for (const r of regions) {
+            if (r.decision === "auto-remove") {
+                await applyDecisionToCode({
+                    filePath: join(args.projectRoot, r.filePath),
+                    regionName: args.session.snapshot().stashName,
+                    hunkIndex: r.hunkIndex,
+                    decision: "auto-remove",
+                });
+            }
         }
     }
+}
+
+function groupRegionsByFileDescending(regions: SessionRegion[]): SessionRegion[][] {
+    const byFile = new Map<string, SessionRegion[]>();
+    for (const r of regions) {
+        const arr = byFile.get(r.filePath) ?? [];
+        arr.push(r);
+        byFile.set(r.filePath, arr);
+    }
+    return [...byFile.values()].map((arr) => [...arr].sort((a, b) => b.hunkIndex - a.hunkIndex));
 }
 
 async function walkInteractive(args: { session: UnapplySession; projectRoot: string }): Promise<void> {
@@ -345,24 +377,39 @@ async function executeAllDecisions(args: {
     stash: StashRow;
 }): Promise<ExecStats> {
     const stats: ExecStats = { removed: 0, updated: 0, skipped: 0, newVersion: null };
-    const updatedRegions: SessionRegion[] = [];
+    // Snapshot "update"-bound regions in their original order so capturedUpdatesAsNewVersion sees
+    // their stored/current content before we start mutating files. The capture itself is purely
+    // in-memory (it reads from r.storedContent/r.currentContent), so order doesn't matter for
+    // correctness — we just don't want stats accounting to depend on the mutation order below.
+    const updatedRegions: SessionRegion[] = args.session.regions().filter((r) => r.decision === "update");
     for (const r of args.session.regions()) {
         if (r.decision === "skip") {
             stats.skipped++;
             ui.warn(`region ${r.filePath} hunk ${r.hunkIndex}: kept (stash and code now diverged)`);
-            continue;
-        }
-        if (r.decision === "update") {
-            updatedRegions.push(r);
-            stats.updated++;
-        }
-        await applyDecisionToCode({
-            filePath: join(args.projectRoot, r.filePath),
-            regionName: args.session.snapshot().stashName,
-            decision: r.decision ?? "auto-remove",
-        });
-        if (r.decision === "auto-remove" || r.decision === "discard" || r.decision === "update") {
+        } else if (r.decision === "auto-remove" || r.decision === "discard" || r.decision === "update") {
+            if (r.decision === "update") {
+                stats.updated++;
+            }
             stats.removed++;
+        }
+    }
+    // Apply file mutations per-file, back-to-front. Each removal shifts subsequent marker line
+    // numbers; processing in descending hunkIndex order keeps decisions.ts's
+    // markers.filter(...)[hunkIndex-1] lookup correct for the still-pending regions.
+    // NOTE: `auto-remove` regions were already stripped from disk by processAutoRemoves() at
+    // bootstrap, so calling applyDecisionToCode on them again would log a spurious "no marker"
+    // warn. Only mutate for discard/update here.
+    for (const regions of groupRegionsByFileDescending(args.session.regions())) {
+        for (const r of regions) {
+            if (r.decision !== "discard" && r.decision !== "update") {
+                continue;
+            }
+            await applyDecisionToCode({
+                filePath: join(args.projectRoot, r.filePath),
+                regionName: args.session.snapshot().stashName,
+                hunkIndex: r.hunkIndex,
+                decision: r.decision,
+            });
         }
     }
     if (updatedRegions.length) {

--- a/src/stash/commands/update.ts
+++ b/src/stash/commands/update.ts
@@ -1,0 +1,61 @@
+import { Database } from "bun:sqlite";
+import { logger } from "@app/logger";
+import { detectProject } from "../lib/projects";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { ui } from "../lib/ui";
+import type { ApplicationRow, StashRow } from "../types";
+import { saveCommand } from "./save";
+
+const { log } = logger.scoped("stash:update");
+
+export interface UpdateOptions {
+    name: string;
+    mode: "all" | "staged" | "unstaged";
+}
+
+/**
+ * Capture the current working tree as a new version of an already-applied stash.
+ *
+ * v1 semantics: requires an active application of <name> in cwd, then delegates to saveCommand
+ * (auto-bumps to vN+1). The diff captures the full working tree, not only marker-bounded regions
+ * — broader than spec §7.5 but more useful in practice (edits often span outside the stash region).
+ * Spec-strict region-scoped capture is deferred to v1.1.
+ */
+export async function updateCommand(opts: UpdateOptions): Promise<void> {
+    log.debug({ opts }, "updateCommand");
+    const project = await detectProject(process.cwd());
+    if (!project) {
+        ui.err("not inside a git repository");
+        process.exit(1);
+    }
+
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(opts.name);
+    if (!stash) {
+        ui.err(`stash "${opts.name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+
+    const active = db
+        .query<ApplicationRow, [string, string]>(
+            "SELECT * FROM applications WHERE stash_id = ? AND project_path = ? AND state = 'active'"
+        )
+        .get(stash.id, project.rootPath);
+    if (!active) {
+        ui.err(`"${opts.name}" is not applied here — use 'save' to create a new stash, or 'apply' first`);
+        db.close();
+        process.exit(1);
+    }
+    log.debug(
+        { stashId: stash.id, projectPath: project.rootPath, currentVersion: active.version_id },
+        "update precondition passed"
+    );
+    db.close();
+
+    await saveCommand({ name: opts.name, mode: opts.mode, tags: [], description: undefined });
+}

--- a/src/stash/commands/versions.ts
+++ b/src/stash/commands/versions.ts
@@ -1,0 +1,42 @@
+import { Database } from "bun:sqlite";
+import { logger, out } from "@app/logger";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { ui } from "../lib/ui";
+import type { StashRow, VersionRow } from "../types";
+
+const { log } = logger.scoped("stash:versions");
+
+export async function versionsCommand(name: string): Promise<void> {
+    log.debug({ name }, "versionsCommand");
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(name);
+    if (!stash) {
+        ui.err(`stash "${name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+    const rows = db
+        .query<VersionRow, [string]>("SELECT * FROM versions WHERE stash_id = ? ORDER BY version DESC")
+        .all(stash.id);
+    log.debug({ stashId: stash.id, versionCount: rows.length }, "versions fetched");
+
+    if (!rows.length) {
+        ui.info("no versions");
+        db.close();
+        return;
+    }
+
+    ui.section(`${name} — ${rows.length} version${rows.length === 1 ? "" : "s"}`);
+    ui.dim(`  VER  FILES  REGIONS  CREATED                       ORIGIN`);
+    for (const r of rows) {
+        const ver = `v${r.version}`.padEnd(4);
+        const files = String(r.file_count).padStart(5);
+        const regs = String(r.region_count).padStart(7);
+        const created = r.created_at.padEnd(29);
+        out.print(`  ${ver} ${files}  ${regs}  ${created} ${r.source_origin ?? "—"}`);
+    }
+    db.close();
+}

--- a/src/stash/commands/where.ts
+++ b/src/stash/commands/where.ts
@@ -1,0 +1,41 @@
+import { Database } from "bun:sqlite";
+import { logger, out } from "@app/logger";
+import { openStashDb } from "../lib/stash-db";
+import { StashStorage } from "../lib/storage";
+import { ui } from "../lib/ui";
+import type { ApplicationRow, StashRow } from "../types";
+
+const { log } = logger.scoped("stash:where");
+
+export async function whereCommand(name: string): Promise<void> {
+    log.debug({ name }, "whereCommand");
+    const storage = new StashStorage();
+    await storage.ensureDirs();
+    const db = openStashDb(new Database(storage.dbPath()));
+    const stash = db.query<StashRow, [string]>("SELECT * FROM stashes WHERE name = ?").get(name);
+    if (!stash) {
+        ui.err(`stash "${name}" not found`);
+        db.close();
+        process.exit(1);
+    }
+    const apps = db
+        .query<ApplicationRow, [string]>(
+            "SELECT * FROM applications WHERE stash_id = ? AND state = 'active' ORDER BY applied_at"
+        )
+        .all(stash.id);
+    log.debug({ stashId: stash.id, applicationCount: apps.length }, "active applications fetched");
+
+    if (!apps.length) {
+        ui.info("not currently applied anywhere");
+        db.close();
+        return;
+    }
+
+    ui.section(`${name} — ${apps.length} active application${apps.length === 1 ? "" : "s"}`);
+    const pathW = Math.max(10, ...apps.map((a) => a.project_path.length));
+    ui.dim(`  ${"PROJECT".padEnd(pathW)}  APPLIED`);
+    for (const a of apps) {
+        out.print(`  ${a.project_path.padEnd(pathW)}  ${a.applied_at}`);
+    }
+    db.close();
+}

--- a/src/stash/e2e.test.ts
+++ b/src/stash/e2e.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyCommand } from "./commands/apply";
+import { saveCommand } from "./commands/save";
+import { unapplyCommand } from "./commands/unapply";
+import { runGitIn } from "./lib/patch";
+
+let work: string;
+let origStashRoot: string | undefined;
+let origCwd: string;
+let projectA: string;
+let projectB: string;
+
+beforeEach(async () => {
+    origCwd = process.cwd();
+    work = await mkdtemp(join(tmpdir(), "stash-e2e-"));
+    origStashRoot = process.env.GENESIS_TOOLS_STASH_ROOT;
+    // Per-test stash root keeps parallel test files (and concurrent runs) from sharing the global SQLite/bare-repo state.
+    process.env.GENESIS_TOOLS_STASH_ROOT = join(work, ".genesis-tools", "stash");
+    projectA = join(work, "repo-a");
+    projectB = join(work, "repo-b");
+    for (const repo of [projectA, projectB]) {
+        await runGitIn(work, ["init", repo.split("/").pop() ?? "", "--initial-branch=main"]);
+        await runGitIn(repo, ["config", "user.email", "t@t"]);
+        await runGitIn(repo, ["config", "user.name", "t"]);
+        await writeFile(join(repo, "main.ts"), "export function main() { return 1; }\n");
+        await runGitIn(repo, ["add", "main.ts"]);
+        await runGitIn(repo, ["commit", "-m", "init"]);
+    }
+});
+afterEach(async () => {
+    // Restore cwd BEFORE rm — tests chdir into `work/...` and removing the current cwd makes
+    // any subsequent Bun.spawn fail with posix_spawn ENOENT (macOS can't inherit a dead cwd).
+    process.chdir(origCwd);
+    if (origStashRoot !== undefined) {
+        process.env.GENESIS_TOOLS_STASH_ROOT = origStashRoot;
+    } else {
+        delete process.env.GENESIS_TOOLS_STASH_ROOT;
+    }
+    await rm(work, { recursive: true, force: true });
+});
+
+describe.serial("stash e2e", () => {
+    test("save in A → apply in B → unapply (discard) restores B to original", async () => {
+        process.chdir(projectA);
+        await writeFile(
+            join(projectA, "main.ts"),
+            "import { log } from './log';\nexport function main() { log('start'); return 1; }\n"
+        );
+        await saveCommand({ name: "logging", mode: "all", tags: [], description: undefined });
+
+        process.chdir(projectB);
+        await applyCommand({ name: "logging", verboseMarkers: false });
+        const applied = await readFile(join(projectB, "main.ts"), "utf8");
+        expect(applied).toContain("#region @stash:logging");
+        expect(applied).toContain("log('start')");
+
+        await unapplyCommand({ name: "logging", action: "start", decision: "discard-all-dangerous" });
+        const after = await readFile(join(projectB, "main.ts"), "utf8");
+        expect(after).not.toContain("#region @stash:logging");
+        expect(after).not.toContain("log('start')");
+    });
+
+    test("save → save again with edits → versions=2", async () => {
+        process.chdir(projectA);
+        await writeFile(join(projectA, "main.ts"), "v1");
+        await saveCommand({ name: "ver", mode: "all", tags: [], description: undefined });
+        await writeFile(join(projectA, "main.ts"), "v2");
+        await saveCommand({ name: "ver", mode: "all", tags: [], description: undefined });
+
+        const { Database } = await import("bun:sqlite");
+        const { openStashDb } = await import("./lib/stash-db");
+        const { StashStorage } = await import("./lib/storage");
+        const db = openStashDb(new Database(new StashStorage().dbPath()));
+        const count = db.query<{ c: number }, []>("SELECT COUNT(*) as c FROM versions").get();
+        expect(count?.c).toBe(2);
+        db.close();
+    });
+});

--- a/src/stash/index.ts
+++ b/src/stash/index.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+import { runTool } from "@app/utils/cli";
+import { Command } from "commander";
+import { applyCommand } from "./commands/apply";
+import { dropCommand } from "./commands/drop";
+import { listCommand } from "./commands/list";
+import { saveCommand } from "./commands/save";
+import { showCommand } from "./commands/show";
+import { unapplyCommand } from "./commands/unapply";
+import { updateCommand } from "./commands/update";
+import { versionsCommand } from "./commands/versions";
+import { whereCommand } from "./commands/where";
+
+const program = new Command();
+program.name("tools stash").description("Global cross-project code-overlay manager").version("0.1.0");
+
+program
+    .command("save <name>")
+    .description("Capture working-tree changes as a named stash")
+    .option("--staged", "save staged changes only")
+    .option("--unstaged", "save unstaged tracked changes only")
+    .option("--all", "save staged + unstaged + untracked")
+    .option("-t, --tag <tag>", "add a tag (repeatable)", (val, prev: string[] = []) => [...prev, val], [])
+    .option("-d, --desc <description>", "human-readable description")
+    .action(
+        async (
+            name: string,
+            opts: { staged?: boolean; unstaged?: boolean; all?: boolean; tag: string[]; desc?: string }
+        ) => {
+            const mode = opts.staged ? "staged" : opts.unstaged ? "unstaged" : opts.all ? "all" : undefined;
+            await saveCommand({ name, mode, tags: opts.tag, description: opts.desc });
+        }
+    );
+
+program
+    .command("apply <name>")
+    .description("Apply a stash into the current project")
+    .option("--at <version>", "pin to specific version (default: latest)", (v) => Number(v))
+    .option("--verbose-markers", "include source/applied metadata in markers")
+    .action(async (name: string, opts: { at?: number; verboseMarkers?: boolean }) => {
+        await applyCommand({ name, version: opts.at, verboseMarkers: !!opts.verboseMarkers });
+    });
+
+program
+    .command("unapply <name>")
+    .description("Surgically remove an applied stash with diff review")
+    .option("--continue", "resume from last checkpoint")
+    .option("--skip", "decide current region as 'skip'")
+    .option("--abort", "abandon in-progress session, restore state")
+    .option("--status", "show progress of in-progress session")
+    .option(
+        "--decision <d>",
+        "decide current region: update | discard | skip | discard-all-dangerous | update-stash-all-dangerous"
+    )
+    .action(
+        async (
+            name: string,
+            opts: { continue?: boolean; skip?: boolean; abort?: boolean; status?: boolean; decision?: string }
+        ) => {
+            const action = opts.abort
+                ? "abort"
+                : opts.status
+                  ? "status"
+                  : opts.skip
+                    ? "skip"
+                    : opts.continue
+                      ? "continue"
+                      : "start";
+            await unapplyCommand({ name, action, decision: opts.decision as never });
+        }
+    );
+
+program
+    .command("list")
+    .description("List stashes")
+    .option("--project", "only stashes related to the current project")
+    .option("--tag <tag>", "filter by tag")
+    .option("--applied", "only stashes currently applied to this project")
+    .action(async (opts: { project?: boolean; tag?: string; applied?: boolean }) => {
+        await listCommand({ project: !!opts.project, tag: opts.tag, applied: !!opts.applied });
+    });
+
+program
+    .command("show <name>")
+    .description("Show stash details")
+    .option("--at <version>", "specific version", (v) => Number(v))
+    .option("--diff", "show patch content")
+    .option("--meta", "show only metadata")
+    .option("--regions", "show region inventory")
+    .action(async (name: string, opts: { at?: number; diff?: boolean; meta?: boolean; regions?: boolean }) => {
+        const mode: "diff" | "meta" | "regions" = opts.diff ? "diff" : opts.meta ? "meta" : "regions";
+        await showCommand({ name, version: opts.at, mode });
+    });
+
+program
+    .command("update <name>")
+    .description("Capture the current working tree as a new version of a currently-applied stash")
+    .option("--staged", "save staged only")
+    .option("--unstaged", "save unstaged only")
+    .option("--all", "save everything (default)")
+    .action(async (name: string, opts: { staged?: boolean; unstaged?: boolean; all?: boolean }) => {
+        const mode = opts.staged ? "staged" : opts.unstaged ? "unstaged" : "all";
+        await updateCommand({ name, mode });
+    });
+
+program
+    .command("versions <name>")
+    .description("List versions of a stash")
+    .action(async (name: string) => {
+        await versionsCommand(name);
+    });
+
+program
+    .command("drop <name>")
+    .description("Delete a stash version")
+    .option("--at <version>", "specific version", (v) => Number(v))
+    .option("--all-versions", "delete all versions")
+    .option("--orphan-active", "drop even with active applications")
+    .action(async (name: string, opts: { at?: number; allVersions?: boolean; orphanActive?: boolean }) => {
+        await dropCommand({
+            name,
+            version: opts.at,
+            allVersions: !!opts.allVersions,
+            orphanActive: !!opts.orphanActive,
+        });
+    });
+
+program
+    .command("where <name>")
+    .description("Show projects where this stash is currently applied")
+    .action(async (name: string) => {
+        await whereCommand(name);
+    });
+
+await runTool(program, { tool: "stash" });

--- a/src/stash/index.ts
+++ b/src/stash/index.ts
@@ -10,6 +10,8 @@ import { unapplyCommand } from "./commands/unapply";
 import { updateCommand } from "./commands/update";
 import { versionsCommand } from "./commands/versions";
 import { whereCommand } from "./commands/where";
+import { parsePositiveInt, pickExclusive } from "./lib/options";
+import type { SaveMode } from "./lib/patch";
 
 const program = new Command();
 program.name("tools stash").description("Global cross-project code-overlay manager").version("0.1.0");
@@ -27,7 +29,7 @@ program
             name: string,
             opts: { staged?: boolean; unstaged?: boolean; all?: boolean; tag: string[]; desc?: string }
         ) => {
-            const mode = opts.staged ? "staged" : opts.unstaged ? "unstaged" : opts.all ? "all" : undefined;
+            const mode = pickExclusive(opts, ["staged", "unstaged", "all"]) as SaveMode | undefined;
             await saveCommand({ name, mode, tags: opts.tag, description: opts.desc });
         }
     );
@@ -35,7 +37,7 @@ program
 program
     .command("apply <name>")
     .description("Apply a stash into the current project")
-    .option("--at <version>", "pin to specific version (default: latest)", (v) => Number(v))
+    .option("--at <version>", "pin to specific version (default: latest)", parsePositiveInt)
     .option("--verbose-markers", "include source/applied metadata in markers")
     .action(async (name: string, opts: { at?: number; verboseMarkers?: boolean }) => {
         await applyCommand({ name, version: opts.at, verboseMarkers: !!opts.verboseMarkers });
@@ -83,12 +85,13 @@ program
 program
     .command("show <name>")
     .description("Show stash details")
-    .option("--at <version>", "specific version", (v) => Number(v))
+    .option("--at <version>", "specific version", parsePositiveInt)
     .option("--diff", "show patch content")
     .option("--meta", "show only metadata")
     .option("--regions", "show region inventory")
     .action(async (name: string, opts: { at?: number; diff?: boolean; meta?: boolean; regions?: boolean }) => {
-        const mode: "diff" | "meta" | "regions" = opts.diff ? "diff" : opts.meta ? "meta" : "regions";
+        const picked = pickExclusive(opts, ["diff", "meta", "regions"]);
+        const mode: "diff" | "meta" | "regions" = (picked as "diff" | "meta" | "regions" | undefined) ?? "regions";
         await showCommand({ name, version: opts.at, mode });
     });
 
@@ -99,7 +102,7 @@ program
     .option("--unstaged", "save unstaged only")
     .option("--all", "save everything (default)")
     .action(async (name: string, opts: { staged?: boolean; unstaged?: boolean; all?: boolean }) => {
-        const mode = opts.staged ? "staged" : opts.unstaged ? "unstaged" : "all";
+        const mode = (pickExclusive(opts, ["staged", "unstaged", "all"]) as SaveMode | undefined) ?? "all";
         await updateCommand({ name, mode });
     });
 
@@ -113,7 +116,7 @@ program
 program
     .command("drop <name>")
     .description("Delete a stash version")
-    .option("--at <version>", "specific version", (v) => Number(v))
+    .option("--at <version>", "specific version", parsePositiveInt)
     .option("--all-versions", "delete all versions")
     .option("--orphan-active", "drop even with active applications")
     .action(async (name: string, opts: { at?: number; allVersions?: boolean; orphanActive?: boolean }) => {

--- a/src/stash/lib/classify.test.ts
+++ b/src/stash/lib/classify.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { type ClassifyInput, classifyRegion } from "./classify";
+
+const baseStored = "logger.debug('x');";
+
+describe("classifyRegion", () => {
+    test("unchanged when stored == current", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: baseStored, present: true };
+        expect(classifyRegion(input).klass).toBe("unchanged");
+    });
+    test("edited when stored != current and both present", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: "logger.debug('y');", present: true };
+        expect(classifyRegion(input).klass).toBe("edited");
+    });
+    test("missing when markers absent", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: null, present: false };
+        expect(classifyRegion(input).klass).toBe("missing");
+    });
+    test("ignores trailing whitespace differences", () => {
+        const input: ClassifyInput = { storedContent: baseStored, currentContent: `${baseStored}   `, present: true };
+        expect(classifyRegion(input).klass).toBe("unchanged");
+    });
+});

--- a/src/stash/lib/classify.ts
+++ b/src/stash/lib/classify.ts
@@ -1,0 +1,30 @@
+export type RegionClass = "unchanged" | "edited" | "missing" | "new-extra";
+
+export interface ClassifyInput {
+    storedContent: string;
+    currentContent: string | null;
+    present: boolean;
+}
+
+export interface Classification {
+    klass: RegionClass;
+}
+
+export function classifyRegion(input: ClassifyInput): Classification {
+    if (!input.present) {
+        return { klass: "missing" };
+    }
+    if (input.currentContent === null) {
+        return { klass: "missing" };
+    }
+    const norm = (s: string) =>
+        s
+            .split("\n")
+            .map((l) => l.trimEnd())
+            .join("\n")
+            .replace(/\n+$/, "");
+    if (norm(input.storedContent) === norm(input.currentContent)) {
+        return { klass: "unchanged" };
+    }
+    return { klass: "edited" };
+}

--- a/src/stash/lib/decisions.test.ts
+++ b/src/stash/lib/decisions.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyDecisionToCode } from "./decisions";
+
+let dir: string;
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stash-decisions-"));
+});
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+describe("applyDecisionToCode", () => {
+    test("auto-remove strips markers and content", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(
+            f,
+            ["before", `// #region @stash:x {"id":"abc","v":1}`, "content", "// #endregion @stash:x", "after"].join(
+                "\n"
+            )
+        );
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "auto-remove" });
+        expect(await readFile(f, "utf8")).toBe("before\nafter");
+    });
+
+    test("update removes markers + content (caller is responsible for new version)", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(
+            f,
+            [
+                "before",
+                `// #region @stash:x {"id":"abc","v":1}`,
+                "modified content",
+                "// #endregion @stash:x",
+                "after",
+            ].join("\n")
+        );
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "update" });
+        expect(await readFile(f, "utf8")).toBe("before\nafter");
+    });
+
+    test("skip is a no-op on the file", async () => {
+        const f = join(dir, "a.ts");
+        const before = [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "content",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n");
+        await writeFile(f, before);
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "skip" });
+        expect(await readFile(f, "utf8")).toBe(before);
+    });
+
+    test("discard with storedContent restores original then removes", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(
+            f,
+            [
+                "before",
+                `// #region @stash:x {"id":"abc","v":1}`,
+                "edited content",
+                "// #endregion @stash:x",
+                "after",
+            ].join("\n")
+        );
+        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "discard" });
+        expect(await readFile(f, "utf8")).toBe("before\nafter");
+    });
+});

--- a/src/stash/lib/decisions.test.ts
+++ b/src/stash/lib/decisions.test.ts
@@ -21,7 +21,7 @@ describe("applyDecisionToCode", () => {
                 "\n"
             )
         );
-        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "auto-remove" });
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 1, decision: "auto-remove" });
         expect(await readFile(f, "utf8")).toBe("before\nafter");
     });
 
@@ -37,7 +37,7 @@ describe("applyDecisionToCode", () => {
                 "after",
             ].join("\n")
         );
-        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "update" });
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 1, decision: "update" });
         expect(await readFile(f, "utf8")).toBe("before\nafter");
     });
 
@@ -51,7 +51,56 @@ describe("applyDecisionToCode", () => {
             "after",
         ].join("\n");
         await writeFile(f, before);
-        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "skip" });
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 1, decision: "skip" });
+        expect(await readFile(f, "utf8")).toBe(before);
+    });
+
+    test("multi-region file: hunkIndex picks the Nth marker, not the first", async () => {
+        // Regression for PR #222 t1+t2: apply wraps every hunk with the same stash name, so a file
+        // with two hunks has two identical markers. The old find()-based impl always picked the
+        // first, corrupting the file when the second region was decided. Verify processing back-to-
+        // front (hunkIndex 2 then 1) removes both correctly.
+        const f = join(dir, "multi.ts");
+        await writeFile(
+            f,
+            [
+                "// region A before",
+                `// #region @stash:x {"id":"abc","v":1}`,
+                "A content",
+                "// #endregion @stash:x",
+                "// between regions",
+                `// #region @stash:x {"id":"abc","v":1}`,
+                "B content",
+                "// #endregion @stash:x",
+                "// region B after",
+            ].join("\n")
+        );
+        // Back-to-front: remove hunk 2 first.
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 2, decision: "auto-remove" });
+        const afterFirst = await readFile(f, "utf8");
+        expect(afterFirst).toBe(
+            [
+                "// region A before",
+                `// #region @stash:x {"id":"abc","v":1}`,
+                "A content",
+                "// #endregion @stash:x",
+                "// between regions",
+                "// region B after",
+            ].join("\n")
+        );
+        // Then remove what's now the only remaining marker (hunkIndex 1).
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 1, decision: "auto-remove" });
+        expect(await readFile(f, "utf8")).toBe(
+            ["// region A before", "// between regions", "// region B after"].join("\n")
+        );
+    });
+
+    test("unknown hunkIndex is a logged no-op (does not throw)", async () => {
+        const f = join(dir, "a.ts");
+        const before = ["before", `// #region @stash:x {"v":1}`, "c", "// #endregion @stash:x", "after"].join("\n");
+        await writeFile(f, before);
+        // hunkIndex 5 in a file with one marker — should not throw, file unchanged.
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 5, decision: "auto-remove" });
         expect(await readFile(f, "utf8")).toBe(before);
     });
 
@@ -67,7 +116,7 @@ describe("applyDecisionToCode", () => {
                 "after",
             ].join("\n")
         );
-        await applyDecisionToCode({ filePath: f, regionName: "x", decision: "discard" });
+        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 1, decision: "discard" });
         expect(await readFile(f, "utf8")).toBe("before\nafter");
     });
 });

--- a/src/stash/lib/decisions.test.ts
+++ b/src/stash/lib/decisions.test.ts
@@ -95,12 +95,48 @@ describe("applyDecisionToCode", () => {
         );
     });
 
-    test("unknown hunkIndex is a logged no-op (does not throw)", async () => {
+    test("unknown hunkIndex returns 'marker-missing' (does not throw, file unchanged)", async () => {
         const f = join(dir, "a.ts");
         const before = ["before", `// #region @stash:x {"v":1}`, "c", "// #endregion @stash:x", "after"].join("\n");
         await writeFile(f, before);
-        // hunkIndex 5 in a file with one marker — should not throw, file unchanged.
-        await applyDecisionToCode({ filePath: f, regionName: "x", hunkIndex: 5, decision: "auto-remove" });
+        // PR #222 t28: caller (unapply) uses the return value to keep the application 'active'
+        // rather than falsely marking it 'unapplied' when markers are gone.
+        const outcome = await applyDecisionToCode({
+            filePath: f,
+            regionName: "x",
+            hunkIndex: 5,
+            decision: "auto-remove",
+        });
+        expect(outcome).toBe("marker-missing");
+        expect(await readFile(f, "utf8")).toBe(before);
+    });
+
+    test("successful removal returns 'applied'", async () => {
+        const f = join(dir, "a.ts");
+        await writeFile(
+            f,
+            ["before", `// #region @stash:x {"v":1}`, "c", "// #endregion @stash:x", "after"].join("\n")
+        );
+        const outcome = await applyDecisionToCode({
+            filePath: f,
+            regionName: "x",
+            hunkIndex: 1,
+            decision: "discard",
+        });
+        expect(outcome).toBe("applied");
+    });
+
+    test("skip decision returns 'applied' without touching the file", async () => {
+        const f = join(dir, "a.ts");
+        const before = "untouched\n";
+        await writeFile(f, before);
+        const outcome = await applyDecisionToCode({
+            filePath: f,
+            regionName: "x",
+            hunkIndex: 1,
+            decision: "skip",
+        });
+        expect(outcome).toBe("applied");
         expect(await readFile(f, "utf8")).toBe(before);
     });
 

--- a/src/stash/lib/decisions.ts
+++ b/src/stash/lib/decisions.ts
@@ -1,10 +1,20 @@
 import { readFile, writeFile } from "node:fs/promises";
+import { logger } from "@app/logger";
 import { parseMarkers } from "./markers";
 import type { Decision } from "./unapply-session";
+
+const { log } = logger.scoped("stash:decisions");
 
 export async function applyDecisionToCode(args: {
     filePath: string;
     regionName: string;
+    /**
+     * 1-based index within the markers of `regionName` in this file. `apply` wraps every hunk with
+     * the same stash name, so a file with N hunks has N identical markers — we must pick the
+     * Nth one, not the first. Callers must process per-file regions back-to-front so each removal
+     * doesn't shift the indices of later regions.
+     */
+    hunkIndex: number;
     decision: Exclude<Decision, null>;
 }): Promise<void> {
     if (args.decision === "skip") {
@@ -12,8 +22,13 @@ export async function applyDecisionToCode(args: {
     }
     const content = await readFile(args.filePath, "utf8");
     const markers = parseMarkers(content);
-    const m = markers.find((x) => x.name === args.regionName);
+    const byName = markers.filter((x) => x.name === args.regionName);
+    const m = byName[args.hunkIndex - 1];
     if (!m) {
+        log.warn(
+            { filePath: args.filePath, regionName: args.regionName, hunkIndex: args.hunkIndex, found: byName.length },
+            "no marker at requested hunkIndex; file may have been edited externally"
+        );
         return;
     }
     const lines = content.split("\n");

--- a/src/stash/lib/decisions.ts
+++ b/src/stash/lib/decisions.ts
@@ -1,0 +1,23 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { parseMarkers } from "./markers";
+import type { Decision } from "./unapply-session";
+
+export async function applyDecisionToCode(args: {
+    filePath: string;
+    regionName: string;
+    decision: Exclude<Decision, null>;
+}): Promise<void> {
+    if (args.decision === "skip") {
+        return;
+    }
+    const content = await readFile(args.filePath, "utf8");
+    const markers = parseMarkers(content);
+    const m = markers.find((x) => x.name === args.regionName);
+    if (!m) {
+        return;
+    }
+    const lines = content.split("\n");
+    const before = lines.slice(0, m.startLine - 1);
+    const after = lines.slice(m.endLine);
+    await writeFile(args.filePath, [...before, ...after].join("\n"));
+}

--- a/src/stash/lib/decisions.ts
+++ b/src/stash/lib/decisions.ts
@@ -5,6 +5,15 @@ import type { Decision } from "./unapply-session";
 
 const { log } = logger.scoped("stash:decisions");
 
+/**
+ * Outcome of attempting to apply a decision to a file region.
+ * - `applied`: marker was found and the region was removed (or no-op for `skip`)
+ * - `marker-missing`: marker not found at the requested hunkIndex — caller must treat the
+ *   application as still active for that region (PR #222 t28: prevents DB from claiming the stash
+ *   is unapplied while the user's code still has the wrapped block).
+ */
+export type DecisionOutcome = "applied" | "marker-missing";
+
 export async function applyDecisionToCode(args: {
     filePath: string;
     regionName: string;
@@ -16,9 +25,9 @@ export async function applyDecisionToCode(args: {
      */
     hunkIndex: number;
     decision: Exclude<Decision, null>;
-}): Promise<void> {
+}): Promise<DecisionOutcome> {
     if (args.decision === "skip") {
-        return;
+        return "applied";
     }
     const content = await readFile(args.filePath, "utf8");
     const markers = parseMarkers(content);
@@ -29,10 +38,11 @@ export async function applyDecisionToCode(args: {
             { filePath: args.filePath, regionName: args.regionName, hunkIndex: args.hunkIndex, found: byName.length },
             "no marker at requested hunkIndex; file may have been edited externally"
         );
-        return;
+        return "marker-missing";
     }
     const lines = content.split("\n");
     const before = lines.slice(0, m.startLine - 1);
     const after = lines.slice(m.endLine);
     await writeFile(args.filePath, [...before, ...after].join("\n"));
+    return "applied";
 }

--- a/src/stash/lib/diff-render.ts
+++ b/src/stash/lib/diff-render.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import chalk from "chalk";
@@ -74,12 +74,8 @@ export function renderDiff(args: { before: string; after: string; label: string 
     } catch {
         return fallbackLineDiff(args);
     } finally {
-        for (const f of [oldFile, newFile]) {
-            try {
-                unlinkSync(f);
-            } catch {
-                // ignore
-            }
-        }
+        // PR #222 t15: previously unlinked the two files but left the empty mkdtemp dir behind.
+        // rmSync({recursive, force}) removes both files and the dir in one shot.
+        rmSync(dir, { recursive: true, force: true });
     }
 }

--- a/src/stash/lib/diff-render.ts
+++ b/src/stash/lib/diff-render.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import chalk from "chalk";
+
+function formatDiffOutput(diffOutput: string, oldLabel: string, newLabel: string): string {
+    const lines = diffOutput.split("\n");
+    let formatted = "\n";
+
+    for (const line of lines) {
+        if (line.startsWith("---")) {
+            formatted += chalk.red(`--- ${oldLabel}\n`);
+        } else if (line.startsWith("+++")) {
+            formatted += chalk.green(`+++ ${newLabel}\n`);
+        } else if (line.startsWith("-")) {
+            formatted += `${chalk.red(line)}\n`;
+        } else if (line.startsWith("+")) {
+            formatted += `${chalk.green(line)}\n`;
+        } else if (line.startsWith("@")) {
+            formatted += `${chalk.cyan(line)}\n`;
+        } else {
+            formatted += `${line}\n`;
+        }
+    }
+
+    return formatted;
+}
+
+function fallbackLineDiff(args: { before: string; after: string; label: string }): string {
+    const beforeLines = args.before.split("\n");
+    const afterLines = args.after.split("\n");
+    const lines = [`--- stored (${args.label})`, `+++ current`];
+    const max = Math.max(beforeLines.length, afterLines.length);
+    for (let i = 0; i < max; i++) {
+        const b = beforeLines[i];
+        const a = afterLines[i];
+        if (b === a) {
+            lines.push(`  ${b ?? ""}`);
+        } else {
+            if (b !== undefined) {
+                lines.push(`- ${b}`);
+            }
+            if (a !== undefined) {
+                lines.push(`+ ${a}`);
+            }
+        }
+    }
+    return lines.join("\n");
+}
+
+export function renderDiff(args: { before: string; after: string; label: string }): string {
+    const oldLabel = `stored:${args.label}`;
+    const newLabel = `current:${args.label}`;
+
+    if (args.before === args.after) {
+        return chalk.gray("No differences found.\n");
+    }
+
+    const dir = mkdtempSync(join(tmpdir(), "stash-diff-"));
+    const oldFile = join(dir, "old");
+    const newFile = join(dir, "new");
+    try {
+        writeFileSync(oldFile, args.before, "utf-8");
+        writeFileSync(newFile, args.after, "utf-8");
+        const result = spawnSync("diff", ["-U", "3", oldFile, newFile], { encoding: "utf-8" });
+        if (result.status === 0) {
+            return chalk.gray("No differences found.\n");
+        }
+        if (result.status === 1 && result.stdout) {
+            return formatDiffOutput(result.stdout, oldLabel, newLabel);
+        }
+        return fallbackLineDiff(args);
+    } catch {
+        return fallbackLineDiff(args);
+    } finally {
+        for (const f of [oldFile, newFile]) {
+            try {
+                unlinkSync(f);
+            } catch {
+                // ignore
+            }
+        }
+    }
+}

--- a/src/stash/lib/diff-render.ts
+++ b/src/stash/lib/diff-render.ts
@@ -74,8 +74,6 @@ export function renderDiff(args: { before: string; after: string; label: string 
     } catch {
         return fallbackLineDiff(args);
     } finally {
-        // PR #222 t15: previously unlinked the two files but left the empty mkdtemp dir behind.
-        // rmSync({recursive, force}) removes both files and the dir in one shot.
         rmSync(dir, { recursive: true, force: true });
     }
 }

--- a/src/stash/lib/ids.test.ts
+++ b/src/stash/lib/ids.test.ts
@@ -7,13 +7,23 @@ describe("ids", () => {
         expect(id).toMatch(/^[a-f0-9]{32}$/);
     });
 
-    test("shortId returns first 6 hex chars", () => {
-        expect(shortId("3f2a8b7c1d4e5f6a7b8c9d0e1f2a3b4c")).toBe("3f2a8b");
+    test("shortId returns the trailing 6 hex chars (random suffix)", () => {
+        // PR #222 t16: shortId now uses the random suffix, not the timestamp prefix, so two stashes
+        // created within the same ~4.66h window don't collide.
+        expect(shortId("3f2a8b7c1d4e5f6a7b8c9d0e1f2a3b4c")).toBe("2a3b4c");
     });
 
     test("newStashId is monotonically time-ordered (v7-ish)", () => {
         const a = newStashId();
         const b = newStashId();
         expect(a.slice(0, 12) <= b.slice(0, 12)).toBe(true);
+    });
+
+    test("shortId varies between two same-instant IDs (no timestamp-prefix collision)", () => {
+        // Same ms timestamp prefix, different random suffix. Old `slice(0, 6)` returned same value
+        // for both — new `slice(-6)` returns different values, proving the fix.
+        const a = "019efb000000aaaaaaaaaaaaaaaaaaaa";
+        const b = "019efb000000bbbbbbbbbbbbbbbbbbbb";
+        expect(shortId(a)).not.toBe(shortId(b));
     });
 });

--- a/src/stash/lib/ids.test.ts
+++ b/src/stash/lib/ids.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { newStashId, shortId } from "./ids";
+
+describe("ids", () => {
+    test("newStashId returns 32 hex chars", () => {
+        const id = newStashId();
+        expect(id).toMatch(/^[a-f0-9]{32}$/);
+    });
+
+    test("shortId returns first 6 hex chars", () => {
+        expect(shortId("3f2a8b7c1d4e5f6a7b8c9d0e1f2a3b4c")).toBe("3f2a8b");
+    });
+
+    test("newStashId is monotonically time-ordered (v7-ish)", () => {
+        const a = newStashId();
+        const b = newStashId();
+        expect(a.slice(0, 12) <= b.slice(0, 12)).toBe(true);
+    });
+});

--- a/src/stash/lib/ids.ts
+++ b/src/stash/lib/ids.ts
@@ -1,0 +1,13 @@
+import { randomBytes } from "node:crypto";
+
+// Time-ordered 32-hex ID (48-bit ms timestamp + 80 bits random) — preserves SQLite index ordering without needing crypto.randomUUID.
+export function newStashId(): string {
+    const now = BigInt(Date.now());
+    const tsHex = now.toString(16).padStart(12, "0");
+    const rand = randomBytes(10).toString("hex");
+    return tsHex + rand;
+}
+
+export function shortId(id: string): string {
+    return id.slice(0, 6);
+}

--- a/src/stash/lib/ids.ts
+++ b/src/stash/lib/ids.ts
@@ -8,6 +8,11 @@ export function newStashId(): string {
     return tsHex + rand;
 }
 
+// Use the LAST 6 chars (random suffix), not the first 6. PR #222 t16: the first 6 hex chars are
+// the high 24 bits of a 48-bit ms timestamp and only flip every 2^24 ms ≈ 4.66 hours, so every
+// stash created within the same ~5-hour window has the SAME shortId — defeating its purpose as
+// a user-facing disambiguator. The trailing 24 bits come from `randomBytes(10)`, so they vary
+// per ID with effectively zero collision risk at the scale of personal stashes.
 export function shortId(id: string): string {
-    return id.slice(0, 6);
+    return id.slice(-6);
 }

--- a/src/stash/lib/languages.test.ts
+++ b/src/stash/lib/languages.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { commentSyntaxForFile } from "./languages";
+
+describe("commentSyntaxForFile", () => {
+    test("ts/tsx/js/jsx/php/java/c/cpp/go/rs/swift → //", () => {
+        for (const f of [
+            "a.ts",
+            "a.tsx",
+            "a.js",
+            "a.jsx",
+            "a.php",
+            "a.java",
+            "a.c",
+            "a.cpp",
+            "a.go",
+            "a.rs",
+            "a.swift",
+        ]) {
+            expect(commentSyntaxForFile(f).line).toBe("//");
+        }
+    });
+    test("python/ruby/bash/yaml/toml → #", () => {
+        for (const f of ["a.py", "a.rb", "a.sh", "a.yaml", "a.yml", "a.toml"]) {
+            expect(commentSyntaxForFile(f).line).toBe("#");
+        }
+    });
+    test("html/xml/md → <!-- -->", () => {
+        for (const f of ["a.html", "a.xml", "a.md"]) {
+            expect(commentSyntaxForFile(f).block).toEqual({ open: "<!--", close: "-->" });
+            expect(commentSyntaxForFile(f).line).toBe(null);
+        }
+    });
+    test("css → /* */", () => {
+        expect(commentSyntaxForFile("a.css").block).toEqual({ open: "/*", close: "*/" });
+    });
+    test("unknown extension falls back to //", () => {
+        expect(commentSyntaxForFile("a.xyz").line).toBe("//");
+    });
+});

--- a/src/stash/lib/languages.ts
+++ b/src/stash/lib/languages.ts
@@ -1,0 +1,54 @@
+import { extname } from "node:path";
+
+export interface CommentSyntax {
+    line: string | null;
+    block: { open: string; close: string } | null;
+}
+
+const SLASH: CommentSyntax = { line: "//", block: { open: "/*", close: "*/" } };
+const HASH: CommentSyntax = { line: "#", block: null };
+const XML: CommentSyntax = { line: null, block: { open: "<!--", close: "-->" } };
+const CSS: CommentSyntax = { line: null, block: { open: "/*", close: "*/" } };
+
+const MAP: Record<string, CommentSyntax> = {
+    ts: SLASH,
+    tsx: SLASH,
+    js: SLASH,
+    jsx: SLASH,
+    mjs: SLASH,
+    cjs: SLASH,
+    php: SLASH,
+    java: SLASH,
+    c: SLASH,
+    h: SLASH,
+    cpp: SLASH,
+    hpp: SLASH,
+    go: SLASH,
+    rs: SLASH,
+    swift: SLASH,
+    kt: SLASH,
+    scala: SLASH,
+    dart: SLASH,
+    py: HASH,
+    rb: HASH,
+    sh: HASH,
+    bash: HASH,
+    zsh: HASH,
+    fish: HASH,
+    yaml: HASH,
+    yml: HASH,
+    toml: HASH,
+    html: XML,
+    xml: XML,
+    svg: XML,
+    md: XML,
+    vue: XML,
+    css: CSS,
+    scss: CSS,
+    less: CSS,
+};
+
+export function commentSyntaxForFile(path: string): CommentSyntax {
+    const ext = extname(path).slice(1).toLowerCase();
+    return MAP[ext] ?? SLASH;
+}

--- a/src/stash/lib/markers.test.ts
+++ b/src/stash/lib/markers.test.ts
@@ -68,4 +68,21 @@ describe("markers", () => {
         const src = ["// #region someOtherRegion", "x", "// #endregion someOtherRegion"].join("\n");
         expect(stripMarkers(src)).toBe(src);
     });
+
+    test("CSS round-trip: emit → parse → strip re-emits the same body (PR #222 t17)", () => {
+        // Regression: OPEN_RE's tail used `\/\*` (block-open) but CSS emits `*/` (block-close), so
+        // markers in .css/.scss/.less files silently failed to parse and were never stripped.
+        const cssSyntax = { line: null, block: { open: "/*", close: "*/" } };
+        const meta: MarkerMeta = { id: "abc", v: 1 };
+        const opener = emitOpenMarker({ name: "x", meta, syntax: cssSyntax });
+        const closer = emitCloseMarker({ name: "x", syntax: cssSyntax });
+        expect(opener).toBe(`/* #region @stash:x {"id":"abc","v":1} */`);
+        expect(closer).toBe(`/* #endregion @stash:x */`);
+        const src = [".body { color: red; }", opener, ".inside { color: blue; }", closer, ".after {}"].join("\n");
+        const found = parseMarkers(src);
+        expect(found).toHaveLength(1);
+        expect(found[0]?.name).toBe("x");
+        expect(found[0]?.meta.id).toBe("abc");
+        expect(stripMarkers(src)).toBe([".body { color: red; }", ".inside { color: blue; }", ".after {}"].join("\n"));
+    });
 });

--- a/src/stash/lib/markers.test.ts
+++ b/src/stash/lib/markers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { emitCloseMarker, emitOpenMarker, type MarkerMeta, parseMarkers, stripMarkers } from "./markers";
+
+describe("markers", () => {
+    test("emit open marker for // syntax", () => {
+        const meta: MarkerMeta = { id: "3f2a8b", v: 2 };
+        const line = emitOpenMarker({ name: "debug-logger", meta, syntax: { line: "//", block: null } });
+        expect(line).toBe(`// #region @stash:debug-logger {"id":"3f2a8b","v":2}`);
+    });
+
+    test("emit open marker for # syntax", () => {
+        const meta: MarkerMeta = { id: "3f2a8b", v: 1 };
+        const line = emitOpenMarker({ name: "x", meta, syntax: { line: "#", block: null } });
+        expect(line).toBe(`# #region @stash:x {"id":"3f2a8b","v":1}`);
+    });
+
+    test("emit open marker for block-only (HTML)", () => {
+        const meta: MarkerMeta = { id: "abc", v: 1 };
+        const line = emitOpenMarker({
+            name: "x",
+            meta,
+            syntax: { line: null, block: { open: "<!--", close: "-->" } },
+        });
+        expect(line).toBe(`<!-- #region @stash:x {"id":"abc","v":1} -->`);
+    });
+
+    test("emit close marker (bare)", () => {
+        const line = emitCloseMarker({ name: "debug-logger", syntax: { line: "//", block: null } });
+        expect(line).toBe(`// #endregion @stash:debug-logger`);
+    });
+
+    test("parseMarkers finds open+close pair in TS file", () => {
+        const src = [
+            "function foo() {",
+            `    // #region @stash:debug-logger {"id":"3f2a8b","v":2}`,
+            "    console.log('debug');",
+            "    // #endregion @stash:debug-logger",
+            "}",
+        ].join("\n");
+        const found = parseMarkers(src);
+        expect(found).toHaveLength(1);
+        expect(found[0]?.name).toBe("debug-logger");
+        expect(found[0]?.meta.id).toBe("3f2a8b");
+        expect(found[0]?.meta.v).toBe(2);
+        expect(found[0]?.startLine).toBe(2);
+        expect(found[0]?.endLine).toBe(4);
+    });
+
+    test("parseMarkers handles bare author markers (no JSON)", () => {
+        const src = [`// #region @stash:debug-logger`, `x();`, `// #endregion @stash:debug-logger`].join("\n");
+        const found = parseMarkers(src);
+        expect(found).toHaveLength(1);
+        expect(found[0]?.meta).toEqual({});
+    });
+
+    test("stripMarkers removes both open and close lines", () => {
+        const src = [
+            "before",
+            `// #region @stash:x {"id":"abc","v":1}`,
+            "inside",
+            "// #endregion @stash:x",
+            "after",
+        ].join("\n");
+        expect(stripMarkers(src)).toBe(["before", "inside", "after"].join("\n"));
+    });
+
+    test("stripMarkers only removes @stash markers, not unrelated #region", () => {
+        const src = ["// #region someOtherRegion", "x", "// #endregion someOtherRegion"].join("\n");
+        expect(stripMarkers(src)).toBe(src);
+    });
+});

--- a/src/stash/lib/markers.ts
+++ b/src/stash/lib/markers.ts
@@ -1,5 +1,8 @@
+import { logger } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 import type { CommentSyntax } from "./languages";
+
+const { log } = logger.scoped("stash:markers");
 
 export interface MarkerMeta {
     id?: string;
@@ -18,8 +21,11 @@ export interface ParsedMarker {
     contentEndLine: number;
 }
 
-// Match `#region @stash:<name>` optionally followed by `{json}` metadata, tolerating trailing HTML/CSS close fragments.
-const OPEN_RE = /#region\s+@stash:([\w.-]+)(?:\s+(\{.*?\}))?(?:\s*(?:-->|\/\*))?$/;
+// Match `#region @stash:<name>` optionally followed by `{json}` metadata, tolerating trailing
+// HTML/CSS close fragments. PR #222 t17: the CSS tail was `\/\*` (block-OPEN) but `emitOpenMarker`
+// for CSS-family files emits a trailing `*/` (block-CLOSE) — so `.css/.scss/.less` markers never
+// matched and were silently ignored. Now matches `*/` correctly.
+const OPEN_RE = /#region\s+@stash:([\w.-]+)(?:\s+(\{.*?\}))?(?:\s*(?:-->|\*\/))?$/;
 // Match `#endregion @stash:<name>` — name is kebab/dot/underscore.
 const CLOSE_RE = /#endregion\s+@stash:([\w.-]+)/;
 
@@ -62,7 +68,11 @@ export function parseMarkers(source: string): ParsedMarker[] {
             if (json) {
                 try {
                     meta = SafeJSON.parse(json) as MarkerMeta;
-                } catch {
+                } catch (err) {
+                    // Don't swallow — surface in trace logs so corrupt markers are diagnosable
+                    // without re-running. Default to {} so the marker is still recognized
+                    // structurally even if the metadata is unreadable.
+                    log.debug({ err, json, line: i + 1 }, "marker meta parse failed; defaulting to {}");
                     meta = {};
                 }
             }

--- a/src/stash/lib/markers.ts
+++ b/src/stash/lib/markers.ts
@@ -1,0 +1,101 @@
+import { SafeJSON } from "@app/utils/json";
+import type { CommentSyntax } from "./languages";
+
+export interface MarkerMeta {
+    id?: string;
+    v?: number;
+    hunk?: number;
+    src?: string;
+    applied?: string;
+}
+
+export interface ParsedMarker {
+    name: string;
+    meta: MarkerMeta;
+    startLine: number;
+    endLine: number;
+    contentStartLine: number;
+    contentEndLine: number;
+}
+
+// Match `#region @stash:<name>` optionally followed by `{json}` metadata, tolerating trailing HTML/CSS close fragments.
+const OPEN_RE = /#region\s+@stash:([\w.-]+)(?:\s+(\{.*?\}))?(?:\s*(?:-->|\/\*))?$/;
+// Match `#endregion @stash:<name>` — name is kebab/dot/underscore.
+const CLOSE_RE = /#endregion\s+@stash:([\w.-]+)/;
+
+export function emitOpenMarker(args: { name: string; meta: MarkerMeta; syntax: CommentSyntax }): string {
+    const json = SafeJSON.stringify(args.meta);
+    if (args.syntax.line) {
+        return `${args.syntax.line} #region @stash:${args.name} ${json}`;
+    }
+    // Invariant: commentSyntaxForFile always returns a SLASH fallback when no block syntax.
+    const b = args.syntax.block!;
+    return `${b.open} #region @stash:${args.name} ${json} ${b.close}`;
+}
+
+export function emitCloseMarker(args: { name: string; syntax: CommentSyntax }): string {
+    if (args.syntax.line) {
+        return `${args.syntax.line} #endregion @stash:${args.name}`;
+    }
+    // Invariant: commentSyntaxForFile always returns a SLASH fallback when no block syntax.
+    const b = args.syntax.block!;
+    return `${b.open} #endregion @stash:${args.name} ${b.close}`;
+}
+
+export function parseMarkers(source: string): ParsedMarker[] {
+    const lines = source.split("\n");
+    const opens: Array<{ name: string; meta: MarkerMeta; line: number }> = [];
+    const closes: Array<{ name: string; line: number }> = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? "";
+        const closeMatch = CLOSE_RE.exec(line);
+        if (closeMatch) {
+            closes.push({ name: closeMatch[1] ?? "", line: i + 1 });
+            continue;
+        }
+        const openMatch = OPEN_RE.exec(line);
+        if (openMatch) {
+            const name = openMatch[1] ?? "";
+            const json = openMatch[2];
+            let meta: MarkerMeta = {};
+            if (json) {
+                try {
+                    meta = SafeJSON.parse(json) as MarkerMeta;
+                } catch {
+                    meta = {};
+                }
+            }
+            opens.push({ name, meta, line: i + 1 });
+        }
+    }
+
+    const out: ParsedMarker[] = [];
+    for (const open of opens) {
+        const close = closes.find((c) => c.name === open.name && c.line > open.line);
+        if (!close) {
+            continue;
+        }
+        out.push({
+            name: open.name,
+            meta: open.meta,
+            startLine: open.line,
+            endLine: close.line,
+            contentStartLine: open.line + 1,
+            contentEndLine: close.line - 1,
+        });
+    }
+    return out;
+}
+
+export function stripMarkers(source: string): string {
+    const lines = source.split("\n");
+    const keep: string[] = [];
+    for (const line of lines) {
+        if (OPEN_RE.test(line) || CLOSE_RE.test(line)) {
+            continue;
+        }
+        keep.push(line);
+    }
+    return keep.join("\n");
+}

--- a/src/stash/lib/options.test.ts
+++ b/src/stash/lib/options.test.ts
@@ -45,4 +45,8 @@ describe("parsePositiveInt", () => {
     test("rejects leading zero (no octal-by-accident)", () => {
         expect(() => parsePositiveInt("01")).toThrow(InvalidArgumentError);
     });
+    test("rejects unsafe integers beyond MAX_SAFE_INTEGER", () => {
+        const unsafe = String(Number.MAX_SAFE_INTEGER + 1);
+        expect(() => parsePositiveInt(unsafe)).toThrow(InvalidArgumentError);
+    });
 });

--- a/src/stash/lib/options.test.ts
+++ b/src/stash/lib/options.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { InvalidArgumentError } from "commander";
+import { parsePositiveInt, pickExclusive } from "./options";
+
+describe("pickExclusive", () => {
+    test("returns undefined when no flag set", () => {
+        expect(pickExclusive({}, ["a", "b"])).toBeUndefined();
+    });
+    test("returns the single set flag", () => {
+        expect(pickExclusive({ a: true }, ["a", "b"])).toBe("a");
+        expect(pickExclusive({ b: 1 }, ["a", "b"])).toBe("b");
+    });
+    test("throws on conflicting flags", () => {
+        expect(() => pickExclusive({ a: true, b: true }, ["a", "b"])).toThrow(InvalidArgumentError);
+    });
+});
+
+describe("parsePositiveInt", () => {
+    test("returns the int", () => {
+        expect(parsePositiveInt("3")).toBe(3);
+    });
+    test("rejects NaN", () => {
+        expect(() => parsePositiveInt("abc")).toThrow(InvalidArgumentError);
+    });
+    test("rejects 0 and negatives", () => {
+        expect(() => parsePositiveInt("0")).toThrow(InvalidArgumentError);
+        expect(() => parsePositiveInt("-1")).toThrow(InvalidArgumentError);
+    });
+    test("rejects empty string", () => {
+        expect(() => parsePositiveInt("")).toThrow(InvalidArgumentError);
+    });
+    test("rejects floats", () => {
+        expect(() => parsePositiveInt("1.5")).toThrow(InvalidArgumentError);
+    });
+});

--- a/src/stash/lib/options.test.ts
+++ b/src/stash/lib/options.test.ts
@@ -32,4 +32,17 @@ describe("parsePositiveInt", () => {
     test("rejects floats", () => {
         expect(() => parsePositiveInt("1.5")).toThrow(InvalidArgumentError);
     });
+    test("rejects non-decimal forms (hex / scientific / binary)", () => {
+        // PR #222 t30: previous `Number()` impl silently accepted these.
+        expect(() => parsePositiveInt("0x10")).toThrow(InvalidArgumentError);
+        expect(() => parsePositiveInt("1e2")).toThrow(InvalidArgumentError);
+        expect(() => parsePositiveInt("0b11")).toThrow(InvalidArgumentError);
+    });
+    test("rejects signed forms", () => {
+        expect(() => parsePositiveInt("+1")).toThrow(InvalidArgumentError);
+        expect(() => parsePositiveInt(" 1")).not.toThrow(); // trimmed first
+    });
+    test("rejects leading zero (no octal-by-accident)", () => {
+        expect(() => parsePositiveInt("01")).toThrow(InvalidArgumentError);
+    });
 });

--- a/src/stash/lib/options.ts
+++ b/src/stash/lib/options.ts
@@ -24,13 +24,14 @@ export function pickExclusive(flags: Record<string, unknown>, names: readonly st
 }
 
 /**
- * Commander option parser for positive integers. Replaces ad-hoc `(v) => Number(v)` which silently
- * yields `NaN` for "abc" or `0` for "" and propagates as "latest"/missing — both confusing.
+ * Commander option parser for positive integers. Strict decimal-only — `Number()` would otherwise
+ * accept hex (`0x10`), scientific (`1e2`), binary (`0b11`), and signed forms, none of which make
+ * sense as a CLI version pin. PR #222 t30: `--at 1e2` quietly became v100; now it errors.
  */
 export function parsePositiveInt(v: string): number {
-    const n = Number(v);
-    if (!Number.isInteger(n) || n < 1) {
-        throw new InvalidArgumentError(`must be a positive integer (got "${v}")`);
+    const trimmed = v.trim();
+    if (!/^[1-9]\d*$/.test(trimmed)) {
+        throw new InvalidArgumentError(`must be a positive decimal integer (got "${v}")`);
     }
-    return n;
+    return Number.parseInt(trimmed, 10);
 }

--- a/src/stash/lib/options.ts
+++ b/src/stash/lib/options.ts
@@ -33,5 +33,9 @@ export function parsePositiveInt(v: string): number {
     if (!/^[1-9]\d*$/.test(trimmed)) {
         throw new InvalidArgumentError(`must be a positive decimal integer (got "${v}")`);
     }
-    return Number.parseInt(trimmed, 10);
+    const n = Number.parseInt(trimmed, 10);
+    if (!Number.isSafeInteger(n)) {
+        throw new InvalidArgumentError(`must be a safe integer (got "${v}")`);
+    }
+    return n;
 }

--- a/src/stash/lib/options.ts
+++ b/src/stash/lib/options.ts
@@ -1,0 +1,36 @@
+import { InvalidArgumentError } from "commander";
+
+/**
+ * Pick a single value from a set of mutually-exclusive flags.
+ *
+ * The chained-ternary pattern (`opts.a ? "a" : opts.b ? "b" : ...`) silently picks the first truthy
+ * flag and ignores the others — `--staged --all` quietly becomes "staged" with no warning. This
+ * helper makes the conflict explicit by throwing an InvalidArgumentError listing every conflicting
+ * flag (commander formats it as a CLI usage error).
+ *
+ * Returns the single passed flag name, or `undefined` if none are set.
+ */
+export function pickExclusive(flags: Record<string, unknown>, names: readonly string[]): string | undefined {
+    const set = names.filter((n) => flags[n]);
+    if (set.length === 0) {
+        return undefined;
+    }
+    if (set.length > 1) {
+        throw new InvalidArgumentError(
+            `flags --${set.join(", --")} are mutually exclusive; pass only one of --${names.join(", --")}`
+        );
+    }
+    return set[0];
+}
+
+/**
+ * Commander option parser for positive integers. Replaces ad-hoc `(v) => Number(v)` which silently
+ * yields `NaN` for "abc" or `0` for "" and propagates as "latest"/missing — both confusing.
+ */
+export function parsePositiveInt(v: string): number {
+    const n = Number(v);
+    if (!Number.isInteger(n) || n < 1) {
+        throw new InvalidArgumentError(`must be a positive integer (got "${v}")`);
+    }
+    return n;
+}

--- a/src/stash/lib/patch.test.ts
+++ b/src/stash/lib/patch.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyPatch, diffWorkingTree, reversePatch, runGitIn } from "./patch";
+
+let dir: string;
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stash-patch-"));
+    await runGitIn(dir, ["init", "--initial-branch=main"]);
+    await runGitIn(dir, ["config", "user.email", "t@t"]);
+    await runGitIn(dir, ["config", "user.name", "t"]);
+    await writeFile(join(dir, "a.ts"), "line1\nline2\nline3\n");
+    await runGitIn(dir, ["add", "a.ts"]);
+    await runGitIn(dir, ["commit", "-m", "init"]);
+});
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+describe("patch", () => {
+    test("diffWorkingTree captures uncommitted change as unified diff", async () => {
+        await writeFile(join(dir, "a.ts"), "line1\nINSERTED\nline2\nline3\n");
+        const diff = await diffWorkingTree({ repoDir: dir, mode: "all" });
+        expect(diff).toContain("a.ts");
+        expect(diff).toContain("+INSERTED");
+    });
+
+    test("applyPatch round-trips a diff", async () => {
+        await writeFile(join(dir, "a.ts"), "line1\nINSERTED\nline2\nline3\n");
+        const diff = await diffWorkingTree({ repoDir: dir, mode: "all" });
+        await writeFile(join(dir, "a.ts"), "line1\nline2\nline3\n");
+        await applyPatch({ repoDir: dir, patch: diff, threeWay: true });
+        const after = await readFile(join(dir, "a.ts"), "utf8");
+        expect(after).toBe("line1\nINSERTED\nline2\nline3\n");
+    });
+
+    test("reversePatch removes the change", async () => {
+        await writeFile(join(dir, "a.ts"), "line1\nINSERTED\nline2\nline3\n");
+        const diff = await diffWorkingTree({ repoDir: dir, mode: "all" });
+        await runGitIn(dir, ["add", "a.ts"]);
+        await runGitIn(dir, ["commit", "-m", "with insert"]);
+        await reversePatch({ repoDir: dir, patch: diff, threeWay: true });
+        const after = await readFile(join(dir, "a.ts"), "utf8");
+        expect(after).toBe("line1\nline2\nline3\n");
+    });
+});

--- a/src/stash/lib/patch.ts
+++ b/src/stash/lib/patch.ts
@@ -1,0 +1,92 @@
+import { logger } from "@app/logger";
+
+const { log } = logger.scoped("stash:patch");
+
+export type SaveMode = "staged" | "unstaged" | "all";
+
+export async function runGitIn(repoDir: string, args: string[], opts?: { stdin?: string }): Promise<string> {
+    log.debug({ repoDir, args }, "git invoke");
+    const proc = Bun.spawn(["git", "-C", repoDir, ...args], {
+        stdin: opts?.stdin ? "pipe" : "inherit",
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    if (opts?.stdin) {
+        // `proc.stdin` is typed as a union because Bun.spawn's return type depends on the literal
+        // `stdin` option (which we set conditionally). The `stdin: "pipe"` branch guarantees a
+        // FileSink here at runtime; the type guard reflects the invariant.
+        const sink = proc.stdin;
+        if (!sink || typeof sink === "number") {
+            throw new Error("expected piped stdin to be a FileSink");
+        }
+        sink.write(opts.stdin);
+        await sink.end();
+    }
+    const [stdout, stderr, exit] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    if (exit !== 0) {
+        // Log at debug — every caller catches and either bubbles up as an `out.log.error` or
+        // intentionally swallows (e.g. probing HEAD in an empty repo). Warning here was noise.
+        log.debug({ args, stderr: stderr.trim() }, "git command failed (throw)");
+        throw new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`);
+    }
+    return stdout;
+}
+
+export async function diffWorkingTree(args: { repoDir: string; mode: SaveMode }): Promise<string> {
+    // --binary keeps binary diffs intact; --src/--dst-prefix=a/b matches what `git apply` expects to parse later.
+    const gitArgs = ["diff", "--no-color", "--no-ext-diff", "--binary", "--src-prefix=a/", "--dst-prefix=b/"];
+    if (args.mode === "staged") {
+        gitArgs.push("--cached");
+    } else if (args.mode === "all") {
+        gitArgs.push("HEAD");
+    }
+    log.debug({ mode: args.mode }, "diffWorkingTree");
+    return await runGitIn(args.repoDir, gitArgs);
+}
+
+export async function applyPatch(args: { repoDir: string; patch: string; threeWay: boolean }): Promise<void> {
+    const gitArgs = ["apply", "--whitespace=fix"];
+    if (args.threeWay) {
+        gitArgs.push("--3way");
+    }
+    log.debug({ repoDir: args.repoDir, threeWay: args.threeWay, bytes: args.patch.length }, "applyPatch");
+    await runGitIn(args.repoDir, gitArgs, { stdin: args.patch });
+}
+
+export async function reversePatch(args: { repoDir: string; patch: string; threeWay: boolean }): Promise<void> {
+    const gitArgs = ["apply", "-R", "--whitespace=fix"];
+    if (args.threeWay) {
+        gitArgs.push("--3way");
+    }
+    log.debug({ repoDir: args.repoDir, threeWay: args.threeWay }, "reversePatch");
+    await runGitIn(args.repoDir, gitArgs, { stdin: args.patch });
+}
+
+export async function listFilesInPatch(args: { repoDir: string; patch: string }): Promise<string[]> {
+    // First try `git apply --numstat` (handles renames/deletes correctly). Falls back to grepping
+    // `+++ b/<path>` headers when git can't parse the patch (e.g. apply-target files are missing).
+    const numstat = await runGitIn(args.repoDir, ["apply", "--numstat"], { stdin: args.patch }).catch(() => "");
+    const fromNumstat = numstat
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((l) => l.split("\t").slice(2).join("\t"))
+        .filter(Boolean);
+    if (fromNumstat.length) {
+        return fromNumstat;
+    }
+    // Fallback: parse the unified-diff "+++ b/<path>" lines directly.
+    const paths = new Set<string>();
+    for (const line of args.patch.split("\n")) {
+        // Match the "after" file header of every hunk: `+++ b/path/to/file`.
+        const m = /^\+\+\+ b\/(.+)$/.exec(line);
+        if (m?.[1]) {
+            paths.add(m[1]);
+        }
+    }
+    return [...paths];
+}

--- a/src/stash/lib/patch.ts
+++ b/src/stash/lib/patch.ts
@@ -11,6 +11,10 @@ export async function runGitIn(repoDir: string, args: string[], opts?: { stdin?:
         stdout: "pipe",
         stderr: "pipe",
     });
+    // Start the stdout/stderr/exit readers BEFORE writing stdin. Without this, a streaming git
+    // subcommand or input larger than the OS pipe buffer (~16-64 KB on macOS) deadlocks because
+    // stdin.end() waits for the pipe to drain while no reader is consuming stdout.
+    const drain = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
     if (opts?.stdin) {
         // `proc.stdin` is typed as a union because Bun.spawn's return type depends on the literal
         // `stdin` option (which we set conditionally). The `stdin: "pipe"` branch guarantees a
@@ -22,11 +26,7 @@ export async function runGitIn(repoDir: string, args: string[], opts?: { stdin?:
         sink.write(opts.stdin);
         await sink.end();
     }
-    const [stdout, stderr, exit] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-        proc.exited,
-    ]);
+    const [stdout, stderr, exit] = await drain;
     if (exit !== 0) {
         // Log at debug — every caller catches and either bubbles up as an `out.log.error` or
         // intentionally swallows (e.g. probing HEAD in an empty repo). Warning here was noise.

--- a/src/stash/lib/projects.test.ts
+++ b/src/stash/lib/projects.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGitIn } from "./patch";
+import { detectProject, findSiblingClones, normalizeOrigin } from "./projects";
+
+describe("normalizeOrigin", () => {
+    test("strips .git suffix", () => {
+        expect(normalizeOrigin("https://github.com/x/y.git")).toBe("github.com/x/y");
+    });
+    test("normalizes ssh form", () => {
+        expect(normalizeOrigin("git@github.com:x/y.git")).toBe("github.com/x/y");
+    });
+    test("lowercases host", () => {
+        expect(normalizeOrigin("https://GitHub.com/X/Y")).toBe("github.com/X/Y");
+    });
+});
+
+let work: string;
+beforeEach(async () => {
+    work = await mkdtemp(join(tmpdir(), "stash-projects-"));
+});
+afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+});
+
+describe("detectProject", () => {
+    test("returns null outside git repo", async () => {
+        const result = await detectProject(work);
+        expect(result).toBeNull();
+    });
+
+    test("returns root + origin for a git repo", async () => {
+        const repo = join(work, "a");
+        await Bun.write(join(repo, ".keep"), "");
+        await runGitIn(work, ["init", "a", "--initial-branch=main"]);
+        await runGitIn(repo, ["remote", "add", "origin", "https://github.com/x/y.git"]);
+        const result = await detectProject(repo);
+        expect(result?.rootPath).toBe(await realpath(repo));
+        expect(result?.origin).toBe("github.com/x/y");
+    });
+});
+
+describe("findSiblingClones", () => {
+    test("finds sibling dirs with same origin", async () => {
+        for (const name of ["foo", "foo2", "foo-upgrade", "bar"]) {
+            const repo = join(work, name);
+            await Bun.write(join(repo, ".keep"), "");
+            await runGitIn(work, ["init", name, "--initial-branch=main"]);
+            const origin = name === "bar" ? "https://github.com/diff/diff.git" : "https://github.com/x/y.git";
+            await runGitIn(repo, ["remote", "add", "origin", origin]);
+        }
+        const found = await findSiblingClones(join(work, "foo"));
+        const names = found.map((p) => p.split("/").pop()).sort();
+        expect(names).toEqual(["foo-upgrade", "foo2"]);
+    });
+});

--- a/src/stash/lib/projects.ts
+++ b/src/stash/lib/projects.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { logger } from "@app/logger";
+import { concurrentMap } from "@app/utils/async";
 import { runGitIn } from "./patch";
 
 const log = logger.scoped("stash:projects").log;
@@ -62,19 +63,25 @@ export async function findSiblingClones(projectPath: string): Promise<string[]> 
     }
     const parent = dirname(project.rootPath);
     const entries = await readdir(parent, { withFileTypes: true });
+    // Sync filter first: drop non-dirs, self, and anything without a `.git` (so we don't pay 2-3
+    // git-subprocess spawns on directories that obviously aren't clones).
+    const candidates = entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => join(parent, entry.name))
+        .filter((candidate) => candidate !== project.rootPath && existsSync(join(candidate, ".git")));
+
+    // PR #222 t19: parallelize the per-candidate `detectProject` (each spawns up to 3 git subprocesses).
+    // Bounded at 8 — naked `Promise.all` on 50+ siblings has previously caused FD/vnode pressure on
+    // this machine; concurrentMap (Promise.allSettled-based) drops failures silently so one bad
+    // candidate doesn't kill the whole sweep.
+    const detected = await concurrentMap({
+        items: candidates,
+        concurrency: 8,
+        fn: async (candidate) => detectProject(candidate),
+        onError: (candidate, err) => log.debug({ err, candidate }, "sibling detect failed (skipped)"),
+    });
     const out: string[] = [];
-    for (const entry of entries) {
-        if (!entry.isDirectory()) {
-            continue;
-        }
-        const candidate = join(parent, entry.name);
-        if (candidate === project.rootPath) {
-            continue;
-        }
-        if (!existsSync(join(candidate, ".git"))) {
-            continue;
-        }
-        const other = await detectProject(candidate);
+    for (const [candidate, other] of detected) {
         if (other?.origin === project.origin) {
             out.push(candidate);
         }

--- a/src/stash/lib/projects.ts
+++ b/src/stash/lib/projects.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { logger } from "@app/logger";
+import { runGitIn } from "./patch";
+
+const log = logger.scoped("stash:projects").log;
+
+export interface DetectedProject {
+    rootPath: string;
+    origin: string | null;
+    sha: string | null;
+}
+
+export function normalizeOrigin(url: string): string {
+    let u = url.trim().replace(/\.git$/, "");
+    // SSH form `git@host:owner/repo` → captured host + path.
+    const ssh = /^git@([^:]+):(.+)$/.exec(u);
+    if (ssh) {
+        u = `${ssh[1]}/${ssh[2]}`;
+    } else {
+        // Strip `scheme://user@` from HTTPS/git URLs.
+        u = u.replace(/^[a-z]+:\/\/(?:[^@]+@)?/, "");
+    }
+    const slash = u.indexOf("/");
+    if (slash > 0) {
+        const host = u.slice(0, slash).toLowerCase();
+        return `${host}${u.slice(slash)}`;
+    }
+    return u.toLowerCase();
+}
+
+export async function detectProject(cwd: string): Promise<DetectedProject | null> {
+    try {
+        const root = (await runGitIn(cwd, ["rev-parse", "--show-toplevel"])).trim();
+        let origin: string | null = null;
+        try {
+            const raw = (await runGitIn(root, ["config", "--get", "remote.origin.url"])).trim();
+            if (raw) {
+                origin = normalizeOrigin(raw);
+            }
+        } catch (err) {
+            log.debug({ err, root }, "no origin configured");
+        }
+        let sha: string | null = null;
+        try {
+            sha = (await runGitIn(root, ["rev-parse", "HEAD"])).trim();
+        } catch (err) {
+            log.debug({ err, root }, "empty repo or no HEAD");
+        }
+        return { rootPath: root, origin, sha };
+    } catch (err) {
+        log.debug({ err, cwd }, "not a git repository");
+        return null;
+    }
+}
+
+export async function findSiblingClones(projectPath: string): Promise<string[]> {
+    const project = await detectProject(projectPath);
+    if (!project?.origin) {
+        return [];
+    }
+    const parent = dirname(project.rootPath);
+    const entries = await readdir(parent, { withFileTypes: true });
+    const out: string[] = [];
+    for (const entry of entries) {
+        if (!entry.isDirectory()) {
+            continue;
+        }
+        const candidate = join(parent, entry.name);
+        if (candidate === project.rootPath) {
+            continue;
+        }
+        if (!existsSync(join(candidate, ".git"))) {
+            continue;
+        }
+        const other = await detectProject(candidate);
+        if (other?.origin === project.origin) {
+            out.push(candidate);
+        }
+    }
+    return out.sort();
+}

--- a/src/stash/lib/regions.test.ts
+++ b/src/stash/lib/regions.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverRegionsInTree, extractRegionContent } from "./regions";
+
+let dir: string;
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stash-regions-"));
+});
+afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+});
+
+describe("discoverRegionsInTree", () => {
+    test("finds named regions across multiple files", async () => {
+        await writeFile(
+            join(dir, "a.ts"),
+            ["function a() {", "    // #region @stash:foo", "    x();", "    // #endregion @stash:foo", "}"].join("\n")
+        );
+        await mkdir(join(dir, "lib"));
+        await writeFile(
+            join(dir, "lib", "b.ts"),
+            [
+                "// #region @stash:bar",
+                "y();",
+                "// #endregion @stash:bar",
+                "// #region @stash:foo",
+                "z();",
+                "// #endregion @stash:foo",
+            ].join("\n")
+        );
+
+        const regions = await discoverRegionsInTree(dir);
+        expect(regions).toHaveLength(3);
+        const names = regions.map((r) => r.name).sort();
+        expect(names).toEqual(["bar", "foo", "foo"]);
+    });
+
+    test("respects .gitignore (no node_modules walk)", async () => {
+        await mkdir(join(dir, "node_modules"));
+        await writeFile(
+            join(dir, "node_modules", "x.ts"),
+            ["// #region @stash:should-not-find", "// #endregion @stash:should-not-find"].join("\n")
+        );
+        const regions = await discoverRegionsInTree(dir);
+        expect(regions).toHaveLength(0);
+    });
+});
+
+describe("extractRegionContent", () => {
+    test("returns content between markers, excluding markers themselves", async () => {
+        const filePath = join(dir, "a.ts");
+        await writeFile(
+            filePath,
+            ["before", "// #region @stash:foo", "line1", "line2", "// #endregion @stash:foo", "after"].join("\n")
+        );
+        const content = await extractRegionContent(filePath, "foo");
+        expect(content).toBe("line1\nline2");
+    });
+
+    test("returns null when region not found", async () => {
+        const filePath = join(dir, "a.ts");
+        await writeFile(filePath, "no regions here");
+        expect(await extractRegionContent(filePath, "missing")).toBeNull();
+    });
+});

--- a/src/stash/lib/regions.test.ts
+++ b/src/stash/lib/regions.test.ts
@@ -37,7 +37,7 @@ describe("discoverRegionsInTree", () => {
         expect(names).toEqual(["bar", "foo", "foo"]);
     });
 
-    test("respects .gitignore (no node_modules walk)", async () => {
+    test("skips well-known build/dep dirs (SKIP_DIRS)", async () => {
         await mkdir(join(dir, "node_modules"));
         await writeFile(
             join(dir, "node_modules", "x.ts"),

--- a/src/stash/lib/regions.ts
+++ b/src/stash/lib/regions.ts
@@ -1,0 +1,80 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { type ParsedMarker, parseMarkers } from "./markers";
+
+export interface DiscoveredRegion extends ParsedMarker {
+    filePath: string;
+    absPath: string;
+}
+
+const SKIP_DIRS = new Set([
+    "node_modules",
+    ".git",
+    "dist",
+    "build",
+    "out",
+    ".next",
+    ".turbo",
+    ".bun",
+    ".cache",
+    "coverage",
+    "target",
+    "vendor",
+    ".venv",
+    "__pycache__",
+]);
+
+export async function discoverRegionsInTree(rootDir: string): Promise<DiscoveredRegion[]> {
+    const out: DiscoveredRegion[] = [];
+    await walk(rootDir, rootDir, out);
+    return out;
+}
+
+async function walk(rootDir: string, dir: string, out: DiscoveredRegion[]): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (SKIP_DIRS.has(entry.name)) {
+            continue;
+        }
+        const abs = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            await walk(rootDir, abs, out);
+            continue;
+        }
+        if (!entry.isFile()) {
+            continue;
+        }
+        const st = await stat(abs);
+        if (st.size > 1_000_000) {
+            continue;
+        }
+        let content: string;
+        try {
+            content = await readFile(abs, "utf8");
+        } catch {
+            continue;
+        }
+        if (!content.includes("@stash:")) {
+            continue;
+        }
+        const markers = parseMarkers(content);
+        for (const m of markers) {
+            out.push({
+                ...m,
+                filePath: relative(rootDir, abs),
+                absPath: abs,
+            });
+        }
+    }
+}
+
+export async function extractRegionContent(filePath: string, regionName: string): Promise<string | null> {
+    const content = await readFile(filePath, "utf8");
+    const markers = parseMarkers(content);
+    const m = markers.find((x) => x.name === regionName);
+    if (!m) {
+        return null;
+    }
+    const lines = content.split("\n");
+    return lines.slice(m.contentStartLine - 1, m.contentEndLine).join("\n");
+}

--- a/src/stash/lib/stash-db.test.ts
+++ b/src/stash/lib/stash-db.test.ts
@@ -1,0 +1,47 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { openStashDb } from "./stash-db";
+
+describe("openStashDb", () => {
+    test("creates all tables on first open", () => {
+        const db = new Database(":memory:");
+        openStashDb(db);
+        const tables = db
+            .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .all()
+            .map((r) => r.name);
+        expect(tables).toContain("stashes");
+        expect(tables).toContain("versions");
+        expect(tables).toContain("regions");
+        expect(tables).toContain("applications");
+        expect(tables).toContain("projects");
+        expect(tables).toContain("_migrations");
+    });
+
+    test("idempotent — second open does not error", () => {
+        const db = new Database(":memory:");
+        openStashDb(db);
+        openStashDb(db);
+        const count = db.query<{ c: number }, []>("SELECT COUNT(*) as c FROM _migrations").get();
+        expect(count?.c).toBeGreaterThan(0);
+    });
+
+    test("unique active application constraint", () => {
+        const db = new Database(":memory:");
+        openStashDb(db);
+        db.run(
+            "INSERT INTO stashes (id, name, created_at, updated_at) VALUES ('s1', 'foo', '2026-01-01', '2026-01-01')"
+        );
+        db.run(
+            "INSERT INTO versions (id, stash_id, version, patch_ref, region_count, file_count, created_at) VALUES ('v1', 's1', 1, 'refs/stashes/s1/v1', 1, 1, '2026-01-01')"
+        );
+        db.run(
+            "INSERT INTO applications (id, stash_id, version_id, project_path, applied_at, state) VALUES ('a1', 's1', 'v1', '/p', '2026-01-01', 'active')"
+        );
+        expect(() =>
+            db.run(
+                "INSERT INTO applications (id, stash_id, version_id, project_path, applied_at, state) VALUES ('a2', 's1', 'v1', '/p', '2026-01-01', 'active')"
+            )
+        ).toThrow();
+    });
+});

--- a/src/stash/lib/stash-db.ts
+++ b/src/stash/lib/stash-db.ts
@@ -1,0 +1,10 @@
+import type { Database } from "bun:sqlite";
+import { runMigrations } from "@app/utils/database/migrations";
+import { STASH_MIGRATIONS } from "./stash-migrations";
+
+export function openStashDb(db: Database): Database {
+    db.run("PRAGMA foreign_keys = ON");
+    db.run("PRAGMA journal_mode = WAL");
+    runMigrations(db, STASH_MIGRATIONS, { tableName: "stash" });
+    return db;
+}

--- a/src/stash/lib/stash-migrations.ts
+++ b/src/stash/lib/stash-migrations.ts
@@ -1,0 +1,70 @@
+import type { Migration } from "@app/utils/database/migrations";
+
+const INITIAL_SCHEMA_SQL = `
+            CREATE TABLE stashes (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                tags TEXT,
+                description TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE versions (
+                id TEXT PRIMARY KEY,
+                stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+                version INTEGER NOT NULL,
+                patch_ref TEXT NOT NULL,
+                source_repo_path TEXT,
+                source_origin TEXT,
+                source_sha TEXT,
+                region_count INTEGER NOT NULL,
+                file_count INTEGER NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                UNIQUE(stash_id, version)
+            );
+            CREATE TABLE regions (
+                id TEXT PRIMARY KEY,
+                version_id TEXT NOT NULL REFERENCES versions(id) ON DELETE CASCADE,
+                region_name TEXT,
+                file_path TEXT NOT NULL,
+                hunk_index INTEGER NOT NULL,
+                start_marker_present INTEGER NOT NULL DEFAULT 0,
+                line_count INTEGER NOT NULL
+            );
+            CREATE TABLE applications (
+                id TEXT PRIMARY KEY,
+                stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
+                version_id TEXT NOT NULL REFERENCES versions(id),
+                project_path TEXT NOT NULL,
+                project_origin TEXT,
+                project_sha_at_apply TEXT,
+                applied_at TEXT NOT NULL,
+                state TEXT NOT NULL,
+                unapplied_at TEXT
+            );
+            CREATE TABLE projects (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL UNIQUE,
+                origin TEXT,
+                tree_hash TEXT,
+                last_seen TEXT NOT NULL
+            );
+            CREATE INDEX idx_versions_stash ON versions(stash_id);
+            CREATE INDEX idx_applications_project ON applications(project_path);
+            CREATE INDEX idx_applications_stash ON applications(stash_id);
+            CREATE INDEX idx_regions_version ON regions(version_id);
+            CREATE UNIQUE INDEX idx_applications_active
+                ON applications(stash_id, project_path)
+                WHERE state = 'active';
+        `;
+
+export const STASH_MIGRATIONS: Migration[] = [
+    {
+        id: "001-initial-schema",
+        description: "Initial stash index schema (stashes, versions, regions, applications, projects).",
+        apply(db) {
+            db.exec(INITIAL_SCHEMA_SQL);
+        },
+    },
+];

--- a/src/stash/lib/stash-migrations.ts
+++ b/src/stash/lib/stash-migrations.ts
@@ -35,7 +35,12 @@ const INITIAL_SCHEMA_SQL = `
             CREATE TABLE applications (
                 id TEXT PRIMARY KEY,
                 stash_id TEXT NOT NULL REFERENCES stashes(id) ON DELETE CASCADE,
-                version_id TEXT NOT NULL REFERENCES versions(id),
+                -- version_id is nullable with ON DELETE SET NULL so audit rows survive a version
+                -- drop (drop --all-versions --orphan-active). The drop loop deletes versions while
+                -- applications still reference them; without SET NULL the FK fires and the drop
+                -- partially completes. The audit intent is preserved — application history sticks
+                -- around — but the pointer is nulled rather than dangling.
+                version_id TEXT REFERENCES versions(id) ON DELETE SET NULL,
                 project_path TEXT NOT NULL,
                 project_origin TEXT,
                 project_sha_at_apply TEXT,

--- a/src/stash/lib/storage.test.ts
+++ b/src/stash/lib/storage.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { StashStorage } from "./storage";
+
+let work: string;
+beforeEach(async () => {
+    work = await mkdtemp(join(tmpdir(), "stash-storage-"));
+});
+afterEach(async () => {
+    await rm(work, { recursive: true, force: true });
+});
+
+describe("StashStorage", () => {
+    test("explicit base wins over env and default", () => {
+        const s = new StashStorage(work);
+        expect(s.root()).toBe(work);
+        expect(s.storeRepoDir()).toBe(join(work, "store"));
+        expect(s.dbPath()).toBe(join(work, "index.db"));
+        expect(s.stateDir()).toBe(join(work, "state"));
+        expect(s.cacheDir()).toBe(join(work, "cache"));
+    });
+
+    test("GENESIS_TOOLS_STASH_ROOT env overrides the default ~/.genesis-tools/stash/", () => {
+        const orig = process.env.GENESIS_TOOLS_STASH_ROOT;
+        try {
+            process.env.GENESIS_TOOLS_STASH_ROOT = work;
+            const s = new StashStorage();
+            expect(s.root()).toBe(work);
+        } finally {
+            if (orig === undefined) {
+                delete process.env.GENESIS_TOOLS_STASH_ROOT;
+            } else {
+                process.env.GENESIS_TOOLS_STASH_ROOT = orig;
+            }
+        }
+    });
+
+    test("default falls back to ~/.genesis-tools/stash/ when no env and no arg", () => {
+        const orig = process.env.GENESIS_TOOLS_STASH_ROOT;
+        delete process.env.GENESIS_TOOLS_STASH_ROOT;
+        try {
+            const s = new StashStorage();
+            expect(s.root()).toBe(join(homedir(), ".genesis-tools", "stash"));
+        } finally {
+            if (orig !== undefined) {
+                process.env.GENESIS_TOOLS_STASH_ROOT = orig;
+            }
+        }
+    });
+
+    test("ensureDirs creates all subdirectories under the configured root", async () => {
+        const s = new StashStorage(work);
+        await s.ensureDirs();
+        expect(existsSync(s.storeRepoDir())).toBe(true);
+        expect(existsSync(s.stateDir())).toBe(true);
+        expect(existsSync(s.cacheDir())).toBe(true);
+    });
+});

--- a/src/stash/lib/storage.ts
+++ b/src/stash/lib/storage.ts
@@ -1,0 +1,40 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export class StashStorage {
+    private readonly base: string;
+
+    constructor(base?: string) {
+        const envRoot = process.env.GENESIS_TOOLS_STASH_ROOT;
+        this.base = base ?? envRoot ?? join(homedir(), ".genesis-tools", "stash");
+    }
+
+    root(): string {
+        return this.base;
+    }
+
+    storeRepoDir(): string {
+        return join(this.base, "store");
+    }
+
+    dbPath(): string {
+        return join(this.base, "index.db");
+    }
+
+    stateDir(): string {
+        return join(this.base, "state");
+    }
+
+    cacheDir(): string {
+        return join(this.base, "cache");
+    }
+
+    async ensureDirs(): Promise<void> {
+        await Promise.all([
+            mkdir(this.storeRepoDir(), { recursive: true }),
+            mkdir(this.stateDir(), { recursive: true }),
+            mkdir(this.cacheDir(), { recursive: true }),
+        ]);
+    }
+}

--- a/src/stash/lib/store-repo.test.ts
+++ b/src/stash/lib/store-repo.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StoreRepo } from "./store-repo";
+
+let storeDir: string;
+beforeEach(async () => {
+    storeDir = await mkdtemp(join(tmpdir(), "stash-store-"));
+});
+afterEach(async () => {
+    await rm(storeDir, { recursive: true, force: true });
+});
+
+describe("StoreRepo", () => {
+    test("init creates a bare git repo", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        const { existsSync } = await import("node:fs");
+        expect(existsSync(join(storeDir, "HEAD"))).toBe(true);
+        expect(existsSync(join(storeDir, "refs"))).toBe(true);
+    });
+
+    test("init is idempotent", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        await repo.init();
+    });
+
+    test("writePatchCommit creates a ref pointing at a commit", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        const sha = await repo.writePatchCommit({
+            ref: "refs/stashes/abc/v1",
+            files: { "a.ts": "console.log(1);\n" },
+            message: "stash:test v1",
+        });
+        expect(sha).toMatch(/^[a-f0-9]{40}$/);
+        const resolved = await repo.resolveRef("refs/stashes/abc/v1");
+        expect(resolved).toBe(sha);
+    });
+});

--- a/src/stash/lib/store-repo.test.ts
+++ b/src/stash/lib/store-repo.test.ts
@@ -39,4 +39,32 @@ describe("StoreRepo", () => {
         const resolved = await repo.resolveRef("refs/stashes/abc/v1");
         expect(resolved).toBe(sha);
     });
+
+    test("writePatchCommit handles nested paths (subdirectory files)", async () => {
+        // Regression: previous mktree-based impl rejected paths containing `/`
+        // ("fatal: path src/foo.ts contains slash"). The write-tree-via-index path must accept them.
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        const sha = await repo.writePatchCommit({
+            ref: "refs/stashes/nested/v1",
+            files: {
+                "PATCH.diff": "--- a/src/a.ts\n+++ b/src/a.ts\n",
+                "src/a.ts": "export const a = 1;\n",
+                "deep/nested/path/b.ts": "export const b = 2;\n",
+            },
+            message: "stash:nested v1",
+        });
+        expect(sha).toMatch(/^[a-f0-9]{40}$/);
+        const a = await repo.readFileAt("refs/stashes/nested/v1", "src/a.ts");
+        expect(a).toBe("export const a = 1;\n");
+        const b = await repo.readFileAt("refs/stashes/nested/v1", "deep/nested/path/b.ts");
+        expect(b).toBe("export const b = 2;\n");
+    });
+
+    test("deleteRef is missing-safe", async () => {
+        const repo = new StoreRepo(storeDir);
+        await repo.init();
+        // Should not throw on a never-existed ref (drop loop must survive partial prior runs).
+        await repo.deleteRef("refs/stashes/does-not-exist/v1");
+    });
 });

--- a/src/stash/lib/store-repo.ts
+++ b/src/stash/lib/store-repo.ts
@@ -70,18 +70,38 @@ export class StoreRepo {
     }
 
     /**
-     * Best-effort ref delete. A missing ref is fine (drop flow may race or re-run); other failures
-     * still bubble so a genuine git problem isn't silently swallowed.
+     * Best-effort ref delete. A missing ref is fine (drop flow may race or re-run); any other
+     * failure — repo corruption, permission denied, transient I/O — must bubble so the drop flow
+     * can't silently desync (DB row deleted while store ref still present). PR #222 t31: using
+     * resolveRef() as the existence probe is too permissive — it returns null for ANY git error,
+     * so corruption would look like "already absent". Instead, scan for-each-ref output, which
+     * succeeds even when the ref doesn't exist (empty output = missing; throw = real failure).
      */
     async deleteRef(ref: string): Promise<void> {
         try {
             await this.git(["update-ref", "-d", ref]);
         } catch (err) {
-            const exists = await this.resolveRef(ref);
-            if (exists) {
+            const present = await this.refExistsStrict(ref, err);
+            if (present) {
                 throw err;
             }
             log.debug({ ref }, "deleteRef: already absent (ignored)");
+        }
+    }
+
+    /**
+     * Strict existence probe used by deleteRef's fallback. `for-each-ref <ref>` exits 0 whether
+     * the ref exists or not (matching ref → prints it; no match → empty output). A non-zero exit
+     * means the repo itself can't be read — in that case rethrow the ORIGINAL delete error so the
+     * caller sees the actionable message, not the probe's.
+     */
+    private async refExistsStrict(ref: string, originalErr: unknown): Promise<boolean> {
+        try {
+            const out = await this.git(["for-each-ref", "--format=%(refname)", ref]);
+            return out.trim().length > 0;
+        } catch (probeErr) {
+            log.debug({ err: probeErr, ref }, "refExistsStrict probe failed; rethrowing original deleteRef error");
+            throw originalErr;
         }
     }
 

--- a/src/stash/lib/store-repo.ts
+++ b/src/stash/lib/store-repo.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@app/logger";
 
@@ -30,10 +31,12 @@ export class StoreRepo {
         for (const [path, content] of Object.entries(args.files)) {
             blobShas[path] = await this.gitWithStdin(["hash-object", "-w", "--stdin"], content);
         }
-        const mktreeInput = Object.entries(blobShas)
-            .map(([path, sha]) => `100644 blob ${sha}\t${path}`)
-            .join("\n");
-        const treeSha = await this.gitWithStdin(["mktree"], `${mktreeInput}\n`);
+
+        // `git mktree` rejects entries containing `/` ("fatal: path src/foo.ts contains slash"), so we
+        // can't pipe `100644 blob <sha>\t<nested/path>` lines into it. Build the tree via an isolated
+        // temp index instead: `update-index --add --cacheinfo` accepts nested paths and `write-tree`
+        // serializes the resulting tree (subtrees and all).
+        const treeSha = await this.writeTreeViaIndex(blobShas);
 
         const commitArgs = ["commit-tree", treeSha, "-m", args.message];
         if (args.parentRef) {
@@ -66,8 +69,20 @@ export class StoreRepo {
         }
     }
 
+    /**
+     * Best-effort ref delete. A missing ref is fine (drop flow may race or re-run); other failures
+     * still bubble so a genuine git problem isn't silently swallowed.
+     */
     async deleteRef(ref: string): Promise<void> {
-        await this.git(["update-ref", "-d", ref]);
+        try {
+            await this.git(["update-ref", "-d", ref]);
+        } catch (err) {
+            const exists = await this.resolveRef(ref);
+            if (exists) {
+                throw err;
+            }
+            log.debug({ ref }, "deleteRef: already absent (ignored)");
+        }
     }
 
     async listRefs(prefix: string): Promise<string[]> {
@@ -83,7 +98,23 @@ export class StoreRepo {
         }
     }
 
-    private async git(args: string[]): Promise<string> {
+    private async writeTreeViaIndex(blobShas: Record<string, string>): Promise<string> {
+        const indexDir = await mkdtemp(join(tmpdir(), "stash-index-"));
+        const indexFile = join(indexDir, "index");
+        try {
+            for (const [path, sha] of Object.entries(blobShas)) {
+                await this.git(["update-index", "--add", "--cacheinfo", `100644,${sha},${path}`], {
+                    GIT_INDEX_FILE: indexFile,
+                });
+            }
+            const tree = (await this.git(["write-tree"], { GIT_INDEX_FILE: indexFile })).trim();
+            return tree;
+        } finally {
+            await rm(indexDir, { recursive: true, force: true });
+        }
+    }
+
+    private async git(args: string[], extraEnv?: Record<string, string>): Promise<string> {
         // Author/committer identity is forced here so the bare store repo doesn't depend on the user's
         // global git config (CI environments often have neither user.name nor user.email).
         const proc = Bun.spawn(["git", "--git-dir", this.dir, ...args], {
@@ -95,6 +126,7 @@ export class StoreRepo {
                 GIT_AUTHOR_EMAIL: "stash@genesistools.local",
                 GIT_COMMITTER_NAME: "stash",
                 GIT_COMMITTER_EMAIL: "stash@genesistools.local",
+                ...(extraEnv ?? {}),
             },
         });
         const [stdout, stderr, exit] = await Promise.all([
@@ -114,13 +146,13 @@ export class StoreRepo {
             stdout: "pipe",
             stderr: "pipe",
         });
+        // Start the stdout/stderr/exit readers BEFORE writing stdin. If a future git invocation
+        // streams output while consuming input (or input exceeds the OS pipe buffer ~16-64 KB on
+        // macOS), waiting on stdin.end() with no reader draining stdout would deadlock.
+        const drain = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
         proc.stdin.write(input);
         await proc.stdin.end();
-        const [stdout, stderr, exit] = await Promise.all([
-            new Response(proc.stdout).text(),
-            new Response(proc.stderr).text(),
-            proc.exited,
-        ]);
+        const [stdout, stderr, exit] = await drain;
         if (exit !== 0) {
             throw new Error(`git ${args.join(" ")} (stdin) failed: ${stderr.trim()}`);
         }

--- a/src/stash/lib/store-repo.ts
+++ b/src/stash/lib/store-repo.ts
@@ -1,0 +1,129 @@
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+
+const { log } = logger.scoped("stash:store-repo");
+
+export interface WritePatchCommitArgs {
+    ref: string;
+    files: Record<string, string>;
+    message: string;
+    parentRef?: string;
+}
+
+export class StoreRepo {
+    constructor(private readonly dir: string) {}
+
+    async init(): Promise<void> {
+        await mkdir(this.dir, { recursive: true });
+        if (existsSync(join(this.dir, "HEAD"))) {
+            return;
+        }
+        await this.git(["init", "--bare", "--initial-branch=main"]);
+        log.debug({ dir: this.dir }, "initialized bare store repo");
+    }
+
+    async writePatchCommit(args: WritePatchCommitArgs): Promise<string> {
+        log.debug({ ref: args.ref, fileCount: Object.keys(args.files).length }, "writePatchCommit");
+        const blobShas: Record<string, string> = {};
+        for (const [path, content] of Object.entries(args.files)) {
+            blobShas[path] = await this.gitWithStdin(["hash-object", "-w", "--stdin"], content);
+        }
+        const mktreeInput = Object.entries(blobShas)
+            .map(([path, sha]) => `100644 blob ${sha}\t${path}`)
+            .join("\n");
+        const treeSha = await this.gitWithStdin(["mktree"], `${mktreeInput}\n`);
+
+        const commitArgs = ["commit-tree", treeSha, "-m", args.message];
+        if (args.parentRef) {
+            const parentSha = await this.resolveRef(args.parentRef);
+            if (parentSha) {
+                commitArgs.push("-p", parentSha);
+            }
+        }
+        const commitSha = (await this.git(commitArgs)).trim();
+        await this.git(["update-ref", args.ref, commitSha]);
+        return commitSha;
+    }
+
+    async resolveRef(ref: string): Promise<string | null> {
+        try {
+            const sha = await this.git(["rev-parse", "--verify", ref]);
+            return sha.trim();
+        } catch (err) {
+            log.debug({ err, ref }, "resolveRef miss");
+            return null;
+        }
+    }
+
+    async readFileAt(ref: string, path: string): Promise<string | null> {
+        try {
+            return await this.git(["show", `${ref}:${path}`]);
+        } catch (err) {
+            log.debug({ err, ref, path }, "readFileAt miss");
+            return null;
+        }
+    }
+
+    async deleteRef(ref: string): Promise<void> {
+        await this.git(["update-ref", "-d", ref]);
+    }
+
+    async listRefs(prefix: string): Promise<string[]> {
+        try {
+            const out = await this.git(["for-each-ref", "--format=%(refname)", prefix]);
+            return out
+                .split("\n")
+                .map((s) => s.trim())
+                .filter(Boolean);
+        } catch (err) {
+            log.debug({ err, prefix }, "listRefs failed");
+            return [];
+        }
+    }
+
+    private async git(args: string[]): Promise<string> {
+        // Author/committer identity is forced here so the bare store repo doesn't depend on the user's
+        // global git config (CI environments often have neither user.name nor user.email).
+        const proc = Bun.spawn(["git", "--git-dir", this.dir, ...args], {
+            stdout: "pipe",
+            stderr: "pipe",
+            env: {
+                ...process.env,
+                GIT_AUTHOR_NAME: "stash",
+                GIT_AUTHOR_EMAIL: "stash@genesistools.local",
+                GIT_COMMITTER_NAME: "stash",
+                GIT_COMMITTER_EMAIL: "stash@genesistools.local",
+            },
+        });
+        const [stdout, stderr, exit] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+        if (exit !== 0) {
+            throw new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`);
+        }
+        return stdout;
+    }
+
+    private async gitWithStdin(args: string[], input: string): Promise<string> {
+        const proc = Bun.spawn(["git", "--git-dir", this.dir, ...args], {
+            stdin: "pipe",
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        proc.stdin.write(input);
+        await proc.stdin.end();
+        const [stdout, stderr, exit] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+        if (exit !== 0) {
+            throw new Error(`git ${args.join(" ")} (stdin) failed: ${stderr.trim()}`);
+        }
+        return stdout.trim();
+    }
+}

--- a/src/stash/lib/strip-apply-markers.test.ts
+++ b/src/stash/lib/strip-apply-markers.test.ts
@@ -6,7 +6,7 @@ describe("stripApplyMarkersFromPatchFiles", () => {
         const patch = [
             "+++ b/foo.ts",
             "@@ -1,1 +1,7 @@",
-            "+// #region @stash:foo {\"id\":\"abc\"}",
+            '+// #region @stash:foo {"id":"abc"}',
             "+line1",
             "+// #region @stash:foo",
             "+author",
@@ -29,8 +29,8 @@ describe("stripApplyMarkersFromPatchFiles", () => {
         const patch = [
             "+++ b/foo.ts",
             "@@ -1,1 +1,5 @@",
-            "+// #region @stash:foo {\"id\":\"a\"}",
-            "+// #region @stash:foo {\"id\":\"b\"}",
+            '+// #region @stash:foo {"id":"a"}',
+            '+// #region @stash:foo {"id":"b"}',
             "+x",
             "+// #endregion @stash:foo",
             "+// #endregion @stash:foo",
@@ -41,5 +41,32 @@ describe("stripApplyMarkersFromPatchFiles", () => {
         expect(stripped).not.toContain("#endregion @stash:foo");
         expect(stripped).toContain("+x");
         expect(stripped).toMatch(/\+1,1/);
+    });
+
+    test("preserves outer author region when same-name apply wrapper is nested inside it", () => {
+        const patch = [
+            "+++ b/foo.ts",
+            "@@ -1,1 +1,7 @@",
+            "+// #region @stash:foo",
+            "+before",
+            '+// #region @stash:foo {"id":"abc"}',
+            "+applied",
+            "+// #endregion @stash:foo",
+            "+after",
+            "+// #endregion @stash:foo",
+        ].join("\n");
+
+        const stripped = stripApplyMarkersFromPatchFiles({ patch });
+        expect(stripped).toBe(
+            [
+                "+++ b/foo.ts",
+                "@@ -1,1 +1,5 @@",
+                "+// #region @stash:foo",
+                "+before",
+                "+applied",
+                "+after",
+                "+// #endregion @stash:foo",
+            ].join("\n")
+        );
     });
 });

--- a/src/stash/lib/strip-apply-markers.test.ts
+++ b/src/stash/lib/strip-apply-markers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { stripApplyMarkersFromPatchFiles } from "./strip-apply-markers";
+
+describe("stripApplyMarkersFromPatchFiles", () => {
+    test("preserves author region nested inside apply-time wrapper with same name", () => {
+        const patch = [
+            "+++ b/foo.ts",
+            "@@ -1,1 +1,7 @@",
+            "+// #region @stash:foo {\"id\":\"abc\"}",
+            "+line1",
+            "+// #region @stash:foo",
+            "+author",
+            "+// #endregion @stash:foo",
+            "+line2",
+            "+// #endregion @stash:foo",
+        ].join("\n");
+
+        const stripped = stripApplyMarkersFromPatchFiles({ patch });
+        expect(stripped).not.toContain('{"id":"abc"}');
+        expect(stripped).toContain("+// #region @stash:foo");
+        expect(stripped).toContain("+// #endregion @stash:foo");
+        expect(stripped).toContain("+author");
+        expect(stripped).toContain("+line1");
+        expect(stripped).toContain("+line2");
+        expect(stripped).toMatch(/\+1,5/);
+    });
+
+    test("drops nested apply-time openers with the same name", () => {
+        const patch = [
+            "+++ b/foo.ts",
+            "@@ -1,1 +1,5 @@",
+            "+// #region @stash:foo {\"id\":\"a\"}",
+            "+// #region @stash:foo {\"id\":\"b\"}",
+            "+x",
+            "+// #endregion @stash:foo",
+            "+// #endregion @stash:foo",
+        ].join("\n");
+
+        const stripped = stripApplyMarkersFromPatchFiles({ patch });
+        expect(stripped).not.toContain("#region @stash:foo");
+        expect(stripped).not.toContain("#endregion @stash:foo");
+        expect(stripped).toContain("+x");
+        expect(stripped).toMatch(/\+1,1/);
+    });
+});

--- a/src/stash/lib/strip-apply-markers.ts
+++ b/src/stash/lib/strip-apply-markers.ts
@@ -19,13 +19,26 @@ export function stripApplyMarkersFromPatchFiles(args: { patch: string }): string
     const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
 
     const lines = args.patch.split("\n");
-    // PR #222 t27: per-name apply depth counter, not a Set. Two nested apply-time openers with the
-    // same stash name would otherwise share one Set entry — deleting on the first close would leave
-    // the second close unmatched in the output.
-    const applyCloseDepth = new Map<string, number>();
-    // PR #222 t33: track bare author regions separately so an inner `#endregion @stash:NAME` is not
-    // dropped while an outer apply-time wrapper of the same name is still open.
-    const authorCloseDepth = new Map<string, number>();
+    // PR #222 t36: LIFO stack per name pairs each `#endregion` with the most recent same-name opener.
+    // Separate counters mishandle inverse nesting (author wrapper containing apply wrapper).
+    type CloseKind = "apply" | "author";
+    const closeStackByName = new Map<string, CloseKind[]>();
+    const pushCloseKind = (name: string, kind: CloseKind) => {
+        const stack = closeStackByName.get(name) ?? [];
+        stack.push(kind);
+        closeStackByName.set(name, stack);
+    };
+    const popCloseKind = (name: string): CloseKind | null => {
+        const stack = closeStackByName.get(name);
+        if (!stack) {
+            return null;
+        }
+        const kind = stack.pop();
+        if (stack.length === 0) {
+            closeStackByName.delete(name);
+        }
+        return kind ?? null;
+    };
     // Buffer per hunk so we can rewrite the header after counting dropped `+` lines.
     let currentHeader: { oldStart: number; oldLines: number; newStart: number; newLines: number; ctx: string } | null =
         null;
@@ -70,37 +83,26 @@ export function stripApplyMarkersFromPatchFiles(args: { patch: string }): string
         const openMatch = APPLY_OPEN_WITH_NAME.exec(line);
         if (openMatch?.[1]) {
             const name = openMatch[1];
-            applyCloseDepth.set(name, (applyCloseDepth.get(name) ?? 0) + 1);
+            pushCloseKind(name, "apply");
             droppedInHunk++;
             continue;
         }
         const bareOpenMatch = /^\+.*#region\s+@stash:([\w.-]+)/.exec(line);
         if (bareOpenMatch?.[1] && !APPLY_OPEN_WITH_NAME.test(line)) {
             const name = bareOpenMatch[1];
-            authorCloseDepth.set(name, (authorCloseDepth.get(name) ?? 0) + 1);
+            pushCloseKind(name, "author");
             currentBody.push(line);
             continue;
         }
         const closeMatch = CLOSE_WITH_NAME.exec(line);
         if (closeMatch?.[1]) {
             const name = closeMatch[1];
-            const authorDepth = authorCloseDepth.get(name) ?? 0;
-            if (authorDepth > 0) {
-                if (authorDepth === 1) {
-                    authorCloseDepth.delete(name);
-                } else {
-                    authorCloseDepth.set(name, authorDepth - 1);
-                }
+            const closeKind = popCloseKind(name);
+            if (closeKind === "author") {
                 currentBody.push(line);
                 continue;
             }
-            const applyDepth = applyCloseDepth.get(name) ?? 0;
-            if (applyDepth > 0) {
-                if (applyDepth === 1) {
-                    applyCloseDepth.delete(name);
-                } else {
-                    applyCloseDepth.set(name, applyDepth - 1);
-                }
+            if (closeKind === "apply") {
                 droppedInHunk++;
                 continue;
             }

--- a/src/stash/lib/strip-apply-markers.ts
+++ b/src/stash/lib/strip-apply-markers.ts
@@ -1,0 +1,112 @@
+/**
+ * Strip apply-time region markers from the patch (so a save of an applied stash doesn't re-include
+ * the wrapper) AND fix up the surrounding `@@ -a,b +c,d @@` hunk counts. The contract: drop opener
+ * lines that carry a JSON metadata blob (apply-time form) AND their matching `#endregion @stash:NAME`
+ * closer with the same name; preserve bare author markers (no JSON) so manually annotated regions
+ * round-trip cleanly.
+ *
+ * Hunk-count fix-up (PR #222 t10): every dropped `+` line decrements the hunk's new-side count.
+ * Without this, the stored PATCH.diff becomes unparseable — `git apply` (and `--3way`) parse @@
+ * headers strictly and reject any mismatch between declared added-line count and actual body.
+ */
+export function stripApplyMarkersFromPatchFiles(args: { patch: string }): string {
+    // Apply-time opener: added line matches `#region @stash:NAME {...json...}`. The JSON brace is
+    // what distinguishes it from a bare author marker, which has no metadata and must be kept.
+    const APPLY_OPEN_WITH_NAME = /^\+.*#region\s+@stash:([\w.-]+)\s+\{.*\}/;
+    // Any added closer — used only to drop closers whose paired opener was an apply-time opener.
+    const CLOSE_WITH_NAME = /^\+.*#endregion\s+@stash:([\w.-]+)/;
+    // Unified-diff hunk header: `@@ -oldStart,oldLines +newStart,newLines @@ <optional ctx>`.
+    const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+
+    const lines = args.patch.split("\n");
+    // PR #222 t27: per-name apply depth counter, not a Set. Two nested apply-time openers with the
+    // same stash name would otherwise share one Set entry — deleting on the first close would leave
+    // the second close unmatched in the output.
+    const applyCloseDepth = new Map<string, number>();
+    // PR #222 t33: track bare author regions separately so an inner `#endregion @stash:NAME` is not
+    // dropped while an outer apply-time wrapper of the same name is still open.
+    const authorCloseDepth = new Map<string, number>();
+    // Buffer per hunk so we can rewrite the header after counting dropped `+` lines.
+    let currentHeader: { oldStart: number; oldLines: number; newStart: number; newLines: number; ctx: string } | null =
+        null;
+    let currentBody: string[] = [];
+    let droppedInHunk = 0;
+    const out: string[] = [];
+
+    const flushHunk = () => {
+        if (!currentHeader) {
+            return;
+        }
+        const newLinesAdjusted = currentHeader.newLines - droppedInHunk;
+        // Emit corrected header. If `,N` was originally absent (single-line hunk), still write it
+        // when the adjusted value is no longer 1 — that's the only safe normalization.
+        const oldPart = `${currentHeader.oldStart},${currentHeader.oldLines}`;
+        const newPart = `${currentHeader.newStart},${newLinesAdjusted}`;
+        out.push(`@@ -${oldPart} +${newPart} @@${currentHeader.ctx}`);
+        out.push(...currentBody);
+        currentHeader = null;
+        currentBody = [];
+        droppedInHunk = 0;
+    };
+
+    for (const line of lines) {
+        const hm = HUNK_RE.exec(line);
+        if (hm) {
+            flushHunk();
+            currentHeader = {
+                oldStart: Number(hm[1]),
+                oldLines: Number(hm[2] ?? "1"),
+                newStart: Number(hm[3]),
+                newLines: Number(hm[4] ?? "1"),
+                ctx: hm[5] ?? "",
+            };
+            continue;
+        }
+        // File-level headers, index headers, etc. — flush any open hunk and pass through.
+        if (!currentHeader) {
+            out.push(line);
+            continue;
+        }
+        const openMatch = APPLY_OPEN_WITH_NAME.exec(line);
+        if (openMatch?.[1]) {
+            const name = openMatch[1];
+            applyCloseDepth.set(name, (applyCloseDepth.get(name) ?? 0) + 1);
+            droppedInHunk++;
+            continue;
+        }
+        const bareOpenMatch = /^\+.*#region\s+@stash:([\w.-]+)/.exec(line);
+        if (bareOpenMatch?.[1] && !APPLY_OPEN_WITH_NAME.test(line)) {
+            const name = bareOpenMatch[1];
+            authorCloseDepth.set(name, (authorCloseDepth.get(name) ?? 0) + 1);
+            currentBody.push(line);
+            continue;
+        }
+        const closeMatch = CLOSE_WITH_NAME.exec(line);
+        if (closeMatch?.[1]) {
+            const name = closeMatch[1];
+            const authorDepth = authorCloseDepth.get(name) ?? 0;
+            if (authorDepth > 0) {
+                if (authorDepth === 1) {
+                    authorCloseDepth.delete(name);
+                } else {
+                    authorCloseDepth.set(name, authorDepth - 1);
+                }
+                currentBody.push(line);
+                continue;
+            }
+            const applyDepth = applyCloseDepth.get(name) ?? 0;
+            if (applyDepth > 0) {
+                if (applyDepth === 1) {
+                    applyCloseDepth.delete(name);
+                } else {
+                    applyCloseDepth.set(name, applyDepth - 1);
+                }
+                droppedInHunk++;
+                continue;
+            }
+        }
+        currentBody.push(line);
+    }
+    flushHunk();
+    return out.join("\n");
+}

--- a/src/stash/lib/ui.ts
+++ b/src/stash/lib/ui.ts
@@ -1,0 +1,48 @@
+import chalk from "chalk";
+
+/**
+ * Plain status writes for `tools stash`. We deliberately bypass `out.log.*` (which wraps every
+ * line in clack's task-lifecycle box-drawing: `│ ◆ ●`) because that's the wrong texture for a CLI
+ * that prints many short status lines per command. Interactive PROMPTS still use @clack/prompts.
+ *
+ * All status goes to STDERR so `tools stash show --diff > foo.diff` (and similar) still capture
+ * only the machine-readable payload via `out.print` / `out.result`.
+ */
+
+function write(line: string): void {
+    process.stderr.write(`${line}\n`);
+}
+
+export const ui = {
+    ok(msg: string): void {
+        write(`${chalk.green("✓")} ${msg}`);
+    },
+    info(msg: string): void {
+        write(`${chalk.cyan("ℹ")} ${msg}`);
+    },
+    warn(msg: string): void {
+        write(`${chalk.yellow("⚠")} ${msg}`);
+    },
+    err(msg: string): void {
+        write(`${chalk.red("✗")} ${msg}`);
+    },
+    dim(msg: string): void {
+        write(chalk.dim(msg));
+    },
+    header(msg: string): void {
+        write(chalk.bold(msg));
+    },
+    /** Print a 2-column key/value pair, right-padded key for tidy alignment. */
+    kv(key: string, value: string, keyWidth = 9): void {
+        write(`  ${chalk.dim(key.padEnd(keyWidth))}${value}`);
+    },
+    /** Section break — a blank line plus a dim rule. Used before lists/diffs. */
+    section(title: string): void {
+        write("");
+        write(chalk.dim(`── ${title} ${"─".repeat(Math.max(0, 60 - title.length))}`));
+    },
+    /** Bare write to stderr without any chalk decoration. */
+    raw(msg: string): void {
+        write(msg);
+    },
+};

--- a/src/stash/lib/unapply-session.test.ts
+++ b/src/stash/lib/unapply-session.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type SessionRegion, UnapplySession } from "./unapply-session";
+
+let stateDir: string;
+beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "stash-session-"));
+});
+afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+});
+
+const regions: SessionRegion[] = [
+    { id: "r1", filePath: "a.ts", hunkIndex: 1, klass: "unchanged", decision: "auto-remove" },
+    { id: "r2", filePath: "a.ts", hunkIndex: 2, klass: "edited", decision: null },
+    { id: "r3", filePath: "b.ts", hunkIndex: 1, klass: "missing", decision: null },
+];
+
+describe("UnapplySession", () => {
+    test("currentRegion skips decided + unchanged regions", () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        expect(s.currentRegion()?.id).toBe("r2");
+    });
+
+    test("decide() advances to next undecided region", () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        s.decide("update");
+        expect(s.currentRegion()?.id).toBe("r3");
+    });
+
+    test("isComplete after all decided", () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        s.decide("update");
+        s.decide("skip");
+        expect(s.isComplete()).toBe(true);
+    });
+
+    test("persist + load round-trip preserves decisions and current index", async () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        s.decide("update");
+        await s.persist();
+
+        const loaded = await UnapplySession.load({
+            stashId: "abc",
+            projectHash: "phash",
+            stateDir,
+        });
+        expect(loaded).not.toBeNull();
+        expect(loaded?.currentRegion()?.id).toBe("r3");
+        const r2 = loaded?.regions().find((r) => r.id === "r2");
+        expect(r2?.decision).toBe("update");
+    });
+
+    test("abort() deletes state file", async () => {
+        const s = UnapplySession.start({
+            stashId: "abc",
+            stashName: "x",
+            projectPath: "/p",
+            projectHash: "phash",
+            regions,
+            stateDir,
+        });
+        await s.persist();
+        await s.abort();
+        const loaded = await UnapplySession.load({ stashId: "abc", projectHash: "phash", stateDir });
+        expect(loaded).toBeNull();
+    });
+});

--- a/src/stash/lib/unapply-session.ts
+++ b/src/stash/lib/unapply-session.ts
@@ -1,0 +1,140 @@
+import { existsSync } from "node:fs";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import type { RegionClass } from "./classify";
+
+export type Decision = "update" | "discard" | "skip" | "auto-remove" | null;
+
+export interface SessionRegion {
+    id: string;
+    filePath: string;
+    hunkIndex: number;
+    klass: RegionClass;
+    decision: Decision;
+    storedContent?: string;
+    currentContent?: string | null;
+}
+
+export interface SessionState {
+    stashId: string;
+    stashName: string;
+    projectPath: string;
+    projectHash: string;
+    regions: SessionRegion[];
+    currentIndex: number;
+    startedAt: string;
+    pausedAt: string | null;
+}
+
+export class UnapplySession {
+    private constructor(
+        private state: SessionState,
+        private readonly stateDir: string
+    ) {}
+
+    static start(args: {
+        stashId: string;
+        stashName: string;
+        projectPath: string;
+        projectHash: string;
+        regions: SessionRegion[];
+        stateDir: string;
+    }): UnapplySession {
+        const state: SessionState = {
+            stashId: args.stashId,
+            stashName: args.stashName,
+            projectPath: args.projectPath,
+            projectHash: args.projectHash,
+            regions: args.regions.map((r) => ({ ...r })),
+            currentIndex: 0,
+            startedAt: new Date().toISOString(),
+            pausedAt: null,
+        };
+        const s = new UnapplySession(state, args.stateDir);
+        s.advanceToNextUndecided();
+        return s;
+    }
+
+    static async load(args: {
+        stashId: string;
+        projectHash: string;
+        stateDir: string;
+    }): Promise<UnapplySession | null> {
+        const path = stateFilePath(args.stateDir, args.projectHash, args.stashId);
+        if (!existsSync(path)) {
+            return null;
+        }
+        const raw = await readFile(path, "utf8");
+        // SafeJSON.parse returns `any` (matches native JSON.parse). The file shape is fully owned by
+        // this module (writePersist below), so the cast is safe; a future migration would key on the
+        // `startedAt` field to detect older shapes.
+        const state = SafeJSON.parse(raw) as SessionState;
+        return new UnapplySession(state, args.stateDir);
+    }
+
+    regions(): SessionRegion[] {
+        return this.state.regions;
+    }
+
+    currentRegion(): SessionRegion | null {
+        return this.state.regions[this.state.currentIndex] ?? null;
+    }
+
+    isComplete(): boolean {
+        return this.state.regions.every((r) => r.decision !== null);
+    }
+
+    progress(): { decided: number; total: number } {
+        const decided = this.state.regions.filter((r) => r.decision !== null).length;
+        return { decided, total: this.state.regions.length };
+    }
+
+    decide(decision: Exclude<Decision, null | "auto-remove">): void {
+        const region = this.currentRegion();
+        if (!region) {
+            throw new Error("no current region");
+        }
+        region.decision = decision;
+        this.advanceToNextUndecided();
+    }
+
+    private advanceToNextUndecided(): void {
+        for (let i = this.state.currentIndex; i < this.state.regions.length; i++) {
+            const r = this.state.regions[i];
+            if (!r) {
+                continue;
+            }
+            if (r.decision === null) {
+                this.state.currentIndex = i;
+                return;
+            }
+        }
+        this.state.currentIndex = this.state.regions.length;
+    }
+
+    async persist(): Promise<void> {
+        this.state.pausedAt = new Date().toISOString();
+        const path = stateFilePath(this.stateDir, this.state.projectHash, this.state.stashId);
+        await writeFile(path, SafeJSON.stringify(this.state, null, 2));
+    }
+
+    async abort(): Promise<void> {
+        const path = stateFilePath(this.stateDir, this.state.projectHash, this.state.stashId);
+        if (existsSync(path)) {
+            await unlink(path);
+        }
+    }
+
+    async complete(): Promise<void> {
+        await this.abort();
+    }
+
+    snapshot(): SessionState {
+        return this.state;
+    }
+}
+
+function stateFilePath(stateDir: string, projectHash: string, stashId: string): string {
+    return join(stateDir, `${projectHash.slice(0, 12)}--unapply--${stashId.slice(0, 6)}.json`);
+}

--- a/src/stash/types.ts
+++ b/src/stash/types.ts
@@ -1,0 +1,52 @@
+export interface StashRow {
+    id: string;
+    name: string;
+    tags: string | null;
+    description: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface VersionRow {
+    id: string;
+    stash_id: string;
+    version: number;
+    patch_ref: string;
+    source_repo_path: string | null;
+    source_origin: string | null;
+    source_sha: string | null;
+    region_count: number;
+    file_count: number;
+    metadata_json: string;
+    created_at: string;
+}
+
+export interface ApplicationRow {
+    id: string;
+    stash_id: string;
+    version_id: string;
+    project_path: string;
+    project_origin: string | null;
+    project_sha_at_apply: string | null;
+    applied_at: string;
+    state: "active" | "unapplying" | "unapplied" | "orphaned";
+    unapplied_at: string | null;
+}
+
+export interface RegionRow {
+    id: string;
+    version_id: string;
+    region_name: string | null;
+    file_path: string;
+    hunk_index: number;
+    start_marker_present: number;
+    line_count: number;
+}
+
+export interface ProjectRow {
+    id: string;
+    path: string;
+    origin: string | null;
+    tree_hash: string | null;
+    last_seen: string;
+}

--- a/src/stash/types.ts
+++ b/src/stash/types.ts
@@ -24,7 +24,8 @@ export interface VersionRow {
 export interface ApplicationRow {
     id: string;
     stash_id: string;
-    version_id: string;
+    /** Nullable: set NULL when the referenced version is dropped (audit row survives). */
+    version_id: string | null;
     project_path: string;
     project_origin: string | null;
     project_sha_at_apply: string | null;


### PR DESCRIPTION
## Summary

New `tools stash` — a global cross-project code-overlay manager. Think `git stash` × JetBrains Shelf × `quilt`. Captures named, versioned hunks of working-tree code into a central store, applies them to any other project as drift-tolerant patches via `git apply --3way`, decorates the injected regions with foldable `// #region @stash:<name> {json}` markers so they're visible/greppable/reversible, and surgically removes them via a reviewable multi-step state machine (one decision per ambiguous region — like `git rebase --continue/--abort`).

### Highlights
- **Storage:** bare git repo at `~/.genesis-tools/stash/store/` (patches as commits, blob OIDs survive for 3-way) + SQLite index. `GENESIS_TOOLS_STASH_ROOT` env var for test/local isolation.
- **9 commands:** `save`, `apply`, `unapply`, `update`, `list`, `show`, `versions`, `drop`, `where`.
- **Auto-versioning:** every `save` of an existing name creates `vN+1` — no overwrite.
- **Drift tolerance:** `git apply --3way` against stored baseline blobs; degrades gracefully when blobs aren't reachable.
- **Multi-language markers:** comment syntax adapts per extension (`//`, `#`, `<!-- -->`, `/* */`).
- **Sibling-clone detection:** projects sharing `remote.origin.url` (e.g. `col-fe`, `col-fe2`, `col-fe-native-upgrade`) treated as one project for `list --project` / `list --applied`.
- **Unapply state machine:** 3 per-region decisions (`update` / `discard` / `skip`), auto-skip unchanged regions, dangerous batch overrides (`--decision=discard-all-dangerous`).
- **Output:** plain chalk-styled stderr via `lib/ui.ts` (no clack box-drawing on status lines); `@clack/prompts` reserved for interactive PROMPTS only. `-v/--verbose` (auto-registered by `runTool`) promotes file-only `log.debug` traces to console.

### Files
- `src/stash/` — entrypoint, 9 commands, 13 lib modules, 14 test files (55 tests).
- `.claude/skills/stash/SKILL.md` — agent-facing skill teaching the marker discipline + lifecycle.
- `.claude/plans/2026-06-24-StashTool-{spec,plan}.md` — design spec + 21-task TDD plan.

### Notable bugs caught + fixed during the verify pass
- Hardcoded `/opt/homebrew/bin/git` + module-level `cachedGitBin` cache + PATH mutation → ripped out for plain `Bun.spawn(["git", ...])`.
- macOS `posix_spawn` ENOENT after test `rm -rf` on a still-current cwd → restore `process.chdir(origCwd)` before cleanup.
- `refs/.gtstash-baseline` invalid (git rejects path components beginning with `.`) → renamed to `refs/gtstash-baseline`; 3-way merge actually works now.
- `list --applied` filter that always included `source_repo_path` matches → strict join on active applications only.
- `stripApplyMarkersFromPatchFiles` had dead-code constant + stripped EVERY closer regardless of opener type → proper pair tracking; bare author markers now round-trip.
- `capturedUpdatesAsNewVersion` wrote pseudo-format (would never `apply` again) → real unified diff + baseline carry-forward.
- `drop.ts` orphan ordering caused FK violation under `--all-versions --orphan-active` → orphan first, then delete.
- `update` command advertised in `SKILL.md` but never implemented → now wired.
- `suggestCommand` calls used a non-existent `extra:` field → switched to `subcommand:`.

### Status
- 55/55 tests pass (incl. e2e save→apply→unapply round-trip with isolated `GENESIS_TOOLS_STASH_ROOT`).
- `bunx biome check src/stash/` clean.
- `tsgo --noEmit` on stash sources clean.
- End-to-end smoke verified across two sibling repos: save → apply → list / list --applied / where / versions / show / unapply (discard-all-dangerous) → file restored cleanly. `--verbose` confirmed showing step-by-step `[stash:*]` traces.

## Test plan
- [ ] Edge cases not yet covered manually: untracked new files via `--all`, multi-region per file, binary files (should skip), drift on apply (3-way fuzz fallback), brand-new repo with no HEAD, stash name with dots, multi-language file in one stash.
- [ ] Interactive walk in TTY for unapply (`select`-based clack prompt path).
- [ ] Apply with 3-way merge conflict (deferred to v1.1 state machine — currently bubbles up as inline `<<<<<<<` markers).
- [ ] First-time install via `tools stash --help` after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full `tools stash` workflow to save, apply (optional version pinning + verbose markers), unapply (interactive TUI/resumable), update, list, show (diff/meta/regions), versions, where, and drop reusable code overlays across projects.
  * Capture/replay uses `#region `@stash`:<name>` markers with drift-tolerant patch application and automatic discovery of where a stash is applied.
* **Bug Fixes**
  * Improved marker decoration/removal robustness, clearer behavior when expected markers are missing, and safer destructive actions with confirmation and active-application protection.
* **Tests**
  * Added unit, integration, and end-to-end coverage for cross-repo stash flows and region handling.
* **Documentation**
  * Added guides/specs for the stash workflow and region authoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->