### PR TITLE
feat(ai-proxy): per-client keys, no-resale guard, monthly quotas + usage ledger

### DIFF
--- a/src/ai-proxy/README.md
+++ b/src/ai-proxy/README.md
@@ -128,6 +128,21 @@ The proxy appends one JSON object per completed request under `~/.genesis-tools/
 
 Data stays on disk locally only. To reset history, truncate or delete `requests.jsonl` (and optionally `daily.json`).
 
+### Client billing (2026-07)
+
+Multi-user (VPS) mode: give each downstream user its own key via `clients` in `~/.genesis-tools/ai-proxy/config.json`, while `proxyApiKey` stays the owner key. Example:
+
+```json
+"clients": [
+  { "name": "eve-service", "key": "<32+ char secret>", "monthlyTokenCap": 5000000, "monthlyCostCapUsd": 25 }
+]
+```
+
+- **No-resale invariant:** client keys can NEVER route to subscription providers (grok / copilot / anthropic / openai subscription) — only `proxyApiKey` (owner) can. Client attempts get `403 {"type":"forbidden","code":"provider_not_allowed"}`; a config that grants a subscription provider to a client refuses to boot.
+- **Quotas:** `monthlyTokenCap` / `monthlyCostCapUsd` are enforced per UTC month against `usage/clients.json`; over-cap requests get `429 {"type":"quota_exceeded","code":"monthly_quota_exceeded"}`.
+- **Manage:** `tools ai-proxy clients add <name> [--token-cap N] [--cost-cap USD] [--provider <type>...]` prints the generated key ONCE; `tools ai-proxy clients list` (keys masked); `tools ai-proxy clients usage [--month YYYY-MM] [--csv]` (CSV = the v1 invoicing export).
+- **eve-service:** eve connects as ONE client key (`eve-service`) with its own caps — set that key as eve's OpenAI-compatible API key against the proxy; splitting eve traffic per end-user is a later plan.
+
 ## Internal
 
 ```bash

