### PR TITLE
fix(dev-dashboard): share auth, preload errors, and raw MD toggle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "asciichart": "^1.5.25",
         "axios": "^1.13.2",
         "babel-plugin-react-compiler": "^1.0.0",
+        "babel-preset-solid": "^1.9.10",
         "bonjour-service": "^1.4.0",
         "boxen": "^8.0.1",
         "chalk": "^5.6.0",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,7 +7,5 @@ minimumReleaseAge = 604800
 [test]
 preload = [
     "./src/utils/bun/preload-test-process-exit.ts",
-    "./src/utils/bun/preload-solid-scoped.ts",
-    "./src/utils/search/stores/sqlite-vec-preload.ts",
     "./src/indexer/lib/test-cleanup-preload.ts",
 ]

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
         "@ast-grep/napi": "^0.42.0",
         "@babel/core": "^7.28.6",
         "@babel/preset-typescript": "^7.28.5",
+        "babel-preset-solid": "^1.9.10",
         "@clack/prompts": "^1.0.0",
         "@crawlee/utils": "^3.16.0",
         "@genesiscz/darwinkit": "0.7.5",

--- a/src/dev-dashboard/lib/obsidian/share-template.test.ts
+++ b/src/dev-dashboard/lib/obsidian/share-template.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { renderSharePage } from "@app/dev-dashboard/lib/obsidian/share-template";
+
+describe("renderSharePage", () => {
+    test("includes raw source toggle and embedded markdown", () => {
+        const page = renderSharePage({
+            title: "Test Note",
+            rendered: { html: "<p>Hello</p>", hasMath: false, hasMermaid: false, tags: [] },
+            source: "# Hello\n\nWorld",
+            sourcePath: "notes/test.md",
+        });
+
+        expect(page).toContain('id="dd-share-view-btn"');
+        expect(page).toContain('id="dd-share-source-panel"');
+        expect(page).toContain('id="dd-share-source-data"');
+        expect(page).toContain("# Hello\\n\\nWorld");
+        expect(page).toContain("Show raw markdown source");
+    });
+});

--- a/src/dev-dashboard/lib/obsidian/share-template.ts
+++ b/src/dev-dashboard/lib/obsidian/share-template.ts
@@ -1,9 +1,11 @@
 import type { RenderResult } from "@app/dev-dashboard/lib/obsidian/markdown";
+import { SafeJSON } from "@app/utils/json";
 import { escapeHtml } from "@app/utils/string";
 
 interface ShareTemplateOptions {
     title: string;
     rendered: RenderResult;
+    source: string;
     sourcePath?: string;
 }
 
@@ -365,6 +367,62 @@ footer.dd-share-footer .dd-share-source {
     word-break: break-all;
 }
 
