### PR TITLE
feat(ai-proxy): anthropic + openai subscription providers

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -75,7 +75,8 @@
             "!src/claude-history-dashboard",
             "!**/routeTree.gen.ts",
             "!scripts/codemod/__fixtures__",
-            "!scripts/benchmarks/clones/microbenches"
+            "!scripts/benchmarks/clones/microbenches",
+            "!apps/eve"
         ]
     },
     "overrides": [

--- a/src/ai-proxy/README.md
+++ b/src/ai-proxy/README.md
@@ -1,6 +1,6 @@
 # ai-proxy
 
-OpenAI-compatible local proxy for Grok subscription, GitHub Copilot subscription, and future providers. Cursor connects once; model ids use the `account/provider/model` prefix.
+OpenAI-compatible local proxy for Grok subscription, GitHub Copilot subscription, Anthropic (Claude Max/Pro) subscription, OpenAI (ChatGPT/Codex) subscription, and future providers. Cursor connects once; model ids use the `account/provider/model` prefix.
 
 ## Quick start
 
@@ -41,6 +41,8 @@ Canonical format:
 Examples:
 - `genesiscz/grok/grok-composer-2.5-fast`
 - `genesiscz/github-copilot/claude-sonnet-4`
+- `genesiscz/claude-sub/sonnet` (aliases: `sonnet`, `opus`, `haiku`, `fable` — resolve to the current dated Claude model ids)
+- `genesiscz/codex/gpt-5.5`
 
 ## Auth
 
@@ -70,6 +72,44 @@ Account config shape:
   }
 }
 ```
+
+### Anthropic (Claude Max/Pro) subscription
+
+Speaks OpenAI (`/v1/chat/completions`) to proxy clients and forwards the Claude Code spoof (Bearer OAuth token + billing header + beta flags) to `api.anthropic.com/v1/messages`. There is no interactive `accounts login` flow for this provider yet — add the account to `~/.genesis-tools/ai-proxy/config.json` by hand, pointing `anthropicSub.accountName` at an account already configured for `tools claude` / `tools ask` (run `tools claude login` first if you don't have one):
+
+```json
+{
+  "name": "genesiscz",
+  "provider": "anthropic-subscription",
+  "providerSlug": "claude-sub",
+  "enabled": true,
+  "anthropicSub": {
+    "accountName": "foltyn"
+  }
+}
+```
+
+`accountName` is the name of the account in `~/.genesis-tools/ai/config.json` (the shared AI config used by `tools claude`/`tools ask`) whose OAuth token gets billed — it does not have to match the proxy account's own `name`. The Responses API (`/v1/responses`) is not supported by this provider; use `/v1/chat/completions`.
+
+### OpenAI (ChatGPT/Codex) subscription
+
+Speaks OpenAI to proxy clients on both `/v1/chat/completions` and `/v1/responses`, converting to/from the ChatGPT backend's Responses-only WHAM API (`chatgpt.com/backend-api/wham/responses`, streaming-only — non-streaming callers get the SSE accumulated into a single JSON response). No interactive `accounts login` flow yet — add the account by hand:
+
+```json
+{
+  "name": "genesiscz",
+  "provider": "openai-subscription",
+  "providerSlug": "codex",
+  "enabled": true,
+  "openaiSub": {
+    "accountName": "codex-account"
+  }
+}
+```
+
+Two token sources, tried in order:
+- `openaiSub.accountName` set → the named `openai-sub` account in `~/.genesis-tools/ai/config.json` (refreshed via Codex OAuth and persisted).
+- `openaiSub.accountName` omitted → the Codex CLI's own cache (`~/.codex/auth.json`, read-only; run `codex login` to refresh it). Override the path with `openaiSub.codexAuthPath`.
 
 ## Usage analytics
 

--- a/src/ai-proxy/lib/account-config.ts
+++ b/src/ai-proxy/lib/account-config.ts
@@ -24,6 +24,8 @@ export function accountConfigFingerprint(account: AiProxyAccountConfig): string 
         baseUrl: account.baseUrl,
         grok: account.grok,
         githubCopilot: account.githubCopilot,
+        anthropicSub: account.anthropicSub,
+        openaiSub: account.openaiSub,
         apiKeyEnv: account.apiKeyEnv,
         managementKeyEnv: account.managementKeyEnv,
         teamId: account.teamId,

--- a/src/ai-proxy/lib/catalog.ts
+++ b/src/ai-proxy/lib/catalog.ts
@@ -1,4 +1,9 @@
-import { listCopilotProxyModels, listGrokProxyModels } from "@app/ai-proxy/lib/model-meta";
+import {
+    listAnthropicSubProxyModels,
+    listCopilotProxyModels,
+    listGrokProxyModels,
+    listOpenAiSubProxyModels,
+} from "@app/ai-proxy/lib/model-meta";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
 import { GROK_CLI_CHAT_PROXY_BASE_URL } from "@app/utils/ai/grok";
 
@@ -19,6 +24,14 @@ export async function buildProxyModelCatalog(accounts: AiProxyAccountConfig[]): 
 
         if (account.provider === "github-copilot-subscription") {
             models.push(...(await listCopilotProxyModels(account)));
+        }
+
+        if (account.provider === "anthropic-subscription") {
+            models.push(...listAnthropicSubProxyModels(account));
+        }
+
+        if (account.provider === "openai-subscription") {
+            models.push(...listOpenAiSubProxyModels(account));
         }
     }
 

--- a/src/ai-proxy/lib/model-meta.test.ts
+++ b/src/ai-proxy/lib/model-meta.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { listAnthropicSubProxyModels, listOpenAiSubProxyModels } from "@app/ai-proxy/lib/model-meta";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { ANTHROPIC_SUB_STATIC_CATALOG } from "@app/utils/ai/anthropic/models";
+import { OPENAI_SUB_STATIC_CATALOG } from "@app/utils/ai/openai/sub-models";
+
+const account: AiProxyAccountConfig = {
+    name: "martin",
+    provider: "anthropic-subscription",
+    providerSlug: "claude-sub",
+    enabled: true,
+};
+
+const codexAccount: AiProxyAccountConfig = {
+    name: "codex",
+    provider: "openai-subscription",
+    providerSlug: "codex",
+    enabled: true,
+};
+
+describe("listAnthropicSubProxyModels", () => {
+    it("reports the real 1M context window for sonnet/opus/fable, 200K for haiku", () => {
+        const models = listAnthropicSubProxyModels(account);
+        const byAlias = Object.fromEntries(models.map((model) => [model.upstreamId, model.contextWindow]));
+
+        expect(byAlias.sonnet).toBe(1_000_000);
+        expect(byAlias.opus).toBe(1_000_000);
+        expect(byAlias.fable).toBe(1_000_000);
+        expect(byAlias.haiku).toBe(200_000);
+    });
+
+    it("advertises every concrete catalog id alongside the aliases", () => {
+        const models = listAnthropicSubProxyModels(account);
+        const upstreamIds = new Set(models.map((model) => model.upstreamId));
+
+        for (const record of ANTHROPIC_SUB_STATIC_CATALOG) {
+            expect(upstreamIds.has(record.id)).toBe(true);
+        }
+
+        expect(models.find((model) => model.upstreamId === "claude-sonnet-5")?.proxyId).toBe(
+            "martin/claude-sub/claude-sonnet-5"
+        );
+    });
+});
+
+describe("listOpenAiSubProxyModels", () => {
+    it("maps catalog records to proxy metas with their real context windows", () => {
+        const models = listOpenAiSubProxyModels(codexAccount);
+        const byId = Object.fromEntries(models.map((model) => [model.upstreamId, model]));
+
+        expect(byId["gpt-5.6-sol"].contextWindow).toBe(372_000);
+        expect(byId["gpt-5.5"].contextWindow).toBe(272_000);
+        expect(byId["gpt-5.5"].proxyId).toBe("codex/codex/gpt-5.5");
+    });
+
+    it("only advertises visibility=list catalog entries", () => {
+        const models = listOpenAiSubProxyModels(codexAccount);
+        const listed = OPENAI_SUB_STATIC_CATALOG.filter((record) => record.visibility === "list");
+
+        expect(models.length).toBe(listed.length);
+    });
+});

--- a/src/ai-proxy/lib/model-meta.ts
+++ b/src/ai-proxy/lib/model-meta.ts
@@ -2,11 +2,19 @@ import { loadCatalogFile } from "@app/ai-proxy/lib/catalog-file";
 import { resolveCopilotModelRecords } from "@app/ai-proxy/lib/copilot-models-cache";
 import { providerKey } from "@app/ai-proxy/lib/providers/registry";
 import type { AiProxyAccountConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
+import {
+    ANTHROPIC_SUB_ALIASES,
+    ANTHROPIC_SUB_STATIC_CATALOG,
+    inferAnthropicContextWindow,
+    resolveAnthropicSubModel,
+} from "@app/utils/ai/anthropic/models";
 import { toProxyId as toCopilotProxyId } from "@app/utils/ai/github-copilot/models";
 import { COPILOT_INDIVIDUAL_API } from "@app/utils/ai/github-copilot/paths";
 import type { CopilotModelRecord } from "@app/utils/ai/github-copilot/types";
 import type { GrokModelRecord } from "@app/utils/ai/grok";
 import { GROK_STATIC_CATALOG, toProxyId } from "@app/utils/ai/grok";
+import { WHAM_BASE_URL } from "@app/utils/ai/openai/codex-auth";
+import { OPENAI_SUB_STATIC_CATALOG } from "@app/utils/ai/openai/sub-models";
 
 import { SafeJSON } from "@app/utils/json";
 
@@ -99,6 +107,71 @@ export function copilotRecordToProxyMeta(
 
 export function listGrokProxyModels(account: AiProxyAccountConfig, baseUrl: string): ProxyModelMeta[] {
     return GROK_STATIC_CATALOG.map((record) => grokRecordToProxyMeta(account, record, baseUrl));
+}
+
+export const ANTHROPIC_MESSAGES_BASE_URL = "https://api.anthropic.com/v1";
+
+export function listAnthropicSubProxyModels(account: AiProxyAccountConfig): ProxyModelMeta[] {
+    const shared = (upstreamId: string) => ({
+        proxyId: toProxyId(account.name, account.providerSlug, upstreamId),
+        accountName: account.name,
+        providerSlug: account.providerSlug,
+        upstreamId,
+        provider: account.provider,
+        baseUrl: ANTHROPIC_MESSAGES_BASE_URL,
+        visibility: "high" as const,
+        speed: "medium" as const,
+        supportsTools: true,
+        billingPlane: "subscription" as const,
+        source: "static" as const,
+        object: "model" as const,
+        created: 1_740_960_000,
+        owned_by: providerKey(account),
+    });
+
+    const aliases: ProxyModelMeta[] = ANTHROPIC_SUB_ALIASES.map((alias) => {
+        const concrete = resolveAnthropicSubModel(alias);
+
+        return {
+            ...shared(alias),
+            thinking: alias === "haiku" ? "none" : "reasoning",
+            contextWindow: inferAnthropicContextWindow(concrete),
+            description: `Claude ${alias} via subscription (${concrete})`,
+        };
+    });
+
+    const concrete: ProxyModelMeta[] = ANTHROPIC_SUB_STATIC_CATALOG.map((record) => ({
+        ...shared(record.id),
+        thinking: record.thinking,
+        contextWindow: record.contextWindow,
+        description: `${record.displayName} via subscription`,
+    }));
+
+    return [...aliases, ...concrete];
+}
+
+export const WHAM_RESPONSES_BASE_URL = WHAM_BASE_URL;
+
+export function listOpenAiSubProxyModels(account: AiProxyAccountConfig): ProxyModelMeta[] {
+    return OPENAI_SUB_STATIC_CATALOG.filter((record) => record.visibility === "list").map((record) => ({
+        proxyId: toProxyId(account.name, account.providerSlug, record.slug),
+        accountName: account.name,
+        providerSlug: account.providerSlug,
+        upstreamId: record.slug,
+        provider: account.provider,
+        baseUrl: WHAM_RESPONSES_BASE_URL,
+        visibility: "high",
+        speed: "medium",
+        thinking: "reasoning",
+        contextWindow: record.contextWindow,
+        supportsTools: true,
+        billingPlane: "subscription",
+        source: "static",
+        description: `${record.displayName} via ChatGPT/Codex subscription`,
+        object: "model",
+        created: 1_740_960_000,
+        owned_by: providerKey(account),
+    }));
 }
 
 function catalogCopilotRecords(account: AiProxyAccountConfig): CopilotModelRecord[] {

--- a/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { SUBSCRIPTION_BETAS } from "@app/utils/claude/subscription-billing";
+import { SafeJSON } from "@app/utils/json";
+
+const TEST_TOKEN = "sk-ant-oat01-TESTTOKEN";
+
+mock.module("@app/utils/claude/subscription-auth", () => ({
+    resolveAccountToken: async () => ({
+        token: TEST_TOKEN,
+        account: { name: "foltyn", accessToken: TEST_TOKEN },
+        refreshed: false,
+    }),
+}));
+
+const account: AiProxyAccountConfig = {
+    name: "martin",
+    provider: "anthropic-subscription",
+    providerSlug: "claude-sub",
+    enabled: true,
+    anthropicSub: { accountName: "foltyn" },
+};
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+describe("AnthropicSubscriptionProvider", () => {
+    it("forwards the Claude Code spoof and maps the response to OpenAI shape", async () => {
+        let capturedUrl: unknown;
+        let capturedInit: RequestInit | undefined;
+
+        globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+            capturedUrl = url;
+            capturedInit = init;
+
+            return new Response(
+                SafeJSON.stringify({
+                    id: "msg_test",
+                    role: "assistant",
+                    content: [{ type: "text", text: "OK from claude" }],
+                    stop_reason: "end_turn",
+                    usage: { input_tokens: 5, output_tokens: 3 },
+                }),
+                { status: 200, headers: { "content-type": "application/json" } }
+            );
+        }) as typeof fetch;
+
+        const { AnthropicSubscriptionProvider } = await import("./anthropic-subscription");
+        const provider = await AnthropicSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "martin/claude-sub/haiku",
+            messages: [{ role: "user", content: "say OK" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "haiku", bodyText);
+
+        expect(res.status).toBe(200);
+        const completion = (await res.json()) as {
+            object: string;
+            choices: Array<{ message: { content: string } }>;
+        };
+        expect(completion.object).toBe("chat.completion");
+        expect(completion.choices[0]?.message.content).toBe("OK from claude");
+
+        // upstream targeted the Anthropic Messages API
+        expect(capturedUrl).toBe("https://api.anthropic.com/v1/messages");
+
+        // spoof headers: Bearer oat, betas, NO x-api-key
+        const headers = new Headers(capturedInit?.headers);
+        expect(headers.get("authorization")).toBe(`Bearer ${TEST_TOKEN}`);
+        expect(headers.get("anthropic-beta")).toBe(SUBSCRIPTION_BETAS);
+        expect(headers.get("x-api-key")).toBeNull();
+
+        // body: concrete model id + billing header as system[0] + Claude Code prefix
+        const sentBody = SafeJSON.parse(String(capturedInit?.body)) as {
+            model: string;
+            system: Array<{ text: string }>;
+            messages: unknown[];
+        };
+        expect(sentBody.model).toBe("claude-haiku-4-5-20251001");
+        expect(sentBody.system[0]?.text.startsWith("x-anthropic-billing-header")).toBe(true);
+        expect(sentBody.system[1]?.text).toContain("You are Claude Code");
+        expect(sentBody.messages).toHaveLength(1);
+    });
+
+    it("returns 400 (not a 502) for a non-object JSON body", async () => {
+        const { AnthropicSubscriptionProvider } = await import("./anthropic-subscription");
+        const provider = await AnthropicSubscriptionProvider.create(account);
+
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: "null" });
+        const res = await provider.chatCompletions(req, "haiku", "null");
+
+        expect(res.status).toBe(400);
+    });
+
+    it("streams as text/event-stream ending in [DONE]", async () => {
+        const anthropicSse =
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"m","model":"claude-haiku-4-5-20251001"}}\n\n' +
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}\n\n' +
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n' +
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => {
+            const encoder = new TextEncoder();
+            const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(encoder.encode(anthropicSse));
+                    controller.close();
+                },
+            });
+
+            return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+        }) as typeof fetch;
+
+        const { AnthropicSubscriptionProvider } = await import("./anthropic-subscription");
+        const provider = await AnthropicSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "martin/claude-sub/haiku",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "haiku", bodyText);
+
+        expect(res.headers.get("content-type")).toContain("text/event-stream");
+        const text = await res.text();
+        expect(text).toContain('"object":"chat.completion.chunk"');
+        expect(text).toContain("Hi");
+        expect(text).toContain("data: [DONE]");
+    });
+});

--- a/src/ai-proxy/lib/providers/anthropic-subscription.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.ts
@@ -1,0 +1,228 @@
+import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { clientAbortResponse } from "@app/ai-proxy/lib/providers/client-abort";
+import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import {
+    anthropicMessageToOpenAiCompletion,
+    anthropicSseToOpenAiChatStream,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions";
+import {
+    type OpenAiChatBody,
+    openAiChatToAnthropicMessages,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages";
+import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
+import { logger } from "@app/logger";
+import {
+    ANTHROPIC_SUB_ALIASES,
+    fetchAnthropicSubModels,
+    resolveAnthropicSubModel,
+} from "@app/utils/ai/anthropic/models";
+import { resolveAccountToken } from "@app/utils/claude/subscription-auth";
+import {
+    applySystemPromptPrefix,
+    createSubscriptionFetch,
+    SUBSCRIPTION_BETAS,
+    SUBSCRIPTION_SYSTEM_PREFIX,
+} from "@app/utils/claude/subscription-billing";
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+
+/**
+ * Bills the owner's Claude Max/Pro subscription. Speaks OpenAI to proxy
+ * clients, forwards the Claude Code spoof (Bearer OAuth token + billing header
+ * + beta flags) to api.anthropic.com/v1/messages, and maps responses back.
+ */
+export class AnthropicSubscriptionProvider implements ProxyProvider {
+    readonly id = "anthropic-subscription";
+    readonly accountFingerprint: string;
+    private readonly account: AiProxyAccountConfig;
+    /** Name of the anthropic-sub account (in ~/.genesis-tools/ai/config.json) whose token is billed. */
+    private readonly billingAccountName: string;
+    private readonly upstreamFetch: typeof fetch;
+
+    constructor(account: AiProxyAccountConfig) {
+        this.account = account;
+        this.accountFingerprint = accountConfigFingerprint(account);
+        this.billingAccountName = account.anthropicSub?.accountName ?? account.name;
+        this.upstreamFetch = createSubscriptionFetch();
+    }
+
+    static async create(account: AiProxyAccountConfig): Promise<AnthropicSubscriptionProvider> {
+        return new AnthropicSubscriptionProvider(account);
+    }
+
+    async listModels(): Promise<OpenAiModel[]> {
+        const aliases: OpenAiModel[] = ANTHROPIC_SUB_ALIASES.map((alias) => ({
+            id: `${this.account.name}/${this.account.providerSlug}/${alias}`,
+            object: "model",
+            created: 1_740_960_000,
+            owned_by: "anthropic",
+            description: `Claude ${alias} via subscription (${resolveAnthropicSubModel(alias)})`,
+        }));
+
+        const { token } = await resolveAccountToken(this.billingAccountName);
+        const records = await fetchAnthropicSubModels(token);
+
+        return [
+            ...aliases,
+            ...records.map((record) => ({
+                id: `${this.account.name}/${this.account.providerSlug}/${record.id}`,
+                object: "model" as const,
+                created: 1_740_960_000,
+                owned_by: "anthropic",
+                description: `${record.displayName} via subscription`,
+            })),
+        ];
+    }
+
+    async chatCompletions(req: Request, model: string, bodyText: string): Promise<Response> {
+        const proxyModelId = `${this.account.name}/${this.account.providerSlug}/${model}`;
+        const concreteModel = resolveAnthropicSubModel(model);
+
+        let openAiBody: OpenAiChatBody;
+        try {
+            const parsedBody = SafeJSON.parse(bodyText, { strict: true });
+            if (!isObject(parsedBody)) {
+                return jsonError(400, "Invalid JSON body");
+            }
+
+            openAiBody = parsedBody as OpenAiChatBody;
+        } catch (err) {
+            logger.debug({ err }, "ai-proxy: anthropic-subscription got invalid JSON body");
+            return jsonError(400, "Invalid JSON body");
+        }
+
+        const streaming = openAiBody.stream === true;
+        const anthropicBody = openAiChatToAnthropicMessages(openAiBody, { model: concreteModel });
+        anthropicBody.system = applySystemPromptPrefix(SUBSCRIPTION_SYSTEM_PREFIX, anthropicBody.system ?? "");
+
+        let token: string;
+        try {
+            ({ token } = await resolveAccountToken(this.billingAccountName));
+        } catch (err) {
+            logger.warn(
+                { err, account: this.account.name, billingAccount: this.billingAccountName },
+                "ai-proxy: anthropic-subscription token resolution failed"
+            );
+            return jsonError(
+                502,
+                `Anthropic subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
+
+        const started = performance.now();
+        let upstream: Response;
+        try {
+            upstream = await this.upstreamFetch(ANTHROPIC_MESSAGES_URL, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "anthropic-version": ANTHROPIC_VERSION,
+                    "anthropic-beta": SUBSCRIPTION_BETAS,
+                    Authorization: `Bearer ${token}`,
+                    Accept: streaming ? "text/event-stream" : "application/json",
+                },
+                body: SafeJSON.stringify(anthropicBody),
+                signal: req.signal,
+            });
+        } catch (err) {
+            const aborted = clientAbortResponse(err, { err, account: this.account.name, model: concreteModel });
+            if (aborted) {
+                return aborted;
+            }
+
+            logger.warn(
+                { err, account: this.account.name, model: concreteModel },
+                "ai-proxy: anthropic upstream fetch failed"
+            );
+            return jsonError(
+                502,
+                `Failed to reach Anthropic upstream: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
+
+        const elapsedMs = Math.round(performance.now() - started);
+
+        if (!upstream.ok) {
+            const errorText = await upstream.text();
+            logger.warn(
+                {
+                    account: this.account.name,
+                    upstreamModel: concreteModel,
+                    requestedModel: proxyModelId,
+                    status: upstream.status,
+                    elapsedMs,
+                    body: errorText.slice(0, 500),
+                },
+                "ai-proxy: anthropic upstream request failed"
+            );
+
+            return new Response(errorText, {
+                status: upstream.status,
+                headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+            });
+        }
+
+        logger.debug(
+            {
+                account: this.account.name,
+                upstreamModel: concreteModel,
+                requestedModel: proxyModelId,
+                streaming,
+                elapsedMs,
+            },
+            "ai-proxy: anthropic upstream request ok"
+        );
+
+        if (streaming) {
+            if (!upstream.body) {
+                return jsonError(502, "Anthropic upstream returned no stream body");
+            }
+
+            return new Response(anthropicSseToOpenAiChatStream(upstream.body, { model: proxyModelId }), {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/event-stream; charset=utf-8",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                },
+            });
+        }
+
+        const message = (await upstream.json()) as Record<string, unknown>;
+        const completion = anthropicMessageToOpenAiCompletion(message, { model: proxyModelId });
+
+        return new Response(SafeJSON.stringify(completion), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    async responses(_req: Request, _model: string, _bodyText: string): Promise<Response> {
+        // The Claude subscription upstream has no Responses API. Clients should
+        // use /v1/chat/completions for anthropic-subscription models. (Cursor
+        // request translation is disabled for this provider — see
+        // shouldTranslateChatRequest — so this path is not hit in normal flows.)
+        return jsonError(
+            400,
+            "anthropic-subscription does not support the Responses API — use POST /v1/chat/completions with this model."
+        );
+    }
+
+    async getUsage(): Promise<UsageSummary> {
+        return {
+            accountName: this.account.name,
+            provider: "anthropic-subscription",
+            summary: "subscription (usage not exposed by the Anthropic OAuth API)",
+        };
+    }
+}
+
+function jsonError(status: number, message: string): Response {
+    return new Response(SafeJSON.stringify({ error: { message } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}

--- a/src/ai-proxy/lib/providers/client-abort.ts
+++ b/src/ai-proxy/lib/providers/client-abort.ts
@@ -1,0 +1,17 @@
+import { logger } from "@app/logger";
+
+/**
+ * When a proxy client hangs up, the `req.signal` we forward to the upstream
+ * fetch (or SSE read) rejects with an `AbortError`. That is not an upstream
+ * failure — logging it as warn + returning 502 is noise. Detect the client
+ * abort, log it at debug, and return a 499 ("Client Closed Request"); callers
+ * fall through to their real warn + 502 handling when this returns `null`.
+ */
+export function clientAbortResponse(err: unknown, context: Record<string, unknown>): Response | null {
+    if (err instanceof Error && err.name === "AbortError") {
+        logger.debug(context, "ai-proxy: upstream request aborted by client");
+        return new Response("Aborted", { status: 499 });
+    }
+
+    return null;
+}

--- a/src/ai-proxy/lib/providers/openai-sub-token.test.ts
+++ b/src/ai-proxy/lib/providers/openai-sub-token.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveOpenAiSubToken } from "@app/ai-proxy/lib/providers/openai-sub-token";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { AIConfig } from "@app/utils/ai/AIConfig";
+import { codexOAuth } from "@app/utils/ai/openai/codex-auth";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+
+const ORIGINAL_HOME = env.get("GENESIS_TOOLS_HOME");
+
+function writeAiConfig(home: string): void {
+    const aiDir = join(home, ".genesis-tools", "ai");
+    mkdirSync(aiDir, { recursive: true });
+    writeFileSync(
+        join(aiDir, "config.json"),
+        SafeJSON.stringify(
+            {
+                _schemaVersion: 3,
+                accounts: [
+                    {
+                        name: "codex-test",
+                        provider: "openai-sub",
+                        tokens: {
+                            accessToken: "stale-access",
+                            refreshToken: "refresh-0",
+                            expiresAt: Date.now() - 60_000, // expired → needs refresh
+                        },
+                    },
+                ],
+            },
+            null,
+            2
+        )
+    );
+}
+
+const PROXY_ACCOUNT: AiProxyAccountConfig = {
+    name: "proxy-codex",
+    provider: "openai-subscription",
+    providerSlug: "codex",
+    enabled: true,
+    openaiSub: { accountName: "codex-test" },
+};
+
+describe("resolveOpenAiSubToken — single-flight refresh", () => {
+    let tempHome: string;
+
+    beforeEach(async () => {
+        tempHome = mkdtempSync(join(tmpdir(), "openai-sub-token-"));
+        env.testing.set("GENESIS_TOOLS_HOME", tempHome);
+        writeAiConfig(tempHome);
+        AIConfig.invalidate();
+        // Prime the singleton (and run migrations) serially so the two concurrent
+        // resolves race only inside withLock, not inside AIConfig.load().
+        await AIConfig.load();
+    });
+
+    afterEach(() => {
+        AIConfig.invalidate();
+        mock.restore();
+
+        if (ORIGINAL_HOME === undefined) {
+            env.testing.unset("GENESIS_TOOLS_HOME");
+        } else {
+            env.testing.set("GENESIS_TOOLS_HOME", ORIGINAL_HOME);
+        }
+    });
+
+    it("refreshes a single-use Codex token only once under concurrent resolves", async () => {
+        let refreshCount = 0;
+        const refreshSpy = spyOn(codexOAuth, "refresh").mockImplementation(async () => {
+            refreshCount += 1;
+            // Hold the lock long enough that the second resolve is still waiting.
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            return {
+                accessToken: `fresh-access-${refreshCount}`,
+                refreshToken: `refresh-${refreshCount}`,
+                expiresAt: Date.now() + 3_600_000,
+            };
+        });
+
+        const [first, second] = await Promise.all([
+            resolveOpenAiSubToken(PROXY_ACCOUNT),
+            resolveOpenAiSubToken(PROXY_ACCOUNT),
+        ]);
+
+        // Second resolve must observe the already-refreshed token, not POST the
+        // same single-use refresh token a second time.
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+        expect(first.token).toBe("fresh-access-1");
+        expect(second.token).toBe("fresh-access-1");
+    });
+});

--- a/src/ai-proxy/lib/providers/openai-sub-token.ts
+++ b/src/ai-proxy/lib/providers/openai-sub-token.ts
@@ -1,0 +1,54 @@
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { logger } from "@app/logger";
+import {
+    CODEX_AUTH_PATH,
+    codexOAuth,
+    extractAccountId,
+    readCodexAuthJson,
+    resolveCodexAccountToken,
+} from "@app/utils/ai/openai/codex-auth";
+
+export interface OpenAiSubToken {
+    token: string;
+    accountId?: string;
+}
+
+/**
+ * Resolve a ChatGPT/Codex access token for an openai-subscription proxy account.
+ *
+ * Two sources:
+ *  - `openaiSub.accountName` set → the named `openai-sub` account in the unified
+ *    AI config, via the canonical single-flight resolveCodexAccountToken().
+ *    This is the deploy path.
+ *  - otherwise → the Codex CLI cache (`~/.codex/auth.json`), read-only. The CLI
+ *    keeps this fresh; the local proxy piggybacks on the machine's `codex login`.
+ */
+export async function resolveOpenAiSubToken(account: AiProxyAccountConfig): Promise<OpenAiSubToken> {
+    const accountName = account.openaiSub?.accountName;
+
+    if (accountName) {
+        return resolveCodexAccountToken(accountName);
+    }
+
+    return resolveFromCodexCli(account.openaiSub?.codexAuthPath);
+}
+
+async function resolveFromCodexCli(authPath?: string): Promise<OpenAiSubToken> {
+    const path = authPath ?? CODEX_AUTH_PATH;
+    const tokens = await readCodexAuthJson(path);
+
+    if (!tokens?.accessToken) {
+        throw new Error(
+            `No Codex CLI auth at ${path}. Run \`codex login\`, or set openaiSub.accountName to a configured openai-sub account.`
+        );
+    }
+
+    if (tokens.expiresAt && codexOAuth.needsRefresh(tokens.expiresAt)) {
+        logger.warn(
+            { path },
+            "ai-proxy: Codex CLI token is expired — run `codex login` (the proxy does not write the CLI cache)"
+        );
+    }
+
+    return { token: tokens.accessToken, accountId: tokens.accountId ?? extractAccountId(tokens.accessToken) };
+}

