### PR TITLE
feat(youtube,deploy): service-key auth + VPS deploy templates

### DIFF
--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -1,0 +1,171 @@
+# VPS deploy — youtube + ai-proxy + eve trio
+
+Runs the three services behind one TLS nginx front so the browser extension can
+talk to a hosted stack instead of each user's laptop. Auth model: **per-user
+service key** (Bearer), multi-tenancy is a **shared corpus** for the beta, and
+all model calls **bill the owner's subscription** via ai-proxy — so keys are the
+only thing standing between a user and the owner's spend. Issue them deliberately.
+
+## Topology
+
+```text
+                         :443 TLS (nginx)
+   extension / clients ─────────────────────────▶  nginx  ──┐
+                                                            │  127.0.0.1 loopback
+     /ai/*                    ──▶ ai-proxy  :8317  ◀────────┤  (firewall blocks
+     /yt/*                    ──▶ youtube    :9876  ◀────────┤   these ports from
+     /eve/*                   ──▶ eve        :2000  ◀────────┤   the public net)
+     /.well-known/workflow/*  ──▶ eve        :2000  ◀────────┘
+```
+
+- **ai-proxy** — OpenAI-compatible; auth is its own `proxyApiKey` (clients send
+  `Authorization: Bearer <proxyApiKey>`). Serves `/v1/*`; nginx strips the `/ai`
+  prefix.
+- **youtube** — the API the extension consumes; auth is `YOUTUBE_SERVICE_KEY`
+  (comma-separated, one per user). Serves `/api/v1/*`; nginx strips the `/yt`
+  prefix. `/api/v1/healthz` stays open for probes.
+- **eve** — the agent (Nitro). Needs **both** `/eve/` **and**
+  `/.well-known/workflow/` forwarded or workflow runs stall. Route protection is
+  a merge-time follow-up (see below).
+
+## Prerequisites
+
+- A Linux VPS (systemd), a DNS `A`/`AAAA` record → its IP.
+- `bun` installed system-wide (`curl -fsSL https://bun.sh/install | bash`; note
+  `which bun` and fix the `ExecStart=` paths in the unit files if it isn't
+  `/usr/local/bin/bun`).
+- `nginx` and `certbot` (`apt install nginx certbot`).
+- A dedicated `genesis` service user whose `~/.genesis-tools/` holds the
+  ai-proxy config (`ai-proxy/config.json` with a `proxyApiKey`) and the
+  subscription tokens (`ai/config.json` with the `anthropic-sub` / `openai-sub`
+  accounts). Copy these from your working laptop — they are NOT in the repo.
+
+## Bring-up
+
+```bash
+# 1. Service user + repo checkout
+sudo useradd --system --create-home --shell /usr/sbin/nologin genesis
+sudo mkdir -p /opt/genesis-tools
+sudo chown genesis:genesis /opt/genesis-tools
+sudo -u genesis git clone <REPO_URL> /opt/genesis-tools
+cd /opt/genesis-tools && sudo -u genesis bun install
+
+# 2. eve build (separate branch/checkout: apps/eve on feat/eve-01-foundation)
+#    Build it, then place the output at /opt/eve (or edit WorkingDirectory).
+#    e.g.  bun run build   →   copy the app dir (with .output/) to /opt/eve
+
+# 3. Owner config — copy your laptop's ~/.genesis-tools to the service user.
+sudo -u genesis mkdir -p /home/genesis/.genesis-tools
+sudo rsync -a ~/.genesis-tools/ai-proxy /home/genesis/.genesis-tools/
+sudo rsync -a ~/.genesis-tools/ai       /home/genesis/.genesis-tools/
+sudo chown -R genesis:genesis /home/genesis/.genesis-tools
+
+# 4. Environment file
+sudo mkdir -p /etc/genesis-tools
+sudo cp deploy/vps/genesis.env.example /etc/genesis-tools/genesis.env
+sudo $EDITOR /etc/genesis-tools/genesis.env   # set DOMAIN, YOUTUBE_SERVICE_KEY, EVE_*
+sudo chmod 600 /etc/genesis-tools/genesis.env
+#    Generate per-user keys:  openssl rand -hex 24
+
+# 5. systemd units
+sudo cp deploy/vps/systemd/genesis-*.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now genesis-ai-proxy genesis-youtube genesis-eve
+sudo systemctl status genesis-youtube --no-pager     # expect active (running)
+
+# 6. TLS certificate (webroot; nginx must be serving :80 first — see step 7)
+sudo mkdir -p /var/www/certbot
+sudo certbot certonly --webroot -w /var/www/certbot -d "$DOMAIN"
+
+# 7. nginx
+sudo sed "s/__DOMAIN__/$DOMAIN/g" deploy/vps/nginx.conf | sudo tee /etc/nginx/nginx.conf >/dev/null
+sudo nginx -t && sudo systemctl reload nginx
+
+# 8. Firewall — expose ONLY ssh + http + https; keep the app ports private.
+sudo ufw allow 22,80,443/tcp
+sudo ufw deny 8317 && sudo ufw deny 9876 && sudo ufw deny 2000
+sudo ufw enable
+```
+
+> Both ai-proxy and youtube bind loopback (`127.0.0.1`) by default, so nginx is
+> the only path to them; the firewall rules are defense in depth. To reach the
+> youtube API directly (e.g. LAN testing), set `YOUTUBE_HOST=0.0.0.0` in
+> `genesis.env` (or the systemd unit) — and keep the firewall in front.
+
+> Chicken-and-egg on step 6/7: certbot `--webroot` needs nginx answering :80.
+> Either bring nginx up with a plain `:80` server first (the config's HTTP block
+> already serves `/.well-known/acme-challenge/`), run certbot, then reload; or
+> use `certbot --nginx`.
+
+## Verification (from a second machine)
+
+```bash
+# Health is open (no key):
+curl -sS https://$DOMAIN/yt/api/v1/healthz            # → 200 {"status":...}
+
+# A real route requires the service key:
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  https://$DOMAIN/yt/api/v1/videos                    # → 401
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer <one-of-YOUTUBE_SERVICE_KEY>" \
+  https://$DOMAIN/yt/api/v1/videos                    # → 200
+
+# ai-proxy models (needs the proxyApiKey):
+curl -sS https://$DOMAIN/ai/v1/models \
+  -H "Authorization: Bearer <proxyApiKey>"            # → model list
+```
+
+An eve session round-trip over `https://$DOMAIN/eve/...` completes the picture
+once eve route protection lands.
+
+## Extension repoint
+
+In the extension popup/options set the **API base URL** to `https://$DOMAIN/yt`
+and the **service key** to the user's key. See the C3 changes (host permissions +
+`Authorization: Bearer` on fetch/WS). The events WebSocket sends the key as
+`?access_token=` because browsers can't set headers on a WS handshake.
+
+## ⚠️ Merge-time follow-up — eve route protection (C1-eve)
+
+**Not implemented in this branch.** eve lives at `apps/eve/` on
+`feat/eve-01-foundation`, not in `feat/vps-service`, so its auth hook must be
+added when those branches merge. Required (per eve docs
+`develop/auth-and-route-protection`):
+
+- Add a Nitro server middleware (e.g. `apps/eve/server/middleware/auth.ts`) that
+  requires `Authorization: Bearer <key>` on `/eve/v1/*`, mirroring
+  `src/youtube/lib/server/auth.ts` (`requireServiceKey`): open when no key is
+  configured, 401 on missing/wrong key, timing-safe compare, multi-key via a
+  comma-separated env.
+- Read the key from a shared env (reuse `YOUTUBE_SERVICE_KEY`, or add
+  `EVE_SERVICE_KEY` to `genesis.env` and this README) so extension users present
+  one credential to the whole stack.
+- **Leave `/.well-known/workflow/*` and any eve health route UNAUTHENTICATED** —
+  gating them breaks workflow execution (the reason both are forwarded).
+
+Until this lands, `/eve/*` is open behind TLS; keep the box private (firewalled /
+trusted clients only) if eve must not be publicly reachable.
+
+## ⚠️ Known limitation — service key in the WS handshake URL
+
+Browsers cannot set an `Authorization` header on a WebSocket handshake, so the
+extension's `/yt/api/v1/events` connection sends the durable `YOUTUBE_SERVICE_KEY`
+as `?access_token=`. nginx is configured to log that route with a redacted format
+(no query string) so the key doesn't land in `/var/log/nginx/access.log`, but the
+key is still visible in browser devtools network panels and any full-URL logging
+you add elsewhere.
+
+**Follow-up (not in this PR):** replace the durable key with a short-lived,
+single-use WS ticket — add a Bearer-authenticated `POST /api/v1/ws-ticket` that
+mints a ticket, have the extension call it right before connecting, and have the
+WS handshake use `?ticket=` instead of `?access_token=`.
+
+## Notes
+
+- This is a template — no VPS is provisioned yet. `nginx.conf` was validated with
+  `nginx -t` (adjusted cert/domain paths); the systemd units are Type=simple
+  foreground processes and were review-verified (no local systemd on the author's
+  macOS).
+- Prefer systemd here (native bun from a repo checkout) over Docker: mounting a
+  macOS `node_modules` into a Linux container breaks native modules; a Docker
+  path would need an in-image `bun install`.

