### PR TITLE
feat(agents): cross-agent communication CLI

### DIFF
--- a/plugins/genesis-tools/hooks/agents-talk-hint.ts
+++ b/plugins/genesis-tools/hooks/agents-talk-hint.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+
+import { SafeJSON } from "@app/utils/json";
+
+const reminder =
+    "Before spawning subagents that need to communicate with each other or with you, invoke `/gt:agents-talk` (the cross-agent messaging protocol via `tools agents`).";
+
+const payload = {
+    hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: reminder,
+    },
+};
+
+process.stdout.write(`${SafeJSON.stringify(payload, { strict: true })}\n`);

--- a/plugins/genesis-tools/hooks/hooks.json
+++ b/plugins/genesis-tools/hooks/hooks.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/track-session-files.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/agents-talk-hint.ts"
           }
         ]
       }

--- a/plugins/genesis-tools/skills/agents-talk/SKILL.md
+++ b/plugins/genesis-tools/skills/agents-talk/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: agents-talk
+description: Cross-agent messaging protocol via `tools agents`. Use when the main agent is about to spawn subagents that should be able to message each other (or back to the main agent) during their work. Teaches the login (auto-registers) / message / discover / listen pattern, the stream-vs-once receive modes, and the no-loss delivery contract.
+---
+
+# `/agents-talk` — cross-agent communication protocol
+
+You're about to spawn (or have just been spawned as) one of N agents that need to exchange messages while they work. This skill teaches how. **All communication goes through `tools agents`.** No MCP server is required.
+
+## Mental model in one sentence
+
+There's a shared **feed.jsonl** per session under `~/.genesis-tools/agents/<session>/`. Anyone can append events (login auto-registers, message). Each agent runs a long-lived `login` process that tails the feed, filters lines addressed to them, and emits them as JSONL on stdout — which the harness `Monitor` tool follows.
+
+## Topology (the only one you need)
+
+```text
+                  ┌──────────────────────────┐
+   ┌──────────►   │     feed.jsonl           │   ◄──────────┐
+   │              │   (append-only, seq #)   │              │
+   │              └──────────────────────────┘              │
+   │       ▲                                       ▲        │
+   │       │ append                                │ append │
+   │       │                                       │        │
+   │  ┌────┴────┐         ┌─────────┐         ┌────┴────┐  │
+   └──┤  lead   │         │ research│         │ reviewer├──┘
+      │ (main_) │         │ er      │         │         │
+      └─────────┘         └─────────┘         └─────────┘
+        login                login                login
+        (stream)             (once-loop          (once-loop
+                              or stream)          or stream)
+```
+
+Every agent is symmetric: anyone can message anyone, anyone can broadcast. The "lead" is just an agent with `main_` prefix and `is_main:true` in the registry.
+
+## Main agent flow (you're the orchestrator)
+
+```bash
+# 1. Attach as main. login auto-registers on first use — no separate register
+#    step. Run via run_in_background:true so your main turn can keep working
+#    while a background process tails messages back to you via Monitor.
+tools agents login --agent-main --agent-name lead                  # (background; stream mode)
+
+# 2. Spawn each subagent (via the Agent tool with run_in_background:true).
+#    Include in their prompt: "Right after you start, run: tools agents login --agent-name <name>"
+#    There's no pre-allocated slot to wait on — the subagent's own login call
+#    auto-registers it the moment it runs.
+
+# 3. Send instructions to a subagent (after it has logged in):
+tools agents message --from lead --to researcher \
+  --body 'find recent React Compiler benchmarks and post the findings'
+
+# 4. Broadcast to all:
+tools agents message --from lead \
+  --body 'team status check'
+
+# 5. Inspect the roster any time:
+tools agents discover
+
+# 6. Watch the whole conversation in a separate terminal (human-friendly):
+tools agents listen
+
+# Enable verbose lifecycle visibility for ALL peers (default: only main sees
+# stream-mode join/leave + real-failure logout; other peers see nothing):
+tools agents login --agent-main --agent-name lead --debug
+```
+
+## Subagent flow (you've just been spawned)
+
+Your spawn prompt should already include your `--agent-name`. The very first thing you do:
+
+```bash
+# A. Log in (auto-registers on first use — no separate register step). Two
+# modes — pick based on your harness:
+#
+# Claude Code (you have access to the Monitor tool): use stream mode + background spawn.
+tools agents login --agent-name researcher           # run via run_in_background:true,
+                                                     # then use Monitor on that shell to
+                                                     # receive each new line as it arrives.
+#
+# Other hosts (no Monitor): use --once in a loop.
+while true; do
+  tools agents login --agent-name researcher --once  # blocks until a message arrives,
+                                                     # prints it, exits 0. Re-invoke.
+done
+```
+
+> ⚠️ **Monitor only stdout, never stderr.** `login`'s stdout is the JSONL event stream. Stderr is for diagnostics (auto-registration notices, the resume-hint on exit, warnings). If you pipe with `2>&1` you'll see log lines in your event stream and the agent will treat them as malformed events. Correct form: `tools agents login --agent-name X | <pipeline>` — no `2>&1`. If using a Monitor harness directly, point it at stdout only.
+
+`login` writes received events to stdout as JSONL lines. Each line is one event you should react to.
+
+```bash
+# B. Send a message to a specific peer:
+tools agents message --from researcher --to reviewer \
+  --body 'I found library X has a critical bug in v2.1'
+
+# C. Broadcast (no --to):
+tools agents message --from researcher \
+  --body 'finding #1 ready for review'
+
+# D. Reply to a specific message (auto-routes to its sender, correlates by message_id):
+tools agents message --from reviewer --reply 0001 \
+  --body 'confirmed — also affects v2.0'
+
+# E. Pure ack (no body):
+tools agents message --from reviewer --reply 0001
+```
+
+## What you receive on the `login` stream
+
+Each event is a JSON line. The most important `type` values:
+
+| type | meaning |
+|---|---|
+| `message` | someone sent you (or broadcast) something. There is no separate `respond`/`ack` event — a reply is a `message` with `in_reply_to` set to the original `message_id` (empty `body` = pure ack). |
+| `logged_in` / `logged_out` | a peer joined or left. Main agents see real joins/leaves by default; non-main peers see nothing unless the swarm was started with `--debug`. `--once`-mode polling churn is always hidden. |
+
+**You never see your own sends.** The CLI filters out events where `from_agent_id == your id` before they reach your stream — no echo-prevention logic needed on your end.
+
+**The tool dedupes for you.** Delivery uses a monotonic per-agent cursor (`slots/<agent_id>.cursor`), not a content hash — a crashed-and-reconnected receive process resumes from its last-acked `seq` instead of re-emitting already-seen events.
+
+## Receive-mode comparison
+
+| | `--stream` (default, CC) | `--once` (any host) |
+|---|---|---|
+| Lifetime | Long-running, ~1h sanity cap | Returns when a message arrives or harness kills it |
+| Harness tool | `Monitor` follows stdout | Caller re-invokes in a loop |
+| Resume after exit | Continues where it left off | Continues where it left off |
+| Cost | One held process per agent | One short-lived call per receive |
+| Best for | Always-on receive during a task | Polling pattern when Monitor isn't available |
+
+On exit (signal, cap, or crash), the tool prints a `tools agents login ...` resume command on **stderr** so the caller knows exactly how to continue.
+
+## Session resolution
+
+The CLI auto-detects the session in this order:
+
+1. `--session <id>` explicit
+2. `$CLAUDE_CODE_SESSION_ID` env var (set by Claude Code; subagent Bash inherits it)
+3. Single session active (feed touched) in the last 60 seconds
+4. Otherwise: a friendly error asking for `--session` or `$CLAUDE_CODE_SESSION_ID`
+
+You normally don't pass `--session` — it's automatic.
+
+## Common pitfalls
+
+- **Don't poll the file yourself with `cat`.** Use `login` (or `login --once`). The tool handles cursors, dedup, and filtering.
+- **There's no separate register step.** `login --agent-name X` auto-registers X the first time it's called — just spawn the subagent and have it call `login` directly.
+- **Don't message agents that aren't registered.** You'll get an error. Call `discover` if unsure.
+- **Don't expect mid-tool-call interrupts.** Stream-mode `login` delivers between tool calls (via Monitor), `login --once` returns when next called. Neither preempts a running tool.
+- **One main per session.** A second `login --agent-main` errors. Use a different `--agent-name` for additional coordinators.
+
+## Quick reference
+
+| Command | Purpose |
+|---|---|
+| `tools agents login --agent-main --agent-name lead [--debug]` | Auto-register + attach as main, stream mode (optionally enable verbose lifecycle for the whole swarm) |
+| `tools agents login --agent-name X` | Auto-register + attach as X, stream mode (Monitor follows stdout) |
+| `tools agents login --agent-name X --once` | Auto-register + attach, one-shot mode (poll loop) |
+| `tools agents login --agent-id Y --agent-name X` | Attach with a chosen id |
+| `tools agents message --from X --to Y --body '...'` | Direct |
+| `tools agents message --from X --body '...'` | Broadcast (every peer except the sender) |
+| `tools agents message --from X --reply 0001 --body '...'` | Reply (auto-routes to the original sender) |
+| `tools agents message --from X --reply 0001` | Pure ack (no body) |
+| `tools agents discover` | List all agents in session |
+| `tools agents listen` | Human-facing color-formatted feed follower (sees everything) |
+
+### ID formats (per session)
+
+- `agent_id` for subagents: `agt_0001` → `agt_ffff` (monotonic, 4-hex zero-padded)
+- `agent_id` for the main agent: `main_<sessionSlug>` (derived from session id; recognizable at a glance)
+- `message_id`: `0001` → `ffff` (monotonic, 4-hex, same cap as agent_id)
+- `seq`: monotonic feed sequence number (decimal, unbounded for v1 practical use)

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -1,0 +1,78 @@
+# `tools agents` — cross-agent communication
+
+CLI for **bi-directional messaging across a swarm of LLM agents** (main agent ↔ subagent ↔ subagent), via a per-session append-only feed at `~/.genesis-tools/agents/<session-id>/feed.jsonl`. No daemon, no MCP server, no network. Built on the GenesisTools storage primitives.
+
+For the *protocol-level* documentation aimed at the agents themselves (when to call which command, mode choices, etc.), see [`plugins/genesis-tools/skills/agents-talk/SKILL.md`](../../plugins/genesis-tools/skills/agents-talk/SKILL.md) (`/gt:agents-talk`).
+
+For the design background and research, see [`.claude/plans/2026-06-29-AgentsTalk-design.md`](../../.claude/plans/2026-06-29-AgentsTalk-design.md).
+
+## Commands
+
+```bash
+tools agents login --agent-name lead --agent-main              # auto-registers + attaches, stream mode
+tools agents login --agent-name researcher                     # auto-registers + attaches (stream mode)
+tools agents login --agent-id agt_xxx --agent-name X            # attach with a chosen id
+tools agents login --agent-name X --once                       # one-shot (poll loop)
+tools agents message --from X --to Y --body '...'
+tools agents message --from X --body '...'                     # broadcast (no --to)
+tools agents message --from X --reply 0001 --body '...'        # reply (auto-routes to original sender)
+tools agents message --from X --reply 0001                     # pure ack (no body)
+tools agents discover                                          # list registry
+tools agents listen                                            # human-facing color follower
+```
+
+There is no separate `register` command — `login` auto-registers on first use for a given `--agent-name`/`--agent-id`. There is no separate `respond` command — replies go through `message --reply <msg-id>`.
+
+## Session resolution
+
+Resolves in order:
+
+1. `--session <id>` explicit
+2. `$CLAUDE_CODE_SESSION_ID` env var
+3. Single session active (feed touched) in the last 60s
+4. Otherwise: friendly error asking for `--session` or `$CLAUDE_CODE_SESSION_ID`
+
+## Key files (per session)
+
+```
+~/.genesis-tools/agents/<session>/
+  feed.jsonl          ← append-only event log, monotonic seq — the single source of truth
+  session-meta.json   ← {debug} session-wide flags
+  slots/<id>.login    ← live login PID lock (one per attached agent)
+  slots/<id>.cursor   ← per-agent delivery cursor {seq} — also the only dedup mechanism
+```
+
+The registry (who's registered, logged in/out) is derived by replaying `feed.jsonl` on every read — there is no persisted `registry.json` or counters file.
+
+## Reused utilities
+
+- `@app/utils/storage` (`withFileLock`, atomic writes)
+- `@app/utils/storage/storage` (`atomicWriteFileSync`)
+- `@app/utils/storage/stale-lock-sweep` (new — generic stale-PID lock reaper)
+- `@app/utils/log-session/jsonl-reader` (line-safe JSONL parsing)
+- `@app/utils/json` (`SafeJSON`, never `JSON`)
+- `@app/utils/process-alive` (`isProcessAlive`)
+- `@app/utils/cli` (`runTool`, `suggestCommand`, `isInteractive`)
+- `@app/utils/env` (`env.tools.getHome()`)
+
+## V1 limits
+
+- `message_id` capped at `ffff` (65536 messages per session). Counter exhaustion is a hard error.
+- `private:true` is stored in the feed but **not enforced** (anyone with FS access reads everything). V2 will add per-recipient sharding.
+- No cross-session messaging. Each session is its own feed.
+- No HTTP / TCP transport. Local FS only.
+- One main per session (enforced via `is_main:true` uniqueness).
+- Listener (`listen`) is read-only; never claim it can interact.
+
+## Build / test
+
+```bash
+bunx tsgo --noEmit                                # type-check
+tools agents --help                               # show command tree
+tools agents login --agent-main --agent-name lead --once --session demo
+tools agents discover --session demo
+```
+
+## Why a CLI, not an MCP server?
+
+Per the research at `.claude/plans/2026-06-29-AgentsTalk-design.md`: MCP cannot push, only respond to tool calls. By using a CLI whose `login` writes JSONL to stdout, we let the agent's harness `Monitor` tool deliver lines as notifications — sidestepping the entire blocking-MCP-tool / lost-result class of bugs. Send is also a tool call (any `tools agents message`), but receive is a streaming process. This composes with every host that can spawn background processes and read stdout, not just hosts with an MCP client.

--- a/src/agents/commands/discover.ts
+++ b/src/agents/commands/discover.ts
@@ -1,0 +1,89 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import chalk from "chalk";
+import type { Command } from "commander";
+import { readCursor } from "../lib/cursor";
+import { deriveRegistry } from "../lib/derived-registry";
+import { runWithFriendlyErrors } from "../lib/errors";
+import { readFeed } from "../lib/feed";
+import { ensureSessionDir, sessionPaths } from "../lib/paths";
+import { resolveSession } from "../lib/session-resolve";
+import { runStaleSweep } from "../lib/slot-lock";
+
+interface DiscoverOpts {
+    session?: string;
+    format?: "json" | "table";
+}
+
+async function runDiscoverImpl(opts: DiscoverOpts): Promise<void> {
+    const resolved = resolveSession(opts.session);
+    const paths = sessionPaths(resolved.session);
+    ensureSessionDir(paths);
+    await runStaleSweep(paths);
+
+    const events = await readFeed(paths);
+    const records = deriveRegistry(events);
+    const format = opts.format ?? (process.stdout.isTTY ? "table" : "json");
+
+    if (format === "json") {
+        out.result(SafeJSON.stringify(records, { strict: true }));
+        return;
+    }
+
+    if (records.length === 0) {
+        out.println(chalk.dim(`(no agents registered in session "${paths.session}")`));
+        return;
+    }
+
+    const rows: string[][] = [["AGENT_ID", "NAME", "STATUS", "MAIN", "ROLE", "LAST_SEQ"]];
+
+    for (const r of records) {
+        let status = "registered";
+
+        if (r.logged_in_at) {
+            status = r.logged_out_at ? "logged_out" : "logged_in";
+        }
+
+        rows.push([
+            r.agent_id || "(awaiting login)",
+            r.agent_name,
+            status,
+            r.is_main ? "yes" : "",
+            r.role ?? "",
+            String(readCursor(paths, r.agent_id)),
+        ]);
+    }
+
+    const colWidths = rows[0]?.map((_, idx) => Math.max(...rows.map((row) => (row[idx] ?? "").length))) ?? [];
+
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+
+        if (!row) {
+            continue;
+        }
+
+        const line = row.map((cell, idx) => cell.padEnd(colWidths[idx] ?? 0)).join("  ");
+
+        if (i === 0) {
+            out.println(chalk.bold(line));
+        } else {
+            out.println(line);
+        }
+    }
+}
+
+export async function runDiscover(opts: DiscoverOpts): Promise<void> {
+    await runWithFriendlyErrors(() => runDiscoverImpl(opts));
+}
+
+export function registerDiscoverCommand(program: Command): void {
+    program
+        .command("discover")
+        .description("List all registered agents in the session")
+        .option("--session <id>", "Override session resolution")
+        .option("--format <fmt>", "Output format: json or table (default: table on TTY, json otherwise)")
+        .action(async (opts: DiscoverOpts) => {
+            await runDiscover(opts);
+        });
+}

