### PR TITLE
feat(ai-proxy): anthropic + openai subscription providers

### DIFF
--- a/src/ai-proxy/lib/account-config.ts
+++ b/src/ai-proxy/lib/account-config.ts
@@ -24,6 +24,8 @@ export function accountConfigFingerprint(account: AiProxyAccountConfig): string 
         baseUrl: account.baseUrl,
         grok: account.grok,
         githubCopilot: account.githubCopilot,
+        anthropicSub: account.anthropicSub,
+        openaiSub: account.openaiSub,
         apiKeyEnv: account.apiKeyEnv,
         managementKeyEnv: account.managementKeyEnv,
         teamId: account.teamId,

--- a/src/ai-proxy/lib/catalog.ts
+++ b/src/ai-proxy/lib/catalog.ts
@@ -1,4 +1,4 @@
-import { listCopilotProxyModels, listGrokProxyModels } from "@app/ai-proxy/lib/model-meta";
+import { listAnthropicSubProxyModels, listCopilotProxyModels, listGrokProxyModels } from "@app/ai-proxy/lib/model-meta";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
 import { GROK_CLI_CHAT_PROXY_BASE_URL } from "@app/utils/ai/grok";
 
@@ -19,6 +19,10 @@ export async function buildProxyModelCatalog(accounts: AiProxyAccountConfig[]): 
 
         if (account.provider === "github-copilot-subscription") {
             models.push(...(await listCopilotProxyModels(account)));
+        }
+
+        if (account.provider === "anthropic-subscription") {
+            models.push(...listAnthropicSubProxyModels(account));
         }
     }
 

--- a/src/ai-proxy/lib/catalog.ts
+++ b/src/ai-proxy/lib/catalog.ts
@@ -1,4 +1,9 @@
-import { listAnthropicSubProxyModels, listCopilotProxyModels, listGrokProxyModels } from "@app/ai-proxy/lib/model-meta";
+import {
+    listAnthropicSubProxyModels,
+    listCopilotProxyModels,
+    listGrokProxyModels,
+    listOpenAiSubProxyModels,
+} from "@app/ai-proxy/lib/model-meta";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
 import { GROK_CLI_CHAT_PROXY_BASE_URL } from "@app/utils/ai/grok";
 
@@ -23,6 +28,10 @@ export async function buildProxyModelCatalog(accounts: AiProxyAccountConfig[]): 
 
         if (account.provider === "anthropic-subscription") {
             models.push(...listAnthropicSubProxyModels(account));
+        }
+
+        if (account.provider === "openai-subscription") {
+            models.push(...listOpenAiSubProxyModels(account));
         }
     }
 

--- a/src/ai-proxy/lib/model-meta.ts
+++ b/src/ai-proxy/lib/model-meta.ts
@@ -1,5 +1,9 @@
 import { loadCatalogFile } from "@app/ai-proxy/lib/catalog-file";
 import { resolveCopilotModelRecords } from "@app/ai-proxy/lib/copilot-models-cache";
+import {
+    ANTHROPIC_SUB_ALIASES,
+    resolveAnthropicSubModel,
+} from "@app/ai-proxy/lib/providers/anthropic-sub-models";
 import { providerKey } from "@app/ai-proxy/lib/providers/registry";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
 import { toProxyId as toCopilotProxyId } from "@app/utils/ai/github-copilot/models";
@@ -99,6 +103,30 @@ export function copilotRecordToProxyMeta(
 
 export function listGrokProxyModels(account: AiProxyAccountConfig, baseUrl: string): ProxyModelMeta[] {
     return GROK_STATIC_CATALOG.map((record) => grokRecordToProxyMeta(account, record, baseUrl));
+}
+
+export const ANTHROPIC_MESSAGES_BASE_URL = "https://api.anthropic.com/v1";
+
+export function listAnthropicSubProxyModels(account: AiProxyAccountConfig): ProxyModelMeta[] {
+    return ANTHROPIC_SUB_ALIASES.map((alias) => ({
+        proxyId: toProxyId(account.name, account.providerSlug, alias),
+        accountName: account.name,
+        providerSlug: account.providerSlug,
+        upstreamId: alias,
+        provider: account.provider,
+        baseUrl: ANTHROPIC_MESSAGES_BASE_URL,
+        visibility: "high",
+        speed: "medium",
+        thinking: alias === "opus" || alias === "fable" ? "reasoning" : "none",
+        contextWindow: 200_000,
+        supportsTools: true,
+        billingPlane: "subscription",
+        source: "static",
+        description: `Claude ${alias} via subscription (${resolveAnthropicSubModel(alias)})`,
+        object: "model",
+        created: 1_740_960_000,
+        owned_by: providerKey(account),
+    }));
 }
 
 function catalogCopilotRecords(account: AiProxyAccountConfig): CopilotModelRecord[] {

--- a/src/ai-proxy/lib/model-meta.ts
+++ b/src/ai-proxy/lib/model-meta.ts
@@ -1,6 +1,7 @@
 import { loadCatalogFile } from "@app/ai-proxy/lib/catalog-file";
 import { resolveCopilotModelRecords } from "@app/ai-proxy/lib/copilot-models-cache";
 import { ANTHROPIC_SUB_ALIASES, resolveAnthropicSubModel } from "@app/ai-proxy/lib/providers/anthropic-sub-models";
+import { OPENAI_SUB_MODELS } from "@app/ai-proxy/lib/providers/openai-sub-models";
 import { providerKey } from "@app/ai-proxy/lib/providers/registry";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
 import { toProxyId as toCopilotProxyId } from "@app/utils/ai/github-copilot/models";
@@ -120,6 +121,30 @@ export function listAnthropicSubProxyModels(account: AiProxyAccountConfig): Prox
         billingPlane: "subscription",
         source: "static",
         description: `Claude ${alias} via subscription (${resolveAnthropicSubModel(alias)})`,
+        object: "model",
+        created: 1_740_960_000,
+        owned_by: providerKey(account),
+    }));
+}
+
+export const WHAM_RESPONSES_BASE_URL = "https://chatgpt.com/backend-api/wham";
+
+export function listOpenAiSubProxyModels(account: AiProxyAccountConfig): ProxyModelMeta[] {
+    return OPENAI_SUB_MODELS.map((id) => ({
+        proxyId: toProxyId(account.name, account.providerSlug, id),
+        accountName: account.name,
+        providerSlug: account.providerSlug,
+        upstreamId: id,
+        provider: account.provider,
+        baseUrl: WHAM_RESPONSES_BASE_URL,
+        visibility: "high",
+        speed: "medium",
+        thinking: "reasoning",
+        contextWindow: 272_000,
+        supportsTools: true,
+        billingPlane: "subscription",
+        source: "static",
+        description: `${id} via ChatGPT/Codex subscription`,
         object: "model",
         created: 1_740_960_000,
         owned_by: providerKey(account),

--- a/src/ai-proxy/lib/model-meta.ts
+++ b/src/ai-proxy/lib/model-meta.ts
@@ -1,9 +1,6 @@
 import { loadCatalogFile } from "@app/ai-proxy/lib/catalog-file";
 import { resolveCopilotModelRecords } from "@app/ai-proxy/lib/copilot-models-cache";
-import {
-    ANTHROPIC_SUB_ALIASES,
-    resolveAnthropicSubModel,
-} from "@app/ai-proxy/lib/providers/anthropic-sub-models";
+import { ANTHROPIC_SUB_ALIASES, resolveAnthropicSubModel } from "@app/ai-proxy/lib/providers/anthropic-sub-models";
 import { providerKey } from "@app/ai-proxy/lib/providers/registry";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
 import { toProxyId as toCopilotProxyId } from "@app/utils/ai/github-copilot/models";

--- a/src/ai-proxy/lib/providers/anthropic-sub-models.ts
+++ b/src/ai-proxy/lib/providers/anthropic-sub-models.ts
@@ -1,0 +1,29 @@
+/**
+ * Alias → concrete model id map for the Claude subscription proxy provider.
+ * Aliases are advertised as `<account>/claude-sub/<alias>`; the provider
+ * forwards the concrete id to api.anthropic.com/v1/messages.
+ *
+ * Concrete ids verified live against GET api.anthropic.com/v1/models with a
+ * subscription OAuth token (2026-07-12). The bare `claude-haiku-4-5` is NOT
+ * served — the dated id is required.
+ */
+
+export const ANTHROPIC_SUB_ALIASES = ["sonnet", "opus", "haiku", "fable"] as const;
+
+export type AnthropicSubAlias = (typeof ANTHROPIC_SUB_ALIASES)[number];
+
+const ANTHROPIC_SUB_MODEL_MAP: Record<AnthropicSubAlias, string> = {
+    sonnet: "claude-sonnet-4-6",
+    opus: "claude-opus-4-6",
+    haiku: "claude-haiku-4-5-20251001",
+    fable: "claude-fable-5",
+};
+
+/**
+ * Resolve an alias to its concrete Anthropic model id. Unknown values pass
+ * through unchanged so a client can also request a concrete id directly
+ * (e.g. `<account>/claude-sub/claude-sonnet-5`).
+ */
+export function resolveAnthropicSubModel(alias: string): string {
+    return ANTHROPIC_SUB_MODEL_MAP[alias as AnthropicSubAlias] ?? alias;
+}

--- a/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { SafeJSON } from "@app/utils/json";
+import { SUBSCRIPTION_BETAS } from "@app/utils/claude/subscription-billing";
+
+const TEST_TOKEN = "sk-ant-oat01-TESTTOKEN";
+
+mock.module("@app/utils/claude/subscription-auth", () => ({
+    resolveAccountToken: async () => ({
+        token: TEST_TOKEN,
+        account: { name: "foltyn", accessToken: TEST_TOKEN },
+        refreshed: false,
+    }),
+}));
+
+const account: AiProxyAccountConfig = {
+    name: "martin",
+    provider: "anthropic-subscription",
+    providerSlug: "claude-sub",
+    enabled: true,
+    anthropicSub: { accountName: "foltyn" },
+};
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+describe("AnthropicSubscriptionProvider", () => {
+    it("forwards the Claude Code spoof and maps the response to OpenAI shape", async () => {
+        let capturedUrl: unknown;
+        let capturedInit: RequestInit | undefined;
+
+        globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+            capturedUrl = url;
+            capturedInit = init;
+
+            return new Response(
+                SafeJSON.stringify({
+                    id: "msg_test",
+                    role: "assistant",
+                    content: [{ type: "text", text: "OK from claude" }],
+                    stop_reason: "end_turn",
+                    usage: { input_tokens: 5, output_tokens: 3 },
+                }),
+                { status: 200, headers: { "content-type": "application/json" } }
+            );
+        }) as typeof fetch;
+
+        const { AnthropicSubscriptionProvider } = await import("./anthropic-subscription");
+        const provider = await AnthropicSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "martin/claude-sub/haiku",
+            messages: [{ role: "user", content: "say OK" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "haiku", bodyText);
+
+        expect(res.status).toBe(200);
+        const completion = (await res.json()) as {
+            object: string;
+            choices: Array<{ message: { content: string } }>;
+        };
+        expect(completion.object).toBe("chat.completion");
+        expect(completion.choices[0]?.message.content).toBe("OK from claude");
+
+        // upstream targeted the Anthropic Messages API
+        expect(capturedUrl).toBe("https://api.anthropic.com/v1/messages");
+
+        // spoof headers: Bearer oat, betas, NO x-api-key
+        const headers = new Headers(capturedInit?.headers);
+        expect(headers.get("authorization")).toBe(`Bearer ${TEST_TOKEN}`);
+        expect(headers.get("anthropic-beta")).toBe(SUBSCRIPTION_BETAS);
+        expect(headers.get("x-api-key")).toBeNull();
+
+        // body: concrete model id + billing header as system[0] + Claude Code prefix
+        const sentBody = SafeJSON.parse(String(capturedInit?.body)) as {
+            model: string;
+            system: Array<{ text: string }>;
+            messages: unknown[];
+        };
+        expect(sentBody.model).toBe("claude-haiku-4-5-20251001");
+        expect(sentBody.system[0]?.text.startsWith("x-anthropic-billing-header")).toBe(true);
+        expect(sentBody.system[1]?.text).toContain("You are Claude Code");
+        expect(sentBody.messages).toHaveLength(1);
+    });
+
+    it("streams as text/event-stream ending in [DONE]", async () => {
+        const anthropicSse =
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"m","model":"claude-haiku-4-5-20251001"}}\n\n' +
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}\n\n' +
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n' +
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => {
+            const encoder = new TextEncoder();
+            const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(encoder.encode(anthropicSse));
+                    controller.close();
+                },
+            });
+
+            return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+        }) as typeof fetch;
+
+        const { AnthropicSubscriptionProvider } = await import("./anthropic-subscription");
+        const provider = await AnthropicSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "martin/claude-sub/haiku",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "haiku", bodyText);
+
+        expect(res.headers.get("content-type")).toContain("text/event-stream");
+        const text = await res.text();
+        expect(text).toContain('"object":"chat.completion.chunk"');
+        expect(text).toContain("Hi");
+        expect(text).toContain("data: [DONE]");
+    });
+});

