### PR TITLE
feat(claude,boards): claude.com OAuth migration, logout/login-secondary/keychain, boards UI polish

### DIFF
--- a/.claude/commands/learn-from-fable.md
+++ b/.claude/commands/learn-from-fable.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Agent
 
 Incrementally mine local Claude Code transcripts of `claude-fable-5` sessions and distill them into the **Fable Pack**, so weaker models (Sonnet/Opus/Haiku) inherit Fable's *procedure*: how it plans, sequences commands, verifies before claiming done, reports outcomes, and recovers from errors.
 
-Research & rationale behind this design: `/Users/Martin/Tresors/Projects/GenesisBrain/Claude/Fable/2026-07-08-PreserveFable5Style.md`
+Research & rationale behind this design (author's local vault note, not committed to this repo): `/Users/Martin/Tresors/Projects/GenesisBrain/Claude/Fable/2026-07-08-PreserveFable5Style.md`
 
 **Arguments** (`$ARGUMENTS`): first numeric token = max sessions to mine this run (call it **MAX**; default **3**). `--archive-only` = run Stages 0–1 only. `--repack` = skip mining, regenerate the skill from the existing spec (Stages 0 + 5 + 6 only).
 

--- a/plugins/genesis-tools/skills/improve-agents-md/SKILL.md
+++ b/plugins/genesis-tools/skills/improve-agents-md/SKILL.md
@@ -111,7 +111,7 @@ Write one question per testable claim. Rules for good questions:
 
 **FALLBACK (older versions / canary failure / non-Claude harnesses):** hide the **entire detected set** from Phase 0 — not just the user-global file — with a trap-guaranteed restore. The bundled wrapper owns that dangerous part:
 
-```
+```bash
 <skill-dir>/scripts/with-hidden-instructions.sh <file1> <file2> ... -- <command...>
 ```
 

--- a/plugins/genesis-tools/skills/improve-agents-md/scripts/with-hidden-instructions.sh
+++ b/plugins/genesis-tools/skills/improve-agents-md/scripts/with-hidden-instructions.sh
@@ -32,7 +32,14 @@ done_marker=""
 # --- parse leading options ---
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --done-marker) done_marker="$2"; shift 2 ;;
+    --done-marker)
+      if [[ $# -lt 2 || "$2" == "--" ]]; then
+        emit "--done-marker requires a path"
+        exit 2
+      fi
+      done_marker="$2"
+      shift 2
+      ;;
     --) shift; break ;;   # no files, straight to command (unusual but allowed)
     -*) emit "unknown option: $1"; exit 2 ;;
     *) break ;;           # first non-option => start of file list
@@ -69,7 +76,12 @@ restore() {
   for (( i = 1; i <= ${#hidden_src[@]}; i++ )); do
     src="${hidden_src[$i]}"; dst="${hidden_dst[$i]}"
     if [[ -e "$dst" ]]; then
-      if ! mv "$dst" "$src" 2>/dev/null; then
+      if [[ -e "$src" || -L "$src" ]]; then
+        emit "FATAL refusing to overwrite recreated $src; recover from $dst"
+        restore_failed=1
+        continue
+      fi
+      if ! mv -- "$dst" "$src" 2>/dev/null; then
         emit "WARN failed to restore $src"
         restore_failed=1
       fi
@@ -77,8 +89,27 @@ restore() {
   done
 }
 
+# zsh signal traps run the handler then CONTINUE execution — unlike EXIT, a
+# bare 'restore' on INT/TERM/HUP would restore files and then fall through to
+# running (or resuming) the command with instructions visible. Each signal
+# handler must exit itself after restoring.
+on_signal() {
+  # NOTE: do not name this local 'status' — zsh reserves $status as a
+  # read-only alias for $?, and `local status=...` errors at runtime.
+  local sig_exit="$1"
+  restore
+  trap - EXIT INT TERM HUP
+  if (( restore_failed )); then
+    exit 3
+  fi
+  exit "$sig_exit"
+}
+
 # trap must be armed BEFORE any mv so a kill during hide still restores.
-trap 'restore' EXIT INT TERM HUP
+trap 'restore' EXIT
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
+trap 'on_signal 129' HUP
 
 # A hide failure is FATAL, not a warning: running the command with an instruction
 # file still in place would break the "physical exclusion" contamination proof the
@@ -89,7 +120,10 @@ hide_failed=0
 for f in "${files[@]}"; do
   if [[ -f "$f" ]]; then
     dst="${f}${suffix}"
-    if mv "$f" "$dst" 2>/dev/null; then
+    if [[ -e "$dst" || -L "$dst" ]]; then
+      emit "FATAL hidden destination already exists: $dst"
+      hide_failed=1
+    elif mv -- "$f" "$dst" 2>/dev/null; then
       hidden_src+=("$f"); hidden_dst+=("$dst")
       emit "hid $f"
     else
@@ -137,7 +171,10 @@ fi
 
 # --- done marker only after a clean restore ---
 if [[ -n "$done_marker" ]]; then
-  print -r -- "done status=$cmd_status" > "$done_marker"
+  if ! print -r -- "done status=$cmd_status" > "$done_marker"; then
+    emit "FATAL could not write done marker: $done_marker"
+    exit 3
+  fi
 fi
 
 exit $cmd_status

--- a/src/boards/lib/client.ts
+++ b/src/boards/lib/client.ts
@@ -51,13 +51,19 @@ export interface HttpResult<T> {
 /** Low-level request — never throws on a non-2xx status, so callers that need to
  *  branch on the status code (409 conflicts, transport-error backoff) can inspect it. */
 export async function rawRequest<T>(base: string, path: string, init?: RequestInit): Promise<HttpResult<T>> {
+    const signal = init?.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+
     let res: Response;
     try {
         res = await fetch(`${base}${path}`, {
             ...init,
-            signal: init?.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+            signal,
         });
     } catch (err) {
+        if (signal.aborted) {
+            throw new Error(`boards request aborted (${init?.method ?? "GET"} ${base}${path})`);
+        }
+
         const msg = err instanceof Error ? err.message : String(err);
         throw new Error(
             `boards: cannot reach dev-dashboard at ${base} (${init?.method ?? "GET"} ${path}: ${msg}). ` +

--- a/src/cc/index.ts
+++ b/src/cc/index.ts
@@ -12,6 +12,8 @@ const SUBCOMMANDS = new Set([
     "migrate",
     "login",
     "login-long",
+    "login-secondary",
+    "logout",
     "start",
     "run",
 ]);

--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -22,7 +22,7 @@ function maskToken(token: string): string {
     return `${token.slice(0, 20)}...`;
 }
 
-async function generateAuthUrl(): Promise<string> {
+export async function generateAuthUrl(): Promise<string> {
     const spinner = p.spinner();
     spinner.start("Generating authorization URL...");
     const authUrl = await claudeOAuth.startLogin();
@@ -30,7 +30,7 @@ async function generateAuthUrl(): Promise<string> {
     return authUrl;
 }
 
-async function presentAuthUrl(authUrl: string): Promise<void> {
+export async function presentAuthUrl(authUrl: string): Promise<void> {
     p.note(
         [
             "1. Open the URL below in your browser",
@@ -63,7 +63,7 @@ async function presentAuthUrl(authUrl: string): Promise<void> {
     }
 }
 
-async function promptAndExchangeCode(): Promise<Awaited<ReturnType<typeof claudeOAuth.exchangeCode>> | null> {
+export async function promptAndExchangeCode(): Promise<Awaited<ReturnType<typeof claudeOAuth.exchangeCode>> | null> {
     const code = await p.text({
         message: "Paste the authorization code:",
         placeholder: "code#state",
@@ -90,7 +90,7 @@ async function promptAndExchangeCode(): Promise<Awaited<ReturnType<typeof claude
     }
 }
 
-async function fetchAndDisplayProfile(
+export async function fetchAndDisplayProfile(
     tokens: Awaited<ReturnType<typeof claudeOAuth.exchangeCode>>
 ): Promise<Awaited<ReturnType<typeof fetchOAuthProfile>>> {
     const spinner = p.spinner();
@@ -830,22 +830,25 @@ export function registerConfigCommand(program: Command): void {
             }
             out.println();
 
-            // Read code from stdin
-            process.stdout.write("Paste authorization code: ");
-            const reader = Bun.stdin.stream().getReader();
-            let value: Uint8Array | undefined;
-            try {
-                const result = await reader.read();
-                value = result.value;
-            } finally {
-                reader.releaseLock();
-            }
-            const code = new TextDecoder().decode(value ?? new Uint8Array()).trim();
+            // clack's confirm above pauses stdin on completion — a manual
+            // Bun.stdin.stream() read after it returns instant EOF and kills
+            // the flow. Stay on clack for the code paste.
+            const codeInput = await p.text({
+                message: "Paste authorization code:",
+                placeholder: "code#state",
+                validate: (val) => {
+                    if (!val?.trim()) {
+                        return "Code is required";
+                    }
+                },
+            });
 
-            if (!code) {
-                out.error(pc.red("No code provided."));
-                process.exit(1);
+            if (p.isCancel(codeInput)) {
+                out.println(pc.dim("Login cancelled."));
+                process.exit(0);
             }
+
+            const code = (codeInput as string).trim();
 
             // Exchange code
             out.println(pc.dim("Exchanging code for tokens..."));

--- a/src/claude/commands/login-secondary.ts
+++ b/src/claude/commands/login-secondary.ts
@@ -1,0 +1,154 @@
+import { out } from "@app/logger";
+import { AIConfig } from "@app/utils/ai/AIConfig";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import type { AIAccountEntry, AISecondaryLogin } from "@app/utils/config/ai.types";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { fetchAndDisplayProfile, generateAuthUrl, presentAuthUrl, promptAndExchangeCode } from "./config";
+
+function maskToken(token: string): string {
+    if (token.length < 24) {
+        return "****";
+    }
+    return `${token.slice(0, 16)}…${token.slice(-4)}`;
+}
+
+async function pickAccount(accounts: AIAccountEntry[]): Promise<string | null> {
+    const picked = await p.select({
+        message: "Attach the secondary login to which account?",
+        options: accounts.map((acc) => ({
+            value: acc.name,
+            label: acc.label ? `${acc.name} ${pc.dim(`(${acc.label})`)}` : acc.name,
+            hint: acc.secondary ? pc.yellow("has secondary login — will overwrite") : undefined,
+        })),
+    });
+
+    if (p.isCancel(picked)) {
+        return null;
+    }
+
+    return picked as string;
+}
+
+export function registerLoginSecondaryCommand(program: Command): void {
+    program
+        .command("login-secondary [name]")
+        .description(
+            "OAuth login stored as a SECONDARY token set on an account — a separate grant used by " +
+                "`tools claude start <name> --keychain`, never by usage polling"
+        )
+        .action(async (name?: string) => {
+            if (!isInteractive()) {
+                out.error(pc.red("login-secondary requires an interactive terminal (code paste)."));
+                process.exit(1);
+            }
+
+            const aiConfig = await AIConfig.load();
+            const accounts = aiConfig.getAccountsByProvider("anthropic-sub");
+
+            if (accounts.length === 0) {
+                out.error(pc.red("No Claude accounts configured. Run `tools claude login` first."));
+                process.exit(1);
+            }
+
+            let accountName = name;
+
+            if (accountName) {
+                if (!aiConfig.getAccount(accountName)) {
+                    out.error(pc.red(`Account "${accountName}" not found.`));
+                    out.printlnErr(pc.dim(`Known: ${accounts.map((a) => a.name).join(", ")}`));
+                    process.exit(1);
+                }
+            } else {
+                const picked = await pickAccount(accounts);
+                if (!picked) {
+                    p.cancel("Cancelled");
+                    process.exit(0);
+                }
+
+                accountName = picked;
+            }
+
+            const account = accounts.find((a) => a.name === accountName)!;
+
+            p.intro(pc.bgCyan(pc.black(` secondary login → ${accountName} `)));
+            p.log.info(
+                `The account's primary tokens (usage polling) and long-lived token stay untouched.\n` +
+                    `${pc.dim("Log into the matching Anthropic account in the browser before authorizing.")}`
+            );
+
+            if (account.secondary) {
+                const overwrite = await p.confirm({
+                    message:
+                        `"${accountName}" already has a secondary login ` +
+                        `(${maskToken(account.secondary.accessToken)}${account.secondary.emailAddress ? `, ${account.secondary.emailAddress}` : ""}). Overwrite?`,
+                    initialValue: false,
+                });
+
+                if (p.isCancel(overwrite) || !overwrite) {
+                    p.cancel("Cancelled");
+                    process.exit(0);
+                }
+            }
+
+            const authUrl = await generateAuthUrl();
+            await presentAuthUrl(authUrl);
+
+            const tokens = await promptAndExchangeCode();
+            if (!tokens) {
+                p.cancel("Cancelled — no tokens retrieved.");
+                process.exit(0);
+            }
+
+            const profile = await fetchAndDisplayProfile(tokens);
+
+            // Guard the sync-back match key: an unexpected identity here would
+            // route future keychain rotations to the wrong account.
+            if (
+                account.secondary?.accountUuid &&
+                tokens.account?.uuid &&
+                account.secondary.accountUuid !== tokens.account.uuid
+            ) {
+                const proceed = await p.confirm({
+                    message:
+                        `This grant belongs to ${tokens.account.email ?? tokens.account.uuid}, but the previous ` +
+                        `secondary login was a DIFFERENT Anthropic account. Save anyway?`,
+                    initialValue: false,
+                });
+
+                if (p.isCancel(proceed) || !proceed) {
+                    p.cancel("Cancelled — nothing saved.");
+                    process.exit(0);
+                }
+            }
+
+            const subscriptionType = profile?.account.has_claude_max
+                ? "max"
+                : profile?.account.has_claude_pro
+                  ? "pro"
+                  : null;
+
+            const secondary: AISecondaryLogin = {
+                accessToken: tokens.accessToken,
+                refreshToken: tokens.refreshToken,
+                expiresAt: tokens.expiresAt,
+                scopes: tokens.scopes,
+                subscriptionType,
+                rateLimitTier: profile?.organization.rate_limit_tier ?? null,
+                accountUuid: tokens.account?.uuid,
+                emailAddress: tokens.account?.email,
+                organizationUuid: tokens.organization?.uuid,
+            };
+
+            await aiConfig.updateAccount(accountName, { secondary });
+
+            p.log.success(
+                `Secondary login saved to "${accountName}" (${maskToken(tokens.accessToken)}` +
+                    `${tokens.account?.email ? `, ${tokens.account.email}` : ""}).`
+            );
+            p.outro(
+                `Launch with it: ${pc.cyan(suggestCommand(`tools cc run ${accountName}`, { add: ["--keychain"] }))}`
+            );
+        });
+}

