### PR TITLE
feat(youtube): phase 2 billing — Stripe subscriptions, resetting allowance, free tier, referrals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -147,6 +147,7 @@
         "solid-js": "1.9.11",
         "sonner": "^2.0.7",
         "sqlite-vec": "^0.1.7",
+        "stripe": "^22.3.1",
         "supports-color": "^10.2.2",
         "tar-stream": "^3.2.0",
         "telegram": "^2.26.22",
@@ -3268,6 +3269,8 @@
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "stripe": ["stripe@22.3.1", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw=="],
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
         "solid-js": "1.9.11",
         "sonner": "^2.0.7",
         "sqlite-vec": "^0.1.7",
+        "stripe": "^22.3.1",
         "supports-color": "^10.2.2",
         "tar-stream": "^3.2.0",
         "telegram": "^2.26.22",

--- a/src/youtube/extension/shared/messages.ts
+++ b/src/youtube/extension/shared/messages.ts
@@ -7,6 +7,7 @@ import type {
     LedgerPage,
     LlmEstimate,
     LockedArtifact,
+    MeBillingContext,
     PipelineJob,
     PromptPreset,
     QaHistoryItem,
@@ -186,7 +187,7 @@ export interface ExtensionApiMap {
     "api:register": { user: YtUser; token: string };
     "api:login": { user: YtUser; token: string };
     "api:logout": { ok: true };
-    "api:me": { user: YtUser; role: YtRole };
+    "api:me": { user: YtUser; role: YtRole; billing: MeBillingContext };
     "api:queueStats": { queue: QueueStats };
     "api:topup": { user: YtUser };
     "api:qaHistory": { items: QaHistoryItem[] };

--- a/src/youtube/lib/__tests__/billing-cycle.test.ts
+++ b/src/youtube/lib/__tests__/billing-cycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { computeAllowanceReset, computePeriodState, monthKeyUtc } from "@app/youtube/lib/billing-cycle";
+
+const base = { periodStartBalance: 3200, allowanceGranted: 3000, newAllowance: 3000 };
+
+describe("computeAllowanceReset", () => {
+    it("A: no-spend renewal is NOT additive (delta 0)", () => {
+        expect(computeAllowanceReset({ ...base, balance: 3200, grantsSince: 0 })).toEqual({
+            spentSince: 0,
+            allowanceRemaining: 3000,
+            topupRemainder: 200,
+            newBalance: 3200,
+            delta: 0,
+        });
+    });
+
+    it("B: partial spend refills exactly what was used", () => {
+        expect(computeAllowanceReset({ ...base, balance: 2000, grantsSince: 0 })).toEqual({
+            spentSince: 1200,
+            allowanceRemaining: 1800,
+            topupRemainder: 200,
+            newBalance: 3200,
+            delta: 1200,
+        });
+    });
+
+    it("C: overspend into topup — full allowance refill, topup remainder kept", () => {
+        expect(computeAllowanceReset({ ...base, balance: 100, grantsSince: 0 })).toEqual({
+            spentSince: 3100,
+            allowanceRemaining: 0,
+            topupRemainder: 100,
+            newBalance: 3100,
+            delta: 3000,
+        });
+    });
+
+    it("D: mid-period pack purchase survives the reset", () => {
+        expect(computeAllowanceReset({ ...base, balance: 2500, grantsSince: 500 })).toEqual({
+            spentSince: 1200,
+            allowanceRemaining: 1800,
+            topupRemainder: 700,
+            newBalance: 3700,
+            delta: 1200,
+        });
+    });
+
+    it("E: downgrade produces a negative delta but never touches topup", () => {
+        expect(computeAllowanceReset({ ...base, balance: 2500, grantsSince: 500, newAllowance: 1000 })).toEqual({
+            spentSince: 1200,
+            allowanceRemaining: 1800,
+            topupRemainder: 700,
+            newBalance: 1700,
+            delta: -800,
+        });
+    });
+});
+
+describe("computePeriodState / monthKeyUtc", () => {
+    it("clamps allowanceRemaining by current balance", () => {
+        const state = computePeriodState({
+            balance: 50,
+            periodStartBalance: 3000,
+            grantsSince: 0,
+            allowanceGranted: 3000,
+        });
+
+        expect(state.allowanceRemaining).toBe(50);
+        expect(state.topupRemainder).toBe(0);
+    });
+
+    it("formats UTC month keys", () => {
+        expect(monthKeyUtc(new Date("2026-07-17T23:59:59Z"))).toBe("2026-07");
+        expect(monthKeyUtc(new Date("2026-12-01T00:00:00Z"))).toBe("2026-12");
+    });
+});

--- a/src/youtube/lib/__tests__/billing-db.test.ts
+++ b/src/youtube/lib/__tests__/billing-db.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("subscriptions", () => {
+    it("upserts by user and reads back by user and stripe id", () => {
+        const created = db.upsertSubscription({
+            userId: 7,
+            stripeCustomerId: "cus_1",
+            stripeSubscriptionId: "sub_1",
+            planId: "sub-monthly",
+            status: "active",
+            allowance: 3000,
+            periodStartBalance: 100,
+        });
+
+        expect(created.status).toBe("active");
+        expect(db.getSubscriptionByUserId(7)?.stripeSubscriptionId).toBe("sub_1");
+        expect(db.getSubscriptionByStripeId("sub_1")?.userId).toBe(7);
+
+        const again = db.upsertSubscription({
+            userId: 7,
+            stripeCustomerId: "cus_1",
+            stripeSubscriptionId: "sub_1",
+            planId: "sub-monthly",
+            status: "past_due",
+            allowance: 3000,
+        });
+
+        expect(again.id).toBe(created.id);
+        expect(db.getSubscriptionByUserId(7)?.status).toBe("past_due");
+    });
+
+    it("applies partial updates", () => {
+        const sub = db.upsertSubscription({ userId: 8, planId: "sub-monthly", status: "active", allowance: 3000 });
+        db.updateSubscription(sub.id, {
+            status: "canceled",
+            cancelAtPeriodEnd: true,
+            periodEnd: "2026-08-01T00:00:00.000Z",
+        });
+        const read = db.getSubscriptionByUserId(8);
+
+        expect(read?.status).toBe("canceled");
+        expect(read?.cancelAtPeriodEnd).toBe(true);
+        expect(read?.periodEnd).toBe("2026-08-01T00:00:00.000Z");
+    });
+});
+
+describe("payments + webhook logs", () => {
+    it("payments are replay-safe on stripe_ref", () => {
+        db.recordPayment({
+            userId: 7,
+            kind: "pack",
+            stripeRef: "cs_1",
+            packId: "pack-small",
+            amountCents: 499,
+            currency: "usd",
+            credits: 500,
+            status: "succeeded",
+        });
+        db.recordPayment({
+            userId: 7,
+            kind: "pack",
+            stripeRef: "cs_1",
+            packId: "pack-small",
+            amountCents: 499,
+            currency: "usd",
+            credits: 500,
+            status: "succeeded",
+        });
+
+        expect(db.listPayments({ userId: 7 })).toHaveLength(1);
+    });
+
+    it("webhook logs upsert on event id", () => {
+        db.recordWebhookLog({
+            stripeEventId: "evt_1",
+            type: "invoice.paid",
+            payloadHash: "aa",
+            outcome: "error",
+            detail: "boom",
+        });
+        db.recordWebhookLog({ stripeEventId: "evt_1", type: "invoice.paid", payloadHash: "aa", outcome: "processed" });
+        const log = db.getWebhookLog("evt_1");
+
+        expect(log?.outcome).toBe("processed");
+        expect(log?.detail).toBeNull();
+        expect(db.getWebhookLog("evt_missing")).toBeNull();
+    });
+});
+
+describe("quota + grants", () => {
+    it("increments quota until the limit, then denies without incrementing", () => {
+        expect(db.incrementQuotaIfBelow(7, "2026-07", 2)).toEqual({ allowed: true, used: 1 });
+        expect(db.incrementQuotaIfBelow(7, "2026-07", 2)).toEqual({ allowed: true, used: 2 });
+        expect(db.incrementQuotaIfBelow(7, "2026-07", 2)).toEqual({ allowed: false, used: 2 });
+        expect(db.getQuotaUsed(7, "2026-07")).toBe(2);
+        expect(db.getQuotaUsed(7, "2026-08")).toBe(0);
+    });
+
+    it("getGrantsSince sums only grant-type positive deltas; hasAnyStripeGrant detects payers", () => {
+        const user = db.createUser({ email: "g@example.com", passwordHash: "h", apiToken: "ytu_g" });
+        db.grantCredits(user.id, 100, "register-grant");
+        db.grantCredits(user.id, 500, "stripe:cs_x");
+        db.spendCredits(user.id, 50, "ask");
+        const since = "2000-01-01T00:00:00.000Z";
+
+        expect(db.getGrantsSince(user.id, since)).toBe(600);
+        expect(db.getUserCredits(user.id)).toBe(550);
+        expect(db.getUserCredits(999_999)).toBeNull();
+        expect(db.hasAnyStripeGrant(user.id)).toBe(true);
+        const other = db.createUser({ email: "n@example.com", passwordHash: "h", apiToken: "ytu_n" });
+
+        expect(db.hasAnyStripeGrant(other.id)).toBe(false);
+    });
+});

--- a/src/youtube/lib/__tests__/billing-gateway.test.ts
+++ b/src/youtube/lib/__tests__/billing-gateway.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "bun:test";
+import { createStripeGateway } from "@app/youtube/lib/billing-gateway";
+
+describe("createStripeGateway", () => {
+    it("constructs offline and exposes both checkout methods", () => {
+        const gateway = createStripeGateway("sk_test_offline_construct_only");
+
+        expect(typeof gateway.createPackCheckout).toBe("function");
+        expect(typeof gateway.createSubscriptionCheckout).toBe("function");
+    });
+});

--- a/src/youtube/lib/__tests__/billing-webhooks.test.ts
+++ b/src/youtube/lib/__tests__/billing-webhooks.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import { handleStripeEvent } from "@app/youtube/lib/billing";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+const SECRET = "whsec_p2_tests";
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+function signPayload(secret: string, payloadObj: unknown): { payload: string; signature: string } {
+    const payload = SafeJSON.stringify(payloadObj, { strict: true });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const sig = createHmac("sha256", secret).update(`${timestamp}.${payload}`).digest("hex");
+
+    return { payload, signature: `t=${timestamp},v1=${sig}` };
+}
+
+async function deliver(eventObj: unknown): Promise<void> {
+    const { payload, signature } = signPayload(SECRET, eventObj);
+
+    await env.testing.withOverrides({ STRIPE_WEBHOOK_SECRET: SECRET }, async () => {
+        await handleStripeEvent(db, payload, signature);
+    });
+}
+
+function subCheckoutEvent(userId: number, eventId = "evt_co_1") {
+    return {
+        id: eventId,
+        type: "checkout.session.completed",
+        data: {
+            object: {
+                id: "cs_sub_1",
+                mode: "subscription",
+                customer: "cus_1",
+                subscription: "sub_1",
+                client_reference_id: String(userId),
+                metadata: { planId: "sub-monthly", userId: String(userId) },
+            },
+        },
+    };
+}
+
+function invoicePaidEvent(eventId: string, invoiceId: string, periodStartSec: number, periodEndSec: number) {
+    return {
+        id: eventId,
+        type: "invoice.paid",
+        data: {
+            object: {
+                id: invoiceId,
+                subscription: "sub_1",
+                amount_paid: 999,
+                currency: "usd",
+                lines: { data: [{ period: { start: periodStartSec, end: periodEndSec } }] },
+            },
+        },
+    };
+}
+
+describe("subscription webhook lifecycle", () => {
+    it("checkout.session.completed (subscription) creates the subscription row", async () => {
+        const user = db.createUser({ email: "w@example.com", passwordHash: "h", apiToken: "ytu_w" });
+        await deliver(subCheckoutEvent(user.id));
+        const sub = db.getSubscriptionByUserId(user.id);
+
+        expect(sub?.stripeSubscriptionId).toBe("sub_1");
+        expect(sub?.status).toBe("active");
+        expect(sub?.periodStart).toBeNull();
+        expect(db.getWebhookLog("evt_co_1")?.outcome).toBe("processed");
+    });
+
+    it("first invoice.paid grants the allowance additively; renewal resets instead of stacking", async () => {
+        const user = db.createUser({ email: "w2@example.com", passwordHash: "h", apiToken: "ytu_w2" });
+        db.grantCredits(user.id, 100, "register-grant");
+        await deliver(subCheckoutEvent(user.id));
+        // Period start sits an hour AFTER the register-grant ledger row: the
+        // renewal's getGrantsSince(periodStart) must not re-count pre-period
+        // grants (they are already inside period_start_balance). Same-second
+        // timestamps would double-count and break the reset assertion.
+        const periodStartSec = Math.floor(Date.now() / 1000) + 3600;
+
+        await deliver(invoicePaidEvent("evt_inv_1", "in_1", periodStartSec, periodStartSec + 2_592_000));
+        expect(db.getUserCredits(user.id)).toBe(3100);
+
+        db.spendCredits(user.id, 1200, "ask");
+        await deliver(invoicePaidEvent("evt_inv_2", "in_2", periodStartSec + 2_592_000, periodStartSec + 5_184_000));
+        // Reset, not additive: topup remainder (100) + fresh allowance (3000).
+        expect(db.getUserCredits(user.id)).toBe(3100);
+        expect(db.listPayments({ userId: user.id })).toHaveLength(2);
+    });
+
+    it("is idempotent across exact redelivery AND distinct events for the same invoice", async () => {
+        const user = db.createUser({ email: "w3@example.com", passwordHash: "h", apiToken: "ytu_w3" });
+        await deliver(subCheckoutEvent(user.id));
+        const nowSec = Math.floor(Date.now() / 1000);
+
+        await deliver(invoicePaidEvent("evt_inv_a", "in_x", nowSec, nowSec + 2_592_000));
+        await deliver(invoicePaidEvent("evt_inv_a", "in_x", nowSec, nowSec + 2_592_000));
+        await deliver(invoicePaidEvent("evt_inv_b", "in_x", nowSec, nowSec + 2_592_000));
+        expect(db.getUserCredits(user.id)).toBe(3000);
+    });
+
+    it("invoice.payment_failed marks past_due and records a failed payment", async () => {
+        const user = db.createUser({ email: "w4@example.com", passwordHash: "h", apiToken: "ytu_w4" });
+        await deliver(subCheckoutEvent(user.id));
+        await deliver({
+            id: "evt_fail_1",
+            type: "invoice.payment_failed",
+            data: { object: { id: "in_fail", subscription: "sub_1", amount_due: 999, currency: "usd" } },
+        });
+
+        expect(db.getSubscriptionByUserId(user.id)?.status).toBe("past_due");
+        expect(db.listPayments({ userId: user.id })[0]?.status).toBe("failed");
+    });
+
+    it("customer.subscription.updated + deleted track status", async () => {
+        const user = db.createUser({ email: "w5@example.com", passwordHash: "h", apiToken: "ytu_w5" });
+        await deliver(subCheckoutEvent(user.id));
+        await deliver({
+            id: "evt_upd_1",
+            type: "customer.subscription.updated",
+            data: {
+                object: {
+                    id: "sub_1",
+                    status: "active",
+                    cancel_at_period_end: true,
+                    current_period_end: 1_800_000_000,
+                },
+            },
+        });
+
+        expect(db.getSubscriptionByUserId(user.id)?.cancelAtPeriodEnd).toBe(true);
+
+        await deliver({
+            id: "evt_del_1",
+            type: "customer.subscription.deleted",
+            data: { object: { id: "sub_1", status: "canceled" } },
+        });
+        expect(db.getSubscriptionByUserId(user.id)?.status).toBe("canceled");
+    });
+
+    it("unhandled event types log outcome skipped", async () => {
+        await deliver({ id: "evt_misc", type: "customer.created", data: { object: {} } });
+        expect(db.getWebhookLog("evt_misc")?.outcome).toBe("skipped");
+    });
+});

--- a/src/youtube/lib/__tests__/billing.test.ts
+++ b/src/youtube/lib/__tests__/billing.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { createHmac } from "node:crypto";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
-import { createCheckoutSession, handleStripeEvent, verifyStripeSignature } from "@app/youtube/lib/billing";
+import {
+    createCheckoutSession,
+    createSubscriptionCheckoutSession,
+    handleStripeEvent,
+    verifyStripeSignature,
+} from "@app/youtube/lib/billing";
 import { YoutubeDatabase } from "@app/youtube/lib/db";
 
 // Golden vector — recomputed via:
@@ -83,69 +88,80 @@ function signPayload(secret: string, payloadObj: unknown): { payload: string; si
     return { payload, signature: `t=${t},v1=${sig}` };
 }
 
-describe("createCheckoutSession", () => {
-    const originalFetch = globalThis.fetch;
+function fakeGateway() {
+    const calls: { pack: unknown[]; sub: unknown[] } = { pack: [], sub: [] };
+    const gateway = {
+        createPackCheckout: async (input: unknown) => {
+            calls.pack.push(input);
+            return { id: "cs_fake", url: "https://checkout.stripe.test/cs_fake" };
+        },
+        createSubscriptionCheckout: async (input: unknown) => {
+            calls.sub.push(input);
+            return { id: "cs_sub_fake", url: "https://checkout.stripe.test/cs_sub_fake" };
+        },
+    };
 
-    afterEach(() => {
-        globalThis.fetch = originalFetch;
-    });
+    return { gateway, calls };
+}
 
-    it("posts to the stripe REST API and returns the checkout url", async () => {
-        let capturedBody = "";
-        let capturedAuth = "";
-        globalThis.fetch = (async (_input, init) => {
-            capturedBody = String(init?.body ?? "");
-            capturedAuth = String((init?.headers as Record<string, string> | undefined)?.Authorization ?? "");
+describe("createCheckoutSession (gateway)", () => {
+    const user = { id: 7, email: "u@example.com", credits: 0, createdAt: "", outputLang: null, ttsVoice: null };
 
-            return new Response(
-                SafeJSON.stringify({ url: "https://checkout.stripe.com/session/abc" }, { strict: true }),
-                { status: 200, headers: { "Content-Type": "application/json" } }
-            );
-        }) as typeof fetch;
+    it("resolves the pack price and returns the gateway url", async () => {
+        const { gateway, calls } = fakeGateway();
+        let url = "";
 
         await env.testing.withOverrides(
-            { STRIPE_SECRET_KEY: "sk_test_123", STRIPE_PRICE_PACK_MEDIUM: "price_medium_123" },
+            { STRIPE_SECRET_KEY: "sk_test_x", STRIPE_PRICE_PACK_SMALL: "price_small" },
             async () => {
-                const result = await createCheckoutSession({
-                    user: {
-                        id: 7,
-                        email: "buyer@example.com",
-                        credits: 0,
-                        createdAt: "2026-01-01T00:00:00.000Z",
-                        outputLang: null,
-                        ttsVoice: null,
-                    },
-                    packId: "pack-medium",
-                    origin: "https://example.com",
-                });
-
-                expect(result.url).toBe("https://checkout.stripe.com/session/abc");
+                ({ url } = await createCheckoutSession({ user, packId: "pack-small", origin: "o", gateway }));
             }
         );
 
-        expect(capturedAuth).toBe("Bearer sk_test_123");
-        expect(capturedBody).toContain("metadata%5BpackId%5D=pack-medium");
-        expect(capturedBody).toContain("metadata%5BuserId%5D=7");
-        expect(capturedBody).toContain("success_url=https%3A%2F%2Fwww.youtube.com");
+        expect(url).toBe("https://checkout.stripe.test/cs_fake");
+        expect(calls.pack).toEqual([{ priceId: "price_small", userId: 7, packId: "pack-small" }]);
     });
 
     it("throws 'billing not configured' when STRIPE_SECRET_KEY is unset", async () => {
+        const { gateway } = fakeGateway();
+
         await env.testing.withOverrides({ STRIPE_SECRET_KEY: undefined }, async () => {
-            await expect(
-                createCheckoutSession({
-                    user: {
-                        id: 1,
-                        email: "a@example.com",
-                        credits: 0,
-                        createdAt: "2026-01-01T00:00:00.000Z",
-                        outputLang: null,
-                        ttsVoice: null,
-                    },
-                    packId: "pack-small",
-                    origin: "https://example.com",
-                })
-            ).rejects.toThrow("billing not configured");
+            await expect(createCheckoutSession({ user, packId: "pack-small", origin: "o", gateway })).rejects.toThrow(
+                "billing not configured"
+            );
         });
+    });
+});
+
+describe("createSubscriptionCheckoutSession", () => {
+    const user = { id: 7, email: "u@example.com", credits: 0, createdAt: "", outputLang: null, ttsVoice: null };
+
+    it("resolves the plan price and returns the gateway url", async () => {
+        const { gateway, calls } = fakeGateway();
+        let url = "";
+
+        await env.testing.withOverrides(
+            { STRIPE_SECRET_KEY: "sk_test_x", STRIPE_PRICE_SUB_MONTHLY: "price_sub" },
+            async () => {
+                ({ url } = await createSubscriptionCheckoutSession({
+                    user,
+                    planId: "sub-monthly",
+                    origin: "o",
+                    gateway,
+                }));
+            }
+        );
+
+        expect(url).toBe("https://checkout.stripe.test/cs_sub_fake");
+        expect(calls.sub).toEqual([{ priceId: "price_sub", userId: 7, planId: "sub-monthly" }]);
+    });
+
+    it("rejects unknown plans", async () => {
+        const { gateway } = fakeGateway();
+
+        await expect(
+            createSubscriptionCheckoutSession({ user, planId: "sub-yearly", origin: "o", gateway })
+        ).rejects.toThrow("unknown subscription plan");
     });
 });
 

--- a/src/youtube/lib/__tests__/config-foundations.test.ts
+++ b/src/youtube/lib/__tests__/config-foundations.test.ts
@@ -50,11 +50,31 @@ describe("config foundations (powerUsers / ai / referrals)", () => {
     });
 
     it("merges referrals shallowly with offers replaced wholesale", async () => {
-        await config.update({ referrals: { enabled: true, offers: [{ from: "2026-07-01T00:00:00Z", to: "2026-08-01T00:00:00Z", reward: 25 }] } });
+        await config.update({
+            referrals: {
+                enabled: true,
+                offers: [{ from: "2026-07-01T00:00:00Z", to: "2026-08-01T00:00:00Z", reward: 25 }],
+            },
+        });
         await config.update({ referrals: { enabled: false } });
         const all = await config.getAll();
 
         expect(all.referrals.enabled).toBe(false);
         expect(all.referrals.offers).toHaveLength(1);
+    });
+});
+
+describe("config freeTier (Phase 2)", () => {
+    it("defaults to disabled metering", async () => {
+        const all = await config.getAll();
+
+        expect(all.freeTier).toEqual({ actionsPerMonth: null });
+    });
+
+    it("round-trips a configured monthly limit", async () => {
+        await config.update({ freeTier: { actionsPerMonth: 20 } });
+        const fresh = new YoutubeConfig({ baseDir: dir });
+
+        expect((await fresh.getAll()).freeTier.actionsPerMonth).toBe(20);
     });
 });

--- a/src/youtube/lib/__tests__/quota.test.ts
+++ b/src/youtube/lib/__tests__/quota.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { enforceFreeQuota } from "@app/youtube/lib/quota";
+import { handleVideosRoute } from "@app/youtube/lib/server/routes/videos";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-quota-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    return db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+}
+
+describe("enforceFreeQuota", () => {
+    it("is a no-op while metering is disabled (default config)", async () => {
+        const user = createUser("q0@example.com");
+
+        expect(await enforceFreeQuota(yt, user)).toBeNull();
+        expect(await enforceFreeQuota(yt, user)).toBeNull();
+    });
+
+    it("allows N actions then returns a typed 402", async () => {
+        await yt.config.update({ freeTier: { actionsPerMonth: 2 } });
+        const user = createUser("q1@example.com");
+
+        expect(await enforceFreeQuota(yt, user)).toBeNull();
+        expect(await enforceFreeQuota(yt, user)).toBeNull();
+        const denied = await enforceFreeQuota(yt, user);
+
+        expect(denied?.status).toBe(402);
+        const body = (await denied?.json()) as { code?: string };
+
+        expect(body.code).toBe("quota_exhausted");
+    });
+
+    it("exempts active subscribers and stripe payers", async () => {
+        await yt.config.update({ freeTier: { actionsPerMonth: 0 } });
+        const subscriber = createUser("q2@example.com");
+        db.upsertSubscription({ userId: subscriber.id, planId: "sub-monthly", status: "active", allowance: 3000 });
+
+        expect(await enforceFreeQuota(yt, subscriber)).toBeNull();
+
+        const payer = createUser("q3@example.com");
+        db.grantCredits(payer.id, 500, "stripe:cs_seed");
+
+        expect(await enforceFreeQuota(yt, payer)).toBeNull();
+
+        const pleb = createUser("q4@example.com");
+
+        expect((await enforceFreeQuota(yt, pleb))?.status).toBe(402);
+    });
+
+    it("does not exempt canceled subscriptions", async () => {
+        await yt.config.update({ freeTier: { actionsPerMonth: 0 } });
+        const churned = createUser("q5@example.com");
+        db.upsertSubscription({ userId: churned.id, planId: "sub-monthly", status: "canceled", allowance: 3000 });
+
+        expect((await enforceFreeQuota(yt, churned))?.status).toBe(402);
+    });
+});
+
+describe("quota gate wiring (translate route)", () => {
+    it("402s at the charge point before any provider work", async () => {
+        await yt.config.update({ freeTier: { actionsPerMonth: 0 } });
+        const user = db.createUser({ email: "q6@example.com", passwordHash: "h", apiToken: "ytu_q6" });
+        db.grantCredits(user.id, 100, "register-grant");
+        db.upsertChannel({ handle: "@chan" });
+        db.upsertVideo({ id: "vid00000001", channelHandle: "@chan", title: "t" });
+        db.saveTranscript({
+            videoId: "vid00000001",
+            lang: "en",
+            source: "captions",
+            text: "hi",
+            segments: [{ text: "hi", start: 0, end: 1 }],
+        });
+
+        const url = new URL("http://localhost/api/v1/videos/vid00000001/transcript/translate");
+        const req = new Request(url, {
+            method: "POST",
+            headers: { Authorization: "Bearer ytu_q6", "Content-Type": "application/json" },
+            body: '{"lang":"cs"}',
+        });
+        const res = await handleVideosRoute(req, url, yt);
+
+        expect(res.status).toBe(402);
+        expect(((await res.json()) as { code?: string }).code).toBe("quota_exhausted");
+        // The gate fired before the credit reserve — balance untouched.
+        expect(db.getUserCredits(user.id)).toBe(100);
+    });
+});

--- a/src/youtube/lib/__tests__/referrals-db.test.ts
+++ b/src/youtube/lib/__tests__/referrals-db.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+let db: YoutubeDatabase;
+
+beforeEach(() => {
+    db = new YoutubeDatabase(":memory:");
+});
+
+afterEach(() => {
+    db.close();
+});
+
+describe("referral storage", () => {
+    it("getOrCreateReferralCode is stable per user and unique across users", () => {
+        const first = db.getOrCreateReferralCode(1, "AAAA2222");
+        const again = db.getOrCreateReferralCode(1, "BBBB3333");
+
+        expect(first).toBe("AAAA2222");
+        expect(again).toBe("AAAA2222");
+        expect(db.getReferralCodeOwner("AAAA2222")).toBe(1);
+        expect(db.getReferralCodeOwner("NOPE0000")).toBeNull();
+    });
+
+    it("one redemption per referee, listable by referrer", () => {
+        db.getOrCreateReferralCode(1, "AAAA2222");
+        const id = db.createReferral({
+            code: "AAAA2222",
+            referrerUserId: 1,
+            refereeUserId: 2,
+            reward: 25,
+            offerFrom: "2026-07-01T00:00:00Z",
+            offerTo: "2026-08-01T00:00:00Z",
+        });
+
+        expect(id).toBeGreaterThan(0);
+        expect(db.getReferralByReferee(2)?.referrerUserId).toBe(1);
+        expect(db.getReferralByReferee(3)).toBeNull();
+        expect(db.listReferralsByReferrer(1)).toHaveLength(1);
+        expect(() =>
+            db.createReferral({
+                code: "AAAA2222",
+                referrerUserId: 1,
+                refereeUserId: 2,
+                reward: 25,
+                offerFrom: "2026-07-01T00:00:00Z",
+                offerTo: "2026-08-01T00:00:00Z",
+            })
+        ).toThrow();
+    });
+});

--- a/src/youtube/lib/__tests__/referrals.test.ts
+++ b/src/youtube/lib/__tests__/referrals.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { findActiveOffer, generateReferralCode, maskEmail } from "@app/youtube/lib/referrals";
+
+const offers = {
+    enabled: true,
+    offers: [
+        { from: "2026-01-01T00:00:00Z", to: "2026-02-01T00:00:00Z", reward: 10 },
+        { from: "2026-07-01T00:00:00Z", to: "2026-08-01T00:00:00Z", reward: 25 },
+    ],
+};
+
+describe("findActiveOffer", () => {
+    it("returns the first offer whose window contains now", () => {
+        expect(findActiveOffer(offers, "2026-07-17T12:00:00Z")?.reward).toBe(25);
+        expect(findActiveOffer(offers, "2026-01-15T00:00:00Z")?.reward).toBe(10);
+    });
+
+    it("returns null outside every window or when disabled", () => {
+        expect(findActiveOffer(offers, "2026-03-01T00:00:00Z")).toBeNull();
+        expect(findActiveOffer({ ...offers, enabled: false }, "2026-07-17T12:00:00Z")).toBeNull();
+        expect(findActiveOffer({ enabled: true, offers: [] }, "2026-07-17T12:00:00Z")).toBeNull();
+    });
+});
+
+describe("maskEmail / generateReferralCode", () => {
+    it("masks the local part after two characters", () => {
+        expect(maskEmail("martin@foltyn.dev")).toBe("ma***@foltyn.dev");
+        expect(maskEmail("a@b.c")).toBe("a***@b.c");
+        expect(maskEmail("broken")).toBe("***");
+    });
+
+    it("generates 8-char codes from the unambiguous alphabet", () => {
+        const code = generateReferralCode();
+
+        expect(code).toMatch(/^[A-HJ-NP-Z2-9]{8}$/);
+        expect(generateReferralCode()).not.toBe(code);
+    });
+});

--- a/src/youtube/lib/billing-cycle.ts
+++ b/src/youtube/lib/billing-cycle.ts
@@ -1,0 +1,69 @@
+import type { SubscriptionStatus } from "@app/youtube/lib/billing.types";
+
+/**
+ * Pure allowance math for the subscription tier (single-balance design):
+ * the ONE spendable balance stays `users.credits`; allowance vs topup are
+ * DERIVED. Spends draw the allowance first, so:
+ *   spentSince        = grantsSince − (balance − periodStartBalance)
+ *   allowanceRemaining = clamp(allowanceGranted − spentSince, 0..balance)
+ *   topupRemainder     = balance − allowanceRemaining   (survives resets)
+ *   reset newBalance   = topupRemainder + newAllowance  (RESET, not additive)
+ */
+export interface PeriodStateInput {
+    balance: number;
+    periodStartBalance: number;
+    /** SUM of positive grant-type ledger deltas since period start (db.getGrantsSince). */
+    grantsSince: number;
+    allowanceGranted: number;
+}
+
+export interface PeriodState {
+    spentSince: number;
+    allowanceRemaining: number;
+    topupRemainder: number;
+}
+
+export function computePeriodState(input: PeriodStateInput): PeriodState {
+    const netSince = input.balance - input.periodStartBalance;
+    const spentSince = Math.max(0, input.grantsSince - netSince);
+    const allowanceRemaining = Math.max(0, Math.min(input.balance, input.allowanceGranted - spentSince));
+    const topupRemainder = Math.max(0, input.balance - allowanceRemaining);
+
+    return { spentSince, allowanceRemaining, topupRemainder };
+}
+
+export interface AllowanceResetInput extends PeriodStateInput {
+    newAllowance: number;
+}
+
+export interface AllowanceResetResult extends PeriodState {
+    newBalance: number;
+    /** Ledger delta to apply (can be 0 on an unspent renewal, negative on downgrade). */
+    delta: number;
+}
+
+export function computeAllowanceReset(input: AllowanceResetInput): AllowanceResetResult {
+    const state = computePeriodState(input);
+    const newBalance = state.topupRemainder + input.newAllowance;
+    const delta = newBalance - input.balance;
+
+    return { ...state, newBalance, delta };
+}
+
+/** UTC month bucket key for quota_usage rows. */
+export function monthKeyUtc(date: Date = new Date()): string {
+    return date.toISOString().slice(0, 7);
+}
+
+/** Narrow a stored status string to the frozen union without a cast. */
+export function toSubscriptionStatus(raw: string): SubscriptionStatus {
+    if (raw === "canceled") {
+        return "canceled";
+    }
+
+    if (raw === "past_due") {
+        return "past_due";
+    }
+
+    return "active";
+}

--- a/src/youtube/lib/billing-gateway.ts
+++ b/src/youtube/lib/billing-gateway.ts
@@ -1,0 +1,72 @@
+import Stripe from "stripe";
+
+/** Per spec, success/cancel both return to YouTube — the extension polls balance; no landing page. */
+const CHECKOUT_RETURN_URL = "https://www.youtube.com";
+
+export interface CheckoutSessionResult {
+    id: string;
+    url: string;
+}
+
+export interface PackCheckoutInput {
+    priceId: string;
+    userId: number;
+    packId: string;
+}
+
+export interface SubscriptionCheckoutInput {
+    priceId: string;
+    userId: number;
+    planId: string;
+}
+
+/** The only seam that talks to Stripe outbound — tests substitute a fake. */
+export interface StripeGateway {
+    createPackCheckout(input: PackCheckoutInput): Promise<CheckoutSessionResult>;
+    createSubscriptionCheckout(input: SubscriptionCheckoutInput): Promise<CheckoutSessionResult>;
+}
+
+export function createStripeGateway(secretKey: string): StripeGateway {
+    const stripe = new Stripe(secretKey);
+
+    return {
+        async createPackCheckout(input: PackCheckoutInput): Promise<CheckoutSessionResult> {
+            const session = await stripe.checkout.sessions.create({
+                mode: "payment",
+                client_reference_id: String(input.userId),
+                line_items: [{ price: input.priceId, quantity: 1 }],
+                metadata: { packId: input.packId, userId: String(input.userId) },
+                // Session metadata does not propagate to the charge — set it on
+                // the PaymentIntent too so charge.refunded can attribute refunds.
+                payment_intent_data: { metadata: { packId: input.packId, userId: String(input.userId) } },
+                success_url: CHECKOUT_RETURN_URL,
+                cancel_url: CHECKOUT_RETURN_URL,
+            });
+
+            return toResult(session);
+        },
+        async createSubscriptionCheckout(input: SubscriptionCheckoutInput): Promise<CheckoutSessionResult> {
+            const session = await stripe.checkout.sessions.create({
+                mode: "subscription",
+                client_reference_id: String(input.userId),
+                line_items: [{ price: input.priceId, quantity: 1 }],
+                metadata: { planId: input.planId, userId: String(input.userId) },
+                // Propagate onto the Subscription object so invoice.paid and
+                // subscription.updated events can attribute without lookups.
+                subscription_data: { metadata: { planId: input.planId, userId: String(input.userId) } },
+                success_url: CHECKOUT_RETURN_URL,
+                cancel_url: CHECKOUT_RETURN_URL,
+            });
+
+            return toResult(session);
+        },
+    };
+}
+
+function toResult(session: Stripe.Checkout.Session): CheckoutSessionResult {
+    if (!session.url) {
+        throw new Error("stripe checkout session response missing url");
+    }
+
+    return { id: session.id, url: session.url };
+}

--- a/src/youtube/lib/billing.ts
+++ b/src/youtube/lib/billing.ts
@@ -1,21 +1,39 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { logger } from "@app/logger";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
-import { DIAMOND_PACKS, type DiamondPack } from "@app/youtube/lib/billing.types";
+import {
+    DIAMOND_PACKS,
+    type DiamondPack,
+    LOW_BALANCE_THRESHOLD,
+    type MeBillingContext,
+    SUBSCRIPTION_PLANS,
+    type SubscriptionStatus,
+} from "@app/youtube/lib/billing.types";
+import {
+    computeAllowanceReset,
+    computePeriodState,
+    monthKeyUtc,
+    toSubscriptionStatus,
+} from "@app/youtube/lib/billing-cycle";
+import { createStripeGateway, type StripeGateway } from "@app/youtube/lib/billing-gateway";
+import type { YoutubeConfig } from "@app/youtube/lib/config";
 import type { YoutubeDatabase } from "@app/youtube/lib/db";
-import type { YtUser } from "@app/youtube/lib/users.types";
+import type { CreditReason, YtUser } from "@app/youtube/lib/users.types";
 
 /**
- * Creates a Stripe Checkout session for a diamond pack via the Stripe REST API
- * directly (no SDK dependency). `origin` is accepted for interface symmetry
- * with the route layer but unused — per spec, success/cancel both point at
- * https://www.youtube.com (the extension polls balance; no landing page).
+ * Creates a Stripe Checkout session for a diamond pack. The outbound call goes
+ * through `billing-gateway.ts` (the official Stripe SDK); tests inject a fake
+ * gateway and never hit the network. `origin` is accepted for interface
+ * symmetry with the route layer but unused — per spec, success/cancel both
+ * point at https://www.youtube.com (the extension polls balance; no landing page).
  */
 export async function createCheckoutSession(opts: {
     user: YtUser;
     packId: string;
     origin: string;
+    /** Test seam — production callers omit it and get the SDK gateway. */
+    gateway?: StripeGateway;
 }): Promise<{ url: string }> {
     const pack = DIAMOND_PACKS.find((candidate) => candidate.id === opts.packId);
 
@@ -36,48 +54,41 @@ export async function createCheckoutSession(opts: {
         throw new Error(`billing not configured: ${priceEnvKey} unset`);
     }
 
-    const body = new URLSearchParams();
-    body.set("mode", "payment");
-    body.set("client_reference_id", String(opts.user.id));
-    body.set("line_items[0][price]", priceId);
-    body.set("line_items[0][quantity]", "1");
-    body.set("metadata[packId]", pack.id);
-    body.set("metadata[userId]", String(opts.user.id));
-    // Session-level metadata does not auto-propagate to the resulting charge —
-    // set it on the PaymentIntent too so charge.refunded can attribute the refund.
-    body.set("payment_intent_data[metadata][userId]", String(opts.user.id));
-    body.set("payment_intent_data[metadata][packId]", pack.id);
-    body.set("success_url", "https://www.youtube.com");
-    body.set("cancel_url", "https://www.youtube.com");
+    const gateway = opts.gateway ?? createStripeGateway(secretKey);
+    const session = await gateway.createPackCheckout({ priceId, userId: opts.user.id, packId: pack.id });
 
-    const res = await fetch("https://api.stripe.com/v1/checkout/sessions", {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${secretKey}`,
-            "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: body.toString(),
-    });
+    return { url: session.url };
+}
 
-    if (!res.ok) {
-        const detail = await res.text().catch((err) => {
-            logger.debug({ error: err }, "youtube billing: failed to read stripe error body");
-            return "";
-        });
-        logger.warn(
-            { status: res.status, detail: detail.slice(0, 500) },
-            "youtube billing: checkout session create failed"
-        );
-        throw new Error(`stripe checkout session create failed: ${res.status}`);
+/** Subscription checkout for a monthly plan. Mirrors the pack flow: env-gated, gateway-backed. */
+export async function createSubscriptionCheckoutSession(opts: {
+    user: YtUser;
+    planId: string;
+    origin: string;
+    gateway?: StripeGateway;
+}): Promise<{ url: string }> {
+    const plan = SUBSCRIPTION_PLANS.find((candidate) => candidate.id === opts.planId);
+
+    if (!plan) {
+        throw new Error(`unknown subscription plan: ${opts.planId}`);
     }
 
-    const data = (await res.json()) as { url?: string };
+    const secretKey = env.stripe.getSecretKey();
 
-    if (!data.url) {
-        throw new Error("stripe checkout session response missing url");
+    if (!secretKey) {
+        throw new Error("billing not configured");
     }
 
-    return { url: data.url };
+    const priceId = env.getTrimmed("STRIPE_PRICE_SUB_MONTHLY");
+
+    if (!priceId) {
+        throw new Error("billing not configured: STRIPE_PRICE_SUB_MONTHLY unset");
+    }
+
+    const gateway = opts.gateway ?? createStripeGateway(secretKey);
+    const session = await gateway.createSubscriptionCheckout({ priceId, userId: opts.user.id, planId: plan.id });
+
+    return { url: session.url };
 }
 
 interface StripeEvent {
@@ -105,21 +116,62 @@ export async function handleStripeEvent(db: YoutubeDatabase, payload: string, si
     }
 
     const event = SafeJSON.parse(payload, { strict: true }) as StripeEvent;
+    const existing = db.getWebhookLog(event.id);
 
-    if (event.type === "checkout.session.completed") {
-        applyCheckoutCompleted(db, event.data.object);
+    if (existing && existing.outcome !== "error") {
+        logger.debug({ eventId: event.id, type: event.type }, "youtube billing: duplicate webhook delivery ignored");
         return;
+    }
+
+    const payloadHash = createHash("sha256").update(payload).digest("hex");
+
+    try {
+        const outcome = applyStripeEvent(db, event);
+        db.recordWebhookLog({ stripeEventId: event.id, type: event.type, payloadHash, outcome });
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        db.recordWebhookLog({ stripeEventId: event.id, type: event.type, payloadHash, outcome: "error", detail });
+        // Rethrow → route answers 400 → Stripe retries; the retry reprocesses
+        // because an "error" outcome does not short-circuit above.
+        throw error;
+    }
+}
+
+function applyStripeEvent(db: YoutubeDatabase, event: StripeEvent): "processed" | "skipped" {
+    if (event.type === "checkout.session.completed") {
+        return applyCheckoutCompleted(db, event.data.object);
+    }
+
+    if (event.type === "invoice.paid") {
+        return applyInvoicePaid(db, event.data.object);
+    }
+
+    if (event.type === "invoice.payment_failed") {
+        return applyInvoicePaymentFailed(db, event.data.object);
+    }
+
+    if (event.type === "customer.subscription.updated") {
+        return applySubscriptionUpdated(db, event.data.object);
+    }
+
+    if (event.type === "customer.subscription.deleted") {
+        return applySubscriptionDeleted(db, event.data.object);
     }
 
     if (event.type === "charge.refunded") {
-        applyChargeRefunded(db, event.data.object);
-        return;
+        return applyChargeRefunded(db, event.data.object);
     }
 
     logger.debug({ type: event.type, id: event.id }, "youtube billing: unhandled stripe event type");
+
+    return "skipped";
 }
 
-function applyCheckoutCompleted(db: YoutubeDatabase, session: Record<string, unknown>): void {
+function applyCheckoutCompleted(db: YoutubeDatabase, session: Record<string, unknown>): "processed" | "skipped" {
+    if (session.mode === "subscription") {
+        return applySubscriptionCheckout(db, session);
+    }
+
     const sessionId = typeof session.id === "string" ? session.id : null;
     const metadata = (session.metadata ?? {}) as Record<string, unknown>;
     const packId = typeof metadata.packId === "string" ? metadata.packId : null;
@@ -127,28 +179,40 @@ function applyCheckoutCompleted(db: YoutubeDatabase, session: Record<string, unk
 
     if (!sessionId || !packId || userId === null) {
         logger.warn({ sessionId, packId, userId }, "youtube billing: checkout.session.completed missing fields");
-        return;
+        return "skipped";
     }
 
     const pack = DIAMOND_PACKS.find((candidate) => candidate.id === packId);
 
     if (!pack) {
         logger.warn({ sessionId, packId }, "youtube billing: checkout.session.completed unknown pack");
-        return;
+        return "skipped";
     }
 
     const reason = `stripe:${sessionId}` as const;
 
     if (db.hasLedgerReason(userId, reason)) {
         logger.debug({ sessionId, userId }, "youtube billing: checkout.session.completed already granted");
-        return;
+        return "processed";
     }
 
     db.grantCredits(userId, pack.diamonds, reason);
+    db.recordPayment({
+        userId,
+        kind: "pack",
+        stripeRef: sessionId,
+        packId: pack.id,
+        amountCents: typeof session.amount_total === "number" ? session.amount_total : null,
+        currency: typeof session.currency === "string" ? session.currency : null,
+        credits: pack.diamonds,
+        status: "succeeded",
+    });
     logger.info({ sessionId, userId, diamonds: pack.diamonds }, "youtube billing: granted diamonds from checkout");
+
+    return "processed";
 }
 
-function applyChargeRefunded(db: YoutubeDatabase, charge: Record<string, unknown>): void {
+function applyChargeRefunded(db: YoutubeDatabase, charge: Record<string, unknown>): "processed" | "skipped" {
     const chargeId = typeof charge.id === "string" ? charge.id : null;
     const metadata = (charge.metadata ?? {}) as Record<string, unknown>;
     const packId = typeof metadata.packId === "string" ? metadata.packId : null;
@@ -156,25 +220,231 @@ function applyChargeRefunded(db: YoutubeDatabase, charge: Record<string, unknown
 
     if (!chargeId || !packId || userId === null) {
         logger.warn({ chargeId, packId, userId }, "youtube billing: charge.refunded missing metadata, skipping");
-        return;
+        return "skipped";
     }
 
     const pack = DIAMOND_PACKS.find((candidate) => candidate.id === packId);
 
     if (!pack) {
         logger.warn({ chargeId, packId }, "youtube billing: charge.refunded unknown pack");
-        return;
+        return "skipped";
     }
 
     const reason = `stripe-refund:${chargeId}` as const;
 
     if (db.hasLedgerReason(userId, reason)) {
         logger.debug({ chargeId, userId }, "youtube billing: charge.refunded already reversed");
-        return;
+        return "processed";
     }
 
     db.grantCredits(userId, -pack.diamonds, reason);
+    db.recordPayment({
+        userId,
+        kind: "refund",
+        stripeRef: `refund:${chargeId}`,
+        packId: pack.id,
+        credits: -pack.diamonds,
+        status: "refunded",
+    });
     logger.info({ chargeId, userId, diamonds: -pack.diamonds }, "youtube billing: reversed diamonds from refund");
+
+    return "processed";
+}
+
+function applySubscriptionCheckout(db: YoutubeDatabase, session: Record<string, unknown>): "processed" | "skipped" {
+    const metadata = (session.metadata ?? {}) as Record<string, unknown>;
+    const userId = parseUserId(metadata.userId ?? session.client_reference_id);
+    const planId = typeof metadata.planId === "string" ? metadata.planId : null;
+    const plan = SUBSCRIPTION_PLANS.find((candidate) => candidate.id === planId);
+
+    if (userId === null || !plan) {
+        logger.warn({ userId, planId }, "youtube billing: subscription checkout missing user/plan metadata");
+
+        return "skipped";
+    }
+
+    // Period fields stay null until the first invoice.paid — that is also the
+    // signal for "grant the initial allowance additively" (see applyInvoicePaid).
+    db.upsertSubscription({
+        userId,
+        stripeCustomerId: typeof session.customer === "string" ? session.customer : null,
+        stripeSubscriptionId: typeof session.subscription === "string" ? session.subscription : null,
+        planId: plan.id,
+        status: "active",
+        allowance: plan.allowance,
+    });
+    logger.info({ userId, planId: plan.id }, "youtube billing: subscription created from checkout");
+
+    return "processed";
+}
+
+function applyInvoicePaid(db: YoutubeDatabase, invoice: Record<string, unknown>): "processed" | "skipped" {
+    const invoiceId = typeof invoice.id === "string" ? invoice.id : null;
+    const stripeSubscriptionId = typeof invoice.subscription === "string" ? invoice.subscription : null;
+
+    if (!invoiceId || !stripeSubscriptionId) {
+        logger.warn({ invoiceId, stripeSubscriptionId }, "youtube billing: invoice.paid missing fields");
+
+        return "skipped";
+    }
+
+    const sub = db.getSubscriptionByStripeId(stripeSubscriptionId);
+
+    if (!sub) {
+        logger.warn({ invoiceId, stripeSubscriptionId }, "youtube billing: invoice.paid for unknown subscription");
+
+        return "skipped";
+    }
+
+    const reason: CreditReason = `sub-allowance:${invoiceId}`;
+
+    if (db.hasLedgerReason(sub.userId, reason)) {
+        logger.debug({ invoiceId, userId: sub.userId }, "youtube billing: allowance already granted for invoice");
+
+        return "processed";
+    }
+
+    const balance = db.getUserCredits(sub.userId);
+
+    if (balance === null) {
+        logger.warn({ invoiceId, userId: sub.userId }, "youtube billing: invoice.paid for missing user");
+
+        return "skipped";
+    }
+
+    const period = invoicePeriod(invoice);
+    let delta: number;
+    let newBalance: number;
+
+    if (sub.periodStart === null) {
+        // First invoice: the user never had an allowance — plain additive grant.
+        delta = sub.allowance;
+        newBalance = balance + delta;
+    } else {
+        const reset = computeAllowanceReset({
+            balance,
+            periodStartBalance: sub.periodStartBalance,
+            grantsSince: db.getGrantsSince(sub.userId, sub.periodStart),
+            allowanceGranted: sub.allowance,
+            newAllowance: sub.allowance,
+        });
+        delta = reset.delta;
+        newBalance = reset.newBalance;
+    }
+
+    // A delta of 0 (unspent renewal) still writes the ledger row — the reset
+    // itself is an auditable event, and it doubles as the idempotency marker.
+    db.grantCredits(sub.userId, delta, reason);
+    db.updateSubscription(sub.id, {
+        status: "active",
+        periodStart: period.start,
+        periodEnd: period.end,
+        periodStartBalance: newBalance,
+    });
+    db.recordPayment({
+        userId: sub.userId,
+        kind: "subscription",
+        stripeRef: invoiceId,
+        planId: sub.planId,
+        amountCents: typeof invoice.amount_paid === "number" ? invoice.amount_paid : null,
+        currency: typeof invoice.currency === "string" ? invoice.currency : null,
+        credits: delta,
+        status: "succeeded",
+    });
+    logger.info({ invoiceId, userId: sub.userId, delta, newBalance }, "youtube billing: allowance period applied");
+
+    return "processed";
+}
+
+function applyInvoicePaymentFailed(db: YoutubeDatabase, invoice: Record<string, unknown>): "processed" | "skipped" {
+    const invoiceId = typeof invoice.id === "string" ? invoice.id : null;
+    const stripeSubscriptionId = typeof invoice.subscription === "string" ? invoice.subscription : null;
+    const sub = stripeSubscriptionId ? db.getSubscriptionByStripeId(stripeSubscriptionId) : null;
+
+    if (!invoiceId || !sub) {
+        logger.warn({ invoiceId, stripeSubscriptionId }, "youtube billing: payment_failed for unknown subscription");
+
+        return "skipped";
+    }
+
+    db.updateSubscription(sub.id, { status: "past_due" });
+    // `failed:` prefix keeps the ref distinct from the eventual invoice.paid
+    // row for the same invoice (stripe_ref is UNIQUE).
+    db.recordPayment({
+        userId: sub.userId,
+        kind: "subscription",
+        stripeRef: `failed:${invoiceId}`,
+        planId: sub.planId,
+        amountCents: typeof invoice.amount_due === "number" ? invoice.amount_due : null,
+        currency: typeof invoice.currency === "string" ? invoice.currency : null,
+        status: "failed",
+    });
+    logger.warn({ invoiceId, userId: sub.userId }, "youtube billing: subscription payment failed");
+
+    return "processed";
+}
+
+function applySubscriptionUpdated(db: YoutubeDatabase, subscription: Record<string, unknown>): "processed" | "skipped" {
+    const stripeId = typeof subscription.id === "string" ? subscription.id : null;
+    const sub = stripeId ? db.getSubscriptionByStripeId(stripeId) : null;
+
+    if (!sub) {
+        logger.warn({ stripeId }, "youtube billing: subscription.updated for unknown subscription");
+
+        return "skipped";
+    }
+
+    const periodEnd =
+        typeof subscription.current_period_end === "number"
+            ? new Date(subscription.current_period_end * 1000).toISOString()
+            : undefined;
+    db.updateSubscription(sub.id, {
+        status: mapStripeSubscriptionStatus(subscription.status),
+        cancelAtPeriodEnd: subscription.cancel_at_period_end === true,
+        ...(periodEnd !== undefined ? { periodEnd } : {}),
+    });
+
+    return "processed";
+}
+
+function applySubscriptionDeleted(db: YoutubeDatabase, subscription: Record<string, unknown>): "processed" | "skipped" {
+    const stripeId = typeof subscription.id === "string" ? subscription.id : null;
+    const sub = stripeId ? db.getSubscriptionByStripeId(stripeId) : null;
+
+    if (!sub) {
+        logger.warn({ stripeId }, "youtube billing: subscription.deleted for unknown subscription");
+
+        return "skipped";
+    }
+
+    // Credits already granted stay — no clawback on cancellation.
+    db.updateSubscription(sub.id, { status: "canceled" });
+    logger.info({ userId: sub.userId }, "youtube billing: subscription canceled");
+
+    return "processed";
+}
+
+function mapStripeSubscriptionStatus(raw: unknown): SubscriptionStatus {
+    if (raw === "canceled" || raw === "incomplete_expired") {
+        return "canceled";
+    }
+
+    if (raw === "past_due" || raw === "unpaid" || raw === "incomplete") {
+        return "past_due";
+    }
+
+    return "active";
+}
+
+function invoicePeriod(invoice: Record<string, unknown>): { start: string; end: string | null } {
+    const lines = invoice.lines as { data?: Array<{ period?: { start?: number; end?: number } }> } | undefined;
+    const period = lines?.data?.[0]?.period;
+
+    return {
+        start:
+            typeof period?.start === "number" ? new Date(period.start * 1000).toISOString() : new Date().toISOString(),
+        end: typeof period?.end === "number" ? new Date(period.end * 1000).toISOString() : null,
+    };
 }
 
 function parseUserId(value: unknown): number | null {
@@ -268,4 +538,44 @@ function hexToBuffer(hex: string): Buffer | null {
     }
 
     return Buffer.from(hex, "hex");
+}
+
+/** Balance context for GET /users/me — one authoritative read for client nudges. */
+export async function buildBillingContext(opts: {
+    db: YoutubeDatabase;
+    config: YoutubeConfig;
+    user: YtUser;
+}): Promise<MeBillingContext> {
+    const sub = opts.db.getSubscriptionByUserId(opts.user.id);
+    let subscription: MeBillingContext["subscription"] = null;
+
+    if (sub && sub.status !== "canceled") {
+        const allowanceRemaining =
+            sub.periodStart === null
+                ? 0
+                : computePeriodState({
+                      balance: opts.user.credits,
+                      periodStartBalance: sub.periodStartBalance,
+                      grantsSince: opts.db.getGrantsSince(opts.user.id, sub.periodStart),
+                      allowanceGranted: sub.allowance,
+                  }).allowanceRemaining;
+        subscription = {
+            planId: sub.planId,
+            status: toSubscriptionStatus(sub.status),
+            periodEnd: sub.periodEnd,
+            allowance: sub.allowance,
+            allowanceRemaining,
+            cancelAtPeriodEnd: sub.cancelAtPeriodEnd,
+        };
+    }
+
+    const freeTier = await opts.config.get("freeTier");
+    let freeQuota: MeBillingContext["freeQuota"] = null;
+
+    if (freeTier.actionsPerMonth !== null && subscription === null && !opts.db.hasAnyStripeGrant(opts.user.id)) {
+        const month = monthKeyUtc();
+        freeQuota = { used: opts.db.getQuotaUsed(opts.user.id, month), limit: freeTier.actionsPerMonth, month };
+    }
+
+    return { subscription, freeQuota, lowBalance: opts.user.credits < LOW_BALANCE_THRESHOLD };
 }

--- a/src/youtube/lib/billing.types.ts
+++ b/src/youtube/lib/billing.types.ts
@@ -9,3 +9,31 @@ export const DIAMOND_PACKS: DiamondPack[] = [
     { id: "pack-medium", diamonds: 2000, usd: "14.99" },
     { id: "pack-large", diamonds: 5000, usd: "29.99" },
 ];
+
+export type SubscriptionStatus = "active" | "past_due" | "canceled";
+
+export interface SubscriptionPlan {
+    id: "sub-monthly";
+    /** Diamonds granted each billing period (RESET, not additive). */
+    allowance: number;
+    usd: string;
+}
+
+export const SUBSCRIPTION_PLANS: SubscriptionPlan[] = [{ id: "sub-monthly", allowance: 3000, usd: "9.99" }];
+
+/** Balance below this flips `MeBillingContext.lowBalance` — clients nudge before costly actions. */
+export const LOW_BALANCE_THRESHOLD = 15;
+
+export interface MeBillingContext {
+    subscription: {
+        planId: string;
+        status: SubscriptionStatus;
+        periodEnd: string | null;
+        allowance: number;
+        allowanceRemaining: number;
+        cancelAtPeriodEnd: boolean;
+    } | null;
+    /** Null when metering is disabled or the user is exempt (subscriber / payer). */
+    freeQuota: { used: number; limit: number; month: string } | null;
+    lowBalance: boolean;
+}

--- a/src/youtube/lib/config.ts
+++ b/src/youtube/lib/config.ts
@@ -17,6 +17,7 @@ export const DEFAULT_YOUTUBE_CONFIG: YoutubeConfigShape = {
     powerUsers: [],
     ai: [],
     referrals: { enabled: false, offers: [] },
+    freeTier: { actionsPerMonth: null },
     defaultQuality: "720p",
     concurrency: {
         download: 4,
@@ -134,6 +135,7 @@ function mergeConfig(base: YoutubeConfigShape, patch: YoutubeConfigPatch): Youtu
             ...patch.referrals,
             offers: patch.referrals?.offers ?? base.referrals.offers,
         },
+        freeTier: { ...base.freeTier, ...patch.freeTier },
         concurrency: { ...base.concurrency, ...patch.concurrency },
         ttls: { ...base.ttls, ...patch.ttls },
         preferredLangs: patch.preferredLangs ?? base.preferredLangs,

--- a/src/youtube/lib/config.types.ts
+++ b/src/youtube/lib/config.types.ts
@@ -48,6 +48,8 @@ export interface YoutubeConfigShape {
     ai: AiTaskMapping[];
     /** Referral program schema (logic lands in Phase 2). */
     referrals: ReferralsConfig;
+    /** Monthly free-action cap for logged-in non-subscribers. Null = metering disabled. */
+    freeTier: { actionsPerMonth: number | null };
     defaultQuality: "720p" | "1080p" | "best";
     concurrency: {
         download: number;

--- a/src/youtube/lib/db.ts
+++ b/src/youtube/lib/db.ts
@@ -19,22 +19,31 @@ import type {
     GetTranscriptOpts,
     ListJobsOpts,
     ListVideosOpts,
+    PaymentKind,
+    PaymentRecord,
+    PaymentStatus,
     PruneExpiredBinariesOpts,
     PruneExpiredBinariesResult,
     QueueStats,
     RecordAiCallInput,
     RecordJobActivityInput,
+    RecordPaymentInput,
     RecordVideoLogInput,
+    RecordWebhookLogInput,
+    ReferralRecord,
     SaveTranscriptInput,
     SearchTranscriptsOpts,
     SearchVideosOpts,
     SetVideoBinaryPathInput,
     SetVideoSummaryInput,
+    SubscriptionRecord,
     TranscriptSearchHit,
     UpdateJobPartial,
+    UpdateSubscriptionPartial,
     UpdateUserPrefsInput,
     UpsertChannelInput,
     UpsertQaChunkInput,
+    UpsertSubscriptionInput,
     UpsertVideoInput,
     VideoLite,
     VideoLogKind,
@@ -43,6 +52,8 @@ import type {
     VideoSearchHit,
     VideoWatchRecord,
     WatchlistEntry,
+    WebhookLogRecord,
+    WebhookOutcome,
 } from "@app/youtube/lib/db.types";
 import type {
     JobActivity,
@@ -615,6 +626,84 @@ export class YoutubeDatabase extends BaseDatabase {
                     created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC}),
                     UNIQUE (user_id, channel_handle)
                 );
+            `);
+        });
+
+        // Billing state + audit (Phase 2). No FKs — billing history must
+        // survive user/row deletion, same rationale as add-audit-tables.
+        this.runMigration("add-billing-tables", () => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS subscriptions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL UNIQUE,
+                    stripe_customer_id TEXT,
+                    stripe_subscription_id TEXT UNIQUE,
+                    plan_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    allowance INTEGER NOT NULL,
+                    period_start TEXT,
+                    period_end TEXT,
+                    period_start_balance INTEGER NOT NULL DEFAULT 0,
+                    cancel_at_period_end INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC}),
+                    updated_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+
+                CREATE TABLE IF NOT EXISTS payments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER,
+                    kind TEXT NOT NULL CHECK (kind IN ('pack','subscription','refund')),
+                    stripe_ref TEXT NOT NULL UNIQUE,
+                    pack_id TEXT,
+                    plan_id TEXT,
+                    amount_cents INTEGER,
+                    currency TEXT,
+                    credits INTEGER,
+                    status TEXT NOT NULL CHECK (status IN ('succeeded','failed','refunded')),
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_payments_user ON payments(user_id, id DESC);
+
+                CREATE TABLE IF NOT EXISTS webhook_logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    stripe_event_id TEXT NOT NULL UNIQUE,
+                    type TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    outcome TEXT NOT NULL CHECK (outcome IN ('processed','skipped','duplicate','error')),
+                    detail TEXT,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+
+                CREATE TABLE IF NOT EXISTS quota_usage (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    month TEXT NOT NULL,
+                    actions INTEGER NOT NULL DEFAULT 0,
+                    UNIQUE (user_id, month)
+                );
+            `);
+        });
+
+        this.runMigration("add-referrals", () => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS referral_codes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL UNIQUE,
+                    code TEXT NOT NULL UNIQUE,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+
+                CREATE TABLE IF NOT EXISTS referrals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    code TEXT NOT NULL,
+                    referrer_user_id INTEGER NOT NULL,
+                    referee_user_id INTEGER NOT NULL UNIQUE,
+                    reward INTEGER NOT NULL,
+                    offer_from TEXT NOT NULL,
+                    offer_to TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (${SQL_NOW_UTC})
+                );
+                CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals(referrer_user_id, id DESC);
             `);
         });
 
@@ -1533,6 +1622,297 @@ export class YoutubeDatabase extends BaseDatabase {
             : null;
 
         return { queued, running, perStage, oldestQueuedAgeSec };
+    }
+
+    upsertSubscription(input: UpsertSubscriptionInput): SubscriptionRecord {
+        this.db.run(
+            `INSERT INTO subscriptions
+                (user_id, stripe_customer_id, stripe_subscription_id, plan_id, status, allowance,
+                 period_start, period_end, period_start_balance, cancel_at_period_end, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${SQL_NOW_UTC})
+             ON CONFLICT(user_id) DO UPDATE SET
+                stripe_customer_id = COALESCE(excluded.stripe_customer_id, subscriptions.stripe_customer_id),
+                stripe_subscription_id = COALESCE(excluded.stripe_subscription_id, subscriptions.stripe_subscription_id),
+                plan_id = excluded.plan_id,
+                status = excluded.status,
+                allowance = excluded.allowance,
+                period_start = COALESCE(excluded.period_start, subscriptions.period_start),
+                period_end = COALESCE(excluded.period_end, subscriptions.period_end),
+                period_start_balance = excluded.period_start_balance,
+                cancel_at_period_end = excluded.cancel_at_period_end,
+                updated_at = ${SQL_NOW_UTC}`,
+            [
+                input.userId,
+                input.stripeCustomerId ?? null,
+                input.stripeSubscriptionId ?? null,
+                input.planId,
+                input.status,
+                input.allowance,
+                input.periodStart ?? null,
+                input.periodEnd ?? null,
+                input.periodStartBalance ?? 0,
+                input.cancelAtPeriodEnd ? 1 : 0,
+            ]
+        );
+        const row = this.getSubscriptionByUserId(input.userId);
+
+        if (!row) {
+            throw new Error(`upsertSubscription: user ${input.userId} row missing after upsert`);
+        }
+
+        return row;
+    }
+
+    getSubscriptionByUserId(userId: number): SubscriptionRecord | null {
+        const row = this.db
+            .query<SubscriptionRow, [number]>("SELECT * FROM subscriptions WHERE user_id = ?")
+            .get(userId);
+
+        return row ? rowToSubscription(row) : null;
+    }
+
+    getSubscriptionByStripeId(stripeSubscriptionId: string): SubscriptionRecord | null {
+        const row = this.db
+            .query<SubscriptionRow, [string]>("SELECT * FROM subscriptions WHERE stripe_subscription_id = ?")
+            .get(stripeSubscriptionId);
+
+        return row ? rowToSubscription(row) : null;
+    }
+
+    updateSubscription(id: number, partial: UpdateSubscriptionPartial): void {
+        const sets: string[] = [];
+        const params: Array<string | number | null> = [];
+        const push = (column: string, value: string | number | null): void => {
+            sets.push(`${column} = ?`);
+            params.push(value);
+        };
+
+        if (partial.stripeCustomerId !== undefined) {
+            push("stripe_customer_id", partial.stripeCustomerId);
+        }
+
+        if (partial.stripeSubscriptionId !== undefined) {
+            push("stripe_subscription_id", partial.stripeSubscriptionId);
+        }
+
+        if (partial.status !== undefined) {
+            push("status", partial.status);
+        }
+
+        if (partial.allowance !== undefined) {
+            push("allowance", partial.allowance);
+        }
+
+        if (partial.periodStart !== undefined) {
+            push("period_start", partial.periodStart);
+        }
+
+        if (partial.periodEnd !== undefined) {
+            push("period_end", partial.periodEnd);
+        }
+
+        if (partial.periodStartBalance !== undefined) {
+            push("period_start_balance", partial.periodStartBalance);
+        }
+
+        if (partial.cancelAtPeriodEnd !== undefined) {
+            push("cancel_at_period_end", partial.cancelAtPeriodEnd ? 1 : 0);
+        }
+
+        if (sets.length === 0) {
+            return;
+        }
+
+        sets.push(`updated_at = ${SQL_NOW_UTC}`);
+        params.push(id);
+        this.db.run(`UPDATE subscriptions SET ${sets.join(", ")} WHERE id = ?`, params);
+    }
+
+    /** Replay-safe on `stripe_ref` — a webhook retry inserts nothing new. */
+    recordPayment(input: RecordPaymentInput): void {
+        this.db.run(
+            `INSERT OR IGNORE INTO payments
+                (user_id, kind, stripe_ref, pack_id, plan_id, amount_cents, currency, credits, status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+                input.userId,
+                input.kind,
+                input.stripeRef,
+                input.packId ?? null,
+                input.planId ?? null,
+                input.amountCents ?? null,
+                input.currency ?? null,
+                input.credits ?? null,
+                input.status,
+            ]
+        );
+    }
+
+    listPayments(opts: { userId?: number; limit?: number } = {}): PaymentRecord[] {
+        const where = opts.userId !== undefined ? "WHERE user_id = ?" : "";
+        const params: Array<number> = opts.userId !== undefined ? [opts.userId] : [];
+        const rows = this.db
+            .query<PaymentRow, [...number[], number]>(`SELECT * FROM payments ${where} ORDER BY id DESC LIMIT ?`)
+            .all(...params, opts.limit ?? 100);
+
+        return rows.map(rowToPayment);
+    }
+
+    getWebhookLog(stripeEventId: string): WebhookLogRecord | null {
+        const row = this.db
+            .query<WebhookLogRow, [string]>("SELECT * FROM webhook_logs WHERE stripe_event_id = ?")
+            .get(stripeEventId);
+
+        return row ? rowToWebhookLog(row) : null;
+    }
+
+    recordWebhookLog(input: RecordWebhookLogInput): void {
+        this.db.run(
+            `INSERT INTO webhook_logs (stripe_event_id, type, payload_hash, outcome, detail)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(stripe_event_id) DO UPDATE SET
+                outcome = excluded.outcome,
+                detail = excluded.detail`,
+            [input.stripeEventId, input.type, input.payloadHash, input.outcome, input.detail ?? null]
+        );
+    }
+
+    /** Balance lookup by id — the webhook reset math needs it (users are otherwise fetched by token/email). */
+    getUserCredits(userId: number): number | null {
+        const row = this.db.query<{ credits: number }, [number]>("SELECT credits FROM users WHERE id = ?").get(userId);
+
+        return row?.credits ?? null;
+    }
+
+    getUserEmailById(userId: number): string | null {
+        const row = this.db.query<{ email: string }, [number]>("SELECT email FROM users WHERE id = ?").get(userId);
+
+        return row?.email ?? null;
+    }
+
+    /** SUM of positive grant-type deltas since `sinceIso` — the frozen grant-reason set. */
+    getGrantsSince(userId: number, sinceIso: string): number {
+        const row = this.db
+            .query<{ total: number | null }, [number, string]>(
+                `SELECT SUM(delta) AS total FROM credit_ledger
+                 WHERE user_id = ? AND created_at >= ? AND delta > 0
+                   AND (reason LIKE 'stripe:%' OR reason = 'dev-topup' OR reason LIKE 'referral:%' OR reason = 'register-grant')`
+            )
+            .get(userId, sinceIso);
+
+        return row?.total ?? 0;
+    }
+
+    /** True when the user ever completed a Stripe purchase (quota exemption). */
+    hasAnyStripeGrant(userId: number): boolean {
+        const row = this.db
+            .query<{ found: number }, [number]>(
+                "SELECT 1 AS found FROM credit_ledger WHERE user_id = ? AND delta > 0 AND reason LIKE 'stripe:%' LIMIT 1"
+            )
+            .get(userId);
+
+        return row !== null;
+    }
+
+    /** Atomic check-and-increment: never increments past `limit`. */
+    incrementQuotaIfBelow(userId: number, month: string, limit: number): { allowed: boolean; used: number } {
+        const bump = this.db.transaction(() => {
+            const existing = this.db
+                .query<{ actions: number }, [number, string]>(
+                    "SELECT actions FROM quota_usage WHERE user_id = ? AND month = ?"
+                )
+                .get(userId, month);
+            const used = existing?.actions ?? 0;
+
+            if (used >= limit) {
+                return { allowed: false, used };
+            }
+
+            this.db.run(
+                `INSERT INTO quota_usage (user_id, month, actions) VALUES (?, ?, 1)
+                 ON CONFLICT(user_id, month) DO UPDATE SET actions = actions + 1`,
+                [userId, month]
+            );
+
+            return { allowed: true, used: used + 1 };
+        });
+
+        return bump();
+    }
+
+    getQuotaUsed(userId: number, month: string): number {
+        const row = this.db
+            .query<{ actions: number }, [number, string]>(
+                "SELECT actions FROM quota_usage WHERE user_id = ? AND month = ?"
+            )
+            .get(userId, month);
+
+        return row?.actions ?? 0;
+    }
+
+    /** Returns the user's existing code, or inserts `code` and returns it. */
+    getOrCreateReferralCode(userId: number, code: string): string {
+        const claim = this.db.transaction(() => {
+            const existing = this.db
+                .query<{ code: string }, [number]>("SELECT code FROM referral_codes WHERE user_id = ?")
+                .get(userId);
+
+            if (existing) {
+                return existing.code;
+            }
+
+            this.db.run("INSERT INTO referral_codes (user_id, code) VALUES (?, ?)", [userId, code]);
+
+            return code;
+        });
+
+        return claim();
+    }
+
+    getReferralCodeOwner(code: string): number | null {
+        const row = this.db
+            .query<{ user_id: number }, [string]>("SELECT user_id FROM referral_codes WHERE code = ?")
+            .get(code);
+
+        return row?.user_id ?? null;
+    }
+
+    createReferral(input: {
+        code: string;
+        referrerUserId: number;
+        refereeUserId: number;
+        reward: number;
+        offerFrom: string;
+        offerTo: string;
+    }): number {
+        const row = this.db
+            .query<{ id: number }, [string, number, number, number, string, string]>(
+                `INSERT INTO referrals (code, referrer_user_id, referee_user_id, reward, offer_from, offer_to)
+                 VALUES (?, ?, ?, ?, ?, ?) RETURNING id`
+            )
+            .get(input.code, input.referrerUserId, input.refereeUserId, input.reward, input.offerFrom, input.offerTo);
+
+        if (!row) {
+            throw new Error("createReferral: insert returned no id");
+        }
+
+        return row.id;
+    }
+
+    getReferralByReferee(refereeUserId: number): ReferralRecord | null {
+        const row = this.db
+            .query<ReferralRow, [number]>("SELECT * FROM referrals WHERE referee_user_id = ?")
+            .get(refereeUserId);
+
+        return row ? rowToReferral(row) : null;
+    }
+
+    listReferralsByReferrer(referrerUserId: number): ReferralRecord[] {
+        const rows = this.db
+            .query<ReferralRow, [number]>("SELECT * FROM referrals WHERE referrer_user_id = ? ORDER BY id DESC")
+            .all(referrerUserId);
+
+        return rows.map(rowToReferral);
     }
 
     async pruneExpiredBinaries(opts: PruneExpiredBinariesOpts): Promise<PruneExpiredBinariesResult> {
@@ -3247,6 +3627,116 @@ function rowToAskMessage(row: AskMessageRow): AskMessageRecord {
         content: row.content,
         toolName: row.tool_name,
         toolArgsJson: row.tool_args_json,
+        createdAt: row.created_at,
+    };
+}
+
+interface SubscriptionRow {
+    id: number;
+    user_id: number;
+    stripe_customer_id: string | null;
+    stripe_subscription_id: string | null;
+    plan_id: string;
+    status: string;
+    allowance: number;
+    period_start: string | null;
+    period_end: string | null;
+    period_start_balance: number;
+    cancel_at_period_end: number;
+    created_at: string;
+    updated_at: string;
+}
+
+interface PaymentRow {
+    id: number;
+    user_id: number | null;
+    kind: PaymentKind;
+    stripe_ref: string;
+    pack_id: string | null;
+    plan_id: string | null;
+    amount_cents: number | null;
+    currency: string | null;
+    credits: number | null;
+    status: PaymentStatus;
+    created_at: string;
+}
+
+interface WebhookLogRow {
+    id: number;
+    stripe_event_id: string;
+    type: string;
+    payload_hash: string;
+    outcome: WebhookOutcome;
+    detail: string | null;
+    created_at: string;
+}
+
+function rowToSubscription(row: SubscriptionRow): SubscriptionRecord {
+    return {
+        id: row.id,
+        userId: row.user_id,
+        stripeCustomerId: row.stripe_customer_id,
+        stripeSubscriptionId: row.stripe_subscription_id,
+        planId: row.plan_id,
+        status: row.status,
+        allowance: row.allowance,
+        periodStart: row.period_start,
+        periodEnd: row.period_end,
+        periodStartBalance: row.period_start_balance,
+        cancelAtPeriodEnd: row.cancel_at_period_end === 1,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+function rowToPayment(row: PaymentRow): PaymentRecord {
+    return {
+        id: row.id,
+        userId: row.user_id,
+        kind: row.kind,
+        stripeRef: row.stripe_ref,
+        packId: row.pack_id,
+        planId: row.plan_id,
+        amountCents: row.amount_cents,
+        currency: row.currency,
+        credits: row.credits,
+        status: row.status,
+        createdAt: row.created_at,
+    };
+}
+
+function rowToWebhookLog(row: WebhookLogRow): WebhookLogRecord {
+    return {
+        id: row.id,
+        stripeEventId: row.stripe_event_id,
+        type: row.type,
+        payloadHash: row.payload_hash,
+        outcome: row.outcome,
+        detail: row.detail,
+        createdAt: row.created_at,
+    };
+}
+
+interface ReferralRow {
+    id: number;
+    code: string;
+    referrer_user_id: number;
+    referee_user_id: number;
+    reward: number;
+    offer_from: string;
+    offer_to: string;
+    created_at: string;
+}
+
+function rowToReferral(row: ReferralRow): ReferralRecord {
+    return {
+        id: row.id,
+        code: row.code,
+        referrerUserId: row.referrer_user_id,
+        refereeUserId: row.referee_user_id,
+        reward: row.reward,
+        offerFrom: row.offer_from,
+        offerTo: row.offer_to,
         createdAt: row.created_at,
     };
 }

--- a/src/youtube/lib/db.types.ts
+++ b/src/youtube/lib/db.types.ts
@@ -302,3 +302,103 @@ export interface VideoLite {
     hasSummary: boolean;
     hasTranscript: boolean;
 }
+
+export interface UpsertSubscriptionInput {
+    userId: number;
+    stripeCustomerId?: string | null;
+    stripeSubscriptionId?: string | null;
+    planId: string;
+    status: string;
+    allowance: number;
+    periodStart?: string | null;
+    periodEnd?: string | null;
+    periodStartBalance?: number;
+    cancelAtPeriodEnd?: boolean;
+}
+
+export interface SubscriptionRecord {
+    id: number;
+    userId: number;
+    stripeCustomerId: string | null;
+    stripeSubscriptionId: string | null;
+    planId: string;
+    status: string;
+    allowance: number;
+    periodStart: string | null;
+    periodEnd: string | null;
+    periodStartBalance: number;
+    cancelAtPeriodEnd: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface UpdateSubscriptionPartial {
+    stripeCustomerId?: string | null;
+    stripeSubscriptionId?: string | null;
+    status?: string;
+    allowance?: number;
+    periodStart?: string | null;
+    periodEnd?: string | null;
+    periodStartBalance?: number;
+    cancelAtPeriodEnd?: boolean;
+}
+
+export type PaymentKind = "pack" | "subscription" | "refund";
+export type PaymentStatus = "succeeded" | "failed" | "refunded";
+
+export interface RecordPaymentInput {
+    userId: number | null;
+    kind: PaymentKind;
+    stripeRef: string;
+    packId?: string | null;
+    planId?: string | null;
+    amountCents?: number | null;
+    currency?: string | null;
+    credits?: number | null;
+    status: PaymentStatus;
+}
+
+export interface PaymentRecord {
+    id: number;
+    userId: number | null;
+    kind: PaymentKind;
+    stripeRef: string;
+    packId: string | null;
+    planId: string | null;
+    amountCents: number | null;
+    currency: string | null;
+    credits: number | null;
+    status: PaymentStatus;
+    createdAt: string;
+}
+
+export type WebhookOutcome = "processed" | "skipped" | "duplicate" | "error";
+
+export interface RecordWebhookLogInput {
+    stripeEventId: string;
+    type: string;
+    payloadHash: string;
+    outcome: WebhookOutcome;
+    detail?: string | null;
+}
+
+export interface WebhookLogRecord {
+    id: number;
+    stripeEventId: string;
+    type: string;
+    payloadHash: string;
+    outcome: WebhookOutcome;
+    detail: string | null;
+    createdAt: string;
+}
+
+export interface ReferralRecord {
+    id: number;
+    code: string;
+    referrerUserId: number;
+    refereeUserId: number;
+    reward: number;
+    offerFrom: string;
+    offerTo: string;
+    createdAt: string;
+}

--- a/src/youtube/lib/quota.ts
+++ b/src/youtube/lib/quota.ts
@@ -1,0 +1,49 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { monthKeyUtc } from "@app/youtube/lib/billing-cycle";
+import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
+import type { YtUser } from "@app/youtube/lib/users.types";
+import type { Youtube } from "@app/youtube/lib/youtube";
+
+/**
+ * Monthly free-action metering (spec §4.1). Applies to logged-in users with
+ * NO active/past_due subscription and NO completed Stripe purchase — paying
+ * customers are never metered. Disabled until `freeTier.actionsPerMonth` is
+ * configured. The attempt is counted at gate time; a downstream failure does
+ * not refund the quota unit (accepted simplification).
+ *
+ * Returns the ready 402 Response (code "quota_exhausted") or null to proceed —
+ * the same gate idiom as `requireUser`.
+ */
+export async function enforceFreeQuota(yt: Youtube, user: YtUser): Promise<Response | null> {
+    const freeTier = await yt.config.get("freeTier");
+    const limit = freeTier.actionsPerMonth;
+
+    if (limit === null) {
+        return null;
+    }
+
+    const sub = yt.db.getSubscriptionByUserId(user.id);
+
+    if (sub && sub.status !== "canceled") {
+        return null;
+    }
+
+    if (yt.db.hasAnyStripeGrant(user.id)) {
+        return null;
+    }
+
+    const month = monthKeyUtc();
+    const result = yt.db.incrementQuotaIfBelow(user.id, month, limit);
+
+    if (result.allowed) {
+        return null;
+    }
+
+    logger.info({ userId: user.id, month, used: result.used, limit }, "youtube quota: free tier exhausted");
+
+    return new Response(
+        SafeJSON.stringify({ error: "monthly free quota exhausted", code: "quota_exhausted" }, { strict: true }),
+        { status: 402, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+    );
+}

--- a/src/youtube/lib/referrals.ts
+++ b/src/youtube/lib/referrals.ts
@@ -1,0 +1,46 @@
+import { randomBytes } from "node:crypto";
+import type { ReferralOffer, ReferralsConfig } from "@app/youtube/lib/config.types";
+
+/** No 0/O/1/I — codes get read aloud and retyped. */
+const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const CODE_LENGTH = 8;
+
+export function generateReferralCode(): string {
+    const bytes = randomBytes(CODE_LENGTH);
+    let code = "";
+
+    for (const byte of bytes) {
+        code += CODE_ALPHABET[byte % CODE_ALPHABET.length];
+    }
+
+    return code;
+}
+
+/** First offer whose [from, to] window contains `nowIso`; null when disabled or none match. */
+export function findActiveOffer(config: ReferralsConfig, nowIso: string): ReferralOffer | null {
+    if (!config.enabled) {
+        return null;
+    }
+
+    const now = Date.parse(nowIso);
+
+    return (
+        config.offers.find((offer) => {
+            const from = Date.parse(offer.from);
+            const to = Date.parse(offer.to);
+
+            return Number.isFinite(from) && Number.isFinite(to) && now >= from && now <= to;
+        }) ?? null
+    );
+}
+
+/** Referrers may see WHO converted, not harvest addresses. */
+export function maskEmail(email: string): string {
+    const at = email.indexOf("@");
+
+    if (at <= 0) {
+        return "***";
+    }
+
+    return `${email.slice(0, Math.min(2, at))}***${email.slice(at)}`;
+}

--- a/src/youtube/lib/server/__tests__/me-billing.test.ts
+++ b/src/youtube/lib/server/__tests__/me-billing.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleUsersRoute } from "@app/youtube/lib/server/routes/users";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-me-billing-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+async function getMe(token: string) {
+    const url = new URL("http://localhost/api/v1/users/me");
+    const req = new Request(url, { headers: { Authorization: `Bearer ${token}` } });
+    const res = await handleUsersRoute(req, url, yt);
+
+    return (await res.json()) as {
+        billing?: {
+            subscription: { allowanceRemaining: number; planId: string } | null;
+            freeQuota: { used: number; limit: number } | null;
+            lowBalance: boolean;
+        };
+    };
+}
+
+describe("GET /users/me billing context", () => {
+    it("free user, metering off: null sub, null quota, lowBalance from threshold", async () => {
+        const user = db.createUser({ email: "m1@example.com", passwordHash: "h", apiToken: "ytu_m1" });
+        db.grantCredits(user.id, 10, "register-grant");
+        const body = await getMe("ytu_m1");
+
+        expect(body.billing?.subscription).toBeNull();
+        expect(body.billing?.freeQuota).toBeNull();
+        expect(body.billing?.lowBalance).toBe(true);
+
+        db.grantCredits(user.id, 100, "dev-topup");
+        expect((await getMe("ytu_m1")).billing?.lowBalance).toBe(false);
+    });
+
+    it("metered user sees quota standing", async () => {
+        await yt.config.update({ freeTier: { actionsPerMonth: 5 } });
+        db.createUser({ email: "m2@example.com", passwordHash: "h", apiToken: "ytu_m2" });
+        const body = await getMe("ytu_m2");
+
+        expect(body.billing?.freeQuota).toEqual(expect.objectContaining({ used: 0, limit: 5 }));
+    });
+
+    it("subscriber sees derived allowanceRemaining", async () => {
+        const user = db.createUser({ email: "m3@example.com", passwordHash: "h", apiToken: "ytu_m3" });
+        db.grantCredits(user.id, 3000, "sub-allowance:in_seed");
+        db.upsertSubscription({
+            userId: user.id,
+            planId: "sub-monthly",
+            status: "active",
+            allowance: 3000,
+            periodStart: new Date(Date.now() - 1000).toISOString(),
+            periodEnd: new Date(Date.now() + 2_000_000_000).toISOString(),
+            periodStartBalance: 3000,
+        });
+        db.spendCredits(user.id, 500, "ask");
+        const body = await getMe("ytu_m3");
+
+        expect(body.billing?.subscription?.planId).toBe("sub-monthly");
+        expect(body.billing?.subscription?.allowanceRemaining).toBe(2500);
+    });
+});

--- a/src/youtube/lib/server/__tests__/referral-routes.test.ts
+++ b/src/youtube/lib/server/__tests__/referral-routes.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@app/utils/json";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleUsersRoute } from "@app/youtube/lib/server/routes/users";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "yt-referral-routes-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    const year = new Date().getUTCFullYear();
+    await yt.config.update({
+        referrals: {
+            enabled: true,
+            offers: [{ from: `${year}-01-01T00:00:00Z`, to: `${year + 1}-01-01T00:00:00Z`, reward: 25 }],
+        },
+    });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    const user = db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+    db.grantCredits(user.id, 100, "register-grant");
+
+    return { ...user, credits: 100, token: `ytu_${email}` };
+}
+
+async function call(method: string, path: string, token: string, bodyObj?: unknown) {
+    const url = new URL(`http://localhost${path}`);
+    const req = new Request(url, {
+        method,
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        ...(bodyObj !== undefined ? { body: SafeJSON.stringify(bodyObj, { strict: true }) } : {}),
+    });
+    const res = await handleUsersRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("referral flow", () => {
+    it("issues a stable code, rewards both sides once, lists masked referees", async () => {
+        const referrer = createUser("ref@example.com");
+        const referee = createUser("new.person@example.com");
+        const first = await call("GET", "/api/v1/users/referral", referrer.token);
+        const code = first.json.code as string;
+
+        expect(first.status).toBe(200);
+        expect(code).toMatch(/^[A-HJ-NP-Z2-9]{8}$/);
+        expect((await call("GET", "/api/v1/users/referral", referrer.token)).json.code).toBe(code);
+
+        const redeem = await call("POST", "/api/v1/users/referral/redeem", referee.token, { code });
+
+        expect(redeem.status).toBe(200);
+        expect(redeem.json.reward).toBe(25);
+        expect(db.getUserCredits(referee.id)).toBe(125);
+        expect(db.getUserCredits(referrer.id)).toBe(125);
+
+        const again = await call("POST", "/api/v1/users/referral/redeem", referee.token, { code });
+
+        expect(again.status).toBe(409);
+
+        const view = await call("GET", "/api/v1/users/referral", referrer.token);
+        const referees = view.json.referees as Array<{ email: string; reward: number }>;
+
+        expect(view.json.totalEarned).toBe(25);
+        expect(referees[0].email).toBe("ne***@example.com");
+    });
+
+    it("rejects self-referral and unknown codes; 403 offer_inactive when disabled", async () => {
+        const user = createUser("self@example.com");
+        const code = (await call("GET", "/api/v1/users/referral", user.token)).json.code as string;
+
+        expect((await call("POST", "/api/v1/users/referral/redeem", user.token, { code })).status).toBe(400);
+        expect((await call("POST", "/api/v1/users/referral/redeem", user.token, { code: "NOPE2222" })).status).toBe(
+            400
+        );
+
+        await yt.config.update({ referrals: { enabled: false, offers: [] } });
+        const other = createUser("other@example.com");
+        const inactive = await call("POST", "/api/v1/users/referral/redeem", other.token, { code });
+
+        expect(inactive.status).toBe(403);
+        expect(inactive.json.code).toBe("offer_inactive");
+    });
+});

--- a/src/youtube/lib/server/__tests__/subscribe-route.test.ts
+++ b/src/youtube/lib/server/__tests__/subscribe-route.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleUsersRoute } from "@app/youtube/lib/server/routes/users";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "yt-subscribe-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function createUser(email: string) {
+    const user = db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+
+    return { ...user, token: `ytu_${email}` };
+}
+
+async function subscribe(token: string, planId: string) {
+    const url = new URL("http://localhost/api/v1/users/subscribe");
+    const req = new Request(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: SafeJSON.stringify({ planId }, { strict: true }),
+    });
+    const res = await handleUsersRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("POST /api/v1/users/subscribe", () => {
+    it("400s an unknown plan before touching Stripe", async () => {
+        const user = createUser("s1@example.com");
+        const res = await subscribe(user.token, "sub-yearly");
+
+        expect(res.status).toBe(400);
+    });
+
+    it("503s when billing is not configured", async () => {
+        const user = createUser("s2@example.com");
+        let res: Awaited<ReturnType<typeof subscribe>> | undefined;
+
+        await env.testing.withOverrides({ STRIPE_SECRET_KEY: undefined }, async () => {
+            res = await subscribe(user.token, "sub-monthly");
+        });
+
+        expect(res?.status).toBe(503);
+    });
+
+    it("409s when a subscription is already active", async () => {
+        const user = createUser("s3@example.com");
+        db.upsertSubscription({ userId: user.id, planId: "sub-monthly", status: "active", allowance: 3000 });
+        let res: Awaited<ReturnType<typeof subscribe>> | undefined;
+
+        await env.testing.withOverrides({ STRIPE_SECRET_KEY: "sk_test_x" }, async () => {
+            res = await subscribe(user.token, "sub-monthly");
+        });
+
+        expect(res?.status).toBe(409);
+    });
+});

--- a/src/youtube/lib/server/openapi.ts
+++ b/src/youtube/lib/server/openapi.ts
@@ -1333,6 +1333,69 @@ function buildPaths(): Record<string, OpenApiPathItem> {
                 },
             },
         },
