### PR TITLE
feat(dev-dashboard/boards): seed structured logs across server routes and work-store

### DIFF
--- a/src/dev-dashboard/lib/boards/events.ts
+++ b/src/dev-dashboard/lib/boards/events.ts
@@ -28,9 +28,11 @@ export function subscribeBoard(slug: string, fn: Subscriber): () => void {
 export function publishBoardEvent(slug: string, event: BoardEvent): void {
     const set = subscribers.get(slug);
     if (!set || set.size === 0) {
+        logger.debug({ slug, type: event.type }, "boards sse: publish with no subscribers (dropped)");
         return;
     }
 
+    logger.debug({ slug, type: event.type, subscribers: set.size }, "boards sse: publish");
     const frame = SafeJSON.stringify(event);
     for (const fn of set) {
         try {
@@ -47,6 +49,9 @@ let waiters: Array<() => void> = [];
 export function wakeWorkWaiters(): void {
     const current = waiters;
     waiters = [];
+    if (current.length > 0) {
+        logger.debug({ waiters: current.length }, "boards work signal: waking long-pollers");
+    }
     for (const fn of current) {
         fn();
     }

--- a/src/dev-dashboard/lib/boards/work-store.ts
+++ b/src/dev-dashboard/lib/boards/work-store.ts
@@ -1,3 +1,4 @@
+import { logger } from "@app/logger";
 import type { DatabaseClient } from "@app/utils/database/client";
 import { escapeLike } from "@app/utils/database/predicates";
 import { env } from "@app/utils/env";
@@ -212,12 +213,14 @@ async function revertClaimsForListener(
 export async function reapExpiredListeners(db: DatabaseClient<BoardsDb>): Promise<number[]> {
     const cutoff = new Date(Date.now() - listenerTtlMs()).toISOString();
 
+    let reapedIds: number[] = [];
     const reverted = await db.kysely.transaction().execute(async (trx) => {
         const expired = await trx.selectFrom("listeners").select("id").where("last_seen", "<", cutoff).execute();
         if (expired.length === 0) {
             return [];
         }
         const expiredIds = expired.map((l) => l.id);
+        reapedIds = expiredIds;
 
         const items: Array<{ id: number; boardSlug: string }> = [];
         for (const listenerId of expiredIds) {
@@ -226,6 +229,13 @@ export async function reapExpiredListeners(db: DatabaseClient<BoardsDb>): Promis
         await trx.deleteFrom("listeners").where("id", "in", expiredIds).where("last_seen", "<", cutoff).execute();
         return items;
     });
+
+    if (reapedIds.length > 0) {
+        logger.info(
+            { listeners: reapedIds, revertedAnnotations: reverted.map((item) => item.id), cutoff },
+            "boards listeners: reaped expired leases"
+        );
+    }
 
     for (const item of reverted) {
         publishBoardEvent(item.boardSlug, { type: "status", payload: { id: item.id, status: "open" } });
@@ -263,6 +273,7 @@ export async function claimOrRenewLease(
             RETURNING *
         `.execute(db.kysely);
         const upserted = upsertResult.rows[0];
+        logger.debug({ id: upserted.id, session, actor }, "boards lease: all-scope claim/renew");
         return { conflict: false, id: upserted.id };
     }
 
@@ -281,6 +292,7 @@ export async function claimOrRenewLease(
                 .set({ last_seen: now, actor })
                 .where("id", "=", holder.id)
                 .execute();
+            logger.debug({ id: holder.id, ...cols, session }, "boards lease: renewed");
             return { conflict: false, id: holder.id };
         }
         // Steal expired leases ONLY, and only when the caller asked (takeover) — a live holder is
@@ -289,8 +301,16 @@ export async function claimOrRenewLease(
         const cutoff = new Date(Date.now() - listenerTtlMs()).toISOString();
         const live = holder.last_seen >= cutoff;
         if (!(takeover && !live)) {
+            logger.warn(
+                { ...cols, requestor: session, holderId: holder.id, holderSession: holder.session, live, takeover },
+                "boards lease: claim conflict"
+            );
             return { conflict: true, holder: toListenerDto(holder), live };
         }
+        logger.info(
+            { ...cols, requestor: session, holderId: holder.id, holderSession: holder.session },
+            "boards lease: taking over expired lease"
+        );
         await releaseLease(db, holder.id); // revert its claimed items + delete, then claim fresh below
     }
 
@@ -307,6 +327,7 @@ export async function claimOrRenewLease(
         RETURNING *
     `.execute(db.kysely);
     const upserted = upsertResult.rows[0];
+    logger.info({ id: upserted.id, ...cols, session, actor }, "boards lease: claimed");
     return { conflict: false, id: upserted.id };
 }
 
@@ -316,6 +337,7 @@ export async function releaseLease(db: DatabaseClient<BoardsDb>, id: number): Pr
         await trx.deleteFrom("listeners").where("id", "=", id).execute();
         return items;
     });
+    logger.debug({ id, revertedAnnotations: reverted.map((item) => item.id) }, "boards lease: released");
     for (const item of reverted) {
         publishBoardEvent(item.boardSlug, { type: "status", payload: { id: item.id, status: "open" } });
     }
@@ -380,6 +402,7 @@ export async function dispatchBoard(
         };
     });
 
+    logger.info({ board: boardSlug, opened, releasedQuestions }, "boards dispatch: staged items released");
     for (const id of opened) {
         publishBoardEvent(boardSlug, { type: "status", payload: { id, status: "open" } });
     }
@@ -402,6 +425,7 @@ export async function drainChoices(db: DatabaseClient<BoardsDb>, scope: WorkScop
         }
         const ids = rows.map((r) => r.id);
         await trx.updateTable("board_questions").set({ delivered: 1 }).where("id", "in", ids).execute();
+        logger.info({ scope, questionIds: ids }, "boards choices: drained answered questions");
 
         return rows.map((r) => ({
             type: "choice" as const,

--- a/src/dev-dashboard/server/routes/boards-annotations.ts
+++ b/src/dev-dashboard/server/routes/boards-annotations.ts
@@ -69,7 +69,6 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                             cardId: body.cardId,
                             intent: body.intent,
                             status: annotation.status,
-                            createdBy: annotation.createdBy,
                         },
                         "boards annotation: created"
                     );

--- a/src/dev-dashboard/server/routes/boards-annotations.ts
+++ b/src/dev-dashboard/server/routes/boards-annotations.ts
@@ -17,6 +17,7 @@ import { publishBoardEvent, wakeWorkWaiters } from "@app/dev-dashboard/lib/board
 import { getSet, getSetFile, setRefOf } from "@app/dev-dashboard/lib/boards/sets-store";
 import type { MessageAttachmentDto, Region } from "@app/dev-dashboard/lib/boards/types";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { boardsError } from "./boards-errors";
 import { actorFrom } from "./boards-sets";
 
@@ -61,6 +62,17 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                         createdBy: body.createdBy ?? (await actorFrom(ctx)),
                         status: body.status,
                     });
+                    logger.info(
+                        {
+                            id: annotation.id,
+                            board: annotation.boardSlug,
+                            cardId: body.cardId,
+                            intent: body.intent,
+                            status: annotation.status,
+                            createdBy: annotation.createdBy,
+                        },
+                        "boards annotation: created"
+                    );
                     publishBoardEvent(annotation.boardSlug, { type: "annotation", payload: annotation });
                     if (annotation.status === "open") {
                         wakeWorkWaiters();
@@ -103,6 +115,17 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                         claimedBy: body.actor ?? "claude",
                         claimedListener,
                     });
+                    logger.info(
+                        {
+                            id,
+                            board: annotation.boardSlug,
+                            status: body.status,
+                            regionPatched: body.region !== undefined,
+                            actor: body.actor ?? "claude",
+                            claimedListener,
+                        },
+                        "boards annotation: patched"
+                    );
                     if (body.status !== undefined) {
                         publishBoardEvent(annotation.boardSlug, {
                             type: "status",
@@ -125,6 +148,7 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                 try {
                     const id = Number(ctx.params.id);
                     const annotation = await cancelAnnotation(getBoardsDb(), id);
+                    logger.info({ id, board: annotation.boardSlug }, "boards annotation: cancelled");
                     publishBoardEvent(annotation.boardSlug, {
                         type: "status",
                         payload: { id, status: annotation.status },
@@ -142,6 +166,10 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                 try {
                     const id = Number(ctx.params.id);
                     const annotation = await reactivateAnnotation(getBoardsDb(), id);
+                    logger.info(
+                        { id, board: annotation.boardSlug, status: annotation.status },
+                        "boards annotation: reactivated"
+                    );
                     publishBoardEvent(annotation.boardSlug, {
                         type: "status",
                         payload: { id, status: annotation.status },
@@ -160,6 +188,10 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                     const id = Number(ctx.params.id);
                     const annotation = await getAnnotation(getBoardsDb(), id);
                     await deleteAnnotation(getBoardsDb(), id);
+                    logger.info(
+                        { id, board: annotation.boardSlug, status: annotation.status },
+                        "boards annotation: deleted"
+                    );
                     publishBoardEvent(annotation.boardSlug, { type: "annotation_deleted", payload: { id } });
                     return { kind: "json", status: 200, body: { ok: true } };
                 } catch (err) {
@@ -199,6 +231,10 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                         prompt: body.prompt,
                         createdBy: await actorFrom(ctx),
                     });
+                    logger.info(
+                        { id, board: annotation.boardSlug, revisions: annotation.revisions.length },
+                        "boards annotation: prompt revised"
+                    );
                     publishBoardEvent(annotation.boardSlug, { type: "annotation", payload: annotation });
                     return { kind: "json", status: 200, body: annotation };
                 } catch (err) {
@@ -225,10 +261,18 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                         body: body.body,
                         attachments: body.attachments,
                     });
+                    logger.debug(
+                        { id, board: before.boardSlug, author, chars: body.body.length },
+                        "boards annotation: message posted"
+                    );
                     publishBoardEvent(before.boardSlug, { type: "message", payload: message });
 
                     const after = await getAnnotation(getBoardsDb(), id);
                     if (after.status !== before.status) {
+                        logger.info(
+                            { id, board: before.boardSlug, from: before.status, to: after.status, author },
+                            "boards annotation: message flipped status"
+                        );
                         publishBoardEvent(before.boardSlug, { type: "status", payload: { id, status: after.status } });
                         wakeWorkWaiters();
                     }
@@ -270,6 +314,18 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                         commitRef: body.commit,
                     });
                     const annotation = await getAnnotation(getBoardsDb(), id);
+                    logger.info(
+                        {
+                            id,
+                            board: annotation.boardSlug,
+                            attemptId: result.attempt.id,
+                            afterSet: setRefOf(set),
+                            afterVersion: set.version,
+                            file: body.file,
+                            agent: body.agent,
+                        },
+                        "boards annotation: attempt attached"
+                    );
                     publishBoardEvent(annotation.boardSlug, { type: "attempt", payload: result.attempt });
                     publishBoardEvent(annotation.boardSlug, { type: "card", payload: result.card });
                     return { kind: "json", status: 201, body: result };
@@ -286,6 +342,16 @@ export function boardsAnnotationsRoutes(): RouteDef[] {
                     const attemptId = Number(ctx.params.id);
                     const body = await ctx.readJson<{ verdict: "accept" | "reject" }>();
                     const result = await setVerdict(getBoardsDb(), attemptId, body.verdict);
+                    logger.info(
+                        {
+                            attemptId,
+                            annotationId: result.annotation.id,
+                            board: result.annotation.boardSlug,
+                            verdict: body.verdict,
+                            status: result.annotation.status,
+                        },
+                        "boards annotation: verdict set"
+                    );
                     publishBoardEvent(result.annotation.boardSlug, { type: "attempt", payload: result.attempt });
                     if (body.verdict === "accept") {
                         publishBoardEvent(result.annotation.boardSlug, {

--- a/src/dev-dashboard/server/routes/boards-compose.ts
+++ b/src/dev-dashboard/server/routes/boards-compose.ts
@@ -12,6 +12,7 @@ import { type ArrangeBody, runArrange } from "@app/dev-dashboard/lib/boards/layo
 import { scrapeBoard } from "@app/dev-dashboard/lib/boards/scrape";
 import { boardPageUrl } from "@app/dev-dashboard/lib/public-base";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { boardsError } from "./boards-errors";
 import { getOperator } from "./boards-sets";
 
@@ -51,12 +52,34 @@ export function boardsComposeRoutes(): RouteDef[] {
                     const result = await composeBoard(getBoardsDb(), ctx.params.slug, body, actor);
                     if (!result.ok) {
                         const status = STATUS_BY_CODE[result.code] ?? 400;
+                        logger.warn(
+                            {
+                                slug: ctx.params.slug,
+                                actor,
+                                code: result.code,
+                                index: result.index,
+                                message: result.message,
+                            },
+                            "boards compose: rejected"
+                        );
                         return {
                             kind: "json",
                             status,
                             body: { error: result.message, code: result.code, index: result.index },
                         };
                     }
+                    logger.info(
+                        {
+                            slug: ctx.params.slug,
+                            actor,
+                            section: body.section,
+                            layout: body.layout,
+                            cards: result.cards.length,
+                            edges: result.edges.length,
+                            questions: result.questions.length,
+                        },
+                        "boards compose: placed"
+                    );
                     // SSE publishes AFTER the transaction commits.
                     if (result.events.cards.length > 0) {
                         publishBoardEvent(ctx.params.slug, { type: "cards", payload: result.events.cards });
@@ -92,12 +115,25 @@ export function boardsComposeRoutes(): RouteDef[] {
                     const result = await updateCards(getBoardsDb(), ctx.params.slug, body);
                     if (!result.ok) {
                         const status = STATUS_BY_CODE[result.code] ?? 400;
+                        logger.warn(
+                            { slug: ctx.params.slug, code: result.code, message: result.message },
+                            "boards update-cards: rejected"
+                        );
                         return {
                             kind: "json",
                             status,
                             body: { error: result.message, code: result.code, index: result.index },
                         };
                     }
+                    logger.info(
+                        {
+                            slug: ctx.params.slug,
+                            patched: result.patched,
+                            removed: result.removed,
+                            restored: result.restored,
+                        },
+                        "boards update-cards: applied"
+                    );
                     for (const card of result.events.cards) {
                         publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
                     }
@@ -143,8 +179,22 @@ export function boardsComposeRoutes(): RouteDef[] {
                     const body = (await ctx.readJson<ArrangeBody>()) ?? ({} as ArrangeBody);
                     const outcome = await runArrange(getBoardsDb(), ctx.params.slug, body);
                     if (!outcome.ok) {
+                        logger.warn(
+                            { slug: ctx.params.slug, mode: body.mode, scope: body.scope, message: outcome.message },
+                            "boards arrange: rejected"
+                        );
                         return { kind: "json", status: outcome.status, body: { error: outcome.message } };
                     }
+                    logger.info(
+                        {
+                            slug: ctx.params.slug,
+                            mode: body.mode,
+                            scope: body.scope,
+                            moved: outcome.moved,
+                            saved: outcome.saved,
+                        },
+                        "boards arrange: applied"
+                    );
                     // runArrange publishes the layout/card SSE events itself (after its writes commit).
                     return {
                         kind: "json",

--- a/src/dev-dashboard/server/routes/boards-errors.ts
+++ b/src/dev-dashboard/server/routes/boards-errors.ts
@@ -7,29 +7,39 @@ import {
 import { InvalidInputError, SlugConflictError } from "@app/dev-dashboard/lib/boards/boards-store";
 import { NameConflictError, NotFoundError } from "@app/dev-dashboard/lib/boards/sets-store";
 import type { RouteResult } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { errorResult } from "./error";
 
+/** Every boards route funnels its catch through here — the one place that sees ALL failures. */
 export function boardsError(err: unknown): RouteResult {
     if (err instanceof NotFoundError) {
+        logger.debug({ err: err.message }, "boards error: not found");
         return { kind: "json", status: 404, body: { error: err.message || "not found" } };
     }
     if (err instanceof CancelledError) {
+        logger.info({ err: err.message }, "boards error: write against a cancelled annotation");
         return { kind: "json", status: 409, body: { error: "annotation cancelled", code: "cancelled" } };
     }
     if (err instanceof NotCancellableError) {
+        logger.debug({ err: err.message }, "boards error: not cancellable");
         return { kind: "json", status: 409, body: { error: "not cancellable", code: "not_cancellable" } };
     }
     if (err instanceof NotUndoableError) {
+        logger.debug({ err: err.message }, "boards error: not undoable");
         return { kind: "json", status: 409, body: { error: "not undoable", code: "not_undoable" } };
     }
     if (err instanceof NameConflictError || err instanceof SlugConflictError) {
+        logger.info({ err: err.message }, "boards error: name/slug conflict");
         return { kind: "json", status: 409, body: { error: err.message || "conflict", code: "conflict" } };
     }
     if (err instanceof InvalidStatusError) {
+        logger.warn({ err: err.message }, "boards error: invalid status transition");
         return { kind: "json", status: 400, body: { error: err.message || "invalid status" } };
     }
     if (err instanceof InvalidInputError) {
+        logger.warn({ err: err.message }, "boards error: invalid input");
         return { kind: "json", status: 400, body: { error: err.message } };
     }
+    logger.error({ err }, "boards error: unhandled — returning 500");
     return errorResult(err);
 }

--- a/src/dev-dashboard/server/routes/boards-errors.ts
+++ b/src/dev-dashboard/server/routes/boards-errors.ts
@@ -17,7 +17,7 @@ export function boardsError(err: unknown): RouteResult {
         return { kind: "json", status: 404, body: { error: err.message || "not found" } };
     }
     if (err instanceof CancelledError) {
-        logger.info({ err: err.message }, "boards error: write against a cancelled annotation");
+        logger.warn({ err: err.message }, "boards error: write against a cancelled annotation");
         return { kind: "json", status: 409, body: { error: "annotation cancelled", code: "cancelled" } };
     }
     if (err instanceof NotCancellableError) {
@@ -29,7 +29,7 @@ export function boardsError(err: unknown): RouteResult {
         return { kind: "json", status: 409, body: { error: "not undoable", code: "not_undoable" } };
     }
     if (err instanceof NameConflictError || err instanceof SlugConflictError) {
-        logger.info({ err: err.message }, "boards error: name/slug conflict");
+        logger.warn({ err: err.message }, "boards error: name/slug conflict");
         return { kind: "json", status: 409, body: { error: err.message || "conflict", code: "conflict" } };
     }
     if (err instanceof InvalidStatusError) {

--- a/src/dev-dashboard/server/routes/boards-questions.ts
+++ b/src/dev-dashboard/server/routes/boards-questions.ts
@@ -5,6 +5,7 @@ import { getBoardsDb } from "@app/dev-dashboard/lib/boards/db";
 import { publishBoardEvent } from "@app/dev-dashboard/lib/boards/events";
 import type { QuestionDto } from "@app/dev-dashboard/lib/boards/types";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { boardsError } from "./boards-errors";
 import { actorFrom } from "./boards-sets";
 
@@ -42,6 +43,10 @@ export function boardsQuestionsRoutes(): RouteDef[] {
                         }>()) ?? {};
                     const prompt = (body.prompt ?? "").trim();
                     if (!prompt || prompt.length > MAX_QUESTION_PROMPT) {
+                        logger.warn(
+                            { slug: ctx.params.slug, promptChars: prompt.length },
+                            "boards question: rejected — missing/oversized prompt"
+                        );
                         return {
                             kind: "json",
                             status: 400,
@@ -50,6 +55,7 @@ export function boardsQuestionsRoutes(): RouteDef[] {
                     }
                     const normalized = normalizeOptions(body.options);
                     if (!normalized.ok) {
+                        logger.warn({ slug: ctx.params.slug }, "boards question: rejected — invalid options");
                         return {
                             kind: "json",
                             status: 422,
@@ -64,6 +70,16 @@ export function boardsQuestionsRoutes(): RouteDef[] {
                         options: normalized.options,
                         multi: Boolean(body.multiSelect),
                     });
+                    logger.info(
+                        {
+                            slug: ctx.params.slug,
+                            id: question.id,
+                            cardId: question.cardId,
+                            options: normalized.options.length,
+                            multi: Boolean(body.multiSelect),
+                        },
+                        "boards question: created"
+                    );
                     publishBoardEvent(ctx.params.slug, { type: "question", payload: question });
                     return { kind: "json", status: 201, body: toQuestionResponse(question) };
                 } catch (err) {
@@ -101,6 +117,10 @@ export function boardsQuestionsRoutes(): RouteDef[] {
                     const actor = await actorFrom(ctx);
                     const question = await answerQuestion(getBoardsDb(), id, answer, actor);
                     const slug = await boardSlugForQuestionId(id);
+                    logger.info(
+                        { id, slug, actor, staged: question.staged, answerChars: answer.length },
+                        "boards question: answered"
+                    );
                     if (slug) {
                         publishBoardEvent(slug, { type: "question", payload: question });
                     }

--- a/src/dev-dashboard/server/routes/boards-sets.ts
+++ b/src/dev-dashboard/server/routes/boards-sets.ts
@@ -90,11 +90,13 @@ export function boardsSetsRoutes(): RouteDef[] {
             handler: async (ctx) => {
                 const { project, branch, key } = ctx.params;
                 if (!KEY_RE.test(key) || isReservedKey(key)) {
+                    logger.warn({ project, branch, key }, "boards sets: push rejected — invalid key");
                     return { kind: "json", status: 400, body: { error: `invalid set key: ${key}` } };
                 }
 
                 const raw = await ctx.readRawBody();
                 if (raw.length > MAX_UPLOAD_BYTES) {
+                    logger.warn({ project, branch, key, bytes: raw.length }, "boards sets: push rejected — too large");
                     return { kind: "json", status: 413, body: { error: "upload too large (max 200 MiB)" } };
                 }
 
@@ -102,6 +104,7 @@ export function boardsSetsRoutes(): RouteDef[] {
                 try {
                     entries = await untarGz(raw);
                 } catch (err) {
+                    logger.warn({ err, project, branch, key }, "boards sets: push rejected — unparseable tar.gz");
                     return {
                         kind: "json",
                         status: 400,
@@ -122,6 +125,19 @@ export function boardsSetsRoutes(): RouteDef[] {
                         sourceRef: ctx.query.get("source") ?? undefined,
                         entries,
                     });
+
+                    logger.info(
+                        {
+                            project: result.set.project,
+                            branch: result.set.branch,
+                            key: result.set.key,
+                            version: result.set.version,
+                            files: result.set.fileCount,
+                            bytes: result.set.bytes,
+                            created: result.created,
+                        },
+                        "boards sets: set pushed"
+                    );
 
                     try {
                         await notifyStaleCards({
@@ -228,6 +244,7 @@ export function boardsSetsRoutes(): RouteDef[] {
                         ctx.params.selector,
                         body
                     );
+                    logger.info({ ...ctx.params, patch: Object.keys(body) }, "boards sets: set renamed/retitled");
                     return { kind: "json", status: 200, body: updated };
                 } catch (err) {
                     return boardsError(err);
@@ -264,6 +281,7 @@ export function boardsSetsRoutes(): RouteDef[] {
                 const body = await ctx.readJson<{ operator: string }>();
                 const operator = sanitizeOperator(body.operator);
                 await setOperator(operator);
+                logger.info({ operator }, "boards: operator identity changed");
                 return { kind: "json", status: 200, body: { operator } };
             },
         },

--- a/src/dev-dashboard/server/routes/boards-work.ts
+++ b/src/dev-dashboard/server/routes/boards-work.ts
@@ -13,6 +13,7 @@ import {
     releaseLease,
 } from "@app/dev-dashboard/lib/boards/work-store";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { boardsError } from "./boards-errors";
 
 function parseScope(q: URLSearchParams): WorkScope | null {
@@ -36,12 +37,14 @@ export function boardsWorkRoutes(): RouteDef[] {
             method: "GET",
             pattern: "/api/boards/work",
             handler: async (ctx) => {
-                const work = await listWork(getBoardsDb(), {
+                const filter = {
                     status: ctx.query.get("status") ?? undefined,
                     board: ctx.query.get("board") ?? undefined,
                     project: ctx.query.get("project") ?? undefined,
                     branch: ctx.query.get("branch") ?? undefined,
-                });
+                };
+                const work = await listWork(getBoardsDb(), filter);
+                logger.debug({ ...filter, count: work.length }, "boards work: list");
                 return { kind: "json", status: 200, body: { work } };
             },
         },
@@ -58,20 +61,36 @@ export function boardsWorkRoutes(): RouteDef[] {
                     const session = ctx.query.get("session") ?? "";
                     const actor = ctx.query.get("actor") ?? "";
                     const takeover = ctx.query.get("takeover") === "1";
+                    logger.debug({ scope, session, actor, timeoutSec, takeover }, "boards wait: armed");
                     if (session && !scope) {
+                        logger.warn({ session, actor }, "boards wait: leased wait without a scope rejected");
                         return {
                             kind: "json",
                             status: 400,
                             body: { error: "leased waits require a scope (board | project | all=1)" },
                         };
                     }
-                    const deadline = Date.now() + timeoutSec * 1000;
+                    const startedAt = Date.now();
+                    const deadline = startedAt + timeoutSec * 1000;
                     let leaseId: number | undefined;
                     for (;;) {
                         await reapExpiredListeners(db);
                         if (session && scope) {
                             const lease = await claimOrRenewLease(db, scope, session, actor, takeover);
                             if (lease.conflict) {
+                                logger.warn(
+                                    {
+                                        scope,
+                                        session,
+                                        actor,
+                                        takeover,
+                                        holderId: lease.holder.id,
+                                        holderSession: lease.holder.session,
+                                        holderLastSeen: lease.holder.lastSeen,
+                                        live: lease.live,
+                                    },
+                                    "boards wait: lease conflict"
+                                );
                                 return {
                                     kind: "json",
                                     status: 409,
@@ -111,6 +130,18 @@ export function boardsWorkRoutes(): RouteDef[] {
                                     };
                                 })
                             );
+                            logger.info(
+                                {
+                                    scope,
+                                    session,
+                                    listener: leaseId,
+                                    workIds: work.map((w) => w.id),
+                                    choiceIds: choices.map((c) => c.id),
+                                    pending: total,
+                                    waitedMs: Date.now() - startedAt,
+                                },
+                                "boards wait: returning work"
+                            );
                             return {
                                 kind: "json",
                                 status: 200,
@@ -124,6 +155,10 @@ export function boardsWorkRoutes(): RouteDef[] {
                         }
                         const remaining = deadline - Date.now();
                         if (remaining <= 0) {
+                            logger.debug(
+                                { scope, session, listener: leaseId, waitedMs: Date.now() - startedAt },
+                                "boards wait: idle timeout"
+                            );
                             return {
                                 kind: "json",
                                 status: 200,
@@ -151,10 +186,12 @@ export function boardsWorkRoutes(): RouteDef[] {
             handler: async (ctx) => {
                 const id = Number(ctx.params.id);
                 if (!Number.isInteger(id)) {
+                    logger.warn({ raw: ctx.params.id }, "boards listeners: delete with invalid id");
                     return { kind: "json", status: 400, body: { error: "invalid listener id" } };
                 }
 
                 const reverted = await releaseLease(getBoardsDb(), id);
+                logger.info({ id, reverted }, "boards listeners: lease released via DELETE");
                 return { kind: "json", status: 200, body: { reverted } };
             },
         },

--- a/src/dev-dashboard/server/routes/boards-work.ts
+++ b/src/dev-dashboard/server/routes/boards-work.ts
@@ -61,7 +61,9 @@ export function boardsWorkRoutes(): RouteDef[] {
                     const session = ctx.query.get("session") ?? "";
                     const actor = ctx.query.get("actor") ?? "";
                     const takeover = ctx.query.get("takeover") === "1";
+
                     logger.debug({ scope, session, actor, timeoutSec, takeover }, "boards wait: armed");
+
                     if (session && !scope) {
                         logger.warn({ session, actor }, "boards wait: leased wait without a scope rejected");
                         return {
@@ -70,6 +72,7 @@ export function boardsWorkRoutes(): RouteDef[] {
                             body: { error: "leased waits require a scope (board | project | all=1)" },
                         };
                     }
+
                     const startedAt = Date.now();
                     const deadline = startedAt + timeoutSec * 1000;
                     let leaseId: number | undefined;

--- a/src/dev-dashboard/server/routes/boards.ts
+++ b/src/dev-dashboard/server/routes/boards.ts
@@ -31,6 +31,7 @@ import type { MessageAttachmentDto } from "@app/dev-dashboard/lib/boards/types";
 import { dispatchBoard } from "@app/dev-dashboard/lib/boards/work-store";
 import { publicBaseUrl } from "@app/dev-dashboard/lib/public-base";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { logger } from "@app/logger";
 import { boardsError } from "./boards-errors";
 import { actorFrom } from "./boards-sets";
 
@@ -97,6 +98,10 @@ export function boardsRoutes(): RouteDef[] {
                         project?: string;
                     }>();
                     const board = await createBoard(getBoardsDb(), body);
+                    logger.info(
+                        { slug: board.slug, boardType: body.boardType, project: body.project },
+                        "boards: board created"
+                    );
                     const url = `${await publicBaseUrl()}/boards/${board.slug}`;
                     return { kind: "json", status: 201, body: { ...board, url } };
                 } catch (err) {
@@ -144,6 +149,7 @@ export function boardsRoutes(): RouteDef[] {
                 try {
                     const body = await ctx.readJson<{ title?: string; project?: string; archived?: boolean }>();
                     const board = await patchBoard(getBoardsDb(), ctx.params.slug, body);
+                    logger.info({ slug: ctx.params.slug, patch: Object.keys(body) }, "boards: board patched");
                     return { kind: "json", status: 200, body: board };
                 } catch (err) {
                     return boardsError(err);
@@ -185,6 +191,10 @@ export function boardsRoutes(): RouteDef[] {
                         ...body,
                         createdBy: body.createdBy ?? (await actorFrom(ctx)),
                     });
+                    logger.info(
+                        { slug: ctx.params.slug, id: card.id, kind: body.kind, createdBy: card.createdBy },
+                        "boards: card created"
+                    );
                     publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
                     notifyLayoutChanged(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 201, body: card };
@@ -212,6 +222,7 @@ export function boardsRoutes(): RouteDef[] {
                         >();
                     const card = await patchCard(getBoardsDb(), id, body);
                     const slug = await boardSlugForCardId(id);
+                    logger.debug({ id, slug, patch: Object.keys(body) }, "boards: card patched");
                     if (slug) {
                         publishBoardEvent(slug, { type: "card", payload: card });
                         notifyLayoutChanged(getBoardsDb(), slug);
@@ -230,6 +241,7 @@ export function boardsRoutes(): RouteDef[] {
                     const id = Number(ctx.params.id);
                     const slug = await boardSlugForCardId(id);
                     await softDeleteCard(getBoardsDb(), id);
+                    logger.info({ id, slug }, "boards: card soft-deleted");
                     if (slug) {
                         publishBoardEvent(slug, { type: "card_deleted", payload: { id } });
                         notifyLayoutChanged(getBoardsDb(), slug);
@@ -248,6 +260,7 @@ export function boardsRoutes(): RouteDef[] {
                     const id = Number(ctx.params.id);
                     const card = await restoreCard(getBoardsDb(), id);
                     const slug = await boardSlugForCardId(id);
+                    logger.info({ id, slug }, "boards: card restored from trash");
                     if (slug) {
                         publishBoardEvent(slug, { type: "card", payload: card });
                         notifyLayoutChanged(getBoardsDb(), slug);
@@ -290,6 +303,7 @@ export function boardsRoutes(): RouteDef[] {
                         ctx.params.slug,
                         body.strokes.map((s) => ({ ...s, createdBy: s.createdBy ?? actor }))
                     );
+                    logger.debug({ slug: ctx.params.slug, count: strokes.length, actor }, "boards: strokes added");
                     publishBoardEvent(ctx.params.slug, { type: "strokes", payload: strokes });
                     return { kind: "json", status: 201, body: { strokes } };
                 } catch (err) {
@@ -349,6 +363,10 @@ export function boardsRoutes(): RouteDef[] {
                         ...body,
                         createdBy: body.createdBy ?? (await actorFrom(ctx)),
                     });
+                    logger.debug(
+                        { slug: ctx.params.slug, id: edge.id, fromCard: body.fromCard, toCard: body.toCard },
+                        "boards: edge added"
+                    );
                     publishBoardEvent(ctx.params.slug, { type: "edge", payload: edge });
                     return { kind: "json", status: 201, body: edge };
                 } catch (err) {
@@ -380,6 +398,7 @@ export function boardsRoutes(): RouteDef[] {
                 try {
                     const body = await ctx.readJson<{ moves: Array<{ id: number; x: number; y: number }> }>();
                     await bulkLayout(getBoardsDb(), ctx.params.slug, body.moves);
+                    logger.debug({ slug: ctx.params.slug, moves: body.moves.length }, "boards: bulk layout applied");
                     publishBoardEvent(ctx.params.slug, { type: "layout", payload: { moves: body.moves } });
                     return { kind: "json", status: 200, body: { ok: true } };
                 } catch (err) {
@@ -395,6 +414,10 @@ export function boardsRoutes(): RouteDef[] {
                     const body = await ctx.readJson<{ project: string; branch: string; selector: string }>();
                     const set = await getSet(getBoardsDb(), body.project, body.branch, body.selector);
                     const result = await importSet(getBoardsDb(), ctx.params.slug, set);
+                    logger.info(
+                        { slug: ctx.params.slug, ...body, imported: result.cards.length, edges: result.edges.length },
+                        "boards: set imported"
+                    );
                     publishBoardEvent(ctx.params.slug, { type: "cards", payload: result.cards });
                     for (const edge of result.edges) {
                         publishBoardEvent(ctx.params.slug, { type: "edge", payload: edge });
@@ -414,6 +437,15 @@ export function boardsRoutes(): RouteDef[] {
                     const body = await ctx.readJson<{ project: string; branch: string; selector: string }>();
                     const set = await getSet(getBoardsDb(), body.project, body.branch, body.selector);
                     const result = await syncSetCards(getBoardsDb(), ctx.params.slug, set);
+                    logger.info(
+                        {
+                            slug: ctx.params.slug,
+                            ...body,
+                            updated: result.updated,
+                            skipped: result.skippedFiles.length,
+                        },
+                        "boards: set cards synced"
+                    );
                     const doc = await getBoardDoc(getBoardsDb(), ctx.params.slug);
                     publishBoardEvent(ctx.params.slug, { type: "cards", payload: doc.cards });
                     return { kind: "json", status: 200, body: result };
@@ -450,6 +482,10 @@ export function boardsRoutes(): RouteDef[] {
                         payload: { naturalWidth, naturalHeight },
                         createdBy: await actorFrom(ctx),
                     });
+                    logger.info(
+                        { slug: ctx.params.slug, id: card.id, name, mime, bytes: bytes.length, w, h },
+                        "boards: image uploaded as media card"
+                    );
                     publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
                     notifyLayoutChanged(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 201, body: card };
@@ -492,6 +528,10 @@ export function boardsRoutes(): RouteDef[] {
                         body: body.body,
                         attachments: body.attachments,
                     });
+                    logger.debug(
+                        { slug: ctx.params.slug, id: message.id, author: message.author, chars: body.body.length },
+                        "boards: board-level message posted"
+                    );
                     publishBoardEvent(ctx.params.slug, { type: "board_message", payload: message });
                     return { kind: "json", status: 201, body: message };
                 } catch (err) {
@@ -520,11 +560,13 @@ export function boardsRoutes(): RouteDef[] {
             handler: (ctx) => ({
                 kind: "sse",
                 start: (emit) => {
+                    logger.debug({ slug: ctx.params.slug }, "boards sse: stream opened");
                     emit.comment(` board ${ctx.params.slug} stream open`);
                     const unsubscribe = subscribeBoard(ctx.params.slug, (frame) => emit.data(frame));
                     const keepAlive = setInterval(() => emit.comment(" ping"), 12_000);
                     return {
                         close: () => {
+                            logger.debug({ slug: ctx.params.slug }, "boards sse: stream closed");
                             clearInterval(keepAlive);
                             unsubscribe();
                         },

--- a/src/dev-dashboard/server/routes/boards.ts
+++ b/src/dev-dashboard/server/routes/boards.ts
@@ -192,7 +192,7 @@ export function boardsRoutes(): RouteDef[] {
                         createdBy: body.createdBy ?? (await actorFrom(ctx)),
                     });
                     logger.info(
-                        { slug: ctx.params.slug, id: card.id, kind: body.kind, createdBy: card.createdBy },
+                        { slug: ctx.params.slug, id: card.id, kind: body.kind },
                         "boards: card created"
                     );
                     publishBoardEvent(ctx.params.slug, { type: "card", payload: card });

--- a/src/dev-dashboard/server/routes/boards.ts
+++ b/src/dev-dashboard/server/routes/boards.ts
@@ -191,10 +191,7 @@ export function boardsRoutes(): RouteDef[] {
                         ...body,
                         createdBy: body.createdBy ?? (await actorFrom(ctx)),
                     });
-                    logger.info(
-                        { slug: ctx.params.slug, id: card.id, kind: body.kind },
-                        "boards: card created"
-                    );
+                    logger.info({ slug: ctx.params.slug, id: card.id, kind: body.kind }, "boards: card created");
                     publishBoardEvent(ctx.params.slug, { type: "card", payload: card });
                     notifyLayoutChanged(getBoardsDb(), ctx.params.slug);
                     return { kind: "json", status: 201, body: card };


### PR DESCRIPTION
# Observability pass: structured logs across the boards server

Zero → dense logging over the boards server surface, so failures (lease conflicts, staged-vs-open confusion, silent SSE drops) can be diagnosed from `~/.genesis-tools/logs/<date>.log` instead of guesswork. The pino file sink already captures `debug`+ regardless of console level, so everything below is greppable immediately:

```bash
rg '"msg":"boards ' ~/.genesis-tools/logs/2026-07-09.log
```

## What's covered

| Area | Signals |
|------|---------|
| `boards-work.ts` | wait armed / idle / returning-work (with `waitedMs`, work + choice ids, pending), 400/409 lease rejections with holder detail, listener DELETE with reverted claims |
| `work-store.ts` | lease claim / renew / takeover / conflict / release, expired-lease reaping, `dispatchBoard` (staged→open + released questions), drained choice items |
| `boards-errors.ts` | the central catch funnel now logs **every** mapped failure by class; unhandled 500s log at `error` |
| `boards.ts` | board create/patch, card create/patch/soft-delete/restore, strokes, edges, bulk layout, import-set / sync-set, image upload, board messages, SSE stream open/close |
| `boards-annotations.ts` | create / patch (status + claimed listener) / cancel / reactivate / delete, prompt revisions, thread messages (incl. status flips they cause), attempts, verdicts |
| `boards-questions.ts` | create / answer (with `staged` flag), validation rejections |
| `events.ts` | SSE publish per event type (incl. the dropped no-subscriber case), work-waiter wakes |

## Level discipline

- `info` — state transitions (annotation status, dispatch, lease claim/steal, set push)
- `debug` — request-shaped chatter (card patches, SSE publishes, idle waits, renewals)
- `warn` — conflicts and validation rejections (lease 409s, oversized pushes, bad options)
- `error` — only the unhandled 500 path

## Verification

- `tsgo --noEmit` — 0 errors
- `biome check` — clean (1 auto-fix)
- `bun test src/dev-dashboard/{server/routes,lib/boards}` — **207 pass / 0 fail**
- Live probe from the branch against the real boards DB confirmed entries land in the daily log file as structured JSON.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for board work requests (including earlier detection of invalid session/scope combinations).
  * Enhanced handling for set uploads, including clearer detection of oversized payloads and malformed `tar.gz` uploads (responses unchanged, but failures are now more precisely diagnosed).

* **Chores**
  * Added more comprehensive structured logging across board actions, work listeners, questions, annotations, sets, and board event streaming, including richer context, counts, and timing for operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->