--- a/deploy/vps/genesis.env.example
+++ b/deploy/vps/genesis.env.example
@@ -1,0 +1,31 @@
+# GenesisTools VPS service — shared environment.
+# Copy to /etc/genesis-tools/genesis.env, fill in the values, and `chmod 600`.
+# Referenced by every systemd unit via EnvironmentFile=.
+
+# ── Public hostname ────────────────────────────────────────────────────────
+# The domain the extension points at (also used in nginx.conf's __DOMAIN__).
+DOMAIN=vps.example.com
+
+# ── youtube API service keys ───────────────────────────────────────────────
+# Comma-separated, ONE key per user. When set, the youtube server rejects any
+# request without a matching `Authorization: Bearer <key>` (or `?access_token=`
+# for the events WebSocket). Leave unset ONLY for a fully-private/firewalled box.
+# Generate keys with:  openssl rand -hex 24
+YOUTUBE_SERVICE_KEY=user-alice-REPLACE_ME,user-bob-REPLACE_ME
+
+# ── eve ────────────────────────────────────────────────────────────────────
+# eve is built separately (apps/eve on feat/eve-01-foundation). These are the
+# runtime settings its Nitro server reads.
+EVE_WORLD=REPLACE_ME
+# Bill the owner's Claude subscription through ai-proxy (see Part 1). Format is
+# the ai-proxy model id: <account>/claude-sub/<alias>.
+EVE_MODEL_ID=martin/claude-sub/sonnet
+# Whatever world credential(s) your eve build requires (name may differ).
+EVE_WORLD_CREDS=REPLACE_ME
+PORT=2000
+
+# ── ai-proxy ───────────────────────────────────────────────────────────────
+# ai-proxy reads its accounts + proxyApiKey from ~/.genesis-tools/ai-proxy and
+# the subscription tokens from ~/.genesis-tools/ai (owned by the service user).
+# Nothing extra is needed here; clients (eve, Cursor) must send the proxyApiKey
+# as `Authorization: Bearer <proxyApiKey>` to /ai/*.

