### PR TITLE
feat(youtube): phase 1 foundations — roles, ai task mapping, audit tables, typed auth, WS scoping, transcript fallback

### DIFF
--- a/src/utils/ui/components/youtube/insights-tab.tsx
+++ b/src/utils/ui/components/youtube/insights-tab.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@app/utils/ui/components/button";
 import { LlmConfirmDialog, type ModelPreset } from "@app/utils/ui/components/youtube/llm-confirm-dialog";
 import { PanelLoading } from "@app/utils/ui/components/youtube/loading";
+import { errorCodeOf } from "@app/utils/ui/components/youtube/login-required";
 import { OUTPUT_LANGS } from "@app/utils/ui/components/youtube/output-langs";
 import {
     DEFAULT_SUMMARY_CONTROLS,
@@ -214,6 +215,7 @@ export function InsightsTab({
                 busy={generate.isPending}
                 confirmLabel={entries.length === 0 ? "Generate" : "Re-generate"}
                 error={generate.error ? (generate.error as Error).message : null}
+                errorCode={errorCodeOf(generate.error)}
                 showAdvanced={devMode}
                 modelPresets={modelPresets}
                 defaultProvider={modelDefault?.provider}

--- a/src/utils/ui/components/youtube/llm-confirm-dialog.tsx
+++ b/src/utils/ui/components/youtube/llm-confirm-dialog.tsx
@@ -50,6 +50,8 @@ export interface LlmConfirmDialogProps {
     confirmLabel?: string;
     cancelLabel?: string;
     error?: string | null;
+    /** Stable server error code for the same failure (e.g. "login_required"). */
+    errorCode?: string | null;
     /** Dev mode: expose provider/model override select. Regular users don't
      *  see it — server picks its configured default. */
     showAdvanced?: boolean;
@@ -96,6 +98,7 @@ export function LlmConfirmDialog({
     confirmLabel = "Run",
     cancelLabel = "Cancel",
     error,
+    errorCode,
     showAdvanced,
     modelPresets = [],
     estimate,
@@ -285,7 +288,7 @@ export function LlmConfirmDialog({
                 ) : null}
 
                 {error ? (
-                    error === "login required" && onRequireLogin ? (
+                    (error === "login required" || errorCode === "login_required") && onRequireLogin ? (
                         <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/30 p-2.5 text-sm">
                             <p className="text-muted-foreground">This costs diamonds, so it needs an account.</p>
                             <Button size="sm" className="shrink-0" onClick={() => onRequireLogin(confirm)}>

--- a/src/utils/ui/components/youtube/login-required.test.ts
+++ b/src/utils/ui/components/youtube/login-required.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { errorCodeOf, isLoginRequiredError, LOGIN_REQUIRED_CODE } from "./login-required";
+
+class CodedError extends Error {
+    constructor(
+        message: string,
+        public readonly code?: string
+    ) {
+        super(message);
+    }
+}
+
+describe("isLoginRequiredError", () => {
+    it("matches by stable code regardless of message copy", () => {
+        expect(isLoginRequiredError(new CodedError("please sign in", LOGIN_REQUIRED_CODE))).toBe(true);
+        expect(isLoginRequiredError(new CodedError("boom", "rate_limited"))).toBe(false);
+    });
+
+    it("falls back to the legacy message string", () => {
+        expect(isLoginRequiredError(new Error("login required"))).toBe(true);
+        expect(isLoginRequiredError("login required")).toBe(true);
+        expect(isLoginRequiredError(new Error("other"))).toBe(false);
+        expect(isLoginRequiredError(null)).toBe(false);
+    });
+});
+
+describe("errorCodeOf", () => {
+    it("extracts string codes and ignores the rest", () => {
+        expect(errorCodeOf(new CodedError("x", "login_required"))).toBe("login_required");
+        expect(errorCodeOf(new Error("x"))).toBeUndefined();
+        expect(errorCodeOf(undefined)).toBeUndefined();
+    });
+});

--- a/src/utils/ui/components/youtube/login-required.ts
+++ b/src/utils/ui/components/youtube/login-required.ts
@@ -1,0 +1,31 @@
+/** Stable server code for "you must sign in" (server auth.ts `requireUser`). */
+export const LOGIN_REQUIRED_CODE = "login_required";
+
+const LOGIN_REQUIRED_MESSAGE = "login required";
+
+/** String `code` off an error-like object (ApiError, coded Error), else undefined. */
+export function errorCodeOf(error: unknown): string | undefined {
+    if (error && typeof error === "object" && "code" in error) {
+        const code = (error as { code?: unknown }).code;
+
+        return typeof code === "string" ? code : undefined;
+    }
+
+    return undefined;
+}
+
+/** Code-first check with legacy message fallback — new servers send
+ *  `code: "login_required"`, older ones only the message string. */
+export function isLoginRequiredError(error: unknown): boolean {
+    if (!error) {
+        return false;
+    }
+
+    if (errorCodeOf(error) === LOGIN_REQUIRED_CODE) {
+        return true;
+    }
+
+    const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+
+    return message === LOGIN_REQUIRED_MESSAGE;
+}

--- a/src/utils/ui/components/youtube/share-button.tsx
+++ b/src/utils/ui/components/youtube/share-button.tsx
@@ -1,4 +1,5 @@
 import { logger } from "@app/logger/client";
+import { isLoginRequiredError } from "@app/utils/ui/components/youtube/login-required";
 import { Check, Loader2, Share2 } from "lucide-react";
 import { useState } from "react";
 
@@ -63,7 +64,7 @@ export function ShareButton({
             logger.warn({ error }, "share-button: share failed");
             const message = error instanceof Error ? error.message : String(error);
 
-            if (message === "login required" && onRequireLogin) {
+            if (isLoginRequiredError(error) && onRequireLogin) {
                 setState("idle");
                 onRequireLogin(() => void click());
                 return;

--- a/src/utils/ui/components/youtube/summary-tab.tsx
+++ b/src/utils/ui/components/youtube/summary-tab.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@app/utils/ui/components/button";
 import { LlmConfirmDialog, type ModelPreset } from "@app/utils/ui/components/youtube/llm-confirm-dialog";
 import { PanelLoading } from "@app/utils/ui/components/youtube/loading";
+import { errorCodeOf } from "@app/utils/ui/components/youtube/login-required";
 import { LongSummaryView } from "@app/utils/ui/components/youtube/long-summary-view";
 import { OUTPUT_LANGS } from "@app/utils/ui/components/youtube/output-langs";
 import { ShareButton } from "@app/utils/ui/components/youtube/share-button";
@@ -321,6 +322,7 @@ export function SummaryTab({
                 busy={generate.isPending}
                 confirmLabel={long === null ? "Generate" : "Re-generate"}
                 error={generate.error ? (generate.error as Error).message : null}
+                errorCode={errorCodeOf(generate.error)}
                 showAdvanced={devMode}
                 modelPresets={modelPresets}
                 defaultProvider={modelDefault?.provider}

--- a/src/utils/ui/components/youtube/transcript-tab.tsx
+++ b/src/utils/ui/components/youtube/transcript-tab.tsx
@@ -4,6 +4,7 @@ import { Input } from "@app/utils/ui/components/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@app/utils/ui/components/select";
 import { LlmConfirmDialog } from "@app/utils/ui/components/youtube/llm-confirm-dialog";
 import { PanelLoading } from "@app/utils/ui/components/youtube/loading";
+import { errorCodeOf } from "@app/utils/ui/components/youtube/login-required";
 import { OUTPUT_LANGS, outputLangLabel } from "@app/utils/ui/components/youtube/output-langs";
 import { scrollIntoPanelView } from "@app/utils/ui/components/youtube/scroll";
 import type { PipelineProgress, RunPipeline } from "@app/utils/ui/components/youtube/tabs";
@@ -523,6 +524,7 @@ export function TranscriptTab({
                     confirmLabel={`Translate · ${TRANSLATE_COST} 💎`}
                     billingNote={`Cost: ${TRANSLATE_COST} 💎, charged once — cached for every future request.`}
                     error={translate.error ? translate.error.message : null}
+                    errorCode={errorCodeOf(translate.error)}
                     onCancel={() => setTranslateTarget(null)}
                     onConfirm={confirmTranslate}
                 />

--- a/src/youtube/commands/__tests__/cache.test.ts
+++ b/src/youtube/commands/__tests__/cache.test.ts
@@ -49,6 +49,7 @@ const jobs: PipelineJob[] = [
         progress: 1,
         progressMessage: null,
         parentJobId: null,
+        userId: null,
         workerId: null,
         claimedAt: null,
         createdAt: "2026-04-01",

--- a/src/youtube/commands/__tests__/download.test.ts
+++ b/src/youtube/commands/__tests__/download.test.ts
@@ -31,6 +31,7 @@ mock.module("@app/youtube/commands/_shared/ensure-pipeline", () => ({
                     progress: 1,
                     progressMessage: null,
                     parentJobId: null,
+                    userId: null,
                     workerId: null,
                     claimedAt: null,
                     createdAt: "2026-04-01",

--- a/src/youtube/commands/__tests__/pipeline.test.ts
+++ b/src/youtube/commands/__tests__/pipeline.test.ts
@@ -26,6 +26,7 @@ mock.module("@app/youtube/commands/_shared/ensure-pipeline", () => ({
                     progress: 1,
                     progressMessage: null,
                     parentJobId: null,
+                    userId: null,
                     workerId: null,
                     claimedAt: null,
                     createdAt: "2026-04-01",

--- a/src/youtube/extension/api.bridge.ts
+++ b/src/youtube/extension/api.bridge.ts
@@ -1,10 +1,22 @@
 import type { ExtensionRequest, ExtensionResponse } from "@ext/shared/messages";
 
+/** Server error surfaced through the background bridge; `code` carries the
+ *  server's stable error code (e.g. "login_required") when present. */
+export class ApiError extends Error {
+    constructor(
+        message: string,
+        public readonly code?: string
+    ) {
+        super(message);
+        this.name = "ApiError";
+    }
+}
+
 export async function send<T>(req: ExtensionRequest): Promise<T> {
     const res = (await chrome.runtime.sendMessage(req)) as ExtensionResponse;
 
     if (!res.ok) {
-        throw new Error(res.error);
+        throw new ApiError(res.error, res.code);
     }
 
     return res.data as T;

--- a/src/youtube/extension/api.hooks.ts
+++ b/src/youtube/extension/api.hooks.ts
@@ -517,6 +517,7 @@ export function useModels(enabled = true) {
         queryKey: ["models"],
         queryFn: () => send<ExtensionApiMap["api:listModels"]>({ type: "api:listModels" }),
         staleTime: 60_000,
+        retry: false,
         enabled,
     });
 }
@@ -526,6 +527,15 @@ export function useJob(id: number | null) {
         queryKey: ["job", id],
         queryFn: () => send<{ job: PipelineJob }>({ type: "api:getJob", id: id as number }),
         enabled: id !== null,
+    });
+}
+
+export function useQueueStats(enabled = true) {
+    return useQuery({
+        queryKey: ["queueStats"],
+        queryFn: () => send<ExtensionApiMap["api:queueStats"]>({ type: "api:queueStats" }),
+        refetchInterval: 5000,
+        enabled,
     });
 }
 

--- a/src/youtube/extension/background.ts
+++ b/src/youtube/extension/background.ts
@@ -182,6 +182,8 @@ export async function handleRequest(req: ExtensionRequest): Promise<ExtensionRes
             });
         case "api:getJob":
             return apiCall(`${base}/api/v1/jobs/${req.id}`);
+        case "api:queueStats":
+            return apiCall(`${base}/api/v1/jobs/queue`);
         case "api:listModels":
             return apiCall(`${base}/api/v1/models`);
         case "api:estimate": {
@@ -334,15 +336,23 @@ async function apiCall(url: string, init: RequestInit = {}): Promise<ExtensionRe
         });
         if (!res.ok) {
             let detail = "";
+            let code: string | undefined;
             try {
-                const body = (await res.json()) as { error?: unknown };
+                const body = (await res.json()) as { error?: unknown; code?: unknown };
                 if (typeof body.error === "string" && body.error !== "") {
                     detail = body.error;
+                }
+                if (typeof body.code === "string" && body.code !== "") {
+                    code = body.code;
                 }
             } catch {
                 // non-JSON error body — fall back to status line
             }
-            return { ok: false, error: detail !== "" ? detail : `${res.status} ${res.statusText}` };
+            return {
+                ok: false,
+                error: detail !== "" ? detail : `${res.status} ${res.statusText}`,
+                ...(code ? { code } : {}),
+            };
         }
         return { ok: true, data: await res.json() };
     } catch (error) {
@@ -368,8 +378,10 @@ async function reconnectWebsocket(): Promise<void> {
     const cfg = await getExtensionConfig();
     const base = `${cfg.apiBaseUrl.replace(/^http/, "ws").replace(/\/$/, "")}/api/v1/events`;
     // Browsers can't set an Authorization header on a WS handshake, so the
-    // service key rides as a query param (the server reads ?access_token=).
-    const url = cfg.serviceKey ? `${base}?access_token=${encodeURIComponent(cfg.serviceKey)}` : base;
+    // token rides as a query param. The USER token wins: the server scopes the
+    // socket to that user's jobs; the service key would receive everyone's.
+    const token = cfg.userToken ?? cfg.serviceKey;
+    const url = token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
 
     try {
         ws = new WebSocket(url);

--- a/src/youtube/extension/shared/messages.ts
+++ b/src/youtube/extension/shared/messages.ts
@@ -11,6 +11,7 @@ import type {
     PromptPreset,
     QaHistoryItem,
     QaSource,
+    QueueStats,
     ShareSummary,
     SummaryFormat,
     SummaryLength,
@@ -23,6 +24,7 @@ import type {
     VideoId,
     VideoLongSummary,
     VideoReport,
+    YtRole,
     YtUser,
 } from "@app/youtube/lib/types";
 import type { ExtensionConfig } from "@ext/shared/types";
@@ -103,9 +105,10 @@ export type ExtensionRequest =
     | { type: "nav:openWatch"; id: string; t: number } // open watch page in a new tab (cross-video citation)
     | { type: "api:reportEstimate"; videoIds: string[] }
     | { type: "api:createReport"; videoIds: string[]; title?: string }
-    | { type: "api:getReport"; id: number };
+    | { type: "api:getReport"; id: number }
+    | { type: "api:queueStats" };
 
-export type ExtensionResponse = { ok: true; data: unknown } | { ok: false; error: string };
+export type ExtensionResponse = { ok: true; data: unknown } | { ok: false; error: string; code?: string };
 
 export type ExtensionEvent = { type: "job:event"; event: JobEvent } | { type: "ws:status"; connected: boolean };
 
@@ -183,7 +186,8 @@ export interface ExtensionApiMap {
     "api:register": { user: YtUser; token: string };
     "api:login": { user: YtUser; token: string };
     "api:logout": { ok: true };
-    "api:me": { user: YtUser };
+    "api:me": { user: YtUser; role: YtRole };
+    "api:queueStats": { queue: QueueStats };
     "api:topup": { user: YtUser };
     "api:qaHistory": { items: QaHistoryItem[] };
     "api:checkout": { url: string };

--- a/src/youtube/extension/side-panel/playlist-panel.tsx
+++ b/src/youtube/extension/side-panel/playlist-panel.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@app/utils/ui/components/button";
 import { Markdown } from "@app/utils/ui/components/markdown";
 import { LlmConfirmDialog } from "@app/utils/ui/components/youtube/llm-confirm-dialog";
+import { errorCodeOf } from "@app/utils/ui/components/youtube/login-required";
 import type { VideoReport } from "@app/youtube/lib/types";
 import { useCreateReport, useReport, useReportEstimate } from "@ext/api.hooks";
 import type { ReportMemberMeta } from "@ext/shared/messages";
@@ -105,8 +106,8 @@ export function PlaylistPanel({ listId }: { listId: string }) {
                                 <div className="flex items-start gap-3 rounded-2xl border border-dashed border-primary/25 p-5">
                                     <FileText className="mt-0.5 size-5 shrink-0 text-primary" />
                                     <p className="text-sm text-muted-foreground">
-                                        Generate one combined report across the first {memberIds.length} videos:
-                                        shared themes, contradictions, per-video highlights, and a watch/skip verdict.
+                                        Generate one combined report across the first {memberIds.length} videos: shared
+                                        themes, contradictions, per-video highlights, and a watch/skip verdict.
                                     </p>
                                 </div>
                             )}
@@ -122,6 +123,7 @@ export function PlaylistPanel({ listId }: { listId: string }) {
                 busy={create.isPending}
                 confirmLabel="Generate report"
                 error={create.error ? create.error.message : null}
+                errorCode={errorCodeOf(create.error)}
                 billingNote={
                     estimate.data ? (
                         <>

--- a/src/youtube/lib/__tests__/ai-mapping.test.ts
+++ b/src/youtube/lib/__tests__/ai-mapping.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { resolveAiSpecForTask, specOfAiMapping } from "@app/youtube/lib/ai-mapping";
+
+const specExample = {
+    ai: [
+        { provider: "xai", model: "grok-4-fast-reasoning", for: ["insights", "summary"] as Array<"insights" | "summary"> },
+        { provider: "xai", model: "grok-4-fast-non-reasoning", for: ["all"] as Array<"all"> },
+    ],
+    provider: { summarize: "openai/gpt-5" },
+};
+
+describe("resolveAiSpecForTask", () => {
+    it("prefers the explicit task entry", () => {
+        expect(resolveAiSpecForTask(specExample, "insights")).toBe("xai/grok-4-fast-reasoning");
+        expect(resolveAiSpecForTask(specExample, "summary")).toBe("xai/grok-4-fast-reasoning");
+    });
+
+    it("falls back to the 'all' entry when the task has no explicit entry", () => {
+        expect(resolveAiSpecForTask(specExample, "qa")).toBe("xai/grok-4-fast-non-reasoning");
+        expect(resolveAiSpecForTask(specExample, "embed")).toBe("xai/grok-4-fast-non-reasoning");
+    });
+
+    it("falls back to legacy provider.* strings when ai[] is empty", () => {
+        const legacyOnly = { ai: [], provider: { summarize: "openai/gpt-5", qa: "anthropic" } };
+
+        expect(resolveAiSpecForTask(legacyOnly, "summary")).toBe("openai/gpt-5");
+        expect(resolveAiSpecForTask(legacyOnly, "insights")).toBe("openai/gpt-5");
+        expect(resolveAiSpecForTask(legacyOnly, "qa")).toBe("anthropic");
+    });
+
+    it("returns null when nothing is configured", () => {
+        expect(resolveAiSpecForTask({ ai: [], provider: {} }, "transcribe")).toBeNull();
+    });
+
+    it("supports provider-only entries", () => {
+        expect(resolveAiSpecForTask({ ai: [{ provider: "xai", for: ["all"] }], provider: {} }, "qa")).toBe("xai");
+        expect(specOfAiMapping({ provider: "xai", for: ["all"] })).toBe("xai");
+    });
+});

--- a/src/youtube/lib/__tests__/audit.test.ts
+++ b/src/youtube/lib/__tests__/audit.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("audit tables", () => {
+    it("records and lists video watchers (userId nullable)", () => {
+        db.recordVideoWatch({ userId: null, videoId: "vid00000001" });
+        db.recordVideoWatch({ userId: 7, videoId: "vid00000001" });
+        const rows = db.listVideoWatchers("vid00000001");
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0].userId).toBe(7);
+        expect(rows[1].userId).toBeNull();
+        expect(rows[0].createdAt.endsWith("Z")).toBe(true);
+    });
+
+    it("records video logs with meta round-trip and kind filter", () => {
+        db.recordVideoLog({ kind: "insights:view", userId: 3, videoId: "vid00000001", meta: { mode: "timestamped", lang: "en" } });
+        db.recordVideoLog({ kind: "comments:view", userId: null, videoId: "vid00000002", meta: null });
+        const forVideo = db.listVideoLogs({ videoId: "vid00000001" });
+
+        expect(forVideo).toHaveLength(1);
+        expect(forVideo[0].kind).toBe("insights:view");
+        expect(forVideo[0].meta).toEqual({ mode: "timestamped", lang: "en" });
+        expect(db.listVideoLogs({ userId: 3 })).toHaveLength(1);
+        expect(db.listVideoLogs()).toHaveLength(2);
+    });
+
+    it("rejects unknown video_logs kinds via CHECK", () => {
+        expect(() =>
+            db.recordVideoLog({ kind: "bogus:view" as never, userId: null, videoId: "vid00000001" })
+        ).toThrow();
+    });
+
+    it("records ai calls with defaults and filters", () => {
+        db.recordAiCall({ provider: "xai", model: "grok-4", action: "summarize:long", videoId: "vid00000001", userId: 3, inputTokens: 1200, outputTokens: 300, costUsd: 0.0042, jobId: 11 });
+        db.recordAiCall({ provider: "deepgram", model: "nova-3", action: "transcribe:ai" });
+        const forUser = db.listAiCalls({ userId: 3 });
+
+        expect(forUser).toHaveLength(1);
+        expect(forUser[0].costUsd).toBeCloseTo(0.0042);
+        expect(forUser[0].creditsCharged).toBeNull();
+        const bare = db.listAiCalls({ videoId: undefined });
+
+        expect(bare).toHaveLength(2);
+        expect(bare.find((row) => row.provider === "deepgram")?.inputTokens).toBe(0);
+        expect(db.listAiCalls({ jobId: 11 })).toHaveLength(1);
+    });
+});

--- a/src/youtube/lib/__tests__/config-foundations.test.ts
+++ b/src/youtube/lib/__tests__/config-foundations.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeConfig } from "@app/youtube/lib/config";
+
+let dir: string;
+let config: YoutubeConfig;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-config-foundations-"));
+    config = new YoutubeConfig({ baseDir: dir });
+});
+
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("config foundations (powerUsers / ai / referrals)", () => {
+    it("defaults to empty powerUsers, empty ai, disabled referrals", async () => {
+        const all = await config.getAll();
+
+        expect(all.powerUsers).toEqual([]);
+        expect(all.ai).toEqual([]);
+        expect(all.referrals).toEqual({ enabled: false, offers: [] });
+    });
+
+    it("round-trips ai mappings and powerUsers through update()", async () => {
+        await config.update({
+            powerUsers: [{ email: "boss@example.com", type: "admin" }],
+            ai: [
+                { provider: "xai", model: "grok-4-fast-reasoning", for: ["insights", "summary"] },
+                { provider: "xai", model: "grok-4-fast-non-reasoning", for: ["all"] },
+            ],
+        });
+        const fresh = new YoutubeConfig({ baseDir: dir });
+        const all = await fresh.getAll();
+
+        expect(all.powerUsers).toEqual([{ email: "boss@example.com", type: "admin" }]);
+        expect(all.ai).toHaveLength(2);
+        expect(all.ai[1].for).toEqual(["all"]);
+    });
+
+    it("replaces arrays wholesale on patch (no element merge)", async () => {
+        await config.update({ powerUsers: [{ email: "a@example.com", type: "dev" }] });
+        await config.update({ powerUsers: [{ email: "b@example.com", type: "admin" }] });
+        const all = await config.getAll();
+
+        expect(all.powerUsers).toEqual([{ email: "b@example.com", type: "admin" }]);
+    });
+
+    it("merges referrals shallowly with offers replaced wholesale", async () => {
+        await config.update({ referrals: { enabled: true, offers: [{ from: "2026-07-01T00:00:00Z", to: "2026-08-01T00:00:00Z", reward: 25 }] } });
+        await config.update({ referrals: { enabled: false } });
+        const all = await config.getAll();
+
+        expect(all.referrals.enabled).toBe(false);
+        expect(all.referrals.offers).toHaveLength(1);
+    });
+});

--- a/src/youtube/lib/__tests__/jobs-user.test.ts
+++ b/src/youtube/lib/__tests__/jobs-user.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("jobs user attribution", () => {
+    it("stores and returns userId on enqueue", () => {
+        const owned = db.enqueueJob({ targetKind: "video", target: "vid00000001", stages: ["captions"], userId: 42 });
+        const anonymous = db.enqueueJob({ targetKind: "video", target: "vid00000002", stages: ["captions"] });
+
+        expect(owned.userId).toBe(42);
+        expect(anonymous.userId).toBeNull();
+        expect(db.getJob(owned.id)?.userId).toBe(42);
+    });
+
+    it("keeps userId across claim and requeue", () => {
+        const job = db.enqueueJob({ targetKind: "video", target: "vid00000003", stages: ["captions"], userId: 7 });
+        const claimed = db.claimNextJob("worker-1");
+
+        expect(claimed?.id).toBe(job.id);
+        expect(claimed?.userId).toBe(7);
+
+        db.markInterruptedJobsForRequeue();
+        expect(db.getJob(job.id)?.userId).toBe(7);
+    });
+});

--- a/src/youtube/lib/__tests__/roles.test.ts
+++ b/src/youtube/lib/__tests__/roles.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { isPowerRole, roleForEmail } from "@app/youtube/lib/roles";
+
+const powerUsers = [
+    { email: "Boss@Example.com", type: "admin" as const },
+    { email: "dev@example.com", type: "dev" as const },
+];
+
+describe("roleForEmail", () => {
+    it("matches emails case-insensitively", () => {
+        expect(roleForEmail(powerUsers, "boss@example.com")).toBe("admin");
+        expect(roleForEmail(powerUsers, "DEV@EXAMPLE.COM")).toBe("dev");
+    });
+
+    it("defaults to user for unlisted emails", () => {
+        expect(roleForEmail(powerUsers, "random@example.com")).toBe("user");
+        expect(roleForEmail([], "boss@example.com")).toBe("user");
+    });
+});
+
+describe("isPowerRole", () => {
+    it("is true for admin and dev, false for user", () => {
+        expect(isPowerRole("admin")).toBe(true);
+        expect(isPowerRole("dev")).toBe(true);
+        expect(isPowerRole("user")).toBe(false);
+    });
+});

--- a/src/youtube/lib/__tests__/transcript-fallback.test.ts
+++ b/src/youtube/lib/__tests__/transcript-fallback.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeConfig } from "@app/youtube/lib/config";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { TranscriptService } from "@app/youtube/lib/transcripts";
+import type { TranscriptServiceDeps } from "@app/youtube/lib/transcripts.types";
+
+let dir: string;
+let db: YoutubeDatabase;
+let config: YoutubeConfig;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-transcript-fallback-"));
+    db = new YoutubeDatabase(":memory:");
+    config = new YoutubeConfig({ baseDir: dir });
+    db.upsertChannel({ handle: "@chan" });
+    db.upsertVideo({ id: "vid00000001", channelHandle: "@chan", title: "Video one" });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function fakeDeps(opts: { captions: boolean }): TranscriptServiceDeps {
+    return {
+        fetchCaptions: async () =>
+            opts.captions
+                ? { text: "from captions", segments: [{ text: "from captions", start: 0, end: 1 }], lang: "en" }
+                : null,
+        downloadAudio: async (input) => {
+            await Bun.write(input.outPath, "riff");
+
+            return { path: input.outPath, sizeBytes: 4, durationSec: null };
+        },
+        createTranscriber: async () => ({
+            transcribe: async () => ({
+                text: "from asr",
+                segments: [{ text: "from asr", start: 0, end: 1 }],
+                language: "en",
+                duration: 1,
+            }),
+            dispose: () => {},
+        }),
+    };
+}
+
+describe("transcript fallback chain", () => {
+    it("captions available → free tier, hook not called", async () => {
+        let gated = 0;
+        const service = new TranscriptService(db, config, fakeDeps({ captions: true }));
+        const transcript = await service.transcribe({
+            videoId: "vid00000001",
+            beforeAiTranscription: () => {
+                gated += 1;
+            },
+        });
+
+        expect(transcript.source).toBe("captions");
+        expect(gated).toBe(0);
+    });
+
+    it("no captions → hook awaited once, then AI transcript", async () => {
+        let gated = 0;
+        const service = new TranscriptService(db, config, fakeDeps({ captions: false }));
+        const transcript = await service.transcribe({
+            videoId: "vid00000001",
+            beforeAiTranscription: () => {
+                gated += 1;
+            },
+        });
+
+        expect(gated).toBe(1);
+        expect(transcript.source).toBe("ai");
+        expect(transcript.text).toBe("from asr");
+    });
+
+    it("hook rejection aborts before ASR and saves nothing", async () => {
+        const service = new TranscriptService(db, config, fakeDeps({ captions: false }));
+
+        await expect(
+            service.transcribe({
+                videoId: "vid00000001",
+                beforeAiTranscription: () => {
+                    throw new Error("Insufficient credits: have 0, need 10");
+                },
+            })
+        ).rejects.toThrow("Insufficient credits");
+        expect(db.getTranscript("vid00000001")).toBeNull();
+    });
+
+    it("forceTranscribe also passes through the gate", async () => {
+        let gated = 0;
+        const service = new TranscriptService(db, config, fakeDeps({ captions: true }));
+        const transcript = await service.transcribe({
+            videoId: "vid00000001",
+            forceTranscribe: true,
+            beforeAiTranscription: () => {
+                gated += 1;
+            },
+        });
+
+        expect(gated).toBe(1);
+        expect(transcript.source).toBe("ai");
+    });
+});

--- a/src/youtube/lib/__tests__/transcripts.test.ts
+++ b/src/youtube/lib/__tests__/transcripts.test.ts
@@ -129,6 +129,7 @@ describe("TranscriptService", () => {
             expect(transcriberTranscribeCalls[0]).toMatchObject({ audioPath: expectedAudioPath });
             expect(transcriberDisposeCalls).toHaveLength(1);
             expect(progress).toEqual([
+                { phase: "audio", message: "no captions available — preparing AI transcription" },
                 { phase: "audio", message: "downloading audio" },
                 { phase: "audio", percent: 50, message: "half" },
                 { phase: "transcribe", message: "running ASR" },

--- a/src/youtube/lib/__tests__/usage-audit.test.ts
+++ b/src/youtube/lib/__tests__/usage-audit.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { withJobActivity } from "@app/youtube/lib/job-activity";
+import { withRequestContext } from "@app/youtube/lib/request-context";
+import { recordYoutubeUsage } from "@app/youtube/lib/usage";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("recordYoutubeUsage → ai_calls", () => {
+    it("writes an ai_calls row with request-context attribution", async () => {
+        await withRequestContext({ userId: 42, db }, async () => {
+            await recordYoutubeUsage({
+                action: "qa:ask",
+                provider: "xai",
+                model: "grok-4",
+                videoId: "vid00000001",
+                scope: "vid00000001",
+            });
+        });
+        const calls = db.listAiCalls({ userId: 42 });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].action).toBe("qa:ask");
+        expect(calls[0].videoId).toBe("vid00000001");
+        expect(calls[0].jobId).toBeNull();
+        expect(calls[0].inputTokens).toBe(0);
+    });
+
+    it("prefers job-context attribution (jobId + job owner) over request context", async () => {
+        const job = db.enqueueJob({ targetKind: "video", target: "vid00000002", stages: ["summarize"], userId: 7 });
+
+        await withRequestContext({ userId: 99, db }, async () => {
+            await withJobActivity({ jobId: job.id, stage: "summarize", db, userId: 7 }, async () => {
+                await recordYoutubeUsage({
+                    action: "summarize:long",
+                    provider: "xai",
+                    model: "grok-4",
+                    videoId: "vid00000002",
+                });
+            });
+        });
+        const calls = db.listAiCalls({ jobId: job.id });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].userId).toBe(7);
+    });
+
+    it("does not throw without any context (CLI path) and writes nothing", async () => {
+        await recordYoutubeUsage({ action: "transcribe:ai", provider: "deepgram", model: "nova-3" });
+        expect(db.listAiCalls()).toHaveLength(0);
+    });
+});

--- a/src/youtube/lib/ai-mapping.ts
+++ b/src/youtube/lib/ai-mapping.ts
@@ -1,0 +1,39 @@
+import type { AiTask, AiTaskMapping, YoutubeConfigShape } from "@app/youtube/lib/config.types";
+
+/** The slice of config the resolution needs — routes pass `await yt.config.getAll()`. */
+export type AiResolutionSource = Pick<YoutubeConfigShape, "ai" | "provider">;
+
+/** Task→legacy `provider.*` key. Legacy config had no insights/summary split — both map to `summarize`. */
+const LEGACY_TASK_KEYS: Record<AiTask, keyof YoutubeConfigShape["provider"]> = {
+    summary: "summarize",
+    insights: "summarize",
+    qa: "qa",
+    transcribe: "transcribe",
+    embed: "embed",
+};
+
+/** "provider" or "provider/model" — the spec-string shape `resolveProviderChoice({ fallbackSpec })` consumes. */
+export function specOfAiMapping(entry: AiTaskMapping): string {
+    return entry.model ? `${entry.provider}/${entry.model}` : entry.provider;
+}
+
+/**
+ * Resolves the configured model spec for a task: first explicit `ai[]` entry
+ * listing the task, else the first `"all"` fallback entry, else the legacy
+ * `provider.<key>` string, else null (caller falls back to account defaults).
+ */
+export function resolveAiSpecForTask(config: AiResolutionSource, task: AiTask): string | null {
+    const explicit = config.ai.find((entry) => entry.for.includes(task));
+
+    if (explicit) {
+        return specOfAiMapping(explicit);
+    }
+
+    const fallback = config.ai.find((entry) => entry.for.includes("all"));
+
+    if (fallback) {
+        return specOfAiMapping(fallback);
+    }
+
+    return config.provider[LEGACY_TASK_KEYS[task]] ?? null;
+}

--- a/src/youtube/lib/config.ts
+++ b/src/youtube/lib/config.ts
@@ -14,6 +14,9 @@ export const DEFAULT_YOUTUBE_CONFIG: YoutubeConfigShape = {
     apiPort: 9876,
     apiBaseUrl: "http://localhost:9876",
     provider: {},
+    powerUsers: [],
+    ai: [],
+    referrals: { enabled: false, offers: [] },
     defaultQuality: "720p",
     concurrency: {
         download: 4,
@@ -124,6 +127,13 @@ function mergeConfig(base: YoutubeConfigShape, patch: YoutubeConfigPatch): Youtu
         ...base,
         ...patch,
         provider: { ...base.provider, ...patch.provider },
+        powerUsers: patch.powerUsers ?? base.powerUsers,
+        ai: patch.ai ?? base.ai,
+        referrals: {
+            ...base.referrals,
+            ...patch.referrals,
+            offers: patch.referrals?.offers ?? base.referrals.offers,
+        },
         concurrency: { ...base.concurrency, ...patch.concurrency },
         ttls: { ...base.ttls, ...patch.ttls },
         preferredLangs: patch.preferredLangs ?? base.preferredLangs,

--- a/src/youtube/lib/config.types.ts
+++ b/src/youtube/lib/config.types.ts
@@ -1,5 +1,38 @@
 import type { Language } from "@app/youtube/lib/transcript.types";
 
+export type YtRole = "admin" | "dev" | "user";
+
+export interface PowerUserEntry {
+    email: string;
+    type: YtRole;
+}
+
+export const AI_TASKS = ["insights", "summary", "qa", "transcribe", "embed"] as const;
+export type AiTask = (typeof AI_TASKS)[number];
+
+export interface AiTaskMapping {
+    provider: string;
+    /** Optional — a provider-only entry mirrors the legacy `provider.<task>` strings. */
+    model?: string;
+    /** Tasks this entry serves; `"all"` marks the fallback used when a task has no explicit entry. */
+    for: Array<AiTask | "all">;
+}
+
+export interface ReferralOffer {
+    /** ISO datetime — offer window start. */
+    from: string;
+    /** ISO datetime — offer window end. */
+    to: string;
+    /** Diamonds granted to each side when the referral completes. */
+    reward: number;
+    description?: string;
+}
+
+export interface ReferralsConfig {
+    enabled: boolean;
+    offers: ReferralOffer[];
+}
+
 export interface YoutubeConfigShape {
     apiPort: number;
     apiBaseUrl: string;
@@ -9,6 +42,12 @@ export interface YoutubeConfigShape {
         qa?: string;
         embed?: string;
     };
+    /** Email→role grants. Anyone not listed is a plain "user". */
+    powerUsers: PowerUserEntry[];
+    /** Task→model mapping; supersedes the legacy `provider.*` strings (kept as last-resort fallback). */
+    ai: AiTaskMapping[];
+    /** Referral program schema (logic lands in Phase 2). */
+    referrals: ReferralsConfig;
     defaultQuality: "720p" | "1080p" | "best";
     concurrency: {
         download: number;

--- a/src/youtube/lib/db.ts
+++ b/src/youtube/lib/db.ts
@@ -7,6 +7,7 @@ import { deleteIfExists } from "@app/youtube/lib/cache";
 import type { Channel, ChannelHandle } from "@app/youtube/lib/channel.types";
 import type { FetchedComment, VideoComment } from "@app/youtube/lib/comments.types";
 import type {
+    AiCallRecord,
     ClaimJobOpts,
     EnqueueJobInput,
     GetTranscriptOpts,
@@ -14,7 +15,10 @@ import type {
     ListVideosOpts,
     PruneExpiredBinariesOpts,
     PruneExpiredBinariesResult,
+    QueueStats,
+    RecordAiCallInput,
     RecordJobActivityInput,
+    RecordVideoLogInput,
     SaveTranscriptInput,
     SearchTranscriptsOpts,
     SearchVideosOpts,
@@ -26,8 +30,11 @@ import type {
     UpsertChannelInput,
     UpsertQaChunkInput,
     UpsertVideoInput,
+    VideoLogKind,
+    VideoLogRecord,
     VideoSearchField,
     VideoSearchHit,
+    VideoWatchRecord,
 } from "@app/youtube/lib/db.types";
 import type {
     JobActivity,
@@ -479,6 +486,61 @@ export class YoutubeDatabase extends BaseDatabase {
                 );
                 CREATE INDEX IF NOT EXISTS idx_credit_holds_status ON credit_holds(status);
             `);
+        });
+
+        // Audit trail (Phase 1 foundations). Deliberately NO foreign keys:
+        // audit rows must survive user/video/job deletion — they are the
+        // history, not live state.
+        this.runMigration("add-audit-tables", () => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS video_watchers (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER,
+                    video_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_video_watchers_video ON video_watchers(video_id, id DESC);
+                CREATE INDEX IF NOT EXISTS idx_video_watchers_user ON video_watchers(user_id, id DESC);
+
+                CREATE TABLE IF NOT EXISTS video_logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    kind TEXT NOT NULL CHECK (kind IN ('summary:view','insights:view','transcript:view','comments:view')),
+                    user_id INTEGER,
+                    video_id TEXT NOT NULL,
+                    meta_json TEXT,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_video_logs_video ON video_logs(video_id, id DESC);
+                CREATE INDEX IF NOT EXISTS idx_video_logs_user ON video_logs(user_id, id DESC);
+
+                CREATE TABLE IF NOT EXISTS ai_calls (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    provider TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    video_id TEXT,
+                    user_id INTEGER,
+                    input_tokens INTEGER NOT NULL DEFAULT 0,
+                    output_tokens INTEGER NOT NULL DEFAULT 0,
+                    cost_usd REAL,
+                    credits_charged INTEGER,
+                    job_id INTEGER,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_ai_calls_user ON ai_calls(user_id, id DESC);
+                CREATE INDEX IF NOT EXISTS idx_ai_calls_video ON ai_calls(video_id, id DESC);
+                CREATE INDEX IF NOT EXISTS idx_ai_calls_job ON ai_calls(job_id);
+            `);
+        });
+
+        this.runMigration("add-jobs-user", () => {
+            const cols = this.db.query<{ name: string }, []>("PRAGMA table_info(jobs)").all() as Array<{
+                name: string;
+            }>;
+
+            if (!cols.some((column) => column.name === "user_id")) {
+                this.db.exec("ALTER TABLE jobs ADD COLUMN user_id INTEGER");
+            }
         });
 
         const existing = this.db
@@ -1013,11 +1075,17 @@ export class YoutubeDatabase extends BaseDatabase {
 
     enqueueJob(input: EnqueueJobInput): PipelineJob {
         const result = this.db
-            .query<{ id: number }, [string, string, string, number | null]>(
-                `INSERT INTO jobs (target_kind, target, stages, parent_job_id, status)
-                 VALUES (?, ?, ?, ?, 'pending') RETURNING id`
+            .query<{ id: number }, [string, string, string, number | null, number | null]>(
+                `INSERT INTO jobs (target_kind, target, stages, parent_job_id, user_id, status)
+                 VALUES (?, ?, ?, ?, ?, 'pending') RETURNING id`
             )
-            .get(input.targetKind, input.target, SafeJSON.stringify(input.stages), input.parentJobId ?? null);
+            .get(
+                input.targetKind,
+                input.target,
+                SafeJSON.stringify(input.stages),
+                input.parentJobId ?? null,
+                input.userId ?? null
+            );
 
         if (!result) {
             throw new Error("enqueueJob failed: insert returned no id");
@@ -1241,6 +1309,150 @@ export class YoutubeDatabase extends BaseDatabase {
             .all(jobId);
 
         return rows.map(rowToJobActivity);
+    }
+
+    recordVideoWatch(input: { userId: number | null; videoId: string }): void {
+        this.db.run("INSERT INTO video_watchers (user_id, video_id) VALUES (?, ?)", [input.userId, input.videoId]);
+    }
+
+    recordVideoLog(input: RecordVideoLogInput): void {
+        this.db.run("INSERT INTO video_logs (kind, user_id, video_id, meta_json) VALUES (?, ?, ?, ?)", [
+            input.kind,
+            input.userId,
+            input.videoId,
+            input.meta ? SafeJSON.stringify(input.meta, { strict: true }) : null,
+        ]);
+    }
+
+    recordAiCall(input: RecordAiCallInput): void {
+        this.db.run(
+            `INSERT INTO ai_calls
+                (provider, model, action, video_id, user_id, input_tokens, output_tokens, cost_usd, credits_charged, job_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+                input.provider,
+                input.model,
+                input.action,
+                input.videoId ?? null,
+                input.userId ?? null,
+                input.inputTokens ?? 0,
+                input.outputTokens ?? 0,
+                input.costUsd ?? null,
+                input.creditsCharged ?? null,
+                input.jobId ?? null,
+            ]
+        );
+    }
+
+    listVideoWatchers(videoId: string, limit = 100): VideoWatchRecord[] {
+        const rows = this.db
+            .query<VideoWatcherRow, [string, number]>(
+                "SELECT * FROM video_watchers WHERE video_id = ? ORDER BY id DESC LIMIT ?"
+            )
+            .all(videoId, limit);
+
+        return rows.map((row) => ({
+            id: row.id,
+            userId: row.user_id,
+            videoId: row.video_id,
+            createdAt: row.created_at,
+        }));
+    }
+
+    listVideoLogs(opts: { videoId?: string; userId?: number; limit?: number } = {}): VideoLogRecord[] {
+        const where: string[] = [];
+        const params: Array<string | number> = [];
+
+        if (opts.videoId) {
+            where.push("video_id = ?");
+            params.push(opts.videoId);
+        }
+
+        if (opts.userId !== undefined) {
+            where.push("user_id = ?");
+            params.push(opts.userId);
+        }
+
+        const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+        const rows = this.db
+            .query<VideoLogRow, [...Array<string | number>, number]>(
+                `SELECT * FROM video_logs ${whereClause} ORDER BY id DESC LIMIT ?`
+            )
+            .all(...params, opts.limit ?? 100);
+
+        return rows.map(rowToVideoLog);
+    }
+
+    listAiCalls(opts: { userId?: number; videoId?: string; jobId?: number; limit?: number } = {}): AiCallRecord[] {
+        const where: string[] = [];
+        const params: Array<string | number> = [];
+
+        if (opts.userId !== undefined) {
+            where.push("user_id = ?");
+            params.push(opts.userId);
+        }
+
+        if (opts.videoId) {
+            where.push("video_id = ?");
+            params.push(opts.videoId);
+        }
+
+        if (opts.jobId !== undefined) {
+            where.push("job_id = ?");
+            params.push(opts.jobId);
+        }
+
+        const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+        const rows = this.db
+            .query<AiCallRow, [...Array<string | number>, number]>(
+                `SELECT * FROM ai_calls ${whereClause} ORDER BY id DESC LIMIT ?`
+            )
+            .all(...params, opts.limit ?? 100);
+
+        return rows.map(rowToAiCall);
+    }
+
+    getQueueStats(): QueueStats {
+        const pendingRows = this.db
+            .query<{ stage: string | null; count: number }, []>(
+                `SELECT json_extract(stages, '$[0]') AS stage, COUNT(*) AS count
+                 FROM jobs WHERE status = 'pending' GROUP BY stage`
+            )
+            .all();
+        const runningRows = this.db
+            .query<{ stage: string | null; count: number }, []>(
+                `SELECT COALESCE(current_stage, json_extract(stages, '$[0]')) AS stage, COUNT(*) AS count
+                 FROM jobs WHERE status = 'running' GROUP BY stage`
+            )
+            .all();
+        const oldest = this.db
+            .query<{ created_at: string }, []>(
+                "SELECT created_at FROM jobs WHERE status = 'pending' ORDER BY id ASC LIMIT 1"
+            )
+            .get();
+        const perStage: Record<string, { queued: number; running: number }> = {};
+        let queued = 0;
+        let running = 0;
+
+        for (const row of pendingRows) {
+            const stage = row.stage ?? "unknown";
+            perStage[stage] = perStage[stage] ?? { queued: 0, running: 0 };
+            perStage[stage].queued += row.count;
+            queued += row.count;
+        }
+
+        for (const row of runningRows) {
+            const stage = row.stage ?? "unknown";
+            perStage[stage] = perStage[stage] ?? { queued: 0, running: 0 };
+            perStage[stage].running += row.count;
+            running += row.count;
+        }
+
+        const oldestQueuedAgeSec = oldest
+            ? Math.max(0, Math.round((Date.now() - Date.parse(oldest.created_at)) / 1000))
+            : null;
+
+        return { queued, running, perStage, oldestQueuedAgeSec };
     }
 
     async pruneExpiredBinaries(opts: PruneExpiredBinariesOpts): Promise<PruneExpiredBinariesResult> {
@@ -2250,6 +2462,65 @@ interface QaChunkRow {
     source_ref: string | null;
 }
 
+interface VideoWatcherRow {
+    id: number;
+    user_id: number | null;
+    video_id: string;
+    created_at: string;
+}
+
+interface VideoLogRow {
+    id: number;
+    kind: VideoLogKind;
+    user_id: number | null;
+    video_id: string;
+    meta_json: string | null;
+    created_at: string;
+}
+
+interface AiCallRow {
+    id: number;
+    provider: string;
+    model: string;
+    action: string;
+    video_id: string | null;
+    user_id: number | null;
+    input_tokens: number;
+    output_tokens: number;
+    cost_usd: number | null;
+    credits_charged: number | null;
+    job_id: number | null;
+    created_at: string;
+}
+
+function rowToVideoLog(row: VideoLogRow): VideoLogRecord {
+    return {
+        id: row.id,
+        kind: row.kind,
+        userId: row.user_id,
+        videoId: row.video_id,
+        meta: row.meta_json ? (SafeJSON.parse(row.meta_json) as Record<string, unknown>) : null,
+        createdAt: row.created_at,
+    };
+}
+
+function rowToAiCall(row: AiCallRow): AiCallRecord {
+    return {
+        id: row.id,
+        provider: row.provider,
+        model: row.model,
+        action: row.action,
+        videoId: row.video_id,
+        userId: row.user_id,
+        inputTokens: row.input_tokens,
+        outputTokens: row.output_tokens,
+        costUsd: row.cost_usd,
+        creditsCharged: row.credits_charged,
+        jobId: row.job_id,
+        createdAt: row.created_at,
+    };
+}
+
 interface JobRow {
     id: number;
     target_kind: JobTargetKind;
@@ -2261,6 +2532,7 @@ interface JobRow {
     progress: number;
     progress_message: string | null;
     parent_job_id: number | null;
+    user_id: number | null;
     worker_id: string | null;
     claimed_at: string | null;
     created_at: string;
@@ -2280,6 +2552,7 @@ function rowToJob(row: JobRow): PipelineJob {
         progress: row.progress,
         progressMessage: row.progress_message,
         parentJobId: row.parent_job_id,
+        userId: row.user_id ?? null,
         workerId: row.worker_id,
         claimedAt: row.claimed_at,
         createdAt: row.created_at,

--- a/src/youtube/lib/db.types.ts
+++ b/src/youtube/lib/db.types.ts
@@ -124,6 +124,8 @@ export interface EnqueueJobInput {
     target: string;
     stages: JobStage[];
     parentJobId?: number | null;
+    /** Requesting user, when the job was triggered by an authenticated request. Null for CLI/operator jobs. */
+    userId?: number | null;
 }
 
 export interface ClaimJobOpts {
@@ -177,4 +179,64 @@ export interface RecordJobActivityInput {
     startedAt?: string | null;
     completedAt?: string | null;
     error?: string | null;
+}
+
+export type VideoLogKind = "summary:view" | "insights:view" | "transcript:view" | "comments:view";
+
+export interface RecordVideoLogInput {
+    kind: VideoLogKind;
+    userId: number | null;
+    videoId: string;
+    meta?: Record<string, unknown> | null;
+}
+
+export interface VideoWatchRecord {
+    id: number;
+    userId: number | null;
+    videoId: string;
+    createdAt: string;
+}
+
+export interface VideoLogRecord {
+    id: number;
+    kind: VideoLogKind;
+    userId: number | null;
+    videoId: string;
+    meta: Record<string, unknown> | null;
+    createdAt: string;
+}
+
+export interface RecordAiCallInput {
+    provider: string;
+    model: string;
+    action: string;
+    videoId?: string | null;
+    userId?: number | null;
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+    costUsd?: number | null;
+    creditsCharged?: number | null;
+    jobId?: number | null;
+}
+
+export interface AiCallRecord {
+    id: number;
+    provider: string;
+    model: string;
+    action: string;
+    videoId: string | null;
+    userId: number | null;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number | null;
+    creditsCharged: number | null;
+    jobId: number | null;
+    createdAt: string;
+}
+
+export interface QueueStats {
+    queued: number;
+    running: number;
+    perStage: Record<string, { queued: number; running: number }>;
+    oldestQueuedAgeSec: number | null;
 }

--- a/src/youtube/lib/job-activity.ts
+++ b/src/youtube/lib/job-activity.ts
@@ -13,6 +13,8 @@ import type { JobStage } from "@app/youtube/lib/jobs.types";
 export interface JobActivityContext {
     jobId: number;
     stage: JobStage;
+    /** Owner of the running job — attribution for ai_calls. Undefined/null = operator work. */
+    userId?: number | null;
     db: YoutubeDatabase;
 }
 

--- a/src/youtube/lib/jobs.types.ts
+++ b/src/youtube/lib/jobs.types.ts
@@ -27,6 +27,7 @@ export interface PipelineJob {
     progress: number;
     progressMessage: string | null;
     parentJobId: number | null;
+    userId: number | null;
     workerId: string | null;
     claimedAt: string | null;
     createdAt: string;

--- a/src/youtube/lib/pipeline.ts
+++ b/src/youtube/lib/pipeline.ts
@@ -175,7 +175,9 @@ export class Pipeline {
                 },
             };
 
-            await withJobActivity({ jobId: job.id, stage: claimedStage, db: this.db }, () => handler(ctx));
+            await withJobActivity({ jobId: job.id, stage: claimedStage, db: this.db, userId: job.userId }, () =>
+                handler(ctx)
+            );
             logger.debug(
                 { jobId: job.id, stage: claimedStage, targetKind: job.targetKind, target: job.target },
                 "youtube pipeline stage completed"

--- a/src/youtube/lib/pipeline.types.ts
+++ b/src/youtube/lib/pipeline.types.ts
@@ -21,6 +21,7 @@ export interface EnqueuePipelineJobInput {
     target: string;
     stages: JobStage[];
     parentJobId?: number;
+    userId?: number | null;
 }
 
 export interface ListPipelineJobsOpts {

--- a/src/youtube/lib/qa.ts
+++ b/src/youtube/lib/qa.ts
@@ -1,6 +1,7 @@
 import { logger } from "@app/logger";
 import { callLLM } from "@app/utils/ai/call-llm";
 import { Embedder } from "@app/utils/ai/tasks/Embedder";
+import { resolveAiSpecForTask } from "@app/youtube/lib/ai-mapping";
 import type { ChannelHandle } from "@app/youtube/lib/channel.types";
 import type { VideoComment } from "@app/youtube/lib/comments.types";
 import type { YoutubeConfig } from "@app/youtube/lib/config";
@@ -8,6 +9,7 @@ import type { YoutubeDatabase } from "@app/youtube/lib/db";
 import type { TranscriptSearchHit } from "@app/youtube/lib/db.types";
 import { englishLanguageName } from "@app/youtube/lib/languages";
 import { buildPresetBlock } from "@app/youtube/lib/presets";
+import { parseProviderSpec } from "@app/youtube/lib/provider-choice";
 import type {
     AskOpts,
     AskResult,
@@ -60,10 +62,10 @@ export class QaService {
 
     async index(opts: IndexOpts): Promise<IndexResult> {
         const sources = opts.sources ?? ["transcript"];
-        const provider = await this.config.get("provider");
+        const embedProvider = parseProviderSpec(resolveAiSpecForTask(await this.config.getAll(), "embed")).provider;
         const modelId = opts.model ?? DEFAULT_MODEL_ID;
         const embedder = await this.deps.createEmbedder({
-            provider: opts.provider ?? provider.embed,
+            provider: opts.provider ?? embedProvider,
             model: opts.model,
         });
 
@@ -83,9 +85,10 @@ export class QaService {
                     const vectors = await embedder.embedBatch(chunks.map((chunk) => chunk.text));
                     await recordYoutubeUsage({
                         action: "qa:embed",
-                        provider: opts.provider ?? provider.embed ?? "default",
+                        provider: opts.provider ?? embedProvider ?? "default",
                         model: modelId,
                         scope: opts.videoId,
+                        videoId: opts.videoId,
                     });
 
                     for (let i = 0; i < chunks.length; i++) {
@@ -124,9 +127,10 @@ export class QaService {
                     const vectors = await embedder.embedBatch(chunks.map((chunk) => chunk.text));
                     await recordYoutubeUsage({
                         action: "qa:embed",
-                        provider: opts.provider ?? provider.embed ?? "default",
+                        provider: opts.provider ?? embedProvider ?? "default",
                         model: modelId,
                         scope: opts.videoId,
+                        videoId: opts.videoId,
                     });
 
                     for (let i = 0; i < chunks.length; i++) {
@@ -244,6 +248,7 @@ export class QaService {
                 model: ids.model,
                 usage: result.usage,
                 scope: opts.videoIds.join(","),
+                videoId: opts.videoIds.length === 1 ? opts.videoIds[0] : null,
                 prompt: `system:\n${systemPrompt}\n\nuser:\n${userPrompt}`,
                 response: result.content,
                 durationMs: completedAt.getTime() - startedAt.getTime(),

--- a/src/youtube/lib/request-context.ts
+++ b/src/youtube/lib/request-context.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { YoutubeDatabase } from "@app/youtube/lib/db";
+
+/**
+ * Per-HTTP-request attribution so deep lib code (usage recording) can tie AI
+ * work to the requesting user without threading userId through every
+ * signature. Mirrors the job-activity ALS pattern (`job-activity.ts`) — the
+ * two coexist: job context wins for queue work, request context covers
+ * synchronous routes.
+ */
+export interface YtRequestContext {
+    userId: number | null;
+    db: YoutubeDatabase;
+}
+
+const requestStorage = new AsyncLocalStorage<YtRequestContext>();
+
+export function getRequestContext(): YtRequestContext | undefined {
+    return requestStorage.getStore();
+}
+
+export function withRequestContext<T>(ctx: YtRequestContext, fn: () => Promise<T>): Promise<T> {
+    return requestStorage.run(ctx, fn);
+}

--- a/src/youtube/lib/roles.ts
+++ b/src/youtube/lib/roles.ts
@@ -1,0 +1,13 @@
+import type { PowerUserEntry, YtRole } from "@app/youtube/lib/config.types";
+
+/** Config-derived role. Unlisted emails are plain users. Matching is case-insensitive (users table is COLLATE NOCASE). */
+export function roleForEmail(powerUsers: PowerUserEntry[], email: string): YtRole {
+    const normalized = email.trim().toLowerCase();
+    const entry = powerUsers.find((powerUser) => powerUser.email.trim().toLowerCase() === normalized);
+
+    return entry?.type ?? "user";
+}
+
+export function isPowerRole(role: YtRole): boolean {
+    return role === "admin" || role === "dev";
+}

--- a/src/youtube/lib/server/__tests__/audit-routes.test.ts
+++ b/src/youtube/lib/server/__tests__/audit-routes.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleVideosRoute } from "@app/youtube/lib/server/routes/videos";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-audit-routes-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    db.upsertChannel({ handle: "@chan" });
+    db.upsertVideo({ id: "vid00000001", channelHandle: "@chan", title: "Video one" });
+    db.saveTranscript({
+        videoId: "vid00000001",
+        lang: "en",
+        source: "captions",
+        text: "hello world",
+        segments: [{ text: "hello world", start: 0, end: 2 }],
+    });
+    db.setVideoSummary(
+        "vid00000001",
+        "timestamped",
+        [{ icon: "⚡", title: "t", text: "b", startSec: 0, endSec: 2 }],
+        "en"
+    );
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    const user = db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+
+    return { ...user, token: `ytu_${email}` };
+}
+
+async function get(path: string, token?: string) {
+    const url = new URL(`http://localhost${path}`);
+    const req = new Request(url, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
+
+    return handleVideosRoute(req, url, yt);
+}
+
+describe("audit route hooks", () => {
+    it("GET /videos/:id records a watcher row (user + anonymous)", async () => {
+        const user = createUser("w@example.com");
+
+        expect((await get("/api/v1/videos/vid00000001", user.token)).status).toBe(200);
+        expect((await get("/api/v1/videos/vid00000001")).status).toBe(200);
+        const rows = db.listVideoWatchers("vid00000001");
+
+        expect(rows).toHaveLength(2);
+        expect(rows.map((row) => row.userId).sort((a, b) => Number(a) - Number(b))).toEqual(
+            [null, user.id].sort((a, b) => Number(a) - Number(b))
+        );
+    });
+
+    it("GET summary (timestamped, exists) logs insights:view; missing long summary logs nothing", async () => {
+        // Anonymous on purpose: an authenticated user WITHOUT an artifact_access
+        // row gets the locked teaser (no content, no view log) — the open
+        // anonymous path is the one that serves content here.
+        expect((await get("/api/v1/videos/vid00000001/summary?mode=timestamped")).status).toBe(200);
+        expect((await get("/api/v1/videos/vid00000001/summary?mode=long")).status).toBe(200);
+        const logs = db.listVideoLogs({ videoId: "vid00000001" });
+
+        expect(logs.filter((log) => log.kind === "insights:view")).toHaveLength(1);
+        expect(logs.filter((log) => log.kind === "insights:view")[0].userId).toBeNull();
+        expect(logs.filter((log) => log.kind === "summary:view")).toHaveLength(0);
+    });
+
+    it("locked teaser (authed user without access) logs no view", async () => {
+        const user = createUser("locked@example.com");
+        const res = await get("/api/v1/videos/vid00000001/summary?mode=timestamped", user.token);
+
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { locked?: boolean }).locked).toBe(true);
+        expect(db.listVideoLogs({ videoId: "vid00000001" })).toHaveLength(0);
+    });
+
+    it("GET transcript logs transcript:view; GET comments logs comments:view", async () => {
+        expect((await get("/api/v1/videos/vid00000001/transcript")).status).toBe(200);
+        expect((await get("/api/v1/videos/vid00000001/comments")).status).toBe(200);
+        const logs = db.listVideoLogs({ videoId: "vid00000001" });
+
+        expect(logs.some((log) => log.kind === "transcript:view")).toBe(true);
+        expect(logs.some((log) => log.kind === "comments:view")).toBe(true);
+    });
+
+    it("does not log a transcript view on 404", async () => {
+        expect((await get("/api/v1/videos/vid00000001/transcript?lang=xx&source=ai")).status).toBe(404);
+        const logs = db.listVideoLogs({ videoId: "vid00000001" });
+
+        expect(logs.filter((log) => log.kind === "transcript:view")).toHaveLength(0);
+    });
+});

--- a/src/youtube/lib/server/__tests__/auth.test.ts
+++ b/src/youtube/lib/server/__tests__/auth.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { env } from "@app/utils/env";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
 import {
     extractServiceToken,
     parseServiceKeys,
     requireServiceKey,
+    requireUser,
     resolveServiceKeys,
 } from "@app/youtube/lib/server/auth";
 
@@ -122,5 +124,45 @@ describe("YOUTUBE_SERVICE_KEY env → guard path stays closed on garbage", () =>
             expect(env.youtube.getServiceKey()).toBeUndefined();
             expect(resolveServiceKeys(env.youtube.getServiceKey())).toEqual([]);
         });
+    });
+});
+
+describe("requireServiceKey with user tokens", () => {
+    it("accepts a valid ytu_ user token when keys are configured", () => {
+        const db = new YoutubeDatabase(":memory:");
+        const user = db.createUser({ email: "a@example.com", passwordHash: "h", apiToken: "ytu_valid" });
+        const req = new Request("http://localhost/api/v1/videos", {
+            headers: { Authorization: "Bearer ytu_valid" },
+        });
+
+        expect(user.id).toBeGreaterThan(0);
+        expect(requireServiceKey(req, ["sk-real"], db)).toBeNull();
+        db.close();
+    });
+
+    it("still rejects unknown ytu_ tokens", () => {
+        const db = new YoutubeDatabase(":memory:");
+        const req = new Request("http://localhost/api/v1/videos", {
+            headers: { Authorization: "Bearer ytu_bogus" },
+        });
+        const res = requireServiceKey(req, ["sk-real"], db);
+
+        expect(res?.status).toBe(401);
+        db.close();
+    });
+});
+
+describe("requireUser typed 401", () => {
+    it("returns code login_required in the 401 body", async () => {
+        const db = new YoutubeDatabase(":memory:");
+        const url = new URL("http://localhost/api/v1/users/me");
+        const result = requireUser(new Request(url), url, db);
+
+        expect(result instanceof Response).toBe(true);
+        const body = (await (result as Response).json()) as { error: string; code?: string };
+
+        expect(body.error).toBe("login required");
+        expect(body.code).toBe("login_required");
+        db.close();
     });
 });

--- a/src/youtube/lib/server/__tests__/queue-route.test.ts
+++ b/src/youtube/lib/server/__tests__/queue-route.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handlePipelineRoute } from "@app/youtube/lib/server/routes/pipeline";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-queue-route-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("GET /api/v1/jobs/queue", () => {
+    it("aggregates queued/running per stage with oldest age", async () => {
+        db.enqueueJob({ targetKind: "video", target: "vid00000001", stages: ["captions", "summarize"] });
+        db.enqueueJob({ targetKind: "video", target: "vid00000002", stages: ["captions"] });
+        db.enqueueJob({ targetKind: "video", target: "vid00000003", stages: ["summarize"] });
+        const claimed = db.claimNextJob("worker-1");
+
+        expect(claimed).not.toBeNull();
+
+        const url = new URL("http://localhost/api/v1/jobs/queue");
+        const res = await handlePipelineRoute(new Request(url), url, yt);
+
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+            queue: {
+                queued: number;
+                running: number;
+                perStage: Record<string, { queued: number; running: number }>;
+                oldestQueuedAgeSec: number | null;
+            };
+        };
+
+        expect(body.queue.queued).toBe(2);
+        expect(body.queue.running).toBe(1);
+        expect(body.queue.perStage.captions).toEqual({ queued: 1, running: 1 });
+        expect(body.queue.perStage.summarize).toEqual({ queued: 1, running: 0 });
+        expect(body.queue.oldestQueuedAgeSec).not.toBeNull();
+        expect(body.queue.oldestQueuedAgeSec ?? 0).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns zeros on an empty queue", async () => {
+        const url = new URL("http://localhost/api/v1/jobs/queue");
+        const res = await handlePipelineRoute(new Request(url), url, yt);
+        const body = (await res.json()) as {
+            queue: { queued: number; running: number; oldestQueuedAgeSec: number | null };
+        };
+
+        expect(res.status).toBe(200);
+        expect(body.queue.queued).toBe(0);
+        expect(body.queue.running).toBe(0);
+        expect(body.queue.oldestQueuedAgeSec).toBeNull();
+    });
+});

--- a/src/youtube/lib/server/__tests__/roles-routes.test.ts
+++ b/src/youtube/lib/server/__tests__/roles-routes.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleModelsRoute } from "@app/youtube/lib/server/routes/models";
+import { handleUsersRoute } from "@app/youtube/lib/server/routes/users";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "yt-roles-routes-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    await yt.config.update({ powerUsers: [{ email: "boss@example.com", type: "admin" }] });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    const user = db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+
+    return { ...user, token: `ytu_${email}` };
+}
+
+async function getMe(token: string) {
+    const url = new URL("http://localhost/api/v1/users/me");
+    const req = new Request(url, { headers: { Authorization: `Bearer ${token}` } });
+    const res = await handleUsersRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as { role?: string } };
+}
+
+describe("GET /users/me role", () => {
+    it("returns admin for configured power users", async () => {
+        const boss = createUser("boss@example.com");
+        const res = await getMe(boss.token);
+
+        expect(res.status).toBe(200);
+        expect(res.json.role).toBe("admin");
+    });
+
+    it("returns user for everyone else", async () => {
+        const pleb = createUser("pleb@example.com");
+        const res = await getMe(pleb.token);
+
+        expect(res.status).toBe(200);
+        expect(res.json.role).toBe("user");
+    });
+});
+
+describe("GET /models gating", () => {
+    it("403s an authenticated regular user with code forbidden", async () => {
+        const pleb = createUser("pleb@example.com");
+        const url = new URL("http://localhost/api/v1/models");
+        const req = new Request(url, { headers: { Authorization: `Bearer ${pleb.token}` } });
+        const res = await handleModelsRoute(req, url, yt);
+
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { code?: string };
+
+        expect(body.code).toBe("forbidden");
+    });
+});

--- a/src/youtube/lib/server/__tests__/websocket.test.ts
+++ b/src/youtube/lib/server/__tests__/websocket.test.ts
@@ -70,6 +70,40 @@ describe("youtube server websocket", () => {
             await rm(dir, { recursive: true, force: true });
         }
     });
+
+    it("scopes events to the token's user (ytu_ handshake)", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "youtube-server-ws-"));
+        const handle = await startServer({ port: 0, baseDir: dir, startPipeline: false });
+        const userA = handle.youtube.db.createUser({ email: "a@example.com", passwordHash: "h", apiToken: "ytu_a" });
+        const userB = handle.youtube.db.createUser({ email: "b@example.com", passwordHash: "h", apiToken: "ytu_b" });
+        const ws = new WebSocket(`ws://localhost:${handle.port}/api/v1/events?access_token=ytu_a`);
+
+        try {
+            await nextMessage(ws);
+
+            // B's job first — it must NOT reach A's socket; A's own job must.
+            handle.youtube.pipeline.enqueue({
+                targetKind: "video",
+                target: "bbbbbbbbbbb",
+                stages: ["metadata"],
+                userId: userB.id,
+            });
+            const own = handle.youtube.pipeline.enqueue({
+                targetKind: "video",
+                target: "aaaaaaaaaaa",
+                stages: ["metadata"],
+                userId: userA.id,
+            });
+            const created = await nextMessage(ws);
+
+            expect(created.type).toBe("job:created");
+            expect(created.job?.id).toBe(own.id);
+        } finally {
+            ws.close();
+            await handle.stop();
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
 });
 
 function nextMessage(ws: WebSocket): Promise<WsMessage> {

--- a/src/youtube/lib/server/auth.ts
+++ b/src/youtube/lib/server/auth.ts
@@ -91,12 +91,14 @@ function tokenMatchesAny(presented: string, keys: string[]): boolean {
     return matched;
 }
 
+export const USER_TOKEN_PREFIX = "ytu_";
+
 /**
  * Returns a 401 `Response` when auth is enabled and the request lacks a valid
  * key, or `null` when the request may proceed. With no keys configured every
  * request proceeds (open mode).
  */
-export function requireServiceKey(req: Request, keys: string[]): Response | null {
+export function requireServiceKey(req: Request, keys: string[], db?: YoutubeDatabase): Response | null {
     if (keys.length === 0) {
         return null;
     }
@@ -104,6 +106,15 @@ export function requireServiceKey(req: Request, keys: string[]): Response | null
     const token = extractServiceToken(req);
     const method = req.method;
     const path = new URL(req.url).pathname;
+
+    // A valid per-user token satisfies the top-level gate too: user routes
+    // re-check identity via requireUser/resolveUser, and browser surfaces
+    // (<audio> tags, WS handshakes) can only present the ytu_ token.
+    if (token?.startsWith(USER_TOKEN_PREFIX) && db?.getUserByToken(token)) {
+        logger.debug({ method, path }, "youtube API: accepted request with valid user token");
+
+        return null;
+    }
 
     if (!token || !tokenMatchesAny(token, keys)) {
         // Log the decision — never the presented key — so auth failures are
@@ -124,8 +135,6 @@ export function requireServiceKey(req: Request, keys: string[]): Response | null
 
     return null;
 }
-
-const USER_TOKEN_PREFIX = "ytu_";
 
 /**
  * Returns the authenticated user, or a ready 401 JSON Response. Never throws.
@@ -165,7 +174,7 @@ export function requireUser(req: Request, url: URL, db: YoutubeDatabase): YtUser
         "youtube API: user auth required"
     );
 
-    return new Response(SafeJSON.stringify({ error: "login required" }, { strict: true }), {
+    return new Response(SafeJSON.stringify({ error: "login required", code: "login_required" }, { strict: true }), {
         status: 401,
         headers: { "Content-Type": "application/json", ...CORS_HEADERS },
     });

--- a/src/youtube/lib/server/index.ts
+++ b/src/youtube/lib/server/index.ts
@@ -1,7 +1,14 @@
 import { logger } from "@app/logger";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
-import { requireServiceKey, resolveServiceKeys } from "@app/youtube/lib/server/auth";
+import { withRequestContext } from "@app/youtube/lib/request-context";
+import {
+    extractBearerToken,
+    requireServiceKey,
+    resolveServiceKeys,
+    resolveUser,
+    USER_TOKEN_PREFIX,
+} from "@app/youtube/lib/server/auth";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
 import { clearPid, registerSignalHandlers, writePid } from "@app/youtube/lib/server/daemon";
 import { toErrorResponse } from "@app/youtube/lib/server/error";
@@ -98,7 +105,7 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
                     url.pathname.startsWith("/api/v1/webhooks/");
 
                 if (!isOpenRoute) {
-                    const authError = requireServiceKey(req, serviceKeys);
+                    const authError = requireServiceKey(req, serviceKeys, youtube.db);
 
                     if (authError) {
                         return authError;
@@ -106,7 +113,20 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
                 }
 
                 if (url.pathname === "/api/v1/events") {
-                    if (server.upgrade(req, { data: { subscribedJobIds: "all" } })) {
+                    // Scope the socket at upgrade time: a ytu_ token pins it to
+                    // that user's jobs; service key / open mode stays operator-wide.
+                    const presented =
+                        extractBearerToken(req) ??
+                        url.searchParams.get("access_token") ??
+                        url.searchParams.get("token");
+                    const wsUser = presented?.startsWith(USER_TOKEN_PREFIX)
+                        ? youtube.db.getUserByToken(presented)
+                        : null;
+                    const data: WebsocketState = wsUser
+                        ? { subscribedJobIds: "all", scope: "user", userId: wsUser.id }
+                        : { subscribedJobIds: "all", scope: "all", userId: null };
+
+                    if (server.upgrade(req, { data })) {
                         return undefined;
                     }
 
@@ -116,58 +136,11 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
                     });
                 }
 
-                if (url.pathname.startsWith("/api/v1/channels")) {
-                    return await handleChannelsRoute(req, url, youtube);
-                }
+                const viewer = resolveUser(req, url, youtube.db);
 
-                if (url.pathname.startsWith("/api/v1/videos")) {
-                    return await handleVideosRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/users")) {
-                    return await handleUsersRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/shares")) {
-                    return await handleSharesRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/webhooks")) {
-                    return await handleWebhooksRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/reports")) {
-                    return await handleReportsRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/pipeline") || url.pathname.startsWith("/api/v1/jobs")) {
-                    return await handlePipelineRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/cache")) {
-                    return await handleCacheRoute(req, url, youtube);
-                }
-
-                if (url.pathname.startsWith("/api/v1/config")) {
-                    return await handleConfigRoute(req, url, youtube);
-                }
-
-                if (url.pathname === "/api/v1/models") {
-                    return await handleModelsRoute(req, url, youtube);
-                }
-
-                if (
-                    url.pathname === "/api/v1/healthz" ||
-                    url.pathname === "/api/v1/version" ||
-                    url.pathname === "/api/v1/openapi.json"
-                ) {
-                    return await handleMetaRoute(req, url, { startedAt: STARTED_AT });
-                }
-
-                return new Response(SafeJSON.stringify({ error: "not found" }, { strict: true }), {
-                    status: 404,
-                    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-                });
+                return await withRequestContext({ userId: viewer?.id ?? null, db: youtube.db }, () =>
+                    dispatchApiRoute(req, url, youtube)
+                );
             } catch (err) {
                 return toErrorResponse(err);
             }
@@ -204,6 +177,61 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
             clearPid();
         },
     };
+}
+
+async function dispatchApiRoute(req: Request, url: URL, youtube: Youtube): Promise<Response> {
+    if (url.pathname.startsWith("/api/v1/channels")) {
+        return handleChannelsRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/videos")) {
+        return handleVideosRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/users")) {
+        return handleUsersRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/shares")) {
+        return handleSharesRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/webhooks")) {
+        return handleWebhooksRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/reports")) {
+        return handleReportsRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/pipeline") || url.pathname.startsWith("/api/v1/jobs")) {
+        return handlePipelineRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/cache")) {
+        return handleCacheRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/config")) {
+        return handleConfigRoute(req, url, youtube);
+    }
+
+    if (url.pathname === "/api/v1/models") {
+        return handleModelsRoute(req, url, youtube);
+    }
+
+    if (
+        url.pathname === "/api/v1/healthz" ||
+        url.pathname === "/api/v1/version" ||
+        url.pathname === "/api/v1/openapi.json"
+    ) {
+        return handleMetaRoute(req, url, { startedAt: STARTED_AT });
+    }
+
+    return new Response(SafeJSON.stringify({ error: "not found" }, { strict: true }), {
+        status: 404,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
 }
 
 if (import.meta.main) {

--- a/src/youtube/lib/server/openapi.ts
+++ b/src/youtube/lib/server/openapi.ts
@@ -855,6 +855,31 @@ function buildPaths(): Record<string, OpenApiPathItem> {
                 },
             },
         },
+        "/api/v1/jobs/queue": {
+            get: {
+                operationId: "getJobsQueue",
+                summary: "Pipeline queue statistics",
+                tags: ["jobs"],
+                responses: {
+                    "200": jsonResponse("Queue stats", {
+                        type: "object",
+                        properties: {
+                            queue: {
+                                type: "object",
+                                properties: {
+                                    queued: { type: "integer" },
+                                    running: { type: "integer" },
+                                    perStage: { type: "object" },
+                                    oldestQueuedAgeSec: { type: ["integer", "null"] },
+                                },
+                                required: ["queued", "running", "perStage", "oldestQueuedAgeSec"],
+                            },
+                        },
+                        required: ["queue"],
+                    }),
+                },
+            },
+        },
         "/api/v1/jobs/{id}": {
             get: {
                 operationId: "getJob",

--- a/src/youtube/lib/server/routes/channels.ts
+++ b/src/youtube/lib/server/routes/channels.ts
@@ -1,4 +1,5 @@
 import { SafeJSON } from "@app/utils/json";
+import { resolveUser } from "@app/youtube/lib/server/auth";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
 import { toErrorResponse } from "@app/youtube/lib/server/error";
 import { matchRoute } from "@app/youtube/lib/server/match-route";
@@ -42,10 +43,12 @@ export async function handleChannelsRoute(req: Request, url: URL, yt: Youtube): 
 
         if (sync) {
             const handle = normaliseHandle(sync.handle);
+            const user = resolveUser(req, url, yt.db);
             const job = yt.pipeline.enqueue({
                 targetKind: "channel",
                 target: handle,
                 stages: ["discover", "metadata"],
+                userId: user?.id ?? null,
             });
 
             return Response.json({ enqueuedJobIds: [job.id], enqueuedJobId: job.id }, { headers: CORS_HEADERS });

--- a/src/youtube/lib/server/routes/models.ts
+++ b/src/youtube/lib/server/routes/models.ts
@@ -1,6 +1,9 @@
 import { logger } from "@app/logger";
 import { SafeJSON } from "@app/utils/json";
+import { resolveAiSpecForTask } from "@app/youtube/lib/ai-mapping";
 import { resolveProviderChoice } from "@app/youtube/lib/provider-choice";
+import { isPowerRole, roleForEmail } from "@app/youtube/lib/roles";
+import { resolveUser } from "@app/youtube/lib/server/auth";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
 import { toErrorResponse } from "@app/youtube/lib/server/error";
 import type { Youtube } from "@app/youtube/lib/youtube";
@@ -36,13 +39,31 @@ async function resolveTaskDefault(spec: string | null | undefined): Promise<Reso
  * flatten to a `{provider, model}` matrix. The extension's dev-mode picker
  * renders this so users pick a real account instead of typing model IDs.
  */
-export async function handleModelsRoute(req: Request, _url: URL, yt: Youtube): Promise<Response> {
+export async function handleModelsRoute(req: Request, url: URL, yt: Youtube): Promise<Response> {
     try {
         if (req.method !== "GET") {
             return new Response(SafeJSON.stringify({ error: "method not allowed" }, { strict: true }), {
                 status: 405,
                 headers: { "Content-Type": "application/json", ...CORS_HEADERS },
             });
+        }
+
+        // Model internals are admin/dev-only (spec §1). Anonymous = local
+        // operator (open mode) or service key — those stay allowed; in key
+        // mode anonymous requests were already rejected at the gate.
+        const viewer = resolveUser(req, url, yt.db);
+
+        if (viewer) {
+            const role = roleForEmail(await yt.config.get("powerUsers"), viewer.email);
+
+            if (!isPowerRole(role)) {
+                logger.debug({ userId: viewer.id, role }, "models route: rejected non-power user");
+
+                return new Response(
+                    SafeJSON.stringify({ error: "model catalog is admin-only", code: "forbidden" }, { strict: true }),
+                    { status: 403, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+                );
+            }
         }
 
         const providers = await providerManager.detectProviders();
@@ -60,12 +81,13 @@ export async function handleModelsRoute(req: Request, _url: URL, yt: Youtube): P
             }
         }
 
-        const cfg = await yt.config.get("provider");
+        const all = await yt.config.getAll();
         const defaults = {
-            summarize: await resolveTaskDefault(cfg?.summarize),
-            qa: await resolveTaskDefault(cfg?.qa),
-            transcribe: cfg?.transcribe ?? null,
-            embed: cfg?.embed ?? null,
+            summarize: await resolveTaskDefault(resolveAiSpecForTask(all, "summary")),
+            insights: await resolveTaskDefault(resolveAiSpecForTask(all, "insights")),
+            qa: await resolveTaskDefault(resolveAiSpecForTask(all, "qa")),
+            transcribe: resolveAiSpecForTask(all, "transcribe"),
+            embed: resolveAiSpecForTask(all, "embed"),
         };
 
         return Response.json({ presets, defaults }, { headers: CORS_HEADERS });

--- a/src/youtube/lib/server/routes/pipeline.ts
+++ b/src/youtube/lib/server/routes/pipeline.ts
@@ -1,4 +1,5 @@
 import { SafeJSON } from "@app/utils/json";
+import { resolveUser } from "@app/youtube/lib/server/auth";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
 import { toErrorResponse } from "@app/youtube/lib/server/error";
 import { matchRoute } from "@app/youtube/lib/server/match-route";
@@ -16,7 +17,13 @@ export async function handlePipelineRoute(req: Request, url: URL, yt: Youtube): 
         if (matchRoute(req, "POST", "/api/v1/pipeline", url.pathname)) {
             const body = (await req.json()) as EnqueueBody;
             const targetKind = body.targetKind ?? inferTargetKind(body.target);
-            const job = yt.pipeline.enqueue({ targetKind, target: body.target, stages: body.stages });
+            const user = resolveUser(req, url, yt.db);
+            const job = yt.pipeline.enqueue({
+                targetKind,
+                target: body.target,
+                stages: body.stages,
+                userId: user?.id ?? null,
+            });
 
             return Response.json({ job }, { headers: CORS_HEADERS });
         }
@@ -27,6 +34,10 @@ export async function handlePipelineRoute(req: Request, url: URL, yt: Youtube): 
             const jobs = yt.pipeline.listJobs({ status: status ?? undefined, limit });
 
             return Response.json({ jobs }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/jobs/queue", url.pathname)) {
+            return Response.json({ queue: yt.db.getQueueStats() }, { headers: CORS_HEADERS });
         }
 
         const jobOnly = matchRoute(req, "GET", "/api/v1/jobs/:id", url.pathname);

--- a/src/youtube/lib/server/routes/reports.ts
+++ b/src/youtube/lib/server/routes/reports.ts
@@ -85,6 +85,7 @@ export async function handleReportsRoute(req: Request, url: URL, yt: Youtube): P
                 targetKind: "report",
                 target: String(report.id),
                 stages: ["reportSynthesize"],
+                userId: user.id,
             });
 
             return Response.json(

--- a/src/youtube/lib/server/routes/users.ts
+++ b/src/youtube/lib/server/routes/users.ts
@@ -7,6 +7,7 @@ import { isOutputLang } from "@app/youtube/lib/languages";
 import { getLedgerPage, getUsageSummary } from "@app/youtube/lib/ledger-views";
 import { createPreset, deletePreset, listPresets, updatePreset } from "@app/youtube/lib/presets";
 import type { PresetKind } from "@app/youtube/lib/presets.types";
+import { roleForEmail } from "@app/youtube/lib/roles";
 import { requireUser } from "@app/youtube/lib/server/auth";
 import { safeJsonBody } from "@app/youtube/lib/server/body";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
@@ -56,7 +57,9 @@ export async function handleUsersRoute(req: Request, url: URL, yt: Youtube): Pro
                 return user;
             }
 
-            return Response.json({ user }, { headers: CORS_HEADERS });
+            const role = roleForEmail(await yt.config.get("powerUsers"), user.email);
+
+            return Response.json({ user, role }, { headers: CORS_HEADERS });
         }
 
         if (matchRoute(req, "PATCH", "/api/v1/users/me", url.pathname)) {

--- a/src/youtube/lib/server/routes/videos.ts
+++ b/src/youtube/lib/server/routes/videos.ts
@@ -2,6 +2,7 @@ import { logger } from "@app/logger";
 import { estimateLlmCallCostUsd, estimateSpeechTokens } from "@app/utils/ai/llm-cost";
 import { SafeJSON } from "@app/utils/json";
 import { estimateTokens } from "@app/utils/tokens";
+import { resolveAiSpecForTask } from "@app/youtube/lib/ai-mapping";
 import { grantArtifactAccess, resolveArtifactPrice } from "@app/youtube/lib/artifact-access";
 import { withJobActivity } from "@app/youtube/lib/job-activity";
 import { isOutputLang } from "@app/youtube/lib/languages";
@@ -91,13 +92,15 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 return jsonError("video not found", 404);
             }
 
+            yt.db.recordVideoWatch({ userId: resolveUser(req, url, yt.db)?.id ?? null, videoId: id });
+
             return Response.json({ video, transcripts: yt.db.listTranscripts(id) }, { headers: CORS_HEADERS });
         }
 
         const transcriptRoute = matchRoute(req, "GET", "/api/v1/videos/:id/transcript", url.pathname);
 
         if (transcriptRoute) {
-            return handleTranscriptRoute(url, yt, transcriptRoute.id as VideoId);
+            return handleTranscriptRoute(req, url, yt, transcriptRoute.id as VideoId);
         }
 
         const transcriptTranslate = matchRoute(req, "POST", "/api/v1/videos/:id/transcript/translate", url.pathname);
@@ -338,7 +341,15 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 return jsonError("video not found", 404);
             }
 
-            return Response.json({ comments: yt.db.getComments(id) }, { headers: CORS_HEADERS });
+            const comments = yt.db.getComments(id);
+            yt.db.recordVideoLog({
+                kind: "comments:view",
+                userId: resolveUser(req, url, yt.db)?.id ?? null,
+                videoId: id,
+                meta: { count: comments.length },
+            });
+
+            return Response.json({ comments }, { headers: CORS_HEADERS });
         }
 
         const summaryGet = matchRoute(req, "GET", "/api/v1/videos/:id/summary", url.pathname);
@@ -375,6 +386,15 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                       ? video.summaryLong
                       : video.summaryShort;
             const fallback = mode === "timestamped" ? [] : mode === "long" ? null : "";
+
+            if (cached !== null && cached !== undefined) {
+                yt.db.recordVideoLog({
+                    kind: mode === "timestamped" ? "insights:view" : "summary:view",
+                    userId: resolveUser(req, url, yt.db)?.id ?? null,
+                    videoId: id,
+                    meta: { mode, lang: summaryLangFor(video, mode) },
+                });
+            }
 
             return Response.json(
                 {
@@ -487,7 +507,10 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 ? await resolveProviderChoice({
                       provider,
                       model,
-                      fallbackSpec: (await yt.config.get("provider")).summarize,
+                      fallbackSpec: resolveAiSpecForTask(
+                          await yt.config.getAll(),
+                          mode === "timestamped" ? "insights" : "summary"
+                      ),
                   })
                 : undefined;
             // Reserve BEFORE the pipeline work so concurrent requests cannot pass
@@ -499,7 +522,7 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 context: id,
             });
             const stages = hasTranscript ? (["summarize"] as const) : (["captions", "summarize"] as const);
-            const job = yt.db.enqueueJob({ targetKind: "video", target: id, stages: [...stages] });
+            const job = yt.db.enqueueJob({ targetKind: "video", target: id, stages: [...stages], userId: user.id });
             yt.pipeline.emitExternal({ type: "job:created", job });
             const startedAt = new Date().toISOString();
             yt.db.updateJob(job.id, {
@@ -521,7 +544,7 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                         progress: 0.05,
                         message: "Fetching captions",
                     });
-                    await withJobActivity({ jobId: job.id, stage: "captions", db: yt.db }, () =>
+                    await withJobActivity({ jobId: job.id, stage: "captions", db: yt.db, userId: user.id }, () =>
                         yt.transcripts.transcribe({
                             videoId: id,
                             onProgress: (info) => {
@@ -555,45 +578,47 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                     message: "Compacting transcript",
                 });
 
-                const result = await withJobActivity({ jobId: job.id, stage: "summarize", db: yt.db }, () =>
-                    yt.summary.summarize({
-                        videoId: id,
-                        mode,
-                        provider,
-                        providerChoice,
-                        targetBins,
-                        forceRecompute: force,
-                        tone,
-                        format,
-                        length,
-                        lang,
-                        presetInstructions,
-                        onProgress: (info) => {
-                            const progress = (info.percent ?? 50) / 100;
-                            yt.db.updateJob(job.id, { progress, progressMessage: info.message });
-                            yt.pipeline.emitExternal({
-                                type: "stage:progress",
-                                jobId: job.id,
-                                stage: "summarize",
-                                progress,
-                                message: info.message,
-                            });
-                        },
-                        onPartial: (partial) => {
-                            if (partial === null || typeof partial !== "object") {
-                                logger.debug({ jobId: job.id, videoId: id }, "skipping malformed summary partial");
-                                return;
-                            }
+                const result = await withJobActivity(
+                    { jobId: job.id, stage: "summarize", db: yt.db, userId: user.id },
+                    () =>
+                        yt.summary.summarize({
+                            videoId: id,
+                            mode,
+                            provider,
+                            providerChoice,
+                            targetBins,
+                            forceRecompute: force,
+                            tone,
+                            format,
+                            length,
+                            lang,
+                            presetInstructions,
+                            onProgress: (info) => {
+                                const progress = (info.percent ?? 50) / 100;
+                                yt.db.updateJob(job.id, { progress, progressMessage: info.message });
+                                yt.pipeline.emitExternal({
+                                    type: "stage:progress",
+                                    jobId: job.id,
+                                    stage: "summarize",
+                                    progress,
+                                    message: info.message,
+                                });
+                            },
+                            onPartial: (partial) => {
+                                if (partial === null || typeof partial !== "object") {
+                                    logger.debug({ jobId: job.id, videoId: id }, "skipping malformed summary partial");
+                                    return;
+                                }
 
-                            yt.pipeline.emitExternal({
-                                type: "summary:partial",
-                                jobId: job.id,
-                                videoId: id,
-                                mode,
-                                partial,
-                            });
-                        },
-                    })
+                                yt.pipeline.emitExternal({
+                                    type: "summary:partial",
+                                    jobId: job.id,
+                                    videoId: id,
+                                    mode,
+                                    partial,
+                                });
+                            },
+                        })
                 );
                 yt.db.updateJob(job.id, {
                     status: "completed",
@@ -654,7 +679,10 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 provider: url.searchParams.get("provider") ?? undefined,
                 model: url.searchParams.get("model") ?? undefined,
                 // Estimates front the summary dialog, so quote the summarize default.
-                fallbackSpec: (await yt.config.get("provider")).summarize,
+                fallbackSpec: resolveAiSpecForTask(
+                    await yt.config.getAll(),
+                    mode === "timestamped" ? "insights" : "summary"
+                ),
             });
             const transcript = yt.db.getTranscript(id);
             const video = yt.videos.show(id);
@@ -786,7 +814,7 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
             const providerChoice = await resolveProviderChoice({
                 provider: typeof body.provider === "string" ? body.provider : undefined,
                 model: typeof body.model === "string" ? body.model : undefined,
-                fallbackSpec: (await yt.config.get("provider")).qa,
+                fallbackSpec: resolveAiSpecForTask(await yt.config.getAll(), "qa"),
             });
             const presetId = typeof body.presetId === "number" ? body.presetId : undefined;
             let presetInstructions: string | undefined;
@@ -809,7 +837,7 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 reason: scope === "channel" ? "qa:channel" : "ask",
                 context: id,
             });
-            const job = yt.db.enqueueJob({ targetKind: "video", target: id, stages: ["qa"] });
+            const job = yt.db.enqueueJob({ targetKind: "video", target: id, stages: ["qa"], userId: user.id });
             yt.pipeline.emitExternal({ type: "job:created", job });
             yt.db.updateJob(job.id, { status: "running", currentStage: "qa" });
             const startedJob = yt.db.getJob(job.id) ?? job;
@@ -962,7 +990,7 @@ function insufficientDiamonds(balance: number, required: number): Response {
     });
 }
 
-function handleTranscriptRoute(url: URL, yt: Youtube, id: VideoId): Response {
+function handleTranscriptRoute(req: Request, url: URL, yt: Youtube, id: VideoId): Response {
     const lang = url.searchParams.get("lang") ?? undefined;
     const source = url.searchParams.get("source") ?? undefined;
     const format = url.searchParams.get("format") ?? "json";
@@ -974,6 +1002,13 @@ function handleTranscriptRoute(url: URL, yt: Youtube, id: VideoId): Response {
     if (!transcript) {
         return jsonError("no transcript", 404);
     }
+
+    yt.db.recordVideoLog({
+        kind: "transcript:view",
+        userId: resolveUser(req, url, yt.db)?.id ?? null,
+        videoId: id,
+        meta: { lang: transcript.lang, source: transcript.source, format },
+    });
 
     if (format === "text") {
         return new Response(transcript.text, {

--- a/src/youtube/lib/server/websocket.ts
+++ b/src/youtube/lib/server/websocket.ts
@@ -5,6 +5,9 @@ import type { ServerWebSocket, WebSocketHandler } from "bun";
 
 export interface WebsocketState {
     subscribedJobIds: Set<number> | "all";
+    /** "all" = operator socket (service key or open mode); "user" = only events for jobs owned by userId. */
+    scope: "all" | "user";
+    userId: number | null;
 }
 
 export interface WebsocketServer {
@@ -26,24 +29,61 @@ const PIPELINE_EVENTS: JobEvent["type"][] = [
     "job:cancelled",
 ];
 
+const TERMINAL_EVENTS: ReadonlySet<JobEvent["type"]> = new Set(["job:completed", "job:failed", "job:cancelled"]);
+
 export function setupWebsocket(yt: Youtube): WebsocketServer {
     const sockets = new Set<ServerWebSocket<WebsocketState>>();
+    // jobId → owner, fed by job-carrying events with a lazy DB lookup for
+    // jobId-only events, so user filtering doesn't hit SQLite per socket.
+    const jobOwners = new Map<number, number | null>();
     const offHandlers = PIPELINE_EVENTS.map((event) => yt.pipeline.on(event, broadcast));
+
+    function ownerOf(event: JobEvent): number | null {
+        if ("job" in event) {
+            jobOwners.set(event.job.id, event.job.userId);
+
+            return event.job.userId;
+        }
+
+        const jobId = getEventJobId(event);
+
+        if (jobId === null) {
+            return null;
+        }
+
+        if (!jobOwners.has(jobId)) {
+            jobOwners.set(jobId, yt.db.getJob(jobId)?.userId ?? null);
+        }
+
+        return jobOwners.get(jobId) ?? null;
+    }
 
     function broadcast(event: JobEvent): void {
         const payload = SafeJSON.stringify(event);
+        const owner = ownerOf(event);
 
         for (const ws of sockets) {
-            if (filterMatches(ws.data, event)) {
+            if (filterMatches(ws.data, event, owner)) {
                 ws.send(payload);
             }
+        }
+
+        const jobId = getEventJobId(event);
+
+        if (TERMINAL_EVENTS.has(event.type) && jobId !== null) {
+            jobOwners.delete(jobId);
         }
     }
 
     return {
         handler: {
             open(ws) {
-                ws.data = { subscribedJobIds: "all" };
+                // Keep the upgrade-time scope/user; only (re)set the job filter.
+                ws.data = {
+                    subscribedJobIds: "all",
+                    scope: ws.data?.scope ?? "all",
+                    userId: ws.data?.userId ?? null,
+                };
                 sockets.add(ws);
                 ws.send(SafeJSON.stringify({ type: "hello", protocolVersion: 1 }));
             },
@@ -62,7 +102,7 @@ export function setupWebsocket(yt: Youtube): WebsocketServer {
                     return;
                 }
 
-                ws.data = { subscribedJobIds: message.jobIds ? new Set(message.jobIds) : "all" };
+                ws.data = { ...ws.data, subscribedJobIds: message.jobIds ? new Set(message.jobIds) : "all" };
                 ws.send(SafeJSON.stringify({ type: "subscribed", jobIds: message.jobIds ?? null }));
             },
         },
@@ -76,16 +116,22 @@ export function setupWebsocket(yt: Youtube): WebsocketServer {
             }
 
             sockets.clear();
+            jobOwners.clear();
         },
     };
 }
 
-function filterMatches(state: WebsocketState, event: JobEvent): boolean {
+function filterMatches(state: WebsocketState, event: JobEvent, owner: number | null): boolean {
+    if (state.scope === "user" && owner !== state.userId) {
+        return false;
+    }
+
     if (state.subscribedJobIds === "all") {
         return true;
     }
 
     const jobId = getEventJobId(event);
+
     return jobId !== null && state.subscribedJobIds.has(jobId);
 }
 
@@ -116,6 +162,7 @@ function parseClientMessage(raw: string | Buffer): ClientMessage | null {
             }
 
             const jobIds = parsed.jobIds.filter((value): value is number => Number.isInteger(value));
+
             return { type: "subscribe", jobIds };
         }
     } catch {

--- a/src/youtube/lib/summarize.ts
+++ b/src/youtube/lib/summarize.ts
@@ -1,6 +1,7 @@
 import { logger } from "@app/logger";
 import { callLLM, callLLMStructured } from "@app/utils/ai/call-llm";
 import { Summarizer } from "@app/utils/ai/tasks/Summarizer";
+import { resolveAiSpecForTask } from "@app/youtube/lib/ai-mapping";
 import type { YoutubeConfig } from "@app/youtube/lib/config";
 import type { YoutubeDatabase } from "@app/youtube/lib/db";
 import { englishLanguageName } from "@app/youtube/lib/languages";
@@ -218,6 +219,7 @@ export class SummaryService {
                 model: ids.model,
                 usage: result.usage,
                 scope: opts.videoId,
+                videoId: opts.videoId,
                 prompt: formatPrompt(systemPrompt, text),
                 response: result.content,
                 durationMs: completedAt.getTime() - startedAt.getTime(),
@@ -228,9 +230,9 @@ export class SummaryService {
             return result.content;
         }
 
-        const provider = await this.config.get("provider");
-        const providerName = opts.provider ?? provider.summarize ?? "default";
-        const summarizer = await this.deps.createSummarizer({ provider: opts.provider ?? provider.summarize });
+        const configuredSpec = resolveAiSpecForTask(await this.config.getAll(), "summary");
+        const providerName = opts.provider ?? configuredSpec ?? "default";
+        const summarizer = await this.deps.createSummarizer({ provider: opts.provider ?? configuredSpec ?? undefined });
 
         try {
             const result = await summarizer.summarize(text);
@@ -239,6 +241,7 @@ export class SummaryService {
                 provider: providerName,
                 model: "(summarizer-default)",
                 scope: opts.videoId,
+                videoId: opts.videoId,
             });
 
             return result.summary;
@@ -309,6 +312,7 @@ export class SummaryService {
             model: ids.model,
             usage: result.usage,
             scope: opts.videoId,
+            videoId: opts.videoId,
             prompt: formatPrompt(systemPrompt, userPrompt),
             response: result.content,
             durationMs: completedAt.getTime() - startedAt.getTime(),
@@ -366,6 +370,7 @@ export class SummaryService {
             model: ids.model,
             usage: result.usage,
             scope: opts.videoId,
+            videoId: opts.videoId,
             prompt: formatPrompt(systemPrompt, userPrompt),
             response: result.content,
             durationMs: completedAt.getTime() - startedAt.getTime(),
@@ -432,6 +437,7 @@ export class SummaryService {
             model: ids.model,
             usage: result.usage,
             scope: opts.members.map((member) => member.videoId).join(","),
+            videoId: opts.members.map((member) => member.videoId).join(","),
             prompt: formatPrompt(REPORT_SYSTEM_BASE, userPrompt),
             response: result.content,
             durationMs: completedAt.getTime() - startedAt.getTime(),

--- a/src/youtube/lib/summary-audio.ts
+++ b/src/youtube/lib/summary-audio.ts
@@ -174,6 +174,7 @@ export async function getOrSynthesizeSummaryAudio(opts: {
         provider: target.providerId,
         model: "(tts-default)",
         scope: opts.videoId,
+        videoId: opts.videoId,
     });
     await pruneStaleSummaryAudio(opts.videoId, target.path);
 

--- a/src/youtube/lib/transcripts.ts
+++ b/src/youtube/lib/transcripts.ts
@@ -5,12 +5,14 @@ import { Transcriber } from "@app/utils/ai/tasks/Transcriber";
 import { speakerIndexFromLabel } from "@app/utils/ai/transcription/speaker-label";
 import { withFileLock } from "@app/utils/storage";
 import { estimateTokens } from "@app/utils/tokens";
+import { resolveAiSpecForTask } from "@app/youtube/lib/ai-mapping";
 import { audioPath, ensureBinaryDir } from "@app/youtube/lib/cache";
 import { fetchCaptions } from "@app/youtube/lib/captions";
 import type { YoutubeConfig } from "@app/youtube/lib/config";
 import type { YoutubeDatabase } from "@app/youtube/lib/db";
 import { englishLanguageName } from "@app/youtube/lib/languages";
-import type { Transcript, TranscriptSegment } from "@app/youtube/lib/transcript.types";
+import { parseProviderSpec } from "@app/youtube/lib/provider-choice";
+import type { Language, Transcript, TranscriptSegment } from "@app/youtube/lib/transcript.types";
 import type {
     TranscribeOpts,
     TranscriberProgressInfo,
@@ -39,37 +41,38 @@ export class TranscriptService {
         private readonly deps: TranscriptServiceDeps = DEFAULT_TRANSCRIPT_DEPS
     ) {}
 
-    async transcribe(opts: TranscribeOpts): Promise<Transcript> {
+    /** Free tier: cached transcript or fresh YouTube captions. Null = no captions available. */
+    async tryCaptions(opts: { videoId: VideoId; lang?: Language }): Promise<Transcript | null> {
+        const cached = this.db.getTranscript(opts.videoId, { preferLang: opts.lang ? [opts.lang] : undefined });
+
+        if (cached) {
+            return cached;
+        }
+
+        const preferredLangs = await this.preferredLangs(opts.lang);
+        const captions = await this.deps.fetchCaptions({ videoId: opts.videoId, preferredLangs });
+
+        if (!captions) {
+            return null;
+        }
+
+        this.db.saveTranscript({
+            videoId: opts.videoId,
+            lang: captions.lang,
+            source: "captions",
+            text: captions.text,
+            segments: captions.segments,
+        });
+
+        return this.db.getTranscript(opts.videoId, { lang: captions.lang, source: "captions" });
+    }
+
+    /** Paid tier: audio download + ASR. Gate credits via `beforeAiTranscription` on `transcribe()`. */
+    async transcribeAudio(opts: TranscribeOpts): Promise<Transcript> {
         const video = this.db.getVideo(opts.videoId);
 
         if (!video) {
             throw new Error(`unknown video: ${opts.videoId}`);
-        }
-
-        if (!opts.forceTranscribe) {
-            const cached = this.db.getTranscript(opts.videoId, { preferLang: opts.lang ? [opts.lang] : undefined });
-
-            if (cached) {
-                return cached;
-            }
-
-            const preferredLangs = await this.preferredLangs(opts.lang);
-            const captions = await this.deps.fetchCaptions({ videoId: opts.videoId, preferredLangs });
-
-            if (captions) {
-                this.db.saveTranscript({
-                    videoId: opts.videoId,
-                    lang: captions.lang,
-                    source: "captions",
-                    text: captions.text,
-                    segments: captions.segments,
-                });
-                const saved = this.db.getTranscript(opts.videoId, { lang: captions.lang, source: "captions" });
-
-                if (saved) {
-                    return saved;
-                }
-            }
         }
 
         let audio = video.audioPath;
@@ -93,8 +96,8 @@ export class TranscriptService {
             audio = nextAudio;
         }
 
-        const provider = await this.config.get("provider");
-        const providerName = opts.provider ?? provider.transcribe;
+        const configuredSpec = resolveAiSpecForTask(await this.config.getAll(), "transcribe");
+        const providerName = opts.provider ?? parseProviderSpec(configuredSpec).provider;
         // Diarization is Deepgram-native only; other providers would trigger the
         // heavy local-pyannote fallback, so keep them exactly as before.
         const diarize = providerName?.includes("deepgram") ?? false;
@@ -116,6 +119,7 @@ export class TranscriptService {
                 provider: providerName ?? "default",
                 model: "(transcriber-default)",
                 scope: opts.videoId,
+                videoId: opts.videoId,
             });
             const lang = result.language ?? opts.lang ?? "en";
             this.db.saveTranscript({
@@ -146,6 +150,29 @@ export class TranscriptService {
         } finally {
             transcriber.dispose();
         }
+    }
+
+    /** The chain: cached/captions (free) → beforeAiTranscription gate → audio+ASR (paid). */
+    async transcribe(opts: TranscribeOpts): Promise<Transcript> {
+        const video = this.db.getVideo(opts.videoId);
+
+        if (!video) {
+            throw new Error(`unknown video: ${opts.videoId}`);
+        }
+
+        if (!opts.forceTranscribe) {
+            const fromCaptions = await this.tryCaptions({ videoId: opts.videoId, lang: opts.lang });
+
+            if (fromCaptions) {
+                return fromCaptions;
+            }
+
+            opts.onProgress?.({ phase: "audio", message: "no captions available — preparing AI transcription" });
+        }
+
+        await opts.beforeAiTranscription?.();
+
+        return this.transcribeAudio(opts);
     }
 
     private async preferredLangs(lang?: string): Promise<string[]> {
@@ -265,6 +292,7 @@ async function translateChunk(opts: {
             model: ids.model,
             usage: result.usage,
             scope: opts.videoId,
+            videoId: opts.videoId,
             prompt: `system:\n${systemPrompt}\n\nuser:\n${userPrompt}`,
             response: result.content,
         });

--- a/src/youtube/lib/transcripts.types.ts
+++ b/src/youtube/lib/transcripts.types.ts
@@ -14,6 +14,10 @@ export interface TranscribeProgressInfo {
 export interface TranscribeOpts {
     videoId: VideoId;
     forceTranscribe?: boolean;
+    /** Awaited immediately before ANY paid ASR run (no-captions fallback AND
+     *  forceTranscribe). Throwing aborts the transcription — the pipeline's
+     *  diamond gate reserves credits here. */
+    beforeAiTranscription?: () => void | Promise<void>;
     lang?: Language;
     provider?: string;
     persistProvider?: boolean;

--- a/src/youtube/lib/types.ts
+++ b/src/youtube/lib/types.ts
@@ -2,8 +2,22 @@ export type { CacheLayout } from "@app/youtube/lib/cache.types";
 export type { FetchCaptionsOpts, FetchCaptionsResult } from "@app/youtube/lib/captions.types";
 export type { Channel, ChannelHandle } from "@app/youtube/lib/channel.types";
 export type { FetchCommentsOpts, FetchedComment, VideoComment } from "@app/youtube/lib/comments.types";
-export type { YoutubeConfigShape } from "@app/youtube/lib/config.types";
-export type { SearchVideosOpts, VideoSearchField, VideoSearchHit } from "@app/youtube/lib/db.types";
+export type {
+    AiTask,
+    AiTaskMapping,
+    PowerUserEntry,
+    ReferralOffer,
+    ReferralsConfig,
+    YoutubeConfigShape,
+    YtRole,
+} from "@app/youtube/lib/config.types";
+export type {
+    QueueStats,
+    SearchVideosOpts,
+    VideoLogKind,
+    VideoSearchField,
+    VideoSearchHit,
+} from "@app/youtube/lib/db.types";
 export type {
     JobActivity,
     JobActivityKind,

--- a/src/youtube/lib/usage.ts
+++ b/src/youtube/lib/usage.ts
@@ -14,6 +14,7 @@
 import { logger } from "@app/logger";
 import { getJobActivityContext } from "@app/youtube/lib/job-activity";
 import type { JobActivityKind } from "@app/youtube/lib/jobs.types";
+import { getRequestContext } from "@app/youtube/lib/request-context";
 import { costTracker } from "@ask/output/CostTracker";
 import { dynamicPricingManager } from "@ask/providers/DynamicPricing";
 import type { ProviderChoice } from "@ask/types";
@@ -37,6 +38,8 @@ export interface RecordYoutubeUsageInput {
     usage?: LanguageModelUsage;
     /** Free-form scope: video id or "channel:@handle" so the operator can group. */
     scope?: string;
+    /** Video the call was about — lands in `ai_calls.video_id` for the audit trail. */
+    videoId?: string | null;
     /** When set, surfaces in the jobs-inspector activity drawer. Truncated to 64 KB. */
     prompt?: string | null;
     response?: string | null;
@@ -47,28 +50,35 @@ export interface RecordYoutubeUsageInput {
 }
 
 /**
- * Best-effort persistence of an AI usage event to the shared usage DB and (if a job
- * activity context is active) the youtube `job_activity` table. Never throws —
+ * Best-effort persistence of an AI usage event to (1) the shared usage DB,
+ * (2) the youtube `job_activity` table when a job context is active, and
+ * (3) the youtube `ai_calls` audit table when either a job or request context
+ * provides a DB handle. Never throws, and each sink fails independently —
  * usage telemetry shouldn't break the work it's tracking.
  */
 export async function recordYoutubeUsage(input: RecordYoutubeUsageInput): Promise<void> {
+    const usage: LanguageModelUsage =
+        input.usage ?? ({ inputTokens: 0, outputTokens: 0, totalTokens: 0 } as LanguageModelUsage);
+    const jobCtx = getJobActivityContext();
+    const requestCtx = getRequestContext();
+    const costUsd = await safeCalculateCost(input.provider, input.model, usage);
+
     try {
         const sessionId = `youtube:${input.action}${input.scope ? `:${input.scope}` : ""}`;
-        const usage: LanguageModelUsage =
-            input.usage ?? ({ inputTokens: 0, outputTokens: 0, totalTokens: 0 } as LanguageModelUsage);
         await costTracker.trackUsage(input.provider, input.model, usage, sessionId);
         logger.debug(
             { action: input.action, provider: input.provider, model: input.model, scope: input.scope },
             "youtube usage recorded"
         );
+    } catch (error) {
+        logger.warn({ err: error, action: input.action }, "youtube usage tracker failed (continuing)");
+    }
 
-        const ctx = getJobActivityContext();
-
-        if (ctx) {
-            const costUsd = await safeCalculateCost(input.provider, input.model, usage);
-            ctx.db.recordJobActivity({
-                jobId: ctx.jobId,
-                stage: ctx.stage,
+    try {
+        if (jobCtx) {
+            jobCtx.db.recordJobActivity({
+                jobId: jobCtx.jobId,
+                stage: jobCtx.stage,
                 kind: actionToKind(input.action),
                 action: input.action,
                 provider: input.provider,
@@ -86,7 +96,30 @@ export async function recordYoutubeUsage(input: RecordYoutubeUsageInput): Promis
             });
         }
     } catch (error) {
-        logger.warn({ err: error, action: input.action }, "youtube usage record failed (continuing)");
+        logger.warn({ err: error, action: input.action }, "youtube job activity record failed (continuing)");
+    }
+
+    try {
+        const db = jobCtx?.db ?? requestCtx?.db;
+
+        if (db) {
+            db.recordAiCall({
+                provider: input.provider,
+                model: input.model,
+                action: input.action,
+                videoId: input.videoId ?? null,
+                userId: jobCtx?.userId ?? requestCtx?.userId ?? null,
+                inputTokens: usage.inputTokens ?? 0,
+                outputTokens: usage.outputTokens ?? 0,
+                costUsd,
+                creditsCharged: null,
+                jobId: jobCtx?.jobId ?? null,
+            });
+        } else {
+            logger.debug({ action: input.action }, "youtube ai_calls skipped: no db in context (CLI path)");
+        }
+    } catch (error) {
+        logger.warn({ err: error, action: input.action }, "youtube ai_calls record failed (continuing)");
     }
 }
 

--- a/src/youtube/lib/users.types.ts
+++ b/src/youtube/lib/users.types.ts
@@ -37,6 +37,7 @@ export type CreditReason =
     | "summary:timestamped"
     | "summary:short"
     | "transcript:translate"
+    | "transcribe:ai"
     | "dev-topup"
     | `stripe:${string}`
     | `stripe-refund:${string}`
@@ -70,6 +71,7 @@ export const CREDIT_COSTS = {
     "summary:timestamped": 10,
     "summary:short": 5,
     "transcript:translate": 5,
+    "transcribe:ai": 10,
     "tts:summary": 5,
 } as const;
 

--- a/src/youtube/lib/youtube.ts
+++ b/src/youtube/lib/youtube.ts
@@ -9,11 +9,12 @@ import { YoutubeDatabase } from "@app/youtube/lib/db";
 import type { UpsertVideoInput } from "@app/youtube/lib/db.types";
 import type { JobStage } from "@app/youtube/lib/jobs.types";
 import { Pipeline } from "@app/youtube/lib/pipeline";
-import type { PipelineHandlerMap } from "@app/youtube/lib/pipeline.types";
+import type { PipelineHandlerMap, StageHandlerCtx } from "@app/youtube/lib/pipeline.types";
 import { resolveProviderChoice } from "@app/youtube/lib/provider-choice";
 import { QaService } from "@app/youtube/lib/qa";
 import { type ReportMember, SummaryService } from "@app/youtube/lib/summarize";
 import { TranscriptService } from "@app/youtube/lib/transcripts";
+import { CREDIT_COSTS } from "@app/youtube/lib/users.types";
 import type { VideoId } from "@app/youtube/lib/video.types";
 import type { YoutubeDeps, YoutubeOptions } from "@app/youtube/lib/youtube.types";
 import {
@@ -366,7 +367,7 @@ export class Youtube {
                 await this.comments.fetch(ctx.job.target as VideoId, { signal: ctx.signal });
             },
             captions: async (ctx) => {
-                await this.transcripts.transcribe({ videoId: ctx.job.target as VideoId, signal: ctx.signal });
+                await this.runGatedTranscribe(ctx, { forceTranscribe: false });
             },
             audio: async (ctx) => {
                 const video = await this.videos.ensureMetadata(ctx.job.target as VideoId, { signal: ctx.signal });
@@ -390,11 +391,7 @@ export class Youtube {
                 await this.downloadVideo(ctx.job.target as VideoId, { signal: ctx.signal });
             },
             transcribe: async (ctx) => {
-                await this.transcripts.transcribe({
-                    videoId: ctx.job.target as VideoId,
-                    forceTranscribe: true,
-                    signal: ctx.signal,
-                });
+                await this.runGatedTranscribe(ctx, { forceTranscribe: true });
             },
             summarize: async (ctx) => {
                 await this.summary.summarize({ videoId: ctx.job.target as VideoId, mode: "short", signal: ctx.signal });
@@ -479,6 +476,54 @@ export class Youtube {
         };
     }
 
+    /** Shared captions/transcribe stage body: metadata ensure → free captions
+     *  tier → diamond-gated ASR fallback, with progress + hold semantics. */
+    private async runGatedTranscribe(ctx: StageHandlerCtx, opts: { forceTranscribe: boolean }): Promise<void> {
+        const videoId = ctx.job.target as VideoId;
+        // Queue path previously skipped metadata → "unknown video" job failures
+        // on fresh videos (POST /pipeline does not ingest, unlike POST /summary).
+        await this.videos.ensureMetadata(videoId, { signal: ctx.signal });
+        const userId = ctx.job.userId;
+        // Ref object (not a bare `let`): TS never invalidates `let` narrowing from
+        // assignments inside a closure, so a `let hold` read after the await would
+        // narrow to `never`; property access on a ref resets narrowing per-read.
+        const holdRef: { current: { holdId: number; credits: number } | null } = { current: null };
+
+        try {
+            await this.transcripts.transcribe({
+                videoId,
+                signal: ctx.signal,
+                forceTranscribe: opts.forceTranscribe,
+                beforeAiTranscription: () => {
+                    if (userId === null) {
+                        return;
+                    }
+
+                    // Reserve before the provider spend; committed on success,
+                    // released on failure. Throws InsufficientCreditsError →
+                    // job fails with an explicit balance message.
+                    holdRef.current = this.db.reserveCredits({
+                        userId,
+                        amount: CREDIT_COSTS["transcribe:ai"],
+                        reason: "transcribe:ai",
+                        context: videoId,
+                    });
+                },
+                onProgress: (info) => ctx.onProgress(transcribeStageFraction(info), info.message),
+            });
+
+            if (holdRef.current) {
+                this.db.commitHold(holdRef.current.holdId);
+            }
+        } catch (error) {
+            if (holdRef.current) {
+                this.db.releaseHold(holdRef.current.holdId);
+            }
+
+            throw error;
+        }
+    }
+
     async downloadVideo(id: VideoId, opts: { quality?: "720p" | "1080p" | "best"; signal?: AbortSignal } = {}) {
         logger.info({ videoId: id, quality: opts.quality }, "youtube video download requested");
         const video = await this.videos.ensureMetadata(id, { signal: opts.signal });
@@ -521,4 +566,11 @@ function listedVideoToInput(handle: ChannelHandle, video: ListedVideo): UpsertVi
         isShort: video.isShort,
         isLive: video.isLive,
     };
+}
+
+/** Maps transcript progress onto the stage's 0..1 bar: audio download fills the first half, ASR the second. */
+function transcribeStageFraction(info: { phase: string; percent?: number }): number {
+    const within = Math.max(0, Math.min(1, (info.percent ?? 0) / 100));
+
+    return info.phase === "audio" ? within * 0.5 : 0.5 + within * 0.5;
 }


### PR DESCRIPTION
## Summary

- Config schema for power users, AI task mapping, and referrals; `resolveAiSpecForTask` with legacy `provider.*` fallback
- Config-derived user roles (admin/dev/user); audit tables (video_watchers, video_logs, ai_calls) with write hooks on content GETs
- User attribution on pipeline jobs, request-context propagation, and ai_calls audit from the single usage funnel
- Typed `login_required` 401, per-user events WS scoping, role on `/users/me`, `/models` gated to admin/dev
- Provider defaults routed through the `ai[]` task mapping; queue stats endpoint; transcript fallback chain hardening

## Stack

1. feat(youtube): product surface base
2. fix(youtube): phase 0 — panel scroll, comments feedback, dialog rework, audit sweep
3. **feat(youtube): phase 1 foundations — roles, ai task mapping, audit tables, typed auth, WS scoping, transcript fallback** ← you are here
4. feat(youtube): phase 3 web features — history, collections, collection-ask agent, watchlist + digest
5. feat(youtube): phase 2 billing — Stripe subscriptions, resetting allowance, free tier, referrals
6. feat(youtube): phase 4 extension — feature port, monetization UI, 16:9 admin panel + admin API
7. feat(youtube): phase 5 customization + production polish — settings, sweep fixes, review-fix wave

Part of the #263 split; merge bottom-up.