--- a/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
-import { SafeJSON } from "@app/utils/json";
 import { SUBSCRIPTION_BETAS } from "@app/utils/claude/subscription-billing";
+import { SafeJSON } from "@app/utils/json";
 
 const TEST_TOKEN = "sk-ant-oat01-TESTTOKEN";
 

--- a/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
@@ -87,6 +87,16 @@ describe("AnthropicSubscriptionProvider", () => {
         expect(sentBody.messages).toHaveLength(1);
     });
 
+    it("returns 400 (not a 502) for a non-object JSON body", async () => {
+        const { AnthropicSubscriptionProvider } = await import("./anthropic-subscription");
+        const provider = await AnthropicSubscriptionProvider.create(account);
+
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: "null" });
+        const res = await provider.chatCompletions(req, "haiku", "null");
+
+        expect(res.status).toBe(400);
+    });
+
     it("streams as text/event-stream ending in [DONE]", async () => {
         const anthropicSse =
             'event: message_start\ndata: {"type":"message_start","message":{"id":"m","model":"claude-haiku-4-5-20251001"}}\n\n' +

--- a/src/ai-proxy/lib/providers/anthropic-subscription.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.ts
@@ -1,0 +1,177 @@
+import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { ANTHROPIC_SUB_ALIASES, resolveAnthropicSubModel } from "@app/ai-proxy/lib/providers/anthropic-sub-models";
+import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
+import {
+    anthropicMessageToOpenAiCompletion,
+    anthropicSseToOpenAiChatStream,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions";
+import {
+    type OpenAiChatBody,
+    openAiChatToAnthropicMessages,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages";
+import { logger } from "@app/logger";
+import { resolveAccountToken } from "@app/utils/claude/subscription-auth";
+import {
+    applySystemPromptPrefix,
+    createSubscriptionFetch,
+    SUBSCRIPTION_BETAS,
+    SUBSCRIPTION_SYSTEM_PREFIX,
+} from "@app/utils/claude/subscription-billing";
+import { SafeJSON } from "@app/utils/json";
+
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+
+/**
+ * Bills the owner's Claude Max/Pro subscription. Speaks OpenAI to proxy
+ * clients, forwards the Claude Code spoof (Bearer OAuth token + billing header
+ * + beta flags) to api.anthropic.com/v1/messages, and maps responses back.
+ */
+export class AnthropicSubscriptionProvider implements ProxyProvider {
+    readonly id = "anthropic-subscription";
+    readonly accountFingerprint: string;
+    private readonly account: AiProxyAccountConfig;
+    /** Name of the anthropic-sub account (in ~/.genesis-tools/ai/config.json) whose token is billed. */
+    private readonly billingAccountName: string;
+    private readonly upstreamFetch: typeof fetch;
+
+    constructor(account: AiProxyAccountConfig) {
+        this.account = account;
+        this.accountFingerprint = accountConfigFingerprint(account);
+        this.billingAccountName = account.anthropicSub?.accountName ?? account.name;
+        this.upstreamFetch = createSubscriptionFetch();
+    }
+
+    static async create(account: AiProxyAccountConfig): Promise<AnthropicSubscriptionProvider> {
+        return new AnthropicSubscriptionProvider(account);
+    }
+
+    async listModels(): Promise<OpenAiModel[]> {
+        return ANTHROPIC_SUB_ALIASES.map((alias) => ({
+            id: `${this.account.name}/${this.account.providerSlug}/${alias}`,
+            object: "model",
+            created: 1_740_960_000,
+            owned_by: "anthropic",
+            description: `Claude ${alias} via subscription (${resolveAnthropicSubModel(alias)})`,
+        }));
+    }
+
+    async chatCompletions(req: Request, model: string, bodyText: string): Promise<Response> {
+        const proxyModelId = `${this.account.name}/${this.account.providerSlug}/${model}`;
+        const concreteModel = resolveAnthropicSubModel(model);
+
+        let openAiBody: OpenAiChatBody;
+        try {
+            openAiBody = SafeJSON.parse(bodyText, { strict: true }) as OpenAiChatBody;
+        } catch (err) {
+            logger.debug({ err }, "ai-proxy: anthropic-subscription got invalid JSON body");
+            return jsonError(400, "Invalid JSON body");
+        }
+
+        const streaming = openAiBody.stream === true;
+        const anthropicBody = openAiChatToAnthropicMessages(openAiBody, { model: concreteModel });
+        anthropicBody.system = applySystemPromptPrefix(SUBSCRIPTION_SYSTEM_PREFIX, anthropicBody.system ?? "");
+
+        let token: string;
+        try {
+            ({ token } = await resolveAccountToken(this.billingAccountName));
+        } catch (err) {
+            logger.warn(
+                { err, account: this.account.name, billingAccount: this.billingAccountName },
+                "ai-proxy: anthropic-subscription token resolution failed"
+            );
+            return jsonError(502, `Anthropic subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`);
+        }
+
+        const started = performance.now();
+        const upstream = await this.upstreamFetch(ANTHROPIC_MESSAGES_URL, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "anthropic-version": ANTHROPIC_VERSION,
+                "anthropic-beta": SUBSCRIPTION_BETAS,
+                Authorization: `Bearer ${token}`,
+                Accept: streaming ? "text/event-stream" : "application/json",
+            },
+            body: SafeJSON.stringify(anthropicBody),
+            signal: req.signal,
+        });
+
+        const elapsedMs = Math.round(performance.now() - started);
+
+        if (!upstream.ok) {
+            const errorText = await upstream.text();
+            logger.warn(
+                {
+                    account: this.account.name,
+                    upstreamModel: concreteModel,
+                    requestedModel: proxyModelId,
+                    status: upstream.status,
+                    elapsedMs,
+                    body: errorText.slice(0, 500),
+                },
+                "ai-proxy: anthropic upstream request failed"
+            );
+
+            return new Response(errorText, {
+                status: upstream.status,
+                headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+            });
+        }
+
+        logger.debug(
+            { account: this.account.name, upstreamModel: concreteModel, requestedModel: proxyModelId, streaming, elapsedMs },
+            "ai-proxy: anthropic upstream request ok"
+        );
+
+        if (streaming) {
+            if (!upstream.body) {
+                return jsonError(502, "Anthropic upstream returned no stream body");
+            }
+
+            return new Response(anthropicSseToOpenAiChatStream(upstream.body, { model: proxyModelId }), {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/event-stream; charset=utf-8",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                },
+            });
+        }
+
+        const message = (await upstream.json()) as Record<string, unknown>;
+        const completion = anthropicMessageToOpenAiCompletion(message, { model: proxyModelId });
+
+        return new Response(SafeJSON.stringify(completion), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    async responses(_req: Request, _model: string, _bodyText: string): Promise<Response> {
+        // The Claude subscription upstream has no Responses API. Clients should
+        // use /v1/chat/completions for anthropic-subscription models. (Cursor
+        // request translation is disabled for this provider — see
+        // shouldTranslateChatRequest — so this path is not hit in normal flows.)
+        return jsonError(
+            400,
+            "anthropic-subscription does not support the Responses API — use POST /v1/chat/completions with this model."
+        );
+    }
+
+    async getUsage(): Promise<UsageSummary> {
+        return {
+            accountName: this.account.name,
+            provider: "anthropic-subscription",
+            summary: "subscription (usage not exposed by the Anthropic OAuth API)",
+        };
+    }
+}
+
+function jsonError(status: number, message: string): Response {
+    return new Response(SafeJSON.stringify({ error: { message } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}

--- a/src/ai-proxy/lib/providers/anthropic-subscription.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.ts
@@ -19,6 +19,7 @@ import {
     SUBSCRIPTION_SYSTEM_PREFIX,
 } from "@app/utils/claude/subscription-billing";
 import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
 
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
@@ -63,7 +64,12 @@ export class AnthropicSubscriptionProvider implements ProxyProvider {
 
         let openAiBody: OpenAiChatBody;
         try {
-            openAiBody = SafeJSON.parse(bodyText, { strict: true }) as OpenAiChatBody;
+            const parsedBody = SafeJSON.parse(bodyText, { strict: true });
+            if (!isObject(parsedBody)) {
+                return jsonError(400, "Invalid JSON body");
+            }
+
+            openAiBody = parsedBody as OpenAiChatBody;
         } catch (err) {
             logger.debug({ err }, "ai-proxy: anthropic-subscription got invalid JSON body");
             return jsonError(400, "Invalid JSON body");

--- a/src/ai-proxy/lib/providers/anthropic-subscription.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.ts
@@ -1,7 +1,6 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { ANTHROPIC_SUB_ALIASES, resolveAnthropicSubModel } from "@app/ai-proxy/lib/providers/anthropic-sub-models";
 import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
-import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
     anthropicMessageToOpenAiCompletion,
     anthropicSseToOpenAiChatStream,
@@ -10,6 +9,7 @@ import {
     type OpenAiChatBody,
     openAiChatToAnthropicMessages,
 } from "@app/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages";
+import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import { logger } from "@app/logger";
 import { resolveAccountToken } from "@app/utils/claude/subscription-auth";
 import {
@@ -81,7 +81,10 @@ export class AnthropicSubscriptionProvider implements ProxyProvider {
                 { err, account: this.account.name, billingAccount: this.billingAccountName },
                 "ai-proxy: anthropic-subscription token resolution failed"
             );
-            return jsonError(502, `Anthropic subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`);
+            return jsonError(
+                502,
+                `Anthropic subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`
+            );
         }
 
         const started = performance.now();
@@ -121,7 +124,13 @@ export class AnthropicSubscriptionProvider implements ProxyProvider {
         }
 
         logger.debug(
-            { account: this.account.name, upstreamModel: concreteModel, requestedModel: proxyModelId, streaming, elapsedMs },
+            {
+                account: this.account.name,
+                upstreamModel: concreteModel,
+                requestedModel: proxyModelId,
+                streaming,
+                elapsedMs,
+            },
             "ai-proxy: anthropic upstream request ok"
         );
 

--- a/src/ai-proxy/lib/providers/openai-sub-models.ts
+++ b/src/ai-proxy/lib/providers/openai-sub-models.ts
@@ -1,0 +1,20 @@
+/**
+ * Model ids advertised by the Codex/ChatGPT subscription proxy provider,
+ * as `<account>/codex/<id>`. The upstream is the ChatGPT WHAM backend, which
+ * only accepts Codex-supported models for a ChatGPT account.
+ *
+ * Verified live (2026-07-12, plan "plus" account): `gpt-5.5` works; `gpt-5`,
+ * `gpt-5-codex`, `gpt-5.1`, `gpt-5.5-codex`, `gpt-5.1-codex` return
+ * "not supported when using Codex with a ChatGPT account". `gpt-5-codex` is
+ * kept advertised because higher plans (Pro) do serve it; unsupported ids
+ * surface WHAM's own 400 to the caller.
+ */
+
+export const OPENAI_SUB_MODELS = ["gpt-5.5", "gpt-5-codex"] as const;
+
+export type OpenAiSubModel = (typeof OPENAI_SUB_MODELS)[number];
+
+/** Codex model ids are already concrete; unknown values pass through unchanged. */
+export function resolveOpenAiSubModel(id: string): string {
+    return id;
+}

--- a/src/ai-proxy/lib/providers/openai-sub-token.ts
+++ b/src/ai-proxy/lib/providers/openai-sub-token.ts
@@ -1,0 +1,88 @@
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { logger } from "@app/logger";
+import { CODEX_AUTH_PATH, codexOAuth, extractAccountId, readCodexAuthJson } from "@app/utils/ai/openai/codex-auth";
+
+export interface OpenAiSubToken {
+    token: string;
+    accountId?: string;
+}
+
+/**
+ * Resolve a ChatGPT/Codex access token for an openai-subscription proxy account.
+ *
+ * Two sources:
+ *  - `openaiSub.accountName` set → the named `openai-sub` account in the unified
+ *    AI config (refreshed via Codex OAuth and persisted, mirroring the ask
+ *    resolver). This is the deploy path.
+ *  - otherwise → the Codex CLI cache (`~/.codex/auth.json`), read-only. The CLI
+ *    keeps this fresh; the local proxy piggybacks on the machine's `codex login`.
+ */
+export async function resolveOpenAiSubToken(account: AiProxyAccountConfig): Promise<OpenAiSubToken> {
+    const accountName = account.openaiSub?.accountName;
+
+    if (accountName) {
+        return resolveFromAiConfig(accountName);
+    }
+
+    return resolveFromCodexCli(account.openaiSub?.codexAuthPath);
+}
+
+async function resolveFromCodexCli(authPath?: string): Promise<OpenAiSubToken> {
+    const path = authPath ?? CODEX_AUTH_PATH;
+    const tokens = await readCodexAuthJson(path);
+
+    if (!tokens?.accessToken) {
+        throw new Error(
+            `No Codex CLI auth at ${path}. Run \`codex login\`, or set openaiSub.accountName to a configured openai-sub account.`
+        );
+    }
+
+    if (tokens.expiresAt && codexOAuth.needsRefresh(tokens.expiresAt)) {
+        logger.warn(
+            { path },
+            "ai-proxy: Codex CLI token is expired — run `codex login` (the proxy does not write the CLI cache)"
+        );
+    }
+
+    return { token: tokens.accessToken, accountId: tokens.accountId ?? extractAccountId(tokens.accessToken) };
+}
+
+async function resolveFromAiConfig(accountName: string): Promise<OpenAiSubToken> {
+    const { AIConfig } = await import("@app/utils/ai/AIConfig");
+    const config = await AIConfig.load();
+    const entry = config.getAccount(accountName);
+
+    if (!entry) {
+        throw new Error(`openai-sub account "${accountName}" not found in AI config.`);
+    }
+
+    let accessToken = entry.tokens.accessToken;
+
+    if (!accessToken) {
+        throw new Error(`No access token for openai-sub account "${accountName}". Run \`tools ask config\`.`);
+    }
+
+    if (entry.tokens.expiresAt && codexOAuth.needsRefresh(entry.tokens.expiresAt)) {
+        const refreshToken = entry.tokens.refreshToken;
+
+        if (!refreshToken) {
+            throw new Error(`Token for "${accountName}" is expired and no refresh token is available.`);
+        }
+
+        const refreshed = await codexOAuth.refresh(refreshToken);
+
+        await config.mutate((data) => {
+            const acc = data.accounts.find((a) => a.name === accountName);
+
+            if (acc) {
+                acc.tokens.accessToken = refreshed.accessToken;
+                acc.tokens.refreshToken = refreshed.refreshToken;
+                acc.tokens.expiresAt = refreshed.expiresAt;
+            }
+        });
+
+        accessToken = refreshed.accessToken;
+    }
+
+    return { token: accessToken, accountId: extractAccountId(accessToken) };
+}

--- a/src/ai-proxy/lib/providers/openai-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { SafeJSON } from "@app/utils/json";
+
+const TEST_TOKEN = "codex-access-token";
+const TEST_ACCOUNT_ID = "acct-123";
+
+mock.module("@app/ai-proxy/lib/providers/openai-sub-token", () => ({
+    resolveOpenAiSubToken: async () => ({ token: TEST_TOKEN, accountId: TEST_ACCOUNT_ID }),
+}));
+
+const account: AiProxyAccountConfig = {
+    name: "codex",
+    provider: "openai-subscription",
+    providerSlug: "codex",
+    enabled: true,
+    openaiSub: {},
+};
+
+const WHAM_SSE =
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.5","status":"in_progress"}}\n\n' +
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"CODEX"}\n\n' +
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"_OK"}\n\n' +
+    'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.5","status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":3,"total_tokens":13}}}\n\n';
+
+function whamStreamResponse(): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoder.encode(WHAM_SSE));
+            controller.close();
+        },
+    });
+
+    return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+describe("buildWhamResponsesBody", () => {
+    it("extracts system→instructions, maps messages→input, forces stream", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+        const body = buildWhamResponsesBody(
+            {
+                model: "codex/codex/gpt-5.5",
+                messages: [
+                    { role: "system", content: "You are helpful." },
+                    { role: "user", content: "hi" },
+                ],
+                max_tokens: 64,
+            },
+            "gpt-5.5"
+        );
+
+        expect(body.model).toBe("gpt-5.5");
+        expect(body.stream).toBe(true);
+        expect(body.store).toBe(false);
+        expect(body.instructions).toBe("You are helpful.");
+        expect(Array.isArray(body.input)).toBe(true);
+        expect(body.max_output_tokens).toBe(64);
+    });
+
+    it("maps chat function tools to flat Responses tools", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+        const body = buildWhamResponsesBody(
+            {
+                messages: [{ role: "user", content: "go" }],
+                tools: [{ type: "function", function: { name: "search", description: "d", parameters: { type: "object" } } }],
+            },
+            "gpt-5.5"
+        );
+
+        expect(body.tools).toEqual([{ type: "function", name: "search", description: "d", parameters: { type: "object" } }]);
+    });
+});
+
+describe("OpenAiSubscriptionProvider", () => {
+    it("forwards a chat request to WHAM and maps the response to chat.completion", async () => {
+        let capturedUrl: unknown;
+        let capturedInit: RequestInit | undefined;
+
+        globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+            capturedUrl = url;
+            capturedInit = init;
+            return whamStreamResponse();
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [
+                { role: "system", content: "Be terse." },
+                { role: "user", content: "say ok" },
+            ],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(200);
+        const completion = (await res.json()) as {
+            object: string;
+            choices: Array<{ message: { content: string } }>;
+        };
+        expect(completion.object).toBe("chat.completion");
+        expect(completion.choices[0]?.message.content).toBe("CODEX_OK");
+
+        // upstream targeted WHAM with the Codex token + account id
+        expect(capturedUrl).toBe("https://chatgpt.com/backend-api/wham/responses");
+        const headers = new Headers(capturedInit?.headers);
+        expect(headers.get("authorization")).toBe(`Bearer ${TEST_TOKEN}`);
+        expect(headers.get("chatgpt-account-id")).toBe(TEST_ACCOUNT_ID);
+        expect(headers.get("openai-beta")).toBe("responses=experimental");
+
+        // body was converted to Responses shape with the concrete model + stream
+        const sentBody = SafeJSON.parse(String(capturedInit?.body)) as { model: string; stream: boolean; instructions: string; input: unknown[] };
+        expect(sentBody.model).toBe("gpt-5.5");
+        expect(sentBody.stream).toBe(true);
+        expect(sentBody.instructions).toBe("Be terse.");
+        expect(Array.isArray(sentBody.input)).toBe(true);
+    });
+
+    it("streams chat.completion.chunk when the client requests streaming", async () => {
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => whamStreamResponse()) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.headers.get("content-type")).toContain("text/event-stream");
+        const text = await res.text();
+        expect(text).toContain('"object":"chat.completion.chunk"');
+        expect(text).toContain("CODEX");
+        expect(text).toContain("[DONE]");
+    });
+});

