### PR TITLE
chore(deps): upgrade zod v3 → v4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -153,7 +153,7 @@
         "xlsx": "^0.18.5",
         "yargs": "^18.0.0",
         "youtube-transcript": "^1.3.0",
-        "zod": "^3.25.76",
+        "zod": "^4.4.3",
         "zustand": "^5.0.12",
       },
       "devDependencies": {
@@ -3497,7 +3497,7 @@
 
     "youtube-transcript": ["youtube-transcript@1.3.0", "", {}, "sha512-laWv9RcKIWh6rZUH3hVnOngEvtKAhFMV5UepUO6AgevPYqe2zv8KW/uCkZJDSnPwf5/AdVu0Q66/1RDblKsp6Q=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -3549,9 +3549,43 @@
 
     "@jimp/core/file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
+    "@jimp/plugin-blit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-circle/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-color/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-contain/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-cover/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-crop/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-displace/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-fisheye/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-flip/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-mask/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-print/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-quantize/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-resize/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-rotate/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-threshold/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@modelcontextprotocol/server-github/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.0.1", "", { "dependencies": { "content-type": "^1.0.5", "raw-body": "^3.0.0", "zod": "^3.23.8" } }, "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w=="],
 
     "@modelcontextprotocol/server-github/@types/node": ["@types/node@22.18.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg=="],
+
+    "@modelcontextprotocol/server-github/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@modelcontextprotocol/server-github/zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
@@ -3615,7 +3649,11 @@
 
     "@tanstack/router-generator/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/router-utils/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
@@ -3628,6 +3666,8 @@
     "@tanstack/start-plugin-core/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@tanstack/start-plugin-core/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "@tanstack/start-plugin-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@types/cacheable-request/@types/http-cache-semantics": ["@types/http-cache-semantics@4.0.4", "", {}, "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="],
 
@@ -3666,6 +3706,8 @@
     "cheerio/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "cheerio/parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
         "@ast-grep/napi": "^0.42.0",
         "@babel/core": "^7.28.6",
         "@babel/preset-typescript": "^7.28.5",
-        "babel-preset-solid": "^1.9.10",
         "@clack/prompts": "^1.0.0",
         "@crawlee/utils": "^3.16.0",
         "@genesiscz/darwinkit": "0.7.5",
@@ -134,6 +133,7 @@
         "asciichart": "^1.5.25",
         "axios": "^1.13.2",
         "babel-plugin-react-compiler": "^1.0.0",
+        "babel-preset-solid": "^1.9.10",
         "bonjour-service": "^1.4.0",
         "boxen": "^8.0.1",
         "chalk": "^5.6.0",
@@ -216,7 +216,7 @@
         "xlsx": "^0.18.5",
         "yargs": "^18.0.0",
         "youtube-transcript": "^1.3.0",
-        "zod": "^3.25.76",
+        "zod": "^4.4.3",
         "zustand": "^5.0.12"
     },
     "patchedDependencies": {

--- a/src/automate/lib/schema.ts
+++ b/src/automate/lib/schema.ts
@@ -13,7 +13,7 @@ export const presetStepSchema = z.object({
     id: z.string().regex(/^[a-zA-Z0-9_-]+$/, "Step ID must be alphanumeric with hyphens/underscores"),
     name: z.string(),
     action: z.string(),
-    params: z.record(z.unknown()).optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
     output: z.string().optional(),
     onError: z.enum(["stop", "continue", "skip"]).optional(),
     interactive: z.boolean().optional(),
@@ -34,7 +34,7 @@ export const presetSchema = z.object({
             interval: z.string().min(1, "Schedule interval is required"),
         }),
     ]),
-    vars: z.record(presetVariableSchema).optional(),
+    vars: z.record(z.string(), presetVariableSchema).optional(),
     steps: z.array(presetStepSchema).min(1, "At least one step is required"),
 });
 

