### PR TITLE
feat(youtube): phase 3 web features — history, collections, collection-ask agent, watchlist + digest

### DIFF
--- a/src/utils/ui/components/youtube/collection-ask-panel.tsx
+++ b/src/utils/ui/components/youtube/collection-ask-panel.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@app/utils/ui/components/button";
+import { Card, CardContent } from "@app/utils/ui/components/card";
+import { Input } from "@app/utils/ui/components/input";
+import type { AskMessageRecord } from "@app/youtube/lib/types";
+import { useState } from "react";
+
+export interface CollectionAskPanelProps {
+    messages: AskMessageRecord[];
+    busy: boolean;
+    error?: string | null;
+    onSend: (question: string) => void;
+}
+
+export function CollectionAskPanel({ messages, busy, error, onSend }: CollectionAskPanelProps) {
+    const [draft, setDraft] = useState("");
+    const send = () => {
+        const question = draft.trim();
+
+        if (!question || busy) {
+            return;
+        }
+
+        onSend(question);
+        setDraft("");
+    };
+
+    return (
+        <Card>
+            <CardContent className="space-y-3 pt-4">
+                <div className="max-h-96 space-y-2 overflow-y-auto">
+                    {messages.map((message) => {
+                        if (message.role === "tool") {
+                            return (
+                                <p key={message.id} className="text-xs italic text-muted-foreground">
+                                    Looked at:{" "}
+                                    {message.toolName === "list_videos"
+                                        ? "collection videos"
+                                        : `transcript (${message.toolArgsJson ?? ""})`}
+                                </p>
+                            );
+                        }
+
+                        return (
+                            <div
+                                key={message.id}
+                                className={
+                                    message.role === "user" ? "text-sm font-medium" : "text-sm text-muted-foreground"
+                                }
+                            >
+                                {message.content}
+                            </div>
+                        );
+                    })}
+                    {busy ? <p className="text-sm text-muted-foreground">Thinking…</p> : null}
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+                <div className="flex gap-2">
+                    <Input
+                        placeholder="Ask about this collection… (10 💎)"
+                        value={draft}
+                        disabled={busy}
+                        onChange={(event) => setDraft(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                                send();
+                            }
+                        }}
+                    />
+                    <Button disabled={busy || !draft.trim()} onClick={send}>
+                        Ask
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/utils/ui/components/youtube/history-view.tsx
+++ b/src/utils/ui/components/youtube/history-view.tsx
@@ -1,0 +1,116 @@
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@app/utils/ui/components/card";
+import type { ActionHistoryGroup, VideoHistoryGroup, VideoLite } from "@app/youtube/lib/types";
+
+export interface HistoryViewProps {
+    mode: "video" | "action";
+    onModeChange: (mode: "video" | "action") => void;
+    videoGroups?: VideoHistoryGroup[];
+    actionGroups?: ActionHistoryGroup[];
+    videosById: Record<string, VideoLite | undefined>;
+    onOpenVideo: (videoId: string) => void;
+    loading?: boolean;
+}
+
+/** Friendly labels for the frozen history action vocabulary. */
+const ACTION_LABELS: Record<string, string> = {
+    watch: "Opened video",
+    "summary:view": "Read summary",
+    "insights:view": "Viewed insights",
+    "transcript:view": "Read transcript",
+    "comments:view": "Browsed comments",
+    ask: "Asked a question",
+};
+
+function actionLabel(action: string): string {
+    if (ACTION_LABELS[action]) {
+        return ACTION_LABELS[action];
+    }
+
+    if (action.startsWith("job:")) {
+        return `Ran ${action.slice(4)}`;
+    }
+
+    return action;
+}
+
+export function HistoryView({
+    mode,
+    onModeChange,
+    videoGroups,
+    actionGroups,
+    videosById,
+    onOpenVideo,
+    loading,
+}: HistoryViewProps) {
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center gap-2">
+                <Button
+                    size="sm"
+                    variant={mode === "video" ? "default" : "outline"}
+                    onClick={() => onModeChange("video")}
+                >
+                    By video
+                </Button>
+                <Button
+                    size="sm"
+                    variant={mode === "action" ? "default" : "outline"}
+                    onClick={() => onModeChange("action")}
+                >
+                    By action
+                </Button>
+            </div>
+            {loading ? <p className="text-sm text-muted-foreground">Loading history…</p> : null}
+            {mode === "video"
+                ? (videoGroups ?? []).map((group) => (
+                      <Card key={group.videoId}>
+                          <CardHeader>
+                              <CardTitle className="flex items-center justify-between gap-3 text-base">
+                                  <button
+                                      type="button"
+                                      className="truncate text-left hover:underline"
+                                      onClick={() => onOpenVideo(group.videoId)}
+                                  >
+                                      {videosById[group.videoId]?.title ?? group.videoId}
+                                  </button>
+                                  <span className="shrink-0 text-xs text-muted-foreground">
+                                      {new Date(group.lastTs).toLocaleString()}
+                                  </span>
+                              </CardTitle>
+                          </CardHeader>
+                          <CardContent className="flex flex-wrap gap-2">
+                              {Object.entries(group.counts).map(([action, count]) => (
+                                  <Badge key={action} variant="secondary">
+                                      {actionLabel(action)} ×{count}
+                                  </Badge>
+                              ))}
+                          </CardContent>
+                      </Card>
+                  ))
+                : (actionGroups ?? []).map((group) => (
+                      <Card key={group.action}>
+                          <CardHeader>
+                              <CardTitle className="text-base">
+                                  {actionLabel(group.action)} <Badge variant="secondary">×{group.count}</Badge>
+                              </CardTitle>
+                          </CardHeader>
+                          <CardContent className="space-y-1">
+                              {group.entries.slice(0, 20).map((entry, index) => (
+                                  <button
+                                      key={`${entry.videoId}-${entry.ts}-${index}`}
+                                      type="button"
+                                      className="block w-full truncate text-left text-sm text-muted-foreground hover:underline"
+                                      onClick={() => onOpenVideo(entry.videoId)}
+                                  >
+                                      {new Date(entry.ts).toLocaleString()} —{" "}
+                                      {videosById[entry.videoId]?.title ?? entry.videoId}
+                                  </button>
+                              ))}
+                          </CardContent>
+                      </Card>
+                  ))}
+        </div>
+    );
+}

--- a/src/youtube/lib/__tests__/ask-threads-db.test.ts
+++ b/src/youtube/lib/__tests__/ask-threads-db.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("ask threads", () => {
+    it("creates threads, appends ordered messages, scopes reads to the owner", () => {
+        const thread = db.createAskThread({ userId: 1, collectionId: 5, title: "What did I learn?" });
+
+        db.appendAskMessage({ threadId: thread.id, role: "user", content: "Summarize the collection" });
+        db.appendAskMessage({
+            threadId: thread.id,
+            role: "tool",
+            content: '[{"id":"vid00000001"}]',
+            toolName: "list_videos",
+            toolArgsJson: "{}",
+        });
+        db.appendAskMessage({ threadId: thread.id, role: "assistant", content: "You watched 1 video about X." });
+
+        const messages = db.listAskMessages(thread.id);
+
+        expect(messages.map((message) => message.role)).toEqual(["user", "tool", "assistant"]);
+        expect(messages[1].toolName).toBe("list_videos");
+        expect(db.getAskThread(1, thread.id)?.title).toBe("What did I learn?");
+        expect(db.getAskThread(2, thread.id)).toBeNull();
+        expect(db.listAskThreads(1, 5)).toHaveLength(1);
+        expect(db.listAskThreads(1, 999)).toHaveLength(0);
+    });
+
+    it("touchAskThread bumps updated_at ordering", async () => {
+        const older = db.createAskThread({ userId: 1, collectionId: 5, title: "old" });
+        const newer = db.createAskThread({ userId: 1, collectionId: 5, title: "new" });
+
+        expect(older.id).toBeLessThan(newer.id);
+        await Bun.sleep(2);
+        db.touchAskThread(older.id);
+        const threads = db.listAskThreads(1, 5);
+
+        expect(threads[0].id).toBe(older.id);
+    });
+});

--- a/src/youtube/lib/__tests__/collection-ask.test.ts
+++ b/src/youtube/lib/__tests__/collection-ask.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
+import { askCollection, MAX_TOOL_CALLS } from "@app/youtube/lib/collection-ask";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import type { ProviderChoice } from "@ask/types";
+
+let db: YoutubeDatabase;
+const providerChoice = {
+    provider: { name: "fake" },
+    model: { id: "fake-model" },
+} as unknown as ProviderChoice;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+    db.upsertChannel({ handle: "@chan" });
+    db.upsertVideo({ id: "vidWatched01", channelHandle: "@chan", title: "Watched" });
+    db.upsertVideo({ id: "vidUnseen001", channelHandle: "@chan", title: "Unseen" });
+    db.saveTranscript({
+        videoId: "vidWatched01",
+        lang: "en",
+        source: "captions",
+        text: "the answer is 42",
+        segments: [{ text: "the answer is 42", start: 0, end: 2 }],
+    });
+    db.recordVideoWatch({ userId: 1, videoId: "vidWatched01" });
+});
+
+afterEach(() => {
+    db.close();
+});
+
+function setupCollection() {
+    const collection = db.createCollection({ userId: 1, name: "test", kind: "manual" });
+    db.addCollectionVideo(collection.id, "vidWatched01");
+    db.addCollectionVideo(collection.id, "vidUnseen001");
+
+    return collection;
+}
+
+type FakeStep =
+    | { action: "list_videos" }
+    | { action: "get_transcript"; videoId: string }
+    | { action: "answer"; text: string };
+
+function fakeLLM(steps: FakeStep[]) {
+    const prompts: string[] = [];
+    let index = 0;
+    const deps = {
+        callLLMStructured: async (opts: { userPrompt: string }) => {
+            prompts.push(opts.userPrompt);
+            const step = steps[Math.min(index, steps.length - 1)];
+            index += 1;
+
+            return {
+                object: step,
+                content: SafeJSON.stringify(step, { strict: true }),
+            };
+        },
+    };
+
+    return { deps, prompts };
+}
+
+describe("askCollection", () => {
+    it("answers directly with zero tool calls and persists the thread", async () => {
+        const collection = setupCollection();
+        const { deps } = fakeLLM([{ action: "answer", text: "All about testing." }]);
+        const result = await askCollection({ db, userId: 1, collection, question: "Theme?", providerChoice, deps });
+
+        expect(result.answer).toBe("All about testing.");
+        expect(result.toolCalls).toBe(0);
+        const messages = db.listAskMessages(result.threadId);
+
+        expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    });
+
+    it("runs tools, feeds results back, and gates unwatched transcripts", async () => {
+        const collection = setupCollection();
+        const { deps, prompts } = fakeLLM([
+            { action: "list_videos" },
+            { action: "get_transcript", videoId: "vidWatched01" },
+            { action: "get_transcript", videoId: "vidUnseen001" },
+            { action: "answer", text: "42, from the one video you watched." },
+        ]);
+        const result = await askCollection({ db, userId: 1, collection, question: "What?", providerChoice, deps });
+
+        expect(result.toolCalls).toBe(3);
+        const toolMessages = db.listAskMessages(result.threadId).filter((message) => message.role === "tool");
+
+        expect(toolMessages).toHaveLength(3);
+        expect(toolMessages[0].toolName).toBe("list_videos");
+        expect(toolMessages[1].content).toContain("the answer is 42");
+        expect(toolMessages[2].content).toContain("REFUSED");
+        expect(prompts.at(-1)).toContain("REFUSED");
+    });
+
+    it("throws once the tool budget is exhausted without an answer", async () => {
+        const collection = setupCollection();
+        const { deps } = fakeLLM([{ action: "list_videos" }]);
+
+        await expect(
+            askCollection({ db, userId: 1, collection, question: "Loop?", providerChoice, deps })
+        ).rejects.toThrow("tool budget");
+        const collectionThread = db.listAskThreads(1, collection.id)[0];
+
+        expect(db.listAskMessages(collectionThread.id).filter((message) => message.role === "tool")).toHaveLength(
+            MAX_TOOL_CALLS
+        );
+    });
+
+    it("continues an existing thread and rejects foreign threads", async () => {
+        const collection = setupCollection();
+        const { deps } = fakeLLM([{ action: "answer", text: "first" }]);
+        const first = await askCollection({ db, userId: 1, collection, question: "One?", providerChoice, deps });
+        const { deps: deps2 } = fakeLLM([{ action: "answer", text: "second" }]);
+        const second = await askCollection({
+            db,
+            userId: 1,
+            collection,
+            question: "Two?",
+            threadId: first.threadId,
+            providerChoice,
+            deps: deps2,
+        });
+
+        expect(second.threadId).toBe(first.threadId);
+        expect(db.listAskMessages(first.threadId)).toHaveLength(4);
+
+        await expect(
+            askCollection({
+                db,
+                userId: 2,
+                collection,
+                question: "steal",
+                threadId: first.threadId,
+                providerChoice,
+                deps,
+            })
+        ).rejects.toThrow("unknown ask thread");
+    });
+});

--- a/src/youtube/lib/__tests__/collection-rules.test.ts
+++ b/src/youtube/lib/__tests__/collection-rules.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { parseCollectionRule, resolveCollectionVideoIds, ruleCutoffIso } from "@app/youtube/lib/collection-rules";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+describe("parseCollectionRule / ruleCutoffIso", () => {
+    it("accepts watched rules and floors fractional days", () => {
+        expect(parseCollectionRule({ type: "watched", sinceDays: 30.9 })).toEqual({ type: "watched", sinceDays: 30 });
+    });
+
+    it("rejects bad shapes", () => {
+        expect(parseCollectionRule({ type: "watched", sinceDays: -1 })).toBeNull();
+        expect(parseCollectionRule({ type: "watched", sinceDays: 400 })).toBeNull();
+        expect(parseCollectionRule({ type: "nope" })).toBeNull();
+        expect(parseCollectionRule(null)).toBeNull();
+        expect(parseCollectionRule("watched")).toBeNull();
+    });
+
+    it("computes the UTC cutoff", () => {
+        expect(ruleCutoffIso({ type: "watched", sinceDays: 30 }, new Date("2026-07-17T00:00:00.000Z"))).toBe(
+            "2026-06-17T00:00:00.000Z"
+        );
+    });
+});
+
+describe("resolveCollectionVideoIds", () => {
+    let db: YoutubeDatabase;
+
+    beforeEach(() => {
+        db = new YoutubeDatabase(":memory:");
+    });
+
+    afterEach(() => {
+        db.close();
+    });
+
+    it("manual → membership rows; dynamic → watched-since; broken rule → empty", () => {
+        const manual = db.createCollection({ userId: 1, name: "m", kind: "manual" });
+        db.addCollectionVideo(manual.id, "vid00000001");
+
+        expect(resolveCollectionVideoIds(db, manual)).toEqual(["vid00000001"]);
+
+        db.recordVideoWatch({ userId: 1, videoId: "vid00000002" });
+        const dynamic = db.createCollection({
+            userId: 1,
+            name: "d",
+            kind: "dynamic",
+            ruleJson: '{"type":"watched","sinceDays":30}',
+        });
+
+        expect(resolveCollectionVideoIds(db, dynamic)).toEqual(["vid00000002"]);
+
+        const broken = db.createCollection({ userId: 1, name: "b", kind: "dynamic", ruleJson: '{"type":"nope"}' });
+
+        expect(resolveCollectionVideoIds(db, broken)).toEqual([]);
+    });
+});

