### PR TITLE
feat(debugging-master): log wrap, expandable DBG panes, full JSON

### DIFF
--- a/src/debugging-master/dashboard/App.tsx
+++ b/src/debugging-master/dashboard/App.tsx
@@ -1,6 +1,6 @@
 import type { IndexedLogEntry, LogLevel } from "@app/debugging-master/types";
 import type { DashboardSession, LogSourceId } from "@app/utils/log-viewer/log-source";
-import { isLogSourceId } from "@app/utils/log-viewer/session-key";
+import { isLogSourceId, sessionKey } from "@app/utils/log-viewer/session-key";
 import { sortSessionsByRecency } from "@app/utils/log-viewer/session-recency";
 import { DirPathPrefixProvider } from "@ui/components/DirPath";
 import { IconTooltipProvider } from "@ui/components/icon-button";
@@ -498,6 +498,11 @@ export function App(): React.ReactElement {
                                                 matchCount={logDisplay.matchCount}
                                                 isSearchActive={logDisplay.isFilterActive}
                                                 jumpEnabled={logDisplay.isSearchActive}
+                                                paneKey={
+                                                    activeSource && activeSession
+                                                        ? sessionKey(activeSource, activeSession)
+                                                        : undefined
+                                                }
                                                 onToggle={onToggleExpand}
                                                 onFilterHypothesis={onChangeHypothesis}
                                                 onAutoScrollChange={onAutoScrollChange}

--- a/src/debugging-master/dashboard/components/ActiveSessionMosaicToolbar.tsx
+++ b/src/debugging-master/dashboard/components/ActiveSessionMosaicToolbar.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 import type { MultiplexLogEntry } from "@/lib/sse";
 import { AutoscrollToggle } from "./AutoscrollToggle";
 import { DisplaySettingsButton } from "./DisplaySettingsButton";
+import { FullJsonContextToggle } from "./FullJsonContextToggle";
 import { LogSearchControl } from "./LogSearchControl";
 import type { LogSearchState } from "./LogSearchPopover";
 import { SessionDeleteButton, SessionRowBar } from "./SessionRowBar";
@@ -10,12 +11,15 @@ import { SessionDeleteButton, SessionRowBar } from "./SessionRowBar";
 interface Props {
     session: DashboardSession;
     lines: MultiplexLogEntry[];
+    paneKey: string;
     logSearch: LogSearchState;
     onLogSearchChange: (next: LogSearchState) => void;
     logMatchCount: number;
     logLineCount: number;
     paused: boolean;
     onTogglePause: () => void;
+    fullJsonContext: boolean;
+    onToggleFullJsonContext: () => void;
     onOpen: () => void;
     onDeleteConfirmed?: () => void;
 }
@@ -31,12 +35,15 @@ function latestLineTimestamp(lines: MultiplexLogEntry[]): number | undefined {
 export function ActiveSessionMosaicToolbar({
     session,
     lines,
+    paneKey,
     logSearch,
     onLogSearchChange,
     logMatchCount,
     logLineCount,
     paused,
     onTogglePause,
+    fullJsonContext,
+    onToggleFullJsonContext,
     onOpen,
     onDeleteConfirmed,
 }: Props): ReactElement {
@@ -56,8 +63,9 @@ export function ActiveSessionMosaicToolbar({
                         matchCount={logMatchCount}
                         lineCount={logLineCount}
                     />
-                    <DisplaySettingsButton variant="log" />
+                    <DisplaySettingsButton variant="log" paneKey={paneKey} />
                     {isLive ? <AutoscrollToggle paused={paused} onToggle={onTogglePause} /> : null}
+                    <FullJsonContextToggle enabled={fullJsonContext} onToggle={onToggleFullJsonContext} />
                     <SessionDeleteButton session={session} onConfirmed={onDeleteConfirmed} />
                 </>
             }

--- a/src/debugging-master/dashboard/components/DisplaySettingsButton.tsx
+++ b/src/debugging-master/dashboard/components/DisplaySettingsButton.tsx
@@ -7,6 +7,7 @@ import {
     type LogFontFamily,
     type TimestampMode,
 } from "@/lib/display-settings";
+import { usePaneWrapLongLines } from "@/lib/use-pane-wrap-long-lines";
 import { useDisplaySettings } from "./DisplaySettingsProvider";
 
 function FontSizeField({
@@ -80,12 +81,18 @@ function LogDisplayFields({
     updateSettings,
     onReset,
     resetLabel,
+    paneKey,
+    showWrap,
 }: {
     settings: ReturnType<typeof useDisplaySettings>["settings"];
     updateSettings: ReturnType<typeof useDisplaySettings>["updateSettings"];
     onReset: () => void;
     resetLabel: string;
+    paneKey?: string;
+    showWrap: boolean;
 }): ReactElement {
+    const paneWrap = usePaneWrapLongLines(paneKey);
+
     return (
         <>
             <SegmentedField<TimestampMode>
@@ -122,6 +129,45 @@ function LogDisplayFields({
                     updateSettings({ showLineId: next === "show" });
                 }}
             />
+            {showWrap ? (
+                <>
+                    <SegmentedField<"wrap" | "nowrap">
+                        legend={paneKey ? "Wrap long lines (pane)" : "Wrap long lines"}
+                        value={
+                            paneKey
+                                ? paneWrap.effective
+                                    ? "wrap"
+                                    : "nowrap"
+                                : settings.wrapLongLines
+                                  ? "wrap"
+                                  : "nowrap"
+                        }
+                        options={[
+                            { value: "wrap", label: "Wrap" },
+                            { value: "nowrap", label: "No wrap" },
+                        ]}
+                        onChange={(next) => {
+                            const wrapLongLines = next === "wrap";
+
+                            if (paneKey) {
+                                paneWrap.setWrapLongLines(wrapLongLines);
+                                return;
+                            }
+
+                            updateSettings({ wrapLongLines });
+                        }}
+                    />
+                    {paneKey && paneWrap.override !== undefined ? (
+                        <button
+                            type="button"
+                            onClick={paneWrap.resetToGlobal}
+                            className="dbg-ui-text-xs uppercase tracking-wider text-cyan-400/70 hover:text-cyan-300"
+                        >
+                            use global wrap ({paneWrap.global ? "wrap" : "no wrap"})
+                        </button>
+                    ) : null}
+                </>
+            ) : null}
             <button
                 type="button"
                 onClick={onReset}
@@ -135,6 +181,7 @@ function LogDisplayFields({
 
 interface Props {
     variant?: "full" | "log";
+    paneKey?: string;
 }
 
 function ResetDefaultsButton({ label, onClick }: { label: string; onClick: () => void }): ReactElement {
@@ -149,7 +196,7 @@ function ResetDefaultsButton({ label, onClick }: { label: string; onClick: () =>
     );
 }
 
-export function DisplaySettingsButton({ variant = "full" }: Props): ReactElement {
+export function DisplaySettingsButton({ variant = "full", paneKey }: Props): ReactElement {
     const { settings, updateSettings, resetTypographySettings, resetLogSettings } = useDisplaySettings();
     const isLogOnly = variant === "log";
 
@@ -205,6 +252,20 @@ export function DisplaySettingsButton({ variant = "full" }: Props): ReactElement
                         }}
                     />
                     <ResetDefaultsButton label="reset typography defaults" onClick={resetTypographySettings} />
+                    <SegmentedField<"wrap" | "nowrap">
+                        legend="Wrap long lines (global)"
+                        value={settings.wrapLongLines ? "wrap" : "nowrap"}
+                        options={[
+                            { value: "wrap", label: "Wrap" },
+                            { value: "nowrap", label: "No wrap" },
+                        ]}
+                        onChange={(next) => {
+                            updateSettings({ wrapLongLines: next === "wrap" });
+                        }}
+                    />
+                    <p className="dbg-ui-text-xs text-white/30">
+                        Global wrap applies to all panes; per-pane wrench can override.
+                    </p>
                 </>
             ) : null}
             <LogDisplayFields
@@ -212,6 +273,8 @@ export function DisplaySettingsButton({ variant = "full" }: Props): ReactElement
                 updateSettings={updateSettings}
                 onReset={resetLogSettings}
                 resetLabel={isLogOnly ? "reset log defaults" : "reset log display defaults"}
+                paneKey={isLogOnly ? paneKey : undefined}
+                showWrap={isLogOnly}
             />
         </IconPopover>
     );

--- a/src/debugging-master/dashboard/components/DisplaySettingsProvider.tsx
+++ b/src/debugging-master/dashboard/components/DisplaySettingsProvider.tsx
@@ -9,6 +9,7 @@ import {
     type DisplaySettings,
     parseDisplaySettings,
 } from "@/lib/display-settings";
+import { clearAllPaneWrapOverrides } from "@/lib/pane-display-overrides";
 
 const { Provider: BaseProvider, useSettings: useBaseDisplaySettings } = createSettingsProvider<DisplaySettings>({
     displayName: "DisplaySettings",
@@ -25,9 +26,17 @@ export function DisplaySettingsProvider({ children }: { children: ReactNode }): 
 export function useDisplaySettings() {
     const base = useBaseDisplaySettings();
 
+    const updateSettings = (partial: Partial<DisplaySettings>) => {
+        if ("wrapLongLines" in partial) {
+            clearAllPaneWrapOverrides();
+        }
+
+        base.updateSettings(partial);
+    };
+
     return {
         settings: base.settings,
-        updateSettings: base.updateSettings,
+        updateSettings,
         resetSettings: base.resetSettings,
         resetTypographySettings: () => {
             base.resetPartial(DEFAULT_TYPOGRAPHY_SETTINGS);

--- a/src/debugging-master/dashboard/components/EntryList.tsx
+++ b/src/debugging-master/dashboard/components/EntryList.tsx
@@ -3,6 +3,7 @@ import { useAutoScroll } from "@app/utils/ui/hooks/useAutoScroll";
 import { memo, useEffect, useImperativeHandle, useMemo } from "react";
 import { DEFAULT_LOG_SEARCH, type LogSearchState } from "@/components/LogSearchPopover";
 import { filterDisplayLogLines, shouldShowLogTimestamp } from "@/lib/log-line-display";
+import { usePaneWrapLongLines } from "@/lib/use-pane-wrap-long-lines";
 import { useScrollToFirstLogMatch } from "@/lib/use-scroll-to-first-log-match";
 import { useDisplaySettings } from "./DisplaySettingsProvider";
 import { EntryRow } from "./EntryRow";
@@ -25,6 +26,7 @@ interface Props {
     matchCount?: number;
     isSearchActive?: boolean;
     jumpEnabled?: boolean;
+    paneKey?: string;
     onToggle: (index: number) => void;
     onFilterHypothesis: (h: string) => void;
     onAutoScrollChange: (enabled: boolean) => void;
@@ -43,12 +45,14 @@ function EntryListImpl({
     matchCount = 0,
     isSearchActive = false,
     jumpEnabled = false,
+    paneKey,
     onToggle,
     onFilterHypothesis,
     onAutoScrollChange,
     resumeRef,
 }: Props): React.ReactElement {
     const { settings } = useDisplaySettings();
+    const { effective: wrapLongLines } = usePaneWrapLongLines(paneKey);
     const { registerScrollContainer } = useLogLineJump();
     const edge = sortDir === "desc" ? "top" : "bottom";
     const visibleEntries = useMemo(() => filterDisplayLogLines(entries), [entries]);
@@ -85,7 +89,12 @@ function EntryListImpl({
     }
 
     return (
-        <div ref={ref} onScroll={onScroll} className="flex-1 overflow-y-auto overflow-x-auto dbg-log-text font-mono">
+        <div
+            ref={ref}
+            onScroll={onScroll}
+            className="flex-1 overflow-y-auto overflow-x-auto dbg-log-text font-mono"
+            data-dbg-wrap-lines={wrapLongLines ? "true" : "false"}
+        >
             {visibleEntries.map((e, index) => {
                 const previousTs = index > 0 ? visibleEntries[index - 1]?.ts : undefined;
                 const showTimestamp = shouldShowLogTimestamp({
@@ -108,6 +117,7 @@ function EntryListImpl({
                         highlightTokens={highlightTokens}
                         isMatch={hit?.isMatch}
                         isContext={hit?.isContext}
+                        fullJsonContext={settings.fullJsonContext}
                         onToggle={onToggle}
                         onFilterHypothesis={onFilterHypothesis}
                     />

--- a/src/debugging-master/dashboard/components/EntryRow.tsx
+++ b/src/debugging-master/dashboard/components/EntryRow.tsx
@@ -25,6 +25,7 @@ interface Props {
     highlightTokens?: string[];
     isMatch?: boolean;
     isContext?: boolean;
+    fullJsonContext?: boolean;
     onToggle: (index: number) => void;
     onFilterHypothesis?: (h: string) => void;
 }
@@ -39,6 +40,7 @@ function EntryRowImpl({
     highlightTokens = [],
     isMatch = false,
     isContext = false,
+    fullJsonContext = false,
     onToggle,
     onFilterHypothesis,
 }: Props): React.ReactElement {
@@ -52,6 +54,16 @@ function EntryRowImpl({
     const inline: InlinePayload = expandable && !expanded ? getInlinePayload(entry) : null;
     const showLevelChip = !entry.msgAnsi;
 
+    const handleToggle = () => {
+        const selection = window.getSelection();
+
+        if (selection && selection.type === "Range" && selection.toString().length > 0) {
+            return;
+        }
+
+        onToggle(entry.index);
+    };
+
     return (
         <div
             className="entry-row"
@@ -61,7 +73,7 @@ function EntryRowImpl({
             data-expandable={expandable ? "true" : "false"}
             data-log-index={entry.index}
             data-log-match={isMatch ? "true" : undefined}
-            onClick={expandable ? () => onToggle(entry.index) : undefined}
+            onClick={expandable ? handleToggle : undefined}
             onKeyDown={
                 expandable
                     ? (e) => {
@@ -144,15 +156,28 @@ function EntryRowImpl({
                 </div>
             </BlinkingBox>
             {inline ? (
-                <div className="json-tree px-3 sm:px-4 pb-1.5 pl-[5.5rem] sm:pl-[6.5rem] text-[11px] truncate-mono">
+                <div
+                    className={`json-tree px-3 sm:px-4 pb-1.5 pl-[5.5rem] sm:pl-[6.5rem] text-[11px] select-text${fullJsonContext ? " dbg-json-inline-full" : " truncate-mono"}`}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                    }}
+                >
                     {inline.kind === "json" ? (
-                        <InlineJsonPreview value={inline.value} maxChars={200} />
+                        <InlineJsonPreview value={inline.value} maxChars={200} unlimited={fullJsonContext} />
                     ) : (
                         <span className="text-rose-200/70">{inline.value}</span>
                     )}
                 </div>
             ) : null}
-            {expanded && expandable ? <ExpandedView entry={entry} /> : null}
+            {expanded && expandable ? (
+                <div
+                    onClick={(event) => {
+                        event.stopPropagation();
+                    }}
+                >
+                    <ExpandedView entry={entry} />
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/src/debugging-master/dashboard/components/FilterBar.tsx
+++ b/src/debugging-master/dashboard/components/FilterBar.tsx
@@ -1,11 +1,14 @@
 import type { LogLevel } from "@app/debugging-master/types";
 import type { DashboardSession } from "@app/utils/log-viewer/log-source";
+import { sessionKey } from "@app/utils/log-viewer/session-key";
 import type { FilterState } from "@/lib/filters";
 import { FILTER_ORDER, LEVEL_META } from "@/lib/levels";
 import { formatSessionHeaderParts } from "@/lib/session-run-context";
 import { SessionLiveStatus } from "@/lib/ui/SessionLiveStatus";
 import { AutoscrollToggle } from "./AutoscrollToggle";
 import { DisplaySettingsButton } from "./DisplaySettingsButton";
+import { useDisplaySettings } from "./DisplaySettingsProvider";
+import { FullJsonContextToggle } from "./FullJsonContextToggle";
 import { LevelTooltip } from "./LevelTooltip";
 import { LogSearchControl } from "./LogSearchControl";
 import type { LogSearchState } from "./LogSearchPopover";
@@ -48,9 +51,11 @@ export function FilterBar({
     onTogglePause,
     onToggleSort,
 }: Props): React.ReactElement {
+    const { settings, updateSettings } = useDisplaySettings();
     const allOn = state.levels.size === FILTER_ORDER.length;
     const sessionContext = session ? formatSessionHeaderParts(session) : null;
     const showSessionContext = Boolean(sessionContext?.cwd || sessionContext?.command);
+    const paneKey = session ? sessionKey(session.source, session.name) : undefined;
 
     return (
         <div className="sticky top-[3.25rem] sm:top-[3.5rem] z-10 glass-card border-b border-white/8 px-3 sm:px-5 py-2.5 flex flex-col gap-2.5">
@@ -106,7 +111,7 @@ export function FilterBar({
                     matchCount={logMatchCount}
                     lineCount={logLineCount}
                 />
-                <DisplaySettingsButton variant="log" />
+                <DisplaySettingsButton variant="log" paneKey={paneKey} />
                 {logSearch.query.trim().length > 0 ? (
                     <span className="dbg-ui-text-xs text-white/35 truncate min-w-0 flex-1">
                         {logSearch.frozen ? (
@@ -150,6 +155,12 @@ export function FilterBar({
                         {sortDir === "asc" ? "↓ newest" : "↑ newest"}
                     </button>
                     <AutoscrollToggle paused={paused} onToggle={onTogglePause} />
+                    <FullJsonContextToggle
+                        enabled={settings.fullJsonContext}
+                        onToggle={() => {
+                            updateSettings({ fullJsonContext: !settings.fullJsonContext });
+                        }}
+                    />
                 </div>
             </div>
         </div>

--- a/src/debugging-master/dashboard/components/FullJsonContextToggle.tsx
+++ b/src/debugging-master/dashboard/components/FullJsonContextToggle.tsx
@@ -1,0 +1,37 @@
+import type { CSSProperties, ReactElement } from "react";
+
+interface Props {
+    enabled: boolean;
+    onToggle: () => void;
+    className?: string;
+}
+
+export function FullJsonContextToggle({ enabled, onToggle, className = "" }: Props): ReactElement {
+    const style: CSSProperties = enabled
+        ? {
+              color: "var(--lvl-info)",
+              borderColor: "rgba(56,189,248,0.45)",
+              background: "rgba(56,189,248,0.08)",
+          }
+        : {
+              color: "rgba(255,255,255,0.55)",
+              borderColor: "rgba(255,255,255,0.12)",
+              background: "transparent",
+          };
+
+    return (
+        <button
+            type="button"
+            onClick={onToggle}
+            className={`dbg-ui-btn inline-flex items-center gap-1.5 uppercase tracking-wider px-2.5 py-1 border rounded-md transition-colors ${className}`}
+            style={style}
+            title={
+                enabled
+                    ? "Showing full JSON context lines (click for truncated preview)"
+                    : "Showing truncated JSON context (click for full copy-pasteable JSON)"
+            }
+        >
+            {enabled ? "full json" : "slice json"}
+        </button>
+    );
+}

--- a/src/debugging-master/dashboard/components/InlineJsonPreview.tsx
+++ b/src/debugging-master/dashboard/components/InlineJsonPreview.tsx
@@ -5,6 +5,8 @@ interface Props {
     value: unknown;
     /** Soft cap on rendered chars; further content is truncated with an ellipsis. */
     maxChars?: number;
+    /** When true, render the full JSON without a char cap. */
+    unlimited?: boolean;
 }
 
 interface RenderCtx {
@@ -23,8 +25,8 @@ interface RenderCtx {
  * scroll, this skips re-rendering the JSON span tree entirely on the common
  * "row remounts at a different scroll offset" path.
  */
-function InlineJsonPreviewImpl({ value, maxChars = 800 }: Props): ReactNode {
-    const ctx: RenderCtx = { out: [], remaining: maxChars, key: 0 };
+function InlineJsonPreviewImpl({ value, maxChars = 800, unlimited = false }: Props): ReactNode {
+    const ctx: RenderCtx = { out: [], remaining: unlimited ? Number.MAX_SAFE_INTEGER : maxChars, key: 0 };
     render(value, ctx);
     return <>{ctx.out}</>;
 }

--- a/src/debugging-master/dashboard/components/SessionsHome.tsx
+++ b/src/debugging-master/dashboard/components/SessionsHome.tsx
@@ -12,6 +12,7 @@ import { Mosaic, type MosaicNode, MosaicWindow } from "react-mosaic-component";
 import { freezeLogSearch } from "@/components/LogSearchPopover";
 import { api } from "@/lib/api";
 import type { TimestampMode } from "@/lib/display-settings";
+import { EntriesContext } from "@/lib/entries-context";
 import { filterDisplayLogLines, shouldShowLogTimestamp, visibleLogText } from "@/lib/log-line-display";
 import { isSessionInActivePool } from "@/lib/session-active-pool";
 import { activeSessionRetentionMs } from "@/lib/session-pool-settings";
@@ -19,12 +20,13 @@ import { formatSessionHeaderParts } from "@/lib/session-run-context";
 import type { ConnectionStatus, MultiplexLogEntry } from "@/lib/sse";
 import { connectActiveStream } from "@/lib/sse";
 import { useLogSearchDisplay } from "@/lib/use-log-search-display";
+import { usePaneWrapLongLines } from "@/lib/use-pane-wrap-long-lines";
 import { useScrollToFirstLogMatch } from "@/lib/use-scroll-to-first-log-match";
 import { ActiveSessionMosaicToolbar } from "./ActiveSessionMosaicToolbar";
 import { DisplaySettingsButton } from "./DisplaySettingsButton";
 import { useDisplaySettings } from "./DisplaySettingsProvider";
+import { EntryRow } from "./EntryRow";
 import { LogLineJumpProvider, useLogLineJump } from "./LogLineJumpProvider";
-import { LogPreviewLine } from "./LogPreviewLine";
 import { SessionHeaderLine } from "./SessionHeaderLine";
 import { SessionPoolSettingsButton } from "./SessionPoolSettingsButton";
 import { useSessionPoolSettings } from "./SessionPoolSettingsProvider";
@@ -161,6 +163,11 @@ function ActiveSessionTile({
     onScroll,
     timestampMode,
     jumpEnabled,
+    expandedIds,
+    onToggleExpand,
+    wrapLongLines,
+    showLineId,
+    fullJsonContext,
 }: {
     lineHits: Array<{ line: MultiplexLogEntry; isMatch: boolean; isContext: boolean }>;
     highlightTokens: string[];
@@ -168,18 +175,25 @@ function ActiveSessionTile({
     onScroll: () => void;
     timestampMode: TimestampMode;
     jumpEnabled: boolean;
+    expandedIds: Set<number>;
+    onToggleExpand: (index: number) => void;
+    wrapLongLines: boolean;
+    showLineId: boolean;
+    fullJsonContext: boolean;
 }): React.ReactElement {
     const { registerScrollContainer } = useLogLineJump();
 
     useEffect(() => {
         registerScrollContainer(scrollRef);
     }, [registerScrollContainer, scrollRef]);
+
     return (
         <div className="h-full flex flex-col bg-black/30">
             <div
                 ref={scrollRef}
                 onScroll={onScroll}
                 className="flex-1 min-h-0 overflow-y-auto overflow-x-auto font-mono dbg-log-text"
+                data-dbg-wrap-lines={wrapLongLines ? "true" : "false"}
             >
                 {lineHits.length === 0 ? (
                     <p className="px-2 py-2 text-white/25 italic">
@@ -195,16 +209,19 @@ function ActiveSessionTile({
                         });
 
                         return (
-                            <LogPreviewLine
+                            <EntryRow
                                 key={`${line.index}-${line.ts}`}
                                 entry={line}
-                                previewText={previewText(line)}
+                                expanded={expandedIds.has(line.index)}
+                                fresh={false}
                                 showTimestamp={showTimestamp}
-                                lineIdPresentation="hover-rail"
+                                showLineId={showLineId}
                                 jumpEnabled={jumpEnabled}
                                 highlightTokens={highlightTokens}
                                 isMatch={isMatch}
                                 isContext={isContext}
+                                fullJsonContext={fullJsonContext}
+                                onToggle={onToggleExpand}
                             />
                         );
                     })
@@ -219,6 +236,7 @@ interface ActiveSessionMosaicPaneProps {
     path: string[];
     lines: MultiplexLogEntry[];
     timestampMode: TimestampMode;
+    showLineId: boolean;
     onOpenSession: (source: LogSourceId, name: string) => void;
     onDeleteConfirmed: (session: DashboardSession) => void;
 }
@@ -228,10 +246,15 @@ function ActiveSessionMosaicPane({
     path,
     lines,
     timestampMode,
+    showLineId,
     onOpenSession,
     onDeleteConfirmed,
 }: ActiveSessionMosaicPaneProps): React.ReactElement {
     const [paused, setPaused] = useState(false);
+    const [expandedIds, setExpandedIds] = useState<Set<number>>(() => new Set());
+    const paneKey = sessionKey(session.source, session.name);
+    const { settings, updateSettings } = useDisplaySettings();
+    const { effective: wrapLongLines } = usePaneWrapLongLines(paneKey);
 
     const onAutoscrollChange = useCallback((enabled: boolean) => {
         setPaused(!enabled);
@@ -267,47 +290,73 @@ function ActiveSessionMosaicPane({
         setPaused(true);
     }, [paused, resume]);
 
+    const onToggleExpand = useCallback((index: number) => {
+        setExpandedIds((prev) => {
+            const next = new Set(prev);
+
+            if (next.has(index)) {
+                next.delete(index);
+            } else {
+                next.add(index);
+            }
+
+            return next;
+        });
+    }, []);
+
     return (
-        <LogLineJumpProvider
-            onBeforeJump={() => {
-                logDisplay.setLogSearch((prev) => freezeLogSearch(prev));
-            }}
-        >
-            <MosaicWindow<string>
-                path={path}
-                title=""
-                toolbarControls={<span />}
-                renderToolbar={() => (
-                    <div className="flex w-full min-w-0">
-                        <ActiveSessionMosaicToolbar
-                            session={session}
-                            lines={lines}
-                            logSearch={logDisplay.logSearch}
-                            onLogSearchChange={logDisplay.setLogSearch}
-                            logMatchCount={logDisplay.matchCount}
-                            logLineCount={logDisplay.lineCount}
-                            paused={paused}
-                            onTogglePause={togglePause}
-                            onOpen={() => {
-                                onOpenSession(session.source, session.name);
-                            }}
-                            onDeleteConfirmed={() => {
-                                onDeleteConfirmed(session);
-                            }}
-                        />
-                    </div>
-                )}
+        <EntriesContext.Provider value={lines}>
+            <LogLineJumpProvider
+                onBeforeJump={() => {
+                    logDisplay.setLogSearch((prev) => freezeLogSearch(prev));
+                }}
             >
-                <ActiveSessionTile
-                    lineHits={lineHits}
-                    highlightTokens={logDisplay.highlightTokens}
-                    scrollRef={ref}
-                    onScroll={onScroll}
-                    timestampMode={timestampMode}
-                    jumpEnabled={logDisplay.isSearchActive}
-                />
-            </MosaicWindow>
-        </LogLineJumpProvider>
+                <MosaicWindow<string>
+                    path={path}
+                    title=""
+                    toolbarControls={<span />}
+                    renderToolbar={() => (
+                        <div className="flex w-full min-w-0">
+                            <ActiveSessionMosaicToolbar
+                                session={session}
+                                lines={lines}
+                                paneKey={paneKey}
+                                logSearch={logDisplay.logSearch}
+                                onLogSearchChange={logDisplay.setLogSearch}
+                                logMatchCount={logDisplay.matchCount}
+                                logLineCount={logDisplay.lineCount}
+                                paused={paused}
+                                onTogglePause={togglePause}
+                                fullJsonContext={settings.fullJsonContext}
+                                onToggleFullJsonContext={() => {
+                                    updateSettings({ fullJsonContext: !settings.fullJsonContext });
+                                }}
+                                onOpen={() => {
+                                    onOpenSession(session.source, session.name);
+                                }}
+                                onDeleteConfirmed={() => {
+                                    onDeleteConfirmed(session);
+                                }}
+                            />
+                        </div>
+                    )}
+                >
+                    <ActiveSessionTile
+                        lineHits={lineHits}
+                        highlightTokens={logDisplay.highlightTokens}
+                        scrollRef={ref}
+                        onScroll={onScroll}
+                        timestampMode={timestampMode}
+                        jumpEnabled={logDisplay.isSearchActive}
+                        expandedIds={expandedIds}
+                        onToggleExpand={onToggleExpand}
+                        wrapLongLines={wrapLongLines}
+                        showLineId={showLineId}
+                        fullJsonContext={settings.fullJsonContext}
+                    />
+                </MosaicWindow>
+            </LogLineJumpProvider>
+        </EntriesContext.Provider>
     );
 }
 
@@ -730,6 +779,7 @@ export function SessionsHome({
                                     path={path}
                                     lines={lines}
                                     timestampMode={settings.timestampMode}
+                                    showLineId={settings.showLineId}
                                     onOpenSession={onOpenSession}
                                     onDeleteConfirmed={clearDeletedSessionLocalState}
                                 />

--- a/src/debugging-master/dashboard/lib/display-settings.ts
+++ b/src/debugging-master/dashboard/lib/display-settings.ts
@@ -52,6 +52,8 @@ export interface DisplaySettings {
     logFontFamily: LogFontFamily;
     timestampMode: TimestampMode;
     showLineId: boolean;
+    wrapLongLines: boolean;
+    fullJsonContext: boolean;
 }
 
 export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
@@ -62,12 +64,19 @@ export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
     logFontFamily: "default",
     timestampMode: "every",
     showLineId: true,
+    wrapLongLines: true,
+    fullJsonContext: false,
 };
 
-export const DEFAULT_LOG_DISPLAY_SETTINGS: Pick<DisplaySettings, "timestampMode" | "lineBoundaries" | "showLineId"> = {
+export const DEFAULT_LOG_DISPLAY_SETTINGS: Pick<
+    DisplaySettings,
+    "timestampMode" | "lineBoundaries" | "showLineId" | "wrapLongLines" | "fullJsonContext"
+> = {
     timestampMode: DEFAULT_DISPLAY_SETTINGS.timestampMode,
     lineBoundaries: DEFAULT_DISPLAY_SETTINGS.lineBoundaries,
     showLineId: DEFAULT_DISPLAY_SETTINGS.showLineId,
+    wrapLongLines: DEFAULT_DISPLAY_SETTINGS.wrapLongLines,
+    fullJsonContext: DEFAULT_DISPLAY_SETTINGS.fullJsonContext,
 };
 
 export const DEFAULT_TYPOGRAPHY_SETTINGS: Pick<
@@ -107,6 +116,8 @@ export function parseDisplaySettings(raw: unknown): DisplaySettings {
         logFontFamily: parseLogFontFamily(parsed.logFontFamily),
         timestampMode: parseTimestampMode(parsed.timestampMode),
         showLineId: parsed.showLineId !== false,
+        wrapLongLines: parsed.wrapLongLines !== false,
+        fullJsonContext: parsed.fullJsonContext === true,
     };
 }
 
@@ -184,4 +195,5 @@ export function applyDisplaySettings(settings: DisplaySettings): void {
     root.dataset.dbgLineBoundaries = settings.lineBoundaries;
     root.dataset.dbgTimestampMode = settings.timestampMode;
     root.dataset.dbgShowLineId = settings.showLineId ? "true" : "false";
+    root.dataset.dbgWrapLines = settings.wrapLongLines ? "true" : "false";
 }

--- a/src/debugging-master/dashboard/lib/pane-display-overrides.test.ts
+++ b/src/debugging-master/dashboard/lib/pane-display-overrides.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import {
+    clearAllPaneWrapOverrides,
+    loadPaneWrapOverrides,
+    resolveWrapLongLines,
+    setPaneWrapOverride,
+} from "@app/debugging-master/dashboard/lib/pane-display-overrides";
+
+describe("pane-display-overrides", () => {
+    it("resolves global when no pane override exists", () => {
+        clearAllPaneWrapOverrides();
+        expect(resolveWrapLongLines(true, "pane-a")).toBe(true);
+        expect(resolveWrapLongLines(false, "pane-a")).toBe(false);
+    });
+
+    it("uses pane override when set", () => {
+        clearAllPaneWrapOverrides();
+        setPaneWrapOverride("pane-a", false);
+        expect(resolveWrapLongLines(true, "pane-a")).toBe(false);
+        expect(loadPaneWrapOverrides()["pane-a"]).toBe(false);
+    });
+});

--- a/src/debugging-master/dashboard/lib/pane-display-overrides.ts
+++ b/src/debugging-master/dashboard/lib/pane-display-overrides.ts
@@ -1,0 +1,56 @@
+import { loadPersistedSettings, savePersistedSettings } from "@ui/settings";
+
+const STORAGE_KEY = "dbg.paneWrapOverrides";
+
+const persistOptions = {
+    storageKey: STORAGE_KEY,
+    defaults: {} as Record<string, boolean>,
+    parse: (raw: unknown): Record<string, boolean> => {
+        if (!raw || typeof raw !== "object") {
+            return {};
+        }
+
+        const out: Record<string, boolean> = {};
+
+        for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+            if (typeof value === "boolean") {
+                out[key] = value;
+            }
+        }
+
+        return out;
+    },
+};
+
+export function loadPaneWrapOverrides(): Record<string, boolean> {
+    return loadPersistedSettings(persistOptions);
+}
+
+export function setPaneWrapOverride(paneKey: string, value: boolean): void {
+    const current = loadPaneWrapOverrides();
+    savePersistedSettings(persistOptions, { ...current, [paneKey]: value });
+}
+
+export function clearPaneWrapOverride(paneKey: string): void {
+    const current = { ...loadPaneWrapOverrides() };
+    delete current[paneKey];
+    savePersistedSettings(persistOptions, current);
+}
+
+export function clearAllPaneWrapOverrides(): void {
+    savePersistedSettings(persistOptions, {});
+}
+
+export function resolveWrapLongLines(global: boolean, paneKey: string | undefined): boolean {
+    if (!paneKey) {
+        return global;
+    }
+
+    const overrides = loadPaneWrapOverrides();
+
+    if (paneKey in overrides) {
+        return overrides[paneKey] ?? global;
+    }
+
+    return global;
+}

--- a/src/debugging-master/dashboard/lib/use-pane-wrap-long-lines.ts
+++ b/src/debugging-master/dashboard/lib/use-pane-wrap-long-lines.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { useDisplaySettings } from "@/components/DisplaySettingsProvider";
+import { clearPaneWrapOverride, loadPaneWrapOverrides, setPaneWrapOverride } from "@/lib/pane-display-overrides";
+
+export function usePaneWrapLongLines(paneKey: string | undefined): {
+    effective: boolean;
+    override: boolean | undefined;
+    global: boolean;
+    setWrapLongLines: (value: boolean) => void;
+    resetToGlobal: () => void;
+} {
+    const { settings } = useDisplaySettings();
+    const [override, setOverride] = useState<boolean | undefined>(() => {
+        if (!paneKey) {
+            return undefined;
+        }
+
+        const overrides = loadPaneWrapOverrides();
+
+        if (paneKey in overrides) {
+            return overrides[paneKey];
+        }
+
+        return undefined;
+    });
+
+    useEffect(() => {
+        if (!paneKey) {
+            setOverride(undefined);
+            return;
+        }
+
+        const overrides = loadPaneWrapOverrides();
+
+        if (paneKey in overrides) {
+            setOverride(overrides[paneKey]);
+            return;
+        }
+
+        setOverride(undefined);
+    }, [paneKey, settings.wrapLongLines]);
+
+    const effective = override ?? settings.wrapLongLines;
+
+    const setWrapLongLines = useCallback(
+        (value: boolean) => {
+            if (!paneKey) {
+                return;
+            }
+
+            setPaneWrapOverride(paneKey, value);
+            setOverride(value);
+        },
+        [paneKey]
+    );
+
+    const resetToGlobal = useCallback(() => {
+        if (!paneKey) {
+            return;
+        }
+
+        clearPaneWrapOverride(paneKey);
+        setOverride(undefined);
+    }, [paneKey]);
+
+    return {
+        effective,
+        override,
+        global: settings.wrapLongLines,
+        setWrapLongLines,
+        resetToGlobal,
+    };
+}

--- a/src/debugging-master/dashboard/styles.css
+++ b/src/debugging-master/dashboard/styles.css
@@ -186,6 +186,24 @@ body {
     overflow-wrap: anywhere;
 }
 
+[data-dbg-wrap-lines="false"] .dbg-log-wrap,
+[data-dbg-wrap-lines="false"] .ansi-log {
+    white-space: pre;
+    overflow-wrap: normal;
+}
+
+.entry-row[data-expandable="true"] .dbg-log-wrap,
+.entry-row .dbg-json-inline-full,
+.entry-row .json-tree.select-text {
+    user-select: text;
+}
+
+.dbg-json-inline-full {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .dbg-log-line__id-rail .dbg-log-line__id-btn {
     color: rgba(255, 255, 255, 0.32);
 }

--- a/src/dev-dashboard/lib/obsidian/share-template.test.ts
+++ b/src/dev-dashboard/lib/obsidian/share-template.test.ts
@@ -20,7 +20,12 @@ describe("renderSharePage", () => {
     test("SRI-pins the Mermaid ESM entry when the note uses mermaid", () => {
         const page = renderSharePage({
             title: "Diagram",
-            rendered: { html: '<div class="mermaid">graph TD; A-->B</div>', hasMath: false, hasMermaid: true, tags: [] },
+            rendered: {
+                html: '<div class="mermaid">graph TD; A-->B</div>',
+                hasMath: false,
+                hasMermaid: true,
+                tags: [],
+            },
             source: "```mermaid\ngraph TD; A-->B\n```",
         });
 

--- a/src/dev-dashboard/lib/obsidian/share-template.test.ts
+++ b/src/dev-dashboard/lib/obsidian/share-template.test.ts
@@ -16,4 +16,27 @@ describe("renderSharePage", () => {
         expect(page).toContain("# Hello\\n\\nWorld");
         expect(page).toContain("Show raw markdown source");
     });
+
+    test("SRI-pins the Mermaid ESM entry when the note uses mermaid", () => {
+        const page = renderSharePage({
+            title: "Diagram",
+            rendered: { html: '<div class="mermaid">graph TD; A-->B</div>', hasMath: false, hasMermaid: true, tags: [] },
+            source: "```mermaid\ngraph TD; A-->B\n```",
+        });
+
+        expect(page).toContain('rel="modulepreload"');
+        expect(page).toContain("mermaid@11.15.0/dist/mermaid.esm.min.mjs");
+        expect(page).toMatch(/integrity="sha384-[A-Za-z0-9+/=]+"/);
+        expect(page).toContain('crossorigin="anonymous"');
+    });
+
+    test("does not emit the Mermaid preload when the note has no mermaid", () => {
+        const page = renderSharePage({
+            title: "Plain",
+            rendered: { html: "<p>plain</p>", hasMath: false, hasMermaid: false, tags: [] },
+            source: "plain",
+        });
+
+        expect(page).not.toContain("mermaid.esm.min.mjs");
+    });
 });

--- a/src/dev-dashboard/lib/obsidian/share-template.ts
+++ b/src/dev-dashboard/lib/obsidian/share-template.ts
@@ -14,6 +14,11 @@ const HLJS_CSS_SRI = "sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH
 const KATEX_CSS_URL = "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css";
 const KATEX_CSS_SRI = "sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+";
 const MERMAID_JS_URL = "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs";
+// SRI for the Mermaid ESM entry. Update whenever MERMAID_JS_URL's version
+// changes (regenerate via `openssl dgst -sha384 -binary <file> | openssl base64
+// -A`). Covers the ~28 KB entry only; lazy-loaded diagram chunks ship from the
+// same CDN unprotected — a full seal needs self-hosting.
+const MERMAID_JS_SRI = "sha384-whY2DyvhZRFfs9hvtGdZaKcgbETgqMlDN+KNlWnXEL2QDa2XQkBOApUT7arfftO9";
 const INTER_FONT_URL =
     "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&family=Lora:ital,wght@0,400;0,600;1,400&display=swap";
 
@@ -509,6 +514,12 @@ export function renderSharePage(options: ShareTemplateOptions): string {
     if (rendered.hasMath) {
         headExtras.push(
             `<link rel="stylesheet" href="${KATEX_CSS_URL}" integrity="${KATEX_CSS_SRI}" crossorigin="anonymous">`
+        );
+    }
+
+    if (rendered.hasMermaid) {
+        headExtras.push(
+            `<link rel="modulepreload" href="${MERMAID_JS_URL}" integrity="${MERMAID_JS_SRI}" crossorigin="anonymous">`
         );
     }
 

--- a/src/utils/terminal/locale.ts
+++ b/src/utils/terminal/locale.ts
@@ -64,12 +64,23 @@ export function resolveUtf8Locale(): string {
 export function buildTerminalSpawnEnv(base: NodeJS.ProcessEnv = env.getProcessEnv()): NodeJS.ProcessEnv {
     const locale = resolveUtf8Locale();
 
-    // NO_COLOR (no-color.org) forces chalk/supports-color to level 0 and overrides
-    // everything else. Some parents (Claude Code subprocess paths, captured tmux
-    // server globals) set it to keep ANSI out of captured output — but for a
-    // terminal we OWN it's poison. Strip it so the child app can decide.
+    // Color env vars come in two shapes: "force monochrome" (NO_COLOR, FORCE_COLOR=0,
+    // CLICOLOR_FORCE=0, CARGO_TERM_COLOR=never, PIP_NO_COLOR=1) and "force color"
+    // (FORCE_COLOR=1, CLICOLOR=1, CLICOLOR_FORCE=1). Parents like Claude Code
+    // subprocess paths or a stale tmux server's captured global env commonly inject
+    // the monochrome variants to keep ANSI out of captured tool output — and once a
+    // tmux server captures them in its global env they outlive every dashboard
+    // restart, making Claude TUI and other coloured CLIs render monochrome forever.
+    // For a terminal we OWN we want colours, so strip the monochrome vars and
+    // overlay positives below. Strips intentionally include FORCE_COLOR/CLICOLOR_FORCE
+    // even though we re-set them — the parent's value may be "0", and a later spread
+    // would otherwise resurrect it.
     const childEnv: NodeJS.ProcessEnv = { ...base };
     delete childEnv.NO_COLOR;
+    delete childEnv.FORCE_COLOR;
+    delete childEnv.CLICOLOR_FORCE;
+    delete childEnv.CARGO_TERM_COLOR;
+    delete childEnv.PIP_NO_COLOR;
 
     return {
         ...childEnv,
@@ -82,6 +93,9 @@ export function buildTerminalSpawnEnv(base: NodeJS.ProcessEnv = env.getProcessEn
         // Claude Code clamps to 256-color whenever $TMUX is set unless this is
         // present at process launch (settings.json is too late — module load time).
         CLAUDE_CODE_TMUX_TRUECOLOR: base.CLAUDE_CODE_TMUX_TRUECOLOR || "1",
+        FORCE_COLOR: "1",
+        CLICOLOR: "1",
+        CLICOLOR_FORCE: "1",
     };
 }
 

--- a/src/utils/tmux/sessions.ts
+++ b/src/utils/tmux/sessions.ts
@@ -13,7 +13,16 @@ export function buildTmuxSpawnEnv(): NodeJS.ProcessEnv {
     return buildTerminalSpawnEnv();
 }
 
-const TMUX_SESSION_ENV_KEYS = ["LANG", "LC_ALL", "LC_CTYPE", "COLORTERM", "CLAUDE_CODE_TMUX_TRUECOLOR"] as const;
+const TMUX_SESSION_ENV_KEYS = [
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "COLORTERM",
+    "CLAUDE_CODE_TMUX_TRUECOLOR",
+    "FORCE_COLOR",
+    "CLICOLOR",
+    "CLICOLOR_FORCE",
+] as const;
 
 function resolveLoginShell(shell: string): string {
     const trimmed = shell.trim();
@@ -227,13 +236,16 @@ export function createTmuxSession(sessionName: string, cwd: string, command: str
  * uses tmux as a session daemon that must outlive restarts, so force the durable
  * options on every time it touches the server.
  *
- * The env scrub fixes a separate bug: if the founder process had `NO_COLOR=1`
- * (Claude Code subprocesses commonly do) or `COLORTERM=""`, tmux captures it in
- * the SERVER GLOBAL env and seeds EVERY new session's shell with the same vars
- * — making Claude TUI render monochrome inside ttyd panes. `-gu NO_COLOR` unsets
- * it for the whole server; setting COLORTERM=truecolor on the global ensures new
- * sessions don't inherit an empty value either. All set-options are idempotent
- * and safe.
+ * The env scrub fixes a separate bug: tmux captures its founder process's env
+ * in the SERVER GLOBAL env and seeds EVERY new session's shell with the same
+ * vars — including any chalk/supports-color poison the founder happened to
+ * carry (NO_COLOR=1, FORCE_COLOR=0, CLICOLOR_FORCE=0, CARGO_TERM_COLOR=never,
+ * PIP_NO_COLOR=1; Claude Code subprocess paths set these to keep ANSI out of
+ * captured tool output, and once tmux freezes them in its global env they
+ * outlive every dashboard restart). `-gu` unsets the monochrome vars for the
+ * whole server, `-g` forces the positive ones, and once a server has been
+ * touched by this function its global env is colour-clean regardless of who
+ * bootstrapped it. All set-options are idempotent and safe.
  */
 export function ensureTmuxServerPersists(tmuxBin?: string): void {
     let bin: string;
@@ -250,7 +262,12 @@ export function ensureTmuxServerPersists(tmuxBin?: string): void {
     // → next createTmuxSession) gets the clean env.
     const setOptionArgs: string[][] = [
         ["set-environment", "-gu", "NO_COLOR"],
+        ["set-environment", "-gu", "CARGO_TERM_COLOR"],
+        ["set-environment", "-gu", "PIP_NO_COLOR"],
         ["set-environment", "-g", "COLORTERM", "truecolor"],
+        ["set-environment", "-g", "FORCE_COLOR", "1"],
+        ["set-environment", "-g", "CLICOLOR", "1"],
+        ["set-environment", "-g", "CLICOLOR_FORCE", "1"],
         ["set-option", "-s", "exit-empty", "off"],
         ["set-option", "-g", "destroy-unattached", "off"],
     ];


### PR DESCRIPTION
## Summary
- Global **wrap long lines** setting (full display wrench) with per-pane override in log wrench; changing global clears pane overrides
- Mosaic DBG panes use **EntryRow** with expandable lines matching session detail view
- **Full JSON** toggle next to autoscroll switches inline context from truncated (200 chars) to copy-pasteable full JSON
- Fix expand row collapsing when selecting text to copy

## Test plan
- [x] `bun test src/debugging-master/dashboard/lib/pane-display-overrides.test.ts`
- [ ] Toggle wrap globally and per-pane in mosaic wrench; verify horizontal scroll when wrap off
- [ ] Expand lines in DBG mosaic pane and detail view; select/copy text without collapse
- [ ] Toggle full JSON next to autoscroll; verify inline context shows complete payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a source/reading toggle on shared note pages, including a control to show the raw markdown source.
  * Added per-pane “wrap long lines” controls and a full JSON context mode in the debugging dashboard (with per-pane reset to the global wrap setting).
* **Bug Fixes**
  * Public share links now work more reliably for `GET`/`HEAD` requests, including trailing slashes.
  * Expanded log rows now avoid accidental toggles when selecting text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->