+        "/api/v1/users/subscribe": {
+            post: {
+                operationId: "subscribeUser",
+                summary: "Start a monthly subscription checkout session",
+                tags: ["users"],
+                requestBody: jsonBody(
+                    { type: "object", properties: { planId: { type: "string" } }, required: ["planId"] },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Checkout session", {
+                        type: "object",
+                        properties: { url: { type: "string" } },
+                        required: ["url"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                    "409": errorResponse,
+                    "503": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/referral": {
+            get: {
+                operationId: "getReferral",
+                summary: "The signed-in user's referral code and redeemed referees",
+                tags: ["users"],
+                responses: {
+                    "200": jsonResponse("Referral standing", {
+                        type: "object",
+                        properties: {
+                            code: { type: "string" },
+                            referees: arrayOf({ type: "object" }),
+                            totalEarned: { type: "integer" },
+                        },
+                        required: ["code", "referees", "totalEarned"],
+                    }),
+                    "401": errorResponse,
+                },
+            },
+        },
+        "/api/v1/users/referral/redeem": {
+            post: {
+                operationId: "redeemReferral",
+                summary: "Redeem a referral code for both-side rewards",
+                tags: ["users"],
+                requestBody: jsonBody(
+                    { type: "object", properties: { code: { type: "string" } }, required: ["code"] },
+                    { required: true }
+                ),
+                responses: {
+                    "200": jsonResponse("Reward granted", {
+                        type: "object",
+                        properties: { reward: { type: "integer" }, credits: { type: "integer" } },
+                        required: ["reward", "credits"],
+                    }),
+                    "400": errorResponse,
+                    "401": errorResponse,
+                    "403": errorResponse,
+                    "409": errorResponse,
+                },
+            },
+        },
         "/api/v1/users/history": {
             get: {
                 operationId: "getUserHistory",

--- a/src/youtube/lib/server/routes/reports.ts
+++ b/src/youtube/lib/server/routes/reports.ts
@@ -1,5 +1,6 @@
 import { SafeJSON } from "@app/utils/json";
 import { grantArtifactAccess } from "@app/youtube/lib/artifact-access";
+import { enforceFreeQuota } from "@app/youtube/lib/quota";
 import { estimateReportCost, REPORT_MAX_MEMBERS, REPORT_MIN_MEMBERS } from "@app/youtube/lib/reports";
 import { requireUser } from "@app/youtube/lib/server/auth";
 import { safeJsonBody } from "@app/youtube/lib/server/body";
@@ -67,6 +68,12 @@ export async function handleReportsRoute(req: Request, url: URL, yt: Youtube): P
                 memberIds: videoIds,
                 params: { provider, model },
             });
+            const quotaError = await enforceFreeQuota(yt, user);
+
+            if (quotaError) {
+                return quotaError;
+            }
+
             // The full quote is charged up front; member access rows are granted
             // at their quoted price so summaries generated (or reused) for this
             // report stay unlocked for the requester afterwards.

--- a/src/youtube/lib/server/routes/users.ts
+++ b/src/youtube/lib/server/routes/users.ts
@@ -1,14 +1,19 @@
 import { logger } from "@app/logger";
 import { env } from "@app/utils/env";
 import { SafeJSON } from "@app/utils/json";
-import { createCheckoutSession } from "@app/youtube/lib/billing";
-import { DIAMOND_PACKS } from "@app/youtube/lib/billing.types";
+import {
+    buildBillingContext,
+    createCheckoutSession,
+    createSubscriptionCheckoutSession,
+} from "@app/youtube/lib/billing";
+import { DIAMOND_PACKS, SUBSCRIPTION_PLANS } from "@app/youtube/lib/billing.types";
 import type { ChannelHandle } from "@app/youtube/lib/channel.types";
 import { buildHistoryEntries, groupHistoryByAction, groupHistoryByVideo } from "@app/youtube/lib/history";
 import { isOutputLang } from "@app/youtube/lib/languages";
 import { getLedgerPage, getUsageSummary } from "@app/youtube/lib/ledger-views";
 import { createPreset, deletePreset, listPresets, updatePreset } from "@app/youtube/lib/presets";
 import type { PresetKind } from "@app/youtube/lib/presets.types";
+import { findActiveOffer, generateReferralCode, maskEmail } from "@app/youtube/lib/referrals";
 import { roleForEmail } from "@app/youtube/lib/roles";
 import { requireUser } from "@app/youtube/lib/server/auth";
 import { safeJsonBody } from "@app/youtube/lib/server/body";
@@ -60,8 +65,9 @@ export async function handleUsersRoute(req: Request, url: URL, yt: Youtube): Pro
             }
 
             const role = roleForEmail(await yt.config.get("powerUsers"), user.email);
+            const billing = await buildBillingContext({ db: yt.db, config: yt.config, user });
 
-            return Response.json({ user, role }, { headers: CORS_HEADERS });
+            return Response.json({ user, role, billing }, { headers: CORS_HEADERS });
         }
 
         if (matchRoute(req, "PATCH", "/api/v1/users/me", url.pathname)) {
@@ -133,6 +139,120 @@ export async function handleUsersRoute(req: Request, url: URL, yt: Youtube): Pro
                 logger.warn({ error, userId: user.id, packId }, "youtube billing: checkout session failed");
                 return jsonError(message, message.includes("not configured") ? 503 : 400);
             }
+        }
+
+        if (matchRoute(req, "POST", "/api/v1/users/subscribe", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const planId = typeof body.planId === "string" ? body.planId : null;
+
+            if (!planId || !SUBSCRIPTION_PLANS.some((plan) => plan.id === planId)) {
+                return jsonError("body must include a known {planId}", 400);
+            }
+
+            if (!env.stripe.getSecretKey()) {
+                return jsonError("billing not configured", 503);
+            }
+
+            const existing = yt.db.getSubscriptionByUserId(user.id);
+
+            if (existing && existing.status === "active") {
+                return jsonError("subscription already active", 409);
+            }
+
+            try {
+                const origin = req.headers.get("Origin") ?? "https://www.youtube.com";
+                const result = await createSubscriptionCheckoutSession({ user, planId, origin });
+                return Response.json(result, { headers: CORS_HEADERS });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                logger.warn({ error, userId: user.id, planId }, "youtube billing: subscribe session failed");
+                return jsonError(message, message.includes("not configured") ? 503 : 400);
+            }
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/users/referral", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const code = yt.db.getOrCreateReferralCode(user.id, generateReferralCode());
+            const referrals = yt.db.listReferralsByReferrer(user.id);
+            const referees = referrals.map((referral) => ({
+                email: maskEmail(yt.db.getUserEmailById(referral.refereeUserId) ?? "unknown"),
+                redeemedAt: referral.createdAt,
+                reward: referral.reward,
+            }));
+            const totalEarned = referrals.reduce((sum, referral) => sum + referral.reward, 0);
+
+            return Response.json({ code, referees, totalEarned }, { headers: CORS_HEADERS });
+        }
+
+        if (matchRoute(req, "POST", "/api/v1/users/referral/redeem", url.pathname)) {
+            const user = requireUser(req, url, yt.db);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const body = (await safeJsonBody(req)) ?? {};
+            const code = typeof body.code === "string" ? body.code.trim().toUpperCase() : null;
+
+            if (!code) {
+                return jsonError("body must include {code}", 400);
+            }
+
+            const referrerUserId = yt.db.getReferralCodeOwner(code);
+
+            if (referrerUserId === null) {
+                return jsonError("unknown referral code", 400);
+            }
+
+            if (referrerUserId === user.id) {
+                return jsonError("cannot redeem your own code", 400);
+            }
+
+            if (yt.db.getReferralByReferee(user.id)) {
+                return jsonError("referral already redeemed", 409);
+            }
+
+            const offer = findActiveOffer(await yt.config.get("referrals"), new Date().toISOString());
+
+            if (!offer) {
+                return new Response(
+                    SafeJSON.stringify(
+                        { error: "no referral offer is currently active", code: "offer_inactive" },
+                        { strict: true }
+                    ),
+                    { status: 403, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+                );
+            }
+
+            const referralId = yt.db.createReferral({
+                code,
+                referrerUserId,
+                refereeUserId: user.id,
+                reward: offer.reward,
+                offerFrom: offer.from,
+                offerTo: offer.to,
+            });
+            // Both-side reward: two ledger rows share the referral id so the
+            // activity feed can label each side.
+            yt.db.grantCredits(referrerUserId, offer.reward, `referral:${referralId}:referrer`);
+            const credits = yt.db.grantCredits(user.id, offer.reward, `referral:${referralId}:referee`);
+            logger.info(
+                { referralId, referrerUserId, refereeUserId: user.id, reward: offer.reward },
+                "youtube referrals: redeemed"
+            );
+
+            return Response.json({ reward: offer.reward, credits }, { headers: CORS_HEADERS });
         }
 
         if (matchRoute(req, "GET", "/api/v1/users/ledger", url.pathname)) {

--- a/src/youtube/lib/server/routes/videos.ts
+++ b/src/youtube/lib/server/routes/videos.ts
@@ -9,6 +9,7 @@ import { isOutputLang } from "@app/youtube/lib/languages";
 import { getPresetForUse } from "@app/youtube/lib/presets";
 import { resolveProviderChoice } from "@app/youtube/lib/provider-choice";
 import { selectCandidateVideos } from "@app/youtube/lib/qa";
+import { enforceFreeQuota } from "@app/youtube/lib/quota";
 import { requireUser, resolveUser } from "@app/youtube/lib/server/auth";
 import { safeJsonBody } from "@app/youtube/lib/server/body";
 import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
@@ -136,6 +137,12 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
             }
 
             const creditCost = CREDIT_COSTS["transcript:translate"];
+            const quotaError = await enforceFreeQuota(yt, user);
+
+            if (quotaError) {
+                return quotaError;
+            }
+
             // Reserve BEFORE the LLM call so concurrent requests cannot pass a
             // stale balance check and burn provider cost; released on failure.
             const hold = yt.db.reserveCredits({
@@ -207,6 +214,12 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
             let hold: { holdId: number; credits: number } | undefined;
 
             if (!cached) {
+                const quotaError = await enforceFreeQuota(yt, user);
+
+                if (quotaError) {
+                    return quotaError;
+                }
+
                 // Reserve BEFORE synthesis so concurrent requests cannot pass a
                 // stale balance check and burn provider cost; released on failure.
                 hold = yt.db.reserveCredits({ userId: user.id, amount: creditCost, reason: `tts:${id}` });
@@ -513,6 +526,12 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                       ),
                   })
                 : undefined;
+            const quotaError = await enforceFreeQuota(yt, user);
+
+            if (quotaError) {
+                return quotaError;
+            }
+
             // Reserve BEFORE the pipeline work so concurrent requests cannot pass
             // a stale balance check and burn provider cost; released on failure.
             const hold = yt.db.reserveCredits({
@@ -521,6 +540,12 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 reason: `summary:${mode}`,
                 context: id,
             });
+            // Q2 (frozen): the ASR fallback costs the same as the standalone
+            // transcribe path. Reserved lazily — only if captions actually miss.
+            // Ref container: the reserve happens inside a deeply-nested callback,
+            // and TS's closure-assignment narrowing collapses a plain `let` to
+            // `never` at the later checks — a stable object property does not.
+            const transcribeHold: { current: { holdId: number; credits: number } | null } = { current: null };
             const stages = hasTranscript ? (["summarize"] as const) : (["captions", "summarize"] as const);
             const job = yt.db.enqueueJob({ targetKind: "video", target: id, stages: [...stages], userId: user.id });
             yt.pipeline.emitExternal({ type: "job:created", job });
@@ -547,6 +572,14 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                     await withJobActivity({ jobId: job.id, stage: "captions", db: yt.db, userId: user.id }, () =>
                         yt.transcripts.transcribe({
                             videoId: id,
+                            beforeAiTranscription: () => {
+                                transcribeHold.current = yt.db.reserveCredits({
+                                    userId: user.id,
+                                    amount: CREDIT_COSTS["transcribe:ai"],
+                                    reason: "transcribe:ai",
+                                    context: id,
+                                });
+                            },
                             onProgress: (info) => {
                                 const stagePct = (info.percent ?? 0) / 100;
                                 const overall = Math.min(0.25, 0.05 + stagePct * 0.2);
@@ -638,6 +671,10 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                     videoId: id,
                     creditsSpent: creditCost,
                 });
+                if (transcribeHold.current !== null) {
+                    yt.db.commitHold(transcribeHold.current.holdId);
+                }
+
                 // Last DB action before the response: anything throwing above
                 // still finds the hold "held" and releasable in the catch.
                 yt.db.commitHold(hold.holdId);
@@ -655,13 +692,18 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                         cached: false,
                         jobId: job.id,
                         startedAt,
-                        creditsSpent: creditCost,
-                        credits: hold.credits,
+                        creditsSpent:
+                            creditCost + (transcribeHold.current !== null ? CREDIT_COSTS["transcribe:ai"] : 0),
+                        credits: transcribeHold.current !== null ? transcribeHold.current.credits : hold.credits,
                     },
                     { headers: CORS_HEADERS }
                 );
             } catch (error) {
                 yt.db.releaseHold(hold.holdId);
+                if (transcribeHold.current !== null) {
+                    yt.db.releaseHold(transcribeHold.current.holdId);
+                }
+
                 const message = error instanceof Error ? error.message : String(error);
                 yt.db.updateJob(job.id, { status: "failed", error: message, completedAt: new Date().toISOString() });
                 const failedJob = yt.db.getJob(job.id) ?? job;
@@ -735,6 +777,7 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                     estUsd,
                     basis,
                     creditCost: reusable ? (hasAccess ? 0 : REUSE_COST) : CREDIT_COSTS[`summary:${mode}`],
+                    transcribeCredits: transcript ? 0 : CREDIT_COSTS["transcribe:ai"],
                     reused,
                 },
                 { headers: CORS_HEADERS }
@@ -827,6 +870,12 @@ export async function handleVideosRoute(req: Request, url: URL, yt: Youtube): Pr
                 }
 
                 presetInstructions = preset.instructions;