--- a/src/claude/commands/logout.ts
+++ b/src/claude/commands/logout.ts
@@ -152,7 +152,7 @@ export function registerLogoutCommand(program: Command): void {
             let accountName = name;
 
             if (accountName) {
-                if (!aiConfig.getAccount(accountName)) {
+                if (!accounts.some((a) => a.name === accountName)) {
                     out.error(pc.red(`Account "${accountName}" not found.`));
                     out.printlnErr(pc.dim(`Known: ${accounts.map((a) => a.name).join(", ")}`));
                     process.exit(1);

--- a/src/claude/commands/logout.ts
+++ b/src/claude/commands/logout.ts
@@ -1,0 +1,265 @@
+import { out } from "@app/logger";
+import { AIConfig } from "@app/utils/ai/AIConfig";
+import { isInteractive, suggestCommand } from "@app/utils/cli";
+import type { AIAccountEntry, AIAccountTokens } from "@app/utils/config/ai.types";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+type LogoutScope = "oauth" | "long" | "both";
+
+interface LogoutOptions {
+    oauth?: boolean;
+    longLived?: boolean;
+    both?: boolean;
+    yes?: boolean;
+}
+
+function maskToken(token: string): string {
+    if (token.length < 24) {
+        return "****";
+    }
+    return `${token.slice(0, 16)}…${token.slice(-4)}`;
+}
+
+function hasOAuthPair(acc: AIAccountEntry): boolean {
+    return Boolean(acc.tokens.accessToken || acc.tokens.refreshToken);
+}
+
+function tokenInventory(acc: AIAccountEntry): string {
+    const parts: string[] = [];
+
+    if (hasOAuthPair(acc)) {
+        parts.push("oauth");
+    }
+
+    if (acc.tokens.longLivedToken) {
+        parts.push("long-lived");
+    }
+
+    return parts.length > 0 ? parts.join(" + ") : "no tokens";
+}
+
+function scopeFromFlags(opts: LogoutOptions): LogoutScope | undefined {
+    if (opts.both) {
+        return "both";
+    }
+
+    if (opts.oauth && opts.longLived) {
+        return "both";
+    }
+
+    if (opts.oauth) {
+        return "oauth";
+    }
+
+    if (opts.longLived) {
+        return "long";
+    }
+
+    return undefined;
+}
+
+function describeScope(scope: LogoutScope, acc: AIAccountEntry): string[] {
+    const lines: string[] = [];
+
+    if (scope === "oauth" || scope === "both") {
+        const access = acc.tokens.accessToken ? maskToken(acc.tokens.accessToken) : pc.dim("none");
+        const refresh = acc.tokens.refreshToken ? maskToken(acc.tokens.refreshToken) : pc.dim("none");
+        lines.push(`Access token:     ${access}`);
+        lines.push(`Refresh token:    ${refresh}`);
+        lines.push(pc.yellow("→ usage polling stops for this account (tools claude usage)"));
+    }
+
+    if (scope === "long" || scope === "both") {
+        const long = acc.tokens.longLivedToken ? maskToken(acc.tokens.longLivedToken) : pc.dim("none");
+        lines.push(`Long-lived token: ${long}`);
+        lines.push(pc.yellow("→ tools claude start/run stops working for this account"));
+    }
+
+    return lines;
+}
+
+async function pickAccount(accounts: AIAccountEntry[]): Promise<string | null> {
+    const picked = await p.select({
+        message: "Logout which account?",
+        options: accounts.map((acc) => ({
+            value: acc.name,
+            label: acc.label ? `${acc.name} ${pc.dim(`(${acc.label})`)}` : acc.name,
+            hint: tokenInventory(acc),
+        })),
+    });
+
+    if (p.isCancel(picked)) {
+        return null;
+    }
+
+    return picked as string;
+}
+
+async function pickScope(acc: AIAccountEntry): Promise<LogoutScope | null> {
+    const oauth = hasOAuthPair(acc);
+    const long = Boolean(acc.tokens.longLivedToken);
+
+    const options: Array<{ value: LogoutScope; label: string; hint: string }> = [];
+
+    if (oauth) {
+        options.push({
+            value: "oauth",
+            label: "Access + refresh token",
+            hint: "stops usage polling; long-lived token (start/run) keeps working",
+        });
+    }
+
+    if (long) {
+        options.push({
+            value: "long",
+            label: "Long-lived token",
+            hint: "tools claude start/run stops working; usage polling keeps working",
+        });
+    }
+
+    if (oauth && long) {
+        options.push({ value: "both", label: "Both", hint: "full logout — account entry stays in config" });
+    }
+
+    const picked = await p.select({ message: "Remove which tokens?", options });
+
+    if (p.isCancel(picked)) {
+        return null;
+    }
+
+    return picked as LogoutScope;
+}
+
+export function registerLogoutCommand(program: Command): void {
+    program
+        .command("logout [name]")
+        .description("Remove saved tokens from an account (OAuth pair, long-lived token, or both)")
+        .option("--oauth", "Remove the access + refresh token (stops usage polling)")
+        .option("--long-lived", "Remove the long-lived token (used by start/run)")
+        .option("--both", "Remove all tokens")
+        .option("-y, --yes", "Skip the confirmation prompt")
+        .action(async (name: string | undefined, opts: LogoutOptions) => {
+            const aiConfig = await AIConfig.load();
+            const accounts = aiConfig.getAccountsByProvider("anthropic-sub");
+
+            if (accounts.length === 0) {
+                out.error(pc.red("No Claude accounts configured."));
+                process.exit(1);
+            }
+
+            let accountName = name;
+
+            if (accountName) {
+                if (!aiConfig.getAccount(accountName)) {
+                    out.error(pc.red(`Account "${accountName}" not found.`));
+                    out.printlnErr(pc.dim(`Known: ${accounts.map((a) => a.name).join(", ")}`));
+                    process.exit(1);
+                }
+            } else {
+                if (!isInteractive()) {
+                    out.error(pc.red("Account name required in non-interactive mode."));
+                    out.printlnErr(
+                        suggestCommand("tools claude logout", {
+                            add: [accounts[0]?.name ?? "<name>", "--oauth", "--yes"],
+                        })
+                    );
+                    process.exit(1);
+                }
+
+                const picked = await pickAccount(accounts);
+                if (!picked) {
+                    p.cancel("Cancelled");
+                    process.exit(0);
+                }
+
+                accountName = picked;
+            }
+
+            const account = accounts.find((a) => a.name === accountName)!;
+
+            if (!hasOAuthPair(account) && !account.tokens.longLivedToken) {
+                p.log.warn(`Account "${accountName}" has no tokens to remove.`);
+                process.exit(0);
+            }
+
+            let scope = scopeFromFlags(opts);
+
+            if (scope) {
+                if ((scope === "oauth" || scope === "both") && !hasOAuthPair(account)) {
+                    out.error(pc.red(`Account "${accountName}" has no access/refresh token.`));
+                    process.exit(1);
+                }
+
+                if ((scope === "long" || scope === "both") && !account.tokens.longLivedToken) {
+                    out.error(pc.red(`Account "${accountName}" has no long-lived token.`));
+                    process.exit(1);
+                }
+            } else {
+                if (!isInteractive()) {
+                    out.error(pc.red("Token scope required in non-interactive mode."));
+                    out.printlnErr(
+                        suggestCommand("tools claude logout", {
+                            add: [accountName, "--oauth|--long-lived|--both", "--yes"],
+                        })
+                    );
+                    process.exit(1);
+                }
+
+                const picked = await pickScope(account);
+                if (!picked) {
+                    p.cancel("Cancelled");
+                    process.exit(0);
+                }
+
+                scope = picked;
+            }
+
+            if (!opts.yes) {
+                if (!isInteractive()) {
+                    out.error(pc.red("Confirmation required: pass --yes in non-interactive mode."));
+                    process.exit(1);
+                }
+
+                p.note(describeScope(scope, account).join("\n"), `Logout "${accountName}"`);
+
+                const confirmed = await p.confirm({
+                    message: "Remove these tokens?",
+                    initialValue: false,
+                });
+
+                if (p.isCancel(confirmed) || !confirmed) {
+                    p.cancel("Cancelled — nothing removed.");
+                    process.exit(0);
+                }
+            }
+
+            const tokens: AIAccountTokens = { ...account.tokens };
+
+            if (scope === "oauth" || scope === "both") {
+                delete tokens.accessToken;
+                delete tokens.refreshToken;
+                delete tokens.expiresAt;
+            }
+
+            if (scope === "long" || scope === "both") {
+                delete tokens.longLivedToken;
+            }
+
+            await aiConfig.updateAccount(accountName, { tokens });
+
+            const removed =
+                scope === "both" ? "all tokens" : scope === "oauth" ? "access + refresh token" : "long-lived token";
+            p.log.success(`Removed ${removed} from "${accountName}".`);
+
+            const remaining = tokenInventory({ ...account, tokens });
+            p.log.info(pc.dim(`Remaining: ${remaining}. Account entry kept in config.`));
+            p.log.info(
+                pc.dim(
+                    `Re-login: ${pc.cyan(`tools claude login ${accountName}`)} · ` +
+                        `full removal: ${pc.cyan(`tools claude config remove ${accountName}`)}`
+                )
+            );
+        });
+}

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -13,6 +13,7 @@ import { SafeJSON } from "@app/utils/json";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
+import { finishKeychainSession, injectSecondaryLogin, inspectKeychainBeforeInject } from "../lib/keychain-session";
 import { pickSessionForResume } from "./resume";
 
 const CLAUDE_JSON = join(homedir(), ".claude.json");
@@ -23,6 +24,7 @@ interface StartOptions {
     model?: string;
     resume?: string | boolean;
     continue?: boolean;
+    keychain?: boolean;
 }
 
 /**
@@ -258,13 +260,20 @@ async function resolveResumeArgs(opts: StartOptions): Promise<string[]> {
 
 async function main(nameArg: string | undefined, opts: StartOptions, passthrough: string[]): Promise<never> {
     const aiConfig = await AIConfig.load();
-    const withToken = aiConfig.getAccountsByProvider("anthropic-sub").filter((a) => Boolean(a.tokens.longLivedToken));
+    const withToken = aiConfig
+        .getAccountsByProvider("anthropic-sub")
+        .filter((a) => (opts.keychain ? Boolean(a.secondary) : Boolean(a.tokens.longLivedToken)));
 
     if (withToken.length === 0) {
-        out.error(pc.red("No accounts with a long-lived token."));
-        out.printlnErr(
-            pc.dim(`Run ${pc.cyan("tools claude login-long")} first to save one (see \`claude setup-token\`).`)
-        );
+        if (opts.keychain) {
+            out.error(pc.red("No accounts with a secondary login."));
+            out.printlnErr(pc.dim(`Run ${pc.cyan("tools claude login-secondary <name>")} first to save one.`));
+        } else {
+            out.error(pc.red("No accounts with a long-lived token."));
+            out.printlnErr(
+                pc.dim(`Run ${pc.cyan("tools claude login-long")} first to save one (see \`claude setup-token\`).`)
+            );
+        }
         await out.flush();
         process.exit(1);
     }
@@ -277,7 +286,10 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
         const match = withToken.find((a) => a.name === nameArg);
         if (!match) {
             const hasEntry = aiConfig.getAccount(nameArg);
-            if (hasEntry) {
+            if (hasEntry && opts.keychain) {
+                out.error(pc.red(`Account "${nameArg}" has no secondary login.`));
+                out.printlnErr(pc.dim(`Save one with: ${pc.cyan(`tools claude login-secondary ${nameArg}`)}`));
+            } else if (hasEntry) {
                 out.error(pc.red(`Account "${nameArg}" has no long-lived token.`));
                 out.printlnErr(pc.dim(`Save one with: ${pc.cyan(`tools claude login-long ${nameArg}`)}`));
             } else {
@@ -293,11 +305,60 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
     }
 
     const account = withToken.find((a) => a.name === accountName)!;
-    const token = account.tokens.longLivedToken!;
 
     const resumeArgs = await resolveResumeArgs(opts);
 
-    await ensureOnboardingSkippedForOAuthToken();
+    let injectedUuid: string | undefined;
+    let foreignBackupPath: string | undefined;
+
+    if (opts.keychain) {
+        const { preSync, foreign } = await inspectKeychainBeforeInject(aiConfig);
+
+        if (preSync.status === "synced") {
+            out.printlnErr(pc.dim(`Keychain held a rotated login — synced back to "${preSync.account}".`));
+        }
+
+        if (foreign) {
+            const who = foreign.uuid ? `account uuid ${foreign.uuid}` : "an unknown account";
+            if (!isInteractive()) {
+                out.error(
+                    pc.red(
+                        `Keychain holds a Claude Code login for ${who} that no configured secondary login matches. ` +
+                            "Refusing to overwrite it non-interactively."
+                    )
+                );
+                await out.flush();
+                process.exit(1);
+            }
+
+            const proceed = await p.confirm({
+                message:
+                    `The keychain holds a Claude Code login for ${who} (probably a direct /login). ` +
+                    "Back it up and restore it after this session?",
+                initialValue: false,
+            });
+
+            if (p.isCancel(proceed) || !proceed) {
+                p.cancel("Cancelled — keychain untouched.");
+                process.exit(0);
+            }
+        }
+
+        // Re-read: the pre-inject sync may have refreshed this account's secondary tokens.
+        const fresh = aiConfig.getAccount(accountName);
+        const secondary = fresh?.secondary;
+
+        if (!secondary) {
+            out.error(pc.red(`Account "${accountName}" lost its secondary login — run login-secondary again.`));
+            await out.flush();
+            process.exit(1);
+        }
+
+        injectedUuid = secondary.accountUuid;
+        foreignBackupPath = await injectSecondaryLogin(secondary, foreign !== null);
+    } else {
+        await ensureOnboardingSkippedForOAuthToken();
+    }
 
     const cmd = await findClaudeCommand();
     const shell = env.paths.getShell("/bin/sh");
@@ -318,15 +379,22 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
         .filter(Boolean)
         .join(" ");
 
-    out.printlnErr(pc.dim(`Starting Claude as ${pc.cyan(accountName)}${detail ? ` ${detail}` : ""}...`));
-    logger.debug({ cmd, accountName, modelId, resumeArgs, passthrough }, "Spawning claude with long-lived token");
+    const mode = opts.keychain ? "keychain login" : "long-lived token";
+    out.printlnErr(pc.dim(`Starting Claude as ${pc.cyan(accountName)} (${mode})${detail ? ` ${detail}` : ""}...`));
+    logger.debug({ cmd, accountName, modelId, resumeArgs, passthrough, mode }, "Spawning claude");
 
-    const proc = Bun.spawn({
-        cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
-        stdio: ["inherit", "inherit", "inherit"],
-        env: {
+    let launchEnv: Record<string, string | undefined>;
+
+    if (opts.keychain) {
+        // Keychain auth: the env token must NOT be set (it takes precedence
+        // over the keychain), and the full-scope login needs none of the
+        // setup-token workarounds — the bootstrap catalog loads natively.
+        launchEnv = { ...process.env };
+        delete launchEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    } else {
+        launchEnv = {
             ...process.env,
-            CLAUDE_CODE_OAUTH_TOKEN: token,
+            CLAUDE_CODE_OAUTH_TOKEN: account.tokens.longLivedToken!,
             // Interactive CC can't resolve the tier from an inference-only setup token,
             // which blocks opus/sonnet [1m] model switches (see claude-code#70124).
             CLAUDE_CODE_SUBSCRIPTION_TYPE: account.label?.split(" ")[0] ?? "max",
@@ -344,10 +412,36 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
             ANTHROPIC_CUSTOM_MODEL_OPTION: "claude-fable-5[1m]",
             ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: "Fable 5",
             ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION: "Fable 5 · Most capable for hardest and longest-running tasks",
-        },
+        };
+    }
+
+    const proc = Bun.spawn({
+        cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
+        stdio: ["inherit", "inherit", "inherit"],
+        env: launchEnv,
     });
 
     const exitCode = await proc.exited;
+
+    if (opts.keychain) {
+        try {
+            const result = await finishKeychainSession(aiConfig, injectedUuid, foreignBackupPath);
+
+            if (result.status === "synced") {
+                out.printlnErr(pc.dim(`Synced rotated keychain tokens back to "${result.account}".`));
+            } else if (result.status === "no-match") {
+                out.printlnErr(
+                    pc.yellow(
+                        `Keychain now holds a different login (uuid ${result.uuid}) — left untouched, nothing synced.`
+                    )
+                );
+            }
+        } catch (err) {
+            logger.error({ err }, "[keychain] post-session sync failed");
+            out.printlnErr(pc.red(`Keychain sync-back failed: ${err instanceof Error ? err.message : err}`));
+        }
+    }
+
     process.exit(exitCode);
 }
 
@@ -364,6 +458,11 @@ export function registerStartCommand(program: Command): void {
         .option("-m, --model <spec>", "Model to launch: alias or substring filter (fable, opus, 4.8 1m, ...)")
         .option("-r, --resume [query]", "Resume a session: bare uses claude's own picker, query searches locally")
         .option("-c, --continue", "Continue the most recent session")
+        .option(
+            "--keychain",
+            "Run logged-in via the account's secondary login injected into the macOS keychain " +
+                "(instead of CLAUDE_CODE_OAUTH_TOKEN); rotated tokens sync back to the account on exit"
+        )
         .action(async (name: string | undefined, opts: StartOptions, command: Command) => {
             const operands = command.args;
             let nameArg = name;

--- a/src/claude/commands/usage/components/sessions/sessions-view.tsx
+++ b/src/claude/commands/usage/components/sessions/sessions-view.tsx
@@ -203,8 +203,10 @@ export function SessionsView({ notifications }: SessionsViewProps) {
             const session = flatRows[selectedIndex];
 
             if (session) {
-                // Control chars / newlines in titles break Ink's row layout.
-                const cleanTitle = session.title?.replace(/\p{Cc}+/gu, " ").trim() ?? null;
+                // Control chars / newlines in titles break Ink's row layout. `|| null` (not `??`)
+                // so an all-control-char title collapses to null and the render site falls back to
+                // the session id instead of showing an empty "Session: ".
+                const cleanTitle = session.title?.replace(/\p{Cc}+/gu, " ").trim() || null;
                 setActionMenu({
                     open: true,
                     sessionId: session.sessionId,

--- a/src/claude/commands/usage/components/sessions/sessions-view.tsx
+++ b/src/claude/commands/usage/components/sessions/sessions-view.tsx
@@ -203,10 +203,12 @@ export function SessionsView({ notifications }: SessionsViewProps) {
             const session = flatRows[selectedIndex];
 
             if (session) {
+                // Control chars / newlines in titles break Ink's row layout.
+                const cleanTitle = session.title?.replace(/\p{Cc}+/gu, " ").trim() ?? null;
                 setActionMenu({
                     open: true,
                     sessionId: session.sessionId,
-                    title: session.title,
+                    title: cleanTitle,
                 });
             }
         }

--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -15,6 +15,8 @@ import { registerDesktopCommand } from "./commands/desktop";
 import { registerExportCommand } from "./commands/export";
 import { registerHistoryCommand } from "./commands/history";
 import { registerLoginLongCommand } from "./commands/login-long";
+import { registerLoginSecondaryCommand } from "./commands/login-secondary";
+import { registerLogoutCommand } from "./commands/logout";
 import { registerMcpCommand } from "./commands/mcp";
 import { registerMemoryCommand } from "./commands/memory";
 import { registerMigrateCommand } from "./commands/migrate";
@@ -47,6 +49,8 @@ registerMigrateCommand(program);
 registerWarmupCommand(program);
 registerMcpCommand(program);
 registerLoginLongCommand(program);
+registerLoginSecondaryCommand(program);
+registerLogoutCommand(program);
 registerStartCommand(program);
 
 addGlobalVerboseOption(program);

--- a/src/claude/lib/keychain-session.ts
+++ b/src/claude/lib/keychain-session.ts
@@ -1,0 +1,161 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import type { AIConfig } from "@app/utils/ai/AIConfig";
+import {
+    backupKeychainPayload,
+    deleteKeychainEntry,
+    type KeychainSyncResult,
+    readKeychainPayload,
+    secondaryToKeychainPayload,
+    syncKeychainToConfig,
+    writeKeychainPayload,
+} from "@app/utils/claude/keychain";
+import type { AISecondaryLogin } from "@app/utils/config/ai.types";
+import { SafeJSON } from "@app/utils/json";
+
+const CLAUDE_JSON = join(homedir(), ".claude.json");
+
+export interface KeychainSessionPrep {
+    /** Set when the keychain held a login not tracked by any account's secondary. */
+    foreignPayloadBackup?: string;
+    /** Result of the pre-inject sync (crash-recovery of a prior session's rotation). */
+    preSync: KeychainSyncResult;
+}
+
+export interface ForeignKeychainEntry {
+    uuid?: string;
+}
+
+/**
+ * Inspect the keychain BEFORE injecting. Returns the foreign entry when the
+ * current credentials belong to nobody we track — the caller must get user
+ * confirmation before proceeding (overwriting logs that login out).
+ */
+export async function inspectKeychainBeforeInject(aiConfig: AIConfig): Promise<{
+    preSync: KeychainSyncResult;
+    foreign: ForeignKeychainEntry | null;
+}> {
+    const preSync = await syncKeychainToConfig(aiConfig);
+
+    if (preSync.status === "no-match") {
+        return { preSync, foreign: { uuid: preSync.uuid } };
+    }
+
+    if (preSync.status === "no-identity") {
+        return { preSync, foreign: {} };
+    }
+
+    return { preSync, foreign: null };
+}
+
+/**
+ * Inject the account's secondary login into the keychain and seed
+ * ~/.claude.json so Claude Code starts logged-in (it re-fetches the full
+ * oauthAccount from /api/oauth/profile itself).
+ */
+export async function injectSecondaryLogin(
+    secondary: AISecondaryLogin,
+    backupForeign: boolean
+): Promise<string | undefined> {
+    let backupPath: string | undefined;
+
+    if (backupForeign) {
+        const existing = await readKeychainPayload();
+
+        if (existing?.claudeAiOauth) {
+            backupPath = await backupKeychainPayload(existing);
+        }
+    }
+
+    await writeKeychainPayload(secondaryToKeychainPayload(secondary));
+    await seedClaudeJson(secondary);
+    return backupPath;
+}
+
+/**
+ * After the Claude Code session ends: pull any rotation back into the right
+ * account, then return the keychain to its pre-inject state — but ONLY if the
+ * entry still belongs to the injected identity. A different identity means
+ * the user logged in directly mid-session; that login must survive.
+ */
+export async function finishKeychainSession(
+    aiConfig: AIConfig,
+    injectedUuid: string | undefined,
+    foreignBackupPath: string | undefined
+): Promise<KeychainSyncResult> {
+    const postSync = await syncKeychainToConfig(aiConfig);
+
+    const currentUuid =
+        postSync.status === "synced" || postSync.status === "unchanged" || postSync.status === "no-match"
+            ? postSync.uuid
+            : undefined;
+
+    if (postSync.status === "no-entry") {
+        // User ran /logout inside Claude Code — nothing to sync. Restore the
+        // pre-existing login if we displaced one.
+        if (foreignBackupPath) {
+            await restoreBackup(foreignBackupPath);
+        }
+
+        return postSync;
+    }
+
+    if (!injectedUuid || !currentUuid || currentUuid !== injectedUuid) {
+        logger.info(
+            `[keychain] entry identity changed during session (now ${currentUuid ?? "unknown"}) — leaving keychain as-is`
+        );
+        return postSync;
+    }
+
+    // Entry is still our injected chain (already synced above). Put the
+    // keychain back the way we found it.
+    if (foreignBackupPath) {
+        await restoreBackup(foreignBackupPath);
+    } else {
+        await deleteKeychainEntry();
+    }
+
+    return postSync;
+}
+
+async function restoreBackup(backupPath: string): Promise<void> {
+    try {
+        const payload = SafeJSON.parse(await Bun.file(backupPath).text(), { strict: true });
+        await writeKeychainPayload(payload);
+        logger.info(`[keychain] restored pre-session entry from ${backupPath}`);
+    } catch (err) {
+        logger.error({ err, backupPath }, "[keychain] restore failed — backup file kept");
+    }
+}
+
+/**
+ * Best-effort ~/.claude.json patch: skip onboarding and seed oauthAccount
+ * identity so the TUI shows the right account immediately. Failures must
+ * never block the launch.
+ */
+async function seedClaudeJson(secondary: AISecondaryLogin): Promise<void> {
+    try {
+        const file = Bun.file(CLAUDE_JSON);
+        const config = (await file.exists())
+            ? (SafeJSON.parse(await file.text(), { strict: true }) as Record<string, unknown>)
+            : {};
+
+        config.hasCompletedOnboarding = true;
+
+        if (secondary.accountUuid) {
+            const previous = (config.oauthAccount ?? {}) as Record<string, unknown>;
+            config.oauthAccount = {
+                ...previous,
+                accountUuid: secondary.accountUuid,
+                emailAddress: secondary.emailAddress,
+                organizationUuid: secondary.organizationUuid,
+            };
+        }
+
+        await Bun.write(CLAUDE_JSON, SafeJSON.stringify(config, null, 2));
+        logger.debug({ path: CLAUDE_JSON }, "Seeded oauthAccount + onboarding for keychain launch");
+    } catch (error) {
+        logger.warn({ error, path: CLAUDE_JSON }, "Could not seed ~/.claude.json for keychain launch");
+    }
+}

--- a/src/claude/lib/usage/api.ts
+++ b/src/claude/lib/usage/api.ts
@@ -162,6 +162,15 @@ export async function fetchAllAccountsUsage(
         accounts = accounts.filter((a) => filterSet.has(a.name));
     }
 
+    // Logged-out accounts (no OAuth pair — e.g. after `tools claude logout`)
+    // are invisible to polling: they can't fetch usage and would only render
+    // permanent error rows.
+    const loggedOut = accounts.filter((a) => !a.tokens.accessToken && !a.tokens.refreshToken);
+    if (loggedOut.length > 0) {
+        logger.debug(`[usage] skipping logged-out account(s): ${loggedOut.map((a) => a.name).join(", ")}`);
+        accounts = accounts.filter((a) => a.tokens.accessToken || a.tokens.refreshToken);
+    }
+
     if (accounts.length === 0) {
         return [];
     }
@@ -196,10 +205,25 @@ export async function fetchAllAccountsUsage(
                 // check keeps concurrent consumers to one rotation per exhausted
                 // token. 401 (token rejected) takes the same path.
                 logger.debug(`${tag} got ${err.statusCode}, attempting force-refresh`);
-                const { token: freshToken, refreshed } = await resolveAccountToken(account.name, {
-                    staleAccessToken: token,
-                    forceRefresh: true,
-                });
+
+                let freshToken: string;
+                let refreshed: boolean;
+
+                try {
+                    ({ token: freshToken, refreshed } = await resolveAccountToken(account.name, {
+                        staleAccessToken: token,
+                        forceRefresh: true,
+                    }));
+                } catch (refreshErr) {
+                    // A dead refresh token (invalid_grant / cooldown) must not
+                    // upgrade a routine 429 into a hard auth error — the access
+                    // token can still land requests once another consumer rotates
+                    // it. Keep the original status as the account error and carry
+                    // the refresh failure as context.
+                    const detail = refreshErr instanceof Error ? refreshErr.message : String(refreshErr);
+                    logger.warn(`${tag} token refresh after ${err.statusCode} failed: ${detail}`);
+                    throw new RetryableApiError(err.statusCode, `${err.message} (token refresh failed: ${detail})`);
+                }
 
                 if (!refreshed) {
                     logger.warn(`${tag} force-refresh did not produce a new token, re-throwing ${err.statusCode}`);

--- a/src/claude/mcp/tools/boards/compose-tools.ts
+++ b/src/claude/mcp/tools/boards/compose-tools.ts
@@ -80,7 +80,8 @@ export async function handleComposeBoard(args: {
         if (err instanceof BoardsHttpError && err.status === 404) {
             throw new Error(
                 `${err.message} — compose never auto-creates a board; ` +
-                    `create "${args.board}" first with boards_create_board, then compose onto it.`
+                    `create "${args.board}" first with boards_create_board, then compose onto it.`,
+                { cause: err }
             );
         }
         throw err;

--- a/src/claude/mcp/tools/boards/schemas.ts
+++ b/src/claude/mcp/tools/boards/schemas.ts
@@ -15,6 +15,7 @@ export const CREATE_BOARD_SCHEMA = {
     properties: {
         slug: {
             type: "string",
+            pattern: "^[a-z0-9][a-z0-9-]{0,63}$",
             description: "Board slug (URL path segment): ^[a-z0-9][a-z0-9-]{0,63}$",
         },
         title: { type: "string", description: "Human title (defaults to the slug)" },

--- a/src/dev-dashboard/lib/boards/annotations-store.ts
+++ b/src/dev-dashboard/lib/boards/annotations-store.ts
@@ -501,6 +501,7 @@ function normalizeAttachments(raw: MessageAttachmentDto[] | undefined): MessageA
     if (!Array.isArray(raw)) {
         return [];
     }
+
     const out: MessageAttachmentDto[] = [];
     for (const a of raw) {
         if (a && typeof a.blobKey === "string" && a.blobKey.length > 0) {

--- a/src/dev-dashboard/lib/boards/boards-store.test.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.test.ts
@@ -226,6 +226,45 @@ describe("boards-store", () => {
         expect(byId.get(m1.id)?.y).toBe(80);
     });
 
+    it("patchCard moving an outer section carries its nested section subtree (frames + members)", async () => {
+        await createBoard(db, { slug: "b1" });
+        const outer = await createCard(db, "b1", {
+            kind: "section",
+            x: 0,
+            y: 0,
+            w: 800,
+            h: 800,
+            payload: { title: "Outer" },
+        });
+        // A nested section fully inside the outer frame.
+        const inner = await createCard(db, "b1", {
+            kind: "section",
+            x: 100,
+            y: 100,
+            w: 300,
+            h: 300,
+            payload: { title: "Inner" },
+        });
+        // A member of the nested inner section (center 175,175 → smallest containing = inner).
+        const innerMember = await createCard(db, "b1", { kind: "note", x: 150, y: 150, w: 50, h: 50 });
+        // A member of the outer section only (center 625,625 → outside inner, inside outer).
+        const outerMember = await createCard(db, "b1", { kind: "note", x: 600, y: 600, w: 50, h: 50 });
+        // A card outside every frame.
+        const far = await createCard(db, "b1", { kind: "note", x: 1200, y: 1200, w: 50, h: 50 });
+
+        await patchCard(db, outer.id, { x: 200 });
+
+        const byId = new Map((await getBoardDoc(db, "b1")).cards.map((c) => [c.id, c]));
+        // The whole subtree translated +200 in x exactly once; y untouched.
+        expect(byId.get(outer.id)?.x).toBe(200);
+        expect(byId.get(inner.id)?.x).toBe(300);
+        expect(byId.get(inner.id)?.y).toBe(100);
+        expect([byId.get(innerMember.id)?.x, byId.get(innerMember.id)?.y]).toEqual([350, 150]);
+        expect([byId.get(outerMember.id)?.x, byId.get(outerMember.id)?.y]).toEqual([800, 600]);
+        // The card outside every frame is not part of the subtree → untouched.
+        expect(byId.get(far.id)?.x).toBe(1200);
+    });
+
     it("bulkLayout applies a section+member batch verbatim (no double translation)", async () => {
         await createBoard(db, { slug: "b1" });
         const sec = await createCard(db, "b1", {

--- a/src/dev-dashboard/lib/boards/boards-store.ts
+++ b/src/dev-dashboard/lib/boards/boards-store.ts
@@ -14,7 +14,7 @@ import type {
     BoardsTable,
 } from "./db-types";
 import { publishBoardEvent } from "./events";
-import { containingSection, sectionFrames } from "./sections";
+import { cardCenter, type SectionCard, sectionFrames } from "./sections";
 import { NotFoundError, setRefOf } from "./sets-store";
 import { nowIso } from "./time";
 import type {
@@ -394,6 +394,42 @@ export async function getCard(db: DatabaseClient<BoardsDb>, cardId: number): Pro
     return toCardDto(row);
 }
 
+/** Walks the smallest-containing-frame chain up from `probe` (by center, self excluded) and reports
+ *  whether it reaches `targetId`. Used when a section frame moves: every descendant — member cards
+ *  AND nested section frames plus their own members — belongs to the moved subtree. */
+function frameSubtreeReaches(frames: SectionCard[], probe: SectionCard, targetId: number): boolean {
+    const visited = new Set<number>();
+    let node: SectionCard = probe;
+    for (;;) {
+        const { cx, cy } = cardCenter(node);
+        let parent: SectionCard | null = null;
+        let bestArea = Number.POSITIVE_INFINITY;
+        for (const f of frames) {
+            if (f.id === node.id || cx < f.x || cy < f.y || cx > f.x + f.w || cy > f.y + f.h) {
+                continue;
+            }
+
+            const area = f.w * f.h;
+            if (parent === null || area < bestArea) {
+                parent = f;
+                bestArea = area;
+            }
+        }
+        if (!parent) {
+            return false;
+        }
+        if (parent.id === targetId) {
+            return true;
+        }
+        if (visited.has(parent.id)) {
+            return false;
+        }
+
+        visited.add(parent.id);
+        node = parent;
+    }
+}
+
 export async function patchCard(
     db: DatabaseClient<BoardsDb>,
     cardId: number,
@@ -421,8 +457,9 @@ export async function patchCard(
     const memberMoves: Array<{ id: number; x: number; y: number; w: number; h: number }> = [];
     const updated = await db.kysely.transaction().execute(async (trx) => {
         if (carriesMembers) {
-            // Membership is resolved on the PRE-move geometry (smallest containing frame), so nested
-            // sections don't double-carry.
+            // Membership is resolved on the PRE-move geometry, so each element translates exactly
+            // once. The moved frame is a container: its whole transitive subtree travels with it —
+            // member cards, nested section frames, and those nested frames' own members.
             const boardCards = await trx
                 .selectFrom("board_cards")
                 .selectAll()
@@ -440,7 +477,7 @@ export async function patchCard(
             }));
             const probeFrames = sectionFrames(probes);
             for (const p of probes) {
-                if (p.kind === "section" || containingSection(probeFrames, p)?.id !== existing.id) {
+                if (p.id === existing.id || !frameSubtreeReaches(probeFrames, p, existing.id)) {
                     continue;
                 }
 

--- a/src/dev-dashboard/lib/boards/layout-engine.test.ts
+++ b/src/dev-dashboard/lib/boards/layout-engine.test.ts
@@ -255,6 +255,71 @@ describe("runArrange — section-aware broad scope (composite units)", () => {
         expect(byId.get(l1.id)).toBeDefined();
         expect(byId.get(l2.id)).toBeDefined();
     });
+
+    it("rejects an explicit unknown id with 404 even when the selection touches a section", async () => {
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 400, h: 400, payload: { title: "S" } });
+        const m1 = await createCard(db, "b1", { kind: "note", x: 40, y: 80, w: 100, h: 100 });
+
+        const outcome = await runArrange(db, "b1", { mode: "grid", ids: [m1.id, 999999] });
+        expect(outcome.ok).toBe(false);
+        expect(outcome.status).toBe(404);
+    });
+
+    it("two ids inside one section fall through to a per-card arrange (not a no-op success)", async () => {
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 400, h: 400, payload: { title: "S" } });
+        const m1 = await createCard(db, "b1", { kind: "note", x: 40, y: 80, w: 100, h: 100 });
+        const m2 = await createCard(db, "b1", { kind: "note", x: 200, y: 250, w: 100, h: 100 });
+
+        const outcome = await runArrange(db, "b1", { mode: "column", ids: [m1.id, m2.id] });
+        // Composite collapses to one unit; the per-card path actually arranges both members.
+        expect(outcome.ok).toBe(true);
+        expect(outcome.moved).toBe(2);
+        expect(outcome.cards.map((c) => c.id).sort((a, b) => a - b)).toEqual([m1.id, m2.id]);
+    });
+
+    it("rejects save:true on a broad scope when sections are present (400)", async () => {
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 400, h: 400, payload: { title: "S" } });
+        await createCard(db, "b1", { kind: "note", x: 40, y: 80, w: 100, h: 100 });
+        await createCard(db, "b1", { kind: "note", x: 200, y: 250, w: 100, h: 100 });
+        await createCard(db, "b1", { kind: "note", x: 900, y: 0, w: 100, h: 100 }); // a loose unit
+
+        const outcome = await runArrange(db, "b1", { mode: "grid", scope: "all", save: true });
+        expect(outcome.ok).toBe(false);
+        expect(outcome.status).toBe(400);
+        expect(outcome.message).toContain("save needs a section scope");
+    });
+
+    it("rejects sizing:uniform when sections are arranged as units (400)", async () => {
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 400, h: 400, payload: { title: "S" } });
+        await createCard(db, "b1", { kind: "note", x: 40, y: 80, w: 100, h: 100 });
+        await createCard(db, "b1", { kind: "note", x: 900, y: 0, w: 100, h: 100 }); // a loose unit
+
+        const outcome = await runArrange(db, "b1", { mode: "grid", scope: "all", sizing: "uniform" });
+        expect(outcome.ok).toBe(false);
+        expect(outcome.status).toBe(400);
+    });
+
+    it("fails with a clean 400 when composite expansion exceeds the 500-move batch limit", async () => {
+        await createBoard(db, { slug: "b1" });
+        await createCard(db, "b1", { kind: "section", x: 0, y: 0, w: 2000, h: 2000, payload: { title: "S" } });
+        // 500 members inside the section → the unit expands to 501 writes (frame + members).
+        for (let i = 0; i < 500; i += 1) {
+            const x = 100 + (i % 20) * 50;
+            const y = 100 + Math.floor(i / 20) * 50;
+            await createCard(db, "b1", { kind: "note", x, y, w: 40, h: 40 });
+        }
+        // A loose card gives a second unit so the arrange doesn't collapse to a single-unit no-op.
+        await createCard(db, "b1", { kind: "note", x: 4000, y: 4000, w: 40, h: 40 });
+
+        const outcome = await runArrange(db, "b1", { mode: "grid", scope: "all" });
+        expect(outcome.ok).toBe(false);
+        expect(outcome.status).toBe(400);
+        expect(outcome.message).toContain("500");
+    });
 });
 
 describe("displaceSections (bug 7 — section-over-section shifts DOWN, not a wild jump)", () => {

--- a/src/dev-dashboard/lib/boards/layout-engine.ts
+++ b/src/dev-dashboard/lib/boards/layout-engine.ts
@@ -520,6 +520,10 @@ interface ArrangeOutcome {
     saved: boolean;
 }
 
+function arrangeFail(status: number, message: string): ArrangeOutcome {
+    return { ok: false, status, message, moved: 0, cards: [], saved: false };
+}
+
 async function arrangeCompare(
     db: DatabaseClient<BoardsDb>,
     slug: string,
@@ -698,6 +702,16 @@ async function arrangeComposite(
         return null; // no section involvement → let the per-card path handle it
     }
 
+    // Sections are arranged as whole-unit containers, so the per-card sizing/save behaviors can't
+    // apply here. Reject them explicitly rather than silently no-op'ing (matches the per-card path's
+    // save error, and never reports success with saved:false when save was requested).
+    if (body.save) {
+        return arrangeFail(400, "save needs a section scope (scope: section:<Name>)");
+    }
+    if (body.sizing === "uniform") {
+        return arrangeFail(400, "sizing: uniform is not supported when sections are arranged as units");
+    }
+
     // Loose units: in-scope non-section cards with no containing section.
     const looseCards: CardRect[] = [];
     for (const c of all) {
@@ -724,7 +738,13 @@ async function arrangeComposite(
         carry.set(c.id, [c.id]);
     }
     if (rects.length < 2) {
-        // A single unit: nothing to rearrange at the top level (members keep their in-frame layout).
+        // An explicit id selection that collapses to a single unit (e.g. two members of the same
+        // section) is not a composite arrange — fall through to the per-card path.
+        if (body.ids && body.ids.length > 0) {
+            return null;
+        }
+        // Implicit seed (scope:all / default ai layer) with a single unit: nothing to rearrange at
+        // the top level (members keep their in-frame layout).
         return { ok: true, status: 200, moved: 0, cards: [], saved: false };
     }
 
@@ -754,6 +774,14 @@ async function arrangeComposite(
     if (writeMoves.length === 0) {
         return { ok: true, status: 200, moved: 0, cards: [], saved: false };
     }
+    // Expanding each unit to frame+members can exceed bulkLayout's 500-move batch cap where a flat
+    // per-card arrange never would; preflight it as a clean 400 instead of a bubbled 500.
+    if (writeMoves.length > 500) {
+        return arrangeFail(
+            400,
+            `section-aware arrange would move ${writeMoves.length} cards, over the 500-move batch limit`
+        );
+    }
 
     await bulkLayout(db, slug, writeMoves);
     publishBoardEvent(slug, { type: "layout", payload: { moves: writeMoves } });
@@ -765,14 +793,7 @@ export async function runArrange(
     slug: string,
     body: ArrangeBody
 ): Promise<ArrangeOutcome> {
-    const fail = (status: number, message: string): ArrangeOutcome => ({
-        ok: false,
-        status,
-        message,
-        moved: 0,
-        cards: [],
-        saved: false,
-    });
+    const fail = arrangeFail;
     if (!ARRANGE_MODES.has(body.mode)) {
         return fail(400, "mode: column|row|grid|flow|lanes|masonry|timeline|timeaxis|compare|align-*|distribute-*");
     }
@@ -798,6 +819,15 @@ export async function runArrange(
     }
 
     const frames = sectionFrames(all);
+
+    // Explicit-id selections must reference cards that exist on this board — validate BEFORE the
+    // composite dispatch so an unknown id can't slip through a section-aware arrange as a success.
+    if (body.ids && body.ids.length > 0) {
+        const present = new Set(all.map((c) => c.id));
+        if (body.ids.some((id) => !present.has(id))) {
+            return fail(404, "a card is not on this board");
+        }
+    }
 
     // Broad-scope arrange (all / ai / an id set that spans sections): sections are containers, so
     // arrange each section+members as ONE unit instead of scattering members across the board.

--- a/src/dev-dashboard/lib/obsidian/publish.test.ts
+++ b/src/dev-dashboard/lib/obsidian/publish.test.ts
@@ -1,35 +1,35 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
     findPublishedByPath,
     findPublishedBySlug,
     publishNote,
     unpublishNote,
 } from "@app/dev-dashboard/lib/obsidian/publish";
-import { getDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
-
-const storage = getDevDashboardStorage();
-
-let originalConfig: string | null = null;
+import { getDevDashboardStorage, resetDevDashboardStorage } from "@app/dev-dashboard/lib/storage";
+import { env } from "@app/utils/env";
 
 describe("obsidian publish registry", () => {
-    beforeAll(async () => {
-        const configPath = storage.getConfigPath();
-        originalConfig = existsSync(configPath) ? await Bun.file(configPath).text() : null;
-    });
+    let dir = "";
 
     beforeEach(async () => {
-        await storage.setConfig({ port: 3042, obsidianVault: "/x", publishedNotes: [], cmuxPollIntervalMs: 2000 });
+        dir = mkdtempSync(join(tmpdir(), "publish-registry-"));
+        env.testing.set("GENESIS_TOOLS_HOME", dir);
+        resetDevDashboardStorage();
+        await getDevDashboardStorage().setConfig({
+            port: 3042,
+            obsidianVault: "/x",
+            publishedNotes: [],
+            cmuxPollIntervalMs: 2000,
+        });
     });
 
-    afterAll(async () => {
-        if (originalConfig === null) {
-            await storage.clearConfig();
-            return;
-        }
-
-        await storage.ensureDirs();
-        await Bun.write(storage.getConfigPath(), originalConfig);
+    afterEach(() => {
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        resetDevDashboardStorage();
+        rmSync(dir, { recursive: true, force: true });
     });
 
     test("publishNote stores a unique slug and round-trips by slug", async () => {

--- a/src/dev-dashboard/lib/ports/enrich.ts
+++ b/src/dev-dashboard/lib/ports/enrich.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { PortInfo } from "@app/dev-dashboard/lib/ports/types";
 import { selectWebapps } from "@app/dev-dashboard/lib/ports/webapps";
 import { logger } from "@app/logger";
@@ -128,7 +129,7 @@ async function resolveCwd(pid: number): Promise<string | null> {
 
 async function readPackageName(cwd: string): Promise<string | null> {
     try {
-        const file = Bun.file(`${cwd}/package.json`);
+        const file = Bun.file(join(cwd, "package.json"));
         if (!(await file.exists())) {
             return null;
         }
@@ -178,7 +179,7 @@ function pruneExpired(now: number): void {
 }
 
 async function enrichOne(port: PortInfo): Promise<Enrichment> {
-    const key = `${port.pid}:${port.port}`;
+    const key = `${port.pid}:${port.port}:${port.proto}:${port.address}`;
     const cached = cache.get(key);
     if (cached && cached.expiresAt > Date.now()) {
         return cached.value;
@@ -202,9 +203,14 @@ async function enrichOne(port: PortInfo): Promise<Enrichment> {
     const packageName = cwd ? await readPackageName(cwd) : null;
 
     if (registryName) {
-        // A known repo dashboard: authoritative name, and definitionally a web app — no probe needed.
+        // A known repo dashboard: authoritative name always wins over any probed title, but the
+        // dashboard still has to actually be running (probe) before we call it a live web app.
         enrichment.title = registryName;
-        enrichment.isWebapp = true;
+
+        if (isLocalAddress(port.address)) {
+            const probe = await probeHttp(port.port);
+            enrichment.isWebapp = probe.http;
+        }
     } else if (isLocalAddress(port.address)) {
         const probe = await probeHttp(port.port);
         if (probe.http) {

--- a/src/dev-dashboard/lib/system/poller.test.ts
+++ b/src/dev-dashboard/lib/system/poller.test.ts
@@ -24,7 +24,7 @@ describe("system pulse poller client-gating", () => {
         stopPulsePolling();
     });
 
-    test("pauses collection when no client has fetched /api/system/pulse recently", async () => {
+    test("throttles to one cold-start baseline sample when no client has fetched /api/system/pulse recently", async () => {
         const { startPulsePolling } = await import("./poller");
         let collectCount = 0;
 
@@ -36,6 +36,8 @@ describe("system pulse poller client-gating", () => {
         });
         await new Promise((r) => setTimeout(r, 200));
 
-        expect(collectCount).toBeLessThanOrEqual(1);
+        // one immediate baseline sample fires so history isn't empty on cold open, then
+        // idle ticks are skipped until IDLE_RECORD_INTERVAL_MS elapses (far beyond this window)
+        expect(collectCount).toBe(1);
     });
 });

--- a/src/dev-dashboard/lib/system/poller.ts
+++ b/src/dev-dashboard/lib/system/poller.ts
@@ -8,6 +8,8 @@ import type { PulseSeries, PulseSnapshot } from "./types";
 const PUBLIC_IP_MAX_AGE_MS = 5 * 60 * 1000;
 const DEFAULT_RETENTION_HOURS = 24;
 const IDLE_THRESHOLD_MS = 60_000;
+// keep a once-a-minute baseline even while idle, so history isn't empty on cold open
+const IDLE_RECORD_INTERVAL_MS = 60_000;
 
 interface IpifyResponse {
     ip?: string;
@@ -19,6 +21,7 @@ let db: PulseHistoryDb | null = null;
 let lastSnapshot: PulseSnapshot | null = null;
 let retentionHours = DEFAULT_RETENTION_HOURS;
 let lastClientSeenAt = 0;
+let lastIdleRecordAt = 0;
 
 export interface PulsePollingOptions {
     collectOverride?: () => Promise<PulseSnapshot>;
@@ -115,8 +118,15 @@ export function startPulsePolling(intervalMs: number, opts: PulsePollingOptions 
     }
 
     handle = startWakefulInterval(intervalMs, async () => {
-        if (Date.now() - lastClientSeenAt > IDLE_THRESHOLD_MS) {
-            return;
+        const now = Date.now();
+        const clientActive = now - lastClientSeenAt <= IDLE_THRESHOLD_MS;
+
+        if (!clientActive) {
+            if (now - lastIdleRecordAt < IDLE_RECORD_INTERVAL_MS) {
+                return;
+            }
+
+            lastIdleRecordAt = now;
         }
 
         if (opts.collectOverride) {

--- a/src/dev-dashboard/server/routes/boards.ts
+++ b/src/dev-dashboard/server/routes/boards.ts
@@ -26,7 +26,7 @@ import { publishBoardEvent, subscribeBoard } from "@app/dev-dashboard/lib/boards
 import { readImageDims } from "@app/dev-dashboard/lib/boards/image-size";
 import { notifyLayoutChanged } from "@app/dev-dashboard/lib/boards/layout-engine";
 import { sectionsToJSON } from "@app/dev-dashboard/lib/boards/sections";
-import { getSet } from "@app/dev-dashboard/lib/boards/sets-store";
+import { getSet, NotFoundError } from "@app/dev-dashboard/lib/boards/sets-store";
 import type { MessageAttachmentDto } from "@app/dev-dashboard/lib/boards/types";
 import { dispatchBoard } from "@app/dev-dashboard/lib/boards/work-store";
 import { publicBaseUrl } from "@app/dev-dashboard/lib/public-base";
@@ -499,6 +499,15 @@ export function boardsRoutes(): RouteDef[] {
             pattern: "/api/boards/:slug/msg-uploads",
             handler: async (ctx) => {
                 try {
+                    const board = await getBoardsDb()
+                        .kysely.selectFrom("boards")
+                        .select("id")
+                        .where("slug", "=", ctx.params.slug)
+                        .executeTakeFirst();
+                    if (!board) {
+                        throw new NotFoundError(`board not found: ${ctx.params.slug}`);
+                    }
+
                     const bytes = await ctx.readRawBody();
                     const name = ctx.query.get("name") ?? "";
                     const mime = ctx.query.get("mime") || mimeForPath(name);

--- a/src/dev-dashboard/tests/global-setup.ts
+++ b/src/dev-dashboard/tests/global-setup.ts
@@ -1,0 +1,13 @@
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Creates (and truncates) a run-scoped file for tracking created board slugs, then shares its
+ *  path with worker processes via PW_RUN_SLUGS_FILE. boards-test-api.ts's freshBoard() appends
+ *  every slug it creates; global-teardown.ts reads the file back to archive only the boards THIS
+ *  run created — not every "pw-*" board on the shared singleton dev-dashboard server. */
+export default function globalSetup(): void {
+    const file = join(tmpdir(), `pw-board-slugs-${Date.now()}-${process.pid}.txt`);
+    writeFileSync(file, "");
+    process.env.PW_RUN_SLUGS_FILE = file;
+}

--- a/src/dev-dashboard/tests/global-setup.ts
+++ b/src/dev-dashboard/tests/global-setup.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -6,8 +5,8 @@ import { join } from "node:path";
  *  path with worker processes via PW_RUN_SLUGS_FILE. boards-test-api.ts's freshBoard() appends
  *  every slug it creates; global-teardown.ts reads the file back to archive only the boards THIS
  *  run created — not every "pw-*" board on the shared singleton dev-dashboard server. */
-export default function globalSetup(): void {
+export default async function globalSetup(): Promise<void> {
     const file = join(tmpdir(), `pw-board-slugs-${Date.now()}-${process.pid}.txt`);
-    writeFileSync(file, "");
+    await Bun.write(file, "");
     process.env.PW_RUN_SLUGS_FILE = file;
 }

--- a/src/dev-dashboard/tests/global-teardown.ts
+++ b/src/dev-dashboard/tests/global-teardown.ts
@@ -8,7 +8,7 @@ import { SafeJSON } from "@app/utils/json";
  *  singleton dev-dashboard server (localhost:3042) don't archive each other's boards. Archive,
  *  not delete — the server has no hard-delete and the data stays recoverable. */
 export default async function globalTeardown(): Promise<void> {
-    const slugsFile = process.env.PW_RUN_SLUGS_FILE;
+    const slugsFile = env.get("PW_RUN_SLUGS_FILE");
 
     if (!slugsFile || !existsSync(slugsFile)) {
         return;
@@ -37,6 +37,11 @@ export default async function globalTeardown(): Promise<void> {
         const { boards } = SafeJSON.parse(await res.text(), { strict: true }) as {
             boards: Array<{ slug: string; archived: boolean }>;
         };
+
+        if (!Array.isArray(boards)) {
+            logger.warn("[boards tests] teardown GET /api/boards returned unexpected shape");
+            return;
+        }
 
         for (const board of boards) {
             if (!created.has(board.slug) || board.archived) {

--- a/src/dev-dashboard/tests/global-teardown.ts
+++ b/src/dev-dashboard/tests/global-teardown.ts
@@ -1,30 +1,64 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { logger } from "@app/logger";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 
-/** Archive every board the suite created (pw-* slugs) so spec runs don't clutter the boards
- *  list. Archive, not delete — the server has no hard-delete and the data stays recoverable. */
+/** Archive every board THIS run created (tracked via freshBoard() in boards-test-api.ts into the
+ *  PW_RUN_SLUGS_FILE set up by global-setup.ts) so concurrent spec runs sharing the strict-port
+ *  singleton dev-dashboard server (localhost:3042) don't archive each other's boards. Archive,
+ *  not delete — the server has no hard-delete and the data stays recoverable. */
 export default async function globalTeardown(): Promise<void> {
-    const base = env.dashboard.getQaBaseUrl();
+    const slugsFile = process.env.PW_RUN_SLUGS_FILE;
+
+    if (!slugsFile || !existsSync(slugsFile)) {
+        return;
+    }
 
     try {
-        const res = await fetch(`${base}/api/boards`);
+        const created = new Set(
+            readFileSync(slugsFile, "utf8")
+                .split("\n")
+                .map((line) => line.trim())
+                .filter(Boolean)
+        );
 
-        if (!res.ok) {
+        if (created.size === 0) {
             return;
         }
 
-        const { boards } = (await res.json()) as { boards: Array<{ slug: string; archived: boolean }> };
+        const base = env.dashboard.getQaBaseUrl();
+        const res = await fetch(`${base}/api/boards`);
+
+        if (!res.ok) {
+            logger.warn({ status: res.status }, "[boards tests] teardown GET /api/boards failed");
+            return;
+        }
+
+        const { boards } = SafeJSON.parse(await res.text(), { strict: true }) as {
+            boards: Array<{ slug: string; archived: boolean }>;
+        };
 
         for (const board of boards) {
-            if (board.slug.startsWith("pw-") && board.slug !== "pw-bug-lab" && !board.archived) {
-                await fetch(`${base}/api/boards/${board.slug}`, {
-                    method: "PATCH",
-                    headers: { "Content-Type": "application/json" },
-                    body: SafeJSON.stringify({ archived: true }),
-                });
+            if (!created.has(board.slug) || board.archived) {
+                continue;
+            }
+
+            const patchRes = await fetch(`${base}/api/boards/${board.slug}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify({ archived: true }),
+            });
+
+            if (!patchRes.ok) {
+                logger.warn(
+                    { slug: board.slug, status: patchRes.status },
+                    "[boards tests] teardown archive PATCH failed"
+                );
             }
         }
     } catch (err) {
-        console.warn("[boards tests] teardown archive sweep failed", err);
+        logger.warn({ err }, "[boards tests] teardown archive sweep failed");
+    } finally {
+        unlinkSync(slugsFile);
     }
 }

--- a/src/dev-dashboard/tests/helpers/boards-test-api.ts
+++ b/src/dev-dashboard/tests/helpers/boards-test-api.ts
@@ -1,4 +1,5 @@
 import { appendFileSync } from "node:fs";
+import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 import type { APIRequestContext } from "@playwright/test";
 import { expect } from "@playwright/test";
@@ -34,7 +35,7 @@ export async function freshBoard(request: APIRequestContext, prefix: string): Pr
     const res = await request.post("/api/boards", { data: { slug, title: `Playwright ${prefix}` } });
     expect(res.status(), `create board ${slug}`).toBe(201);
 
-    const slugsFile = process.env.PW_RUN_SLUGS_FILE;
+    const slugsFile = env.get("PW_RUN_SLUGS_FILE");
 
     if (slugsFile) {
         appendFileSync(slugsFile, `${slug}\n`);

--- a/src/dev-dashboard/tests/helpers/boards-test-api.ts
+++ b/src/dev-dashboard/tests/helpers/boards-test-api.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from "node:fs";
+import { SafeJSON } from "@app/utils/json";
 import type { APIRequestContext } from "@playwright/test";
 import { expect } from "@playwright/test";
 
@@ -31,13 +33,20 @@ export async function freshBoard(request: APIRequestContext, prefix: string): Pr
     const slug = `pw-${prefix}-${Date.now().toString(36)}-${seq}`;
     const res = await request.post("/api/boards", { data: { slug, title: `Playwright ${prefix}` } });
     expect(res.status(), `create board ${slug}`).toBe(201);
+
+    const slugsFile = process.env.PW_RUN_SLUGS_FILE;
+
+    if (slugsFile) {
+        appendFileSync(slugsFile, `${slug}\n`);
+    }
+
     return slug;
 }
 
 export async function boardDoc(request: APIRequestContext, slug: string): Promise<TestBoardDoc> {
     const res = await request.get(`/api/boards/${slug}`);
     expect(res.ok(), `GET board ${slug}`).toBeTruthy();
-    return (await res.json()) as TestBoardDoc;
+    return SafeJSON.parse(await res.text(), { strict: true }) as TestBoardDoc;
 }
 
 /** API-seed a card so specs don't depend on UI creation flows they aren't testing. */
@@ -50,7 +59,7 @@ export async function seedCard(
         data: { x: 100, y: 100, w: 240, h: 140, payload: {}, ...card },
     });
     expect(res.ok(), `seed ${card.kind} card on ${slug}`).toBeTruthy();
-    return (await res.json()) as TestCard;
+    return SafeJSON.parse(await res.text(), { strict: true }) as TestCard;
 }
 
 export async function seedNote(

--- a/src/dev-dashboard/tests/pages/board-detail-page.ts
+++ b/src/dev-dashboard/tests/pages/board-detail-page.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { errors } from "@playwright/test";
 
 export type ToolName = "move" | "ink" | "annotate" | "note" | "connect" | "section" | "table";
 
@@ -30,8 +31,12 @@ export class BoardDetailPage {
 
         try {
             await input.waitFor({ timeout: 1_500 });
-        } catch {
-            return; // already identified (localStorage persisted)
+        } catch (err) {
+            if (err instanceof errors.TimeoutError) {
+                return; // already identified (localStorage persisted)
+            }
+
+            throw err;
         }
 
         await input.fill(name);

--- a/src/dev-dashboard/tests/playwright.config.ts
+++ b/src/dev-dashboard/tests/playwright.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "@playwright/test";
  *  override with DD_QA_BASE_URL. Serial: specs create/mutate boards through the real API. */
 export default defineConfig({
     testDir: `${import.meta.dirname}/specs`,
+    globalSetup: `${import.meta.dirname}/global-setup.ts`,
     globalTeardown: `${import.meta.dirname}/global-teardown.ts`,
     timeout: 60_000,
     retries: 0,

--- a/src/dev-dashboard/tests/specs/board-interactions.spec.ts
+++ b/src/dev-dashboard/tests/specs/board-interactions.spec.ts
@@ -439,6 +439,8 @@ test.describe("ink manipulation + reposition", () => {
 
         // Relative offsets inside the frame are preserved (frame+members moved as one unit).
         expect(doc.cards.find((c) => c.id === memberA.id)!.x - frame.x).toBe(memberA.x - section.x);
+        expect(doc.cards.find((c) => c.id === memberA.id)!.y - frame.y).toBe(memberA.y - section.y);
+        expect(doc.cards.find((c) => c.id === memberB.id)!.x - frame.x).toBe(memberB.x - section.x);
         expect(doc.cards.find((c) => c.id === memberB.id)!.y - frame.y).toBe(memberB.y - section.y);
     });
 

--- a/src/dev-dashboard/ui/src/components/SearchInput.tsx
+++ b/src/dev-dashboard/ui/src/components/SearchInput.tsx
@@ -1,0 +1,24 @@
+import { Input } from "@ui/components/input";
+import { Search } from "lucide-react";
+
+interface SearchInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    className?: string;
+}
+
+export function SearchInput({ value, onChange, placeholder, className }: SearchInputProps) {
+    return (
+        <div className={`relative min-w-0 w-full ${className ?? ""}`}>
+            <Search className="absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-[var(--dd-text-muted)]" />
+            <Input
+                type="search"
+                placeholder={placeholder ?? "Search…"}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="w-full pl-8"
+            />
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/boards/CardView.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/CardView.tsx
@@ -129,6 +129,51 @@ function InlineEditor({
     );
 }
 
+/** Single-line section-title rename input. Same commit-on-unmount guard as InlineEditor: a canvas
+ *  click can tear the input down before the native blur fires, which would silently drop the rename.
+ *  A done-flag prevents double commits (unmount + blur). */
+function SectionTitleInput({ initial, onCommit }: { initial: string; onCommit: (text: string) => void }) {
+    const [draft, setDraft] = useState(initial);
+    const draftRef = useRef(draft);
+    draftRef.current = draft;
+    const done = useRef(false);
+    const commitRef = useRef(onCommit);
+    commitRef.current = onCommit;
+
+    const finish = () => {
+        if (done.current) {
+            return;
+        }
+
+        done.current = true;
+        commitRef.current(draftRef.current);
+    };
+
+    const finishRef = useRef(finish);
+    finishRef.current = finish;
+
+    useEffect(() => {
+        return () => finishRef.current();
+    }, []);
+
+    return (
+        <input
+            autoFocus
+            value={draft}
+            onFocus={(e) => e.currentTarget.select()}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={finish}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === "Escape") {
+                    e.currentTarget.blur();
+                }
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="absolute -top-6 left-0 w-48 rounded bg-[var(--dd-bg-panel)] px-1 font-mono text-xs font-semibold text-[var(--dd-text-primary)] outline-none"
+        />
+    );
+}
+
 export function CardView({
     card,
     selected,
@@ -287,19 +332,7 @@ export function CardView({
                 {...editHandlers}
             >
                 {editing ? (
-                    <input
-                        autoFocus
-                        defaultValue={title}
-                        onFocus={(e) => e.currentTarget.select()}
-                        onBlur={(e) => onEditCommit(card, e.currentTarget.value)}
-                        onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === "Escape") {
-                                e.currentTarget.blur();
-                            }
-                        }}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        className="absolute -top-6 left-0 w-48 rounded bg-[var(--dd-bg-panel)] px-1 font-mono text-xs font-semibold text-[var(--dd-text-primary)] outline-none"
-                    />
+                    <SectionTitleInput initial={title} onCommit={(text) => onEditCommit(card, text)} />
                 ) : (
                     <span className="absolute -top-6 left-0 cursor-move font-mono text-xs font-semibold text-[var(--dd-text-secondary)]">
                         {title}

--- a/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
@@ -1,7 +1,7 @@
 import type { CardDto, QuestionDto } from "@app/dev-dashboard/contract/dto";
 import { SafeJSON } from "@app/utils/json";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { boardsApi } from "./boards-api";
 
 const OTHER_LABEL = "Other / Něco jiného";
@@ -11,6 +11,16 @@ function QuestionCard({ slug, question }: { slug: string; question: QuestionDto 
     const queryClient = useQueryClient();
     const [picked, setPicked] = useState<Set<string>>(new Set(question.answer ?? []));
     const [otherText, setOtherText] = useState("");
+
+    // Boards are multi-operator: every SSE event refetches the board query, which can hand this
+    // still-mounted card (keyed by q.id) a new answer picked in another session — resync it.
+    // Keyed on content, not array reference: refetches mint a new array every time, and a
+    // reference-keyed reset would stomp an in-progress re-pick on every unrelated board event.
+    const answerKey = SafeJSON.stringify(question.answer ?? []);
+
+    useEffect(() => {
+        setPicked(new Set(question.answer ?? []));
+    }, [answerKey]);
 
     const answerMutation = useMutation({
         mutationFn: (answer: string) => boardsApi.answerQuestion(question.id, answer),

--- a/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/QuestionCard.tsx
@@ -50,9 +50,15 @@ function QuestionCard({ slug, question }: { slug: string; question: QuestionDto 
             next.add(label);
         }
 
+        // The last toggle can't empty a staged answer: leaving picked (and the server's staged
+        // answer) as-is beats clearing the checkboxes while the previous answer still dispatches.
+        if (answered && next.size === 0) {
+            return;
+        }
+
         setPicked(next);
 
-        // Re-picks re-POST immediately while staged; the last toggle can't empty the answer.
+        // Re-picks re-POST immediately while staged.
         if (answered && next.size > 0) {
             submit([...next]);
         }

--- a/src/dev-dashboard/ui/src/components/boards/WirePanel.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/WirePanel.tsx
@@ -2,7 +2,7 @@ import type { AnnotationDto, MessageDto, QuestionDto, RevisionDto } from "@app/d
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
 import type { ClipboardEvent as ReactClipboardEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { STATUS_COLOR } from "./AnnotationLayer";
 import { boardsApi } from "./boards-api";
 import { CompareDeck } from "./CompareDeck";
@@ -272,8 +272,11 @@ export function WirePanel({
         }
     };
 
-    const feed = annotation ? buildFeed(annotation) : [];
-    const sessionFeed = annotation ? [] : buildSessionFeed(boardMessages, annotations, questions);
+    const feed = useMemo(() => (annotation ? buildFeed(annotation) : []), [annotation]);
+    const sessionFeed = useMemo(
+        () => (annotation ? [] : buildSessionFeed(boardMessages, annotations, questions)),
+        [annotation, boardMessages, annotations, questions]
+    );
 
     return (
         <div

--- a/src/dev-dashboard/ui/src/components/boards/WirePanel.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/WirePanel.tsx
@@ -44,7 +44,12 @@ function buildSessionFeed(
         })),
         ...questions
             .filter((q) => q.answer !== null)
-            .map((question) => ({ kind: "question" as const, createdAt: question.createdAt, question })),
+            .map((question) => ({
+                kind: "question" as const,
+                // answeredAt is "" until answered; fall back to createdAt so it still sorts.
+                createdAt: question.answeredAt || question.createdAt,
+                question,
+            })),
     ];
     return items.sort((a, b) => (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0));
 }
@@ -252,9 +257,12 @@ export function WirePanel({
 
         e.preventDefault();
 
-        for (const file of images) {
+        for (const [i, file] of images.entries()) {
+            // MIME-derived extension + per-item index: same-millisecond multi-image paste must
+            // not collide, and a JPEG paste must not masquerade as .png.
+            const ext = file.type.startsWith("image/") ? file.type.split("/")[1] : "png";
             void boardsApi
-                .uploadMessageImage(slug, file, `reply-${Date.now()}.png`)
+                .uploadMessageImage(slug, file, `reply-${Date.now()}-${i}.${ext}`)
                 .then(({ blobKey, name }) => {
                     setDraft(
                         (d) => `${d}${d && !d.endsWith("\n") ? "\n" : ""}![${name}](/api/boards/blobs/${blobKey})\n`

--- a/src/dev-dashboard/ui/src/components/boards/markdown.tsx
+++ b/src/dev-dashboard/ui/src/components/boards/markdown.tsx
@@ -1,4 +1,4 @@
-import { Marked } from "marked";
+import { Marked, type Tokens } from "marked";
 import { memo, useMemo } from "react";
 
 /** Full markdown for board cards (tables, fenced code, links, lists, blockquotes) — replaces
@@ -13,13 +13,39 @@ function escapeHtml(html: string): string {
     return html.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/** Attribute-context escape: escapeHtml plus the double-quote that would break out of href="…". */
+function escapeAttr(value: string): string {
+    return escapeHtml(value).replace(/"/g, "&quot;");
+}
+
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+/** Allow http/https/mailto and relative/anchor URLs; reject javascript:/data:/vbscript: etc.
+ *  Relative and anchor hrefs resolve against the placeholder base to https:, so they pass. */
+function isSafeHref(href: string): boolean {
+    try {
+        return SAFE_LINK_PROTOCOLS.has(new URL(href, "https://relative.invalid/").protocol);
+    } catch {
+        return false;
+    }
+}
+
 marked.use({
     renderer: {
         html({ text }: { text: string }) {
             return escapeHtml(text);
         },
-        link({ href, text }: { href: string; text: string }) {
-            return `<a href="${href}" target="_blank" rel="noreferrer noopener">${text}</a>`;
+        // Regular function so `this.parser` binds to the renderer; the label is rendered from its
+        // tokens (marked escapes it) rather than interpolating the raw text — a label like
+        // `<img onerror=…>` must never reach dangerouslySetInnerHTML unescaped.
+        link(token: Tokens.Link) {
+            const label = this.parser.parseInline(token.tokens);
+
+            if (!isSafeHref(token.href)) {
+                return label;
+            }
+
+            return `<a href="${escapeAttr(token.href)}" target="_blank" rel="noreferrer noopener">${label}</a>`;
         },
     },
 });

--- a/src/dev-dashboard/ui/src/components/boards/useBoardOps.ts
+++ b/src/dev-dashboard/ui/src/components/boards/useBoardOps.ts
@@ -197,7 +197,7 @@ export function useBoardOps(slug: string, history: BoardHistory) {
         (stroke: { cardId?: number; path: number[][]; color: string; width: number }) => {
             tempSeq.current -= 1;
             const tempId = tempSeq.current;
-            const optimistic = { id: tempId, cardId: stroke.cardId ?? null, ...stroke } as unknown as StrokeDto;
+            const optimistic = { ...stroke, id: tempId, cardId: stroke.cardId ?? null } as unknown as StrokeDto;
             setDoc((d) => upsertStroke(d, optimistic));
 
             // The history entry tracks the live id across undo/redo cycles (re-adds mint new ids).

--- a/src/dev-dashboard/ui/src/components/boards/useViewport.ts
+++ b/src/dev-dashboard/ui/src/components/boards/useViewport.ts
@@ -49,7 +49,7 @@ export function fitBounds(
  *  still move further in the wheel's dominant direction. */
 function scrollableAncestorCanConsume(e: WheelEvent, root: HTMLElement): boolean {
     const vertical = Math.abs(e.deltaY) >= Math.abs(e.deltaX);
-    let node = e.target instanceof HTMLElement ? e.target : null;
+    let node = e.target instanceof HTMLElement ? e.target : e.target instanceof Node ? e.target.parentElement : null;
 
     while (node && node !== root) {
         const style = window.getComputedStyle(node);

--- a/src/dev-dashboard/ui/src/components/port-killer/PortsTable.tsx
+++ b/src/dev-dashboard/ui/src/components/port-killer/PortsTable.tsx
@@ -1,9 +1,16 @@
 import type { PortInfo, PortsResult } from "@app/dev-dashboard/lib/ports/types";
+import { fuzzySearchByHaystack } from "@app/utils/fuzzy-search";
+import { useState } from "react";
+import { SearchInput } from "@/components/SearchInput";
 
 interface PortsTableProps {
     result: PortsResult;
     onKill: (port: PortInfo) => void;
     killingPid: number | null;
+}
+
+function portHaystack(p: PortInfo): string {
+    return [p.port, p.command, p.fullCommand, p.title, p.pid, p.address].filter(Boolean).join(" ");
 }
 
 function protoLabel(proto: PortInfo["proto"]): string {
@@ -15,6 +22,8 @@ function sortByPortAsc(ports: PortInfo[]): PortInfo[] {
 }
 
 export function PortsTable({ result, onKill, killingPid }: PortsTableProps) {
+    const [query, setQuery] = useState("");
+
     if (!result.lsofAvailable) {
         return (
             <div className="dd-panel flex h-full items-center justify-center p-8 text-center text-[var(--dd-text-muted)]">
@@ -23,11 +32,23 @@ export function PortsTable({ result, onKill, killingPid }: PortsTableProps) {
         );
     }
 
-    const ports = sortByPortAsc(result.ports);
+    const sorted = sortByPortAsc(result.ports);
+    const ports = fuzzySearchByHaystack(sorted, query, portHaystack).items;
 
     return (
         <div className="dd-panel flex flex-col gap-4 p-4">
-            <h3 className="dd-accent-text text-lg font-semibold">Listening ports ({ports.length})</h3>
+            <div className="flex items-center justify-between gap-4">
+                <h3 className="dd-accent-text text-lg font-semibold">
+                    Listening ports ({ports.length}
+                    {query ? ` / ${sorted.length}` : ""})
+                </h3>
+                <SearchInput
+                    value={query}
+                    onChange={setQuery}
+                    placeholder="Search ports — command, pid, address…"
+                    className="max-w-xs"
+                />
+            </div>
             <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                     <thead>
@@ -85,7 +106,9 @@ export function PortsTable({ result, onKill, killingPid }: PortsTableProps) {
                     </tbody>
                 </table>
                 {ports.length === 0 ? (
-                    <p className="px-2 py-4 text-[var(--dd-text-muted)]">No listening ports.</p>
+                    <p className="px-2 py-4 text-[var(--dd-text-muted)]">
+                        {query ? `No ports match "${query}".` : "No listening ports."}
+                    </p>
                 ) : null}
             </div>
         </div>

--- a/src/dev-dashboard/ui/src/components/webapps/WebappsPanel.tsx
+++ b/src/dev-dashboard/ui/src/components/webapps/WebappsPanel.tsx
@@ -1,23 +1,41 @@
-import type { PortsResult } from "@app/dev-dashboard/lib/ports/types";
+import type { PortInfo, PortsResult } from "@app/dev-dashboard/lib/ports/types";
 import { selectWebapps } from "@app/dev-dashboard/lib/ports/webapps";
+import { fuzzySearchByHaystack } from "@app/utils/fuzzy-search";
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { SearchInput } from "@/components/SearchInput";
 import { portsApi } from "@/lib/api";
 
+function webappHaystack(p: PortInfo): string {
+    return [p.port, p.title, p.command, p.cwd, p.pid].filter(Boolean).join(" ");
+}
+
 export function WebappsPanel() {
+    const [query, setQuery] = useState("");
+
     const { data } = useQuery<PortsResult>({
         queryKey: ["ports"],
         queryFn: () => portsApi.list(),
         refetchInterval: 8000,
     });
 
-    const webapps = data ? selectWebapps(data.ports) : [];
+    const allWebapps = data ? selectWebapps(data.ports) : [];
+    const webapps = fuzzySearchByHaystack(allWebapps, query, webappHaystack).items;
 
     return (
         <div className="dd-panel flex flex-col gap-3 p-4">
-            <h3 className="dd-accent-text text-sm font-bold tracking-widest">WEBAPPS ({webapps.length})</h3>
+            <div className="flex items-center justify-between gap-3">
+                <h3 className="dd-accent-text text-sm font-bold tracking-widest">
+                    WEBAPPS ({webapps.length}
+                    {query ? ` / ${allWebapps.length}` : ""})
+                </h3>
+            </div>
+            {allWebapps.length > 0 ? (
+                <SearchInput value={query} onChange={setQuery} placeholder="Filter webapps…" />
+            ) : null}
             {webapps.length === 0 ? (
                 <p className="font-mono text-sm text-[var(--dd-text-muted)]">
-                    {data ? "No local web servers listening." : "Scanning…"}
+                    {!data ? "Scanning…" : query ? `No webapps match "${query}".` : "No local web servers listening."}
                 </p>
             ) : (
                 <ul className="flex flex-col gap-2">

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -127,15 +127,10 @@ function createDailyFileStream(logDir: string): Writable {
 
     return new Writable({
         decodeStrings: false,
-        write(chunk: string | Uint8Array, _enc, cb) {
+        write(chunk, _enc, cb) {
             try {
                 const fdNow = ensureFd();
-
-                if (typeof chunk === "string") {
-                    fs.writeSync(fdNow, chunk);
-                } else {
-                    fs.writeSync(fdNow, chunk);
-                }
+                fs.writeSync(fdNow, chunk);
             } catch (err) {
                 if (!fileLogWarningShown && process.stderr && typeof process.stderr.write === "function") {
                     fileLogWarningShown = true;
@@ -144,6 +139,18 @@ function createDailyFileStream(logDir: string): Writable {
             }
 
             cb();
+        },
+        destroy(err, cb) {
+            if (fd !== null) {
+                try {
+                    fs.closeSync(fd);
+                } catch {
+                    // ignore during teardown
+                }
+                fd = null;
+            }
+
+            cb(err);
         },
     });
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -77,9 +77,11 @@ export interface LoggerConfig {
     level?: LogLevel;
 }
 
-// Global config
+// Global config. includeTimestamp only gates the CONSOLE time prefix —
+// file records always carry an ISO `time` field (day-stamped files without
+// intra-day times made log forensics impossible).
 let globalConfig: LoggerConfig = {
-    includeTimestamp: false, // Default: no timestamps
+    includeTimestamp: false,
     timestampFormat: "HH:MM:ss",
 };
 let fileLogWarningShown = false;
@@ -198,7 +200,14 @@ export const createLogger = (options: LoggerOptions = {}): pino.Logger => {
             // without ignoring them every console line echoes `tool: "x"` as
             // an indented field line. component stays visible inline instead.
             messageFormat: "{if component}[{component}] {end}{msg}",
-            ignore: showPid ? "hostname,tool,component" : "pid,hostname,tool,component",
+            // `time` is always in the record for the file sink; hide it on the
+            // console unless the caller opted into timestamps.
+            ignore: [
+                showPid ? "hostname,tool,component" : "pid,hostname,tool,component",
+                includeTimestamp ? null : "time",
+            ]
+                .filter(Boolean)
+                .join(","),
         };
 
         // minimalLevels: hide level for info/debug/trace, colored WARN:/ERROR:.
@@ -242,7 +251,9 @@ export const createLogger = (options: LoggerOptions = {}): pino.Logger => {
 
     const baseConfig: pino.LoggerOptions = {
         level: "trace",
-        timestamp: includeTimestamp ? pino.stdTimeFunctions.isoTime : false,
+        // Always stamp records — the file sink needs `time` for forensics;
+        // console visibility is controlled via pino-pretty's ignore list above.
+        timestamp: pino.stdTimeFunctions.isoTime,
         ...(showPid && { base: { pid: process.pid } }),
     };
 

--- a/src/utils/claude/auth.ts
+++ b/src/utils/claude/auth.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { logger } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
 
 export interface OAuthProfileAccount {
@@ -53,13 +54,20 @@ export interface KeychainCredentials {
 }
 
 // Claude Code's official OAuth client ID
-const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
-const AUTH_URL = "https://claude.ai/oauth/authorize";
-const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
-const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
+export const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+// Endpoints + scopes mirror Claude Code (verified against the 2.1.206 binary;
+// migrated off claude.ai/console.anthropic.com in CC 2.1.6+).
+const AUTH_URL = "https://claude.com/cai/oauth/authorize";
+const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
 
-// Full scopes for usage monitoring (same as Claude Code login)
-const FULL_SCOPES = "user:inference user:profile user:mcp_servers user:sessions:claude_code";
+// Full scopes in Claude Code's order (its WJo union for normal login)
+const FULL_SCOPES =
+    "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+// Claude Code sends expires_in=31536000 (1 year) on its setup-token and
+// login-from-refresh-token exchanges; we request the same on login.
+const ONE_YEAR_SECONDS = 31536000;
 
 export interface PKCEChallenge {
     verifier: string;
@@ -120,18 +128,36 @@ export class ClaudeOAuthClient {
         // Claude returns "code#state" format
         const [code, state] = codeInput.includes("#") ? codeInput.split("#") : [codeInput, ""];
 
-        const res = await fetch(TOKEN_URL, {
+        const body: Record<string, unknown> = {
+            grant_type: "authorization_code",
+            client_id: CLAUDE_CODE_CLIENT_ID,
+            code,
+            state,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: verifier,
+            expires_in: ONE_YEAR_SECONDS,
+        };
+
+        let res = await fetch(TOKEN_URL, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: SafeJSON.stringify({
-                grant_type: "authorization_code",
-                client_id: CLAUDE_CODE_CLIENT_ID,
-                code,
-                state,
-                redirect_uri: REDIRECT_URI,
-                code_verifier: verifier,
-            }),
+            body: SafeJSON.stringify(body),
         });
+
+        if (!res.ok && res.status >= 400 && res.status < 500) {
+            // Server may reject the 1-year expires_in for this grant type —
+            // retry once without it rather than failing the whole login.
+            const text = await res.text();
+            logger.warn(
+                `[oauth] exchange with expires_in failed (${res.status} ${text.slice(0, 200)}), retrying without`
+            );
+            delete body.expires_in;
+            res = await fetch(TOKEN_URL, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify(body),
+            });
+        }
 
         if (!res.ok) {
             const text = await res.text();

--- a/src/utils/claude/keychain.ts
+++ b/src/utils/claude/keychain.ts
@@ -36,7 +36,7 @@ interface KeychainPayload {
 function keychainUser(): string {
     let user: string;
     try {
-        user = process.env.USER || userInfo().username;
+        user = env.device.getUser() || userInfo().username;
     } catch {
         user = "claude-code-user";
     }
@@ -146,7 +146,7 @@ export async function resolveKeychainAccountUuid(oauth: ClaudeAiOauthCredentials
     }
 
     try {
-        const claudeJson = await Bun.file(join(homedir(), ".claude.json")).json();
+        const claudeJson = SafeJSON.parse(await Bun.file(join(homedir(), ".claude.json")).text(), { strict: true });
         const uuid = claudeJson?.oauthAccount?.accountUuid;
 
         if (typeof uuid === "string" && uuid) {

--- a/src/utils/claude/keychain.ts
+++ b/src/utils/claude/keychain.ts
@@ -1,0 +1,231 @@
+import { chmodSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
+import { join } from "node:path";
+import { logger } from "@app/logger";
+import type { AIConfig } from "@app/utils/ai/AIConfig";
+import type { AISecondaryLogin } from "@app/utils/config/ai.types";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import { CLAUDE_CODE_CLIENT_ID, fetchOAuthProfile } from "./auth";
+
+/**
+ * Claude Code's keychain credential storage, mirrored from the 2.1.206 binary:
+ * service "Claude Code-credentials" (unsuffixed for the default config dir),
+ * account = $USER (validated), payload = JSON with a `claudeAiOauth` root key,
+ * written hex-encoded via `security add-generic-password -U ... -X <hex>`.
+ */
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+const VALID_KEYCHAIN_USER = /^[a-zA-Z0-9._-]+$/;
+
+export interface ClaudeAiOauthCredentials {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    refreshTokenExpiresAt?: number | null;
+    scopes: string[];
+    subscriptionType?: string | null;
+    rateLimitTier?: string | null;
+    clientId?: string;
+}
+
+interface KeychainPayload {
+    claudeAiOauth?: ClaudeAiOauthCredentials;
+    [key: string]: unknown;
+}
+
+function keychainUser(): string {
+    let user: string;
+    try {
+        user = process.env.USER || userInfo().username;
+    } catch {
+        user = "claude-code-user";
+    }
+
+    return VALID_KEYCHAIN_USER.test(user) ? user : "claude-code-user";
+}
+
+function assertMacOS(): void {
+    if (process.platform !== "darwin") {
+        throw new Error("Claude Code keychain injection is only supported on macOS.");
+    }
+}
+
+/** Read the raw keychain payload Claude Code stores. Returns null when absent. */
+export async function readKeychainPayload(): Promise<KeychainPayload | null> {
+    assertMacOS();
+
+    const proc = Bun.spawn({
+        cmd: ["security", "find-generic-password", "-a", keychainUser(), "-w", "-s", KEYCHAIN_SERVICE],
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const text = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0 || !text.trim()) {
+        logger.debug(`[keychain] no "${KEYCHAIN_SERVICE}" entry (exit ${exitCode})`);
+        return null;
+    }
+
+    try {
+        return SafeJSON.parse(text.trim(), { strict: true }) as KeychainPayload;
+    } catch (err) {
+        logger.warn({ err }, "[keychain] payload is not valid JSON");
+        return null;
+    }
+}
+
+/**
+ * Write the payload the way Claude Code does (`security -i` stdin with the
+ * hex-encoded password, argv fallback for oversized payloads). `-U` updates
+ * an existing entry in place.
+ */
+export async function writeKeychainPayload(payload: KeychainPayload): Promise<void> {
+    assertMacOS();
+
+    const json = SafeJSON.stringify(payload);
+    const hex = Buffer.from(json, "utf-8").toString("hex");
+    const user = keychainUser();
+    const stdinCommand = `add-generic-password -U -a "${user}" -s "${KEYCHAIN_SERVICE}" -X "${hex}"\n`;
+
+    const proc = Bun.spawn({
+        cmd: ["security", "-i"],
+        stdin: new TextEncoder().encode(stdinCommand),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(`Keychain write failed (exit ${exitCode}): ${stderr.trim().slice(0, 300)}`);
+    }
+
+    logger.info("[keychain] wrote Claude Code credentials entry");
+}
+
+/** Delete Claude Code's credential entry. Returns false when it was absent. */
+export async function deleteKeychainEntry(): Promise<boolean> {
+    assertMacOS();
+
+    const proc = Bun.spawn({
+        cmd: ["security", "delete-generic-password", "-a", keychainUser(), "-s", KEYCHAIN_SERVICE],
+        stdout: "ignore",
+        stderr: "ignore",
+    });
+    const ok = (await proc.exited) === 0;
+    logger.info(`[keychain] delete entry: ${ok ? "removed" : "not present"}`);
+    return ok;
+}
+
+/** Build the keychain payload for an account's secondary login. */
+export function secondaryToKeychainPayload(secondary: AISecondaryLogin): KeychainPayload {
+    return {
+        claudeAiOauth: {
+            accessToken: secondary.accessToken,
+            refreshToken: secondary.refreshToken,
+            expiresAt: secondary.expiresAt ?? 0,
+            scopes: secondary.scopes ?? [],
+            subscriptionType: secondary.subscriptionType ?? null,
+            rateLimitTier: secondary.rateLimitTier ?? null,
+            clientId: CLAUDE_CODE_CLIENT_ID,
+        },
+    };
+}
+
+/**
+ * Resolve WHOSE credentials the keychain currently holds. Profile fetch on the
+ * access token is authoritative; ~/.claude.json oauthAccount is the offline
+ * fallback (Claude Code rewrites it from the same profile endpoint).
+ */
+export async function resolveKeychainAccountUuid(oauth: ClaudeAiOauthCredentials): Promise<string | undefined> {
+    const profile = await fetchOAuthProfile(oauth.accessToken);
+
+    if (profile?.account?.uuid) {
+        return profile.account.uuid;
+    }
+
+    try {
+        const claudeJson = await Bun.file(join(homedir(), ".claude.json")).json();
+        const uuid = claudeJson?.oauthAccount?.accountUuid;
+
+        if (typeof uuid === "string" && uuid) {
+            logger.debug("[keychain] identity via ~/.claude.json fallback (profile fetch failed)");
+            return uuid;
+        }
+    } catch (err) {
+        logger.debug({ err }, "[keychain] ~/.claude.json fallback failed");
+    }
+
+    return undefined;
+}
+
+export type KeychainSyncResult =
+    | { status: "no-entry" }
+    | { status: "no-identity" }
+    | { status: "no-match"; uuid: string }
+    | { status: "unchanged"; account: string; uuid: string }
+    | { status: "synced"; account: string; uuid: string };
+
+/**
+ * Pull the keychain credentials back into the ONE config account whose
+ * secondary.accountUuid matches. Never touches any other account; never
+ * writes when the identity is unknown or unmatched (e.g. the user did
+ * /login to a different account or /logout inside Claude Code directly).
+ */
+export async function syncKeychainToConfig(aiConfig: AIConfig): Promise<KeychainSyncResult> {
+    const payload = await readKeychainPayload();
+    const oauth = payload?.claudeAiOauth;
+
+    if (!oauth?.accessToken || !oauth.refreshToken) {
+        return { status: "no-entry" };
+    }
+
+    const uuid = await resolveKeychainAccountUuid(oauth);
+    if (!uuid) {
+        logger.warn("[keychain] cannot resolve keychain identity — skipping sync to avoid a wrong-account write");
+        return { status: "no-identity" };
+    }
+
+    const account = aiConfig
+        .getAccountsByProvider("anthropic-sub")
+        .find((a) => a.secondary?.accountUuid && a.secondary.accountUuid === uuid);
+
+    if (!account?.secondary) {
+        logger.info(`[keychain] entry belongs to uuid ${uuid} — no configured secondary login matches, not syncing`);
+        return { status: "no-match", uuid };
+    }
+
+    if (account.secondary.accessToken === oauth.accessToken && account.secondary.refreshToken === oauth.refreshToken) {
+        return { status: "unchanged", account: account.name, uuid };
+    }
+
+    await aiConfig.updateAccount(account.name, {
+        secondary: {
+            ...account.secondary,
+            accessToken: oauth.accessToken,
+            refreshToken: oauth.refreshToken,
+            expiresAt: oauth.expiresAt,
+            scopes: oauth.scopes?.length ? oauth.scopes : account.secondary.scopes,
+            subscriptionType: oauth.subscriptionType ?? account.secondary.subscriptionType,
+            rateLimitTier: oauth.rateLimitTier ?? account.secondary.rateLimitTier,
+        },
+    });
+
+    logger.info(`[keychain] synced rotated credentials to account "${account.name}" (uuid ${uuid})`);
+    return { status: "synced", account: account.name, uuid };
+}
+
+/**
+ * Back up a keychain payload we are about to overwrite (foreign logins the
+ * user made directly in Claude Code). chmod 600 — same sensitivity as the
+ * ai config. Returns the backup path.
+ */
+export async function backupKeychainPayload(payload: KeychainPayload): Promise<string> {
+    const dir = join(env.tools.getHome() || homedir(), ".genesis-tools", "claude", "keychain-backups");
+    const path = join(dir, `keychain-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+    await Bun.write(path, SafeJSON.stringify(payload, null, 2));
+    chmodSync(path, 0o600);
+    logger.info(`[keychain] backed up existing entry to ${path}`);
+    return path;
+}

--- a/src/utils/claude/subscription-auth.ts
+++ b/src/utils/claude/subscription-auth.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, chmodSync, existsSync } from "node:fs";
+import { appendFileSync, chmodSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@app/logger";
@@ -78,7 +78,6 @@ function journalTokenRotation(account: string, oldTokens: Partial<OAuthTokens>, 
     try {
         const dir = join(env.tools.getHome() || homedir(), ".genesis-tools", "ai");
         const path = join(dir, "token-journal.jsonl");
-        const isNew = !existsSync(path);
         appendFileSync(
             path,
             `${SafeJSON.stringify({
@@ -89,12 +88,11 @@ function journalTokenRotation(account: string, oldTokens: Partial<OAuthTokens>, 
                 newAccessToken: newTokens.accessToken,
                 newRefreshToken: newTokens.refreshToken,
                 newExpiresAt: newTokens.expiresAt,
-            })}\n`
+            })}\n`,
+            { mode: 0o600 }
         );
 
-        if (isNew) {
-            chmodSync(path, 0o600);
-        }
+        chmodSync(path, 0o600);
     } catch (err) {
         logger.warn({ err, account }, "[token-refresh] journal append failed");
     }

--- a/src/utils/claude/subscription-auth.ts
+++ b/src/utils/claude/subscription-auth.ts
@@ -163,11 +163,6 @@ export async function resolveAccountToken(accountName?: string, options?: Resolv
         };
     }
 
-    const lastInvalidGrant = invalidGrantAt.get(name);
-    if (lastInvalidGrant && Date.now() - lastInvalidGrant < INVALID_GRANT_COOLDOWN_MS) {
-        throw new Error(`Token expired (invalid_grant). Run: tools claude login ${name}`);
-    }
-
     const caller = forceRefresh ? "force-refresh" : "token-expired";
     logger.info(`[token-refresh] ${name}: initiating refresh (reason: ${caller})`);
 
@@ -193,6 +188,16 @@ export async function resolveAccountToken(accountName?: string, options?: Resolv
         if (!diskAccount.tokens.refreshToken) {
             logger.warn(`[token-refresh] ${name}: no refresh token available`);
             return null;
+        }
+
+        // Cooldown is checked here — after the disk re-read — not before the lock: if another
+        // process re-logged in, the fresh-token detection above already returned the new token.
+        // Only a refresh token that is still dead on disk hits the cooldown, so a re-login is
+        // picked up immediately instead of being blocked for the full window.
+        const lastInvalidGrant = invalidGrantAt.get(name);
+
+        if (lastInvalidGrant && Date.now() - lastInvalidGrant < INVALID_GRANT_COOLDOWN_MS) {
+            throw new Error(`Token expired (invalid_grant). Run: tools claude login ${name}`);
         }
 
         // Refresh with retry on transient errors (5xx, network)

--- a/src/utils/cli/parse.ts
+++ b/src/utils/cli/parse.ts
@@ -4,5 +4,11 @@ export function parseNonNegativeInt(value: string, flag: string): number {
         throw new Error(`${flag} must be a non-negative integer, got "${value}"`);
     }
 
-    return Number.parseInt(value, 10);
+    const parsed = Number.parseInt(value, 10);
+
+    if (!Number.isSafeInteger(parsed)) {
+        throw new Error(`${flag} must be a non-negative integer, got "${value}"`);
+    }
+
+    return parsed;
 }

--- a/src/utils/config/ai.types.ts
+++ b/src/utils/config/ai.types.ts
@@ -18,10 +18,29 @@ export interface AIAccountTokens {
     longLivedToken?: string; // Long-lived OAuth token from `claude setup-token` (sk-ant-oat01-...); passed via CLAUDE_CODE_OAUTH_TOKEN
 }
 
+/**
+ * A second, independent OAuth grant for the same Anthropic account —
+ * injected into the macOS keychain by `tools claude start --keychain` so
+ * Claude Code runs fully logged-in, without fighting the primary token
+ * chain that usage polling refreshes (refresh tokens are single-use).
+ */
+export interface AISecondaryLogin {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt?: number; // Unix ms
+    scopes?: string[];
+    subscriptionType?: string | null; // keychain claudeAiOauth field ("max" | "pro" | null)
+    rateLimitTier?: string | null;
+    accountUuid?: string; // Anthropic account uuid — the keychain sync-back match key
+    emailAddress?: string;
+    organizationUuid?: string;
+}
+
 export interface AIAccountEntry {
     name: string;
     provider: AIProvider;
     tokens: AIAccountTokens;
+    secondary?: AISecondaryLogin;
     label?: string; // e.g. "max 20x", "pro"
     apps?: string[]; // which tools use this: ["ask", "claude"]
 }


### PR DESCRIPTION
## What

Three work streams that accumulated on this branch:

### Claude auth (latest)
- **OAuth migration to claude.com** — authorize `claude.com/cai/oauth/authorize`, token `platform.claude.com/v1/oauth/token`, redirect `platform.claude.com/oauth/code/callback`, full 6-scope set (`org:create_api_key` + `user:file_upload` added) — all verified against the Claude Code 2.1.206 binary.
- **1-year token expiry** — `exchangeCode` sends `expires_in=31536000` (as CC's setup-token/refresh-login flows do), with a retry-without fallback on 4xx.
- **`tools claude logout <acc>`** — remove OAuth pair / long-lived token / both, with confirmation; usage polling skips logged-out accounts.
- **`tools claude login-secondary <acc>`** — a second, independent OAuth grant stored per account (never used by usage polling).
- **`tools claude start/run --keychain`** — injects the secondary login into the macOS keychain (byte-exact to CC's own writer), launches Claude Code fully logged-in, and syncs rotated tokens back to the correct account by account-UUID matching. Foreign keychain logins are backed up and restored; unresolvable identity means no sync (never a wrong-account write).
- **Login crash fix** — answering "No" to "Open URL in browser?" killed the app (`ReadableStream is locked`); the code paste now uses a clack prompt.

### Boards / dev-dashboard UI polish
- UI polish round 2: canvas fixes, AI card renderers, ports enrichment.
- Public board links from server config (`https://<allowedHost>` first, localhost fallback).
- MIME-correct unique paste filenames.

### Claude usage dashboard
- Two-column overview when accounts overflow the viewport.
- 429 handling: stop refresh-token rotation storm, restore metered rotation, TUI flicker/input fixes.
- Poller/autopick/start hardening from earlier review rounds.
- Midnight logger file rollover.

## Notes
- Live verification of the keychain flow on a low-stakes account is tracked separately (needs an interactive OAuth login).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude secondary-login and logout commands.
  * Expanded Claude start with account/model selection, resume/continue, passthrough arguments, and keychain support.
  * Added board session feeds, pasted-image uploads, safer Markdown links, and searchable ports/web apps.
  * Added board creation, stroke editing, and improved section layout handling.
* **Bug Fixes**
  * Improved request error messages, token refresh handling, session-title display, scrolling, question selection, and keychain restoration.
  * Added safer board validation and more reliable test cleanup.
* **Security**
  * Strengthened credential storage, OAuth handling, hidden-file restoration, and Markdown link sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->