--- a/deploy/vps/nginx.conf
+++ b/deploy/vps/nginx.conf
@@ -1,0 +1,156 @@
+# GenesisTools VPS reverse proxy — TLS front for the ai-proxy + youtube + eve trio.
+#
+# This is a COMPLETE nginx config (events + http), meant to be dropped at
+# /etc/nginx/nginx.conf on the VPS. The trio runs on the host loopback under
+# systemd (see deploy/vps/systemd/*.service), so the upstreams are 127.0.0.1.
+#
+# Before deploying, replace every __DOMAIN__ with your real hostname and obtain
+# a certificate (see deploy/vps/README.md). To syntax-check locally:
+#     nginx -t -c /absolute/path/to/nginx.conf
+# (127.0.0.1 upstreams resolve fine; the TLS cert paths only need to exist at
+# runtime, not at -t time when the http block has at least one plain server.)
+
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 65;
+
+    # WebSocket upgrade plumbing (youtube /yt/api/v1/events, and any eve stream
+    # that upgrades). A request carrying `Upgrade: websocket` maps to
+    # `Connection: upgrade`; everything else maps to `Connection: close`.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    # Redact query strings for the youtube route — the WS handshake carries a
+    # durable service key as ?access_token=, which must not land in access logs.
+    log_format yt_redacted '$remote_addr - [$time_local] "$request_method $uri" $status $body_bytes_sent '
+                            '"$http_referer" "$http_user_agent"';
+
+    upstream ai_proxy { server 127.0.0.1:8317; }
+    upstream youtube  { server 127.0.0.1:9876; }
+    upstream eve      { server 127.0.0.1:2000; }
+
+    # ── HTTP :80 — ACME challenge + redirect to HTTPS ──────────────────────
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name __DOMAIN__;
+
+        # Let's Encrypt webroot challenge (certbot --webroot -w /var/www/certbot).
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # ── HTTPS :443 — the service front ─────────────────────────────────────
+    server {
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name __DOMAIN__;
+
+        ssl_certificate     /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        # Extension uploads (transcripts, large POST bodies).
+        client_max_body_size 25m;
+
+        # ai-proxy (OpenAI-compatible). Trailing slash strips the /ai prefix:
+        #   /ai/v1/chat/completions -> http://127.0.0.1:8317/v1/chat/completions
+        # Bearer auth is enforced by ai-proxy itself (its proxyApiKey).
+        location = /ai {
+            return 301 $scheme://$http_host/ai/;
+        }
+
+        location /ai/ {
+            proxy_pass http://ai_proxy/;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            # SSE streaming for chat completions — never buffer.
+            proxy_buffering off;
+            proxy_read_timeout 600s;
+        }
+
+        # youtube API. Trailing slash strips the /yt prefix:
+        #   /yt/api/v1/videos  -> http://127.0.0.1:9876/api/v1/videos
+        #   /yt/api/v1/events  -> WebSocket upgrade (service-key via ?access_token=)
+        # Bearer/query-param service-key auth is enforced by the youtube server
+        # (YOUTUBE_SERVICE_KEY); /api/v1/healthz stays open for probes.
+        location = /yt {
+            return 301 $scheme://$http_host/yt/;
+        }
+
+        location /yt/ {
+            access_log /var/log/nginx/yt-access.log yt_redacted;
+            proxy_pass http://youtube/;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        $connection_upgrade;
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+        }
+
+        location = /eve {
+            return 301 $scheme://$http_host/eve/;
+        }
+
+        # eve HTTP surface. NO trailing slash on proxy_pass — the /eve/ prefix
+        # is PRESERVED (eve serves its routes under /eve/..., matching the
+        # workflow-framework convention). If your eve build serves at root
+        # instead, change this to `proxy_pass http://eve/;` to strip the prefix.
+        location /eve/ {
+            proxy_pass http://eve;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        $connection_upgrade;
+            # eve session streams are NDJSON — must not be buffered.
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+            chunked_transfer_encoding on;
+        }
+
+        location = /.well-known/workflow {
+            return 301 $scheme://$http_host/.well-known/workflow/;
+        }
+
+        # eve's durable-workflow endpoints. REQUIRED — eve runs stall if
+        # /.well-known/workflow/ is not forwarded to the same upstream (documented
+        # eve gotcha). Prefix preserved.
+        location /.well-known/workflow/ {
+            proxy_pass http://eve;
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+        }
+    }
+}