--- a/src/ai-proxy/lib/providers/openai-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { SafeJSON } from "@app/utils/json";
+
+const TEST_TOKEN = "codex-access-token";
+const TEST_ACCOUNT_ID = "acct-123";
+
+mock.module("@app/ai-proxy/lib/providers/openai-sub-token", () => ({
+    resolveOpenAiSubToken: async () => ({ token: TEST_TOKEN, accountId: TEST_ACCOUNT_ID }),
+}));
+
+const account: AiProxyAccountConfig = {
+    name: "codex",
+    provider: "openai-subscription",
+    providerSlug: "codex",
+    enabled: true,
+    openaiSub: {},
+};
+
+const WHAM_SSE =
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.5","status":"in_progress"}}\n\n' +
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"CODEX"}\n\n' +
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"_OK"}\n\n' +
+    'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.5","status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":3,"total_tokens":13}}}\n\n';
+
+function whamStreamResponse(): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoder.encode(WHAM_SSE));
+            controller.close();
+        },
+    });
+
+    return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+describe("buildWhamResponsesBody", () => {
+    it("extracts system→instructions, maps messages→input, forces stream", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+        const body = buildWhamResponsesBody(
+            {
+                model: "codex/codex/gpt-5.5",
+                messages: [
+                    { role: "system", content: "You are helpful." },
+                    { role: "user", content: "hi" },
+                ],
+                max_tokens: 64,
+            },
+            "gpt-5.5"
+        );
+
+        expect(body.model).toBe("gpt-5.5");
+        expect(body.stream).toBe(true);
+        expect(body.store).toBe(false);
+        expect(body.instructions).toBe("You are helpful.");
+        expect(Array.isArray(body.input)).toBe(true);
+        // WHAM rejects max_output_tokens ("Unsupported parameter"), so the
+        // caller's max_tokens cap must NOT be forwarded (verified live 2026-07-12).
+        expect(body.max_output_tokens).toBeUndefined();
+    });
+
+    it("maps chat function tools to flat Responses tools", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+        const body = buildWhamResponsesBody(
+            {
+                messages: [{ role: "user", content: "go" }],
+                tools: [
+                    {
+                        type: "function",
+                        function: { name: "search", description: "d", parameters: { type: "object" } },
+                    },
+                ],
+            },
+            "gpt-5.5"
+        );
+
+        expect(body.tools).toEqual([
+            { type: "function", name: "search", description: "d", parameters: { type: "object" } },
+        ]);
+    });
+});
+
+describe("OpenAiSubscriptionProvider", () => {
+    it("forwards a chat request to WHAM and maps the response to chat.completion", async () => {
+        let capturedUrl: unknown;
+        let capturedInit: RequestInit | undefined;
+
+        globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+            capturedUrl = url;
+            capturedInit = init;
+            return whamStreamResponse();
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [
+                { role: "system", content: "Be terse." },
+                { role: "user", content: "say ok" },
+            ],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(200);
+        const completion = (await res.json()) as {
+            object: string;
+            choices: Array<{ message: { content: string } }>;
+        };
+        expect(completion.object).toBe("chat.completion");
+        expect(completion.choices[0]?.message.content).toBe("CODEX_OK");
+
+        // upstream targeted WHAM with the Codex token + account id
+        expect(capturedUrl).toBe("https://chatgpt.com/backend-api/wham/responses");
+        const headers = new Headers(capturedInit?.headers);
+        expect(headers.get("authorization")).toBe(`Bearer ${TEST_TOKEN}`);
+        expect(headers.get("chatgpt-account-id")).toBe(TEST_ACCOUNT_ID);
+        expect(headers.get("openai-beta")).toBe("responses=experimental");
+
+        // body was converted to Responses shape with the concrete model + stream
+        const sentBody = SafeJSON.parse(String(capturedInit?.body)) as {
+            model: string;
+            stream: boolean;
+            instructions: string;
+            input: unknown[];
+        };
+        expect(sentBody.model).toBe("gpt-5.5");
+        expect(sentBody.stream).toBe(true);
+        expect(sentBody.instructions).toBe("Be terse.");
+        expect(Array.isArray(sentBody.input)).toBe(true);
+    });
+
+    it("streams chat.completion.chunk when the client requests streaming", async () => {
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) =>
+            whamStreamResponse()) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.headers.get("content-type")).toContain("text/event-stream");
+        const text = await res.text();
+        expect(text).toContain('"object":"chat.completion.chunk"');
+        expect(text).toContain("CODEX");
+        expect(text).toContain("[DONE]");
+    });
+
+    it("returns 400 (not a 502) for a non-object JSON body", async () => {
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const req = new Request("http://localhost/v1/responses", { method: "POST", body: "null" });
+        const res = await provider.responses(req, "gpt-5.5", "null");
+
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 502 (not 200 with empty output) when WHAM emits response.failed", async () => {
+        const FAILED_SSE =
+            'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.5","status":"in_progress"}}\n\n' +
+            'event: response.failed\ndata: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"message":"upstream boom"}}}\n\n';
+
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => {
+            const encoder = new TextEncoder();
+            const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(encoder.encode(FAILED_SSE));
+                    controller.close();
+                },
+            });
+            return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/responses", { method: "POST", body: bodyText });
+        const res = await provider.responses(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(502);
+        const errorBody = (await res.json()) as { error: { message: string } };
+        expect(errorBody.error.message).toBe("upstream boom");
+    });
+});

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -1,0 +1,388 @@
+import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { convertMessagesToInput } from "@app/ai-proxy/lib/chat-to-responses-body";
+import { clientAbortResponse } from "@app/ai-proxy/lib/providers/client-abort";
+import { resolveOpenAiSubToken } from "@app/ai-proxy/lib/providers/openai-sub-token";
+import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { responsesToChat } from "@app/ai-proxy/lib/translators/responses-to-chat";
+import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
+import { logger } from "@app/logger";
+import { WHAM_BASE_URL } from "@app/utils/ai/openai/codex-auth";
+import { fetchWhamModels, resolveOpenAiSubModel } from "@app/utils/ai/openai/sub-models";
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+const WHAM_RESPONSES_URL = `${WHAM_BASE_URL}/responses`;
+
+/**
+ * Bills the owner's ChatGPT/Codex subscription. The ChatGPT WHAM backend speaks
+ * the OpenAI Responses API (streaming-only), so `responses()` converts an
+ * incoming chat- or responses-shaped body into a WHAM Responses request and
+ * forwards it; `chatCompletions()` delegates to the shared `responsesToChat`
+ * translator (which calls `responses()` and maps the Responses output back to
+ * chat.completion / chat.completion.chunk).
+ */
+export class OpenAiSubscriptionProvider implements ProxyProvider {
+    readonly id = "openai-subscription";
+    readonly accountFingerprint: string;
+    private readonly account: AiProxyAccountConfig;
+
+    constructor(account: AiProxyAccountConfig) {
+        this.account = account;
+        this.accountFingerprint = accountConfigFingerprint(account);
+    }
+
+    static async create(account: AiProxyAccountConfig): Promise<OpenAiSubscriptionProvider> {
+        return new OpenAiSubscriptionProvider(account);
+    }
+
+    async listModels(): Promise<OpenAiModel[]> {
+        const { token, accountId } = await resolveOpenAiSubToken(this.account);
+        const records = await fetchWhamModels(token, accountId);
+
+        return records
+            .filter((record) => record.visibility === "list")
+            .map((record) => ({
+                id: `${this.account.name}/${this.account.providerSlug}/${record.slug}`,
+                object: "model",
+                created: 1_740_960_000,
+                owned_by: "openai",
+                description: `${record.displayName} via ChatGPT/Codex subscription`,
+            }));
+    }
+
+    async chatCompletions(req: Request, model: string, bodyText: string): Promise<Response> {
+        const proxyModel = `${this.account.name}/${this.account.providerSlug}/${model}`;
+        const { response } = await responsesToChat({ provider: this, upstreamModel: model, proxyModel, req, bodyText });
+        return response;
+    }
+
+    async responses(req: Request, model: string, bodyText: string): Promise<Response> {
+        const concreteModel = resolveOpenAiSubModel(model);
+
+        let parsed: Record<string, unknown>;
+        try {
+            const parsedBody = SafeJSON.parse(bodyText, { strict: true });
+            if (!isObject(parsedBody)) {
+                return jsonError(400, "Invalid JSON body");
+            }
+
+            parsed = parsedBody;
+        } catch (err) {
+            logger.debug({ err }, "ai-proxy: openai-subscription got invalid JSON body");
+            return jsonError(400, "Invalid JSON body");
+        }
+
+        const wantStream = parsed.stream === true;
+        const whamBody = buildWhamResponsesBody(parsed, concreteModel);
+
+        let token: string;
+        let accountId: string | undefined;
+        try {
+            ({ token, accountId } = await resolveOpenAiSubToken(this.account));
+        } catch (err) {
+            logger.warn({ err, account: this.account.name }, "ai-proxy: openai-subscription token resolution failed");
+            return jsonError(
+                502,
+                `Codex subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
+
+        const started = performance.now();
+        let upstream: Response;
+        try {
+            upstream = await fetch(WHAM_RESPONSES_URL, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "chatgpt-account-id": accountId ?? "",
+                    "Content-Type": "application/json",
+                    "OpenAI-Beta": "responses=experimental",
+                    originator: "codex_cli_rs",
+                    session_id: crypto.randomUUID(),
+                    Accept: "text/event-stream",
+                },
+                body: SafeJSON.stringify(whamBody),
+                signal: req.signal,
+            });
+        } catch (err) {
+            const aborted = clientAbortResponse(err, { err, account: this.account.name });
+            if (aborted) {
+                return aborted;
+            }
+
+            logger.warn({ err, account: this.account.name }, "ai-proxy: WHAM upstream fetch failed");
+            return jsonError(
+                502,
+                `Failed to reach ChatGPT upstream: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
+
+        const elapsedMs = Math.round(performance.now() - started);
+
+        if (!upstream.ok) {
+            const errorText = await upstream.text();
+            logger.warn(
+                {
+                    account: this.account.name,
+                    model: concreteModel,
+                    status: upstream.status,
+                    elapsedMs,
+                    body: errorText.slice(0, 500),
+                },
+                "ai-proxy: WHAM upstream request failed"
+            );
+
+            return new Response(errorText, {
+                status: upstream.status,
+                headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+            });
+        }
+
+        logger.debug(
+            { account: this.account.name, model: concreteModel, wantStream, elapsedMs },
+            "ai-proxy: WHAM upstream request ok"
+        );
+
+        if (!upstream.body) {
+            return jsonError(502, "WHAM upstream returned no body");
+        }
+
+        if (wantStream) {
+            return new Response(upstream.body, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/event-stream; charset=utf-8",
+                    "Cache-Control": "no-cache",
+                    Connection: "keep-alive",
+                },
+            });
+        }
+
+        // Non-streaming caller: WHAM only streams, so accumulate the SSE into a
+        // Responses JSON. The final `response.completed` event carries empty
+        // output on WHAM, so text is reassembled from output_text deltas.
+        let accumulated: Awaited<ReturnType<typeof accumulateResponsesJson>>;
+        try {
+            accumulated = await accumulateResponsesJson(upstream.body);
+        } catch (err) {
+            const aborted = clientAbortResponse(err, { err, account: this.account.name });
+            if (aborted) {
+                return aborted;
+            }
+
+            logger.warn({ err, account: this.account.name }, "ai-proxy: failed to accumulate WHAM response");
+            return jsonError(
+                502,
+                `Failed to read ChatGPT upstream response: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
+
+        if (accumulated.failed) {
+            logger.warn(
+                { account: this.account.name, model: concreteModel, error: accumulated.error },
+                "ai-proxy: WHAM stream reported response.failed"
+            );
+            return jsonError(502, accumulated.error);
+        }
+
+        return new Response(accumulated.body, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    async getUsage(): Promise<UsageSummary> {
+        return {
+            accountName: this.account.name,
+            provider: "openai-subscription",
+            summary: "subscription (usage not exposed by the ChatGPT backend)",
+        };
+    }
+}
+
+function extractText(content: unknown): string {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    if (Array.isArray(content)) {
+        return content.map((part) => (isObject(part) && typeof part.text === "string" ? part.text : "")).join("");
+    }
+
+    return "";
+}
+
+function mapChatToolsToResponses(tools: unknown): unknown[] | undefined {
+    if (!Array.isArray(tools)) {
+        return undefined;
+    }
+
+    const mapped: unknown[] = [];
+
+    for (const tool of tools) {
+        if (!isObject(tool)) {
+            continue;
+        }
+
+        // Already Responses-shaped (flat function tool).
+        if (tool.type === "function" && typeof tool.name === "string") {
+            mapped.push(tool);
+            continue;
+        }
+
+        const fn = isObject(tool.function) ? tool.function : undefined;
+
+        if (fn && typeof fn.name === "string") {
+            mapped.push({
+                type: "function",
+                name: fn.name,
+                description: typeof fn.description === "string" ? fn.description : undefined,
+                parameters: fn.parameters ?? { type: "object", properties: {} },
+            });
+        }
+    }
+
+    return mapped.length > 0 ? mapped : undefined;
+}
+
+/** Convert a chat- or responses-shaped body into a WHAM Responses request. */
+export function buildWhamResponsesBody(parsed: Record<string, unknown>, model: string): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+        model,
+        stream: true,
+        store: false,
+        include: [],
+    };
+
+    if (Array.isArray(parsed.input)) {
+        // Already a Responses body.
+        body.input = parsed.input;
+
+        if (typeof parsed.instructions === "string") {
+            body.instructions = parsed.instructions;
+        }
+
+        if (parsed.tools) {
+            body.tools = parsed.tools;
+        }
+    } else {
+        const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+        const instructions: string[] = [];
+        const rest: unknown[] = [];
+
+        for (const message of messages) {
+            if (isObject(message) && (message.role === "system" || message.role === "developer")) {
+                instructions.push(extractText(message.content));
+                continue;
+            }
+
+            rest.push(message);
+        }
+
+        body.input = convertMessagesToInput(rest);
+
+        if (instructions.length > 0) {
+            body.instructions = instructions.join("\n\n");
+        }
+
+        const tools = mapChatToolsToResponses(parsed.tools);
+
+        if (tools) {
+            body.tools = tools;
+        }
+    }
+
+    // WHAM rejects max_output_tokens outright ("Unsupported parameter"), so a
+    // caller's max_tokens cap is intentionally dropped rather than forwarded.
+
+    if (isObject(parsed.reasoning)) {
+        body.reasoning = parsed.reasoning;
+    } else {
+        body.reasoning = { effort: "low" };
+    }
+
+    return body;
+}
+
+async function accumulateResponsesJson(
+    stream: ReadableStream<Uint8Array>
+): Promise<{ failed: false; body: string } | { failed: true; error: string }> {
+    const raw = await new Response(stream).text();
+    let text = "";
+    const functionCalls: unknown[] = [];
+    let completed: Record<string, unknown> = {};
+    let failure: string | undefined;
+
+    for (const line of raw.split("\n")) {
+        const trimmed = line.trimStart();
+
+        if (!trimmed.startsWith("data:")) {
+            continue;
+        }
+
+        const payload = trimmed.slice("data:".length).trim();
+
+        if (payload.length === 0 || payload === "[DONE]") {
+            continue;
+        }
+
+        let event: unknown;
+        try {
+            event = SafeJSON.parse(payload, { strict: true });
+        } catch (err) {
+            logger.debug({ err, payload }, "ai-proxy: WHAM SSE line parse failed");
+            continue;
+        }
+
+        if (!isObject(event)) {
+            continue;
+        }
+
+        if (event.type === "response.output_text.delta" && typeof event.delta === "string") {
+            text += event.delta;
+            continue;
+        }
+
+        if (event.type === "response.output_item.done" && isObject(event.item) && event.item.type === "function_call") {
+            functionCalls.push(event.item);
+            continue;
+        }
+
+        if (event.type === "response.completed" && isObject(event.response)) {
+            completed = event.response;
+            continue;
+        }
+
+        if (event.type === "response.failed") {
+            const response = isObject(event.response) ? event.response : undefined;
+            const error = response && isObject(response.error) ? response.error : undefined;
+            failure = error && typeof error.message === "string" ? error.message : "WHAM response.failed";
+        }
+    }
+
+    if (failure) {
+        return { failed: true, error: failure };
+    }
+
+    const output: unknown[] = [];
+
+    if (text.length > 0) {
+        output.push({
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text, annotations: [] }],
+        });
+    }
+
+    output.push(...functionCalls);
+
+    return { failed: false, body: SafeJSON.stringify({ ...completed, object: "response", output }) };
+}
+
+function jsonError(status: number, message: string): Response {
+    return new Response(SafeJSON.stringify({ error: { message } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}

--- a/src/ai-proxy/lib/providers/registry.ts
+++ b/src/ai-proxy/lib/providers/registry.ts
@@ -1,5 +1,7 @@
+import { AnthropicSubscriptionProvider } from "@app/ai-proxy/lib/providers/anthropic-subscription";
 import { GithubCopilotSubscriptionProvider } from "@app/ai-proxy/lib/providers/github-copilot-subscription";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
+import { OpenAiSubscriptionProvider } from "@app/ai-proxy/lib/providers/openai-subscription";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { logger } from "@app/logger";
@@ -13,7 +15,12 @@ export function routeProviderKey(route: { accountName: string; providerSlug: str
 }
 
 export function isProviderImplemented(provider: AiProxyAccountConfig["provider"]): boolean {
-    return provider === "grok-subscription" || provider === "github-copilot-subscription";
+    return (
+        provider === "grok-subscription" ||
+        provider === "github-copilot-subscription" ||
+        provider === "anthropic-subscription" ||
+        provider === "openai-subscription"
+    );
 }
 
 export async function buildProviderMap(
@@ -48,6 +55,14 @@ export async function createProvider(account: AiProxyAccountConfig): Promise<Pro
 
     if (account.provider === "github-copilot-subscription") {
         return GithubCopilotSubscriptionProvider.create(account);
+    }
+
+    if (account.provider === "anthropic-subscription") {
+        return AnthropicSubscriptionProvider.create(account);
+    }
+
+    if (account.provider === "openai-subscription") {
+        return OpenAiSubscriptionProvider.create(account);
     }
 
     throw new Error(`Provider not implemented yet: ${account.provider}`);

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
+import { anthropicMessageToOpenAiCompletion, anthropicSseToOpenAiChatStream } from "./anthropic-to-openai-completions";
+
+const MODEL = "martin/claude-sub/haiku";
+
+function streamFrom(text: string): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoder.encode(text));
+            controller.close();
+        },
+    });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let out = "";
+
+    for (;;) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+            break;
+        }
+
+        out += decoder.decode(value, { stream: true });
+    }
+
+    return out;
+}
+
+/** Parse `data: {...}` lines (ignoring [DONE]) into objects. */
+function parseChunks(sse: string): Array<Record<string, unknown>> {
+    return sse
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith("data:") && !line.includes("[DONE]"))
+        .map((line) => SafeJSON.parse(line.slice("data:".length).trim()) as Record<string, unknown>);
+}
+
+describe("anthropicMessageToOpenAiCompletion", () => {
+    it("maps a text message to an OpenAI chat.completion", () => {
+        const completion = anthropicMessageToOpenAiCompletion(
+            {
+                id: "msg_123",
+                role: "assistant",
+                content: [{ type: "text", text: "Hello there" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 10, output_tokens: 3 },
+            },
+            { model: MODEL }
+        );
+
+        expect(completion.object).toBe("chat.completion");
+        expect(completion.model).toBe(MODEL);
+        expect(completion.choices[0]?.message.content).toBe("Hello there");
+        expect(completion.choices[0]?.finish_reason).toBe("stop");
+        expect(completion.usage).toEqual({ prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 });
+    });
+
+    it("maps tool_use blocks to tool_calls with finish_reason tool_calls", () => {
+        const completion = anthropicMessageToOpenAiCompletion(
+            {
+                id: "msg_x",
+                role: "assistant",
+                content: [{ type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "Prague" } }],
+                stop_reason: "tool_use",
+                usage: { input_tokens: 5, output_tokens: 8 },
+            },
+            { model: MODEL }
+        );
+
+        expect(completion.choices[0]?.message.content).toBeNull();
+        expect(completion.choices[0]?.message.tool_calls).toEqual([
+            {
+                index: 0,
+                id: "toolu_1",
+                type: "function",
+                function: { name: "get_weather", arguments: '{"city":"Prague"}' },
+            },
+        ]);
+        expect(completion.choices[0]?.finish_reason).toBe("tool_calls");
+    });
+
+    it("maps max_tokens stop_reason to length", () => {
+        const completion = anthropicMessageToOpenAiCompletion(
+            { id: "m", role: "assistant", content: [{ type: "text", text: "x" }], stop_reason: "max_tokens" },
+            { model: MODEL }
+        );
+
+        expect(completion.choices[0]?.finish_reason).toBe("length");
+    });
+});
+
+describe("anthropicSseToOpenAiChatStream", () => {
+    it("streams text deltas as chat.completion.chunk events ending in [DONE]", async () => {
+        const anthropicSse = [
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","model":"claude-haiku-4-5-20251001","usage":{"input_tokens":4}}}\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n',
+        ].join("\n");
+
+        const out = await collect(anthropicSseToOpenAiChatStream(streamFrom(anthropicSse), { model: MODEL }));
+        const chunks = parseChunks(out);
+
+        expect(out).toContain("data: [DONE]");
+        expect(out).toContain('"object":"chat.completion.chunk"');
+
+        // first chunk announces the assistant role
+        const firstDelta = (chunks[0]?.choices as Array<{ delta: Record<string, unknown> }>)[0]?.delta;
+        expect(firstDelta).toEqual({ role: "assistant" });
+
+        // reassembled content
+        const content = chunks
+            .flatMap((c) => c.choices as Array<{ delta: { content?: string } }>)
+            .map((choice) => choice.delta.content ?? "")
+            .join("");
+        expect(content).toBe("Hello");
+
+        // final chunk carries finish_reason stop
+        const finishReasons = chunks
+            .flatMap((c) => c.choices as Array<{ finish_reason: string | null }>)
+            .map((choice) => choice.finish_reason)
+            .filter((reason) => reason !== null);
+        expect(finishReasons).toEqual(["stop"]);
+    });
+
+    it("streams tool_use as tool_call deltas", async () => {
+        const anthropicSse = [
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_2","model":"claude-haiku-4-5-20251001"}}\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_9","name":"search"}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"q\\":"}}\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"cats\\"}"}}\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n',
+        ].join("\n");
+
+        const out = await collect(anthropicSseToOpenAiChatStream(streamFrom(anthropicSse), { model: MODEL }));
+        const chunks = parseChunks(out);
+
+        const toolCalls = chunks
+            .flatMap(
+                (c) =>
+                    c.choices as Array<{
+                        delta: {
+                            tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }>;
+                        };
+                    }>
+            )
+            .flatMap((choice) => choice.delta.tool_calls ?? []);
+
+        // first tool_call chunk names the function
+        expect(toolCalls[0]?.id).toBe("toolu_9");
+        expect(toolCalls[0]?.function?.name).toBe("search");
+
+        // arguments reassemble
+        const args = toolCalls.map((tc) => tc.function?.arguments ?? "").join("");
+        expect(args).toBe('{"q":"cats"}');
+
+        const finishReasons = chunks
+            .flatMap((c) => c.choices as Array<{ finish_reason: string | null }>)
+            .map((choice) => choice.finish_reason)
+            .filter((reason) => reason !== null);
+        expect(finishReasons).toEqual(["tool_calls"]);
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-openai-completions.ts
@@ -1,0 +1,313 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+/**
+ * Maps Anthropic `/v1/messages` responses back into the OpenAI
+ * chat-completions shape the proxy's clients expect — both the non-streaming
+ * final message and the streaming SSE event flow.
+ */
+
+export interface OpenAiToolCall {
+    index?: number;
+    id?: string;
+    type: "function";
+    function: { name?: string; arguments: string };
+}
+
+export interface OpenAiChatCompletion {
+    id: string;
+    object: "chat.completion";
+    created: number;
+    model: string;
+    choices: Array<{
+        index: number;
+        message: { role: "assistant"; content: string | null; tool_calls?: OpenAiToolCall[] };
+        finish_reason: string;
+    }>;
+    usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+}
+
+type AnthropicStopReason = "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | string | null | undefined;
+
+function mapFinishReason(stopReason: AnthropicStopReason): string {
+    if (stopReason === "max_tokens") {
+        return "length";
+    }
+
+    if (stopReason === "tool_use") {
+        return "tool_calls";
+    }
+
+    return "stop";
+}
+
+function nowSeconds(): number {
+    return Math.floor(Date.now() / 1000);
+}
+
+/** Non-streaming: an Anthropic message object → an OpenAI chat.completion. */
+export function anthropicMessageToOpenAiCompletion(
+    message: Record<string, unknown>,
+    options: { model: string }
+): OpenAiChatCompletion {
+    const contentBlocks = Array.isArray(message.content) ? message.content : [];
+    const textParts: string[] = [];
+    const toolCalls: OpenAiToolCall[] = [];
+
+    for (const block of contentBlocks) {
+        if (!isObject(block)) {
+            continue;
+        }
+
+        if (block.type === "text" && typeof block.text === "string") {
+            textParts.push(block.text);
+            continue;
+        }
+
+        if (block.type === "tool_use") {
+            toolCalls.push({
+                index: toolCalls.length,
+                id: typeof block.id === "string" ? block.id : `call_${crypto.randomUUID()}`,
+                type: "function",
+                function: {
+                    name: typeof block.name === "string" ? block.name : "unknown",
+                    arguments: SafeJSON.stringify(block.input ?? {}),
+                },
+            });
+        }
+    }
+
+    const usage = isObject(message.usage) ? message.usage : undefined;
+    const inputTokens = usage && typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+    const outputTokens = usage && typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
+
+    const completion: OpenAiChatCompletion = {
+        id: `chatcmpl-${typeof message.id === "string" ? message.id : crypto.randomUUID()}`,
+        object: "chat.completion",
+        created: nowSeconds(),
+        model: options.model,
+        choices: [
+            {
+                index: 0,
+                message: {
+                    role: "assistant",
+                    content: textParts.length > 0 ? textParts.join("") : null,
+                    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+                },
+                finish_reason: mapFinishReason(message.stop_reason as AnthropicStopReason),
+            },
+        ],
+        usage: {
+            prompt_tokens: inputTokens,
+            completion_tokens: outputTokens,
+            total_tokens: inputTokens + outputTokens,
+        },
+    };
+
+    return completion;
+}
+
+interface ChunkDelta {
+    role?: "assistant";
+    content?: string;
+    tool_calls?: OpenAiToolCall[];
+}
+
+function chunk(input: {
+    id: string;
+    model: string;
+    created: number;
+    delta: ChunkDelta;
+    finishReason: string | null;
+}): string {
+    const payload = {
+        id: input.id,
+        object: "chat.completion.chunk",
+        created: input.created,
+        model: input.model,
+        choices: [{ index: 0, delta: input.delta, finish_reason: input.finishReason }],
+    };
+
+    return `data: ${SafeJSON.stringify(payload)}\n\n`;
+}
+
+/**
+ * Streaming: transform an Anthropic Messages SSE byte stream into an OpenAI
+ * chat.completion.chunk SSE byte stream.
+ */
+export function anthropicSseToOpenAiChatStream(
+    upstream: ReadableStream<Uint8Array>,
+    options: { model: string }
+): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = upstream.getReader();
+
+    const id = `chatcmpl-${crypto.randomUUID()}`;
+    const created = nowSeconds();
+    const model = options.model;
+
+    let buffer = "";
+    let roleEmitted = false;
+    let finishReason: string | null = null;
+    let nextToolIndex = 0;
+    const blockToToolIndex = new Map<number, number>();
+
+    function handleEvent(
+        event: Record<string, unknown>,
+        controller: ReadableStreamDefaultController<Uint8Array>
+    ): void {
+        const type = event.type;
+
+        if (type === "message_start") {
+            if (!roleEmitted) {
+                roleEmitted = true;
+                controller.enqueue(
+                    encoder.encode(chunk({ id, model, created, delta: { role: "assistant" }, finishReason: null }))
+                );
+            }
+
+            return;
+        }
+
+        if (type === "content_block_start" && isObject(event.content_block) && typeof event.index === "number") {
+            const contentBlock = event.content_block;
+
+            if (contentBlock.type === "tool_use") {
+                const toolIndex = nextToolIndex++;
+                blockToToolIndex.set(event.index, toolIndex);
+                controller.enqueue(
+                    encoder.encode(
+                        chunk({
+                            id,
+                            model,
+                            created,
+                            delta: {
+                                tool_calls: [
+                                    {
+                                        index: toolIndex,
+                                        id:
+                                            typeof contentBlock.id === "string"
+                                                ? contentBlock.id
+                                                : `call_${crypto.randomUUID()}`,
+                                        type: "function",
+                                        function: {
+                                            name: typeof contentBlock.name === "string" ? contentBlock.name : "unknown",
+                                            arguments: "",
+                                        },
+                                    },
+                                ],
+                            },
+                            finishReason: null,
+                        })
+                    )
+                );
+            }
+
+            return;
+        }
+
+        if (type === "content_block_delta" && isObject(event.delta) && typeof event.index === "number") {
+            const delta = event.delta;
+
+            if (delta.type === "text_delta" && typeof delta.text === "string") {
+                controller.enqueue(
+                    encoder.encode(chunk({ id, model, created, delta: { content: delta.text }, finishReason: null }))
+                );
+                return;
+            }
+
+            if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+                const toolIndex = blockToToolIndex.get(event.index) ?? 0;
+                controller.enqueue(
+                    encoder.encode(
+                        chunk({
+                            id,
+                            model,
+                            created,
+                            delta: {
+                                tool_calls: [
+                                    { index: toolIndex, type: "function", function: { arguments: delta.partial_json } },
+                                ],
+                            },
+                            finishReason: null,
+                        })
+                    )
+                );
+            }
+
+            return;
+        }
+
+        if (type === "message_delta" && isObject(event.delta)) {
+            const stopReason = event.delta.stop_reason;
+
+            if (typeof stopReason === "string") {
+                finishReason = mapFinishReason(stopReason);
+            }
+
+            return;
+        }
+    }
+
+    function processLine(line: string, controller: ReadableStreamDefaultController<Uint8Array>): void {
+        const trimmed = line.trimStart();
+
+        if (!trimmed.startsWith("data:")) {
+            return;
+        }
+
+        const payload = trimmed.slice("data:".length).trim();
+
+        if (payload.length === 0) {
+            return;
+        }
+
+        try {
+            const event = SafeJSON.parse(payload, { strict: true });
+
+            if (isObject(event)) {
+                handleEvent(event, controller);
+            }
+        } catch (err) {
+            logger.debug({ err, payload }, "ai-proxy: anthropic SSE line parse failed");
+        }
+    }
+
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            try {
+                const { done, value } = await reader.read();
+
+                if (done) {
+                    if (buffer.trim().length > 0) {
+                        processLine(buffer, controller);
+                        buffer = "";
+                    }
+
+                    controller.enqueue(
+                        encoder.encode(chunk({ id, model, created, delta: {}, finishReason: finishReason ?? "stop" }))
+                    );
+                    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                    controller.close();
+                    return;
+                }
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split("\n");
+                buffer = lines.pop() ?? "";
+
+                for (const line of lines) {
+                    processLine(line, controller);
+                }
+            } catch (err) {
+                logger.warn({ err }, "ai-proxy: anthropic SSE stream error");
+                controller.error(err);
+            }
+        },
+        cancel(reason) {
+            reader.cancel(reason).catch(() => {});
+        },
+    });
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import { openAiChatToAnthropicMessages } from "./openai-to-anthropic-messages";
+
+const MODEL = "claude-haiku-4-5-20251001";
+
+describe("openAiChatToAnthropicMessages", () => {
+    it("extracts system, maps roles, sets max_tokens", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                model: "martin/claude-sub/haiku",
+                messages: [
+                    { role: "system", content: "You are helpful." },
+                    { role: "user", content: "Hi" },
+                ],
+                max_tokens: 256,
+                temperature: 0.5,
+            },
+            { model: MODEL }
+        );
+
+        expect(body.model).toBe(MODEL);
+        expect(body.max_tokens).toBe(256);
+        expect(body.system).toBe("You are helpful.");
+        expect(body.temperature).toBe(0.5);
+        expect(body.messages).toEqual([{ role: "user", content: [{ type: "text", text: "Hi" }] }]);
+    });
+
+    it("defaults max_tokens when the request omits it", () => {
+        const body = openAiChatToAnthropicMessages(
+            { messages: [{ role: "user", content: "yo" }] },
+            { model: MODEL, maxTokensDefault: 1234 }
+        );
+
+        expect(body.max_tokens).toBe(1234);
+    });
+
+    it("maps assistant tool_calls to tool_use and tool results to a user tool_result turn", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    { role: "user", content: "weather?" },
+                    {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: "call_1",
+                                type: "function",
+                                function: { name: "get_weather", arguments: '{"city":"Prague"}' },
+                            },
+                        ],
+                    },
+                    { role: "tool", tool_call_id: "call_1", content: "sunny" },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[1]).toEqual({
+            role: "assistant",
+            content: [{ type: "tool_use", id: "call_1", name: "get_weather", input: { city: "Prague" } }],
+        });
+        expect(body.messages[2]).toEqual({
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "call_1", content: "sunny" }],
+        });
+    });
+
+    it("coalesces adjacent same-role turns (tool result + trailing user text)", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [{ id: "c1", type: "function", function: { name: "f", arguments: "{}" } }],
+                    },
+                    { role: "tool", tool_call_id: "c1", content: "r1" },
+                    { role: "user", content: "and now this" },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        // the tool_result user turn and the plain user turn must merge into one
+        // (the leading synthetic user turn from the first-user rule is separate)
+        const toolResultTurns = body.messages.filter(
+            (m) => m.role === "user" && m.content.some((block) => block.type === "tool_result")
+        );
+        expect(toolResultTurns).toHaveLength(1);
+        expect(toolResultTurns[0]?.content).toEqual([
+            { type: "tool_result", tool_use_id: "c1", content: "r1" },
+            { type: "text", text: "and now this" },
+        ]);
+    });
+
+    it("maps tools and tool_choice", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [{ role: "user", content: "go" }],
+                tools: [
+                    {
+                        type: "function",
+                        function: {
+                            name: "search",
+                            description: "search the web",
+                            parameters: { type: "object", properties: { q: { type: "string" } } },
+                        },
+                    },
+                ],
+                tool_choice: { type: "function", function: { name: "search" } },
+            },
+            { model: MODEL }
+        );
+
+        expect(body.tools).toEqual([
+            {
+                name: "search",
+                description: "search the web",
+                input_schema: { type: "object", properties: { q: { type: "string" } } },
+            },
+        ]);
+        expect(body.tool_choice).toEqual({ type: "tool", name: "search" });
+    });
+
+    it("maps tool_choice 'none' to Anthropic's native none while keeping tools", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [{ role: "user", content: "go" }],
+                tools: [{ type: "function", function: { name: "search", parameters: { type: "object" } } }],
+                tool_choice: "none",
+            },
+            { model: MODEL }
+        );
+
+        expect(body.tools).toHaveLength(1);
+        expect(body.tool_choice).toEqual({ type: "none" });
+    });
+
+    it("prepends a user turn when the first message is an assistant turn", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    { role: "assistant", content: "earlier reply" },
+                    { role: "user", content: "follow-up" },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[0]?.role).toBe("user");
+        expect(body.messages[1]?.role).toBe("assistant");
+    });
+
+    it("maps string and array stop to stop_sequences", () => {
+        expect(
+            openAiChatToAnthropicMessages({ messages: [{ role: "user", content: "x" }], stop: "END" }, { model: MODEL })
+                .stop_sequences
+        ).toEqual(["END"]);
+        expect(
+            openAiChatToAnthropicMessages(
+                { messages: [{ role: "user", content: "x" }], stop: ["A", "B"] },
+                { model: MODEL }
+            ).stop_sequences
+        ).toEqual(["A", "B"]);
+    });
+
+    it("falls back to _raw for tool_call arguments that only lenient JSON would accept (trailing comma)", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    { role: "user", content: "weather?" },
+                    {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: "call_1",
+                                type: "function",
+                                function: { name: "get_weather", arguments: '{"city":"Prague",}' },
+                            },
+                        ],
+                    },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[1]).toEqual({
+            role: "assistant",
+            content: [{ type: "tool_use", id: "call_1", name: "get_weather", input: { _raw: '{"city":"Prague",}' } }],
+        });
+    });
+
+    it("maps multi-part text + image_url content", () => {
+        const body = openAiChatToAnthropicMessages(
+            {
+                messages: [
+                    {
+                        role: "user",
+                        content: [
+                            { type: "text", text: "what is this" },
+                            { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+                        ],
+                    },
+                ],
+            },
+            { model: MODEL }
+        );
+
+        expect(body.messages[0]?.content).toEqual([
+            { type: "text", text: "what is this" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+        ]);
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-messages.ts
@@ -1,0 +1,404 @@
+import { SafeJSON } from "@app/utils/json";
+import { isObject } from "@app/utils/object";
+
+/**
+ * Maps an OpenAI chat-completions request body into an Anthropic
+ * `/v1/messages` request body. The proxy speaks OpenAI to its clients but the
+ * Claude subscription upstream expects the Anthropic Messages shape.
+ *
+ * Handles: system extraction (Anthropic keeps system top-level), role mapping,
+ * multi-part text/image content, assistant tool_calls → tool_use, tool-role
+ * messages → user tool_result, tool/tool_choice translation, sampling params,
+ * and coalescing of adjacent same-role turns (Anthropic requires strict
+ * alternation and rejects consecutive same-role messages).
+ */
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+export interface OpenAiChatBody {
+    model?: string;
+    messages?: unknown;
+    max_tokens?: number;
+    max_completion_tokens?: number;
+    temperature?: number;
+    top_p?: number;
+    stop?: string | string[];
+    stream?: boolean;
+    tools?: unknown;
+    tool_choice?: unknown;
+    [key: string]: unknown;
+}
+
+export interface AnthropicTextBlock {
+    type: "text";
+    text: string;
+}
+
+export interface AnthropicImageBlock {
+    type: "image";
+    source: { type: "base64"; media_type: string; data: string } | { type: "url"; url: string };
+}
+
+export interface AnthropicToolUseBlock {
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+}
+
+export interface AnthropicToolResultBlock {
+    type: "tool_result";
+    tool_use_id: string;
+    content: string | AnthropicTextBlock[];
+}
+
+export type AnthropicContentBlock =
+    | AnthropicTextBlock
+    | AnthropicImageBlock
+    | AnthropicToolUseBlock
+    | AnthropicToolResultBlock;
+
+export interface AnthropicMessage {
+    role: "user" | "assistant";
+    content: AnthropicContentBlock[];
+}
+
+export interface AnthropicTool {
+    name: string;
+    description?: string;
+    input_schema: unknown;
+}
+
+export type AnthropicToolChoice =
+    | { type: "auto" }
+    | { type: "any" }
+    | { type: "none" }
+    | { type: "tool"; name: string };
+
+export interface AnthropicMessagesBody {
+    model: string;
+    max_tokens: number;
+    system?: string;
+    messages: AnthropicMessage[];
+    temperature?: number;
+    top_p?: number;
+    stop_sequences?: string[];
+    stream?: boolean;
+    tools?: AnthropicTool[];
+    tool_choice?: AnthropicToolChoice;
+}
+
+export interface OpenAiToAnthropicOptions {
+    /** Concrete Anthropic model id to forward (e.g. claude-haiku-4-5-20251001). */
+    model: string;
+    /** max_tokens fallback when the request omits it (Anthropic requires it). */
+    maxTokensDefault?: number;
+}
+
+function textBlock(text: string): AnthropicTextBlock {
+    return { type: "text", text };
+}
+
+function imageBlockFromUrl(url: string): AnthropicImageBlock {
+    const dataUrl = /^data:([^;]+);base64,(.*)$/s.exec(url);
+
+    if (dataUrl) {
+        return {
+            type: "image",
+            source: { type: "base64", media_type: dataUrl[1] ?? "image/png", data: dataUrl[2] ?? "" },
+        };
+    }
+
+    return { type: "image", source: { type: "url", url } };
+}
+
+function contentToBlocks(content: unknown): AnthropicContentBlock[] {
+    if (typeof content === "string") {
+        return content.length > 0 ? [textBlock(content)] : [];
+    }
+
+    if (!Array.isArray(content)) {
+        return content == null ? [] : [textBlock(String(content))];
+    }
+
+    const blocks: AnthropicContentBlock[] = [];
+
+    for (const part of content) {
+        if (!isObject(part)) {
+            continue;
+        }
+
+        if (part.type === "text" && typeof part.text === "string") {
+            blocks.push(textBlock(part.text));
+            continue;
+        }
+
+        if (part.type === "image_url" && isObject(part.image_url) && typeof part.image_url.url === "string") {
+            blocks.push(imageBlockFromUrl(part.image_url.url));
+        }
+    }
+
+    return blocks;
+}
+
+function toolUseBlocksFromToolCalls(toolCalls: unknown): AnthropicToolUseBlock[] {
+    if (!Array.isArray(toolCalls)) {
+        return [];
+    }
+
+    const blocks: AnthropicToolUseBlock[] = [];
+
+    for (const call of toolCalls) {
+        if (!isObject(call)) {
+            continue;
+        }
+
+        const fn = isObject(call.function) ? call.function : {};
+        const rawArgs = typeof fn.arguments === "string" ? fn.arguments : "";
+        let input: unknown = {};
+
+        if (rawArgs.length > 0) {
+            try {
+                input = SafeJSON.parse(rawArgs, { strict: true });
+            } catch {
+                input = { _raw: rawArgs };
+            }
+        }
+
+        blocks.push({
+            type: "tool_use",
+            id: typeof call.id === "string" ? call.id : `call_${crypto.randomUUID()}`,
+            name: typeof fn.name === "string" ? fn.name : "unknown",
+            input,
+        });
+    }
+
+    return blocks;
+}
+
+function toolResultContent(content: unknown): string | AnthropicTextBlock[] {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    if (Array.isArray(content)) {
+        const parts: AnthropicTextBlock[] = [];
+
+        for (const part of content) {
+            if (isObject(part) && part.type === "text" && typeof part.text === "string") {
+                parts.push(textBlock(part.text));
+            }
+        }
+
+        if (parts.length > 0) {
+            return parts;
+        }
+    }
+
+    return SafeJSON.stringify(content ?? "");
+}
+
+function mapMessage(message: Record<string, unknown>): AnthropicMessage | null {
+    const role = message.role;
+
+    if (role === "tool" && typeof message.tool_call_id === "string") {
+        return {
+            role: "user",
+            content: [
+                {
+                    type: "tool_result",
+                    tool_use_id: message.tool_call_id,
+                    content: toolResultContent(message.content),
+                },
+            ],
+        };
+    }
+
+    if (role === "assistant") {
+        const blocks: AnthropicContentBlock[] = [
+            ...contentToBlocks(message.content),
+            ...toolUseBlocksFromToolCalls(message.tool_calls),
+        ];
+
+        if (blocks.length === 0) {
+            return null;
+        }
+
+        return { role: "assistant", content: blocks };
+    }
+
+    const blocks = contentToBlocks(message.content);
+
+    if (blocks.length === 0) {
+        return null;
+    }
+
+    return { role: "user", content: blocks };
+}
+
+/** Merge adjacent same-role turns (Anthropic rejects consecutive same-role messages). */
+function coalesce(messages: AnthropicMessage[]): AnthropicMessage[] {
+    const merged: AnthropicMessage[] = [];
+
+    for (const message of messages) {
+        const last = merged.at(-1);
+
+        if (last && last.role === message.role) {
+            last.content.push(...message.content);
+            continue;
+        }
+
+        merged.push(message);
+    }
+
+    return merged;
+}
+
+function extractSystem(messages: Record<string, unknown>[]): string | undefined {
+    const parts: string[] = [];
+
+    for (const message of messages) {
+        if (message.role !== "system" && message.role !== "developer") {
+            continue;
+        }
+
+        for (const block of contentToBlocks(message.content)) {
+            if (block.type === "text") {
+                parts.push(block.text);
+            }
+        }
+    }
+
+    return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+function mapTools(tools: unknown): AnthropicTool[] | undefined {
+    if (!Array.isArray(tools)) {
+        return undefined;
+    }
+
+    const mapped: AnthropicTool[] = [];
+
+    for (const tool of tools) {
+        if (!isObject(tool)) {
+            continue;
+        }
+
+        const fn = isObject(tool.function) ? tool.function : tool;
+        const name = typeof fn.name === "string" ? fn.name : undefined;
+
+        if (!name) {
+            continue;
+        }
+
+        mapped.push({
+            name,
+            description: typeof fn.description === "string" ? fn.description : undefined,
+            input_schema: fn.parameters ?? fn.input_schema ?? { type: "object", properties: {} },
+        });
+    }
+
+    return mapped.length > 0 ? mapped : undefined;
+}
+
+function mapToolChoice(toolChoice: unknown): AnthropicToolChoice | undefined {
+    if (toolChoice === "auto") {
+        return { type: "auto" };
+    }
+
+    if (toolChoice === "required") {
+        return { type: "any" };
+    }
+
+    if (toolChoice === "none") {
+        // Anthropic's native tool_choice "none" keeps the tools attached (so they
+        // stay visible to the model / extended thinking) but forbids calling them.
+        // Omitting it would let Anthropic default to "auto" with tools present.
+        return { type: "none" };
+    }
+
+    if (isObject(toolChoice) && toolChoice.type === "function" && isObject(toolChoice.function)) {
+        const name = toolChoice.function.name;
+
+        if (typeof name === "string") {
+            return { type: "tool", name };
+        }
+    }
+
+    return undefined;
+}
+
+export function openAiChatToAnthropicMessages(
+    body: OpenAiChatBody,
+    options: OpenAiToAnthropicOptions
+): AnthropicMessagesBody {
+    const rawMessages = Array.isArray(body.messages) ? body.messages : [];
+    const objectMessages = rawMessages.filter(isObject);
+
+    const mapped: AnthropicMessage[] = [];
+
+    for (const message of objectMessages) {
+        if (message.role === "system" || message.role === "developer") {
+            continue;
+        }
+
+        const anthropicMessage = mapMessage(message);
+
+        if (anthropicMessage) {
+            mapped.push(anthropicMessage);
+        }
+    }
+
+    const messages = coalesce(mapped);
+
+    // Anthropic requires the first message to use the "user" role. Client-side
+    // history truncation can leave an assistant turn first — prepend a minimal
+    // user turn so the request is not rejected with a 400.
+    if (messages[0]?.role === "assistant") {
+        messages.unshift({ role: "user", content: [{ type: "text", text: "(continue)" }] });
+    }
+
+    const result: AnthropicMessagesBody = {
+        model: options.model,
+        max_tokens: body.max_tokens ?? body.max_completion_tokens ?? options.maxTokensDefault ?? DEFAULT_MAX_TOKENS,
+        messages,
+    };
+
+    const system = extractSystem(objectMessages);
+
+    if (system !== undefined) {
+        result.system = system;
+    }
+
+    if (typeof body.temperature === "number") {
+        result.temperature = body.temperature;
+    }
+
+    if (typeof body.top_p === "number") {
+        result.top_p = body.top_p;
+    }
+
+    if (typeof body.stop === "string") {
+        result.stop_sequences = [body.stop];
+    } else if (Array.isArray(body.stop)) {
+        result.stop_sequences = body.stop.filter((entry): entry is string => typeof entry === "string");
+    }
+
+    if (typeof body.stream === "boolean") {
+        result.stream = body.stream;
+    }
+
+    const tools = mapTools(body.tools);
+
+    if (tools) {
+        result.tools = tools;
+
+        const toolChoice = mapToolChoice(body.tool_choice);
+
+        if (toolChoice) {
+            result.tool_choice = toolChoice;
+        }
+    }
+
+    return result;
+}

--- a/src/ai-proxy/lib/translators/index.ts
+++ b/src/ai-proxy/lib/translators/index.ts
@@ -22,7 +22,9 @@ export function shouldTranslateChatRequest({
 
     // Grok subscription chat/completions already streams Cursor-native reasoning_content.
     // Re-encoding via /responses drops role coalescing and breaks the thinking UI.
-    if (providerId === "grok-subscription") {
+    // anthropic-subscription has no Responses upstream — its chatCompletions is the
+    // only supported path, so never route it through the /responses translation.
+    if (providerId === "grok-subscription" || providerId === "anthropic-subscription") {
         return false;
     }
 

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -6,7 +6,13 @@ export type CursorTranslationMode = "auto" | "on" | "off";
 /** How Grok reasoning is presented to Cursor. */
 export type ThinkingPresentationMode = "raw" | "cursor" | "folded";
 
-export type AiProxyProviderType = "grok-subscription" | "github-copilot-subscription" | "xai-api-key" | "openai";
+export type AiProxyProviderType =
+    | "grok-subscription"
+    | "github-copilot-subscription"
+    | "xai-api-key"
+    | "openai"
+    | "anthropic-subscription"
+    | "openai-subscription";
 
 export interface AiProxyListenConfig {
     host: string;
@@ -71,6 +77,22 @@ export interface AiProxyGithubCopilotAccountConfig {
     type?: CopilotAccountType;
 }
 
+export interface AiProxyAnthropicSubAccountConfig {
+    /** Name of the anthropic-sub account in ~/.genesis-tools/ai/config.json to bill. */
+    accountName: string;
+}
+
+export interface AiProxyOpenAiSubAccountConfig {
+    /**
+     * Name of the openai-sub account in ~/.genesis-tools/ai/config.json to bill
+     * (refreshed + persisted on use). When omitted, the provider reads the token
+     * from the Codex CLI cache (~/.codex/auth.json, read-only, CLI-refreshed).
+     */
+    accountName?: string;
+    /** Override path to the Codex CLI auth.json (defaults to ~/.codex/auth.json). */
+    codexAuthPath?: string;
+}
+
 export interface AiProxyAccountConfig {
     name: string;
     label?: string;
@@ -79,6 +101,8 @@ export interface AiProxyAccountConfig {
     enabled: boolean;
     grok?: AiProxyGrokAccountConfig;
     githubCopilot?: AiProxyGithubCopilotAccountConfig;
+    anthropicSub?: AiProxyAnthropicSubAccountConfig;
+    openaiSub?: AiProxyOpenAiSubAccountConfig;
     apiKeyEnv?: string;
     baseUrl?: string;
     managementKeyEnv?: string;

--- a/src/utils/ai/anthropic/models.ts
+++ b/src/utils/ai/anthropic/models.ts
@@ -1,0 +1,97 @@
+import { logger } from "@app/logger";
+
+export interface AnthropicSubModelRecord {
+    id: string;
+    displayName: string;
+    contextWindow: number;
+    thinking: "reasoning" | "none";
+}
+
+/**
+ * Claude models served to subscription (OAuth) tokens, newest first. Verified
+ * live against GET api.anthropic.com/v1/models (2026-07-12); refresh via
+ * fetchAnthropicSubModels() when Anthropic ships a new family.
+ */
+export const ANTHROPIC_SUB_STATIC_CATALOG: AnthropicSubModelRecord[] = [
+    { id: "claude-sonnet-5", displayName: "Claude Sonnet 5", contextWindow: 1_000_000, thinking: "reasoning" },
+    { id: "claude-fable-5", displayName: "Claude Fable 5", contextWindow: 1_000_000, thinking: "reasoning" },
+    { id: "claude-opus-4-8", displayName: "Claude Opus 4.8", contextWindow: 1_000_000, thinking: "reasoning" },
+    { id: "claude-opus-4-7", displayName: "Claude Opus 4.7", contextWindow: 1_000_000, thinking: "reasoning" },
+    { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", contextWindow: 1_000_000, thinking: "reasoning" },
+    { id: "claude-opus-4-6", displayName: "Claude Opus 4.6", contextWindow: 1_000_000, thinking: "reasoning" },
+    { id: "claude-opus-4-5-20251101", displayName: "Claude Opus 4.5", contextWindow: 200_000, thinking: "reasoning" },
+    { id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5", contextWindow: 200_000, thinking: "none" },
+    {
+        id: "claude-sonnet-4-5-20250929",
+        displayName: "Claude Sonnet 4.5",
+        contextWindow: 200_000,
+        thinking: "reasoning",
+    },
+    { id: "claude-opus-4-1-20250805", displayName: "Claude Opus 4.1", contextWindow: 200_000, thinking: "reasoning" },
+];
+
+/**
+ * Short aliases advertised alongside the concrete ids — always tracking the
+ * newest model of each family. The bare `claude-haiku-4-5` is NOT served by
+ * the API; the dated id is required.
+ */
+export const ANTHROPIC_SUB_ALIASES = ["sonnet", "opus", "haiku", "fable"] as const;
+
+export type AnthropicSubAlias = (typeof ANTHROPIC_SUB_ALIASES)[number];
+
+const ANTHROPIC_SUB_ALIAS_MAP: Record<AnthropicSubAlias, string> = {
+    sonnet: "claude-sonnet-5",
+    opus: "claude-opus-4-8",
+    haiku: "claude-haiku-4-5-20251001",
+    fable: "claude-fable-5",
+};
+
+/**
+ * Resolve an alias to its concrete Anthropic model id. Unknown values pass
+ * through unchanged so a caller can also request a concrete id directly.
+ */
+export function resolveAnthropicSubModel(alias: string): string {
+    return ANTHROPIC_SUB_ALIAS_MAP[alias as AnthropicSubAlias] ?? alias;
+}
+
+/** The models list endpoint returns no context size — infer from the family. */
+export function inferAnthropicContextWindow(id: string): number {
+    return /sonnet-5|fable-5|opus-4-[678]|sonnet-4-6/.test(id) ? 1_000_000 : 200_000;
+}
+
+interface AnthropicModelsResponse {
+    data: Array<{ id: string; display_name: string }>;
+}
+
+/**
+ * Live model list for a subscription OAuth token. Falls back to the static
+ * catalog on any failure so callers always get a usable list.
+ */
+export async function fetchAnthropicSubModels(token: string): Promise<AnthropicSubModelRecord[]> {
+    try {
+        const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": "oauth-2025-04-20",
+            },
+            signal: AbortSignal.timeout(5_000),
+        });
+
+        if (!res.ok) {
+            throw new Error(`GET /v1/models returned ${res.status}`);
+        }
+
+        const data = (await res.json()) as AnthropicModelsResponse;
+
+        return data.data.map((m) => ({
+            id: m.id,
+            displayName: m.display_name,
+            contextWindow: inferAnthropicContextWindow(m.id),
+            thinking: m.id.includes("haiku") ? "none" : "reasoning",
+        }));
+    } catch (err) {
+        logger.debug({ err }, "anthropic: live model fetch failed, using static catalog");
+        return ANTHROPIC_SUB_STATIC_CATALOG;
+    }
+}

--- a/src/utils/ai/openai/codex-auth.ts
+++ b/src/utils/ai/openai/codex-auth.ts
@@ -286,3 +286,61 @@ export class CodexOAuthClient {
 }
 
 export const codexOAuth = new CodexOAuthClient();
+
+export interface ResolvedCodexToken {
+    token: string;
+    accountId?: string;
+}
+
+/**
+ * Canonical "give me a usable access token for a named `openai-sub` account"
+ * — mirrors resolveAccountToken() in utils/claude/subscription-auth.
+ *
+ * Codex rotates the refresh token on every refresh (single-use), so N
+ * concurrent expired callers must not each POST the same token — the losers
+ * get invalid_grant and the whole grant dies. The refresh is serialized with
+ * the cross-process AI-config lock, re-read inside the lock, and
+ * short-circuits if another caller/process already refreshed while waiting.
+ */
+export async function resolveCodexAccountToken(accountName: string): Promise<ResolvedCodexToken> {
+    const { AIConfig } = await import("../AIConfig");
+    const config = await AIConfig.load();
+    const entry = config.getAccount(accountName);
+
+    if (!entry) {
+        throw new Error(`openai-sub account "${accountName}" not found in AI config.`);
+    }
+
+    let accessToken = entry.tokens.accessToken;
+
+    if (!accessToken) {
+        throw new Error(`No access token for openai-sub account "${accountName}". Run \`tools ask config\`.`);
+    }
+
+    if (entry.tokens.expiresAt && codexOAuth.needsRefresh(entry.tokens.expiresAt)) {
+        accessToken = await config.withLock(async (data) => {
+            const acc = data.accounts.find((a) => a.name === accountName);
+
+            if (!acc) {
+                throw new Error(`openai-sub account "${accountName}" not found in AI config.`);
+            }
+
+            if (acc.tokens.expiresAt && !codexOAuth.needsRefresh(acc.tokens.expiresAt) && acc.tokens.accessToken) {
+                return acc.tokens.accessToken;
+            }
+
+            if (!acc.tokens.refreshToken) {
+                throw new Error(`Token for "${accountName}" is expired and no refresh token is available.`);
+            }
+
+            const refreshed = await codexOAuth.refresh(acc.tokens.refreshToken);
+            acc.tokens.accessToken = refreshed.accessToken;
+            acc.tokens.refreshToken = refreshed.refreshToken;
+            acc.tokens.expiresAt = refreshed.expiresAt;
+
+            return refreshed.accessToken;
+        });
+    }
+
+    return { token: accessToken, accountId: extractAccountId(accessToken) };
+}

--- a/src/utils/ai/openai/sub-models.ts
+++ b/src/utils/ai/openai/sub-models.ts
@@ -1,0 +1,85 @@
+import { logger } from "@app/logger";
+import { WHAM_BASE_URL } from "./codex-auth";
+
+export interface WhamModelRecord {
+    slug: string;
+    displayName: string;
+    contextWindow: number;
+    visibility: "list" | "hide";
+    inputModalities?: string[];
+    supportsParallelToolCalls?: boolean;
+}
+
+/**
+ * Codex/ChatGPT (WHAM backend) models, newest first. Verified live against
+ * GET wham/models (2026-07-12, plan "plus"); refresh via fetchWhamModels().
+ * `gpt-5-codex` is not served on Plus but higher plans do serve it —
+ * unsupported ids surface WHAM's own 400 to the caller.
+ */
+export const OPENAI_SUB_STATIC_CATALOG: WhamModelRecord[] = [
+    { slug: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", contextWindow: 372_000, visibility: "list" },
+    { slug: "gpt-5.6-terra", displayName: "GPT-5.6-Terra", contextWindow: 372_000, visibility: "list" },
+    { slug: "gpt-5.6-luna", displayName: "GPT-5.6-Luna", contextWindow: 372_000, visibility: "list" },
+    { slug: "gpt-5.5", displayName: "GPT-5.5", contextWindow: 272_000, visibility: "list" },
+    { slug: "gpt-5.4", displayName: "GPT-5.4", contextWindow: 272_000, visibility: "list" },
+    { slug: "gpt-5.4-mini", displayName: "GPT-5.4-Mini", contextWindow: 272_000, visibility: "list" },
+    { slug: "gpt-5-codex", displayName: "GPT-5-Codex", contextWindow: 272_000, visibility: "list" },
+];
+
+/** Codex model ids are already concrete; unknown values pass through unchanged. */
+export function resolveOpenAiSubModel(id: string): string {
+    return id;
+}
+
+const WHAM_CLIENT_VERSION = "1.0.26";
+
+interface WhamModelsResponse {
+    models: Array<{
+        slug: string;
+        display_name: string;
+        context_window: number;
+        visibility: "list" | "hide";
+        input_modalities?: string[];
+        supports_parallel_tool_calls?: boolean;
+    }>;
+}
+
+/**
+ * Live model list from the WHAM `/models` endpoint (non-standard schema).
+ * Falls back to the static catalog on any failure so callers always get a
+ * usable list.
+ */
+export async function fetchWhamModels(accessToken: string, accountId?: string): Promise<WhamModelRecord[]> {
+    try {
+        const headers: Record<string, string> = {
+            Authorization: `Bearer ${accessToken}`,
+        };
+
+        if (accountId) {
+            headers["ChatGPT-Account-Id"] = accountId;
+        }
+
+        const res = await fetch(`${WHAM_BASE_URL}/models?client_version=${WHAM_CLIENT_VERSION}`, {
+            headers,
+            signal: AbortSignal.timeout(5_000),
+        });
+
+        if (!res.ok) {
+            throw new Error(`WHAM /models returned ${res.status}`);
+        }
+
+        const data = (await res.json()) as WhamModelsResponse;
+
+        return data.models.map((m) => ({
+            slug: m.slug,
+            displayName: m.display_name,
+            contextWindow: m.context_window,
+            visibility: m.visibility,
+            inputModalities: m.input_modalities,
+            supportsParallelToolCalls: m.supports_parallel_tool_calls,
+        }));
+    } catch (err) {
+        logger.debug({ err }, "codex: live WHAM model fetch failed, using static catalog");
+        return OPENAI_SUB_STATIC_CATALOG;
+    }
+}

--- a/src/utils/ai/resolvers/OpenAISubResolver.ts
+++ b/src/utils/ai/resolvers/OpenAISubResolver.ts
@@ -1,88 +1,59 @@
-import { logger } from "@app/logger";
 import type { AIProvider } from "@app/utils/config/ai.types";
 import type { DetectedProvider, ModelInfo } from "@ask/types";
 import type { AccountResolver } from "./index";
-
-/** WHAM /models response schema (differs from standard OpenAI API) */
-interface WhamModel {
-    slug: string;
-    display_name: string;
-    context_window: number;
-    visibility: "list" | "hide";
-    input_modalities?: string[];
-    supports_parallel_tool_calls?: boolean;
-}
-
-interface WhamModelsResponse {
-    models: WhamModel[];
-}
-
-const WHAM_CLIENT_VERSION = "1.0.26";
 
 export class OpenAISubResolver implements AccountResolver {
     readonly providerType: AIProvider = "openai-sub";
 
     async resolve(accountName: string): Promise<DetectedProvider> {
+        const { resolveCodexAccountToken, WHAM_BASE_URL } = await import("../openai/codex-auth");
+        const { token, accountId } = await resolveCodexAccountToken(accountName);
+
         const { AIConfig } = await import("../AIConfig");
         const config = await AIConfig.load();
         const entry = config.getAccount(accountName);
 
-        if (!entry) {
-            throw new Error(`Account "${accountName}" not found in AI config.`);
-        }
-
-        let accessToken = entry.tokens.accessToken;
-        const refreshToken = entry.tokens.refreshToken;
-
-        if (!accessToken) {
-            throw new Error(
-                `No access token for OpenAI subscription account "${accountName}". ` +
-                    `Run \`tools ask config\` → Add account → OpenAI/Codex.`
-            );
-        }
-
-        // Refresh if expired
-        const { codexOAuth, extractAccountId, WHAM_BASE_URL } = await import("../openai/codex-auth");
-
-        if (entry.tokens.expiresAt && codexOAuth.needsRefresh(entry.tokens.expiresAt)) {
-            if (!refreshToken) {
-                throw new Error(
-                    `Token for "${accountName}" is expired and no refresh token is available. ` +
-                        `Run \`tools ask config\` and re-authenticate.`
-                );
-            }
-
-            const refreshed = await codexOAuth.refresh(refreshToken);
-
-            await config.mutate((data) => {
-                const acc = data.accounts.find((a) => a.name === accountName);
-
-                if (acc) {
-                    acc.tokens.accessToken = refreshed.accessToken;
-                    acc.tokens.refreshToken = refreshed.refreshToken;
-                    acc.tokens.expiresAt = refreshed.expiresAt;
-                }
-            });
-
-            accessToken = refreshed.accessToken;
-        }
-
-        const accountId = extractAccountId(accessToken);
-
         const { createOpenAI } = await import("@ai-sdk/openai");
         const provider = createOpenAI({
-            apiKey: accessToken,
+            apiKey: token,
             baseURL: WHAM_BASE_URL,
             headers: accountId ? { "ChatGPT-Account-Id": accountId } : undefined,
         });
 
-        // Fetch live models from WHAM (non-standard schema)
-        const models = await this.fetchWhamModels(accessToken, accountId, WHAM_BASE_URL);
+        const { fetchWhamModels } = await import("../openai/sub-models");
+        const records = await fetchWhamModels(token, accountId);
+
+        const models: ModelInfo[] = records
+            .filter((record) => record.visibility === "list")
+            .map((record) => {
+                const capabilities: string[] = ["chat"];
+
+                if (record.inputModalities?.includes("image")) {
+                    capabilities.push("vision");
+                }
+
+                if (record.supportsParallelToolCalls) {
+                    capabilities.push("function-calling");
+                }
+
+                if (record.slug.includes("codex")) {
+                    capabilities.push("code");
+                }
+
+                return {
+                    id: record.slug,
+                    name: record.displayName,
+                    contextWindow: record.contextWindow,
+                    capabilities,
+                    provider: "openai",
+                    category: record.slug.includes("mini") ? "mini" : "standard",
+                };
+            });
 
         return {
             name: "openai",
             type: "openai-sub",
-            key: `${accessToken.slice(0, 20)}...`,
+            key: `${token.slice(0, 20)}...`,
             provider,
             models,
             config: {
@@ -91,79 +62,7 @@ export class OpenAISubResolver implements AccountResolver {
                 envKey: "",
                 priority: 1,
             },
-            account: { name: entry.name, label: entry.label },
+            account: { name: entry?.name ?? accountName, label: entry?.label },
         };
-    }
-
-    private async fetchWhamModels(
-        accessToken: string,
-        accountId: string | undefined,
-        baseURL: string
-    ): Promise<ModelInfo[]> {
-        try {
-            const headers: Record<string, string> = {
-                Authorization: `Bearer ${accessToken}`,
-            };
-
-            if (accountId) {
-                headers["ChatGPT-Account-Id"] = accountId;
-            }
-
-            const res = await fetch(`${baseURL}/models?client_version=${WHAM_CLIENT_VERSION}`, { headers });
-
-            if (!res.ok) {
-                throw new Error(`WHAM /models returned ${res.status}`);
-            }
-
-            const data = (await res.json()) as WhamModelsResponse;
-
-            return data.models
-                .filter((m) => m.visibility === "list")
-                .map((m) => {
-                    const capabilities: string[] = ["chat"];
-
-                    if (m.input_modalities?.includes("image")) {
-                        capabilities.push("vision");
-                    }
-
-                    if (m.supports_parallel_tool_calls) {
-                        capabilities.push("function-calling");
-                    }
-
-                    if (m.slug.includes("codex")) {
-                        capabilities.push("code");
-                    }
-
-                    return {
-                        id: m.slug,
-                        name: m.display_name,
-                        contextWindow: m.context_window,
-                        capabilities,
-                        provider: "openai",
-                        category: m.slug.includes("mini") ? "mini" : "standard",
-                    };
-                });
-        } catch (err) {
-            logger.warn(`Failed to fetch WHAM models: ${err}`);
-            // Fallback to a minimal known set
-            return [
-                {
-                    id: "gpt-5.4",
-                    name: "gpt-5.4",
-                    contextWindow: 272000,
-                    capabilities: ["chat", "vision", "function-calling"],
-                    provider: "openai",
-                    category: "standard",
-                },
-                {
-                    id: "gpt-5.4-mini",
-                    name: "GPT-5.4-Mini",
-                    contextWindow: 272000,
-                    capabilities: ["chat", "vision", "function-calling"],
-                    provider: "openai",
-                    category: "mini",
-                },
-            ];
-        }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Supersedes #243 — original was merged prematurely (stacked-base mishap); master was reset. Branch restored at its pre-merge state.

## What

Adds two subscription providers to the local `ai-proxy` so eve (and Cursor, and anything OpenAI-compatible) can bill the owner's Claude / Codex subscriptions instead of an API key. **Both parts done + live-verified against real APIs.**

Executes Part 1 of `.claude/plans/2026-07-11-EveP0-AiProxySubsAndVpsService.md`.

## Part 1 — `anthropic-subscription` (Claude Max)

- **A1** — extended `AiProxyProviderType` (+`anthropic-subscription`, +`openai-subscription`), added `AiProxyAnthropicSubAccountConfig` / `AiProxyOpenAiSubAccountConfig` + `anthropicSub?`/`openaiSub?` on `AiProxyAccountConfig`, wired into `accountConfigFingerprint`.
- **A2** — new OpenAI↔Anthropic mappers under `src/ai-proxy/lib/translators/formats/anthropic/` (the only genuinely new logic, TDD'd): request (`openai-to-anthropic-messages.ts`) + response non-streaming & streaming SSE (`anthropic-to-openai-completions.ts`). 12 unit tests.
- **A3** — `AnthropicSubscriptionProvider` + `anthropic-sub-models.ts` alias map, registry + `/v1/models` catalog wiring, Cursor-translation exclusion (mirrors grok). Token via `resolveAccountToken(anthropicSub.accountName)`; upstream via the existing Claude Code spoof (`createSubscriptionFetch()` → Bearer OAuth + billing header + beta flags + Claude Code system prefix) to `api.anthropic.com/v1/messages`.

Aliases (verified live via `GET /v1/models`): `sonnet`→`claude-sonnet-4-6`, `opus`→`claude-opus-4-6`, `haiku`→`claude-haiku-4-5-20251001`, `fable`→`claude-fable-5`.

## Part 1b — `openai-subscription` (Codex / ChatGPT)

- **B1** — `OpenAiSubscriptionProvider` + `openai-sub-models.ts` + `openai-sub-token.ts`, registry + catalog wiring. Upstream = ChatGPT **WHAM** Responses API (`chatgpt.com/backend-api/wham/responses`, streaming-only). `responses()` converts a chat/responses body → WHAM Responses request (system→instructions, messages→input, forces `stream:true`+`store:false`, maps tools) and forwards with the Codex headers; `chatCompletions()` delegates to the existing `responsesToChat` translator. Non-streaming callers get an SSE→Responses-JSON accumulation (WHAM's `response.completed` output is empty; text is reassembled from `output_text.delta`).
- Token source: named `openai-sub` account (refresh+persist) or the Codex CLI cache `~/.codex/auth.json` (read-only) when `accountName` is omitted.
- Models: `gpt-5.5` (verified serving on a "plus" account) + `gpt-5-codex` (served on Pro).

## Verification

- `bun test src/ai-proxy` — **109/109 pass**. `tsgo --noEmit` — 0 ai-proxy errors. Pre-push CI mirror (biome + full typecheck) green.
- **Live Claude Max (real spend):** `/v1/models` lists the four `claude/claude-sub/*` ids; `claude/claude-sub/haiku` → `PROXY_OK`; streaming produces a clean `chat.completion.chunk` flow; logs confirm upstream `api.anthropic.com/v1/messages` resolving `haiku`→`claude-haiku-4-5-20251001`.
- **Live Codex/ChatGPT (real spend):** a read-only probe with the Codex CLI token proved the plain Responses forward works (no app-server handshake needed). `/v1/models` lists `codex/codex/{gpt-5.5,gpt-5-codex}`; `codex/codex/gpt-5.5` → `CODEX_PROXY_OK`; streaming works; logs confirm the WHAM upstream.
- All live tests ran on a throwaway port against a temporary account; the shared ai-proxy config and the running proxy were left untouched (config backed up + restored).

## Deviations

- `anthropic-subscription.responses()` returns HTTP 400 — Claude has no Responses API; the provider is excluded from Cursor request-translation so it always uses `/v1/chat/completions`.
- `/v1/models` needed a `buildProxyModelCatalog` branch in addition to the registry (separate path from `provider.listModels()`).
- B1 added a `~/.codex/auth.json` token source (made `openaiSub.accountName` optional) — the ai-config `openai-sub` token was expired and its config is read-only; the CLI cache is a fresh read-only source ideal for a local proxy.

Base: `feat/ai-sdk-7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Anthropic Claude subscription support, including model aliases, streaming, tool calls, and OpenAI-compatible chat completions.
  * Added OpenAI ChatGPT/Codex subscription support for chat completions and Responses API requests, including streaming.
  * Added subscription model discovery, account configuration, token loading, and automatic token refresh.
  * Added fallback model catalogs and expanded proxy documentation.

* **Bug Fixes**
  * Client disconnects are now handled without being reported as upstream failures.
  * Improved request and response translation between OpenAI-compatible formats and subscription providers.

* **Tests**
  * Added coverage for streaming, tool calls, authentication refresh, model metadata, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