--- a/src/youtube/lib/__tests__/collections-db.test.ts
+++ b/src/youtube/lib/__tests__/collections-db.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("collections storage", () => {
+    it("creates, lists, renames, deletes — scoped to the owner", () => {
+        const mine = db.createCollection({ userId: 1, name: "AI talks", kind: "manual" });
+        db.createCollection({ userId: 2, name: "not mine", kind: "manual" });
+
+        expect(mine.kind).toBe("manual");
+        expect(db.listCollections(1)).toHaveLength(1);
+        expect(db.getCollection(2, mine.id)).toBeNull();
+
+        const renamed = db.updateCollectionName(1, mine.id, "AI talks 2026");
+
+        expect(renamed?.name).toBe("AI talks 2026");
+        expect(db.updateCollectionName(2, mine.id, "hijack")).toBeNull();
+        expect(db.deleteCollection(2, mine.id)).toBe(false);
+        expect(db.deleteCollection(1, mine.id)).toBe(true);
+        expect(db.listCollections(1)).toHaveLength(0);
+    });
+
+    it("stores dynamic rules and membership idempotently", () => {
+        const dynamic = db.createCollection({
+            userId: 1,
+            name: "last month",
+            kind: "dynamic",
+            ruleJson: '{"type":"watched","sinceDays":30}',
+        });
+
+        expect(dynamic.ruleJson).toContain("watched");
+
+        const manual = db.createCollection({ userId: 1, name: "picks", kind: "manual" });
+        db.addCollectionVideo(manual.id, "vid00000001");
+        db.addCollectionVideo(manual.id, "vid00000001");
+        db.addCollectionVideo(manual.id, "vid00000002");
+
+        expect(db.listCollectionVideoIds(manual.id)).toEqual(["vid00000001", "vid00000002"]);
+        expect(db.removeCollectionVideo(manual.id, "vid00000001")).toBe(true);
+        expect(db.removeCollectionVideo(manual.id, "vid00000001")).toBe(false);
+        expect(db.listCollectionVideoIds(manual.id)).toEqual(["vid00000002"]);
+    });
+
+    it("deleting a collection removes its membership rows", () => {
+        const manual = db.createCollection({ userId: 1, name: "picks", kind: "manual" });
+        db.addCollectionVideo(manual.id, "vid00000001");
+
+        expect(db.deleteCollection(1, manual.id)).toBe(true);
+        expect(db.listCollectionVideoIds(manual.id)).toEqual([]);
+    });
+});

--- a/src/youtube/lib/__tests__/history.test.ts
+++ b/src/youtube/lib/__tests__/history.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { buildHistoryEntries, groupHistoryByAction, groupHistoryByVideo } from "@app/youtube/lib/history";
+
+const entries = [
+    { ts: "2026-07-15T10:00:00.000Z", action: "watch", videoId: "vidA" },
+    { ts: "2026-07-16T09:00:00.000Z", action: "summary:view", videoId: "vidA" },
+    { ts: "2026-07-14T08:00:00.000Z", action: "watch", videoId: "vidB" },
+    { ts: "2026-07-17T07:00:00.000Z", action: "ask", videoId: "vidA" },
+    { ts: "2026-07-13T06:00:00.000Z", action: "watch", videoId: "vidA" },
+];
+
+describe("history groupers (pure)", () => {
+    it("groups by video, newest activity first, with per-action counts", () => {
+        const groups = groupHistoryByVideo(entries);
+
+        expect(groups.map((group) => group.videoId)).toEqual(["vidA", "vidB"]);
+        expect(groups[0].lastTs).toBe("2026-07-17T07:00:00.000Z");
+        expect(groups[0].counts).toEqual({ watch: 2, "summary:view": 1, ask: 1 });
+    });
+
+    it("groups by action, most frequent first", () => {
+        const groups = groupHistoryByAction(entries);
+
+        expect(groups.map((group) => `${group.action}=${group.count}`)).toEqual(["watch=3", "summary:view=1", "ask=1"]);
+    });
+});
+
+describe("buildHistoryEntries", () => {
+    let db: YoutubeDatabase;
+
+    beforeEach(() => {
+        db = new YoutubeDatabase(":memory:");
+        db.upsertChannel({ handle: "@chan" });
+        db.upsertVideo({ id: "vid00000001", channelHandle: "@chan", title: "One" });
+    });
+
+    afterEach(() => {
+        db.close();
+    });
+
+    it("merges watches, view logs, asks, and user jobs, newest first", () => {
+        const user = db.createUser({ email: "h@example.com", passwordHash: "h", apiToken: "ytu_h" });
+        db.recordVideoWatch({ userId: user.id, videoId: "vid00000001" });
+        db.recordVideoLog({ kind: "transcript:view", userId: user.id, videoId: "vid00000001", meta: null });
+        db.insertQaHistory({
+            userId: user.id,
+            videoId: "vid00000001",
+            question: "q",
+            answer: "a",
+            citations: [],
+            creditsSpent: 5,
+        });
+        db.enqueueJob({ targetKind: "video", target: "vid00000001", stages: ["captions"], userId: user.id });
+        db.recordVideoWatch({ userId: 999, videoId: "vid00000001" });
+
+        const merged = buildHistoryEntries(db, user.id);
+        const actions = merged.map((entry) => entry.action);
+
+        expect(actions).toContain("watch");
+        expect(actions).toContain("transcript:view");
+        expect(actions).toContain("ask");
+        expect(actions).toContain("job:captions");
+        expect(merged).toHaveLength(4);
+        const sorted = [...merged].sort((a, b) => b.ts.localeCompare(a.ts));
+
+        expect(merged).toEqual(sorted);
+    });
+});

--- a/src/youtube/lib/__tests__/watchlist-db.test.ts
+++ b/src/youtube/lib/__tests__/watchlist-db.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+    db.upsertChannel({ handle: "@chan" });
+    db.upsertVideo({ id: "vid00000001", channelHandle: "@chan", title: "One" });
+    db.upsertVideo({ id: "vid00000002", channelHandle: "@chan", title: "Two" });
+    db.saveTranscript({
+        videoId: "vid00000001",
+        lang: "en",
+        source: "captions",
+        text: "hello",
+        segments: [{ text: "hello", start: 0, end: 1 }],
+    });
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("watchlist + gating readers", () => {
+    it("watchlist add/remove is idempotent and user-scoped", () => {
+        db.addWatchlistChannel(1, "@chan");
+        db.addWatchlistChannel(1, "@chan");
+        db.addWatchlistChannel(2, "@chan");
+
+        expect(db.listWatchlist(1)).toHaveLength(1);
+        expect(db.removeWatchlistChannel(1, "@chan")).toBe(true);
+        expect(db.removeWatchlistChannel(1, "@chan")).toBe(false);
+        expect(db.listWatchlist(2)).toHaveLength(1);
+    });
+
+    it("hasWatched + listWatchedVideoIdsSince read video_watchers", () => {
+        db.recordVideoWatch({ userId: 1, videoId: "vid00000001" });
+        db.recordVideoWatch({ userId: 1, videoId: "vid00000001" });
+        db.recordVideoWatch({ userId: 2, videoId: "vid00000002" });
+
+        expect(db.hasWatched(1, "vid00000001")).toBe(true);
+        expect(db.hasWatched(1, "vid00000002")).toBe(false);
+        expect(db.listWatchedVideoIdsSince(1, "2000-01-01T00:00:00.000Z")).toEqual(["vid00000001"]);
+        expect(db.listWatchedVideoIdsSince(1, "2999-01-01T00:00:00.000Z")).toEqual([]);
+    });
+
+    it("getVideosByIds hydrates lite records with content flags", () => {
+        const lites = db.getVideosByIds(["vid00000001", "vid00000002", "vid_missing"]);
+
+        expect(lites).toHaveLength(2);
+        const one = lites.find((lite) => lite.id === "vid00000001");
+
+        expect(one?.hasTranscript).toBe(true);
+        expect(one?.hasSummary).toBe(false);
+        expect(db.getVideosByIds([])).toEqual([]);
+    });
+
+    it("listWatchesByUser returns newest-first watches for one user", () => {
+        db.recordVideoWatch({ userId: 1, videoId: "vid00000001" });
+        db.recordVideoWatch({ userId: 1, videoId: "vid00000002" });
+        db.recordVideoWatch({ userId: 2, videoId: "vid00000001" });
+
+        const watches = db.listWatchesByUser(1);
+
+        expect(watches).toHaveLength(2);
+        expect(watches[0].videoId).toBe("vid00000002");
+        expect(watches.every((watch) => watch.userId === 1)).toBe(true);
+    });
+
+    it("listJobs filters by userId", () => {
+        db.enqueueJob({ targetKind: "video", target: "vid00000001", stages: ["captions"], userId: 1 });
+        db.enqueueJob({ targetKind: "video", target: "vid00000002", stages: ["captions"], userId: 2 });
+
+        expect(db.listJobs({ userId: 1 })).toHaveLength(1);
+        expect(db.listJobs({})).toHaveLength(2);
+    });
+});

--- a/src/youtube/lib/collection-ask.ts
+++ b/src/youtube/lib/collection-ask.ts
@@ -1,0 +1,170 @@
+import { logger } from "@app/logger";
+import type { CallLLMStructuredOptions, CallLLMStructuredResult } from "@app/utils/ai/call-llm";
+import { callLLMStructured } from "@app/utils/ai/call-llm";
+import { SafeJSON } from "@app/utils/json";
+import { resolveCollectionVideoIds } from "@app/youtube/lib/collection-rules";
+import type { YoutubeDatabase } from "@app/youtube/lib/db";
+import type { AskMessageRecord, CollectionRecord } from "@app/youtube/lib/db.types";
+import { identifyProviderChoice, recordYoutubeUsage } from "@app/youtube/lib/usage";
+import type { ProviderChoice } from "@ask/types";
+import { z } from "zod";
+
+export const MAX_TOOL_CALLS = 6;
+export const TRANSCRIPT_CHAR_CAP = 24_000;
+
+const AgentStepSchema = z.discriminatedUnion("action", [
+    z.object({ action: z.literal("list_videos") }),
+    z.object({ action: z.literal("get_transcript"), videoId: z.string() }),
+    z.object({ action: z.literal("answer"), text: z.string() }),
+]);
+
+type AgentStep = z.infer<typeof AgentStepSchema>;
+
+const SYSTEM_PROMPT = [
+    "You are a research assistant answering questions about a user's video collection.",
+    "You take exactly ONE action per turn, as JSON matching the schema:",
+    '- {"action":"list_videos"} — list the collection\'s videos (id, title, channel, watched flag).',
+    '- {"action":"get_transcript","videoId":"<id>"} — transcript excerpt for ONE video the user has watched.',
+    '- {"action":"answer","text":"..."} — your final answer; reference video titles inline.',
+    "Tool results appear as TOOL messages. Transcripts of unwatched videos are REFUSED — answer only from what the user may see.",
+    `Budget: at most ${MAX_TOOL_CALLS} tool calls per question. Answer as soon as you have enough evidence.`,
+].join("\n");
+
+export interface CollectionAskDeps {
+    callLLMStructured: (options: CallLLMStructuredOptions<AgentStep>) => Promise<CallLLMStructuredResult<AgentStep>>;
+}
+
+export interface CollectionAskInput {
+    db: YoutubeDatabase;
+    userId: number;
+    collection: CollectionRecord;
+    question: string;
+    threadId?: number | null;
+    providerChoice: ProviderChoice;
+    /** Test seam — production callers omit it. */
+    deps?: CollectionAskDeps;
+}
+
+export interface CollectionAskResult {
+    threadId: number;
+    answer: string;
+    toolCalls: number;
+}
+
+export async function askCollection(input: CollectionAskInput): Promise<CollectionAskResult> {
+    const deps: CollectionAskDeps = input.deps ?? { callLLMStructured };
+    const thread = input.threadId
+        ? input.db.getAskThread(input.userId, input.threadId)
+        : input.db.createAskThread({
+              userId: input.userId,
+              collectionId: input.collection.id,
+              title: input.question.slice(0, 80),
+          });
+
+    if (!thread) {
+        throw new Error(`unknown ask thread: ${input.threadId}`);
+    }
+
+    if (thread.collectionId !== input.collection.id) {
+        throw new Error("unknown ask thread: belongs to a different collection");
+    }
+
+    input.db.appendAskMessage({ threadId: thread.id, role: "user", content: input.question });
+    let toolCalls = 0;
+
+    for (;;) {
+        const conversation = renderConversation(input.db.listAskMessages(thread.id));
+        const budgetNote = toolCalls >= MAX_TOOL_CALLS ? "\n\nTOOL BUDGET EXHAUSTED — you MUST answer now." : "";
+        const result = await deps.callLLMStructured({
+            systemPrompt: SYSTEM_PROMPT,
+            userPrompt: `Collection: "${input.collection.name}" (${input.collection.kind}).\n\nConversation so far:\n${conversation}${budgetNote}`,
+            providerChoice: input.providerChoice,
+            schema: AgentStepSchema,
+        });
+        const ids = identifyProviderChoice(input.providerChoice);
+        await recordYoutubeUsage({
+            action: "qa:ask",
+            provider: ids.provider,
+            model: ids.model,
+            usage: result.usage,
+            scope: `collection:${input.collection.id}`,
+        });
+        const step = result.object;
+
+        if (step.action === "answer") {
+            input.db.appendAskMessage({ threadId: thread.id, role: "assistant", content: step.text });
+            input.db.touchAskThread(thread.id);
+            logger.info(
+                { threadId: thread.id, collectionId: input.collection.id, toolCalls },
+                "youtube collection-ask: answered"
+            );
+
+            return { threadId: thread.id, answer: step.text, toolCalls };
+        }
+
+        if (toolCalls >= MAX_TOOL_CALLS) {
+            throw new Error("collection ask: tool budget exhausted without an answer");
+        }
+
+        toolCalls += 1;
+        const toolResult = executeTool(input, step);
+        input.db.appendAskMessage({
+            threadId: thread.id,
+            role: "tool",
+            content: toolResult,
+            toolName: step.action,
+            toolArgsJson: SafeJSON.stringify(step, { strict: true }),
+        });
+    }
+}
+
+function executeTool(input: CollectionAskInput, step: Exclude<AgentStep, { action: "answer" }>): string {
+    if (step.action === "list_videos") {
+        const ids = resolveCollectionVideoIds(input.db, input.collection);
+        const videos = input.db.getVideosByIds(ids).map((video) => ({
+            id: video.id,
+            title: video.title,
+            channel: video.channelHandle,
+            watched: input.db.hasWatched(input.userId, video.id),
+            hasTranscript: video.hasTranscript,
+        }));
+
+        return SafeJSON.stringify(videos, { strict: true });
+    }
+
+    // get_transcript — the hard server-side gate: membership AND watched.
+    const memberIds = resolveCollectionVideoIds(input.db, input.collection);
+
+    if (!memberIds.includes(step.videoId)) {
+        return `REFUSED: ${step.videoId} is not in this collection.`;
+    }
+
+    if (!input.db.hasWatched(input.userId, step.videoId)) {
+        return `REFUSED: the user has not watched ${step.videoId}; its transcript is not available.`;
+    }
+
+    const transcript = input.db.getTranscript(step.videoId);
+
+    if (!transcript) {
+        return `NO TRANSCRIPT: ${step.videoId} has no stored transcript yet.`;
+    }
+
+    const text =
+        transcript.text.length > TRANSCRIPT_CHAR_CAP
+            ? `${transcript.text.slice(0, TRANSCRIPT_CHAR_CAP)}\n[...truncated]`
+            : transcript.text;
+
+    return `TRANSCRIPT of ${step.videoId}:\n${text}`;
+}
+
+function renderConversation(messages: AskMessageRecord[]): string {
+    return messages
+        .map((message) => {
+            if (message.role === "tool") {
+                return `TOOL(${message.toolName}): ${message.content}`;
+            }
+
+            return `${message.role.toUpperCase()}: ${message.content}`;
+        })
+        .join("\n\n");
+}