--- a/deploy/vps/systemd/genesis-ai-proxy.service
+++ b/deploy/vps/systemd/genesis-ai-proxy.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=GenesisTools ai-proxy (OpenAI-compatible subscription proxy)
+Documentation=file:/opt/genesis-tools/deploy/vps/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=genesis
+Group=genesis
+NoNewPrivileges=true
+PrivateTmp=true
+# Repo checkout (git clone + bun install done here as the genesis user).
+WorkingDirectory=/opt/genesis-tools
+EnvironmentFile=/etc/genesis-tools/genesis.env
+# Bind loopback only — nginx is the sole public entry point (see nginx.conf).
+# Adjust the bun path to `which bun` on the box (often /root/.bun/bin/bun).
+ExecStart=/usr/local/bin/bun run ./tools ai-proxy serve --host 127.0.0.1 --port 8317
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/vps/systemd/genesis-eve.service
+++ b/deploy/vps/systemd/genesis-eve.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=GenesisTools eve agent (Nitro server)
+Documentation=file:/opt/genesis-tools/deploy/vps/README.md
+After=network-online.target genesis-ai-proxy.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=genesis
+Group=genesis
+NoNewPrivileges=true
+PrivateTmp=true
+# The built eve output (apps/eve on feat/eve-01-foundation → `bun run build`).
+WorkingDirectory=/opt/eve
+EnvironmentFile=/etc/genesis-tools/genesis.env
+# Nitro listens on $PORT (2000, set in genesis.env). Adjust the bun path.
+ExecStart=/usr/local/bin/bun .output/server/index.mjs
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/vps/systemd/genesis-youtube.service
+++ b/deploy/vps/systemd/genesis-youtube.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=GenesisTools youtube AI API server
+Documentation=file:/opt/genesis-tools/deploy/vps/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=genesis
+Group=genesis
+NoNewPrivileges=true
+PrivateTmp=true
+WorkingDirectory=/opt/genesis-tools
+EnvironmentFile=/etc/genesis-tools/genesis.env
+# Bind loopback so the server is reachable only through nginx (127.0.0.1:9876),
+# not directly from the public internet. Set YOUTUBE_HOST=0.0.0.0 (or a LAN IP)
+# only if you want direct access; keep the firewall in front regardless.
+Environment=YOUTUBE_HOST=127.0.0.1
+# Run the server entry directly (foreground, systemd-supervised) rather than
+# `tools youtube server up`, which daemonizes. It reads YOUTUBE_SERVICE_KEY and
+# YOUTUBE_HOST from the environment above. Adjust the bun path to `which bun`.
+ExecStart=/usr/local/bin/bun run ./src/youtube/lib/server/index.ts --port 9876
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/src/utils/env.client.test.ts
+++ b/src/utils/env.client.test.ts
@@ -31,6 +31,9 @@ describe("env.client", () => {
         expect(env.dashboard).toBe(clientEnv.dashboard);
         expect(env.db).toBe(clientEnv.db);
         expect(env.node).toBe(clientEnv.node);
-        expect(env.youtube).toBe(clientEnv.youtube);
+        // env.youtube extends the client domain with server-only getters, so
+        // assert the client getters are re-exposed rather than object identity.
+        expect(env.youtube.getGitSha).toBe(clientEnv.youtube.getGitSha);
+        expect(env.youtube.getUiPort).toBe(clientEnv.youtube.getUiPort);
     });
 });

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -235,7 +235,21 @@ export const env = {
 
     node: envClient.node,
 
-    youtube: envClient.youtube,
+    youtube: {
+        ...envClient.youtube,
+        /**
+         * Optional per-user service key(s) for the YouTube API server. A
+         * comma-separated list — one key per user. When unset the server stays
+         * open (localhost development is unaffected).
+         */
+        getServiceKey: () => getTrimmed("YOUTUBE_SERVICE_KEY"),
+        /**
+         * Bind host for the YouTube API server. Defaults to loopback so a VPS
+         * deploy is not publicly reachable except through the reverse proxy; set
+         * `0.0.0.0` (or a LAN IP) to expose it directly.
+         */
+        getHost: () => getWithDefault("YOUTUBE_HOST", "127.0.0.1"),
+    },
 
     db: envClient.db,
 

--- a/src/youtube/README.md
+++ b/src/youtube/README.md
@@ -4,7 +4,7 @@
 
 > **YouTube transcription and caption utilities.**
 
-Currently a thin umbrella around a `transcribe` subcommand that pulls captions (or falls back to audio transcription) for a given YouTube URL or video ID.
+A toolkit for YouTube caption/transcription plus an API server the companion browser extension talks to — locally, or hosted behind TLS with per-user service-key auth. The `transcribe` subcommand pulls captions (or falls back to audio transcription) for a given YouTube URL or video ID.
 
 ---
 
@@ -25,6 +25,7 @@ tools youtube transcribe dQw4w9WgXcQ
 | Command | Description |
 |---------|-------------|
 | `transcribe <url-or-id>` | Fetch captions or transcribe the audio of a YouTube video |
+| `server` | Run the API server the browser extension consumes (see hosted deployment below) |
 
 Run `tools youtube transcribe --help` for the full option list.
 
@@ -51,3 +52,12 @@ tools youtube pipeline dQw4w9WgXcQ --stages metadata,comments
 ```
 
 Stored comments are served from `GET /api/v1/videos/:id/comments` on the local server and rendered in the video detail UI's Comments tab, which supports search and caps rendering at 50 threads (with a "Show all" expander for larger result sets).
+
+## Hosted deployment & service-key auth
+
+`tools youtube server` serves the API the browser extension consumes. It runs open on localhost by default; to expose it (e.g. a shared VPS) it supports per-user **service-key auth**:
+
+- **`YOUTUBE_SERVICE_KEY`** — comma-separated list of keys, one per user. When set, every route except the open probes (`/api/v1/healthz`, `/api/v1/version`, `/api/v1/openapi.json`) requires `Authorization: Bearer <key>` (the events WebSocket accepts `?access_token=<key>`, since browsers can't set handshake headers). Unset/empty keeps the server open for localhost dev; a value that parses to zero keys (e.g. `,,,`) fails closed at startup rather than silently opening.
+- **`YOUTUBE_HOST`** — bind host, defaults to `127.0.0.1` (loopback). Set to `0.0.0.0` only for direct LAN access, and keep a firewall in front.
+
+A complete VPS template — nginx TLS front plus systemd units for the youtube, ai-proxy, and eve services — lives in [`deploy/vps/`](../../deploy/vps/README.md); see its README for bring-up steps.

--- a/src/youtube/extension/__tests__/storage.test.ts
+++ b/src/youtube/extension/__tests__/storage.test.ts
@@ -6,9 +6,22 @@ function installStorage(initial: Record<string, unknown> = {}): Record<string, u
     globalThis.chrome = {
         storage: {
             local: {
-                get: async (key: string) => ({ [key]: store[key] }),
+                get: async (keys: string | string[]) => {
+                    const list = Array.isArray(keys) ? keys : [keys];
+                    const result: Record<string, unknown> = {};
+                    for (const key of list) {
+                        result[key] = store[key];
+                    }
+                    return result;
+                },
                 set: async (items: Record<string, unknown>) => {
                     Object.assign(store, items);
+                },
+                remove: async (keys: string | string[]) => {
+                    const list = Array.isArray(keys) ? keys : [keys];
+                    for (const key of list) {
+                        delete store[key];
+                    }
                 },
             },
         },
@@ -17,10 +30,13 @@ function installStorage(initial: Record<string, unknown> = {}): Record<string, u
 }
 
 describe("extension storage", () => {
-    it("defaults to localhost API", async () => {
+    it("defaults to localhost API with no service key", async () => {
         installStorage();
 
-        await expect(getExtensionConfig()).resolves.toEqual({ apiBaseUrl: "http://localhost:9876" });
+        await expect(getExtensionConfig()).resolves.toEqual({
+            apiBaseUrl: "http://localhost:9876",
+            serviceKey: undefined,
+        });
     });
 
     it("persists partial config patches", async () => {
@@ -28,7 +44,41 @@ describe("extension storage", () => {
 
         await expect(setExtensionConfig({ apiBaseUrl: "http://localhost:9999" })).resolves.toEqual({
             apiBaseUrl: "http://localhost:9999",
+            serviceKey: undefined,
         });
         expect(store.apiBaseUrl).toBe("http://localhost:9999");
+    });
+
+    it("persists and reads back a service key", async () => {
+        const store = installStorage({ apiBaseUrl: "https://vps.example.com/yt" });
+
+        await setExtensionConfig({ apiBaseUrl: "https://vps.example.com/yt", serviceKey: "alice-key" });
+
+        expect(store.serviceKey).toBe("alice-key");
+        await expect(getExtensionConfig()).resolves.toEqual({
+            apiBaseUrl: "https://vps.example.com/yt",
+            serviceKey: "alice-key",
+        });
+    });
+
+    it("clears the stored key when the service key is emptied", async () => {
+        const store = installStorage({ apiBaseUrl: "https://vps.example.com/yt", serviceKey: "alice-key" });
+
+        await setExtensionConfig({ apiBaseUrl: "https://vps.example.com/yt", serviceKey: undefined });
+
+        expect("serviceKey" in store).toBe(false);
+        await expect(getExtensionConfig()).resolves.toEqual({
+            apiBaseUrl: "https://vps.example.com/yt",
+            serviceKey: undefined,
+        });
+    });
+
+    it("coerces a blank stored key to undefined", async () => {
+        installStorage({ apiBaseUrl: "http://localhost:9876", serviceKey: "" });
+
+        await expect(getExtensionConfig()).resolves.toEqual({
+            apiBaseUrl: "http://localhost:9876",
+            serviceKey: undefined,
+        });
     });
 });

--- a/src/youtube/extension/background.ts
+++ b/src/youtube/extension/background.ts
@@ -24,7 +24,7 @@ export async function handleRequest(req: ExtensionRequest): Promise<ExtensionRes
     }
 
     if (req.type === "config:set") {
-        const next = await setExtensionConfig({ apiBaseUrl: req.apiBaseUrl });
+        const next = await setExtensionConfig({ apiBaseUrl: req.apiBaseUrl, serviceKey: req.serviceKey });
         await reconnectWebsocket();
         return { ok: true, data: next };
     }
@@ -91,10 +91,20 @@ export async function handleRequest(req: ExtensionRequest): Promise<ExtensionRes
 }
 
 async function apiCall(url: string, init: RequestInit = {}): Promise<ExtensionResponse> {
+    const { serviceKey } = await getExtensionConfig();
+    const headers = new Headers(init.headers);
+    if (!headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json");
+    }
+
+    if (serviceKey) {
+        headers.set("Authorization", `Bearer ${serviceKey}`);
+    }
+
     try {
         const res = await fetch(url, {
             ...init,
-            headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+            headers,
         });
         if (!res.ok) {
             return { ok: false, error: `${res.status} ${res.statusText}` };
@@ -107,6 +117,10 @@ async function apiCall(url: string, init: RequestInit = {}): Promise<ExtensionRe
 
 async function reconnectWebsocket(): Promise<void> {
     if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onclose = null;
+        ws.onerror = null;
         ws.close();
         ws = null;
     }
@@ -117,7 +131,10 @@ async function reconnectWebsocket(): Promise<void> {
     }
 
     const cfg = await getExtensionConfig();
-    const url = `${cfg.apiBaseUrl.replace(/^http/, "ws").replace(/\/$/, "")}/api/v1/events`;
+    const base = `${cfg.apiBaseUrl.replace(/^http/, "ws").replace(/\/$/, "")}/api/v1/events`;
+    // Browsers can't set an Authorization header on a WS handshake, so the
+    // service key rides as a query param (the server reads ?access_token=).
+    const url = cfg.serviceKey ? `${base}?access_token=${encodeURIComponent(cfg.serviceKey)}` : base;
 
     try {
         ws = new WebSocket(url);

--- a/src/youtube/extension/chrome.types.ts
+++ b/src/youtube/extension/chrome.types.ts
@@ -31,9 +31,20 @@ declare global {
 
         namespace storage {
             const local: {
-                get(keys: string): Promise<Partial<ExtensionConfig>>;
+                get(keys: string | string[]): Promise<Partial<ExtensionConfig>>;
                 set(items: Partial<ExtensionConfig>): Promise<void>;
+                remove(keys: string | string[]): Promise<void>;
             };
+        }
+
+        namespace permissions {
+            interface Permissions {
+                origins?: string[];
+                permissions?: string[];
+            }
+
+            function contains(permissions: Permissions): Promise<boolean>;
+            function request(permissions: Permissions): Promise<boolean>;
         }
     }
 }

--- a/src/youtube/extension/manifest.json
+++ b/src/youtube/extension/manifest.json
@@ -5,6 +5,7 @@
     "description": "Surface AI-powered insights, summaries, and Q&A inside YouTube via your local GenesisTools server.",
     "permissions": ["storage", "activeTab", "scripting"],
     "host_permissions": ["http://localhost:9876/*", "https://www.youtube.com/*"],
+    "optional_host_permissions": ["https://*/*"],
     "action": {
         "default_popup": "popup/popup.html",
         "default_icon": { "16": "icons/icon16.png", "48": "icons/icon48.png", "128": "icons/icon128.png" }

--- a/src/youtube/extension/popup/popup.tsx
+++ b/src/youtube/extension/popup/popup.tsx
@@ -10,20 +10,56 @@ import "./popup.css";
 
 const queryClient = new QueryClient();
 
+function isLocalhost(hostname: string): boolean {
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+/**
+ * A non-localhost origin isn't in the manifest's static host_permissions, so
+ * request it at runtime (from the Save click gesture). Returns "granted" when the
+ * extension may talk to the origin, "denied" when the user rejected the prompt,
+ * and "invalid-url" when the input didn't parse as a URL.
+ */
+async function ensureHostPermission(rawUrl: string): Promise<"granted" | "denied" | "invalid-url"> {
+    let origin: string;
+    try {
+        const parsed = new URL(rawUrl);
+        if (isLocalhost(parsed.hostname)) {
+            return "granted";
+        }
+        origin = `${parsed.protocol}//${parsed.host}/*`;
+    } catch {
+        return "invalid-url";
+    }
+
+    if (await chrome.permissions.contains({ origins: [origin] })) {
+        return "granted";
+    }
+
+    return (await chrome.permissions.request({ origins: [origin] })) ? "granted" : "denied";
+}
+
 function Popup() {
     const [apiUrl, setApiUrl] = useState("http://localhost:9876");
+    const [serviceKey, setServiceKey] = useState("");
     const [status, setStatus] = useState<"unknown" | "ok" | "down">("unknown");
+    const [note, setNote] = useState<string | null>(null);
     const [busy, setBusy] = useState(false);
 
     useEffect(() => {
-        send<{ apiBaseUrl: string }>({ type: "config:get" })
-            .then((config) => setApiUrl(config.apiBaseUrl))
+        send<{ apiBaseUrl: string; serviceKey?: string }>({ type: "config:get" })
+            .then((config) => {
+                setApiUrl(config.apiBaseUrl);
+                setServiceKey(config.serviceKey ?? "");
+            })
             .catch(() => setStatus("down"));
     }, []);
 
     async function checkHealth(): Promise<void> {
         try {
-            const res = await fetch(`${apiUrl.replace(/\/$/, "")}/api/v1/healthz`);
+            const base = apiUrl.replace(/\/$/, "");
+            const authHeaders: Record<string, string> = serviceKey ? { Authorization: `Bearer ${serviceKey}` } : {};
+            const res = await fetch(`${base}/api/v1/channels`, { headers: authHeaders });
             setStatus(res.ok ? "ok" : "down");
         } catch {
             setStatus("down");
@@ -32,9 +68,26 @@ function Popup() {
 
     async function save(): Promise<void> {
         setBusy(true);
+        setNote(null);
         try {
-            await send({ type: "config:set", apiBaseUrl: apiUrl });
+            const permission = await ensureHostPermission(apiUrl);
+            if (permission === "invalid-url") {
+                setNote("That doesn't look like a valid URL.");
+                setStatus("down");
+                return;
+            }
+
+            if (permission === "denied") {
+                setNote("Permission for that origin was denied — the extension can't reach it.");
+                setStatus("down");
+                return;
+            }
+
+            await send({ type: "config:set", apiBaseUrl: apiUrl, serviceKey: serviceKey.trim() || undefined });
             await checkHealth();
+        } catch (error) {
+            setNote(error instanceof Error ? error.message : String(error));
+            setStatus("down");
         } finally {
             setBusy(false);
         }
@@ -73,6 +126,19 @@ function Popup() {
                     placeholder="http://localhost:9876"
                 />
             </section>
+            <section className="space-y-2">
+                <label className="text-xs text-muted-foreground" htmlFor="serviceKey">
+                    Service key (for a hosted server)
+                </label>
+                <Input
+                    id="serviceKey"
+                    type="password"
+                    value={serviceKey}
+                    onChange={(event) => setServiceKey(event.target.value)}
+                    placeholder="leave blank for localhost"
+                />
+            </section>
+            {note ? <p className="text-xs text-destructive">{note}</p> : null}
             <div className="grid grid-cols-2 gap-2">
                 <Button onClick={save} disabled={busy}>
                     Save

--- a/src/youtube/extension/shared/messages.ts
+++ b/src/youtube/extension/shared/messages.ts
@@ -13,7 +13,7 @@ import type { ExtensionConfig } from "@ext/shared/types";
 
 export type ExtensionRequest =
     | { type: "config:get" }
-    | { type: "config:set"; apiBaseUrl: string }
+    | { type: "config:set"; apiBaseUrl: string; serviceKey?: string }
     | { type: "api:listChannels" }
     | { type: "api:addChannel"; handle: ChannelHandle }
     | { type: "api:getVideo"; id: VideoId }

--- a/src/youtube/extension/shared/storage.ts
+++ b/src/youtube/extension/shared/storage.ts
@@ -3,13 +3,24 @@ import type { ExtensionConfig } from "@ext/shared/types";
 const DEFAULT_CONFIG: ExtensionConfig = { apiBaseUrl: "http://localhost:9876" };
 
 export async function getExtensionConfig(): Promise<ExtensionConfig> {
-    const stored = await chrome.storage.local.get("apiBaseUrl");
-    return { apiBaseUrl: typeof stored.apiBaseUrl === "string" ? stored.apiBaseUrl : DEFAULT_CONFIG.apiBaseUrl };
+    const stored = await chrome.storage.local.get(["apiBaseUrl", "serviceKey"]);
+    return {
+        apiBaseUrl: typeof stored.apiBaseUrl === "string" ? stored.apiBaseUrl : DEFAULT_CONFIG.apiBaseUrl,
+        serviceKey:
+            typeof stored.serviceKey === "string" && stored.serviceKey.length > 0 ? stored.serviceKey : undefined,
+    };
 }
 
 export async function setExtensionConfig(patch: Partial<ExtensionConfig>): Promise<ExtensionConfig> {
     const current = await getExtensionConfig();
-    const next = { ...current, ...patch };
-    await chrome.storage.local.set(next);
+    const next: ExtensionConfig = { ...current, ...patch };
+
+    if (next.serviceKey) {
+        await chrome.storage.local.set({ apiBaseUrl: next.apiBaseUrl, serviceKey: next.serviceKey });
+    } else {
+        await chrome.storage.local.set({ apiBaseUrl: next.apiBaseUrl });
+        await chrome.storage.local.remove("serviceKey");
+    }
+
     return next;
 }

--- a/src/youtube/extension/shared/types.ts
+++ b/src/youtube/extension/shared/types.ts
@@ -1,3 +1,9 @@
 export interface ExtensionConfig {
     apiBaseUrl: string;
+    /**
+     * Per-user service key for an authed (VPS) server. Sent as
+     * `Authorization: Bearer` on API fetches and as `?access_token=` on the
+     * events WebSocket. Empty/undefined for an open localhost server.
+     */
+    serviceKey?: string;
 }

--- a/src/youtube/lib/server/__tests__/auth.test.ts
+++ b/src/youtube/lib/server/__tests__/auth.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import { env } from "@app/utils/env";
+import {
+    extractServiceToken,
+    parseServiceKeys,
+    requireServiceKey,
+    resolveServiceKeys,
+} from "@app/youtube/lib/server/auth";
+
+function makeRequest(init: { auth?: string; url?: string } = {}): Request {
+    const headers = new Headers();
+
+    if (init.auth) {
+        headers.set("Authorization", init.auth);
+    }
+
+    return new Request(init.url ?? "http://localhost:9876/api/v1/videos", { headers });
+}
+
+describe("parseServiceKeys", () => {
+    it("returns an empty list when unset", () => {
+        expect(parseServiceKeys(undefined)).toEqual([]);
+        expect(parseServiceKeys("")).toEqual([]);
+    });
+
+    it("splits a comma-separated list and trims blanks", () => {
+        expect(parseServiceKeys("alice-key, bob-key ,, carol-key")).toEqual(["alice-key", "bob-key", "carol-key"]);
+    });
+});
+
+describe("extractServiceToken", () => {
+    it("reads a Bearer header", () => {
+        expect(extractServiceToken(makeRequest({ auth: "Bearer abc123" }))).toBe("abc123");
+    });
+
+    it("falls back to the access_token query param (WebSocket handshakes)", () => {
+        const req = makeRequest({ url: "http://localhost:9876/api/v1/events?access_token=ws-key" });
+        expect(extractServiceToken(req)).toBe("ws-key");
+    });
+
+    it("falls back to the key query param", () => {
+        const req = makeRequest({ url: "http://localhost:9876/api/v1/events?key=ws-key" });
+        expect(extractServiceToken(req)).toBe("ws-key");
+    });
+
+    it("returns null when no token is present", () => {
+        expect(extractServiceToken(makeRequest())).toBeNull();
+    });
+});
+
+describe("requireServiceKey", () => {
+    it("stays open when no keys are configured", () => {
+        expect(requireServiceKey(makeRequest(), [])).toBeNull();
+    });
+
+    it("rejects a request with no key when auth is enabled", () => {
+        const res = requireServiceKey(makeRequest(), ["secret"]);
+        expect(res).not.toBeNull();
+        expect(res?.status).toBe(401);
+    });
+
+    it("rejects a wrong key", () => {
+        const res = requireServiceKey(makeRequest({ auth: "Bearer nope" }), ["secret"]);
+        expect(res?.status).toBe(401);
+    });
+
+    it("accepts a correct key", () => {
+        expect(requireServiceKey(makeRequest({ auth: "Bearer secret" }), ["secret"])).toBeNull();
+    });
+
+    it("accepts any key from the per-user list", () => {
+        const keys = ["alice-key", "bob-key"];
+        expect(requireServiceKey(makeRequest({ auth: "Bearer alice-key" }), keys)).toBeNull();
+        expect(requireServiceKey(makeRequest({ auth: "Bearer bob-key" }), keys)).toBeNull();
+        expect(requireServiceKey(makeRequest({ auth: "Bearer carol-key" }), keys)?.status).toBe(401);
+    });
+
+    it("accepts a key supplied via query param (WebSocket)", () => {
+        const req = makeRequest({ url: "http://localhost:9876/api/v1/events?access_token=alice-key" });
+        expect(requireServiceKey(req, ["alice-key"])).toBeNull();
+    });
+
+    it("matches keys of differing lengths (hash-normalized compare)", () => {
+        const keys = ["short", "a-much-longer-service-key-value-0123456789"];
+        expect(requireServiceKey(makeRequest({ auth: "Bearer short" }), keys)).toBeNull();
+        expect(
+            requireServiceKey(makeRequest({ auth: "Bearer a-much-longer-service-key-value-0123456789" }), keys)
+        ).toBeNull();
+        expect(requireServiceKey(makeRequest({ auth: "Bearer a-much-longer" }), keys)?.status).toBe(401);
+    });
+});
+
+describe("resolveServiceKeys — fail closed on garbage (t19)", () => {
+    it("keeps open mode when the value is unset (localhost dev)", () => {
+        expect(resolveServiceKeys(undefined)).toEqual([]);
+    });
+
+    it("returns the parsed keys for a valid list", () => {
+        expect(resolveServiceKeys("k1,k2")).toEqual(["k1", "k2"]);
+    });
+
+    it("throws for a commas-only value instead of silently opening the API", () => {
+        expect(() => resolveServiceKeys(",,,")).toThrow(/no valid service keys/);
+    });
+
+    it("throws for a value that is all separators and whitespace", () => {
+        expect(() => resolveServiceKeys(", ,\t,")).toThrow(/no valid service keys/);
+    });
+});
+
+describe("YOUTUBE_SERVICE_KEY env → guard path stays closed on garbage", () => {
+    it("commas-only env: the server refuses to start (never falls back to open mode)", async () => {
+        await env.testing.withOverrides({ YOUTUBE_SERVICE_KEY: ",,," }, () => {
+            const raw = env.youtube.getServiceKey();
+            expect(raw).toBe(",,,");
+            expect(() => resolveServiceKeys(raw)).toThrow(/no valid service keys/);
+        });
+    });
+
+    it("empty / whitespace-only env normalizes to 'no key configured' (open mode by design)", async () => {
+        await env.testing.withOverrides({ YOUTUBE_SERVICE_KEY: "   " }, () => {
+            expect(env.youtube.getServiceKey()).toBeUndefined();
+            expect(resolveServiceKeys(env.youtube.getServiceKey())).toEqual([]);
+        });
+    });
+});

--- a/src/youtube/lib/server/auth.ts
+++ b/src/youtube/lib/server/auth.ts
@@ -1,0 +1,124 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
+
+/**
+ * Optional per-user service-key auth for the YouTube API server.
+ *
+ * Enabled only when at least one key is configured (via `YOUTUBE_SERVICE_KEY`,
+ * a comma-separated list — one key per user). When no key is configured the
+ * server stays open, so localhost development is unaffected.
+ *
+ * Browsers cannot set an `Authorization` header on a WebSocket handshake, so
+ * the key may also be supplied as an `access_token` (or `key`) query
+ * parameter. Both the HTTP routes and the `/api/v1/events` WS upgrade run
+ * through `requireServiceKey`.
+ */
+
+/** Split the comma-separated key list into individual keys, dropping blanks. */
+export function parseServiceKeys(raw: string | undefined): string[] {
+    if (!raw) {
+        return [];
+    }
+
+    return raw
+        .split(",")
+        .map((key) => key.trim())
+        .filter((key) => key.length > 0);
+}
+
+/**
+ * Resolve the configured service keys, failing closed when the value is present
+ * but yields no usable keys. A missing value (`undefined` — env normalizes an
+ * unset, empty, or whitespace-only var to `undefined`) keeps the server open so
+ * localhost development is unaffected. A value that is present but parses to zero
+ * keys (e.g. `",,,"`) throws instead of silently falling back to open mode, so a
+ * typo'd `YOUTUBE_SERVICE_KEY` can't quietly expose the whole API.
+ */
+export function resolveServiceKeys(raw: string | undefined): string[] {
+    const keys = parseServiceKeys(raw);
+
+    if (raw && keys.length === 0) {
+        throw new Error("YOUTUBE_SERVICE_KEY is set but contains no valid service keys (check for stray commas)");
+    }
+
+    return keys;
+}
+
+export function extractBearerToken(req: Request): string | null {
+    const header = req.headers.get("Authorization");
+
+    if (!header) {
+        return null;
+    }
+
+    const match = header.match(/^Bearer\s+(.+)$/i);
+    return match?.[1] ?? null;
+}
+
+/** Bearer header first, then `?access_token=` / `?key=` (for WebSocket handshakes). */
+export function extractServiceToken(req: Request): string | null {
+    const bearer = extractBearerToken(req);
+
+    if (bearer) {
+        return bearer;
+    }
+
+    const url = new URL(req.url);
+    return url.searchParams.get("access_token") ?? url.searchParams.get("key");
+}
+
+function tokenMatchesAny(presented: string, keys: string[]): boolean {
+    // Hash both sides to fixed 32-byte SHA-256 digests before comparing: a raw
+    // length guard before timingSafeEqual would leak the configured keys' lengths
+    // via loop timing. Digests are always equal length, so the compare never
+    // varies with the presented token's length. No early-exit so a valid key
+    // later in the list is not distinguishable by timing from one earlier.
+    const presentedHash = createHash("sha256").update(presented).digest();
+    let matched = false;
+
+    for (const key of keys) {
+        const keyHash = createHash("sha256").update(key).digest();
+
+        if (timingSafeEqual(presentedHash, keyHash)) {
+            matched = true;
+        }
+    }
+
+    return matched;
+}
+
+/**
+ * Returns a 401 `Response` when auth is enabled and the request lacks a valid
+ * key, or `null` when the request may proceed. With no keys configured every
+ * request proceeds (open mode).
+ */
+export function requireServiceKey(req: Request, keys: string[]): Response | null {
+    if (keys.length === 0) {
+        return null;
+    }
+
+    const token = extractServiceToken(req);
+    const method = req.method;
+    const path = new URL(req.url).pathname;
+
+    if (!token || !tokenMatchesAny(token, keys)) {
+        // Log the decision — never the presented key — so auth failures are
+        // triageable from the logs alone, distinguishing a missing key from a
+        // wrong one.
+        logger.warn({ method, path, reason: token ? "invalid-key" : "no-key" }, "youtube API: rejected request");
+
+        return new Response(
+            SafeJSON.stringify({ error: { message: "Invalid or missing service key", type: "auth_error" } }),
+            {
+                status: 401,
+                headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+            }
+        );
+    }
+
+    logger.debug({ method, path }, "youtube API: accepted request with valid service key");
+
+    return null;
+}

--- a/src/youtube/lib/server/index.ts
+++ b/src/youtube/lib/server/index.ts
@@ -1,6 +1,7 @@
 import { logger } from "@app/logger";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
+import { requireServiceKey, resolveServiceKeys } from "@app/youtube/lib/server/auth";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
 import { clearPid, registerSignalHandlers, writePid } from "@app/youtube/lib/server/daemon";
 import { toErrorResponse } from "@app/youtube/lib/server/error";
@@ -40,9 +41,17 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
 
     const configuredPort = await youtube.config.get("apiPort");
     const port = opts.port ?? configuredPort;
+    const hostname = env.youtube.getHost();
+    const serviceKeys = resolveServiceKeys(env.youtube.getServiceKey());
+
+    if (serviceKeys.length > 0) {
+        logger.info({ keyCount: serviceKeys.length }, "youtube API server: service-key auth enabled");
+    }
+
     const websocket = setupWebsocket(youtube);
     const server = Bun.serve<WebsocketState>({
         port,
+        hostname,
         websocket: websocket.handler,
         async fetch(req: Request, server): Promise<Response | undefined> {
             try {
@@ -50,6 +59,21 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
 
                 if (req.method === "OPTIONS") {
                     return new Response(null, { status: 204, headers: CORS_HEADERS });
+                }
+
+                // Meta routes (liveness + public discovery) stay open so health
+                // checks and readiness probes work without a key.
+                const isOpenRoute =
+                    url.pathname === "/api/v1/healthz" ||
+                    url.pathname === "/api/v1/version" ||
+                    url.pathname === "/api/v1/openapi.json";
+
+                if (!isOpenRoute) {
+                    const authError = requireServiceKey(req, serviceKeys);
+
+                    if (authError) {
+                        return authError;
+                    }
                 }
 
                 if (url.pathname === "/api/v1/events") {
@@ -118,7 +142,7 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
         });
     }
 
-    logger.info({ port: serverPort }, "youtube API server listening");
+    logger.info({ port: serverPort, hostname }, "youtube API server listening");
 
     return {
         port: serverPort,


### PR DESCRIPTION
> [!NOTE]
> Supersedes #242 — original was merged prematurely (stacked-base mishap); master was reset. Branch restored at its pre-merge state.

## What

Part 2 of Plan P0 (`.claude/plans/2026-07-11-EveP0-AiProxySubsAndVpsService.md`): make the **youtube server + ai-proxy + eve** trio deployable on a VPS as an authed, multi-user service the browser extension consumes.

**Executed decisions** (fixed at task time, not re-opened): auth = per-user service key (Bearer); multi-tenancy = shared corpus for the beta; model billing rides the owner's subscription via ai-proxy, gated by owner-issued keys.

## C1 — youtube service-key auth

- New `src/youtube/lib/server/auth.ts`: `requireServiceKey(req, keys)` — **open when no key is configured** (localhost dev untouched), else timing-safe match. Supports **multiple keys** (per-user) via comma-separated `YOUTUBE_SERVICE_KEY`. Token from `Authorization: Bearer` **or** `?access_token=`/`?key=` query param (browsers can't set headers on a WS handshake).
- Wired in `src/youtube/lib/server/index.ts`: gate after the CORS preflight, before routing. Meta routes (`/api/v1/healthz`, `/api/v1/version`, `/api/v1/openapi.json`) stay open; the `/api/v1/events` WS upgrade is covered by the same gate.
- Env getter `env.youtube.getServiceKey()` (`src/utils/env/envVariables.ts`).
- Unit test `__tests__/auth.test.ts` — no key → open; missing/wrong key → 401; correct Bearer / any per-user key / query-param key → pass.

## C2 — deploy artifacts (`deploy/vps/`)

- `nginx.conf` — complete TLS front. `/ai/*`→:8317, `/yt/*`→:9876, `/eve/*`→:2000, and `/.well-known/workflow/*`→:2000 (required, or eve stalls). WS upgrade plumbing; SSE/NDJSON buffering off.
- **systemd** units for the three services (`Type=simple`, `EnvironmentFile`, `Restart=always`). Chosen over docker-compose: the trio is native bun from a repo checkout, so a container would need an in-image `bun install` (mounting a macOS `node_modules` breaks native modules).
- `genesis.env.example` + `README.md` (exact bring-up, 2nd-machine verification curls, extension repoint, and the eve-auth merge-time follow-up).

## Deviations

- **C1-eve deferred (pre-approved):** eve lives at `apps/eve/` on `feat/eve-01-foundation`, not this branch. The required eve Nitro auth middleware is documented as a merge-time follow-up in `deploy/vps/README.md` (leave `/.well-known/workflow/*` unauthenticated).
- **C4 (deploy dry-run)** is partial by design: the live service-key curl check (401 without key / 200 with key / open health) passed against an isolated youtube server on :9877, but the full trio e2e (youtube → eve billing Claude) is blocked on Part 1 (Claude subscription providers) and was not attempted.

## Verification

- `bun test src/youtube/lib/server/__tests__/` → 25 pass, 0 fail.
- `bunx tsgo --noEmit` → 0 errors (also pre-push CI mirror green).
- `nginx -t` on the config (adjusted cert/domain) → syntax ok.

**Status:** C1, C2, C3 landed; C4 partial (live curl check) done. Full trio e2e + eve route protection are the remaining follow-ups (blocked on Part 1 / merge-time).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete VPS deployment guide for running services securely behind HTTPS.
  * Added deployment templates for environment settings, reverse proxy routing, and automatic service management.
  * Added optional service-key authentication for the YouTube API.
  * Updated the browser extension to configure and use service keys for API and WebSocket access.
  * Added optional host-permission requests for non-local API servers.

* **Documentation**
  * Documented deployment, verification, TLS setup, firewall configuration, and extension configuration steps.

* **Tests**
  * Added coverage for service-key authentication and extension key storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
