### PR TITLE
feat(dev-dashboard/boards): AI expression layer — compose, arrange, sections, questions, scrape

### DIFF
--- a/src/boards/README.md
+++ b/src/boards/README.md
@@ -33,6 +33,7 @@ tools boards watch --board my-board --once           # single check, for scripti
 | `push` | Tar+push the capture root as a new set version. |
 | `board-from-set` | Create (or reuse) a board and import the current shot set. |
 | `watch` | Long-poll for open annotation work; print one line per new-or-changed item. |
+| `operator [name]` | Show or set the operator identity attributed to your board writes. |
 
 ### init — create the sticky set config
 
@@ -57,7 +58,7 @@ appends an entry to `manifest.json`.
 ### push — tar+push the capture root as a new set version
 
 ```bash
-tools boards push [--dir <path>] [--title <title>] [--source <source>] [--base <url>]
+tools boards push [--dir <path>] [--title <title>] [--source <source>] [--base <url>] [--actor <name>]
 ```
 
 Requires `tools boards init` to have run first. `--title`/`--source` are persisted back into
@@ -66,11 +67,23 @@ Requires `tools boards init` to have run first. `--title`/`--source` are persist
 ### board-from-set — create a board and import the pushed set
 
 ```bash
-tools boards board-from-set [--slug <s>] [--title <t>] [--dir <path>] [--base <url>]
+tools boards board-from-set [--slug <s>] [--title <t>] [--dir <path>] [--base <url>] [--actor <name>]
 ```
 
 Creates a board (slug defaults to the set key, lowercased) — or reuses it if it already
 exists — then imports the current set's images as cards in a serpentine layout.
+
+### operator — the identity attributed to your writes
+
+```bash
+tools boards operator                # prints local + server-default identity
+tools boards operator <name> [--base <url>]
+```
+
+Persists `<name>` both locally (`~/.genesis-tools/boards/operator`) and as the server's
+default (`PUT /api/boards/operator`), then that name attributes `push`/`board-from-set`
+writes via the `X-Board-Actor` header (or pass `--actor <name>` on either command to
+override just that one write). Falls back to the literal `"operator"` if never set.
 
 ### watch — the zero-token-idle listener
 
@@ -91,14 +104,26 @@ decide whether to wake an idle agent. Silence means healthy + idle. Diagnostics 
 - `--once` → single wait cycle (`timeout=1`) then exit: `0` if it announced anything, `3` if idle.
 - A live-holder conflict (HTTP 409 on the leased scope) prints `⚠ boards scope held by live
   listener <session>` to stdout and exits `2`.
+- An expired-but-unreaped-holder conflict prints `⚠ boards scope held by expired listener
+  <session> → retry with --takeover to steal the expired lease` and exits `2`. Pass
+  `--takeover` to steal it immediately instead of waiting for the next automatic reap —
+  it only ever steals an EXPIRED lease (past TTL); a live holder always wins.
 - A sustained outage (≥120s unreachable) prints `⚠ boards unreachable for <n>s — listener
   degraded` (re-emitted at most every 10 minutes) and `✓ boards reachable again` on recovery.
-- `--takeover` is accepted for parity with the server's query param but is a no-op — expired
-  leases are reaped automatically at the top of every wait.
 - SIGINT/SIGTERM releases the lease (`DELETE /api/boards/work/listeners/:id`) before exiting 0,
   which immediately reverts any work the listener had claimed.
 - An MCP client's `boards_wait_for_work` called anonymously (no session) never leases, so it
   freely coexists with a live `watch` listener on the same scope — it just drains whatever's open.
+
+### Staged → dispatch: how annotations reach `watch`/`wait_for_work`
+
+Annotations don't necessarily go straight to `open` (the status this listener/MCP surface
+picks up). A user's REPLY on an `in_review` or `resolved` thread — and a reject verdict —
+re-stage it to `staged`, held until the user presses the board's "Send to Claude" bar
+(`POST /api/boards/:slug/dispatch`), which flips every `staged` annotation to `open` in one
+shot and wakes any waiting `watch`/`wait_for_work` listener. Replies on a `working` thread
+are left alone (an active worker isn't interrupted). The same staged→dispatch gate holds
+answered AI-expression-layer questions (§ below) off the work wire until dispatch too.
 
 ---
 
@@ -115,6 +140,33 @@ Monitor({ command: "tools boards watch --board my-board", persistent: true })
 Scope every `list_work`/`wait_for_work` call to the board (or project+branch) you're working
 in — an unscoped call surfaces every board's queue, and items belonging to other boards/sessions
 should be left alone.
+
+`boards_list_work`'s items carry an enriched shape beyond the bare id/status: `intentOther`
+(the custom label when `intent:"other"`), `boardTitle`, and the source `setRef`/`file` — so an
+agent orienting on a fresh work item rarely needs a follow-up `boards_get_annotation` call.
+
+---
+
+## AI expression layer (compose / arrange / questions)
+
+Beyond the fix-loop above, boards are also a PRESENTATION surface: `boards_compose_board`
+places a whole batch of markdown/viz/section/question cards in one call (never one card per
+call), `boards_arrange` auto-layouts them server-side (13 modes, `save:true` for a
+self-maintaining section), `boards_scrape_board` reads a whole board back as a structured
+digest (optionally scoped to one journey `section`, or diffing two sections pairwise), and
+`boards_ask_board`/the board's own UI let a question get answered with one click instead of
+prose — answers are STAGED like annotations, released onto the work wire by the same
+"Send to Claude" dispatch. Call `boards_get_templates` once per new board for compose-ready
+skeletons (QA session, iteration review, decision map, dashboard, presentation deck) instead
+of inventing structure. Full tool schemas are self-documenting via MCP `tools/list`; this
+README stays CLI-focused.
+
+**Known divergences from vitrinka** (the reference implementation this was ported from):
+`boards_wait_for_work` claims a real lease keyed `session=hostname:pid` (vitrinka's own MCP
+tool waits anonymously — GT's CLI `watch` needs a real lease to coordinate with other watchers,
+so the MCP tool inherited the same mechanism for consistency); `CompareDeck`'s reject verdict
+stages the thread (`status → "staged"`) rather than vitrinka's reply-only rejection UX, since
+GT kept a dedicated reject affordance on pending attempts.
 
 ---
 

--- a/src/boards/commands/add.ts
+++ b/src/boards/commands/add.ts
@@ -1,25 +1,9 @@
-import { existsSync } from "node:fs";
 import { copyFile, mkdir } from "node:fs/promises";
-import { basename, extname, join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { printLn } from "@app/utils/cli";
 import type { Command } from "commander";
 import { captureRoot, readSetConfig } from "../lib/config";
-import { appendShot, readManifest, writeManifest } from "../lib/manifest";
-
-/** Picks a collision-free destination basename: `shot.png`, `shot-2.png`, `shot-3.png`, ... */
-function uniqueDestName(root: string, name: string): string {
-    if (!existsSync(join(root, name))) {
-        return name;
-    }
-
-    const ext = extname(name);
-    const stem = name.slice(0, name.length - ext.length);
-    let i = 2;
-    while (existsSync(join(root, `${stem}-${i}${ext}`))) {
-        i += 1;
-    }
-    return `${stem}-${i}${ext}`;
-}
+import { appendShot, readManifest, uniqueDestName, writeManifest } from "../lib/manifest";
 
 export function registerAddCommand(program: Command): void {
     program
@@ -39,6 +23,7 @@ export function registerAddCommand(program: Command): void {
                 const cwd = process.cwd();
                 const root = captureRoot(cwd, opts.dir);
                 const cfg = await readSetConfig(root);
+
                 if (!cfg) {
                     process.stderr.write("no set config found — run `tools boards init` first\n");
                     process.exitCode = 1;

--- a/src/boards/commands/init.ts
+++ b/src/boards/commands/init.ts
@@ -26,6 +26,7 @@ export function registerInitCommand(program: Command): void {
             const root = captureRoot(cwd, opts.dir);
 
             const existing = await readSetConfig(root);
+
             if (existing) {
                 await printLn(`set ${existing.project}/${existing.branch}/${existing.key} (already initialized)`);
                 return;

--- a/src/boards/commands/push.ts
+++ b/src/boards/commands/push.ts
@@ -93,7 +93,7 @@ export function registerPushCommand(program: Command): void {
 
             const base = resolveBaseUrl(opts.base);
             const branchSlug = slugifyBranch(cfg.branch);
-            const provenance = gitProvenance(root); // best-effort; omitted outside a git repo
+            const provenance = gitProvenance(cwd); // best-effort; omitted outside a git repo
             const targetPath = paths.boardsSetContent({
                 project: cfg.project,
                 branch: branchSlug,

--- a/src/boards/commands/watch.test.ts
+++ b/src/boards/commands/watch.test.ts
@@ -28,6 +28,7 @@ describe("runWatch", () => {
                     if (waitCall === 1) {
                         return Response.json({ idle: true, listener: 1 });
                     }
+
                     if (waitCall === 2) {
                         return Response.json({
                             work: [{ id: 1, board: "demo", capsule: "..." }],
@@ -35,6 +36,7 @@ describe("runWatch", () => {
                             listener: 1,
                         });
                     }
+
                     return Response.json(
                         {
                             error: "scope held by a live listener",
@@ -115,6 +117,7 @@ describe("runWatch", () => {
                     if (waitCall <= 2) {
                         return Response.json({ work: [{ id: 1, board: "demo", capsule: "..." }], pending: 1 });
                     }
+
                     return Response.json(
                         {
                             error: "scope held by a live listener",
@@ -187,6 +190,7 @@ describe("runWatch", () => {
             port: 0,
             fetch(req) {
                 const url = new URL(req.url);
+
                 if (url.pathname === "/api/boards/work/wait") {
                     return Response.json(
                         {
@@ -206,6 +210,7 @@ describe("runWatch", () => {
                         { status: 409 }
                     );
                 }
+
                 return new Response("not found", { status: 404 });
             },
         });
@@ -233,9 +238,11 @@ describe("runWatch", () => {
             port: 0,
             fetch(req) {
                 const url = new URL(req.url);
+
                 if (url.pathname === "/api/boards/work/wait") {
                     return Response.json({ idle: true });
                 }
+
                 return new Response("not found", { status: 404 });
             },
         });
@@ -263,10 +270,12 @@ describe("runWatch", () => {
             port: 0,
             fetch(req) {
                 const url = new URL(req.url);
+
                 if (url.pathname === "/api/boards/work/wait") {
                     waitSearch = url.search;
                     return Response.json({ idle: true });
                 }
+
                 return new Response("not found", { status: 404 });
             },
         });
@@ -291,9 +300,11 @@ describe("runWatch", () => {
             port: 0,
             fetch(req) {
                 const url = new URL(req.url);
+
                 if (url.pathname === "/api/boards/work/wait") {
                     return Response.json({ work: [{ id: 5, board: "demo", capsule: "..." }], pending: 1 });
                 }
+
                 if (url.pathname === "/api/boards/work") {
                     return Response.json({
                         work: [
@@ -310,6 +321,7 @@ describe("runWatch", () => {
                         ],
                     });
                 }
+
                 return new Response("not found", { status: 404 });
             },
         });

--- a/src/boards/commands/watch.ts
+++ b/src/boards/commands/watch.ts
@@ -278,7 +278,7 @@ export function registerWatchCommand(program: Command): void {
         .option("--all", "scope to every board/project")
         .option("--once", "single lease-free wait cycle then exit (0=work announced, 3=idle/unreachable)")
         .option("--base <url>", "dev-dashboard base URL")
-        .option("--takeover", "accepted for CLI parity — expired leases are reaped automatically")
+        .option("--takeover", "steal an expired-but-unreaped lease on this scope (never a live one)")
         .action(
             async (opts: {
                 board?: string;

--- a/src/boards/lib/client.ts
+++ b/src/boards/lib/client.ts
@@ -1,3 +1,4 @@
+import { logger } from "@app/logger";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 
@@ -45,7 +46,8 @@ export async function rawRequest<T>(base: string, path: string, init?: RequestIn
     if (text.length > 0) {
         try {
             body = SafeJSON.parse(text, { strict: true }) as T;
-        } catch {
+        } catch (err) {
+            logger.debug({ err, status: res.status, path }, "boards: non-JSON response body");
             body = undefined;
         }
     }

--- a/src/boards/lib/config.test.ts
+++ b/src/boards/lib/config.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import {
@@ -17,8 +17,22 @@ import {
     writeSetConfig,
 } from "./config";
 
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+}
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
 function initGitRepo(): string {
-    const dir = mkdtempSync(join(tmpdir(), "boards-cfg-"));
+    const dir = makeTempDir("boards-cfg-");
     execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
     execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
     execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
@@ -37,14 +51,14 @@ describe("captureRoot", () => {
 
 describe("readSetConfig / writeSetConfig", () => {
     it("round-trips a config", async () => {
-        const root = mkdtempSync(join(tmpdir(), "boards-root-"));
+        const root = makeTempDir("boards-root-");
         const cfg = { project: "demo", branch: "main", key: "s-20260101-0000", kind: "screenshots" };
         await writeSetConfig(root, cfg);
         expect(await readSetConfig(root)).toEqual(cfg);
     });
 
     it("returns null when no config exists", async () => {
-        const root = mkdtempSync(join(tmpdir(), "boards-root-"));
+        const root = makeTempDir("boards-root-");
         expect(await readSetConfig(root)).toBeNull();
     });
 });
@@ -57,7 +71,7 @@ describe("defaultProject / currentBranch", () => {
     });
 
     it("falls back to the cwd basename outside a git repo", () => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-nogit-"));
+        const dir = makeTempDir("boards-nogit-");
         expect(defaultProject(dir)).toBe(basename(dir));
         expect(currentBranch(dir)).toBe("main");
     });
@@ -87,7 +101,7 @@ describe("ensureGitExclude", () => {
     });
 
     it("is a no-op outside a git repo", async () => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-nogit2-"));
+        const dir = makeTempDir("boards-nogit2-");
         await expect(ensureGitExclude(dir, DEFAULT_ROOT)).resolves.toBeUndefined();
     });
 });
@@ -118,7 +132,7 @@ describe("gitProvenance", () => {
     });
 
     it("omits both fields outside a git repo", () => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-noprov-"));
+        const dir = makeTempDir("boards-noprov-");
         expect(gitProvenance(dir)).toEqual({ commit: undefined, repo: undefined });
     });
 });

--- a/src/boards/lib/manifest.ts
+++ b/src/boards/lib/manifest.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { extname, join } from "node:path";
 import { SafeJSON } from "@app/utils/json";
 
 export interface ManifestShot {
@@ -45,4 +45,19 @@ export async function writeManifest(root: string, m: Manifest): Promise<void> {
 /** Appends `shot`, replacing any existing entry for the same file. */
 export function appendShot(m: Manifest, shot: ManifestShot): Manifest {
     return { ...m, shots: [...m.shots.filter((s) => s.file !== shot.file), shot] };
+}
+
+/** Picks a collision-free destination basename: `shot.png`, `shot-2.png`, `shot-3.png`, ... */
+export function uniqueDestName(root: string, name: string): string {
+    if (!existsSync(join(root, name))) {
+        return name;
+    }
+
+    const ext = extname(name);
+    const stem = name.slice(0, name.length - ext.length);
+    let i = 2;
+    while (existsSync(join(root, `${stem}-${i}${ext}`))) {
+        i += 1;
+    }
+    return `${stem}-${i}${ext}`;
 }

--- a/src/claude/mcp/boards.e2e.test.ts
+++ b/src/claude/mcp/boards.e2e.test.ts
@@ -177,4 +177,119 @@ describe("boards MCP tools (stdio e2e against a real agent-mode dev-dashboard)",
             proc.kill();
         }
     }, 60000);
+
+    it("drives a composed-board loop: compose → sections/scrape → ask/answer → dispatch → wait choice", async () => {
+        const home = mkdtempSync(join(tmpdir(), "boards-e2e-compose-home-"));
+        const port = await findFreePort();
+        const base = `http://127.0.0.1:${port}`;
+
+        const dashboardEntry = join(import.meta.dir, "../../dev-dashboard/index.ts");
+        const proc = Bun.spawn([process.execPath, "run", dashboardEntry, "agent", "--port", String(port)], {
+            env: { ...env.getProcessEnv(), GENESIS_TOOLS_HOME: home },
+            stdout: "ignore",
+            stderr: "ignore",
+        });
+
+        try {
+            await waitReady(base, Date.now() + 10_000);
+
+            const slug = "e2e-compose-board";
+            const boardRes = await fetch(`${base}/api/boards`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: SafeJSON.stringify({ slug, title: "E2E compose board" }),
+            });
+            expect(boardRes.ok).toBe(true);
+
+            const transport = new StdioClientTransport({
+                command: process.execPath,
+                args: ["run", join(import.meta.dir, "../index.ts"), "mcp"],
+                env: { ...env.getProcessEnv(), BOARDS_BASE_URL: base },
+            });
+            const client = new Client({ name: "boards-compose-e2e", version: "1.0.0" });
+            await client.connect(transport);
+
+            try {
+                const tools = await client.listTools();
+                const names = tools.tools.map((t) => t.name);
+                for (const expected of [
+                    "boards_compose_board",
+                    "boards_arrange",
+                    "boards_update_cards",
+                    "boards_scrape_board",
+                    "boards_list_sections",
+                    "boards_ask_board",
+                    "boards_list_projects",
+                    "boards_update_set",
+                    "boards_get_templates",
+                ]) {
+                    expect(names).toContain(expected);
+                }
+
+                const composeRes = await client.callTool({
+                    name: "boards_compose_board",
+                    arguments: {
+                        board: slug,
+                        cards: [
+                            { ref: "s", kind: "section", payload: { title: "Checkout" }, children: ["a", "b"] },
+                            { ref: "a", kind: "text", payload: { md: "idea A" } },
+                            { ref: "b", kind: "note", payload: { text: "note B" } },
+                        ],
+                        questions: [{ prompt: "pick one", options: ["x", "y"], cardRef: "a" }],
+                    },
+                });
+                const composeBody = SafeJSON.parse(toolText(composeRes), { strict: true }) as {
+                    cards: Array<{ id: number; ref?: string }>;
+                    questions: number[];
+                };
+                expect(composeBody.cards.length).toBe(3);
+                expect(composeBody.questions.length).toBe(1);
+                const questionId = composeBody.questions[0];
+
+                const sectionsRes = await client.callTool({
+                    name: "boards_list_sections",
+                    arguments: { board: slug },
+                });
+                const sectionsBody = SafeJSON.parse(toolText(sectionsRes), { strict: true }) as {
+                    sections: Array<{ name: string; cards: number }>;
+                };
+                expect(sectionsBody.sections).toHaveLength(1);
+                expect(sectionsBody.sections[0]).toMatchObject({ name: "Checkout", cards: 2 });
+
+                const scrapeRes = await client.callTool({
+                    name: "boards_scrape_board",
+                    arguments: { board: slug, section: "Checkout" },
+                });
+                const scrapeBody = SafeJSON.parse(toolText(scrapeRes), { strict: true }) as { cards: unknown[] };
+                expect(scrapeBody.cards.length).toBe(2);
+
+                // Answering is a human/UI action over plain HTTP — boards_ask_board only CREATES
+                // the question; there is no dedicated "answer" MCP tool.
+                const answerRes = await fetch(`${base}/api/boards/questions/${questionId}/answer`, {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: SafeJSON.stringify({ answer: "x" }),
+                });
+                expect(answerRes.ok).toBe(true);
+
+                const dispatchRes = await fetch(`${base}/api/boards/${slug}/dispatch`, { method: "POST" });
+                expect(dispatchRes.ok).toBe(true);
+
+                const waitRes = await client.callTool({
+                    name: "boards_wait_for_work",
+                    arguments: { board: slug, timeoutSec: 2 },
+                });
+                const waitBody = SafeJSON.parse(toolText(waitRes), { strict: true }) as {
+                    choices?: Array<{ id: number; option: string[] }>;
+                };
+                expect(waitBody.choices?.length).toBe(1);
+                expect(waitBody.choices?.[0].id).toBe(questionId);
+                expect(waitBody.choices?.[0].option).toEqual(["x"]);
+            } finally {
+                await client.close();
+            }
+        } finally {
+            proc.kill();
+        }
+    }, 60000);
 });

--- a/src/claude/mcp/boards.e2e.test.ts
+++ b/src/claude/mcp/boards.e2e.test.ts
@@ -263,6 +263,45 @@ describe("boards MCP tools (stdio e2e against a real agent-mode dev-dashboard)",
                 const scrapeBody = SafeJSON.parse(toolText(scrapeRes), { strict: true }) as { cards: unknown[] };
                 expect(scrapeBody.cards.length).toBe(2);
 
+                // Route-registration gate: arrange, update_cards and the standalone questions
+                // create/list routes over REAL HTTP through the assembled server (not a direct
+                // handler call) — a 404 here means registry.ts's ordering is wrong.
+                const arrangeRes = await client.callTool({
+                    name: "boards_arrange",
+                    arguments: { board: slug, mode: "column", scope: "section:Checkout", save: true },
+                });
+                const arrangeBody = SafeJSON.parse(toolText(arrangeRes), { strict: true }) as {
+                    ok: boolean;
+                    saved: boolean;
+                };
+                expect(arrangeBody.ok).toBe(true);
+                expect(arrangeBody.saved).toBe(true);
+
+                const cardA = composeBody.cards.find((c) => c.ref === "a");
+                if (!cardA) {
+                    throw new Error("compose did not return card ref 'a'");
+                }
+                const updateRes = await client.callTool({
+                    name: "boards_update_cards",
+                    arguments: { board: slug, patch: [{ id: cardA.id, payload: { md: "idea A (edited)" } }] },
+                });
+                const updateBody = SafeJSON.parse(toolText(updateRes), { strict: true }) as { patched: number };
+                expect(updateBody.patched).toBe(1);
+
+                const createQRes = await fetch(`${base}/api/boards/${slug}/questions`, {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: SafeJSON.stringify({ prompt: "board-level question", options: ["p", "q"] }),
+                });
+                expect(createQRes.status).toBe(201);
+                const createdQ = (await createQRes.json()) as { id: number };
+
+                const listQRes = await fetch(`${base}/api/boards/${slug}/questions`);
+                expect(listQRes.ok).toBe(true);
+                const listQBody = (await listQRes.json()) as { questions: Array<{ id: number }> };
+                expect(listQBody.questions.map((q) => q.id)).toContain(createdQ.id);
+                expect(listQBody.questions.map((q) => q.id)).toContain(questionId);
+
                 // Answering is a human/UI action over plain HTTP — boards_ask_board only CREATES
                 // the question; there is no dedicated "answer" MCP tool.
                 const answerRes = await fetch(`${base}/api/boards/questions/${questionId}/answer`, {

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -3,6 +3,17 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import {
+    handleArrange,
+    handleAskBoard,
+    handleComposeBoard,
+    handleGetTemplates,
+    handleListProjects,
+    handleListSections,
+    handleScrapeBoard,
+    handleUpdateCards,
+    handleUpdateSet,
+} from "./tools/boards/compose-tools";
+import {
     handleGetAnnotation,
     handleGetCapsule,
     handleGetSet,
@@ -11,16 +22,25 @@ import {
     handleListWork,
 } from "./tools/boards/read-tools";
 import {
+    ARRANGE_SCHEMA,
+    ASK_BOARD_SCHEMA,
     ATTACH_AFTER_SCHEMA,
+    COMPOSE_BOARD_SCHEMA,
     GET_ANNOTATION_SCHEMA,
     GET_CAPSULE_SCHEMA,
     GET_SET_SCHEMA,
+    GET_TEMPLATES_SCHEMA,
     HIGHLIGHT_SCHEMA,
     LIST_BOARDS_SCHEMA,
+    LIST_PROJECTS_SCHEMA,
+    LIST_SECTIONS_SCHEMA,
     LIST_SETS_SCHEMA,
     LIST_WORK_SCHEMA,
     REPLY_SCHEMA,
+    SCRAPE_BOARD_SCHEMA,
     SET_STATUS_SCHEMA,
+    UPDATE_CARDS_SCHEMA,
+    UPDATE_SET_SCHEMA,
     WAIT_FOR_WORK_SCHEMA,
 } from "./tools/boards/schemas";
 import { handleWaitForWork } from "./tools/boards/wait-for-work";
@@ -59,7 +79,24 @@ const SERVER_INSTRUCTIONS =
     "sessions.\n" +
     '- A 409 "cancelled" on any write means the user withdrew the item: revert its changes, no reply, move on.\n' +
     "- Prefer the `tools boards watch` CLI via a background Monitor for idle listening (zero token cost); use " +
-    "boards_wait_for_work to DRAIN after a wake, with timeoutSec 1.";
+    "boards_wait_for_work to DRAIN after a wake, with timeoutSec 1.\n\n" +
+    "BOARD VOCABULARY (AI expression layer): you can PRESENT on boards, not just answer. boards_compose_board " +
+    "places a whole thought in ONE call — markdown text cards (roles: heading/idea/pro/con/risk), data-only viz " +
+    "cards (table/matrix/flow/bars/timeline/line/stat — always cheaper than an HTML artifact), cluster frames " +
+    "grouping a direction, wires, and anchored multiple-choice questions (options carry {label,hint,recommended}; " +
+    "answers arrive staged and are only released onto the work wire once the user dispatches). Batch-or-bust: " +
+    "never place cards one call at a time. Never send coordinates — pick a layout (column/row/grid) and use " +
+    "boards_arrange to tidy (13 modes; save:true persists the layout so the server auto-reflows it forever). " +
+    'JOURNEY SECTIONS: name board regions after customer journeys with kind "section" frames ("Onboarding", ' +
+    '"Checkout") — always visible, auto-indexed (boards_list_sections), and every tool scopes to them: ' +
+    'boards_compose_board {section}, boards_arrange {scope:"section:Name"}, boards_scrape_board {section} for ' +
+    "an isolated digest. Sections are also the ITERATION surface: present the next pass of a journey as its own " +
+    'section beside the current one (boards_compose_board {journey,pass:"next"}) instead of mixing takes ' +
+    "together — boards_scrape_board {diff:[a,b]} then diffs two sections pairwise. boards_update_cards edits or " +
+    "trashes only your own AI-layer cards (plus section frames) — the user's shots and notes are untouchable. " +
+    "boards_ask_board asks a first-class multiple-choice question outside a compose batch. Call " +
+    "boards_get_templates once before structuring a new board and start from a matching skeleton instead of " +
+    "inventing structure.";
 
 interface ToolEntry {
     description: string;
@@ -159,6 +196,135 @@ function buildToolRegistry(): Record<string, ToolEntry> {
             inputSchema: WAIT_FOR_WORK_SCHEMA as unknown as Record<string, unknown>,
             handler: async (args) =>
                 handleWaitForWork(args as { board?: string; project?: string; branch?: string; timeoutSec?: number }),
+        },
+        boards_ask_board: {
+            description:
+                "Ask the operator a first-class multiple-choice question on a board — rendered as one-click " +
+                "pills, optionally anchored to a card. The answer is STAGED until the operator dispatches, then " +
+                'returns on the work wire as a {type:"choice"} item (boards_wait_for_work). An "Other" free-text ' +
+                "escape is always added by the engine — pass only the real options, never hard-block off-" +
+                "vocabulary answers.",
+            inputSchema: ASK_BOARD_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) =>
+                handleAskBoard(
+                    args as {
+                        board: string;
+                        prompt: string;
+                        options: Array<string | { label: string; hint?: string; recommended?: boolean }>;
+                        multiSelect?: boolean;
+                        cardId?: number;
+                    }
+                ),
+        },
+        boards_compose_board: {
+            description:
+                "Place a BATCH of AI-authored content on a board in one call — text blocks, notes, viz, sections " +
+                "and questions, wired together. Batch-or-bust: compose the whole thought in ONE call (never one " +
+                "card per call); the server owns geometry — never send coordinates. All-or-nothing: on 400 the " +
+                "error carries {code,index} pointing at the bad item and nothing was placed.",
+            inputSchema: COMPOSE_BOARD_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) =>
+                handleComposeBoard(
+                    args as {
+                        board: string;
+                        layout?: "column" | "row" | "grid";
+                        anchorCardId?: number;
+                        section?: string;
+                        journey?: string;
+                        pass?: number | "next";
+                        cards?: unknown[];
+                        edges?: unknown[];
+                        questions?: unknown[];
+                    }
+                ),
+        },
+        boards_arrange: {
+            description:
+                "Auto-align board cards server-side — geometry is computed for you and lands as one atomic " +
+                "layout event. Default scope is the AI expression layer; scope 'all' tidies everything; " +
+                "'section:<Name>' reflows one journey section inside its frame. Pass save:true with a section " +
+                "scope to persist the layout so the server auto-reflows it on every future change.",
+            inputSchema: ARRANGE_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) =>
+                handleArrange(
+                    args as {
+                        board: string;
+                        mode: string;
+                        save?: boolean;
+                        sections?: string[];
+                        scope?: string;
+                        ids?: number[];
+                        gap?: string | number;
+                        padding?: string | number;
+                        cols?: number;
+                        sizing?: "natural" | "uniform";
+                    }
+                ),
+        },
+        boards_update_cards: {
+            description:
+                "Batch-edit YOUR OWN board layer — patch payload/geometry or remove cards you composed. " +
+                "Restricted to AI-layer cards plus section frames: the user's shots and notes are untouchable, " +
+                'a non-AI target 403s with {code:"not_ai_layer"}. Removals are soft (trashed, restorable via ' +
+                "restore) — the response of a remove is your undo handle.",
+            inputSchema: UPDATE_CARDS_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) =>
+                handleUpdateCards(
+                    args as {
+                        board: string;
+                        patch?: Array<{
+                            id: number;
+                            x?: number;
+                            y?: number;
+                            w?: number;
+                            h?: number;
+                            payload?: Record<string, unknown>;
+                        }>;
+                        remove?: number[];
+                        restore?: number[];
+                    }
+                ),
+        },
+        boards_scrape_board: {
+            description:
+                "Read a WHOLE board as one structured testing digest — every media image (URL), note text and " +
+                'annotation, connect-tool edges walked into ordered journey chains ("flow": [[A,B,C]]), and the ' +
+                "journey sections summarized. Pass section to isolate the digest to one journey, or diff to " +
+                "compare two sections pairwise (iteration diff). Images are absolute URLs — fetch them to SEE " +
+                "each step.",
+            inputSchema: SCRAPE_BOARD_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) => handleScrapeBoard(args as { board: string; section?: string; diff?: string[] }),
+        },
+        boards_list_sections: {
+            description:
+                "The automatic journey-section index of a board: every section (name, bounds, member count, " +
+                "reading order, journey/pass when part of an iteration chain) plus journeys:[{journey,passes," +
+                "latest}] — the one-call orientation on which journeys exist and where the latest pass is.",
+            inputSchema: LIST_SECTIONS_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) => handleListSections(args as { board: string }),
+        },
+        boards_list_projects: {
+            description: "List all projects known to the boards/sets library (name, branch count, set count).",
+            inputSchema: LIST_PROJECTS_SCHEMA as unknown as Record<string, unknown>,
+            handler: async () => handleListProjects(),
+        },
+        boards_update_set: {
+            description:
+                "Edit a set's mutable metadata: custom name and/or human title. Omitted fields stay untouched; " +
+                'empty string ("") clears the field.',
+            inputSchema: UPDATE_SET_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) =>
+                handleUpdateSet(
+                    args as { project: string; branch: string; selector: string; name?: string; title?: string }
+                ),
+        },
+        boards_get_templates: {
+            description:
+                "The board template library (markdown): compose-ready skeletons for QA sessions, iteration " +
+                "reviews, decision maps, metrics dashboards and presentation decks. Fetch ONCE before structuring " +
+                "a new board and start from the matching template instead of inventing structure.",
+            inputSchema: GET_TEMPLATES_SCHEMA as unknown as Record<string, unknown>,
+            handler: async () => handleGetTemplates(),
         },
     };
 }

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -23,6 +23,7 @@ import {
 } from "./tools/boards/read-tools";
 import {
     ARRANGE_SCHEMA,
+    type ArrangeMode,
     ASK_BOARD_SCHEMA,
     ATTACH_AFTER_SCHEMA,
     COMPOSE_BOARD_SCHEMA,
@@ -249,7 +250,7 @@ function buildToolRegistry(): Record<string, ToolEntry> {
                 handleArrange(
                     args as {
                         board: string;
-                        mode: string;
+                        mode: ArrangeMode;
                         save?: boolean;
                         sections?: string[];
                         scope?: string;

--- a/src/claude/mcp/tools/boards/compose-tools.test.ts
+++ b/src/claude/mcp/tools/boards/compose-tools.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import { findFreePort } from "@app/utils/net/free-port";
+import {
+    handleArrange,
+    handleAskBoard,
+    handleComposeBoard,
+    handleGetTemplates,
+    handleListProjects,
+    handleListSections,
+    handleScrapeBoard,
+    handleUpdateCards,
+    handleUpdateSet,
+} from "./compose-tools";
+import { resetBoardsBaseUrl } from "./http";
+
+interface RecordedRequest {
+    method: string;
+    path: string;
+    body: unknown;
+}
+
+async function stubServer(respond: (req: RecordedRequest) => { status: number; body: unknown; text?: string }) {
+    const requests: RecordedRequest[] = [];
+    const port = await findFreePort();
+    const server = Bun.serve({
+        port,
+        fetch: async (req) => {
+            const url = new URL(req.url);
+            const bodyText = await req.text();
+            const body = bodyText ? SafeJSON.parse(bodyText, { strict: true }) : undefined;
+            const recorded = { method: req.method, path: `${url.pathname}${url.search}`, body };
+            requests.push(recorded);
+            const { status, body: resBody, text } = respond(recorded);
+            if (text !== undefined) {
+                return new Response(text, { status, headers: { "content-type": "text/markdown" } });
+            }
+            return Response.json(resBody, { status });
+        },
+    });
+    env.testing.set("BOARDS_BASE_URL", `http://127.0.0.1:${port}`);
+    return { requests, stop: () => server.stop() };
+}
+
+afterEach(() => {
+    env.testing.unset("BOARDS_BASE_URL");
+    resetBoardsBaseUrl();
+});
+
+describe("handleAskBoard", () => {
+    it("POSTs prompt/options, omitting multiSelect/cardId when unset", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 201, body: { id: 1 } }));
+        try {
+            await handleAskBoard({ board: "b1", prompt: "pick one", options: ["a", "b"] });
+            expect(requests[0].method).toBe("POST");
+            expect(requests[0].path).toBe("/api/boards/b1/questions");
+            expect(requests[0].body).toEqual({ prompt: "pick one", options: ["a", "b"] });
+        } finally {
+            stop();
+        }
+    });
+
+    it("includes multiSelect and cardId when given", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 201, body: { id: 1 } }));
+        try {
+            await handleAskBoard({ board: "b1", prompt: "pick some", options: ["a"], multiSelect: true, cardId: 7 });
+            expect(requests[0].body).toEqual({ prompt: "pick some", options: ["a"], multiSelect: true, cardId: 7 });
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleComposeBoard", () => {
+    it("POSTs cards/edges/questions defaulting to empty arrays, omitting unset optional fields", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 201, body: { cards: [] } }));
+        try {
+            await handleComposeBoard({ board: "b1", cards: [{ kind: "text", payload: { md: "hi" } }] });
+            expect(requests[0].path).toBe("/api/boards/b1/compose");
+            expect(requests[0].body).toEqual({
+                cards: [{ kind: "text", payload: { md: "hi" } }],
+                edges: [],
+                questions: [],
+            });
+        } finally {
+            stop();
+        }
+    });
+
+    it("passes through layout/section/journey/pass/anchorCardId when given", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 201, body: {} }));
+        try {
+            await handleComposeBoard({
+                board: "b1",
+                layout: "row",
+                section: "Checkout",
+                journey: "checkout",
+                pass: "next",
+            });
+            expect(requests[0].body).toEqual({
+                layout: "row",
+                section: "Checkout",
+                journey: "checkout",
+                pass: "next",
+                cards: [],
+                edges: [],
+                questions: [],
+            });
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleArrange", () => {
+    it("POSTs mode, omitting unset knobs", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { ok: true } }));
+        try {
+            await handleArrange({ board: "b1", mode: "grid" });
+            expect(requests[0].path).toBe("/api/boards/b1/arrange");
+            expect(requests[0].body).toEqual({ mode: "grid" });
+        } finally {
+            stop();
+        }
+    });
+
+    it("includes scope/ids/gap/padding/cols/sizing/save/sections when given", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { ok: true } }));
+        try {
+            await handleArrange({
+                board: "b1",
+                mode: "compare",
+                scope: "section:Checkout",
+                ids: [1, 2],
+                gap: "M",
+                padding: 24,
+                cols: 2,
+                sizing: "uniform",
+                save: true,
+                sections: ["A", "B"],
+            });
+            expect(requests[0].body).toEqual({
+                mode: "compare",
+                scope: "section:Checkout",
+                ids: [1, 2],
+                gap: "M",
+                padding: 24,
+                cols: 2,
+                sizing: "uniform",
+                save: true,
+                sections: ["A", "B"],
+            });
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleUpdateCards", () => {
+    it("POSTs patch/remove defaulting to empty arrays, omitting restore when unset", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { ok: true } }));
+        try {
+            await handleUpdateCards({ board: "b1", patch: [{ id: 1, x: 10 }] });
+            expect(requests[0].path).toBe("/api/boards/b1/update-cards");
+            expect(requests[0].body).toEqual({ patch: [{ id: 1, x: 10 }], remove: [] });
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleScrapeBoard", () => {
+    it("GETs with no query when section/diff are unset", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { cards: [] } }));
+        try {
+            await handleScrapeBoard({ board: "b1" });
+            expect(requests[0].method).toBe("GET");
+            expect(requests[0].path).toBe("/api/boards/b1/scrape");
+        } finally {
+            stop();
+        }
+    });
+
+    it("GETs with ?section= when section is given", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { cards: [] } }));
+        try {
+            await handleScrapeBoard({ board: "b1", section: "Checkout" });
+            expect(requests[0].path).toBe("/api/boards/b1/scrape?section=Checkout");
+        } finally {
+            stop();
+        }
+    });
+
+    it("GETs with ?diff=a,b when exactly two diff names are given", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: {} }));
+        try {
+            await handleScrapeBoard({ board: "b1", diff: ["A", "B"] });
+            expect(requests[0].path).toBe("/api/boards/b1/scrape?diff=A%2CB");
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleListSections", () => {
+    it("GETs the board's sections", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { sections: [] } }));
+        try {
+            await handleListSections({ board: "b1" });
+            expect(requests[0].path).toBe("/api/boards/b1/sections");
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleListProjects", () => {
+    it("GETs /api/boards/projects", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { projects: [] } }));
+        try {
+            await handleListProjects();
+            expect(requests[0].path).toBe("/api/boards/projects");
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleUpdateSet", () => {
+    it("PATCHes only the given fields", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: {} }));
+        try {
+            await handleUpdateSet({ project: "p", branch: "main", selector: "latest", name: "checkout-v2" });
+            expect(requests[0].method).toBe("PATCH");
+            expect(requests[0].path).toBe("/api/boards/sets/p/main/latest");
+            expect(requests[0].body).toEqual({ name: "checkout-v2" });
+        } finally {
+            stop();
+        }
+    });
+
+    it("clears a field with an empty string", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: {} }));
+        try {
+            await handleUpdateSet({ project: "p", branch: "main", selector: "latest", title: "" });
+            expect(requests[0].body).toEqual({ title: "" });
+        } finally {
+            stop();
+        }
+    });
+});
+
+describe("handleGetTemplates", () => {
+    it("GETs the templates.md raw text", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: {}, text: "# Board templates" }));
+        try {
+            const out = await handleGetTemplates();
+            expect(requests[0].path).toBe("/api/boards/templates.md");
+            expect(out).toBe("# Board templates");
+        } finally {
+            stop();
+        }
+    });
+});

--- a/src/claude/mcp/tools/boards/compose-tools.test.ts
+++ b/src/claude/mcp/tools/boards/compose-tools.test.ts
@@ -168,6 +168,16 @@ describe("handleUpdateCards", () => {
             stop();
         }
     });
+
+    it("includes restore when given", async () => {
+        const { requests, stop } = await stubServer(() => ({ status: 200, body: { ok: true } }));
+        try {
+            await handleUpdateCards({ board: "b1", restore: [5] });
+            expect(requests[0].body).toEqual({ patch: [], remove: [], restore: [5] });
+        } finally {
+            stop();
+        }
+    });
 });
 
 describe("handleScrapeBoard", () => {

--- a/src/claude/mcp/tools/boards/compose-tools.ts
+++ b/src/claude/mcp/tools/boards/compose-tools.ts
@@ -4,6 +4,7 @@
 import { paths } from "@app/dev-dashboard/contract/endpoints";
 import { SafeJSON } from "@app/utils/json";
 import { boardsFetch, compact } from "./http";
+import type { ArrangeMode } from "./schemas";
 
 type OptionInput = string | { label: string; hint?: string; recommended?: boolean };
 
@@ -55,7 +56,7 @@ export async function handleComposeBoard(args: {
 
 export async function handleArrange(args: {
     board: string;
-    mode: string;
+    mode: ArrangeMode;
     save?: boolean;
     sections?: string[];
     scope?: string;
@@ -102,7 +103,7 @@ export async function handleUpdateCards(args: {
 export async function handleScrapeBoard(args: { board: string; section?: string; diff?: string[] }): Promise<string> {
     const path = paths.boardScrape(args.board, {
         section: args.section,
-        diff: args.diff && args.diff.length === 2 ? args.diff.join(",") : undefined,
+        diff: args.diff?.join(","),
     });
     const res = await boardsFetch<Record<string, unknown>>(path);
     return compact(res);
@@ -132,10 +133,13 @@ export async function handleUpdateSet(args: {
     if (args.title !== undefined) {
         patch.title = args.title;
     }
-    const res = await boardsFetch<Record<string, unknown>>(paths.boardsSet({ project: args.project, branch: args.branch, selector: args.selector }), {
-        method: "PATCH",
-        body: SafeJSON.stringify(patch),
-    });
+    const res = await boardsFetch<Record<string, unknown>>(
+        paths.boardsSet({ project: args.project, branch: args.branch, selector: args.selector }),
+        {
+            method: "PATCH",
+            body: SafeJSON.stringify(patch),
+        }
+    );
     return compact(res);
 }
 

--- a/src/claude/mcp/tools/boards/compose-tools.ts
+++ b/src/claude/mcp/tools/boards/compose-tools.ts
@@ -132,7 +132,7 @@ export async function handleUpdateSet(args: {
     if (args.title !== undefined) {
         patch.title = args.title;
     }
-    const res = await boardsFetch<Record<string, unknown>>(paths.boardsSet(args.project, args.branch, args.selector), {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardsSet({ project: args.project, branch: args.branch, selector: args.selector }), {
         method: "PATCH",
         body: SafeJSON.stringify(patch),
     });

--- a/src/claude/mcp/tools/boards/compose-tools.ts
+++ b/src/claude/mcp/tools/boards/compose-tools.ts
@@ -1,0 +1,144 @@
+// Thin HTTP wrappers over the AI expression layer routes (compose/arrange/update-cards/scrape/
+// sections/questions) — mirrors read-tools.ts/work-tools.ts's pattern. Handlers return the JSON
+// response raw (compact) so agents consume the same shape the HTTP API returns.
+import { paths } from "@app/dev-dashboard/contract/endpoints";
+import { SafeJSON } from "@app/utils/json";
+import { boardsFetch, compact } from "./http";
+
+type OptionInput = string | { label: string; hint?: string; recommended?: boolean };
+
+export async function handleAskBoard(args: {
+    board: string;
+    prompt: string;
+    options: OptionInput[];
+    multiSelect?: boolean;
+    cardId?: number;
+}): Promise<string> {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardQuestions(args.board), {
+        method: "POST",
+        body: SafeJSON.stringify({
+            prompt: args.prompt,
+            options: args.options,
+            ...(args.multiSelect ? { multiSelect: true } : {}),
+            ...(args.cardId !== undefined ? { cardId: args.cardId } : {}),
+        }),
+    });
+    return compact(res);
+}
+
+export async function handleComposeBoard(args: {
+    board: string;
+    layout?: "column" | "row" | "grid";
+    anchorCardId?: number;
+    section?: string;
+    journey?: string;
+    pass?: number | "next";
+    cards?: unknown[];
+    edges?: unknown[];
+    questions?: unknown[];
+}): Promise<string> {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardCompose(args.board), {
+        method: "POST",
+        body: SafeJSON.stringify({
+            ...(args.layout ? { layout: args.layout } : {}),
+            ...(args.anchorCardId !== undefined ? { anchorCardId: args.anchorCardId } : {}),
+            ...(args.section ? { section: args.section } : {}),
+            ...(args.journey ? { journey: args.journey } : {}),
+            ...(args.pass !== undefined ? { pass: args.pass } : {}),
+            cards: args.cards ?? [],
+            edges: args.edges ?? [],
+            questions: args.questions ?? [],
+        }),
+    });
+    return compact(res);
+}
+
+export async function handleArrange(args: {
+    board: string;
+    mode: string;
+    save?: boolean;
+    sections?: string[];
+    scope?: string;
+    ids?: number[];
+    gap?: string | number;
+    padding?: string | number;
+    cols?: number;
+    sizing?: "natural" | "uniform";
+}): Promise<string> {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardArrange(args.board), {
+        method: "POST",
+        body: SafeJSON.stringify({
+            mode: args.mode,
+            ...(args.scope ? { scope: args.scope } : {}),
+            ...(args.ids && args.ids.length > 0 ? { ids: args.ids } : {}),
+            ...(args.gap !== undefined ? { gap: args.gap } : {}),
+            ...(args.padding !== undefined ? { padding: args.padding } : {}),
+            ...(args.cols !== undefined ? { cols: args.cols } : {}),
+            ...(args.sizing ? { sizing: args.sizing } : {}),
+            ...(args.save ? { save: true } : {}),
+            ...(args.sections && args.sections.length > 0 ? { sections: args.sections } : {}),
+        }),
+    });
+    return compact(res);
+}
+
+export async function handleUpdateCards(args: {
+    board: string;
+    patch?: Array<{ id: number; x?: number; y?: number; w?: number; h?: number; payload?: Record<string, unknown> }>;
+    remove?: number[];
+    restore?: number[];
+}): Promise<string> {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardUpdateCards(args.board), {
+        method: "POST",
+        body: SafeJSON.stringify({
+            patch: args.patch ?? [],
+            remove: args.remove ?? [],
+            ...(args.restore && args.restore.length > 0 ? { restore: args.restore } : {}),
+        }),
+    });
+    return compact(res);
+}
+
+export async function handleScrapeBoard(args: { board: string; section?: string; diff?: string[] }): Promise<string> {
+    const path = paths.boardScrape(args.board, {
+        section: args.section,
+        diff: args.diff && args.diff.length === 2 ? args.diff.join(",") : undefined,
+    });
+    const res = await boardsFetch<Record<string, unknown>>(path);
+    return compact(res);
+}
+
+export async function handleListSections(args: { board: string }): Promise<string> {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardSections(args.board));
+    return compact(res);
+}
+
+export async function handleListProjects(): Promise<string> {
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardsProjects());
+    return compact(res);
+}
+
+export async function handleUpdateSet(args: {
+    project: string;
+    branch: string;
+    selector: string;
+    name?: string;
+    title?: string;
+}): Promise<string> {
+    const patch: Record<string, string> = {};
+    if (args.name !== undefined) {
+        patch.name = args.name;
+    }
+    if (args.title !== undefined) {
+        patch.title = args.title;
+    }
+    const res = await boardsFetch<Record<string, unknown>>(paths.boardsSet(args.project, args.branch, args.selector), {
+        method: "PATCH",
+        body: SafeJSON.stringify(patch),
+    });
+    return compact(res);
+}
+
+export async function handleGetTemplates(): Promise<string> {
+    return boardsFetch<string>(paths.boardsTemplates(), { rawText: true });
+}

--- a/src/claude/mcp/tools/boards/http.ts
+++ b/src/claude/mcp/tools/boards/http.ts
@@ -4,6 +4,9 @@ import { SafeJSON } from "@app/utils/json";
 
 let cachedBase: string | null = null;
 
+/** Guards non-long-poll calls against a hung dev-dashboard; long-poll callers pass their own signal. */
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
 export async function boardsBaseUrl(): Promise<string> {
     if (cachedBase) {
         return cachedBase;
@@ -33,6 +36,7 @@ export async function boardsFetch<T>(path: string, init?: RequestInit & { rawTex
     try {
         res = await fetch(`${base}${path}`, {
             ...init,
+            signal: init?.signal ?? AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS),
             headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
         });
     } catch (err) {

--- a/src/claude/mcp/tools/boards/schemas.ts
+++ b/src/claude/mcp/tools/boards/schemas.ts
@@ -105,6 +105,7 @@ export const WAIT_FOR_WORK_SCHEMA = {
         branch: { type: "string" },
         timeoutSec: { type: "number", minimum: 1, maximum: 55 },
     },
+    anyOf: [{ required: ["board"] }, { required: ["project"] }],
     additionalProperties: false,
 } as const;
 

--- a/src/claude/mcp/tools/boards/schemas.ts
+++ b/src/claude/mcp/tools/boards/schemas.ts
@@ -318,6 +318,8 @@ export const ARRANGE_SCHEMA = {
     additionalProperties: false,
 } as const;
 
+export type ArrangeMode = (typeof ARRANGE_SCHEMA)["properties"]["mode"]["enum"][number];
+
 export const UPDATE_CARDS_SCHEMA = {
     type: "object",
     properties: {
@@ -356,6 +358,8 @@ export const SCRAPE_BOARD_SCHEMA = {
         diff: {
             type: "array",
             items: { type: "string" },
+            minItems: 2,
+            maxItems: 2,
             description:
                 "Exactly two section names — the ITERATION DIFF: members matched pairwise as {pairs:[{a,b}]} " +
                 "plus unpaired leftovers. Mutually exclusive with section.",

--- a/src/claude/mcp/tools/boards/schemas.ts
+++ b/src/claude/mcp/tools/boards/schemas.ts
@@ -107,3 +107,292 @@ export const WAIT_FOR_WORK_SCHEMA = {
     },
     additionalProperties: false,
 } as const;
+
+// ---- AI expression layer (compose/arrange/update_cards/scrape/sections/questions) ----
+
+const optionItem = {
+    anyOf: [
+        { type: "string" },
+        {
+            type: "object",
+            properties: {
+                label: { type: "string" },
+                hint: { type: "string" },
+                recommended: { type: "boolean" },
+            },
+            required: ["label"],
+            additionalProperties: false,
+        },
+    ],
+} as const;
+
+const composeCardKinds = [
+    "text",
+    "note",
+    "shape",
+    "viz",
+    "cluster",
+    "section",
+    "step",
+    "callout",
+    "checklist",
+    "compare",
+    "wireframe",
+] as const;
+
+export const ASK_BOARD_SCHEMA = {
+    type: "object",
+    properties: {
+        board: { type: "string", description: "Board slug (from boards_list_boards)" },
+        prompt: { type: "string", description: "The question" },
+        options: {
+            type: "array",
+            items: optionItem,
+            description:
+                "1-12 answer options — strings, or {label, hint?, recommended?} to carry tradeoffs (hint shows " +
+                'on hover, recommended gets a hairline mark). An "Other" free-text escape is appended automatically.',
+        },
+        multiSelect: { type: "boolean", description: "Allow picking several options (default false)" },
+        cardId: { type: "number", description: "Optional card id to anchor the question to (omit for board-level)" },
+    },
+    required: ["board", "prompt", "options"],
+    additionalProperties: false,
+} as const;
+
+export const COMPOSE_BOARD_SCHEMA = {
+    type: "object",
+    properties: {
+        board: { type: "string", description: "Board slug (from boards_list_boards)" },
+        layout: {
+            type: "string",
+            enum: ["column", "row", "grid"],
+            description: "How the batch flows: column (default — reading order), row, or grid (3 per row)",
+        },
+        anchorCardId: { type: "number", description: "Place the batch beside this existing card" },
+        section: {
+            type: "string",
+            description:
+                "Journey section name (see boards_list_sections): the batch lands INSIDE that frame, below its " +
+                "existing content, and the frame grows to fit. Mutually exclusive with anchorCardId and journey.",
+        },
+        journey: {
+            type: "string",
+            description:
+                'Pass-chain key ("checkout"): target a journey\'s ITERATION chain instead of a named section. ' +
+                "Alone = the batch lands in the chain's LATEST pass (creates pass 1 if none).",
+        },
+        pass: {
+            anyOf: [{ type: "string", enum: ["next"] }, { type: "number" }],
+            description:
+                'With journey: "next" CREATES the next pass section (auto-named, placed beside the previous ' +
+                "pass, layout inherited); a number targets that existing pass. Omit = latest.",
+        },
+        cards: {
+            type: "array",
+            description:
+                "Up to 60 cards. Give each a ref so edges/questions in the same call can reference it. kind " +
+                '"text": payload {md, role: idea|note|pro|con|risk|heading|caption}. kind "note": payload {text}. ' +
+                'kind "shape": payload {shape: rect|ellipse, color}. kind "viz": payload {viz, data, title?} — ' +
+                "table {cols,rows}, matrix {x:[lo,hi],y:[lo,hi],points:[{label,x,y}]}, flow {steps:[label]}, " +
+                "bars {items:[{label,value}]}, timeline {items:[{label,when}]}, line {series:[{label,points}],x?}, " +
+                'stat {items:[{label,value,delta?,unit?}]}. kind "cluster": payload {title} — a frame; list member ' +
+                'refs in "children". kind "section": payload {title} — a NAMED JOURNEY FRAME, always visible, ' +
+                'auto-indexed (boards_list_sections); membership is spatial. kind "step" {n?, title, note?, ' +
+                "status: todo|pass|fail, cardId?} — cardId references an EXISTING shot card for a live thumbnail. " +
+                'kind "callout" {tone: info|warn|success|decision, md}. kind "checklist" {title?, items:[{text, ' +
+                'done?}]}. kind "compare" {a:{cardId}, b:{cardId}}. kind "wireframe" {title?, device: phone|tablet' +
+                "|web, fidelity?: lo|tokens, nodes:[{t, label?, …}]} — a lo-fi UI sketch (cheaper than an HTML " +
+                "artifact): nodes render top-to-bottom; t: nav, tabbar, heading, text, button, input, img (h: s|m|" +
+                "l), list (n), listitem, divider, chiprow, modal. Optional w/h override the per-kind default size.",
+            items: {
+                type: "object",
+                properties: {
+                    ref: { type: "string", description: "Batch-local handle for edges/questions/children" },
+                    children: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "cluster/section only: refs of batch cards to lay out inside this frame",
+                    },
+                    kind: { type: "string", enum: composeCardKinds },
+                    payload: { type: "object", description: "Kind-specific payload (see cards description)" },
+                    w: { type: "number" },
+                    h: { type: "number" },
+                },
+                required: ["kind", "payload"],
+                additionalProperties: false,
+            },
+        },
+        edges: {
+            type: "array",
+            description: "Up to 40 wires between cards. from/to: a ref string from this batch, or a card id.",
+            items: {
+                type: "object",
+                properties: {
+                    from: { description: "Card ref (string) or existing card id (number)" },
+                    to: { description: "Card ref (string) or existing card id (number)" },
+                    label: { type: "string" },
+                },
+                required: ["from", "to"],
+                additionalProperties: false,
+            },
+        },
+        questions: {
+            type: "array",
+            description:
+                "Up to 12 questions, optionally anchored to a batch card (cardRef) or existing card (cardId). " +
+                "Same staged-answer mechanics as boards_ask_board.",
+            items: {
+                type: "object",
+                properties: {
+                    prompt: { type: "string" },
+                    options: { type: "array", items: optionItem },
+                    multiSelect: { type: "boolean" },
+                    cardRef: { type: "string" },
+                    cardId: { type: "number" },
+                },
+                required: ["prompt", "options"],
+                additionalProperties: false,
+            },
+        },
+    },
+    required: ["board"],
+    additionalProperties: false,
+} as const;
+
+export const ARRANGE_SCHEMA = {
+    type: "object",
+    properties: {
+        board: { type: "string", description: "Board slug" },
+        mode: {
+            type: "string",
+            enum: [
+                "column",
+                "row",
+                "grid",
+                "flow",
+                "lanes",
+                "masonry",
+                "timeline",
+                "timeaxis",
+                "compare",
+                "align-left",
+                "align-top",
+                "distribute-h",
+                "distribute-v",
+            ],
+        },
+        save: {
+            type: "boolean",
+            description:
+                "With a section scope: persist this layout onto the section so the server auto-reflows it on " +
+                "every future change",
+        },
+        sections: {
+            type: "array",
+            items: { type: "string" },
+            description: 'mode "compare" only: exactly two section names to align side-by-side',
+        },
+        scope: {
+            type: "string",
+            description:
+                'Which cards move: "ai" (default — the expression layer), "all", or "section:<Name>" ' +
+                "(that journey's members, arranged inside the frame)",
+        },
+        ids: { type: "array", items: { type: "number" }, description: "Explicit card ids; overrides scope" },
+        gap: {
+            anyOf: [{ type: "string", enum: ["S", "M", "L"] }, { type: "number" }],
+            description: "Spacing between cards: S (12), M (24, default), L (48) or explicit px 0-400",
+        },
+        padding: {
+            anyOf: [{ type: "string", enum: ["S", "M", "L"] }, { type: "number" }],
+            description: "Frame inner padding when scoped to a section (default 24)",
+        },
+        cols: { type: "number", description: "grid mode: cards per row (default 3)" },
+        sizing: {
+            type: "string",
+            enum: ["natural", "uniform"],
+            description: "uniform = every card takes the selection's max footprint; default natural",
+        },
+    },
+    required: ["board", "mode"],
+    additionalProperties: false,
+} as const;
+
+export const UPDATE_CARDS_SCHEMA = {
+    type: "object",
+    properties: {
+        board: { type: "string", description: "Board slug" },
+        patch: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    id: { type: "number" },
+                    payload: {
+                        type: "object",
+                        description: 'Replacement payload (the "layer" marker is preserved automatically)',
+                    },
+                    x: { type: "number" },
+                    y: { type: "number" },
+                    w: { type: "number" },
+                    h: { type: "number" },
+                },
+                required: ["id"],
+                additionalProperties: false,
+            },
+        },
+        remove: { type: "array", items: { type: "number" }, description: "Card ids to TRASH (AI layer only)" },
+        restore: { type: "array", items: { type: "number" }, description: "Trashed card ids to lift back" },
+    },
+    required: ["board"],
+    additionalProperties: false,
+} as const;
+
+export const SCRAPE_BOARD_SCHEMA = {
+    type: "object",
+    properties: {
+        board: { type: "string", description: "Board slug (from boards_list_boards)" },
+        section: { type: "string", description: "Journey section name — digest only that frame's members" },
+        diff: {
+            type: "array",
+            items: { type: "string" },
+            description:
+                "Exactly two section names — the ITERATION DIFF: members matched pairwise as {pairs:[{a,b}]} " +
+                "plus unpaired leftovers. Mutually exclusive with section.",
+        },
+    },
+    required: ["board"],
+    additionalProperties: false,
+} as const;
+
+export const LIST_SECTIONS_SCHEMA = {
+    type: "object",
+    properties: { board: { type: "string", description: "Board slug" } },
+    required: ["board"],
+    additionalProperties: false,
+} as const;
+
+export const LIST_PROJECTS_SCHEMA = {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+} as const;
+
+export const UPDATE_SET_SCHEMA = {
+    type: "object",
+    properties: {
+        project: { type: "string" },
+        branch: { type: "string" },
+        selector: { type: "string", description: "version number | 'latest' | set name | set key" },
+        name: { type: "string", description: 'New name slug; "" clears; omit to leave unchanged' },
+        title: { type: "string", description: 'New human title; "" clears; omit to leave unchanged' },
+    },
+    required: ["project", "branch", "selector"],
+    additionalProperties: false,
+} as const;
+
+export const GET_TEMPLATES_SCHEMA = {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+} as const;

--- a/src/claude/mcp/tools/boards/wait-for-work.ts
+++ b/src/claude/mcp/tools/boards/wait-for-work.ts
@@ -23,8 +23,15 @@ export async function handleWaitForWork(args: {
             q.branch = args.branch;
         }
     }
-    q.timeout = String(Math.min(55, Math.max(1, args.timeoutSec ?? 50)));
+    const timeoutSec = Math.min(55, Math.max(1, args.timeoutSec ?? 50));
+    q.timeout = String(timeoutSec);
     q.session = `${hostname()}:${process.pid}`;
     q.actor = "claude";
-    return compact(await boardsFetch<WorkWaitRes>(paths.workWait(q)));
+    // This is a long-poll: the server holds the connection open for up to timeoutSec, so the
+    // client abort must exceed that (boardsFetch's default is too short and would cut it off).
+    return compact(
+        await boardsFetch<WorkWaitRes>(paths.workWait(q), {
+            signal: AbortSignal.timeout((timeoutSec + 10) * 1000),
+        })
+    );
 }

--- a/src/dev-dashboard/README.md
+++ b/src/dev-dashboard/README.md
@@ -37,6 +37,17 @@ Live updates go out over `GET /api/boards/:slug/events` (SSE). Annotations follo
 annotation is `staged` by default (invisible to the work queue) until a `dispatch` call flips
 it to `open`, so a human can review/edit the prompt before it goes live to an agent.
 
+The AI expression layer (`compose`/`arrange`/`update-cards`/`scrape`/`sections`/`questions` —
+20 `boards_*` MCP tools total) lets an agent PRESENT on a board, not just answer: batched
+markdown/viz/section/question cards placed in one call, server-side auto-layout, a
+structured board-digest read, and staged multiple-choice questions that release onto the
+work wire on the same `dispatch` gate as annotations. AI-authored cards carry
+`payload.layer === "ai"` (no schema column); journey sections are `kind:"section"` cards
+with spatial (not FK) membership. Question rows live in `board_questions`
+(`board_id, card_id, prompt, options, answer, staged, delivered, multi`) — `delivered` gives
+the work-wire's exactly-once drain. See `src/boards/README.md` for the CLI-facing summary and
+`src/dev-dashboard/server/static/boards-templates.md` for compose-ready skeletons.
+
 ## Public surface
 
 When tunneled (host, allowed identities, and tunnel name are read from local config, not committed here):

--- a/src/dev-dashboard/contract/endpoints.ts
+++ b/src/dev-dashboard/contract/endpoints.ts
@@ -182,6 +182,15 @@ export const paths = {
     }) => `/api/boards/sets/${params.project}/${params.branch}/${params.key}/content${qs(params.q ?? {})}`,
     boardsBlob: (key: string) => `/api/boards/blobs/${key}`,
     boardsOperator: () => "/api/boards/operator",
+    boardsProjects: () => "/api/boards/projects",
+    boardsTemplates: () => "/api/boards/templates.md",
+    boardCompose: (slug: string) => `/api/boards/${slug}/compose`,
+    boardArrange: (slug: string) => `/api/boards/${slug}/arrange`,
+    boardUpdateCards: (slug: string) => `/api/boards/${slug}/update-cards`,
+    boardScrape: (slug: string, q: { section?: string; diff?: string } = {}) => `/api/boards/${slug}/scrape${qs(q)}`,
+    boardSections: (slug: string) => `/api/boards/${slug}/sections`,
+    boardQuestions: (slug: string) => `/api/boards/${slug}/questions`,
+    boardQuestionAnswer: (id: number) => `/api/boards/questions/${id}/answer`,
 } as const;
 
 // Response type aliases for the typed client methods.

--- a/src/dev-dashboard/lib/boards/annotations-store.ts
+++ b/src/dev-dashboard/lib/boards/annotations-store.ts
@@ -720,6 +720,9 @@ export async function setVerdict(
     if (!annotationRow) {
         throw new NotFoundError(`annotation not found: ${attemptRow.annotation_id}`);
     }
+    if (annotationRow.status === "cancelled") {
+        throw new CancelledError(`annotation ${annotationRow.id} is cancelled`);
+    }
 
     const now = nowIso();
     const card = await db.kysely.transaction().execute(async (trx) => {

--- a/src/dev-dashboard/lib/boards/blobs.test.ts
+++ b/src/dev-dashboard/lib/boards/blobs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
@@ -7,8 +7,10 @@ import { env } from "@app/utils/env";
 import { blobPath, putBlob } from "./blobs";
 
 describe("blob store", () => {
+    let dir = "";
+
     beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-blob-"));
+        dir = mkdtempSync(join(tmpdir(), "boards-blob-"));
         env.testing.set("GENESIS_TOOLS_HOME", dir);
         resetDevDashboardStorage();
     });
@@ -16,6 +18,7 @@ describe("blob store", () => {
     afterEach(() => {
         env.testing.unset("GENESIS_TOOLS_HOME");
         resetDevDashboardStorage();
+        rmSync(dir, { recursive: true, force: true });
     });
 
     it("writes a blob and returns a 64-hex key with the mime's extension", async () => {

--- a/src/dev-dashboard/lib/boards/boards-store.test.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
@@ -80,9 +80,10 @@ function pngFile(path: string, width: number, height: number) {
 
 describe("boards-store", () => {
     let db: DatabaseClient<BoardsDb>;
+    let dir = "";
 
     beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-store-"));
+        dir = mkdtempSync(join(tmpdir(), "boards-store-"));
         env.testing.set("GENESIS_TOOLS_HOME", dir);
         resetDevDashboardStorage();
         db = makeTestDb();
@@ -92,6 +93,7 @@ describe("boards-store", () => {
         db.close();
         env.testing.unset("GENESIS_TOOLS_HOME");
         resetDevDashboardStorage();
+        rmSync(dir, { recursive: true, force: true });
     });
 
     it("creates, lists, gets, and patches a board", async () => {

--- a/src/dev-dashboard/lib/boards/boards-store.test.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.test.ts
@@ -5,18 +5,22 @@ import { join } from "node:path";
 import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
 import { createKyselyClient, type DatabaseClient } from "@app/utils/database/client";
 import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
 import {
     addEdge,
     addStrokes,
+    answerQuestion,
     appendCardVersion,
     bulkLayout,
     createBoard,
     createCard,
+    createQuestion,
     getBoardBySlug,
     getBoardDoc,
     importSet,
     listBoards,
     listCardVersions,
+    listQuestions,
     listTrash,
     patchBoard,
     patchCard,
@@ -380,5 +384,64 @@ describe("boards-store", () => {
         const versions = await listCardVersions(db, card.id);
         expect(versions.map((v) => v.version)).toEqual([1, 2, 3]);
         expect(versions.map((v) => v.blobKey)).toEqual(["hash1.png", "hash2.png", "hash3.png"]);
+    });
+
+    it("createQuestion inserts staged/undelivered with a null cardId for board-level questions", async () => {
+        await createBoard(db, { slug: "b1" });
+        const q = await createQuestion(db, "b1", {
+            cardId: 0,
+            prompt: "pick one",
+            options: [{ label: "a" }, { label: "b" }],
+            multi: false,
+        });
+        expect(q).toMatchObject({
+            cardId: null,
+            prompt: "pick one",
+            options: [{ label: "a" }, { label: "b" }],
+            answer: null,
+            answeredBy: "",
+            staged: true,
+            multi: false,
+        });
+    });
+
+    it("createQuestion rejects a cardId that isn't a live card on this board", async () => {
+        await createBoard(db, { slug: "b1" });
+        await expect(
+            createQuestion(db, "b1", { cardId: 999, prompt: "pick one", options: [{ label: "a" }], multi: false })
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it("listQuestions returns a board's questions oldest-first", async () => {
+        await createBoard(db, { slug: "b1" });
+        const q1 = await createQuestion(db, "b1", { cardId: 0, prompt: "first", options: [{ label: "a" }] });
+        const q2 = await createQuestion(db, "b1", { cardId: 0, prompt: "second", options: [{ label: "a" }] });
+        const list = await listQuestions(db, "b1");
+        expect(list.map((q) => q.id)).toEqual([q1.id, q2.id]);
+    });
+
+    it("answerQuestion wraps a single-select answer as a one-element JSON array", async () => {
+        await createBoard(db, { slug: "b1" });
+        const q = await createQuestion(db, "b1", { cardId: 0, prompt: "pick one", options: [{ label: "picked" }] });
+        const answered = await answerQuestion(db, q.id, "picked", "user");
+        expect(answered.answer).toEqual(["picked"]);
+        expect(answered.answeredBy).toBe("user");
+        expect(answered.staged).toBe(true); // still staged — dispatch releases it, not the answer itself
+    });
+
+    it("answerQuestion stores a multi-select answer's pre-encoded JSON array as-is", async () => {
+        await createBoard(db, { slug: "b1" });
+        const q = await createQuestion(db, "b1", {
+            cardId: 0,
+            prompt: "pick some",
+            options: [{ label: "a" }, { label: "b" }],
+            multi: true,
+        });
+        const answered = await answerQuestion(db, q.id, SafeJSON.stringify(["a", "b"]), "user");
+        expect(answered.answer).toEqual(["a", "b"]);
+    });
+
+    it("answerQuestion on an unknown id throws NotFoundError", async () => {
+        await expect(answerQuestion(db, 999, "picked", "user")).rejects.toThrow(NotFoundError);
     });
 });

--- a/src/dev-dashboard/lib/boards/boards-store.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.ts
@@ -943,6 +943,17 @@ export async function answerQuestion(
         if (!existing) {
             throw new NotFoundError(`question not found: ${questionId}`);
         }
+        if (existing.multi === 1) {
+            let parsed: unknown;
+            try {
+                parsed = SafeJSON.parse(answer, { strict: true });
+            } catch {
+                throw new InvalidInputError("multi-select answer must be a JSON array");
+            }
+            if (!Array.isArray(parsed)) {
+                throw new InvalidInputError("multi-select answer must be a JSON array");
+            }
+        }
         const stored = existing.multi === 1 ? answer : SafeJSON.stringify([answer]);
         const row = await trx
             .updateTable("board_questions")

--- a/src/dev-dashboard/lib/boards/boards-store.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.ts
@@ -515,7 +515,7 @@ export async function deleteEdge(db: DatabaseClient<BoardsDb>, edgeId: number): 
 export async function bulkLayout(
     db: DatabaseClient<BoardsDb>,
     boardSlug: string,
-    moves: Array<{ id: number; x: number; y: number }>
+    moves: Array<{ id: number; x: number; y: number; w?: number; h?: number }>
 ): Promise<void> {
     if (moves.length < 1 || moves.length > 500) {
         throw new InvalidInputError(`bulkLayout: expected 1-500 moves, got ${moves.length}`);
@@ -527,7 +527,13 @@ export async function bulkLayout(
         for (const m of moves) {
             await trx
                 .updateTable("board_cards")
-                .set({ x: m.x, y: m.y, updated_at: now })
+                .set({
+                    x: m.x,
+                    y: m.y,
+                    ...(m.w !== undefined ? { w: m.w } : {}),
+                    ...(m.h !== undefined ? { h: m.h } : {}),
+                    updated_at: now,
+                })
                 .where("id", "=", m.id)
                 .where("board_id", "=", board.id)
                 .execute();

--- a/src/dev-dashboard/lib/boards/boards-store.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.ts
@@ -3,6 +3,7 @@ import { escapeLike } from "@app/utils/database/predicates";
 import { SafeJSON } from "@app/utils/json";
 import { type Kysely, type Selectable, type SqlBool, sql } from "kysely";
 import { getBoardAnnotations } from "./annotations-store";
+import type { NormalizedOption } from "./compose-validate";
 import type {
     AnnotationMessagesTable,
     BoardCardsTable,
@@ -868,4 +869,87 @@ export async function listCardVersions(
         attemptId: r.attempt_id === 0 ? null : r.attempt_id,
         createdAt: r.created_at,
     }));
+}
+
+/** Create a board (cardId=0) or card-anchored question. Options must already be normalized
+ *  (compose-validate.ts's `normalizeOptions`) — callers validate prompt/option shape before this. */
+export async function createQuestion(
+    db: DatabaseClient<BoardsDb>,
+    boardSlug: string,
+    input: { cardId: number; prompt: string; options: NormalizedOption[]; multi?: boolean }
+): Promise<QuestionDto> {
+    const board = await getBoardRow(db, boardSlug);
+    if (input.cardId > 0) {
+        const card = await db.kysely
+            .selectFrom("board_cards")
+            .select("id")
+            .where("id", "=", input.cardId)
+            .where("board_id", "=", board.id)
+            .where("deleted_at", "=", "")
+            .executeTakeFirst();
+        if (!card) {
+            throw new NotFoundError(`card not found on this board: ${input.cardId}`);
+        }
+    }
+    const row = await db.kysely
+        .insertInto("board_questions")
+        .values({
+            board_id: board.id,
+            card_id: input.cardId,
+            prompt: input.prompt,
+            options: SafeJSON.stringify(input.options),
+            answer: "",
+            answered_by: "",
+            delivered: 0,
+            staged: 1,
+            multi: input.multi ? 1 : 0,
+            created_at: nowIso(),
+            answered_at: "",
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    return toQuestionDto(row);
+}
+
+/** A board's questions, oldest first (the poll surface for callers not holding the work wire). */
+export async function listQuestions(db: DatabaseClient<BoardsDb>, boardSlug: string): Promise<QuestionDto[]> {
+    const board = await getBoardRow(db, boardSlug);
+    const rows = await db.kysely
+        .selectFrom("board_questions")
+        .selectAll()
+        .where("board_id", "=", board.id)
+        .orderBy("created_at", "asc")
+        .execute();
+    return rows.map(toQuestionDto);
+}
+
+/** Answer is any string (never hard-blocked — off-vocabulary "Other" text is a valid answer).
+ *  Storage is always a JSON-encoded array (drainChoices parses it uniformly): single-select
+ *  answers are wrapped as a one-element array; multi-select answers arrive pre-encoded by the
+ *  caller (decision §0.1.6) and are stored as-is. The answer stays staged — dispatchBoard
+ *  releases it onto the work wire, so re-answering before a dispatch costs nothing. */
+export async function answerQuestion(
+    db: DatabaseClient<BoardsDb>,
+    questionId: number,
+    answer: string,
+    actor: string
+): Promise<QuestionDto> {
+    return db.kysely.transaction().execute(async (trx) => {
+        const existing = await trx
+            .selectFrom("board_questions")
+            .select("multi")
+            .where("id", "=", questionId)
+            .executeTakeFirst();
+        if (!existing) {
+            throw new NotFoundError(`question not found: ${questionId}`);
+        }
+        const stored = existing.multi === 1 ? answer : SafeJSON.stringify([answer]);
+        const row = await trx
+            .updateTable("board_questions")
+            .set({ answer: stored, answered_by: actor, answered_at: nowIso() })
+            .where("id", "=", questionId)
+            .returningAll()
+            .executeTakeFirstOrThrow();
+        return toQuestionDto(row);
+    });
 }

--- a/src/dev-dashboard/lib/boards/boards-store.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.ts
@@ -698,15 +698,6 @@ export async function syncSetCards(
     // the version counter is shared per (project, branch), so a newer key strands the older
     // key's cards at a lower version (mirrors vitrinka store.SyncCards, boards.go:811-868).
     const pattern = `${escapeLike(`${set.project}/${set.branch}/`)}%`;
-    const staleCards = await db.kysely
-        .selectFrom("board_cards")
-        .selectAll()
-        .where("board_id", "=", board.id)
-        .where("kind", "=", "shot")
-        .where(sql<SqlBool>`set_ref LIKE ${pattern} ESCAPE '\\'`)
-        .where("set_version", "<", set.version)
-        .where("deleted_at", "=", "")
-        .execute();
 
     const filesByPath = new Map(set.files.map((f) => [f.path, f]));
     const skippedFiles: string[] = [];
@@ -714,6 +705,19 @@ export async function syncSetCards(
     const now = nowIso();
 
     await db.kysely.transaction().execute(async (trx) => {
+        // Read staleCards (and each row's payload) inside the tx: reading them beforehand would
+        // let a concurrent patchCard/appendCardVersion land between the read and this loop, and
+        // the payload merge below would silently clobber that write with the stale snapshot.
+        const staleCards = await trx
+            .selectFrom("board_cards")
+            .selectAll()
+            .where("board_id", "=", board.id)
+            .where("kind", "=", "shot")
+            .where(sql<SqlBool>`set_ref LIKE ${pattern} ESCAPE '\\'`)
+            .where("set_version", "<", set.version)
+            .where("deleted_at", "=", "")
+            .execute();
+
         for (const card of staleCards) {
             const file = filesByPath.get(card.file_path);
             if (!file) {

--- a/src/dev-dashboard/lib/boards/capsule.test.ts
+++ b/src/dev-dashboard/lib/boards/capsule.test.ts
@@ -64,9 +64,11 @@ describe("buildCapsule", () => {
         expect(capsule).not.toContain("reshoot intent");
     });
 
-    it("appends the reshoot caveat when intent is reshoot", () => {
+    it("replaces the default protocol with the reshoot protocol when intent is reshoot", () => {
         const capsule = buildCapsule(makeAnnotation({ intent: "reshoot" }), makeCard(), "my-board");
-        expect(capsule).toContain("(reshoot intent: NO code changes — recapture only.)");
+        expect(capsule).toContain("**Protocol (reshoot):** NO code changes");
+        expect(capsule).toContain("boards_attach_after");
+        expect(capsule).not.toContain("**Protocol:** boards_set_status working");
     });
 
     it("uses intentOther for an 'other' intent", () => {
@@ -100,5 +102,32 @@ describe("buildCapsule", () => {
         expect(capsule).toContain("**Region:** 10,20 100×50 px on `shot`");
         expect(capsule).not.toContain("— image:");
         expect(capsule).not.toContain("**Source:**");
+    });
+
+    it("adds a Section line with a scoped scrape URL when the card sits inside a journey section", () => {
+        const section = { id: 99, kind: "section", x: 0, y: 0, w: 500, h: 500, payload: { title: "Checkout" } };
+        const capsule = buildCapsule(makeAnnotation(), makeCard(), "my-board", { boardCards: [section, makeCard()] });
+        expect(capsule).toContain(
+            "**Section:** Checkout — scoped digest: /api/boards/my-board/scrape?section=Checkout"
+        );
+    });
+
+    it("prefixes the Section digest URL with base when given", () => {
+        const section = { id: 99, kind: "section", x: 0, y: 0, w: 500, h: 500, payload: { title: "Checkout" } };
+        const capsule = buildCapsule(makeAnnotation(), makeCard(), "my-board", {
+            boardCards: [section, makeCard()],
+            base: "http://127.0.0.1:1234",
+        });
+        expect(capsule).toContain(
+            "**Section:** Checkout — scoped digest: http://127.0.0.1:1234/api/boards/my-board/scrape?section=Checkout"
+        );
+    });
+
+    it("omits the Section line when the card isn't inside any section, or boardCards isn't given", () => {
+        const outside = { id: 99, kind: "section", x: 900, y: 900, w: 50, h: 50, payload: { title: "Elsewhere" } };
+        expect(buildCapsule(makeAnnotation(), makeCard(), "my-board", { boardCards: [outside] })).not.toContain(
+            "**Section:**"
+        );
+        expect(buildCapsule(makeAnnotation(), makeCard(), "my-board")).not.toContain("**Section:**");
     });
 });

--- a/src/dev-dashboard/lib/boards/capsule.ts
+++ b/src/dev-dashboard/lib/boards/capsule.ts
@@ -1,10 +1,16 @@
 import { blobUrl } from "./blobs";
+import { containingSection, type SectionCard, sectionFrames, sectionTitle } from "./sections";
 import type { AnnotationDto, CardDto } from "./types";
 
 const THREAD_LIMIT = 5;
 const CLIP = 300;
 
-export function buildCapsule(a: AnnotationDto, card: CardDto, boardSlug: string): string {
+export function buildCapsule(
+    a: AnnotationDto,
+    card: CardDto,
+    boardSlug: string,
+    opts?: { boardCards?: SectionCard[]; base?: string }
+): string {
     const rev = a.revisions[a.revisions.length - 1];
     const lines: string[] = [];
     lines.push(
@@ -22,6 +28,15 @@ export function buildCapsule(a: AnnotationDto, card: CardDto, boardSlug: string)
             `**Source:** set \`${card.setRef}\` v${card.setVersion} (card ${card.id}, drawn on v${a.cardVersion})`
         );
     }
+    if (opts?.boardCards) {
+        const section = containingSection(sectionFrames(opts.boardCards), card);
+        if (section) {
+            const name = sectionTitle(section);
+            lines.push(
+                `**Section:** ${name} — scoped digest: ${opts.base ?? ""}/api/boards/${boardSlug}/scrape?section=${encodeURIComponent(name)}`
+            );
+        }
+    }
     const thread = a.messages.slice(-THREAD_LIMIT);
 
     if (thread.length > 0) {
@@ -32,10 +47,15 @@ export function buildCapsule(a: AnnotationDto, card: CardDto, boardSlug: string)
         }
     }
     lines.push(
-        "**Protocol:** boards_set_status working → fix → push a new set version → boards_attach_after → " +
-            "boards_reply (1-3 lines) → boards_set_status in_review. Never set resolved (user-only). " +
-            'A 409 "cancelled" on any write = the user withdrew this item — revert your changes for it and move on.' +
-            (a.intent === "reshoot" ? " (reshoot intent: NO code changes — recapture only.)" : "")
+        a.intent === "reshoot"
+            ? `**Protocol (reshoot):** NO code changes — the shot caught a bad state (loading/broken). ` +
+                  `boards_set_status working → re-capture this screen (route/surface in the set manifest for ` +
+                  `\`${card.filePath || card.kind}\`), wait for the app to settle → push the new set ` +
+                  `(\`tools boards push\`) → boards_attach_after → boards_reply (1 line) → boards_set_status ` +
+                  `in_review. A 409 "cancelled" from ANY tool means the user withdrew №${a.id}: reply once, move on.`
+            : "**Protocol:** boards_set_status working → fix → push a new set version → boards_attach_after → " +
+                  "boards_reply (1-3 lines) → boards_set_status in_review. Never set resolved (user-only). " +
+                  'A 409 "cancelled" on any write = the user withdrew this item — revert your changes for it and move on.'
     );
     lines.push(
         "**Scope:** this board only — keep draining with the same scope; other boards belong to other sessions."

--- a/src/dev-dashboard/lib/boards/compose-store.test.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createKyselyClient, type DatabaseClient } from "@app/utils/database/client";
+import { createBoard, createCard, getBoardDoc } from "./boards-store";
+import { composeBoard } from "./compose-store";
+import { BOOTSTRAP_DDL } from "./db";
+import type { BoardsDb } from "./db-types";
+
+function makeTestDb(): DatabaseClient<BoardsDb> {
+    return createKyselyClient<BoardsDb>({ path: ":memory:", bootstrap: BOOTSTRAP_DDL, pragmas: { foreignKeys: true } });
+}
+
+const textCard = (ref: string, md: string) => ({ ref, kind: "text", payload: { md } });
+
+describe("composeBoard", () => {
+    let db: DatabaseClient<BoardsDb>;
+
+    beforeEach(async () => {
+        db = makeTestDb();
+        await createBoard(db, { slug: "b1" });
+    });
+    afterEach(() => db.close());
+
+    it("rejects an empty batch", async () => {
+        const r = await composeBoard(db, "b1", { cards: [] });
+        expect(r).toMatchObject({ ok: false, code: "empty", index: -1 });
+    });
+
+    it("rejects more than 60 cards with limit (413)", async () => {
+        const cards = Array.from({ length: 61 }, (_, i) => textCard(`c${i}`, "x"));
+        expect(await composeBoard(db, "b1", { cards })).toMatchObject({ ok: false, code: "limit" });
+    });
+
+    it("rejects a duplicate ref", async () => {
+        const r = await composeBoard(db, "b1", { cards: [textCard("a", "x"), textCard("a", "y")] });
+        expect(r).toMatchObject({ ok: false, code: "bad_ref", index: 1 });
+    });
+
+    it("rejects an edge pointing at an unknown ref", async () => {
+        const r = await composeBoard(db, "b1", {
+            cards: [textCard("a", "x")],
+            edges: [{ from: "a", to: "ghost" }],
+        });
+        expect(r).toMatchObject({ ok: false, code: "bad_ref", index: 0 });
+    });
+
+    it("rejects children on a non-cluster/section card", async () => {
+        const r = await composeBoard(db, "b1", {
+            cards: [{ ref: "t", kind: "text", payload: { md: "x" }, children: ["m"] }, textCard("m", "y")],
+        });
+        expect(r).toMatchObject({ ok: false, code: "bad_payload", index: 0 });
+    });
+
+    it("rejects a child claimed by two frames", async () => {
+        const r = await composeBoard(db, "b1", {
+            cards: [
+                { ref: "c1", kind: "cluster", payload: {}, children: ["m"] },
+                { ref: "c2", kind: "cluster", payload: {}, children: ["m"] },
+                textCard("m", "y"),
+            ],
+        });
+        expect(r).toMatchObject({ ok: false, code: "bad_ref", index: 1 });
+    });
+
+    it("rejects a compare card referencing a card not on the board", async () => {
+        const r = await composeBoard(db, "b1", {
+            cards: [{ kind: "compare", payload: { a: { cardId: 999 }, b: { cardId: 998 } } }],
+        });
+        expect(r).toMatchObject({ ok: false, code: "not_found", index: 0 });
+    });
+
+    it("rejects both section and anchor together (bad_payload)", async () => {
+        const anchor = await createCard(db, "b1", { kind: "note", x: 0, y: 0, w: 100, h: 100, payload: { text: "x" } });
+        const r = await composeBoard(db, "b1", {
+            section: "Checkout",
+            anchorCardId: anchor.id,
+            cards: [textCard("a", "x")],
+        });
+        expect(r).toMatchObject({ ok: false, code: "bad_payload", index: -1 });
+    });
+
+    it("happy path: 3 texts + 1 edge + 1 question, layer-stamped, elemNos, staged question", async () => {
+        const r = await composeBoard(db, "b1", {
+            cards: [textCard("a", "A"), textCard("b", "B"), textCard("c", "C")],
+            edges: [{ from: "a", to: "b", label: "then" }],
+            questions: [{ cardRef: "c", prompt: "Which?", options: ["one", "two"] }],
+        });
+        expect(r.ok).toBe(true);
+        if (!r.ok) {
+            return;
+        }
+        expect(r.cards).toHaveLength(3);
+        expect(r.cards.map((c) => c.ref)).toEqual(["a", "b", "c"]);
+        expect(r.cards.every((c) => c.elemNo > 0)).toBe(true);
+        expect(r.edges).toHaveLength(1);
+        expect(r.questions).toHaveLength(1);
+        expect(r.region.w).toBeGreaterThan(0);
+
+        const doc = await getBoardDoc(db, "b1");
+        const composed = doc.cards.filter((c) => c.kind === "text");
+        expect(composed).toHaveLength(3);
+        expect(composed.every((c) => c.payload.layer === "ai")).toBe(true);
+        expect(doc.questions).toHaveLength(1);
+        expect(doc.questions[0].staged).toBe(true);
+    });
+
+    it("section-anchored batch places below members and grows the frame", async () => {
+        await createCard(db, "b1", {
+            kind: "section",
+            x: 0,
+            y: 0,
+            w: 300,
+            h: 200,
+            payload: { title: "Checkout" },
+        });
+        const r = await composeBoard(db, "b1", {
+            section: "Checkout",
+            cards: [{ kind: "wireframe", payload: { nodes: [{ t: "nav" }], device: "phone" } }], // 260x520
+        });
+        expect(r.ok).toBe(true);
+
+        const doc = await getBoardDoc(db, "b1");
+        const section = doc.cards.find((c) => c.kind === "section");
+        expect(section).toBeDefined();
+        // The 520-tall wireframe forces the 200-tall frame to grow.
+        expect((section?.h ?? 0) > 200).toBe(true);
+        // The placed card sits inside the (grown) frame's bounds.
+        const wf = doc.cards.find((c) => c.kind === "wireframe");
+        expect(wf).toBeDefined();
+        expect((wf?.y ?? 0) >= 0).toBe(true);
+    });
+
+    it("all-or-nothing: an invalid card at index 4 persists nothing and reports its index", async () => {
+        const before = (await getBoardDoc(db, "b1")).cards.length;
+        const r = await composeBoard(db, "b1", {
+            cards: [
+                textCard("a", "A"),
+                textCard("b", "B"),
+                textCard("c", "C"),
+                textCard("d", "D"),
+                { kind: "text", payload: {} }, // index 4: missing md
+            ],
+        });
+        expect(r).toMatchObject({ ok: false, code: "bad_payload", index: 4 });
+        const after = (await getBoardDoc(db, "b1")).cards.length;
+        expect(after).toBe(before);
+    });
+});

--- a/src/dev-dashboard/lib/boards/compose-store.test.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.test.ts
@@ -4,6 +4,7 @@ import { createBoard, createCard, getBoardDoc } from "./boards-store";
 import { composeBoard } from "./compose-store";
 import { BOOTSTRAP_DDL } from "./db";
 import type { BoardsDb } from "./db-types";
+import { __resetLayoutDebounce } from "./layout-engine";
 
 function makeTestDb(): DatabaseClient<BoardsDb> {
     return createKyselyClient<BoardsDb>({ path: ":memory:", bootstrap: BOOTSTRAP_DDL, pragmas: { foreignKeys: true } });
@@ -18,7 +19,10 @@ describe("composeBoard", () => {
         db = makeTestDb();
         await createBoard(db, { slug: "b1" });
     });
-    afterEach(() => db.close());
+    afterEach(() => {
+        __resetLayoutDebounce();
+        db.close();
+    });
 
     it("rejects an empty batch", async () => {
         const r = await composeBoard(db, "b1", { cards: [] });

--- a/src/dev-dashboard/lib/boards/compose-store.test.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.test.ts
@@ -72,6 +72,20 @@ describe("composeBoard", () => {
         expect(r).toMatchObject({ ok: false, code: "not_found", index: 0 });
     });
 
+    it("rejects a negative question cardId while still accepting the cardId:0 sentinel", async () => {
+        const r = await composeBoard(db, "b1", {
+            cards: [textCard("a", "A")],
+            questions: [{ prompt: "Which?", options: ["one", "two"], cardId: -1 }],
+        });
+        expect(r).toMatchObject({ ok: false, code: "not_found", index: 0 });
+
+        const ok = await composeBoard(db, "b1", {
+            cards: [textCard("b", "B")],
+            questions: [{ prompt: "Which?", options: ["one", "two"], cardId: 0 }],
+        });
+        expect(ok.ok).toBe(true);
+    });
+
     it("rejects both section and anchor together (bad_payload)", async () => {
         const anchor = await createCard(db, "b1", { kind: "note", x: 0, y: 0, w: 100, h: 100, payload: { text: "x" } });
         const r = await composeBoard(db, "b1", {

--- a/src/dev-dashboard/lib/boards/compose-store.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.ts
@@ -638,7 +638,7 @@ export async function composeBoard(
         ...(cardsIn[i].ref ? { ref: cardsIn[i].ref } : {}),
     }));
 
-    notifyLayoutChanged(board.id);
+    notifyLayoutChanged(db, slug);
 
     return {
         ok: true,

--- a/src/dev-dashboard/lib/boards/compose-store.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.ts
@@ -1,6 +1,6 @@
 import type { DatabaseClient } from "@app/utils/database/client";
 import { SafeJSON } from "@app/utils/json";
-import { toCardDto } from "./boards-store";
+import { getBoardDoc, listTrash, patchCard, restoreCard, softDeleteCard, toCardDto } from "./boards-store";
 import {
     COMPOSE_GAP,
     COMPOSE_GRID,
@@ -17,7 +17,7 @@ import {
     SECTION_PAD_TOP,
     SECTION_PAD_X,
 } from "./compose-types";
-import { composeDefaultSize, normalizeOptions, validateComposeCard } from "./compose-validate";
+import { composeDefaultSize, normalizeOptions, stampLayer, validateComposeCard } from "./compose-validate";
 import type { BoardsDb } from "./db-types";
 import { notifyLayoutChanged } from "./layout-engine";
 import { containingSection, resolveJourneyPass, type SectionCard, sectionByName, sectionFrames } from "./sections";
@@ -653,5 +653,123 @@ export async function composeBoard(
             questions: written.createdQuestions,
             boardId: board.id,
         },
+    };
+}
+
+const UPDATE_MAX_OPS = 100;
+
+export interface UpdateCardsBody {
+    patch?: Array<{
+        id: number;
+        x?: number;
+        y?: number;
+        w?: number;
+        h?: number;
+        z?: number;
+        payload?: Record<string, unknown>;
+    }>;
+    remove?: number[];
+    restore?: number[];
+}
+
+export type UpdateCardsResult =
+    | { ok: true; patched: number; removed: number; restored: number; events: { cards: CardDto[]; deleted: number[] } }
+    | { ok: false; code: ComposeErrorCode; index: number; message: string };
+
+/** Batch edit of the agent's OWN layer: patch geometry/payload, soft-remove, and restore — every op
+ *  restricted to payload.layer === "ai" cards (sections count, being shared journey structure).
+ *  Mirrors handlers_compose.go:1221-1372. Validated as a whole, then applied per-op (GT's helpers
+ *  are self-transacting and can't nest — same shape as vitrinka's per-op application). */
+export async function updateCards(
+    db: DatabaseClient<BoardsDb>,
+    slug: string,
+    body: UpdateCardsBody
+): Promise<UpdateCardsResult> {
+    const patch = body.patch ?? [];
+    const remove = body.remove ?? [];
+    const restore = body.restore ?? [];
+    const n = patch.length + remove.length + restore.length;
+    if (n === 0) {
+        return err("empty", -1, "patch+remove+restore: at least 1 entry required") as UpdateCardsResult;
+    }
+    if (n > UPDATE_MAX_OPS) {
+        return err("limit", -1, `patch+remove+restore: at most ${UPDATE_MAX_OPS} entries`) as UpdateCardsResult;
+    }
+
+    const doc = await getBoardDoc(db, slug); // throws NotFoundError → route maps to 404
+    const aiCards = new Set<number>();
+    const sectionCards = new Set<number>();
+    const kindById = new Map<number, string>();
+    for (const c of doc.cards) {
+        kindById.set(c.id, c.kind);
+        if (c.kind === "section") {
+            aiCards.add(c.id);
+            sectionCards.add(c.id);
+        } else if (c.payload.layer === "ai") {
+            aiCards.add(c.id);
+        }
+    }
+
+    // Validate everything first (all-or-nothing).
+    for (let i = 0; i < patch.length; i += 1) {
+        if (!aiCards.has(patch[i].id)) {
+            return err("not_ai_layer", i, `card ${patch[i].id} is not on the AI layer`) as UpdateCardsResult;
+        }
+    }
+    for (let i = 0; i < remove.length; i += 1) {
+        if (!aiCards.has(remove[i])) {
+            return err("not_ai_layer", i, `card ${remove[i]} is not on the AI layer`) as UpdateCardsResult;
+        }
+    }
+    if (restore.length > 0) {
+        // Removals are SOFT (trash) — restore is validated against the board's TRASH, not its live cards.
+        const trash = await listTrash(db, slug);
+        const trashAI = new Set<number>();
+        for (const c of trash) {
+            if (c.kind === "section" || c.payload.layer === "ai") {
+                trashAI.add(c.id);
+            }
+        }
+        for (let i = 0; i < restore.length; i += 1) {
+            if (!trashAI.has(restore[i])) {
+                return err(
+                    "not_ai_layer",
+                    i,
+                    `card ${restore[i]} is not an AI-layer card in this board's trash`
+                ) as UpdateCardsResult;
+            }
+        }
+    }
+
+    const cardEvents: CardDto[] = [];
+    const deleted: number[] = [];
+    for (const p of patch) {
+        const kind = (kindById.get(p.id) ?? "text") as ComposeKind;
+        const card = await patchCard(db, p.id, {
+            x: p.x,
+            y: p.y,
+            w: p.w,
+            h: p.h,
+            z: p.z,
+            // Re-stamp layer:ai (agent can't unstamp itself by omitting it); sections stay neutral.
+            payload: p.payload !== undefined ? stampLayer(kind, p.payload) : undefined,
+        });
+        cardEvents.push(card);
+    }
+    for (const id of remove) {
+        await softDeleteCard(db, id);
+        deleted.push(id);
+    }
+    for (const id of restore) {
+        cardEvents.push(await restoreCard(db, id));
+    }
+
+    notifyLayoutChanged(db, slug);
+    return {
+        ok: true,
+        patched: patch.length,
+        removed: remove.length,
+        restored: restore.length,
+        events: { cards: cardEvents, deleted },
     };
 }

--- a/src/dev-dashboard/lib/boards/compose-store.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.ts
@@ -63,6 +63,8 @@ export interface ComposeRegion {
     w: number;
     h: number;
 }
+export type ErrorResult = { ok: false; code: ComposeErrorCode; index: number; message: string };
+
 export type ComposeResult =
     | {
           ok: true;
@@ -72,7 +74,7 @@ export type ComposeResult =
           region: ComposeRegion;
           events: { cards: CardDto[]; edges: EdgeDto[]; questions: QuestionDto[]; boardId: number };
       }
-    | { ok: false; code: ComposeErrorCode; index: number; message: string };
+    | ErrorResult;
 
 interface PlaceCard {
     kind: ComposeKind;
@@ -82,7 +84,7 @@ interface PlaceCard {
     h: number;
 }
 
-function err(code: ComposeErrorCode, index: number, message: string): ComposeResult {
+function err(code: ComposeErrorCode, index: number, message: string): ErrorResult {
     return { ok: false, code, index, message };
 }
 
@@ -317,7 +319,7 @@ export async function composeBoard(
             cardIdx = ci;
             withQuestion.add(ci);
         }
-        if (q.cardId && q.cardId > 0 && !existingIds.has(q.cardId)) {
+        if (q.cardId && (q.cardId <= 0 || !existingIds.has(q.cardId))) {
             return err("not_found", i, `question cardId ${q.cardId} is not on this board`);
         }
         const opts = normalizeOptions(q.options);
@@ -457,7 +459,12 @@ export async function composeBoard(
     // 8) ONE transaction: adopt/create journey frame, insert cards + edges + questions, grow section.
     const now = nowIso();
     const written = await db.kysely.transaction().execute(async (trx) => {
-        let elemSeq = board.elem_seq;
+        const currentBoard = await trx
+            .selectFrom("boards")
+            .select("elem_seq")
+            .where("id", "=", board.id)
+            .executeTakeFirstOrThrow();
+        let elemSeq = currentBoard.elem_seq;
         let createdSection: CardDto | null = null;
 
         if (adopt) {
@@ -674,7 +681,7 @@ export interface UpdateCardsBody {
 
 export type UpdateCardsResult =
     | { ok: true; patched: number; removed: number; restored: number; events: { cards: CardDto[]; deleted: number[] } }
-    | { ok: false; code: ComposeErrorCode; index: number; message: string };
+    | ErrorResult;
 
 /** Batch edit of the agent's OWN layer: patch geometry/payload, soft-remove, and restore — every op
  *  restricted to payload.layer === "ai" cards (sections count, being shared journey structure).
@@ -690,10 +697,30 @@ export async function updateCards(
     const restore = body.restore ?? [];
     const n = patch.length + remove.length + restore.length;
     if (n === 0) {
-        return err("empty", -1, "patch+remove+restore: at least 1 entry required") as UpdateCardsResult;
+        return err("empty", -1, "patch+remove+restore: at least 1 entry required");
     }
     if (n > UPDATE_MAX_OPS) {
-        return err("limit", -1, `patch+remove+restore: at most ${UPDATE_MAX_OPS} entries`) as UpdateCardsResult;
+        return err("limit", -1, `patch+remove+restore: at most ${UPDATE_MAX_OPS} entries`);
+    }
+
+    const seenIds = new Set<number>();
+    for (const p of patch) {
+        if (seenIds.has(p.id)) {
+            return err("bad_payload", -1, `duplicate card ID ${p.id} in batch`);
+        }
+        seenIds.add(p.id);
+    }
+    for (const id of remove) {
+        if (seenIds.has(id)) {
+            return err("bad_payload", -1, `duplicate card ID ${id} in batch`);
+        }
+        seenIds.add(id);
+    }
+    for (const id of restore) {
+        if (seenIds.has(id)) {
+            return err("bad_payload", -1, `duplicate card ID ${id} in batch`);
+        }
+        seenIds.add(id);
     }
 
     const doc = await getBoardDoc(db, slug); // throws NotFoundError → route maps to 404
@@ -713,12 +740,12 @@ export async function updateCards(
     // Validate everything first (all-or-nothing).
     for (let i = 0; i < patch.length; i += 1) {
         if (!aiCards.has(patch[i].id)) {
-            return err("not_ai_layer", i, `card ${patch[i].id} is not on the AI layer`) as UpdateCardsResult;
+            return err("not_ai_layer", i, `card ${patch[i].id} is not on the AI layer`);
         }
     }
     for (let i = 0; i < remove.length; i += 1) {
         if (!aiCards.has(remove[i])) {
-            return err("not_ai_layer", i, `card ${remove[i]} is not on the AI layer`) as UpdateCardsResult;
+            return err("not_ai_layer", i, `card ${remove[i]} is not on the AI layer`);
         }
     }
     if (restore.length > 0) {
@@ -732,11 +759,7 @@ export async function updateCards(
         }
         for (let i = 0; i < restore.length; i += 1) {
             if (!trashAI.has(restore[i])) {
-                return err(
-                    "not_ai_layer",
-                    i,
-                    `card ${restore[i]} is not an AI-layer card in this board's trash`
-                ) as UpdateCardsResult;
+                return err("not_ai_layer", i, `card ${restore[i]} is not an AI-layer card in this board's trash`);
             }
         }
     }

--- a/src/dev-dashboard/lib/boards/compose-store.ts
+++ b/src/dev-dashboard/lib/boards/compose-store.ts
@@ -1,0 +1,657 @@
+import type { DatabaseClient } from "@app/utils/database/client";
+import { SafeJSON } from "@app/utils/json";
+import { toCardDto } from "./boards-store";
+import {
+    COMPOSE_GAP,
+    COMPOSE_GRID,
+    COMPOSE_GUTTER,
+    COMPOSE_MAX_CARDS,
+    COMPOSE_MAX_EDGES,
+    COMPOSE_MAX_QUESTIONS,
+    type ComposeErrorCode,
+    type ComposeKind,
+    type ComposeRef,
+    MAX_QUESTION_PROMPT,
+    QUESTION_ROOM,
+    SECTION_PAD_BOT,
+    SECTION_PAD_TOP,
+    SECTION_PAD_X,
+} from "./compose-types";
+import { composeDefaultSize, normalizeOptions, validateComposeCard } from "./compose-validate";
+import type { BoardsDb } from "./db-types";
+import { notifyLayoutChanged } from "./layout-engine";
+import { containingSection, resolveJourneyPass, type SectionCard, sectionByName, sectionFrames } from "./sections";
+import { nowIso } from "./time";
+import type { CardDto, EdgeDto, QuestionDto } from "./types";
+
+const ZERO_H = 220; // legacy zero-height card footprint for member-bottom math
+
+export interface ComposeCardInput {
+    ref?: string;
+    kind: string;
+    payload?: Record<string, unknown>;
+    w?: number;
+    h?: number;
+    children?: string[];
+}
+export interface ComposeEdgeInput {
+    from: ComposeRef;
+    to: ComposeRef;
+    label?: string;
+}
+export interface ComposeQuestionInput {
+    prompt: string;
+    options: unknown[];
+    multiSelect?: boolean;
+    cardRef?: string;
+    cardId?: number;
+}
+export interface ComposeBody {
+    layout?: string;
+    section?: string;
+    journey?: string;
+    pass?: number | "next";
+    anchorCardId?: number;
+    cards: ComposeCardInput[];
+    edges?: ComposeEdgeInput[];
+    questions?: ComposeQuestionInput[];
+}
+
+export interface ComposeRegion {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+export type ComposeResult =
+    | {
+          ok: true;
+          cards: Array<{ id: number; elemNo: number; ref?: string }>;
+          edges: number[];
+          questions: number[];
+          region: ComposeRegion;
+          events: { cards: CardDto[]; edges: EdgeDto[]; questions: QuestionDto[]; boardId: number };
+      }
+    | { ok: false; code: ComposeErrorCode; index: number; message: string };
+
+interface PlaceCard {
+    kind: ComposeKind;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+function err(code: ComposeErrorCode, index: number, message: string): ComposeResult {
+    return { ok: false, code, index, message };
+}
+
+/** composePlace (handlers_compose.go:640-748): assign x/y to the batch in place, growing cluster/
+ *  section frames around their children, and return the covered region. */
+function composePlace(opts: {
+    cards: PlaceCard[];
+    existing: SectionCard[];
+    anchor: SectionCard | null;
+    origin: { x: number; y: number } | null;
+    mode: string;
+    withQuestion: Set<number>;
+    childParent: Map<number, number>;
+}): ComposeRegion {
+    const { cards, existing, anchor, origin, mode, withQuestion, childParent } = opts;
+    const CLUSTER_PAD_X = 20;
+    const CLUSTER_PAD_TOP = 44;
+    const CLUSTER_PAD_BOT = 20;
+
+    // Cluster/section inner pass: members flow 2-per-row inside their frame (relative coords).
+    const childrenOf = new Map<number, number[]>();
+    for (const [child, parent] of childParent) {
+        const list = childrenOf.get(parent) ?? [];
+        list.push(child);
+        childrenOf.set(parent, list);
+    }
+    for (const [parent, kids] of childrenOf) {
+        kids.sort((a, b) => a - b);
+        const padTop = cards[parent].kind === "section" ? SECTION_PAD_TOP : CLUSTER_PAD_TOP;
+        let x = 0;
+        let y = 0;
+        let rowH = 0;
+        let maxW = 0;
+        kids.forEach((ci, n) => {
+            if (n > 0 && n % 2 === 0) {
+                x = 0;
+                y += rowH + COMPOSE_GAP;
+                rowH = 0;
+            }
+            cards[ci].x = x;
+            cards[ci].y = y;
+            const h = cards[ci].h + (withQuestion.has(ci) ? QUESTION_ROOM : 0);
+            rowH = Math.max(rowH, h);
+            maxW = Math.max(maxW, x + cards[ci].w);
+            x += cards[ci].w + COMPOSE_GAP;
+        });
+        cards[parent].w = maxW + 2 * CLUSTER_PAD_X;
+        cards[parent].h = y + rowH + padTop + CLUSTER_PAD_BOT;
+    }
+
+    let ox = 80;
+    let oy = 80;
+    if (origin) {
+        ox = origin.x;
+        oy = origin.y;
+    } else if (anchor) {
+        const aw = anchor.w > 0 ? anchor.w : 340;
+        ox = anchor.x + aw + COMPOSE_GUTTER;
+        oy = anchor.y;
+    } else if (existing.length > 0) {
+        let maxX = Number.NEGATIVE_INFINITY;
+        let minY = Number.POSITIVE_INFINITY;
+        for (const c of existing) {
+            const cw = c.w > 0 ? c.w : 340;
+            maxX = Math.max(maxX, c.x + cw);
+            minY = Math.min(minY, c.y);
+        }
+        ox = maxX + COMPOSE_GUTTER;
+        oy = minY;
+    }
+    if (!origin) {
+        ox = Math.round(ox / COMPOSE_GRID) * COMPOSE_GRID;
+        oy = Math.round(oy / COMPOSE_GRID) * COMPOSE_GRID;
+    }
+
+    let perRow = 1;
+    if (mode === "row") {
+        perRow = cards.length;
+    } else if (mode === "grid" || mode === "none") {
+        perRow = 3;
+    }
+    if (perRow < 1) {
+        perRow = 1;
+    }
+
+    let x = ox;
+    let y = oy;
+    let rowH = 0;
+    let maxX = ox;
+    let maxY = oy;
+    let n = 0;
+    for (let i = 0; i < cards.length; i += 1) {
+        if (childParent.has(i)) {
+            continue; // placed relative to its frame below
+        }
+        if (n > 0 && n % perRow === 0) {
+            x = ox;
+            y += rowH + COMPOSE_GAP;
+            rowH = 0;
+        }
+        cards[i].x = x;
+        cards[i].y = y;
+        const h = cards[i].h + (withQuestion.has(i) ? QUESTION_ROOM : 0);
+        rowH = Math.max(rowH, h);
+        maxX = Math.max(maxX, x + cards[i].w);
+        maxY = Math.max(maxY, y + h);
+        x += cards[i].w + COMPOSE_GAP;
+        n += 1;
+    }
+
+    // Children go absolute: frame origin + inner padding + their relative slot.
+    for (const [child, parent] of childParent) {
+        cards[child].x += cards[parent].x + CLUSTER_PAD_X;
+        cards[child].y += cards[parent].y + (cards[parent].kind === "section" ? SECTION_PAD_TOP : CLUSTER_PAD_TOP);
+    }
+
+    return { x: ox, y: oy, w: maxX - ox, h: maxY - oy };
+}
+
+function resolveRefIndex(cr: ComposeRef, refIdx: Map<string, number>): { idx: number; id: number } | null {
+    if (typeof cr === "string") {
+        const i = refIdx.get(cr);
+        return i === undefined ? null : { idx: i, id: 0 };
+    }
+    if (typeof cr === "number" && cr > 0) {
+        return { idx: -1, id: cr };
+    }
+    return null;
+}
+
+/** Batched AI card/edge/question authoring with server-side placement. All-or-nothing: everything
+ *  is validated first, then written in ONE transaction (handlers_compose.go:139-574). */
+export async function composeBoard(
+    db: DatabaseClient<BoardsDb>,
+    slug: string,
+    body: ComposeBody,
+    actor = "claude"
+): Promise<ComposeResult> {
+    const cardsIn = body.cards ?? [];
+    const edgesIn = body.edges ?? [];
+    const questionsIn = body.questions ?? [];
+
+    if (cardsIn.length === 0 && edgesIn.length === 0 && questionsIn.length === 0) {
+        return err("empty", -1, "empty batch: send cards, edges or questions");
+    }
+    if (cardsIn.length > COMPOSE_MAX_CARDS) {
+        return err("limit", -1, `max ${COMPOSE_MAX_CARDS} cards per compose`);
+    }
+    if (edgesIn.length > COMPOSE_MAX_EDGES) {
+        return err("limit", -1, `max ${COMPOSE_MAX_EDGES} edges per compose`);
+    }
+    if (questionsIn.length > COMPOSE_MAX_QUESTIONS) {
+        return err("limit", -1, `max ${COMPOSE_MAX_QUESTIONS} questions per compose`);
+    }
+
+    // Load board + live cards (validation + placement operate on this snapshot).
+    const board = await db.kysely.selectFrom("boards").selectAll().where("slug", "=", slug).executeTakeFirst();
+    if (!board) {
+        return err("not_found", -1, `board not found: ${slug}`);
+    }
+    const existingRows = await db.kysely
+        .selectFrom("board_cards")
+        .selectAll()
+        .where("board_id", "=", board.id)
+        .where("deleted_at", "=", "")
+        .execute();
+    const existing: SectionCard[] = existingRows.map(toCardDto);
+    const existingIds = new Set(existing.map((c) => c.id));
+
+    // 1) Cards: validate kind + payload, stamp layer, size; track batch refs.
+    const refIdx = new Map<string, number>();
+    const placed: PlaceCard[] = [];
+    const payloads: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < cardsIn.length; i += 1) {
+        const c = cardsIn[i];
+        const v = validateComposeCard({ kind: c.kind, payload: c.payload ?? {} });
+        if (!v.ok) {
+            return err(v.code, i, `card ${i}: ${v.code}`);
+        }
+        const size = composeDefaultSize(c.kind as ComposeKind, v.payload);
+        placed.push({
+            kind: c.kind as ComposeKind,
+            x: 0,
+            y: 0,
+            w: c.w && c.w > 0 ? c.w : size.w,
+            h: c.h && c.h > 0 ? c.h : size.h,
+        });
+        payloads.push(v.payload);
+        if (c.ref) {
+            if (refIdx.has(c.ref)) {
+                return err("bad_ref", i, `duplicate ref "${c.ref}"`);
+            }
+            refIdx.set(c.ref, i);
+        }
+    }
+
+    // 2) Edges: resolve from/to refs.
+    const edgeResolved: Array<{ fromIdx: number; fromId: number; toIdx: number; toId: number; label: string }> = [];
+    for (let i = 0; i < edgesIn.length; i += 1) {
+        const e = edgesIn[i];
+        const from = resolveRefIndex(e.from, refIdx);
+        if (!from || (from.id > 0 && !existingIds.has(from.id))) {
+            return err("bad_ref", i, `edge from: no such ref/card in this batch or board`);
+        }
+        const to = resolveRefIndex(e.to, refIdx);
+        if (!to || (to.id > 0 && !existingIds.has(to.id))) {
+            return err("bad_ref", i, `edge to: no such ref/card in this batch or board`);
+        }
+        edgeResolved.push({ fromIdx: from.idx, fromId: from.id, toIdx: to.idx, toId: to.id, label: e.label ?? "" });
+    }
+
+    // 3) Questions: prompt, options, cardRef/cardId anchor.
+    const withQuestion = new Set<number>();
+    const questionResolved: Array<{
+        prompt: string;
+        options: string;
+        multi: boolean;
+        cardIdx: number;
+        cardId: number;
+    }> = [];
+    for (let i = 0; i < questionsIn.length; i += 1) {
+        const q = questionsIn[i];
+        if (!q.prompt || q.prompt.length > MAX_QUESTION_PROMPT) {
+            return err("bad_question", i, "question needs a prompt (≤1000 chars)");
+        }
+        let cardIdx = -1;
+        if (q.cardRef) {
+            const ci = refIdx.get(q.cardRef);
+            if (ci === undefined) {
+                return err("bad_ref", i, `question cardRef "${q.cardRef}": no such ref in this batch`);
+            }
+            cardIdx = ci;
+            withQuestion.add(ci);
+        }
+        if (q.cardId && q.cardId > 0 && !existingIds.has(q.cardId)) {
+            return err("not_found", i, `question cardId ${q.cardId} is not on this board`);
+        }
+        const opts = normalizeOptions(q.options);
+        if (!opts.ok) {
+            return err(opts.code, i, "question options: 1-12 of string|{label,hint?,recommended?}");
+        }
+        questionResolved.push({
+            prompt: q.prompt,
+            options: SafeJSON.stringify(opts.options),
+            multi: q.multiSelect === true,
+            cardIdx,
+            cardId: q.cardId ?? 0,
+        });
+    }
+
+    // 4) Children (cluster/section only; one parent; frames don't nest).
+    const childParent = new Map<number, number>();
+    for (let i = 0; i < cardsIn.length; i += 1) {
+        const children = cardsIn[i].children;
+        if (!children || children.length === 0) {
+            continue;
+        }
+        if (cardsIn[i].kind !== "cluster" && cardsIn[i].kind !== "section") {
+            return err("bad_payload", i, "children are only valid on cluster and section cards");
+        }
+        for (const ref of children) {
+            const ci = refIdx.get(ref);
+            if (ci === undefined) {
+                return err("bad_ref", i, `cluster child "${ref}": no such ref in this batch`);
+            }
+            if (cardsIn[ci].kind === "cluster" || cardsIn[ci].kind === "section") {
+                return err("bad_ref", i, "frames (cluster/section) cannot nest as children");
+            }
+            if (childParent.has(ci)) {
+                return err("bad_ref", i, `card "${ref}" is already in another cluster`);
+            }
+            childParent.set(ci, i);
+        }
+    }
+
+    // 5) Anchor / section / journey resolution (mutually exclusive).
+    let anchor: SectionCard | null = null;
+    if (body.anchorCardId && body.anchorCardId > 0) {
+        anchor = existing.find((c) => c.id === body.anchorCardId) ?? null;
+        if (!anchor) {
+            return err("not_found", -1, `anchor card ${body.anchorCardId} is not on this board`);
+        }
+    }
+
+    const frames = sectionFrames(existing);
+    let targetFrame: { id?: number; x: number; y: number; w: number; h: number } | null = null;
+    let adopt: { sectionId: number; journey: string } | null = null;
+    let createFrame: { x: number; y: number; w: number; h: number; payload: Record<string, unknown> } | null = null;
+
+    if (body.journey) {
+        if (anchor || body.section) {
+            return err("bad_payload", -1, "journey is mutually exclusive with anchor and section");
+        }
+        const res = resolveJourneyPass({ cards: existing, journey: body.journey, pass: body.pass });
+        if (res.action === "error") {
+            return err(res.code, -1, res.message);
+        }
+        if (res.action === "create") {
+            createFrame = res.frame;
+            targetFrame = { x: res.frame.x, y: res.frame.y, w: res.frame.w, h: res.frame.h };
+        } else {
+            if (res.action === "adopt") {
+                adopt = { sectionId: res.section.id, journey: res.journey };
+            }
+            targetFrame = {
+                id: res.section.id,
+                x: res.section.x,
+                y: res.section.y,
+                w: res.section.w,
+                h: res.section.h,
+            };
+        }
+    }
+    if (body.section) {
+        if (anchor) {
+            return err("bad_payload", -1, "anchor and section are mutually exclusive");
+        }
+        const sec = sectionByName(frames, body.section);
+        if (!sec) {
+            return err("not_found", -1, `no section named "${body.section}" on this board`);
+        }
+        targetFrame = { id: sec.id, x: sec.x, y: sec.y, w: sec.w, h: sec.h };
+    }
+
+    // 6) step/compare reference validation (their thumbnails render from existing cards' faces).
+    for (let i = 0; i < placed.length; i += 1) {
+        if (placed[i].kind !== "step" && placed[i].kind !== "compare") {
+            continue;
+        }
+        const p = payloads[i];
+        const refs: unknown[] = [
+            p.cardId,
+            (p.a as Record<string, unknown> | undefined)?.cardId,
+            (p.b as Record<string, unknown> | undefined)?.cardId,
+        ];
+        for (const id of refs) {
+            if (typeof id === "number" && id > 0 && !existingIds.has(id)) {
+                return err("not_found", i, `referenced card ${id} is not on this board`);
+            }
+        }
+    }
+
+    // 7) Origin for a section/journey target: inside the frame, below existing members.
+    let origin: { x: number; y: number } | null = null;
+    if (targetFrame) {
+        const ox = targetFrame.x + SECTION_PAD_X;
+        let oy = targetFrame.y + SECTION_PAD_TOP;
+        if (targetFrame.id !== undefined) {
+            for (const m of existing) {
+                if (m.kind === "section" || containingSection(frames, m)?.id !== targetFrame.id) {
+                    continue;
+                }
+                const h = m.h > 0 ? m.h : ZERO_H;
+                if (m.y + h + COMPOSE_GAP > oy) {
+                    oy = m.y + h + COMPOSE_GAP;
+                }
+            }
+        }
+        origin = { x: ox, y: oy };
+    }
+
+    const region = composePlace({
+        cards: placed,
+        existing,
+        anchor,
+        origin,
+        mode: body.layout ?? "",
+        withQuestion,
+        childParent,
+    });
+
+    // 8) ONE transaction: adopt/create journey frame, insert cards + edges + questions, grow section.
+    const now = nowIso();
+    const written = await db.kysely.transaction().execute(async (trx) => {
+        let elemSeq = board.elem_seq;
+        let createdSection: CardDto | null = null;
+
+        if (adopt) {
+            const secRow = await trx
+                .selectFrom("board_cards")
+                .select("payload")
+                .where("id", "=", adopt.sectionId)
+                .executeTakeFirst();
+            const merged = {
+                ...(SafeJSON.parse(secRow?.payload || "{}", { strict: true }) as Record<string, unknown>),
+                journey: adopt.journey,
+                pass: 1,
+            };
+            await trx
+                .updateTable("board_cards")
+                .set({ payload: SafeJSON.stringify(merged), updated_at: now })
+                .where("id", "=", adopt.sectionId)
+                .execute();
+        }
+        if (createFrame) {
+            elemSeq += 1;
+            const secInserted = await trx
+                .insertInto("board_cards")
+                .values({
+                    board_id: board.id,
+                    kind: "section",
+                    x: createFrame.x,
+                    y: createFrame.y,
+                    w: createFrame.w,
+                    h: createFrame.h,
+                    z: -2,
+                    set_ref: "",
+                    set_version: 0,
+                    file_path: "",
+                    blob_key: "",
+                    payload: SafeJSON.stringify(createFrame.payload),
+                    created_by: actor,
+                    elem_no: elemSeq,
+                    current_version: 1,
+                    deleted_at: "",
+                    created_at: now,
+                    updated_at: now,
+                })
+                .returningAll()
+                .executeTakeFirstOrThrow();
+            createdSection = toCardDto(secInserted);
+            targetFrame = {
+                id: secInserted.id,
+                x: createFrame.x,
+                y: createFrame.y,
+                w: createFrame.w,
+                h: createFrame.h,
+            };
+        }
+
+        const createdCards: CardDto[] = [];
+        for (let i = 0; i < placed.length; i += 1) {
+            elemSeq += 1;
+            const z = placed[i].kind === "cluster" ? -1 : placed[i].kind === "section" ? -2 : 0;
+            const inserted = await trx
+                .insertInto("board_cards")
+                .values({
+                    board_id: board.id,
+                    kind: placed[i].kind,
+                    x: placed[i].x,
+                    y: placed[i].y,
+                    w: placed[i].w,
+                    h: placed[i].h,
+                    z,
+                    set_ref: "",
+                    set_version: 0,
+                    file_path: "",
+                    blob_key: "",
+                    payload: SafeJSON.stringify(payloads[i]),
+                    created_by: actor,
+                    elem_no: elemSeq,
+                    current_version: 1,
+                    deleted_at: "",
+                    created_at: now,
+                    updated_at: now,
+                })
+                .returningAll()
+                .executeTakeFirstOrThrow();
+            createdCards.push(toCardDto(inserted));
+        }
+
+        await trx
+            .updateTable("boards")
+            .set({ elem_seq: elemSeq, updated_at: now })
+            .where("id", "=", board.id)
+            .execute();
+
+        const createdEdges: EdgeDto[] = [];
+        for (const e of edgeResolved) {
+            const fromCard = e.fromIdx >= 0 ? createdCards[e.fromIdx].id : e.fromId;
+            const toCard = e.toIdx >= 0 ? createdCards[e.toIdx].id : e.toId;
+            const inserted = await trx
+                .insertInto("board_edges")
+                .values({
+                    board_id: board.id,
+                    from_card: fromCard,
+                    to_card: toCard,
+                    to_x: 0,
+                    to_y: 0,
+                    label: e.label,
+                    created_by: actor,
+                    created_at: now,
+                })
+                .returningAll()
+                .executeTakeFirstOrThrow();
+            createdEdges.push({
+                id: inserted.id,
+                boardId: inserted.board_id,
+                fromCard: inserted.from_card,
+                toCard: inserted.to_card === 0 ? null : inserted.to_card,
+                toX: inserted.to_x,
+                toY: inserted.to_y,
+                label: inserted.label,
+            });
+        }
+
+        const createdQuestions: QuestionDto[] = [];
+        for (const q of questionResolved) {
+            const cardId = q.cardIdx >= 0 ? createdCards[q.cardIdx].id : q.cardId;
+            const inserted = await trx
+                .insertInto("board_questions")
+                .values({
+                    board_id: board.id,
+                    card_id: cardId,
+                    prompt: q.prompt,
+                    options: q.options,
+                    answer: "",
+                    answered_by: "",
+                    delivered: 0,
+                    staged: 1,
+                    multi: q.multi ? 1 : 0,
+                    created_at: now,
+                    answered_at: "",
+                })
+                .returningAll()
+                .executeTakeFirstOrThrow();
+            createdQuestions.push({
+                id: inserted.id,
+                boardId: inserted.board_id,
+                cardId: inserted.card_id === 0 ? null : inserted.card_id,
+                prompt: inserted.prompt,
+                options: SafeJSON.parse(inserted.options || "[]", { strict: true }) as QuestionDto["options"],
+                answer: inserted.answer ? (SafeJSON.parse(inserted.answer, { strict: true }) as string[]) : null,
+                answeredBy: inserted.answered_by,
+                staged: inserted.staged === 1,
+                multi: inserted.multi === 1,
+                createdAt: inserted.created_at,
+                answeredAt: inserted.answered_at,
+            });
+        }
+
+        // Grow the targeted section to fit what just landed (+ padding).
+        if (targetFrame?.id !== undefined) {
+            const needW = region.x + region.w + SECTION_PAD_X - targetFrame.x;
+            const needH = region.y + region.h + SECTION_PAD_BOT - targetFrame.y;
+            if (needW > targetFrame.w || needH > targetFrame.h) {
+                const nw = Math.max(needW, targetFrame.w);
+                const nh = Math.max(needH, targetFrame.h);
+                await trx
+                    .updateTable("board_cards")
+                    .set({ w: nw, h: nh, updated_at: now })
+                    .where("id", "=", targetFrame.id)
+                    .execute();
+            }
+        }
+
+        return { createdCards, createdEdges, createdQuestions, createdSection };
+    });
+
+    const cardsOut = written.createdCards.map((c, i) => ({
+        id: c.id,
+        elemNo: c.elemNo,
+        ...(cardsIn[i].ref ? { ref: cardsIn[i].ref } : {}),
+    }));
+
+    notifyLayoutChanged(board.id);
+
+    return {
+        ok: true,
+        cards: cardsOut,
+        edges: written.createdEdges.map((e) => e.id),
+        questions: written.createdQuestions.map((q) => q.id),
+        region,
+        events: {
+            // A freshly-created journey section rides the same bulk cards event so the UI sees it.
+            cards: written.createdSection ? [written.createdSection, ...written.createdCards] : written.createdCards,
+            edges: written.createdEdges,
+            questions: written.createdQuestions,
+            boardId: board.id,
+        },
+    };
+}

--- a/src/dev-dashboard/lib/boards/compose-types.ts
+++ b/src/dev-dashboard/lib/boards/compose-types.ts
@@ -1,0 +1,103 @@
+// Shared vocabulary for the AI expression layer (compose / arrange / sections / scrape / questions).
+// Constants and per-kind sizing mirror vitrinka's internal/web/handlers_compose.go exactly.
+
+export type ComposeKind =
+    | "text"
+    | "note"
+    | "shape"
+    | "viz"
+    | "cluster"
+    | "section"
+    | "step"
+    | "callout"
+    | "checklist"
+    | "compare"
+    | "wireframe";
+
+export type VizKind = "table" | "matrix" | "flow" | "bars" | "timeline" | "line" | "stat";
+
+export type ArrangeMode =
+    | "column"
+    | "row"
+    | "grid"
+    | "flow"
+    | "lanes"
+    | "masonry"
+    | "timeline"
+    | "timeaxis"
+    | "compare"
+    | "align-left"
+    | "align-top"
+    | "distribute-h"
+    | "distribute-v";
+
+// A compose ref is a batch-local string handle XOR an existing card id (number).
+export type ComposeRef = string | number;
+
+// Batch limits (handlers_compose.go:26-28).
+export const COMPOSE_MAX_CARDS = 60;
+export const COMPOSE_MAX_EDGES = 40;
+export const COMPOSE_MAX_QUESTIONS = 12;
+
+// Geometry (handlers_compose.go:29-37).
+export const COMPOSE_GRID = 28; // snap lattice px
+export const COMPOSE_GAP = 24; // default inter-card gap
+export const COMPOSE_GUTTER = 80; // free-space distance from the existing bbox / anchor
+export const QUESTION_ROOM = 130; // extra height reserved under a card carrying an anchored question
+export const SECTION_PAD_X = 24;
+export const SECTION_PAD_TOP = 56; // journey title headroom inside a section frame
+export const SECTION_PAD_BOT = 24;
+export const DEFAULT_WRAP_W = 1200; // flow wrap width outside a section
+
+// Question option limits (1-12 options; label ≤200; hint ≤300; prompt ≤1000).
+export const MAX_QUESTION_OPTIONS = 12;
+export const MAX_OPTION_LABEL = 200;
+export const MAX_OPTION_HINT = 300;
+export const MAX_QUESTION_PROMPT = 1000;
+export const MAX_ANSWER_LEN = 500;
+
+// arrange gap/padding token map (S/M/L). M matches composeGap.
+export const SPACING = { S: 12, M: 24, L: 48 } as const;
+
+export const COMPOSE_KINDS: ReadonlySet<ComposeKind> = new Set<ComposeKind>([
+    "text",
+    "note",
+    "shape",
+    "viz",
+    "cluster",
+    "section",
+    "step",
+    "callout",
+    "checklist",
+    "compare",
+    "wireframe",
+]);
+
+export const VIZ_KINDS: ReadonlySet<string> = new Set<VizKind>([
+    "table",
+    "matrix",
+    "flow",
+    "bars",
+    "timeline",
+    "line",
+    "stat",
+]);
+
+// step status and callout tone vocab (handlers_compose.go:52-53).
+export const STEP_STATUSES: ReadonlySet<string> = new Set(["", "todo", "pass", "fail"]);
+export const CALLOUT_TONES: ReadonlySet<string> = new Set(["info", "warn", "success", "decision"]);
+export const WIREFRAME_DEVICES: ReadonlySet<string> = new Set(["", "phone", "tablet", "web"]);
+export const WIREFRAME_FIDELITY: ReadonlySet<string> = new Set(["", "lo", "tokens"]);
+
+/** Compose error codes (vitrinka parity, handlers_compose.go). `limit`→413, `not_found`→404,
+ *  `not_ai_layer`→403, everything else→400. */
+export type ComposeErrorCode =
+    | "empty"
+    | "limit"
+    | "bad_kind"
+    | "bad_payload"
+    | "bad_ref"
+    | "bad_question"
+    | "bad_journey"
+    | "not_found"
+    | "not_ai_layer";

--- a/src/dev-dashboard/lib/boards/compose-types.ts
+++ b/src/dev-dashboard/lib/boards/compose-types.ts
@@ -56,6 +56,10 @@ export const MAX_OPTION_HINT = 300;
 export const MAX_QUESTION_PROMPT = 1000;
 export const MAX_ANSWER_LEN = 500;
 
+// Per-kind payload size caps.
+export const MAX_CHECKLIST_ITEMS = 50;
+export const MAX_WIREFRAME_NODES = 40;
+
 // arrange gap/padding token map (S/M/L). M matches composeGap.
 export const SPACING = { S: 12, M: 24, L: 48 } as const;
 

--- a/src/dev-dashboard/lib/boards/compose-validate.test.ts
+++ b/src/dev-dashboard/lib/boards/compose-validate.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { composeDefaultSize, normalizeOptions, stampLayer, validateComposeCard } from "./compose-validate";
+
+function code(kind: string, payload: Record<string, unknown>): string | "ok" {
+    const r = validateComposeCard({ kind, payload });
+    return r.ok ? "ok" : r.code;
+}
+
+describe("validateComposeCard — per-kind payloads", () => {
+    it("accepts well-formed cards of every kind", () => {
+        expect(code("text", { md: "# hi" })).toBe("ok");
+        expect(code("note", { text: "sticky" })).toBe("ok");
+        expect(code("shape", {})).toBe("ok"); // shape has no payload constraints
+        expect(code("cluster", {})).toBe("ok"); // cluster has no payload constraints
+        expect(code("viz", { viz: "table", data: {} })).toBe("ok");
+        expect(code("section", { title: "Checkout" })).toBe("ok");
+        expect(code("step", { title: "Cart", status: "pass" })).toBe("ok");
+        expect(code("step", { title: "Cart", status: "" })).toBe("ok"); // empty status allowed
+        expect(code("callout", { md: "note", tone: "info" })).toBe("ok");
+        expect(code("callout", { md: "note" })).toBe("ok"); // tone optional
+        expect(code("checklist", { items: [{ text: "one" }] })).toBe("ok");
+        expect(code("wireframe", { nodes: [{ t: "nav" }], device: "phone" })).toBe("ok");
+        expect(code("compare", { a: { cardId: 12 }, b: { cardId: 15 } })).toBe("ok");
+    });
+
+    it("rejects malformed payloads with bad_payload", () => {
+        expect(code("text", {})).toBe("bad_payload"); // no md
+        expect(code("note", {})).toBe("bad_payload"); // no text
+        expect(code("viz", { viz: "pie", data: {} })).toBe("bad_payload"); // unknown viz
+        expect(code("viz", { viz: "table" })).toBe("bad_payload"); // no data object
+        expect(code("section", {})).toBe("bad_payload"); // no title
+        expect(code("step", { title: "x", status: "maybe" })).toBe("bad_payload");
+        expect(code("callout", { md: "x", tone: "angry" })).toBe("bad_payload");
+        expect(code("checklist", { items: [] })).toBe("bad_payload"); // 0 items
+        expect(code("checklist", { items: Array.from({ length: 51 }, () => ({ text: "x" })) })).toBe("bad_payload");
+        expect(code("checklist", { items: [{ done: true }] })).toBe("bad_payload"); // item without text
+        expect(code("wireframe", { nodes: [] })).toBe("bad_payload"); // 0 nodes
+        expect(code("wireframe", { nodes: Array.from({ length: 41 }, () => ({ t: "text" })) })).toBe("bad_payload");
+        expect(code("wireframe", { nodes: [{ label: "x" }] })).toBe("bad_payload"); // node without t
+        expect(code("wireframe", { nodes: [{ t: "nav" }], device: "watch" })).toBe("bad_payload");
+        expect(code("wireframe", { nodes: [{ t: "nav" }], fidelity: "hi" })).toBe("bad_payload");
+        expect(code("compare", { a: { cardId: 0 }, b: { cardId: 15 } })).toBe("bad_payload");
+        expect(code("compare", { a: { cardId: 12 } })).toBe("bad_payload"); // missing b
+    });
+
+    it("rejects an unknown kind with bad_kind", () => {
+        expect(code("hologram", { md: "x" })).toBe("bad_kind");
+    });
+});
+
+describe("stampLayer / validateComposeCard layer marker", () => {
+    it("stamps layer:ai on non-section cards and preserves an explicit layer", () => {
+        const r = validateComposeCard({ kind: "text", payload: { md: "x" } });
+        expect(r.ok && r.payload.layer).toBe("ai");
+        const kept = validateComposeCard({ kind: "text", payload: { md: "x", layer: "base" } });
+        expect(kept.ok && kept.payload.layer).toBe("base");
+    });
+
+    it("strips the layer marker from section cards", () => {
+        const r = validateComposeCard({ kind: "section", payload: { title: "Onboarding", layer: "ai" } });
+        expect(r.ok && "layer" in r.payload).toBe(false);
+    });
+
+    it("stampLayer does not mutate its input", () => {
+        const input = { md: "x" };
+        stampLayer("text", input);
+        expect("layer" in input).toBe(false);
+    });
+});
+
+describe("composeDefaultSize (vitrinka-exact)", () => {
+    it("returns per-kind default footprints", () => {
+        expect(composeDefaultSize("text", { role: "heading" })).toEqual({ w: 420, h: 72 });
+        expect(composeDefaultSize("text", {})).toEqual({ w: 280, h: 150 });
+        expect(composeDefaultSize("note", {})).toEqual({ w: 230, h: 140 });
+        expect(composeDefaultSize("viz", { viz: "table" })).toEqual({ w: 380, h: 260 });
+        expect(composeDefaultSize("viz", { viz: "matrix" })).toEqual({ w: 340, h: 340 });
+        expect(composeDefaultSize("wireframe", { device: "phone" })).toEqual({ w: 260, h: 520 });
+        expect(composeDefaultSize("wireframe", { device: "web" })).toEqual({ w: 520, h: 380 });
+        expect(composeDefaultSize("checklist", { items: [{ text: "a" }, { text: "b" }] })).toEqual({ w: 300, h: 124 });
+        expect(composeDefaultSize("compare", {})).toEqual({ w: 480, h: 340 });
+    });
+});
+
+describe("normalizeOptions", () => {
+    it("accepts strings and objects, normalizing to {label, hint?, recommended?}", () => {
+        const r = normalizeOptions(["A", { label: "B", hint: "why B", recommended: true }]);
+        expect(r).toEqual({ ok: true, options: [{ label: "A" }, { label: "B", hint: "why B", recommended: true }] });
+    });
+
+    it("rejects 0 options, >12 options, empty labels, and oversized labels/hints", () => {
+        expect(normalizeOptions([])).toEqual({ ok: false, code: "bad_question" });
+        expect(normalizeOptions(Array.from({ length: 13 }, () => "x"))).toEqual({ ok: false, code: "bad_question" });
+        expect(normalizeOptions([""])).toEqual({ ok: false, code: "bad_question" });
+        expect(normalizeOptions([{ label: "a".repeat(201) }])).toEqual({ ok: false, code: "bad_question" });
+        expect(normalizeOptions([{ label: "ok", hint: "h".repeat(301) }])).toEqual({ ok: false, code: "bad_question" });
+    });
+});

--- a/src/dev-dashboard/lib/boards/compose-validate.ts
+++ b/src/dev-dashboard/lib/boards/compose-validate.ts
@@ -3,9 +3,11 @@ import {
     COMPOSE_KINDS,
     type ComposeErrorCode,
     type ComposeKind,
+    MAX_CHECKLIST_ITEMS,
     MAX_OPTION_HINT,
     MAX_OPTION_LABEL,
     MAX_QUESTION_OPTIONS,
+    MAX_WIREFRAME_NODES,
     STEP_STATUSES,
     VIZ_KINDS,
     WIREFRAME_DEVICES,
@@ -136,7 +138,7 @@ export function validateComposeCard(input: { kind: string; payload: Payload }): 
             break;
         case "checklist": {
             const items = payload.items;
-            if (!Array.isArray(items) || items.length === 0 || items.length > 50) {
+            if (!Array.isArray(items) || items.length === 0 || items.length > MAX_CHECKLIST_ITEMS) {
                 return bad;
             }
             for (const it of items) {
@@ -152,7 +154,7 @@ export function validateComposeCard(input: { kind: string; payload: Payload }): 
         }
         case "wireframe": {
             const nodes = payload.nodes;
-            if (!Array.isArray(nodes) || nodes.length === 0 || nodes.length > 40) {
+            if (!Array.isArray(nodes) || nodes.length === 0 || nodes.length > MAX_WIREFRAME_NODES) {
                 return bad;
             }
             for (const nd of nodes) {

--- a/src/dev-dashboard/lib/boards/compose-validate.ts
+++ b/src/dev-dashboard/lib/boards/compose-validate.ts
@@ -1,0 +1,235 @@
+import {
+    CALLOUT_TONES,
+    COMPOSE_KINDS,
+    type ComposeErrorCode,
+    type ComposeKind,
+    MAX_OPTION_HINT,
+    MAX_OPTION_LABEL,
+    MAX_QUESTION_OPTIONS,
+    STEP_STATUSES,
+    VIZ_KINDS,
+    WIREFRAME_DEVICES,
+    WIREFRAME_FIDELITY,
+} from "./compose-types";
+
+type Payload = Record<string, unknown>;
+
+/** Stamp the toggleable AI-layer marker: non-section cards gain `layer:"ai"` unless already set;
+ *  sections are layer-neutral journey structure, so their marker is stripped (handlers_compose.go:272-278). */
+export function stampLayer(kind: ComposeKind, payload: Payload): Payload {
+    const next = { ...payload };
+    if (kind === "section") {
+        delete next.layer;
+    } else if (!("layer" in next)) {
+        next.layer = "ai";
+    }
+    return next;
+}
+
+/** Per-kind default footprint in px — vitrinka's composeDefaultSize (handlers_compose.go:578-634). */
+export function composeDefaultSize(kind: ComposeKind, payload: Payload): { w: number; h: number } {
+    switch (kind) {
+        case "text":
+            return payload.role === "heading" ? { w: 420, h: 72 } : { w: 280, h: 150 };
+        case "note":
+            return { w: 230, h: 140 };
+        case "viz":
+            switch (payload.viz) {
+                case "matrix":
+                    return { w: 340, h: 340 };
+                case "flow":
+                    return { w: 460, h: 130 };
+                case "timeline":
+                    return { w: 360, h: 240 };
+                case "bars":
+                    return { w: 340, h: 220 };
+                case "line":
+                    return { w: 420, h: 240 };
+                case "stat":
+                    return { w: 420, h: 140 };
+                default:
+                    return { w: 380, h: 260 }; // table
+            }
+        case "cluster":
+            return { w: 640, h: 420 };
+        case "section":
+            return { w: 960, h: 640 };
+        case "shape":
+            return { w: 200, h: 140 };
+        case "step":
+            return payload.cardId != null ? { w: 300, h: 220 } : { w: 300, h: 120 };
+        case "callout":
+            return { w: 320, h: 120 };
+        case "checklist": {
+            const items = Array.isArray(payload.items) ? payload.items : null;
+            return items ? { w: 300, h: Math.min(64 + items.length * 30, 480) } : { w: 300, h: 180 };
+        }
+        case "compare":
+            return { w: 480, h: 340 };
+        case "wireframe":
+            if (payload.device === "tablet") {
+                return { w: 420, h: 320 };
+            }
+            if (payload.device === "web") {
+                return { w: 520, h: 380 };
+            }
+            return { w: 260, h: 520 }; // phone
+        default:
+            return { w: 300, h: 200 };
+    }
+}
+
+type ValidateResult = { ok: true; payload: Payload } | { ok: false; code: ComposeErrorCode };
+
+/** Validate a compose card's kind + payload, returning the AI-layer-stamped payload on success.
+ *  Mirrors handlers_compose.go:172-278 exactly. compare's cardId EXISTENCE is checked later against
+ *  the board (here only that a.cardId/b.cardId are positive numbers). */
+export function validateComposeCard(input: { kind: string; payload: Payload }): ValidateResult {
+    const { kind, payload } = input;
+    if (!COMPOSE_KINDS.has(kind as ComposeKind)) {
+        return { ok: false, code: "bad_kind" };
+    }
+    const bad: ValidateResult = { ok: false, code: "bad_payload" };
+    const str = (k: string): string => (typeof payload[k] === "string" ? (payload[k] as string) : "");
+
+    switch (kind) {
+        case "text":
+            if (!str("md")) {
+                return bad;
+            }
+            break;
+        case "note":
+            if (!str("text")) {
+                return bad;
+            }
+            break;
+        case "viz": {
+            if (!VIZ_KINDS.has(str("viz"))) {
+                return bad;
+            }
+            const data = payload.data;
+            if (typeof data !== "object" || data === null || Array.isArray(data)) {
+                return bad;
+            }
+            break;
+        }
+        case "section":
+            if (!str("title")) {
+                return bad;
+            }
+            break;
+        case "step":
+            if (!str("title")) {
+                return bad;
+            }
+            if (!STEP_STATUSES.has(str("status"))) {
+                return bad;
+            }
+            break;
+        case "callout":
+            if (!str("md")) {
+                return bad;
+            }
+            if (str("tone") !== "" && !CALLOUT_TONES.has(str("tone"))) {
+                return bad;
+            }
+            break;
+        case "checklist": {
+            const items = payload.items;
+            if (!Array.isArray(items) || items.length === 0 || items.length > 50) {
+                return bad;
+            }
+            for (const it of items) {
+                if (typeof it !== "object" || it === null) {
+                    return bad;
+                }
+                const t = (it as Payload).text;
+                if (typeof t !== "string" || t === "") {
+                    return bad;
+                }
+            }
+            break;
+        }
+        case "wireframe": {
+            const nodes = payload.nodes;
+            if (!Array.isArray(nodes) || nodes.length === 0 || nodes.length > 40) {
+                return bad;
+            }
+            for (const nd of nodes) {
+                if (typeof nd !== "object" || nd === null) {
+                    return bad;
+                }
+                const t = (nd as Payload).t;
+                if (typeof t !== "string" || t === "") {
+                    return bad;
+                }
+            }
+            if (!WIREFRAME_DEVICES.has(str("device"))) {
+                return bad;
+            }
+            if (!WIREFRAME_FIDELITY.has(str("fidelity"))) {
+                return bad;
+            }
+            break;
+        }
+        case "compare":
+            for (const side of ["a", "b"]) {
+                const m = payload[side];
+                if (typeof m !== "object" || m === null) {
+                    return bad;
+                }
+                const id = (m as Payload).cardId;
+                if (typeof id !== "number" || id <= 0) {
+                    return bad;
+                }
+            }
+            break;
+        // "shape" and "cluster" carry no payload constraints.
+    }
+
+    return { ok: true, payload: stampLayer(kind as ComposeKind, payload) };
+}
+
+export interface NormalizedOption {
+    label: string;
+    hint?: string;
+    recommended?: boolean;
+}
+
+/** Normalize question options (string XOR {label, hint?, recommended?}); 1-12 options, label ≤200,
+ *  hint ≤300. Shared by compose (Task 14) and the questions routes (Task 18). */
+export function normalizeOptions(
+    options: unknown
+): { ok: true; options: NormalizedOption[] } | { ok: false; code: ComposeErrorCode } {
+    if (!Array.isArray(options) || options.length < 1 || options.length > MAX_QUESTION_OPTIONS) {
+        return { ok: false, code: "bad_question" };
+    }
+    const out: NormalizedOption[] = [];
+    for (const opt of options) {
+        if (typeof opt === "string") {
+            if (opt.length === 0 || opt.length > MAX_OPTION_LABEL) {
+                return { ok: false, code: "bad_question" };
+            }
+            out.push({ label: opt });
+            continue;
+        }
+        if (typeof opt !== "object" || opt === null) {
+            return { ok: false, code: "bad_question" };
+        }
+        const o = opt as Payload;
+        const label = typeof o.label === "string" ? o.label : "";
+        if (!label || label.length > MAX_OPTION_LABEL) {
+            return { ok: false, code: "bad_question" };
+        }
+        const hint = typeof o.hint === "string" ? o.hint : undefined;
+        if (hint && hint.length > MAX_OPTION_HINT) {
+            return { ok: false, code: "bad_question" };
+        }
+        out.push({
+            label,
+            ...(hint ? { hint } : {}),
+            ...(o.recommended === true ? { recommended: true } : {}),
+        });
+    }
+    return { ok: true, options: out };
+}

--- a/src/dev-dashboard/lib/boards/layout-engine.test.ts
+++ b/src/dev-dashboard/lib/boards/layout-engine.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createKyselyClient, type DatabaseClient } from "@app/utils/database/client";
+import { createBoard, createCard, getBoardDoc } from "./boards-store";
+import type { ArrangeMode } from "./compose-types";
+import { BOOTSTRAP_DDL } from "./db";
+import type { BoardsDb } from "./db-types";
+import {
+    __resetLayoutDebounce,
+    arrangeMoves,
+    type CardRect,
+    readingOrder,
+    reflowBoard,
+    spacingToken,
+} from "./layout-engine";
+
+function rect(id: number, x: number, y: number, opts: Partial<CardRect> = {}): CardRect {
+    return { id, kind: "text", x, y, w: 100, h: 100, payload: {}, ...opts };
+}
+
+const ORIGIN = { x: 0, y: 0 };
+function pos(cards: CardRect[], mode: ArrangeMode, extra: Record<string, unknown> = {}) {
+    return arrangeMoves(cards, { mode, gap: 24, origin: ORIGIN, ...extra }).map((m) => [m.id, m.x, m.y]);
+}
+
+describe("readingOrder", () => {
+    it("bands y into 16px rows so a small y-jitter doesn't reorder a row (x wins within a band)", () => {
+        const A = rect(1, 400, 96);
+        const B = rect(2, 100, 100); // same 16px band, to the left → reads first
+        expect(readingOrder([A, B]).map((c) => c.id)).toEqual([2, 1]);
+    });
+});
+
+describe("spacingToken", () => {
+    it("maps S/M/L and clamps px to 0-400", () => {
+        expect(spacingToken(undefined, 24)).toBe(24);
+        expect(spacingToken("S", 24)).toBe(12);
+        expect(spacingToken("L", 24)).toBe(48);
+        expect(spacingToken(40, 24)).toBe(40);
+        expect(spacingToken(401, 24)).toBeNull();
+        expect(spacingToken("XL", 24)).toBeNull();
+    });
+});
+
+describe("arrangeMoves — per mode", () => {
+    const A = rect(1, 0, 0);
+    const B = rect(2, 0, 200);
+    const C = rect(3, 0, 400);
+
+    it("column stacks vertically", () => {
+        expect(pos([A, B], "column")).toEqual([
+            [1, 0, 0],
+            [2, 0, 124],
+        ]);
+    });
+
+    it("row lays out horizontally", () => {
+        expect(pos([A, B], "row")).toEqual([
+            [1, 0, 0],
+            [2, 124, 0],
+        ]);
+    });
+
+    it("grid wraps at cols", () => {
+        expect(pos([A, B, C], "grid", { cols: 2 })).toEqual([
+            [1, 0, 0],
+            [2, 124, 0],
+            [3, 0, 124],
+        ]);
+    });
+
+    it("flow wraps at wrapW", () => {
+        expect(pos([A, B, C], "flow", { wrapW: 250 })).toEqual([
+            [1, 0, 0],
+            [2, 124, 0],
+            [3, 0, 124],
+        ]);
+    });
+
+    it("align-left snaps x to the min, align-top snaps y", () => {
+        const cards = [rect(1, 300, 10), rect(2, 50, 60)];
+        expect(arrangeMoves(cards, { mode: "align-left", gap: 24, origin: ORIGIN }).map((m) => m.x)).toEqual([0, 0]);
+        expect(arrangeMoves(cards, { mode: "align-top", gap: 24, origin: ORIGIN }).map((m) => m.y)).toEqual([0, 0]);
+    });
+
+    it("distribute-h/v pack along one axis in sorted order", () => {
+        const cards = [rect(2, 300, 5), rect(1, 50, 5)];
+        expect(pos(cards, "distribute-h")).toEqual([
+            [1, 0, 5],
+            [2, 124, 5],
+        ]);
+    });
+
+    it("timeline lays out in creation order", () => {
+        const cards = [
+            rect(2, 0, 0, { createdAt: "2026-07-08T00:00:02Z" }),
+            rect(1, 0, 0, { createdAt: "2026-07-08T00:00:01Z" }),
+        ];
+        expect(pos(cards, "timeline")).toEqual([
+            [1, 0, 0],
+            [2, 124, 0],
+        ]);
+    });
+
+    it("timeaxis with two equal timestamps keeps cards from overlapping", () => {
+        const ts = "2026-07-08T00:00:00Z";
+        const cards = [rect(1, 0, 0, { createdAt: ts }), rect(2, 0, 0, { createdAt: ts })];
+        const moves = arrangeMoves(cards, { mode: "timeaxis", gap: 24, origin: ORIGIN, wrapW: 1000 });
+        expect(moves[1].x).toBeGreaterThanOrEqual(moves[0].x + 100);
+    });
+
+    it("lanes groups by payload.lane, unlabeled last", () => {
+        const cards = [
+            rect(1, 0, 0, { payload: { lane: "happy" }, createdAt: "2026-07-08T00:00:01Z" }),
+            rect(2, 0, 0, { payload: {}, createdAt: "2026-07-08T00:00:02Z" }),
+            rect(3, 0, 0, { payload: { lane: "happy" }, createdAt: "2026-07-08T00:00:03Z" }),
+        ];
+        const moves = arrangeMoves(cards, { mode: "lanes", gap: 24, origin: ORIGIN });
+        const byId = new Map(moves.map((m) => [m.id, m]));
+        // lane "happy" (cards 1,3) on the top row; unlabeled (card 2) on a lower row.
+        expect(byId.get(1)?.y).toBe(byId.get(3)?.y);
+        expect((byId.get(2)?.y ?? 0) > (byId.get(1)?.y ?? 0)).toBe(true);
+    });
+
+    it("masonry drops each card into the shortest column and is a fixed point under reflow", () => {
+        const cards = [
+            rect(1, 0, 0, { h: 100, createdAt: "2026-07-08T00:00:01Z" }),
+            rect(2, 0, 0, { h: 50, createdAt: "2026-07-08T00:00:02Z" }),
+            rect(3, 0, 0, { h: 100, createdAt: "2026-07-08T00:00:03Z" }),
+        ];
+        const opts = { mode: "masonry" as ArrangeMode, gap: 24, origin: ORIGIN, cols: 2 };
+        const first = arrangeMoves(cards, opts);
+        expect(first.map((m) => [m.id, m.x, m.y])).toEqual([
+            [1, 0, 0],
+            [2, 124, 0],
+            [3, 124, 74],
+        ]);
+        // Apply the moves, re-run: creation-order packing means identical positions (stable reflow).
+        const applied = cards.map((c) => {
+            const m = first.find((mm) => mm.id === c.id);
+            return m ? { ...c, x: m.x, y: m.y } : c;
+        });
+        expect(arrangeMoves(applied, opts)).toEqual(first);
+    });
+});
+
+describe("reflowBoard (saved-layout auto-reflow)", () => {
+    let db: DatabaseClient<BoardsDb>;
+
+    beforeEach(() => {
+        db = createKyselyClient<BoardsDb>({
+            path: ":memory:",
+            bootstrap: BOOTSTRAP_DDL,
+            pragmas: { foreignKeys: true },
+        });
+    });
+    afterEach(() => {
+        __resetLayoutDebounce();
+        db.close();
+    });
+
+    it("positions a section's members per its saved column layout at the frame inner origin", async () => {
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", {
+            kind: "section",
+            x: 0,
+            y: 0,
+            w: 400,
+            h: 400,
+            payload: { title: "S", layout: { mode: "column", gap: "M" } },
+        });
+        // Two members placed messily inside the frame.
+        await createCard(db, "b1", { kind: "note", x: 200, y: 300, w: 100, h: 100, payload: { text: "1" } });
+        await createCard(db, "b1", { kind: "note", x: 50, y: 100, w: 100, h: 100, payload: { text: "2" } });
+
+        await reflowBoard(db, "b1");
+
+        const doc = await getBoardDoc(db, "b1");
+        const notes = doc.cards.filter((c) => c.kind === "note").sort((a, b) => a.y - b.y);
+        // column-stacked at origin {pad:24, max(pad,titleHeadroom 56):56}, gap M(24).
+        expect(notes.map((n) => [n.x, n.y])).toEqual([
+            [24, 56],
+            [24, 180],
+        ]);
+    });
+});

--- a/src/dev-dashboard/lib/boards/layout-engine.ts
+++ b/src/dev-dashboard/lib/boards/layout-engine.ts
@@ -1,0 +1,8 @@
+// Layout engine — 13 arrange modes + the saved-layout reflow debouncer.
+// Task 14 depends only on the `notifyLayoutChanged` hook; Task 15 fills in the engine + debouncer.
+
+/** Trailing-debounced per-board reflow trigger. Stubbed as a no-op for Task 14; Task 15 wires the
+ *  real 150ms debounce + reflowBoard. Kept as a stable export so compose/update-cards can call it now. */
+export function notifyLayoutChanged(_boardId: number): void {
+    // no-op until Task 15 lands the reflow debouncer
+}

--- a/src/dev-dashboard/lib/boards/layout-engine.ts
+++ b/src/dev-dashboard/lib/boards/layout-engine.ts
@@ -1,8 +1,906 @@
-// Layout engine — 13 arrange modes + the saved-layout reflow debouncer.
-// Task 14 depends only on the `notifyLayoutChanged` hook; Task 15 fills in the engine + debouncer.
+// Layout engine (vitrinka internal/web/autolayout.go + handlers_compose.go:770-1212): the 12
+// selection arrange modes (+ compare, a two-section verb), section growth/displacement, and the
+// debounced saved-layout reflow. The pure geometry is testable in isolation; DB writes go through
+// bulkLayout and SSE publishes after the writes commit.
 
-/** Trailing-debounced per-board reflow trigger. Stubbed as a no-op for Task 14; Task 15 wires the
- *  real 150ms debounce + reflowBoard. Kept as a stable export so compose/update-cards can call it now. */
-export function notifyLayoutChanged(_boardId: number): void {
-    // no-op until Task 15 lands the reflow debouncer
+import { logger } from "@app/logger";
+import type { DatabaseClient } from "@app/utils/database/client";
+import { SafeJSON } from "@app/utils/json";
+import { bulkLayout, toCardDto } from "./boards-store";
+import {
+    type ArrangeMode,
+    COMPOSE_GAP,
+    COMPOSE_GRID,
+    DEFAULT_WRAP_W,
+    SECTION_PAD_BOT,
+    SECTION_PAD_TOP,
+    SECTION_PAD_X,
+    SPACING,
+} from "./compose-types";
+import type { BoardsDb } from "./db-types";
+import { publishBoardEvent } from "./events";
+import { containingSection, type SectionCard, sectionByName, sectionFrames } from "./sections";
+import type { CardDto } from "./types";
+
+// ---- pure geometry ----
+
+/** Richer than CardDto: carries created_at, file_path and parsed payload that layout modes need. */
+export interface CardRect {
+    id: number;
+    kind: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    createdAt?: string;
+    filePath?: string;
+    payload: Record<string, unknown>;
+}
+
+export interface Move {
+    id: number;
+    x: number;
+    y: number;
+    w?: number;
+    h?: number;
+}
+
+export interface ArrangeOpts {
+    mode: ArrangeMode;
+    gap: number;
+    cols?: number;
+    origin?: { x: number; y: number };
+    wrapW?: number;
+}
+
+const DEFAULT_W = 340;
+const DEFAULT_H = 220;
+const DISPLACE_GUTTER = 80;
+const LANE_GUTTER_FACTOR = 1.6;
+
+function wOf(c: { w: number }): number {
+    return c.w > 0 ? c.w : DEFAULT_W;
+}
+function hOf(c: { h: number }): number {
+    return c.h > 0 ? c.h : DEFAULT_H;
+}
+
+/** Parse a gap/padding token: absent → default; "S"|"M"|"L" → 12|24|48; number 0-400 → itself;
+ *  anything else → null (the caller 400s). */
+export function spacingToken(raw: unknown, def: number): number | null {
+    if (raw === undefined || raw === null) {
+        return def;
+    }
+    if (typeof raw === "string") {
+        const up = raw.trim().toUpperCase();
+        if (up === "S") {
+            return SPACING.S;
+        }
+        if (up === "M") {
+            return SPACING.M;
+        }
+        if (up === "L") {
+            return SPACING.L;
+        }
+        return null;
+    }
+    if (typeof raw === "number" && raw >= 0 && raw <= 400) {
+        return raw;
+    }
+    return null;
+}
+
+/** Banded-Y reading order (16px quanta, then x): a few-pixel jiggle never reorders a row. */
+export function readingOrder<T extends { x: number; y: number }>(cards: T[]): T[] {
+    return cards.slice().sort((a, b) => {
+        const ba = Math.round(a.y / 16);
+        const bb = Math.round(b.y / 16);
+        return ba !== bb ? ba - bb : a.x - b.x;
+    });
+}
+
+function creationCmp(a: CardRect, b: CardRect): number {
+    const ca = a.createdAt ?? "";
+    const cb = b.createdAt ?? "";
+    if (ca !== cb) {
+        return ca < cb ? -1 : 1;
+    }
+    return a.id - b.id;
+}
+
+/** Compute new positions for one selection arrange mode (compare is handled separately). */
+export function arrangeMoves(sel: CardRect[], opts: ArrangeOpts): Move[] {
+    const gap = opts.gap > 0 ? opts.gap : COMPOSE_GAP;
+    const gs = sel.map((c) => ({ c, w: wOf(c), h: hOf(c) }));
+
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    for (const g of gs) {
+        minX = Math.min(minX, g.c.x);
+        minY = Math.min(minY, g.c.y);
+    }
+    if (opts.origin) {
+        minX = opts.origin.x;
+        minY = opts.origin.y;
+    } else {
+        minX = Math.round(minX / COMPOSE_GRID) * COMPOSE_GRID;
+        minY = Math.round(minY / COMPOSE_GRID) * COMPOSE_GRID;
+    }
+
+    // Reading order with banded y (Array.sort is stable in bun/V8).
+    gs.sort((a, b) => {
+        const ba = Math.round(a.c.y / 16);
+        const bb = Math.round(b.c.y / 16);
+        return ba !== bb ? ba - bb : a.c.x - b.c.x;
+    });
+
+    const moves: Move[] = [];
+    const snap = (v: number): number => Math.round(v);
+
+    switch (opts.mode) {
+        case "align-left":
+            for (const g of gs) {
+                moves.push({ id: g.c.id, x: snap(minX), y: snap(g.c.y) });
+            }
+            break;
+        case "align-top":
+            for (const g of gs) {
+                moves.push({ id: g.c.id, x: snap(g.c.x), y: snap(minY) });
+            }
+            break;
+        case "distribute-h": {
+            gs.sort((a, b) => a.c.x - b.c.x);
+            let x = minX;
+            for (const g of gs) {
+                moves.push({ id: g.c.id, x: snap(x), y: snap(g.c.y) });
+                x += g.w + gap;
+            }
+            break;
+        }
+        case "distribute-v": {
+            gs.sort((a, b) => a.c.y - b.c.y);
+            let y = minY;
+            for (const g of gs) {
+                moves.push({ id: g.c.id, x: snap(g.c.x), y: snap(y) });
+                y += g.h + gap;
+            }
+            break;
+        }
+        case "masonry": {
+            gs.sort((a, b) => creationCmp(a.c, b.c));
+            const cols = opts.cols && opts.cols > 0 ? opts.cols : 3;
+            let colW = 0;
+            for (const g of gs) {
+                colW = Math.max(colW, g.w);
+            }
+            const heights = new Array(cols).fill(0);
+            for (const g of gs) {
+                let c = 0;
+                for (let k = 1; k < cols; k += 1) {
+                    if (heights[k] < heights[c]) {
+                        c = k;
+                    }
+                }
+                moves.push({ id: g.c.id, x: snap(minX + c * (colW + gap)), y: snap(minY + heights[c]) });
+                heights[c] += g.h + gap;
+            }
+            break;
+        }
+        case "timeline": {
+            gs.sort((a, b) => creationCmp(a.c, b.c));
+            let x = minX;
+            for (const g of gs) {
+                moves.push({ id: g.c.id, x: snap(x), y: snap(minY) });
+                x += g.w + gap;
+            }
+            break;
+        }
+        case "timeaxis": {
+            gs.sort((a, b) => creationCmp(a.c, b.c));
+            let packedW = 0;
+            for (const g of gs) {
+                packedW += g.w + gap;
+            }
+            packedW -= gap;
+            const axisW = Math.max(opts.wrapW ?? 0, packedW);
+            const t0 = new Date(gs[0].c.createdAt ?? 0).getTime();
+            const span = (new Date(gs[gs.length - 1].c.createdAt ?? 0).getTime() - t0) / 1000;
+            let x = minX;
+            for (const g of gs) {
+                let gx = x;
+                if (span > 0) {
+                    const frac = (new Date(g.c.createdAt ?? 0).getTime() - t0) / 1000 / span;
+                    gx = Math.max(x, minX + frac * (axisW - g.w));
+                }
+                moves.push({ id: g.c.id, x: snap(gx), y: snap(minY) });
+                x = gx + g.w + gap;
+            }
+            break;
+        }
+        case "lanes": {
+            gs.sort((a, b) => creationCmp(a.c, b.c));
+            const laneOf = (c: CardRect): string => (typeof c.payload.lane === "string" ? c.payload.lane : "");
+            const laneOrder: string[] = [];
+            const lanes = new Map<string, Array<(typeof gs)[number]>>();
+            for (const g of gs) {
+                const k = laneOf(g.c);
+                if (!lanes.has(k)) {
+                    laneOrder.push(k);
+                    lanes.set(k, []);
+                }
+                lanes.get(k)?.push(g);
+            }
+            laneOrder.sort((a, b) => (a !== "" && b === "" ? -1 : 0)); // unlabeled lane reads last (stable)
+            let y = minY;
+            for (const k of laneOrder) {
+                let x = minX;
+                let rowH = 0;
+                for (const g of lanes.get(k) ?? []) {
+                    moves.push({ id: g.c.id, x: snap(x), y: snap(y) });
+                    rowH = Math.max(rowH, g.h);
+                    x += g.w + gap;
+                }
+                y += rowH + gap * LANE_GUTTER_FACTOR;
+            }
+            break;
+        }
+        case "flow": {
+            const wrapW = opts.wrapW && opts.wrapW > 0 ? opts.wrapW : DEFAULT_WRAP_W;
+            let x = minX;
+            let y = minY;
+            let rowH = 0;
+            for (const g of gs) {
+                if (x > minX && x + g.w > minX + wrapW) {
+                    x = minX;
+                    y += rowH + gap;
+                    rowH = 0;
+                }
+                moves.push({ id: g.c.id, x: snap(x), y: snap(y) });
+                rowH = Math.max(rowH, g.h);
+                x += g.w + gap;
+            }
+            break;
+        }
+        default: {
+            // column | row | grid
+            let perRow = 1;
+            if (opts.mode === "row") {
+                perRow = gs.length;
+            } else if (opts.mode === "grid") {
+                perRow = opts.cols && opts.cols > 0 ? opts.cols : 3;
+            }
+            if (perRow < 1) {
+                perRow = 1;
+            }
+            let x = minX;
+            let y = minY;
+            let rowH = 0;
+            gs.forEach((g, i) => {
+                if (i > 0 && i % perRow === 0) {
+                    x = minX;
+                    y += rowH + gap;
+                    rowH = 0;
+                }
+                moves.push({ id: g.c.id, x: snap(x), y: snap(y) });
+                rowH = Math.max(rowH, g.h);
+                x += g.w + gap;
+            });
+        }
+    }
+    return moves;
+}
+
+/** Modes a section may persist for auto-reflow (compare is excluded — it's a manual verb). */
+export const AUTO_LAYOUT_MODES: ReadonlySet<string> = new Set([
+    "grid",
+    "column",
+    "row",
+    "flow",
+    "lanes",
+    "masonry",
+    "timeline",
+    "timeaxis",
+]);
+
+interface LayoutSpec {
+    mode: ArrangeMode;
+    gap: number;
+    cols: number;
+    pad: number;
+}
+
+/** Parse a section card's persisted payload.layout; null = a manual section (no auto-reflow). */
+export function sectionLayoutSpec(card: SectionCard): LayoutSpec | null {
+    const layout = card.payload.layout;
+    if (typeof layout !== "object" || layout === null) {
+        return null;
+    }
+    const l = layout as Record<string, unknown>;
+    const mode = typeof l.mode === "string" ? l.mode : "";
+    if (!AUTO_LAYOUT_MODES.has(mode)) {
+        return null;
+    }
+    const gap = spacingToken(l.gap, COMPOSE_GAP) ?? COMPOSE_GAP;
+    const pad = spacingToken(l.padding, SECTION_PAD_X) ?? SECTION_PAD_X;
+    return { mode: mode as ArrangeMode, gap, cols: typeof l.cols === "number" ? l.cols : 0, pad };
+}
+
+// ---- impure: load, membership, displacement, compare, reflow ----
+
+function rowToRect(r: {
+    id: number;
+    kind: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    created_at: string;
+    file_path: string;
+    payload: string;
+}): CardRect {
+    return {
+        id: r.id,
+        kind: r.kind,
+        x: r.x,
+        y: r.y,
+        w: r.w,
+        h: r.h,
+        createdAt: r.created_at,
+        filePath: r.file_path,
+        payload: SafeJSON.parse(r.payload || "{}", { strict: true }) as Record<string, unknown>,
+    };
+}
+
+async function loadCards(db: DatabaseClient<BoardsDb>, slug: string): Promise<CardRect[] | null> {
+    const board = await db.kysely.selectFrom("boards").select(["id"]).where("slug", "=", slug).executeTakeFirst();
+    if (!board) {
+        return null;
+    }
+    const rows = await db.kysely
+        .selectFrom("board_cards")
+        .selectAll()
+        .where("board_id", "=", board.id)
+        .where("deleted_at", "=", "")
+        .execute();
+    return rows.map(rowToRect);
+}
+
+/** Snapshot spatial membership as plain ids, taken BEFORE geometry mutates. */
+export function memberIdsBySection(cards: CardRect[]): Map<number, number[]> {
+    const frames = sectionFrames(cards);
+    const out = new Map<number, number[]>();
+    for (const c of cards) {
+        if (c.kind === "section") {
+            continue;
+        }
+        const owner = containingSection(frames, c);
+        if (owner) {
+            out.set(owner.id, [...(out.get(owner.id) ?? []), c.id]);
+        }
+    }
+    return out;
+}
+
+/** Resolve frame overlaps after growth: a later-reading section overlapped by an earlier one shifts
+ *  DOWN below it (+gutter) with its pre-op members. Bounded 4-iteration cascade. Returns the moves. */
+async function displaceSections(
+    db: DatabaseClient<BoardsDb>,
+    slug: string,
+    cards: CardRect[],
+    memberIds: Map<number, number[]>
+): Promise<Move[]> {
+    const pos = new Map<number, CardRect>();
+    for (const c of cards) {
+        pos.set(c.id, { ...c });
+    }
+    const secs = sectionFrames(Array.from(pos.values()));
+    if (secs.length < 2) {
+        return [];
+    }
+    const shifted = new Set<number>();
+    for (let iter = 0; iter < 4; iter += 1) {
+        let moved = false;
+        for (let i = 0; i < secs.length; i += 1) {
+            const cur = pos.get(secs[i].id);
+            if (!cur) {
+                continue;
+            }
+            const cw = wOf(cur);
+            const ch = hOf(cur);
+            for (let j = 0; j < i; j += 1) {
+                const p = pos.get(secs[j].id);
+                if (!p) {
+                    continue;
+                }
+                const pw = wOf(p);
+                const ph = hOf(p);
+                if (cur.x >= p.x + pw || p.x >= cur.x + cw || cur.y >= p.y + ph || p.y >= cur.y + ch) {
+                    continue; // no overlap
+                }
+                const dy = p.y + ph + DISPLACE_GUTTER - cur.y;
+                if (dy <= 0) {
+                    continue;
+                }
+                cur.y += dy;
+                for (const mid of memberIds.get(cur.id) ?? []) {
+                    const m = pos.get(mid);
+                    if (m) {
+                        m.y += dy;
+                    }
+                }
+                shifted.add(cur.id);
+                moved = true;
+            }
+        }
+        if (!moved) {
+            break;
+        }
+    }
+    if (shifted.size === 0) {
+        return [];
+    }
+    const moves: Move[] = [];
+    for (const id of shifted) {
+        for (const cid of [id, ...(memberIds.get(id) ?? [])]) {
+            const c = pos.get(cid);
+            if (c) {
+                moves.push({ id: c.id, x: c.x, y: c.y, w: wOf(c), h: hOf(c) });
+            }
+        }
+    }
+    if (moves.length > 0) {
+        await bulkLayout(db, slug, moves);
+    }
+    return moves;
+}
+
+// ---- compare (two sections side-by-side) ----
+
+function baseName(filePath: string | undefined): string {
+    if (!filePath) {
+        return "";
+    }
+    const i = filePath.lastIndexOf("/");
+    return (i >= 0 ? filePath.slice(i + 1) : filePath).toLowerCase();
+}
+
+/** Pair iteration counterparts: same screenshot basename first, remaining by index order. */
+export function pairSectionMembers(as: CardRect[], bs: CardRect[]): Array<{ a?: CardRect; b?: CardRect }> {
+    const usedB = new Array(bs.length).fill(false);
+    const byName = new Map<string, number>();
+    bs.forEach((c, j) => {
+        const k = baseName(c.filePath);
+        if (k && !byName.has(k)) {
+            byName.set(k, j);
+        }
+    });
+    const pairs: Array<{ a?: CardRect; b?: CardRect }> = [];
+    for (const a of as) {
+        const k = baseName(a.filePath);
+        const j = k ? byName.get(k) : undefined;
+        if (j !== undefined && !usedB[j]) {
+            usedB[j] = true;
+            pairs.push({ a, b: bs[j] });
+        } else {
+            pairs.push({ a });
+        }
+    }
+    let bi = 0;
+    for (const pair of pairs) {
+        if (pair.b) {
+            continue;
+        }
+        while (bi < bs.length && usedB[bi]) {
+            bi += 1;
+        }
+        if (bi < bs.length) {
+            usedB[bi] = true;
+            pair.b = bs[bi];
+        }
+    }
+    bs.forEach((c, j) => {
+        if (!usedB[j]) {
+            pairs.push({ b: c });
+        }
+    });
+    return pairs;
+}
+
+interface ArrangeOutcome {
+    ok: boolean;
+    status: number;
+    message?: string;
+    moved: number;
+    cards: Move[];
+    saved: boolean;
+}
+
+async function arrangeCompare(
+    db: DatabaseClient<BoardsDb>,
+    slug: string,
+    cards: CardRect[],
+    names: string[],
+    gap: number,
+    pad: number
+): Promise<ArrangeOutcome> {
+    if (names.length !== 2) {
+        return {
+            ok: false,
+            status: 400,
+            message: 'mode "compare" needs sections: ["A", "B"]',
+            moved: 0,
+            cards: [],
+            saved: false,
+        };
+    }
+    const frames = sectionFrames(cards);
+    const sa = sectionByName(frames, names[0]);
+    const sb = sectionByName(frames, names[1]);
+    if (!sa || !sb) {
+        return { ok: false, status: 404, message: "no such section on this board", moved: 0, cards: [], saved: false };
+    }
+    if (sa.id === sb.id) {
+        return {
+            ok: false,
+            status: 400,
+            message: "compare needs two different sections",
+            moved: 0,
+            cards: [],
+            saved: false,
+        };
+    }
+    const membersOf = (name: string): CardRect[] =>
+        cards.filter(
+            (c) => c.kind !== "section" && containingSection(frames, c)?.id === sectionByName(frames, name)?.id
+        );
+    const ma = membersOf(names[0]);
+    const mb = membersOf(names[1]);
+    if (ma.length === 0 && mb.length === 0) {
+        return {
+            ok: false,
+            status: 400,
+            message: "nothing to compare: both sections are empty",
+            moved: 0,
+            cards: [],
+            saved: false,
+        };
+    }
+    const colW = (ms: CardRect[]): number => ms.reduce((w, m) => Math.max(w, m.w), 340);
+    const wa = colW(ma);
+    const wb = colW(mb);
+    const padTop = Math.max(pad, SECTION_PAD_TOP);
+    const nbx = sa.x + wa + 2 * pad + DISPLACE_GUTTER;
+    const nby = sa.y;
+    const aox = sa.x + pad;
+    const box = nbx + pad;
+    let y = sa.y + padTop;
+    const moves: Move[] = [];
+    for (const p of pairSectionMembers(ma, mb)) {
+        let rowH = 0;
+        if (p.a) {
+            rowH = Math.max(rowH, hOf(p.a));
+            moves.push({ id: p.a.id, x: aox, y });
+        }
+        if (p.b) {
+            rowH = Math.max(rowH, hOf(p.b));
+            moves.push({ id: p.b.id, x: box, y });
+        }
+        y += rowH + gap;
+    }
+    const frameBottom = y - gap + SECTION_PAD_BOT;
+    // Grow/move both frames (resize via bulkLayout w/h) + move B beside A.
+    moves.push({ id: sa.id, x: sa.x, y: sa.y, w: wa + 2 * pad, h: frameBottom - sa.y });
+    moves.push({ id: sb.id, x: nbx, y: nby, w: wb + 2 * pad, h: frameBottom - nby });
+    await bulkLayout(db, slug, moves);
+
+    // Compare is MANUAL: strip any saved auto-layout from both sections so reflow won't undo it.
+    for (const sec of [sa, sb]) {
+        if (sec.payload.layout !== undefined) {
+            const merged = { ...sec.payload };
+            delete merged.layout;
+            await db.kysely
+                .updateTable("board_cards")
+                .set({ payload: SafeJSON.stringify(merged) })
+                .where("id", "=", sec.id)
+                .execute();
+        }
+    }
+    const displaceMoves = await displaceSections(db, slug, cards, memberIdsBySection(cards));
+    const all = [...moves, ...displaceMoves];
+    publishBoardEvent(slug, { type: "layout", payload: { moves: all } });
+    return { ok: true, status: 200, moved: all.length, cards: all, saved: false };
+}
+
+// ---- arrange orchestrator (the route calls this) ----
+
+export interface ArrangeBody {
+    mode: string;
+    scope?: string;
+    ids?: number[];
+    gap?: unknown;
+    padding?: unknown;
+    cols?: number;
+    sizing?: string;
+    save?: boolean;
+    sections?: string[];
+}
+
+const ARRANGE_MODES: ReadonlySet<string> = new Set([
+    "column",
+    "row",
+    "grid",
+    "flow",
+    "lanes",
+    "masonry",
+    "timeline",
+    "timeaxis",
+    "compare",
+    "align-left",
+    "align-top",
+    "distribute-h",
+    "distribute-v",
+]);
+
+export async function runArrange(
+    db: DatabaseClient<BoardsDb>,
+    slug: string,
+    body: ArrangeBody
+): Promise<ArrangeOutcome> {
+    const fail = (status: number, message: string): ArrangeOutcome => ({
+        ok: false,
+        status,
+        message,
+        moved: 0,
+        cards: [],
+        saved: false,
+    });
+    if (!ARRANGE_MODES.has(body.mode)) {
+        return fail(400, "mode: column|row|grid|flow|lanes|masonry|timeline|timeaxis|compare|align-*|distribute-*");
+    }
+    if (body.sizing && body.sizing !== "natural" && body.sizing !== "uniform") {
+        return fail(400, "sizing: natural or uniform");
+    }
+    const gap = spacingToken(body.gap, COMPOSE_GAP);
+    if (gap === null) {
+        return fail(400, 'gap: "S", "M", "L" or 0-400 px');
+    }
+    const pad = spacingToken(body.padding, SECTION_PAD_X);
+    if (pad === null) {
+        return fail(400, 'padding: "S", "M", "L" or 0-400 px');
+    }
+
+    const all = await loadCards(db, slug);
+    if (!all) {
+        return fail(404, `board not found: ${slug}`);
+    }
+
+    if (body.mode === "compare") {
+        return arrangeCompare(db, slug, all, body.sections ?? [], gap, pad);
+    }
+
+    const frames = sectionFrames(all);
+    let sel: CardRect[];
+    let sec: SectionCard | null = null;
+    if (body.ids && body.ids.length > 0) {
+        const want = new Set(body.ids);
+        sel = all.filter((c) => want.has(c.id));
+        if (sel.length !== body.ids.length) {
+            return fail(404, "a card is not on this board");
+        }
+    } else if (body.scope?.startsWith("section:")) {
+        const name = body.scope.slice("section:".length);
+        sec = sectionByName(frames, name);
+        if (!sec) {
+            return fail(404, `no section named "${name}" on this board`);
+        }
+        sel = all.filter((c) => c.kind !== "section" && containingSection(frames, c)?.id === sec?.id);
+    } else if (body.scope === "all") {
+        sel = all.filter((c) => c.kind !== "section");
+    } else {
+        sel = all.filter((c) => c.payload.layer === "ai");
+    }
+    if (sel.length < 2) {
+        return fail(400, "nothing to arrange: fewer than 2 cards in scope");
+    }
+
+    // Uniform sizing: every card takes the selection's max footprint before geometry runs.
+    if (body.sizing === "uniform") {
+        let maxW = 0;
+        let maxH = 0;
+        for (const c of sel) {
+            maxW = Math.max(maxW, c.w);
+            maxH = Math.max(maxH, c.h);
+        }
+        maxW = maxW > 0 ? maxW : DEFAULT_W;
+        maxH = maxH > 0 ? maxH : DEFAULT_H;
+        for (const c of sel) {
+            if (c.w !== maxW || c.h !== maxH) {
+                c.w = maxW;
+                c.h = maxH;
+            }
+        }
+    }
+
+    const opts: ArrangeOpts = { mode: body.mode as ArrangeMode, gap, cols: body.cols };
+    if (sec) {
+        opts.origin = { x: sec.x + pad, y: sec.y + Math.max(pad, SECTION_PAD_TOP) };
+        opts.wrapW = sec.w - 2 * pad;
+    }
+    const moves = arrangeMoves(sel, opts);
+    // Merge uniform w/h into the moves so bulkLayout resizes in the same pass.
+    const dimById = new Map(sel.map((c) => [c.id, { w: wOf(c), h: hOf(c) }]));
+    const writeMoves: Move[] = moves.map((m) =>
+        body.sizing === "uniform" ? { ...m, w: dimById.get(m.id)?.w, h: dimById.get(m.id)?.h } : m
+    );
+    await bulkLayout(db, slug, writeMoves);
+
+    // Per-card ground truth + frame fit.
+    const movesOut: Move[] = moves.map((m) => {
+        const d = dimById.get(m.id) ?? { w: DEFAULT_W, h: DEFAULT_H };
+        return { id: m.id, x: m.x, y: m.y, w: d.w, h: d.h };
+    });
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+    for (const m of movesOut) {
+        maxX = Math.max(maxX, m.x + (m.w ?? DEFAULT_W));
+        maxY = Math.max(maxY, m.y + (m.h ?? DEFAULT_H));
+    }
+    const cardEvents: CardDto[] = [];
+    if (sec && moves.length > 0) {
+        const needW = maxX + pad - sec.x;
+        const needH = maxY + pad - sec.y;
+        if (needW > sec.w || needH > sec.h) {
+            const nw = Math.max(needW, sec.w);
+            const nh = Math.max(needH, sec.h);
+            await bulkLayout(db, slug, [{ id: sec.id, x: sec.x, y: sec.y, w: nw, h: nh }]);
+            const grown = await reloadCard(db, sec.id);
+            if (grown) {
+                cardEvents.push(grown);
+            }
+        }
+        movesOut.push(...(await displaceSections(db, slug, all, memberIdsBySection(all))));
+    }
+
+    // save: persist the layout onto the section so it self-maintains from now on.
+    let saved = false;
+    if (body.save) {
+        if (!sec) {
+            return fail(400, "save needs a section scope (scope: section:<Name>)");
+        }
+        if (!AUTO_LAYOUT_MODES.has(body.mode)) {
+            return fail(400, "save supports self-maintaining modes only");
+        }
+        const layout: Record<string, unknown> = { mode: body.mode, gap, padding: pad };
+        if (body.cols && body.cols > 0) {
+            layout.cols = body.cols;
+        }
+        const merged = { ...sec.payload, layout };
+        await db.kysely
+            .updateTable("board_cards")
+            .set({ payload: SafeJSON.stringify(merged) })
+            .where("id", "=", sec.id)
+            .execute();
+        const updated = await reloadCard(db, sec.id);
+        if (updated) {
+            cardEvents.push(updated);
+        }
+        saved = true;
+    }
+
+    for (const c of cardEvents) {
+        publishBoardEvent(slug, { type: "card", payload: c });
+    }
+    publishBoardEvent(slug, { type: "layout", payload: { moves: movesOut } });
+    return { ok: true, status: 200, moved: moves.length, cards: movesOut, saved };
+}
+
+async function reloadCard(db: DatabaseClient<BoardsDb>, id: number): Promise<CardDto | null> {
+    const row = await db.kysely.selectFrom("board_cards").selectAll().where("id", "=", id).executeTakeFirst();
+    return row ? toCardDto(row) : null;
+}
+
+// ---- reflow (debounced saved-layout maintenance) ----
+
+/** Solve every auto-layout section on the board, write only real changes, grow frames, displace
+ *  neighbors, and publish ONE layout event. Returns the moves (for tests). */
+export async function reflowBoard(db: DatabaseClient<BoardsDb>, slug: string): Promise<Move[]> {
+    const cards = await loadCards(db, slug);
+    if (!cards) {
+        return [];
+    }
+    const frames = sectionFrames(cards);
+    if (frames.length === 0) {
+        return [];
+    }
+    const preMembers = memberIdsBySection(cards);
+    const movesOut: Move[] = [];
+    const cardEvents: CardDto[] = [];
+
+    for (const frame of frames) {
+        const spec = sectionLayoutSpec(frame);
+        if (!spec) {
+            continue;
+        }
+        const members = cards.filter((c) => c.kind !== "section" && containingSection(frames, c)?.id === frame.id);
+        if (members.length === 0) {
+            continue;
+        }
+        const opts: ArrangeOpts = {
+            mode: spec.mode,
+            gap: spec.gap,
+            cols: spec.cols,
+            origin: { x: frame.x + spec.pad, y: frame.y + Math.max(spec.pad, SECTION_PAD_TOP) },
+            wrapW: frame.w - 2 * spec.pad,
+        };
+        const moves = arrangeMoves(members, opts);
+        const dimById = new Map(members.map((m) => [m.id, { w: wOf(m), h: hOf(m) }]));
+        const curById = new Map(members.map((m) => [m.id, { x: m.x, y: m.y }]));
+        const changed: Move[] = [];
+        let maxX = Number.NEGATIVE_INFINITY;
+        let maxY = Number.NEGATIVE_INFINITY;
+        for (const m of moves) {
+            const d = dimById.get(m.id) ?? { w: DEFAULT_W, h: DEFAULT_H };
+            maxX = Math.max(maxX, m.x + d.w);
+            maxY = Math.max(maxY, m.y + d.h);
+            const cur = curById.get(m.id);
+            if (cur && Math.abs(cur.x - m.x) < 0.5 && Math.abs(cur.y - m.y) < 0.5) {
+                continue; // no real change → zero writes, zero SSE
+            }
+            changed.push(m);
+            movesOut.push({ id: m.id, x: m.x, y: m.y, w: d.w, h: d.h });
+        }
+        if (changed.length > 0) {
+            await bulkLayout(db, slug, changed);
+        }
+        const needW = maxX + spec.pad - frame.x;
+        const needH = maxY + spec.pad - frame.y;
+        if (needW > frame.w + 0.5 || needH > frame.h + 0.5) {
+            await bulkLayout(db, slug, [
+                { id: frame.id, x: frame.x, y: frame.y, w: Math.max(needW, frame.w), h: Math.max(needH, frame.h) },
+            ]);
+            const grown = await reloadCard(db, frame.id);
+            if (grown) {
+                cardEvents.push(grown);
+            }
+        }
+    }
+
+    movesOut.push(...(await displaceSections(db, slug, cards, preMembers)));
+    for (const c of cardEvents) {
+        publishBoardEvent(slug, { type: "card", payload: c });
+    }
+    if (movesOut.length > 0) {
+        publishBoardEvent(slug, { type: "layout", payload: { moves: movesOut } });
+    }
+    return movesOut;
+}
+
+// ---- debounced trigger ----
+
+const REFLOW_DEBOUNCE_MS = 150;
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Schedule a trailing-debounced reflow of the board's auto-layout sections. Call after any card
+ *  geometry/membership change (compose, patch, delete, restore, upload, import). */
+export function notifyLayoutChanged(db: DatabaseClient<BoardsDb>, slug: string): void {
+    const existing = timers.get(slug);
+    if (existing) {
+        clearTimeout(existing);
+    }
+    const t = setTimeout(() => {
+        timers.delete(slug);
+        reflowBoard(db, slug).catch((err) => logger.debug({ err, slug }, "boards reflow failed"));
+    }, REFLOW_DEBOUNCE_MS);
+    if (typeof (t as { unref?: () => void }).unref === "function") {
+        (t as { unref: () => void }).unref();
+    }
+    timers.set(slug, t);
+}
+
+/** Test-only: clear pending reflow timers so they don't fire against a torn-down db. */
+export function __resetLayoutDebounce(): void {
+    for (const t of timers.values()) {
+        clearTimeout(t);
+    }
+    timers.clear();
 }

--- a/src/dev-dashboard/lib/boards/layout-engine.ts
+++ b/src/dev-dashboard/lib/boards/layout-engine.ts
@@ -203,13 +203,18 @@ export function arrangeMoves(sel: CardRect[], opts: ArrangeOpts): Move[] {
             }
             packedW -= gap;
             const axisW = Math.max(opts.wrapW ?? 0, packedW);
-            const t0 = new Date(gs[0].c.createdAt ?? 0).getTime();
-            const span = (new Date(gs[gs.length - 1].c.createdAt ?? 0).getTime() - t0) / 1000;
+            const getTime = (d: string | undefined) => {
+                const t = d ? Date.parse(d) : 0;
+                return Number.isNaN(t) ? 0 : t;
+            };
+            const t0 = getTime(gs[0].c.createdAt);
+            const span = (getTime(gs[gs.length - 1].c.createdAt) - t0) / 1000;
             let x = minX;
             for (const g of gs) {
                 let gx = x;
                 if (span > 0) {
-                    const frac = (new Date(g.c.createdAt ?? 0).getTime() - t0) / 1000 / span;
+                    const t = getTime(g.c.createdAt);
+                    const frac = (t - t0) / 1000 / span;
                     gx = Math.max(x, minX + frac * (axisW - g.w));
                 }
                 moves.push({ id: g.c.id, x: snap(gx), y: snap(minY) });

--- a/src/dev-dashboard/lib/boards/scrape.test.ts
+++ b/src/dev-dashboard/lib/boards/scrape.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createKyselyClient, type DatabaseClient } from "@app/utils/database/client";
+import { createAnnotation } from "./annotations-store";
+import { addEdge, createBoard, createCard, getBoardDoc } from "./boards-store";
+import { BOOTSTRAP_DDL } from "./db";
+import type { BoardsDb } from "./db-types";
+import { type ScrapeCard, scrapeBoard } from "./scrape";
+
+function makeTestDb(): DatabaseClient<BoardsDb> {
+    return createKyselyClient<BoardsDb>({ path: ":memory:", bootstrap: BOOTSTRAP_DDL, pragmas: { foreignKeys: true } });
+}
+
+describe("scrapeBoard", () => {
+    let db: DatabaseClient<BoardsDb>;
+
+    beforeEach(async () => {
+        db = makeTestDb();
+        await createBoard(db, { slug: "b1", title: "Board One" });
+    });
+    afterEach(() => db.close());
+
+    it("digests every non-section card with per-kind text, ai flag, and embedded annotations", async () => {
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 600, h: 600, payload: { title: "Checkout" } });
+        await createCard(db, "b1", {
+            kind: "text",
+            x: 50,
+            y: 80,
+            w: 100,
+            h: 100,
+            payload: { md: "hello", layer: "ai" },
+        });
+        await createCard(db, "b1", { kind: "note", x: 50, y: 200, w: 100, h: 100, payload: { text: "a sticky" } });
+        const shot = await createCard(db, "b1", {
+            kind: "shot",
+            x: 50,
+            y: 320,
+            w: 100,
+            h: 100,
+            filePath: "home.png",
+            blobKey: "hash1",
+            payload: {},
+        });
+        await createAnnotation(db, {
+            boardSlug: "b1",
+            cardId: shot.id,
+            region: { x: 0, y: 0, w: 1, h: 1 },
+            intent: "fix",
+            prompt: "tighten spacing",
+            status: "open",
+        });
+
+        const doc = await getBoardDoc(db, "b1");
+        const res = scrapeBoard({ doc, base: "http://x" });
+        expect(res.ok).toBe(true);
+        if (!res.ok) {
+            return;
+        }
+        expect(res.body.board).toEqual({ slug: "b1", title: "Board One" });
+        expect((res.body.sections as unknown[]).length).toBe(1);
+        const cards = res.body.cards as ScrapeCard[];
+        expect(cards.some((c) => c.kind === "section")).toBe(false); // frames excluded
+        const text = cards.find((c) => c.kind === "text");
+        expect(text?.text).toBe("hello");
+        expect(text?.ai).toBe(true);
+        expect(text?.section).toBe("Checkout");
+        expect(cards.find((c) => c.kind === "note")?.text).toBe("a sticky");
+        const shotCard = cards.find((c) => c.kind === "shot");
+        expect(shotCard?.image).toBe("http://x/api/boards/blobs/hash1");
+        expect(shotCard?.annotations?.[0]).toMatchObject({ intent: "fix", status: "open", prompt: "tighten spacing" });
+    });
+
+    it("walks edges into ordered flow chains; isolated cards become their own chain", async () => {
+        const a = await createCard(db, "b1", { kind: "text", x: 0, y: 0, w: 50, h: 50, payload: { md: "A" } });
+        const b = await createCard(db, "b1", { kind: "text", x: 0, y: 100, w: 50, h: 50, payload: { md: "B" } });
+        const c = await createCard(db, "b1", { kind: "text", x: 0, y: 200, w: 50, h: 50, payload: { md: "C" } });
+        const d = await createCard(db, "b1", { kind: "text", x: 0, y: 300, w: 50, h: 50, payload: { md: "D" } });
+        await addEdge(db, "b1", { fromCard: a.id, toCard: b.id });
+        await addEdge(db, "b1", { fromCard: b.id, toCard: c.id });
+        await addEdge(db, "b1", { fromCard: a.id, toX: 500, toY: 500 }); // point-anchored → not a step
+
+        const doc = await getBoardDoc(db, "b1");
+        const res = scrapeBoard({ doc });
+        expect(res.ok).toBe(true);
+        if (!res.ok) {
+            return;
+        }
+        expect(res.body.flow).toEqual([[a.id, b.id, c.id], [d.id]]);
+    });
+
+    it("?section narrows the digest and 404s an unknown section", async () => {
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 300, h: 300, payload: { title: "A" } });
+        await createCard(db, "b1", { kind: "section", x: 400, y: 0, w: 300, h: 300, payload: { title: "B" } });
+        await createCard(db, "b1", { kind: "text", x: 50, y: 80, w: 50, h: 50, payload: { md: "in-a" } });
+        await createCard(db, "b1", { kind: "text", x: 450, y: 80, w: 50, h: 50, payload: { md: "in-b" } });
+
+        const doc = await getBoardDoc(db, "b1");
+        const scoped = scrapeBoard({ doc, section: "A" });
+        expect(scoped.ok).toBe(true);
+        if (scoped.ok) {
+            expect((scoped.body.cards as ScrapeCard[]).map((c) => c.text)).toEqual(["in-a"]);
+        }
+        expect(scrapeBoard({ doc, section: "nope" })).toMatchObject({ ok: false, status: 404 });
+        expect(scrapeBoard({ doc, section: "A", diff: "A,B" })).toMatchObject({ ok: false, status: 400 });
+    });
+
+    it("?diff pairs two sections' members by file basename", async () => {
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 300, h: 300, payload: { title: "V1" } });
+        await createCard(db, "b1", { kind: "section", x: 400, y: 0, w: 300, h: 300, payload: { title: "V2" } });
+        await createCard(db, "b1", {
+            kind: "shot",
+            x: 50,
+            y: 80,
+            w: 50,
+            h: 50,
+            filePath: "home.png",
+            blobKey: "h1",
+            payload: {},
+        });
+        await createCard(db, "b1", {
+            kind: "shot",
+            x: 450,
+            y: 80,
+            w: 50,
+            h: 50,
+            filePath: "home.png",
+            blobKey: "h2",
+            payload: {},
+        });
+
+        const doc = await getBoardDoc(db, "b1");
+        const res = scrapeBoard({ doc, diff: "V1,V2" });
+        expect(res.ok).toBe(true);
+        if (!res.ok) {
+            return;
+        }
+        expect(res.body.a).toMatchObject({ name: "V1", cards: 1 });
+        expect(res.body.b).toMatchObject({ name: "V2", cards: 1 });
+        const pairs = res.body.pairs as Array<{ a?: ScrapeCard; b?: ScrapeCard }>;
+        expect(pairs).toHaveLength(1);
+        expect(pairs[0].a?.image).toContain("h1");
+        expect(pairs[0].b?.image).toContain("h2");
+    });
+});

--- a/src/dev-dashboard/lib/boards/scrape.ts
+++ b/src/dev-dashboard/lib/boards/scrape.ts
@@ -289,13 +289,13 @@ export function scrapeBoard(opts: { doc: BoardDocDto; base?: string; section?: s
         }
     }
 
+    const { sections, journeys } = sectionsToJSON(cards);
     const body: Record<string, unknown> = {
         board,
-        sections: sectionsToJSON(cards).sections,
+        sections,
         flow,
         cards: outCards,
     };
-    const journeys = sectionsToJSON(cards).journeys;
     if (journeys.length > 0) {
         body.journeys = journeys;
     }

--- a/src/dev-dashboard/lib/boards/scrape.ts
+++ b/src/dev-dashboard/lib/boards/scrape.ts
@@ -1,0 +1,303 @@
+// Board scrape digest (vitrinka handlers_capture.go:397-764): the whole board as ONE structured,
+// token-cheap digest for the agent — media images, note/text/element digests, annotations, and the
+// connect-tool edges walked into ordered journey chains. Pure over the loaded board doc.
+
+import { SafeJSON } from "@app/utils/json";
+import { blobUrl } from "./blobs";
+import { pairSectionMembers } from "./layout-engine";
+import { containingSection, type SectionCard, sectionByName, sectionFrames, sectionsToJSON } from "./sections";
+import type { AnnotationDto, BoardDocDto, CardDto, EdgeDto } from "./types";
+
+function scrapeTruncate(s: string): string {
+    return s.length > 300 ? `${s.slice(0, 297)}…` : s;
+}
+
+function str(payload: Record<string, unknown>, key: string): string {
+    return typeof payload[key] === "string" ? (payload[key] as string) : "";
+}
+
+/** One-line digest for a UI-core element (step/callout/checklist/compare/wireframe). */
+function elementDigestLine(kind: string, payload: Record<string, unknown>): string {
+    switch (kind) {
+        case "step": {
+            const st = str(payload, "status") || "todo";
+            let line = `${str(payload, "title")} — ${st}`;
+            const n = typeof payload.n === "number" ? payload.n : 0;
+            if (n > 0) {
+                line = `${n}. ${line}`;
+            }
+            if (str(payload, "note")) {
+                line += ` · ${str(payload, "note")}`;
+            }
+            return scrapeTruncate(line);
+        }
+        case "callout":
+            return scrapeTruncate(`${str(payload, "tone") || "info"}: ${str(payload, "md")}`);
+        case "checklist": {
+            const items = Array.isArray(payload.items) ? (payload.items as Array<Record<string, unknown>>) : [];
+            const done = items.filter((it) => it.done === true).length;
+            let line = `${done}/${items.length} done`;
+            if (str(payload, "title")) {
+                line += ` · ${str(payload, "title")}`;
+            }
+            const open = items
+                .filter((it) => it.done !== true)
+                .map((it) => (typeof it.text === "string" ? it.text : ""))
+                .filter(Boolean);
+            if (open.length > 0) {
+                line += ` — open: ${open.join("; ")}`;
+            }
+            return scrapeTruncate(line);
+        }
+        case "compare": {
+            const a = (payload.a as Record<string, unknown> | undefined)?.cardId ?? 0;
+            const b = (payload.b as Record<string, unknown> | undefined)?.cardId ?? 0;
+            return `compare card ${a} ↔ ${b} (${str(payload, "mode") || "wipe"})`;
+        }
+        case "wireframe": {
+            const nodes = Array.isArray(payload.nodes) ? (payload.nodes as Array<Record<string, unknown>>) : [];
+            let line = `wireframe (${str(payload, "device") || "phone"}): ${str(payload, "title")} — ${nodes.length} nodes`;
+            const labeled = nodes.filter((n) => typeof n.label === "string" && n.label).map((n) => `${n.t}:${n.label}`);
+            if (labeled.length > 0) {
+                line += ` · ${labeled.join(", ")}`;
+            }
+            return scrapeTruncate(line);
+        }
+        default:
+            return "";
+    }
+}
+
+function cardText(kind: string, payload: Record<string, unknown>): string {
+    switch (kind) {
+        case "note":
+            return str(payload, "text");
+        case "text":
+            return scrapeTruncate(str(payload, "md"));
+        case "viz":
+            return scrapeTruncate(
+                `${str(payload, "viz")} ${str(payload, "title")} ${payload.data ? SafeJSON.stringify(payload.data) : ""}`.trim()
+            );
+        case "cluster":
+            return str(payload, "title");
+        case "step":
+        case "callout":
+        case "checklist":
+        case "compare":
+        case "wireframe":
+            return elementDigestLine(kind, payload);
+        default:
+            return "";
+    }
+}
+
+export interface ScrapeAnnotation {
+    id: number;
+    intent: string;
+    status: string;
+    prompt: string;
+    by?: string;
+}
+
+export interface ScrapeCard {
+    id: number;
+    kind: string;
+    ai: boolean;
+    by?: string;
+    section?: string;
+    image?: string;
+    text?: string;
+    annotations?: ScrapeAnnotation[];
+}
+
+export type ScrapeResult = { ok: true; body: Record<string, unknown> } | { ok: false; status: number; message: string };
+
+/** Turn card→card edges into ordered journey chains: roots (no incoming edge) walked DFS in reading
+ *  order; point-anchored/dangling edges are not steps; cycle-trapped cards become singleton chains. */
+function walkFlow(order: number[], pos: Map<number, { x: number; y: number }>, edges: EdgeDto[]): number[][] {
+    const exists = new Set(order);
+    const adj = new Map<number, number[]>();
+    const indeg = new Map<number, number>();
+    for (const e of edges) {
+        if (e.toCard === null || e.toCard === 0 || !exists.has(e.fromCard) || !exists.has(e.toCard)) {
+            continue;
+        }
+        adj.set(e.fromCard, [...(adj.get(e.fromCard) ?? []), e.toCard]);
+        indeg.set(e.toCard, (indeg.get(e.toCard) ?? 0) + 1);
+    }
+    const roots = order.filter((id) => (indeg.get(id) ?? 0) === 0);
+    roots.sort((a, b) => {
+        const pa = pos.get(a) ?? { x: 0, y: 0 };
+        const pb = pos.get(b) ?? { x: 0, y: 0 };
+        return pa.y !== pb.y ? pa.y - pb.y : pa.x - pb.x;
+    });
+    const visited = new Set<number>();
+    const chains: number[][] = [];
+    for (const root of roots) {
+        if (visited.has(root)) {
+            continue;
+        }
+        const chain: number[] = [];
+        const dfs = (id: number): void => {
+            if (visited.has(id)) {
+                return;
+            }
+            visited.add(id);
+            chain.push(id);
+            for (const nxt of adj.get(id) ?? []) {
+                dfs(nxt);
+            }
+        };
+        dfs(root);
+        chains.push(chain);
+    }
+    for (const id of order) {
+        if (!visited.has(id)) {
+            visited.add(id);
+            chains.push([id]);
+        }
+    }
+    return chains;
+}
+
+function annotationsByCard(anns: AnnotationDto[]): Map<number, ScrapeAnnotation[]> {
+    const out = new Map<number, ScrapeAnnotation[]>();
+    for (const a of anns) {
+        const intent = a.intent === "other" && a.intentOther ? a.intentOther : a.intent;
+        const sa: ScrapeAnnotation = {
+            id: a.id,
+            intent,
+            status: a.status,
+            prompt: a.prompt,
+            ...(a.createdBy ? { by: a.createdBy } : {}),
+        };
+        out.set(a.cardId, [...(out.get(a.cardId) ?? []), sa]);
+    }
+    return out;
+}
+
+function toScrapeCard(card: CardDto, owner: SectionCard | null, base: string, anns: ScrapeAnnotation[]): ScrapeCard {
+    const e: ScrapeCard = {
+        id: card.id,
+        kind: card.kind,
+        ai: card.payload.layer === "ai",
+    };
+    if (card.createdBy) {
+        e.by = card.createdBy;
+    }
+    if (owner) {
+        e.section = str(owner.payload, "title");
+    }
+    if (card.blobKey) {
+        e.image = `${base}${blobUrl(card.blobKey)}`;
+    }
+    const text = cardText(card.kind, card.payload);
+    if (text) {
+        e.text = text;
+    }
+    if (anns.length > 0) {
+        e.annotations = anns;
+    }
+    return e;
+}
+
+/** Scrape the board into a digest. `section` narrows to one frame's members; `diff=A,B` returns the
+ *  pairwise iteration digest; the two are mutually exclusive. */
+export function scrapeBoard(opts: { doc: BoardDocDto; base?: string; section?: string; diff?: string }): ScrapeResult {
+    const { doc } = opts;
+    const base = opts.base ?? "";
+    const cards = doc.cards;
+    const frames = sectionFrames(cards);
+    const annByCard = annotationsByCard(doc.annotations);
+
+    let only: SectionCard | null = null;
+    if (opts.section) {
+        only = sectionByName(frames, opts.section);
+        if (!only) {
+            return { ok: false, status: 404, message: `no section named "${opts.section}" on this board` };
+        }
+    }
+    if (opts.diff && only) {
+        return { ok: false, status: 400, message: "section and diff are mutually exclusive" };
+    }
+
+    const entries = new Map<number, ScrapeCard>();
+    const pos = new Map<number, { x: number; y: number }>();
+    const order: number[] = [];
+    for (const card of cards) {
+        if (card.kind === "section") {
+            continue; // frames live in sections[], not the card list
+        }
+        const owner = frames.length > 0 ? containingSection(frames, card) : null;
+        if (only && owner?.id !== only.id) {
+            continue;
+        }
+        entries.set(card.id, toScrapeCard(card, owner, base, annByCard.get(card.id) ?? []));
+        pos.set(card.id, { x: card.x, y: card.y });
+        order.push(card.id);
+    }
+
+    const board = { slug: doc.board.slug, title: doc.board.title };
+
+    if (opts.diff) {
+        const parts = opts.diff.split(",");
+        if (parts.length !== 2 || !parts[0].trim() || !parts[1].trim()) {
+            return { ok: false, status: 400, message: "diff wants two section names: ?diff=A,B" };
+        }
+        const sa = sectionByName(frames, parts[0]);
+        const sb = sectionByName(frames, parts[1]);
+        if (!sa || !sb) {
+            return { ok: false, status: 404, message: "no such section on this board" };
+        }
+        // Members as CardDto (they carry filePath, which pairSectionMembers matches on).
+        const membersOf = (sec: SectionCard): CardDto[] =>
+            cards.filter((c) => c.kind !== "section" && containingSection(frames, c)?.id === sec.id);
+        const ma = membersOf(sa);
+        const mb = membersOf(sb);
+        const pairs = pairSectionMembers(ma, mb).map((p) => ({
+            ...(p.a ? { a: entries.get(p.a.id) } : {}),
+            ...(p.b ? { b: entries.get(p.b.id) } : {}),
+        }));
+        return {
+            ok: true,
+            body: {
+                board,
+                a: { name: str(sa.payload, "title"), cards: ma.length },
+                b: { name: str(sb.payload, "title"), cards: mb.length },
+                pairs,
+            },
+        };
+    }
+
+    const flow = walkFlow(order, pos, doc.edges);
+    const seen = new Set<number>();
+    const outCards: ScrapeCard[] = [];
+    for (const chain of flow) {
+        for (const id of chain) {
+            const e = entries.get(id);
+            if (e && !seen.has(id)) {
+                seen.add(id);
+                outCards.push(e);
+            }
+        }
+    }
+    for (const id of order) {
+        const e = entries.get(id);
+        if (e && !seen.has(id)) {
+            seen.add(id);
+            outCards.push(e);
+        }
+    }
+
+    const body: Record<string, unknown> = {
+        board,
+        sections: sectionsToJSON(cards).sections,
+        flow,
+        cards: outCards,
+    };
+    const journeys = sectionsToJSON(cards).journeys;
+    if (journeys.length > 0) {
+        body.journeys = journeys;
+    }
+    return { ok: true, body };
+}

--- a/src/dev-dashboard/lib/boards/sections.test.ts
+++ b/src/dev-dashboard/lib/boards/sections.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import {
+    containingSection,
+    journeyKey,
+    resolveJourneyPass,
+    type SectionCard,
+    sectionMembers,
+    sectionsToJSON,
+} from "./sections";
+
+function frame(id: number, x: number, y: number, w: number, h: number, payload: Record<string, unknown>): SectionCard {
+    return { id, kind: "section", x, y, w, h, payload };
+}
+function card(id: number, x: number, y: number, w = 50, h = 50): SectionCard {
+    return { id, kind: "shot", x, y, w, h, payload: {} };
+}
+
+describe("containingSection — spatial membership", () => {
+    const A = frame(1, 0, 0, 1000, 1000, { title: "A" });
+    const B = frame(2, 50, 50, 200, 200, { title: "B" });
+
+    it("returns the frame whose bounds contain the card center", () => {
+        expect(containingSection([A], card(10, 500, 500))?.id).toBe(1);
+    });
+
+    it("returns the SMALLEST frame when nested", () => {
+        // center (125,125) lies inside both A and B → the smaller B wins.
+        expect(containingSection([A, B], card(10, 100, 100))?.id).toBe(2);
+    });
+
+    it("probes a zero-size card with a 340x220 footprint (center = x+170, y+110)", () => {
+        const holder = frame(3, 0, 0, 300, 300, { title: "Z" });
+        const zero: SectionCard = { id: 9, kind: "shot", x: 10, y: 10, w: 0, h: 0, payload: {} };
+        // center = (180, 120) → inside the 300x300 frame
+        expect(containingSection([holder], zero)?.id).toBe(3);
+    });
+
+    it("returns null when no frame holds the card", () => {
+        expect(containingSection([A], card(10, 5000, 5000))).toBeNull();
+    });
+});
+
+describe("journeyKey", () => {
+    it("normalizes spaces/case to a dash slug so variants chain up", () => {
+        expect(journeyKey("Checkout Flow")).toBe("checkout-flow");
+        expect(journeyKey("checkout-flow")).toBe("checkout-flow");
+        expect(journeyKey("  Checkout   Flow!! ")).toBe("checkout-flow");
+        expect(journeyKey("---")).toBe("");
+    });
+});
+
+describe("sectionsToJSON / journeys", () => {
+    it("counts spatial members and summarizes a 3-pass chain", () => {
+        const cards: SectionCard[] = [
+            frame(1, 0, 0, 400, 400, { title: "Checkout", journey: "checkout", pass: 1 }),
+            frame(2, 480, 0, 400, 400, { title: "Checkout — pass 2", journey: "checkout", pass: 2 }),
+            frame(3, 960, 0, 400, 400, { title: "Checkout — pass 3", journey: "checkout", pass: 3 }),
+            card(10, 100, 100), // inside pass 1
+            card(11, 580, 100), // inside pass 2
+        ];
+        const { sections, journeys } = sectionsToJSON(cards);
+        expect(sections.map((s) => s.cards)).toEqual([1, 1, 0]);
+        expect(sections[0].order).toBe(0);
+        expect(journeys).toEqual([{ journey: "checkout", title: "Checkout", passes: 3, latest: "Checkout — pass 3" }]);
+    });
+
+    it("sectionMembers resolves the named section case-insensitively", () => {
+        const cards: SectionCard[] = [frame(1, 0, 0, 400, 400, { title: "Checkout" }), card(10, 100, 100)];
+        const frames = cards.filter((c) => c.kind === "section");
+        expect(sectionMembers(frames, cards, "checkout").map((c) => c.id)).toEqual([10]);
+        expect(sectionMembers(frames, cards, "nope")).toEqual([]);
+    });
+});
+
+describe("resolveJourneyPass", () => {
+    it("adopts a plain section titled like the journey as pass 1", () => {
+        const cards: SectionCard[] = [frame(5, 0, 0, 960, 640, { title: "Onboarding" })];
+        const r = resolveJourneyPass({ cards, journey: "onboarding" });
+        expect(r.action).toBe("adopt");
+        if (r.action === "adopt") {
+            expect(r.section.id).toBe(5);
+            expect(r.journey).toBe("onboarding");
+        }
+    });
+
+    it("creates pass 1 when no matching section exists", () => {
+        const r = resolveJourneyPass({ cards: [], journey: "checkout" });
+        expect(r.action).toBe("create");
+        if (r.action === "create") {
+            expect(r.frame.payload).toMatchObject({ journey: "checkout", pass: 1, title: "Checkout" });
+        }
+    });
+
+    it("'next' creates pass N+1 named from the prev base title, beside it, inheriting layout", () => {
+        const cards: SectionCard[] = [
+            frame(1, 100, 40, 400, 300, { title: "Checkout", journey: "checkout", pass: 1, layout: { mode: "grid" } }),
+        ];
+        const r = resolveJourneyPass({ cards, journey: "checkout", pass: "next" });
+        expect(r.action).toBe("create");
+        if (r.action === "create") {
+            expect(r.frame.x).toBe(100 + 400 + 80); // prev.x + prev.w + gutter
+            expect(r.frame.y).toBe(40);
+            expect(r.frame.w).toBe(400);
+            expect(r.frame.payload).toMatchObject({
+                journey: "checkout",
+                pass: 2,
+                title: "Checkout — pass 2",
+                layout: { mode: "grid" },
+            });
+        }
+    });
+
+    it("errors bad_journey on a pass that would leave a gap", () => {
+        const cards: SectionCard[] = [frame(1, 0, 0, 400, 300, { title: "Checkout", journey: "checkout", pass: 1 })];
+        const r = resolveJourneyPass({ cards, journey: "checkout", pass: 3 });
+        expect(r.action).toBe("error");
+        if (r.action === "error") {
+            expect(r.code).toBe("bad_journey");
+            expect(r.message).toContain("gap");
+        }
+    });
+});

--- a/src/dev-dashboard/lib/boards/sections.ts
+++ b/src/dev-dashboard/lib/boards/sections.ts
@@ -1,0 +1,322 @@
+// Journey sections (vitrinka internal/web/sections.go): a section is a kind "section" frame card
+// named after a customer journey. Membership is SPATIAL — a card belongs to the smallest section
+// whose bounds contain its center, computed at read time — so there is no children bookkeeping.
+
+// Minimal structural view of a board card (CardDto is a structural superset).
+export interface SectionCard {
+    id: number;
+    kind: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    payload: Record<string, unknown>;
+    createdBy?: string;
+}
+
+const ZERO_W = 340; // legacy zero-size membership footprint (cardCenter probe)
+const ZERO_H = 220;
+const PASS_GUTTER = 80; // side-by-side gap between consecutive pass frames
+const DEFAULT_FRAME_W = 960;
+const DEFAULT_FRAME_H = 640;
+
+function str(payload: Record<string, unknown>, key: string): string {
+    return typeof payload[key] === "string" ? (payload[key] as string) : "";
+}
+
+/** Section frames in reading order (top-to-bottom, then left-to-right) — vitrinka sortsectionsOf
+ *  by raw Y then X (NOT banded), so the pill bar / scrape order matches. */
+export function sectionFrames(cards: SectionCard[]): SectionCard[] {
+    return cards
+        .filter((c) => c.kind === "section")
+        .slice()
+        .sort((a, b) => (a.y !== b.y ? a.y - b.y : a.x - b.x));
+}
+
+export function sectionTitle(card: SectionCard): string {
+    return str(card.payload, "title");
+}
+
+/** Normalize a journey name to its chain key: lowercase, non-alnum runs collapsed to single dashes,
+ *  no leading/trailing dash — "Checkout Flow" and "checkout-flow" chain up. */
+export function journeyKey(s: string): string {
+    const lower = s.trim().toLowerCase();
+    let out = "";
+    let dash = false;
+    for (const ch of lower) {
+        if ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9")) {
+            out += ch;
+            dash = false;
+        } else if (!dash && out.length > 0) {
+            out += "-";
+            dash = true;
+        }
+    }
+    return out.replace(/-+$/, "");
+}
+
+/** Reads payload.{journey, pass}; journey "" = a plain section. pass floors to 1. */
+export function sectionJourney(card: SectionCard): { journey: string; pass: number } {
+    const journeyRaw = str(card.payload, "journey");
+    if (!journeyRaw) {
+        return { journey: "", pass: 0 };
+    }
+    const passRaw = card.payload.pass;
+    const pass = typeof passRaw === "number" && passRaw >= 1 ? passRaw : 1;
+    return { journey: journeyKey(journeyRaw), pass };
+}
+
+/** A journey's sections ordered by pass (input assumed reading-sorted for stable ties). */
+function passChain(frames: SectionCard[], journey: string): SectionCard[] {
+    const key = journeyKey(journey);
+    if (!key) {
+        return [];
+    }
+    return frames
+        .filter((sec) => sectionJourney(sec).journey === key)
+        .slice()
+        .sort((a, b) => sectionJourney(a).pass - sectionJourney(b).pass);
+}
+
+/** Strip the " — pass N" suffix so pass N+1 inherits the human name. */
+export function journeyBaseTitle(title: string): string {
+    const i = title.lastIndexOf(" — pass ");
+    return i >= 0 ? title.slice(0, i) : title;
+}
+
+/** Title-case a raw journey input for a fresh chain ("checkout-flow" → "Checkout Flow"). */
+export function journeyHumanTitle(raw: string): string {
+    return raw
+        .trim()
+        .split(/[-_ ]+/)
+        .filter((f) => f.length > 0)
+        .map((f) => f[0].toUpperCase() + f.slice(1))
+        .join(" ");
+}
+
+/** Membership probe point — zero-size legacy cards get the default footprint. */
+export function cardCenter(card: SectionCard): { cx: number; cy: number } {
+    const w = card.w > 0 ? card.w : ZERO_W;
+    const h = card.h > 0 ? card.h : ZERO_H;
+    return { cx: card.x + w / 2, cy: card.y + h / 2 };
+}
+
+/** The SMALLEST section frame whose bounds contain the card's center; null when none holds it. */
+export function containingSection(frames: SectionCard[], card: SectionCard): SectionCard | null {
+    const { cx, cy } = cardCenter(card);
+    let best: SectionCard | null = null;
+    let bestArea = Number.POSITIVE_INFINITY;
+    for (const s of frames) {
+        if (cx < s.x || cy < s.y || cx > s.x + s.w || cy > s.y + s.h) {
+            continue;
+        }
+        const area = s.w * s.h;
+        if (best === null || area < bestArea) {
+            best = s;
+            bestArea = area;
+        }
+    }
+    return best;
+}
+
+/** Resolve a section frame by its journey title, case-insensitively. */
+export function sectionByName(frames: SectionCard[], name: string): SectionCard | null {
+    const want = name.trim().toLowerCase();
+    return frames.find((s) => sectionTitle(s).trim().toLowerCase() === want) ?? null;
+}
+
+/** Non-section cards whose center sits in the named section (smallest-wins, so a nested section's
+ *  cards aren't double-counted). Empty when the section name is unknown. */
+export function sectionMembers(frames: SectionCard[], cards: SectionCard[], name: string): SectionCard[] {
+    const sec = sectionByName(frames, name);
+    if (!sec) {
+        return [];
+    }
+    return cards.filter((c) => c.kind !== "section" && containingSection(frames, c)?.id === sec.id);
+}
+
+export interface SectionJSON {
+    id: number;
+    name: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    cards: number;
+    order: number;
+    by?: string;
+    journey?: string;
+    pass?: number;
+}
+
+export interface JourneyJSON {
+    journey: string;
+    title: string;
+    passes: number;
+    latest: string;
+}
+
+/** The one-line orientation summary per pass chain. */
+export function listJourneys(frames: SectionCard[]): JourneyJSON[] {
+    const seen = new Set<string>();
+    const out: JourneyJSON[] = [];
+    for (const sec of frames) {
+        const { journey } = sectionJourney(sec);
+        if (!journey || seen.has(journey)) {
+            continue;
+        }
+        seen.add(journey);
+        const chain = passChain(frames, journey);
+        const last = chain[chain.length - 1];
+        out.push({
+            journey,
+            title: journeyBaseTitle(sectionTitle(last)),
+            passes: chain.length,
+            latest: sectionTitle(last),
+        });
+    }
+    return out;
+}
+
+/** GET .../sections payload: every journey section with bounds, member count and reading order,
+ *  plus the pass-chain summaries. */
+export function sectionsToJSON(cards: SectionCard[]): { sections: SectionJSON[]; journeys: JourneyJSON[] } {
+    const frames = sectionFrames(cards);
+    const members = new Map<number, number>();
+    for (const c of cards) {
+        if (c.kind === "section") {
+            continue;
+        }
+        const owner = containingSection(frames, c);
+        if (owner) {
+            members.set(owner.id, (members.get(owner.id) ?? 0) + 1);
+        }
+    }
+    const sections = frames.map((sec, order) => {
+        const { journey, pass } = sectionJourney(sec);
+        const j: SectionJSON = {
+            id: sec.id,
+            name: sectionTitle(sec),
+            x: sec.x,
+            y: sec.y,
+            w: sec.w,
+            h: sec.h,
+            cards: members.get(sec.id) ?? 0,
+            order,
+            ...(sec.createdBy ? { by: sec.createdBy } : {}),
+            ...(journey ? { journey, pass } : {}),
+        };
+        return j;
+    });
+    return { sections, journeys: listJourneys(frames) };
+}
+
+/** Descriptor for compose's {journey, pass} target. `resolveJourneyPass` is pure over cards; the
+ *  caller (compose store) applies the side effect (adopt-patch / create-insert) inside its tx. */
+export type JourneyPassResolution =
+    | { action: "existing"; section: SectionCard }
+    | { action: "adopt"; section: SectionCard; journey: string }
+    | { action: "create"; frame: { x: number; y: number; w: number; h: number; payload: Record<string, unknown> } }
+    | { action: "error"; code: "bad_journey"; message: string };
+
+/** Resolve compose's {journey, pass} target (passes decisions §3). pass omitted = the chain's latest
+ *  (or pass 1 if none); "next"/max+1 creates the next pass beside pass N−1 with layout inherited; a
+ *  number targets that existing pass; a gap (>max+1) errors. Mirrors sections.go:135-252 (minus DB). */
+export function resolveJourneyPass(opts: {
+    cards: SectionCard[];
+    journey: string;
+    pass?: number | "next";
+}): JourneyPassResolution {
+    const key = journeyKey(opts.journey);
+    if (!key) {
+        return { action: "error", code: "bad_journey", message: "journey must contain letters or digits" };
+    }
+    const frames = sectionFrames(opts.cards);
+    let chain = passChain(frames, key);
+
+    // A plain section whose TITLE matches the journey seeds the chain as pass 1. Treat it as pass 1
+    // for the chain math here; the caller stamps the real journey/pass when it applies the "adopt".
+    let adoptTarget: SectionCard | null = null;
+    if (chain.length === 0) {
+        const named = sectionByName(frames, opts.journey);
+        if (named && sectionJourney(named).journey === "") {
+            adoptTarget = named;
+            chain = [{ ...named, payload: { ...named.payload, journey: key, pass: 1 } }];
+        }
+    }
+    const maxPass = chain.length > 0 ? sectionJourney(chain[chain.length - 1]).pass : 0;
+
+    // Parse the pass selector.
+    let want = 0;
+    let create = false;
+    if (opts.pass === undefined) {
+        if (chain.length === 0) {
+            want = 1;
+            create = true;
+        } else {
+            want = maxPass;
+        }
+    } else if (opts.pass === "next") {
+        want = maxPass + 1;
+        create = true;
+    } else if (typeof opts.pass === "number" && opts.pass >= 1) {
+        want = opts.pass;
+        if (want === maxPass + 1) {
+            create = true;
+        } else if (want > maxPass + 1) {
+            return {
+                action: "error",
+                code: "bad_journey",
+                message: `journey "${key}" has ${maxPass} passes — pass ${want} would leave a gap (use ${maxPass + 1} or "next")`,
+            };
+        }
+    } else {
+        return { action: "error", code: "bad_journey", message: 'pass: "next" or a pass number' };
+    }
+
+    if (!create) {
+        const found = chain.find((c) => sectionJourney(c).pass === want);
+        if (found) {
+            // An adopted plain section resolving to pass 1 still needs the journey stamp applied.
+            if (adoptTarget && adoptTarget.id === found.id) {
+                return { action: "adopt", section: adoptTarget, journey: key };
+            }
+            return { action: "existing", section: found };
+        }
+        return { action: "error", code: "bad_journey", message: `journey "${key}" has no pass ${want}` };
+    }
+
+    // Create the next pass frame: name from the previous pass's base title, placed beside it.
+    const prev = chain.length > 0 ? chain[chain.length - 1] : null;
+    const payload: Record<string, unknown> = { journey: key, pass: want };
+    let x = 80;
+    let y = 80;
+    let w = DEFAULT_FRAME_W;
+    let h = DEFAULT_FRAME_H;
+    let title = journeyHumanTitle(opts.journey);
+    if (prev) {
+        title = journeyBaseTitle(sectionTitle(prev));
+        if (prev.payload.layout !== undefined) {
+            payload.layout = prev.payload.layout;
+        }
+        w = prev.w;
+        h = prev.h;
+        x = prev.x + prev.w + PASS_GUTTER;
+        y = prev.y;
+    } else if (opts.cards.length > 0) {
+        let maxX = Number.NEGATIVE_INFINITY;
+        let minY = Number.POSITIVE_INFINITY;
+        for (const c of opts.cards) {
+            const cw = c.w > 0 ? c.w : ZERO_W;
+            maxX = Math.max(maxX, c.x + cw);
+            minY = Math.min(minY, c.y);
+        }
+        x = maxX + PASS_GUTTER;
+        y = minY;
+    }
+    if (want > 1) {
+        title = `${title} — pass ${want}`;
+    }
+    payload.title = title;
+    return { action: "create", frame: { x, y, w, h, payload } };
+}

--- a/src/dev-dashboard/lib/boards/sections.ts
+++ b/src/dev-dashboard/lib/boards/sections.ts
@@ -259,7 +259,7 @@ export function resolveJourneyPass(opts: {
     } else if (opts.pass === "next") {
         want = maxPass + 1;
         create = true;
-    } else if (typeof opts.pass === "number" && opts.pass >= 1) {
+    } else if (typeof opts.pass === "number" && Number.isInteger(opts.pass) && opts.pass >= 1) {
         want = opts.pass;
         if (want === maxPass + 1) {
             create = true;

--- a/src/dev-dashboard/lib/boards/work-store.test.ts
+++ b/src/dev-dashboard/lib/boards/work-store.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createKyselyClient, type DatabaseClient } from "@app/utils/database/client";
 import { SafeJSON } from "@app/utils/json";
 import { createAnnotation, patchAnnotation } from "./annotations-store";
-import { createBoard, createCard } from "./boards-store";
+import { answerQuestion, createBoard, createCard, createQuestion } from "./boards-store";
 import { BOOTSTRAP_DDL } from "./db";
 import type { BoardsDb } from "./db-types";
 import { resetEventHub } from "./events";
@@ -404,6 +404,31 @@ describe("work-store", () => {
         const first = await drainChoices(db, { kind: "board", board: "b1" });
         expect(first.length).toBe(1);
         expect(first[0].option).toEqual(["a"]);
+
+        const second = await drainChoices(db, { kind: "board", board: "b1" });
+        expect(second.length).toBe(0);
+    });
+
+    it("full loop through the real API: staged until dispatch, then delivered exactly once", async () => {
+        await createBoard(db, { slug: "b1" });
+        const question = await createQuestion(db, "b1", {
+            cardId: 0,
+            prompt: "pick one",
+            options: [{ label: "picked" }, { label: "other" }],
+        });
+
+        await answerQuestion(db, question.id, "picked", "user");
+
+        // Answered but still staged: dispatch hasn't released it onto the wire yet.
+        expect(await drainChoices(db, { kind: "board", board: "b1" })).toEqual([]);
+
+        const { releasedQuestions } = await dispatchBoard(db, "b1");
+        expect(releasedQuestions).toEqual([question.id]);
+
+        const first = await drainChoices(db, { kind: "board", board: "b1" });
+        expect(first.length).toBe(1);
+        expect(first[0].option).toEqual(["picked"]);
+        expect(first[0].actor).toBe("user");
 
         const second = await drainChoices(db, { kind: "board", board: "b1" });
         expect(second.length).toBe(0);

--- a/src/dev-dashboard/lib/boards/work-store.ts
+++ b/src/dev-dashboard/lib/boards/work-store.ts
@@ -67,7 +67,7 @@ function scopeColumns(scope: WorkScope): { scope_kind: string; scope: string; br
     if (scope.kind === "board") {
         return { scope_kind: "board", scope: scope.board, branch: "" };
     }
-    return { scope_kind: "project", scope: scope.project, branch: scope.branch };
+    return { scope_kind: "project", scope: scope.project, branch: slugifyBranch(scope.branch) };
 }
 
 /** default status "open"; FIFO by created_at. project/branch matches the annotated card's

--- a/src/dev-dashboard/server/registry.ts
+++ b/src/dev-dashboard/server/registry.ts
@@ -5,6 +5,7 @@ import { Router } from "@app/dev-dashboard/server/router";
 import { attentionRoutes } from "@app/dev-dashboard/server/routes/attention";
 import { boardsRoutes } from "@app/dev-dashboard/server/routes/boards";
 import { boardsAnnotationsRoutes } from "@app/dev-dashboard/server/routes/boards-annotations";
+import { boardsComposeRoutes } from "@app/dev-dashboard/server/routes/boards-compose";
 import { boardsSetsRoutes } from "@app/dev-dashboard/server/routes/boards-sets";
 import { boardsWorkRoutes } from "@app/dev-dashboard/server/routes/boards-work";
 import { claudeRoutes } from "@app/dev-dashboard/server/routes/claude";
@@ -37,6 +38,7 @@ export function createDashboardRouter(): Router {
         ...boardsSetsRoutes(),
         ...boardsWorkRoutes(),
         ...boardsAnnotationsRoutes(),
+        ...boardsComposeRoutes(),
         ...boardsRoutes(),
         ...systemRoutes(),
         ...netRoutes(),

--- a/src/dev-dashboard/server/registry.ts
+++ b/src/dev-dashboard/server/registry.ts
@@ -6,6 +6,7 @@ import { attentionRoutes } from "@app/dev-dashboard/server/routes/attention";
 import { boardsRoutes } from "@app/dev-dashboard/server/routes/boards";
 import { boardsAnnotationsRoutes } from "@app/dev-dashboard/server/routes/boards-annotations";
 import { boardsComposeRoutes } from "@app/dev-dashboard/server/routes/boards-compose";
+import { boardsQuestionsRoutes } from "@app/dev-dashboard/server/routes/boards-questions";
 import { boardsSetsRoutes } from "@app/dev-dashboard/server/routes/boards-sets";
 import { boardsWorkRoutes } from "@app/dev-dashboard/server/routes/boards-work";
 import { claudeRoutes } from "@app/dev-dashboard/server/routes/claude";
@@ -39,6 +40,7 @@ export function createDashboardRouter(): Router {
         ...boardsWorkRoutes(),
         ...boardsAnnotationsRoutes(),
         ...boardsComposeRoutes(),
+        ...boardsQuestionsRoutes(),
         ...boardsRoutes(),
         ...systemRoutes(),
         ...netRoutes(),

--- a/src/dev-dashboard/server/routes/boards-annotations.test.ts
+++ b/src/dev-dashboard/server/routes/boards-annotations.test.ts
@@ -1,18 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { blobUrl } from "@app/dev-dashboard/lib/boards/blobs";
 import { createBoard, createCard, softDeleteCard } from "@app/dev-dashboard/lib/boards/boards-store";
-import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
-import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import { getSet, syncSet } from "@app/dev-dashboard/lib/boards/sets-store";
 import { dispatchBoard } from "@app/dev-dashboard/lib/boards/work-store";
-import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
-import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 import { boardsAnnotationsRoutes } from "./boards-annotations";
+import { setupBoardsTestEnv } from "./boards-route-test-utils";
 import { boardsSetsRoutes } from "./boards-sets";
 
 function findRoute(method: string, pattern: string): RouteDef {
@@ -96,22 +92,7 @@ function buildPng(width: number, height: number): Uint8Array {
 }
 
 describe("boardsAnnotationsRoutes", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-ann-routes-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-
-    afterEach(() => {
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        resetEventHub();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-ann-routes-");
 
     it("full lifecycle: staged create -> dispatch -> claim -> attempt swaps the face -> user reply re-queues -> accept resolves", async () => {
         const db = getBoardsDb();

--- a/src/dev-dashboard/server/routes/boards-annotations.ts
+++ b/src/dev-dashboard/server/routes/boards-annotations.ts
@@ -10,7 +10,7 @@ import {
     reactivateAnnotation,
     setVerdict,
 } from "@app/dev-dashboard/lib/boards/annotations-store";
-import { getCard } from "@app/dev-dashboard/lib/boards/boards-store";
+import { getBoardDoc, getCard } from "@app/dev-dashboard/lib/boards/boards-store";
 import { buildCapsule } from "@app/dev-dashboard/lib/boards/capsule";
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent, wakeWorkWaiters } from "@app/dev-dashboard/lib/boards/events";
@@ -175,8 +175,12 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                     const id = Number(ctx.params.id);
                     const annotation = await getAnnotation(getBoardsDb(), id);
                     const card = await getCard(getBoardsDb(), annotation.cardId);
-                    const capsule = buildCapsule(annotation, card, annotation.boardSlug);
+                    const doc = await getBoardDoc(getBoardsDb(), annotation.boardSlug);
                     const base = ctx.query.get("base");
+                    const capsule = buildCapsule(annotation, card, annotation.boardSlug, {
+                        boardCards: doc.cards,
+                        base: base ?? undefined,
+                    });
                     const body = base ? capsule.replace("image: /api/", `image: ${base}/api/`) : capsule;
                     return { kind: "text", status: 200, contentType: "text/markdown", body };
                 } catch (err) {

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -2,9 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBoard } from "@app/dev-dashboard/lib/boards/boards-store";
+import { createBoard, createCard, getBoardDoc } from "@app/dev-dashboard/lib/boards/boards-store";
 import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { resetEventHub } from "@app/dev-dashboard/lib/boards/events";
+import { __resetLayoutDebounce } from "@app/dev-dashboard/lib/boards/layout-engine";
 import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
 import { env } from "@app/utils/env";
@@ -48,6 +49,7 @@ describe("POST /api/boards/:slug/compose", () => {
         resetEventHub();
     });
     afterEach(() => {
+        __resetLayoutDebounce();
         resetEventHub();
         resetBoardsDb();
         resetDevDashboardStorage();
@@ -93,5 +95,64 @@ describe("POST /api/boards/:slug/compose", () => {
         const res = await compose({ cards: [{ kind: "compare", payload: { a: { cardId: 9 }, b: { cardId: 8 } } }] });
         expect(res.status).toBe(404);
         expect(res.body).toMatchObject({ code: "not_found" });
+    });
+});
+
+describe("POST /api/boards/:slug/arrange", () => {
+    beforeEach(() => {
+        const dir = mkdtempSync(join(tmpdir(), "boards-arrange-route-"));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        env.testing.set("BOARDS_DB_PATH", ":memory:");
+        resetDevDashboardStorage();
+        resetBoardsDb();
+        resetEventHub();
+    });
+    afterEach(() => {
+        __resetLayoutDebounce();
+        resetEventHub();
+        resetBoardsDb();
+        resetDevDashboardStorage();
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        env.testing.unset("BOARDS_DB_PATH");
+    });
+
+    function findArrange(): RouteDef {
+        const def = boardsComposeRoutes().find((d) => d.method === "POST" && d.pattern === "/api/boards/:slug/arrange");
+        if (!def) {
+            throw new Error("arrange route not found");
+        }
+        return def;
+    }
+    async function arrange(body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+        return asJson(await findArrange().handler(makeCtx({ params: { slug: "b1" }, body })));
+    }
+
+    it("arranges an explicit id selection", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1" });
+        const c1 = await createCard(db, "b1", { kind: "text", x: 0, y: 0, w: 100, h: 100, payload: { md: "a" } });
+        const c2 = await createCard(db, "b1", { kind: "text", x: 300, y: 300, w: 100, h: 100, payload: { md: "b" } });
+        const res = await arrange({ mode: "row", ids: [c1.id, c2.id] });
+        expect(res.status).toBe(200);
+        expect(res.body.moved).toBe(2);
+    });
+
+    it("400s a scope with fewer than 2 cards", async () => {
+        await createBoard(getBoardsDb(), { slug: "b1" });
+        expect((await arrange({ mode: "grid", scope: "all" })).status).toBe(400);
+    });
+
+    it("save persists the layout onto the scoped section", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 600, h: 400, payload: { title: "Checkout" } });
+        await createCard(db, "b1", { kind: "text", x: 50, y: 80, w: 100, h: 100, payload: { md: "a", layer: "ai" } });
+        await createCard(db, "b1", { kind: "text", x: 200, y: 80, w: 100, h: 100, payload: { md: "b", layer: "ai" } });
+        const res = await arrange({ mode: "grid", scope: "section:Checkout", cols: 2, save: true });
+        expect(res.status).toBe(200);
+        expect(res.body.saved).toBe(true);
+        const doc = await getBoardDoc(db, "b1");
+        const sec = doc.cards.find((c) => c.kind === "section");
+        expect((sec?.payload.layout as { mode?: string })?.mode).toBe("grid");
     });
 });

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -308,3 +308,20 @@ describe("GET /api/boards/:slug/scrape", () => {
         expect(asJson(await route.handler(ctx({ section: "nope" }))).status).toBe(404);
     });
 });
+
+describe("GET /api/boards/templates.md", () => {
+    it("serves the template library as markdown", async () => {
+        const route = boardsComposeRoutes().find((d) => d.method === "GET" && d.pattern === "/api/boards/templates.md");
+        if (!route) {
+            throw new Error("templates route not found");
+        }
+        const result = await route.handler(makeCtx({}));
+        if (result.kind !== "text") {
+            throw new Error(`expected text result, got ${result.kind}`);
+        }
+        expect(result.status).toBe(200);
+        expect(result.contentType).toBe("text/markdown");
+        expect(result.body).toContain("# Board templates");
+        expect(result.body).toContain("boards_compose_board");
+    });
+});

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -1,7 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import {
     createBoard,
     createCard,
@@ -9,13 +6,10 @@ import {
     listTrash,
     softDeleteCard,
 } from "@app/dev-dashboard/lib/boards/boards-store";
-import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
-import { resetEventHub } from "@app/dev-dashboard/lib/boards/events";
-import { __resetLayoutDebounce } from "@app/dev-dashboard/lib/boards/layout-engine";
-import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
-import { env } from "@app/utils/env";
 import { boardsComposeRoutes } from "./boards-compose";
+import { setupBoardsTestEnv } from "./boards-route-test-utils";
 
 function findRoute(method: string, pattern: string): RouteDef {
     const def = boardsComposeRoutes().find((d) => d.method === method && d.pattern === pattern);
@@ -43,26 +37,6 @@ function asJson(result: RouteResult): { status: number; body: Record<string, unk
         throw new Error(`expected json result, got ${result.kind}`);
     }
     return { status: result.status, body: result.body as Record<string, unknown> };
-}
-
-/** Shared per-test board DB fixture (mkdtemp'd home + in-memory db, reset on both ends). */
-function setupBoardsTestEnv(prefix: string): void {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), prefix));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-    afterEach(() => {
-        __resetLayoutDebounce();
-        resetEventHub();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
 }
 
 describe("POST /api/boards/:slug/compose", () => {

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -265,3 +265,46 @@ describe("POST /api/boards/:slug/update-cards", () => {
         expect(doc.cards.map((c) => c.id)).toContain(doomed.id);
     });
 });
+
+describe("GET /api/boards/:slug/scrape", () => {
+    beforeEach(() => {
+        const dir = mkdtempSync(join(tmpdir(), "boards-scrape-route-"));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        env.testing.set("BOARDS_DB_PATH", ":memory:");
+        resetDevDashboardStorage();
+        resetBoardsDb();
+        resetEventHub();
+    });
+    afterEach(() => {
+        __resetLayoutDebounce();
+        resetEventHub();
+        resetBoardsDb();
+        resetDevDashboardStorage();
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        env.testing.unset("BOARDS_DB_PATH");
+    });
+
+    it("returns the board digest, 404s an unknown section", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1", title: "T" });
+        await createCard(db, "b1", { kind: "text", x: 0, y: 0, w: 50, h: 50, payload: { md: "hi", layer: "ai" } });
+        const route = boardsComposeRoutes().find((d) => d.method === "GET" && d.pattern === "/api/boards/:slug/scrape");
+        if (!route) {
+            throw new Error("scrape route not found");
+        }
+        const ctx = (query: Record<string, string>): RouteContext => ({
+            method: "GET",
+            pathname: "/",
+            query: new URLSearchParams(query),
+            params: { slug: "b1" },
+            headers: {},
+            readJson: async <T>() => ({}) as T,
+            readRawBody: async () => new Uint8Array(),
+            services: {} as RouteContext["services"],
+        });
+        const ok = asJson(await route.handler(ctx({})));
+        expect(ok.status).toBe(200);
+        expect((ok.body.cards as unknown[]).length).toBe(1);
+        expect(asJson(await route.handler(ctx({ section: "nope" }))).status).toBe(404);
+    });
+});

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBoard, createCard, getBoardDoc } from "@app/dev-dashboard/lib/boards/boards-store";
+import {
+    createBoard,
+    createCard,
+    getBoardDoc,
+    listTrash,
+    softDeleteCard,
+} from "@app/dev-dashboard/lib/boards/boards-store";
 import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { resetEventHub } from "@app/dev-dashboard/lib/boards/events";
 import { __resetLayoutDebounce } from "@app/dev-dashboard/lib/boards/layout-engine";
@@ -154,5 +160,108 @@ describe("POST /api/boards/:slug/arrange", () => {
         const doc = await getBoardDoc(db, "b1");
         const sec = doc.cards.find((c) => c.kind === "section");
         expect((sec?.payload.layout as { mode?: string })?.mode).toBe("grid");
+    });
+});
+
+describe("POST /api/boards/:slug/update-cards", () => {
+    beforeEach(() => {
+        const dir = mkdtempSync(join(tmpdir(), "boards-update-route-"));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        env.testing.set("BOARDS_DB_PATH", ":memory:");
+        resetDevDashboardStorage();
+        resetBoardsDb();
+        resetEventHub();
+    });
+    afterEach(() => {
+        __resetLayoutDebounce();
+        resetEventHub();
+        resetBoardsDb();
+        resetDevDashboardStorage();
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        env.testing.unset("BOARDS_DB_PATH");
+    });
+
+    function findUpdate(): RouteDef {
+        const def = boardsComposeRoutes().find(
+            (d) => d.method === "POST" && d.pattern === "/api/boards/:slug/update-cards"
+        );
+        if (!def) {
+            throw new Error("update-cards route not found");
+        }
+        return def;
+    }
+    async function update(body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+        return asJson(await findUpdate().handler(makeCtx({ params: { slug: "b1" }, body })));
+    }
+    const aiText = async (db: ReturnType<typeof getBoardsDb>) =>
+        createCard(db, "b1", { kind: "text", x: 0, y: 0, w: 100, h: 100, payload: { md: "x", layer: "ai" } });
+
+    it("400 empty on zero ops, 413 on >100", async () => {
+        await createBoard(getBoardsDb(), { slug: "b1" });
+        expect((await update({})).status).toBe(400);
+        expect((await update({ remove: Array.from({ length: 101 }, (_, i) => i + 1) })).status).toBe(413);
+    });
+
+    it("403 not_ai_layer when patching a card that isn't on the AI layer", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1" });
+        const shot = await createCard(db, "b1", { kind: "shot", x: 0, y: 0, w: 100, h: 100, payload: {} });
+        const res = await update({ patch: [{ id: shot.id, x: 50 }] });
+        expect(res.status).toBe(403);
+        expect(res.body).toMatchObject({ code: "not_ai_layer", index: 0 });
+    });
+
+    it("allows patching a section card and re-stamps layer:ai on a non-section patch", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1" });
+        const section = await createCard(db, "b1", {
+            kind: "section",
+            x: 0,
+            y: 0,
+            w: 300,
+            h: 200,
+            payload: { title: "S" },
+        });
+        const text = await aiText(db);
+        const res = await update({
+            patch: [
+                { id: section.id, w: 400 },
+                { id: text.id, payload: { md: "edited" } }, // omits layer → must be re-stamped
+            ],
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.patched).toBe(2);
+
+        const doc = await getBoardDoc(db, "b1");
+        const sec = doc.cards.find((c) => c.id === section.id);
+        expect(sec?.w).toBe(400);
+        expect("layer" in (sec?.payload ?? {})).toBe(false); // section stays layer-neutral
+        const txt = doc.cards.find((c) => c.id === text.id);
+        expect(txt?.payload.layer).toBe("ai"); // re-stamped
+        expect(txt?.payload.md).toBe("edited");
+    });
+
+    it("remove soft-deletes into the trash", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1" });
+        const text = await aiText(db);
+        expect((await update({ remove: [text.id] })).body.removed).toBe(1);
+        const trash = await listTrash(db, "b1");
+        expect(trash.map((c) => c.id)).toContain(text.id);
+    });
+
+    it("restore 403s a live (non-trashed) card, and restores a trashed AI card", async () => {
+        const db = getBoardsDb();
+        await createBoard(db, { slug: "b1" });
+        const live = await aiText(db);
+        expect((await update({ restore: [live.id] })).status).toBe(403); // not in trash
+
+        const doomed = await aiText(db);
+        await softDeleteCard(db, doomed.id);
+        const res = await update({ restore: [doomed.id] });
+        expect(res.status).toBe(200);
+        expect(res.body.restored).toBe(1);
+        const doc = await getBoardDoc(db, "b1");
+        expect(doc.cards.map((c) => c.id)).toContain(doomed.id);
     });
 });

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createBoard } from "@app/dev-dashboard/lib/boards/boards-store";
+import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { resetEventHub } from "@app/dev-dashboard/lib/boards/events";
+import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
+import { env } from "@app/utils/env";
+import { boardsComposeRoutes } from "./boards-compose";
+
+function findRoute(method: string, pattern: string): RouteDef {
+    const def = boardsComposeRoutes().find((d) => d.method === method && d.pattern === pattern);
+    if (!def) {
+        throw new Error(`route not found: ${method} ${pattern}`);
+    }
+    return def;
+}
+
+function makeCtx(opts: { params?: Record<string, string>; body?: unknown }): RouteContext {
+    return {
+        method: "POST",
+        pathname: "/",
+        query: new URLSearchParams(),
+        params: opts.params ?? {},
+        headers: {},
+        readJson: async <T>() => opts.body as T,
+        readRawBody: async () => new Uint8Array(),
+        services: {} as RouteContext["services"],
+    };
+}
+
+function asJson(result: RouteResult): { status: number; body: Record<string, unknown> } {
+    if (result.kind !== "json") {
+        throw new Error(`expected json result, got ${result.kind}`);
+    }
+    return { status: result.status, body: result.body as Record<string, unknown> };
+}
+
+describe("POST /api/boards/:slug/compose", () => {
+    beforeEach(() => {
+        const dir = mkdtempSync(join(tmpdir(), "boards-compose-route-"));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        env.testing.set("BOARDS_DB_PATH", ":memory:");
+        resetDevDashboardStorage();
+        resetBoardsDb();
+        resetEventHub();
+    });
+    afterEach(() => {
+        resetEventHub();
+        resetBoardsDb();
+        resetDevDashboardStorage();
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        env.testing.unset("BOARDS_DB_PATH");
+    });
+
+    async function compose(body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
+        const route = findRoute("POST", "/api/boards/:slug/compose");
+        return asJson(await route.handler(makeCtx({ params: { slug: "b1" }, body })));
+    }
+
+    it("201 with cards/edges/questions/region on the happy path", async () => {
+        await createBoard(getBoardsDb(), { slug: "b1" });
+        const res = await compose({
+            cards: [
+                { ref: "a", kind: "text", payload: { md: "A" } },
+                { ref: "b", kind: "note", payload: { text: "B" } },
+            ],
+            edges: [{ from: "a", to: "b" }],
+        });
+        expect(res.status).toBe(201);
+        expect((res.body.cards as unknown[]).length).toBe(2);
+        expect((res.body.edges as unknown[]).length).toBe(1);
+        expect(res.body.region).toMatchObject({ x: expect.any(Number), w: expect.any(Number) });
+    });
+
+    it("400 {error,code,index} on an empty batch", async () => {
+        await createBoard(getBoardsDb(), { slug: "b1" });
+        const res = await compose({ cards: [] });
+        expect(res.status).toBe(400);
+        expect(res.body).toMatchObject({ code: "empty", index: -1 });
+    });
+
+    it("413 on a limit breach", async () => {
+        await createBoard(getBoardsDb(), { slug: "b1" });
+        const cards = Array.from({ length: 61 }, (_, i) => ({ ref: `c${i}`, kind: "text", payload: { md: "x" } }));
+        expect((await compose({ cards })).status).toBe(413);
+    });
+
+    it("404 on a compare referencing a card not on the board", async () => {
+        await createBoard(getBoardsDb(), { slug: "b1" });
+        const res = await compose({ cards: [{ kind: "compare", payload: { a: { cardId: 9 }, b: { cardId: 8 } } }] });
+        expect(res.status).toBe(404);
+        expect(res.body).toMatchObject({ code: "not_found" });
+    });
+});

--- a/src/dev-dashboard/server/routes/boards-compose.test.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.test.ts
@@ -45,9 +45,10 @@ function asJson(result: RouteResult): { status: number; body: Record<string, unk
     return { status: result.status, body: result.body as Record<string, unknown> };
 }
 
-describe("POST /api/boards/:slug/compose", () => {
+/** Shared per-test board DB fixture (mkdtemp'd home + in-memory db, reset on both ends). */
+function setupBoardsTestEnv(prefix: string): void {
     beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-compose-route-"));
+        const dir = mkdtempSync(join(tmpdir(), prefix));
         env.testing.set("GENESIS_TOOLS_HOME", dir);
         env.testing.set("BOARDS_DB_PATH", ":memory:");
         resetDevDashboardStorage();
@@ -62,6 +63,10 @@ describe("POST /api/boards/:slug/compose", () => {
         env.testing.unset("GENESIS_TOOLS_HOME");
         env.testing.unset("BOARDS_DB_PATH");
     });
+}
+
+describe("POST /api/boards/:slug/compose", () => {
+    setupBoardsTestEnv("boards-compose-route-");
 
     async function compose(body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
         const route = findRoute("POST", "/api/boards/:slug/compose");
@@ -105,22 +110,7 @@ describe("POST /api/boards/:slug/compose", () => {
 });
 
 describe("POST /api/boards/:slug/arrange", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-arrange-route-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-    afterEach(() => {
-        __resetLayoutDebounce();
-        resetEventHub();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-arrange-route-");
 
     function findArrange(): RouteDef {
         const def = boardsComposeRoutes().find((d) => d.method === "POST" && d.pattern === "/api/boards/:slug/arrange");
@@ -164,22 +154,7 @@ describe("POST /api/boards/:slug/arrange", () => {
 });
 
 describe("POST /api/boards/:slug/update-cards", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-update-route-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-    afterEach(() => {
-        __resetLayoutDebounce();
-        resetEventHub();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-update-route-");
 
     function findUpdate(): RouteDef {
         const def = boardsComposeRoutes().find(
@@ -267,22 +242,7 @@ describe("POST /api/boards/:slug/update-cards", () => {
 });
 
 describe("GET /api/boards/:slug/scrape", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-scrape-route-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-    afterEach(() => {
-        __resetLayoutDebounce();
-        resetEventHub();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-scrape-route-");
 
     it("returns the board digest, 404s an unknown section", async () => {
         const db = getBoardsDb();

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -1,6 +1,7 @@
 import { type ComposeBody, composeBoard } from "@app/dev-dashboard/lib/boards/compose-store";
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
+import { type ArrangeBody, runArrange } from "@app/dev-dashboard/lib/boards/layout-engine";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
 import { boardsError } from "./boards-errors";
 import { getOperator } from "./boards-sets";
@@ -52,6 +53,27 @@ export function boardsComposeRoutes(): RouteDef[] {
                             questions: result.questions,
                             region: result.region,
                         },
+                    };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+        {
+            method: "POST",
+            pattern: "/api/boards/:slug/arrange",
+            handler: async (ctx) => {
+                try {
+                    const body = await ctx.readJson<ArrangeBody>();
+                    const outcome = await runArrange(getBoardsDb(), ctx.params.slug, body);
+                    if (!outcome.ok) {
+                        return { kind: "json", status: outcome.status, body: { error: outcome.message } };
+                    }
+                    // runArrange publishes the layout/card SSE events itself (after its writes commit).
+                    return {
+                        kind: "json",
+                        status: 200,
+                        body: { ok: true, moved: outcome.moved, cards: outcome.cards, saved: outcome.saved },
                     };
                 } catch (err) {
                     return boardsError(err);

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -1,0 +1,62 @@
+import { type ComposeBody, composeBoard } from "@app/dev-dashboard/lib/boards/compose-store";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
+import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { boardsError } from "./boards-errors";
+import { getOperator } from "./boards-sets";
+
+/** Compose error code → HTTP status (handlers_compose.go); everything else is a 400. */
+const STATUS_BY_CODE: Record<string, number> = { limit: 413, not_found: 404, not_ai_layer: 403 };
+
+async function actorOf(header: string | undefined): Promise<string> {
+    if (header) {
+        return header;
+    }
+    return (await getOperator()) || "claude";
+}
+
+export function boardsComposeRoutes(): RouteDef[] {
+    return [
+        {
+            method: "POST",
+            pattern: "/api/boards/:slug/compose",
+            handler: async (ctx) => {
+                try {
+                    const body = await ctx.readJson<ComposeBody>();
+                    const actor = await actorOf(ctx.headers["x-board-actor"]);
+                    const result = await composeBoard(getBoardsDb(), ctx.params.slug, body, actor);
+                    if (!result.ok) {
+                        const status = STATUS_BY_CODE[result.code] ?? 400;
+                        return {
+                            kind: "json",
+                            status,
+                            body: { error: result.message, code: result.code, index: result.index },
+                        };
+                    }
+                    // SSE publishes AFTER the transaction commits.
+                    if (result.events.cards.length > 0) {
+                        publishBoardEvent(ctx.params.slug, { type: "cards", payload: result.events.cards });
+                    }
+                    for (const edge of result.events.edges) {
+                        publishBoardEvent(ctx.params.slug, { type: "edge", payload: edge });
+                    }
+                    for (const question of result.events.questions) {
+                        publishBoardEvent(ctx.params.slug, { type: "question", payload: question });
+                    }
+                    return {
+                        kind: "json",
+                        status: 201,
+                        body: {
+                            cards: result.cards,
+                            edges: result.edges,
+                            questions: result.questions,
+                            region: result.region,
+                        },
+                    };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+    ];
+}

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -1,4 +1,9 @@
-import { type ComposeBody, composeBoard } from "@app/dev-dashboard/lib/boards/compose-store";
+import {
+    type ComposeBody,
+    composeBoard,
+    type UpdateCardsBody,
+    updateCards,
+} from "@app/dev-dashboard/lib/boards/compose-store";
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
 import { type ArrangeBody, runArrange } from "@app/dev-dashboard/lib/boards/layout-engine";
@@ -53,6 +58,37 @@ export function boardsComposeRoutes(): RouteDef[] {
                             questions: result.questions,
                             region: result.region,
                         },
+                    };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+        {
+            method: "POST",
+            pattern: "/api/boards/:slug/update-cards",
+            handler: async (ctx) => {
+                try {
+                    const body = await ctx.readJson<UpdateCardsBody>();
+                    const result = await updateCards(getBoardsDb(), ctx.params.slug, body);
+                    if (!result.ok) {
+                        const status = STATUS_BY_CODE[result.code] ?? 400;
+                        return {
+                            kind: "json",
+                            status,
+                            body: { error: result.message, code: result.code, index: result.index },
+                        };
+                    }
+                    for (const card of result.events.cards) {
+                        publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
+                    }
+                    for (const id of result.events.deleted) {
+                        publishBoardEvent(ctx.params.slug, { type: "card_deleted", payload: { id } });
+                    }
+                    return {
+                        kind: "json",
+                        status: 200,
+                        body: { ok: true, patched: result.patched, removed: result.removed, restored: result.restored },
                     };
                 } catch (err) {
                     return boardsError(err);

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -32,8 +32,12 @@ export function boardsComposeRoutes(): RouteDef[] {
             method: "GET",
             pattern: "/api/boards/templates.md",
             handler: async () => {
-                const body = await Bun.file(TEMPLATES_PATH).text();
-                return { kind: "text", status: 200, contentType: "text/markdown", body };
+                try {
+                    const body = await Bun.file(TEMPLATES_PATH).text();
+                    return { kind: "text", status: 200, contentType: "text/markdown", body };
+                } catch (err) {
+                    return boardsError(err);
+                }
             },
         },
         {

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { getBoardDoc } from "@app/dev-dashboard/lib/boards/boards-store";
 import {
     type ComposeBody,
@@ -23,8 +24,18 @@ async function actorOf(header: string | undefined): Promise<string> {
     return (await getOperator()) || "claude";
 }
 
+const TEMPLATES_PATH = resolve(import.meta.dirname, "../static/boards-templates.md");
+
 export function boardsComposeRoutes(): RouteDef[] {
     return [
+        {
+            method: "GET",
+            pattern: "/api/boards/templates.md",
+            handler: async () => {
+                const body = await Bun.file(TEMPLATES_PATH).text();
+                return { kind: "text", status: 200, contentType: "text/markdown", body };
+            },
+        },
         {
             method: "POST",
             pattern: "/api/boards/:slug/compose",

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -45,7 +45,7 @@ export function boardsComposeRoutes(): RouteDef[] {
             pattern: "/api/boards/:slug/compose",
             handler: async (ctx) => {
                 try {
-                    const body = await ctx.readJson<ComposeBody>();
+                    const body = (await ctx.readJson<ComposeBody>()) ?? ({} as ComposeBody);
                     const actor = await actorOf(ctx.headers["x-board-actor"]);
                     const result = await composeBoard(getBoardsDb(), ctx.params.slug, body, actor);
                     if (!result.ok) {
@@ -86,7 +86,7 @@ export function boardsComposeRoutes(): RouteDef[] {
             pattern: "/api/boards/:slug/update-cards",
             handler: async (ctx) => {
                 try {
-                    const body = await ctx.readJson<UpdateCardsBody>();
+                    const body = (await ctx.readJson<UpdateCardsBody>()) ?? ({} as UpdateCardsBody);
                     const result = await updateCards(getBoardsDb(), ctx.params.slug, body);
                     if (!result.ok) {
                         const status = STATUS_BY_CODE[result.code] ?? 400;
@@ -138,7 +138,7 @@ export function boardsComposeRoutes(): RouteDef[] {
             pattern: "/api/boards/:slug/arrange",
             handler: async (ctx) => {
                 try {
-                    const body = await ctx.readJson<ArrangeBody>();
+                    const body = (await ctx.readJson<ArrangeBody>()) ?? ({} as ArrangeBody);
                     const outcome = await runArrange(getBoardsDb(), ctx.params.slug, body);
                     if (!outcome.ok) {
                         return { kind: "json", status: outcome.status, body: { error: outcome.message } };

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -1,3 +1,4 @@
+import { getBoardDoc } from "@app/dev-dashboard/lib/boards/boards-store";
 import {
     type ComposeBody,
     composeBoard,
@@ -7,6 +8,7 @@ import {
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
 import { type ArrangeBody, runArrange } from "@app/dev-dashboard/lib/boards/layout-engine";
+import { scrapeBoard } from "@app/dev-dashboard/lib/boards/scrape";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
 import { boardsError } from "./boards-errors";
 import { getOperator } from "./boards-sets";
@@ -90,6 +92,27 @@ export function boardsComposeRoutes(): RouteDef[] {
                         status: 200,
                         body: { ok: true, patched: result.patched, removed: result.removed, restored: result.restored },
                     };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+        {
+            method: "GET",
+            pattern: "/api/boards/:slug/scrape",
+            handler: async (ctx) => {
+                try {
+                    const doc = await getBoardDoc(getBoardsDb(), ctx.params.slug);
+                    const result = scrapeBoard({
+                        doc,
+                        base: ctx.query.get("base") ?? "",
+                        section: ctx.query.get("section") ?? undefined,
+                        diff: ctx.query.get("diff") ?? undefined,
+                    });
+                    if (!result.ok) {
+                        return { kind: "json", status: result.status, body: { error: result.message } };
+                    }
+                    return { kind: "json", status: 200, body: result.body };
                 } catch (err) {
                     return boardsError(err);
                 }

--- a/src/dev-dashboard/server/routes/boards-questions.test.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createCard } from "@app/dev-dashboard/lib/boards/boards-store";
+import { createCard, createBoard as storeCreateBoard } from "@app/dev-dashboard/lib/boards/boards-store";
 import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
@@ -40,7 +40,6 @@ function asJson(result: RouteResult): { status: number; body: Record<string, unk
 }
 
 async function createBoard(slug: string): Promise<void> {
-    const { createBoard: storeCreateBoard } = await import("@app/dev-dashboard/lib/boards/boards-store");
     await storeCreateBoard(getBoardsDb(), { slug });
 }
 

--- a/src/dev-dashboard/server/routes/boards-questions.test.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.test.ts
@@ -1,15 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { createCard, createBoard as storeCreateBoard } from "@app/dev-dashboard/lib/boards/boards-store";
-import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
-import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
-import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
-import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 import { boardsQuestionsRoutes } from "./boards-questions";
+import { setupBoardsTestEnv } from "./boards-route-test-utils";
 
 function findRoute(method: string, pattern: string): RouteDef {
     const def = boardsQuestionsRoutes().find((d) => d.method === method && d.pattern === pattern);
@@ -49,21 +45,7 @@ async function create(body: unknown, slug = "b1"): Promise<{ status: number; bod
 }
 
 describe("boardsQuestionsRoutes", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-questions-route-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-    afterEach(() => {
-        resetEventHub();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-questions-route-");
 
     it("201 questionJSON on the happy path, with otherLabel added at render time", async () => {
         await createBoard("b1");
@@ -150,6 +132,23 @@ describe("boardsQuestionsRoutes", () => {
             )
         );
         expect(offVocab.status).toBe(200);
+    });
+
+    it("answer: 400 on a malformed multi-select answer; a subsequent read stays clean", async () => {
+        await createBoard("b1");
+        const created = await create({ prompt: "pick some", options: ["a", "b"], multiSelect: true });
+        const answerRoute = findRoute("POST", "/api/boards/questions/:id/answer");
+        const res = asJson(
+            await answerRoute.handler(
+                makeCtx({ params: { id: String(created.body.id) }, body: { answer: "not a json array" } })
+            )
+        );
+        expect(res.status).toBe(400);
+
+        const listRoute = findRoute("GET", "/api/boards/:slug/questions");
+        const listRes = asJson(await listRoute.handler(makeCtx({ params: { slug: "b1" } })));
+        expect(listRes.status).toBe(200);
+        expect((listRes.body.questions as Array<{ answer: unknown }>)[0].answer).toBeNull();
     });
 
     it("answer: 404 on an unknown question id", async () => {

--- a/src/dev-dashboard/server/routes/boards-questions.test.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCard } from "@app/dev-dashboard/lib/boards/boards-store";
+import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
+import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import { boardsQuestionsRoutes } from "./boards-questions";
+
+function findRoute(method: string, pattern: string): RouteDef {
+    const def = boardsQuestionsRoutes().find((d) => d.method === method && d.pattern === pattern);
+    if (!def) {
+        throw new Error(`route not found: ${method} ${pattern}`);
+    }
+    return def;
+}
+
+function makeCtx(opts: { params?: Record<string, string>; body?: unknown }): RouteContext {
+    return {
+        method: "POST",
+        pathname: "/",
+        query: new URLSearchParams(),
+        params: opts.params ?? {},
+        headers: {},
+        readJson: async <T>() => opts.body as T,
+        readRawBody: async () => new Uint8Array(),
+        services: {} as RouteContext["services"],
+    };
+}
+
+function asJson(result: RouteResult): { status: number; body: Record<string, unknown> } {
+    if (result.kind !== "json") {
+        throw new Error(`expected json result, got ${result.kind}`);
+    }
+    return { status: result.status, body: result.body as Record<string, unknown> };
+}
+
+async function createBoard(slug: string): Promise<void> {
+    const { createBoard: storeCreateBoard } = await import("@app/dev-dashboard/lib/boards/boards-store");
+    await storeCreateBoard(getBoardsDb(), { slug });
+}
+
+async function create(body: unknown, slug = "b1"): Promise<{ status: number; body: Record<string, unknown> }> {
+    const route = findRoute("POST", "/api/boards/:slug/questions");
+    return asJson(await route.handler(makeCtx({ params: { slug }, body })));
+}
+
+describe("boardsQuestionsRoutes", () => {
+    beforeEach(() => {
+        const dir = mkdtempSync(join(tmpdir(), "boards-questions-route-"));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        env.testing.set("BOARDS_DB_PATH", ":memory:");
+        resetDevDashboardStorage();
+        resetBoardsDb();
+        resetEventHub();
+    });
+    afterEach(() => {
+        resetEventHub();
+        resetBoardsDb();
+        resetDevDashboardStorage();
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        env.testing.unset("BOARDS_DB_PATH");
+    });
+
+    it("201 questionJSON on the happy path, with otherLabel added at render time", async () => {
+        await createBoard("b1");
+        const res = await create({ prompt: "pick one", options: ["a", "b"] });
+        expect(res.status).toBe(201);
+        expect(res.body).toMatchObject({
+            prompt: "pick one",
+            options: [{ label: "a" }, { label: "b" }],
+            otherLabel: "Other / Něco jiného",
+            staged: true,
+        });
+        expect(res.body.id).toEqual(expect.any(Number));
+        expect(res.body.multi).toBe(false);
+    });
+
+    it("400 when the prompt is missing or over 1000 chars", async () => {
+        await createBoard("b1");
+        expect((await create({ prompt: "", options: ["a"] })).status).toBe(400);
+        expect((await create({ prompt: "x".repeat(1001), options: ["a"] })).status).toBe(400);
+    });
+
+    it("422 when options is empty or over 12 entries", async () => {
+        await createBoard("b1");
+        expect((await create({ prompt: "pick one", options: [] })).status).toBe(422);
+        const many = Array.from({ length: 13 }, (_, i) => `opt${i}`);
+        expect((await create({ prompt: "pick one", options: many })).status).toBe(422);
+    });
+
+    it("404 when cardId is not a live card on this board", async () => {
+        await createBoard("b1");
+        const res = await create({ prompt: "pick one", options: ["a"], cardId: 999 });
+        expect(res.status).toBe(404);
+    });
+
+    it("anchors to a live card when cardId is given", async () => {
+        await createBoard("b1");
+        const card = await createCard(getBoardsDb(), "b1", { kind: "note", x: 0, y: 0, w: 10, h: 10 });
+        const res = await create({ prompt: "pick one", options: ["a"], cardId: card.id });
+        expect(res.status).toBe(201);
+        expect(res.body.cardId).toBe(card.id);
+    });
+
+    it("GET lists a board's questions oldest-first", async () => {
+        await createBoard("b1");
+        const first = await create({ prompt: "first", options: ["a"] });
+        const second = await create({ prompt: "second", options: ["a"] });
+        const route = findRoute("GET", "/api/boards/:slug/questions");
+        const res = asJson(await route.handler(makeCtx({ params: { slug: "b1" } })));
+        expect(res.status).toBe(200);
+        const ids = (res.body.questions as Array<{ id: number }>).map((q) => q.id);
+        expect(ids).toEqual([first.body.id as number, second.body.id as number]);
+    });
+
+    it("answer: 200, staged remains true (dispatch releases it, not the answer), wraps a single string", async () => {
+        await createBoard("b1");
+        const created = await create({ prompt: "pick one", options: ["picked", "other"] });
+        const answerRoute = findRoute("POST", "/api/boards/questions/:id/answer");
+        const res = asJson(
+            await answerRoute.handler(makeCtx({ params: { id: String(created.body.id) }, body: { answer: "picked" } }))
+        );
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ answer: ["picked"], staged: true, answeredBy: "operator" });
+    });
+
+    it("answer: 400 when empty or over 500 chars; any string is otherwise accepted (off-vocabulary 'Other' text)", async () => {
+        await createBoard("b1");
+        const created = await create({ prompt: "pick one", options: ["picked"] });
+        const answerRoute = findRoute("POST", "/api/boards/questions/:id/answer");
+        expect(
+            asJson(
+                await answerRoute.handler(makeCtx({ params: { id: String(created.body.id) }, body: { answer: "" } }))
+            ).status
+        ).toBe(400);
+        expect(
+            asJson(
+                await answerRoute.handler(
+                    makeCtx({ params: { id: String(created.body.id) }, body: { answer: "x".repeat(501) } })
+                )
+            ).status
+        ).toBe(400);
+        const offVocab = asJson(
+            await answerRoute.handler(
+                makeCtx({ params: { id: String(created.body.id) }, body: { answer: "totally different text" } })
+            )
+        );
+        expect(offVocab.status).toBe(200);
+    });
+
+    it("answer: 404 on an unknown question id", async () => {
+        const answerRoute = findRoute("POST", "/api/boards/questions/:id/answer");
+        const res = asJson(await answerRoute.handler(makeCtx({ params: { id: "999" }, body: { answer: "picked" } })));
+        expect(res.status).toBe(404);
+    });
+
+    it("emits a `question` SSE event on create and on answer", async () => {
+        await createBoard("b1");
+        const events: string[] = [];
+        subscribeBoard("b1", (frame) =>
+            events.push((SafeJSON.parse(frame, { strict: true }) as { type: string }).type)
+        );
+        const created = await create({ prompt: "pick one", options: ["picked"] });
+        const answerRoute = findRoute("POST", "/api/boards/questions/:id/answer");
+        await answerRoute.handler(makeCtx({ params: { id: String(created.body.id) }, body: { answer: "picked" } }));
+        expect(events.filter((t) => t === "question").length).toBe(2);
+    });
+});

--- a/src/dev-dashboard/server/routes/boards-questions.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.ts
@@ -33,12 +33,13 @@ export function boardsQuestionsRoutes(): RouteDef[] {
             pattern: "/api/boards/:slug/questions",
             handler: async (ctx) => {
                 try {
-                    const body = await ctx.readJson<{
-                        cardId?: number;
-                        prompt?: string;
-                        options?: unknown;
-                        multiSelect?: boolean;
-                    }>();
+                    const body =
+                        (await ctx.readJson<{
+                            cardId?: number;
+                            prompt?: string;
+                            options?: unknown;
+                            multiSelect?: boolean;
+                        }>()) ?? {};
                     const prompt = (body.prompt ?? "").trim();
                     if (!prompt || prompt.length > MAX_QUESTION_PROMPT) {
                         return {
@@ -88,7 +89,7 @@ export function boardsQuestionsRoutes(): RouteDef[] {
             handler: async (ctx) => {
                 try {
                     const id = Number(ctx.params.id);
-                    const body = await ctx.readJson<{ answer?: string }>();
+                    const body = (await ctx.readJson<{ answer?: string }>()) ?? {};
                     const answer = (body.answer ?? "").trim();
                     if (!answer || answer.length > MAX_ANSWER_LEN) {
                         return {

--- a/src/dev-dashboard/server/routes/boards-questions.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.ts
@@ -1,0 +1,123 @@
+import { answerQuestion, createQuestion, listQuestions } from "@app/dev-dashboard/lib/boards/boards-store";
+import { MAX_ANSWER_LEN, MAX_QUESTION_PROMPT } from "@app/dev-dashboard/lib/boards/compose-types";
+import { normalizeOptions } from "@app/dev-dashboard/lib/boards/compose-validate";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
+import type { QuestionDto } from "@app/dev-dashboard/lib/boards/types";
+import type { RouteContext, RouteDef } from "@app/dev-dashboard/server/types";
+import { boardsError } from "./boards-errors";
+import { getOperator } from "./boards-sets";
+
+/** vitrinka's always-present free-text escape (handlers_questions.go) — rendered on every
+ *  response, never stored: the answer endpoint accepts any string regardless. */
+const OTHER_LABEL = "Other / Něco jiného";
+
+function toQuestionResponse(q: QuestionDto): Record<string, unknown> {
+    return { ...q, otherLabel: OTHER_LABEL };
+}
+
+/** Answering a question is a human/UI action by default (mirrors boards.ts's actorFrom). */
+async function actorFrom(ctx: RouteContext): Promise<string> {
+    const header = ctx.headers["x-board-actor"];
+    if (header) {
+        return header;
+    }
+    const operator = await getOperator();
+    return operator || "operator";
+}
+
+async function boardSlugForQuestionId(id: number): Promise<string | null> {
+    const row = await getBoardsDb()
+        .kysely.selectFrom("board_questions")
+        .innerJoin("boards", "boards.id", "board_questions.board_id")
+        .select("boards.slug")
+        .where("board_questions.id", "=", id)
+        .executeTakeFirst();
+    return row?.slug ?? null;
+}
+
+export function boardsQuestionsRoutes(): RouteDef[] {
+    return [
+        {
+            method: "POST",
+            pattern: "/api/boards/:slug/questions",
+            handler: async (ctx) => {
+                try {
+                    const body = await ctx.readJson<{
+                        cardId?: number;
+                        prompt?: string;
+                        options?: unknown;
+                        multiSelect?: boolean;
+                    }>();
+                    const prompt = (body.prompt ?? "").trim();
+                    if (!prompt || prompt.length > MAX_QUESTION_PROMPT) {
+                        return {
+                            kind: "json",
+                            status: 400,
+                            body: { error: `prompt is required (max ${MAX_QUESTION_PROMPT} chars)` },
+                        };
+                    }
+                    const normalized = normalizeOptions(body.options);
+                    if (!normalized.ok) {
+                        return {
+                            kind: "json",
+                            status: 422,
+                            body: {
+                                error: "options: 1-12 entries required (the 'Other' escape is added automatically)",
+                            },
+                        };
+                    }
+                    const question = await createQuestion(getBoardsDb(), ctx.params.slug, {
+                        cardId: body.cardId && body.cardId > 0 ? body.cardId : 0,
+                        prompt,
+                        options: normalized.options,
+                        multi: Boolean(body.multiSelect),
+                    });
+                    publishBoardEvent(ctx.params.slug, { type: "question", payload: question });
+                    return { kind: "json", status: 201, body: toQuestionResponse(question) };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+        {
+            method: "GET",
+            pattern: "/api/boards/:slug/questions",
+            handler: async (ctx) => {
+                try {
+                    const questions = await listQuestions(getBoardsDb(), ctx.params.slug);
+                    return { kind: "json", status: 200, body: { questions: questions.map(toQuestionResponse) } };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+        {
+            method: "POST",
+            pattern: "/api/boards/questions/:id/answer",
+            handler: async (ctx) => {
+                try {
+                    const id = Number(ctx.params.id);
+                    const body = await ctx.readJson<{ answer?: string }>();
+                    const answer = (body.answer ?? "").trim();
+                    if (!answer || answer.length > MAX_ANSWER_LEN) {
+                        return {
+                            kind: "json",
+                            status: 400,
+                            body: { error: `answer is required (max ${MAX_ANSWER_LEN} chars)` },
+                        };
+                    }
+                    const actor = await actorFrom(ctx);
+                    const question = await answerQuestion(getBoardsDb(), id, answer, actor);
+                    const slug = await boardSlugForQuestionId(id);
+                    if (slug) {
+                        publishBoardEvent(slug, { type: "question", payload: question });
+                    }
+                    return { kind: "json", status: 200, body: toQuestionResponse(question) };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+    ];
+}

--- a/src/dev-dashboard/server/routes/boards-questions.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.ts
@@ -4,9 +4,9 @@ import { normalizeOptions } from "@app/dev-dashboard/lib/boards/compose-validate
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
 import type { QuestionDto } from "@app/dev-dashboard/lib/boards/types";
-import type { RouteContext, RouteDef } from "@app/dev-dashboard/server/types";
+import type { RouteDef } from "@app/dev-dashboard/server/types";
 import { boardsError } from "./boards-errors";
-import { getOperator } from "./boards-sets";
+import { actorFrom } from "./boards-sets";
 
 /** vitrinka's always-present free-text escape (handlers_questions.go) — rendered on every
  *  response, never stored: the answer endpoint accepts any string regardless. */
@@ -14,16 +14,6 @@ const OTHER_LABEL = "Other / Něco jiného";
 
 function toQuestionResponse(q: QuestionDto): Record<string, unknown> {
     return { ...q, otherLabel: OTHER_LABEL };
-}
-
-/** Answering a question is a human/UI action by default (mirrors boards.ts's actorFrom). */
-async function actorFrom(ctx: RouteContext): Promise<string> {
-    const header = ctx.headers["x-board-actor"];
-    if (header) {
-        return header;
-    }
-    const operator = await getOperator();
-    return operator || "operator";
 }
 
 async function boardSlugForQuestionId(id: number): Promise<string | null> {

--- a/src/dev-dashboard/server/routes/boards-route-test-utils.ts
+++ b/src/dev-dashboard/server/routes/boards-route-test-utils.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { resetEventHub } from "@app/dev-dashboard/lib/boards/events";
+import { __resetLayoutDebounce } from "@app/dev-dashboard/lib/boards/layout-engine";
+import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import { env } from "@app/utils/env";
+
+/** Shared per-test board DB fixture (mkdtemp'd home + in-memory db, reset on both ends). */
+export function setupBoardsTestEnv(prefix: string): void {
+    let dir = "";
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), prefix));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        env.testing.set("BOARDS_DB_PATH", ":memory:");
+        resetDevDashboardStorage();
+        resetBoardsDb();
+        resetEventHub();
+    });
+
+    afterEach(() => {
+        __resetLayoutDebounce();
+        resetEventHub();
+        resetBoardsDb();
+        resetDevDashboardStorage();
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        env.testing.unset("BOARDS_DB_PATH");
+        rmSync(dir, { recursive: true, force: true });
+    });
+}

--- a/src/dev-dashboard/server/routes/boards-sets.test.ts
+++ b/src/dev-dashboard/server/routes/boards-sets.test.ts
@@ -1,16 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { createBoard, importSet } from "@app/dev-dashboard/lib/boards/boards-store";
-import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
-import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
+import { subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import { getSet } from "@app/dev-dashboard/lib/boards/sets-store";
 import { tarGz } from "@app/dev-dashboard/lib/boards/tar";
-import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
-import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
+import { setupBoardsTestEnv } from "./boards-route-test-utils";
 import { boardsSetsRoutes } from "./boards-sets";
 
 function findRoute(method: string, pattern: string): RouteDef {
@@ -98,25 +94,7 @@ async function putContent(
 }
 
 describe("boardsSetsRoutes", () => {
-    let dir: string;
-
-    beforeEach(() => {
-        dir = mkdtempSync(join(tmpdir(), "boards-sets-route-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-
-    afterEach(() => {
-        resetEventHub();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-        rmSync(dir, { recursive: true, force: true });
-    });
+    setupBoardsTestEnv("boards-sets-route-");
 
     it("PUT content: first push 201, re-push 200 with the same version and replaced file rows", async () => {
         const first = await putContent("proj", "main", "s1", [

--- a/src/dev-dashboard/server/routes/boards-sets.ts
+++ b/src/dev-dashboard/server/routes/boards-sets.ts
@@ -1,3 +1,4 @@
+import { sanitizeOperator } from "@app/boards/lib/operator";
 import { blobPath, blobUrl, mimeForPath } from "@app/dev-dashboard/lib/boards/blobs";
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
@@ -14,6 +15,7 @@ import {
 } from "@app/dev-dashboard/lib/boards/sets-store";
 import { untarGz } from "@app/dev-dashboard/lib/boards/tar";
 import type { RouteContext, RouteDef } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { escapeLike } from "@app/utils/database/predicates";
 import { type SqlBool, sql } from "kysely";
 import { boardsError } from "./boards-errors";
@@ -33,7 +35,10 @@ export async function getOperator(): Promise<string> {
 export async function actorFrom(ctx: RouteContext): Promise<string> {
     const header = ctx.headers["x-board-actor"];
     if (header) {
-        return header;
+        const sanitized = sanitizeOperator(header);
+        if (sanitized) {
+            return sanitized;
+        }
     }
 
     const operator = await getOperator();
@@ -118,12 +123,19 @@ export function boardsSetsRoutes(): RouteDef[] {
                         entries,
                     });
 
-                    await notifyStaleCards({
-                        project: result.set.project,
-                        branch: result.set.branch,
-                        key: result.set.key,
-                        version: result.set.version,
-                    });
+                    try {
+                        await notifyStaleCards({
+                            project: result.set.project,
+                            branch: result.set.branch,
+                            key: result.set.key,
+                            version: result.set.version,
+                        });
+                    } catch (err) {
+                        logger.warn(
+                            { err, project: result.set.project, branch: result.set.branch },
+                            "notifyStaleCards failed after syncSet already committed"
+                        );
+                    }
 
                     return {
                         kind: "json",
@@ -250,8 +262,9 @@ export function boardsSetsRoutes(): RouteDef[] {
             pattern: "/api/boards/operator",
             handler: async (ctx) => {
                 const body = await ctx.readJson<{ operator: string }>();
-                await setOperator(body.operator);
-                return { kind: "json", status: 200, body: { operator: body.operator } };
+                const operator = sanitizeOperator(body.operator);
+                await setOperator(operator);
+                return { kind: "json", status: 200, body: { operator } };
             },
         },
     ];

--- a/src/dev-dashboard/server/routes/boards-work.test.ts
+++ b/src/dev-dashboard/server/routes/boards-work.test.ts
@@ -1,16 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { createAnnotation } from "@app/dev-dashboard/lib/boards/annotations-store";
 import { createBoard, createCard } from "@app/dev-dashboard/lib/boards/boards-store";
-import { getBoardsDb, resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
-import { resetEventHub } from "@app/dev-dashboard/lib/boards/events";
+import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { claimOrRenewLease, dispatchBoard } from "@app/dev-dashboard/lib/boards/work-store";
-import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
-import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
+import { setupBoardsTestEnv } from "./boards-route-test-utils";
 import { boardsWorkRoutes } from "./boards-work";
 
 function findRoute(method: string, pattern: string): RouteDef {
@@ -44,22 +39,7 @@ function asJson(result: RouteResult): { status: number; body: Record<string, unk
 const REGION = { x: 0, y: 0, w: 1, h: 1 };
 
 describe("boardsWorkRoutes", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-work-routes-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-
-    afterEach(() => {
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        resetEventHub();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-work-routes-");
 
     it("(a) wait returns immediately when open work exists, capped at 3 capsules, with the right pending count", async () => {
         const db = getBoardsDb();

--- a/src/dev-dashboard/server/routes/boards-work.ts
+++ b/src/dev-dashboard/server/routes/boards-work.ts
@@ -90,9 +90,18 @@ export function boardsWorkRoutes(): RouteDef[] {
                         const { items, total } = await listOpenWorkDetailed(db, effectiveScope, 3);
                         const choices = await drainChoices(db, effectiveScope);
                         if (items.length > 0 || choices.length > 0) {
+                            const docCache = new Map<string, ReturnType<typeof getBoardDoc>>();
+                            const docFor = (slug: string) => {
+                                let doc = docCache.get(slug);
+                                if (!doc) {
+                                    doc = getBoardDoc(db, slug);
+                                    docCache.set(slug, doc);
+                                }
+                                return doc;
+                            };
                             const work = await Promise.all(
                                 items.map(async (it) => {
-                                    const doc = await getBoardDoc(db, it.boardSlug);
+                                    const doc = await docFor(it.boardSlug);
                                     return {
                                         id: it.annotation.id,
                                         board: it.boardSlug,

--- a/src/dev-dashboard/server/routes/boards-work.ts
+++ b/src/dev-dashboard/server/routes/boards-work.ts
@@ -1,3 +1,4 @@
+import { getBoardDoc } from "@app/dev-dashboard/lib/boards/boards-store";
 import { buildCapsule } from "@app/dev-dashboard/lib/boards/capsule";
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { waitForWorkSignal } from "@app/dev-dashboard/lib/boards/events";
@@ -89,11 +90,18 @@ export function boardsWorkRoutes(): RouteDef[] {
                         const { items, total } = await listOpenWorkDetailed(db, effectiveScope, 3);
                         const choices = await drainChoices(db, effectiveScope);
                         if (items.length > 0 || choices.length > 0) {
-                            const work = items.map((it) => ({
-                                id: it.annotation.id,
-                                board: it.boardSlug,
-                                capsule: buildCapsule(it.annotation, it.card, it.boardSlug),
-                            }));
+                            const work = await Promise.all(
+                                items.map(async (it) => {
+                                    const doc = await getBoardDoc(db, it.boardSlug);
+                                    return {
+                                        id: it.annotation.id,
+                                        board: it.boardSlug,
+                                        capsule: buildCapsule(it.annotation, it.card, it.boardSlug, {
+                                            boardCards: doc.cards,
+                                        }),
+                                    };
+                                })
+                            );
                             return {
                                 kind: "json",
                                 status: 200,

--- a/src/dev-dashboard/server/routes/boards.test.ts
+++ b/src/dev-dashboard/server/routes/boards.test.ts
@@ -1,15 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
-import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
-import { __resetLayoutDebounce } from "@app/dev-dashboard/lib/boards/layout-engine";
-import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import { describe, expect, it } from "bun:test";
+import { subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
-import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 import { boardsRoutes } from "./boards";
+import { setupBoardsTestEnv } from "./boards-route-test-utils";
 
 function findRoute(method: string, pattern: string): RouteDef {
     const def = boardsRoutes().find((d) => d.method === method && d.pattern === pattern);
@@ -94,23 +88,7 @@ async function createCard(slug: string, kind = "note"): Promise<Record<string, u
 }
 
 describe("boardsRoutes", () => {
-    beforeEach(() => {
-        const dir = mkdtempSync(join(tmpdir(), "boards-routes-"));
-        env.testing.set("GENESIS_TOOLS_HOME", dir);
-        env.testing.set("BOARDS_DB_PATH", ":memory:");
-        resetDevDashboardStorage();
-        resetBoardsDb();
-        resetEventHub();
-    });
-
-    afterEach(() => {
-        __resetLayoutDebounce();
-        resetBoardsDb();
-        resetDevDashboardStorage();
-        resetEventHub();
-        env.testing.unset("GENESIS_TOOLS_HOME");
-        env.testing.unset("BOARDS_DB_PATH");
-    });
+    setupBoardsTestEnv("boards-routes-");
 
     it("GET /api/boards/:slug/sections returns spatial sections with member counts and journeys", async () => {
         const { getBoardsDb } = await import("@app/dev-dashboard/lib/boards/db");

--- a/src/dev-dashboard/server/routes/boards.test.ts
+++ b/src/dev-dashboard/server/routes/boards.test.ts
@@ -110,6 +110,30 @@ describe("boardsRoutes", () => {
         env.testing.unset("BOARDS_DB_PATH");
     });
 
+    it("GET /api/boards/:slug/sections returns spatial sections with member counts and journeys", async () => {
+        const { getBoardsDb } = await import("@app/dev-dashboard/lib/boards/db");
+        const { createCard: storeCreateCard } = await import("@app/dev-dashboard/lib/boards/boards-store");
+        await createBoard("b1");
+        const db = getBoardsDb();
+        await storeCreateCard(db, "b1", {
+            kind: "section",
+            x: 0,
+            y: 0,
+            w: 400,
+            h: 400,
+            payload: { title: "Checkout", journey: "checkout", pass: 1 },
+        });
+        await storeCreateCard(db, "b1", { kind: "note", x: 100, y: 100, w: 50, h: 50, payload: { text: "hi" } });
+
+        const route = findRoute("GET", "/api/boards/:slug/sections");
+        const res = asJson(await route.handler(makeCtx({ params: { slug: "b1" } })));
+        expect(res.status).toBe(200);
+        const sections = res.body.sections as Array<{ name: string; cards: number; journey?: string }>;
+        expect(sections).toHaveLength(1);
+        expect(sections[0]).toMatchObject({ name: "Checkout", cards: 1, journey: "checkout", pass: 1 });
+        expect(res.body.journeys).toEqual([{ journey: "checkout", title: "Checkout", passes: 1, latest: "Checkout" }]);
+    });
+
     it("creates a board (201) and rejects a duplicate slug (409)", async () => {
         const post = findRoute("POST", "/api/boards");
         const first = await post.handler(makeCtx({ method: "POST", body: { slug: "b1" } }));

--- a/src/dev-dashboard/server/routes/boards.test.ts
+++ b/src/dev-dashboard/server/routes/boards.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resetBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { resetEventHub, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
+import { __resetLayoutDebounce } from "@app/dev-dashboard/lib/boards/layout-engine";
 import { resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
 import type { RouteContext, RouteDef, RouteResult } from "@app/dev-dashboard/server/types";
 import { env } from "@app/utils/env";
@@ -103,6 +104,7 @@ describe("boardsRoutes", () => {
     });
 
     afterEach(() => {
+        __resetLayoutDebounce();
         resetBoardsDb();
         resetDevDashboardStorage();
         resetEventHub();

--- a/src/dev-dashboard/server/routes/boards.ts
+++ b/src/dev-dashboard/server/routes/boards.ts
@@ -23,6 +23,7 @@ import {
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import { readImageDims } from "@app/dev-dashboard/lib/boards/image-size";
+import { notifyLayoutChanged } from "@app/dev-dashboard/lib/boards/layout-engine";
 import { sectionsToJSON } from "@app/dev-dashboard/lib/boards/sections";
 import { getSet } from "@app/dev-dashboard/lib/boards/sets-store";
 import { dispatchBoard } from "@app/dev-dashboard/lib/boards/work-store";
@@ -173,6 +174,7 @@ export function boardsRoutes(): RouteDef[] {
                         createdBy: body.createdBy ?? (await actorFrom(ctx)),
                     });
                     publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
+                    notifyLayoutChanged(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 201, body: card };
                 } catch (err) {
                     return boardsError(err);
@@ -200,6 +202,7 @@ export function boardsRoutes(): RouteDef[] {
                     const slug = await boardSlugForCardId(id);
                     if (slug) {
                         publishBoardEvent(slug, { type: "card", payload: card });
+                        notifyLayoutChanged(getBoardsDb(), slug);
                     }
                     return { kind: "json", status: 200, body: card };
                 } catch (err) {
@@ -217,6 +220,7 @@ export function boardsRoutes(): RouteDef[] {
                     await softDeleteCard(getBoardsDb(), id);
                     if (slug) {
                         publishBoardEvent(slug, { type: "card_deleted", payload: { id } });
+                        notifyLayoutChanged(getBoardsDb(), slug);
                     }
                     return { kind: "json", status: 200, body: { ok: true } };
                 } catch (err) {
@@ -234,6 +238,7 @@ export function boardsRoutes(): RouteDef[] {
                     const slug = await boardSlugForCardId(id);
                     if (slug) {
                         publishBoardEvent(slug, { type: "card", payload: card });
+                        notifyLayoutChanged(getBoardsDb(), slug);
                     }
                     return { kind: "json", status: 200, body: card };
                 } catch (err) {
@@ -364,6 +369,7 @@ export function boardsRoutes(): RouteDef[] {
                     for (const edge of result.edges) {
                         publishBoardEvent(ctx.params.slug, { type: "edge", payload: edge });
                     }
+                    notifyLayoutChanged(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 200, body: result };
                 } catch (err) {
                     return boardsError(err);
@@ -415,6 +421,7 @@ export function boardsRoutes(): RouteDef[] {
                         createdBy: await actorFrom(ctx),
                     });
                     publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
+                    notifyLayoutChanged(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 201, body: card };
                 } catch (err) {
                     return boardsError(err);

--- a/src/dev-dashboard/server/routes/boards.ts
+++ b/src/dev-dashboard/server/routes/boards.ts
@@ -23,6 +23,7 @@ import {
 import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent, subscribeBoard } from "@app/dev-dashboard/lib/boards/events";
 import { readImageDims } from "@app/dev-dashboard/lib/boards/image-size";
+import { sectionsToJSON } from "@app/dev-dashboard/lib/boards/sections";
 import { getSet } from "@app/dev-dashboard/lib/boards/sets-store";
 import { dispatchBoard } from "@app/dev-dashboard/lib/boards/work-store";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
@@ -103,6 +104,18 @@ export function boardsRoutes(): RouteDef[] {
                 try {
                     const doc = await getBoardDoc(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 200, body: doc };
+                } catch (err) {
+                    return boardsError(err);
+                }
+            },
+        },
+        {
+            method: "GET",
+            pattern: "/api/boards/:slug/sections",
+            handler: async (ctx) => {
+                try {
+                    const doc = await getBoardDoc(getBoardsDb(), ctx.params.slug);
+                    return { kind: "json", status: 200, body: sectionsToJSON(doc.cards) };
                 } catch (err) {
                     return boardsError(err);
                 }

--- a/src/dev-dashboard/server/static/boards-templates.md
+++ b/src/dev-dashboard/server/static/boards-templates.md
@@ -33,6 +33,7 @@ boards_compose_board {
   ]
 }
 ```
+
 Then: `boards_arrange {"board":"<slug>","scope":"section:Checkout","mode":"lanes","save":true}`
 (steps carry `payload.lane` when testing per-device).
 
@@ -47,6 +48,7 @@ boards_compose_board: {"board":"<slug>","journey":"checkout","pass":"next","card
 boards_arrange:       {"board":"<slug>","mode":"compare","sections":["Checkout","Checkout — pass 2"]}
 boards_scrape_board:  {"board":"<slug>","diff":["Checkout","Checkout — pass 2"]}  → matched pairs, one line each
 ```
+
 `boards_list_sections` → `journeys:[{journey,passes,latest}]` orients a fresh
 session; `{"journey":"checkout"}` without pass composes into the LATEST pass.
 Pixel-level: a `compare` card `{a:{cardId:v1},b:{cardId:v2},"mode":"wipe"}` per
@@ -95,6 +97,7 @@ boards_compose_board: {"board":"<slug>","cards":[
   {"ref":"co3","kind":"callout","payload":{"tone":"decision","md":"Ship behind a flag; measure for a week"}}
 ]}
 ```
+
 Per-slide layout: `boards_arrange {"board":"<slug>","scope":"section:1 · Problem","mode":"column","save":true}`
 (or grid for denser slides).
 
@@ -127,6 +130,7 @@ boards_compose_board: {"board":"<slug>","layout":"row","cards":[
     {"t":"tabbar","label":"home · search · profile"}]}}],
  "questions":[{"prompt":"Which login direction?","options":["A — classic","B — social-first"],"cardRef":"a"}]}
 ```
+
 Escalate to a TW4 artifact only after a direction wins.
 
 ---

--- a/src/dev-dashboard/server/static/boards-templates.md
+++ b/src/dev-dashboard/server/static/boards-templates.md
@@ -1,0 +1,136 @@
+# Board templates
+
+Canonical compositions for the AI expression layer — compose-ready skeletons an
+agent (or a human via the MCP tools) drops onto a board instead of inventing
+structure each time. Every template is ONE `boards_compose_board` call
+(batch-or-bust) plus at most one `boards_arrange {save:true}` for a
+self-maintaining layout. All elements are data-only (~100–300 tokens each);
+reference existing cards (`cardId`) — never re-upload a screen you can point at.
+
+Vocabulary these templates draw on: `section` (journey frame, auto-indexed,
+pill-navigable), `step`/`callout`/`checklist`/`compare` elements, `viz`
+(`table|matrix|flow|bars|timeline|line|stat`), `cluster` (+ `role:"kanban"`),
+auto-layout (`boards_arrange {scope:"section:…", mode, save:true}`).
+
+---
+
+## 1. QA session — one journey under test
+
+One section per journey; steps reference the pasted/snapped screens; a
+checklist tracks the sweep; callouts carry findings.
+
+```json
+boards_compose_board {
+  "board": "<slug>",
+  "cards": [
+    {"ref":"s","kind":"section","payload":{"title":"Checkout"},
+     "children":["st1","st2","cl","co"]},
+    {"ref":"st1","kind":"step","payload":{"n":1,"title":"Open cart","status":"pass","cardId":<shotId>}},
+    {"ref":"st2","kind":"step","payload":{"n":2,"title":"Pay","status":"fail","cardId":<shotId>,"note":"spinner never resolves"}},
+    {"ref":"cl","kind":"checklist","payload":{"title":"Sweep","items":[
+      {"text":"empty cart state"},{"text":"invalid card","done":true},{"text":"3DS redirect"}]}},
+    {"ref":"co","kind":"callout","payload":{"tone":"warn","md":"Pay button stays enabled while the request is in flight"}}
+  ]
+}
+```
+Then: `boards_arrange {"board":"<slug>","scope":"section:Checkout","mode":"lanes","save":true}`
+(steps carry `payload.lane` when testing per-device).
+
+## 2. Iteration review — pass chains
+
+Ship the rework as the journey's NEXT PASS (never mix takes): one compose call
+opens the linked section — auto-named, beside the previous pass, layout
+inherited — and fills it.
+
+```json
+boards_compose_board: {"board":"<slug>","journey":"checkout","pass":"next","cards":[…new shots/steps…]}
+boards_arrange:       {"board":"<slug>","mode":"compare","sections":["Checkout","Checkout — pass 2"]}
+boards_scrape_board:  {"board":"<slug>","diff":["Checkout","Checkout — pass 2"]}  → matched pairs, one line each
+```
+`boards_list_sections` → `journeys:[{journey,passes,latest}]` orients a fresh
+session; `{"journey":"checkout"}` without pass composes into the LATEST pass.
+Pixel-level: a `compare` card `{a:{cardId:v1},b:{cardId:v2},"mode":"wipe"}` per
+screen pair that matters.
+
+## 3. Decision map (brainstorm)
+
+Heading + one idea card per decision (stakes in the md), wired in dependency
+order, each with an anchored question; clusters per direction when the fork is
+wide. One `boards_compose_board` call places the whole map.
+
+## 4. Metrics / status dashboard
+
+One auto-layout section of viz cards — data-only, no artifacts.
+
+```json
+boards_compose_board: {"board":"<slug>","section":"Metrics","cards":[
+  {"kind":"viz","payload":{"viz":"stat","title":"today","data":{"items":[
+    {"label":"p95","value":"118","unit":"ms","delta":"-8%"},
+    {"label":"errors","value":"3","delta":"+1"},
+    {"label":"tokens","value":"412k","delta":"-12%"}]}}},
+  {"kind":"viz","payload":{"viz":"line","title":"tokens/day","data":{
+    "series":[{"label":"in","points":[380,401,395,412]},{"label":"out","points":[90,84,88,79]}],
+    "x":["mon","tue","wed","thu"]}}},
+  {"kind":"viz","payload":{"viz":"bars","data":{"items":[{"label":"web","value":14},{"label":"api","value":9}]}}}
+]}
+boards_arrange: {"board":"<slug>","scope":"section:Metrics","mode":"grid","cols":2,"gap":"M","save":true}
+```
+
+## 5. Presentation deck — sections ARE the slides
+
+Generate a deck as a series of sections in reading order. One slide = one
+section: a heading text card + at most 2–3 supporting cards (stat/line viz,
+callout, step, or a referenced shot). Keep slides sparse — it's a stage, not a
+dashboard.
+
+```json
+boards_compose_board: {"board":"<slug>","cards":[
+  {"ref":"s1","kind":"section","payload":{"title":"1 · Problem"},"children":["h1","c1"]},
+  {"ref":"h1","kind":"text","payload":{"role":"heading","md":"## Checkout drop-off"}},
+  {"ref":"c1","kind":"viz","payload":{"viz":"stat","data":{"items":[{"label":"drop-off","value":"38%","delta":"+6%"}]}}},
+  {"ref":"s2","kind":"section","payload":{"title":"2 · Evidence"},"children":["st"]},
+  {"ref":"st","kind":"step","payload":{"n":1,"title":"Pay fails on 3DS","status":"fail","cardId":<shotId>}},
+  {"ref":"s3","kind":"section","payload":{"title":"3 · Proposal"},"children":["h3","co3"]},
+  {"ref":"h3","kind":"text","payload":{"role":"heading","md":"## Inline 3DS + optimistic state"}},
+  {"ref":"co3","kind":"callout","payload":{"tone":"decision","md":"Ship behind a flag; measure for a week"}}
+]}
+```
+Per-slide layout: `boards_arrange {"board":"<slug>","scope":"section:1 · Problem","mode":"column","save":true}`
+(or grid for denser slides).
+
+## 6. Finding triage — kanban columns
+
+Three kanban clusters; drag findings between them (purely visual v1).
+
+```json
+boards_compose_board: {"board":"<slug>","cards":[
+  {"ref":"k1","kind":"cluster","payload":{"title":"Inbox","role":"kanban"},"children":[…]},
+  {"ref":"k2","kind":"cluster","payload":{"title":"Doing","role":"kanban"}},
+  {"ref":"k3","kind":"cluster","payload":{"title":"Done","role":"kanban"}}
+]}
+```
+
+## 7. UI proposal — wireframe screens
+
+Sketch proposed screens with `wireframe` cards (~100-250 tokens each) instead
+of HTML artifacts; put 2-3 variants in one row and anchor a question.
+
+```json
+boards_compose_board: {"board":"<slug>","layout":"row","cards":[
+  {"ref":"a","kind":"wireframe","payload":{"title":"Login A","device":"phone","nodes":[
+    {"t":"nav","label":"‹ back"},{"t":"img","h":"m"},
+    {"t":"input","label":"email"},{"t":"input","label":"password"},
+    {"t":"button","label":"sign in","primary":true},{"t":"text","label":"forgot password?"}]}},
+  {"ref":"b","kind":"wireframe","payload":{"title":"Login B","device":"phone","nodes":[
+    {"t":"heading","label":"Welcome back"},{"t":"list","n":2},
+    {"t":"divider"},{"t":"button","label":"continue with apple","primary":true},
+    {"t":"tabbar","label":"home · search · profile"}]}}],
+ "questions":[{"prompt":"Which login direction?","options":["A — classic","B — social-first"],"cardRef":"a"}]}
+```
+Escalate to a TW4 artifact only after a direction wins.
+
+---
+
+House rules that apply to every template: quiet-wire (no decorative boxes),
+batch-or-bust, never send coordinates, viz > artifact unless it must be a live
+HTML mockup, staged dispatch (the user's "Send to Claude" bar commits answers).

--- a/src/dev-dashboard/ui/src/components/boards/AiCards.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/AiCards.tsx
@@ -328,6 +328,7 @@ function WireframeNode({ node }: { node: Payload }) {
     if (t === "divider") {
         return <div className="my-1 h-px bg-[var(--dd-border)]" />;
     }
+
     if (t === "img") {
         const h = str(node, "h") || "m";
         const height = h === "s" ? "h-8" : h === "l" ? "h-24" : "h-14";
@@ -339,6 +340,7 @@ function WireframeNode({ node }: { node: Payload }) {
             </div>
         );
     }
+
     if (t === "list") {
         const n = num(node, "n") ?? 3;
         return (
@@ -349,6 +351,7 @@ function WireframeNode({ node }: { node: Payload }) {
             </div>
         );
     }
+
     if (t === "button") {
         return (
             <div
@@ -360,6 +363,7 @@ function WireframeNode({ node }: { node: Payload }) {
             </div>
         );
     }
+
     if (t === "input") {
         return (
             <div className="rounded border border-[var(--dd-border)] px-2 py-1 text-[10px] text-[var(--dd-text-muted)]">
@@ -367,9 +371,11 @@ function WireframeNode({ node }: { node: Payload }) {
             </div>
         );
     }
+
     if (t === "heading") {
         return <div className="text-xs font-semibold">{NODE_LABEL.heading(node)}</div>;
     }
+
     const label = NODE_LABEL[t]?.(node);
     return label ? (
         <div className="text-[10px] text-[var(--dd-text-muted)]">{label}</div>

--- a/src/dev-dashboard/ui/src/components/boards/AiCards.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/AiCards.tsx
@@ -1,0 +1,436 @@
+// Inner-content renderers for the AI expression layer's card kinds (payload.layer "ai"). Parity
+// of information, not pixel-perfection (plan decision §0.1.9) — CardView.tsx owns position/drag/
+// selection chrome and just delegates to these for the card BODY.
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { renderMdLite } from "./md-lite";
+
+type Payload = Record<string, unknown>;
+
+function str(payload: Payload, key: string): string {
+    return typeof payload[key] === "string" ? (payload[key] as string) : "";
+}
+
+function num(payload: Payload, key: string): number | undefined {
+    return typeof payload[key] === "number" ? (payload[key] as number) : undefined;
+}
+
+const ROLE_ACCENT: Record<string, string> = {
+    heading: "border-l-4 border-[var(--dd-accent-from)]",
+    idea: "border-l-4 border-sky-400",
+    pro: "border-l-4 border-emerald-400",
+    con: "border-l-4 border-[var(--dd-danger)]",
+    risk: "border-l-4 border-[var(--dd-warning)]",
+};
+
+/** kind "text": md-lite render with a left accent strip when payload.role is set. */
+export function TextCard({ payload }: { payload: Payload }) {
+    const role = str(payload, "role");
+    const accent = ROLE_ACCENT[role] ?? "";
+    return <div className={`h-full w-full overflow-auto p-1 pl-2 ${accent}`}>{renderMdLite(str(payload, "md"))}</div>;
+}
+
+const CALLOUT_TONE: Record<string, string> = {
+    info: "border-sky-400 bg-sky-400/10",
+    warn: "border-[var(--dd-warning)] bg-[var(--dd-warning)]/10",
+    success: "border-emerald-400 bg-emerald-400/10",
+    decision: "border-violet-400 bg-violet-400/10",
+};
+
+/** kind "callout": tone-colored border/background + md-lite body. */
+export function CalloutCard({ payload }: { payload: Payload }) {
+    const tone = str(payload, "tone") || "info";
+    return (
+        <div
+            className={`h-full w-full overflow-auto rounded-md border-l-4 p-2 ${CALLOUT_TONE[tone] ?? CALLOUT_TONE.info}`}
+        >
+            {renderMdLite(str(payload, "md"))}
+        </div>
+    );
+}
+
+const STEP_STATUS_DOT: Record<string, string> = {
+    pass: "bg-emerald-400",
+    fail: "bg-[var(--dd-danger)]",
+    todo: "bg-[var(--dd-text-muted)]",
+};
+
+/** kind "step": numbered journey step with a status chip, optional note. */
+export function StepCard({ payload }: { payload: Payload }) {
+    const n = num(payload, "n");
+    const status = str(payload, "status") || "todo";
+    const note = str(payload, "note");
+    return (
+        <div className="flex h-full w-full flex-col gap-1 overflow-auto p-2 text-sm">
+            <div className="flex items-center gap-2">
+                <span className={`h-2 w-2 shrink-0 rounded-full ${STEP_STATUS_DOT[status] ?? STEP_STATUS_DOT.todo}`} />
+                <span className="font-semibold text-[var(--dd-text-primary)]">
+                    {n != null ? `${n}. ` : ""}
+                    {str(payload, "title")}
+                </span>
+            </div>
+            {note ? <p className="text-xs text-[var(--dd-text-muted)]">{note}</p> : null}
+        </div>
+    );
+}
+
+/** kind "checklist": read-only items with a done count header. */
+export function ChecklistCard({ payload }: { payload: Payload }) {
+    const items = Array.isArray(payload.items) ? (payload.items as Array<{ text?: string; done?: boolean }>) : [];
+    const done = items.filter((it) => it.done).length;
+    return (
+        <div className="h-full w-full overflow-auto p-2 text-sm">
+            <div className="mb-1 font-semibold text-[var(--dd-text-primary)]">
+                {str(payload, "title") || "Checklist"} — {done}/{items.length}
+            </div>
+            <ul className="space-y-0.5">
+                {items.map((it, i) => (
+                    <li key={i} className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            checked={Boolean(it.done)}
+                            readOnly
+                            className="accent-[var(--dd-accent-from)]"
+                        />
+                        <span className={it.done ? "text-[var(--dd-text-muted)] line-through" : ""}>
+                            {it.text ?? ""}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function VizTable({ data }: { data: Payload }) {
+    const cols = Array.isArray(data.cols) ? (data.cols as string[]) : [];
+    const rows = Array.isArray(data.rows) ? (data.rows as unknown[][]) : [];
+    return (
+        <table className="w-full text-left text-xs">
+            <thead>
+                <tr>
+                    {cols.map((c, i) => (
+                        <th key={i} className="border-b border-[var(--dd-border)] pb-1 font-semibold">
+                            {c}
+                        </th>
+                    ))}
+                </tr>
+            </thead>
+            <tbody>
+                {rows.map((row, i) => (
+                    <tr key={i}>
+                        {row.map((cell, j) => (
+                            <td key={j} className="py-0.5">
+                                {String(cell)}
+                            </td>
+                        ))}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}
+
+function VizBars({ data }: { data: Payload }) {
+    const items = Array.isArray(data.items) ? (data.items as Array<{ label: string; value: number }>) : [];
+    const max = Math.max(1, ...items.map((it) => it.value));
+    return (
+        <div className="flex h-full flex-col justify-center gap-1.5">
+            {items.map((it, i) => (
+                <div key={i} className="flex items-center gap-2 text-xs">
+                    <span className="w-16 shrink-0 truncate text-[var(--dd-text-secondary)]">{it.label}</span>
+                    <div className="h-3 flex-1 rounded bg-[var(--dd-border)]">
+                        <div
+                            className="h-3 rounded bg-[var(--dd-accent-from)]"
+                            style={{ width: `${(it.value / max) * 100}%` }}
+                        />
+                    </div>
+                    <span className="w-8 shrink-0 text-right">{it.value}</span>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function VizTimeline({ data }: { data: Payload }) {
+    const items = Array.isArray(data.items) ? (data.items as Array<{ label: string; when: string }>) : [];
+    return (
+        <ul className="space-y-1 text-xs">
+            {items.map((it, i) => (
+                <li key={i} className="flex justify-between gap-2">
+                    <span>{it.label}</span>
+                    <span className="text-[var(--dd-text-muted)]">{it.when}</span>
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+function VizMatrix({ data }: { data: Payload }) {
+    const points = Array.isArray(data.points) ? (data.points as Array<{ label: string; x: number; y: number }>) : [];
+    return (
+        <div className="relative h-full w-full rounded border border-[var(--dd-border)]">
+            {points.map((p, i) => (
+                <span
+                    key={i}
+                    title={p.label}
+                    className="absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--dd-accent-from)]"
+                    style={{ left: `${p.x * 100}%`, top: `${(1 - p.y) * 100}%` }}
+                />
+            ))}
+        </div>
+    );
+}
+
+function VizFlow({ data }: { data: Payload }) {
+    const steps = Array.isArray(data.steps) ? (data.steps as string[]) : [];
+    return (
+        <div className="flex h-full items-center gap-1 overflow-auto text-xs">
+            {steps.map((s, i) => (
+                <span key={i} className="flex items-center gap-1 whitespace-nowrap">
+                    <span className="rounded-full bg-[var(--dd-border)] px-2 py-0.5">{s}</span>
+                    {i < steps.length - 1 ? <span className="text-[var(--dd-text-muted)]">→</span> : null}
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function VizLine({ data }: { data: Payload }) {
+    const series = Array.isArray(data.series) ? (data.series as Array<{ label: string; points: number[] }>) : [];
+    const all = series.flatMap((s) => s.points);
+    const min = Math.min(0, ...all);
+    const max = Math.max(1, ...all);
+    return (
+        <svg viewBox="0 0 100 40" preserveAspectRatio="none" className="h-full w-full">
+            {series.map((s, i) => {
+                const pts = s.points
+                    .map((v, j) => {
+                        const x = (j / Math.max(1, s.points.length - 1)) * 100;
+                        const y = 40 - ((v - min) / (max - min || 1)) * 40;
+                        return `${x},${y}`;
+                    })
+                    .join(" ");
+                return (
+                    <polyline
+                        key={i}
+                        points={pts}
+                        fill="none"
+                        stroke={i === 0 ? "var(--dd-accent-from)" : "var(--dd-text-muted)"}
+                        strokeWidth={1.5}
+                    />
+                );
+            })}
+        </svg>
+    );
+}
+
+function VizStat({ data }: { data: Payload }) {
+    const items = Array.isArray(data.items)
+        ? (data.items as Array<{ label: string; value: string | number; delta?: string; unit?: string }>)
+        : [];
+    return (
+        <div className="grid h-full grid-cols-1 gap-2 overflow-auto">
+            {items.map((it, i) => (
+                <div key={i}>
+                    <div className="text-lg font-bold text-[var(--dd-text-primary)]">
+                        {it.value}
+                        {it.unit ? <span className="text-xs font-normal"> {it.unit}</span> : null}
+                    </div>
+                    <div className="text-xs text-[var(--dd-text-muted)]">
+                        {it.label}
+                        {it.delta ? <span className="ml-1">{it.delta}</span> : null}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+/** kind "viz": dispatch on payload.viz — data-only visualizations, no charting dependency. */
+export function VizCard({ payload }: { payload: Payload }) {
+    const viz = str(payload, "viz") || "table";
+    const data = (typeof payload.data === "object" && payload.data !== null ? payload.data : {}) as Payload;
+    const title = str(payload, "title");
+    return (
+        <div className="flex h-full w-full flex-col gap-1 overflow-hidden p-2">
+            {title ? (
+                <div className="shrink-0 text-xs font-semibold text-[var(--dd-text-secondary)]">{title}</div>
+            ) : null}
+            <div className="min-h-0 flex-1">
+                {viz === "matrix" ? (
+                    <VizMatrix data={data} />
+                ) : viz === "flow" ? (
+                    <VizFlow data={data} />
+                ) : viz === "bars" ? (
+                    <VizBars data={data} />
+                ) : viz === "timeline" ? (
+                    <VizTimeline data={data} />
+                ) : viz === "line" ? (
+                    <VizLine data={data} />
+                ) : viz === "stat" ? (
+                    <VizStat data={data} />
+                ) : (
+                    <VizTable data={data} />
+                )}
+            </div>
+        </div>
+    );
+}
+
+/** kind "cluster": translucent frame + title. Renders under member cards — the frame itself is
+ *  pointer-events:none (clicks pass through to cards on top); only the title strip is
+ *  draggable/selectable. */
+export function ClusterFrame({
+    payload,
+    onTitlePointerDown,
+    onPointerMove,
+    onPointerUp,
+}: {
+    payload: Payload;
+    onTitlePointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (e: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (e: ReactPointerEvent<HTMLDivElement>) => void;
+}) {
+    return (
+        <div className="pointer-events-none h-full w-full rounded-lg border-2 border-dashed border-[var(--dd-border)] bg-[var(--dd-bg-panel)]/40">
+            <div
+                onPointerDown={onTitlePointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+                className="pointer-events-auto w-fit rounded-br-lg rounded-tl-lg bg-[var(--dd-bg-panel)] px-2 py-1 text-xs font-semibold text-[var(--dd-text-secondary)]"
+            >
+                {str(payload, "title") || "Cluster"}
+            </div>
+        </div>
+    );
+}
+
+const DEVICE_FRAME: Record<string, string> = {
+    phone: "rounded-2xl border-4",
+    tablet: "rounded-xl border-4",
+    web: "rounded-md border-2",
+};
+
+const NODE_LABEL: Record<string, (n: Payload) => string> = {
+    nav: (n) => str(n, "label") || "‹ back",
+    tabbar: (n) => str(n, "label") || "tab · tab · tab",
+    heading: (n) => str(n, "label") || "Heading",
+    text: (n) => str(n, "label"),
+    button: (n) => str(n, "label") || "Button",
+    input: (n) => str(n, "label") || "input",
+    listitem: (n) => str(n, "label") || "",
+    modal: (n) => str(n, "label") || "Modal",
+    chiprow: (n) => str(n, "label") || "",
+};
+
+function WireframeNode({ node }: { node: Payload }) {
+    const t = str(node, "t");
+    if (t === "divider") {
+        return <div className="my-1 h-px bg-[var(--dd-border)]" />;
+    }
+    if (t === "img") {
+        const h = str(node, "h") || "m";
+        const height = h === "s" ? "h-8" : h === "l" ? "h-24" : "h-14";
+        return (
+            <div
+                className={`flex ${height} items-center justify-center rounded bg-[var(--dd-border)] text-[9px] text-[var(--dd-text-muted)]`}
+            >
+                ⤫
+            </div>
+        );
+    }
+    if (t === "list") {
+        const n = num(node, "n") ?? 3;
+        return (
+            <div className="space-y-1">
+                {Array.from({ length: n }).map((_, i) => (
+                    <div key={i} className="h-3 rounded bg-[var(--dd-border)]" />
+                ))}
+            </div>
+        );
+    }
+    if (t === "button") {
+        return (
+            <div
+                className={`rounded px-2 py-1 text-center text-[10px] ${
+                    node.primary ? "bg-[var(--dd-accent-from)] text-black" : "border border-[var(--dd-border)]"
+                }`}
+            >
+                {NODE_LABEL.button(node)}
+            </div>
+        );
+    }
+    if (t === "input") {
+        return (
+            <div className="rounded border border-[var(--dd-border)] px-2 py-1 text-[10px] text-[var(--dd-text-muted)]">
+                {NODE_LABEL.input(node)}
+            </div>
+        );
+    }
+    if (t === "heading") {
+        return <div className="text-xs font-semibold">{NODE_LABEL.heading(node)}</div>;
+    }
+    const label = NODE_LABEL[t]?.(node);
+    return label ? (
+        <div className="text-[10px] text-[var(--dd-text-muted)]">{label}</div>
+    ) : (
+        <div className="rounded border border-dashed border-[var(--dd-border)] px-2 py-1 text-center text-[9px] text-[var(--dd-text-muted)]">
+            {t || "?"}
+        </div>
+    );
+}
+
+/** kind "wireframe": lo-fi UI sketch — nodes render top-to-bottom inside a device-shaped frame. */
+export function WireframeCard({ payload }: { payload: Payload }) {
+    const device = str(payload, "device") || "phone";
+    const nodes = Array.isArray(payload.nodes) ? (payload.nodes as Payload[]) : [];
+    return (
+        <div className="flex h-full w-full flex-col overflow-hidden">
+            {str(payload, "title") ? (
+                <div className="mb-1 shrink-0 text-xs font-semibold text-[var(--dd-text-secondary)]">
+                    {str(payload, "title")}
+                </div>
+            ) : null}
+            <div
+                className={`flex-1 space-y-1.5 overflow-auto border-[var(--dd-border)] bg-[var(--dd-bg-panel)] p-2 ${
+                    DEVICE_FRAME[device] ?? DEVICE_FRAME.phone
+                }`}
+            >
+                {nodes.map((n, i) => (
+                    <WireframeNode key={i} node={n} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+/** kind "shape": plain rounded rect with an optional label. */
+export function ShapeCard({ payload }: { payload: Payload }) {
+    const shape = str(payload, "shape") || "rect";
+    const color = str(payload, "color") || "var(--dd-accent-from)";
+    return (
+        <div
+            className={`flex h-full w-full items-center justify-center border-2 text-xs ${
+                shape === "ellipse" ? "rounded-full" : "rounded-md"
+            }`}
+            style={{ borderColor: color }}
+        >
+            {str(payload, "label")}
+        </div>
+    );
+}
+
+/** kind "compare": a lightweight reference card — the actual pixel diff lives in CompareDeck;
+ *  this is just a label pointing at the two cards it compares. */
+export function CompareRefCard({ payload }: { payload: Payload }) {
+    const a = (payload.a ?? {}) as Payload;
+    const b = (payload.b ?? {}) as Payload;
+    return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border border-[var(--dd-border)] text-xs text-[var(--dd-text-secondary)]">
+            <span>compare</span>
+            <span className="font-mono">
+                card {String(a.cardId ?? "?")} ↔ card {String(b.cardId ?? "?")}
+            </span>
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/boards/AnnotateComposer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/AnnotateComposer.tsx
@@ -87,7 +87,7 @@ export function AnnotateComposer({ screenX, screenY, onSubmit, onCancel }: Annot
                 <button
                     type="button"
                     onClick={submit}
-                    disabled={!prompt.trim()}
+                    disabled={!prompt.trim() || (intent === "other" && !intentOther.trim())}
                     className="dd-btn-accent rounded-full px-3 py-1 text-xs"
                 >
                     add

--- a/src/dev-dashboard/ui/src/components/boards/AnnotationLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/AnnotationLayer.tsx
@@ -87,14 +87,17 @@ export function AnnotationLayer({
                                 borderColor: color,
                                 color,
                                 background: "var(--dd-bg-base)",
+                                // Cards carry zIndex: card.z (z-order feature) — without an explicit
+                                // stack the pin paints under its own card and is unclickable.
+                                zIndex: 9999,
                             }}
                         >
                             {annotation.id}
                         </button>
                         {annotation.status === "staged" ? (
                             <div
-                                className="absolute z-10 w-56 rounded-md border border-[var(--dd-border)] bg-[var(--dd-bg-panel)] p-2 text-xs shadow-lg"
-                                style={{ left: rect.x + 16, top: rect.y + 16 }}
+                                className="absolute w-56 rounded-md border border-[var(--dd-border)] bg-[var(--dd-bg-panel)] p-2 text-xs shadow-lg"
+                                style={{ left: rect.x + 16, top: rect.y + 16, zIndex: 10000 }}
                             >
                                 <textarea
                                     defaultValue={annotation.prompt}

--- a/src/dev-dashboard/ui/src/components/boards/AnnotationLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/AnnotationLayer.tsx
@@ -1,9 +1,15 @@
 import type { AnnotationDto, AnnotationStatus, CardDto, Region } from "@app/dev-dashboard/contract/dto";
+import { useMemo } from "react";
+
+/** World px per source px: card.w / naturalWidth (falls back to card.w when naturalWidth is unknown). */
+export function getCardScaleFactor(card: CardDto): number {
+    const naturalWidth = typeof card.payload.naturalWidth === "number" ? card.payload.naturalWidth : card.w;
+    return card.w / naturalWidth;
+}
 
 /** Source-image px (as stored on the annotation) -> world px (as rendered on the card). */
 export function regionToWorldRect(card: CardDto, region: Region): { x: number; y: number; w: number; h: number } {
-    const naturalWidth = typeof card.payload.naturalWidth === "number" ? card.payload.naturalWidth : card.w;
-    const factor = card.w / naturalWidth; // world px per source px
+    const factor = getCardScaleFactor(card);
     return { x: card.x + region.x * factor, y: card.y + region.y * factor, w: region.w * factor, h: region.h * factor };
 }
 
@@ -43,7 +49,7 @@ export function AnnotationLayer({
     onReviseStaged,
     onDeleteStaged,
 }: AnnotationLayerProps) {
-    const cardById = new Map(cards.map((c) => [c.id, c]));
+    const cardById = useMemo(() => new Map(cards.map((c) => [c.id, c])), [cards]);
 
     return (
         <>

--- a/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
@@ -149,12 +149,16 @@ export function BoardCanvas({
     const renameSectionMutation = useMutation({
         mutationFn: ({ id, title }: { id: number; title: string }) => {
             const card = doc.cards.find((c) => c.id === id);
-            return boardsApi.patchCard(id, { payload: { ...(card?.payload ?? {}), title } });
+            if (!card) {
+                throw new Error(`section card not found: ${id}`);
+            }
+            return boardsApi.patchCard(id, { payload: { ...card.payload, title } });
         },
         onSuccess: () => {
             setRenamingSectionId(null);
             invalidate();
         },
+        onError: (err) => console.error("[boards] rename section failed", err),
     });
 
     const createAnnotationMutation = useMutation({

--- a/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
@@ -8,6 +8,9 @@ import { boardsApi } from "./boards-api";
 import { CardView } from "./CardView";
 import { EdgeLayer } from "./EdgeLayer";
 import { distanceToPolyline, InkLayer, strokeToWorldPath } from "./InkLayer";
+import { AnchoredQuestions, BoardLevelQuestions } from "./QuestionCard";
+import { SectionLayer } from "./SectionLayer";
+import { SectionPills } from "./SectionPills";
 import { type Tool, Toolbar } from "./Toolbar";
 import { fitBounds, panBy, resetZoom, screenToWorld, useViewport, zoomAt } from "./useViewport";
 
@@ -29,7 +32,9 @@ interface PanState {
 
 type Gesture =
     | { kind: "ink"; points: number[][] }
-    | { kind: "region"; cardId: number; start: { x: number; y: number }; current: { x: number; y: number } };
+    | { kind: "region"; cardId: number; start: { x: number; y: number }; current: { x: number; y: number } }
+    | { kind: "connect"; fromCardId: number; current: { x: number; y: number } }
+    | { kind: "section"; start: { x: number; y: number }; current: { x: number; y: number } };
 
 interface PendingRegion {
     cardId: number;
@@ -39,7 +44,8 @@ interface PendingRegion {
 }
 
 const ERASE_THRESHOLD_SCREEN_PX = 8;
-const TOOL_KEYS: Record<string, Tool> = { v: "move", p: "ink", a: "annotate", n: "note" };
+const MIN_SECTION_SIZE = 40;
+const TOOL_KEYS: Record<string, Tool> = { v: "move", p: "ink", a: "annotate", n: "note", c: "connect", s: "section" };
 
 function isTypingTarget(target: EventTarget | null): boolean {
     return (
@@ -65,6 +71,7 @@ export function BoardCanvas({
     const [dragOverrides, setDragOverrides] = useState<Record<number, { x: number; y: number }>>({});
     const [gesture, setGesture] = useState<Gesture | null>(null);
     const [pendingRegion, setPendingRegion] = useState<PendingRegion | null>(null);
+    const [renamingSectionId, setRenamingSectionId] = useState<number | null>(null);
 
     const invalidate = () => {
         void queryClient.invalidateQueries({ queryKey: ["board", slug] });
@@ -122,6 +129,32 @@ export function BoardCanvas({
         mutationFn: (id: number) => boardsApi.deleteStroke(id),
         onSuccess: invalidate,
         onError: (err) => console.error("[boards] delete stroke failed", err),
+    });
+
+    const addEdgeMutation = useMutation({
+        mutationFn: (edge: { fromCard: number; toCard?: number; toX?: number; toY?: number }) =>
+            boardsApi.addEdge(slug, edge),
+        onSuccess: invalidate,
+    });
+
+    const createSectionMutation = useMutation({
+        mutationFn: (region: { x: number; y: number; w: number; h: number }) =>
+            boardsApi.createCard(slug, { kind: "section", ...region, payload: { title: "Section" } }),
+        onSuccess: (card) => {
+            setRenamingSectionId(card.id as number);
+            invalidate();
+        },
+    });
+
+    const renameSectionMutation = useMutation({
+        mutationFn: ({ id, title }: { id: number; title: string }) => {
+            const card = doc.cards.find((c) => c.id === id);
+            return boardsApi.patchCard(id, { payload: { ...(card?.payload ?? {}), title } });
+        },
+        onSuccess: () => {
+            setRenamingSectionId(null);
+            invalidate();
+        },
     });
 
     const createAnnotationMutation = useMutation({
@@ -281,6 +314,16 @@ export function BoardCanvas({
         return hits.length === 0 ? null : hits.reduce((top, c) => (c.z > top.z ? c : top));
     };
 
+    // Connect tool: any card kind is a valid wire endpoint EXCEPT section frames (journey
+    // structure, not a connectable node).
+    const findAnyCardAt = (point: { x: number; y: number }): CardDto | null => {
+        const hits = cards.filter(
+            (c) =>
+                c.kind !== "section" && point.x >= c.x && point.x <= c.x + c.w && point.y >= c.y && point.y <= c.y + c.h
+        );
+        return hits.length === 0 ? null : hits.reduce((top, c) => (c.z > top.z ? c : top));
+    };
+
     const eraseStrokeNear = (point: { x: number; y: number }) => {
         const cardById = new Map(cards.map((c) => [c.id, c]));
         const threshold = ERASE_THRESHOLD_SCREEN_PX / vp.scale;
@@ -403,6 +446,28 @@ export function BoardCanvas({
             gestureRef.current = { pointerId: e.pointerId };
             const local = { x: point.x - card.x, y: point.y - card.y };
             setGesture({ kind: "region", cardId: card.id, start: local, current: local });
+            return;
+        }
+
+        if (tool === "connect") {
+            const point = worldPointFromEvent(e);
+            const card = findAnyCardAt(point);
+
+            if (!card) {
+                return;
+            }
+
+            e.currentTarget.setPointerCapture(e.pointerId);
+            gestureRef.current = { pointerId: e.pointerId };
+            setGesture({ kind: "connect", fromCardId: card.id, current: point });
+            return;
+        }
+
+        if (tool === "section") {
+            const point = worldPointFromEvent(e);
+            e.currentTarget.setPointerCapture(e.pointerId);
+            gestureRef.current = { pointerId: e.pointerId };
+            setGesture({ kind: "section", start: point, current: point });
         }
     };
 
@@ -423,6 +488,10 @@ export function BoardCanvas({
 
             if (g.kind === "ink") {
                 return { ...g, points: [...g.points, [point.x, point.y]] };
+            }
+
+            if (g.kind === "connect" || g.kind === "section") {
+                return { ...g, current: point };
             }
 
             const card = cards.find((c) => c.id === g.cardId);
@@ -465,6 +534,31 @@ export function BoardCanvas({
 
             if (path.length > 1) {
                 addStrokeMutation.mutate(path);
+            }
+
+            return;
+        }
+
+        if (g.kind === "connect") {
+            const target = findAnyCardAt(endPoint);
+
+            if (target && target.id !== g.fromCardId) {
+                addEdgeMutation.mutate({ fromCard: g.fromCardId, toCard: target.id });
+            } else if (!target) {
+                addEdgeMutation.mutate({ fromCard: g.fromCardId, toX: endPoint.x, toY: endPoint.y });
+            }
+
+            return;
+        }
+
+        if (g.kind === "section") {
+            const minX = Math.min(g.start.x, endPoint.x);
+            const minY = Math.min(g.start.y, endPoint.y);
+            const w = Math.abs(endPoint.x - g.start.x);
+            const h = Math.abs(endPoint.y - g.start.y);
+
+            if (w >= MIN_SECTION_SIZE && h >= MIN_SECTION_SIZE) {
+                createSectionMutation.mutate({ x: minX, y: minY, w, h });
             }
 
             return;
@@ -518,6 +612,11 @@ export function BoardCanvas({
                 className="absolute top-0 left-0"
                 style={{ transform: `translate(${vp.x}px, ${vp.y}px) scale(${vp.scale})`, transformOrigin: "0 0" }}
             >
+                <SectionLayer
+                    cards={cards}
+                    renamingId={renamingSectionId}
+                    onRename={(id, title) => renameSectionMutation.mutate({ id, title })}
+                />
                 {cards.map((card) => (
                     <CardView
                         key={card.id}
@@ -532,7 +631,7 @@ export function BoardCanvas({
                         panningRef={spaceDown}
                     />
                 ))}
-                <EdgeLayer edges={doc.edges} cards={cards} />
+                <EdgeLayer edges={doc.edges} cards={cards} liveEdge={gesture?.kind === "connect" ? gesture : null} />
                 <InkLayer
                     strokes={doc.strokes}
                     cards={cards}
@@ -547,13 +646,41 @@ export function BoardCanvas({
                     onReviseStaged={(id, prompt) => reviseAnnotationMutation.mutate({ id, prompt })}
                     onDeleteStaged={(id) => deleteAnnotationMutation.mutate(id)}
                 />
+                <AnchoredQuestions slug={slug} questions={doc.questions} cards={cards} />
+                {gesture?.kind === "section" ? (
+                    <div
+                        style={{
+                            position: "absolute",
+                            left: Math.min(gesture.start.x, gesture.current.x),
+                            top: Math.min(gesture.start.y, gesture.current.y),
+                            width: Math.abs(gesture.current.x - gesture.start.x),
+                            height: Math.abs(gesture.current.y - gesture.start.y),
+                            pointerEvents: "none",
+                        }}
+                        className="rounded-lg border-2 border-dashed border-[var(--dd-accent-from)]"
+                    />
+                ) : null}
             </div>
+
+            <SectionPills
+                slug={slug}
+                onSelect={(bounds) => {
+                    const el = containerRef.current;
+                    if (el) {
+                        setVp(fitBounds(bounds, el.clientWidth, el.clientHeight));
+                    }
+                }}
+            />
+            <BoardLevelQuestions slug={slug} questions={doc.questions} />
 
             <div
                 className="absolute inset-0"
                 style={{
                     pointerEvents: tool === "move" ? "none" : "auto",
-                    cursor: tool === "annotate" ? "crosshair" : tool === "ink" ? "crosshair" : "default",
+                    cursor:
+                        tool === "annotate" || tool === "ink" || tool === "connect" || tool === "section"
+                            ? "crosshair"
+                            : "default",
                 }}
                 onPointerDown={onOverlayPointerDown}
                 onPointerMove={onOverlayPointerMove}

--- a/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AnnotateComposer, type AnnotateSubmitInput } from "./AnnotateComposer";
-import { AnnotationLayer } from "./AnnotationLayer";
+import { AnnotationLayer, getCardScaleFactor } from "./AnnotationLayer";
 import { boardsApi } from "./boards-api";
 import { CardView } from "./CardView";
 import { EdgeLayer } from "./EdgeLayer";
@@ -590,8 +590,7 @@ export function BoardCanvas({
             return;
         }
 
-        const naturalWidth = typeof card.payload.naturalWidth === "number" ? card.payload.naturalWidth : card.w;
-        const factor = naturalWidth / card.w; // source px per world px
+        const factor = 1 / getCardScaleFactor(card); // source px per world px
         const region = {
             x: Math.round(minX * factor),
             y: Math.round(minY * factor),

--- a/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
@@ -667,7 +667,7 @@ export function BoardCanvas({
                 onSelect={(bounds) => {
                     const el = containerRef.current;
                     if (el) {
-                        setVp(fitBounds(bounds, el.clientWidth, el.clientHeight));
+                        setVp(fitBounds(bounds, { width: el.clientWidth, height: el.clientHeight }));
                     }
                 }}
             />

--- a/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/BoardCanvas.tsx
@@ -158,7 +158,10 @@ export function BoardCanvas({
             setRenamingSectionId(null);
             invalidate();
         },
-        onError: (err) => console.error("[boards] rename section failed", err),
+        onError: (err) => {
+            console.error("[boards] rename section failed", err);
+            setRenamingSectionId(null);
+        },
     });
 
     const createAnnotationMutation = useMutation({
@@ -619,7 +622,14 @@ export function BoardCanvas({
                 <SectionLayer
                     cards={cards}
                     renamingId={renamingSectionId}
-                    onRename={(id, title) => renameSectionMutation.mutate({ id, title })}
+                    onRename={(id, title) => {
+                        const trimmed = title.trim();
+                        if (trimmed) {
+                            renameSectionMutation.mutate({ id, title: trimmed });
+                        } else {
+                            setRenamingSectionId(null);
+                        }
+                    }}
                 />
                 {cards.map((card) => (
                     <CardView

--- a/src/dev-dashboard/ui/src/components/boards/CardView.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/CardView.tsx
@@ -2,7 +2,17 @@ import type { CardDto } from "@app/dev-dashboard/contract/dto";
 import { paths } from "@app/dev-dashboard/contract/endpoints";
 import type { CSSProperties, PointerEvent as ReactPointerEvent, RefObject } from "react";
 import { useRef, useState } from "react";
-import { renderMdLite } from "./md-lite";
+import {
+    CalloutCard,
+    ChecklistCard,
+    ClusterFrame,
+    CompareRefCard,
+    ShapeCard,
+    StepCard,
+    TextCard,
+    VizCard,
+    WireframeCard,
+} from "./AiCards";
 
 interface CardViewProps {
     card: CardDto;
@@ -153,9 +163,12 @@ export function CardView({
         );
     }
 
-    if (card.kind === "text") {
-        const md = stringField(card.payload, "md");
+    // Section frames render as always-visible background layers via SectionLayer.tsx, not here.
+    if (card.kind === "section") {
+        return null;
+    }
 
+    if (card.kind === "text") {
         return (
             <div
                 style={style}
@@ -165,7 +178,118 @@ export function CardView({
                 onPointerUp={onPointerUp}
                 onPointerCancel={onPointerUp}
             >
-                {renderMdLite(md)}
+                <TextCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "callout") {
+        return (
+            <div
+                style={style}
+                className={ring}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <CalloutCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "step") {
+        return (
+            <div
+                style={style}
+                className={`rounded-md bg-[var(--dd-bg-panel)] ${ring}`}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <StepCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "checklist") {
+        return (
+            <div
+                style={style}
+                className={`rounded-md bg-[var(--dd-bg-panel)] ${ring}`}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <ChecklistCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "viz") {
+        return (
+            <div
+                style={style}
+                className={`rounded-md bg-[var(--dd-bg-panel)] ${ring}`}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <VizCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "wireframe") {
+        return (
+            <div
+                style={style}
+                className={ring}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <WireframeCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "shape") {
+        return (
+            <div
+                style={style}
+                className={ring}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <ShapeCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "compare") {
+        return (
+            <div
+                style={style}
+                className={`rounded-md bg-[var(--dd-bg-panel)] ${ring}`}
+                onPointerDown={beginDrag}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+            >
+                <CompareRefCard payload={card.payload} />
+            </div>
+        );
+    }
+
+    if (card.kind === "cluster") {
+        return (
+            <div style={style}>
+                <ClusterFrame
+                    payload={card.payload}
+                    onTitlePointerDown={beginDrag}
+                    onPointerMove={onPointerMove}
+                    onPointerUp={onPointerUp}
+                />
             </div>
         );
     }

--- a/src/dev-dashboard/ui/src/components/boards/EdgeLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/EdgeLayer.tsx
@@ -1,13 +1,18 @@
 import type { CardDto, EdgeDto } from "@app/dev-dashboard/contract/dto";
+import { nearestSidePair, nearestSideToPoint } from "./edge-anchor";
 
 interface EdgeLayerProps {
     edges: EdgeDto[];
     cards: CardDto[];
+    /** The connect tool's in-progress drag, drawn as a dashed preview. */
+    liveEdge?: { fromCardId: number; current: { x: number; y: number } } | null;
 }
 
 /** One absolutely-positioned SVG spanning the world; overflow-visible so it never clips lines. */
-export function EdgeLayer({ edges, cards }: EdgeLayerProps) {
+export function EdgeLayer({ edges, cards, liveEdge }: EdgeLayerProps) {
     const cardById = new Map(cards.map((c) => [c.id, c]));
+    const liveFrom = liveEdge ? cardById.get(liveEdge.fromCardId) : null;
+    const liveStart = liveFrom && liveEdge ? nearestSideToPoint(liveFrom, liveEdge.current) : null;
 
     return (
         <svg className="absolute top-0 left-0 overflow-visible" style={{ pointerEvents: "none" }}>
@@ -38,26 +43,25 @@ export function EdgeLayer({ edges, cards }: EdgeLayerProps) {
                     return null;
                 }
 
-                const x1 = from.x + from.w;
-                const y1 = from.y + from.h / 2;
-                const x2 = to ? to.x : edge.toX;
-                const y2 = to ? to.y + to.h / 2 : edge.toY;
+                const [p1, p2] = to
+                    ? nearestSidePair(from, to)
+                    : [nearestSideToPoint(from, { x: edge.toX, y: edge.toY }), { x: edge.toX, y: edge.toY }];
 
                 return (
                     <g key={edge.id}>
                         <line
-                            x1={x1}
-                            y1={y1}
-                            x2={x2}
-                            y2={y2}
+                            x1={p1.x}
+                            y1={p1.y}
+                            x2={p2.x}
+                            y2={p2.y}
                             stroke="var(--dd-text-muted)"
                             strokeWidth={1.5}
                             markerEnd="url(#dd-edge-arrow)"
                         />
                         {edge.label ? (
                             <text
-                                x={(x1 + x2) / 2}
-                                y={(y1 + y2) / 2 - 4}
+                                x={(p1.x + p2.x) / 2}
+                                y={(p1.y + p2.y) / 2 - 4}
                                 textAnchor="middle"
                                 fontFamily="monospace"
                                 fontSize={10}
@@ -69,6 +73,17 @@ export function EdgeLayer({ edges, cards }: EdgeLayerProps) {
                     </g>
                 );
             })}
+            {liveStart && liveEdge ? (
+                <line
+                    x1={liveStart.x}
+                    y1={liveStart.y}
+                    x2={liveEdge.current.x}
+                    y2={liveEdge.current.y}
+                    stroke="var(--dd-accent-from)"
+                    strokeWidth={1.5}
+                    strokeDasharray="4 3"
+                />
+            ) : null}
         </svg>
     );
 }

--- a/src/dev-dashboard/ui/src/components/boards/InkLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/InkLayer.tsx
@@ -1,5 +1,6 @@
 import type { CardDto, StrokeDto } from "@app/dev-dashboard/contract/dto";
 import { useMemo } from "react";
+import { getCardScaleFactor } from "./AnnotationLayer";
 
 /** Convert a stroke's stored path to world-space points. Card-scoped strokes are stored in
  * the card's natural-image pixel space and need scaling by card.w / naturalWidth; board-level
@@ -18,8 +19,7 @@ export function strokeToWorldPath(
         return [];
     }
 
-    const naturalWidth = typeof card.payload.naturalWidth === "number" ? card.payload.naturalWidth : card.w;
-    const factor = card.w / naturalWidth;
+    const factor = getCardScaleFactor(card);
     return stroke.path.map(([x, y]) => [card.x + x * factor, card.y + y * factor]);
 }
 

--- a/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
@@ -28,10 +28,11 @@ function QuestionCard({ slug, question }: { slug: string; question: QuestionDto 
     }
 
     const submit = (labels: string[]) => {
-        if (labels.length === 0) {
+        const trimmed = labels.map((l) => l.trim()).filter((l) => l.length > 0);
+        if (trimmed.length === 0) {
             return;
         }
-        answerMutation.mutate(question.multi ? SafeJSON.stringify(labels) : labels[0]);
+        answerMutation.mutate(question.multi ? SafeJSON.stringify(trimmed) : trimmed[0]);
     };
 
     const toggle = (label: string) => {
@@ -60,7 +61,7 @@ function QuestionCard({ slug, question }: { slug: string; question: QuestionDto 
                         className={`rounded border px-2 py-1 text-left ${
                             picked.has(opt.label)
                                 ? "border-[var(--dd-accent-from)] bg-[var(--dd-accent-from)]/10"
-                                : "border-[var(--dd-border)] hover:bg-white/5"
+                                : "border-[var(--dd-border)] hover:bg-[var(--dd-bg-hover)]"
                         } ${opt.recommended ? "ring-1 ring-[var(--dd-accent-from)]" : ""}`}
                     >
                         {question.multi ? (picked.has(opt.label) ? "☑ " : "☐ ") : ""}
@@ -78,7 +79,14 @@ function QuestionCard({ slug, question }: { slug: string; question: QuestionDto 
                     {otherText ? (
                         <button
                             type="button"
-                            onClick={() => (question.multi ? toggle(otherText) : submit([otherText]))}
+                            onClick={() => {
+                                if (question.multi) {
+                                    toggle(otherText);
+                                    setOtherText("");
+                                } else {
+                                    submit([otherText]);
+                                }
+                            }}
                             className="dd-btn-accent rounded px-2"
                         >
                             {question.multi ? "add" : "send"}

--- a/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
@@ -1,0 +1,149 @@
+import type { CardDto, QuestionDto } from "@app/dev-dashboard/contract/dto";
+import { SafeJSON } from "@app/utils/json";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { boardsApi } from "./boards-api";
+
+const OTHER_LABEL = "Other / Něco jiného";
+const CARD_GAP = 12;
+
+function QuestionCard({ slug, question }: { slug: string; question: QuestionDto }) {
+    const queryClient = useQueryClient();
+    const [picked, setPicked] = useState<Set<string>>(new Set());
+    const [otherText, setOtherText] = useState("");
+
+    const answerMutation = useMutation({
+        mutationFn: (answer: string) => boardsApi.answerQuestion(question.id, answer),
+        onSuccess: () => void queryClient.invalidateQueries({ queryKey: ["board", slug] }),
+    });
+
+    if (question.answer !== null) {
+        return (
+            <div className="dd-panel w-64 rounded-md border border-[var(--dd-border)] p-2 text-xs text-[var(--dd-text-secondary)]">
+                <p className="mb-1 font-semibold text-[var(--dd-text-primary)]">{question.prompt}</p>
+                <p>picked: {question.answer.join(", ")}</p>
+                <p className="mt-1 text-[var(--dd-text-muted)]">staged — will send with next dispatch</p>
+            </div>
+        );
+    }
+
+    const submit = (labels: string[]) => {
+        if (labels.length === 0) {
+            return;
+        }
+        answerMutation.mutate(question.multi ? SafeJSON.stringify(labels) : labels[0]);
+    };
+
+    const toggle = (label: string) => {
+        setPicked((prev) => {
+            const next = new Set(prev);
+            if (next.has(label)) {
+                next.delete(label);
+            } else {
+                next.add(label);
+            }
+            return next;
+        });
+    };
+
+    return (
+        <div className="dd-panel w-64 rounded-md border border-[var(--dd-border)] p-2 text-xs">
+            <p className="mb-2 font-semibold text-[var(--dd-text-primary)]">{question.prompt}</p>
+            <div className="flex flex-col gap-1">
+                {question.options.map((opt) => (
+                    <button
+                        key={opt.label}
+                        type="button"
+                        title={opt.hint}
+                        onClick={() => (question.multi ? toggle(opt.label) : submit([opt.label]))}
+                        disabled={answerMutation.isPending}
+                        className={`rounded border px-2 py-1 text-left ${
+                            picked.has(opt.label)
+                                ? "border-[var(--dd-accent-from)] bg-[var(--dd-accent-from)]/10"
+                                : "border-[var(--dd-border)] hover:bg-white/5"
+                        } ${opt.recommended ? "ring-1 ring-[var(--dd-accent-from)]" : ""}`}
+                    >
+                        {question.multi ? (picked.has(opt.label) ? "☑ " : "☐ ") : ""}
+                        {opt.label}
+                    </button>
+                ))}
+                <div className="flex gap-1">
+                    <input
+                        type="text"
+                        value={otherText}
+                        onChange={(e) => setOtherText(e.target.value)}
+                        placeholder={OTHER_LABEL}
+                        className="min-w-0 flex-1 rounded border border-[var(--dd-border)] bg-transparent px-2 py-1 outline-none focus:border-[var(--dd-accent-from)]"
+                    />
+                    {otherText ? (
+                        <button
+                            type="button"
+                            onClick={() => (question.multi ? toggle(otherText) : submit([otherText]))}
+                            className="dd-btn-accent rounded px-2"
+                        >
+                            {question.multi ? "add" : "send"}
+                        </button>
+                    ) : null}
+                </div>
+                {question.multi ? (
+                    <button
+                        type="button"
+                        disabled={picked.size === 0 || answerMutation.isPending}
+                        onClick={() => submit([...picked])}
+                        className="dd-btn-accent mt-1 rounded px-2 py-1 disabled:opacity-40"
+                    >
+                        submit ({picked.size})
+                    </button>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+/** Card-anchored questions: pinned below their card, in WORLD space (pans/zooms with the canvas). */
+export function AnchoredQuestions({
+    slug,
+    questions,
+    cards,
+}: {
+    slug: string;
+    questions: QuestionDto[];
+    cards: CardDto[];
+}) {
+    const cardById = new Map(cards.map((c) => [c.id, c]));
+
+    return (
+        <>
+            {questions
+                .filter((q) => q.cardId != null)
+                .map((q) => {
+                    const card = cardById.get(q.cardId as number);
+                    if (!card) {
+                        return null;
+                    }
+                    return (
+                        <div key={q.id} style={{ position: "absolute", left: card.x, top: card.y + card.h + CARD_GAP }}>
+                            <QuestionCard slug={slug} question={q} />
+                        </div>
+                    );
+                })}
+        </>
+    );
+}
+
+/** Board-level questions: a fixed corner stack in SCREEN space (doesn't move with pan/zoom). */
+export function BoardLevelQuestions({ slug, questions }: { slug: string; questions: QuestionDto[] }) {
+    const boardLevel = questions.filter((q) => q.cardId == null);
+
+    if (boardLevel.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="absolute top-14 right-3 z-20 flex flex-col gap-2">
+            {boardLevel.map((q) => (
+                <QuestionCard key={q.id} slug={slug} question={q} />
+            ))}
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/boards/SectionLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/SectionLayer.tsx
@@ -1,0 +1,56 @@
+import type { CardDto } from "@app/dev-dashboard/contract/dto";
+
+interface SectionLayerProps {
+    cards: CardDto[];
+    /** The section currently being inline-renamed (just created by the "section" tool), if any. */
+    renamingId?: number | null;
+    onRename?: (id: number, title: string) => void;
+}
+
+/** Journey section frames: always-visible background layers (title top-left), z-under content.
+ *  Read-only in the canvas — editing goes through the AI-layer MCP tools (compose/update_cards)
+ *  or the "section" tool's drag-to-create + inline rename. */
+export function SectionLayer({ cards, renamingId, onRename }: SectionLayerProps) {
+    const sections = cards.filter((c) => c.kind === "section");
+
+    return (
+        <>
+            {sections.map((s) => {
+                const title = typeof s.payload.title === "string" ? s.payload.title : "";
+                return (
+                    <div
+                        key={s.id}
+                        style={{
+                            position: "absolute",
+                            left: s.x,
+                            top: s.y,
+                            width: s.w,
+                            height: s.h,
+                            pointerEvents: "none",
+                        }}
+                        className="rounded-lg border border-[var(--dd-border)]"
+                    >
+                        {renamingId === s.id ? (
+                            <input
+                                autoFocus
+                                defaultValue={title}
+                                onFocus={(e) => e.currentTarget.select()}
+                                onBlur={(e) => onRename?.(s.id, e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                        e.currentTarget.blur();
+                                    }
+                                }}
+                                className="pointer-events-auto absolute -top-6 left-0 w-40 rounded bg-[var(--dd-bg-panel)] px-1 font-mono text-xs font-semibold text-[var(--dd-text-primary)] outline-none"
+                            />
+                        ) : (
+                            <span className="absolute -top-6 left-0 font-mono text-xs font-semibold text-[var(--dd-text-secondary)]">
+                                {title}
+                            </span>
+                        )}
+                    </div>
+                );
+            })}
+        </>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/boards/SectionLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/SectionLayer.tsx
@@ -35,12 +35,7 @@ export function SectionLayer({ cards, renamingId, onRename }: SectionLayerProps)
                                 autoFocus
                                 defaultValue={title}
                                 onFocus={(e) => e.currentTarget.select()}
-                                onBlur={(e) => {
-                                    const next = e.currentTarget.value.trim();
-                                    if (next && next !== title) {
-                                        onRename?.(s.id, next);
-                                    }
-                                }}
+                                onBlur={(e) => onRename?.(s.id, e.currentTarget.value)}
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter") {
                                         e.currentTarget.blur();

--- a/src/dev-dashboard/ui/src/components/boards/SectionLayer.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/SectionLayer.tsx
@@ -35,7 +35,12 @@ export function SectionLayer({ cards, renamingId, onRename }: SectionLayerProps)
                                 autoFocus
                                 defaultValue={title}
                                 onFocus={(e) => e.currentTarget.select()}
-                                onBlur={(e) => onRename?.(s.id, e.currentTarget.value)}
+                                onBlur={(e) => {
+                                    const next = e.currentTarget.value.trim();
+                                    if (next && next !== title) {
+                                        onRename?.(s.id, next);
+                                    }
+                                }}
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter") {
                                         e.currentTarget.blur();

--- a/src/dev-dashboard/ui/src/components/boards/SectionPills.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/SectionPills.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+import { boardsApi } from "./boards-api";
+
+interface SectionPillsProps {
+    slug: string;
+    onSelect: (bounds: { minX: number; minY: number; maxX: number; maxY: number }) => void;
+}
+
+/** Pill navigation row over a board's journey sections (GET .../sections) — click pans/zooms the
+ *  viewport to fit that section's frame. */
+export function SectionPills({ slug, onSelect }: SectionPillsProps) {
+    const query = useQuery({
+        queryKey: ["board-sections", slug],
+        queryFn: () => boardsApi.sections(slug),
+        staleTime: 500,
+    });
+
+    const sections = query.data?.sections ?? [];
+
+    if (sections.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="absolute top-2 left-1/2 z-20 flex max-w-[80%] -translate-x-1/2 gap-1 overflow-x-auto rounded-full border border-[var(--dd-border)] bg-[var(--dd-bg-panel)] px-2 py-1">
+            {sections.map((s) => (
+                <button
+                    key={s.id}
+                    type="button"
+                    title={`${s.name} — ${s.cards} card${s.cards === 1 ? "" : "s"}`}
+                    onClick={() => onSelect({ minX: s.x, minY: s.y, maxX: s.x + s.w, maxY: s.y + s.h })}
+                    className="shrink-0 rounded-full px-2 py-0.5 text-xs whitespace-nowrap text-[var(--dd-text-secondary)] hover:bg-white/5 hover:text-[var(--dd-text-primary)]"
+                >
+                    {s.name}
+                    {s.pass != null ? <span className="ml-1 opacity-60">· pass {s.pass}</span> : null}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/boards/SectionPills.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/SectionPills.tsx
@@ -29,7 +29,7 @@ export function SectionPills({ slug, onSelect }: SectionPillsProps) {
                     type="button"
                     title={`${s.name} — ${s.cards} card${s.cards === 1 ? "" : "s"}`}
                     onClick={() => onSelect({ minX: s.x, minY: s.y, maxX: s.x + s.w, maxY: s.y + s.h })}
-                    className="shrink-0 rounded-full px-2 py-0.5 text-xs whitespace-nowrap text-[var(--dd-text-secondary)] hover:bg-white/5 hover:text-[var(--dd-text-primary)]"
+                    className="shrink-0 rounded-full px-2 py-0.5 text-xs whitespace-nowrap text-[var(--dd-text-secondary)] hover:bg-[var(--dd-bg-hover)] hover:text-[var(--dd-text-primary)]"
                 >
                     {s.name}
                     {s.pass != null ? <span className="ml-1 opacity-60">· pass {s.pass}</span> : null}

--- a/src/dev-dashboard/ui/src/components/boards/Toolbar.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/Toolbar.tsx
@@ -1,7 +1,7 @@
-import { MousePointer2, Pen, SquareDashedMousePointer, StickyNote } from "lucide-react";
+import { Frame, MousePointer2, Pen, Spline, SquareDashedMousePointer, StickyNote } from "lucide-react";
 import type { ComponentType } from "react";
 
-export type Tool = "move" | "ink" | "annotate" | "note";
+export type Tool = "move" | "ink" | "annotate" | "note" | "connect" | "section";
 
 interface ToolDef {
     tool: Tool;
@@ -15,6 +15,8 @@ const TOOLS: ToolDef[] = [
     { tool: "ink", label: "Ink", key: "P", Icon: Pen },
     { tool: "annotate", label: "Annotate", key: "A", Icon: SquareDashedMousePointer },
     { tool: "note", label: "Note", key: "N", Icon: StickyNote },
+    { tool: "connect", label: "Connect", key: "C", Icon: Spline },
+    { tool: "section", label: "Section", key: "S", Icon: Frame },
 ];
 
 interface ToolbarProps {

--- a/src/dev-dashboard/ui/src/components/boards/WirePanel.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/WirePanel.tsx
@@ -141,13 +141,13 @@ export function WirePanel({ slug, annotation, boardMessages, operator, onClose }
             return;
         }
 
-        if (annotation) {
-            replyMutation.mutate(body);
-        } else {
-            boardMessageMutation.mutate(body);
-        }
-
         setDraft("");
+
+        if (annotation) {
+            replyMutation.mutate(body, { onError: () => setDraft(body) });
+        } else {
+            boardMessageMutation.mutate(body, { onError: () => setDraft(body) });
+        }
     };
 
     const feed = annotation ? buildFeed(annotation) : [];

--- a/src/dev-dashboard/ui/src/components/boards/boards-api.ts
+++ b/src/dev-dashboard/ui/src/components/boards/boards-api.ts
@@ -8,6 +8,7 @@ import type {
     CardDto,
     EdgeDto,
     MessageDto,
+    QuestionDto,
     Region,
     StrokeDto,
 } from "@app/dev-dashboard/contract/dto";
@@ -24,6 +25,29 @@ export interface CardVersionDto {
     blobKey: string;
     attemptId: number | null;
     createdAt: string;
+}
+
+/** GET .../sections shapes — not part of the type-only contract (sections.ts isn't in dto.ts's
+ *  re-export allowlist), so declared here. */
+export interface SectionSummaryDto {
+    id: number;
+    name: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    cards: number;
+    order: number;
+    by?: string;
+    journey?: string;
+    pass?: number;
+}
+
+export interface JourneySummaryDto {
+    journey: string;
+    title: string;
+    passes: number;
+    latest: string;
 }
 
 function jsonInit(method: string, body: unknown): RequestInit {
@@ -83,4 +107,8 @@ export const boardsApi = {
     getOperator: () => fetchJson<{ operator: string }>(paths.boardsOperator()),
     setOperator: (operator: string) =>
         fetchJson<{ operator: string }>(paths.boardsOperator(), jsonInit("PUT", { operator })),
+    sections: (slug: string) =>
+        fetchJson<{ sections: SectionSummaryDto[]; journeys: JourneySummaryDto[] }>(paths.boardSections(slug)),
+    answerQuestion: (id: number, answer: string) =>
+        fetchJson<QuestionDto>(paths.boardQuestionAnswer(id), jsonInit("POST", { answer })),
 };

--- a/src/dev-dashboard/ui/src/components/boards/edge-anchor.test.ts
+++ b/src/dev-dashboard/ui/src/components/boards/edge-anchor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { cardSides, nearestSidePair, nearestSideToPoint } from "./edge-anchor";
+
+describe("cardSides", () => {
+    it("returns top/bottom/left/right midpoints", () => {
+        const sides = cardSides({ x: 0, y: 0, w: 100, h: 50 });
+        expect(sides).toEqual([
+            { x: 50, y: 0 },
+            { x: 50, y: 50 },
+            { x: 0, y: 25 },
+            { x: 100, y: 25 },
+        ]);
+    });
+});
+
+describe("nearestSidePair", () => {
+    it("picks right-of-a / left-of-b when b sits to the right", () => {
+        const a = { x: 0, y: 0, w: 100, h: 100 };
+        const b = { x: 300, y: 0, w: 100, h: 100 };
+        const [pa, pb] = nearestSidePair(a, b);
+        expect(pa).toEqual({ x: 100, y: 50 }); // a's right side
+        expect(pb).toEqual({ x: 300, y: 50 }); // b's left side
+    });
+
+    it("picks bottom-of-a / top-of-b when b sits directly below", () => {
+        const a = { x: 0, y: 0, w: 100, h: 100 };
+        const b = { x: 0, y: 300, w: 100, h: 100 };
+        const [pa, pb] = nearestSidePair(a, b);
+        expect(pa).toEqual({ x: 50, y: 100 }); // a's bottom side
+        expect(pb).toEqual({ x: 50, y: 300 }); // b's top side
+    });
+
+    it("is symmetric: swapping a/b swaps the returned pair", () => {
+        // Offset asymmetrically (not a 45° diagonal) so there's no exact tie between candidate pairs.
+        const a = { x: 0, y: 0, w: 100, h: 100 };
+        const b = { x: 400, y: 300, w: 100, h: 100 };
+        const [pa, pb] = nearestSidePair(a, b);
+        const [pb2, pa2] = nearestSidePair(b, a);
+        expect(pa).toEqual(pa2);
+        expect(pb).toEqual(pb2);
+    });
+});
+
+describe("nearestSideToPoint", () => {
+    it("picks the side closest to a point below-left of the card", () => {
+        const r = { x: 0, y: 0, w: 100, h: 100 };
+        const side = nearestSideToPoint(r, { x: -50, y: 200 });
+        expect(side).toEqual({ x: 50, y: 100 }); // bottom is closest
+    });
+});

--- a/src/dev-dashboard/ui/src/components/boards/edge-anchor.ts
+++ b/src/dev-dashboard/ui/src/components/boards/edge-anchor.ts
@@ -1,0 +1,51 @@
+// Pure geometry for EdgeLayer's connect-tool wires — port of vitrinka's edgeAnchors/cardSides
+// (board-1.mjs:485-517): a wire always leaves/enters the CLOSEST face of each card, not a fixed
+// side, so it reads naturally regardless of relative card position.
+export interface Rect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+export interface Point {
+    x: number;
+    y: number;
+}
+
+/** The four side-midpoints of a card's bounds: [top, bottom, left, right]. */
+export function cardSides(r: Rect): Point[] {
+    return [
+        { x: r.x + r.w / 2, y: r.y },
+        { x: r.x + r.w / 2, y: r.y + r.h },
+        { x: r.x, y: r.y + r.h / 2 },
+        { x: r.x + r.w, y: r.y + r.h / 2 },
+    ];
+}
+
+export function dist(a: Point, b: Point): number {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/** The pair of side-midpoints (one per rect) minimizing distance between them. */
+export function nearestSidePair(a: Rect, b: Rect): [Point, Point] {
+    let best: [Point, Point] = [cardSides(a)[3], cardSides(b)[2]];
+    let bestDist = Number.POSITIVE_INFINITY;
+
+    for (const pa of cardSides(a)) {
+        for (const pb of cardSides(b)) {
+            const d = dist(pa, pb);
+            if (d < bestDist) {
+                bestDist = d;
+                best = [pa, pb];
+            }
+        }
+    }
+
+    return best;
+}
+
+/** The side-midpoint of a rect nearest a fixed point (for point-anchored edges). */
+export function nearestSideToPoint(r: Rect, p: Point): Point {
+    return cardSides(r).reduce((best, side) => (dist(side, p) < dist(best, p) ? side : best));
+}

--- a/src/dev-dashboard/ui/src/components/boards/useBoardEvents.ts
+++ b/src/dev-dashboard/ui/src/components/boards/useBoardEvents.ts
@@ -4,10 +4,11 @@ import { SafeJSON } from "@app/utils/json";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
-/** Coarse P0 strategy: every SSE event invalidates ["board", slug] — correct but not
- * granular. A per-event-type cache patch is explicitly out of P0 scope (see plan §Task 25).
- * `onEvent` is an additional hook for callers that need a specific event's payload (e.g. the
- * set_version sync banner) — invalidation stays the default behavior regardless. */
+/** Coarse P0 strategy: every SSE event invalidates ["board", slug] (and the sibling
+ * ["board-sections", slug] query — section membership/journeys can change on any card write) —
+ * correct but not granular. A per-event-type cache patch is explicitly out of P0 scope (see plan
+ * §Task 25). `onEvent` is an additional hook for callers that need a specific event's payload
+ * (e.g. the set_version sync banner) — invalidation stays the default behavior regardless. */
 export function useBoardEvents(slug: string, onEvent?: (e: BoardEventDto) => void): { live: boolean } {
     const [live, setLive] = useState(false);
     const qc = useQueryClient();
@@ -21,16 +22,21 @@ export function useBoardEvents(slug: string, onEvent?: (e: BoardEventDto) => voi
         let attempt = 0;
         const MAX_RETRY_MS = 30_000;
 
+        const invalidate = () => {
+            void qc.invalidateQueries({ queryKey: ["board", slug] });
+            void qc.invalidateQueries({ queryKey: ["board-sections", slug] });
+        };
+
         const connect = () => {
             es = new EventSource(paths.boardEvents(slug));
             es.onopen = () => {
                 setLive(true);
                 attempt = 0;
                 // Full refetch on (re)connect — recovers any gap missed while disconnected.
-                void qc.invalidateQueries({ queryKey: ["board", slug] });
+                invalidate();
             };
             es.onmessage = (ev) => {
-                void qc.invalidateQueries({ queryKey: ["board", slug] });
+                invalidate();
 
                 try {
                     onEventRef.current?.(SafeJSON.parse(ev.data, { strict: true }) as BoardEventDto);


### PR DESCRIPTION
## What

Part II of the boards gap-fill plan: the AI expression layer on top of the annotation boards
port from PR #230. An agent can now PRESENT on a board, not just answer inside a fix-loop —
batched markdown/viz/section/question cards in one call, server-side auto-layout, a
structured board-digest read, spatial journey sections with iteration passes, and staged
multiple-choice questions that release onto the work wire on the same dispatch gate as
annotations.

10 commits, base `feat/dev-dashboard-boards` (retarget to `master` if PR #230 merges first):

- `feat(dev-dashboard/boards): compose payload validators + AI layer stamping` (Task 12)
- `feat(dev-dashboard/boards): spatial sections engine + journeys + GET sections` (Task 13)
- `feat(dev-dashboard/boards): compose — batched AI card/edge/question authoring with server-side placement` (Task 14)
- `feat(dev-dashboard/boards): arrange — 13-mode layout engine, section growth/displacement, saved-layout auto-reflow` (Task 15)
- `feat(dev-dashboard/boards): update-cards — batched AI-layer patch/remove/restore with trash undo` (Task 16)
- `feat(dev-dashboard/boards): scrape — flow-walked board digest with section scoping and A/B diff` (Task 17)
- `feat(dev-dashboard/boards): questions — create/list/answer routes completing the staged choice wire` (Task 18)
- `feat(claude-mcp/boards): expression-layer tools (compose/arrange/update_cards/scrape/sections/ask_board) + templates + capsule section/reshoot` (Task 19)
- `feat(dev-dashboard/boards-ui): AI card renderers, section frames+pills, question cards, connect tool` (Task 20)
- `test(dev-dashboard/boards): full-loop e2e over real HTTP + docs (operator, takeover, staged-dispatch, AI layer)` (Task 21)

## Why

Vitrinka (the reference implementation) already ships this expression layer; GT's boards port
(PR #230) only had the fix-loop half. Without compose/arrange/questions, an agent working a
board can reply in prose but can't present a decision map, a QA sweep, a metrics dashboard, or
a one-click multiple-choice question — the whole "board as a presentation surface" half of the
product was missing.

## Key decisions (plan §0.1 — do not relitigate)

1. **Reply-restage → vitrinka parity**: a reply on `in_review`/`resolved` re-stages to
   `staged`; replies on `working` don't touch status.
2. **Reject verdict**: GT keeps one reject affordance (CompareDeck only); it now guards
   superseded faces and stages the thread, rather than vitrinka's reply-only rejection UX.
3. **Dispatch is real UI**: `boardsApi.dispatch()` is wired to a staged-count "Send to Claude"
   bar — without it, staged annotations/questions have no way back onto the work wire.
4. **`wait_for_work` auto-leasing stays** (GT divergence): sessions lease with
   `session=hostname:pid`; the server gained `takeover=1` (expired-lease-only steal) for CLI
   parity with `tools boards watch --takeover`.
5. **AI layer marker**: `payload.layer === "ai"` in the card JSON, no new DB column. Section
   cards are layer-neutral (marker stripped — shared journey structure, not agent-owned).
6. **Questions answer body** is `{answer: string}` — a single string; multi-select answers are
   a JSON-array-encoded string INSIDE that string. Implemented against `drainChoices`'s actual
   parsing, not an earlier draft's `string[]` paraphrase.
7. **Section membership is spatial** (smallest frame containing a card's center) — no FK, no
   persisted children column.
8. **Dropped** (not ported): eve/AI review, components registry, project @-index, minimap,
   presentation mode, share pages, Plane/GH integrations, S3 blobs.
9. **Viz kinds**: all 7 (`table, matrix, flow, bars, timeline, line, stat`) validated
   server-side; UI renders all 7 simply — no charting dependency.
10. Part II built in a separate worktree/branch stacked on `feat/dev-dashboard-boards`.

## Verification

- `bun test` (boards/lib/server/contract/mcp/ui): 352 tests across 61 files — 351 pass, the
  sole intermittent failure is a pre-existing, documented `processes.test.ts` flake (live `ps`
  output ordering; unrelated to this change, confirmed non-deterministic across reruns, and
  passes clean on other runs of the same suite).
- `tsgo --noEmit` (whole repo) and `tsgo -p src/dev-dashboard/ui/tsconfig.json --noEmit`: 0
  errors.
- `bunx biome check`: clean.
- e2e: `src/claude/mcp/boards.e2e.test.ts` spins up a real dev-dashboard agent process and
  drives both the original annotate→wait→work→attach→in_review loop AND a full
  compose→sections→scrape→arrange→update_cards→questions(create/list/answer)→dispatch→wait
  loop over real HTTP through the assembled server (not direct handler calls) — this was the
  hard gate for this PR, since every Part II route test elsewhere calls its handler directly
  and never proved `registry.ts`'s registration order actually resolves through the real
  router. Both e2e tests pass.

## Demo (MCP compose loop)

```
boards_compose_board({
  board: "my-board",
  cards: [
    { ref: "s", kind: "section", payload: { title: "Checkout" }, children: ["a", "b"] },
    { ref: "a", kind: "text", payload: { md: "idea A" } },
    { ref: "b", kind: "note", payload: { text: "note B" } },
  ],
  questions: [{ prompt: "pick one", options: ["x", "y"], cardRef: "a" }],
})
boards_list_sections({ board: "my-board" })   // -> Checkout, 2 cards
boards_scrape_board({ board: "my-board", section: "Checkout" })
boards_arrange({ board: "my-board", mode: "column", scope: "section:Checkout", save: true })
```

The user answers the question with one click on the board; `POST /api/boards/:slug/dispatch`
(the "Send to Claude" bar) releases it onto `boards_wait_for_work`'s `choices[]`.

## Explicit backlog (not this plan)

Shot index + `search_shots` + `/library` UI; crop.png region crops + `annotation_elements` +
capsule Elements/Refs blocks; version-fan/time-machine UI + bulk card-versions endpoint;
thumbnails (needs a `sharp` decision); message attachments; multi-select foundation
(marquee/⌘G/clipboard/z-order/nudge) + undo/redo; wire-panel conversation rail; @-token/slash
completion (needs a project index — dropped); board rename affordance; artifact card kind +
TW4 wrapper; media multi-upload; presence cursors; viewport persistence + pinch; blob GC on
re-sync; tar extraction hardening; SSE subscriber backpressure; `doctor`; `snap` capture/WebP;
unattended work daemon; GT-native skills rewrite; board `url` field in `list_boards`; per-set
`--name` on push; shell completion.

## Known gap

Task 20's UI (11 card-kind renderers, section pills, question cards, connect tool) is verified
by `tsgo`/`biome`/pure-logic geometry tests only — a live browser smoke test (compose a brief
via MCP against a running dev-dashboard, screenshot the render) was not performed in this pass.
Recommend a human or a follow-up session with browser tooling do that before calling the UI
production-ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added board sections, question handling, and AI-assisted compose/arrange workflows.
  * Boards can now show section summaries, journey grouping, and question cards in the UI.
  * New board templates and a richer board digest are available for common workflows.

* **Bug Fixes**
  * Improved layout behavior, edge connections, and section resizing for board interactions.
  * Fixed question answer handling so single- and multi-select responses are stored consistently.
  * Improved lease/takeover messaging and operator handling for board writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->