### PR TITLE
fix(say): macos TTS fallback when cloud provider key missing

### DIFF
--- a/src/claude/commands/code/index.ts
+++ b/src/claude/commands/code/index.ts
@@ -1,13 +1,11 @@
-import { Command, Option } from "commander";
+import { type Command, Option } from "commander";
 import { bisectCommand } from "./commands/bisect";
 import { diffCommand } from "./commands/diff";
 import { unpackCommand } from "./commands/unpack";
 import { versionsCommand } from "./commands/versions";
 
 export function registerCodeCommand(program: Command): void {
-    const code = program
-        .command("code")
-        .description("Unpack, diff, and bisect npm-published Claude Code CLI bundles");
+    const code = program.command("code").description("Unpack, diff, and bisect npm-published Claude Code CLI bundles");
 
     code.command("versions")
         .description("List published @anthropic-ai/claude-code versions with publish dates")

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -184,9 +184,22 @@ const program = new Command()
         }
 
         if (provider !== "macos" && !envForProvider(provider)) {
-            out.error(pc.red(`[say] env var for ${provider} is not set.`));
-            out.error(pc.dim(suggestCommand("tools say", { add: ["--provider", "macos"] })));
-            process.exit(1);
+            if (opts.fallback === false) {
+                out.error(pc.red(`[say] env var for ${provider} is not set.`));
+                out.error(pc.dim(suggestCommand("tools say", { add: ["--provider", "macos"] })));
+                process.exit(1);
+            }
+
+            out.error(pc.yellow(`[say] env var for ${provider} is not set — falling back to macos.`));
+            provider = "macos";
+
+            if (!isFromCLI(cmd, "voice")) {
+                effectiveForRun.voice = null;
+            }
+
+            if (!isFromCLI(cmd, "model")) {
+                effectiveForRun.model = null;
+            }
         }
 
         const stream = opts.stream === true ? true : opts.noStream === true ? false : undefined;


### PR DESCRIPTION
Recovered from a shared-checkout collision during tonight's PR review campaign — legit standalone fix, unrelated to any of the in-flight PRs.

- `fix(say)`: fire-and-forget TTS notification silently died on `process.exit(1)` when the configured cloud provider (xai/openai) had no API key. Now falls back to macOS TTS automatically (drops provider-specific voice/model); `--no-fallback` preserves the old hard-fail.
- `style(claude/code)`: trivial biome import-type fix on the code/index.ts moved in #260.