+            }
+
+            const quotaError = await enforceFreeQuota(yt, user);
+
+            if (quotaError) {
+                return quotaError;
             }
 
             // Reserve BEFORE the retrieval/LLM work so concurrent requests cannot

--- a/src/youtube/lib/types.ts
+++ b/src/youtube/lib/types.ts
@@ -1,3 +1,5 @@
+export type { MeBillingContext, SubscriptionPlan, SubscriptionStatus } from "@app/youtube/lib/billing.types";
+export { LOW_BALANCE_THRESHOLD, SUBSCRIPTION_PLANS } from "@app/youtube/lib/billing.types";
 export type { CacheLayout } from "@app/youtube/lib/cache.types";
 export type { FetchCaptionsOpts, FetchCaptionsResult } from "@app/youtube/lib/captions.types";
 export type { Channel, ChannelHandle } from "@app/youtube/lib/channel.types";

--- a/src/youtube/lib/users.types.ts
+++ b/src/youtube/lib/users.types.ts
@@ -44,6 +44,8 @@ export type CreditReason =
     | `refund:${string}`
     | `hold:${string}`
     | `hold-release:${string}`
+    | `sub-allowance:${string}`
+    | `referral:${string}`
     | `reuse:${string}`
     | `report:${string}`
     | `tts:${string}`;