+.dd-share-toolbar {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 100;
+}
+
+.dd-share-view-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--dd-border-strong);
+    border-radius: 8px;
+    background: var(--dd-bg-elevated);
+    color: var(--dd-text-dim);
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.dd-share-view-btn:hover {
+    color: var(--dd-accent);
+    border-color: var(--dd-accent);
+    background: var(--dd-accent-soft);
+}
+
+.dd-share-view-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.dd-share-source-panel {
+    display: none;
+    font-family: var(--dd-mono);
+    font-size: 13px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--dd-text);
+    background: var(--dd-bg-panel);
+    border: 1px solid var(--dd-border);
+    border-radius: 8px;
+    padding: 16px 20px;
+    overflow-x: auto;
+    margin: 0;
+}
+
+body.dd-share-mode-source article {
+    display: none;
+}
+
+body.dd-share-mode-source .dd-share-source-panel {
+    display: block;
+}
+
 @media (max-width: 600px) {
     body { padding: 28px 16px 64px; }
     article { font-size: 16px; }
@@ -399,8 +457,48 @@ mermaid.initialize({
 </script>`;
 }
 
+const FILE_CODE_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 12.5 8 15l2 2.5"/><path d="m14 12.5 2 2.5-2 2.5"/></svg>';
+
+const BOOK_OPEN_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>';
+
+function embedSourceJson(source: string): string {
+    return SafeJSON.stringify(source).replace(/</g, "\\u003c");
+}
+
+function buildViewToggleScript(): string {
+    return `<script>
+(function () {
+    var btn = document.getElementById("dd-share-view-btn");
+    var panel = document.getElementById("dd-share-source-panel");
+    var dataEl = document.getElementById("dd-share-source-data");
+    if (!btn || !panel || !dataEl) {
+        return;
+    }
+
+    panel.textContent = JSON.parse(dataEl.textContent);
+
+    var fileCodeIcon = ${SafeJSON.stringify(FILE_CODE_ICON)};
+    var bookOpenIcon = ${SafeJSON.stringify(BOOK_OPEN_ICON)};
+    var mode = "reading";
+
+    btn.addEventListener("click", function () {
+        mode = mode === "reading" ? "source" : "reading";
+        document.body.classList.toggle("dd-share-mode-source", mode === "source");
+        btn.innerHTML = mode === "reading" ? fileCodeIcon : bookOpenIcon;
+        btn.setAttribute(
+            "aria-label",
+            mode === "reading" ? "Show raw markdown source" : "Show rendered note"
+        );
+        btn.title = btn.getAttribute("aria-label") ?? "";
+    });
+})();
+</script>`;
+}
+
 export function renderSharePage(options: ShareTemplateOptions): string {
-    const { title, rendered, sourcePath } = options;
+    const { title, rendered, source, sourcePath } = options;
     const headExtras: string[] = [
         `<link rel="preconnect" href="https://fonts.googleapis.com">`,
         `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`,
@@ -420,6 +518,8 @@ export function renderSharePage(options: ShareTemplateOptions): string {
         bodyExtras.push(buildMermaidScript());
     }
 
+    bodyExtras.push(buildViewToggleScript());
+
     const sourceLine = sourcePath ? `<span class="dd-share-source">${escapeHtml(sourcePath)}</span>` : "";
 
     return `<!doctype html>
@@ -433,10 +533,15 @@ ${headExtras.join("\n")}
 <style>${buildCss()}</style>
 </head>
 <body>
+<div class="dd-share-toolbar">
+<button type="button" class="dd-share-view-btn" id="dd-share-view-btn" aria-label="Show raw markdown source" title="Show raw markdown source">${FILE_CODE_ICON}</button>
+</div>
 <main>
 <article>${rendered.html}</article>
+<pre class="dd-share-source-panel" id="dd-share-source-panel"></pre>
 <footer class="dd-share-footer">shared via dev-dashboard${sourceLine}</footer>
 </main>
+<script type="application/json" id="dd-share-source-data">${embedSourceJson(source)}</script>
 ${bodyExtras.join("\n")}
 </body>
 </html>`;

--- a/src/dev-dashboard/lib/share-auth.test.ts
+++ b/src/dev-dashboard/lib/share-auth.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { isPublicShareRequest } from "@app/dev-dashboard/lib/share-auth";
+
+describe("isPublicShareRequest", () => {
+    it("allows GET and HEAD on /share/<slug>", () => {
+        expect(isPublicShareRequest("GET", "/share/tok")).toBe(true);
+        expect(isPublicShareRequest("HEAD", "/share/tok")).toBe(true);
+    });
+
+    it("allows optional trailing slash", () => {
+        expect(isPublicShareRequest("GET", "/share/tok/")).toBe(true);
+        expect(isPublicShareRequest("HEAD", "/share/tok/")).toBe(true);
+    });
+
+    it("rejects nested paths and other methods", () => {
+        expect(isPublicShareRequest("GET", "/share/tok/extra")).toBe(false);
+        expect(isPublicShareRequest("POST", "/share/tok")).toBe(false);
+        expect(isPublicShareRequest("GET", "/api/share/tok")).toBe(false);
+    });
+});

--- a/src/dev-dashboard/lib/share-auth.ts
+++ b/src/dev-dashboard/lib/share-auth.ts
@@ -1,0 +1,5 @@
+const PUBLIC_SHARE_PATH_RE = /^\/share\/[^/]+\/?$/;
+
+export function isPublicShareRequest(method: string, pathname: string): boolean {
+    return (method === "GET" || method === "HEAD") && PUBLIC_SHARE_PATH_RE.test(pathname);
+}

--- a/src/dev-dashboard/server/auth-guard.test.ts
+++ b/src/dev-dashboard/server/auth-guard.test.ts
@@ -21,6 +21,15 @@ describe("decideApiAuth", () => {
         expect(d.decision).toBe("allow");
     });
 
+    it("allows HEAD and trailing-slash share URLs without auth", () => {
+        expect(decideApiAuth({ method: "HEAD", pathname: "/share/tok", headers: {}, provision }).decision).toBe(
+            "allow"
+        );
+        expect(decideApiAuth({ method: "GET", pathname: "/share/tok/", headers: {}, provision }).decision).toBe(
+            "allow"
+        );
+    });
+
     it("allows + mints a cookie for a valid Basic header", () => {
         const d = decideApiAuth({
             method: "GET",

--- a/src/dev-dashboard/server/auth-guard.ts
+++ b/src/dev-dashboard/server/auth-guard.ts
@@ -8,8 +8,7 @@ import {
     verifyBasicAuthHeader,
     verifySessionToken,
 } from "@app/dev-dashboard/lib/auth";
-
-const SHARE_BYPASS_RE = /^\/share\/[^/]+$/;
+import { isPublicShareRequest } from "@app/dev-dashboard/lib/share-auth";
 
 export interface AuthInput {
     method: string;
@@ -30,7 +29,7 @@ export interface AuthResult {
 export function decideApiAuth(input: AuthInput): AuthResult {
     const { method, pathname, headers, provision } = input;
 
-    if (method === "GET" && SHARE_BYPASS_RE.test(pathname)) {
+    if (isPublicShareRequest(method, pathname)) {
         return { decision: "allow" };
     }
 

--- a/src/dev-dashboard/server/routes/share.ts
+++ b/src/dev-dashboard/server/routes/share.ts
@@ -52,7 +52,7 @@ export function shareRoutes(): RouteDef[] {
                         },
                     });
                     const title = (note.vaultPath.split("/").pop() ?? note.vaultPath).replace(/\.md$/, "");
-                    const page = renderSharePage({ title, rendered, sourcePath: note.vaultPath });
+                    const page = renderSharePage({ title, rendered, source, sourcePath: note.vaultPath });
 
                     return {
                         kind: "raw",

--- a/src/dev-dashboard/ui/src/components/ObsidianReader.tsx
+++ b/src/dev-dashboard/ui/src/components/ObsidianReader.tsx
@@ -3,7 +3,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Button } from "@ui/components/button";
 import { Copy, Globe, GlobeLock } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { QaSourceToggle, type QaViewMode } from "@/components/QaSourceToggle";
 import { obsidianApi } from "@/lib/api";
 
 interface Props {
@@ -19,6 +20,11 @@ export function ObsidianReader({ path }: Props) {
         queryFn: () => obsidianApi.note(path),
     });
     const [copied, setCopied] = useState(false);
+    const [viewMode, setViewMode] = useState<QaViewMode>("reading");
+
+    useEffect(() => {
+        setViewMode("reading");
+    }, [path]);
 
     const publish = useMutation({
         mutationFn: () => obsidianApi.publish(path),
@@ -79,7 +85,10 @@ export function ObsidianReader({ path }: Props) {
     return (
         <div className="dd-panel flex h-full flex-col overflow-hidden">
             <div className="flex items-center justify-between gap-2 border-b border-[var(--dd-border)] px-3 py-2 text-[11px]">
-                <span className="truncate font-mono text-[var(--dd-text-secondary)]">{path}</span>
+                <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <QaSourceToggle mode={viewMode} onChange={setViewMode} />
+                    <span className="truncate font-mono text-[var(--dd-text-secondary)]">{path}</span>
+                </div>
                 {shareUrl ? (
                     <div className="flex min-w-0 items-center gap-2">
                         <code className="truncate text-[10px] text-[var(--dd-text-muted)]">{shareUrl}</code>
@@ -112,11 +121,17 @@ export function ObsidianReader({ path }: Props) {
                     </Button>
                 )}
             </div>
-            <article
-                className="dd-markdown flex-1 overflow-auto px-5 py-4"
-                dangerouslySetInnerHTML={{ __html: data.html }}
-                onClick={onArticleClick}
-            />
+            {viewMode === "reading" ? (
+                <article
+                    className="dd-markdown flex-1 overflow-auto px-5 py-4"
+                    dangerouslySetInnerHTML={{ __html: data.html }}
+                    onClick={onArticleClick}
+                />
+            ) : (
+                <pre className="flex-1 overflow-auto px-5 py-4 font-mono text-xs whitespace-pre-wrap text-[var(--dd-text-secondary)]">
+                    {data.source}
+                </pre>
+            )}
         </div>
     );
 }

--- a/src/dev-dashboard/ui/vite-middleware.ts
+++ b/src/dev-dashboard/ui/vite-middleware.ts
@@ -8,6 +8,7 @@ import {
     verifyBasicAuthHeader,
     verifySessionToken,
 } from "@app/dev-dashboard/lib/auth";
+import { isPublicShareRequest } from "@app/dev-dashboard/lib/share-auth";
 import { handleWithRouter } from "@app/dev-dashboard/server/adapters/node-connect";
 import { defaultSystemCollector } from "@app/dev-dashboard/server/collector/SystemCollector";
 import { createDashboardRouter, startBackgroundServices } from "@app/dev-dashboard/server/registry";
@@ -23,13 +24,8 @@ import type { Connect } from "vite";
 
 let loggedGeneratedPassword = false;
 
-// Only an exact single-segment /share/<slug> GET bypasses auth. URL already
-// normalizes "..", but matching the precise shape (not a startsWith prefix)
-// makes the bypass intent explicit and refactor-proof.
-const SHARE_BYPASS_RE = /^\/share\/[^/]+$/;
-
 async function requireDashboardAuth(req: IncomingMessage, res: ServerResponse, url: URL): Promise<boolean> {
-    if (req.method === "GET" && SHARE_BYPASS_RE.test(url.pathname)) {
+    if (isPublicShareRequest(req.method ?? "GET", url.pathname)) {
         return true;
     }
 

--- a/src/utils/bun/preload-solid-scoped.ts
+++ b/src/utils/bun/preload-solid-scoped.ts
@@ -13,14 +13,18 @@
  * This preload mirrors the upstream Solid transform but tightens `filter` to
  * files under `src/doctor/` (the only place Solid is used). Everything else
  * goes through Bun's native react-jsx loader untouched.
+ *
+ * Babel packages are loaded lazily via createRequire(PROJECT_ROOT) so preloads
+ * keep working when Bun is invoked from another cwd (tools launcher, IDE hooks).
  */
 
-import { transformAsync } from "@babel/core";
-// @ts-expect-error - no published types
-import babelPresetTypescript from "@babel/preset-typescript";
-// @ts-expect-error - no published types
-import babelPresetSolid from "babel-preset-solid";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { type BunPlugin, plugin as registerBunPlugin } from "bun";
+
+const PROJECT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const requireFromRoot = createRequire(join(PROJECT_ROOT, "package.json"));
 
 const SOLID_PATH_FILTER = /[/\\]src[/\\]doctor[/\\][^?#]*\.[jt]sx(?:[?#].*)?$/;
 
@@ -31,10 +35,34 @@ function stripQueryAndHash(path: string): string {
     return cuts.length === 0 ? path : path.slice(0, cuts[0]);
 }
 
+interface BabelModules {
+    transformAsync: typeof import("@babel/core")["transformAsync"];
+    babelPresetTypescript: unknown;
+    babelPresetSolid: unknown;
+}
+
+let babelModules: BabelModules | undefined;
+
+function loadBabelModules(): BabelModules {
+    if (babelModules) {
+        return babelModules;
+    }
+
+    const { transformAsync } = requireFromRoot("@babel/core") as typeof import("@babel/core");
+    babelModules = {
+        transformAsync,
+        babelPresetTypescript: requireFromRoot("@babel/preset-typescript"),
+        babelPresetSolid: requireFromRoot("babel-preset-solid"),
+    };
+
+    return babelModules;
+}
+
 const scopedSolidPlugin: BunPlugin = {
     name: "bun-plugin-solid-scoped",
     setup(build) {
         build.onLoad({ filter: SOLID_PATH_FILTER }, async (args) => {
+            const { transformAsync, babelPresetTypescript, babelPresetSolid } = loadBabelModules();
             const path = stripQueryAndHash(args.path);
             const code = await Bun.file(path).text();
 

--- a/src/utils/search/stores/sqlite-vec-bootstrap.ts
+++ b/src/utils/search/stores/sqlite-vec-bootstrap.ts
@@ -1,0 +1,99 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+
+interface SqliteVecGlobalState {
+    extensionAvailable: boolean | null;
+    customSqliteAttempted: boolean;
+    homebrewDylibFound: boolean;
+}
+
+interface SqliteVecLog {
+    debug(message: string): void;
+    warn(message: string): void;
+}
+
+const STATE_KEY = Symbol.for("genesis-tools.sqlite-vec.loader-state");
+
+export const HOMEBREW_SQLITE_PATHS = [
+    "/opt/homebrew/opt/sqlite3/lib/libsqlite3.dylib",
+    "/usr/local/opt/sqlite3/lib/libsqlite3.dylib",
+];
+
+function state(): SqliteVecGlobalState {
+    const g = globalThis as typeof globalThis & {
+        [STATE_KEY]?: SqliteVecGlobalState;
+    };
+
+    if (!g[STATE_KEY]) {
+        g[STATE_KEY] = {
+            extensionAvailable: null,
+            customSqliteAttempted: false,
+            homebrewDylibFound: false,
+        };
+    }
+
+    return g[STATE_KEY];
+}
+
+export function getSqliteVecLoaderState(): SqliteVecGlobalState {
+    return state();
+}
+
+export function resetSqliteVecLoaderState(): void {
+    const g = globalThis as typeof globalThis & {
+        [STATE_KEY]?: SqliteVecGlobalState;
+    };
+
+    delete g[STATE_KEY];
+}
+
+export function ensureExtensionCapableSQLiteCore(log?: SqliteVecLog): void {
+    const s = state();
+
+    if (s.customSqliteAttempted) {
+        return;
+    }
+
+    s.customSqliteAttempted = true;
+
+    if (process.platform !== "darwin") {
+        s.homebrewDylibFound = true;
+        return;
+    }
+
+    for (const libPath of HOMEBREW_SQLITE_PATHS) {
+        if (existsSync(libPath)) {
+            try {
+                const swapped = Database.setCustomSQLite(libPath);
+
+                if (swapped === false) {
+                    log?.warn(
+                        `[sqlite-vec] setCustomSQLite(${libPath}) returned false - a Database may have been ` +
+                            "created before the preload ran; sqlite-vec will be unavailable."
+                    );
+                    return;
+                }
+
+                s.homebrewDylibFound = true;
+                log?.debug(`[sqlite-vec] swapped in extension-capable SQLite: ${libPath}`);
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+
+                if (message.includes("SQLite already loaded")) {
+                    log?.debug(
+                        `[sqlite-vec] setCustomSQLite(${libPath}) skipped - SQLite already loaded ` +
+                            "in this process (swap attempted by an earlier module instance / preload)."
+                    );
+                    return;
+                }
+
+                log?.warn(
+                    `[sqlite-vec] setCustomSQLite(${libPath}) failed - sqlite-vec will be unavailable. ` +
+                        `Cause: ${message}`
+                );
+            }
+
+            return;
+        }
+    }
+}

--- a/src/utils/search/stores/sqlite-vec-loader.ts
+++ b/src/utils/search/stores/sqlite-vec-loader.ts
@@ -1,51 +1,15 @@
-import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
+import type { Database } from "bun:sqlite";
 import { logger } from "@app/logger";
+import {
+    ensureExtensionCapableSQLiteCore,
+    getSqliteVecLoaderState,
+    HOMEBREW_SQLITE_PATHS,
+    resetSqliteVecLoaderState,
+} from "./sqlite-vec-bootstrap";
 
-/**
- * `Database.setCustomSQLite()` is a *process-global, one-shot* native call.
- * The guard that tracks "have we already attempted it?" must therefore live
- * at process scope too, NOT module scope.
- *
- * This module is loaded TWICE in a normal `tools` invocation: once via the
- * launcher's `--preload <absolute path>` and once via bunfig.toml's relative
- * `./src/...` preload entry. Bun keys its module cache by specifier, so the
- * absolute and relative paths resolve to two distinct module instances. A
- * module-level `let` guard is `false` in each, so the second instance called
- * `setCustomSQLite()` again — the native side throws "SQLite already loaded"
- * and we logged a spurious WARN (15-27/day) even though the first call had
- * already swapped successfully and sqlite-vec was working fine. Hanging the
- * state off `globalThis` makes both instances share one guard.
- */
-interface SqliteVecGlobalState {
-    extensionAvailable: boolean | null;
-    customSqliteAttempted: boolean;
-    homebrewDylibFound: boolean;
-}
+export { HOMEBREW_SQLITE_PATHS };
 
-const STATE_KEY = Symbol.for("genesis-tools.sqlite-vec.loader-state");
-
-function state(): SqliteVecGlobalState {
-    const g = globalThis as typeof globalThis & {
-        [STATE_KEY]?: SqliteVecGlobalState;
-    };
-
-    if (!g[STATE_KEY]) {
-        g[STATE_KEY] = {
-            extensionAvailable: null,
-            customSqliteAttempted: false,
-            homebrewDylibFound: false,
-        };
-    }
-
-    return g[STATE_KEY];
-}
-
-/** Known paths for Homebrew sqlite3 with extension support (arm64 first) */
-const HOMEBREW_SQLITE_PATHS = [
-    "/opt/homebrew/opt/sqlite3/lib/libsqlite3.dylib",
-    "/usr/local/opt/sqlite3/lib/libsqlite3.dylib",
-];
+const state = getSqliteVecLoaderState;
 
 /**
  * Try to swap bun:sqlite to a build that supports extension loading.
@@ -56,63 +20,7 @@ const HOMEBREW_SQLITE_PATHS = [
  * your program entry point if you plan to use sqlite-vec.
  */
 export function ensureExtensionCapableSQLite(): void {
-    const s = state();
-
-    if (s.customSqliteAttempted) {
-        return;
-    }
-
-    s.customSqliteAttempted = true;
-
-    if (process.platform !== "darwin") {
-        // Linux and Windows ship Bun with extension-capable SQLite already.
-        s.homebrewDylibFound = true;
-        return;
-    }
-
-    for (const libPath of HOMEBREW_SQLITE_PATHS) {
-        if (existsSync(libPath)) {
-            try {
-                const swapped = Database.setCustomSQLite(libPath);
-                if (swapped === false) {
-                    logger.warn(
-                        `[sqlite-vec] setCustomSQLite(${libPath}) returned false - a Database may have been ` +
-                            "created before the preload ran; sqlite-vec will be unavailable."
-                    );
-                    return;
-                }
-
-                s.homebrewDylibFound = true;
-                logger.debug(`[sqlite-vec] swapped in extension-capable SQLite: ${libPath}`);
-            } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-
-                // "SQLite already loaded" is the benign double-attempt: another
-                // module instance / duplicate preload already ran the one-shot
-                // swap in THIS process (the global guard makes that a no-op, but
-                // a path that bypasses it still lands here). If the earlier
-                // attempt succeeded, sqlite-vec works fine; if a Database loaded
-                // SQLite before any swap, loadSqliteVec() reports the real,
-                // actionable failure with its own warn. Either way THIS throw
-                // is not actionable — debug, not warn, so it stops being noise.
-                if (message.includes("SQLite already loaded")) {
-                    logger.debug(
-                        `[sqlite-vec] setCustomSQLite(${libPath}) skipped - SQLite already loaded ` +
-                            "in this process (swap attempted by an earlier module instance / preload)."
-                    );
-
-                    return;
-                }
-
-                logger.warn(
-                    `[sqlite-vec] setCustomSQLite(${libPath}) failed - sqlite-vec will be unavailable. ` +
-                        `Cause: ${message}`
-                );
-            }
-
-            return;
-        }
-    }
+    ensureExtensionCapableSQLiteCore(logger);
 }
 
 /**
@@ -165,9 +73,6 @@ export function loadSqliteVec(db: Database): boolean {
         return false;
     }
 
-    // ensureExtensionCapableSQLite() should already have been called before
-    // any Database was created. Call it here as a safety net, but it may be
-    // too late if a Database instance already exists.
     if (!s.customSqliteAttempted) {
         ensureExtensionCapableSQLite();
     }
@@ -214,9 +119,5 @@ export function isSqliteVecAvailable(): boolean {
  * one-shot swap and availability is re-probed.
  */
 export function resetSqliteVecState(): void {
-    const g = globalThis as typeof globalThis & {
-        [STATE_KEY]?: SqliteVecGlobalState;
-    };
-
-    delete g[STATE_KEY];
+    resetSqliteVecLoaderState();
 }

--- a/src/utils/search/stores/sqlite-vec-preload.ts
+++ b/src/utils/search/stores/sqlite-vec-preload.ts
@@ -1,15 +1,11 @@
 /**
  * Preload script: swaps in extension-capable SQLite before any Database is
  * created in the process. Wired into the `tools` launcher (see `tools`,
- * executeTool) and into bunfig.toml's `preload` plus `[test].preload`.
+ * executeTool) and into bunfig.toml's `preload`.
  *
- * Delegates to ensureExtensionCapableSQLite() so the loader's module-level
- * state is set correctly and every later call is a clean no-op.
- *
- * Usage: bun run --preload ./src/utils/search/stores/sqlite-vec-preload.ts <entry>
+ * Uses sqlite-vec-bootstrap (no @app/* imports) so Bun preloads keep working
+ * when invoked from another cwd (tools launcher, IDE hooks).
  */
-import { logger } from "@app/logger";
-import { ensureExtensionCapableSQLite } from "./sqlite-vec-loader";
+import { ensureExtensionCapableSQLiteCore } from "./sqlite-vec-bootstrap";
 
-ensureExtensionCapableSQLite();
-logger.debug("[sqlite-vec-preload] ensureExtensionCapableSQLite() ran at preload time");
+ensureExtensionCapableSQLiteCore();


### PR DESCRIPTION
## Summary
- Fix Bun preload failures (`@babel/core`, `@app/logger`) when invoked from a non-project cwd by lazy-loading Babel and extracting a logger-free sqlite-vec bootstrap
- Fix published `/share/:slug` URLs incorrectly requiring Basic Auth for `HEAD` requests and trailing-slash paths
- Add raw markdown source toggle to public share pages and the in-app Obsidian reader

## Test plan
- [x] `bun test src/dev-dashboard/lib/share-auth.test.ts src/dev-dashboard/server/auth-guard.test.ts src/dev-dashboard/lib/obsidian/share-template.test.ts src/utils/search/stores/sqlite-vec-loader.test.ts`
- [ ] Restart dev-dashboard and open a published share URL in an incognito window (no Basic Auth prompt)
- [ ] Verify share page FileCode toggle shows raw markdown
- [ ] Verify Obsidian reader reading/source toggle in dashboard UI
- [ ] Confirm `curl -I https://<host>/share/<slug>` returns 200 (not 401)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle to switch shared notes between rendered view and raw markdown source.
  * Public share pages now include the original source content for display in the source view.

* **Bug Fixes**
  * Improved access handling for public share links, including support for `HEAD` requests and trailing slashes.
  * Fixed dashboard auth bypass behavior so public share pages work more reliably.

* **Tests**
  * Added coverage for the new share-view toggle and public share request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->