--- a/src/youtube/lib/collection-rules.ts
+++ b/src/youtube/lib/collection-rules.ts
@@ -1,0 +1,54 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { YoutubeDatabase } from "@app/youtube/lib/db";
+import type { CollectionRecord } from "@app/youtube/lib/db.types";
+
+export interface WatchedRule {
+    type: "watched";
+    /** Look-back window; 1..365 whole days. */
+    sinceDays: number;
+}
+
+/** Discriminated union — extend with new rule types here, never ad-hoc JSON. */
+export type CollectionRule = WatchedRule;
+
+export function parseCollectionRule(raw: unknown): CollectionRule | null {
+    if (!raw || typeof raw !== "object") {
+        return null;
+    }
+
+    const candidate = raw as { type?: unknown; sinceDays?: unknown };
+
+    if (candidate.type !== "watched") {
+        return null;
+    }
+
+    const sinceDays = candidate.sinceDays;
+
+    if (typeof sinceDays !== "number" || !Number.isFinite(sinceDays) || sinceDays <= 0 || sinceDays > 365) {
+        return null;
+    }
+
+    return { type: "watched", sinceDays: Math.floor(sinceDays) };
+}
+
+export function ruleCutoffIso(rule: CollectionRule, now: Date = new Date()): string {
+    return new Date(now.getTime() - rule.sinceDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/** Manual → membership rows; dynamic → rule over the owner's watch history. Broken rules resolve empty (never throw at read time). */
+export function resolveCollectionVideoIds(db: YoutubeDatabase, collection: CollectionRecord): string[] {
+    if (collection.kind === "manual") {
+        return db.listCollectionVideoIds(collection.id);
+    }
+
+    const rule = parseCollectionRule(collection.ruleJson ? SafeJSON.parse(collection.ruleJson) : null);
+
+    if (!rule) {
+        logger.warn({ collectionId: collection.id }, "youtube collections: dynamic rule failed to parse");
+
+        return [];
+    }
+
+    return db.listWatchedVideoIdsSince(collection.userId, ruleCutoffIso(rule));
+}

--- a/src/youtube/lib/db.ts
+++ b/src/youtube/lib/db.ts
@@ -8,7 +8,13 @@ import type { Channel, ChannelHandle } from "@app/youtube/lib/channel.types";
 import type { FetchedComment, VideoComment } from "@app/youtube/lib/comments.types";
 import type {
     AiCallRecord,
+    AskMessageRecord,
+    AskMessageRole,
+    AskThreadRecord,
     ClaimJobOpts,
+    CollectionKind,
+    CollectionRecord,
+    CreateCollectionInput,
     EnqueueJobInput,
     GetTranscriptOpts,
     ListJobsOpts,
@@ -30,11 +36,13 @@ import type {
     UpsertChannelInput,
     UpsertQaChunkInput,
     UpsertVideoInput,
+    VideoLite,
     VideoLogKind,
     VideoLogRecord,
     VideoSearchField,
     VideoSearchHit,
     VideoWatchRecord,
+    WatchlistEntry,
 } from "@app/youtube/lib/db.types";
 import type {
     JobActivity,
@@ -541,6 +549,73 @@ export class YoutubeDatabase extends BaseDatabase {
             if (!cols.some((column) => column.name === "user_id")) {
                 this.db.exec("ALTER TABLE jobs ADD COLUMN user_id INTEGER");
             }
+        });
+
+        // User-owned video collections (Phase 3). Manual and dynamic share one
+        // table (`kind` + nullable rule); membership rows are only meaningful
+        // for kind='manual' — dynamic membership resolves live from rules.
+        this.runMigration("add-collections", () => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS collections (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    kind TEXT NOT NULL CHECK (kind IN ('manual','dynamic')),
+                    rule_json TEXT,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC}),
+                    updated_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_collections_user ON collections(user_id, id DESC);
+
+                CREATE TABLE IF NOT EXISTS collection_videos (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    collection_id INTEGER NOT NULL,
+                    video_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC}),
+                    UNIQUE (collection_id, video_id)
+                );
+            `);
+        });
+
+        // Collection-Ask conversations (Phase 3). Tool calls persist as
+        // role='tool' rows so a replay shows WHAT the agent looked at.
+        this.runMigration("add-ask-threads", () => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS ask_threads (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    collection_id INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC}),
+                    updated_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_ask_threads_user ON ask_threads(user_id, updated_at DESC);
+
+                CREATE TABLE IF NOT EXISTS ask_messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    thread_id INTEGER NOT NULL,
+                    role TEXT NOT NULL CHECK (role IN ('user','assistant','tool')),
+                    content TEXT NOT NULL,
+                    tool_name TEXT,
+                    tool_args_json TEXT,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_ask_messages_thread ON ask_messages(thread_id, id ASC);
+            `);
+        });
+
+        // Per-user channel follows (Phase 3). Distinct from the global
+        // `channels` table, which is operator state.
+        this.runMigration("add-watchlist", () => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS channel_watchlist (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    channel_handle TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC}),
+                    UNIQUE (user_id, channel_handle)
+                );
+            `);
         });
 
         const existing = this.db
@@ -1204,6 +1279,11 @@ export class YoutubeDatabase extends BaseDatabase {
         if (opts.parentJobId !== undefined) {
             where.push("parent_job_id = ?");
             params.push(opts.parentJobId);
+        }
+
+        if (opts.userId !== undefined) {
+            where.push("user_id = ?");
+            params.push(opts.userId);
         }
 
         const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
@@ -2101,6 +2181,257 @@ export class YoutubeDatabase extends BaseDatabase {
         this.db.run("UPDATE reports SET result_json = ? WHERE id = ?", [SafeJSON.stringify(result), id]);
     }
 
+    createCollection(input: CreateCollectionInput): CollectionRecord {
+        const row = this.db
+            .query<CollectionRow, [number, string, string, string | null]>(
+                `INSERT INTO collections (user_id, name, kind, rule_json)
+                 VALUES (?, ?, ?, ?) RETURNING *`
+            )
+            .get(input.userId, input.name, input.kind, input.ruleJson ?? null);
+
+        if (!row) {
+            throw new Error("createCollection: insert returned no row");
+        }
+
+        return rowToCollection(row);
+    }
+
+    getCollection(userId: number, id: number): CollectionRecord | null {
+        const row = this.db
+            .query<CollectionRow, [number, number]>("SELECT * FROM collections WHERE id = ? AND user_id = ?")
+            .get(id, userId);
+
+        return row ? rowToCollection(row) : null;
+    }
+
+    listCollections(userId: number): CollectionRecord[] {
+        const rows = this.db
+            .query<CollectionRow, [number]>("SELECT * FROM collections WHERE user_id = ? ORDER BY id DESC")
+            .all(userId);
+
+        return rows.map(rowToCollection);
+    }
+
+    updateCollectionName(userId: number, id: number, name: string): CollectionRecord | null {
+        const row = this.db
+            .query<CollectionRow, [string, number, number]>(
+                `UPDATE collections SET name = ?, updated_at = ${SQL_NOW_UTC}
+                 WHERE id = ? AND user_id = ? RETURNING *`
+            )
+            .get(name, id, userId);
+
+        return row ? rowToCollection(row) : null;
+    }
+
+    deleteCollection(userId: number, id: number): boolean {
+        const removed = this.db.transaction(() => {
+            const result = this.db.run("DELETE FROM collections WHERE id = ? AND user_id = ?", [id, userId]);
+
+            if (result.changes > 0) {
+                this.db.run("DELETE FROM collection_videos WHERE collection_id = ?", [id]);
+            }
+
+            return result.changes > 0;
+        });
+
+        return removed();
+    }
+
+    addCollectionVideo(collectionId: number, videoId: string): void {
+        this.db.run("INSERT OR IGNORE INTO collection_videos (collection_id, video_id) VALUES (?, ?)", [
+            collectionId,
+            videoId,
+        ]);
+    }
+
+    removeCollectionVideo(collectionId: number, videoId: string): boolean {
+        const result = this.db.run("DELETE FROM collection_videos WHERE collection_id = ? AND video_id = ?", [
+            collectionId,
+            videoId,
+        ]);
+
+        return result.changes > 0;
+    }
+
+    listCollectionVideoIds(collectionId: number): string[] {
+        const rows = this.db
+            .query<{ video_id: string }, [number]>(
+                "SELECT video_id FROM collection_videos WHERE collection_id = ? ORDER BY id ASC"
+            )
+            .all(collectionId);
+
+        return rows.map((row) => row.video_id);
+    }
+
+    createAskThread(input: { userId: number; collectionId: number; title: string }): AskThreadRecord {
+        const row = this.db
+            .query<AskThreadRow, [number, number, string]>(
+                "INSERT INTO ask_threads (user_id, collection_id, title) VALUES (?, ?, ?) RETURNING *"
+            )
+            .get(input.userId, input.collectionId, input.title);
+
+        if (!row) {
+            throw new Error("createAskThread: insert returned no row");
+        }
+
+        return rowToAskThread(row);
+    }
+
+    getAskThread(userId: number, id: number): AskThreadRecord | null {
+        const row = this.db
+            .query<AskThreadRow, [number, number]>("SELECT * FROM ask_threads WHERE id = ? AND user_id = ?")
+            .get(id, userId);
+
+        return row ? rowToAskThread(row) : null;
+    }
+
+    listAskThreads(userId: number, collectionId?: number): AskThreadRecord[] {
+        const rows =
+            collectionId !== undefined
+                ? this.db
+                      .query<AskThreadRow, [number, number]>(
+                          "SELECT * FROM ask_threads WHERE user_id = ? AND collection_id = ? ORDER BY updated_at DESC, id DESC"
+                      )
+                      .all(userId, collectionId)
+                : this.db
+                      .query<AskThreadRow, [number]>(
+                          "SELECT * FROM ask_threads WHERE user_id = ? ORDER BY updated_at DESC, id DESC"
+                      )
+                      .all(userId);
+
+        return rows.map(rowToAskThread);
+    }
+
+    appendAskMessage(input: {
+        threadId: number;
+        role: AskMessageRole;
+        content: string;
+        toolName?: string | null;
+        toolArgsJson?: string | null;
+    }): AskMessageRecord {
+        const row = this.db
+            .query<AskMessageRow, [number, string, string, string | null, string | null]>(
+                `INSERT INTO ask_messages (thread_id, role, content, tool_name, tool_args_json)
+                 VALUES (?, ?, ?, ?, ?) RETURNING *`
+            )
+            .get(input.threadId, input.role, input.content, input.toolName ?? null, input.toolArgsJson ?? null);
+
+        if (!row) {
+            throw new Error("appendAskMessage: insert returned no row");
+        }
+
+        return rowToAskMessage(row);
+    }
+
+    listAskMessages(threadId: number): AskMessageRecord[] {
+        const rows = this.db
+            .query<AskMessageRow, [number]>("SELECT * FROM ask_messages WHERE thread_id = ? ORDER BY id ASC")
+            .all(threadId);
+
+        return rows.map(rowToAskMessage);
+    }
+
+    touchAskThread(id: number): void {
+        this.db.run(`UPDATE ask_threads SET updated_at = ${SQL_NOW_UTC} WHERE id = ?`, [id]);
+    }
+
+    addWatchlistChannel(userId: number, channelHandle: string): void {
+        this.db.run("INSERT OR IGNORE INTO channel_watchlist (user_id, channel_handle) VALUES (?, ?)", [
+            userId,
+            channelHandle,
+        ]);
+    }
+
+    removeWatchlistChannel(userId: number, channelHandle: string): boolean {
+        const result = this.db.run("DELETE FROM channel_watchlist WHERE user_id = ? AND channel_handle = ?", [
+            userId,
+            channelHandle,
+        ]);
+
+        return result.changes > 0;
+    }
+
+    listWatchlist(userId: number): WatchlistEntry[] {
+        const rows = this.db
+            .query<{ id: number; user_id: number; channel_handle: string; created_at: string }, [number]>(
+                "SELECT * FROM channel_watchlist WHERE user_id = ? ORDER BY id ASC"
+            )
+            .all(userId);
+
+        return rows.map((row) => ({
+            id: row.id,
+            userId: row.user_id,
+            channelHandle: row.channel_handle,
+            createdAt: row.created_at,
+        }));
+    }
+
+    /** Server-side gate for the collection-ask transcript tool. */
+    hasWatched(userId: number, videoId: string): boolean {
+        const row = this.db
+            .query<{ found: number }, [number, string]>(
+                "SELECT 1 AS found FROM video_watchers WHERE user_id = ? AND video_id = ? LIMIT 1"
+            )
+            .get(userId, videoId);
+
+        return row !== null;
+    }
+
+    /** Distinct watched video ids since `sinceIso`, most recently watched first. */
+    listWatchedVideoIdsSince(userId: number, sinceIso: string): string[] {
+        const rows = this.db
+            .query<{ video_id: string }, [number, string]>(
+                `SELECT video_id, MAX(id) AS last_id FROM video_watchers
+                 WHERE user_id = ? AND created_at >= ?
+                 GROUP BY video_id ORDER BY last_id DESC`
+            )
+            .all(userId, sinceIso);
+
+        return rows.map((row) => row.video_id);
+    }
+
+    listWatchesByUser(userId: number, limit = 200): VideoWatchRecord[] {
+        const rows = this.db
+            .query<VideoWatcherRow, [number, number]>(
+                "SELECT * FROM video_watchers WHERE user_id = ? ORDER BY id DESC LIMIT ?"
+            )
+            .all(userId, limit);
+
+        return rows.map((row) => ({
+            id: row.id,
+            userId: row.user_id,
+            videoId: row.video_id,
+            createdAt: row.created_at,
+        }));
+    }
+
+    getVideosByIds(ids: string[]): VideoLite[] {
+        if (ids.length === 0) {
+            return [];
+        }
+
+        const placeholders = ids.map(() => "?").join(",");
+        const rows = this.db
+            .query<VideoLiteRow, string[]>(
+                `SELECT v.id, v.title, v.channel_handle, v.thumb_url, v.upload_date, v.duration_sec,
+                        (v.summary_short IS NOT NULL OR v.summary_timestamped_json IS NOT NULL OR v.summary_long_json IS NOT NULL) AS has_summary,
+                        EXISTS (SELECT 1 FROM transcripts t WHERE t.video_id = v.id) AS has_transcript
+                 FROM videos v WHERE v.id IN (${placeholders})`
+            )
+            .all(...ids);
+
+        return rows.map((row) => ({
+            id: row.id,
+            title: row.title,
+            channelHandle: row.channel_handle,
+            thumbUrl: row.thumb_url,
+            uploadDate: row.upload_date,
+            durationSec: row.duration_sec,
+            hasSummary: row.has_summary === 1,
+            hasTranscript: row.has_transcript === 1,
+        }));
+    }
+
     initSchemaForTest(): void {
         this.initSchema();
     }
@@ -2843,4 +3174,79 @@ function snippetAround(text: string, loweredQuery: string, contextChars = 80): s
     const suffix = end < text.length ? "…" : "";
 
     return `${prefix}${text.slice(start, end)}${suffix}`.replace(/\s+/g, " ").trim();
+}
+
+interface CollectionRow {
+    id: number;
+    user_id: number;
+    name: string;
+    kind: CollectionKind;
+    rule_json: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+function rowToCollection(row: CollectionRow): CollectionRecord {
+    return {
+        id: row.id,
+        userId: row.user_id,
+        name: row.name,
+        kind: row.kind,
+        ruleJson: row.rule_json,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+interface AskThreadRow {
+    id: number;
+    user_id: number;
+    collection_id: number;
+    title: string;
+    created_at: string;
+    updated_at: string;
+}
+
+function rowToAskThread(row: AskThreadRow): AskThreadRecord {
+    return {
+        id: row.id,
+        userId: row.user_id,
+        collectionId: row.collection_id,
+        title: row.title,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+interface AskMessageRow {
+    id: number;
+    thread_id: number;
+    role: AskMessageRole;
+    content: string;
+    tool_name: string | null;
+    tool_args_json: string | null;
+    created_at: string;
+}
+
+interface VideoLiteRow {
+    id: string;
+    title: string;
+    channel_handle: string;
+    thumb_url: string | null;
+    upload_date: string | null;
+    duration_sec: number | null;
+    has_summary: number;
+    has_transcript: number;
+}
+
+function rowToAskMessage(row: AskMessageRow): AskMessageRecord {
+    return {
+        id: row.id,
+        threadId: row.thread_id,
+        role: row.role,
+        content: row.content,
+        toolName: row.tool_name,
+        toolArgsJson: row.tool_args_json,
+        createdAt: row.created_at,
+    };
 }

--- a/src/youtube/lib/db.types.ts
+++ b/src/youtube/lib/db.types.ts
@@ -146,6 +146,8 @@ export interface ListJobsOpts {
     targetKind?: JobTargetKind;
     target?: string;
     parentJobId?: number;
+    /** Only jobs attributed to this user (`jobs.user_id`). */
+    userId?: number;
     limit?: number;
     offset?: number;
 }
@@ -239,4 +241,64 @@ export interface QueueStats {
     running: number;
     perStage: Record<string, { queued: number; running: number }>;
     oldestQueuedAgeSec: number | null;
+}
+
+export type CollectionKind = "manual" | "dynamic";
+
+export interface CollectionRecord {
+    id: number;
+    userId: number;
+    name: string;
+    kind: CollectionKind;
+    /** Serialized `CollectionRule` for `kind='dynamic'`; null for manual collections. */
+    ruleJson: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CreateCollectionInput {
+    userId: number;
+    name: string;
+    kind: CollectionKind;
+    ruleJson?: string | null;
+}
+
+export interface AskThreadRecord {
+    id: number;
+    userId: number;
+    collectionId: number;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export type AskMessageRole = "user" | "assistant" | "tool";
+
+export interface AskMessageRecord {
+    id: number;
+    threadId: number;
+    role: AskMessageRole;
+    content: string;
+    toolName: string | null;
+    toolArgsJson: string | null;
+    createdAt: string;
+}
+
+export interface WatchlistEntry {
+    id: number;
+    userId: number;
+    channelHandle: string;
+    createdAt: string;
+}
+
+/** Cheap hydration record for list surfaces (history, collections, digest). */
+export interface VideoLite {
+    id: string;
+    title: string;
+    channelHandle: string;
+    thumbUrl: string | null;
+    uploadDate: string | null;
+    durationSec: number | null;
+    hasSummary: boolean;
+    hasTranscript: boolean;
 }

--- a/src/youtube/lib/history.ts
+++ b/src/youtube/lib/history.ts
@@ -1,0 +1,91 @@
+import type { YoutubeDatabase } from "@app/youtube/lib/db";
+
+export interface HistoryEntry {
+    ts: string;
+    /** "watch" | VideoLogKind | "ask" | `job:<firstStage>` */
+    action: string;
+    videoId: string;
+    meta?: Record<string, unknown> | null;
+}
+
+export interface VideoHistoryGroup {
+    videoId: string;
+    lastTs: string;
+    counts: Record<string, number>;
+    entries: HistoryEntry[];
+}
+
+export interface ActionHistoryGroup {
+    action: string;
+    count: number;
+    entries: HistoryEntry[];
+}
+
+const DEFAULT_HISTORY_LIMIT = 500;
+
+/** Merges the four user-scoped activity sources into one newest-first stream. */
+export function buildHistoryEntries(
+    db: YoutubeDatabase,
+    userId: number,
+    limit = DEFAULT_HISTORY_LIMIT
+): HistoryEntry[] {
+    const entries: HistoryEntry[] = [];
+
+    for (const watch of db.listWatchesByUser(userId, limit)) {
+        entries.push({ ts: watch.createdAt, action: "watch", videoId: watch.videoId });
+    }
+
+    for (const log of db.listVideoLogs({ userId, limit })) {
+        entries.push({ ts: log.createdAt, action: log.kind, videoId: log.videoId, meta: log.meta });
+    }
+
+    for (const qa of db.listQaHistory(userId, undefined, limit)) {
+        entries.push({ ts: qa.createdAt, action: "ask", videoId: qa.videoId, meta: { question: qa.question } });
+    }
+
+    for (const job of db.listJobs({ userId, limit })) {
+        if (job.targetKind === "video") {
+            entries.push({ ts: job.createdAt, action: `job:${job.stages[0] ?? "unknown"}`, videoId: job.target });
+        }
+    }
+
+    entries.sort((a, b) => b.ts.localeCompare(a.ts));
+
+    return entries.slice(0, limit);
+}
+
+export function groupHistoryByVideo(entries: HistoryEntry[]): VideoHistoryGroup[] {
+    const byVideo = new Map<string, VideoHistoryGroup>();
+
+    for (const entry of entries) {
+        const group = byVideo.get(entry.videoId) ?? {
+            videoId: entry.videoId,
+            lastTs: entry.ts,
+            counts: {},
+            entries: [],
+        };
+        group.counts[entry.action] = (group.counts[entry.action] ?? 0) + 1;
+
+        if (entry.ts > group.lastTs) {
+            group.lastTs = entry.ts;
+        }
+
+        group.entries.push(entry);
+        byVideo.set(entry.videoId, group);
+    }
+
+    return [...byVideo.values()].sort((a, b) => b.lastTs.localeCompare(a.lastTs));
+}
+
+export function groupHistoryByAction(entries: HistoryEntry[]): ActionHistoryGroup[] {
+    const byAction = new Map<string, ActionHistoryGroup>();
+
+    for (const entry of entries) {
+        const group = byAction.get(entry.action) ?? { action: entry.action, count: 0, entries: [] };
+        group.count += 1;
+        group.entries.push(entry);
+        byAction.set(entry.action, group);
+    }
+
+    return [...byAction.values()].sort((a, b) => b.count - a.count);
+}

--- a/src/youtube/lib/server/__tests__/collections-routes.test.ts
+++ b/src/youtube/lib/server/__tests__/collections-routes.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleCollectionsRoute } from "@app/youtube/lib/server/routes/collections";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-collections-routes-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    db.upsertChannel({ handle: "@chan" });
+    db.upsertVideo({ id: "vid00000001", channelHandle: "@chan", title: "One" });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    const user = db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+
+    return { ...user, token: `ytu_${email}` };
+}
+
+async function call(method: string, path: string, token?: string, bodyObj?: unknown) {
+    const url = new URL(`http://localhost${path}`);
+    const req = new Request(url, {
+        method,
+        headers: {
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            "Content-Type": "application/json",
+        },
+        ...(bodyObj !== undefined ? { body: SafeJSON.stringify(bodyObj, { strict: true }) } : {}),
+    });
+    const res = await handleCollectionsRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("collections routes", () => {
+    it("requires login with the typed code", async () => {
+        const res = await call("GET", "/api/v1/collections");
+
+        expect(res.status).toBe(401);
+        expect(res.json.code).toBe("login_required");
+    });
+
+    it("CRUD round-trip with ownership isolation", async () => {
+        const owner = createUser("o@example.com");
+        const stranger = createUser("s@example.com");
+        const created = await call("POST", "/api/v1/collections", owner.token, { name: "Picks", kind: "manual" });
+
+        expect(created.status).toBe(200);
+        const id = (created.json.collection as { id: number }).id;
+
+        await call("POST", `/api/v1/collections/${id}/videos`, owner.token, { videoId: "vid00000001" });
+        const detail = await call("GET", `/api/v1/collections/${id}`, owner.token);
+        const videos = detail.json.videos as Array<{ id: string }>;
+
+        expect(videos.map((video) => video.id)).toEqual(["vid00000001"]);
+        expect((await call("GET", `/api/v1/collections/${id}`, stranger.token)).status).toBe(404);
+        expect((await call("PATCH", `/api/v1/collections/${id}`, owner.token, { name: "Picks 2" })).status).toBe(200);
+        expect((await call("DELETE", `/api/v1/collections/${id}/videos/vid00000001`, owner.token)).status).toBe(200);
+        expect((await call("DELETE", `/api/v1/collections/${id}`, owner.token)).json.deleted).toBe(true);
+    });
+
+    it("validates dynamic rules at creation", async () => {
+        const owner = createUser("d@example.com");
+        const bad = await call("POST", "/api/v1/collections", owner.token, {
+            name: "broken",
+            kind: "dynamic",
+            rule: { type: "nope" },
+        });
+
+        expect(bad.status).toBe(400);
+
+        const good = await call("POST", "/api/v1/collections", owner.token, {
+            name: "last month",
+            kind: "dynamic",
+            rule: { type: "watched", sinceDays: 30 },
+        });
+
+        expect(good.status).toBe(200);
+        db.recordVideoWatch({ userId: owner.id, videoId: "vid00000001" });
+        const detail = await call(
+            "GET",
+            `/api/v1/collections/${(good.json.collection as { id: number }).id}`,
+            owner.token
+        );
+
+        expect((detail.json.videos as unknown[]).length).toBe(1);
+    });
+});
+
+describe("POST /collections/:id/ask (pre-LLM paths)", () => {
+    it("404s foreign collections and 400s a missing question", async () => {
+        const owner = createUser("a1@example.com");
+        const stranger = createUser("a2@example.com");
+        const created = await call("POST", "/api/v1/collections", owner.token, { name: "c", kind: "manual" });
+        const id = (created.json.collection as { id: number }).id;
+
+        expect((await call("POST", `/api/v1/collections/${id}/ask`, stranger.token, { question: "?" })).status).toBe(
+            404
+        );
+        expect((await call("POST", `/api/v1/collections/${id}/ask`, owner.token, {})).status).toBe(400);
+    });
+
+    it("402s with a typed code when the balance cannot cover the ask", async () => {
+        const owner = createUser("a3@example.com");
+        const created = await call("POST", "/api/v1/collections", owner.token, { name: "c", kind: "manual" });
+        const id = (created.json.collection as { id: number }).id;
+        const res = await call("POST", `/api/v1/collections/${id}/ask`, owner.token, { question: "hi" });
+
+        expect(res.status).toBe(402);
+        expect(res.json.code).toBe("insufficient_credits");
+    });
+});