--- a/src/ai-proxy/lib/providers/openai-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.test.ts
@@ -158,4 +158,14 @@ describe("OpenAiSubscriptionProvider", () => {
         expect(text).toContain("CODEX");
         expect(text).toContain("[DONE]");
     });
+
+    it("returns 400 (not a 502) for a non-object JSON body", async () => {
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const req = new Request("http://localhost/v1/responses", { method: "POST", body: "null" });
+        const res = await provider.responses(req, "gpt-5.5", "null");
+
+        expect(res.status).toBe(400);
+    });
 });

--- a/src/ai-proxy/lib/providers/openai-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.test.ts
@@ -69,12 +69,19 @@ describe("buildWhamResponsesBody", () => {
         const body = buildWhamResponsesBody(
             {
                 messages: [{ role: "user", content: "go" }],
-                tools: [{ type: "function", function: { name: "search", description: "d", parameters: { type: "object" } } }],
+                tools: [
+                    {
+                        type: "function",
+                        function: { name: "search", description: "d", parameters: { type: "object" } },
+                    },
+                ],
             },
             "gpt-5.5"
         );
 
-        expect(body.tools).toEqual([{ type: "function", name: "search", description: "d", parameters: { type: "object" } }]);
+        expect(body.tools).toEqual([
+            { type: "function", name: "search", description: "d", parameters: { type: "object" } },
+        ]);
     });
 });
 