--- a/src/ai-proxy/commands/clients.ts
+++ b/src/ai-proxy/commands/clients.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from "node:crypto";
+import { validateClients } from "@app/ai-proxy/lib/clients";
+import { loadConfigFresh, saveConfig } from "@app/ai-proxy/lib/config";
+import type { AiProxyClientConfig, AiProxyProviderType } from "@app/ai-proxy/lib/types";
+import { readClientLedger } from "@app/ai-proxy/lib/usage/client-ledger";
+import { logger, out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+
+export async function clientsList(): Promise<void> {
+    const config = await loadConfigFresh();
+    const clients = config.clients ?? [];
+
+    if (clients.length === 0) {
+        out.log.info("No clients configured (proxyApiKey/owner only).");
+        return;
+    }
+
+    out.result(
+        SafeJSON.stringify(
+            clients.map(({ key, ...rest }) => ({ ...rest, key: `${key.slice(0, 4)}…${key.slice(-4)}` })),
+            null,
+            2
+        ) ?? "[]"
+    );
+}
+
+export async function clientsAdd(input: {
+    name: string;
+    tokenCap?: number;
+    costCap?: number;
+    providers?: AiProxyProviderType[];
+}): Promise<void> {
+    if (input.tokenCap !== undefined && (!Number.isFinite(input.tokenCap) || input.tokenCap <= 0)) {
+        out.log.error("--token-cap must be a positive number");
+        process.exitCode = 1;
+        return;
+    }
+
+    if (input.costCap !== undefined && (!Number.isFinite(input.costCap) || input.costCap <= 0)) {
+        out.log.error("--cost-cap must be a positive number");
+        process.exitCode = 1;
+        return;
+    }
+
+    const config = await loadConfigFresh();
+    const key = randomBytes(24).toString("base64url");
+    const client: AiProxyClientConfig = {
+        name: input.name,
+        key,
+        ...(input.providers?.length ? { allowedProviders: input.providers } : {}),
+        ...(input.tokenCap !== undefined ? { monthlyTokenCap: input.tokenCap } : {}),
+        ...(input.costCap !== undefined ? { monthlyCostCapUsd: input.costCap } : {}),
+    };
+    const next = [...(config.clients ?? []), client];
+    const problems = validateClients(next);
+
+    if (problems.length > 0) {
+        logger.error({ problems }, "ai-proxy: refusing to add client");
+        out.log.error(problems.join("\n"));
+        process.exitCode = 1;
+        return;
+    }
+
+    await saveConfig({ ...config, clients: next });
+    out.log.success(`Client "${input.name}" added.`);
+    out.print(key);
+    out.log.info("This key is shown ONCE — hand it to the user now.");
+}
+
+export async function clientsUsage(input: { month?: string; csv?: boolean }): Promise<void> {
+    const month = input.month ?? new Date().toISOString().slice(0, 7);
+    const byClient = readClientLedger().months[month] ?? {};
+    const rows = Object.entries(byClient).map(([client, usage]) => ({ client, month, ...usage }));
+
+    if (input.csv) {
+        const header = "client,month,requests,prompt_tokens,completion_tokens,total_tokens,cost_usd,unpriced_requests";
+        const lines = rows.map(
+            (row) =>
+                `${row.client},${row.month},${row.requests},${row.prompt_tokens},${row.completion_tokens},${row.total_tokens},${row.cost_usd.toFixed(4)},${row.unpriced_requests}`
+        );
+        out.print([header, ...lines].join("\n"));
+        return;
+    }
+
+    out.result(SafeJSON.stringify(rows, null, 2) ?? "[]");
+}

--- a/src/ai-proxy/index.ts
+++ b/src/ai-proxy/index.ts
@@ -2,6 +2,7 @@
 
 import { runAccountsList, runAccountsRemove, runAccountsTest } from "@app/ai-proxy/commands/accounts";
 import { runAccountsLogin } from "@app/ai-proxy/commands/accounts-login";
+import { clientsAdd, clientsList, clientsUsage } from "@app/ai-proxy/commands/clients";
 import { runConfigDetect, runConfigInit, runConfigSet, runConfigShow } from "@app/ai-proxy/commands/config";
 import { runConfigMenu, runSetupCloudflaredTunnel } from "@app/ai-proxy/commands/config-wizard";
 import { runDownCommand } from "@app/ai-proxy/commands/down";
@@ -13,7 +14,7 @@ import { runStatusCommand } from "@app/ai-proxy/commands/status";
 import { runUpCommand } from "@app/ai-proxy/commands/up";
 import { runUsageCommand } from "@app/ai-proxy/commands/usage";
 import { isValidThinkingMode } from "@app/ai-proxy/lib/thinking-config";
-import type { CursorTranslationMode, ThinkingPresentationMode } from "@app/ai-proxy/lib/types";
+import type { AiProxyProviderType, CursorTranslationMode, ThinkingPresentationMode } from "@app/ai-proxy/lib/types";
 import { runTool } from "@app/utils/cli";
 import { Command } from "commander";
 
@@ -76,6 +77,39 @@ program
     .option("--cursor-ids", "Print only proxy ids")
     .action(async (options) => {
         await runModelsCommand(options);
+    });
+
+const clientsCmd = program.command("clients").description("Manage per-user client keys + usage ledger");
+
+clientsCmd
+    .command("list")
+    .description("List configured clients (keys masked)")
+    .action(async () => {
+        await clientsList();
+    });
+
+clientsCmd
+    .command("add <name>")
+    .description("Add a client; prints its generated key ONCE")
+    .option("--token-cap <n>", "Monthly total-token cap", (v) => Number.parseInt(v, 10))
+    .option("--cost-cap <usd>", "Monthly cost cap in USD", (v) => Number.parseFloat(v))
+    .option("--provider <type...>", "Restrict to provider types (never subscription types)")
+    .action(async (name: string, opts: { tokenCap?: number; costCap?: number; provider?: string[] }) => {
+        await clientsAdd({
+            name,
+            tokenCap: opts.tokenCap,
+            costCap: opts.costCap,
+            providers: opts.provider as AiProxyProviderType[] | undefined,
+        });
+    });
+
+clientsCmd
+    .command("usage")
+    .description("Per-client monthly usage (JSON, or CSV for invoicing)")
+    .option("--month <YYYY-MM>", "Month to report (default: current UTC month)")
+    .option("--csv", "CSV output")
+    .action(async (opts: { month?: string; csv?: boolean }) => {
+        await clientsUsage(opts);
     });
 
 program

--- a/src/ai-proxy/lib/billing/pricing.test.ts
+++ b/src/ai-proxy/lib/billing/pricing.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { estimateCostUsd } from "@app/ai-proxy/lib/billing/pricing";
+
+describe("estimateCostUsd", () => {
+    it("prices a known model per 1M tokens", () => {
+        // grok-4-fast: $0.20/1M in, $0.50/1M out → 1M in + 1M out = $0.70
+        expect(estimateCostUsd("grok-4-fast", { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 })).toBeCloseTo(
+            0.7,
+            10
+        );
+    });
+
+    it("matches dated model ids by prefix", () => {
+        const cost = estimateCostUsd("claude-haiku-4-5-20251001", {
+            prompt_tokens: 2_000_000,
+            completion_tokens: 0,
+        });
+        expect(cost).toBeCloseTo(2.0, 10);
+    });
+
+    it("returns undefined for unknown models and zero-usage requests", () => {
+        expect(estimateCostUsd("mystery-model", { prompt_tokens: 5 })).toBeUndefined();
+        expect(estimateCostUsd("grok-4-fast", {})).toBe(0);
+    });
+});

--- a/src/ai-proxy/lib/billing/pricing.ts
+++ b/src/ai-proxy/lib/billing/pricing.ts
@@ -1,0 +1,52 @@
+/**
+ * Static USD-per-1M-token pricing for cost estimation on the client ledger.
+ * Longest-prefix match so dated ids (claude-haiku-4-5-20251001) hit their
+ * family entry. Unknown model → undefined (ledger records tokens, adds $0,
+ * CLI marks the estimate incomplete) — never guess a price.
+ *
+ * Rates: public list prices as of 2026-07. Update deliberately; this table is
+ * the invoicing source of truth.
+ */
+interface ModelRate {
+    inputUsdPerMTok: number;
+    outputUsdPerMTok: number;
+}
+
+const MODEL_RATES: Record<string, ModelRate> = {
+    "claude-fable-5": { inputUsdPerMTok: 25, outputUsdPerMTok: 125 },
+    "claude-opus-4": { inputUsdPerMTok: 15, outputUsdPerMTok: 75 },
+    "claude-sonnet-4": { inputUsdPerMTok: 3, outputUsdPerMTok: 15 },
+    "claude-haiku-4": { inputUsdPerMTok: 1, outputUsdPerMTok: 5 },
+    "gpt-5.5": { inputUsdPerMTok: 1.25, outputUsdPerMTok: 10 },
+    "gpt-5-codex": { inputUsdPerMTok: 1.25, outputUsdPerMTok: 10 },
+    "grok-4-fast": { inputUsdPerMTok: 0.2, outputUsdPerMTok: 0.5 },
+    "grok-4": { inputUsdPerMTok: 3, outputUsdPerMTok: 15 },
+    "grok-code-fast": { inputUsdPerMTok: 0.2, outputUsdPerMTok: 1.5 },
+};
+
+function findRate(upstreamModel: string): ModelRate | undefined {
+    let best: { prefix: string; rate: ModelRate } | undefined;
+
+    for (const [prefix, rate] of Object.entries(MODEL_RATES)) {
+        if (upstreamModel.startsWith(prefix) && (!best || prefix.length > best.prefix.length)) {
+            best = { prefix, rate };
+        }
+    }
+
+    return best?.rate;
+}
+
+export function estimateCostUsd(
+    upstreamModel: string,
+    usage: { prompt_tokens?: number; completion_tokens?: number }
+): number | undefined {
+    const rate = findRate(upstreamModel);
+
+    if (!rate) {
+        return undefined;
+    }
+
+    const input = usage.prompt_tokens ?? 0;
+    const output = usage.completion_tokens ?? 0;
+    return (input / 1_000_000) * rate.inputUsdPerMTok + (output / 1_000_000) * rate.outputUsdPerMTok;
+}

--- a/src/ai-proxy/lib/clients.test.ts
+++ b/src/ai-proxy/lib/clients.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import {
+    clientProviderDenial,
+    OWNER_CLIENT_NAME,
+    resolveClient,
+    SUBSCRIPTION_PROVIDER_TYPES,
+    validateClients,
+} from "@app/ai-proxy/lib/clients";
+import type { AiProxyClientConfig, AiProxyConfig } from "@app/ai-proxy/lib/types";
+
+const good: AiProxyClientConfig = { name: "alice", key: "k".repeat(24) };
+
+describe("validateClients", () => {
+    it("accepts a valid list and an absent list", () => {
+        expect(validateClients(undefined)).toEqual([]);
+        expect(validateClients([good])).toEqual([]);
+    });
+
+    it("rejects short keys, duplicate names, duplicate keys, and reserved owner name", () => {
+        const problems = validateClients([
+            { name: "alice", key: "short" },
+            { name: "alice", key: "x".repeat(24) },
+            { name: OWNER_CLIENT_NAME, key: "y".repeat(24) },
+            { name: "bob", key: "x".repeat(24) },
+        ]);
+        expect(problems.some((p) => p.includes("at least 16"))).toBe(true);
+        expect(problems.some((p) => p.includes("duplicate client name"))).toBe(true);
+        expect(problems.some((p) => p.includes("duplicate client key"))).toBe(true);
+        expect(problems.some((p) => p.includes("reserved"))).toBe(true);
+    });
+
+    it("rejects allowedProviders containing a subscription type", () => {
+        const problems = validateClients([{ ...good, allowedProviders: ["anthropic-subscription"] }]);
+        expect(problems.some((p) => p.includes("subscription providers cannot be granted"))).toBe(true);
+        expect(SUBSCRIPTION_PROVIDER_TYPES.has("anthropic-subscription")).toBe(true);
+    });
+
+    it("reports malformed name/key/allowedProviders instead of throwing", () => {
+        const malformed = { name: 123, key: true, allowedProviders: {} } as unknown as AiProxyClientConfig;
+        const problems = validateClients([malformed]);
+        expect(problems.some((p) => p.includes("must be a non-empty string of alphanumerics"))).toBe(true);
+        expect(problems.some((p) => p.includes("key must be a string"))).toBe(true);
+        expect(problems.some((p) => p.includes("allowedProviders must be an array"))).toBe(true);
+    });
+
+    it("reports a non-array clients config instead of throwing", () => {
+        const malformed = { owner: true } as unknown as AiProxyClientConfig[];
+        expect(validateClients(malformed)).toEqual(["clients config must be an array of client entries"]);
+    });
+});
+
+function reqWithBearer(token: string | null): Request {
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+    return new Request("http://localhost/v1/chat/completions", { method: "POST", headers });
+}
+
+function cfg(clients?: AiProxyConfig["clients"]): AiProxyConfig {
+    return { proxyApiKey: "owner-key-0123456789", clients } as AiProxyConfig;
+}
+
+describe("resolveClient", () => {
+    it("resolves proxyApiKey to the owner identity", () => {
+        const resolved = resolveClient(reqWithBearer("owner-key-0123456789"), cfg());
+        expect(resolved).toEqual({ name: "owner", isOwner: true });
+    });
+
+    it("resolves a client key to its named identity", () => {
+        const alice = { name: "alice", key: "alice-key-0123456789" };
+        const resolved = resolveClient(reqWithBearer("alice-key-0123456789"), cfg([alice]));
+        expect(resolved?.name).toBe("alice");
+        expect(resolved?.isOwner).toBe(false);
+        expect(resolved?.config).toEqual(alice);
+    });
+
+    it("rejects wrong keys, missing header, and disabled clients", () => {
+        const disabled = { name: "mallory", key: "mallory-key-0123456", disabled: true };
+        expect(resolveClient(reqWithBearer("nope-nope-nope-nope"), cfg([disabled]))).toBeNull();
+        expect(resolveClient(reqWithBearer(null), cfg())).toBeNull();
+        expect(resolveClient(reqWithBearer("mallory-key-0123456"), cfg([disabled]))).toBeNull();
+    });
+
+    it("skips a non-string client key and doesn't throw", () => {
+        const malformed = { name: "mallory", key: 12345 } as unknown as NonNullable<AiProxyConfig["clients"]>[number];
+        expect(resolveClient(reqWithBearer("owner-key-0123456789"), cfg([malformed]))).toEqual({
+            name: "owner",
+            isOwner: true,
+        });
+        expect(resolveClient(reqWithBearer("anything"), cfg([malformed]))).toBeNull();
+    });
+
+    it("treats a non-array clients config as empty instead of throwing", () => {
+        const malformed = { owner: true } as unknown as AiProxyConfig["clients"];
+        expect(resolveClient(reqWithBearer("owner-key-0123456789"), cfg(malformed))).toEqual({
+            name: "owner",
+            isOwner: true,
+        });
+    });
+});
+
+describe("clientProviderDenial", () => {
+    const owner = { name: "owner", isOwner: true } as const;
+    const alice = { name: "alice", isOwner: false, config: { name: "alice", key: "k".repeat(24) } };
+    const bob = {
+        name: "bob",
+        isOwner: false,
+        config: { name: "bob", key: "b".repeat(24), allowedProviders: ["xai-api-key" as const] },
+    };
+
+    it("owner may route anywhere", () => {
+        expect(clientProviderDenial(owner, "anthropic-subscription")).toBeNull();
+        expect(clientProviderDenial(owner, "xai-api-key")).toBeNull();
+    });
+
+    it("clients are always denied subscription providers", () => {
+        expect(clientProviderDenial(alice, "anthropic-subscription")).toContain("subscription");
+        expect(clientProviderDenial(bob, "openai-subscription")).toContain("subscription");
+    });
+
+    it("clients without allowedProviders get any non-subscription provider", () => {
+        expect(clientProviderDenial(alice, "xai-api-key")).toBeNull();
+        expect(clientProviderDenial(alice, "openai")).toBeNull();
+    });
+
+    it("allowedProviders restricts to the listed set", () => {
+        expect(clientProviderDenial(bob, "xai-api-key")).toBeNull();
+        expect(clientProviderDenial(bob, "openai")).toContain("not allowed");
+    });
+
+    it("treats a non-array allowedProviders as unrestricted instead of throwing", () => {
+        const malformed = {
+            name: "eve",
+            isOwner: false,
+            config: { name: "eve", key: "e".repeat(24), allowedProviders: {} },
+        } as unknown as Parameters<typeof clientProviderDenial>[0];
+        expect(clientProviderDenial(malformed, "xai-api-key")).toBeNull();
+        expect(clientProviderDenial(malformed, "anthropic-subscription")).toContain("subscription");
+    });
+});

--- a/src/ai-proxy/lib/clients.ts
+++ b/src/ai-proxy/lib/clients.ts
@@ -1,0 +1,162 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { extractBearerToken } from "@app/ai-proxy/lib/auth-middleware";
+import type { AiProxyClientConfig, AiProxyConfig, AiProxyProviderType } from "@app/ai-proxy/lib/types";
+
+export const OWNER_CLIENT_NAME = "owner";
+
+const MIN_KEY_LENGTH = 16;
+
+/**
+ * Provider types that bill a personal subscription (Claude Max, ChatGPT, Grok,
+ * Copilot). Serving these to third parties is subscription resale — a ToS
+ * violation — so ONLY the owner key (proxyApiKey) may ever route to them.
+ * FROZEN: config cannot grant these to a client; validation rejects the attempt.
+ */
+export const SUBSCRIPTION_PROVIDER_TYPES: ReadonlySet<AiProxyProviderType> = new Set([
+    "grok-subscription",
+    "github-copilot-subscription",
+    "anthropic-subscription",
+    "openai-subscription",
+]);
+
+/** Every known provider type — catches allowedProviders typos at validation time. */
+export const VALID_PROVIDER_TYPES: ReadonlySet<AiProxyProviderType> = new Set([
+    ...SUBSCRIPTION_PROVIDER_TYPES,
+    "xai-api-key",
+    "openai",
+]);
+
+export function validateClients(clients: AiProxyClientConfig[] | undefined): string[] {
+    if (clients === undefined) {
+        return [];
+    }
+
+    if (!Array.isArray(clients)) {
+        return ["clients config must be an array of client entries"];
+    }
+
+    if (clients.length === 0) {
+        return [];
+    }
+
+    const problems: string[] = [];
+    const names = new Set<string>();
+    const keys = new Set<string>();
+
+    for (const client of clients) {
+        if (typeof client.name !== "string" || !/^[a-zA-Z0-9_-]+$/.test(client.name)) {
+            problems.push(
+                `client name ${SafeStr(client.name)} must be a non-empty string of alphanumerics, hyphens, or underscores`
+            );
+        }
+
+        if (client.name === OWNER_CLIENT_NAME) {
+            problems.push(`client name "${OWNER_CLIENT_NAME}" is reserved for the proxyApiKey identity`);
+        }
+
+        if (names.has(client.name)) {
+            problems.push(`duplicate client name: ${client.name}`);
+        }
+
+        names.add(client.name);
+
+        if (typeof client.key !== "string" || client.key.length < MIN_KEY_LENGTH) {
+            problems.push(`client "${client.name}": key must be a string of at least ${MIN_KEY_LENGTH} characters`);
+        }
+
+        if (keys.has(client.key)) {
+            problems.push(`duplicate client key (client "${client.name}")`);
+        }
+
+        keys.add(client.key);
+
+        if (client.allowedProviders !== undefined && !Array.isArray(client.allowedProviders)) {
+            problems.push(`client "${client.name}": allowedProviders must be an array`);
+        } else {
+            for (const provider of client.allowedProviders ?? []) {
+                if (!VALID_PROVIDER_TYPES.has(provider)) {
+                    problems.push(`client "${client.name}": unknown provider type "${provider}"`);
+                } else if (SUBSCRIPTION_PROVIDER_TYPES.has(provider)) {
+                    problems.push(
+                        `client "${client.name}": subscription providers cannot be granted to clients (${provider})`
+                    );
+                }
+            }
+        }
+    }
+
+    return problems;
+}
+
+function SafeStr(value: string | undefined): string {
+    return value === undefined ? "<missing>" : `"${value}"`;
+}
+
+export interface ResolvedClient {
+    name: string;
+    isOwner: boolean;
+    config?: AiProxyClientConfig;
+}
+
+function digestsEqual(a: string, b: string): boolean {
+    const hashA = createHash("sha256").update(a).digest();
+    const hashB = createHash("sha256").update(b).digest();
+    return timingSafeEqual(hashA, hashB);
+}
+
+/**
+ * Resolve the presented Bearer to a client identity. The legacy proxyApiKey is
+ * the implicit "owner". No early exit: every candidate is compared so a match's
+ * list position is not observable via timing.
+ */
+export function resolveClient(req: Request, config: AiProxyConfig): ResolvedClient | null {
+    const token = extractBearerToken(req);
+
+    if (!token) {
+        return null;
+    }
+
+    let resolved: ResolvedClient | null = null;
+
+    if (typeof config.proxyApiKey === "string" && digestsEqual(token, config.proxyApiKey)) {
+        resolved = { name: OWNER_CLIENT_NAME, isOwner: true };
+    }
+
+    for (const client of Array.isArray(config.clients) ? config.clients : []) {
+        if (typeof client.key !== "string") {
+            continue;
+        }
+
+        const matches = digestsEqual(token, client.key);
+
+        if (matches && !client.disabled && resolved === null) {
+            resolved = { name: client.name, isOwner: false, config: client };
+        }
+    }
+
+    return resolved;
+}
+
+/**
+ * Returns null when the client may route to the provider type, else a
+ * human-readable denial. Subscription providers are denied to every non-owner
+ * client unconditionally — this is the no-resale invariant; allowedProviders
+ * cannot override it (and validation already rejects the attempt).
+ */
+export function clientProviderDenial(client: ResolvedClient, providerType: AiProxyProviderType): string | null {
+    if (client.isOwner) {
+        return null;
+    }
+
+    if (SUBSCRIPTION_PROVIDER_TYPES.has(providerType)) {
+        return `provider "${providerType}" bills a personal subscription and is owner-only`;
+    }
+
+    const allowed = client.config?.allowedProviders;
+
+    if (Array.isArray(allowed) && !allowed.includes(providerType)) {
+        return `provider "${providerType}" is not allowed for client "${client.name}"`;
+    }
+
+    return null;
+}

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -1,6 +1,6 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
-import { requireProxyApiKey } from "@app/ai-proxy/lib/auth-middleware";
 import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
+import { clientProviderDenial, resolveClient, validateClients } from "@app/ai-proxy/lib/clients";
 import { loadConfigFresh } from "@app/ai-proxy/lib/config";
 import { stripBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { buildProviderMap, routeProviderKey, tryCreateProvider } from "@app/ai-proxy/lib/providers/registry";
@@ -12,6 +12,7 @@ import { handleChatCompletions } from "@app/ai-proxy/lib/translators";
 import { identityPipeline } from "@app/ai-proxy/lib/translators/identity-pipeline";
 import type { AiProxyConfig, ResolvedRoute, ThinkingPresentationMode } from "@app/ai-proxy/lib/types";
 import { scheduleBillingSync } from "@app/ai-proxy/lib/usage/billing-sync";
+import { checkClientQuota } from "@app/ai-proxy/lib/usage/client-ledger";
 import { scheduleUsageTracking } from "@app/ai-proxy/lib/usage/track-response";
 import { logger } from "@app/logger";
 import { CopilotAuthExpiredError } from "@app/utils/ai/github-copilot";
@@ -76,6 +77,7 @@ function normalizePath(pathname: string, basePath?: string): string {
 function trackProxyRequest(input: {
     runtime: AiProxyRuntime;
     route: ResolvedRoute;
+    client: string;
     proxyModel: string;
     path: string;
     status: number;
@@ -87,6 +89,7 @@ function trackProxyRequest(input: {
 }): void {
     scheduleUsageTracking({
         route: input.route,
+        client: input.client,
         proxyModel: input.proxyModel,
         path: input.path,
         status: input.status,
@@ -100,6 +103,12 @@ function trackProxyRequest(input: {
 }
 
 export function startAiProxyServer(runtime: AiProxyRuntime) {
+    const clientProblems = validateClients(runtime.config.clients);
+
+    if (clientProblems.length > 0) {
+        throw new Error(`ai-proxy: invalid clients config — ${clientProblems.join("; ")}`);
+    }
+
     const listen = runtime.config.listen;
 
     return Bun.serve({
@@ -119,9 +128,13 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
             const config = await loadConfigFresh();
 
             if (path === "/v1/models" && req.method === "GET") {
-                const authError = requireProxyApiKey(req, config.proxyApiKey);
-                if (authError) {
-                    return authError;
+                const client = resolveClient(req, config);
+
+                if (!client) {
+                    return new Response(
+                        SafeJSON.stringify({ error: { message: "Invalid proxy API key", type: "auth_error" } }),
+                        { status: 401, headers: { "Content-Type": "application/json" } }
+                    );
                 }
 
                 const models = await buildProxyModelCatalog(config.accounts);
@@ -142,9 +155,13 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
             }
 
             if ((path === "/v1/chat/completions" || path === "/v1/responses") && req.method === "POST") {
-                const authError = requireProxyApiKey(req, config.proxyApiKey);
-                if (authError) {
-                    return authError;
+                const client = resolveClient(req, config);
+
+                if (!client) {
+                    return new Response(
+                        SafeJSON.stringify({ error: { message: "Invalid proxy API key", type: "auth_error" } }),
+                        { status: 401, headers: { "Content-Type": "application/json" } }
+                    );
                 }
 
                 const requestStarted = performance.now();
@@ -190,6 +207,35 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
 
                 try {
                     const route = resolveModel(parsed.model, config.accounts);
+
+                    const denial = clientProviderDenial(client, route.account.provider);
+
+                    if (denial) {
+                        logger.warn({ client: client.name, model: parsed.model, denial }, "ai-proxy: provider denied");
+                        return new Response(
+                            SafeJSON.stringify({
+                                error: { message: denial, type: "forbidden", code: "provider_not_allowed" },
+                            }),
+                            { status: 403, headers: { "Content-Type": "application/json" } }
+                        );
+                    }
+
+                    const quota = checkClientQuota(client);
+
+                    if (!quota.ok) {
+                        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: quota exceeded");
+                        return new Response(
+                            SafeJSON.stringify({
+                                error: {
+                                    message: quota.reason,
+                                    type: "quota_exceeded",
+                                    code: "monthly_quota_exceeded",
+                                },
+                            }),
+                            { status: 429, headers: { "Content-Type": "application/json" } }
+                        );
+                    }
+
                     const key = routeProviderKey(route);
                     const fingerprint = accountConfigFingerprint(route.account);
                     let provider = runtime.providers.get(key);
@@ -233,6 +279,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         trackProxyRequest({
                             runtime,
                             route,
+                            client: client.name,
                             proxyModel: parsed.model,
                             path,
                             status: response.status,
@@ -284,6 +331,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                     trackProxyRequest({
                         runtime,
                         route,
+                        client: client.name,
                         proxyModel: parsed.model,
                         path,
                         status: response.status,

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -109,9 +109,21 @@ export interface AiProxyAccountConfig {
     teamId?: string;
 }
 
+export interface AiProxyClientConfig {
+    name: string;
+    key: string;
+    /** Provider types this client may route to. Omitted = all NON-subscription providers. */
+    allowedProviders?: AiProxyProviderType[];
+    monthlyTokenCap?: number;
+    monthlyCostCapUsd?: number;
+    disabled?: boolean;
+}
+
 export interface AiProxyConfig {
     listen: AiProxyListenConfig;
     proxyApiKey: string;
+    /** Per-user keys for multi-client (VPS) mode. proxyApiKey remains the owner key. */
+    clients?: AiProxyClientConfig[];
     translation: AiProxyTranslationConfig;
     public?: AiProxyPublicConfig;
     accounts: AiProxyAccountConfig[];

--- a/src/ai-proxy/lib/usage/client-ledger.test.ts
+++ b/src/ai-proxy/lib/usage/client-ledger.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    checkClientQuota,
+    monthKeyFromTs,
+    readClientLedger,
+    recordClientUsage,
+    setClientLedgerDirForTests,
+} from "@app/ai-proxy/lib/usage/client-ledger";
+
+let dir: string;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "client-ledger-"));
+    setClientLedgerDirForTests(dir);
+});
+
+afterEach(() => {
+    setClientLedgerDirForTests(null);
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("monthKeyFromTs", () => {
+    it("uses the UTC month", () => {
+        expect(monthKeyFromTs("2026-07-01T00:30:00.000Z")).toBe("2026-07");
+        expect(monthKeyFromTs("2026-12-31T23:59:59.000Z")).toBe("2026-12");
+    });
+});
+
+describe("recordClientUsage + readClientLedger", () => {
+    it("accumulates tokens and cost per client per month", () => {
+        recordClientUsage({
+            client: "alice",
+            ts: "2026-07-10T10:00:00.000Z",
+            upstreamModel: "grok-4-fast",
+            usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000, total_tokens: 2_000_000 },
+        });
+        recordClientUsage({
+            client: "alice",
+            ts: "2026-07-11T10:00:00.000Z",
+            upstreamModel: "mystery-model",
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        });
+
+        const ledger = readClientLedger();
+        const alice = ledger.months["2026-07"]?.alice;
+        expect(alice?.requests).toBe(2);
+        expect(alice?.total_tokens).toBe(2_000_015);
+        expect(alice?.cost_usd).toBeCloseTo(0.7, 10);
+    });
+});
+
+describe("checkClientQuota", () => {
+    const client = (caps: { monthlyTokenCap?: number; monthlyCostCapUsd?: number }) => ({
+        name: "alice",
+        isOwner: false,
+        config: { name: "alice", key: "k".repeat(24), ...caps },
+    });
+
+    it("owner and cap-less clients always pass", () => {
+        expect(checkClientQuota({ name: "owner", isOwner: true }).ok).toBe(true);
+        expect(checkClientQuota(client({})).ok).toBe(true);
+    });
+
+    it("enforces the token cap for the CURRENT UTC month", () => {
+        const now = new Date().toISOString();
+        recordClientUsage({
+            client: "alice",
+            ts: now,
+            upstreamModel: "grok-4-fast",
+            usage: { prompt_tokens: 900, completion_tokens: 200, total_tokens: 1_100 },
+        });
+
+        expect(checkClientQuota(client({ monthlyTokenCap: 2_000 })).ok).toBe(true);
+        const denied = checkClientQuota(client({ monthlyTokenCap: 1_000 }));
+        expect(denied.ok).toBe(false);
+
+        if (!denied.ok) {
+            expect(denied.reason).toContain("token");
+        }
+    });
+
+    it("enforces the cost cap", () => {
+        recordClientUsage({
+            client: "alice",
+            ts: new Date().toISOString(),
+            upstreamModel: "grok-4",
+            usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000, total_tokens: 2_000_000 },
+        });
+
+        const denied = checkClientQuota(client({ monthlyCostCapUsd: 10 }));
+        expect(denied.ok).toBe(false);
+    });
+});

--- a/src/ai-proxy/lib/usage/client-ledger.ts
+++ b/src/ai-proxy/lib/usage/client-ledger.ts
@@ -1,0 +1,159 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { estimateCostUsd } from "@app/ai-proxy/lib/billing/pricing";
+import type { ResolvedClient } from "@app/ai-proxy/lib/clients";
+import { getAiProxyStorage } from "@app/ai-proxy/lib/storage";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { atomicWriteFileSync } from "@app/utils/storage/storage";
+
+export interface ClientMonthUsage {
+    requests: number;
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    cost_usd: number;
+    /** Count of requests whose model had no pricing entry (cost under-estimated). */
+    unpriced_requests: number;
+}
+
+export interface ClientLedgerStore {
+    version: 1;
+    months: Record<string, Record<string, ClientMonthUsage>>;
+}
+
+let dirOverride: string | null = null;
+let cachedLedger: ClientLedgerStore | null = null;
+
+/** Test hook — point the ledger at a temp dir. Pass null to restore. */
+export function setClientLedgerDirForTests(dir: string | null): void {
+    dirOverride = dir;
+    cachedLedger = null;
+}
+
+function ledgerDir(): string {
+    return dirOverride ?? join(getAiProxyStorage().getBaseDir(), "usage");
+}
+
+function ledgerPath(): string {
+    return join(ledgerDir(), "clients.json");
+}
+
+function emptyLedger(): ClientLedgerStore {
+    return { version: 1, months: {} };
+}
+
+export function monthKeyFromTs(ts: string): string {
+    return ts.slice(0, 7);
+}
+
+export function readClientLedger(): ClientLedgerStore {
+    if (cachedLedger) {
+        return cachedLedger;
+    }
+
+    const path = ledgerPath();
+
+    if (!existsSync(path)) {
+        cachedLedger = emptyLedger();
+        return cachedLedger;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as ClientLedgerStore;
+
+        if (typeof parsed !== "object" || parsed === null || typeof parsed.months !== "object" || !parsed.months) {
+            throw new Error("ledger file has no months object");
+        }
+
+        cachedLedger = parsed;
+        return cachedLedger;
+    } catch (err) {
+        logger.warn({ err, path }, "ai-proxy: client ledger unreadable, starting fresh");
+        cachedLedger = emptyLedger();
+        return cachedLedger;
+    }
+}
+
+function emptyMonthUsage(): ClientMonthUsage {
+    return { requests: 0, prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, cost_usd: 0, unpriced_requests: 0 };
+}
+
+export function recordClientUsage(input: {
+    client: string;
+    ts: string;
+    upstreamModel: string;
+    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}): void {
+    const dir = ledgerDir();
+
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    const ledger = readClientLedger();
+    const month = monthKeyFromTs(input.ts);
+    let byClient = ledger.months[month];
+
+    if (!byClient) {
+        byClient = {};
+        ledger.months[month] = byClient;
+    }
+
+    let entry = byClient[input.client];
+
+    if (!entry) {
+        entry = emptyMonthUsage();
+        byClient[input.client] = entry;
+    }
+
+    entry.requests += 1;
+    entry.prompt_tokens += input.usage?.prompt_tokens ?? 0;
+    entry.completion_tokens += input.usage?.completion_tokens ?? 0;
+    entry.total_tokens += input.usage?.total_tokens ?? 0;
+
+    const cost = estimateCostUsd(input.upstreamModel, input.usage ?? {});
+
+    if (cost === undefined) {
+        entry.unpriced_requests += 1;
+    } else {
+        entry.cost_usd += cost;
+    }
+
+    atomicWriteFileSync(ledgerPath(), SafeJSON.stringify(ledger, null, 2) ?? "{}");
+}
+
+export function checkClientQuota(client: ResolvedClient): { ok: true } | { ok: false; reason: string } {
+    if (client.isOwner || !client.config) {
+        return { ok: true };
+    }
+
+    const { monthlyTokenCap, monthlyCostCapUsd } = client.config;
+
+    if (monthlyTokenCap === undefined && monthlyCostCapUsd === undefined) {
+        return { ok: true };
+    }
+
+    const month = monthKeyFromTs(new Date().toISOString());
+    const usage = readClientLedger().months[month]?.[client.name];
+
+    if (!usage) {
+        return { ok: true };
+    }
+
+    if (monthlyTokenCap !== undefined && usage.total_tokens >= monthlyTokenCap) {
+        return {
+            ok: false,
+            reason: `monthly token quota exceeded (${usage.total_tokens}/${monthlyTokenCap} tokens used in ${month})`,
+        };
+    }
+
+    if (monthlyCostCapUsd !== undefined && usage.cost_usd >= monthlyCostCapUsd) {
+        return {
+            ok: false,
+            reason: `monthly cost quota exceeded ($${usage.cost_usd.toFixed(2)}/$${monthlyCostCapUsd} in ${month})`,
+        };
+    }
+
+    return { ok: true };
+}

--- a/src/ai-proxy/lib/usage/track-response.test.ts
+++ b/src/ai-proxy/lib/usage/track-response.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { readClientLedger, setClientLedgerDirForTests } from "@app/ai-proxy/lib/usage/client-ledger";
 import type { UsageRequestRecord } from "@app/ai-proxy/lib/usage/types";
 import { SafeJSON } from "@app/utils/json";
 
@@ -25,6 +29,18 @@ const route = {
     account,
 };
 
+let ledgerTempDir: string;
+
+beforeEach(() => {
+    ledgerTempDir = mkdtempSync(join(tmpdir(), "track-response-ledger-"));
+    setClientLedgerDirForTests(ledgerTempDir);
+});
+
+afterEach(() => {
+    setClientLedgerDirForTests(null);
+    rmSync(ledgerTempDir, { recursive: true, force: true });
+});
+
 describe("trackCompletedRequest", () => {
     beforeEach(() => {
         recordUsageRequest.mockClear();
@@ -37,6 +53,7 @@ describe("trackCompletedRequest", () => {
 
         trackCompletedRequest({
             route,
+            client: "alice",
             proxyModel: "genesiscz/grok/grok-composer-2.5-fast",
             path: "/v1/chat/completions",
             status: 200,
@@ -68,6 +85,10 @@ describe("trackCompletedRequest", () => {
         expect(record.rateLimited).toBe(false);
         expect(record.error).toBe(false);
         expect(record.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(record.client).toBe("alice");
+
+        const monthKey = record.ts.slice(0, 7);
+        expect(readClientLedger().months[monthKey]?.alice?.requests).toBe(1);
     });
 
     it("records usage from translated SSE buffers", () => {
@@ -82,6 +103,7 @@ describe("trackCompletedRequest", () => {
 
         trackCompletedRequest({
             route,
+            client: "alice",
             proxyModel: "genesiscz/grok/grok-composer-2.5-fast",
             path: "/v1/chat/completions",
             status: 200,
@@ -106,6 +128,7 @@ describe("trackCompletedRequest", () => {
     it("flags rate limits and errors from status codes", () => {
         trackCompletedRequest({
             route,
+            client: "alice",
             proxyModel: "genesiscz/grok/grok-composer-2.5-fast",
             path: "/v1/responses",
             status: 429,
@@ -123,6 +146,7 @@ describe("trackCompletedRequest", () => {
 
         trackCompletedRequest({
             route,
+            client: "alice",
             proxyModel: "genesiscz/grok/grok-composer-2.5-fast",
             path: "/v1/chat/completions",
             status: 500,

--- a/src/ai-proxy/lib/usage/track-response.ts
+++ b/src/ai-proxy/lib/usage/track-response.ts
@@ -1,10 +1,12 @@
 import type { ResolvedRoute } from "@app/ai-proxy/lib/types";
+import { recordClientUsage } from "@app/ai-proxy/lib/usage/client-ledger";
 import { bodyWantsStream, extractLatestUsageFromSse, extractUsageFromJsonBody } from "@app/ai-proxy/lib/usage/extract";
 import { recordUsageRequest } from "@app/ai-proxy/lib/usage/store";
 import { logger } from "@app/logger";
 
 export function trackCompletedRequest(input: {
     route: ResolvedRoute;
+    client: string;
     proxyModel: string;
     path: string;
     status: number;
@@ -21,6 +23,7 @@ export function trackCompletedRequest(input: {
     const record = {
         ts: new Date().toISOString(),
         account: input.route.accountName,
+        client: input.client,
         provider: input.route.account.provider,
         proxyModel: input.proxyModel,
         upstreamModel: input.route.upstreamId,
@@ -37,6 +40,13 @@ export function trackCompletedRequest(input: {
 
     recordUsageRequest(record);
 
+    recordClientUsage({
+        client: input.client,
+        ts: record.ts,
+        upstreamModel: record.upstreamModel,
+        usage: record.usage,
+    });
+
     logger.debug(
         {
             account: record.account,
@@ -50,6 +60,7 @@ export function trackCompletedRequest(input: {
 
 export function scheduleUsageTracking(input: {
     route: ResolvedRoute;
+    client: string;
     proxyModel: string;
     path: string;
     status: number;

--- a/src/ai-proxy/lib/usage/types.ts
+++ b/src/ai-proxy/lib/usage/types.ts
@@ -11,6 +11,8 @@ export interface TokenUsage {
 export interface UsageRequestRecord {
     ts: string;
     account: string;
+    /** Proxy client (key identity) that issued the request. Absent on pre-billing records. */
+    client?: string;
     provider: string;
     proxyModel: string;
     upstreamModel: string;


### PR DESCRIPTION
Recreation of #253 (auto-closed when its stacked base `feat/ai-proxy-subscriptions` merged into master as #251 and was deleted). Same branch, rebased onto master via `--onto` so the diff is exactly the client-billing work.

Carries over from #253: gemini round 1 (5 threads, largely addressed by the ledger-cache/type-guard/CLI-validation commit) + 5 copilot notes — will be re-adjudicated here.