--- a/src/agents/commands/listen.ts
+++ b/src/agents/commands/listen.ts
@@ -1,0 +1,223 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { logger, out } from "@app/logger";
+import { isInteractive } from "@app/utils/cli";
+import { watchFileFeed } from "@app/utils/fs/file-feed-watcher";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { deriveRegistry } from "../lib/derived-registry";
+import { readFeed, readFeedSince } from "../lib/feed";
+import { formatEventPretty } from "../lib/format-pretty";
+import { onShutdown } from "../lib/lifecycle";
+import { agentsRoot, ensureSessionDir, sessionPaths } from "../lib/paths";
+import { runStaleSweep } from "../lib/slot-lock";
+import type { FeedEvent } from "../lib/types";
+
+const RECENT_WINDOW_MS = 60 * 60 * 1000;
+const WATCH_DEBOUNCE_MS = 200;
+
+const log = logger.child({ component: "agents:listen" });
+
+interface ListenOpts {
+    session?: string;
+    sessionName?: string;
+    recentHour?: boolean;
+    format?: "pretty" | "json";
+}
+
+interface SessionSummary {
+    session: string;
+    mainName: string | null;
+    agentCount: number;
+    lastEventAgo: string;
+    mtimeMs: number;
+}
+
+async function listSessions(): Promise<SessionSummary[]> {
+    const root = agentsRoot();
+
+    if (!existsSync(root)) {
+        return [];
+    }
+
+    const entries = readdirSync(root);
+    const out: SessionSummary[] = [];
+
+    for (const entry of entries) {
+        const dir = join(root, entry);
+
+        try {
+            const stat = statSync(dir);
+
+            if (!stat.isDirectory()) {
+                continue;
+            }
+        } catch (err) {
+            log.debug({ err, dir }, "skipping unreadable agents session directory");
+            continue;
+        }
+
+        const paths = sessionPaths(entry);
+
+        if (!existsSync(paths.feedPath)) {
+            continue;
+        }
+
+        const events = await readFeed(paths);
+        const records = deriveRegistry(events);
+        const main = records.find((r) => r.is_main);
+        const mtime = statSync(paths.feedPath).mtimeMs;
+        out.push({
+            session: entry,
+            mainName: main ? main.agent_name : null,
+            agentCount: records.length,
+            lastEventAgo: formatAgo(Date.now() - mtime),
+            mtimeMs: mtime,
+        });
+    }
+
+    return out.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+function formatAgo(ms: number): string {
+    if (ms < 1000) {
+        return "now";
+    }
+
+    if (ms < 60_000) {
+        return `${Math.floor(ms / 1000)}s ago`;
+    }
+
+    if (ms < 3_600_000) {
+        return `${Math.floor(ms / 60_000)}m ago`;
+    }
+
+    if (ms < 86_400_000) {
+        return `${Math.floor(ms / 3_600_000)}h ago`;
+    }
+
+    return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+async function pickSession(opts: ListenOpts): Promise<string | null> {
+    if (opts.session) {
+        return opts.session;
+    }
+
+    if (opts.sessionName) {
+        const sessions = await listSessions();
+        const found = sessions.find((s) => s.mainName === opts.sessionName);
+        return found ? found.session : null;
+    }
+
+    const sessions = await listSessions();
+    const filtered = opts.recentHour ? sessions.filter((s) => Date.now() - s.mtimeMs < RECENT_WINDOW_MS) : sessions;
+
+    if (filtered.length === 0) {
+        return null;
+    }
+
+    if (!isInteractive()) {
+        if (filtered.length === 1 && filtered[0]) {
+            return filtered[0].session;
+        }
+
+        out.log.warn(`multiple active sessions; pass --session <id> or --session-name <name>. Available:`);
+
+        for (const s of filtered) {
+            out.println(`  ${s.session}  ${s.mainName ?? "(no main)"}  ${s.agentCount} agents  ${s.lastEventAgo}`);
+        }
+
+        return null;
+    }
+
+    const { select } = await import("@app/utils/prompts/clack");
+    const choices = filtered.map((s) => ({
+        label: `${s.session.slice(0, 12)} — ${s.mainName ?? "(no main)"} — ${s.agentCount} agents — ${s.lastEventAgo}`,
+        value: s.session,
+    }));
+    const picked = await select({ message: "Pick a session to follow:", options: choices });
+    return typeof picked === "string" ? picked : null;
+}
+
+function nextListenerId(): string {
+    return `obs_${randomBytes(3).toString("hex")}`;
+}
+
+function emitPretty(event: FeedEvent, format: "pretty" | "json"): void {
+    if (format === "json") {
+        out.println(SafeJSON.stringify(event, { strict: true }));
+    } else {
+        out.println(formatEventPretty(event));
+    }
+}
+
+export async function runListen(opts: ListenOpts): Promise<void> {
+    const session = await pickSession(opts);
+
+    if (!session) {
+        out.log.error("no session selected; nothing to listen to");
+        process.exit(1);
+        return;
+    }
+
+    const paths = sessionPaths(session);
+    ensureSessionDir(paths);
+    await runStaleSweep(paths);
+
+    const format = opts.format ?? (process.stdout.isTTY ? "pretty" : "json");
+    const listenerId = nextListenerId();
+    let lastSeq = 0;
+
+    const controller = new AbortController();
+
+    onShutdown(() => {
+        log.debug({ listenerId }, "listener detaching");
+        controller.abort();
+    });
+
+    const initial = await readFeed(paths);
+
+    for (const event of initial) {
+        emitPretty(event, format);
+
+        if (event.seq > lastSeq) {
+            lastSeq = event.seq;
+        }
+    }
+
+    // watchFileFeed always runs a poll-fallback timer alongside fs.watch (not
+    // gated on watch() succeeding), so a watcher setup/runtime failure can't
+    // strand this command waiting forever — the prior hand-rolled watch()
+    // here only logged "using poll-only" without ever actually polling.
+    await watchFileFeed({
+        path: paths.feedPath,
+        debounceMs: WATCH_DEBOUNCE_MS,
+        signal: controller.signal,
+        onChange: async () => {
+            const next = await readFeedSince(paths, lastSeq);
+
+            for (const event of next) {
+                emitPretty(event, format);
+
+                if (event.seq > lastSeq) {
+                    lastSeq = event.seq;
+                }
+            }
+        },
+    });
+}
+
+export function registerListenCommand(program: Command): void {
+    program
+        .command("listen")
+        .description("Follow a session feed in human-friendly form")
+        .option("--session <id>", "Session id to follow")
+        .option("--session-name <name>", "Pick session whose main agent has this name")
+        .option("--recent-hour", "Only consider sessions active in the last hour when picking")
+        .option("--format <fmt>", "pretty (default in TTY) or json")
+        .action(async (opts: ListenOpts) => {
+            await runListen(opts);
+        });
+}

--- a/src/agents/commands/login.ts
+++ b/src/agents/commands/login.ts
@@ -1,0 +1,496 @@
+import { logger, out } from "@app/logger";
+import { isInteractive } from "@app/utils/cli";
+import { watchFileFeed } from "@app/utils/fs/file-feed-watcher";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { readCursor, writeCursor } from "../lib/cursor";
+import { deriveRegistry, findById, findByName, nextSubagentId } from "../lib/derived-registry";
+import { FriendlyError, runWithFriendlyErrors } from "../lib/errors";
+import { readFeedSince, withFeedLock } from "../lib/feed";
+import { isVisibleToAgent } from "../lib/filter";
+import { formatEventPretty } from "../lib/format-pretty";
+import { deriveMainAgentId, isMainId } from "../lib/id-gen";
+import { onShutdown } from "../lib/lifecycle";
+import { ensureSessionDir, sessionPaths } from "../lib/paths";
+import { readSessionMeta, type SessionMeta } from "../lib/session-meta";
+import { resolveSession } from "../lib/session-resolve";
+import { readSlotPayload, releaseSlot, runStaleSweep, slotLockPath, tryAcquireSlot } from "../lib/slot-lock";
+import type { AgentRecord, FeedEvent, SessionPaths, SlotLockPayload } from "../lib/types";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const log = logger.child({ component: "agents:login" });
+
+interface LoginOpts {
+    agentId?: string;
+    agentName?: string;
+    agentMain?: boolean;
+    role?: string;
+    meta?: string;
+    debug?: boolean;
+    once?: boolean;
+    session?: string;
+    observer?: boolean;
+    format?: "pretty" | "json";
+}
+
+interface ActiveLogin {
+    paths: SessionPaths;
+    record: AgentRecord;
+    lockPath: string;
+    mode: "stream" | "once";
+    meta: SessionMeta;
+    observer: boolean;
+    format: "pretty" | "json";
+    cursorSeq: number;
+}
+
+async function pickAgent(records: AgentRecord[]): Promise<AgentRecord | null> {
+    if (records.length === 0) {
+        return null;
+    }
+
+    if (records.length === 1 && records[0]) {
+        return records[0];
+    }
+
+    if (!isInteractive()) {
+        return null;
+    }
+
+    const { select } = await import("@app/utils/prompts/clack");
+    const choices = records.map((r) => ({
+        label: `${r.agent_name} (${r.agent_id || "awaiting login"})${r.is_main ? " — main" : ""}`,
+        value: r.agent_id || r.agent_name,
+    }));
+    const picked = await select({ message: "Which agent should I log in as?", options: choices });
+
+    if (typeof picked !== "string") {
+        return null;
+    }
+
+    const found = findById(records, picked) ?? records.find((r) => r.agent_name === picked) ?? null;
+    return found;
+}
+
+function parseMeta(raw: string | undefined): Record<string, unknown> {
+    if (!raw) {
+        return {};
+    }
+
+    const parsed = SafeJSON.parse(raw);
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new FriendlyError("--meta must be a JSON object", `Example: --meta '{"role":"reader"}'`);
+    }
+
+    return parsed as Record<string, unknown>;
+}
+
+/**
+ * Resolve which agent we're attaching as — or atomically register a new one.
+ *
+ * Both branches (lookup-existing + create-new) run inside ONE withFeedLock
+ * critical section so two parallel `login --agent-name X` invocations cannot
+ * derive the same agt_xxxx id and double-register.
+ */
+async function findOrRegisterAgent(paths: SessionPaths, opts: LoginOpts): Promise<AgentRecord> {
+    if (!opts.agentId && !opts.agentName) {
+        // No --agent-id/--agent-name to resolve or register — just an interactive
+        // pick from the existing registry. Read outside withFeedLock so
+        // pickAgent()'s prompt (which can wait indefinitely on user input) never
+        // holds the feed lock and blocks every other agent's send/login/lifecycle
+        // append for the session.
+        const { readFeed } = await import("../lib/feed");
+        const registry = deriveRegistry(await readFeed(paths));
+        const picked = await pickAgent(registry);
+
+        if (picked) {
+            return picked;
+        }
+
+        throw new FriendlyError(
+            registry.length === 0
+                ? `no agents in session "${paths.session}"; log in with --agent-name <name>`
+                : "--agent-id or --agent-name is required (multiple agents in session; could not auto-pick)",
+            registry.length === 0
+                ? `Example:\n  tools agents login --agent-name lead --agent-main\n  tools agents login --agent-name researcher`
+                : `Available agents in "${paths.session}":\n  ${registry.map((r) => `tools agents login --agent-name ${r.agent_name}`).join("\n  ")}`
+        );
+    }
+
+    return withFeedLock(paths, async ({ events, appendNonMessage }) => {
+        const registry = deriveRegistry(events);
+
+        if (opts.agentId) {
+            const found = findById(registry, opts.agentId);
+
+            if (found) {
+                if (opts.agentName && found.agent_name !== opts.agentName) {
+                    throw new FriendlyError(
+                        `agent_id ${opts.agentId} belongs to "${found.agent_name}", not "${opts.agentName}"`,
+                        "Pass either the matching --agent-name, or omit --agent-name when using --agent-id."
+                    );
+                }
+
+                return found;
+            }
+
+            // explicit id, not registered — register with that exact id
+            const isMain = opts.agentMain ?? isMainId(opts.agentId);
+
+            if (isMain && registry.some((r) => r.is_main)) {
+                const existingMain = registry.find((r) => r.is_main);
+                throw new FriendlyError(
+                    `a main agent is already registered for this session (${existingMain?.agent_name ?? "?"})`,
+                    `Pick a different --agent-name without --agent-main, OR target a fresh --session.`
+                );
+            }
+
+            return registerInLock({
+                appendNonMessage,
+                agentId: opts.agentId,
+                agentName: opts.agentName ?? opts.agentId,
+                isMain,
+                role: opts.role ?? null,
+                meta: parseMeta(opts.meta),
+            });
+        }
+
+        if (opts.agentName) {
+            const found = findByName(registry, opts.agentName);
+
+            if (found) {
+                return found;
+            }
+
+            const isMain = Boolean(opts.agentMain);
+
+            if (isMain && registry.some((r) => r.is_main)) {
+                const existingMain = registry.find((r) => r.is_main);
+                throw new FriendlyError(
+                    `a main agent is already registered for this session (${existingMain?.agent_name ?? "?"})`,
+                    `Pick a different --agent-name without --agent-main, OR target a fresh --session.`
+                );
+            }
+
+            const id = isMain ? deriveMainAgentId(paths.session) : nextSubagentId(registry);
+
+            if (findById(registry, id)) {
+                throw new FriendlyError(
+                    `derived agent_id ${id} is already taken`,
+                    `Pass an explicit --agent-id instead.`
+                );
+            }
+
+            return registerInLock({
+                appendNonMessage,
+                agentId: id,
+                agentName: opts.agentName,
+                isMain,
+                role: opts.role ?? null,
+                meta: parseMeta(opts.meta),
+            });
+        }
+
+        // unreachable: the !opts.agentId && !opts.agentName case is handled above,
+        // before entering withFeedLock, and one of opts.agentId/opts.agentName is
+        // always set by the time we reach here.
+        throw new FriendlyError(
+            "--agent-id or --agent-name is required",
+            `Example:\n  tools agents login --agent-name lead --agent-main\n  tools agents login --agent-name researcher`
+        );
+    });
+}
+
+function registerInLock(opts: {
+    appendNonMessage: (event: {
+        type: "registered";
+        agent_name: string;
+        agent_id: string;
+        awaiting_login: boolean;
+        is_main: boolean;
+        role: string | null;
+        meta: Record<string, unknown>;
+    }) => FeedEvent;
+    agentId: string;
+    agentName: string;
+    isMain: boolean;
+    role: string | null;
+    meta: Record<string, unknown>;
+}): AgentRecord {
+    log.debug({ agentName: opts.agentName, agentId: opts.agentId }, "auto-registering via login");
+
+    const event = opts.appendNonMessage({
+        type: "registered",
+        agent_name: opts.agentName,
+        agent_id: opts.agentId,
+        awaiting_login: false,
+        is_main: opts.isMain,
+        role: opts.role,
+        meta: opts.meta,
+    });
+
+    return {
+        agent_id: opts.agentId,
+        agent_name: opts.agentName,
+        is_main: opts.isMain,
+        role: opts.role,
+        registered_at: event.ts,
+        logged_in_at: null,
+        logged_out_at: null,
+        mode: null,
+        meta: opts.meta,
+    };
+}
+
+function claimSlot({ paths, record, mode }: { paths: SessionPaths; record: AgentRecord; mode: "stream" | "once" }): {
+    lockPath: string;
+} {
+    const lockPath = slotLockPath(paths, record.agent_id);
+    const payload: SlotLockPayload = {
+        pid: process.pid,
+        since: new Date().toISOString(),
+        owner: record.agent_id,
+        kind: "login",
+        mode,
+    };
+
+    if (!tryAcquireSlot(lockPath, payload)) {
+        const existing = readSlotPayload(lockPath);
+        const heldBy = existing ? `pid ${existing.pid} since ${existing.since}` : "an unknown process";
+        throw new FriendlyError(
+            `another login for ${payload.owner} is already held by ${heldBy}`,
+            existing
+                ? `Stop the other login first: kill ${existing.pid}\nDead PIDs are reaped automatically on the next register/login.`
+                : "Try again — the stale-lock sweep should reap unreadable locks on the next attempt."
+        );
+    }
+
+    return { lockPath };
+}
+
+function emitVisibleEvent(event: FeedEvent, active: ActiveLogin): boolean {
+    if (!active.observer && !isVisibleToAgent(event, active.record, active.meta)) {
+        return false;
+    }
+
+    if (active.format === "pretty") {
+        out.println(formatEventPretty(event));
+    } else {
+        out.println(SafeJSON.stringify(event, { strict: true }));
+    }
+
+    return true;
+}
+
+async function drainPending(active: ActiveLogin): Promise<number> {
+    const events = await readFeedSince(active.paths, active.cursorSeq);
+    let lastSeq = active.cursorSeq;
+    let emitted = 0;
+
+    for (const event of events) {
+        if (emitVisibleEvent(event, active)) {
+            emitted += 1;
+        }
+
+        if (event.seq > lastSeq) {
+            lastSeq = event.seq;
+        }
+    }
+
+    if (lastSeq > active.cursorSeq) {
+        active.cursorSeq = lastSeq;
+        writeCursor(active.paths, active.record.agent_id, lastSeq);
+    }
+
+    return emitted;
+}
+
+async function watchUntilDeadline(active: ActiveLogin, deadlineAt: number, exitOnFirst: boolean): Promise<void> {
+    await watchFileFeed({
+        path: active.paths.feedPath,
+        deadlineAt,
+        onChange: async () => {
+            const before = active.cursorSeq;
+            const emitted = await drainPending(active);
+
+            if (emitted > 0) {
+                log.debug({ before, after: active.cursorSeq }, "drained while watching");
+
+                if (exitOnFirst) {
+                    return { done: true };
+                }
+            }
+        },
+    });
+}
+
+async function emitLoggedIn({
+    paths,
+    record,
+    mode,
+}: {
+    paths: SessionPaths;
+    record: AgentRecord;
+    mode: "stream" | "once";
+}): Promise<void> {
+    const { appendFeed } = await import("../lib/feed");
+    await appendFeed(paths, {
+        type: "logged_in",
+        agent_id: record.agent_id,
+        agent_name: record.agent_name,
+        mode,
+    });
+}
+
+async function emitLoggedOut({
+    paths,
+    record,
+    reason,
+    mode,
+}: {
+    paths: SessionPaths;
+    record: AgentRecord;
+    reason: "signal" | "clean_exit" | "cap";
+    mode: "stream" | "once";
+}): Promise<void> {
+    const { appendFeed } = await import("../lib/feed");
+    await appendFeed(paths, {
+        type: "logged_out",
+        agent_id: record.agent_id,
+        reason,
+        mode,
+    });
+}
+
+function emitResumeHint(record: AgentRecord, mode: "stream" | "once"): void {
+    const parts = ["tools", "agents", "login", "--agent-id", record.agent_id];
+
+    if (mode === "once") {
+        parts.push("--once");
+    }
+
+    process.stderr.write(`\n# To resume listening:\n${parts.join(" ")}\n`);
+}
+
+async function runLoginImpl(opts: LoginOpts): Promise<void> {
+    const resolved = resolveSession(opts.session);
+
+    if (resolved.note) {
+        out.log.warn(resolved.note);
+    }
+
+    const paths = sessionPaths(resolved.session);
+    ensureSessionDir(paths);
+    await runStaleSweep(paths);
+
+    if (opts.debug) {
+        const { updateSessionMeta } = await import("../lib/session-meta");
+        await updateSessionMeta(paths, { debug: true });
+        log.debug({ session: paths.session }, "session debug mode enabled");
+    }
+
+    const record = await findOrRegisterAgent(paths, opts);
+    const mode: "stream" | "once" = opts.once ? "once" : "stream";
+    const { lockPath } = claimSlot({ paths, record, mode });
+
+    // claimSlot() succeeded — from here until the onShutdown handler below is
+    // registered, a thrown error would otherwise skip releaseSlot() entirely
+    // (no finally covers this span), permanently locking out this agent_id
+    // until stale-lock reaping. Release explicitly on any setup failure.
+    let active: ActiveLogin;
+
+    try {
+        const meta = readSessionMeta(paths);
+        const format: "pretty" | "json" = opts.format ?? (opts.observer && process.stdout.isTTY ? "pretty" : "json");
+        active = {
+            paths,
+            record,
+            lockPath,
+            mode,
+            meta,
+            observer: Boolean(opts.observer),
+            format,
+            cursorSeq: readCursor(paths, record.agent_id),
+        };
+
+        await emitLoggedIn({ paths, record, mode });
+    } catch (err) {
+        releaseSlot(lockPath);
+        throw err;
+    }
+
+    let exitReason: "signal" | "clean_exit" | "cap" = "clean_exit";
+
+    onShutdown(async (reason) => {
+        exitReason = reason;
+
+        try {
+            await drainPending(active);
+        } catch (err) {
+            log.warn({ err }, "final drain failed during shutdown");
+        }
+
+        try {
+            await emitLoggedOut({ paths, record: active.record, reason, mode });
+        } catch (err) {
+            log.warn({ err }, "logged_out emit failed during shutdown");
+        }
+
+        releaseSlot(lockPath);
+        emitResumeHint(active.record, mode);
+    });
+
+    if (isMainId(record.agent_id)) {
+        log.debug({ agentId: record.agent_id }, "main agent logged in");
+    }
+
+    try {
+        if (mode === "once") {
+            const initialEmitted = await drainPending(active);
+
+            if (initialEmitted === 0) {
+                const deadline = Date.now() + ONE_HOUR_MS;
+                await watchUntilDeadline(active, deadline, true);
+            }
+        } else {
+            const deadline = Date.now() + ONE_HOUR_MS;
+            await watchUntilDeadline(active, deadline, false);
+            exitReason = "cap";
+        }
+    } finally {
+        try {
+            await drainPending(active);
+        } catch (err) {
+            log.warn({ err }, "final drain failed");
+        }
+
+        await emitLoggedOut({ paths, record: active.record, reason: exitReason, mode });
+        releaseSlot(lockPath);
+        emitResumeHint(active.record, mode);
+    }
+}
+
+export async function runLogin(opts: LoginOpts): Promise<void> {
+    await runWithFriendlyErrors(() => runLoginImpl(opts));
+}
+
+export function registerLoginCommand(program: Command): void {
+    program
+        .command("login")
+        .description("Attach as an agent and receive messages (auto-registers if --agent-name is new)")
+        .option("--agent-id <id>", "Agent ID (auto-generated if omitted; main_ prefix added when --agent-main)")
+        .option("--agent-name <name>", "Agent name (unique per session; auto-registers if new)")
+        .option("--agent-main", "Mark this agent as the session's main (one per session, must come with --agent-name)")
+        .option("--role <role>", "Optional role label stored on the agent record")
+        .option("--meta <json>", "Optional JSON object stored on the agent record")
+        .option("--debug", "Enable session debug mode: lifecycle events visible to all agents on the feed")
+        .option("--once", "Read pending and exit (or wait for first message, then exit)")
+        .option("--session <id>", "Override session resolution")
+        .option("--observer", "Read-only: bypass per-agent visibility filter and see ALL events")
+        .option("--format <fmt>", "pretty | json (default: json; observer in TTY → pretty)")
+        .action(async (opts: LoginOpts) => {
+            await runLogin(opts);
+        });
+}

--- a/src/agents/commands/message.ts
+++ b/src/agents/commands/message.ts
@@ -1,0 +1,171 @@
+import { logger, out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { deriveRegistry } from "../lib/derived-registry";
+import { FriendlyError, listAvailableNames, runWithFriendlyErrors } from "../lib/errors";
+import { withFeedLock } from "../lib/feed";
+import { ensureSessionDir, sessionPaths } from "../lib/paths";
+import { resolveMany, resolveOne } from "../lib/resolve-token";
+import { resolveSession } from "../lib/session-resolve";
+import { runStaleSweep } from "../lib/slot-lock";
+import type { AgentRecord, MessageEvent } from "../lib/types";
+
+const log = logger.child({ component: "agents:message" });
+
+interface MessageOpts {
+    from?: string;
+    to?: string;
+    body?: string;
+    reply?: string;
+    meta?: string;
+    private?: boolean;
+    session?: string;
+}
+
+function parseMeta(raw: string | undefined): Record<string, unknown> {
+    if (!raw) {
+        return {};
+    }
+
+    const parsed = SafeJSON.parse(raw);
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new FriendlyError("--meta must be a JSON object", `Example: --meta '{"priority":"high"}'`);
+    }
+
+    return parsed as Record<string, unknown>;
+}
+
+async function runMessageImpl(opts: MessageOpts): Promise<void> {
+    const hasBody = typeof opts.body === "string" && opts.body.length > 0;
+    const isAck = !hasBody && Boolean(opts.reply);
+
+    if (!hasBody && !isAck) {
+        const records = await sessionRegistryQuietly(opts.session);
+        throw new FriendlyError(
+            "--body is required (or --reply <msg-id> with no --body for a pure ack)",
+            `Examples:\n  tools agents message --from ${exampleSenderName(records)} --to peer --body 'hi'\n  tools agents message --from ${exampleSenderName(records)} --reply 0001 --body 'thanks'\n  tools agents message --from ${exampleSenderName(records)} --reply 0001                # ack`
+        );
+    }
+
+    const resolved = resolveSession(opts.session);
+    const paths = sessionPaths(resolved.session);
+    ensureSessionDir(paths);
+    await runStaleSweep(paths);
+
+    const meta = parseMeta(opts.meta);
+
+    const event = await withFeedLock(paths, ({ events, appendMessageEvent }) => {
+        const registry = deriveRegistry(events);
+
+        if (!opts.from) {
+            throw new FriendlyError(
+                "--from is required",
+                `Registered: ${listAvailableNames(registry)}\nExample:\n  tools agents message --from <one of above> --body 'hi'`
+            );
+        }
+
+        const sender = resolveOne(registry, opts.from, "sender");
+        const toIds = resolveMany(registry, opts.to, "recipient");
+
+        if (opts.reply) {
+            const originalSender = findOriginalSenderInEvents(events, opts.reply);
+
+            if (originalSender) {
+                if (originalSender !== sender.agent_id && !toIds.includes(originalSender)) {
+                    toIds.push(originalSender);
+                }
+            } else if (toIds.length === 0) {
+                throw new FriendlyError(
+                    `Could not resolve original sender for reply to message "${opts.reply}"`,
+                    "Specify explicit recipients with --to, or verify the message ID."
+                );
+            }
+        }
+
+        if (toIds.includes(sender.agent_id)) {
+            out.log.warn(
+                `recipient list includes the sender (${sender.agent_id}); senders do NOT see their own messages on their own login stream — the message is stored but the sender's stream filters it out.`
+            );
+        }
+
+        const messageInput: Omit<MessageEvent, "seq" | "ts" | "message_id"> = {
+            type: "message",
+            from_agent_id: sender.agent_id,
+            from_agent_name: sender.agent_name,
+            to_agent_ids: toIds,
+            body: hasBody ? (opts.body as string) : "",
+            meta,
+            private: Boolean(opts.private),
+            ...(opts.reply ? { in_reply_to: opts.reply } : {}),
+        };
+
+        return appendMessageEvent(messageInput);
+    });
+
+    const isBroadcast = !opts.reply && event.to_agent_ids.length === 0;
+    out.println(
+        SafeJSON.stringify(
+            {
+                message_id: event.message_id,
+                seq: event.seq,
+                kind: opts.reply ? (hasBody ? "reply" : "ack") : isBroadcast ? "broadcast" : "direct",
+                in_reply_to: opts.reply ?? null,
+                recipients: isBroadcast ? "(all peers except sender)" : event.to_agent_ids,
+            },
+            { strict: true }
+        )
+    );
+}
+
+function findOriginalSenderInEvents(
+    events: { type: string; message_id?: string; from_agent_id?: string }[],
+    messageId: string
+): string | null {
+    for (let i = events.length - 1; i >= 0; i--) {
+        const event = events[i];
+
+        if (event?.type === "message" && event.message_id === messageId) {
+            return event.from_agent_id ?? null;
+        }
+    }
+
+    return null;
+}
+
+async function sessionRegistryQuietly(sessionExplicit?: string): Promise<AgentRecord[]> {
+    try {
+        const resolved = resolveSession(sessionExplicit);
+        const paths = sessionPaths(resolved.session);
+        const { readFeed } = await import("../lib/feed");
+        const events = await readFeed(paths);
+        return deriveRegistry(events);
+    } catch (err) {
+        log.debug({ err, sessionExplicit }, "could not load registry for message examples");
+        return [];
+    }
+}
+
+function exampleSenderName(records: AgentRecord[]): string {
+    return records[0]?.agent_name ?? "lead";
+}
+
+export async function runMessage(opts: MessageOpts): Promise<void> {
+    await runWithFriendlyErrors(() => runMessageImpl(opts));
+}
+
+export function registerMessageCommand(program: Command): void {
+    program
+        .command("message")
+        .description("Send a message (direct, broadcast, reply, or pure ack)")
+        .option("--from <token>", "Sender agent — name or id")
+        .option("--to <csv>", "Recipient agents — comma-separated names or ids; empty = broadcast")
+        .option("--body <text>", "Message body (omit + --reply for pure ack)")
+        .option("--reply <msg-id>", "Mark this as a reply to a previous message_id (auto-routes to original sender)")
+        .option("--meta <json>", "Optional JSON object")
+        .option("--private", "Mark as private (v1: stored, not enforced)")
+        .option("--session <id>", "Override session resolution")
+        .action(async (opts: MessageOpts) => {
+            await runMessage(opts);
+        });
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env bun
+
+import { runTool } from "@app/utils/cli";
+import { handleReadmeFlag } from "@app/utils/readme";
+import { Command } from "commander";
+import { registerDiscoverCommand } from "./commands/discover";
+import { registerListenCommand } from "./commands/listen";
+import { registerLoginCommand } from "./commands/login";
+import { registerMessageCommand } from "./commands/message";
+
+handleReadmeFlag(import.meta.url);
+
+const program = new Command();
+
+program
+    .name("agents")
+    .description("Cross-agent communication: register/login/message/discover/listen across the swarm")
+    .version("0.1.0");
+
+registerLoginCommand(program);
+registerMessageCommand(program);
+registerDiscoverCommand(program);
+registerListenCommand(program);
+
+await runTool(program, { tool: "agents" });

--- a/src/agents/lib/cursor.ts
+++ b/src/agents/lib/cursor.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { atomicWriteFileSync } from "@app/utils/storage/storage";
+import { assertSafePathSegment } from "./paths";
+import type { SessionPaths } from "./types";
+
+const log = logger.child({ component: "agents:cursor" });
+
+/**
+ * Per-agent delivery cursor sidecar — `slots/<agent_id>.cursor` (JSON {"seq":N}).
+ *
+ * Lives separately from the derived registry because it's *runtime state* of an
+ * active login (advances on every drain); deriving it from the feed would
+ * require persisting a "cursor_advanced" event per drain — that defeats the
+ * point of feed-as-truth.
+ *
+ * Missing/unreadable cursor → seq 0 (start of feed). Cursor reset is just
+ * `rm <agent_id>.cursor`.
+ */
+
+interface CursorPayload {
+    seq: number;
+}
+
+function cursorPath(paths: SessionPaths, agentId: string): string {
+    assertSafePathSegment(agentId, "agentId");
+    return join(paths.slotsDir, `${agentId}.cursor`);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export function readCursor(paths: SessionPaths, agentId: string): number {
+    const path = cursorPath(paths, agentId);
+
+    if (!existsSync(path)) {
+        return 0;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(readFileSync(path, "utf8"));
+
+        if (!isPlainObject(parsed)) {
+            return 0;
+        }
+
+        const seq = parsed.seq;
+        return typeof seq === "number" && Number.isFinite(seq) ? seq : 0;
+    } catch (err) {
+        log.warn({ err, path, agentId }, "unreadable cursor file; replaying from seq 0");
+        return 0;
+    }
+}
+
+export function writeCursor(paths: SessionPaths, agentId: string, seq: number): void {
+    const payload: CursorPayload = { seq };
+    atomicWriteFileSync(cursorPath(paths, agentId), SafeJSON.stringify(payload, { strict: true }));
+}

--- a/src/agents/lib/derived-registry.ts
+++ b/src/agents/lib/derived-registry.ts
@@ -1,0 +1,99 @@
+import type { AgentMode, AgentRecord, FeedEvent } from "./types";
+
+/**
+ * Replay feed events into the current set of AgentRecords.
+ *
+ * This is the single source of truth — there is no persisted `registry.json`.
+ * `last_delivered_seq` lives in a per-agent cursor sidecar file (cursor.ts),
+ * not in the AgentRecord, because it's runtime state of an active login.
+ */
+export function deriveRegistry(events: FeedEvent[]): AgentRecord[] {
+    const byId = new Map<string, AgentRecord>();
+
+    for (const event of events) {
+        if (event.type === "registered") {
+            if (!event.agent_id) {
+                continue;
+            }
+
+            byId.set(event.agent_id, {
+                agent_id: event.agent_id,
+                agent_name: event.agent_name,
+                is_main: event.is_main,
+                role: event.role,
+                registered_at: event.ts,
+                logged_in_at: null,
+                logged_out_at: null,
+                mode: null,
+                meta: event.meta,
+            });
+            continue;
+        }
+
+        if (event.type === "logged_in") {
+            const existing = byId.get(event.agent_id);
+
+            if (!existing) {
+                continue;
+            }
+
+            byId.set(event.agent_id, {
+                ...existing,
+                logged_in_at: event.ts,
+                logged_out_at: null,
+                mode: event.mode satisfies AgentMode,
+            });
+            continue;
+        }
+
+        if (event.type === "logged_out") {
+            const existing = byId.get(event.agent_id);
+
+            if (!existing) {
+                continue;
+            }
+
+            byId.set(event.agent_id, { ...existing, logged_out_at: event.ts });
+        }
+    }
+
+    return Array.from(byId.values());
+}
+
+export function findByName(records: AgentRecord[], agentName: string): AgentRecord | undefined {
+    return records.find((r) => r.agent_name === agentName);
+}
+
+export function findById(records: AgentRecord[], agentId: string): AgentRecord | undefined {
+    return records.find((r) => r.agent_id === agentId);
+}
+
+export function isMainRegistered(records: AgentRecord[]): boolean {
+    return records.some((r) => r.is_main);
+}
+
+const AGT_SUFFIX_RE = /^agt_([0-9a-f]+)$/i;
+
+/**
+ * Pick the next `agt_xxxx` id by taking max(numeric-suffix)+1 across registered
+ * agents. Count+1 would collide if a user passed `--agent-id agt_0005` directly.
+ */
+export function nextSubagentId(records: AgentRecord[]): string {
+    let maxSuffix = 0;
+
+    for (const r of records) {
+        const match = AGT_SUFFIX_RE.exec(r.agent_id);
+
+        if (!match?.[1]) {
+            continue;
+        }
+
+        const n = Number.parseInt(match[1], 16);
+
+        if (Number.isFinite(n) && n > maxSuffix) {
+            maxSuffix = n;
+        }
+    }
+
+    return `agt_${(maxSuffix + 1).toString(16).padStart(4, "0")}`;
+}

--- a/src/agents/lib/errors.ts
+++ b/src/agents/lib/errors.ts
@@ -1,0 +1,49 @@
+import { out } from "@app/logger";
+
+export class FriendlyError extends Error {
+    public readonly hint?: string;
+
+    constructor(message: string, hint?: string) {
+        super(message);
+        this.name = "FriendlyError";
+        this.hint = hint;
+    }
+}
+
+export async function runWithFriendlyErrors<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+        return await fn();
+    } catch (err) {
+        if (err instanceof FriendlyError) {
+            out.log.error(err.message);
+
+            if (err.hint) {
+                process.stderr.write(`\n${err.hint}\n`);
+            }
+
+            process.exit(1);
+        }
+
+        const msg = err instanceof Error ? err.message : String(err);
+        out.log.error(msg);
+        process.exit(1);
+    }
+}
+
+export function listAvailableNames(records: { agent_name: string }[]): string {
+    if (records.length === 0) {
+        return "(none registered)";
+    }
+
+    return records.map((r) => r.agent_name).join(", ");
+}
+
+export function listAvailableIds(records: { agent_id: string; agent_name: string }[]): string {
+    const visible = records.filter((r) => r.agent_id !== "");
+
+    if (visible.length === 0) {
+        return "(none registered)";
+    }
+
+    return visible.map((r) => `${r.agent_id} (${r.agent_name})`).join(", ");
+}

--- a/src/agents/lib/feed.ts
+++ b/src/agents/lib/feed.ts
@@ -1,0 +1,176 @@
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { readJsonlFile } from "@app/utils/log-session/jsonl-reader";
+import { withFileLock } from "@app/utils/storage";
+import type { FeedEvent, MessageEvent, SessionPaths } from "./types";
+
+const FEED_LOCK_TIMEOUT_MS = 10_000;
+const MAX_MESSAGE_ID = 0xffff;
+
+function ensureFeedFile(path: string): void {
+    const dir = dirname(path);
+
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    if (!existsSync(path)) {
+        appendFileSync(path, "");
+    }
+}
+
+type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
+export type FeedEventInput = DistributiveOmit<FeedEvent, "seq" | "ts">;
+type NonMessageInput = Exclude<FeedEventInput, { type: "message" }>;
+export type MessageEventInput = DistributiveOmit<MessageEvent, "seq" | "ts" | "message_id">;
+
+export async function readFeed(paths: SessionPaths): Promise<FeedEvent[]> {
+    if (!existsSync(paths.feedPath)) {
+        return [];
+    }
+
+    const records = await readJsonlFile(paths.feedPath);
+    return records as unknown as FeedEvent[];
+}
+
+export async function readFeedSince(paths: SessionPaths, sinceSeq: number): Promise<FeedEvent[]> {
+    const all = await readFeed(paths);
+    return all.filter((e) => e.seq > sinceSeq);
+}
+
+function nextSeqFromEvents(events: FeedEvent[]): number {
+    if (events.length === 0) {
+        return 1;
+    }
+
+    const last = events[events.length - 1];
+    return (last?.seq ?? 0) + 1;
+}
+
+function nextMessageIdFromEvents(events: FeedEvent[]): string {
+    let lastMessageId = 0;
+
+    for (let i = events.length - 1; i >= 0; i--) {
+        const e = events[i];
+
+        if (e && e.type === "message") {
+            lastMessageId = Number.parseInt(e.message_id, 16);
+            break;
+        }
+    }
+
+    const next = lastMessageId + 1;
+
+    if (next > MAX_MESSAGE_ID) {
+        throw new MessageIdExhaustedError();
+    }
+
+    return next.toString(16).padStart(4, "0");
+}
+
+function appendLine(path: string, event: FeedEvent): void {
+    appendFileSync(path, `${SafeJSON.stringify(event, { strict: true })}\n`);
+}
+
+export class MessageIdExhaustedError extends Error {
+    constructor() {
+        super(`message_id space exhausted (>= ${MAX_MESSAGE_ID.toString(16)})`);
+        this.name = "MessageIdExhaustedError";
+    }
+}
+
+/**
+ * Append a non-message event (registered/logged_in/logged_out/stale_lock_reaped).
+ * Allocates seq + ts under the single feed lock — no separate counters file.
+ */
+export async function appendFeed(paths: SessionPaths, event: NonMessageInput): Promise<FeedEvent> {
+    return withFileLock(
+        `${paths.feedPath}.lock`,
+        async () => {
+            ensureFeedFile(paths.feedPath);
+            const existing = await readFeed(paths);
+            const seq = nextSeqFromEvents(existing);
+            const fullEvent = { ...event, seq, ts: new Date().toISOString() } as unknown as FeedEvent;
+            appendLine(paths.feedPath, fullEvent);
+            return fullEvent;
+        },
+        FEED_LOCK_TIMEOUT_MS
+    );
+}
+
+/**
+ * Append a message event. Allocates seq + message_id + ts under one lock.
+ * message_id stays a separate 0001-based counter (not seq) so first message is
+ * always "0001" regardless of how many lifecycle events precede it.
+ */
+export async function appendMessage(paths: SessionPaths, event: MessageEventInput): Promise<MessageEvent> {
+    return withFileLock(
+        `${paths.feedPath}.lock`,
+        async () => {
+            ensureFeedFile(paths.feedPath);
+            const existing = await readFeed(paths);
+            const seq = nextSeqFromEvents(existing);
+            const messageId = nextMessageIdFromEvents(existing);
+            const fullEvent: MessageEvent = {
+                ...event,
+                seq,
+                ts: new Date().toISOString(),
+                message_id: messageId,
+            };
+            appendLine(paths.feedPath, fullEvent);
+            return fullEvent;
+        },
+        FEED_LOCK_TIMEOUT_MS
+    );
+}
+
+/**
+ * Read the feed under the lock and pass it to `fn`, which may decide to append
+ * one or more events synthesized from the current state. Used for atomic
+ * registration where derive-state + conflict-check + allocate-id + write must
+ * be a single critical section.
+ */
+export async function withFeedLock<T>(
+    paths: SessionPaths,
+    fn: (helpers: {
+        events: FeedEvent[];
+        appendNonMessage: (event: NonMessageInput) => FeedEvent;
+        appendMessageEvent: (event: MessageEventInput) => MessageEvent;
+    }) => Promise<T> | T
+): Promise<T> {
+    return withFileLock(
+        `${paths.feedPath}.lock`,
+        async () => {
+            ensureFeedFile(paths.feedPath);
+            const events = await readFeed(paths);
+            const appended: FeedEvent[] = [];
+
+            const appendNonMessage = (event: NonMessageInput): FeedEvent => {
+                const seq = nextSeqFromEvents([...events, ...appended]);
+                const full = { ...event, seq, ts: new Date().toISOString() } as unknown as FeedEvent;
+                appended.push(full);
+                appendLine(paths.feedPath, full);
+                return full;
+            };
+
+            const appendMessageEvent = (event: MessageEventInput): MessageEvent => {
+                const all = [...events, ...appended];
+                const seq = nextSeqFromEvents(all);
+                const messageId = nextMessageIdFromEvents(all);
+                const full: MessageEvent = {
+                    ...event,
+                    seq,
+                    ts: new Date().toISOString(),
+                    message_id: messageId,
+                };
+                appended.push(full);
+                appendLine(paths.feedPath, full);
+                return full;
+            };
+
+            return fn({ events, appendNonMessage, appendMessageEvent });
+        },
+        FEED_LOCK_TIMEOUT_MS
+    );
+}

--- a/src/agents/lib/filter.ts
+++ b/src/agents/lib/filter.ts
@@ -1,0 +1,62 @@
+import type { SessionMeta } from "./session-meta";
+import type { AgentRecord, FeedEvent, MessageEvent } from "./types";
+
+export function isVisibleToAgent(event: FeedEvent, agent: AgentRecord, meta?: SessionMeta): boolean {
+    if (event.type === "message") {
+        return visibleMessage(event, agent);
+    }
+
+    if (event.type === "logged_in" || event.type === "logged_out") {
+        return visibleLifecycle(event, agent, meta);
+    }
+
+    if (event.type === "registered") {
+        return Boolean(meta?.debug);
+    }
+
+    return false;
+}
+
+function visibleMessage(event: MessageEvent, agent: AgentRecord): boolean {
+    if (event.from_agent_id === agent.agent_id) {
+        return false;
+    }
+
+    if (event.to_agent_ids.length === 0) {
+        return true;
+    }
+
+    return event.to_agent_ids.includes(agent.agent_id);
+}
+
+function visibleLifecycle(event: FeedEvent, agent: AgentRecord, meta?: SessionMeta): boolean {
+    if (event.type !== "logged_in" && event.type !== "logged_out") {
+        return false;
+    }
+
+    if (event.agent_id === agent.agent_id) {
+        return false;
+    }
+
+    if (event.mode === "once") {
+        return false;
+    }
+
+    if (meta?.debug) {
+        return true;
+    }
+
+    if (agent.is_main) {
+        if (event.type === "logged_in") {
+            return event.mode === "stream";
+        }
+
+        return event.reason !== "clean_exit";
+    }
+
+    return false;
+}
+
+export function filterForAgent(events: FeedEvent[], agent: AgentRecord, meta?: SessionMeta): FeedEvent[] {
+    return events.filter((e) => isVisibleToAgent(e, agent, meta));
+}

--- a/src/agents/lib/format-pretty.ts
+++ b/src/agents/lib/format-pretty.ts
@@ -1,0 +1,66 @@
+import { SafeJSON } from "@app/utils/json";
+import chalk from "chalk";
+import type { FeedEvent } from "./types";
+
+export function formatEventPretty(event: FeedEvent): string {
+    const ts = event.ts.slice(11, 19);
+    const seq = chalk.dim(`#${String(event.seq).padStart(4, "0")}`);
+    const time = chalk.gray(ts);
+    const tag = colorType(event.type);
+
+    if (event.type === "registered") {
+        const awaiting = event.awaiting_login ? chalk.yellow("(awaiting login)") : "";
+        const idStr = event.agent_id ? chalk.cyan(event.agent_id) : chalk.dim("(no id)");
+        const mainTag = event.is_main ? chalk.magenta("MAIN") : "";
+        return `${time} ${seq} ${tag} ${chalk.bold(event.agent_name)} ${idStr} ${mainTag} ${awaiting}`;
+    }
+
+    if (event.type === "logged_in") {
+        const modeTag = event.mode === "stream" ? chalk.green("stream") : chalk.blue("once");
+        return `${time} ${seq} ${tag} ${chalk.bold(event.agent_name)} ${chalk.cyan(event.agent_id)} (${modeTag})`;
+    }
+
+    if (event.type === "logged_out") {
+        return `${time} ${seq} ${tag} ${chalk.cyan(event.agent_id)} reason=${event.reason}`;
+    }
+
+    if (event.type === "stale_lock_reaped") {
+        return `${time} ${seq} ${tag} ${chalk.yellow(event.lock)} pid=${event.pid}`;
+    }
+
+    if (event.type === "message") {
+        const id = chalk.bold(`[${event.message_id}]`);
+        const priv = event.private ? chalk.red("PRIVATE ") : "";
+
+        if (event.in_reply_to) {
+            if (!event.body) {
+                return `${time} ${seq} ${tag} ${chalk.cyan(event.from_agent_name)} ack ${chalk.dim(event.in_reply_to)}`;
+            }
+
+            return `${time} ${seq} ${tag} ${id} ${priv}${chalk.cyan(event.from_agent_name)} → reply to ${chalk.dim(event.in_reply_to)}: ${event.body}`;
+        }
+
+        const recipients =
+            event.to_agent_ids.length === 0 ? chalk.magenta("(broadcast)") : event.to_agent_ids.join(",");
+        return `${time} ${seq} ${tag} ${id} ${priv}${chalk.cyan(event.from_agent_name)} → ${recipients}: ${event.body}`;
+    }
+
+    return `${time} ${seq} ${tag} ${SafeJSON.stringify(event, { strict: true })}`;
+}
+
+function colorType(type: string): string {
+    switch (type) {
+        case "message":
+            return chalk.green(type);
+        case "registered":
+            return chalk.magenta(type);
+        case "logged_in":
+            return chalk.green(type);
+        case "logged_out":
+            return chalk.dim(type);
+        case "stale_lock_reaped":
+            return chalk.yellow(type);
+        default:
+            return chalk.gray(type);
+    }
+}

--- a/src/agents/lib/id-gen.ts
+++ b/src/agents/lib/id-gen.ts
@@ -1,0 +1,36 @@
+const SESSION_PREFIX_CHARS = 12;
+
+export function deriveMainAgentId(session: string): string {
+    const slug = session
+        .replace(/[^a-z0-9]/gi, "")
+        .slice(0, SESSION_PREFIX_CHARS)
+        .toLowerCase();
+
+    if (slug.length === 0) {
+        return `main_${Math.floor(Math.random() * 0xffffff)
+            .toString(16)
+            .padStart(6, "0")}`;
+    }
+
+    return `main_${slug}`;
+}
+
+export function isMainId(agentId: string): boolean {
+    return agentId.startsWith("main_");
+}
+
+export function ensureMainPrefix(agentId: string, session: string): string {
+    if (isMainId(agentId)) {
+        return agentId;
+    }
+
+    if (agentId.startsWith("agt_")) {
+        return `main_${agentId.slice(4)}`;
+    }
+
+    if (agentId === "" || agentId === "main_") {
+        return deriveMainAgentId(session);
+    }
+
+    return `main_${agentId}`;
+}

--- a/src/agents/lib/lifecycle.ts
+++ b/src/agents/lib/lifecycle.ts
@@ -1,0 +1,54 @@
+import { logger } from "@app/logger";
+
+const log = logger.child({ component: "agents:lifecycle" });
+
+export type ShutdownReason = "signal" | "clean_exit" | "cap";
+
+export type ShutdownHandler = (reason: ShutdownReason) => Promise<void> | void;
+
+const handlers: ShutdownHandler[] = [];
+let signalsInstalled = false;
+let shuttingDown = false;
+
+async function runHandlers(reason: ShutdownReason): Promise<void> {
+    if (shuttingDown) {
+        return;
+    }
+
+    shuttingDown = true;
+    const ordered = [...handlers].reverse();
+
+    for (const handler of ordered) {
+        try {
+            await handler(reason);
+        } catch (err) {
+            log.warn({ err }, "shutdown handler threw");
+        }
+    }
+}
+
+function installSignals(): void {
+    if (signalsInstalled) {
+        return;
+    }
+
+    signalsInstalled = true;
+    const onSignal = async (sig: NodeJS.Signals): Promise<void> => {
+        log.debug({ sig }, "received signal");
+        await runHandlers("signal");
+        process.exit(0);
+    };
+
+    process.on("SIGINT", onSignal);
+    process.on("SIGTERM", onSignal);
+    process.on("SIGHUP", onSignal);
+}
+
+export function onShutdown(handler: ShutdownHandler): void {
+    installSignals();
+    handlers.push(handler);
+}
+
+export async function triggerShutdown(reason: ShutdownReason): Promise<void> {
+    await runHandlers(reason);
+}

--- a/src/agents/lib/paths.ts
+++ b/src/agents/lib/paths.ts
@@ -1,0 +1,49 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+import { FriendlyError } from "./errors";
+import type { SessionPaths } from "./types";
+
+const UNSAFE_SEGMENT_RE = /[/\\]|^\.\.?$/;
+
+/**
+ * Reject path-traversal/absolute-escape segments before they're joined into a
+ * filesystem path. Used for session ids and agent ids (owner/cursor keys) —
+ * both can come from explicit user input (--session, --agent-id,
+ * $CLAUDE_CODE_SESSION_ID) and get joined into paths under agentsRoot().
+ */
+export function assertSafePathSegment(value: string, label: string): string {
+    if (!value || UNSAFE_SEGMENT_RE.test(value)) {
+        throw new FriendlyError(
+            `${label} "${value}" is not a valid path segment`,
+            `${label} must not contain "/", "\\", or be "." / "..".`
+        );
+    }
+
+    return value;
+}
+
+export function agentsRoot(): string {
+    return join(env.tools.getHome(), ".genesis-tools", "agents");
+}
+
+export function sessionPaths(session: string): SessionPaths {
+    assertSafePathSegment(session, "session");
+    const sessionDir = join(agentsRoot(), session);
+    return {
+        session,
+        sessionDir,
+        feedPath: join(sessionDir, "feed.jsonl"),
+        slotsDir: join(sessionDir, "slots"),
+    };
+}
+
+export function ensureSessionDir(paths: SessionPaths): void {
+    if (!existsSync(paths.sessionDir)) {
+        mkdirSync(paths.sessionDir, { recursive: true });
+    }
+
+    if (!existsSync(paths.slotsDir)) {
+        mkdirSync(paths.slotsDir, { recursive: true });
+    }
+}

--- a/src/agents/lib/resolve-token.ts
+++ b/src/agents/lib/resolve-token.ts
@@ -1,0 +1,57 @@
+import { findById, findByName } from "./derived-registry";
+import { FriendlyError, listAvailableNames } from "./errors";
+import type { AgentRecord } from "./types";
+
+const ID_LIKE = /^(agt_|main_)/;
+
+function parseCsv(raw: string | undefined): string[] {
+    if (!raw) {
+        return [];
+    }
+
+    return raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+
+function looksLikeId(token: string): boolean {
+    return ID_LIKE.test(token);
+}
+
+export function resolveOne(records: AgentRecord[], token: string, role: "sender" | "recipient"): AgentRecord {
+    const found = looksLikeId(token) ? findById(records, token) : findByName(records, token);
+
+    if (!found) {
+        throw new FriendlyError(
+            `${role} "${token}" not registered in this session`,
+            `Registered: ${listAvailableNames(records)}\nTokens are matched as agent_id when they start with agt_/main_, else as agent_name.`
+        );
+    }
+
+    if (role === "recipient" && found.agent_id === "") {
+        throw new FriendlyError(
+            `recipient "${token}" is registered but has not logged in yet (no agent_id assigned)`,
+            `Wait for the subagent to run:\n  tools agents login --agent-name ${found.agent_name}\nOr check status:\n  tools agents discover`
+        );
+    }
+
+    return found;
+}
+
+export function resolveMany(records: AgentRecord[], csv: string | undefined, role: "recipient"): string[] {
+    const tokens = parseCsv(csv);
+    const resolved: string[] = [];
+
+    for (const token of tokens) {
+        const found = resolveOne(records, token, role);
+
+        if (!resolved.includes(found.agent_id)) {
+            resolved.push(found.agent_id);
+        }
+    }
+
+    return resolved;
+}
+
+export { parseCsv };

--- a/src/agents/lib/session-meta.ts
+++ b/src/agents/lib/session-meta.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { withFileLock } from "@app/utils/storage";
+import { atomicWriteFileSync } from "@app/utils/storage/storage";
+import type { SessionPaths } from "./types";
+
+const META_LOCK_TIMEOUT_MS = 10_000;
+
+export interface SessionMeta {
+    debug: boolean;
+}
+
+function metaPath(paths: SessionPaths): string {
+    return join(paths.sessionDir, "session-meta.json");
+}
+
+export function readSessionMeta(paths: SessionPaths): SessionMeta {
+    const path = metaPath(paths);
+
+    if (!existsSync(path)) {
+        return { debug: false };
+    }
+
+    const parsed = SafeJSON.parse(readFileSync(path, "utf8"));
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return { debug: false };
+    }
+
+    return { debug: Boolean((parsed as Record<string, unknown>).debug) };
+}
+
+export async function updateSessionMeta(paths: SessionPaths, patch: Partial<SessionMeta>): Promise<SessionMeta> {
+    const path = metaPath(paths);
+    return withFileLock(
+        `${path}.lock`,
+        async () => {
+            const current = readSessionMeta(paths);
+            const next: SessionMeta = { ...current, ...patch };
+            atomicWriteFileSync(path, SafeJSON.stringify(next, { strict: true }));
+            return next;
+        },
+        META_LOCK_TIMEOUT_MS
+    );
+}

--- a/src/agents/lib/session-resolve.ts
+++ b/src/agents/lib/session-resolve.ts
@@ -1,0 +1,99 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { env } from "@app/utils/env";
+import { FriendlyError } from "./errors";
+import { agentsRoot } from "./paths";
+
+const SINGLE_RECENT_WINDOW_MS = 60_000;
+
+const log = logger.child({ component: "agents:session-resolve" });
+
+export interface SessionResolveResult {
+    session: string;
+    source: "explicit" | "env" | "single-recent";
+    note?: string;
+}
+
+function envSession(): string | null {
+    // Dynamic-key lookup (same helper used for ask ProviderConfig.envKey) routed
+    // through the env facade so env.testing.set()/withOverrides() stays the
+    // single override mechanism for this codebase, instead of a parallel
+    // process.env read path.
+    return env.ai.getByEnvKey("CLAUDE_CODE_SESSION_ID") ?? null;
+}
+
+function singleRecentSession(): string | null {
+    const root = agentsRoot();
+
+    if (!existsSync(root)) {
+        return null;
+    }
+
+    const entries = readdirSync(root);
+    const now = Date.now();
+    const recent: string[] = [];
+
+    for (const entry of entries) {
+        if (entry.startsWith("_")) {
+            continue;
+        }
+
+        const sessionDir = join(root, entry);
+        let stat: ReturnType<typeof statSync>;
+
+        try {
+            stat = statSync(sessionDir);
+        } catch (err) {
+            log.debug({ err, sessionDir }, "skipping unreadable session directory during single-recent probe");
+            continue;
+        }
+
+        if (!stat.isDirectory()) {
+            continue;
+        }
+
+        const feed = join(sessionDir, "feed.jsonl");
+
+        if (!existsSync(feed)) {
+            continue;
+        }
+
+        const feedStat = statSync(feed);
+
+        if (now - feedStat.mtimeMs < SINGLE_RECENT_WINDOW_MS) {
+            recent.push(entry);
+        }
+    }
+
+    if (recent.length === 1) {
+        return recent[0] ?? null;
+    }
+
+    return null;
+}
+
+export function resolveSession(explicit: string | undefined): SessionResolveResult {
+    if (explicit && explicit.trim().length > 0) {
+        return { session: explicit.trim(), source: "explicit" };
+    }
+
+    const fromEnv = envSession();
+
+    if (fromEnv) {
+        return { session: fromEnv, source: "env" };
+    }
+
+    const singleRecent = singleRecentSession();
+
+    if (singleRecent) {
+        const note = `auto-bound to session "${singleRecent}" (only recent active session in last 60s)`;
+        log.debug({ singleRecent }, note);
+        return { session: singleRecent, source: "single-recent", note };
+    }
+
+    throw new FriendlyError(
+        "could not resolve a session: --session was not given, $CLAUDE_CODE_SESSION_ID is unset, and no other session has been active in the last 60s",
+        "Pass --session <id> explicitly, OR set CLAUDE_CODE_SESSION_ID, OR start a fresh swarm by running a register/login command with --session <id> first."
+    );
+}

--- a/src/agents/lib/slot-lock.ts
+++ b/src/agents/lib/slot-lock.ts
@@ -1,0 +1,91 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { sweepStaleLocks } from "@app/utils/storage/stale-lock-sweep";
+import { appendFeed } from "./feed";
+import { assertSafePathSegment } from "./paths";
+import type { SessionPaths, SlotLockPayload } from "./types";
+
+const log = logger.child({ component: "agents:slot-lock" });
+
+export function slotLockPath(paths: SessionPaths, owner: string): string {
+    assertSafePathSegment(owner, "owner");
+    return join(paths.slotsDir, `${owner}.login`);
+}
+
+export function tryAcquireSlot(lockPath: string, payload: SlotLockPayload): boolean {
+    const dir = dirname(lockPath);
+
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    try {
+        writeFileSync(lockPath, SafeJSON.stringify(payload, { strict: true }), { flag: "wx" });
+        return true;
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+
+        if (code === "EEXIST") {
+            return false;
+        }
+
+        throw err;
+    }
+}
+
+export function releaseSlot(lockPath: string): void {
+    try {
+        unlinkSync(lockPath);
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+
+        if (code !== "ENOENT") {
+            log.warn({ lockPath, err }, "failed to release slot lock");
+        }
+    }
+}
+
+export function readSlotPayload(lockPath: string): SlotLockPayload | null {
+    if (!existsSync(lockPath)) {
+        return null;
+    }
+
+    try {
+        return SafeJSON.parse(readFileSync(lockPath, "utf8")) as SlotLockPayload;
+    } catch {
+        return null;
+    }
+}
+
+export async function runStaleSweep(paths: SessionPaths): Promise<void> {
+    const report = sweepStaleLocks(paths.slotsDir);
+
+    for (const reaped of report.reaped) {
+        await appendFeed(paths, {
+            type: "stale_lock_reaped",
+            lock: reaped.lock,
+            pid: reaped.pid,
+            reason: reaped.reason,
+        });
+
+        const owner = String(reaped.payload.owner ?? "");
+        const kind = reaped.payload.kind;
+
+        if (reaped.reason === "dead_pid" && kind === "login" && owner) {
+            const reapedMode =
+                reaped.payload.mode === "once" || reaped.payload.mode === "stream" ? reaped.payload.mode : undefined;
+            await appendFeed(paths, {
+                type: "logged_out",
+                agent_id: owner,
+                reason: "dead_pid",
+                mode: reapedMode,
+            });
+        }
+    }
+
+    for (const warning of report.warnings) {
+        log.warn({ lock: warning.lock, pid: warning.pid, age_h: warning.age_h }, "lock is long-lived; left in place");
+    }
+}

--- a/src/agents/lib/types.ts
+++ b/src/agents/lib/types.ts
@@ -1,0 +1,89 @@
+export type AgentMode = "stream" | "once";
+
+export type LifecycleEventType = "registered" | "logged_in" | "logged_out" | "stale_lock_reaped";
+
+export type CommEventType = "message";
+
+export type FeedEventType = LifecycleEventType | CommEventType;
+
+export interface FeedEventBase {
+    seq: number;
+    ts: string;
+    type: FeedEventType;
+}
+
+export interface RegisteredEvent extends FeedEventBase {
+    type: "registered";
+    agent_name: string;
+    agent_id: string | null;
+    awaiting_login: boolean;
+    is_main: boolean;
+    role: string | null;
+    meta: Record<string, unknown>;
+}
+
+export interface LoggedInEvent extends FeedEventBase {
+    type: "logged_in";
+    agent_id: string;
+    agent_name: string;
+    mode: AgentMode;
+}
+
+export interface LoggedOutEvent extends FeedEventBase {
+    type: "logged_out";
+    agent_id: string;
+    reason: "signal" | "clean_exit" | "dead_pid" | "cap";
+    mode?: AgentMode;
+}
+
+export interface StaleLockReapedEvent extends FeedEventBase {
+    type: "stale_lock_reaped";
+    lock: string;
+    pid?: number;
+    reason: "dead_pid" | "unreadable";
+}
+
+export interface MessageEvent extends FeedEventBase {
+    type: "message";
+    message_id: string;
+    from_agent_id: string;
+    from_agent_name: string;
+    to_agent_ids: string[];
+    body: string;
+    meta: Record<string, unknown>;
+    private: boolean;
+    in_reply_to?: string;
+}
+
+export type FeedEvent = RegisteredEvent | LoggedInEvent | LoggedOutEvent | StaleLockReapedEvent | MessageEvent;
+
+/**
+ * Derived from feed events via deriveRegistry(). Not persisted.
+ * Delivery cursor (last_delivered_seq) lives in a per-agent .cursor sidecar.
+ */
+export interface AgentRecord {
+    agent_id: string;
+    agent_name: string;
+    is_main: boolean;
+    role: string | null;
+    registered_at: string;
+    logged_in_at: string | null;
+    logged_out_at: string | null;
+    mode: AgentMode | null;
+    meta: Record<string, unknown>;
+}
+
+export interface SlotLockPayload {
+    pid: number;
+    since: string;
+    owner: string;
+    kind: "login";
+    mode?: AgentMode;
+}
+
+export interface SessionPaths {
+    session: string;
+    sessionDir: string;
+    feedPath: string;
+    slotsDir: string;
+}

--- a/src/agents/tests/filter.test.ts
+++ b/src/agents/tests/filter.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { filterForAgent, isVisibleToAgent } from "../lib/filter";
+import type { AgentRecord, FeedEvent } from "../lib/types";
+
+const agentAlpha: AgentRecord = {
+    agent_id: "agt_alpha",
+    agent_name: "alpha",
+    is_main: false,
+    role: null,
+    registered_at: "2026-01-01T00:00:00Z",
+
+    logged_in_at: "2026-01-01T00:00:01Z",
+    logged_out_at: null,
+    mode: "stream",
+    meta: {},
+};
+
+function msgEvent(overrides: Partial<FeedEvent> & { type: "message" }): FeedEvent {
+    const base = {
+        seq: 10,
+        ts: "2026-01-01T00:00:10Z",
+        type: "message",
+        message_id: "0002",
+        from_agent_id: "agt_beta",
+        from_agent_name: "beta",
+        to_agent_ids: ["agt_alpha"],
+        body: "hi",
+        meta: {},
+        private: false,
+    } as const;
+    return { ...base, ...overrides } as FeedEvent;
+}
+
+describe("filter.isVisibleToAgent", () => {
+    test("delivers direct messages", () => {
+        const e = msgEvent({ type: "message", to_agent_ids: ["agt_alpha"] });
+        expect(isVisibleToAgent(e, agentAlpha)).toBe(true);
+    });
+
+    test("delivers broadcasts", () => {
+        const e = msgEvent({ type: "message", to_agent_ids: [] });
+        expect(isVisibleToAgent(e, agentAlpha)).toBe(true);
+    });
+
+    test("does NOT deliver sender's own broadcast back to them", () => {
+        const e = msgEvent({ type: "message", from_agent_id: "agt_alpha", to_agent_ids: [] });
+        expect(isVisibleToAgent(e, agentAlpha)).toBe(false);
+    });
+
+    test("does NOT deliver sender's own direct message back to them", () => {
+        const e = msgEvent({ type: "message", from_agent_id: "agt_alpha", to_agent_ids: ["agt_other"] });
+        expect(isVisibleToAgent(e, agentAlpha)).toBe(false);
+    });
+
+    test("does not deliver messages addressed to someone else", () => {
+        const e = msgEvent({ type: "message", to_agent_ids: ["agt_other"] });
+        expect(isVisibleToAgent(e, agentAlpha)).toBe(false);
+    });
+
+    test("delivers routed replies to the original sender", () => {
+        const reply: FeedEvent = {
+            seq: 11,
+            ts: "2026-01-01T00:00:11Z",
+            type: "message",
+            message_id: "0003",
+            from_agent_id: "agt_beta",
+            from_agent_name: "beta",
+            to_agent_ids: ["agt_alpha"],
+            in_reply_to: "0001",
+            body: "ack",
+            meta: {},
+            private: false,
+        };
+        expect(isVisibleToAgent(reply, agentAlpha)).toBe(true);
+    });
+
+    test("does not deliver reply to a message the agent did NOT send", () => {
+        const reply: FeedEvent = {
+            seq: 11,
+            ts: "2026-01-01T00:00:11Z",
+            type: "message",
+            message_id: "0003",
+            from_agent_id: "agt_beta",
+            from_agent_name: "beta",
+            to_agent_ids: ["agt_someone"],
+            in_reply_to: "9999",
+            body: "ack",
+            meta: {},
+            private: false,
+        };
+        expect(isVisibleToAgent(reply, agentAlpha)).toBe(false);
+    });
+
+    test("main agent sees stream-mode peer logged_in (no debug needed)", () => {
+        const main: AgentRecord = { ...agentAlpha, agent_id: "main_x", agent_name: "lead", is_main: true };
+        const loggedInStream: FeedEvent = {
+            seq: 12,
+            ts: "t",
+            type: "logged_in",
+            agent_id: "agt_beta",
+            agent_name: "beta",
+            mode: "stream",
+        };
+        const loggedInOnce: FeedEvent = {
+            seq: 13,
+            ts: "t",
+            type: "logged_in",
+            agent_id: "agt_beta",
+            agent_name: "beta",
+            mode: "once",
+        };
+        expect(isVisibleToAgent(loggedInStream, main)).toBe(true);
+        expect(isVisibleToAgent(loggedInOnce, main)).toBe(false);
+    });
+
+    test("main agent sees real-failure peer logged_out (no debug needed)", () => {
+        const main: AgentRecord = { ...agentAlpha, agent_id: "main_x", agent_name: "lead", is_main: true };
+        const dead: FeedEvent = {
+            seq: 12,
+            ts: "t",
+            type: "logged_out",
+            agent_id: "agt_beta",
+            reason: "dead_pid",
+        };
+        const clean: FeedEvent = {
+            seq: 13,
+            ts: "t",
+            type: "logged_out",
+            agent_id: "agt_beta",
+            reason: "clean_exit",
+        };
+        expect(isVisibleToAgent(dead, main)).toBe(true);
+        expect(isVisibleToAgent(clean, main)).toBe(false);
+    });
+
+    test("hides all peer lifecycle events by default for non-main agents (debug off)", () => {
+        const loggedIn: FeedEvent = {
+            seq: 12,
+            ts: "2026-01-01T00:00:12Z",
+            type: "logged_in",
+            agent_id: "agt_beta",
+            agent_name: "beta",
+            mode: "stream",
+        };
+        const loggedOutDead: FeedEvent = {
+            seq: 13,
+            ts: "2026-01-01T00:00:13Z",
+            type: "logged_out",
+            agent_id: "agt_beta",
+            reason: "dead_pid",
+        };
+        const loggedOutClean: FeedEvent = {
+            seq: 14,
+            ts: "2026-01-01T00:00:14Z",
+            type: "logged_out",
+            agent_id: "agt_beta",
+            reason: "clean_exit",
+        };
+        expect(isVisibleToAgent(loggedIn, agentAlpha)).toBe(false);
+        expect(isVisibleToAgent(loggedOutDead, agentAlpha)).toBe(false);
+        expect(isVisibleToAgent(loggedOutClean, agentAlpha)).toBe(false);
+    });
+
+    test("shows all peer lifecycle events when session debug is on", () => {
+        const loggedIn: FeedEvent = {
+            seq: 12,
+            ts: "2026-01-01T00:00:12Z",
+            type: "logged_in",
+            agent_id: "agt_beta",
+            agent_name: "beta",
+            mode: "stream",
+        };
+        const loggedOutDead: FeedEvent = {
+            seq: 13,
+            ts: "2026-01-01T00:00:13Z",
+            type: "logged_out",
+            agent_id: "agt_beta",
+            reason: "dead_pid",
+        };
+        expect(isVisibleToAgent(loggedIn, agentAlpha, { debug: true })).toBe(true);
+        expect(isVisibleToAgent(loggedOutDead, agentAlpha, { debug: true })).toBe(true);
+    });
+
+    test("never shows own lifecycle events even with debug on", () => {
+        const loggedIn: FeedEvent = {
+            seq: 12,
+            ts: "2026-01-01T00:00:12Z",
+            type: "logged_in",
+            agent_id: "agt_alpha",
+            agent_name: "alpha",
+            mode: "stream",
+        };
+        expect(isVisibleToAgent(loggedIn, agentAlpha, { debug: true })).toBe(false);
+    });
+});
+
+describe("filter.filterForAgent", () => {
+    test("excludes own sends and other-target directs; keeps own-target + broadcasts from others", () => {
+        const events: FeedEvent[] = [
+            msgEvent({ type: "message", to_agent_ids: ["agt_alpha"] }),
+            msgEvent({ type: "message", from_agent_id: "agt_alpha", to_agent_ids: [] }),
+            msgEvent({ type: "message", to_agent_ids: [] }),
+            msgEvent({ type: "message", to_agent_ids: ["agt_other"] }),
+        ];
+        const result = filterForAgent(events, agentAlpha);
+        expect(result.length).toBe(2);
+    });
+});

--- a/src/agents/tests/id-gen.test.ts
+++ b/src/agents/tests/id-gen.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { nextSubagentId } from "../lib/derived-registry";
+import { deriveMainAgentId, ensureMainPrefix, isMainId } from "../lib/id-gen";
+import type { AgentRecord } from "../lib/types";
+
+function rec(agent_id: string): AgentRecord {
+    return {
+        agent_id,
+        agent_name: agent_id,
+        is_main: false,
+        role: null,
+        registered_at: "t",
+        logged_in_at: null,
+        logged_out_at: null,
+        mode: null,
+        meta: {},
+    };
+}
+
+describe("derived-registry.nextSubagentId", () => {
+    test("returns agt_0001 from an empty registry", () => {
+        expect(nextSubagentId([])).toBe("agt_0001");
+    });
+
+    test("monotonic from max-suffix+1 (not count+1)", () => {
+        const records = [rec("agt_0001"), rec("agt_0002"), rec("agt_0003")];
+        expect(nextSubagentId(records)).toBe("agt_0004");
+    });
+
+    test("respects gaps — max-suffix+1, not count+1", () => {
+        // User passed `--agent-id agt_0005` explicitly; count would be 2 but max+1 must be 6
+        const records = [rec("agt_0001"), rec("agt_0005")];
+        expect(nextSubagentId(records)).toBe("agt_0006");
+    });
+
+    test("ignores non-agt_ ids when computing max", () => {
+        const records = [rec("agt_0001"), rec("main_lead"), rec("agt_0003")];
+        expect(nextSubagentId(records)).toBe("agt_0004");
+    });
+
+    test("hex suffix > 0xffff still increments (overflow is a runtime concern, not allocator)", () => {
+        const records = [rec("agt_0010"), rec("agt_00ff")];
+        expect(nextSubagentId(records)).toBe("agt_0100");
+    });
+});
+
+describe("id-gen", () => {
+    test("deriveMainAgentId slugs the session", () => {
+        const id = deriveMainAgentId("ABCDEFGH-12345678");
+        expect(id).toBe("main_abcdefgh1234");
+    });
+
+    test("deriveMainAgentId falls back to random when session has no alphanumerics", () => {
+        const id = deriveMainAgentId("!!!!");
+        expect(id).toMatch(/^main_[0-9a-f]{4,6}$/);
+    });
+
+    test("ensureMainPrefix is idempotent on already-prefixed ids", () => {
+        expect(ensureMainPrefix("main_abc12345", "session-xyz")).toBe("main_abc12345");
+    });
+
+    test("ensureMainPrefix rewrites agt_ prefix to main_", () => {
+        expect(ensureMainPrefix("agt_abc12345", "session-xyz")).toBe("main_abc12345");
+    });
+
+    test("ensureMainPrefix prepends to bare ids", () => {
+        expect(ensureMainPrefix("custom", "session-xyz")).toBe("main_custom");
+    });
+
+    test("isMainId detects main_ prefix", () => {
+        expect(isMainId("main_xxx")).toBe(true);
+        expect(isMainId("agt_xxx")).toBe(false);
+        expect(isMainId("")).toBe(false);
+    });
+});

--- a/src/agents/tests/matrix-e2e.test.ts
+++ b/src/agents/tests/matrix-e2e.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+
+// Default-on, opt-out via explicit "0" — route through the env facade (dynamic-key
+// lookup, same helper used for ask ProviderConfig.envKey) so env.testing
+// overrides stay the single mechanism for controlling env-gated behavior.
+const ENABLED = env.ai.getByEnvKey("AGENTS_E2E") !== "0";
+const SCRIPT = join(import.meta.dir, "matrix.sh");
+
+describe.if(ENABLED)("agents matrix e2e", () => {
+    test("all CLI permutations pass", async () => {
+        const proc = Bun.spawn(["bash", SCRIPT], {
+            stdout: "pipe",
+            stderr: "pipe",
+            env: { ...process.env, AGENTS_E2E_RUN: "1" },
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+
+        if (exitCode !== 0) {
+            const tail = stdout.split("\n").slice(-60).join("\n");
+            console.error(`=== matrix.sh stdout (last 60 lines) ===\n${tail}`);
+
+            if (stderr.trim()) {
+                console.error(`=== matrix.sh stderr ===\n${stderr}`);
+            }
+        }
+
+        expect(exitCode).toBe(0);
+    }, 180_000);
+});

--- a/src/agents/tests/matrix.sh
+++ b/src/agents/tests/matrix.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# Agents tool — comprehensive matrix test
+# Runs all permutations and asserts exact behavior.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/../../.." || exit 1
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+red()    { printf '\033[31m%s\033[0m' "$1"; }
+green()  { printf '\033[32m%s\033[0m' "$1"; }
+yellow() { printf '\033[33m%s\033[0m' "$1"; }
+cyan()   { printf '\033[36m%s\033[0m' "$1"; }
+bold()   { printf '\033[1m%s\033[0m' "$1"; }
+
+section() { echo; echo "=== $(cyan "$1") ==="; }
+
+pass() { PASS=$((PASS+1)); echo "  $(green '✓') $1"; }
+
+fail() {
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$1")
+    echo "  $(red '✗') $1"
+    if [ -n "${2:-}" ]; then
+        echo "       $(yellow 'reason:') $2"
+    fi
+}
+
+assert_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        pass "$name"
+    else
+        fail "$name" "expected to contain '$needle' — got: $(head -c 300 <<<"$haystack")"
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        fail "$name" "expected NOT to contain '$needle' — got: $(head -c 300 <<<"$haystack")"
+    else
+        pass "$name"
+    fi
+}
+
+assert_exit() {
+    local name="$1" got="$2" want="$3"
+    if [ "$got" = "$want" ]; then
+        pass "$name (exit $got)"
+    else
+        fail "$name" "expected exit $want, got $got"
+    fi
+}
+
+assert_count() {
+    local name="$1" haystack="$2" needle="$3" want="$4"
+    local got
+    got=$(grep -oF "$needle" <<<"$haystack" | wc -l | tr -d ' ')
+    if [ "$got" = "$want" ]; then
+        pass "$name (count=$got)"
+    else
+        fail "$name" "expected $want occurrences of '$needle', got $got"
+    fi
+}
+
+RUN_ID="m$(date +%s)"
+BG_PIDS=()
+cleanup_sessions() {
+    for pid in "${BG_PIDS[@]:-}"; do
+        [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    done
+    sleep 0.3
+}
+trap cleanup_sessions EXIT
+
+mksess() {
+    echo "${RUN_ID}-$1-$$"
+}
+
+# Helper: log in (auto-register) and exit immediately via --once with no messages
+# Using `timeout 2` so it returns even when nothing's pending.
+quick_login() {
+    timeout 2 ./tools agents login "$@" --once 2>/dev/null || true
+}
+
+# ============================================================
+section "1. Login auto-register matrix"
+# ============================================================
+
+# 1.1 login --agent-name --agent-main (main agent, instant register + login)
+S=$(mksess l1)
+quick_login --agent-name lead --agent-main --session "$S"
+DISC=$(./tools agents discover --session "$S" --format json 2>&1)
+assert_contains "main auto-registered with main_ prefix" "$DISC" '"agent_id":"main_'
+assert_contains "  is_main:true on the record" "$DISC" '"is_main":true'
+
+# 1.2 second --agent-main on same session errors
+OUT=$(./tools agents login --agent-name lead2 --agent-main --once --session "$S" 2>&1); RC=$?
+assert_exit "second --agent-main fails" "$RC" "1"
+assert_contains "  friendly error names existing main" "$OUT" "main agent is already registered"
+
+# 1.3 login --agent-name peer auto-registers as subagent
+quick_login --agent-name peer1 --session "$S"
+DISC=$(./tools agents discover --session "$S" --format json 2>&1)
+assert_contains "peer auto-registered with agt_ prefix" "$DISC" '"agent_id":"agt_0001"'
+
+# 1.4 second peer goes to agt_0002 (monotonic)
+quick_login --agent-name peer2 --session "$S"
+DISC=$(./tools agents discover --session "$S" --format json 2>&1)
+assert_contains "second peer is agt_0002" "$DISC" '"agent_id":"agt_0002"'
+
+# 1.5 login with same name re-attaches (no error)
+quick_login --agent-name peer1 --session "$S"
+DISC=$(./tools agents discover --session "$S" --format json 2>&1)
+assert_count "peer1 still single record" "$DISC" '"agent_name":"peer1"' 1
+
+# 1.6 --debug enables session debug
+S=$(mksess l6)
+quick_login --agent-name lead --agent-main --debug --session "$S"
+META=$(cat ~/.genesis-tools/agents/"$S"/session-meta.json 2>/dev/null || echo "")
+assert_contains "--debug writes session-meta debug:true" "$META" '"debug":true'
+
+# ============================================================
+section "2. Login takeover-fail-loud"
+# ============================================================
+
+# 2.1 second login on same agent FAILS LOUD (no takeover; user must kill old)
+S=$(mksess l21)
+quick_login --agent-name lead --agent-main --session "$S"
+./tools agents login --agent-name lead --session "$S" > /tmp/log21-old.log 2>&1 &
+OLD_PID=$!
+BG_PIDS+=("$OLD_PID")
+LOCK=$(./tools agents discover --session "$S" --format json | tools json 2>/dev/null | grep -oE 'main_[a-z0-9]+' | head -1)
+LOCKPATH=~/.genesis-tools/agents/"$S"/slots/"$LOCK".login
+for i in $(seq 1 30); do
+    [ -f "$LOCKPATH" ] && break
+    sleep 0.1
+done
+[ -f "$LOCKPATH" ] && pass "background stream login holds slot lock" || fail "background stream login holds slot lock"
+
+OUT=$(timeout 3 ./tools agents login --agent-name lead --once --session "$S" 2>&1 || true)
+assert_contains "second login fails loudly (no takeover)" "$OUT" "already held by pid"
+assert_contains "  hint suggests killing the old pid" "$OUT" "kill"
+if kill -0 "$OLD_PID" 2>/dev/null; then
+    pass "old login is still running (we did not steal its lock)"
+else
+    fail "old login is still running" "expected alive, but it exited"
+fi
+
+kill "$OLD_PID" 2>/dev/null
+wait "$OLD_PID" 2>/dev/null || true
+sleep 0.3
+./tools agents message --from lead --to lead --body 'self-ping' --session "$S" > /dev/null 2>&1
+# (no recipient registered besides lead; just verify the re-login works after cleanup)
+OUT=$(timeout 3 ./tools agents login --agent-name lead --once --session "$S" 2>&1 || true)
+assert_not_contains "after old killed, new login does NOT hit lock-held" "$OUT" "already held by pid"
+rm -f /tmp/log21-old.log
+
+# ============================================================
+section "3. Message matrix"
+# ============================================================
+
+S=$(mksess msg)
+quick_login --agent-name lead --agent-main --session "$S"
+quick_login --agent-name a --session "$S"
+quick_login --agent-name b --session "$S"
+quick_login --agent-name c --session "$S"
+
+# 3.1 direct by name
+OUT=$(./tools agents message --from a --to b --body 'd1' --session "$S" 2>&1); RC=$?
+assert_exit "direct by name" "$RC" "0"
+assert_contains "  kind=direct" "$OUT" '"kind":"direct"'
+
+# 3.2 direct by id (token starts with agt_)
+OUT=$(./tools agents message --from agt_0001 --to agt_0002 --body 'd2' --session "$S" 2>&1); RC=$?
+assert_exit "direct by id (sniffed via agt_ prefix)" "$RC" "0"
+assert_contains "  recipients list" "$OUT" '"agt_0002"'
+
+# 3.3 broadcast
+OUT=$(./tools agents message --from a --body 'bc' --session "$S" 2>&1); RC=$?
+assert_exit "broadcast" "$RC" "0"
+assert_contains "  kind=broadcast" "$OUT" '"kind":"broadcast"'
+
+# 3.4 multi-recipient names
+OUT=$(./tools agents message --from a --to b,c --body 'mr' --session "$S" 2>&1)
+assert_contains "multi-recipient: b present" "$OUT" '"agt_0002"'
+assert_contains "multi-recipient: c present" "$OUT" '"agt_0003"'
+
+# 3.5 dedup duplicate names
+OUT=$(./tools agents message --from a --to b,b --body 'dup' --session "$S" 2>&1)
+assert_count "duplicate names → 1 recipient" "$OUT" 'agt_0002' 1
+
+# 3.6 dedup id+name combined for same agent
+OUT=$(./tools agents message --from a --to agt_0002,b --body 'mix' --session "$S" 2>&1)
+assert_count "id+name same agent → 1 recipient" "$OUT" 'agt_0002' 1
+
+# 3.7 self-target warns
+OUT=$(./tools agents message --from a --to a --body 'self' --session "$S" 2>&1)
+assert_contains "self-target warning" "$OUT" "recipient list includes the sender"
+
+# 3.8 missing body
+OUT=$(./tools agents message --from a --session "$S" 2>&1); RC=$?
+assert_exit "missing --body errors" "$RC" "1"
+assert_contains "  friendly error" "$OUT" "--body is required"
+
+# 3.9 missing sender
+OUT=$(./tools agents message --body 'x' --session "$S" 2>&1); RC=$?
+assert_exit "missing --from errors" "$RC" "1"
+assert_contains "  lists available senders" "$OUT" "Registered"
+
+# 3.10 unknown sender
+OUT=$(./tools agents message --from ghost --body 'x' --session "$S" 2>&1); RC=$?
+assert_exit "unknown sender errors" "$RC" "1"
+
+# 3.11 unknown recipient
+OUT=$(./tools agents message --from a --to ghost --body 'x' --session "$S" 2>&1); RC=$?
+assert_exit "unknown recipient errors" "$RC" "1"
+
+# 3.12 message_id starts at 0001, monotonic
+S=$(mksess msgid)
+quick_login --agent-name lead --agent-main --session "$S"
+quick_login --agent-name a --session "$S"
+quick_login --agent-name b --session "$S"
+OUT1=$(./tools agents message --from a --to b --body '1' --session "$S")
+OUT2=$(./tools agents message --from a --to b --body '2' --session "$S")
+OUT3=$(./tools agents message --from a --to b --body '3' --session "$S")
+assert_contains "first message is 0001" "$OUT1" '"message_id":"0001"'
+assert_contains "second message is 0002" "$OUT2" '"message_id":"0002"'
+assert_contains "third message is 0003" "$OUT3" '"message_id":"0003"'
+
+# ============================================================
+section "4. Reply / ack matrix"
+# ============================================================
+
+S=$(mksess resp)
+quick_login --agent-name lead --agent-main --session "$S"
+quick_login --agent-name a --session "$S"
+quick_login --agent-name b --session "$S"
+quick_login --agent-name c --session "$S"
+
+OUT=$(./tools agents message --from a --to b --body 'q1' --session "$S")
+MID=$(sed -nE 's/.*"message_id":"([^"]+)".*/\1/p' <<<"$OUT" | head -1)
+[ -n "$MID" ] && pass "captured original message_id ($MID)" || fail "captured original message_id"
+
+# 4.1 message --reply with body → kind:reply
+OUT=$(./tools agents message --from b --reply "$MID" --body 'r1' --session "$S")
+assert_contains "reply with body → kind:reply" "$OUT" '"kind":"reply"'
+assert_contains "  carries in_reply_to" "$OUT" "\"in_reply_to\":\"$MID\""
+
+# 4.2 message --reply without body → kind:ack
+OUT=$(./tools agents message --from b --reply "$MID" --session "$S")
+assert_contains "reply no body → kind:ack" "$OUT" '"kind":"ack"'
+
+# 4.3 original sender (a) sees the reply
+OUT=$(timeout 4 ./tools agents login --agent-name a --once --session "$S" 2>/dev/null || true)
+assert_contains "  original sender a sees reply" "$OUT" "\"in_reply_to\":\"$MID\""
+assert_not_contains "  original sender a does NOT see own original message" "$OUT" '"body":"q1"'
+
+# 4.4 uninvolved peer c does NOT see reply
+./tools agents message --from a --to c --body 'c-ping' --session "$S" > /dev/null
+OUT=$(timeout 4 ./tools agents login --agent-name c --once --session "$S" 2>/dev/null || true)
+assert_contains "  uninvolved c sees own incoming message" "$OUT" '"body":"c-ping"'
+assert_not_contains "  uninvolved c does NOT see reply to a's message" "$OUT" "\"in_reply_to\":\"$MID\""
+
+# 4.5 unknown in_reply_to with no --to errors (cannot resolve who to route to)
+OUT=$(./tools agents message --from b --reply ffff --session "$S" 2>&1); RC=$?
+assert_exit "reply to unknown msg id with no --to errors" "$RC" "1"
+assert_contains "  friendly error names the unresolved reply" "$OUT" "Could not resolve original sender"
+
+# 4.6 unknown in_reply_to WITH explicit --to is allowed (recipient given, no need to resolve)
+OUT=$(./tools agents message --from b --to a --reply ffff --session "$S" 2>&1); RC=$?
+assert_exit "reply to unknown msg id with explicit --to is allowed" "$RC" "0"
+
+# ============================================================
+section "5. Visibility matrix"
+# ============================================================
+
+# 5.1 Main without --debug does NOT see registered events
+S=$(mksess vis1)
+quick_login --agent-name lead --agent-main --session "$S"
+quick_login --agent-name p --session "$S"
+./tools agents message --from p --to lead --body 'm1' --session "$S" > /dev/null
+OUT=$(timeout 4 ./tools agents login --agent-name lead --once --session "$S" 2>/dev/null || true)
+assert_not_contains "main w/o debug doesn't see registered" "$OUT" '"type":"registered"'
+assert_contains "  main does see the message" "$OUT" '"body":"m1"'
+
+# 5.2 Main WITH --debug sees registered events
+S=$(mksess vis2)
+quick_login --agent-name lead --agent-main --debug --session "$S"
+quick_login --agent-name p --session "$S"
+./tools agents message --from p --to lead --body 'm1' --session "$S" > /dev/null
+OUT=$(timeout 4 ./tools agents login --agent-name lead --once --session "$S" 2>/dev/null || true)
+assert_contains "main WITH debug sees registered" "$OUT" '"type":"registered"'
+
+# 5.3 Non-main peer w/o debug does NOT see lifecycle of others
+S=$(mksess vis3)
+quick_login --agent-name lead --agent-main --session "$S"
+quick_login --agent-name p --session "$S"
+quick_login --agent-name q --session "$S"
+./tools agents message --from p --to q --body 'msg' --session "$S" > /dev/null
+OUT=$(timeout 4 ./tools agents login --agent-name q --once --session "$S" 2>/dev/null || true)
+assert_not_contains "non-main peer w/o debug: no registered events" "$OUT" '"type":"registered"'
+assert_contains "  peer q does see message addressed to it" "$OUT" '"body":"msg"'
+
+# ============================================================
+section "6. Discover"
+# ============================================================
+S=$(mksess disc)
+quick_login --agent-name lead --agent-main --session "$S"
+quick_login --agent-name a --session "$S"
+quick_login --agent-name b --session "$S"
+
+OUT=$(./tools agents discover --session "$S" --format json 2>&1)
+assert_contains "discover lists lead" "$OUT" '"agent_name":"lead"'
+assert_contains "  has a" "$OUT" '"agent_name":"a"'
+assert_contains "  has b" "$OUT" '"agent_name":"b"'
+
+# ============================================================
+section "7. Session resolution + error UX"
+# ============================================================
+
+# 7.1 invalid JSON in --meta
+S=$(mksess err1)
+quick_login --agent-name lead --agent-main --session "$S"
+OUT=$(./tools agents login --agent-name x --meta 'not-json' --once --session "$S" 2>&1); RC=$?
+assert_exit "invalid --meta JSON errors" "$RC" "1"
+
+# 7.2 --meta as array (not object) errors
+OUT=$(./tools agents login --agent-name x --meta '[]' --once --session "$S" 2>&1); RC=$?
+assert_exit "--meta as array errors" "$RC" "1"
+assert_contains "  hint says must be object" "$OUT" "must be a JSON object"
+
+# 7.3 missing session resolution errors
+OUT=$(env -u CLAUDE_CODE_SESSION_ID ./tools agents discover 2>&1); RC=$?
+if [ "$RC" != "0" ] && grep -qF "could not resolve a session" <<<"$OUT"; then
+    pass "no session resolvable → friendly error"
+else
+    fail "no session resolvable → friendly error" "got exit $RC, out: $(head -c 200 <<<"$OUT")"
+fi
+
+# ============================================================
+section "Summary"
+# ============================================================
+echo
+echo "Total: $(bold $((PASS+FAIL)))  $(green "PASS: $PASS")  $(red "FAIL: $FAIL")"
+if [ $FAIL -gt 0 ]; then
+    echo
+    echo "$(red 'Failed tests:')"
+    for t in "${FAILED_TESTS[@]}"; do echo "  - $t"; done
+    exit 1
+fi
+exit 0

--- a/src/utils/fs/file-feed-watcher.ts
+++ b/src/utils/fs/file-feed-watcher.ts
@@ -1,0 +1,164 @@
+import { existsSync, type FSWatcher, watch } from "node:fs";
+import { logger } from "@app/logger";
+
+const log = logger.child({ component: "fs:file-feed-watcher" });
+
+const DEFAULT_DEBOUNCE_MS = 100;
+const DEFAULT_POLL_FALLBACK_MS = 1000;
+
+export interface FileFeedWatcherOptions {
+    path: string;
+    onChange: () => Promise<{ done: boolean } | void> | { done: boolean } | void;
+    deadlineAt?: number;
+    debounceMs?: number;
+    pollFallbackMs?: number;
+    signal?: AbortSignal;
+}
+
+/**
+ * Watches a file for change events and invokes a callback per change.
+ *
+ * - Uses `fs.watch` (inotify/kqueue) with a setInterval polling fallback in case
+ *   the platform's watcher misses events (macOS APFS is known to drop notifications).
+ * - Debounces bursts of change events into a single callback.
+ * - The callback can signal completion by returning `{ done: true }` — the watcher
+ *   stops cleanly and the returned Promise resolves.
+ * - Deadline (optional wall-clock cap, e.g. 1h sanity ceiling) triggers a final
+ *   callback then resolves.
+ * - All timers are cleaned up; late-arriving timer callbacks check `resolved` and
+ *   short-circuit (prevents post-cleanup emissions).
+ *
+ * Returns a Promise that resolves when the watcher exits (deadline or done).
+ */
+export async function watchFileFeed(opts: FileFeedWatcherOptions): Promise<void> {
+    const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    const pollFallbackMs = opts.pollFallbackMs ?? DEFAULT_POLL_FALLBACK_MS;
+
+    let watcher: FSWatcher | null = null;
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let resolved = false;
+    let onAbort: (() => void) | null = null;
+
+    const cleanup = (): void => {
+        if (watcher) {
+            watcher.close();
+            watcher = null;
+        }
+
+        if (pollTimer) {
+            clearInterval(pollTimer);
+            pollTimer = null;
+        }
+
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+        }
+
+        if (onAbort && opts.signal) {
+            opts.signal.removeEventListener("abort", onAbort);
+            onAbort = null;
+        }
+    };
+
+    return new Promise<void>((resolve) => {
+        const finish = (): void => {
+            if (resolved) {
+                return;
+            }
+
+            resolved = true;
+            cleanup();
+            resolve();
+        };
+
+        let checking = false;
+        const check = async (): Promise<void> => {
+            if (resolved || checking) {
+                return;
+            }
+
+            checking = true;
+            try {
+                const result = await opts.onChange();
+
+                if (resolved) {
+                    return;
+                }
+
+                if (result && result.done) {
+                    finish();
+                    return;
+                }
+
+                if (opts.deadlineAt && Date.now() >= opts.deadlineAt) {
+                    finish();
+                    return;
+                }
+            } catch (err) {
+                log.warn({ err, path: opts.path }, "onChange callback threw");
+            } finally {
+                checking = false;
+            }
+        };
+
+        const debounce = (): void => {
+            if (debounceTimer) {
+                return;
+            }
+
+            debounceTimer = setTimeout(() => {
+                debounceTimer = null;
+
+                if (resolved) {
+                    return;
+                }
+
+                void check();
+            }, debounceMs);
+        };
+
+        if (opts.signal) {
+            if (opts.signal.aborted) {
+                finish();
+                return;
+            }
+
+            onAbort = (): void => {
+                finish();
+            };
+            opts.signal.addEventListener("abort", onAbort);
+        }
+
+        try {
+            if (existsSync(opts.path)) {
+                watcher = watch(opts.path, { persistent: true }, debounce);
+                watcher.on("error", (err) => {
+                    log.warn(
+                        { err, path: opts.path },
+                        "fs.watch runtime error; closing watcher, poll fallback continues"
+                    );
+
+                    if (watcher) {
+                        watcher.close();
+                        watcher = null;
+                    }
+                });
+            }
+        } catch (err) {
+            log.warn({ err, path: opts.path }, "fs.watch failed; using poll only");
+        }
+
+        pollTimer = setInterval(() => {
+            if (opts.deadlineAt && Date.now() >= opts.deadlineAt) {
+                finish();
+                return;
+            }
+
+            void check();
+        }, pollFallbackMs);
+
+        void check();
+    });
+}

--- a/src/utils/storage/stale-lock-sweep.ts
+++ b/src/utils/storage/stale-lock-sweep.ts
@@ -1,0 +1,142 @@
+import { existsSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { isProcessAlive } from "@app/utils/process-alive";
+
+const log = logger.child({ component: "storage:stale-lock-sweep" });
+
+export interface LockPayload {
+    pid: number;
+    since?: string;
+    [k: string]: unknown;
+}
+
+export interface ReapedLock {
+    lock: string;
+    pid?: number;
+    reason: "dead_pid" | "unreadable";
+    payload: LockPayload;
+}
+
+export interface WarningLock {
+    lock: string;
+    pid: number;
+    age_h: number;
+    payload: LockPayload;
+}
+
+export interface SweepReport {
+    reaped: ReapedLock[];
+    warnings: WarningLock[];
+    inspected: number;
+}
+
+export interface SweepOptions {
+    maxAgeHours?: number;
+    matchExtensions?: string[];
+}
+
+const DEFAULT_MAX_AGE_HOURS = 24;
+const DEFAULT_EXTENSIONS = [".lock", ".login"];
+
+function parsePayload(path: string): LockPayload | null {
+    try {
+        const text = readFileSync(path, "utf8");
+        const trimmed = text.trim();
+
+        if (!trimmed) {
+            return null;
+        }
+
+        if (/^\d+$/.test(trimmed)) {
+            return { pid: Number.parseInt(trimmed, 10) };
+        }
+
+        const parsed = SafeJSON.parse(trimmed) as Partial<LockPayload>;
+
+        if (typeof parsed.pid !== "number") {
+            return null;
+        }
+
+        return parsed as LockPayload;
+    } catch {
+        return null;
+    }
+}
+
+export function sweepStaleLocks(dir: string, opts: SweepOptions = {}): SweepReport {
+    const maxAgeHours = opts.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
+    const extensions = opts.matchExtensions ?? DEFAULT_EXTENSIONS;
+    const report: SweepReport = { reaped: [], warnings: [], inspected: 0 };
+
+    if (!existsSync(dir)) {
+        return report;
+    }
+
+    const entries = readdirSync(dir);
+    const now = Date.now();
+
+    for (const entry of entries) {
+        if (!extensions.some((ext) => entry.endsWith(ext))) {
+            continue;
+        }
+
+        const fullPath = join(dir, entry);
+        let stat: ReturnType<typeof statSync>;
+
+        try {
+            stat = statSync(fullPath);
+        } catch {
+            continue;
+        }
+
+        if (!stat.isFile()) {
+            continue;
+        }
+
+        report.inspected += 1;
+
+        const payload = parsePayload(fullPath);
+
+        if (!payload) {
+            // Caller contracts (e.g. agents login's slot-already-held error) promise
+            // unreadable locks are reaped on the next sweep attempt. writeFileSync
+            // writes the payload in one syscall, so a corrupt/truncated file here is
+            // a genuine fault, not a write-in-progress race — safe to reap outright.
+            try {
+                unlinkSync(fullPath);
+                report.reaped.push({ lock: fullPath, reason: "unreadable", payload: { pid: 0 } });
+                log.warn({ lock: fullPath }, "reaped unreadable lock file");
+            } catch (err) {
+                log.warn({ lock: fullPath, err }, "failed to unlink unreadable lock");
+            }
+
+            continue;
+        }
+
+        const alive = isProcessAlive(payload.pid);
+
+        if (!alive) {
+            try {
+                unlinkSync(fullPath);
+                report.reaped.push({ lock: fullPath, pid: payload.pid, reason: "dead_pid", payload });
+                log.info({ lock: fullPath, pid: payload.pid }, "reaped stale lock (dead pid)");
+            } catch (err) {
+                log.warn({ lock: fullPath, err }, "failed to unlink stale lock");
+            }
+
+            continue;
+        }
+
+        const ageMs = now - stat.mtimeMs;
+        const ageH = ageMs / 3_600_000;
+
+        if (ageH >= maxAgeHours) {
+            report.warnings.push({ lock: fullPath, pid: payload.pid, age_h: Number(ageH.toFixed(2)), payload });
+            log.warn({ lock: fullPath, pid: payload.pid, age_h: ageH }, "lock alive but older than warning threshold");
+        }
+    }
+
+    return report;
+}


### PR DESCRIPTION
## Summary

Split out of `feat/stash-v1.1` (PR #225 covers the stash tool itself — unrelated scope). This PR carries only the cross-agent communication CLI commits, rebased cleanly onto `master`.

Adds `tools agents`, a CLI for cross-agent messaging between Claude Code sessions:

- `login` / auto-register — slot-lock-based session coordination so an agent claims a named slot, with graceful takeover of a stale login
- `discover` / `listen` — feed-derived registry of who's online, streamed or polled
- `message` / `--reply` — send and reply to messages, with id/name sniffing for `--to`/`--from`
- State is derived entirely from the append-only feed (no separate counters/registry tables to keep in sync) via a reusable `src/utils/fs/file-feed-watcher.ts`

## Test plan

- [x] `bun test src/agents/` — 25 pass, 0 fail
- [x] `bun --bun x tsgo --noEmit` — clean, no errors
- [x] `git diff feat/stash-v1.1 -- src/agents/ src/utils/fs/file-feed-watcher.ts plugins/genesis-tools/skills/agents-talk/` — empty (byte-identical to source branch)
- [x] Pre-push CI mirror (lint + typecheck) passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tools agents` CLI with login, direct messaging, replies/acks, broadcasts, session discovery, and live feed listening.
  * Added `agents-talk` skill documentation and a SessionStart hint to prompt `/gt:agents-talk` usage.
* **Bug Fixes**
  * Improved message visibility and delivery behavior with per-agent deduplication/resume, plus more reliable reply routing.
  * Improved stale-lock reaping and safer handling of session/agent identifiers.
* **Documentation**
  * Added detailed end-to-end guides for the agent messaging workflow and on-disk session layout.
* **Tests**
  * Added unit and e2e/matrix test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->