--- a/src/youtube/lib/server/__tests__/history-routes.test.ts
+++ b/src/youtube/lib/server/__tests__/history-routes.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleUsersRoute } from "@app/youtube/lib/server/routes/users";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-history-routes-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    db.upsertChannel({ handle: "@chan" });
+    db.upsertVideo({
+        id: "vid00000001",
+        channelHandle: "@chan",
+        title: "One",
+        uploadDate: new Date().toISOString().slice(0, 10),
+    });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    const user = db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+
+    return { ...user, token: `ytu_${email}` };
+}
+
+async function call(method: string, path: string, token?: string, bodyObj?: unknown) {
+    const url = new URL(`http://localhost${path}`);
+    const req = new Request(url, {
+        method,
+        headers: {
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            "Content-Type": "application/json",
+        },
+        ...(bodyObj !== undefined ? { body: SafeJSON.stringify(bodyObj, { strict: true }) } : {}),
+    });
+    const res = await handleUsersRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("history + watchlist + digest routes", () => {
+    it("history groups by video by default and by action on request", async () => {
+        const user = createUser("h@example.com");
+        db.recordVideoWatch({ userId: user.id, videoId: "vid00000001" });
+        db.recordVideoLog({ kind: "summary:view", userId: user.id, videoId: "vid00000001", meta: null });
+
+        const byVideo = await call("GET", "/api/v1/users/history", user.token);
+
+        expect(byVideo.status).toBe(200);
+        expect(byVideo.json.groupBy).toBe("video");
+        expect((byVideo.json.videos as Array<{ videoId: string }>)[0].videoId).toBe("vid00000001");
+        expect((byVideo.json.videosById as Record<string, unknown>)["vid00000001"]).toBeDefined();
+
+        const byAction = await call("GET", "/api/v1/users/history?groupBy=action", user.token);
+
+        expect(byAction.json.groupBy).toBe("action");
+        expect((byAction.json.actions as Array<{ action: string }>).map((group) => group.action)).toContain("watch");
+    });
+
+    it("watchlist CRUD is user-scoped", async () => {
+        const user = createUser("w@example.com");
+
+        expect((await call("POST", "/api/v1/users/watchlist", user.token, { handle: "@chan" })).status).toBe(200);
+        const list = await call("GET", "/api/v1/users/watchlist", user.token);
+
+        expect((list.json.channels as unknown[]).length).toBe(1);
+        expect((await call("DELETE", "/api/v1/users/watchlist/@chan", user.token)).status).toBe(200);
+        expect(((await call("GET", "/api/v1/users/watchlist", user.token)).json.channels as unknown[]).length).toBe(0);
+    });
+
+    it("digest lists new videos from watched channels; sync enqueues attributed jobs", async () => {
+        const user = createUser("d@example.com");
+        await call("POST", "/api/v1/users/watchlist", user.token, { handle: "@chan" });
+        const digest = await call("GET", "/api/v1/users/digest?sinceDays=3650", user.token);
+        const channels = digest.json.channels as Array<{ handle: string; videos: unknown[] }>;
+
+        expect(channels[0].handle).toBe("@chan");
+        expect(channels[0].videos.length).toBe(1);
+
+        const sync = await call("POST", "/api/v1/users/digest/sync", user.token);
+        const jobIds = sync.json.enqueuedJobIds as number[];
+
+        expect(jobIds.length).toBe(1);
+        expect(db.getJob(jobIds[0])?.userId).toBe(user.id);
+    });
+});

--- a/src/youtube/lib/server/index.ts
+++ b/src/youtube/lib/server/index.ts
@@ -15,6 +15,7 @@ import { toErrorResponse } from "@app/youtube/lib/server/error";
 import { clearPortFile, writePortFile } from "@app/youtube/lib/server/port-file";
 import { handleCacheRoute } from "@app/youtube/lib/server/routes/cache";
 import { handleChannelsRoute } from "@app/youtube/lib/server/routes/channels";
+import { handleCollectionsRoute } from "@app/youtube/lib/server/routes/collections";
 import { handleConfigRoute } from "@app/youtube/lib/server/routes/config";
 import { handleModelsRoute } from "@app/youtube/lib/server/routes/models";
 import { handlePipelineRoute } from "@app/youtube/lib/server/routes/pipeline";
@@ -206,6 +207,10 @@ async function dispatchApiRoute(req: Request, url: URL, youtube: Youtube): Promi
 
     if (url.pathname.startsWith("/api/v1/pipeline") || url.pathname.startsWith("/api/v1/jobs")) {
         return handlePipelineRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/collections")) {
+        return handleCollectionsRoute(req, url, youtube);
     }
 
     if (url.pathname.startsWith("/api/v1/cache")) {

--- a/src/youtube/lib/server/openapi.ts
+++ b/src/youtube/lib/server/openapi.ts
@@ -1055,6 +1055,405 @@ function buildPaths(): Record<string, OpenApiPathItem> {
                 },
             },
         },
