### PR TITLE
fix(daemon): survive respawn storms, wedges, and unkillable zombies (Jul 3/6/8 incident class)

### DIFF
--- a/src/daemon/commands/restart.ts
+++ b/src/daemon/commands/restart.ts
@@ -1,5 +1,5 @@
 import { getDaemonStatus } from "@app/daemon/lib/launchd";
-import { safeSigterm, waitForDaemonRestart } from "@app/daemon/lib/wait-for-restart";
+import { stopWithEscalation, waitForDaemonRestart } from "@app/daemon/lib/wait-for-restart";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
@@ -34,10 +34,18 @@ export function registerRestartCommand(program: Command): void {
             }
 
             const oldPid = status.pid;
-            safeSigterm(oldPid);
 
             const s = p.spinner();
             s.start("Restarting daemon...");
+
+            // Escalating stop (SIGTERM → SIGTERM → SIGKILL): a wedged daemon
+            // used to ignore the single SIGTERM and 'restart' just timed out.
+            const stopResult = await stopWithEscalation(oldPid);
+
+            if (!stopResult.exited) {
+                s.stop(`Daemon (PID ${oldPid}) survived SIGTERM→SIGTERM→SIGKILL — inspect it manually`);
+                return;
+            }
 
             const result = await waitForDaemonRestart(oldPid);
 

--- a/src/daemon/commands/stop.ts
+++ b/src/daemon/commands/stop.ts
@@ -1,9 +1,15 @@
 import { getDaemonPid } from "@app/daemon/daemon";
 import { getDaemonStatus, uninstallLaunchd } from "@app/daemon/lib/launchd";