@@ -118,7 +125,12 @@ describe("OpenAiSubscriptionProvider", () => {
         expect(headers.get("openai-beta")).toBe("responses=experimental");
 
         // body was converted to Responses shape with the concrete model + stream
-        const sentBody = SafeJSON.parse(String(capturedInit?.body)) as { model: string; stream: boolean; instructions: string; input: unknown[] };
+        const sentBody = SafeJSON.parse(String(capturedInit?.body)) as {
+            model: string;
+            stream: boolean;
+            instructions: string;
+            input: unknown[];
+        };
         expect(sentBody.model).toBe("gpt-5.5");
         expect(sentBody.stream).toBe(true);
         expect(sentBody.instructions).toBe("Be terse.");
@@ -126,7 +138,8 @@ describe("OpenAiSubscriptionProvider", () => {
     });
 
     it("streams chat.completion.chunk when the client requests streaming", async () => {
-        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => whamStreamResponse()) as typeof fetch;
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) =>
+            whamStreamResponse()) as typeof fetch;
 
         const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
         const provider = await OpenAiSubscriptionProvider.create(account);

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -54,7 +54,12 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
 
         let parsed: Record<string, unknown>;
         try {
-            parsed = SafeJSON.parse(bodyText, { strict: true }) as Record<string, unknown>;
+            const parsedBody = SafeJSON.parse(bodyText, { strict: true });
+            if (!isObject(parsedBody)) {
+                return jsonError(400, "Invalid JSON body");
+            }
+
+            parsed = parsedBody;
         } catch (err) {
             logger.debug({ err }, "ai-proxy: openai-subscription got invalid JSON body");
             return jsonError(400, "Invalid JSON body");

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -1,0 +1,322 @@
+import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { convertMessagesToInput } from "@app/ai-proxy/lib/chat-to-responses-body";
+import { OPENAI_SUB_MODELS, resolveOpenAiSubModel } from "@app/ai-proxy/lib/providers/openai-sub-models";
+import { resolveOpenAiSubToken } from "@app/ai-proxy/lib/providers/openai-sub-token";
+import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { responsesToChat } from "@app/ai-proxy/lib/translators/responses-to-chat";
+import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+const WHAM_RESPONSES_URL = "https://chatgpt.com/backend-api/wham/responses";
+
+/**
+ * Bills the owner's ChatGPT/Codex subscription. The ChatGPT WHAM backend speaks
+ * the OpenAI Responses API (streaming-only), so `responses()` converts an
+ * incoming chat- or responses-shaped body into a WHAM Responses request and
+ * forwards it; `chatCompletions()` delegates to the shared `responsesToChat`
+ * translator (which calls `responses()` and maps the Responses output back to
+ * chat.completion / chat.completion.chunk).
+ */
+export class OpenAiSubscriptionProvider implements ProxyProvider {
+    readonly id = "openai-subscription";
+    readonly accountFingerprint: string;
+    private readonly account: AiProxyAccountConfig;
+
+    constructor(account: AiProxyAccountConfig) {
+        this.account = account;
+        this.accountFingerprint = accountConfigFingerprint(account);
+    }
+
+    static async create(account: AiProxyAccountConfig): Promise<OpenAiSubscriptionProvider> {
+        return new OpenAiSubscriptionProvider(account);
+    }
+
+    async listModels(): Promise<OpenAiModel[]> {
+        return OPENAI_SUB_MODELS.map((id) => ({
+            id: `${this.account.name}/${this.account.providerSlug}/${id}`,
+            object: "model",
+            created: 1_740_960_000,
+            owned_by: "openai",
+            description: `${id} via ChatGPT/Codex subscription`,
+        }));
+    }
+
+    async chatCompletions(req: Request, model: string, bodyText: string): Promise<Response> {
+        const proxyModel = `${this.account.name}/${this.account.providerSlug}/${model}`;
+        const { response } = await responsesToChat({ provider: this, upstreamModel: model, proxyModel, req, bodyText });
+        return response;
+    }
+
+    async responses(req: Request, model: string, bodyText: string): Promise<Response> {
+        const concreteModel = resolveOpenAiSubModel(model);
+
+        let parsed: Record<string, unknown>;
+        try {
+            parsed = SafeJSON.parse(bodyText, { strict: true }) as Record<string, unknown>;
+        } catch (err) {
+            logger.debug({ err }, "ai-proxy: openai-subscription got invalid JSON body");
+            return jsonError(400, "Invalid JSON body");
+        }
+
+        const wantStream = parsed.stream === true;
+        const whamBody = buildWhamResponsesBody(parsed, concreteModel);
+
+        let token: string;
+        let accountId: string | undefined;
+        try {
+            ({ token, accountId } = await resolveOpenAiSubToken(this.account));
+        } catch (err) {
+            logger.warn({ err, account: this.account.name }, "ai-proxy: openai-subscription token resolution failed");
+            return jsonError(502, `Codex subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`);
+        }
+
+        const started = performance.now();
+        const upstream = await fetch(WHAM_RESPONSES_URL, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "chatgpt-account-id": accountId ?? "",
+                "Content-Type": "application/json",
+                "OpenAI-Beta": "responses=experimental",
+                originator: "codex_cli_rs",
+                session_id: crypto.randomUUID(),
+                Accept: "text/event-stream",
+            },
+            body: SafeJSON.stringify(whamBody),
+            signal: req.signal,
+        });
+
+        const elapsedMs = Math.round(performance.now() - started);
+
+        if (!upstream.ok) {
+            const errorText = await upstream.text();
+            logger.warn(
+                { account: this.account.name, model: concreteModel, status: upstream.status, elapsedMs, body: errorText.slice(0, 500) },
+                "ai-proxy: WHAM upstream request failed"
+            );
+
+            return new Response(errorText, {
+                status: upstream.status,
+                headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+            });
+        }
+
+        logger.debug(
+            { account: this.account.name, model: concreteModel, wantStream, elapsedMs },
+            "ai-proxy: WHAM upstream request ok"
+        );
+
+        if (!upstream.body) {
+            return jsonError(502, "WHAM upstream returned no body");
+        }
+
+        if (wantStream) {
+            return new Response(upstream.body, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/event-stream; charset=utf-8",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                },
+            });
+        }
+
+        // Non-streaming caller: WHAM only streams, so accumulate the SSE into a
+        // Responses JSON. The final `response.completed` event carries empty
+        // output on WHAM, so text is reassembled from output_text deltas.
+        const responsesJson = await accumulateResponsesJson(upstream.body);
+
+        return new Response(responsesJson, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    async getUsage(): Promise<UsageSummary> {
+        return {
+            accountName: this.account.name,
+            provider: "openai-subscription",
+            summary: "subscription (usage not exposed by the ChatGPT backend)",
+        };
+    }
+}
+
+function extractText(content: unknown): string {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    if (Array.isArray(content)) {
+        return content
+            .map((part) => (isObject(part) && typeof part.text === "string" ? part.text : ""))
+            .join("");
+    }
+
+    return "";
+}
+
+function mapChatToolsToResponses(tools: unknown): unknown[] | undefined {
+    if (!Array.isArray(tools)) {
+        return undefined;
+    }
+
+    const mapped: unknown[] = [];
+
+    for (const tool of tools) {
+        if (!isObject(tool)) {
+            continue;
+        }
+
+        // Already Responses-shaped (flat function tool).
+        if (tool.type === "function" && typeof tool.name === "string") {
+            mapped.push(tool);
+            continue;
+        }
+
+        const fn = isObject(tool.function) ? tool.function : undefined;
+
+        if (fn && typeof fn.name === "string") {
+            mapped.push({
+                type: "function",
+                name: fn.name,
+                description: typeof fn.description === "string" ? fn.description : undefined,
+                parameters: fn.parameters ?? { type: "object", properties: {} },
+            });
+        }
+    }
+
+    return mapped.length > 0 ? mapped : undefined;
+}
+
+/** Convert a chat- or responses-shaped body into a WHAM Responses request. */
+export function buildWhamResponsesBody(parsed: Record<string, unknown>, model: string): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+        model,
+        stream: true,
+        store: false,
+        include: [],
+    };
+
+    if (Array.isArray(parsed.input)) {
+        // Already a Responses body.
+        body.input = parsed.input;
+
+        if (typeof parsed.instructions === "string") {
+            body.instructions = parsed.instructions;
+        }
+
+        if (parsed.tools) {
+            body.tools = parsed.tools;
+        }
+    } else {
+        const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+        const instructions: string[] = [];
+        const rest: unknown[] = [];
+
+        for (const message of messages) {
+            if (isObject(message) && (message.role === "system" || message.role === "developer")) {
+                instructions.push(extractText(message.content));
+                continue;
+            }
+
+            rest.push(message);
+        }
+
+        body.input = convertMessagesToInput(rest);
+
+        if (instructions.length > 0) {
+            body.instructions = instructions.join("\n\n");
+        }
+
+        const tools = mapChatToolsToResponses(parsed.tools);
+
+        if (tools) {
+            body.tools = tools;
+        }
+    }
+
+    const maxOutput = typeof parsed.max_output_tokens === "number" ? parsed.max_output_tokens : parsed.max_tokens;
+
+    if (typeof maxOutput === "number") {
+        body.max_output_tokens = maxOutput;
+    }
+
+    if (isObject(parsed.reasoning)) {
+        body.reasoning = parsed.reasoning;
+    } else {
+        body.reasoning = { effort: "low" };
+    }
+
+    return body;
+}
+
+async function accumulateResponsesJson(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const raw = await new Response(stream).text();
+    let text = "";
+    const functionCalls: unknown[] = [];
+    let completed: Record<string, unknown> = {};
+
+    for (const line of raw.split("\n")) {
+        const trimmed = line.trimStart();
+
+        if (!trimmed.startsWith("data:")) {
+            continue;
+        }
+
+        const payload = trimmed.slice("data:".length).trim();
+
+        if (payload.length === 0 || payload === "[DONE]") {
+            continue;
+        }
+
+        let event: unknown;
+        try {
+            event = SafeJSON.parse(payload, { strict: true });
+        } catch (err) {
+            logger.debug({ err, payload }, "ai-proxy: WHAM SSE line parse failed");
+            continue;
+        }
+
+        if (!isObject(event)) {
+            continue;
+        }
+
+        if (event.type === "response.output_text.delta" && typeof event.delta === "string") {
+            text += event.delta;
+            continue;
+        }
+
+        if (event.type === "response.output_item.done" && isObject(event.item) && event.item.type === "function_call") {
+            functionCalls.push(event.item);
+            continue;
+        }
+
+        if (event.type === "response.completed" && isObject(event.response)) {
+            completed = event.response;
+        }
+    }
+
+    const output: unknown[] = [];
+
+    if (text.length > 0) {
+        output.push({
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text, annotations: [] }],
+        });
+    }
+
+    output.push(...functionCalls);
+
+    return SafeJSON.stringify({ ...completed, object: "response", output });
+}
+
+function jsonError(status: number, message: string): Response {
+    return new Response(SafeJSON.stringify({ error: { message } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -69,7 +69,10 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
             ({ token, accountId } = await resolveOpenAiSubToken(this.account));
         } catch (err) {
             logger.warn({ err, account: this.account.name }, "ai-proxy: openai-subscription token resolution failed");
-            return jsonError(502, `Codex subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`);
+            return jsonError(
+                502,
+                `Codex subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`
+            );
         }
 
         const started = performance.now();
@@ -93,7 +96,13 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
         if (!upstream.ok) {
             const errorText = await upstream.text();
             logger.warn(
-                { account: this.account.name, model: concreteModel, status: upstream.status, elapsedMs, body: errorText.slice(0, 500) },
+                {
+                    account: this.account.name,
+                    model: concreteModel,
+                    status: upstream.status,
+                    elapsedMs,
+                    body: errorText.slice(0, 500),
+                },
                 "ai-proxy: WHAM upstream request failed"
             );
 
@@ -149,9 +158,7 @@ function extractText(content: unknown): string {
     }
 
     if (Array.isArray(content)) {
-        return content
-            .map((part) => (isObject(part) && typeof part.text === "string" ? part.text : ""))
-            .join("");
+        return content.map((part) => (isObject(part) && typeof part.text === "string" ? part.text : "")).join("");
     }
 
     return "";

--- a/src/ai-proxy/lib/providers/registry.ts
+++ b/src/ai-proxy/lib/providers/registry.ts
@@ -1,6 +1,7 @@
 import { AnthropicSubscriptionProvider } from "@app/ai-proxy/lib/providers/anthropic-subscription";
 import { GithubCopilotSubscriptionProvider } from "@app/ai-proxy/lib/providers/github-copilot-subscription";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
+import { OpenAiSubscriptionProvider } from "@app/ai-proxy/lib/providers/openai-subscription";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { logger } from "@app/logger";
@@ -17,7 +18,8 @@ export function isProviderImplemented(provider: AiProxyAccountConfig["provider"]
     return (
         provider === "grok-subscription" ||
         provider === "github-copilot-subscription" ||
-        provider === "anthropic-subscription"
+        provider === "anthropic-subscription" ||
+        provider === "openai-subscription"
     );
 }
 
@@ -57,6 +59,10 @@ export async function createProvider(account: AiProxyAccountConfig): Promise<Pro
 
     if (account.provider === "anthropic-subscription") {
         return AnthropicSubscriptionProvider.create(account);
+    }
+
+    if (account.provider === "openai-subscription") {
+        return OpenAiSubscriptionProvider.create(account);
     }
 
     throw new Error(`Provider not implemented yet: ${account.provider}`);

--- a/src/ai-proxy/lib/providers/registry.ts
+++ b/src/ai-proxy/lib/providers/registry.ts
@@ -1,3 +1,4 @@
+import { AnthropicSubscriptionProvider } from "@app/ai-proxy/lib/providers/anthropic-subscription";
 import { GithubCopilotSubscriptionProvider } from "@app/ai-proxy/lib/providers/github-copilot-subscription";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
@@ -13,7 +14,11 @@ export function routeProviderKey(route: { accountName: string; providerSlug: str
 }
 
 export function isProviderImplemented(provider: AiProxyAccountConfig["provider"]): boolean {
-    return provider === "grok-subscription" || provider === "github-copilot-subscription";
+    return (
+        provider === "grok-subscription" ||
+        provider === "github-copilot-subscription" ||
+        provider === "anthropic-subscription"
+    );
 }
 
 export async function buildProviderMap(
@@ -48,6 +53,10 @@ export async function createProvider(account: AiProxyAccountConfig): Promise<Pro
 
     if (account.provider === "github-copilot-subscription") {
         return GithubCopilotSubscriptionProvider.create(account);
+    }
+
+    if (account.provider === "anthropic-subscription") {
+        return AnthropicSubscriptionProvider.create(account);
     }
 
     throw new Error(`Provider not implemented yet: ${account.provider}`);

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
+import { anthropicMessageToOpenAiCompletion, anthropicSseToOpenAiChatStream } from "./anthropic-to-openai-completions";
+
+const MODEL = "martin/claude-sub/haiku";
+
+function streamFrom(text: string): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoder.encode(text));
+            controller.close();
+        },
+    });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let out = "";
+
+    for (;;) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+            break;
+        }
+
+        out += decoder.decode(value, { stream: true });
+    }
+
+    return out;
+}
+
+/** Parse `data: {...}` lines (ignoring [DONE]) into objects. */
+function parseChunks(sse: string): Array<Record<string, unknown>> {
+    return sse
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith("data:") && !line.includes("[DONE]"))
+        .map((line) => SafeJSON.parse(line.slice("data:".length).trim()) as Record<string, unknown>);
+}
+
+describe("anthropicMessageToOpenAiCompletion", () => {
+    it("maps a text message to an OpenAI chat.completion", () => {
+        const completion = anthropicMessageToOpenAiCompletion(
+            {
+                id: "msg_123",
+                role: "assistant",
+                content: [{ type: "text", text: "Hello there" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 10, output_tokens: 3 },
+            },
+            { model: MODEL }
+        );
+
+        expect(completion.object).toBe("chat.completion");
+        expect(completion.model).toBe(MODEL);
+        expect(completion.choices[0]?.message.content).toBe("Hello there");
+        expect(completion.choices[0]?.finish_reason).toBe("stop");
+        expect(completion.usage).toEqual({ prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 });
+    });
+
+    it("maps tool_use blocks to tool_calls with finish_reason tool_calls", () => {
+        const completion = anthropicMessageToOpenAiCompletion(
+            {
+                id: "msg_x",
+                role: "assistant",
+                content: [{ type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "Prague" } }],
+                stop_reason: "tool_use",
+                usage: { input_tokens: 5, output_tokens: 8 },
+            },
+            { model: MODEL }
+        );
+
+        expect(completion.choices[0]?.message.content).toBeNull();
+        expect(completion.choices[0]?.message.tool_calls).toEqual([
+            { index: 0, id: "toolu_1", type: "function", function: { name: "get_weather", arguments: '{"city":"Prague"}' } },
+        ]);
+        expect(completion.choices[0]?.finish_reason).toBe("tool_calls");
+    });
+
+    it("maps max_tokens stop_reason to length", () => {
+        const completion = anthropicMessageToOpenAiCompletion(
+            { id: "m", role: "assistant", content: [{ type: "text", text: "x" }], stop_reason: "max_tokens" },
+            { model: MODEL }
+        );
+
+        expect(completion.choices[0]?.finish_reason).toBe("length");
+    });
+});
+
+describe("anthropicSseToOpenAiChatStream", () => {
+    it("streams text deltas as chat.completion.chunk events ending in [DONE]", async () => {
+        const anthropicSse = [
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","model":"claude-haiku-4-5-20251001","usage":{"input_tokens":4}}}\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n',
+        ].join("\n");
+
+        const out = await collect(anthropicSseToOpenAiChatStream(streamFrom(anthropicSse), { model: MODEL }));
+        const chunks = parseChunks(out);
+
+        expect(out).toContain("data: [DONE]");
+        expect(out).toContain('"object":"chat.completion.chunk"');
+
+        // first chunk announces the assistant role
+        const firstDelta = (chunks[0]?.choices as Array<{ delta: Record<string, unknown> }>)[0]?.delta;
+        expect(firstDelta).toEqual({ role: "assistant" });
+
+        // reassembled content
+        const content = chunks
+            .flatMap((c) => (c.choices as Array<{ delta: { content?: string } }>))
+            .map((choice) => choice.delta.content ?? "")
+            .join("");
+        expect(content).toBe("Hello");
+
+        // final chunk carries finish_reason stop
+        const finishReasons = chunks
+            .flatMap((c) => c.choices as Array<{ finish_reason: string | null }>)
+            .map((choice) => choice.finish_reason)
+            .filter((reason) => reason !== null);
+        expect(finishReasons).toEqual(["stop"]);
+    });
+
+    it("streams tool_use as tool_call deltas", async () => {
+        const anthropicSse = [
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_2","model":"claude-haiku-4-5-20251001"}}\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_9","name":"search"}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"q\\":"}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"cats\\"}"}}\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n',
+        ].join("\n");
+
+        const out = await collect(anthropicSseToOpenAiChatStream(streamFrom(anthropicSse), { model: MODEL }));
+        const chunks = parseChunks(out);
+
+        const toolCalls = chunks
+            .flatMap((c) => c.choices as Array<{ delta: { tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }> } }>)
+            .flatMap((choice) => choice.delta.tool_calls ?? []);
+
+        // first tool_call chunk names the function
+        expect(toolCalls[0]?.id).toBe("toolu_9");
+        expect(toolCalls[0]?.function?.name).toBe("search");
+
+        // arguments reassemble
+        const args = toolCalls.map((tc) => tc.function?.arguments ?? "").join("");
+        expect(args).toBe('{"q":"cats"}');
+
+        const finishReasons = chunks
+            .flatMap((c) => c.choices as Array<{ finish_reason: string | null }>)
+            .map((choice) => choice.finish_reason)
+            .filter((reason) => reason !== null);
+        expect(finishReasons).toEqual(["tool_calls"]);
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.test.ts
@@ -76,7 +76,12 @@ describe("anthropicMessageToOpenAiCompletion", () => {
 
         expect(completion.choices[0]?.message.content).toBeNull();
         expect(completion.choices[0]?.message.tool_calls).toEqual([
-            { index: 0, id: "toolu_1", type: "function", function: { name: "get_weather", arguments: '{"city":"Prague"}' } },
+            {
+                index: 0,
+                id: "toolu_1",
+                type: "function",
+                function: { name: "get_weather", arguments: '{"city":"Prague"}' },
+            },
         ]);
         expect(completion.choices[0]?.finish_reason).toBe("tool_calls");
     });