+        "/api/v1/collections": {
+            get: {
+                operationId: "listCollections",
+                summary: "List the signed-in user's collections",
+                tags: ["collections"],
+                responses: {
+                    "200": jsonResponse("Collections", {
+                        type: "object",
+                        properties: { collections: arrayOf({ type: "object" }) },
+                        required: ["collections"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+            post: {
+                operationId: "createCollection",
+                summary: "Create a manual or dynamic collection",
+                tags: ["collections"],
+                requestBody: jsonBody(
+                    {
+                        type: "object",
+                        properties: {
+                            name: { type: "string" },
+                            kind: { type: "string", enum: ["manual", "dynamic"] },
+                            rule: {
+                                type: "object",
+                                description: "Required for dynamic collections, e.g. {type:'watched', sinceDays:30}.",
+                            },
+                        },
+                        required: ["name", "kind"],
+                    },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Created collection", {
+                        type: "object",
+                        properties: { collection: { type: "object" } },
+                        required: ["collection"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                },
+            },
+        },
+        "/api/v1/collections/threads/{threadId}": {
+            get: {
+                operationId: "getCollectionThread",
+                summary: "Get an ask thread with its full message transcript",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "threadId",
+                        in: "path",
+                        required: true,
+                        description: "Ask thread id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Thread with messages", {
+                        type: "object",
+                        properties: { thread: { type: "object" }, messages: arrayOf({ type: "object" }) },
+                        required: ["thread", "messages"],
+                    }),
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/collections/{id}": {
+            get: {
+                operationId: "getCollection",
+                summary: "Get a collection with its resolved videos",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Collection detail", {
+                        type: "object",
+                        properties: { collection: { type: "object" }, videos: arrayOf({ type: "object" }) },
+                        required: ["collection", "videos"],
+                    }),
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+            patch: {
+                operationId: "patchCollection",
+                summary: "Rename a collection",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                requestBody: jsonBody(
+                    { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Updated collection", {
+                        type: "object",
+                        properties: { collection: { type: "object" } },
+                        required: ["collection"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+            delete: {
+                operationId: "deleteCollection",
+                summary: "Delete a collection and its membership rows",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Deleted", {
+                        type: "object",
+                        properties: { deleted: { type: "boolean" } },
+                        required: ["deleted"],
+                    }),
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/collections/{id}/ask": {
+            post: {
+                operationId: "askCollection",
+                summary: "Ask a bounded tool-loop agent about a collection (charges credits)",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                requestBody: jsonBody(
+                    {
+                        type: "object",
+                        properties: {
+                            question: { type: "string" },
+                            threadId: nullableInteger("Continue an existing conversation."),
+                            provider: { type: "string" },
+                            model: { type: "string" },
+                        },
+                        required: ["question"],
+                    },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Answer", {
+                        type: "object",
+                        properties: {
+                            threadId: { type: "integer" },
+                            answer: { type: "string" },
+                            toolCalls: { type: "integer" },
+                            creditsSpent: { type: "integer" },
+                            credits: { type: "integer" },
+                        },
+                        required: ["threadId", "answer", "toolCalls", "creditsSpent", "credits"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                    "402": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/collections/{id}/threads": {
+            get: {
+                operationId: "listCollectionThreads",
+                summary: "List ask threads for a collection",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Threads", {
+                        type: "object",
+                        properties: { threads: arrayOf({ type: "object" }) },
+                        required: ["threads"],
+                    }),
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/collections/{id}/videos": {
+            post: {
+                operationId: "addCollectionVideo",
+                summary: "Add a video to a manual collection",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                ],
+                requestBody: jsonBody(
+                    { type: "object", properties: { videoId: { type: "string" } }, required: ["videoId"] },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Added", {
+                        type: "object",
+                        properties: { added: { type: "boolean" } },
+                        required: ["added"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/collections/{id}/videos/{videoId}": {
+            delete: {
+                operationId: "removeCollectionVideo",
+                summary: "Remove a video from a manual collection",
+                tags: ["collections"],
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "Collection id.",
+                        schema: { type: "integer" },
+                    },
+                    {
+                        name: "videoId",
+                        in: "path",
+                        required: true,
+                        description: "YouTube video id.",
+                        schema: { type: "string" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Removed", {
+                        type: "object",
+                        properties: { removed: { type: "boolean" } },
+                        required: ["removed"],
+                    }),
+                    "401": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/history": {
+            get: {
+                operationId: "getUserHistory",
+                summary: "The signed-in user's activity, grouped by video or by action",
+                tags: ["users"],
+                parameters: [
+                    {
+                        name: "groupBy",
+                        in: "query",
+                        required: false,
+                        description: "video (default) or action.",
+                        schema: { type: "string", enum: ["video", "action"] },
+                    },
+                    { name: "limit", in: "query", required: false, schema: { type: "integer" } },
+                ],
+                responses: {
+                    "200": jsonResponse("History", {
+                        type: "object",
+                        properties: {
+                            groupBy: { type: "string", enum: ["video", "action"] },
+                            videos: arrayOf({ type: "object" }),
+                            actions: arrayOf({ type: "object" }),
+                            videosById: { type: "object" },
+                        },
+                        required: ["groupBy", "videosById"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/watchlist": {
+            get: {
+                operationId: "getWatchlist",
+                summary: "List the channels the signed-in user follows",
+                tags: ["users"],
+                responses: {
+                    "200": jsonResponse("Watchlist", {
+                        type: "object",
+                        properties: { channels: arrayOf({ type: "object" }) },
+                        required: ["channels"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+            post: {
+                operationId: "addWatchlistChannel",
+                summary: "Follow a channel",
+                tags: ["users"],
+                requestBody: jsonBody(
+                    { type: "object", properties: { handle: { type: "string" } }, required: ["handle"] },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Added", {
+                        type: "object",
+                        properties: { added: { type: "boolean" } },
+                        required: ["added"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/watchlist/{handle}": {
+            delete: {
+                operationId: "removeWatchlistChannel",
+                summary: "Unfollow a channel",
+                tags: ["users"],
+                parameters: [
+                    {
+                        name: "handle",
+                        in: "path",
+                        required: true,
+                        description: "Channel handle.",
+                        schema: { type: "string" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Removed", {
+                        type: "object",
+                        properties: { removed: { type: "boolean" } },
+                        required: ["removed"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/digest": {
+            get: {
+                operationId: "getDigest",
+                summary: "Recent videos from followed channels",
+                tags: ["users"],
+                parameters: [{ name: "sinceDays", in: "query", required: false, schema: { type: "integer" } }],
+                responses: {
+                    "200": jsonResponse("Digest", {
+                        type: "object",
+                        properties: {
+                            since: { type: "string" },
+                            channels: arrayOf({ type: "object" }),
+                        },
+                        required: ["since", "channels"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/digest/sync": {
+            post: {
+                operationId: "syncDigest",
+                summary: "Enqueue discover+metadata jobs for every followed channel",
+                tags: ["users"],
+                responses: {
+                    "200": jsonResponse("Enqueued jobs", {
+                        type: "object",
+                        properties: { enqueuedJobIds: arrayOf({ type: "integer" }) },
+                        required: ["enqueuedJobIds"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+        },
     };
 }
 

--- a/src/youtube/lib/server/routes/collections.ts
+++ b/src/youtube/lib/server/routes/collections.ts
@@ -1,0 +1,320 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { resolveAiSpecForTask } from "@app/youtube/lib/ai-mapping";
+import { askCollection } from "@app/youtube/lib/collection-ask";
+import { parseCollectionRule, resolveCollectionVideoIds } from "@app/youtube/lib/collection-rules";
+import type { CollectionKind } from "@app/youtube/lib/db.types";
+import { resolveProviderChoice } from "@app/youtube/lib/provider-choice";
+import { requireUser } from "@app/youtube/lib/server/auth";
+import { safeJsonBody } from "@app/youtube/lib/server/body";
+import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
+import { toErrorResponse } from "@app/youtube/lib/server/error";
+import { matchRoute } from "@app/youtube/lib/server/match-route";
+import { CREDIT_COSTS, InsufficientCreditsError } from "@app/youtube/lib/users.types";
+import type { Youtube } from "@app/youtube/lib/youtube";
+
+export async function handleCollectionsRoute(req: Request, url: URL, yt: Youtube): Promise<Response> {
+    try {
+        // "threads" must never parse as a collection id — register first.
+        const threadDetail = matchRoute(req, "GET", "/api/v1/collections/threads/:threadId", url.pathname);
+
+        if (threadDetail) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const threadId = parseId(threadDetail.threadId);
+            const thread = threadId !== null ? yt.db.getAskThread(user.id, threadId) : null;
+
+            if (!thread) {
+                return jsonError("thread not found", 404);
+            }
+
+            return Response.json({ thread, messages: yt.db.listAskMessages(thread.id) }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/collections", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const collections = yt.db.listCollections(user.id).map((collection) => ({
+                ...collection,
+                videoCount: resolveCollectionVideoIds(yt.db, collection).length,
+            }));
+
+            return Response.json({ collections }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "POST", "/api/v1/collections", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const name = typeof body.name === "string" ? body.name.trim() : "";
+            const kind: CollectionKind | null = body.kind === "manual" || body.kind === "dynamic" ? body.kind : null;
+
+            if (!name || !kind) {
+                return jsonError("body must include {name, kind: 'manual'|'dynamic'}", 400);
+            }
+
+            let ruleJson: string | null = null;
+
+            if (kind === "dynamic") {
+                const rule = parseCollectionRule(body.rule);
+
+                if (!rule) {
+                    return jsonError("dynamic collections need a valid rule, e.g. {type:'watched', sinceDays:30}", 400);
+                }
+
+                ruleJson = SafeJSON.stringify(rule, { strict: true });
+            }
+
+            const collection = yt.db.createCollection({ userId: user.id, name, kind, ruleJson });
+            logger.info({ userId: user.id, collectionId: collection.id, kind }, "youtube collections: created");
+
+            return Response.json({ collection }, { headers: CORS_HEADERS });
+        }
+
+        const threadsList = matchRoute(req, "GET", "/api/v1/collections/:id/threads", url.pathname);
+
+        if (threadsList) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const collection = ownedCollection(yt, user.id, threadsList.id);
+
+            if (!collection) {
+                return jsonError("collection not found", 404);
+            }
+
+            return Response.json({ threads: yt.db.listAskThreads(user.id, collection.id) }, { headers: CORS_HEADERS });
+        }
+
+        const ask = matchRoute(req, "POST", "/api/v1/collections/:id/ask", url.pathname);
+
+        if (ask) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const collection = ownedCollection(yt, user.id, ask.id);
+
+            if (!collection) {
+                return jsonError("collection not found", 404);
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const question = typeof body.question === "string" ? body.question.trim() : "";
+
+            if (!question) {
+                return jsonError("body must include {question}", 400);
+            }
+
+            const threadId = typeof body.threadId === "number" ? body.threadId : null;
+            const creditCost = CREDIT_COSTS["qa:channel"];
+            let hold: { holdId: number; credits: number };
+
+            try {
+                // Reserve BEFORE provider work; released on any failure below.
+                hold = yt.db.reserveCredits({
+                    userId: user.id,
+                    amount: creditCost,
+                    reason: "qa:channel",
+                    context: `collection:${collection.id}`,
+                });
+            } catch (error) {
+                if (error instanceof InsufficientCreditsError) {
+                    return new Response(
+                        SafeJSON.stringify({ error: error.message, code: "insufficient_credits" }, { strict: true }),
+                        { status: 402, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+                    );
+                }
+
+                throw error;
+            }
+
+            try {
+                const providerChoice = await resolveProviderChoice({
+                    provider: typeof body.provider === "string" ? body.provider : undefined,
+                    model: typeof body.model === "string" ? body.model : undefined,
+                    fallbackSpec: resolveAiSpecForTask(await yt.config.getAll(), "qa"),
+                });
+                const result = await askCollection({
+                    db: yt.db,
+                    userId: user.id,
+                    collection,
+                    question,
+                    threadId,
+                    providerChoice,
+                });
+                yt.db.commitHold(hold.holdId);
+
+                return Response.json(
+                    { ...result, creditsSpent: creditCost, credits: hold.credits },
+                    { headers: CORS_HEADERS }
+                );
+            } catch (error) {
+                yt.db.releaseHold(hold.holdId);
+                throw error;
+            }
+        }
+
+        const addVideo = matchRoute(req, "POST", "/api/v1/collections/:id/videos", url.pathname);
+
+        if (addVideo) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const collection = ownedCollection(yt, user.id, addVideo.id);
+
+            if (!collection) {
+                return jsonError("collection not found", 404);
+            }
+
+            if (collection.kind !== "manual") {
+                return jsonError("dynamic collections resolve automatically — cannot add videos", 400);
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const videoId = typeof body.videoId === "string" ? body.videoId : null;
+
+            if (!videoId) {
+                return jsonError("body must include {videoId}", 400);
+            }
+
+            yt.db.addCollectionVideo(collection.id, videoId);
+
+            return Response.json({ added: true }, { headers: CORS_HEADERS });
+        }
+
+        const removeVideo = matchRoute(req, "DELETE", "/api/v1/collections/:id/videos/:videoId", url.pathname);
+
+        if (removeVideo) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const collection = ownedCollection(yt, user.id, removeVideo.id);
+
+            if (!collection) {
+                return jsonError("collection not found", 404);
+            }
+
+            return Response.json(
+                { removed: yt.db.removeCollectionVideo(collection.id, removeVideo.videoId) },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        const detail = matchRoute(req, "GET", "/api/v1/collections/:id", url.pathname);
+
+        if (detail) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const collection = ownedCollection(yt, user.id, detail.id);
+
+            if (!collection) {
+                return jsonError("collection not found", 404);
+            }
+
+            const videos = yt.db.getVideosByIds(resolveCollectionVideoIds(yt.db, collection));
+
+            return Response.json({ collection, videos }, { headers: CORS_HEADERS });
+        }
+
+        const patch = matchRoute(req, "PATCH", "/api/v1/collections/:id", url.pathname);
+
+        if (patch) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const name = typeof body.name === "string" ? body.name.trim() : "";
+
+            if (!name) {
+                return jsonError("body must include {name}", 400);
+            }
+
+            const id = parseId(patch.id);
+            const updated = id !== null ? yt.db.updateCollectionName(user.id, id, name) : null;
+
+            if (!updated) {
+                return jsonError("collection not found", 404);
+            }
+
+            return Response.json({ collection: updated }, { headers: CORS_HEADERS });
+        }
+
+        const remove = matchRoute(req, "DELETE", "/api/v1/collections/:id", url.pathname);
+
+        if (remove) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const id = parseId(remove.id);
+            const deleted = id !== null ? yt.db.deleteCollection(user.id, id) : false;
+
+            if (!deleted) {
+                return jsonError("collection not found", 404);
+            }
+
+            return Response.json({ deleted: true }, { headers: CORS_HEADERS });
+        }
+
+        return jsonError("not found", 404);
+    } catch (err) {
+        return toErrorResponse(err);
+    }
+}
+
+function ownedCollection(yt: Youtube, userId: number, rawId: string) {
+    const id = parseId(rawId);
+
+    return id !== null ? yt.db.getCollection(userId, id) : null;
+}
+
+/** Full-segment positive integer — `parseInt` would accept `"1junk"` as 1. */
+function parseId(value: string): number | null {
+    if (!/^[1-9]\d*$/.test(value)) {
+        return null;
+    }
+
+    const id = Number(value);
+
+    return Number.isSafeInteger(id) ? id : null;
+}
+
+function jsonError(error: string, status: number): Response {
+    return new Response(SafeJSON.stringify({ error }, { strict: true }), {
+        status,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+}

--- a/src/youtube/lib/server/routes/users.ts
+++ b/src/youtube/lib/server/routes/users.ts
@@ -3,6 +3,8 @@ import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
 import { createCheckoutSession } from "@app/youtube/lib/billing";
 import { DIAMOND_PACKS } from "@app/youtube/lib/billing.types";
+import type { ChannelHandle } from "@app/youtube/lib/channel.types";
+import { buildHistoryEntries, groupHistoryByAction, groupHistoryByVideo } from "@app/youtube/lib/history";
 import { isOutputLang } from "@app/youtube/lib/languages";
 import { getLedgerPage, getUsageSummary } from "@app/youtube/lib/ledger-views";
 import { createPreset, deletePreset, listPresets, updatePreset } from "@app/youtube/lib/presets";
@@ -265,6 +267,116 @@ export async function handleUsersRoute(req: Request, url: URL, yt: Youtube): Pro
             const items = yt.db.listQaHistory(user.id, video, Number.isNaN(limit) ? undefined : limit);
 
             return Response.json({ items }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/users/history", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const groupBy = url.searchParams.get("groupBy") === "action" ? "action" : "video";
+            const rawLimit = parseInt(url.searchParams.get("limit") ?? "500", 10);
+            const limit = Number.isNaN(rawLimit) ? 500 : Math.min(2000, Math.max(1, rawLimit));
+            const entries = buildHistoryEntries(yt.db, user.id, limit);
+            const videoIds = [...new Set(entries.map((entry) => entry.videoId))];
+            const videosById = Object.fromEntries(yt.db.getVideosByIds(videoIds).map((video) => [video.id, video]));
+
+            if (groupBy === "action") {
+                return Response.json(
+                    { groupBy, actions: groupHistoryByAction(entries), videosById },
+                    { headers: CORS_HEADERS }
+                );
+            }
+
+            return Response.json(
+                { groupBy, videos: groupHistoryByVideo(entries), videosById },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/users/watchlist", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            return Response.json({ channels: yt.db.listWatchlist(user.id) }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "POST", "/api/v1/users/watchlist", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const handle = typeof body.handle === "string" ? body.handle.trim() : "";
+
+            if (!handle.startsWith("@") || handle.length < 2) {
+                return jsonError("body must include {handle: '@channel'}", 400);
+            }
+
+            yt.db.addWatchlistChannel(user.id, handle);
+
+            return Response.json({ added: true }, { headers: CORS_HEADERS });
+        }
+
+        const watchlistRemove = matchRoute(req, "DELETE", "/api/v1/users/watchlist/:handle", url.pathname);
+
+        if (watchlistRemove) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            return Response.json(
+                { removed: yt.db.removeWatchlistChannel(user.id, decodeURIComponent(watchlistRemove.handle)) },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/users/digest", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const rawDays = parseInt(url.searchParams.get("sinceDays") ?? "7", 10);
+            const sinceDays = Number.isNaN(rawDays) ? 7 : Math.min(3650, Math.max(1, rawDays));
+            const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+            const channels = yt.db.listWatchlist(user.id).map((entry) => {
+                const videos = yt.videos.list({ channel: entry.channelHandle as ChannelHandle, since, limit: 50 });
+
+                return { handle: entry.channelHandle, videos: yt.db.getVideosByIds(videos.map((video) => video.id)) };
+            });
+
+            return Response.json({ since, channels }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "POST", "/api/v1/users/digest/sync", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const enqueuedJobIds = yt.db.listWatchlist(user.id).map(
+                (entry) =>
+                    yt.pipeline.enqueue({
+                        targetKind: "channel",
+                        target: entry.channelHandle,
+                        stages: ["discover", "metadata"],
+                        userId: user.id,
+                    }).id
+            );
+
+            return Response.json({ enqueuedJobIds }, { headers: CORS_HEADERS });
         }
 
         return jsonError("not found", 404);

--- a/src/youtube/lib/types.ts
+++ b/src/youtube/lib/types.ts
@@ -1,6 +1,7 @@
 export type { CacheLayout } from "@app/youtube/lib/cache.types";
 export type { FetchCaptionsOpts, FetchCaptionsResult } from "@app/youtube/lib/captions.types";
 export type { Channel, ChannelHandle } from "@app/youtube/lib/channel.types";
+export type { CollectionRule, WatchedRule } from "@app/youtube/lib/collection-rules";
 export type { FetchCommentsOpts, FetchedComment, VideoComment } from "@app/youtube/lib/comments.types";
 export type {
     AiTask,
@@ -12,12 +13,20 @@ export type {
     YtRole,
 } from "@app/youtube/lib/config.types";
 export type {
+    AskMessageRecord,
+    AskMessageRole,
+    AskThreadRecord,
+    CollectionKind,
+    CollectionRecord,
     QueueStats,
     SearchVideosOpts,
+    VideoLite,
     VideoLogKind,
     VideoSearchField,
     VideoSearchHit,
+    WatchlistEntry,
 } from "@app/youtube/lib/db.types";
+export type { ActionHistoryGroup, HistoryEntry, VideoHistoryGroup } from "@app/youtube/lib/history";
 export type {
     JobActivity,
     JobActivityKind,

--- a/src/youtube/ui/api.client.ts
+++ b/src/youtube/ui/api.client.ts
@@ -1,9 +1,14 @@
 import { SafeJSON } from "@app/utils/json";
 import type { YoutubeConfigPatch } from "@app/youtube/lib/config.api.types";
 import type {
+    ActionHistoryGroup,
     AskCitation,
+    AskMessageRecord,
+    AskThreadRecord,
     Channel,
     ChannelHandle,
+    CollectionKind,
+    CollectionRecord,
     JobActivity,
     JobStage,
     JobStatus,
@@ -13,9 +18,13 @@ import type {
     Transcript,
     Video,
     VideoComment,
+    VideoHistoryGroup,
     VideoId,
+    VideoLite,
     VideoLongSummary,
+    WatchlistEntry,
     YoutubeConfigShape,
+    YtUser,
 } from "@app/youtube/lib/types";
 import { fetchUiConfig } from "@app/yt/config.client";
 import { reportBackendReachable, reportBackendUnreachable } from "./backend-status";
@@ -35,6 +44,26 @@ export interface CacheStatsResponse {
     thumbBytes?: number | { n: number };
 }
 
+export interface CollectionAskResponse {
+    threadId: number;
+    answer: string;
+    toolCalls: number;
+    creditsSpent: number;
+    credits: number;
+}
+
+export interface HistoryResponse {
+    groupBy: "video" | "action";
+    videos?: VideoHistoryGroup[];
+    actions?: ActionHistoryGroup[];
+    videosById: Record<string, VideoLite>;
+}
+
+export interface DigestResponse {
+    since: string;
+    channels: Array<{ handle: string; videos: VideoLite[] }>;
+}
+
 let cachedBase: string | null = null;
 
 export function clearApiBaseUrlCache(): void {
@@ -52,14 +81,41 @@ async function baseUrl(): Promise<string> {
     return cachedBase;
 }
 
+const USER_TOKEN_STORAGE_KEY = "yt.userToken";
+
+export function getUserToken(): string | null {
+    if (typeof localStorage === "undefined") {
+        return null;
+    }
+
+    return localStorage.getItem(USER_TOKEN_STORAGE_KEY);
+}
+
+export function setUserToken(token: string | null): void {
+    if (typeof localStorage === "undefined") {
+        return;
+    }
+
+    if (token) {
+        localStorage.setItem(USER_TOKEN_STORAGE_KEY, token);
+    } else {
+        localStorage.removeItem(USER_TOKEN_STORAGE_KEY);
+    }
+}
+
 async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
     const base = await baseUrl();
+    const token = getUserToken();
     let res: Response;
 
     try {
         res = await fetch(`${base}/api/v1${path}`, {
             ...init,
-            headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+            headers: {
+                "Content-Type": "application/json",
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                ...(init.headers ?? {}),
+            },
         });
     } catch (err) {
         // Network-level failure (ERR_CONNECTION_REFUSED etc.) — the backend is down,
@@ -235,4 +291,47 @@ export const apiClient = {
     patchConfig: (patch: YoutubeConfigPatch) =>
         api<{ config: YoutubeConfigShape }>("/config", { method: "PATCH", body: SafeJSON.stringify(patch) }),
     health: () => api<{ ok?: boolean; status?: string }>("/healthz"),
+
+    register: (email: string, password: string) =>
+        api<{ user: YtUser; token: string }>("/users/register", {
+            method: "POST",
+            body: SafeJSON.stringify({ email, password }),
+        }),
+    login: (email: string, password: string) =>
+        api<{ user: YtUser; token: string }>("/users/login", {
+            method: "POST",
+            body: SafeJSON.stringify({ email, password }),
+        }),
+    me: () => api<{ user: YtUser; role: string }>("/users/me"),
+
+    listCollections: () => api<{ collections: Array<CollectionRecord & { videoCount: number }> }>("/collections"),
+    createCollection: (body: { name: string; kind: CollectionKind; rule?: unknown }) =>
+        api<{ collection: CollectionRecord }>("/collections", { method: "POST", body: SafeJSON.stringify(body) }),
+    getCollection: (id: number) => api<{ collection: CollectionRecord; videos: VideoLite[] }>(`/collections/${id}`),
+    deleteCollection: (id: number) => api<{ deleted: boolean }>(`/collections/${id}`, { method: "DELETE" }),
+    addCollectionVideo: (id: number, videoId: string) =>
+        api<{ added: boolean }>(`/collections/${id}/videos`, { method: "POST", body: SafeJSON.stringify({ videoId }) }),
+    removeCollectionVideo: (id: number, videoId: string) =>
+        api<{ removed: boolean }>(`/collections/${id}/videos/${encodeURIComponent(videoId)}`, { method: "DELETE" }),
+    askCollection: (id: number, body: { question: string; threadId?: number; provider?: string; model?: string }) =>
+        api<CollectionAskResponse>(`/collections/${id}/ask`, { method: "POST", body: SafeJSON.stringify(body) }),
+    listThreads: (id: number) => api<{ threads: AskThreadRecord[] }>(`/collections/${id}/threads`),
+    getThread: (threadId: number) =>
+        api<{ thread: AskThreadRecord; messages: AskMessageRecord[] }>(`/collections/threads/${threadId}`),
+
+    getHistory: (groupBy: "video" | "action", limit?: number) =>
+        api<HistoryResponse>(
+            withQuery("/users/history", [
+                ["groupBy", groupBy],
+                ["limit", limit],
+            ])
+        ),
+
+    getWatchlist: () => api<{ channels: WatchlistEntry[] }>("/users/watchlist"),
+    addWatchlistChannel: (handle: string) =>
+        api<{ added: boolean }>("/users/watchlist", { method: "POST", body: SafeJSON.stringify({ handle }) }),
+    removeWatchlistChannel: (handle: string) =>
+        api<{ removed: boolean }>(`/users/watchlist/${encodeURIComponent(handle)}`, { method: "DELETE" }),
+    getDigest: (sinceDays?: number) => api<DigestResponse>(withQuery("/users/digest", [["sinceDays", sinceDays]])),
+    syncDigest: () => api<{ enqueuedJobIds: number[] }>("/users/digest/sync", { method: "POST" }),
 };

--- a/src/youtube/ui/api.hooks.ts
+++ b/src/youtube/ui/api.hooks.ts
@@ -1,6 +1,6 @@
 import type { YoutubeConfigPatch } from "@app/youtube/lib/config.api.types";
-import type { ChannelHandle, JobStage, JobStatus, QaSource, VideoId } from "@app/youtube/lib/types";
-import { apiClient, clearApiBaseUrlCache } from "@app/yt/api.client";
+import type { ChannelHandle, CollectionKind, JobStage, JobStatus, QaSource, VideoId } from "@app/youtube/lib/types";
+import { apiClient, clearApiBaseUrlCache, setUserToken } from "@app/yt/api.client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -251,6 +251,196 @@ export function usePatchServerConfig() {
         },
         onError: (error) => {
             toast.error("Saving settings failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useMe() {
+    return useQuery({ queryKey: ["me"], queryFn: () => apiClient.me(), retry: false });
+}
+
+export function useLogin() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (vars: { email: string; password: string }) => {
+            const result = await apiClient.login(vars.email, vars.password);
+            setUserToken(result.token);
+
+            return result;
+        },
+        onSuccess: () => queryClient.invalidateQueries(),
+    });
+}
+
+export function useRegister() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (vars: { email: string; password: string }) => {
+            const result = await apiClient.register(vars.email, vars.password);
+            setUserToken(result.token);
+
+            return result;
+        },
+        onSuccess: () => queryClient.invalidateQueries(),
+    });
+}
+
+export function useLogout() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async () => {
+            setUserToken(null);
+        },
+        onSuccess: () => queryClient.invalidateQueries(),
+    });
+}
+
+export function useCollections() {
+    return useQuery({
+        queryKey: ["collections"],
+        queryFn: () => apiClient.listCollections(),
+        select: (response) => response.collections,
+    });
+}
+
+export function useCollection(id: number | null) {
+    return useQuery({
+        queryKey: ["collection", id],
+        queryFn: () => apiClient.getCollection(id as number),
+        enabled: id !== null,
+    });
+}
+
+export function useCreateCollection() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (body: { name: string; kind: CollectionKind; rule?: unknown }) => apiClient.createCollection(body),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["collections"] }),
+        onError: (error) => {
+            toast.error("Creating collection failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useDeleteCollection() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (id: number) => apiClient.deleteCollection(id),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["collections"] }),
+        onError: (error) => {
+            toast.error("Deleting collection failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useAddCollectionVideo(id: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (videoId: string) => apiClient.addCollectionVideo(id, videoId),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["collection", id] }),
+        onError: (error) => {
+            toast.error("Adding video failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useRemoveCollectionVideo(id: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (videoId: string) => apiClient.removeCollectionVideo(id, videoId),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["collection", id] }),
+        onError: (error) => {
+            toast.error("Removing video failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useThreads(id: number | null) {
+    return useQuery({
+        queryKey: ["threads", id],
+        queryFn: () => apiClient.listThreads(id as number),
+        enabled: id !== null,
+        select: (response) => response.threads,
+    });
+}
+
+export function useThread(threadId: number | null) {
+    return useQuery({
+        queryKey: ["thread", threadId],
+        queryFn: () => apiClient.getThread(threadId as number),
+        enabled: threadId !== null,
+    });
+}
+
+export function useAskCollection(id: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (body: { question: string; threadId?: number; provider?: string; model?: string }) =>
+            apiClient.askCollection(id, body),
+        onSuccess: (result) => {
+            queryClient.invalidateQueries({ queryKey: ["threads", id] });
+            queryClient.invalidateQueries({ queryKey: ["thread", result.threadId] });
+        },
+        onError: (error) => {
+            toast.error("Ask failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useHistory(groupBy: "video" | "action") {
+    return useQuery({
+        queryKey: ["history", groupBy],
+        queryFn: () => apiClient.getHistory(groupBy),
+    });
+}
+
+export function useWatchlist() {
+    return useQuery({
+        queryKey: ["watchlist"],
+        queryFn: () => apiClient.getWatchlist(),
+        select: (response) => response.channels,
+    });
+}
+
+export function useToggleWatchlist() {
+    const queryClient = useQueryClient();
+
+    return useMutation<{ added: boolean } | { removed: boolean }, Error, { handle: string; follow: boolean }>({
+        mutationFn: (vars) =>
+            vars.follow ? apiClient.addWatchlistChannel(vars.handle) : apiClient.removeWatchlistChannel(vars.handle),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["watchlist"] });
+            queryClient.invalidateQueries({ queryKey: ["digest"] });
+        },
+        onError: (error) => {
+            toast.error("Updating watchlist failed", { description: errorMessage(error) });
+        },
+    });
+}
+
+export function useDigest(sinceDays: number) {
+    return useQuery({
+        queryKey: ["digest", sinceDays],
+        queryFn: () => apiClient.getDigest(sinceDays),
+    });
+}
+
+export function useDigestSync() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => apiClient.syncDigest(),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["digest"] }),
+        onError: (error) => {
+            toast.error("Sync failed", { description: errorMessage(error) });
         },
     });
 }

--- a/src/youtube/ui/components/account/account-section.tsx
+++ b/src/youtube/ui/components/account/account-section.tsx
@@ -1,0 +1,63 @@
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@app/utils/ui/components/card";
+import { Input } from "@app/utils/ui/components/input";
+import { useLogin, useLogout, useMe, useRegister } from "@app/yt/api.hooks";
+import { useState } from "react";
+
+export function AccountSection() {
+    const me = useMe();
+    const login = useLogin();
+    const register = useRegister();
+    const logout = useLogout();
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const busy = login.isPending || register.isPending;
+
+    if (me.data) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        Account <Badge variant="secondary">{me.data.role}</Badge>
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="flex items-center justify-between gap-3">
+                    <p className="text-sm text-muted-foreground">{me.data.user.email}</p>
+                    <Button variant="outline" size="sm" onClick={() => logout.mutate()}>
+                        Sign out
+                    </Button>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Account</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                <p className="text-sm text-muted-foreground">Sign in to use history, collections, and the watchlist.</p>
+                <Input placeholder="email" value={email} onChange={(event) => setEmail(event.target.value)} />
+                <Input
+                    placeholder="password"
+                    type="password"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                />
+                {(login.error ?? register.error) ? (
+                    <p className="text-sm text-destructive">{((login.error ?? register.error) as Error).message}</p>
+                ) : null}
+                <div className="flex gap-2">
+                    <Button disabled={busy} onClick={() => login.mutate({ email, password })}>
+                        Sign in
+                    </Button>
+                    <Button variant="outline" disabled={busy} onClick={() => register.mutate({ email, password })}>
+                        Register
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/youtube/ui/routeTree.gen.ts
+++ b/src/youtube/ui/routeTree.gen.ts
@@ -11,9 +11,13 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as JobsRouteImport } from './routes/jobs'
+import { Route as HistoryRouteImport } from './routes/history'
 import { Route as FirstRunRouteImport } from './routes/first-run'
+import { Route as DigestRouteImport } from './routes/digest'
+import { Route as CollectionsRouteImport } from './routes/collections'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as VideosIdRouteImport } from './routes/videos.$id'
+import { Route as CollectionsIdRouteImport } from './routes/collections.$id'
 import { Route as ChannelsHandleRouteImport } from './routes/channels.$handle'
 
 const SettingsRoute = SettingsRouteImport.update({
@@ -26,9 +30,24 @@ const JobsRoute = JobsRouteImport.update({
   path: '/jobs',
   getParentRoute: () => rootRouteImport,
 } as any)
+const HistoryRoute = HistoryRouteImport.update({
+  id: '/history',
+  path: '/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FirstRunRoute = FirstRunRouteImport.update({
   id: '/first-run',
   path: '/first-run',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DigestRoute = DigestRouteImport.update({
+  id: '/digest',
+  path: '/digest',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CollectionsRoute = CollectionsRouteImport.update({
+  id: '/collections',
+  path: '/collections',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -41,6 +60,11 @@ const VideosIdRoute = VideosIdRouteImport.update({
   path: '/videos/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CollectionsIdRoute = CollectionsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => CollectionsRoute,
+} as any)
 const ChannelsHandleRoute = ChannelsHandleRouteImport.update({
   id: '/channels/$handle',
   path: '/channels/$handle',
@@ -49,59 +73,86 @@ const ChannelsHandleRoute = ChannelsHandleRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/collections': typeof CollectionsRouteWithChildren
+  '/digest': typeof DigestRoute
   '/first-run': typeof FirstRunRoute
+  '/history': typeof HistoryRoute
   '/jobs': typeof JobsRoute
   '/settings': typeof SettingsRoute
   '/channels/$handle': typeof ChannelsHandleRoute
+  '/collections/$id': typeof CollectionsIdRoute
   '/videos/$id': typeof VideosIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/collections': typeof CollectionsRouteWithChildren
+  '/digest': typeof DigestRoute
   '/first-run': typeof FirstRunRoute
+  '/history': typeof HistoryRoute
   '/jobs': typeof JobsRoute
   '/settings': typeof SettingsRoute
   '/channels/$handle': typeof ChannelsHandleRoute
+  '/collections/$id': typeof CollectionsIdRoute
   '/videos/$id': typeof VideosIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/collections': typeof CollectionsRouteWithChildren
+  '/digest': typeof DigestRoute
   '/first-run': typeof FirstRunRoute
+  '/history': typeof HistoryRoute
   '/jobs': typeof JobsRoute
   '/settings': typeof SettingsRoute
   '/channels/$handle': typeof ChannelsHandleRoute
+  '/collections/$id': typeof CollectionsIdRoute
   '/videos/$id': typeof VideosIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/collections'
+    | '/digest'
     | '/first-run'
+    | '/history'
     | '/jobs'
     | '/settings'
     | '/channels/$handle'
+    | '/collections/$id'
     | '/videos/$id'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/collections'
+    | '/digest'
     | '/first-run'
+    | '/history'
     | '/jobs'
     | '/settings'
     | '/channels/$handle'
+    | '/collections/$id'
     | '/videos/$id'
   id:
     | '__root__'
     | '/'
+    | '/collections'
+    | '/digest'
     | '/first-run'
+    | '/history'
     | '/jobs'
     | '/settings'
     | '/channels/$handle'
+    | '/collections/$id'
     | '/videos/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CollectionsRoute: typeof CollectionsRouteWithChildren
+  DigestRoute: typeof DigestRoute
   FirstRunRoute: typeof FirstRunRoute
+  HistoryRoute: typeof HistoryRoute
   JobsRoute: typeof JobsRoute
   SettingsRoute: typeof SettingsRoute
   ChannelsHandleRoute: typeof ChannelsHandleRoute
@@ -124,11 +175,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JobsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/history': {
+      id: '/history'
+      path: '/history'
+      fullPath: '/history'
+      preLoaderRoute: typeof HistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/first-run': {
       id: '/first-run'
       path: '/first-run'
       fullPath: '/first-run'
       preLoaderRoute: typeof FirstRunRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/digest': {
+      id: '/digest'
+      path: '/digest'
+      fullPath: '/digest'
+      preLoaderRoute: typeof DigestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/collections': {
+      id: '/collections'
+      path: '/collections'
+      fullPath: '/collections'
+      preLoaderRoute: typeof CollectionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -145,6 +217,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof VideosIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/collections/$id': {
+      id: '/collections/$id'
+      path: '/$id'
+      fullPath: '/collections/$id'
+      preLoaderRoute: typeof CollectionsIdRouteImport
+      parentRoute: typeof CollectionsRoute
+    }
     '/channels/$handle': {
       id: '/channels/$handle'
       path: '/channels/$handle'
@@ -155,9 +234,24 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface CollectionsRouteChildren {
+  CollectionsIdRoute: typeof CollectionsIdRoute
+}
+
+const CollectionsRouteChildren: CollectionsRouteChildren = {
+  CollectionsIdRoute: CollectionsIdRoute,
+}
+
+const CollectionsRouteWithChildren = CollectionsRoute._addFileChildren(
+  CollectionsRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CollectionsRoute: CollectionsRouteWithChildren,
+  DigestRoute: DigestRoute,
   FirstRunRoute: FirstRunRoute,
+  HistoryRoute: HistoryRoute,
   JobsRoute: JobsRoute,
   SettingsRoute: SettingsRoute,
   ChannelsHandleRoute: ChannelsHandleRoute,

--- a/src/youtube/ui/routes/__root.tsx
+++ b/src/youtube/ui/routes/__root.tsx
@@ -6,7 +6,7 @@ import { pageTitleFromPath } from "@app/yt/lib/theme";
 import { useEventStream } from "@app/yt/ws.client";
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Link, Outlet, redirect, useRouterState } from "@tanstack/react-router";
-import { BriefcaseBusiness, PlaySquare, Settings, Youtube } from "lucide-react";
+import { BriefcaseBusiness, History, Library, Newspaper, PlaySquare, Settings, Youtube } from "lucide-react";
 import type React from "react";
 
 interface RouterContext {
@@ -82,6 +82,9 @@ function RootLayout() {
                             theme: "primary",
                             items: [
                                 { title: "Channels", url: "/", icon: Youtube },
+                                { title: "History", url: "/history", icon: History },
+                                { title: "Collections", url: "/collections", icon: Library },
+                                { title: "Digest", url: "/digest", icon: Newspaper },
                                 { title: "Jobs", url: "/jobs", icon: BriefcaseBusiness },
                                 { title: "Settings", url: "/settings", icon: Settings },
                             ],

--- a/src/youtube/ui/routes/channels.$handle.tsx
+++ b/src/youtube/ui/routes/channels.$handle.tsx
@@ -1,4 +1,6 @@
+import { Button } from "@app/utils/ui/components/button";
 import type { ChannelHandle } from "@app/youtube/lib/types";
+import { useToggleWatchlist, useWatchlist } from "@app/yt/api.hooks";
 import { VideoList } from "@app/yt/components/videos/video-list";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -8,6 +10,23 @@ export const Route = createFileRoute("/channels/$handle")({
 
 function ChannelDetailPage() {
     const { handle } = Route.useParams();
+    const watchlist = useWatchlist();
+    const toggle = useToggleWatchlist();
+    const followed = (watchlist.data ?? []).some((entry) => entry.channelHandle === handle);
 
-    return <VideoList handle={handle as ChannelHandle} />;
+    return (
+        <div className="space-y-3">
+            <div className="flex justify-end">
+                <Button
+                    size="sm"
+                    variant={followed ? "outline" : "default"}
+                    disabled={toggle.isPending}
+                    onClick={() => toggle.mutate({ handle, follow: !followed })}
+                >
+                    {followed ? "Unfollow" : "Follow"}
+                </Button>
+            </div>
+            <VideoList handle={handle as ChannelHandle} />
+        </div>
+    );
 }

--- a/src/youtube/ui/routes/collections.$id.tsx
+++ b/src/youtube/ui/routes/collections.$id.tsx
@@ -1,0 +1,169 @@
+import { SafeJSON } from "@app/utils/json";
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { Card, CardContent } from "@app/utils/ui/components/card";
+import { CollectionAskPanel } from "@app/utils/ui/components/youtube/collection-ask-panel";
+import type { AskMessageRecord } from "@app/youtube/lib/types";
+import { useAskCollection, useCollection, useRemoveCollectionVideo, useThread, useThreads } from "@app/yt/api.hooks";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+export const Route = createFileRoute("/collections/$id")({
+    component: CollectionDetailPage,
+});
+
+function ruleSummary(ruleJson: string | null): string {
+    if (!ruleJson) {
+        return "Dynamic collection";
+    }
+
+    const rule = SafeJSON.parse(ruleJson) as { type?: string; sinceDays?: number } | null;
+
+    if (rule?.type === "watched" && typeof rule.sinceDays === "number") {
+        return `Videos you watched in the last ${rule.sinceDays} days`;
+    }
+
+    return "Dynamic collection";
+}
+
+function optimisticUserMessage(threadId: number | null, content: string): AskMessageRecord {
+    return {
+        id: -1,
+        threadId: threadId ?? -1,
+        role: "user",
+        content,
+        toolName: null,
+        toolArgsJson: null,
+        createdAt: new Date().toISOString(),
+    };
+}
+
+function CollectionDetailPage() {
+    const params = Route.useParams();
+    const id = Number.parseInt(params.id, 10);
+    const validId = Number.isNaN(id) ? null : id;
+    const collection = useCollection(validId);
+    const threads = useThreads(validId);
+    const [threadId, setThreadId] = useState<number | null>(null);
+    const thread = useThread(threadId);
+    const ask = useAskCollection(validId ?? 0);
+    const removeVideo = useRemoveCollectionVideo(validId ?? 0);
+    const navigate = useNavigate();
+    const [pending, setPending] = useState<string | null>(null);
+
+    if (collection.isPending) {
+        return <p className="mx-auto max-w-4xl p-4 text-sm text-muted-foreground">Loading collection…</p>;
+    }
+
+    if (!collection.data) {
+        return <p className="mx-auto max-w-4xl p-4 text-sm text-muted-foreground">Collection not found.</p>;
+    }
+
+    const record = collection.data.collection;
+    const videos = collection.data.videos;
+    const baseMessages = thread.data?.messages ?? [];
+    const messages =
+        ask.isPending && pending ? [...baseMessages, optimisticUserMessage(threadId, pending)] : baseMessages;
+
+    const onSend = (question: string) => {
+        setPending(question);
+        ask.mutate(
+            { question, threadId: threadId ?? undefined },
+            {
+                onSuccess: (result) => setThreadId(result.threadId),
+                onSettled: () => setPending(null),
+            }
+        );
+    };
+
+    return (
+        <div className="mx-auto max-w-4xl space-y-4 p-4">
+            <header className="space-y-1">
+                <h1 className="text-xl font-semibold">{record.name}</h1>
+                <div className="flex items-center gap-2">
+                    <Badge variant="secondary">{record.kind}</Badge>
+                    {record.kind === "dynamic" ? (
+                        <span className="text-xs text-muted-foreground">{ruleSummary(record.ruleJson)}</span>
+                    ) : null}
+                </div>
+            </header>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+                {videos.map((video) => (
+                    <Card key={video.id}>
+                        <CardContent className="flex gap-3 pt-6">
+                            {video.thumbUrl ? (
+                                <button
+                                    type="button"
+                                    className="shrink-0"
+                                    onClick={() => void navigate({ to: "/videos/$id", params: { id: video.id } })}
+                                >
+                                    <img src={video.thumbUrl} alt="" className="h-16 w-28 rounded object-cover" />
+                                </button>
+                            ) : null}
+                            <div className="min-w-0 flex-1">
+                                <button
+                                    type="button"
+                                    className="block truncate text-left text-sm font-medium hover:underline"
+                                    onClick={() => void navigate({ to: "/videos/$id", params: { id: video.id } })}
+                                >
+                                    {video.title}
+                                </button>
+                                <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                                    {video.hasSummary ? <Badge variant="secondary">Summary</Badge> : null}
+                                    {video.hasTranscript ? <Badge variant="secondary">Transcript</Badge> : null}
+                                    {record.kind === "manual" ? (
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            disabled={removeVideo.isPending}
+                                            onClick={() => removeVideo.mutate(video.id)}
+                                        >
+                                            Remove
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+                {videos.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        {record.kind === "manual"
+                            ? "No videos yet. Add some from a video page."
+                            : "No videos match this rule yet."}
+                    </p>
+                ) : null}
+            </div>
+
+            <section className="space-y-2">
+                <h2 className="text-base font-semibold">Ask this collection</h2>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                        size="sm"
+                        variant={threadId === null ? "default" : "outline"}
+                        onClick={() => setThreadId(null)}
+                    >
+                        New conversation
+                    </Button>
+                    {(threads.data ?? []).map((item) => (
+                        <Button
+                            key={item.id}
+                            size="sm"
+                            variant={threadId === item.id ? "default" : "outline"}
+                            onClick={() => setThreadId(item.id)}
+                        >
+                            {item.title}
+                        </Button>
+                    ))}
+                </div>
+                <CollectionAskPanel
+                    messages={messages}
+                    busy={ask.isPending}
+                    error={ask.error ? (ask.error as Error).message : null}
+                    onSend={onSend}
+                />
+            </section>
+        </div>
+    );
+}

--- a/src/youtube/ui/routes/collections.tsx
+++ b/src/youtube/ui/routes/collections.tsx
@@ -1,0 +1,125 @@
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@app/utils/ui/components/card";
+import { Input } from "@app/utils/ui/components/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@app/utils/ui/components/select";
+import { useCollections, useCreateCollection, useDeleteCollection } from "@app/yt/api.hooks";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+
+export const Route = createFileRoute("/collections")({
+    component: CollectionsPage,
+});
+
+const KIND_PRESETS: Array<{ value: string; label: string }> = [
+    { value: "manual", label: "Manual — add videos yourself" },
+    { value: "watched:7", label: "Dynamic — watched last 7 days" },
+    { value: "watched:30", label: "Dynamic — watched last 30 days" },
+    { value: "watched:90", label: "Dynamic — watched last 90 days" },
+];
+
+function buildCreateBody(name: string, preset: string) {
+    if (preset === "manual") {
+        return { name, kind: "manual" as const };
+    }
+
+    const sinceDays = Number.parseInt(preset.split(":")[1] ?? "30", 10);
+
+    return { name, kind: "dynamic" as const, rule: { type: "watched", sinceDays } };
+}
+
+function CollectionsPage() {
+    const collections = useCollections();
+    const create = useCreateCollection();
+    const remove = useDeleteCollection();
+    const navigate = useNavigate();
+    const [name, setName] = useState("");
+    const [preset, setPreset] = useState("manual");
+
+    const onCreate = () => {
+        const trimmed = name.trim();
+
+        if (!trimmed || create.isPending) {
+            return;
+        }
+
+        create.mutate(buildCreateBody(trimmed, preset), { onSuccess: () => setName("") });
+    };
+
+    return (
+        <div className="mx-auto max-w-4xl space-y-4 p-4">
+            <h1 className="text-xl font-semibold">Collections</h1>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">New collection</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                    <Input
+                        placeholder="Collection name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                                onCreate();
+                            }
+                        }}
+                    />
+                    <Select value={preset} onValueChange={setPreset}>
+                        <SelectTrigger className="sm:w-72">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {KIND_PRESETS.map((option) => (
+                                <SelectItem key={option.value} value={option.value}>
+                                    {option.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <Button disabled={create.isPending || !name.trim()} onClick={onCreate}>
+                        Create
+                    </Button>
+                </CardContent>
+            </Card>
+
+            {collections.isPending ? <p className="text-sm text-muted-foreground">Loading collections…</p> : null}
+            {collections.data?.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No collections yet. Create one above.</p>
+            ) : null}
+
+            <div className="space-y-3">
+                {(collections.data ?? []).map((collection) => (
+                    <Card key={collection.id}>
+                        <CardContent className="flex items-center justify-between gap-3 pt-6">
+                            <button
+                                type="button"
+                                className="min-w-0 text-left"
+                                onClick={() =>
+                                    void navigate({ to: "/collections/$id", params: { id: String(collection.id) } })
+                                }
+                            >
+                                <p className="truncate font-medium hover:underline">{collection.name}</p>
+                                <div className="mt-1 flex items-center gap-2">
+                                    <Badge variant="secondary">{collection.kind}</Badge>
+                                    <span className="text-xs text-muted-foreground">
+                                        {collection.videoCount} video{collection.videoCount === 1 ? "" : "s"}
+                                    </span>
+                                </div>
+                            </button>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={remove.isPending}
+                                onClick={() => remove.mutate(collection.id)}
+                            >
+                                <Trash2 className="size-4" />
+                            </Button>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/youtube/ui/routes/digest.tsx
+++ b/src/youtube/ui/routes/digest.tsx
@@ -1,0 +1,116 @@
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@app/utils/ui/components/card";
+import { useDigest, useDigestSync } from "@app/yt/api.hooks";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
+
+export const Route = createFileRoute("/digest")({
+    component: DigestPage,
+});
+
+const SINCE_OPTIONS = [7, 30, 90];
+
+function DigestPage() {
+    const [sinceDays, setSinceDays] = useState(7);
+    const digest = useDigest(sinceDays);
+    const sync = useDigestSync();
+    const navigate = useNavigate();
+    const channels = digest.data?.channels ?? [];
+    const totalVideos = channels.reduce((sum, channel) => sum + channel.videos.length, 0);
+
+    return (
+        <div className="mx-auto max-w-4xl space-y-4 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <h1 className="text-xl font-semibold">Digest</h1>
+                <Button variant="outline" size="sm" disabled={sync.isPending} onClick={() => sync.mutate()}>
+                    <RefreshCw className="mr-2 size-4" /> Check for new videos
+                </Button>
+            </div>
+
+            <div className="flex items-center gap-2">
+                {SINCE_OPTIONS.map((days) => (
+                    <Button
+                        key={days}
+                        size="sm"
+                        variant={sinceDays === days ? "default" : "outline"}
+                        onClick={() => setSinceDays(days)}
+                    >
+                        Last {days} days
+                    </Button>
+                ))}
+            </div>
+
+            {digest.isPending ? <p className="text-sm text-muted-foreground">Loading digest…</p> : null}
+
+            {!digest.isPending && channels.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                    Follow channels to build your digest.{" "}
+                    <Link to="/" className="underline">
+                        Browse channels
+                    </Link>
+                </p>
+            ) : null}
+
+            {!digest.isPending && channels.length > 0 && totalVideos === 0 ? (
+                <p className="text-sm text-muted-foreground">Nothing new since {digest.data?.since}.</p>
+            ) : null}
+
+            <div className="space-y-4">
+                {channels
+                    .filter((channel) => channel.videos.length > 0)
+                    .map((channel) => (
+                        <Card key={channel.handle}>
+                            <CardHeader>
+                                <CardTitle className="text-base">{channel.handle}</CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-2">
+                                {channel.videos.map((video) => (
+                                    <div key={video.id} className="flex items-center gap-3">
+                                        {video.thumbUrl ? (
+                                            <button
+                                                type="button"
+                                                className="shrink-0"
+                                                onClick={() =>
+                                                    void navigate({ to: "/videos/$id", params: { id: video.id } })
+                                                }
+                                            >
+                                                <img
+                                                    src={video.thumbUrl}
+                                                    alt=""
+                                                    className="h-14 w-24 rounded object-cover"
+                                                />
+                                            </button>
+                                        ) : null}
+                                        <div className="min-w-0 flex-1">
+                                            <button
+                                                type="button"
+                                                className="block truncate text-left text-sm font-medium hover:underline"
+                                                onClick={() =>
+                                                    void navigate({ to: "/videos/$id", params: { id: video.id } })
+                                                }
+                                            >
+                                                {video.title}
+                                            </button>
+                                            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                                                {video.uploadDate ? (
+                                                    <span className="text-xs text-muted-foreground">
+                                                        {video.uploadDate}
+                                                    </span>
+                                                ) : null}
+                                                {video.hasSummary ? <Badge variant="secondary">Summary</Badge> : null}
+                                                {video.hasTranscript ? (
+                                                    <Badge variant="secondary">Transcript</Badge>
+                                                ) : null}
+                                            </div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </CardContent>
+                        </Card>
+                    ))}
+            </div>
+        </div>
+    );
+}

--- a/src/youtube/ui/routes/history.tsx
+++ b/src/youtube/ui/routes/history.tsx
@@ -1,0 +1,29 @@
+import { HistoryView } from "@app/utils/ui/components/youtube/history-view";
+import { useHistory } from "@app/yt/api.hooks";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+export const Route = createFileRoute("/history")({
+    component: HistoryPage,
+});
+
+function HistoryPage() {
+    const [mode, setMode] = useState<"video" | "action">("video");
+    const history = useHistory(mode);
+    const navigate = useNavigate();
+
+    return (
+        <div className="mx-auto max-w-4xl space-y-4 p-4">
+            <h1 className="text-xl font-semibold">History</h1>
+            <HistoryView
+                mode={mode}
+                onModeChange={setMode}
+                videoGroups={history.data?.videos}
+                actionGroups={history.data?.actions}
+                videosById={history.data?.videosById ?? {}}
+                onOpenVideo={(videoId) => void navigate({ to: "/videos/$id", params: { id: videoId } })}
+                loading={history.isPending}
+            />
+        </div>
+    );
+}

--- a/src/youtube/ui/routes/settings.tsx
+++ b/src/youtube/ui/routes/settings.tsx
@@ -17,6 +17,7 @@ import { Switch } from "@app/utils/ui/components/switch";
 import type { YoutubeConfigShape } from "@app/youtube/lib/types";
 import { apiClient } from "@app/yt/api.client";
 import { useCacheStats, useClearCache, usePatchServerConfig, usePruneCache, useServerConfig } from "@app/yt/api.hooks";
+import { AccountSection } from "@app/yt/components/account/account-section";
 import { Loading } from "@app/yt/components/shared/loading";
 import { formatBytes } from "@app/yt/lib/format";
 import { createFileRoute } from "@tanstack/react-router";
@@ -113,6 +114,8 @@ function SettingsPage() {
                     Config path: {config.data?.where ?? "~/.genesis-tools/youtube/server.json"}
                 </p>
             </header>
+
+            <AccountSection />
 
             <SettingsCard icon={<Server className="size-5" />} title="API Endpoint">
                 <div className="grid gap-3 md:grid-cols-[1fr_auto] md:items-end">


### PR DESCRIPTION
## Summary

- Collections storage (manual + dynamic rows, membership), ask-thread + message persistence, watchlist storage with watch-gating readers
- Rule-based dynamic collection resolution; user history assembly (by-video / by-action grouping)
- Collections CRUD + thread routes; bounded tool-loop agent for collection ask; history, watchlist, and on-demand digest routes
- Web UI: user token plumbing + account section, history page, collections pages with multi-turn ask panel, digest page + channel follow toggles

## Stack

1. feat(youtube): product surface base
2. fix(youtube): phase 0 — panel scroll, comments feedback, dialog rework, audit sweep
3. feat(youtube): phase 1 foundations — roles, ai task mapping, audit tables, typed auth, WS scoping, transcript fallback
4. **feat(youtube): phase 3 web features — history, collections, collection-ask agent, watchlist + digest** ← you are here
5. feat(youtube): phase 2 billing — Stripe subscriptions, resetting allowance, free tier, referrals
6. feat(youtube): phase 4 extension — feature port, monetization UI, 16:9 admin panel + admin API
7. feat(youtube): phase 5 customization + production polish — settings, sweep fixes, review-fix wave

Part of the #263 split; merge bottom-up.
