### PR TITLE
fix(ai-proxy): Connection: close on SSE responses — undici clients die on keep-alive reuse

### DIFF
--- a/src/ai-proxy/lib/providers/anthropic-subscription.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.ts
@@ -191,6 +191,7 @@ export class AnthropicSubscriptionProvider implements ProxyProvider {
                     // "TypeError: terminated" / UND_ERR_SOCKET) — verified live via the
                     // eve tool-loop. curl tolerates it; undici does not. Close per stream.
                     Connection: "close",
+                    "X-Accel-Buffering": "no",
                 },
             });
         }

--- a/src/ai-proxy/lib/providers/anthropic-subscription.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.ts
@@ -186,7 +186,11 @@ export class AnthropicSubscriptionProvider implements ProxyProvider {
                 headers: {
                     "Content-Type": "text/event-stream; charset=utf-8",
                     "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
+                    // Advertising keep-alive on a chunked SSE body breaks Node/undici
+                    // clients on connection reuse (second request dies with
+                    // "TypeError: terminated" / UND_ERR_SOCKET) — verified live via the
+                    // eve tool-loop. curl tolerates it; undici does not. Close per stream.
+                    Connection: "close",
                 },
             });
         }

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -153,7 +153,11 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
                 headers: {
                     "Content-Type": "text/event-stream; charset=utf-8",
                     "Cache-Control": "no-cache",
-                    Connection: "keep-alive",
+                    // Advertising keep-alive on a chunked SSE body breaks Node/undici
+                    // clients on connection reuse (second request dies with
+                    // "TypeError: terminated" / UND_ERR_SOCKET) — verified live via the
+                    // eve tool-loop. curl tolerates it; undici does not. Close per stream.
+                    Connection: "close",
                 },
             });
         }

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -158,6 +158,7 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
                     // "TypeError: terminated" / UND_ERR_SOCKET) — verified live via the
                     // eve tool-loop. curl tolerates it; undici does not. Close per stream.
                     Connection: "close",
+                    "X-Accel-Buffering": "no",
                 },
             });
         }

--- a/src/ai-proxy/lib/translators/responses-to-chat-sse.ts
+++ b/src/ai-proxy/lib/translators/responses-to-chat-sse.ts
@@ -229,7 +229,10 @@ export async function responsesToChatSse({
             headers: {
                 "Content-Type": "text/event-stream",
                 "Cache-Control": "no-cache",
-                Connection: "keep-alive",
+                // Same undici keep-alive-reuse hazard as the provider SSE paths —
+                // close per stream (see providers/anthropic-subscription.ts).
+                Connection: "close",
+                "X-Accel-Buffering": "no",
             },
         }),
         responseBody


### PR DESCRIPTION
Two-line fix found by the C4 trio e2e (eve → ai-proxy → Claude sub): streamed chat completions advertised `Connection: keep-alive`, but the SSE body's termination doesn't survive connection reuse under Node/undici — the FIRST call streams fine, the SECOND call on the reused socket dies with `TypeError: terminated` / `UND_ERR_SOCKET: other side closed` (eve's tool loop hit this 100% of the time on the post-tool-result model call). curl tolerates the reuse; undici does not.

Fix: respond `Connection: close` on the streaming paths of both subscription providers so strict clients open a fresh socket per stream. Localhost overhead is negligible.

**Verified live:** before — eve session parked with MODEL_CALL_FAILED on every 2nd call; after — full trio e2e completed (3 sequential streamed model calls incl. tool history, `youtube__listChannels` tool round-trip, `turn.completed`).

Follow-up noted (separate): the anthropic provider holds no 401-retry — a token rotated out from under a long-running proxy 401s until restart; worth a force-refresh-once-on-401 in a future PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for streaming AI responses by closing connections cleanly after each stream.
  * Prevented subsequent requests from failing due to reused streaming connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->