### PR DESCRIPTION
## Summary

- StripeGateway seam over the official Stripe SDK; billing vocabulary (plan, thresholds, freeTier config, ledger reasons)
- Billing tables (subscriptions, payments, webhook_logs, quota_usage); referral codes + redemptions storage
- Single-balance allowance math (derived buckets, reset-not-additive); SDK gateway checkout + subscription checkout route
- Subscription webhooks (idempotent logs, allowance reset, failure audit); monthly free-tier metering with typed `quota_exhausted` 402
- Referral codes with both-side rewards + masked referee listing; balance context on `/users/me`

## Stack

1. feat(youtube): product surface base
2. fix(youtube): phase 0 — panel scroll, comments feedback, dialog rework, audit sweep
3. feat(youtube): phase 1 foundations — roles, ai task mapping, audit tables, typed auth, WS scoping, transcript fallback
4. feat(youtube): phase 3 web features — history, collections, collection-ask agent, watchlist + digest
5. **feat(youtube): phase 2 billing — Stripe subscriptions, resetting allowance, free tier, referrals** ← you are here
6. feat(youtube): phase 4 extension — feature port, monetization UI, 16:9 admin panel + admin API
7. feat(youtube): phase 5 customization + production polish — settings, sweep fixes, review-fix wave

Part of the #263 split; merge bottom-up.