-import { safeSigterm, waitForDaemonRestart } from "@app/daemon/lib/wait-for-restart";
+import { stopWithEscalation, waitForDaemonRestart } from "@app/daemon/lib/wait-for-restart";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
+
+const STEP_LABEL: Record<string, string> = {
+    sigterm: "graceful SIGTERM",
+    "sigterm-again": "second SIGTERM (force-exit handler)",
+    sigkill: "SIGKILL",
+};
 
 export function registerStopCommand(program: Command): void {
     program
@@ -26,12 +32,24 @@ export function registerStopCommand(program: Command): void {
                 return;
             }
 
+            let stepNote = "";
+
             if (pid) {
-                safeSigterm(pid);
+                const s = p.spinner();
+                s.start(`Stopping daemon (PID ${pid})...`);
+                const result = await stopWithEscalation(pid);
+                stepNote = result.step ? ` via ${STEP_LABEL[result.step] ?? result.step}` : "";
+
+                if (!result.exited) {
+                    s.stop(`Daemon (PID ${pid}) survived SIGTERM→SIGTERM→SIGKILL — inspect it manually`);
+                    return;
+                }
+
+                s.stop(`Daemon stopped${stepNote}`);
             }
 
             if (!status.installed) {
-                p.log.success(`Sent SIGTERM to daemon (PID ${pid})`);
+                p.log.success(`Daemon stopped (PID ${pid})${stepNote}`);
                 return;
             }
 

--- a/src/daemon/commands/stop.ts
+++ b/src/daemon/commands/stop.ts
@@ -1,11 +1,12 @@
 import { getDaemonPid } from "@app/daemon/daemon";
 import { getDaemonStatus, uninstallLaunchd } from "@app/daemon/lib/launchd";
+import type { EscalationStep } from "@app/daemon/lib/wait-for-restart";
 import { stopWithEscalation, waitForDaemonRestart } from "@app/daemon/lib/wait-for-restart";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 
-const STEP_LABEL: Record<string, string> = {
+const STEP_LABEL: Record<EscalationStep, string> = {
     sigterm: "graceful SIGTERM",
     "sigterm-again": "second SIGTERM (force-exit handler)",
     sigkill: "SIGKILL",

--- a/src/daemon/daemon.test.ts
+++ b/src/daemon/daemon.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { attemptStaleTakeover, verifyPidfileOwnership } from "./daemon";
 
 /**
  * Waits for `marker` to appear in `stream`, reading incrementally so callers don't have to
@@ -70,5 +71,68 @@ describe("daemon SIGTERM shutdown ordering", () => {
         await proc.exited;
 
         expect(existsSync(pidFile)).toBe(false);
+    });
+});
+
+describe("daemon pidfile atomic takeover", () => {
+    let dir: string;
+    let pidFile: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "daemon-takeover-test-"));
+        pidFile = join(dir, "daemon.pid");
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("exactly one of N concurrent racers wins a stale-pidfile takeover", async () => {
+        // Regression test for the Jul 3 incident: a launchd respawn storm got
+        // 31 daemon instances past a check-then-unlink-then-write pidfile
+        // takeover within 8 seconds, and every one of them "won". The
+        // content-verified rename takeover must guarantee exactly one winner —
+        // rename alone is NOT enough (a late racer can rename the previous
+        // winner's fresh pidfile; this exact test caught 2 winners without
+        // the content check).
+        writeFileSync(pidFile, "999999999"); // dead PID — eligible for takeover
+
+        const RACER_COUNT = 12;
+        const results = await Promise.all(
+            Array.from({ length: RACER_COUNT }, () => attemptStaleTakeover(pidFile, "999999999"))
+        );
+
+        expect(results.filter((won) => won === true)).toHaveLength(1);
+
+        expect(existsSync(pidFile)).toBe(true);
+        expect(readFileSync(pidFile, "utf-8").trim()).toBe(String(process.pid));
+        expect(readdirSync(dir)).toEqual(["daemon.pid"]);
+    });
+
+    test("a takeover that grabs a FRESH pidfile restores it and loses", async () => {
+        // TOCTOU guard: the racer validated "999999999" as stale, but by the
+        // time its rename lands, a live owner has re-claimed the slot. The
+        // steal must detect the content mismatch, put the fresh file back,
+        // and report defeat.
+        writeFileSync(pidFile, "12345"); // a "fresh" owner (content ≠ what the racer validated)
+
+        const won = await attemptStaleTakeover(pidFile, "999999999");
+
+        expect(won).toBe(false);
+        expect(readFileSync(pidFile, "utf-8").trim()).toBe("12345"); // restored, not clobbered
+        expect(readdirSync(dir)).toEqual(["daemon.pid"]); // no temp litter
+    });
+
+    test("verifyPidfileOwnership reports loss when the pidfile is stolen out from under us", () => {
+        writeFileSync(pidFile, String(process.pid));
+        expect(verifyPidfileOwnership(pidFile)).toBe(true);
+
+        // Simulate a usurper stealing the pidfile (e.g. we lost a takeover
+        // race we didn't know about, or the file was manually removed).
+        writeFileSync(pidFile, "424242");
+        expect(verifyPidfileOwnership(pidFile)).toBe(false);
+
+        rmSync(pidFile);
+        expect(verifyPidfileOwnership(pidFile)).toBe(false);
     });
 });

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { configureLogger, logger } from "@app/logger";
 import { getLogsBaseDir, getPidFile } from "./lib/config";
@@ -7,27 +7,176 @@ import { runSchedulerLoop } from "./lib/scheduler";
 
 const { log } = logger.scoped("daemon");
 
-export async function startDaemon(): Promise<void> {
-    const pidFile = getPidFile();
-    mkdirSync(dirname(pidFile), { recursive: true });
+/** Exit code when a live daemon already owns the pidfile at startup. */
+export const EXIT_ALREADY_RUNNING = 1;
+/** Exit code when we lose the atomic stale-pidfile takeover race to another racer. */
+export const EXIT_LOST_TAKEOVER_RACE = 2;
+
+const STALE_TAKEOVER_MAX_ATTEMPTS = 3;
+const STALE_TAKEOVER_RETRY_MS = 50;
+
+function isEexist(err: unknown): boolean {
+    return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST";
+}
+
+function isEnoent(err: unknown): boolean {
+    return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+/**
+ * Atomically steal a stale pidfile whose content was pre-validated as dead.
+ *
+ * Renames it to a unique temp path first — rename is atomic on POSIX, so
+ * under N concurrent racers (e.g. a launchd respawn storm) exactly one
+ * rename succeeds; every loser gets ENOENT (the source is already gone
+ * under them) and returns false rather than also "winning".
+ *
+ * The rename alone is NOT sufficient: rename steals whatever currently sits
+ * at the path, so a late racer can grab the pidfile the previous winner just
+ * wrote (validated-stale at check time, fresh at rename time — TOCTOU; a
+ * 12-racer test reproduced two "winners" without this guard). So after the
+ * rename, the stolen content must still equal `expectedContent` — the exact
+ * stale artifact the caller validated. A mismatch means a fresh file was
+ * grabbed: restore it (best-effort `wx`; if someone claimed the slot
+ * meanwhile, the robbed owner's per-tick `verifyPidfileOwnership` self-exit
+ * is the backstop) and lose.
+ *
+ * Uses the async `rename()` (not `renameSync`): Bun's synchronous fs calls
+ * are reentrant under concurrent async-driven load (verified empirically —
+ * many concurrent `renameSync` callers in one process can each observe a
+ * "successful" rename of the same source), which breaks the single-winner
+ * guarantee this function exists to provide. The async version dispatches
+ * through the normal I/O completion queue with no such reentrancy.
+ *
+ * Exported for direct concurrency testing (see daemon.test.ts).
+ */
+export async function attemptStaleTakeover(pidFile: string, expectedContent: string): Promise<boolean> {
+    const tempPath = `${pidFile}.stale-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+
+    try {
+        await rename(pidFile, tempPath);
+    } catch (err) {
+        if (isEnoent(err)) {
+            return false;
+        }
+
+        throw err;
+    }
+
+    let stolen: string | null = null;
+
+    try {
+        stolen = readFileSync(tempPath, "utf-8");
+    } catch {
+        stolen = null;
+    }
+
+    if (stolen === null || stolen.trim() !== expectedContent.trim()) {
+        // We grabbed something other than the validated-stale file — a fresh
+        // owner wrote between our check and our rename. Put it back and lose.
+        if (stolen !== null) {
+            try {
+                await writeFile(pidFile, stolen, { flag: "wx" });
+            } catch {
+                // Slot already re-claimed — the robbed owner self-heals via
+                // its per-tick ownership check.
+            }
+        }
+
+        try {
+            unlinkSync(tempPath);
+        } catch {
+            // best-effort cleanup
+        }
+
+        return false;
+    }
 
     try {
         await writeFile(pidFile, String(process.pid), { flag: "wx" });
     } catch (err) {
-        if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST") {
-            const existing = getDaemonPid();
+        if (isEexist(err)) {
+            return false;
+        }
 
-            if (existing !== null) {
-                log.error({ existingPid: existing }, "[daemon] another daemon is already running");
-                process.exit(1);
-            }
-
-            unlinkSync(pidFile);
-            await writeFile(pidFile, String(process.pid), { flag: "wx" });
-        } else {
-            throw err;
+        throw err;
+    } finally {
+        try {
+            unlinkSync(tempPath);
+        } catch {
+            // best-effort cleanup; ENOENT if somehow already gone
         }
     }
+
+    return true;
+}
+
+/**
+ * Claim the daemon pidfile as our own.
+ *
+ * Fresh case: plain `wx` create. If it already exists, either a live daemon
+ * owns it (fail fast) or it's stale, in which case we atomically race to
+ * take it over. Losing the race means another racer already won and is (or
+ * will shortly be) the live owner, so we re-check and exit cleanly with a
+ * distinct code instead of retrying forever.
+ */
+async function claimPidfile(pidFile: string): Promise<void> {
+    for (let attempt = 1; attempt <= STALE_TAKEOVER_MAX_ATTEMPTS; attempt++) {
+        // Fresh create first — also the recovery path when a previous racer's
+        // takeover left the slot momentarily empty.
+        try {
+            await writeFile(pidFile, String(process.pid), { flag: "wx" });
+            return;
+        } catch (err) {
+            if (!isEexist(err)) {
+                throw err;
+            }
+        }
+
+        const owner = getDaemonPid();
+
+        if (owner !== null && owner !== process.pid) {
+            log.error({ existingPid: owner }, "[daemon] another daemon is already running");
+            process.exit(EXIT_ALREADY_RUNNING);
+        }
+
+        // Read the raw stale content (getDaemonPid returned null, so whatever
+        // pid is in there is dead) — the takeover only steals THIS artifact.
+        let staleContent: string | null = null;
+
+        try {
+            staleContent = readFileSync(pidFile, "utf-8");
+        } catch {
+            staleContent = null; // vanished — loop retries the fresh create
+        }
+
+        if (staleContent !== null && (await attemptStaleTakeover(pidFile, staleContent))) {
+            const confirmedOwner = getDaemonPid();
+
+            if (confirmedOwner !== process.pid) {
+                log.error(
+                    { confirmedOwner },
+                    "[daemon] pidfile takeover succeeded but ownership verification failed; exiting"
+                );
+                process.exit(EXIT_LOST_TAKEOVER_RACE);
+            }
+
+            return;
+        }
+
+        log.debug({ attempt }, "[daemon] lost pidfile takeover race; retrying");
+        await Bun.sleep(STALE_TAKEOVER_RETRY_MS);
+    }
+
+    log.error("[daemon] lost pidfile takeover race after retries; another instance now owns the scope");
+    process.exit(EXIT_LOST_TAKEOVER_RACE);
+}
+
+export async function startDaemon(): Promise<void> {
+    const pidFile = getPidFile();
+    mkdirSync(dirname(pidFile), { recursive: true });
+
+    await claimPidfile(pidFile);
 
     log.info({ pid: process.pid }, "[daemon] starting");
 
@@ -63,8 +212,11 @@ export function getDaemonPid(): number | null {
             process.kill(pid, 0);
             return pid;
         } catch (err) {
-            if (process.platform === "win32" && err instanceof Error && "code" in err) {
-                return (err as NodeJS.ErrnoException).code === "EPERM" ? pid : null;
+            // EPERM means the process exists but belongs to another user —
+            // that's "alive" on every platform, not just win32; treating it
+            // as dead would green-light a pidfile takeover against a live owner.
+            if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EPERM") {
+                return pid;
             }
 
             return null;
@@ -72,6 +224,26 @@ export function getDaemonPid(): number | null {
     } catch (err) {
         logger.debug({ err, pidFile }, "[daemon] failed to read/parse PID file");
         return null;
+    }
+}
+
+/**
+ * Cheap per-tick ownership check: does the pidfile still identify us?
+ *
+ * Guards against a daemon whose pidfile was stolen (or removed) out from
+ * under it continuing to run as an untracked zombie — the scheduler loop
+ * calls this once per tick and self-terminates on the first failed check.
+ */
+export function verifyPidfileOwnership(pidFile: string): boolean {
+    if (!existsSync(pidFile)) {
+        return false;
+    }
+
+    try {
+        const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+        return pid === process.pid;
+    } catch {
+        return false;
     }
 }
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
-import { rename, writeFile } from "node:fs/promises";
+import { readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { configureLogger, logger } from "@app/logger";
 import { getLogsBaseDir, getPidFile } from "./lib/config";
@@ -66,7 +66,7 @@ export async function attemptStaleTakeover(pidFile: string, expectedContent: str
     let stolen: string | null = null;
 
     try {
-        stolen = readFileSync(tempPath, "utf-8");
+        stolen = await readFile(tempPath, "utf-8");
     } catch {
         stolen = null;
     }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -77,9 +77,10 @@ export async function attemptStaleTakeover(pidFile: string, expectedContent: str
         if (stolen !== null) {
             try {
                 await writeFile(pidFile, stolen, { flag: "wx" });
-            } catch {
+            } catch (err) {
                 // Slot already re-claimed — the robbed owner self-heals via
                 // its per-tick ownership check.
+                logger.debug({ err, pidFile }, "[daemon] stale-takeover restore skipped (slot re-claimed)");
             }
         }
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -189,7 +189,9 @@ export async function startDaemon(): Promise<void> {
     };
 
     try {
-        await runSchedulerLoop(getLogsBaseDir());
+        await runSchedulerLoop(getLogsBaseDir(), {
+            verifyOwnership: () => verifyPidfileOwnership(pidFile),
+        });
     } catch (err) {
         log.error({ err }, "[daemon] crashed");
         throw err;

--- a/src/daemon/lib/config.ts
+++ b/src/daemon/lib/config.ts
@@ -6,7 +6,13 @@ import { Storage } from "@app/utils/storage/storage";
 import { parseInterval } from "./interval";
 import type { DaemonConfig, DaemonTask } from "./types";
 
-const storage = new Storage("daemon");
+// Resolved lazily per call — a module-level instance captures the storage
+// base dir at import time, which bypasses GENESIS_TOOLS_HOME overrides set
+// later (the per-file test sandbox trips its real-path guard exactly this
+// way when another test file imported us first).
+function getStorage(): Storage {
+    return new Storage("daemon");
+}
 
 function resolveBaseDir(): string {
     const override = env.getTrimmed("GENESIS_TOOLS_DAEMON_DIR");
@@ -27,7 +33,7 @@ export function getPidFile(): string {
 }
 
 export async function ensureStorage(): Promise<void> {
-    await storage.ensureDirs();
+    await getStorage().ensureDirs();
     mkdirSync(getLogsBaseDir(), { recursive: true });
 }
 
@@ -44,7 +50,7 @@ export function validateTaskIntervals(tasks: DaemonTask[]): DaemonTask[] {
 }
 
 export async function loadConfig(): Promise<DaemonConfig> {
-    const config = await storage.getConfig<DaemonConfig>();
+    const config = await getStorage().getConfig<DaemonConfig>();
 
     if (!config || !Array.isArray(config.tasks)) {
         return { tasks: [] };
@@ -59,7 +65,7 @@ export async function getTask(name: string): Promise<DaemonTask | undefined> {
 }
 
 export async function upsertTask(task: DaemonTask): Promise<void> {
-    await storage.atomicConfigUpdate<DaemonConfig>((config) => {
+    await getStorage().atomicConfigUpdate<DaemonConfig>((config) => {
         if (!Array.isArray(config.tasks)) {
             config.tasks = [];
         }
@@ -77,7 +83,7 @@ export async function upsertTask(task: DaemonTask): Promise<void> {
 export async function removeTask(name: string): Promise<boolean> {
     let removed = false;
 
-    await storage.atomicConfigUpdate<DaemonConfig>((config) => {
+    await getStorage().atomicConfigUpdate<DaemonConfig>((config) => {
         if (!Array.isArray(config.tasks)) {
             config.tasks = [];
             return;
@@ -92,7 +98,7 @@ export async function removeTask(name: string): Promise<boolean> {
 }
 
 export async function setTaskEnabled(name: string, enabled: boolean): Promise<void> {
-    await storage.atomicConfigUpdate<DaemonConfig>((config) => {
+    await getStorage().atomicConfigUpdate<DaemonConfig>((config) => {
         const task = config.tasks?.find((t) => t.name === name);
 
         if (!task) {

--- a/src/daemon/lib/scheduler.test.ts
+++ b/src/daemon/lib/scheduler.test.ts
@@ -6,6 +6,10 @@ import type { DaemonTask, TaskState } from "./types";
 
 const logsBaseDir = mkdtempSync(join(tmpdir(), "scheduler-test-"));
 
+// No-op notifier: bun test must NEVER fire real macOS notification banners
+// (they spammed the user's notification center before this seam existed).
+const noopNotify = async () => {};
+
 let runDurationMs = 1;
 
 const runTaskMock = mock(async () => {
@@ -20,11 +24,7 @@ const runTaskMock = mock(async () => {
     };
 });
 
-mock.module("./runner", () => ({
-    runTask: runTaskMock,
-}));
-
-const { dispatchDueTasks, jitteredNow } = await import("./scheduler");
+import { dispatchDueTasks, EXIT_OWNERSHIP_LOST, EXIT_WEDGED, jitteredNow, runSchedulerLoop } from "./scheduler";
 
 async function drainActiveRuns(activeRuns: Set<string>): Promise<void> {
     const deadline = Date.now() + 5_000;
@@ -106,7 +106,15 @@ describe("scheduler logging consolidation", () => {
         });
 
         try {
-            dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now });
+            dispatchDueTasks({
+                tasks,
+                taskStates,
+                activeRuns,
+                logsBaseDir,
+                now,
+                notify: noopNotify,
+                runTask: runTaskMock,
+            });
             await drainActiveRuns(activeRuns);
 
             const completionLogs = (infoSpy.mock.calls as unknown[][]).filter((call) => {
@@ -164,7 +172,15 @@ describe("scheduler grid anchoring", () => {
         });
 
         runDurationMs = 50;
-        dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now: scheduledAt });
+        dispatchDueTasks({
+            tasks,
+            taskStates,
+            activeRuns,
+            logsBaseDir,
+            now: scheduledAt,
+            notify: noopNotify,
+            runTask: runTaskMock,
+        });
         await drainActiveRuns(activeRuns);
 
         const afterSlowRun = taskStates.get("slow-task");
@@ -173,7 +189,15 @@ describe("scheduler grid anchoring", () => {
 
         runDurationMs = 1;
         runTaskMock.mockClear();
-        dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now: afterSlowRun?.nextRunAt });
+        dispatchDueTasks({
+            tasks,
+            taskStates,
+            activeRuns,
+            logsBaseDir,
+            now: afterSlowRun?.nextRunAt,
+            notify: noopNotify,
+            runTask: runTaskMock,
+        });
         await drainActiveRuns(activeRuns);
 
         expect(runTaskMock).toHaveBeenCalledTimes(1);
@@ -207,7 +231,7 @@ describe("scheduler task .finally() resilience", () => {
             running: false,
         });
 
-        dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now });
+        dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now, notify: noopNotify, runTask: runTaskMock });
         await drainActiveRuns(activeRuns);
 
         expect(runTaskMock).toHaveBeenCalledTimes(1);
@@ -216,9 +240,65 @@ describe("scheduler task .finally() resilience", () => {
         expect(state?.nextRunAt.getTime()).toBeGreaterThan(now.getTime() + 59_000);
 
         runTaskMock.mockClear();
-        dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now });
+        dispatchDueTasks({ tasks, taskStates, activeRuns, logsBaseDir, now, notify: noopNotify, runTask: runTaskMock });
         await drainActiveRuns(activeRuns);
 
         expect(runTaskMock).toHaveBeenCalledTimes(0);
+    });
+});
+
+describe("runSchedulerLoop resilience (Jul 3/6 incident class)", () => {
+    test("per-tick ownership check: a usurped daemon self-terminates instead of running as a zombie", async () => {
+        const codes: number[] = [];
+
+        await runSchedulerLoop(logsBaseDir, {
+            verifyOwnership: () => false,
+            loadConfig: async () => ({ tasks: [] }),
+            exit: (code) => {
+                codes.push(code);
+            },
+            notify: noopNotify,
+        });
+
+        expect(codes).toEqual([EXIT_OWNERSHIP_LOST]);
+    });
+
+    test("wedge watchdog exits with EXIT_WEDGED when the loop goes silent past the threshold", async () => {
+        const codes: number[] = [];
+
+        await runSchedulerLoop(logsBaseDir, {
+            verifyOwnership: () => true,
+            watchdogIntervalMs: 25,
+            wedgeThresholdMs: 80,
+            loadConfig: async () => ({ tasks: [] }),
+            exit: (code) => {
+                codes.push(code);
+                // Unwind the (deliberately silent) loop so the test completes.
+                process.emit("SIGINT");
+            },
+            notify: noopNotify,
+        });
+
+        expect(codes[0]).toBe(EXIT_WEDGED);
+    });
+
+    test("a second shutdown signal force-exits immediately (no more unkillable daemons)", async () => {
+        const codes: number[] = [];
+
+        const loop = runSchedulerLoop(logsBaseDir, {
+            verifyOwnership: () => true,
+            loadConfig: async () => ({ tasks: [] }),
+            exit: (code) => {
+                codes.push(code);
+            },
+            notify: noopNotify,
+        });
+
+        await Bun.sleep(20); // let the loop install its signal handlers
+        process.emit("SIGINT"); // graceful: flips running=false, arms grace timer
+        process.emit("SIGINT"); // impatient: must exit immediately
+        await loop;
+
+        expect(codes).toEqual([1]);
     });
 });

--- a/src/daemon/lib/scheduler.ts
+++ b/src/daemon/lib/scheduler.ts
@@ -1,5 +1,5 @@
 import { logger } from "@app/logger";
-import { wakefulSleep } from "@app/utils/async";
+import { wakefulSleep, withTimeout } from "@app/utils/async";
 import { dispatchNotification } from "@app/utils/notifications";
 import { loadConfig } from "./config";
 import { computeNextRunAt, parseInterval } from "./interval";
@@ -9,6 +9,51 @@ import { runTask } from "./runner";
 import type { DaemonTask, TaskState } from "./types";
 
 const { log } = logger.scoped("daemon");
+
+/** Exit code when the wedge watchdog fires — launchd (KeepAlive) respawns a fresh daemon. */
+export const EXIT_WEDGED = 86;
+/** Exit code when the per-tick pidfile ownership check fails (a usurper owns the scope). */
+export const EXIT_OWNERSHIP_LOST = 87;
+/** How long after the first SIGTERM/SIGINT the daemon force-exits if the loop never unwound. */
+export const HARD_EXIT_GRACE_MS = 20_000;
+/** Watchdog sampling interval. */
+export const WATCHDOG_INTERVAL_MS = 60_000;
+/** Loop silence beyond this = wedged (the loop must tick at least every 60s by design). */
+export const WEDGE_THRESHOLD_MS = 5 * 60_000;
+/** Bound on config loading so a stuck Storage lock surfaces as a loop failure, not an eternal await. */
+export const LOAD_CONFIG_TIMEOUT_MS = 15_000;
+
+/** Notification dispatch seam — tests inject a no-op so `bun test` never fires real banners. */
+export type NotifyFn = typeof dispatchNotification;
+/** Task-runner seam — tests inject a stub instead of `mock.module("./runner")`, which is
+ *  process-global in bun and leaks into every later test file (it made runner.test.ts see
+ *  the mock and fail suite-only). */
+export type RunTaskFn = typeof runTask;
+/** Config-loader seam — same rationale as RunTaskFn (a `mock.module("./config")` would leak). */
+export type LoadConfigFn = typeof loadConfig;
+
+/**
+ * Resilience seams for runSchedulerLoop, born from the Jul 3/6 incident
+ * (wedged-but-alive scheduler, unkillable by SIGTERM, zombies after pidfile
+ * theft). Every threshold is overridable so tests exercise the paths without
+ * minute-long sleeps; `exit` exists because process.exit is untestable.
+ */
+export type SchedulerResilienceOptions = {
+    /** Per-tick ownership check; false = a usurper owns the pidfile, self-terminate. */
+    verifyOwnership?: () => boolean;
+    hardExitGraceMs?: number;
+    watchdogIntervalMs?: number;
+    wedgeThresholdMs?: number;
+    loadConfigTimeoutMs?: number;
+    /** Test seam for process.exit. */
+    exit?: (code: number) => void;
+    /** Test seam for notifications (threaded through to task runs). */
+    notify?: NotifyFn;
+    /** Test seam for the task runner (threaded through to task runs). */
+    runTask?: RunTaskFn;
+    /** Test seam for config loading. */
+    loadConfig?: LoadConfigFn;
+};
 
 /** Scheduler's scoped logger — exported for tests that spy on log calls. */
 export const daemonLog = log;
@@ -37,33 +82,115 @@ export function logSchedulerLoopFailure(err: unknown, consecutiveFailures: numbe
     );
 }
 
-export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
+export async function runSchedulerLoop(
+    logsBaseDir: string,
+    resilience: SchedulerResilienceOptions = {}
+): Promise<void> {
     let running = true;
     const activeRuns = new Set<string>();
     const taskStates = new Map<string, TaskState>();
 
-    const shutdown = () => {
+    const hardExitGraceMs = resilience.hardExitGraceMs ?? HARD_EXIT_GRACE_MS;
+    const watchdogIntervalMs = resilience.watchdogIntervalMs ?? WATCHDOG_INTERVAL_MS;
+    const wedgeThresholdMs = resilience.wedgeThresholdMs ?? WEDGE_THRESHOLD_MS;
+    const loadConfigTimeoutMs = resilience.loadConfigTimeoutMs ?? LOAD_CONFIG_TIMEOUT_MS;
+    const exit = resilience.exit ?? ((code: number) => process.exit(code));
+    const notify = resilience.notify ?? dispatchNotification;
+    const runTaskImpl = resilience.runTask ?? runTask;
+    const loadConfigImpl = resilience.loadConfig ?? loadConfig;
+
+    // Jul 6 incident: the old `process.once` handler only flipped `running`,
+    // so a loop wedged inside an await made the daemon unkillable by SIGTERM
+    // (the flag was never re-read). Now the first signal flips the flag AND
+    // arms an unref'd hard-exit timer; a second signal exits immediately.
+    let signalCount = 0;
+    let hardExitTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const shutdown = (signal: string) => () => {
+        signalCount++;
+
+        if (signalCount > 1) {
+            log.error({ signal }, "[daemon] repeated shutdown signal; exiting immediately");
+            exit(1);
+            return;
+        }
+
         running = false;
+        log.info({ signal, graceMs: hardExitGraceMs }, "[daemon] shutdown requested");
+        hardExitTimer = setTimeout(() => {
+            log.error(
+                { signal, graceMs: hardExitGraceMs },
+                "[daemon] loop did not unwind within the shutdown grace; force-exiting"
+            );
+            exit(1);
+        }, hardExitGraceMs);
+        hardExitTimer.unref();
     };
 
-    process.once("SIGTERM", shutdown);
-    process.once("SIGINT", shutdown);
+    const onSigterm = shutdown("SIGTERM");
+    const onSigint = shutdown("SIGINT");
+    process.on("SIGTERM", onSigterm);
+    process.on("SIGINT", onSigint);
+
+    // Wedge watchdog (Jul 6 incident: the scheduler went silent for 2 days
+    // while the process stayed "running"). The loop must tick at least every
+    // 60s by construction; sustained silence means a body await hung — exit
+    // with a distinct code and let launchd's KeepAlive respawn a fresh daemon.
+    let lastTickAt = Date.now();
+    const watchdog = setInterval(() => {
+        if (!running) {
+            return;
+        }
+
+        const silentMs = Date.now() - lastTickAt;
+
+        if (silentMs > wedgeThresholdMs) {
+            log.error(
+                { silentMs, wedgeThresholdMs },
+                "[daemon] scheduler wedged (no tick within threshold); exiting for launchd respawn"
+            );
+            exit(EXIT_WEDGED);
+        }
+    }, watchdogIntervalMs);
+    watchdog.unref();
 
     try {
         log.info({ logsBaseDir }, "[daemon] scheduler started");
 
-        await initializeTaskStates(taskStates, logsBaseDir);
+        await initializeTaskStates(taskStates, logsBaseDir, loadConfigTimeoutMs, loadConfigImpl);
 
         let consecutiveLoopFailures = 0;
 
         while (running) {
+            lastTickAt = Date.now();
+
             try {
-                const config = await loadConfig();
+                // Jul 3 zombie class: a daemon whose pidfile was stolen must
+                // not keep running as an untracked duplicate scheduler.
+                if (resilience.verifyOwnership && !resilience.verifyOwnership()) {
+                    log.error("[daemon] pidfile ownership lost (usurped or removed); exiting");
+                    exit(EXIT_OWNERSHIP_LOST);
+                    return;
+                }
+
+                const config = await withTimeout(
+                    loadConfigImpl(),
+                    loadConfigTimeoutMs,
+                    new Error(`loadConfig timed out after ${loadConfigTimeoutMs}ms (stuck config lock?)`)
+                );
                 const now = new Date();
 
                 syncTaskStates(taskStates, config.tasks);
 
-                dispatchDueTasks({ tasks: config.tasks, taskStates, activeRuns, logsBaseDir, now });
+                dispatchDueTasks({
+                    tasks: config.tasks,
+                    taskStates,
+                    activeRuns,
+                    logsBaseDir,
+                    now,
+                    notify,
+                    runTask: runTaskImpl,
+                });
 
                 const sleepMs = getNextWakeupMs(taskStates, config.tasks);
                 logSchedulerHeartbeat(sleepMs, activeRuns.size);
@@ -102,8 +229,13 @@ export async function runSchedulerLoop(logsBaseDir: string): Promise<void> {
 
         log.info("[daemon] scheduler stopped");
     } finally {
-        process.off("SIGTERM", shutdown);
-        process.off("SIGINT", shutdown);
+        process.off("SIGTERM", onSigterm);
+        process.off("SIGINT", onSigint);
+        clearInterval(watchdog);
+
+        if (hardExitTimer !== null) {
+            clearTimeout(hardExitTimer);
+        }
     }
 }
 
@@ -113,8 +245,20 @@ export function dispatchDueTasks(options: {
     activeRuns: Set<string>;
     logsBaseDir: string;
     now?: Date;
+    /** Notification seam — tests MUST pass a no-op so `bun test` never fires real banners. */
+    notify?: NotifyFn;
+    /** Task-runner seam — tests inject a stub here instead of a leaking `mock.module`. */
+    runTask?: RunTaskFn;
 }): void {
-    const { tasks, taskStates, activeRuns, logsBaseDir, now = new Date() } = options;
+    const {
+        tasks,
+        taskStates,
+        activeRuns,
+        logsBaseDir,
+        now = new Date(),
+        notify = dispatchNotification,
+        runTask: runTaskImpl = runTask,
+    } = options;
 
     for (const task of tasks) {
         if (!task.enabled) {
@@ -135,7 +279,7 @@ export function dispatchDueTasks(options: {
         state.running = true;
         const scheduledAt = state.nextRunAt;
 
-        executeTask(task, logsBaseDir)
+        executeTask(task, logsBaseDir, notify, runTaskImpl)
             .catch((err) => {
                 log.error({ err, task: task.name }, "[daemon] task execution error");
             })
@@ -162,9 +306,14 @@ export function dispatchDueTasks(options: {
     }
 }
 
-async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void> {
+async function executeTask(
+    task: DaemonTask,
+    logsBaseDir: string,
+    notify: NotifyFn,
+    runTaskImpl: RunTaskFn
+): Promise<void> {
     try {
-        await runAttempts(task, logsBaseDir);
+        await runAttempts(task, logsBaseDir, notify, runTaskImpl);
     } finally {
         if (task.retention) {
             try {
@@ -176,13 +325,18 @@ async function executeTask(task: DaemonTask, logsBaseDir: string): Promise<void>
     }
 }
 
-async function runAttempts(task: DaemonTask, logsBaseDir: string): Promise<void> {
+async function runAttempts(
+    task: DaemonTask,
+    logsBaseDir: string,
+    notify: NotifyFn,
+    runTaskImpl: RunTaskFn
+): Promise<void> {
     const maxAttempts = task.retries + 1;
 
     const shouldNotify = task.notify !== false;
 
     if (shouldNotify) {
-        dispatchNotification({
+        notify({
             app: "daemon",
             title: "Daemon",
             subtitle: task.name,
@@ -193,7 +347,7 @@ async function runAttempts(task: DaemonTask, logsBaseDir: string): Promise<void>
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         log.info({ task: task.name, attempt, maxAttempts, timeoutMs: task.timeoutMs }, "[daemon] running task");
 
-        const result = await runTask(task, attempt, logsBaseDir);
+        const result = await runTaskImpl(task, attempt, logsBaseDir);
 
         if (result.exitCode === 0) {
             log.info(
@@ -202,7 +356,7 @@ async function runAttempts(task: DaemonTask, logsBaseDir: string): Promise<void>
             );
 
             if (shouldNotify) {
-                dispatchNotification({
+                notify({
                     app: "daemon",
                     title: "Daemon",
                     subtitle: task.name,
@@ -226,7 +380,7 @@ async function runAttempts(task: DaemonTask, logsBaseDir: string): Promise<void>
     }
 
     if (shouldNotify) {
-        dispatchNotification({
+        notify({
             app: "daemon",
             title: "Daemon",
             subtitle: task.name,
@@ -235,8 +389,17 @@ async function runAttempts(task: DaemonTask, logsBaseDir: string): Promise<void>
     }
 }
 
-async function initializeTaskStates(taskStates: Map<string, TaskState>, logsBaseDir: string): Promise<void> {
-    const config = await loadConfig();
+async function initializeTaskStates(
+    taskStates: Map<string, TaskState>,
+    logsBaseDir: string,
+    loadConfigTimeoutMs: number = LOAD_CONFIG_TIMEOUT_MS,
+    loadConfigImpl: LoadConfigFn = loadConfig
+): Promise<void> {
+    const config = await withTimeout(
+        loadConfigImpl(),
+        loadConfigTimeoutMs,
+        new Error(`loadConfig timed out after ${loadConfigTimeoutMs}ms (stuck config lock?)`)
+    );
 
     for (const task of config.tasks) {
         const parsed = parseInterval(task.every);

--- a/src/daemon/lib/wait-for-restart.test.ts
+++ b/src/daemon/lib/wait-for-restart.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { stopWithEscalation } from "./wait-for-restart";
+import { defaultIsAlive, defaultKill, stopWithEscalation } from "./wait-for-restart";
+
+function errnoException(code: string): NodeJS.ErrnoException {
+    const err = new Error(code) as NodeJS.ErrnoException;
+    err.code = code;
+    return err;
+}
 
 // All seams injected — no real signals, no real sleeps.
 const instantSleep = async (): Promise<void> => {};
@@ -87,5 +93,48 @@ describe("stopWithEscalation", () => {
 
         expect(result).toEqual({ exited: true, step: "sigterm-again" });
         expect(sent).toEqual(["SIGTERM", "SIGTERM"]);
+    });
+});
+
+describe("defaultIsAlive / defaultKill", () => {
+    test("EPERM: process exists but belongs to another user — alive, and kill doesn't throw", () => {
+        const original = process.kill;
+        process.kill = (() => {
+            throw errnoException("EPERM");
+        }) as typeof process.kill;
+
+        try {
+            expect(defaultIsAlive(4242)).toBe(true);
+            expect(() => defaultKill(4242, "SIGTERM")).not.toThrow();
+        } finally {
+            process.kill = original;
+        }
+    });
+
+    test("ESRCH: process is gone — dead, and kill doesn't throw", () => {
+        const original = process.kill;
+        process.kill = (() => {
+            throw errnoException("ESRCH");
+        }) as typeof process.kill;
+
+        try {
+            expect(defaultIsAlive(4242)).toBe(false);
+            expect(() => defaultKill(4242, "SIGTERM")).not.toThrow();
+        } finally {
+            process.kill = original;
+        }
+    });
+
+    test("other errno (EINVAL): kill rethrows", () => {
+        const original = process.kill;
+        process.kill = (() => {
+            throw errnoException("EINVAL");
+        }) as typeof process.kill;
+
+        try {
+            expect(() => defaultKill(4242, "SIGTERM")).toThrow();
+        } finally {
+            process.kill = original;
+        }
     });
 });

--- a/src/daemon/lib/wait-for-restart.test.ts
+++ b/src/daemon/lib/wait-for-restart.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { stopWithEscalation } from "./wait-for-restart";
+
+// All seams injected — no real signals, no real sleeps.
+const instantSleep = async (): Promise<void> => {};
+
+describe("stopWithEscalation", () => {
+    test("already-dead process: no signals sent", async () => {
+        const sent: string[] = [];
+
+        const result = await stopWithEscalation(4242, {
+            isAlive: () => false,
+            kill: (_pid, signal) => {
+                sent.push(signal);
+            },
+            sleep: instantSleep,
+            firstGraceMs: 10,
+            secondGraceMs: 10,
+            killGraceMs: 10,
+        });
+
+        expect(result).toEqual({ exited: true, step: null });
+        expect(sent).toEqual([]);
+    });
+
+    test("cooperative daemon dies on the first SIGTERM", async () => {
+        const sent: string[] = [];
+        let alive = true;
+
+        const result = await stopWithEscalation(4242, {
+            isAlive: () => alive,
+            kill: (_pid, signal) => {
+                sent.push(signal);
+                alive = false; // exits promptly on the graceful signal
+            },
+            sleep: instantSleep,
+            firstGraceMs: 50,
+            secondGraceMs: 50,
+            killGraceMs: 50,
+        });
+
+        expect(result).toEqual({ exited: true, step: "sigterm" });
+        expect(sent).toEqual(["SIGTERM"]);
+    });
+
+    test("wedged daemon (Jul 6/8 incident): ignores SIGTERMs, dies only to SIGKILL", async () => {
+        const sent: string[] = [];
+        let alive = true;
+
+        const result = await stopWithEscalation(4242, {
+            isAlive: () => alive,
+            kill: (_pid, signal) => {
+                sent.push(signal);
+
+                if (signal === "SIGKILL") {
+                    alive = false; // the kernel doesn't need cooperation
+                }
+            },
+            sleep: instantSleep,
+            firstGraceMs: 10,
+            secondGraceMs: 10,
+            killGraceMs: 10,
+        });
+
+        expect(result).toEqual({ exited: true, step: "sigkill" });
+        expect(sent).toEqual(["SIGTERM", "SIGTERM", "SIGKILL"]);
+    });
+
+    test("second SIGTERM finishes a daemon whose repeat-signal handler force-exits", async () => {
+        const sent: string[] = [];
+        let alive = true;
+
+        const result = await stopWithEscalation(4242, {
+            isAlive: () => alive,
+            kill: (_pid, signal) => {
+                sent.push(signal);
+
+                if (sent.length === 2 && signal === "SIGTERM") {
+                    alive = false; // scheduler's signalCount>1 branch exits immediately
+                }
+            },
+            sleep: instantSleep,
+            firstGraceMs: 10,
+            secondGraceMs: 10,
+            killGraceMs: 10,
+        });
+
+        expect(result).toEqual({ exited: true, step: "sigterm-again" });
+        expect(sent).toEqual(["SIGTERM", "SIGTERM"]);
+    });
+});

--- a/src/daemon/lib/wait-for-restart.ts
+++ b/src/daemon/lib/wait-for-restart.ts
@@ -29,7 +29,7 @@ export type EscalationResult = {
     step: EscalationStep | null;
 };
 
-type EscalationSeams = {
+export type EscalationSeams = {
     firstGraceMs?: number;
     secondGraceMs?: number;
     killGraceMs?: number;
@@ -38,7 +38,7 @@ type EscalationSeams = {
     sleep?: (ms: number) => Promise<void>;
 };
 
-function defaultIsAlive(pid: number): boolean {
+export function defaultIsAlive(pid: number): boolean {
     try {
         process.kill(pid, 0);
         return true;
@@ -48,11 +48,13 @@ function defaultIsAlive(pid: number): boolean {
     }
 }
 
-function defaultKill(pid: number, signal: NodeJS.Signals): void {
+export function defaultKill(pid: number, signal: NodeJS.Signals): void {
     try {
         process.kill(pid, signal);
     } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+        const code = (err as NodeJS.ErrnoException).code;
+        // EPERM = exists but not ours to signal; let the ladder finish and report instead of crashing.
+        if (code !== "ESRCH" && code !== "EPERM") {
             throw err;
         }
     }

--- a/src/daemon/lib/wait-for-restart.ts
+++ b/src/daemon/lib/wait-for-restart.ts
@@ -13,6 +13,112 @@ export function safeSigterm(pid: number): void {
     }
 }
 
+/** Grace after the first SIGTERM (the daemon's graceful unwind window). */
+export const ESCALATION_FIRST_GRACE_MS = 8_000;
+/** Grace after the second SIGTERM (the scheduler's repeat-signal handler exits immediately). */
+export const ESCALATION_SECOND_GRACE_MS = 4_000;
+/** Grace after SIGKILL — the kernel needs no cooperation, this only bounds the poll. */
+export const ESCALATION_KILL_GRACE_MS = 2_000;
+
+export type EscalationStep = "sigterm" | "sigterm-again" | "sigkill";
+
+export type EscalationResult = {
+    /** Whether the process is gone. */
+    exited: boolean;
+    /** The step that finished it (null if it survived even SIGKILL within the poll window). */
+    step: EscalationStep | null;
+};
+
+type EscalationSeams = {
+    firstGraceMs?: number;
+    secondGraceMs?: number;
+    killGraceMs?: number;
+    kill?: (pid: number, signal: NodeJS.Signals) => void;
+    isAlive?: (pid: number) => boolean;
+    sleep?: (ms: number) => Promise<void>;
+};
+
+function defaultIsAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        // EPERM = alive but another user's; only ESRCH means gone.
+        return (err as NodeJS.ErrnoException).code === "EPERM";
+    }
+}
+
+function defaultKill(pid: number, signal: NodeJS.Signals): void {
+    try {
+        process.kill(pid, signal);
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+            throw err;
+        }
+    }
+}
+
+async function pollUntilDead(
+    pid: number,
+    graceMs: number,
+    isAlive: (pid: number) => boolean,
+    sleep: (ms: number) => Promise<void>
+): Promise<boolean> {
+    const deadline = Date.now() + graceMs;
+
+    while (Date.now() < deadline) {
+        if (!isAlive(pid)) {
+            return true;
+        }
+
+        await sleep(200);
+    }
+
+    return !isAlive(pid);
+}
+
+/**
+ * Stop a daemon with escalation: SIGTERM → grace → SIGTERM again (the
+ * scheduler's repeat-signal handler force-exits) → grace → SIGKILL.
+ *
+ * Born from the Jul 6/8 incident: a wedged daemon ignored the single SIGTERM
+ * `stop`/`restart` used to send, so both commands just timed out and left the
+ * zombie running until a human reached for `kill -9`. The ladder makes the
+ * commands terminal: they report which step worked instead of giving up.
+ */
+export async function stopWithEscalation(pid: number, seams: EscalationSeams = {}): Promise<EscalationResult> {
+    const firstGraceMs = seams.firstGraceMs ?? ESCALATION_FIRST_GRACE_MS;
+    const secondGraceMs = seams.secondGraceMs ?? ESCALATION_SECOND_GRACE_MS;
+    const killGraceMs = seams.killGraceMs ?? ESCALATION_KILL_GRACE_MS;
+    const kill = seams.kill ?? defaultKill;
+    const isAlive = seams.isAlive ?? defaultIsAlive;
+    const sleep = seams.sleep ?? ((ms: number) => Bun.sleep(ms));
+
+    if (!isAlive(pid)) {
+        return { exited: true, step: null };
+    }
+
+    kill(pid, "SIGTERM");
+
+    if (await pollUntilDead(pid, firstGraceMs, isAlive, sleep)) {
+        return { exited: true, step: "sigterm" };
+    }
+
+    kill(pid, "SIGTERM");
+
+    if (await pollUntilDead(pid, secondGraceMs, isAlive, sleep)) {
+        return { exited: true, step: "sigterm-again" };
+    }
+
+    kill(pid, "SIGKILL");
+
+    if (await pollUntilDead(pid, killGraceMs, isAlive, sleep)) {
+        return { exited: true, step: "sigkill" };
+    }
+
+    return { exited: false, step: null };
+}
+
 /**
  * Poll launchd until a new PID appears (different from oldPid).
  * Returns `{ pid }` on success, `null` on timeout.

--- a/src/utils/storage/file-lock.test.ts
+++ b/src/utils/storage/file-lock.test.ts
@@ -1,9 +1,9 @@
 // biome-ignore-all lint/plugin: test fixture intentionally uses /tmp/ string literals — production plugins do not apply to test code
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { LockTimeoutError, withFileLock } from "./file-lock";
+import { LockTimeoutError, tryAcquireLock, withFileLock } from "./file-lock";
 
 describe("file-lock: stale/orphaned lock handling", () => {
     let dir: string;
@@ -92,5 +92,28 @@ describe("file-lock: stale/orphaned lock handling", () => {
         expect(result).toBe("ok");
         // The parent dir was created and persists — only the lock file itself is cleaned up.
         expect(existsSync(nestedDir)).toBe(true);
+    });
+
+    it("exactly one of N concurrent racers steals a stale lock (rename-based takeover regression test)", async () => {
+        // Regression test for the Jul 3 incident: launchd respawn storm got 31
+        // daemon instances racing the same stale pidfile/lock past a
+        // check-then-unlink-then-write takeover, and N of them "won". The
+        // rename-based steal must guarantee exactly one winner no matter how
+        // many racers hit it concurrently.
+        const lockPath = join(dir, "target.lock");
+        writeFileSync(lockPath, "999999999"); // dead PID — eligible for steal
+
+        const RACER_COUNT = 12;
+        const results = await Promise.all(Array.from({ length: RACER_COUNT }, () => tryAcquireLock(lockPath)));
+
+        const winners = results.filter((won) => won === true);
+        expect(winners).toHaveLength(1);
+
+        // Exactly one lock file remains, owned by us (the single process all
+        // racers ran in), and no leftover `.stale-*` temp files.
+        expect(existsSync(lockPath)).toBe(true);
+        expect(readFileSync(lockPath, "utf-8").trim()).toBe(String(process.pid));
+
+        expect(readdirSync(dir)).toEqual(["target.lock"]);
     });
 });

--- a/src/utils/storage/file-lock.test.ts
+++ b/src/utils/storage/file-lock.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { LockTimeoutError, tryAcquireLock, withFileLock } from "./file-lock";
+import { attemptRenameSteal, LockTimeoutError, tryAcquireLock, withFileLock } from "./file-lock";
 
 describe("file-lock: stale/orphaned lock handling", () => {
     let dir: string;
@@ -115,5 +115,19 @@ describe("file-lock: stale/orphaned lock handling", () => {
         expect(readFileSync(lockPath, "utf-8").trim()).toBe(String(process.pid));
 
         expect(readdirSync(dir)).toEqual(["target.lock"]);
+    });
+
+    it("a steal that grabs a FRESH lock restores it and loses (TOCTOU guard)", async () => {
+        // The stealer validated "999999999" as dead, but by the time its
+        // rename lands a live holder has re-acquired the lock. The steal must
+        // detect the content mismatch, restore the fresh lock, and lose.
+        const lockPath = join(dir, "target.lock");
+        writeFileSync(lockPath, "12345");
+
+        const won = await attemptRenameSteal(lockPath, "999999999");
+
+        expect(won).toBe(false);
+        expect(readFileSync(lockPath, "utf-8").trim()).toBe("12345"); // restored, not clobbered
+        expect(readdirSync(dir)).toEqual(["target.lock"]); // no temp litter
     });
 });

--- a/src/utils/storage/file-lock.ts
+++ b/src/utils/storage/file-lock.ts
@@ -67,9 +67,10 @@ export async function attemptRenameSteal(lockPath: string, expectedContent: stri
         if (stolen !== null) {
             try {
                 await writeFile(lockPath, stolen, { flag: "wx" });
-            } catch {
+            } catch (err) {
                 // Slot already re-claimed; the robbed holder's release is
                 // ownership-checked, so worst case is one early-released lock.
+                logger.debug(`Steal-restore skipped at ${lockPath} (slot re-claimed): ${err}`);
             }
         }
 

--- a/src/utils/storage/file-lock.ts
+++ b/src/utils/storage/file-lock.ts
@@ -58,7 +58,7 @@ export async function attemptRenameSteal(lockPath: string, expectedContent: stri
     let stolen: string | null = null;
 
     try {
-        stolen = readFileSync(tempPath, "utf-8");
+        stolen = await Bun.file(tempPath).text();
     } catch {
         stolen = null;
     }

--- a/src/utils/storage/file-lock.ts
+++ b/src/utils/storage/file-lock.ts
@@ -24,14 +24,25 @@ function isEnoent(err: unknown): boolean {
 }
 
 /**
- * Atomically steal a stale/orphaned lock file.
+ * Atomically steal a stale/orphaned lock file whose content was pre-validated.
  *
  * Renames the lock to a unique temp path first — `rename` is atomic on POSIX,
  * so under N concurrent stealers exactly one rename succeeds; every loser gets
  * ENOENT (the source is already gone under them) and returns false. Only the
  * rename winner proceeds to claim the path with its own `wx` write.
+ *
+ * The rename alone is NOT sufficient: it steals whatever currently sits at
+ * the path, so a late stealer can grab the lock a legitimate holder just
+ * (re-)acquired (TOCTOU — the daemon pidfile twin of this code reproduced
+ * two "winners" in a 12-racer test without the guard). After the rename the
+ * stolen content must still equal `expectedContent` — the exact stale
+ * artifact the caller validated (a dead pid, or "" for the orphaned-empty
+ * case). On mismatch the fresh file is restored best-effort and the steal
+ * reports defeat.
+ *
+ * Exported for direct race testing (see file-lock.test.ts).
  */
-async function attemptRenameSteal(lockPath: string): Promise<boolean> {
+export async function attemptRenameSteal(lockPath: string, expectedContent: string): Promise<boolean> {
     const tempPath = `${lockPath}.stale-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 
     try {
@@ -42,6 +53,33 @@ async function attemptRenameSteal(lockPath: string): Promise<boolean> {
         }
 
         throw err;
+    }
+
+    let stolen: string | null = null;
+
+    try {
+        stolen = readFileSync(tempPath, "utf-8");
+    } catch {
+        stolen = null;
+    }
+
+    if (stolen === null || stolen.trim() !== expectedContent.trim()) {
+        if (stolen !== null) {
+            try {
+                await writeFile(lockPath, stolen, { flag: "wx" });
+            } catch {
+                // Slot already re-claimed; the robbed holder's release is
+                // ownership-checked, so worst case is one early-released lock.
+            }
+        }
+
+        try {
+            await unlink(tempPath);
+        } catch {
+            // best-effort cleanup
+        }
+
+        return false;
     }
 
     try {
@@ -125,9 +163,10 @@ export async function tryAcquireLock(lockPath: string): Promise<boolean> {
                 // the normal alive/dead check below.
                 lockPid = recheckPid;
             } else {
-                // Still empty after grace — orphaned. Steal.
+                // Still empty after grace — orphaned. Steal (expecting the
+                // empty artifact we validated).
                 logger.debug(`Stealing orphaned lock at ${lockPath} (no PID content)`);
-                return await attemptRenameSteal(lockPath);
+                return await attemptRenameSteal(lockPath, "");
             }
         }
 
@@ -135,9 +174,9 @@ export async function tryAcquireLock(lockPath: string): Promise<boolean> {
             return false;
         }
 
-        // Stale lock (process is dead) — steal it
+        // Stale lock (process is dead) — steal exactly the artifact we validated
         logger.debug(`Stealing stale lock at ${lockPath} (PID ${lockPid} is dead)`);
-        return await attemptRenameSteal(lockPath);
+        return await attemptRenameSteal(lockPath, String(lockPid));
     }
 }
 

--- a/src/utils/storage/file-lock.ts
+++ b/src/utils/storage/file-lock.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
-import { unlink, writeFile } from "node:fs/promises";
+import { rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { logger } from "@app/logger";
 import { isProcessAlive } from "@app/utils/process-alive";
@@ -19,12 +19,60 @@ function isEexist(err: unknown): boolean {
     return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST";
 }
 
+function isEnoent(err: unknown): boolean {
+    return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+/**
+ * Atomically steal a stale/orphaned lock file.
+ *
+ * Renames the lock to a unique temp path first — `rename` is atomic on POSIX,
+ * so under N concurrent stealers exactly one rename succeeds; every loser gets
+ * ENOENT (the source is already gone under them) and returns false. Only the
+ * rename winner proceeds to claim the path with its own `wx` write.
+ */
+async function attemptRenameSteal(lockPath: string): Promise<boolean> {
+    const tempPath = `${lockPath}.stale-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+
+    try {
+        await rename(lockPath, tempPath);
+    } catch (err) {
+        if (isEnoent(err)) {
+            return false;
+        }
+
+        throw err;
+    }
+
+    try {
+        await writeFile(lockPath, String(process.pid), { flag: "wx" });
+    } catch (err) {
+        if (isEexist(err)) {
+            return false;
+        }
+
+        throw err;
+    } finally {
+        try {
+            await unlink(tempPath);
+        } catch {
+            // best-effort cleanup; ENOENT if somehow already gone
+        }
+    }
+
+    return true;
+}
+
 /**
  * Try to acquire a lock file atomically.
  * Uses O_CREAT|O_EXCL semantics (writeFile flag:'wx') so two processes
  * cannot both "acquire" the lock simultaneously.
+ *
+ * Exported for direct concurrency testing (see file-lock.test.ts) —
+ * exercising `withFileLock`'s polling loop end-to-end would obscure the
+ * single-winner guarantee this function itself must provide.
  */
-async function tryAcquireLock(lockPath: string): Promise<boolean> {
+export async function tryAcquireLock(lockPath: string): Promise<boolean> {
     const dir = dirname(lockPath);
 
     if (!existsSync(dir)) {
@@ -79,21 +127,7 @@ async function tryAcquireLock(lockPath: string): Promise<boolean> {
             } else {
                 // Still empty after grace — orphaned. Steal.
                 logger.debug(`Stealing orphaned lock at ${lockPath} (no PID content)`);
-
-                try {
-                    const confirmContent = await Bun.file(lockPath).text();
-
-                    if (confirmContent.trim() !== "") {
-                        // Someone wrote content between our checks — retry
-                        return false;
-                    }
-
-                    await unlink(lockPath);
-                    await writeFile(lockPath, String(process.pid), { flag: "wx" });
-                    return true;
-                } catch {
-                    return false;
-                }
+                return await attemptRenameSteal(lockPath);
             }
         }
 
@@ -103,23 +137,7 @@ async function tryAcquireLock(lockPath: string): Promise<boolean> {
 
         // Stale lock (process is dead) — steal it
         logger.debug(`Stealing stale lock at ${lockPath} (PID ${lockPid} is dead)`);
-
-        try {
-            // Re-read before unlinking to confirm ownership hasn't changed
-            const confirmContent = await Bun.file(lockPath).text();
-
-            if (confirmContent.trim() !== String(lockPid)) {
-                // Another process already rewrote the lock — don't steal it
-                return false;
-            }
-
-            await unlink(lockPath);
-            await writeFile(lockPath, String(process.pid), { flag: "wx" });
-            return true;
-        } catch {
-            // Another process stole it between our read and write
-            return false;
-        }
+        return await attemptRenameSteal(lockPath);
     }
 }
 


### PR DESCRIPTION
# Daemon resilience — fix the Jul 3/6/8 incident class

Root-caused from a live incident: usage-history collection silently died for ~2 days. Forensics: on **Jul 3 18:32** a launchd respawn storm got **31 daemon instances past the pidfile gate in 8 seconds** (all "won" the stale-takeover race and ran schedulers concurrently for days); on **Jul 6 19:25** the poll task failed twice with `LockTimeoutError` (31 daemons stampeding one file lock) and the surviving scheduler **wedged permanently** — alive, zero ticks, zero task runs; on **Jul 8** incident response found all 32 processes **ignored SIGTERM** (`process.once` handler that only flips a flag the hung loop never re-reads) — `stop`/`restart` timed out; only `kill -9` worked.

## Fixes

1. **Content-verified atomic takeover** (`daemon.ts`, `file-lock.ts`): stale pidfile/lock steal now goes through an atomic `rename` to a unique temp path **plus a content check** — only the exact validated-stale artifact can be stolen; grabbing a fresh file restores it and loses. The rename alone was not enough: the 12-racer regression test caught **2 winners** without the content check (a late racer renames the previous winner's fresh file — the same TOCTOU one level deeper).
2. **Per-tick ownership re-validation**: the scheduler verifies the pidfile still names it every tick; a usurped daemon exits (code 87) within one tick instead of running as an untracked zombie.
3. **Wedge watchdog**: unref'd interval; if the loop misses its tick threshold (5 min; the loop ticks ≤60s by design), exit 86 and let launchd KeepAlive respawn a fresh daemon. This alone would have self-healed the Jul 6 wedge.
4. **Real kill-ability**: first SIGTERM flips the flag AND arms an unref'd 20s hard-exit timer; a second SIGTERM exits immediately. `loadConfig()` is bounded by a 15s timeout so a stuck Storage lock surfaces as a caught loop failure.
5. **`stop`/`restart` escalation ladder**: SIGTERM → grace → SIGTERM (triggers the force-exit handler) → grace → SIGKILL, reporting which step worked, instead of sending one signal and giving up.
6. **`getDaemonPid` EPERM fix**: EPERM from `kill(pid, 0)` now counts as *alive* on all platforms (it means "exists, other user") — treating it as dead green-lit takeovers against live owners.

## Test-suite health (fixed en route — all were suite-only failures)

- `scheduler.test`'s `mock.module("./runner")` is **process-global in bun** and leaked into `runner.test` (its timeout test saw the mock's `exitCode 0`). Replaced all module mocks with injected seams (`runTask`/`loadConfig`/`notify`/`exit` + threshold knobs) on `SchedulerResilienceOptions` / `dispatchDueTasks`.
- The `notify` seam also stops `bun test` from **firing real macOS notification banners** (previously spammed the user's notification center with `slow-task`/`bad-interval` fixtures).
- `lib/config.ts`'s module-level `Storage` captured the real home at import time, defeating the per-file `GENESIS_TOOLS_HOME` sandbox (violation in `register.test` when another file imported config first). Now resolved lazily per call.

## Verification

- `bun test src/daemon/ src/utils/storage/` → **66 pass, 0 fail** (previously 2–3 suite-only failures on master), including: 12-racer single-winner takeover, fresh-steal restore, ownership-loss self-exit, watchdog fire, second-signal force-exit, and the full escalation ladder — all via injected seams, no real sleeps/signals/banners.
- `tsgo --noEmit` clean, `biome check` clean.
- Live: the production daemon was force-killed and respawned during incident response; poll runs are green every minute and usage snapshots are flowing again.

🤖 Generated with Claude Code — forensics + fixes from the vitrinka-dev-dashboard session (initial implementation started by a Sonnet agent whose fix-C commit and WIP fix-A survive here, completed in-session after repeated API stalls).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon stop/restart reliability with a termination escalation sequence, clearer progress feedback, and earlier error reporting when shutdown doesn’t complete.
  * Strengthened stale/orphaned pidfile and lock recovery using atomic takeover checks to prevent duplicate daemons and failed startups.
  * Enhanced self-shutdown behavior: the daemon now exits promptly if pidfile ownership is lost or if the scheduler becomes unresponsive, including improved handling of repeated termination signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->