--- a/src/clarity/config.ts
+++ b/src/clarity/config.ts
@@ -16,7 +16,7 @@ const MappingSchema = z.object({
 });
 
 const ClarityConfigSchema = z.object({
-    baseUrl: z.string().url(),
+    baseUrl: z.url(),
     authToken: z.string(),
     sessionId: z.string(),
     cookies: z.string().optional(),

--- a/src/dev-dashboard/config.ts
+++ b/src/dev-dashboard/config.ts
@@ -60,10 +60,10 @@ const DevDashboardConfigSchema = z.object({
     obsidianVault: z.string().optional(),
     publishedNotes: z.array(PublishedNoteSchema).default([]),
     cmuxPollIntervalMs: z.number().int().min(250).default(2000),
-    auth: DashboardAuthSchema.default({}),
+    auth: DashboardAuthSchema.prefault({}),
     ttydSessions: z.array(TtydSessionSchema).default([]),
-    weatherCoords: WeatherCoordsSchema.default({}),
-    pulse: PulseConfigSchema.default({}),
+    weatherCoords: WeatherCoordsSchema.prefault({}),
+    pulse: PulseConfigSchema.prefault({}),
     todoListName: z.string().default("GenesisTools"),
 });
 

--- a/src/indexer/mcp/shared.ts
+++ b/src/indexer/mcp/shared.ts
@@ -1,4 +1,34 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
 import { IndexerManager } from "../lib/manager";
+
+export type McpTextResult = { content: Array<{ type: "text"; text: string }> };
+
+/**
+ * Register an MCP tool whose argument schema is a zod v4 raw shape.
+ *
+ * The MCP SDK resolves its own (nested) copy of zod for the `ZodRawShapeCompat`
+ * type it exposes on `server.tool`. A shape built from our top-level zod v4 is
+ * therefore not nominally assignable at that boundary even though it is
+ * structurally identical and parses correctly at runtime (the SDK duck-types
+ * v3/v4 schemas). This wrapper is the single place that reconciles the two zod
+ * instances; every call site stays fully typed through `Shape`.
+ */
+export function registerTool<Shape extends z.ZodRawShape>(
+    server: McpServer,
+    name: string,
+    description: string,
+    shape: Shape,
+    handler: (args: z.infer<z.ZodObject<Shape>>) => Promise<McpTextResult>
+): void {
+    const register = server.tool.bind(server) as (
+        name: string,
+        description: string,
+        shape: Shape,
+        handler: (args: z.infer<z.ZodObject<Shape>>) => Promise<McpTextResult>
+    ) => void;
+    register(name, description, shape, handler);
+}
 
 let manager: IndexerManager | null = null;
 let managerPromise: Promise<IndexerManager> | null = null;

--- a/src/indexer/mcp/tools/graph.ts
+++ b/src/indexer/mcp/tools/graph.ts
@@ -1,10 +1,11 @@
 import { buildCodeGraph, getGraphStats, toMermaidDiagram } from "@app/indexer/lib/code-graph";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { formatError, getManager } from "../shared";
+import { formatError, getManager, registerTool } from "../shared";
 
 export function registerGraphTools(server: McpServer): void {
-    server.tool(
+    registerTool(
+        server,
         "indexer_graph_build",
         "Build a code dependency graph using static import analysis. The index must already exist.",
         {
@@ -15,7 +16,8 @@ export function registerGraphTools(server: McpServer): void {
         })
     );
 
-    server.tool(
+    registerTool(
+        server,
         "indexer_graph_query",
         "Query the dependency graph for a specific file. Shows what the file imports and what files depend on it.",
         {
@@ -27,7 +29,8 @@ export function registerGraphTools(server: McpServer): void {
         })
     );
 
-    server.tool(
+    registerTool(
+        server,
         "indexer_graph_stats",
         "Get statistics about the code dependency graph: total files, edges, most connected files, orphans.",
         {
@@ -38,7 +41,8 @@ export function registerGraphTools(server: McpServer): void {
         })
     );
 
-    server.tool(
+    registerTool(
+        server,
         "indexer_graph_visualize",
         "Generate a Mermaid diagram of the code dependency graph. Shows the top N most-connected files.",
         {

--- a/src/indexer/mcp/tools/index.ts
+++ b/src/indexer/mcp/tools/index.ts
@@ -2,10 +2,11 @@ import { basename, resolve } from "node:path";
 import type { IndexConfig } from "@app/indexer/lib/types";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { formatError, getManager } from "../shared";
+import { formatError, getManager, registerTool } from "../shared";
 
 export function registerIndexTools(server: McpServer): void {
-    server.tool(
+    registerTool(
+        server,
         "indexer_index",
         "Create a new index for a codebase directory. Scans files, chunks content using AST-aware parsing, and optionally generates embeddings for semantic search. Returns when indexing completes.",
         {
@@ -23,7 +24,8 @@ export function registerIndexTools(server: McpServer): void {
         })
     );
 
-    server.tool(
+    registerTool(
+        server,
         "indexer_sync",
         "Incrementally sync an existing index. Re-scans for changed/added/deleted files and updates the index. Much faster than a full re-index.",
         {

--- a/src/indexer/mcp/tools/manage.ts
+++ b/src/indexer/mcp/tools/manage.ts
@@ -1,10 +1,11 @@
 import { formatBytes, formatDuration, formatRelativeTime } from "@app/utils/format";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { formatError, getManager } from "../shared";
+import { formatError, getManager, registerTool } from "../shared";
 
 export function registerManageTools(server: McpServer): void {
-    server.tool(
+    registerTool(
+        server,
         "indexer_status",
         "Check index status. Without a name, shows a summary of all indexes. With a name, shows detailed stats for that index.",
         {
@@ -15,7 +16,8 @@ export function registerManageTools(server: McpServer): void {
         })
     );
 
-    server.tool(
+    registerTool(
+        server,
         "indexer_remove",
         "Remove an index entirely. Stops watchers, closes the database, and deletes all stored data.",
         {
@@ -26,7 +28,8 @@ export function registerManageTools(server: McpServer): void {
         })
     );
 
-    server.tool(
+    registerTool(
+        server,
         "indexer_stop",
         "Request cancellation of an in-progress sync/index operation. The current batch finishes and checkpoints. Progress is preserved.",
         {

--- a/src/indexer/mcp/tools/models.ts
+++ b/src/indexer/mcp/tools/models.ts
@@ -1,9 +1,11 @@
 import { getModelsForType, MODEL_REGISTRY } from "@app/indexer/lib/model-registry";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { registerTool } from "../shared";
 
 export function registerModelsTools(server: McpServer): void {
-    server.tool(
+    registerTool(
+        server,
         "indexer_models",
         "List available embedding models. Optionally filter by index type to see best recommendations.",
         {

--- a/src/indexer/mcp/tools/search.ts
+++ b/src/indexer/mcp/tools/search.ts
@@ -2,10 +2,11 @@ import { detectMode } from "@app/indexer/lib/search-mode";
 import type { ChunkRecord } from "@app/indexer/lib/types";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { formatError, getManager } from "../shared";
+import { formatError, getManager, registerTool } from "../shared";
 
 export function registerSearchTools(server: McpServer): void {
-    server.tool(
+    registerTool(
+        server,
         "indexer_search",
         "Search across indexed codebases. Returns matching code chunks with file paths, line numbers, and relevance scores. Supports fulltext (BM25), vector (semantic), or hybrid search modes.",
         {

--- a/src/shops/mcp/types.ts
+++ b/src/shops/mcp/types.ts
@@ -17,7 +17,7 @@ export interface JsonSchemaProperty {
 
 export const ShopsGetProductInput = z
     .object({
-        url: z.string().url().optional(),
+        url: z.url().optional(),
         shop: z.string().min(1).optional(),
         slug: z.string().min(1).optional(),
     })
@@ -35,7 +35,7 @@ export const ShopsGetProductInputJsonSchema: JsonSchema = {
 };
 
 export const ShopsMatchProductInput = z.object({
-    url: z.string().url(),
+    url: z.url(),
 });
 export type ShopsMatchProductInputT = z.infer<typeof ShopsMatchProductInput>;
 export const ShopsMatchProductInputJsonSchema: JsonSchema = {
@@ -126,7 +126,7 @@ export const ShopsRecentNotificationsInputJsonSchema: JsonSchema = {
 };
 
 export const ShopsIngestInput = z.object({
-    url: z.string().url(),
+    url: z.url(),
 });
 export type ShopsIngestInputT = z.infer<typeof ShopsIngestInput>;
 export const ShopsIngestInputJsonSchema: JsonSchema = {
@@ -150,7 +150,7 @@ export const ShopsAcceptMatchInputJsonSchema: JsonSchema = {
 };
 
 export const ShopsWatchAddInput = z.object({
-    url: z.string().url(),
+    url: z.url(),
     target_price: z.number().nonnegative().optional(),
     drop_percent: z.number().min(0).max(1).optional(),
     drop_absolute: z.number().nonnegative().optional(),


### PR DESCRIPTION
## What

Upgrades the repo from **zod `^3.25.76` → `^4.4.3`** and fixes every zod v4 breaking change surfaced across `src/`.

Built on top of `feat/ai-sdk-7` (AI SDK v7 already peer-supports zod 4: `^3.25.76 || ^4.1.8`).

## Status

- **`tsgo --noEmit`: 0 errors** (root + `src/claude-history-dashboard` tsconfig — verified by the pre-push CI mirror).
- **Tests: 1628 pass / 2 fail / 56 skip** across the zod-relevant dirs (shops, indexer, dev-dashboard, telegram, youtube, ask, …). The **2 failures are pre-existing** and unrelated to zod (proven by stashing all my changes and re-running — they still fail): `dev-dashboard/server/routes/processes.test.ts` (system-process sort/limit) and `dev-dashboard/lib/net/status.test.ts` (net-status latency threshold). Neither file imports zod.
- The full `bun test src` was **not** used as the gate: several e2e/`*.test.ts` files spawn interactive `tools` subprocesses (`transcribe`, `voice-memos`) that block on stdin prompts in a non-TTY runner — a pre-existing environmental issue, not zod.

## Breaking-change categories fixed

1. **`z.record(V)` → `z.record(z.string(), V)`** — v4 requires an explicit key type. (`src/automate/lib/schema.ts`)
2. **object `.default({})` → `.prefault({})`** — v4's `.default()` no longer re-parses the value through the schema, so `.default({})` on an object whose fields carry their own defaults no longer type-checks (and would skip the inner defaults). `.prefault({})` restores the v3 behaviour (feed `{}` through the schema). Verified the parsed output is identical. (`src/dev-dashboard/config.ts`: `auth`, `weatherCoords`, `pulse`)
3. **deprecated `z.string().url()` → top-level `z.url()`** — parity confirmed for real config URLs incl. `http://localhost`. (`src/clarity/config.ts`, `src/shops/mcp/types.ts`)
4. **MCP SDK zod-v4 type bridge** — see below.

Scanned for and found **none** of: `errorMap` / `invalid_type_error` / `required_error`, `z.function()`, or `ZodError.errors` reads in our `src/` (the `.errors` hits are all on custom result objects, not `ZodError`).

## The MCP SDK duplicate-zod boundary (the interesting bit)

`@modelcontextprotocol/sdk@1.25.2` declares zod `^3.25 || ^4.0`, but bun keeps a **nested `zod@3.25.76`** for it (it reuses the 3.25.76 already pulled in by jimp / tanstack / chromium-bidi rather than resolving to our new top-level 4.4.3). The SDK's `server.tool()` types resolve `zod/v4/core` through that nested copy, so a raw shape built from our **top-level** zod v4 is not *nominally* assignable to the SDK's `ZodRawShapeCompat` — even though it is structurally identical and parses correctly at runtime (the SDK duck-types v3/v4 schemas). This produced the 8+ errors in `src/indexer/mcp/tools/*`.

**Why not just dedupe?** A global `overrides: { "zod": "4.4.3" }` would force jimp / tanstack / chromium-bidi onto v4 too — and tanstack `router-generator` uses `z.function().returns(...)`, which is **removed in v4**, so that would break it at runtime. Bun does not support *nested* overrides (it warns and ignores them). So the two zod copies must coexist.

**Fix:** a single typed wrapper `registerTool()` in `src/indexer/mcp/shared.ts` that reconciles the two zod instances once at the boundary; all indexer tool registrations funnel through it and stay fully typed via `Shape`.

**Runtime verified** with an in-memory MCP client↔server round-trip: zod-4 shape → correct `tools/list` JSON schema, valid args parse + handler runs, and invalid args (`name: 123`) are rejected — all through the SDK's nested zod 3.25.76.

## Lockfile

Top-level `zod` → 4.4.3. Packages that hard-require zod 3 (jimp plugins, tanstack router plugins, chromium-bidi, the MCP SDK) now carry explicit nested `3.25.76` pins (previously deduped with the old top-level 3.x). `bun add` also re-sorted `babel-preset-solid` into alphabetical order — incidental, harmless.

## Unsure / worth a look

- The `.url()` → `z.url()` conversion: deprecated-but-still-functional in 4.4.3, converted per request. v4's `z.url()` uses the WHATWG parser (stricter on edge cases); confirmed parity for the actual config URLs, but flagging in case any exotic URL is expected elsewhere.
- The dashboard sub-project (`src/dashboard/apps/web`) already ships its own `zod@^4.1.11` and is outside the root tsconfig — left untouched.
