### PR TITLE
feat(plugin): gt:plan-it + gt:handoff — weak-executor discipline skills (v1.0.36)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.35",
+    "version": "1.0.36",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,14 +11,18 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.35",
+            "version": "1.0.36",
             "author": {
                 "name": "GenesisTools"
             },
             "source": "./plugins/genesis-tools",
             "category": "development",
-            "commands": ["./commands/"],
-            "skills": ["./skills/"]
+            "commands": [
+                "./commands/"
+            ],
+            "skills": [
+                "./skills/"
+            ]
         },
         {
             "name": "genesis-tools-server",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.34",
+    "version": "1.0.35",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.34",
+            "version": "1.0.35",
             "author": {
                 "name": "GenesisTools"
             },

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.35",
+    "version": "1.0.36",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.34",
+    "version": "1.0.35",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/skills/handoff/SKILL.md
+++ b/plugins/genesis-tools/skills/handoff/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: gt:handoff
+description: Create and maintain a compaction-proof progress file (.claude/plans/<plan>.handoff.md) next to an implementation plan, so any executor - fresh session, post-compact resume, or parallel subagent - knows exactly where the work stands and which plan lines to read next. Invoke when starting to execute a plan, when resuming one, when handing work to another agent, or when the user says "create a handoff" / "prepare the handoff".
+---
+
+# handoff — compaction-proof execution state
+
+The handoff file is the executor's external memory. Context gets compacted, sessions die, agents run in parallel — the handoff file survives all of it. **THE FILE IS THE TRUTH**: if your memory of progress disagrees with the file, the file wins.
+
+It is also **self-describing**: its own `## PROTOCOL` section teaches any reader the rules, so a fresh agent needs nothing but "Read `<plan>.handoff.md` and follow it."
+
+## Where it lives
+
+Next to the plan: `.claude/plans/<PlanName>.md` → `.claude/plans/<PlanName>.handoff.md`.
+If there is no plan file, the handoff still works — its TASKS section carries the step list itself.
+
+## The three iron rules
+
+1. **Read the handoff FIRST** — at session start, after every compaction, before every task. It is small by design (~1–2k tokens) and replaces re-reading the whole plan.
+2. **Update it IMMEDIATELY after every task** — never "at the end". An update you postponed dies with the next compaction.
+3. **STATE/TASKS are rewritten in place; LOG is append-only.** Never rewrite or delete LOG entries — they are the audit trail.
+
+## Creating a handoff (start of execution, or when handing off)
+
+Step 1 — build the plan TOC with real line numbers:
+
+```bash
+rg -n '^#{1,3} ' .claude/plans/<PlanName>.md
+wc -l .claude/plans/<PlanName>.md
+```
+
+Step 2 — Write `.claude/plans/<PlanName>.handoff.md` from this exact skeleton, filling every `<...>` (task list and line ranges come from the TOC you just built; mark independent tasks with the same `[P:n]` group when the plan's DON'T-TOUCH/interface-freeze shows they share no files):
+
+````markdown
+# Handoff: <PlanName>
+
+## PROTOCOL — read this first, every time
+You are executing a plan. This file is your memory; the plan file is your instructions.
+1. Read this whole file (it is small). Trust it over anything you remember.
+2. Read ONLY the plan's preamble (lines 1-<preamble-end>) — goal, covenant, interface freeze.
+3. Find **YOU ARE HERE** below. Read ONLY that task's line range from the plan:
+   `sed -n '<A>,<B>p' .claude/plans/<PlanName>.md` (or Read with offset/limit).
+4. Execute the task exactly as the plan says. Do not improvise; deviations go in the
+   plan's `## Deviations` AND one LOG line here.
+5. IMMEDIATELY update this file: flip the task checkbox, move YOU ARE HERE, append one
+   LOG line. Then go to 3.
+6. After any compaction or restart: start again at 1. Never re-read the whole plan.
+Rules: STATE/TASKS sections are rewritten in place. LOG is append-only, newest at the
+bottom. If a check fails after its ON-FAIL fallback: STOP, log it, report to the user.
+
+## STATE  <!-- rewrite in place -->
+- **Plan:** .claude/plans/<PlanName>.md (<total> lines; preamble = lines 1-<preamble-end>)
+- **Goal:** <one line>
+- **Branch/worktree:** <branch> @ <absolute path>
+- **YOU ARE HERE:** Task <N> — <name> (plan lines <A>-<B>) — <not started | in progress: step <K> | blocked: <why>>
+- **Verify:** <the command that proves the current task done, e.g. `bun test src/x.test.ts`>
+
+## TASKS  <!-- rewrite in place; [P:n] marks tasks safe to run in parallel within group n -->
+- [ ] Task 1 — <name> (lines <A>-<B>)
+- [ ] Task 2 — <name> (lines <C>-<D>) [P:1]
+- [ ] Task 3 — <name> (lines <E>-<F>) [P:1]
+
+## PLAN TOC  <!-- rewrite only when the plan file itself changes -->
+- Preamble (goal, covenant, interface freeze, conventions): lines 1-<preamble-end>
+- Task 1 — <name>: lines <A>-<B>
+- ...
+- Dry-run trace: lines <Y>-<Z>
+- Deviations: lines <>-<end>
+
+## LOG  <!-- append-only, one line per event, newest at bottom -->
+- <YYYY-MM-DD HH:MM> — handoff created; plan has <K> tasks, none started.
+````
+
+Step 3 — verify: `wc -l` the handoff (should be well under ~120 lines) and confirm every TASKS line range matches the TOC.
+
+Step 4 — the handoff prompt for another agent is exactly one sentence:
+> Read `.claude/plans/<PlanName>.handoff.md` and follow its PROTOCOL section. Re-read that file after every compaction.
+
+## Maintaining it (executor duties, after EVERY task)
+
+1. Flip the checkbox in TASKS.
+2. Move **YOU ARE HERE** to the next task (with its line range) and update **Verify**.
+3. Append ONE LOG line with a real timestamp (`date '+%F %H:%M'`), stating the observable result, not intentions:
+   `- 2026-07-08 21:40 — Task 2 done: bun test 14/14 green, committed abc1234. Next: Task 3.`
+4. If anything deviated: one LOG line here + the entry in the plan's `## Deviations`.
+5. Blocked? Set YOU ARE HERE to `blocked: <reason>`, log it, STOP and report — do not skip ahead.
+
+Keep LOG lines terse. Never trim or rewrite old lines; the file staying append-only is worth more than it staying pretty.
+
+## Resuming (fresh session / post-compact)
+
+Read the handoff → read plan preamble lines → read the YOU-ARE-HERE task's line range → work. That's ~2–4k tokens to be fully oriented, no matter how large the plan is. Re-reading the entire plan after a compaction is a protocol violation, not diligence.
+
+## Parallelizing with subagents
+
+- Only tasks sharing a `[P:n]` group may run concurrently; anything unmarked is sequential.
+- **One writer rule:** subagents NEVER edit the handoff. The orchestrator spawns each subagent with: "Execute ONLY Task <N> of `.claude/plans/<PlanName>.md`, lines <A>-<B>. Read the plan preamble (lines 1-<preamble-end>) first. Report the verify output; do not touch other files." The orchestrator updates TASKS/LOG as each returns.
+- If two [P] tasks would touch the same file, the [P] marking is wrong — fix the handoff, run them sequentially.
+
+## Relationship to other conventions
+
+- Pairs with `plan-it` (gt:plan-it): plan-it plans have greppable `## Task N:` headings, per-task VERIFY, and a `## Deviations` section — a handoff maps onto them 1:1. Works with any plan that has task headings, though.
+- The executor should load the `fable-style` skill if available; the handoff governs *where you are*, fable-style governs *how you work*.
+- `*.handoff.md` files are chronological/append-only by repo convention — this skill's STATE/TASKS rewrite-in-place blocks are the explicitly declared exception; LOG keeps the append-only audit trail.

--- a/plugins/genesis-tools/skills/plan-it/SKILL.md
+++ b/plugins/genesis-tools/skills/plan-it/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: gt:plan-it
+description: Write comprehensive implementation plans (subsumes writing-plans - bite-sized TDD tasks, exact paths, complete code) hardened with an executor-proof contract - all judgment spent at plan time, REASON/VERIFY/ON-FAIL per task, no-improvisation covenant - so even the weakest model executes to strong-model-quality output. Invoke INSTEAD of writing-plans whenever the plan may be executed by another session, subagent, or weaker model.
+---
+
+# plan-it — executor-proof implementation plans
+
+**Announce at start:** "I'm using the plan-it skill to create the implementation plan."
+
+This skill **subsumes `writing-plans`** — same comprehensive planning discipline (bite-sized tasks, TDD, complete code, exact paths, self-review, execution handoff), plus an executor-proof contract on top. Never invoke both; this is the superset.
+
+The plan, not the executor, carries the intelligence. Written under this contract, a plan produces near-identical results whether a frontier model or a small one executes it — because every decision is already made, every line of nontrivial code is already written, and every checkpoint is mechanically checkable. The output looks like the planner's code because the code in the plan IS the planner's.
+
+Why this works: weak models match strong ones only when nothing is left to fill in — they fail precisely by filling gaps with their own judgment, and they silently drop project conventions under complexity unless the conventions are restated in-context. Separating REASON (judgment) from ACT (mechanics) is the best-transferring shape.
+
+## Core assumption — the weakest executor
+
+Write for a skilled but completely **literal** engineer with zero context for the codebase, questionable taste in tests and design, and **no access to this conversation**:
+
+- **Self-contained**: every path repo-rooted or absolute; every relevant repo convention restated inside the plan (logger vs out, SafeJSON, prompt facade, import style, …); never "as discussed" or "like we did before".
+- **Interface freeze**: exact file names, exported symbols, type signatures, DB columns declared in the preamble *before* the tasks — executors drift on names first, and a symbol used in Task 7 that was named differently in Task 3 is a plan bug.
+- **DON'T-TOUCH list**: name adjacent files/behaviors that must not change. Weak models "improve" neighboring code unless told not to.
+
+## Where plans go
+
+`.claude/plans/YYYY-MM-DD-<FeatureNameCamelCase>.md` (this convention overrides any other skill's default location).
+
+## Scope check
+
+If the spec covers multiple independent subsystems, split it — one plan per subsystem, each producing working, testable software on its own.
+
+## File structure first
+
+Before writing tasks, map which files will be created/modified and each one's single responsibility. Prefer small focused files; follow the codebase's established patterns rather than restructuring unilaterally. This map locks in the decomposition; each task then produces a self-contained change.
+
+## Plan preamble (mandatory, in this order)
+
+````markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** Execute task-by-task (subagent-driven-development or
+> executing-plans). Steps use checkbox (`- [ ]`) syntax. Load the `fable-style`
+> skill first if it is available. The covenant below is binding.
+
+**Goal:** [one sentence]
+**Architecture:** [2–3 sentences]
+**Tech Stack:** [key technologies]
+**Non-goals:** [what this plan deliberately does not do]
+**DON'T-TOUCH:** [files/behaviors that must not change]
+
+## Interface freeze
+[exact names: files, exported symbols, signatures, types, columns — the vocabulary
+every task below must use verbatim]
+
+## Conventions capsule
+[the repo rules relevant to this change, restated — the executor has not read
+CLAUDE.md and will not infer them]
+
+> **Covenant:** Execute tasks in order, exactly as written. Do not substitute
+> approaches, "improve" adjacent code, rename things, or skip verification steps.
+> If anything is ambiguous, or a check stays red after its single ON-FAIL fallback,
+> stop and report — an honest incomplete run beats a complete improvised one.
+````
+
+## Bite-sized granularity
+
+Each step is ONE action (2–5 minutes): write the failing test → run it, expect FAIL → minimal implementation → run it, expect PASS → commit. DRY. YAGNI. TDD. Frequent commits.
+
+## Task skeleton (mandatory)
+
+````markdown
+### Task N: [Component Name]
+
+**REASON**: <2–4 lines: why this approach, which constraint rules out the obvious
+alternative. The executor must not re-derive or second-guess this.>
+
+**Files:**
+- Create: `exact/path/to/file.ts`
+- Modify: `exact/path/to/existing.ts:123-145` (anchor: quote the exact existing line)
+- Test: `exact/path/to/file.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+<real test code — full block, no "..." elisions>
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `bun test exact/path/to/file.test.ts`
+Expected: FAIL with "<the actual message>"
+
+- [ ] **Step 3: Minimal implementation**
+
+```ts
+<real code — the planner writes it, the executor applies it>
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `bun test exact/path/to/file.test.ts`
+Expected: PASS (and any other observable: exit 0, string to grep)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add exact/path/to/file.test.ts exact/path/to/file.ts
+git commit -m "feat: <concise why>"
+```
+
+**ON-FAIL**: <ONE bounded fallback, e.g. "if the anchor moved, rg for `<symbol>` and
+re-apply once">. Still red after that: STOP, append to `## Deviations`, do not start
+Task N+1.
+````
+
+No test infrastructure in the target repo? Replace test steps with the strongest available observable (`tsgo --noEmit`, lint, a runnable command with expected output) — never drop verification.
+
+## No placeholders — the altitude rule
+
+Spend ALL judgment at plan time. A weak executor doesn't fill gaps with your judgment; it fills them with its own. These are **plan failures** — never write them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases" / "as needed" / "properly"
+- "Write tests for the above" (without the actual test code)
+- "Similar to Task N" (repeat the code — tasks may be read out of order)
+- Steps that describe code without showing it (code blocks required)
+- References to types/functions not defined in the interface freeze or an earlier task
+- Any ACT needing more than ~30 lines of new logic the plan doesn't spell out — judgment leaked into execution; go back and write the code
+
+## Self-review (before publishing)
+
+Run this checklist yourself — not a subagent dispatch:
+
+1. **Spec coverage** — every spec requirement maps to a task; list gaps and add tasks.
+2. **Placeholder scan** — search the plan for every red-flag pattern above; fix inline.
+3. **Type consistency** — names/signatures in later tasks match the interface freeze and earlier tasks.
+4. **Stranger test** — could a model that has never seen this conversation execute it, alone, from the file?
+5. **Observable verification** — every task's checks name expected output, not "check it works".
+6. **Bounded failure** — every task has exactly one ON-FAIL fallback, then stop.
+
+Fix and move on; no re-review loop.
+
+## Deviations section
+
+Every plan ends with an empty `## Deviations` section. The executor appends every deviation there (anchor moved, command adapted, fallback used) — it's the audit trail for the retro.
+
+## Execution handoff
+
+After saving, offer: **1. Subagent-driven** (fresh subagent per task, review between tasks — recommended) or **2. Inline** (executing-plans, batch with checkpoints). Either way, if the `fable-style` skill is available the executor loads it first — plan-it is the planner-side half of the transfer (work arrives pre-chewed); fable-style is the executor-side half (the worker behaves like the strong model).

--- a/plugins/genesis-tools/skills/plan-it/SKILL.md
+++ b/plugins/genesis-tools/skills/plan-it/SKILL.md
@@ -68,10 +68,10 @@ Each step is ONE action (2–5 minutes): write the failing test → run it, expe
 
 ## Task skeleton (mandatory)
 
-Use exactly this heading format — `### Task N: [Component Name]` (three `#`) — executors and graders match on it.
+Use exactly this heading format — `## Task N: [Component Name]` — executors and graders match on `^## Task`.
 
 ````markdown
-### Task N: [Component Name]
+## Task N: [Component Name]
 
 **REASON**: <2–4 lines: why this approach, which constraint rules out the obvious
 alternative. The executor must not re-derive or second-guess this.>
@@ -110,9 +110,8 @@ git add exact/path/to/file.test.ts exact/path/to/file.ts
 git commit -m "feat: <concise why>"
 ```
 
-**ON-FAIL**: <ONE bounded fallback, e.g. "if the anchor moved, rg for `<symbol>` and
-re-apply once">. Still red after that: STOP, append to `## Deviations`, do not start
-Task N+1.
+**ON-FAIL**: If <specific symptom> → <one action> once. Otherwise: STOP, append to
+`## Deviations`, do not start Task N+1.
 ````
 
 ON-FAIL is one sentence, one action. It may NEVER modify anything declared in the interface freeze (names, signatures, frozen constants/sets), and it is not a debugging expedition — if one bounded action doesn't fix it, the answer is STOP, not a second idea.

--- a/plugins/genesis-tools/skills/plan-it/SKILL.md
+++ b/plugins/genesis-tools/skills/plan-it/SKILL.md
@@ -68,6 +68,8 @@ Each step is ONE action (2–5 minutes): write the failing test → run it, expe
 
 ## Task skeleton (mandatory)
 
+Use exactly this heading format — `### Task N: [Component Name]` (three `#`) — executors and graders match on it.
+
 ````markdown
 ### Task N: [Component Name]
 
@@ -113,6 +115,8 @@ re-apply once">. Still red after that: STOP, append to `## Deviations`, do not s
 Task N+1.
 ````
 
+ON-FAIL is one sentence, one action. It may NEVER modify anything declared in the interface freeze (names, signatures, frozen constants/sets), and it is not a debugging expedition — if one bounded action doesn't fix it, the answer is STOP, not a second idea.
+
 No test infrastructure in the target repo? Replace test steps with the strongest available observable (`tsgo --noEmit`, lint, a runnable command with expected output) — never drop verification.
 
 ## No placeholders — the altitude rule
@@ -137,6 +141,7 @@ Run this checklist yourself — not a subagent dispatch:
 4. **Stranger test** — could a model that has never seen this conversation execute it, alone, from the file?
 5. **Observable verification** — every task's checks name expected output, not "check it works".
 6. **Bounded failure** — every task has exactly one ON-FAIL fallback, then stop.
+7. **Dry-run trace** — take the least trivial example/test input in the plan and trace it through the planned code line by line; the traced output must equal the test's expected value. A plan whose own tests fail its own implementation strands the executor at the first VERIFY — the worst possible leak, because the executor is forbidden from fixing it.
 
 Fix and move on; no re-review loop.
 

--- a/plugins/genesis-tools/skills/plan-it/SKILL.md
+++ b/plugins/genesis-tools/skills/plan-it/SKILL.md
@@ -9,6 +9,8 @@ description: Write comprehensive implementation plans (subsumes writing-plans - 
 
 This skill **subsumes `writing-plans`** — same comprehensive planning discipline (bite-sized tasks, TDD, complete code, exact paths, self-review, execution handoff), plus an executor-proof contract on top. Never invoke both; this is the superset.
 
+**Planner floor: Sonnet-class or better.** A five-run evaluation showed Haiku-class models reproduce the contract's *structure* reliably but hallucinate dry-run intermediates and skip do-work requirements (running the empirical trace, resolving design uncertainty); they are executor-tier, not planner-tier. The plan is where all judgment lives — spend a strong model on it.
+
 The plan, not the executor, carries the intelligence. Written under this contract, a plan produces near-identical results whether a frontier model or a small one executes it — because every decision is already made, every line of nontrivial code is already written, and every checkpoint is mechanically checkable. The output looks like the planner's code because the code in the plan IS the planner's.
 
 Why this works: weak models match strong ones only when nothing is left to fill in — they fail precisely by filling gaps with their own judgment, and they silently drop project conventions under complexity unless the conventions are restated in-context. Separating REASON (judgment) from ACT (mechanics) is the best-transferring shape.

--- a/plugins/genesis-tools/skills/plan-it/SKILL.md
+++ b/plugins/genesis-tools/skills/plan-it/SKILL.md
@@ -114,7 +114,9 @@ git commit -m "feat: <concise why>"
 `## Deviations`, do not start Task N+1.
 ````
 
-ON-FAIL is one sentence, one action. It may NEVER modify anything declared in the interface freeze (names, signatures, frozen constants/sets), may NEVER weaken, loosen, or delete a test to make it pass, and is not a debugging expedition — if one bounded action doesn't fix it, the answer is STOP, not a second idea. Commit steps always `git add` explicit paths — never `git add -A`.
+ON-FAIL is one sentence, one action, **25 words maximum**. It may NEVER modify anything declared in the interface freeze (names, signatures, frozen constants/sets), may NEVER weaken, loosen, or delete a test to make it pass, and is not a debugging expedition — if one bounded action doesn't fix it, the answer is STOP, not a second idea. Commit steps always `git add` explicit paths — never `git add -A`.
+
+Granularity guard: one exported symbol (or one cohesive component) per task. If a task's ACT creates two unrelated exports, split it.
 
 No test infrastructure in the target repo? Replace test steps with the strongest available observable (`tsgo --noEmit`, lint, a runnable command with expected output) — never drop verification.
 
@@ -146,7 +148,7 @@ Fix and move on; no re-review loop.
 
 ## Dry-run trace section (mandatory)
 
-Every plan contains, immediately before `## Deviations`, a `## Dry-run trace` section: take the least trivial test input in the plan and walk it through the final planned implementation step by step, SHOWING the intermediate values (the token array after each stage, not just the conclusion), ending with `traced result == expected ✓`. If the trace and the test disagree, the plan is wrong — fix the code or the test before publishing. A plan without this section is incomplete and must not be published. (This exists because a silently-run self-check gets skipped; a required section cannot be.)
+Every plan contains, immediately before `## Deviations`, a `## Dry-run trace` section for the least trivial test input in the plan. The trace must be **empirical, not mental**: paste the planned function into a throwaway eval (e.g. `bun -e '<planned function code>; console.log(fn(<input>))'` — touches no repo files, so it is still PLAN ONLY) and paste the REAL printed output into the section, alongside the per-stage intermediate values (log the token array after each stage). Mental simulation is forbidden — models routinely mis-simulate regex and string operations and then assert wrong intermediates with full confidence. If the actual output and the test's expected value disagree, the plan is wrong — fix the code or the test before publishing. A plan without this section, or with a trace that was not actually executed, is incomplete and must not be published.
 
 ## Deviations section
 

--- a/plugins/genesis-tools/skills/plan-it/SKILL.md
+++ b/plugins/genesis-tools/skills/plan-it/SKILL.md
@@ -114,7 +114,7 @@ git commit -m "feat: <concise why>"
 `## Deviations`, do not start Task N+1.
 ````
 
-ON-FAIL is one sentence, one action. It may NEVER modify anything declared in the interface freeze (names, signatures, frozen constants/sets), and it is not a debugging expedition — if one bounded action doesn't fix it, the answer is STOP, not a second idea.
+ON-FAIL is one sentence, one action. It may NEVER modify anything declared in the interface freeze (names, signatures, frozen constants/sets), may NEVER weaken, loosen, or delete a test to make it pass, and is not a debugging expedition — if one bounded action doesn't fix it, the answer is STOP, not a second idea. Commit steps always `git add` explicit paths — never `git add -A`.
 
 No test infrastructure in the target repo? Replace test steps with the strongest available observable (`tsgo --noEmit`, lint, a runnable command with expected output) — never drop verification.
 
@@ -140,9 +140,13 @@ Run this checklist yourself — not a subagent dispatch:
 4. **Stranger test** — could a model that has never seen this conversation execute it, alone, from the file?
 5. **Observable verification** — every task's checks name expected output, not "check it works".
 6. **Bounded failure** — every task has exactly one ON-FAIL fallback, then stop.
-7. **Dry-run trace** — take the least trivial example/test input in the plan and trace it through the planned code line by line; the traced output must equal the test's expected value. A plan whose own tests fail its own implementation strands the executor at the first VERIFY — the worst possible leak, because the executor is forbidden from fixing it.
+7. **Dry-run trace section present and honest** — the `## Dry-run trace` section exists, its intermediate values are actually computed (not asserted), and its conclusion equals the test's expected value. A plan whose own tests fail its own implementation strands the executor at the first VERIFY — the worst possible leak, because the executor is forbidden from fixing it.
 
 Fix and move on; no re-review loop.
+
+## Dry-run trace section (mandatory)
+
+Every plan contains, immediately before `## Deviations`, a `## Dry-run trace` section: take the least trivial test input in the plan and walk it through the final planned implementation step by step, SHOWING the intermediate values (the token array after each stage, not just the conclusion), ending with `traced result == expected ✓`. If the trace and the test disagree, the plan is wrong — fix the code or the test before publishing. A plan without this section is incomplete and must not be published. (This exists because a silently-run self-check gets skipped; a required section cannot be.)
 
 ## Deviations section
 


### PR DESCRIPTION
## What

Two new skills for the genesis-tools plugin, bumping it to **v1.0.36**:

- **`gt:plan-it`** — executor-proof implementation planning (subsumes `writing-plans`)
- **`gt:handoff`** — compaction-proof progress files for plan execution

Together they form the "weak-executor discipline" toolkit: a strong model spends all judgment once (plan-it), and any model — fresh session, post-compact, or parallel subagent — can pick the work up without losing state (handoff).

## gt:plan-it

Full `writing-plans` discipline (bite-sized TDD tasks, exact paths, complete code, self-review, execution handoff) hardened with a contract that moves ALL judgment to plan time:

- Per-task **REASON** (judgment written down; executor must not re-derive it)
- Preamble: Non-goals, DON'T-TOUCH list, **interface freeze**, **conventions capsule**, binding no-improvisation covenant
- Per-task **ON-FAIL**: one action, ≤25 words, never mutates the interface freeze, never weakens a test; then STOP + deviation note
- **Empirical `## Dry-run trace` section**: the planner must actually RUN the planned function (`bun -e`, plan-only safe) and paste real output — mental simulation is forbidden
- Altitude tripwire (>~30 unwritten lines of logic = plan failure), explicit-path commits only, mandatory `## Deviations` audit section
- **Planner floor: Sonnet-class** (see below); Haiku is executor-tier

### Battle-tested via a 5-run Haiku gauntlet

The skill was iterated against a 13-hoop objective rubric (fixed prompt with a planted vagueness bait, fresh Haiku agent per run, every plan graded and hand-verified):

1. Run 1 (10.5/13): shipped a subtle contraction bug; ON-FAIL mutated frozen constants → added dry-run self-review, ON-FAIL bounds
2. Run 2 (12.5/13): trace caught & fixed the bug — best run
3. Run 3: regression — no trace written, test-weakening ON-FAIL → trace became a **mandatory visible section**; test-weakening banned
4. Run 4: trace present but with **hallucinated intermediates** (asserted `"what's".replace(/[^a-z]/g,"") == "what"`) → trace must be **empirical** (run it, don't simulate it)
5. Run 5: skipped the required execution entirely → conclusion: the residual failures are Haiku's capability floor, not skill leaks — hence the stated **Sonnet-class planner floor**

Structural/textual requirements converged from run 2 onward and stayed converged. Full rubric, per-run log, and all five plan artifacts are archived locally (fable eval repo), not in this PR.

## gt:handoff

Creates `.claude/plans/<Plan>.handoff.md` next to a plan — the executor's external memory that survives compaction, session death, and parallel agents:

- **Self-describing**: the generated file embeds its own PROTOCOL section, so the entire handoff prompt to another agent is one sentence ("Read the handoff and follow its PROTOCOL; re-read after every compaction")
- **STATE** (YOU-ARE-HERE with plan line ranges + current verify command) and **TASKS** (checkboxes, `[P:n]` parallel groups) rewritten in place; **LOG** append-only audit trail
- **PLAN TOC with line ranges** built mechanically (`rg -n '^#{1,3} '`): post-compact resume = handoff + plan preamble + current task segment only (~2–4k tokens regardless of plan size); re-reading the whole plan is declared a protocol violation
- **One-writer rule** for parallelization: subagents execute single tasks by line range and never edit the handoff; the orchestrator updates it

## Notes

- Skill frontmatter `name: gt:plan-it` / `gt:handoff` matches the `gt:research` convention (invoke id comes from the directory name)
- Version bumped in `marketplace.json` (both spots) + `plugin.json` → 1.0.36
- Commits cherry-picked from a working branch; this PR touches only the plugin + marketplace files