@@ -115,7 +120,7 @@ describe("anthropicSseToOpenAiChatStream", () => {
 
         // reassembled content
         const content = chunks
-            .flatMap((c) => (c.choices as Array<{ delta: { content?: string } }>))
+            .flatMap((c) => c.choices as Array<{ delta: { content?: string } }>)
             .map((choice) => choice.delta.content ?? "")
             .join("");
         expect(content).toBe("Hello");
@@ -142,7 +147,14 @@ describe("anthropicSseToOpenAiChatStream", () => {
         const chunks = parseChunks(out);
 
         const toolCalls = chunks
-            .flatMap((c) => c.choices as Array<{ delta: { tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }> } }>)
+            .flatMap(
+                (c) =>
+                    c.choices as Array<{
+                        delta: {
+                            tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }>;
+                        };
+                    }>
+            )
             .flatMap((choice) => choice.delta.tool_calls ?? []);
 
         // first tool_call chunk names the function

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.ts
@@ -1,0 +1,297 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+/**
+ * Maps Anthropic `/v1/messages` responses back into the OpenAI
+ * chat-completions shape the proxy's clients expect — both the non-streaming
+ * final message and the streaming SSE event flow.
+ */
+
+export interface OpenAiToolCall {
+    index?: number;
+    id?: string;
+    type: "function";
+    function: { name?: string; arguments: string };
+}
+
+export interface OpenAiChatCompletion {
+    id: string;
+    object: "chat.completion";
+    created: number;
+    model: string;
+    choices: Array<{
+        index: number;
+        message: { role: "assistant"; content: string | null; tool_calls?: OpenAiToolCall[] };
+        finish_reason: string;
+    }>;
+    usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+}
+
+type AnthropicStopReason = "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | string | null | undefined;
+
+function mapFinishReason(stopReason: AnthropicStopReason): string {
+    if (stopReason === "max_tokens") {
+        return "length";
+    }
+
+    if (stopReason === "tool_use") {
+        return "tool_calls";
+    }
+
+    return "stop";
+}
+
+function nowSeconds(): number {
+    return Math.floor(Date.now() / 1000);
+}
+
+/** Non-streaming: an Anthropic message object → an OpenAI chat.completion. */
+export function anthropicMessageToOpenAiCompletion(
+    message: Record<string, unknown>,
+    options: { model: string }
+): OpenAiChatCompletion {
+    const contentBlocks = Array.isArray(message.content) ? message.content : [];
+    const textParts: string[] = [];
+    const toolCalls: OpenAiToolCall[] = [];
+
+    for (const block of contentBlocks) {
+        if (!isObject(block)) {
+            continue;
+        }
+
+        if (block.type === "text" && typeof block.text === "string") {
+            textParts.push(block.text);
+            continue;
+        }
+
+        if (block.type === "tool_use") {
+            toolCalls.push({
+                index: toolCalls.length,
+                id: typeof block.id === "string" ? block.id : `call_${crypto.randomUUID()}`,
+                type: "function",
+                function: {
+                    name: typeof block.name === "string" ? block.name : "unknown",
+                    arguments: SafeJSON.stringify(block.input ?? {}),
+                },
+            });
+        }
+    }
+
+    const usage = isObject(message.usage) ? message.usage : undefined;
+    const inputTokens = usage && typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+    const outputTokens = usage && typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
+
+    const completion: OpenAiChatCompletion = {
+        id: `chatcmpl-${typeof message.id === "string" ? message.id : crypto.randomUUID()}`,
+        object: "chat.completion",
+        created: nowSeconds(),
+        model: options.model,
+        choices: [
+            {
+                index: 0,
+                message: {
+                    role: "assistant",
+                    content: textParts.length > 0 ? textParts.join("") : null,
+                    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+                },
+                finish_reason: mapFinishReason(message.stop_reason as AnthropicStopReason),
+            },
+        ],
+        usage: {
+            prompt_tokens: inputTokens,
+            completion_tokens: outputTokens,
+            total_tokens: inputTokens + outputTokens,
+        },
+    };
+
+    return completion;
+}
+
+interface ChunkDelta {
+    role?: "assistant";
+    content?: string;
+    tool_calls?: OpenAiToolCall[];
+}
+
+function chunk(input: {
+    id: string;
+    model: string;
+    created: number;
+    delta: ChunkDelta;
+    finishReason: string | null;
+}): string {
+    const payload = {
+        id: input.id,
+        object: "chat.completion.chunk",
+        created: input.created,
+        model: input.model,
+        choices: [{ index: 0, delta: input.delta, finish_reason: input.finishReason }],
+    };
+
+    return `data: ${SafeJSON.stringify(payload)}\n\n`;
+}
+
+/**
+ * Streaming: transform an Anthropic Messages SSE byte stream into an OpenAI
+ * chat.completion.chunk SSE byte stream.
+ */
+export function anthropicSseToOpenAiChatStream(
+    upstream: ReadableStream<Uint8Array>,
+    options: { model: string }
+): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = upstream.getReader();
+
+    const id = `chatcmpl-${crypto.randomUUID()}`;
+    const created = nowSeconds();
+    const model = options.model;
+
+    let buffer = "";
+    let roleEmitted = false;
+    let finishReason: string | null = null;
+    let nextToolIndex = 0;
+    const blockToToolIndex = new Map<number, number>();
+
+    function handleEvent(event: Record<string, unknown>, controller: ReadableStreamDefaultController<Uint8Array>): void {
+        const type = event.type;
+
+        if (type === "message_start") {
+            if (!roleEmitted) {
+                roleEmitted = true;
+                controller.enqueue(encoder.encode(chunk({ id, model, created, delta: { role: "assistant" }, finishReason: null })));
+            }
+
+            return;
+        }
+
+        if (type === "content_block_start" && isObject(event.content_block) && typeof event.index === "number") {
+            const contentBlock = event.content_block;
+
+            if (contentBlock.type === "tool_use") {
+                const toolIndex = nextToolIndex++;
+                blockToToolIndex.set(event.index, toolIndex);
+                controller.enqueue(
+                    encoder.encode(
+                        chunk({
+                            id,
+                            model,
+                            created,
+                            delta: {
+                                tool_calls: [
+                                    {
+                                        index: toolIndex,
+                                        id: typeof contentBlock.id === "string" ? contentBlock.id : `call_${crypto.randomUUID()}`,
+                                        type: "function",
+                                        function: {
+                                            name: typeof contentBlock.name === "string" ? contentBlock.name : "unknown",
+                                            arguments: "",
+                                        },
+                                    },
+                                ],
+                            },
+                            finishReason: null,
+                        })
+                    )
+                );
+            }
+
+            return;
+        }
+
+        if (type === "content_block_delta" && isObject(event.delta) && typeof event.index === "number") {
+            const delta = event.delta;
+
+            if (delta.type === "text_delta" && typeof delta.text === "string") {
+                controller.enqueue(encoder.encode(chunk({ id, model, created, delta: { content: delta.text }, finishReason: null })));
+                return;
+            }
+
+            if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+                const toolIndex = blockToToolIndex.get(event.index) ?? 0;
+                controller.enqueue(
+                    encoder.encode(
+                        chunk({
+                            id,
+                            model,
+                            created,
+                            delta: { tool_calls: [{ index: toolIndex, type: "function", function: { arguments: delta.partial_json } }] },
+                            finishReason: null,
+                        })
+                    )
+                );
+            }
+
+            return;
+        }
+
+        if (type === "message_delta" && isObject(event.delta)) {
+            const stopReason = event.delta.stop_reason;
+
+            if (typeof stopReason === "string") {
+                finishReason = mapFinishReason(stopReason);
+            }
+
+            return;
+        }
+    }
+
+    function processLine(line: string, controller: ReadableStreamDefaultController<Uint8Array>): void {
+        const trimmed = line.trimStart();
+
+        if (!trimmed.startsWith("data:")) {
+            return;
+        }
+
+        const payload = trimmed.slice("data:".length).trim();
+
+        if (payload.length === 0) {
+            return;
+        }
+
+        try {
+            const event = SafeJSON.parse(payload, { strict: true });
+
+            if (isObject(event)) {
+                handleEvent(event, controller);
+            }
+        } catch (err) {
+            logger.debug({ err, payload }, "ai-proxy: anthropic SSE line parse failed");
+        }
+    }
+
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            try {
+                const { done, value } = await reader.read();
+
+                if (done) {
+                    if (buffer.trim().length > 0) {
+                        processLine(buffer, controller);
+                        buffer = "";
+                    }
+
+                    controller.enqueue(encoder.encode(chunk({ id, model, created, delta: {}, finishReason: finishReason ?? "stop" })));
+                    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                    controller.close();
+                    return;
+                }
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split("\n");
+                buffer = lines.pop() ?? "";
+
+                for (const line of lines) {
+                    processLine(line, controller);
+                }
+            } catch (err) {
+                logger.warn({ err }, "ai-proxy: anthropic SSE stream error");
+                controller.error(err);
+            }
+        },
+        cancel(reason) {
+            reader.cancel(reason).catch(() => {});
+        },
+    });
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.ts
@@ -154,13 +154,18 @@ export function anthropicSseToOpenAiChatStream(
     let nextToolIndex = 0;
     const blockToToolIndex = new Map<number, number>();
 
-    function handleEvent(event: Record<string, unknown>, controller: ReadableStreamDefaultController<Uint8Array>): void {
+    function handleEvent(
+        event: Record<string, unknown>,
+        controller: ReadableStreamDefaultController<Uint8Array>
+    ): void {
         const type = event.type;
 
         if (type === "message_start") {
             if (!roleEmitted) {
                 roleEmitted = true;
-                controller.enqueue(encoder.encode(chunk({ id, model, created, delta: { role: "assistant" }, finishReason: null })));
+                controller.enqueue(
+                    encoder.encode(chunk({ id, model, created, delta: { role: "assistant" }, finishReason: null }))
+                );
             }
 
             return;
@@ -182,7 +187,10 @@ export function anthropicSseToOpenAiChatStream(
                                 tool_calls: [
                                     {
                                         index: toolIndex,
-                                        id: typeof contentBlock.id === "string" ? contentBlock.id : `call_${crypto.randomUUID()}`,
+                                        id:
+                                            typeof contentBlock.id === "string"
+                                                ? contentBlock.id
+                                                : `call_${crypto.randomUUID()}`,
                                         type: "function",
                                         function: {
                                             name: typeof contentBlock.name === "string" ? contentBlock.name : "unknown",
@@ -204,7 +212,9 @@ export function anthropicSseToOpenAiChatStream(
             const delta = event.delta;
 
             if (delta.type === "text_delta" && typeof delta.text === "string") {
-                controller.enqueue(encoder.encode(chunk({ id, model, created, delta: { content: delta.text }, finishReason: null })));
+                controller.enqueue(
+                    encoder.encode(chunk({ id, model, created, delta: { content: delta.text }, finishReason: null }))
+                );
                 return;
             }
 
@@ -216,7 +226,11 @@ export function anthropicSseToOpenAiChatStream(
                             id,
                             model,
                             created,
-                            delta: { tool_calls: [{ index: toolIndex, type: "function", function: { arguments: delta.partial_json } }] },
+                            delta: {
+                                tool_calls: [
+                                    { index: toolIndex, type: "function", function: { arguments: delta.partial_json } },
+                                ],
+                            },
                             finishReason: null,
                         })
                     )
@@ -272,7 +286,9 @@ export function anthropicSseToOpenAiChatStream(
                         buffer = "";
                     }
 
-                    controller.enqueue(encoder.encode(chunk({ id, model, created, delta: {}, finishReason: finishReason ?? "stop" })));
+                    controller.enqueue(
+                        encoder.encode(chunk({ id, model, created, delta: {}, finishReason: finishReason ?? "stop" }))
+                    );
                     controller.enqueue(encoder.encode("data: [DONE]\n\n"));
                     controller.close();
                     return;

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
@@ -83,9 +83,12 @@ describe("openAiChatToAnthropicMessages", () => {
         );
 
         // the tool_result user turn and the plain user turn must merge into one
-        const userTurns = body.messages.filter((m) => m.role === "user");
-        expect(userTurns).toHaveLength(1);
-        expect(userTurns[0]?.content).toEqual([
+        // (the leading synthetic user turn from the first-user rule is separate)
+        const toolResultTurns = body.messages.filter(
+            (m) => m.role === "user" && m.content.some((block) => block.type === "tool_result")
+        );
+        expect(toolResultTurns).toHaveLength(1);
+        expect(toolResultTurns[0]?.content).toEqual([
             { type: "tool_result", tool_use_id: "c1", content: "r1" },
             { type: "text", text: "and now this" },
         ]);
@@ -118,6 +121,35 @@ describe("openAiChatToAnthropicMessages", () => {
             },
         ]);
         expect(body.tool_choice).toEqual({ type: "tool", name: "search" });
+    });
+
+    it("maps tool_choice 'none' to Anthropic's native none while keeping tools", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [{ role: "user", content: "go" }],
+                tools: [{ type: "function", function: { name: "search", parameters: { type: "object" } } }],
+                tool_choice: "none",
+            },
+            { model: MODEL }
+        );
+
+        expect(body.tools).toHaveLength(1);
+        expect(body.tool_choice).toEqual({ type: "none" });
+    });
+
+    it("prepends a user turn when the first message is an assistant turn", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    { role: "assistant", content: "earlier reply" },
+                    { role: "user", content: "follow-up" },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[0]?.role).toBe("user");
+        expect(body.messages[1]?.role).toBe("assistant");
     });
 
     it("maps string and array stop to stop_sequences", () => {

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
@@ -43,7 +43,11 @@ describe("openAiChatToAnthropicMessages", () => {
                         role: "assistant",
                         content: null,
                         tool_calls: [
-                            { id: "call_1", type: "function", function: { name: "get_weather", arguments: '{"city":"Prague"}' } },
+                            {
+                                id: "call_1",
+                                type: "function",
+                                function: { name: "get_weather", arguments: '{"city":"Prague"}' },
+                            },
                         ],
                     },
                     { role: "tool", tool_call_id: "call_1", content: "sunny" },
@@ -66,7 +70,11 @@ describe("openAiChatToAnthropicMessages", () => {
         const body = openAiChatToAnthropicMessages(
             {
                 messages: [
-                    { role: "assistant", content: null, tool_calls: [{ id: "c1", type: "function", function: { name: "f", arguments: "{}" } }] },
+                    {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [{ id: "c1", type: "function", function: { name: "f", arguments: "{}" } }],
+                    },
                     { role: "tool", tool_call_id: "c1", content: "r1" },
                     { role: "user", content: "and now this" },
                 ],
@@ -103,17 +111,25 @@ describe("openAiChatToAnthropicMessages", () => {
         );
 
         expect(body.tools).toEqual([
-            { name: "search", description: "search the web", input_schema: { type: "object", properties: { q: { type: "string" } } } },
+            {
+                name: "search",
+                description: "search the web",
+                input_schema: { type: "object", properties: { q: { type: "string" } } },
+            },
         ]);
         expect(body.tool_choice).toEqual({ type: "tool", name: "search" });
     });
 
     it("maps string and array stop to stop_sequences", () => {
         expect(
-            openAiChatToAnthropicMessages({ messages: [{ role: "user", content: "x" }], stop: "END" }, { model: MODEL }).stop_sequences
+            openAiChatToAnthropicMessages({ messages: [{ role: "user", content: "x" }], stop: "END" }, { model: MODEL })
+                .stop_sequences
         ).toEqual(["END"]);
         expect(
-            openAiChatToAnthropicMessages({ messages: [{ role: "user", content: "x" }], stop: ["A", "B"] }, { model: MODEL }).stop_sequences
+            openAiChatToAnthropicMessages(
+                { messages: [{ role: "user", content: "x" }], stop: ["A", "B"] },
+                { model: MODEL }
+            ).stop_sequences
         ).toEqual(["A", "B"]);
     });
 

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import { openAiChatToAnthropicMessages } from "./openai-to-anthropic-messages";
+
+const MODEL = "claude-haiku-4-5-20251001";
+
+describe("openAiChatToAnthropicMessages", () => {
+    it("extracts system, maps roles, sets max_tokens", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                model: "martin/claude-sub/haiku",
+                messages: [
+                    { role: "system", content: "You are helpful." },
+                    { role: "user", content: "Hi" },
+                ],
+                max_tokens: 256,
+                temperature: 0.5,
+            },
+            { model: MODEL }
+        );
+
+        expect(body.model).toBe(MODEL);
+        expect(body.max_tokens).toBe(256);
+        expect(body.system).toBe("You are helpful.");
+        expect(body.temperature).toBe(0.5);
+        expect(body.messages).toEqual([{ role: "user", content: [{ type: "text", text: "Hi" }] }]);
+    });
+
+    it("defaults max_tokens when the request omits it", () => {
+        const body = openAiChatToAnthropicMessages(
+            { messages: [{ role: "user", content: "yo" }] },
+            { model: MODEL, maxTokensDefault: 1234 }
+        );
+
+        expect(body.max_tokens).toBe(1234);
+    });
+
+    it("maps assistant tool_calls to tool_use and tool results to a user tool_result turn", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    { role: "user", content: "weather?" },
+                    {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [
+                            { id: "call_1", type: "function", function: { name: "get_weather", arguments: '{"city":"Prague"}' } },
+                        ],
+                    },
+                    { role: "tool", tool_call_id: "call_1", content: "sunny" },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[1]).toEqual({
+            role: "assistant",
+            content: [{ type: "tool_use", id: "call_1", name: "get_weather", input: { city: "Prague" } }],
+        });
+        expect(body.messages[2]).toEqual({
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "call_1", content: "sunny" }],
+        });
+    });
+
+    it("coalesces adjacent same-role turns (tool result + trailing user text)", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    { role: "assistant", content: null, tool_calls: [{ id: "c1", type: "function", function: { name: "f", arguments: "{}" } }] },
+                    { role: "tool", tool_call_id: "c1", content: "r1" },
+                    { role: "user", content: "and now this" },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        // the tool_result user turn and the plain user turn must merge into one
+        const userTurns = body.messages.filter((m) => m.role === "user");
+        expect(userTurns).toHaveLength(1);
+        expect(userTurns[0]?.content).toEqual([
+            { type: "tool_result", tool_use_id: "c1", content: "r1" },
+            { type: "text", text: "and now this" },
+        ]);
+    });
+
+    it("maps tools and tool_choice", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [{ role: "user", content: "go" }],
+                tools: [
+                    {
+                        type: "function",
+                        function: {
+                            name: "search",
+                            description: "search the web",
+                            parameters: { type: "object", properties: { q: { type: "string" } } },
+                        },
+                    },
+                ],
+                tool_choice: { type: "function", function: { name: "search" } },
+            },
+            { model: MODEL }
+        );
+
+        expect(body.tools).toEqual([
+            { name: "search", description: "search the web", input_schema: { type: "object", properties: { q: { type: "string" } } } },
+        ]);
+        expect(body.tool_choice).toEqual({ type: "tool", name: "search" });
+    });
+
+    it("maps string and array stop to stop_sequences", () => {
+        expect(
+            openAiChatToAnthropicMessages({ messages: [{ role: "user", content: "x" }], stop: "END" }, { model: MODEL }).stop_sequences
+        ).toEqual(["END"]);
+        expect(
+            openAiChatToAnthropicMessages({ messages: [{ role: "user", content: "x" }], stop: ["A", "B"] }, { model: MODEL }).stop_sequences
+        ).toEqual(["A", "B"]);
+    });
+
+    it("maps multi-part text + image_url content", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    {
+                        role: "user",
+                        content: [
+                            { type: "text", text: "what is this" },
+                            { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+                        ],
+                    },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[0]?.content).toEqual([
+            { type: "text", text: "what is this" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+        ]);
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
@@ -1,0 +1,391 @@
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+/**
+ * Maps an OpenAI chat-completions request body into an Anthropic
+ * `/v1/messages` request body. The proxy speaks OpenAI to its clients but the
+ * Claude subscription upstream expects the Anthropic Messages shape.
+ *
+ * Handles: system extraction (Anthropic keeps system top-level), role mapping,
+ * multi-part text/image content, assistant tool_calls → tool_use, tool-role
+ * messages → user tool_result, tool/tool_choice translation, sampling params,
+ * and coalescing of adjacent same-role turns (Anthropic requires strict
+ * alternation and rejects consecutive same-role messages).
+ */
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+export interface OpenAiChatBody {
+    model?: string;
+    messages?: unknown;
+    max_tokens?: number;
+    max_completion_tokens?: number;
+    temperature?: number;
+    top_p?: number;
+    stop?: string | string[];
+    stream?: boolean;
+    tools?: unknown;
+    tool_choice?: unknown;
+    [key: string]: unknown;
+}
+
+export interface AnthropicTextBlock {
+    type: "text";
+    text: string;
+}
+
+export interface AnthropicImageBlock {
+    type: "image";
+    source:
+        | { type: "base64"; media_type: string; data: string }
+        | { type: "url"; url: string };
+}
+
+export interface AnthropicToolUseBlock {
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+}
+
+export interface AnthropicToolResultBlock {
+    type: "tool_result";
+    tool_use_id: string;
+    content: string | AnthropicTextBlock[];
+}
+
+export type AnthropicContentBlock =
+    | AnthropicTextBlock
+    | AnthropicImageBlock
+    | AnthropicToolUseBlock
+    | AnthropicToolResultBlock;
+
+export interface AnthropicMessage {
+    role: "user" | "assistant";
+    content: AnthropicContentBlock[];
+}
+
+export interface AnthropicTool {
+    name: string;
+    description?: string;
+    input_schema: unknown;
+}
+
+export type AnthropicToolChoice =
+    | { type: "auto" }
+    | { type: "any" }
+    | { type: "tool"; name: string };
+
+export interface AnthropicMessagesBody {
+    model: string;
+    max_tokens: number;
+    system?: string;
+    messages: AnthropicMessage[];
+    temperature?: number;
+    top_p?: number;
+    stop_sequences?: string[];
+    stream?: boolean;
+    tools?: AnthropicTool[];
+    tool_choice?: AnthropicToolChoice;
+}
+
+export interface OpenAiToAnthropicOptions {
+    /** Concrete Anthropic model id to forward (e.g. claude-haiku-4-5-20251001). */
+    model: string;
+    /** max_tokens fallback when the request omits it (Anthropic requires it). */
+    maxTokensDefault?: number;
+}
+
+function textBlock(text: string): AnthropicTextBlock {
+    return { type: "text", text };
+}
+
+function imageBlockFromUrl(url: string): AnthropicImageBlock {
+    const dataUrl = /^data:([^;]+);base64,(.*)$/s.exec(url);
+
+    if (dataUrl) {
+        return {
+            type: "image",
+            source: { type: "base64", media_type: dataUrl[1] ?? "image/png", data: dataUrl[2] ?? "" },
+        };
+    }
+
+    return { type: "image", source: { type: "url", url } };
+}
+
+function contentToBlocks(content: unknown): AnthropicContentBlock[] {
+    if (typeof content === "string") {
+        return content.length > 0 ? [textBlock(content)] : [];
+    }
+
+    if (!Array.isArray(content)) {
+        return content == null ? [] : [textBlock(String(content))];
+    }
+
+    const blocks: AnthropicContentBlock[] = [];
+
+    for (const part of content) {
+        if (!isObject(part)) {
+            continue;
+        }
+
+        if (part.type === "text" && typeof part.text === "string") {
+            blocks.push(textBlock(part.text));
+            continue;
+        }
+
+        if (part.type === "image_url" && isObject(part.image_url) && typeof part.image_url.url === "string") {
+            blocks.push(imageBlockFromUrl(part.image_url.url));
+            continue;
+        }
+    }
+
+    return blocks;
+}
+
+function toolUseBlocksFromToolCalls(toolCalls: unknown): AnthropicToolUseBlock[] {
+    if (!Array.isArray(toolCalls)) {
+        return [];
+    }
+
+    const blocks: AnthropicToolUseBlock[] = [];
+
+    for (const call of toolCalls) {
+        if (!isObject(call)) {
+            continue;
+        }
+
+        const fn = isObject(call.function) ? call.function : {};
+        const rawArgs = typeof fn.arguments === "string" ? fn.arguments : "";
+        let input: unknown = {};
+
+        if (rawArgs.length > 0) {
+            try {
+                input = SafeJSON.parse(rawArgs);
+            } catch {
+                input = { _raw: rawArgs };
+            }
+        }
+
+        blocks.push({
+            type: "tool_use",
+            id: typeof call.id === "string" ? call.id : `call_${crypto.randomUUID()}`,
+            name: typeof fn.name === "string" ? fn.name : "unknown",
+            input,
+        });
+    }
+
+    return blocks;
+}
+
+function toolResultContent(content: unknown): string | AnthropicTextBlock[] {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    if (Array.isArray(content)) {
+        const parts: AnthropicTextBlock[] = [];
+
+        for (const part of content) {
+            if (isObject(part) && part.type === "text" && typeof part.text === "string") {
+                parts.push(textBlock(part.text));
+            }
+        }
+
+        if (parts.length > 0) {
+            return parts;
+        }
+    }
+
+    return SafeJSON.stringify(content ?? "");
+}
+
+function mapMessage(message: Record<string, unknown>): AnthropicMessage | null {
+    const role = message.role;
+
+    if (role === "tool" && typeof message.tool_call_id === "string") {
+        return {
+            role: "user",
+            content: [
+                {
+                    type: "tool_result",
+                    tool_use_id: message.tool_call_id,
+                    content: toolResultContent(message.content),
+                },
+            ],
+        };
+    }
+
+    if (role === "assistant") {
+        const blocks: AnthropicContentBlock[] = [...contentToBlocks(message.content), ...toolUseBlocksFromToolCalls(message.tool_calls)];
+
+        if (blocks.length === 0) {
+            return null;
+        }
+
+        return { role: "assistant", content: blocks };
+    }
+
+    const blocks = contentToBlocks(message.content);
+
+    if (blocks.length === 0) {
+        return null;
+    }
+
+    return { role: "user", content: blocks };
+}
+
+/** Merge adjacent same-role turns (Anthropic rejects consecutive same-role messages). */
+function coalesce(messages: AnthropicMessage[]): AnthropicMessage[] {
+    const merged: AnthropicMessage[] = [];
+
+    for (const message of messages) {
+        const last = merged.at(-1);
+
+        if (last && last.role === message.role) {
+            last.content.push(...message.content);
+            continue;
+        }
+
+        merged.push(message);
+    }
+
+    return merged;
+}
+
+function extractSystem(messages: Record<string, unknown>[]): string | undefined {
+    const parts: string[] = [];
+
+    for (const message of messages) {
+        if (message.role !== "system" && message.role !== "developer") {
+            continue;
+        }
+
+        for (const block of contentToBlocks(message.content)) {
+            if (block.type === "text") {
+                parts.push(block.text);
+            }
+        }
+    }
+
+    return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+function mapTools(tools: unknown): AnthropicTool[] | undefined {
+    if (!Array.isArray(tools)) {
+        return undefined;
+    }
+
+    const mapped: AnthropicTool[] = [];
+
+    for (const tool of tools) {
+        if (!isObject(tool)) {
+            continue;
+        }
+
+        const fn = isObject(tool.function) ? tool.function : tool;
+        const name = typeof fn.name === "string" ? fn.name : undefined;
+
+        if (!name) {
+            continue;
+        }
+
+        mapped.push({
+            name,
+            description: typeof fn.description === "string" ? fn.description : undefined,
+            input_schema: fn.parameters ?? fn.input_schema ?? { type: "object", properties: {} },
+        });
+    }
+
+    return mapped.length > 0 ? mapped : undefined;
+}
+
+function mapToolChoice(toolChoice: unknown): AnthropicToolChoice | undefined {
+    if (toolChoice === "auto") {
+        return { type: "auto" };
+    }
+
+    if (toolChoice === "required") {
+        return { type: "any" };
+    }
+
+    if (toolChoice === "none") {
+        return undefined;
+    }
+
+    if (isObject(toolChoice) && toolChoice.type === "function" && isObject(toolChoice.function)) {
+        const name = toolChoice.function.name;
+
+        if (typeof name === "string") {
+            return { type: "tool", name };
+        }
+    }
+
+    return undefined;
+}
+
+export function openAiChatToAnthropicMessages(
+    body: OpenAiChatBody,
+    options: OpenAiToAnthropicOptions
+): AnthropicMessagesBody {
+    const rawMessages = Array.isArray(body.messages) ? body.messages : [];
+    const objectMessages = rawMessages.filter(isObject);
+
+    const mapped: AnthropicMessage[] = [];
+
+    for (const message of objectMessages) {
+        if (message.role === "system" || message.role === "developer") {
+            continue;
+        }
+
+        const anthropicMessage = mapMessage(message);
+
+        if (anthropicMessage) {
+            mapped.push(anthropicMessage);
+        }
+    }
+
+    const result: AnthropicMessagesBody = {
+        model: options.model,
+        max_tokens: body.max_tokens ?? body.max_completion_tokens ?? options.maxTokensDefault ?? DEFAULT_MAX_TOKENS,
+        messages: coalesce(mapped),
+    };
+
+    const system = extractSystem(objectMessages);
+
+    if (system !== undefined) {
+        result.system = system;
+    }
+
+    if (typeof body.temperature === "number") {
+        result.temperature = body.temperature;
+    }
+
+    if (typeof body.top_p === "number") {
+        result.top_p = body.top_p;
+    }
+
+    if (typeof body.stop === "string") {
+        result.stop_sequences = [body.stop];
+    } else if (Array.isArray(body.stop)) {
+        result.stop_sequences = body.stop.filter((entry): entry is string => typeof entry === "string");
+    }
+
+    if (typeof body.stream === "boolean") {
+        result.stream = body.stream;
+    }
+
+    const tools = mapTools(body.tools);
+
+    if (tools) {
+        result.tools = tools;
+
+        const toolChoice = mapToolChoice(body.tool_choice);
+
+        if (toolChoice) {
+            result.tool_choice = toolChoice;
+        }
+    }
+
+    return result;
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
@@ -69,7 +69,7 @@ export interface AnthropicTool {
     input_schema: unknown;
 }
 
-export type AnthropicToolChoice = { type: "auto" } | { type: "any" } | { type: "tool"; name: string };
+export type AnthropicToolChoice = { type: "auto" } | { type: "any" } | { type: "none" } | { type: "tool"; name: string };
 
 export interface AnthropicMessagesBody {
     model: string;
@@ -307,7 +307,10 @@ function mapToolChoice(toolChoice: unknown): AnthropicToolChoice | undefined {
     }
 
     if (toolChoice === "none") {
-        return undefined;
+        // Anthropic's native tool_choice "none" keeps the tools attached (so they
+        // stay visible to the model / extended thinking) but forbids calling them.
+        // Omitting it would let Anthropic default to "auto" with tools present.
+        return { type: "none" };
     }
 
     if (isObject(toolChoice) && toolChoice.type === "function" && isObject(toolChoice.function)) {
@@ -342,10 +345,19 @@ export function openAiChatToAnthropicMessages(
         }
     }
 
+    const messages = coalesce(mapped);
+
+    // Anthropic requires the first message to use the "user" role. Client-side
+    // history truncation can leave an assistant turn first — prepend a minimal
+    // user turn so the request is not rejected with a 400.
+    if (messages[0]?.role === "assistant") {
+        messages.unshift({ role: "user", content: [{ type: "text", text: "(continue)" }] });
+    }
+
     const result: AnthropicMessagesBody = {
         model: options.model,
         max_tokens: body.max_tokens ?? body.max_completion_tokens ?? options.maxTokensDefault ?? DEFAULT_MAX_TOKENS,
-        messages: coalesce(mapped),
+        messages,
     };
 
     const system = extractSystem(objectMessages);

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
@@ -36,9 +36,7 @@ export interface AnthropicTextBlock {
 
 export interface AnthropicImageBlock {
     type: "image";
-    source:
-        | { type: "base64"; media_type: string; data: string }
-        | { type: "url"; url: string };
+    source: { type: "base64"; media_type: string; data: string } | { type: "url"; url: string };
 }
 
 export interface AnthropicToolUseBlock {
@@ -71,10 +69,7 @@ export interface AnthropicTool {
     input_schema: unknown;
 }
 
-export type AnthropicToolChoice =
-    | { type: "auto" }
-    | { type: "any" }
-    | { type: "tool"; name: string };
+export type AnthropicToolChoice = { type: "auto" } | { type: "any" } | { type: "tool"; name: string };
 
 export interface AnthropicMessagesBody {
     model: string;
@@ -136,7 +131,6 @@ function contentToBlocks(content: unknown): AnthropicContentBlock[] {
 
         if (part.type === "image_url" && isObject(part.image_url) && typeof part.image_url.url === "string") {
             blocks.push(imageBlockFromUrl(part.image_url.url));
-            continue;
         }
     }
 
@@ -217,7 +211,10 @@ function mapMessage(message: Record<string, unknown>): AnthropicMessage | null {
     }
 
     if (role === "assistant") {
-        const blocks: AnthropicContentBlock[] = [...contentToBlocks(message.content), ...toolUseBlocksFromToolCalls(message.tool_calls)];
+        const blocks: AnthropicContentBlock[] = [
+            ...contentToBlocks(message.content),
+            ...toolUseBlocksFromToolCalls(message.tool_calls),
+        ];
 
         if (blocks.length === 0) {
             return null;

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
@@ -69,7 +69,11 @@ export interface AnthropicTool {
     input_schema: unknown;
 }
 
-export type AnthropicToolChoice = { type: "auto" } | { type: "any" } | { type: "none" } | { type: "tool"; name: string };
+export type AnthropicToolChoice =
+    | { type: "auto" }
+    | { type: "any" }
+    | { type: "none" }
+    | { type: "tool"; name: string };
 
 export interface AnthropicMessagesBody {
     model: string;

--- a/src/ai-proxy/lib/translators/index.ts
+++ b/src/ai-proxy/lib/translators/index.ts
@@ -22,7 +22,9 @@ export function shouldTranslateChatRequest({
 
     // Grok subscription chat/completions already streams Cursor-native reasoning_content.
     // Re-encoding via /responses drops role coalescing and breaks the thinking UI.
-    if (providerId === "grok-subscription") {
+    // anthropic-subscription has no Responses upstream — its chatCompletions is the
+    // only supported path, so never route it through the /responses translation.
+    if (providerId === "grok-subscription" || providerId === "anthropic-subscription") {
         return false;
     }
 

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -83,8 +83,14 @@ export interface AiProxyAnthropicSubAccountConfig {
 }
 
 export interface AiProxyOpenAiSubAccountConfig {
-    /** Name of the openai-sub account in ~/.genesis-tools/ai/config.json to bill. */
-    accountName: string;
+    /**
+     * Name of the openai-sub account in ~/.genesis-tools/ai/config.json to bill
+     * (refreshed + persisted on use). When omitted, the provider reads the token
+     * from the Codex CLI cache (~/.codex/auth.json, read-only, CLI-refreshed).
+     */
+    accountName?: string;
+    /** Override path to the Codex CLI auth.json (defaults to ~/.codex/auth.json). */
+    codexAuthPath?: string;
 }
 
 export interface AiProxyAccountConfig {

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -6,7 +6,13 @@ export type CursorTranslationMode = "auto" | "on" | "off";
 /** How Grok reasoning is presented to Cursor. */
 export type ThinkingPresentationMode = "raw" | "cursor" | "folded";
 
-export type AiProxyProviderType = "grok-subscription" | "github-copilot-subscription" | "xai-api-key" | "openai";
+export type AiProxyProviderType =
+    | "grok-subscription"
+    | "github-copilot-subscription"
+    | "xai-api-key"
+    | "openai"
+    | "anthropic-subscription"
+    | "openai-subscription";
 
 export interface AiProxyListenConfig {
     host: string;
@@ -71,6 +77,16 @@ export interface AiProxyGithubCopilotAccountConfig {
     type?: CopilotAccountType;
 }
 
+export interface AiProxyAnthropicSubAccountConfig {
+    /** Name of the anthropic-sub account in ~/.genesis-tools/ai/config.json to bill. */
+    accountName: string;
+}
+
+export interface AiProxyOpenAiSubAccountConfig {
+    /** Name of the openai-sub account in ~/.genesis-tools/ai/config.json to bill. */
+    accountName: string;
+}
+
 export interface AiProxyAccountConfig {
     name: string;
     label?: string;
@@ -79,6 +95,8 @@ export interface AiProxyAccountConfig {
     enabled: boolean;
     grok?: AiProxyGrokAccountConfig;
     githubCopilot?: AiProxyGithubCopilotAccountConfig;
+    anthropicSub?: AiProxyAnthropicSubAccountConfig;
+    openaiSub?: AiProxyOpenAiSubAccountConfig;
     apiKeyEnv?: string;
     baseUrl?: string;
     managementKeyEnv?: string;


### PR DESCRIPTION
## What

Adds two subscription providers to the local `ai-proxy` so eve (and Cursor, and anything OpenAI-compatible) can bill the owner's Claude / Codex subscriptions instead of an API key. **Both parts done + live-verified against real APIs.**

Executes Part 1 of `.claude/plans/2026-07-11-EveP0-AiProxySubsAndVpsService.md`.

## Part 1 — `anthropic-subscription` (Claude Max)

- **A1** — extended `AiProxyProviderType` (+`anthropic-subscription`, +`openai-subscription`), added `AiProxyAnthropicSubAccountConfig` / `AiProxyOpenAiSubAccountConfig` + `anthropicSub?`/`openaiSub?` on `AiProxyAccountConfig`, wired into `accountConfigFingerprint`.
- **A2** — new OpenAI↔Anthropic mappers under `src/ai-proxy/lib/translators/formats/anthropic/` (the only genuinely new logic, TDD'd): request (`openai-to-anthropic-messages.ts`) + response non-streaming & streaming SSE (`anthropic-to-openai-completions.ts`). 12 unit tests.
- **A3** — `AnthropicSubscriptionProvider` + `anthropic-sub-models.ts` alias map, registry + `/v1/models` catalog wiring, Cursor-translation exclusion (mirrors grok). Token via `resolveAccountToken(anthropicSub.accountName)`; upstream via the existing Claude Code spoof (`createSubscriptionFetch()` → Bearer OAuth + billing header + beta flags + Claude Code system prefix) to `api.anthropic.com/v1/messages`.

Aliases (verified live via `GET /v1/models`): `sonnet`→`claude-sonnet-4-6`, `opus`→`claude-opus-4-6`, `haiku`→`claude-haiku-4-5-20251001`, `fable`→`claude-fable-5`.

## Part 1b — `openai-subscription` (Codex / ChatGPT)

- **B1** — `OpenAiSubscriptionProvider` + `openai-sub-models.ts` + `openai-sub-token.ts`, registry + catalog wiring. Upstream = ChatGPT **WHAM** Responses API (`chatgpt.com/backend-api/wham/responses`, streaming-only). `responses()` converts a chat/responses body → WHAM Responses request (system→instructions, messages→input, forces `stream:true`+`store:false`, maps tools) and forwards with the Codex headers; `chatCompletions()` delegates to the existing `responsesToChat` translator. Non-streaming callers get an SSE→Responses-JSON accumulation (WHAM's `response.completed` output is empty; text is reassembled from `output_text.delta`).
- Token source: named `openai-sub` account (refresh+persist) or the Codex CLI cache `~/.codex/auth.json` (read-only) when `accountName` is omitted.
- Models: `gpt-5.5` (verified serving on a "plus" account) + `gpt-5-codex` (served on Pro).

## Verification

- `bun test src/ai-proxy` — **109/109 pass**. `tsgo --noEmit` — 0 ai-proxy errors. Pre-push CI mirror (biome + full typecheck) green.
- **Live Claude Max (real spend):** `/v1/models` lists the four `claude/claude-sub/*` ids; `claude/claude-sub/haiku` → `PROXY_OK`; streaming produces a clean `chat.completion.chunk` flow; logs confirm upstream `api.anthropic.com/v1/messages` resolving `haiku`→`claude-haiku-4-5-20251001`.
- **Live Codex/ChatGPT (real spend):** a read-only probe with the Codex CLI token proved the plain Responses forward works (no app-server handshake needed). `/v1/models` lists `codex/codex/{gpt-5.5,gpt-5-codex}`; `codex/codex/gpt-5.5` → `CODEX_PROXY_OK`; streaming works; logs confirm the WHAM upstream.
- All live tests ran on a throwaway port against a temporary account; the shared ai-proxy config and the running proxy were left untouched (config backed up + restored).

## Deviations

- `anthropic-subscription.responses()` returns HTTP 400 — Claude has no Responses API; the provider is excluded from Cursor request-translation so it always uses `/v1/chat/completions`.
- `/v1/models` needed a `buildProxyModelCatalog` branch in addition to the registry (separate path from `provider.listModels()`).
- B1 added a `~/.codex/auth.json` token source (made `openaiSub.accountName` optional) — the ai-config `openai-sub` token was expired and its config is read-only; the CLI cache is a fresh read-only source ideal for a local proxy.

Base: `feat/ai-sdk-7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic and OpenAI subscription-backed models.
  * Added model discovery for supported subscription aliases and model IDs.
  * Supports chat completions with streaming and non-streaming responses.
  * Added tool calling, image inputs, system prompts, and response format translation.
  * Added automatic token resolution and refresh for configured subscription accounts.

* **Bug Fixes**
  * Improved account change detection so subscription settings are reflected reliably.
  * Added clearer handling for unsupported Responses API requests and upstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->