### PR TITLE
feat(youtube): phase 4 extension — feature port, monetization UI, 16:9 admin panel + admin API

### DIFF
--- a/src/utils/ui/components/youtube/activity-graph.tsx
+++ b/src/utils/ui/components/youtube/activity-graph.tsx
@@ -1,0 +1,111 @@
+import type { UsageDay } from "@app/youtube/lib/types";
+import { useState } from "react";
+import { formatDiamonds } from "./diamond";
+
+function shortDate(iso: string): string {
+    const date = new Date(`${iso}T00:00:00.000Z`);
+
+    if (Number.isNaN(date.getTime())) {
+        return iso;
+    }
+
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+/**
+ * Interactive daily-spend graph (spec §7: the previously static activity graph
+ * made interactive). Each bar is a real `<button>` so it's keyboard-focusable
+ * and Enter/Space-activatable for free; hover/focus surfaces the day's value in
+ * a live readout, and clicking a bar drills the surrounding list down to that
+ * day (`onSelectDate`), clicking it again clears. Shared so the extension panel
+ * and web account page use one graph.
+ */
+export function ActivityGraph({
+    days,
+    selectedDate,
+    onSelectDate,
+    loading,
+}: {
+    days: UsageDay[];
+    selectedDate?: string | null;
+    onSelectDate?: (date: string | null) => void;
+    loading?: boolean;
+}) {
+    const [hovered, setHovered] = useState<UsageDay | null>(null);
+    const maxSpent = Math.max(1, ...days.map((day) => day.spent));
+    const active = hovered ?? (selectedDate ? (days.find((day) => day.date === selectedDate) ?? null) : null);
+
+    if (loading) {
+        return (
+            <div className="space-y-2">
+                <GraphLabel />
+                <div className="h-16 animate-pulse rounded-lg bg-white/5" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-baseline justify-between">
+                <GraphLabel />
+                <p className="font-mono text-[12px] tabular-nums text-muted-foreground" aria-live="polite">
+                    {active ? (
+                        <>
+                            <span className="text-foreground">{formatDiamonds(active.spent)} 💎</span>{" "}
+                            {shortDate(active.date)}
+                        </>
+                    ) : selectedDate ? (
+                        <button
+                            type="button"
+                            className="text-primary hover:underline"
+                            onClick={() => onSelectDate?.(null)}
+                        >
+                            clear filter
+                        </button>
+                    ) : (
+                        "hover a day"
+                    )}
+                </p>
+            </div>
+            <div className="flex h-16 items-end gap-[2px]">
+                {days.map((day) => {
+                    const isSelected = day.date === selectedDate;
+                    const height = day.spent === 0 ? 6 : Math.max(12, (day.spent / maxSpent) * 100);
+                    const tone = isSelected
+                        ? "bg-primary"
+                        : day.spent === 0
+                          ? "bg-white/5 hover:bg-white/10"
+                          : "bg-primary/40 hover:bg-primary/70";
+
+                    return (
+                        <button
+                            key={day.date}
+                            type="button"
+                            aria-label={`${shortDate(day.date)}: ${day.spent} diamonds spent, ${day.earned} earned`}
+                            aria-pressed={onSelectDate ? isSelected : undefined}
+                            title={`${shortDate(day.date)} · ${day.spent} 💎 spent`}
+                            onMouseEnter={() => setHovered(day)}
+                            onMouseLeave={() => setHovered(null)}
+                            onFocus={() => setHovered(day)}
+                            onBlur={() => setHovered(null)}
+                            onClick={() => onSelectDate?.(isSelected ? null : day.date)}
+                            disabled={!onSelectDate}
+                            className={`min-w-0 flex-1 rounded-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60 ${tone} ${
+                                onSelectDate ? "cursor-pointer" : "cursor-default"
+                            }`}
+                            style={{ height: `${height}%` }}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function GraphLabel() {
+    return (
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+            activity · last 30 days
+        </p>
+    );
+}

--- a/src/utils/ui/components/youtube/ask-tab.tsx
+++ b/src/utils/ui/components/youtube/ask-tab.tsx
@@ -2,6 +2,7 @@ import { logger } from "@app/logger/client";
 import { Button } from "@app/utils/ui/components/button";
 import { Input } from "@app/utils/ui/components/input";
 import { Markdown } from "@app/utils/ui/components/markdown";
+import { errorCodeOf } from "@app/utils/ui/components/youtube/login-required";
 import { ShareButton } from "@app/utils/ui/components/youtube/share-button";
 import { StyleSelect } from "@app/utils/ui/components/youtube/style-select";
 import type { PipelineProgress, RunPipeline, VideoDetailDataSource } from "@app/utils/ui/components/youtube/tabs";
@@ -72,6 +73,8 @@ export interface AskTabProps {
     /** Invoked by the "Sign in" affordance when the ask endpoint returns 401.
      *  Receives the failed action as `retry` — a successful login re-runs it. */
     onRequireLogin?: (retry?: () => void) => void;
+    /** Opens the diamonds/subscription surface when Ask bounces with a 402. */
+    onUpgrade?: () => void;
     /** Comments presence check for the Comments/Both scopes. */
     useComments?: (id: VideoId | null) => {
         data: { comments: VideoComment[] } | undefined;
@@ -287,6 +290,7 @@ export function AskTab({
     useListPresets,
     useCreatePreset,
     onRequireLogin,
+    onUpgrade,
     useComments,
     runPipeline,
     pipelineProgress,
@@ -305,6 +309,7 @@ export function AskTab({
     const [scope, setScope] = useState<AskScope>("video");
     const [question, setQuestion] = useState("");
     const [error, setError] = useState<string | null>(null);
+    const [errorCode, setErrorCode] = useState<string | null>(null);
     // Session fallback for consumers without server history — keeps the live
     // answer visible when `useQaHistory` isn't wired.
     const [sessionExchange, setSessionExchange] = useState<{
@@ -320,7 +325,8 @@ export function AskTab({
     const items = history?.data?.items ?? [];
     const latest = items[0];
     const older = items.slice(1);
-    const signInRequired = error === "login required";
+    const signInRequired = error === "login required" || errorCode === "login_required";
+    const upgradeRequired = errorCode === "quota_exhausted" || errorCode === "insufficient_credits";
     const commentsUnfetched = useComments !== undefined && (comments?.data?.comments.length ?? 0) === 0;
     const needsCommentsFetch = (scope === "comments" || scope === "both") && commentsUnfetched;
 
@@ -332,6 +338,7 @@ export function AskTab({
         }
 
         setError(null);
+        setErrorCode(null);
         try {
             const result = await ask.mutateAsync({
                 question: trimmed,
@@ -354,6 +361,7 @@ export function AskTab({
         } catch (error) {
             logger.warn({ error }, "ask-tab: submit failed");
             setError(error instanceof Error ? error.message : String(error));
+            setErrorCode(errorCodeOf(error) ?? null);
         }
     }
 
@@ -461,6 +469,25 @@ export function AskTab({
                         {onRequireLogin ? (
                             <Button size="sm" className="mt-2.5" onClick={() => onRequireLogin(() => void submit())}>
                                 Sign in
+                            </Button>
+                        ) : null}
+                    </div>
+                </div>
+            ) : upgradeRequired ? (
+                <div className="flex items-start gap-3 rounded-2xl border border-primary/25 bg-primary/5 p-4">
+                    <LockKeyhole className="mt-0.5 size-4 shrink-0 text-primary" strokeWidth={2} />
+                    <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-foreground/95">
+                            {errorCode === "quota_exhausted" ? "Out of free questions" : "Not enough diamonds"}
+                        </p>
+                        <p className="mt-0.5 text-sm text-muted-foreground">
+                            {errorCode === "quota_exhausted"
+                                ? "You've used your free actions this month. Top up or subscribe to keep asking."
+                                : "Top up or subscribe to keep asking."}
+                        </p>
+                        {onUpgrade ? (
+                            <Button size="sm" className="mt-2.5" onClick={onUpgrade}>
+                                Get diamonds
                             </Button>
                         ) : null}
                     </div>

--- a/src/utils/ui/components/youtube/billing-ui.test.ts
+++ b/src/utils/ui/components/youtube/billing-ui.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { computeCreditBuckets, subscriptionRenewalCopy } from "@app/utils/ui/components/youtube/billing-ui";
+
+const activeSub = {
+    planId: "sub-monthly",
+    status: "active" as const,
+    periodEnd: "2026-07-31T00:00:00.000Z",
+    allowance: 3000,
+    allowanceRemaining: 2400,
+    cancelAtPeriodEnd: false,
+};
+
+describe("computeCreditBuckets", () => {
+    test("splits an active subscription balance into allowance + top-up", () => {
+        // 2600 balance, 2400 of it is remaining allowance → 200 is top-up.
+        expect(computeCreditBuckets({ credits: 2600, subscription: activeSub })).toEqual({
+            total: 2600,
+            allowanceRemaining: 2400,
+            topup: 200,
+            allowance: 3000,
+        });
+    });
+
+    test("clamps allowanceRemaining to the balance when the ledger drifted low", () => {
+        expect(computeCreditBuckets({ credits: 100, subscription: activeSub })).toEqual({
+            total: 100,
+            allowanceRemaining: 100,
+            topup: 0,
+            allowance: 3000,
+        });
+    });
+
+    test("no subscription → everything is top-up", () => {
+        expect(computeCreditBuckets({ credits: 500, subscription: null })).toEqual({
+            total: 500,
+            allowanceRemaining: 0,
+            topup: 500,
+            allowance: 0,
+        });
+    });
+
+    test("canceled subscription contributes no allowance bucket", () => {
+        const canceled = { ...activeSub, status: "canceled" as const };
+        expect(computeCreditBuckets({ credits: 500, subscription: canceled })).toEqual({
+            total: 500,
+            allowanceRemaining: 0,
+            topup: 500,
+            allowance: 0,
+        });
+    });
+});
+
+describe("subscriptionRenewalCopy", () => {
+    test("renews when not cancelling", () => {
+        expect(subscriptionRenewalCopy(activeSub)).toBe("Renews Jul 31");
+    });
+
+    test("ends when cancelAtPeriodEnd", () => {
+        expect(subscriptionRenewalCopy({ ...activeSub, cancelAtPeriodEnd: true })).toBe("Ends Jul 31 — won't renew");
+    });
+
+    test("null when no period end", () => {
+        expect(subscriptionRenewalCopy({ ...activeSub, periodEnd: null })).toBeNull();
+    });
+});

--- a/src/utils/ui/components/youtube/billing-ui.ts
+++ b/src/utils/ui/components/youtube/billing-ui.ts
@@ -1,0 +1,61 @@
+import type { MeBillingContext } from "@app/youtube/lib/billing.types";
+
+export interface CreditBuckets {
+    /** The single credit balance (`user.credits`). */
+    total: number;
+    /** Portion of the balance that came from the current period's allowance —
+     *  claws back to the next period's allowance on renewal. */
+    allowanceRemaining: number;
+    /** Purchased/earned top-up remainder — survives the billing period reset. */
+    topup: number;
+    /** The full period allowance a plan grants (0 when not subscribed). */
+    allowance: number;
+}
+
+/**
+ * Splits the single credit balance into its resetting (subscription allowance)
+ * and persistent (top-up) buckets for the "allowance vs top-up" visualization
+ * (spec §4.2 — diamonds RESET each period, they are not additive). Pure and
+ * browser-safe so both the extension panel and the web account page can render
+ * the same split. Only an ACTIVE subscription contributes an allowance bucket.
+ */
+export function computeCreditBuckets(input: {
+    credits: number;
+    subscription: MeBillingContext["subscription"];
+}): CreditBuckets {
+    const { credits, subscription } = input;
+    const active = subscription !== null && subscription.status === "active";
+    const allowanceRemaining = active ? Math.max(0, Math.min(credits, subscription.allowanceRemaining)) : 0;
+
+    return {
+        total: credits,
+        allowanceRemaining,
+        topup: Math.max(0, credits - allowanceRemaining),
+        allowance: active ? subscription.allowance : 0,
+    };
+}
+
+/** Human copy for a subscription's renewal/cancellation state. Returns null
+ *  when there's nothing dated to say (no period end). */
+export function subscriptionRenewalCopy(subscription: NonNullable<MeBillingContext["subscription"]>): string | null {
+    if (!subscription.periodEnd) {
+        return null;
+    }
+
+    const date = new Date(subscription.periodEnd);
+
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    // Format in UTC so the shown date matches the server's period-end date
+    // regardless of the viewer's timezone (a US viewer must not see "Jul 30"
+    // for a period ending 2026-07-31T00:00Z).
+    const formatted = date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+
+    if (subscription.cancelAtPeriodEnd) {
+        return `Ends ${formatted} — won't renew`;
+    }
+
+    return `Renews ${formatted}`;
+}

--- a/src/utils/ui/components/youtube/collection-ui.ts
+++ b/src/utils/ui/components/youtube/collection-ui.ts
@@ -1,0 +1,30 @@
+import { SafeJSON } from "@app/utils/json";
+import type { AskMessageRecord } from "@app/youtube/lib/types";
+
+/** Human-readable summary of a dynamic collection's stored rule JSON. */
+export function ruleSummary(ruleJson: string | null): string {
+    if (!ruleJson) {
+        return "Dynamic collection";
+    }
+
+    const rule = SafeJSON.parse(ruleJson) as { type?: string; sinceDays?: number } | null;
+
+    if (rule?.type === "watched" && typeof rule.sinceDays === "number") {
+        return `Videos you watched in the last ${rule.sinceDays} days`;
+    }
+
+    return "Dynamic collection";
+}
+
+/** Synthetic user message shown optimistically while a collection ask is in flight. */
+export function optimisticUserMessage(threadId: number | null, content: string): AskMessageRecord {
+    return {
+        id: -1,
+        threadId: threadId ?? -1,
+        role: "user",
+        content,
+        toolName: null,
+        toolArgsJson: null,
+        createdAt: new Date().toISOString(),
+    };
+}

--- a/src/utils/ui/components/youtube/diamond.test.ts
+++ b/src/utils/ui/components/youtube/diamond.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { formatDiamonds } from "@app/utils/ui/components/youtube/diamond";
+
+describe("formatDiamonds", () => {
+    test("thin-space separates thousands", () => {
+        expect(formatDiamonds(1500)).toBe("1 500");
+        expect(formatDiamonds(1_234_567)).toBe("1 234 567");
+    });
+
+    test("leaves sub-thousand values bare", () => {
+        expect(formatDiamonds(0)).toBe("0");
+        expect(formatDiamonds(999)).toBe("999");
+    });
+
+    test("rounds fractional balances", () => {
+        expect(formatDiamonds(15.4)).toBe("15");
+        expect(formatDiamonds(15.6)).toBe("16");
+    });
+});

--- a/src/utils/ui/components/youtube/diamond.tsx
+++ b/src/utils/ui/components/youtube/diamond.tsx
@@ -1,0 +1,105 @@
+import { type CSSProperties, type ReactNode, useId } from "react";
+
+/** Diamond counts are shown with a thin-space thousands separator ("1 500")
+ *  everywhere the credit balance appears — this collapses the repeated
+ *  `.toLocaleString("en-US").replace(",", " ")` dance into one call. */
+export function formatDiamonds(amount: number): string {
+    return Math.round(amount).toLocaleString("en-US").replace(/,/g, " ");
+}
+
+/**
+ * The single diamond glyph for the whole product (spec §7: "diamonds GLOW;
+ * colors more playful, gradients"). An inline SVG gem with a theme-driven
+ * gradient (primary → secondary accent) and an optional soft glow — replaces
+ * the bare `💎` emoji and lucide `Gem` so every surface reads as one currency.
+ *
+ * Browser-safe: no `@app/logger` value import, pure presentational. Gradient
+ * stops reference the shadow-root CSS vars (`--primary` / `--secondary`) so it
+ * tracks the active theme instead of hardcoding a palette.
+ */
+export function Diamond({
+    size = 16,
+    glow = false,
+    className,
+    title,
+}: {
+    size?: number;
+    /** Adds the animated aura — reserve for hero/balance spots, not dense rows. */
+    glow?: boolean;
+    className?: string;
+    /** When set, the glyph is announced to screen readers; otherwise decorative. */
+    title?: string;
+}) {
+    // Each instance needs its own gradient id — two <Diamond>s sharing one id
+    // in the same document would let the first define the paint for both.
+    const gradientId = `yt-diamond-${useId()}`;
+    const glowStyle: CSSProperties | undefined = glow
+        ? { filter: `drop-shadow(0 0 ${size * 0.28}px hsl(var(--primary) / 0.65))` }
+        : undefined;
+
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className={className}
+            style={glowStyle}
+            role={title ? "img" : "presentation"}
+            aria-hidden={title ? undefined : true}
+            aria-label={title}
+        >
+            {title ? <title>{title}</title> : null}
+            <defs>
+                <linearGradient id={gradientId} x1="4" y1="3" x2="20" y2="21" gradientUnits="userSpaceOnUse">
+                    <stop stopColor="hsl(var(--primary))" />
+                    <stop offset="0.55" stopColor="hsl(var(--secondary, var(--primary)))" />
+                    <stop offset="1" stopColor="hsl(var(--primary))" />
+                </linearGradient>
+            </defs>
+            {/* Gem silhouette: crown (top band) + pavilion (point). */}
+            <path
+                d="M6 3.5h12l3.2 5.1L12 21.2 2.8 8.6 6 3.5Z"
+                fill={`url(#${gradientId})`}
+                stroke="hsl(var(--primary-foreground) / 0.35)"
+                strokeWidth="0.6"
+                strokeLinejoin="round"
+            />
+            {/* Facet lines — the sparkle read, kept subtle. */}
+            <path
+                d="M2.8 8.6h18.4M9 3.5 12 8.6l3-5.1M6.4 8.6 12 21.2l5.6-12.6"
+                stroke="hsl(var(--primary-foreground) / 0.4)"
+                strokeWidth="0.6"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                fill="none"
+            />
+        </svg>
+    );
+}
+
+/** Balance/price cluster: the glyph + a tabular-nums count, spaced and aligned
+ *  the way every credit readout in the product wants it. */
+export function DiamondValue({
+    amount,
+    size = 16,
+    glow = false,
+    className,
+    children,
+}: {
+    amount: number;
+    size?: number;
+    glow?: boolean;
+    className?: string;
+    /** Trailing label ("diamonds", "/mo") rendered muted after the count. */
+    children?: ReactNode;
+}) {
+    return (
+        <span className={`inline-flex items-baseline gap-1.5 ${className ?? ""}`}>
+            <Diamond size={size} glow={glow} className="self-center" />
+            <span className="font-semibold tabular-nums">{formatDiamonds(amount)}</span>
+            {children ? <span className="text-xs text-muted-foreground">{children}</span> : null}
+        </span>
+    );
+}

--- a/src/utils/ui/components/youtube/index.ts
+++ b/src/utils/ui/components/youtube/index.ts
@@ -1,6 +1,10 @@
+export { ActivityGraph } from "@app/utils/ui/components/youtube/activity-graph";
 export { AskTab } from "@app/utils/ui/components/youtube/ask-tab";
+export { computeCreditBuckets, subscriptionRenewalCopy } from "@app/utils/ui/components/youtube/billing-ui";
 export { CommentsTab } from "@app/utils/ui/components/youtube/comments-tab";
+export { Diamond, DiamondValue, formatDiamonds } from "@app/utils/ui/components/youtube/diamond";
 export { InsightsTab } from "@app/utils/ui/components/youtube/insights-tab";
+export { formatLedgerReason } from "@app/utils/ui/components/youtube/ledger-copy";
 export { SummaryTab } from "@app/utils/ui/components/youtube/summary-tab";
 export {
     type PipelineProgress,

--- a/src/utils/ui/components/youtube/insights-tab.tsx
+++ b/src/utils/ui/components/youtube/insights-tab.tsx
@@ -87,6 +87,7 @@ export function InsightsTab({
     modelPresets,
     modelDefault,
     onRequireLogin,
+    onUpgrade,
     pipelineProgress,
     partialTimestamped,
     streaming,
@@ -96,6 +97,7 @@ export function InsightsTab({
     modelPresets?: ModelPreset[];
     modelDefault?: { provider: string; model: string } | null;
     onRequireLogin?: (retry?: () => void) => void;
+    onUpgrade?: () => void;
     pipelineProgress?: PipelineProgress | null;
 }) {
     const timestamped = useSummary(videoId, "timestamped");
@@ -216,6 +218,7 @@ export function InsightsTab({
                 confirmLabel={entries.length === 0 ? "Generate" : "Re-generate"}
                 error={generate.error ? (generate.error as Error).message : null}
                 errorCode={errorCodeOf(generate.error)}
+                onUpgrade={onUpgrade}
                 showAdvanced={devMode}
                 modelPresets={modelPresets}
                 defaultProvider={modelDefault?.provider}

--- a/src/utils/ui/components/youtube/ledger-copy.test.ts
+++ b/src/utils/ui/components/youtube/ledger-copy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { formatLedgerReason } from "@app/utils/ui/components/youtube/ledger-copy";
+
+describe("formatLedgerReason", () => {
+    test("exact reasons get friendly labels", () => {
+        expect(formatLedgerReason("register-grant").label).toBe("Welcome bonus");
+        expect(formatLedgerReason("transcribe:ai").label).toBe("AI transcription");
+        expect(formatLedgerReason("qa:channel").label).toBe("Channel question");
+    });
+
+    test("id-suffixed reasons resolve by prefix", () => {
+        expect(formatLedgerReason("stripe:cs_test_123").label).toBe("Diamond pack");
+        expect(formatLedgerReason("sub-allowance:in_9xy").label).toBe("Monthly allowance");
+        expect(formatLedgerReason("stripe-refund:ch_1").label).toBe("Refund");
+    });
+
+    test("referral distinguishes the two sides", () => {
+        expect(formatLedgerReason("referral:42:referrer").label).toBe("Referral reward");
+        expect(formatLedgerReason("referral:42:referee").label).toBe("Referral bonus");
+    });
+
+    test("unknown reasons de-slug rather than showing raw tokens", () => {
+        expect(formatLedgerReason("some-new_reason")).toEqual({ label: "Some new reason" });
+    });
+});

--- a/src/utils/ui/components/youtube/ledger-copy.ts
+++ b/src/utils/ui/components/youtube/ledger-copy.ts
@@ -1,0 +1,73 @@
+/**
+ * Human-facing copy for credit-ledger reasons (spec §7: "register-grant" etc →
+ * user-friendly labels; add context to each activity row). Pure and
+ * browser-safe so both the extension activity view and the web account page
+ * render the same wording. The raw reason strings are the `CreditReason` union
+ * in `users.types.ts`; anything unrecognized falls back to a de-slugged label
+ * so a new reason never shows as a bare machine token.
+ */
+export interface LedgerReasonCopy {
+    label: string;
+    /** One-line context shown under the label, when it adds meaning. */
+    detail?: string;
+}
+
+const EXACT_LABELS: Record<string, LedgerReasonCopy> = {
+    "register-grant": { label: "Welcome bonus", detail: "Diamonds to get you started" },
+    ask: { label: "Question", detail: "Asked about a video" },
+    "qa:channel": { label: "Channel question", detail: "Asked across a channel" },
+    "summary:long": { label: "Full summary" },
+    "summary:timestamped": { label: "Timestamped insights" },
+    "summary:short": { label: "Quick summary" },
+    "transcript:translate": { label: "Transcript translation" },
+    "transcribe:ai": { label: "AI transcription", detail: "Generated captions from audio" },
+    "dev-topup": { label: "Top-up", detail: "Developer grant" },
+};
+
+/** Prefix (segment before the first `:`) → copy, for id-suffixed reasons. */
+const PREFIX_LABELS: Record<string, LedgerReasonCopy> = {
+    stripe: { label: "Diamond pack", detail: "Purchase" },
+    "stripe-refund": { label: "Refund", detail: "Purchase refunded" },
+    refund: { label: "Refund" },
+    hold: { label: "Reserved", detail: "Held for a pending action" },
+    "hold-release": { label: "Refund", detail: "Reservation released" },
+    "sub-allowance": { label: "Monthly allowance", detail: "Subscription reset" },
+    reuse: { label: "Unlocked", detail: "Instant reuse of a shared result" },
+    report: { label: "Multi-video report" },
+    tts: { label: "Audio summary" },
+};
+
+export function formatLedgerReason(reason: string): LedgerReasonCopy {
+    const exact = EXACT_LABELS[reason];
+
+    if (exact) {
+        return exact;
+    }
+
+    // Referral reasons carry a side segment: `referral:<id>:referrer|referee`.
+    if (reason.startsWith("referral:")) {
+        return reason.endsWith(":referrer")
+            ? { label: "Referral reward", detail: "A friend you invited joined" }
+            : { label: "Referral bonus", detail: "Welcome reward for using an invite" };
+    }
+
+    const prefix = reason.includes(":") ? reason.slice(0, reason.indexOf(":")) : reason;
+    const known = PREFIX_LABELS[prefix];
+
+    if (known) {
+        return known;
+    }
+
+    return { label: deslug(prefix) };
+}
+
+/** "some-machine_token" → "Some machine token" — the last-resort label. */
+function deslug(value: string): string {
+    const words = value.replace(/[-_]+/g, " ").trim();
+
+    if (words === "") {
+        return "Activity";
+    }
+
+    return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/src/utils/ui/components/youtube/llm-confirm-dialog.tsx
+++ b/src/utils/ui/components/youtube/llm-confirm-dialog.tsx
@@ -81,6 +81,10 @@ export interface LlmConfirmDialogProps {
      *  passes its own confirm as `retry`, so a successful login immediately
      *  re-runs the generation the user asked for. */
     onRequireLogin?: (retry?: () => void) => void;
+    /** Opens the diamonds/subscription surface when the action bounces with a
+     *  402 (`insufficient_credits` / `quota_exhausted`) — turns the failure into
+     *  a friendly upsell instead of a raw error. */
+    onUpgrade?: () => void;
     onCancel: () => void;
     onConfirm: (overrides: { provider?: string; model?: string }) => void;
 }
@@ -111,6 +115,7 @@ export function LlmConfirmDialog({
     onLangChange,
     currentLang,
     onRequireLogin,
+    onUpgrade,
     onCancel,
     onConfirm,
 }: LlmConfirmDialogProps) {
@@ -293,6 +298,17 @@ export function LlmConfirmDialog({
                             <p className="text-muted-foreground">This costs diamonds, so it needs an account.</p>
                             <Button size="sm" className="shrink-0" onClick={() => onRequireLogin(confirm)}>
                                 Sign in
+                            </Button>
+                        </div>
+                    ) : (errorCode === "quota_exhausted" || errorCode === "insufficient_credits") && onUpgrade ? (
+                        <div className="flex items-center justify-between gap-3 rounded-lg border border-primary/25 bg-primary/5 p-2.5 text-sm">
+                            <p className="text-muted-foreground">
+                                {errorCode === "quota_exhausted"
+                                    ? "You've used your free actions this month. Top up or subscribe to keep going."
+                                    : "Not enough diamonds for this. Top up or subscribe to continue."}
+                            </p>
+                            <Button size="sm" className="shrink-0" onClick={onUpgrade}>
+                                Get diamonds
                             </Button>
                         </div>
                     ) : (

--- a/src/utils/ui/components/youtube/summary-tab.tsx
+++ b/src/utils/ui/components/youtube/summary-tab.tsx
@@ -98,6 +98,7 @@ export function SummaryTab({
     modelPresets,
     modelDefault,
     onRequireLogin,
+    onUpgrade,
     pipelineProgress,
     partialLong,
     streaming,
@@ -112,6 +113,7 @@ export function SummaryTab({
     modelPresets?: ModelPreset[];
     modelDefault?: { provider: string; model: string } | null;
     onRequireLogin?: (retry?: () => void) => void;
+    onUpgrade?: () => void;
     pipelineProgress?: PipelineProgress | null;
 }) {
     const summary = useSummary(videoId, "long");
@@ -323,6 +325,7 @@ export function SummaryTab({
                 confirmLabel={long === null ? "Generate" : "Re-generate"}
                 error={generate.error ? (generate.error as Error).message : null}
                 errorCode={errorCodeOf(generate.error)}
+                onUpgrade={onUpgrade}
                 showAdvanced={devMode}
                 modelPresets={modelPresets}
                 defaultProvider={modelDefault?.provider}

--- a/src/utils/ui/components/youtube/tabs.tsx
+++ b/src/utils/ui/components/youtube/tabs.tsx
@@ -16,6 +16,7 @@ import type {
     PromptPreset,
     QaHistoryItem,
     QaSource,
+    QueueStats,
     SummaryMode,
     TimestampedSummaryEntry,
     Transcript,
@@ -197,10 +198,16 @@ export interface VideoDetailTabsProps {
     };
     /** Live progress of a running job for this video — drives button spinners + dialog progress. */
     pipelineProgress?: PipelineProgress | null;
+    /** Live queue stats — the transcript tab shows how many jobs are ahead. */
+    queueStats?: QueueStats | null;
     /** Opens the sign-in surface (settings dialog) when a spend endpoint
      *  returns 401. Receives the bounced action as `retry` — the owner runs it
      *  after a successful login so the user never has to re-click. */
     onRequireLogin?: (retry?: () => void) => void;
+    /** Opens the diamonds/subscription surface when a spend endpoint returns a
+     *  402 (out of free quota / diamonds) — the confirm dialogs turn it into a
+     *  friendly upsell. */
+    onUpgrade?: () => void;
     /** Open another video's watch page at a timestamp (cross-video citations). */
     onOpenWatch?: (videoId: string, t: number) => void;
     /** Streaming `summary:partial` payloads keyed by mode (long / timestamped). */
@@ -233,7 +240,9 @@ export function VideoDetailTabs({
     modelPresets,
     modelDefaults,
     pipelineProgress,
+    queueStats,
     onRequireLogin,
+    onUpgrade,
     onOpenWatch,
     partialSummaries,
     streamingMode,
@@ -358,6 +367,7 @@ export function VideoDetailTabs({
                         modelPresets={modelPresets}
                         modelDefault={modelDefaults?.summarize}
                         onRequireLogin={onRequireLogin}
+                        onUpgrade={onUpgrade}
                         pipelineProgress={pipelineProgress}
                         partialTimestamped={partialSummaries?.timestamped}
                         streaming={streamingMode === "timestamped"}
@@ -377,6 +387,7 @@ export function VideoDetailTabs({
                         modelPresets={modelPresets}
                         modelDefault={modelDefaults?.summarize}
                         onRequireLogin={onRequireLogin}
+                        onUpgrade={onUpgrade}
                         pipelineProgress={pipelineProgress}
                         partialLong={partialSummaries?.long}
                         streaming={streamingMode === "long"}
@@ -398,6 +409,7 @@ export function VideoDetailTabs({
                         useListPresets={ds.useListPresets}
                         useCreatePreset={ds.useCreatePreset}
                         onRequireLogin={onRequireLogin}
+                        onUpgrade={onUpgrade}
                         useComments={ds.useComments}
                         runPipeline={runPipeline}
                         pipelineProgress={pipelineProgress}
@@ -424,6 +436,7 @@ export function VideoDetailTabs({
                         useTranslateTranscript={ds.useTranslateTranscript}
                         runPipeline={runPipeline}
                         pipelineProgress={pipelineProgress}
+                        queueStats={queueStats}
                         playerTime={playerTime}
                     />
                 </TabsContent>

--- a/src/utils/ui/components/youtube/transcript-tab.tsx
+++ b/src/utils/ui/components/youtube/transcript-tab.tsx
@@ -10,8 +10,15 @@ import { scrollIntoPanelView } from "@app/utils/ui/components/youtube/scroll";
 import type { PipelineProgress, RunPipeline } from "@app/utils/ui/components/youtube/tabs";
 import { formatTimecode } from "@app/utils/ui/components/youtube/time";
 import { segmentsToParagraphs, type TranscriptParagraph } from "@app/utils/ui/components/youtube/transcript-paragraphs";
-import type { Transcript, TranscriptSegment, Video, VideoId } from "@app/youtube/lib/types";
-import { Captions, ChevronDown, ChevronUp, Languages, Loader2, LocateFixed, Search } from "lucide-react";
+import {
+    CREDIT_COSTS,
+    type QueueStats,
+    type Transcript,
+    type TranscriptSegment,
+    type Video,
+    type VideoId,
+} from "@app/youtube/lib/types";
+import { Captions, ChevronDown, ChevronUp, Languages, Loader2, LocateFixed, Search, Sparkles } from "lucide-react";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 /** Sentinel Select value meaning "no lang filter — server picks the default (captions preferred)". */
@@ -100,6 +107,9 @@ export interface TranscriptTabProps {
     };
     runPipeline?: RunPipeline;
     pipelineProgress?: PipelineProgress | null;
+    /** Live queue stats (`GET /jobs/queue`) — shows how many jobs are ahead
+     *  while a fetch waits its turn. Optional; omit to hide queue info. */
+    queueStats?: QueueStats | null;
     /** Current playback second (1 Hz bridge) — drives follow mode. */
     playerTime?: number | null;
     /** Lists every stored transcript row (for the language Select) — reuses
@@ -127,6 +137,7 @@ export function TranscriptTab({
     useTranslateTranscript,
     runPipeline,
     pipelineProgress,
+    queueStats,
     playerTime,
 }: TranscriptTabProps) {
     const [query, setQuery] = useState("");
@@ -298,43 +309,12 @@ export function TranscriptTab({
     }
 
     if (segments.length === 0) {
-        const isRunning = (runPipeline?.isPending ?? false) || pipelineProgress != null;
-
         return (
-            <div className="space-y-3 rounded-xl border border-dashed border-primary/25 p-4">
-                <div className="flex items-start gap-3">
-                    <Captions className="mt-0.5 size-5 shrink-0 text-primary" />
-                    <div className="space-y-1">
-                        <p className="text-sm font-semibold">No transcript yet</p>
-                        <p className="text-sm text-muted-foreground">
-                            Fetch it to read and search everything said in the video.
-                        </p>
-                    </div>
-                </div>
-                <div className="flex flex-wrap items-center gap-3">
-                    {runPipeline ? (
-                        <Button
-                            data-testid="transcript-run-pipeline"
-                            onClick={() => runPipeline.run(["captions"])}
-                            disabled={isRunning}
-                        >
-                            {isRunning ? (
-                                <>
-                                    <Loader2 className="size-4 animate-spin" /> Fetching transcript…
-                                </>
-                            ) : (
-                                "Fetch transcript"
-                            )}
-                        </Button>
-                    ) : null}
-                    {pipelineProgress ? (
-                        <span className="text-xs tabular-nums text-muted-foreground">
-                            {Math.round(pipelineProgress.progress * 100)}%
-                            {pipelineProgress.message ? ` · ${pipelineProgress.message}` : ""}
-                        </span>
-                    ) : null}
-                </div>
-            </div>
+            <TranscriptEmptyState
+                runPipeline={runPipeline}
+                pipelineProgress={pipelineProgress}
+                queueStats={queueStats}
+            />
         );
     }
 
@@ -734,4 +714,107 @@ function countOccurrences(haystack: string, needle: string): number {
 
 function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Empty-state for a video with no transcript yet. Leads with the cheap caption
+ * fetch; when a video has no captions the user can fall back to AI
+ * transcription from the audio, which costs diamonds (`CREDIT_COSTS`
+ * ["transcribe:ai"]) — so that path routes through an explicit cost confirm
+ * before committing. Shows a live progress bar and, while a job waits its turn,
+ * how many jobs are ahead in the queue.
+ */
+function TranscriptEmptyState({
+    runPipeline,
+    pipelineProgress,
+    queueStats,
+}: {
+    runPipeline?: RunPipeline;
+    pipelineProgress?: PipelineProgress | null;
+    queueStats?: QueueStats | null;
+}) {
+    const [confirmAi, setConfirmAi] = useState(false);
+    const isRunning = (runPipeline?.isPending ?? false) || pipelineProgress != null;
+    // Progress is reported 0..1; treat a running job still at 0 as "queued".
+    const queued = pipelineProgress != null && pipelineProgress.progress <= 0;
+    const ahead = queueStats ? queueStats.queued + queueStats.running : 0;
+
+    return (
+        <div className="space-y-3 rounded-xl border border-dashed border-primary/25 p-4">
+            <div className="flex items-start gap-3">
+                <Captions className="mt-0.5 size-5 shrink-0 text-primary" />
+                <div className="space-y-1">
+                    <p className="text-sm font-semibold">No transcript yet</p>
+                    <p className="text-sm text-muted-foreground">
+                        Fetch it to read and search everything said in the video. No captions? Generate one from the
+                        audio with AI.
+                    </p>
+                </div>
+            </div>
+
+            {isRunning ? (
+                <div className="space-y-1.5">
+                    <div className="h-1 overflow-hidden rounded-full bg-muted">
+                        <div
+                            className="h-full rounded-full bg-primary transition-[width] duration-300"
+                            style={{
+                                width: `${Math.round(Math.min(1, Math.max(0, pipelineProgress?.progress ?? 0)) * 100)}%`,
+                            }}
+                        />
+                    </div>
+                    <p className="text-xs tabular-nums text-muted-foreground">
+                        {queued && ahead > 1
+                            ? `In queue · ${ahead} ahead`
+                            : `${Math.round((pipelineProgress?.progress ?? 0) * 100)}%${
+                                  pipelineProgress?.message ? ` · ${pipelineProgress.message}` : ""
+                              }`}
+                    </p>
+                </div>
+            ) : confirmAi ? (
+                <div className="space-y-2 rounded-lg border border-primary/25 bg-primary/5 p-3">
+                    <p className="text-sm text-foreground/95">
+                        Generate a transcript from the audio using AI for{" "}
+                        <span className="font-semibold tabular-nums text-primary">
+                            {CREDIT_COSTS["transcribe:ai"]} 💎
+                        </span>
+                        .
+                    </p>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            size="sm"
+                            data-testid="transcript-run-transcribe"
+                            onClick={() => {
+                                setConfirmAi(false);
+                                runPipeline?.run(["transcribe"]);
+                            }}
+                        >
+                            <Sparkles className="size-4" /> Transcribe · {CREDIT_COSTS["transcribe:ai"]} 💎
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            className="text-muted-foreground"
+                            onClick={() => setConfirmAi(false)}
+                        >
+                            Cancel
+                        </Button>
+                    </div>
+                </div>
+            ) : runPipeline ? (
+                <div className="flex flex-wrap items-center gap-2">
+                    <Button data-testid="transcript-run-pipeline" onClick={() => runPipeline.run(["captions"])}>
+                        Fetch transcript
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-muted-foreground"
+                        onClick={() => setConfirmAi(true)}
+                    >
+                        <Sparkles className="size-4" /> AI transcription · {CREDIT_COSTS["transcribe:ai"]} 💎
+                    </Button>
+                </div>
+            ) : null}
+        </div>
+    );
 }

--- a/src/youtube/extension/__tests__/background.test.ts
+++ b/src/youtube/extension/__tests__/background.test.ts
@@ -174,3 +174,200 @@ describe("extension background request routing", () => {
         expect(body.ttsVoice).toBe("alloy");
     });
 });
+
+describe("extension background — phase 4a collections/history/watchlist/digest", () => {
+    beforeEach(() => {
+        installEnv({ apiBaseUrl: "http://localhost:9876" });
+    });
+
+    afterEach(() => {
+        globalThis.chrome = originalChrome;
+        globalThis.fetch = originalFetch;
+        (globalThis as { WebSocket?: unknown }).WebSocket = originalWebSocket;
+    });
+
+    it("GETs the collections list", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:listCollections" });
+
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections");
+        expect(calls.at(-1)?.init.method ?? "GET").toBe("GET");
+    });
+
+    it("POSTs createCollection with name/kind/rule", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({
+            type: "api:createCollection",
+            name: "last month",
+            kind: "dynamic",
+            rule: { type: "watched", sinceDays: 30 },
+        });
+
+        const call = calls.at(-1);
+        expect(call?.url).toBe("http://localhost:9876/api/v1/collections");
+        expect(call?.init.method).toBe("POST");
+        const body = SafeJSON.parse(String(call?.init.body)) as Record<string, unknown>;
+        expect(body.name).toBe("last month");
+        expect(body.kind).toBe("dynamic");
+        expect(body.rule).toEqual({ type: "watched", sinceDays: 30 });
+    });
+
+    it("routes collection detail, delete, and membership", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:getCollection", id: 7 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections/7");
+
+        await handleRequest({ type: "api:deleteCollection", id: 7 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections/7");
+        expect(calls.at(-1)?.init.method).toBe("DELETE");
+
+        await handleRequest({ type: "api:addCollectionVideo", id: 7, videoId: "vid00000001" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections/7/videos");
+        expect(calls.at(-1)?.init.method).toBe("POST");
+        expect((SafeJSON.parse(String(calls.at(-1)?.init.body)) as { videoId: string }).videoId).toBe("vid00000001");
+
+        await handleRequest({ type: "api:removeCollectionVideo", id: 7, videoId: "a/b" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections/7/videos/a%2Fb");
+        expect(calls.at(-1)?.init.method).toBe("DELETE");
+    });
+
+    it("routes thread list, thread detail, and ask", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:listThreads", id: 3 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections/3/threads");
+
+        await handleRequest({ type: "api:getThread", threadId: 9 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/collections/threads/9");
+
+        await handleRequest({ type: "api:askCollection", id: 3, question: "what?", threadId: 9 });
+        const ask = calls.at(-1);
+        expect(ask?.url).toBe("http://localhost:9876/api/v1/collections/3/ask");
+        expect(ask?.init.method).toBe("POST");
+        const body = SafeJSON.parse(String(ask?.init.body)) as Record<string, unknown>;
+        expect(body.question).toBe("what?");
+        expect(body.threadId).toBe(9);
+    });
+
+    it("builds the userHistory query with groupBy and limit", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:userHistory", groupBy: "action", limit: 200 });
+
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/history?groupBy=action&limit=200");
+    });
+
+    it("routes watchlist add/remove and digest get/sync", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:getWatchlist" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/watchlist");
+
+        await handleRequest({ type: "api:addWatchlistChannel", handle: "@chan" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/watchlist");
+        expect(calls.at(-1)?.init.method).toBe("POST");
+        expect((SafeJSON.parse(String(calls.at(-1)?.init.body)) as { handle: string }).handle).toBe("@chan");
+
+        await handleRequest({ type: "api:removeWatchlistChannel", handle: "@chan" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/watchlist/%40chan");
+        expect(calls.at(-1)?.init.method).toBe("DELETE");
+
+        await handleRequest({ type: "api:getDigest", sinceDays: 30 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/digest?sinceDays=30");
+
+        await handleRequest({ type: "api:syncDigest" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/digest/sync");
+        expect(calls.at(-1)?.init.method).toBe("POST");
+    });
+});
+
+describe("extension background — phase 4b monetization (subscribe/referral)", () => {
+    beforeEach(() => {
+        installEnv({ apiBaseUrl: "http://localhost:9876" });
+    });
+
+    afterEach(() => {
+        globalThis.chrome = originalChrome;
+        globalThis.fetch = originalFetch;
+        (globalThis as { WebSocket?: unknown }).WebSocket = originalWebSocket;
+    });
+
+    it("POSTs the plan id for api:subscribe", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:subscribe", planId: "sub-monthly" });
+
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/subscribe");
+        expect(calls.at(-1)?.init.method).toBe("POST");
+        expect((SafeJSON.parse(String(calls.at(-1)?.init.body)) as { planId: string }).planId).toBe("sub-monthly");
+    });
+
+    it("routes referral get and redeem", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:getReferral" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/referral");
+
+        await handleRequest({ type: "api:redeemReferral", code: "ABCD1234" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/users/referral/redeem");
+        expect(calls.at(-1)?.init.method).toBe("POST");
+        expect((SafeJSON.parse(String(calls.at(-1)?.init.body)) as { code: string }).code).toBe("ABCD1234");
+    });
+});
+
+describe("extension background — phase 4b admin panel", () => {
+    beforeEach(() => {
+        installEnv({ apiBaseUrl: "http://localhost:9876" });
+    });
+
+    afterEach(() => {
+        globalThis.chrome = originalChrome;
+        globalThis.fetch = originalFetch;
+        (globalThis as { WebSocket?: unknown }).WebSocket = originalWebSocket;
+    });
+
+    it("builds the admin users query with search and sort", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:adminUsers", q: "mkbhd", sort: "revenue", dir: "desc" });
+
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/admin/users?q=mkbhd&sort=revenue&dir=desc");
+    });
+
+    it("routes the admin profile drill-in by id", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:adminUser", id: 42 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/admin/users/42");
+    });
+
+    it("builds ops-view queries (ai-calls, webhook-logs, jobs, revenue)", async () => {
+        const calls = installEnv({ apiBaseUrl: "http://localhost:9876" });
+        const handleRequest = await loadHandleRequest();
+
+        await handleRequest({ type: "api:adminAiCalls", provider: "xai", action: "summary" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/admin/ai-calls?provider=xai&action=summary");
+
+        await handleRequest({ type: "api:adminWebhookLogs", outcome: "error" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/admin/webhook-logs?outcome=error");
+
+        await handleRequest({ type: "api:adminJobs", status: "running" });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/admin/jobs?status=running");
+
+        await handleRequest({ type: "api:adminRevenue", days: 30 });
+        expect(calls.at(-1)?.url).toBe("http://localhost:9876/api/v1/admin/revenue?days=30");
+    });
+});

--- a/src/youtube/extension/api.hooks.ts
+++ b/src/youtube/extension/api.hooks.ts
@@ -2,6 +2,7 @@ import type { VideoDetailDataSource } from "@app/utils/ui/components/youtube/tab
 import type {
     Channel,
     ChannelHandle,
+    CollectionKind,
     JobStage,
     PipelineJob,
     QaSource,
@@ -317,6 +318,35 @@ export function useCheckout() {
     });
 }
 
+export function useSubscribe() {
+    return useMutation({
+        mutationFn: (vars: { planId: string }) =>
+            send<ExtensionApiMap["api:subscribe"]>({ type: "api:subscribe", ...vars }),
+    });
+}
+
+export function useReferral(enabled = true) {
+    return useQuery({
+        queryKey: ["referral"],
+        queryFn: () => send<ExtensionApiMap["api:getReferral"]>({ type: "api:getReferral" }),
+        retry: false,
+        enabled,
+    });
+}
+
+export function useRedeemReferral() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (vars: { code: string }) =>
+            send<ExtensionApiMap["api:redeemReferral"]>({ type: "api:redeemReferral", ...vars }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["referral"] });
+            queryClient.invalidateQueries({ queryKey: ["me"] });
+        },
+    });
+}
+
 export function useLedger(enabled = true) {
     return useInfiniteQuery({
         queryKey: ["ledger"],
@@ -535,6 +565,228 @@ export function useQueueStats(enabled = true) {
         queryKey: ["queueStats"],
         queryFn: () => send<ExtensionApiMap["api:queueStats"]>({ type: "api:queueStats" }),
         refetchInterval: 5000,
+        enabled,
+    });
+}
+
+export function useUserHistory(groupBy: "video" | "action") {
+    return useQuery({
+        queryKey: ["userHistory", groupBy],
+        queryFn: () => send<ExtensionApiMap["api:userHistory"]>({ type: "api:userHistory", groupBy }),
+        retry: false,
+    });
+}
+
+export function useCollections(enabled = true) {
+    return useQuery({
+        queryKey: ["collections"],
+        queryFn: () => send<ExtensionApiMap["api:listCollections"]>({ type: "api:listCollections" }),
+        select: (response) => response.collections,
+        retry: false,
+        enabled,
+    });
+}
+
+export function useCollection(id: number | null) {
+    return useQuery({
+        queryKey: ["collection", id],
+        queryFn: () => send<ExtensionApiMap["api:getCollection"]>({ type: "api:getCollection", id: id as number }),
+        enabled: id !== null,
+    });
+}
+
+export function useCreateCollection() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (vars: { name: string; kind: CollectionKind; rule?: unknown }) =>
+            send<ExtensionApiMap["api:createCollection"]>({ type: "api:createCollection", ...vars }),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["collections"] }),
+    });
+}
+
+export function useDeleteCollection() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (id: number) => send<ExtensionApiMap["api:deleteCollection"]>({ type: "api:deleteCollection", id }),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["collections"] }),
+    });
+}
+
+export function useAddCollectionVideo(id: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (videoId: string) =>
+            send<ExtensionApiMap["api:addCollectionVideo"]>({ type: "api:addCollectionVideo", id, videoId }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["collection", id] });
+            queryClient.invalidateQueries({ queryKey: ["collections"] });
+        },
+    });
+}
+
+export function useRemoveCollectionVideo(id: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (videoId: string) =>
+            send<ExtensionApiMap["api:removeCollectionVideo"]>({ type: "api:removeCollectionVideo", id, videoId }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["collection", id] });
+            queryClient.invalidateQueries({ queryKey: ["collections"] });
+        },
+    });
+}
+
+export function useCollectionThreads(id: number | null) {
+    return useQuery({
+        queryKey: ["threads", id],
+        queryFn: () => send<ExtensionApiMap["api:listThreads"]>({ type: "api:listThreads", id: id as number }),
+        select: (response) => response.threads,
+        enabled: id !== null,
+    });
+}
+
+export function useCollectionThread(threadId: number | null) {
+    return useQuery({
+        queryKey: ["thread", threadId],
+        queryFn: () => send<ExtensionApiMap["api:getThread"]>({ type: "api:getThread", threadId: threadId as number }),
+        enabled: threadId !== null,
+    });
+}
+
+export function useAskCollection(id: number) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (vars: { question: string; threadId?: number; provider?: string; model?: string }) =>
+            send<ExtensionApiMap["api:askCollection"]>({ type: "api:askCollection", id, ...vars }),
+        onSuccess: (result) => {
+            queryClient.invalidateQueries({ queryKey: ["threads", id] });
+            queryClient.invalidateQueries({ queryKey: ["thread", result.threadId] });
+            queryClient.invalidateQueries({ queryKey: ["me"] });
+        },
+    });
+}
+
+export function useWatchlist(enabled = true) {
+    return useQuery({
+        queryKey: ["watchlist"],
+        queryFn: () => send<ExtensionApiMap["api:getWatchlist"]>({ type: "api:getWatchlist" }),
+        select: (response) => response.channels,
+        retry: false,
+        enabled,
+    });
+}
+
+export function useToggleWatchlist() {
+    const queryClient = useQueryClient();
+
+    return useMutation<{ added: boolean } | { removed: boolean }, Error, { handle: string; follow: boolean }>({
+        mutationFn: (vars) =>
+            vars.follow
+                ? send<ExtensionApiMap["api:addWatchlistChannel"]>({
+                      type: "api:addWatchlistChannel",
+                      handle: vars.handle,
+                  })
+                : send<ExtensionApiMap["api:removeWatchlistChannel"]>({
+                      type: "api:removeWatchlistChannel",
+                      handle: vars.handle,
+                  }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["watchlist"] });
+            queryClient.invalidateQueries({ queryKey: ["digest"] });
+        },
+    });
+}
+
+export function useDigest(sinceDays: number) {
+    return useQuery({
+        queryKey: ["digest", sinceDays],
+        queryFn: () => send<ExtensionApiMap["api:getDigest"]>({ type: "api:getDigest", sinceDays }),
+        retry: false,
+    });
+}
+
+export function useDigestSync() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => send<ExtensionApiMap["api:syncDigest"]>({ type: "api:syncDigest" }),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["digest"] }),
+    });
+}
+
+export function useAdminUsers(opts: {
+    q?: string;
+    subscription?: string;
+    sort?: "created" | "revenue" | "net" | "credits";
+    dir?: "asc" | "desc";
+    enabled?: boolean;
+}) {
+    return useQuery({
+        queryKey: ["adminUsers", opts.q, opts.subscription, opts.sort, opts.dir],
+        queryFn: () =>
+            send<ExtensionApiMap["api:adminUsers"]>({
+                type: "api:adminUsers",
+                q: opts.q,
+                subscription: opts.subscription,
+                sort: opts.sort,
+                dir: opts.dir,
+            }),
+        retry: false,
+        enabled: opts.enabled !== false,
+    });
+}
+
+export function useAdminUser(id: number | null) {
+    return useQuery({
+        queryKey: ["adminUser", id],
+        queryFn: () => send<ExtensionApiMap["api:adminUser"]>({ type: "api:adminUser", id: id as number }),
+        enabled: id !== null,
+    });
+}
+
+export function useAdminAiCalls(opts: { provider?: string; action?: string; enabled?: boolean }) {
+    return useQuery({
+        queryKey: ["adminAiCalls", opts.provider, opts.action],
+        queryFn: () =>
+            send<ExtensionApiMap["api:adminAiCalls"]>({
+                type: "api:adminAiCalls",
+                provider: opts.provider,
+                action: opts.action,
+            }),
+        retry: false,
+        enabled: opts.enabled !== false,
+    });
+}
+
+export function useAdminWebhookLogs(opts: { outcome?: string; enabled?: boolean }) {
+    return useQuery({
+        queryKey: ["adminWebhookLogs", opts.outcome],
+        queryFn: () =>
+            send<ExtensionApiMap["api:adminWebhookLogs"]>({ type: "api:adminWebhookLogs", outcome: opts.outcome }),
+        retry: false,
+        enabled: opts.enabled !== false,
+    });
+}
+
+export function useAdminJobs(opts: { status?: string; enabled?: boolean }) {
+    return useQuery({
+        queryKey: ["adminJobs", opts.status],
+        queryFn: () => send<ExtensionApiMap["api:adminJobs"]>({ type: "api:adminJobs", status: opts.status }),
+        retry: false,
+        enabled: opts.enabled !== false,
+    });
+}
+
+export function useAdminRevenue(enabled = true) {
+    return useQuery({
+        queryKey: ["adminRevenue"],
+        queryFn: () => send<ExtensionApiMap["api:adminRevenue"]>({ type: "api:adminRevenue", days: 30 }),
+        retry: false,
         enabled,
     });
 }

--- a/src/youtube/extension/background.ts
+++ b/src/youtube/extension/background.ts
@@ -275,6 +275,27 @@ export async function handleRequest(req: ExtensionRequest): Promise<ExtensionRes
             }
             return res;
         }
+        case "api:subscribe": {
+            const res = await apiCall(`${base}/api/v1/users/subscribe`, {
+                method: "POST",
+                body: JSON.stringify({ planId: req.planId }),
+            });
+            // Stripe's hosted subscription page opens in a new tab — never iframed.
+            if (res.ok) {
+                const data = res.data as { url?: string };
+                if (typeof data.url === "string") {
+                    await chrome.tabs.create({ url: data.url });
+                }
+            }
+            return res;
+        }
+        case "api:getReferral":
+            return apiCall(`${base}/api/v1/users/referral`);
+        case "api:redeemReferral":
+            return apiCall(`${base}/api/v1/users/referral/redeem`, {
+                method: "POST",
+                body: JSON.stringify({ code: req.code }),
+            });
         case "api:createShare":
             return apiCall(`${base}/api/v1/shares`, {
                 method: "POST",
@@ -305,6 +326,139 @@ export async function handleRequest(req: ExtensionRequest): Promise<ExtensionRes
             });
         case "api:deletePreset":
             return apiCall(`${base}/api/v1/users/presets/${req.id}`, { method: "DELETE" });
+        case "api:listCollections":
+            return apiCall(`${base}/api/v1/collections`);
+        case "api:createCollection":
+            return apiCall(`${base}/api/v1/collections`, {
+                method: "POST",
+                body: JSON.stringify({ name: req.name, kind: req.kind, rule: req.rule }),
+            });
+        case "api:getCollection":
+            return apiCall(`${base}/api/v1/collections/${req.id}`);
+        case "api:deleteCollection":
+            return apiCall(`${base}/api/v1/collections/${req.id}`, { method: "DELETE" });
+        case "api:addCollectionVideo":
+            return apiCall(`${base}/api/v1/collections/${req.id}/videos`, {
+                method: "POST",
+                body: JSON.stringify({ videoId: req.videoId }),
+            });
+        case "api:removeCollectionVideo":
+            return apiCall(`${base}/api/v1/collections/${req.id}/videos/${encodeURIComponent(req.videoId)}`, {
+                method: "DELETE",
+            });
+        case "api:listThreads":
+            return apiCall(`${base}/api/v1/collections/${req.id}/threads`);
+        case "api:getThread":
+            return apiCall(`${base}/api/v1/collections/threads/${req.threadId}`);
+        case "api:askCollection":
+            return apiCall(`${base}/api/v1/collections/${req.id}/ask`, {
+                method: "POST",
+                body: JSON.stringify({
+                    question: req.question,
+                    threadId: req.threadId,
+                    provider: req.provider,
+                    model: req.model,
+                }),
+            });
+        case "api:userHistory": {
+            const query = new URLSearchParams({ groupBy: req.groupBy });
+            if (typeof req.limit === "number") {
+                query.set("limit", String(req.limit));
+            }
+            return apiCall(`${base}/api/v1/users/history?${query.toString()}`);
+        }
+        case "api:getWatchlist":
+            return apiCall(`${base}/api/v1/users/watchlist`);
+        case "api:addWatchlistChannel":
+            return apiCall(`${base}/api/v1/users/watchlist`, {
+                method: "POST",
+                body: JSON.stringify({ handle: req.handle }),
+            });
+        case "api:removeWatchlistChannel":
+            return apiCall(`${base}/api/v1/users/watchlist/${encodeURIComponent(req.handle)}`, { method: "DELETE" });
+        case "api:getDigest": {
+            const suffix = typeof req.sinceDays === "number" ? `?sinceDays=${req.sinceDays}` : "";
+            return apiCall(`${base}/api/v1/users/digest${suffix}`);
+        }
+        case "api:syncDigest":
+            return apiCall(`${base}/api/v1/users/digest/sync`, { method: "POST" });
+        case "api:adminUsers": {
+            const query = new URLSearchParams();
+            if (req.q) {
+                query.set("q", req.q);
+            }
+            if (req.subscription) {
+                query.set("subscription", req.subscription);
+            }
+            if (req.sort) {
+                query.set("sort", req.sort);
+            }
+            if (req.dir) {
+                query.set("dir", req.dir);
+            }
+            if (typeof req.limit === "number") {
+                query.set("limit", String(req.limit));
+            }
+            if (typeof req.offset === "number") {
+                query.set("offset", String(req.offset));
+            }
+            const suffix = query.toString() ? `?${query.toString()}` : "";
+            return apiCall(`${base}/api/v1/admin/users${suffix}`);
+        }
+        case "api:adminUser":
+            return apiCall(`${base}/api/v1/admin/users/${req.id}`);
+        case "api:adminAiCalls": {
+            const query = new URLSearchParams();
+            if (req.provider) {
+                query.set("provider", req.provider);
+            }
+            if (req.action) {
+                query.set("action", req.action);
+            }
+            if (typeof req.userId === "number") {
+                query.set("userId", String(req.userId));
+            }
+            if (typeof req.limit === "number") {
+                query.set("limit", String(req.limit));
+            }
+            if (typeof req.offset === "number") {
+                query.set("offset", String(req.offset));
+            }
+            const suffix = query.toString() ? `?${query.toString()}` : "";
+            return apiCall(`${base}/api/v1/admin/ai-calls${suffix}`);
+        }
+        case "api:adminWebhookLogs": {
+            const query = new URLSearchParams();
+            if (req.outcome) {
+                query.set("outcome", req.outcome);
+            }
+            if (typeof req.limit === "number") {
+                query.set("limit", String(req.limit));
+            }
+            if (typeof req.offset === "number") {
+                query.set("offset", String(req.offset));
+            }
+            const suffix = query.toString() ? `?${query.toString()}` : "";
+            return apiCall(`${base}/api/v1/admin/webhook-logs${suffix}`);
+        }
+        case "api:adminJobs": {
+            const query = new URLSearchParams();
+            if (req.status) {
+                query.set("status", req.status);
+            }
+            if (typeof req.limit === "number") {
+                query.set("limit", String(req.limit));
+            }
+            if (typeof req.offset === "number") {
+                query.set("offset", String(req.offset));
+            }
+            const suffix = query.toString() ? `?${query.toString()}` : "";
+            return apiCall(`${base}/api/v1/admin/jobs${suffix}`);
+        }
+        case "api:adminRevenue": {
+            const suffix = typeof req.days === "number" ? `?days=${req.days}` : "";
+            return apiCall(`${base}/api/v1/admin/revenue${suffix}`);
+        }
         default: {
             // Exhaustiveness guard: every ExtensionRequest above returns, so a
             // new variant added without a case fails this assignment at compile

--- a/src/youtube/extension/shared/messages.ts
+++ b/src/youtube/extension/shared/messages.ts
@@ -1,7 +1,21 @@
 import type {
+    AdminRevenueSummary,
+    AdminUserTotals,
+    AiCallRecord,
+    PaymentRecord,
+    VideoLogRecord,
+    VideoWatchRecord,
+    WebhookLogRecord,
+} from "@app/youtube/lib/db.types";
+import type {
+    ActionHistoryGroup,
     AskCitation,
+    AskMessageRecord,
+    AskThreadRecord,
     Channel,
     ChannelHandle,
+    CollectionKind,
+    CollectionRecord,
     JobEvent,
     JobStage,
     LedgerPage,
@@ -22,9 +36,12 @@ import type {
     UsageSummary,
     Video,
     VideoComment,
+    VideoHistoryGroup,
     VideoId,
+    VideoLite,
     VideoLongSummary,
     VideoReport,
+    WatchlistEntry,
     YtRole,
     YtUser,
 } from "@app/youtube/lib/types";
@@ -88,6 +105,9 @@ export type ExtensionRequest =
     | { type: "api:topup"; amount?: number }
     | { type: "api:qaHistory"; id?: VideoId; limit?: number }
     | { type: "api:checkout"; packId: string }
+    | { type: "api:subscribe"; planId: string }
+    | { type: "api:getReferral" }
+    | { type: "api:redeemReferral"; code: string }
     | { type: "api:ledger"; before?: number; limit?: number }
     | { type: "api:usageSummary" }
     | {
@@ -107,7 +127,38 @@ export type ExtensionRequest =
     | { type: "api:reportEstimate"; videoIds: string[] }
     | { type: "api:createReport"; videoIds: string[]; title?: string }
     | { type: "api:getReport"; id: number }
-    | { type: "api:queueStats" };
+    | { type: "api:queueStats" }
+    // Phase 4a — per-user collections / history / watchlist / digest.
+    | { type: "api:listCollections" }
+    | { type: "api:createCollection"; name: string; kind: CollectionKind; rule?: unknown }
+    | { type: "api:getCollection"; id: number }
+    | { type: "api:deleteCollection"; id: number }
+    | { type: "api:addCollectionVideo"; id: number; videoId: string }
+    | { type: "api:removeCollectionVideo"; id: number; videoId: string }
+    | { type: "api:listThreads"; id: number }
+    | { type: "api:getThread"; threadId: number }
+    | { type: "api:askCollection"; id: number; question: string; threadId?: number; provider?: string; model?: string }
+    | { type: "api:userHistory"; groupBy: "video" | "action"; limit?: number }
+    | { type: "api:getWatchlist" }
+    | { type: "api:addWatchlistChannel"; handle: string }
+    | { type: "api:removeWatchlistChannel"; handle: string }
+    | { type: "api:getDigest"; sinceDays?: number }
+    | { type: "api:syncDigest" }
+    // Phase 4b — admin panel (role admin|dev, server-gated).
+    | {
+          type: "api:adminUsers";
+          q?: string;
+          subscription?: string;
+          sort?: "created" | "revenue" | "net" | "credits";
+          dir?: "asc" | "desc";
+          limit?: number;
+          offset?: number;
+      }
+    | { type: "api:adminUser"; id: number }
+    | { type: "api:adminAiCalls"; provider?: string; action?: string; userId?: number; limit?: number; offset?: number }
+    | { type: "api:adminWebhookLogs"; outcome?: string; limit?: number; offset?: number }
+    | { type: "api:adminJobs"; status?: string; limit?: number; offset?: number }
+    | { type: "api:adminRevenue"; days?: number };
 
 export type ExtensionResponse = { ok: true; data: unknown } | { ok: false; error: string; code?: string };
 
@@ -192,6 +243,13 @@ export interface ExtensionApiMap {
     "api:topup": { user: YtUser };
     "api:qaHistory": { items: QaHistoryItem[] };
     "api:checkout": { url: string };
+    "api:subscribe": { url: string };
+    "api:getReferral": {
+        code: string;
+        referees: Array<{ email: string; redeemedAt: string; reward: number }>;
+        totalEarned: number;
+    };
+    "api:redeemReferral": { reward: number; credits: number };
     "api:ledger": LedgerPage;
     "api:usageSummary": UsageSummary;
     "api:createShare": { slug: string; url: string };
@@ -205,6 +263,64 @@ export interface ExtensionApiMap {
     "api:reportEstimate": { creditCost: number; membersNeedingSummary: number; perMemberCost: Record<string, number> };
     "api:createReport": { report: ReportRecordShape; jobId: number; creditsSpent: number; credits: number };
     "api:getReport": { report: ReportRecordShape; members: Record<string, ReportMemberMeta> };
+    "api:listCollections": { collections: Array<CollectionRecord & { videoCount: number }> };
+    "api:createCollection": { collection: CollectionRecord };
+    "api:getCollection": { collection: CollectionRecord; videos: VideoLite[] };
+    "api:deleteCollection": { deleted: boolean };
+    "api:addCollectionVideo": { added: boolean };
+    "api:removeCollectionVideo": { removed: boolean };
+    "api:listThreads": { threads: AskThreadRecord[] };
+    "api:getThread": { thread: AskThreadRecord; messages: AskMessageRecord[] };
+    "api:askCollection": { threadId: number; answer: string; toolCalls: number; creditsSpent: number; credits: number };
+    "api:userHistory": {
+        groupBy: "video" | "action";
+        videos?: VideoHistoryGroup[];
+        actions?: ActionHistoryGroup[];
+        videosById: Record<string, VideoLite>;
+    };
+    "api:getWatchlist": { channels: WatchlistEntry[] };
+    "api:addWatchlistChannel": { added: boolean };
+    "api:removeWatchlistChannel": { removed: boolean };
+    "api:getDigest": { since: string; channels: Array<{ handle: string; videos: VideoLite[] }> };
+    "api:syncDigest": { enqueuedJobIds: number[] };
+    "api:adminUsers": { users: AdminUserListItem[]; total: number; limit: number; offset: number };
+    "api:adminUser": AdminUserProfile;
+    "api:adminAiCalls": { aiCalls: AiCallRecord[]; total: number; limit: number; offset: number };
+    "api:adminWebhookLogs": { webhookLogs: WebhookLogRecord[]; total: number; limit: number; offset: number };
+    "api:adminJobs": { jobs: PipelineJob[]; queue: QueueStats; total: number; limit: number; offset: number };
+    "api:adminRevenue": AdminRevenueSummary;
+}
+
+/** One row of the admin users table (route maps `AdminUserRow` + role + net). */
+export interface AdminUserListItem {
+    id: number;
+    email: string;
+    role: YtRole;
+    credits: number;
+    revenueCents: number;
+    aiCostUsd: number;
+    netUsd: number;
+    subscription: { planId: string | null; status: string } | null;
+    createdAt: string;
+    lastLoginAt: string | null;
+}
+
+/** The admin user drill-in (`GET /admin/users/:id`), unmasked emails. */
+export interface AdminUserProfile {
+    user: YtUser;
+    role: YtRole;
+    billing: MeBillingContext;
+    totals: AdminUserTotals & { netUsd: number };
+    ledger: LedgerPage["rows"];
+    payments: PaymentRecord[];
+    referral: {
+        code: string | null;
+        referees: Array<{ email: string; reward: number; redeemedAt: string }>;
+        totalEarned: number;
+        referredBy: { email: string; reward: number; redeemedAt: string } | null;
+    };
+    activity: { watched: VideoWatchRecord[]; logs: VideoLogRecord[] };
+    jobs: PipelineJob[];
 }
 
 /** Wire shape of a stored report (subset of the server's report record). */

--- a/src/youtube/extension/side-panel/account-collections.tsx
+++ b/src/youtube/extension/side-panel/account-collections.tsx
@@ -1,0 +1,316 @@
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { Input } from "@app/utils/ui/components/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@app/utils/ui/components/select";
+import { CollectionAskPanel } from "@app/utils/ui/components/youtube/collection-ask-panel";
+import { optimisticUserMessage, ruleSummary } from "@app/utils/ui/components/youtube/collection-ui";
+import {
+    useAskCollection,
+    useCollection,
+    useCollections,
+    useCollectionThread,
+    useCollectionThreads,
+    useCreateCollection,
+    useDeleteCollection,
+    useRemoveCollectionVideo,
+} from "@ext/api.hooks";
+import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+const KIND_PRESETS: Array<{ value: string; label: string }> = [
+    { value: "manual", label: "Manual — add videos yourself" },
+    { value: "watched:7", label: "Dynamic — watched last 7 days" },
+    { value: "watched:30", label: "Dynamic — watched last 30 days" },
+    { value: "watched:90", label: "Dynamic — watched last 90 days" },
+];
+
+function buildCreateBody(name: string, preset: string) {
+    if (preset === "manual") {
+        return { name, kind: "manual" as const };
+    }
+
+    const sinceDays = Number.parseInt(preset.split(":")[1] ?? "30", 10);
+
+    return { name, kind: "dynamic" as const, rule: { type: "watched", sinceDays } };
+}
+
+export function CollectionsSection({ onOpenWatch }: { onOpenWatch: (videoId: string, t: number) => void }) {
+    const [selectedId, setSelectedId] = useState<number | null>(null);
+
+    if (selectedId !== null) {
+        return <CollectionDetail id={selectedId} onBack={() => setSelectedId(null)} onOpenWatch={onOpenWatch} />;
+    }
+
+    return <CollectionsList onOpen={setSelectedId} />;
+}
+
+function CollectionsList({ onOpen }: { onOpen: (id: number) => void }) {
+    const collections = useCollections();
+    const create = useCreateCollection();
+    const remove = useDeleteCollection();
+    const [name, setName] = useState("");
+    const [preset, setPreset] = useState("manual");
+
+    const onCreate = () => {
+        const trimmed = name.trim();
+
+        if (!trimmed || create.isPending) {
+            return;
+        }
+
+        create.mutate(buildCreateBody(trimmed, preset), { onSuccess: () => setName("") });
+    };
+
+    return (
+        <div className="space-y-3 p-4">
+            <div className="space-y-2 rounded-2xl border border-white/8 bg-black/20 p-3">
+                <Input
+                    placeholder="New collection name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    className="h-9 text-sm"
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                            onCreate();
+                        }
+                    }}
+                />
+                <Select value={preset} onValueChange={setPreset}>
+                    <SelectTrigger className="h-8 w-full text-sm">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {KIND_PRESETS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                <Button size="sm" className="w-full" disabled={create.isPending || !name.trim()} onClick={onCreate}>
+                    Create collection
+                </Button>
+            </div>
+
+            {create.isError ? (
+                <p className="text-xs text-destructive/90">
+                    {create.error instanceof Error ? create.error.message : "Failed to create collection."}
+                </p>
+            ) : null}
+
+            {collections.isError ? (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-2.5 text-sm">
+                    <p className="break-words text-destructive/90">
+                        {collections.error instanceof Error ? collections.error.message : "Failed to load collections."}
+                    </p>
+                </div>
+            ) : collections.isPending ? (
+                <div className="flex items-center justify-center py-6 text-muted-foreground">
+                    <Loader2 className="size-4 animate-spin" />
+                </div>
+            ) : (collections.data ?? []).length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-primary/25 p-4 text-sm text-muted-foreground">
+                    No collections yet. Create one above.
+                </p>
+            ) : (
+                <div className="space-y-2">
+                    {(collections.data ?? []).map((collection) => (
+                        <div
+                            key={collection.id}
+                            className="flex items-center gap-2 rounded-2xl border border-white/8 bg-black/20 p-3"
+                        >
+                            <button
+                                type="button"
+                                className="min-w-0 flex-1 text-left"
+                                onClick={() => onOpen(collection.id)}
+                            >
+                                <p className="truncate text-sm font-semibold text-foreground/95 hover:underline">
+                                    {collection.name}
+                                </p>
+                                <p className="mt-0.5 text-xs text-muted-foreground">
+                                    {collection.kind} · {collection.videoCount} video
+                                    {collection.videoCount === 1 ? "" : "s"}
+                                </p>
+                            </button>
+                            <button
+                                type="button"
+                                aria-label={`Delete ${collection.name}`}
+                                disabled={remove.isPending}
+                                onClick={() => remove.mutate(collection.id)}
+                                className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
+                            >
+                                <Trash2 className="size-4" />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function CollectionDetail({
+    id,
+    onBack,
+    onOpenWatch,
+}: {
+    id: number;
+    onBack: () => void;
+    onOpenWatch: (videoId: string, t: number) => void;
+}) {
+    const collection = useCollection(id);
+    const threads = useCollectionThreads(id);
+    const [threadId, setThreadId] = useState<number | null>(null);
+    const thread = useCollectionThread(threadId);
+    const ask = useAskCollection(id);
+    const removeVideo = useRemoveCollectionVideo(id);
+    const [pending, setPending] = useState<string | null>(null);
+
+    const backRow = (
+        <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+            <ArrowLeft className="size-4" /> Collections
+        </button>
+    );
+
+    if (collection.isPending) {
+        return (
+            <div className="space-y-3 p-4">
+                {backRow}
+                <div className="flex items-center justify-center py-6 text-muted-foreground">
+                    <Loader2 className="size-4 animate-spin" />
+                </div>
+            </div>
+        );
+    }
+
+    if (!collection.data) {
+        return (
+            <div className="space-y-3 p-4">
+                {backRow}
+                <p className="text-sm text-muted-foreground">Collection not found.</p>
+            </div>
+        );
+    }
+
+    const record = collection.data.collection;
+    const videos = collection.data.videos;
+    const baseMessages = thread.data?.messages ?? [];
+    const messages =
+        ask.isPending && pending ? [...baseMessages, optimisticUserMessage(threadId, pending)] : baseMessages;
+
+    const onSend = (question: string) => {
+        setPending(question);
+        ask.mutate(
+            { question, threadId: threadId ?? undefined },
+            {
+                onSuccess: (result) => setThreadId(result.threadId),
+                onSettled: () => setPending(null),
+            }
+        );
+    };
+
+    return (
+        <div className="space-y-3 p-4">
+            {backRow}
+
+            <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-foreground">{record.name}</h2>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary">{record.kind}</Badge>
+                    {record.kind === "dynamic" ? (
+                        <span className="text-xs text-muted-foreground">{ruleSummary(record.ruleJson)}</span>
+                    ) : null}
+                </div>
+            </div>
+
+            {videos.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-primary/25 p-4 text-sm text-muted-foreground">
+                    {record.kind === "manual"
+                        ? "No videos yet. Add some from a video's panel."
+                        : "No videos match this rule yet."}
+                </p>
+            ) : (
+                <ul className="space-y-2">
+                    {videos.map((video) => (
+                        <li key={video.id} className="flex gap-3 rounded-2xl border border-primary/15 bg-black/20 p-2">
+                            <button
+                                type="button"
+                                className="flex min-w-0 flex-1 gap-3 text-left"
+                                onClick={() => onOpenWatch(video.id, 0)}
+                            >
+                                {video.thumbUrl ? (
+                                    <img
+                                        src={video.thumbUrl}
+                                        alt=""
+                                        className="h-14 w-24 shrink-0 rounded-lg object-cover"
+                                    />
+                                ) : null}
+                                <span className="min-w-0 flex-1">
+                                    <span className="block break-words text-sm leading-snug text-foreground/90 hover:underline">
+                                        {video.title}
+                                    </span>
+                                    <span className="mt-1 flex flex-wrap gap-1.5">
+                                        {video.hasSummary ? <Badge variant="secondary">Summary</Badge> : null}
+                                        {video.hasTranscript ? <Badge variant="secondary">Transcript</Badge> : null}
+                                    </span>
+                                </span>
+                            </button>
+                            {record.kind === "manual" ? (
+                                <button
+                                    type="button"
+                                    aria-label={`Remove ${video.title}`}
+                                    disabled={removeVideo.isPending}
+                                    onClick={() => removeVideo.mutate(video.id)}
+                                    className="grid size-7 shrink-0 place-items-center self-start rounded-md text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
+                                >
+                                    <Trash2 className="size-4" />
+                                </button>
+                            ) : null}
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            <section className="space-y-2">
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-secondary">Ask this collection</p>
+                <div className="flex flex-wrap gap-1.5">
+                    <ThreadPill active={threadId === null} label="New" onClick={() => setThreadId(null)} />
+                    {(threads.data ?? []).map((item) => (
+                        <ThreadPill
+                            key={item.id}
+                            active={threadId === item.id}
+                            label={item.title}
+                            onClick={() => setThreadId(item.id)}
+                        />
+                    ))}
+                </div>
+                <CollectionAskPanel
+                    messages={messages}
+                    busy={ask.isPending}
+                    error={ask.error ? (ask.error as Error).message : null}
+                    onSend={onSend}
+                />
+            </section>
+        </div>
+    );
+}
+
+function ThreadPill({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`inline-flex h-6 max-w-[12rem] items-center truncate rounded-full border px-2 text-[12px] transition-colors ${
+                active
+                    ? "border-primary/40 bg-primary/10 text-primary"
+                    : "border-white/8 text-muted-foreground hover:text-foreground"
+            }`}
+        >
+            {label}
+        </button>
+    );
+}

--- a/src/youtube/extension/side-panel/account-digest.tsx
+++ b/src/youtube/extension/side-panel/account-digest.tsx
@@ -1,0 +1,117 @@
+import { Badge } from "@app/utils/ui/components/badge";
+import { Button } from "@app/utils/ui/components/button";
+import { useDigest, useDigestSync } from "@ext/api.hooks";
+import { Loader2, RefreshCw } from "lucide-react";
+import { useState } from "react";
+
+const SINCE_OPTIONS = [7, 30, 90];
+
+export function DigestSection({ onOpenWatch }: { onOpenWatch: (videoId: string, t: number) => void }) {
+    const [sinceDays, setSinceDays] = useState(7);
+    const digest = useDigest(sinceDays);
+    const sync = useDigestSync();
+    const channels = digest.data?.channels ?? [];
+    const totalVideos = channels.reduce((sum, channel) => sum + channel.videos.length, 0);
+
+    return (
+        <div className="space-y-3 p-4">
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex gap-1 rounded-lg border border-white/8 bg-black/20 p-1">
+                    {SINCE_OPTIONS.map((days) => (
+                        <button
+                            key={days}
+                            type="button"
+                            onClick={() => setSinceDays(days)}
+                            className={`h-7 shrink-0 rounded-md px-2.5 text-xs font-medium transition-colors ${
+                                sinceDays === days
+                                    ? "bg-white/10 text-foreground"
+                                    : "text-muted-foreground hover:text-foreground"
+                            }`}
+                        >
+                            {days}d
+                        </button>
+                    ))}
+                </div>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-muted-foreground"
+                    disabled={sync.isPending}
+                    onClick={() => sync.mutate()}
+                >
+                    {sync.isPending ? <Loader2 className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+                    Check
+                </Button>
+            </div>
+
+            {digest.isError ? (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-2.5 text-sm">
+                    <p className="break-words text-destructive/90">
+                        {digest.error instanceof Error ? digest.error.message : "Failed to load digest."}
+                    </p>
+                </div>
+            ) : digest.isPending ? (
+                <div className="flex items-center justify-center py-6 text-muted-foreground">
+                    <Loader2 className="size-4 animate-spin" />
+                </div>
+            ) : channels.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-primary/25 p-4 text-sm text-muted-foreground">
+                    Follow channels (from a channel's panel) to build your digest.
+                </p>
+            ) : totalVideos === 0 ? (
+                <p className="rounded-2xl border border-dashed border-primary/25 p-4 text-sm text-muted-foreground">
+                    Nothing new since {digest.data?.since}.
+                </p>
+            ) : (
+                <div className="space-y-4">
+                    {channels
+                        .filter((channel) => channel.videos.length > 0)
+                        .map((channel) => (
+                            <section key={channel.handle} className="space-y-2">
+                                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-secondary">
+                                    {channel.handle}
+                                </p>
+                                <ul className="space-y-2">
+                                    {channel.videos.map((video) => (
+                                        <li key={video.id}>
+                                            <button
+                                                type="button"
+                                                onClick={() => onOpenWatch(video.id, 0)}
+                                                className="flex w-full gap-3 rounded-2xl border border-primary/15 bg-black/20 p-2 text-left transition-colors hover:border-primary/40"
+                                            >
+                                                {video.thumbUrl ? (
+                                                    <img
+                                                        src={video.thumbUrl}
+                                                        alt=""
+                                                        className="h-14 w-24 shrink-0 rounded-lg object-cover"
+                                                    />
+                                                ) : null}
+                                                <span className="min-w-0 flex-1">
+                                                    <span className="block break-words text-sm leading-snug text-foreground/90">
+                                                        {video.title}
+                                                    </span>
+                                                    <span className="mt-1 flex flex-wrap items-center gap-1.5">
+                                                        {video.uploadDate ? (
+                                                            <span className="text-xs text-muted-foreground">
+                                                                {video.uploadDate}
+                                                            </span>
+                                                        ) : null}
+                                                        {video.hasSummary ? (
+                                                            <Badge variant="secondary">Summary</Badge>
+                                                        ) : null}
+                                                        {video.hasTranscript ? (
+                                                            <Badge variant="secondary">Transcript</Badge>
+                                                        ) : null}
+                                                    </span>
+                                                </span>
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </section>
+                        ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/youtube/extension/side-panel/account-view.tsx
+++ b/src/youtube/extension/side-panel/account-view.tsx
@@ -1,0 +1,119 @@
+import { Button } from "@app/utils/ui/components/button";
+import { HistoryView } from "@app/utils/ui/components/youtube/history-view";
+import { useMe, useUserHistory } from "@ext/api.hooks";
+import { CollectionsSection } from "@ext/side-panel/account-collections";
+import { DigestSection } from "@ext/side-panel/account-digest";
+import { ActivityView } from "@ext/side-panel/activity-view";
+import { ReferralSection } from "@ext/side-panel/referral-section";
+import { ArrowLeft } from "lucide-react";
+import { useState } from "react";
+
+/** Sub-surfaces of the account hub. Grows as Phase 4 features land. */
+export type AccountSection = "activity" | "history" | "collections" | "digest" | "referral";
+
+const SECTIONS: Array<{ id: AccountSection; label: string }> = [
+    { id: "activity", label: "Activity" },
+    { id: "history", label: "History" },
+    { id: "collections", label: "Collections" },
+    { id: "digest", label: "Digest" },
+    { id: "referral", label: "Referral" },
+];
+
+export function AccountView({
+    section,
+    onSectionChange,
+    onBack,
+    onRequireLogin,
+    onOpenWatch,
+}: {
+    section: AccountSection;
+    onSectionChange: (section: AccountSection) => void;
+    onBack: () => void;
+    onRequireLogin: (retry?: () => void) => void;
+    onOpenWatch: (videoId: string, t: number) => void;
+}) {
+    const me = useMe();
+
+    return (
+        <div className="flex flex-col">
+            <div className="space-y-2 border-b border-white/8 p-3">
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                    <ArrowLeft className="size-4" /> Back
+                </button>
+                <div className="flex gap-1 overflow-x-auto rounded-lg border border-white/8 bg-black/20 p-1">
+                    {SECTIONS.map((item) => (
+                        <button
+                            key={item.id}
+                            type="button"
+                            onClick={() => onSectionChange(item.id)}
+                            className={`h-7 shrink-0 rounded-md px-2.5 text-xs font-medium transition-colors ${
+                                section === item.id
+                                    ? "bg-white/10 text-foreground"
+                                    : "text-muted-foreground hover:text-foreground"
+                            }`}
+                        >
+                            {item.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {!me.data?.user ? (
+                <SignInPrompt onRequireLogin={onRequireLogin} />
+            ) : section === "history" ? (
+                <HistorySection onOpenWatch={onOpenWatch} />
+            ) : section === "collections" ? (
+                <CollectionsSection onOpenWatch={onOpenWatch} />
+            ) : section === "digest" ? (
+                <DigestSection onOpenWatch={onOpenWatch} />
+            ) : section === "referral" ? (
+                <ReferralSection />
+            ) : (
+                <ActivityView />
+            )}
+        </div>
+    );
+}
+
+function SignInPrompt({ onRequireLogin }: { onRequireLogin: (retry?: () => void) => void }) {
+    return (
+        <div className="p-4">
+            <div className="flex flex-col items-start gap-3 rounded-2xl border border-dashed border-primary/25 p-5">
+                <p className="text-sm text-muted-foreground">Sign in to see your history, collections, and digest.</p>
+                <Button size="sm" onClick={() => onRequireLogin()}>
+                    Sign in
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+function HistorySection({ onOpenWatch }: { onOpenWatch: (videoId: string, t: number) => void }) {
+    const [mode, setMode] = useState<"video" | "action">("video");
+    const history = useUserHistory(mode);
+
+    return (
+        <div className="space-y-3 p-4">
+            {history.isError ? (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-2.5 text-sm">
+                    <p className="break-words text-destructive/90">
+                        {history.error instanceof Error ? history.error.message : "Failed to load history."}
+                    </p>
+                </div>
+            ) : null}
+            <HistoryView
+                mode={mode}
+                onModeChange={setMode}
+                videoGroups={history.data?.videos}
+                actionGroups={history.data?.actions}
+                videosById={history.data?.videosById ?? {}}
+                onOpenVideo={(videoId) => onOpenWatch(videoId, 0)}
+                loading={history.isPending}
+            />
+        </div>
+    );
+}

--- a/src/youtube/extension/side-panel/activity-view.tsx
+++ b/src/youtube/extension/side-panel/activity-view.tsx
@@ -1,3 +1,5 @@
+import { ActivityGraph } from "@app/utils/ui/components/youtube/activity-graph";
+import { formatLedgerReason } from "@app/utils/ui/components/youtube/ledger-copy";
 import { formatRelativeTime } from "@app/utils/ui/components/youtube/time";
 import { type LedgerRowData, ledgerReasonGroup } from "@app/youtube/lib/types";
 import { useLedger, useUsageSummary } from "@ext/api.hooks";
@@ -12,17 +14,25 @@ import { useEffect, useMemo, useRef, useState } from "react";
  * affordance) — the back row here is a fresh, capsule-consistent pattern
  * (ArrowLeft + "Back", matching Feature 11's PresetEditor block).
  */
-export function ActivityView({ onBack }: { onBack: () => void }) {
+export function ActivityView({ onBack }: { onBack?: () => void }) {
     const summary = useUsageSummary();
     const ledger = useLedger();
     const [selectedReasons, setSelectedReasons] = useState<Set<string>>(new Set());
+    const [selectedDate, setSelectedDate] = useState<string | null>(null);
     const sentinelRef = useRef<HTMLDivElement | null>(null);
 
     const allRows = useMemo(() => ledger.data?.pages.flatMap((page) => page.rows) ?? [], [ledger.data]);
-    const filteredRows =
-        selectedReasons.size === 0
-            ? allRows
-            : allRows.filter((row) => selectedReasons.has(ledgerReasonGroup(row.reason)));
+    const filteredRows = allRows.filter((row) => {
+        if (selectedReasons.size > 0 && !selectedReasons.has(ledgerReasonGroup(row.reason))) {
+            return false;
+        }
+
+        if (selectedDate !== null && row.createdAt.slice(0, 10) !== selectedDate) {
+            return false;
+        }
+
+        return true;
+    });
 
     useEffect(() => {
         const sentinel = sentinelRef.current;
@@ -64,13 +74,15 @@ export function ActivityView({ onBack }: { onBack: () => void }) {
 
     return (
         <div className="space-y-4 p-4">
-            <button
-                type="button"
-                onClick={onBack}
-                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-            >
-                <ArrowLeft className="size-4" /> Back
-            </button>
+            {onBack ? (
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                    <ArrowLeft className="size-4" /> Back
+                </button>
+            ) : null}
 
             <div>
                 <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">activity</p>
@@ -83,12 +95,19 @@ export function ActivityView({ onBack }: { onBack: () => void }) {
                 </p>
             </div>
 
+            <ActivityGraph
+                days={summary.data?.days ?? []}
+                selectedDate={selectedDate}
+                onSelectDate={setSelectedDate}
+                loading={summary.isPending}
+            />
+
             {summary.data && summary.data.byReason.length > 0 ? (
                 <div className="flex flex-wrap gap-1.5">
                     {summary.data.byReason.map((entry) => (
                         <ReasonChip
                             key={entry.reason}
-                            label={entry.reason}
+                            label={formatLedgerReason(entry.reason).label}
                             count={entry.count}
                             active={selectedReasons.has(entry.reason)}
                             onToggle={() => toggleReason(entry.reason)}
@@ -161,22 +180,25 @@ function ReasonChip({
 function LedgerRow({ row }: { row: LedgerRowData }) {
     const [expanded, setExpanded] = useState(false);
     const spend = row.delta < 0;
+    const copy = formatLedgerReason(row.reason);
 
     return (
         <div className="rounded-2xl border border-white/8 bg-black/20 p-3">
             <div className="flex items-start gap-3">
                 <div className="min-w-0 flex-1">
-                    <ReasonChip label={ledgerReasonGroup(row.reason)} />
+                    <p className="text-sm font-medium text-foreground/95">{copy.label}</p>
                     {row.context ? (
                         <button
                             type="button"
                             onClick={() => setExpanded((value) => !value)}
-                            className={`mt-1.5 block w-full text-left text-sm text-muted-foreground hover:text-foreground ${
+                            className={`mt-0.5 block w-full text-left text-sm text-muted-foreground hover:text-foreground ${
                                 expanded ? "" : "truncate"
                             }`}
                         >
                             {row.context}
                         </button>
+                    ) : copy.detail ? (
+                        <p className="mt-0.5 text-sm text-muted-foreground">{copy.detail}</p>
                     ) : null}
                 </div>
                 <div className="shrink-0 text-right">

--- a/src/youtube/extension/side-panel/admin-panel.tsx
+++ b/src/youtube/extension/side-panel/admin-panel.tsx
@@ -1,0 +1,656 @@
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@app/utils/ui/components/dialog";
+import { Input } from "@app/utils/ui/components/input";
+import { computeCreditBuckets } from "@app/utils/ui/components/youtube/billing-ui";
+import { formatDiamonds } from "@app/utils/ui/components/youtube/diamond";
+import { formatLedgerReason } from "@app/utils/ui/components/youtube/ledger-copy";
+import { formatRelativeTime } from "@app/utils/ui/components/youtube/time";
+import {
+    useAdminAiCalls,
+    useAdminJobs,
+    useAdminRevenue,
+    useAdminUser,
+    useAdminUsers,
+    useAdminWebhookLogs,
+} from "@ext/api.hooks";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { type ReactNode, useState } from "react";
+
+type AdminTab = "users" | "ai-calls" | "webhooks" | "jobs" | "revenue";
+
+const TABS: Array<{ id: AdminTab; label: string }> = [
+    { id: "users", label: "Users" },
+    { id: "ai-calls", label: "AI calls" },
+    { id: "webhooks", label: "Webhooks" },
+    { id: "jobs", label: "Jobs" },
+    { id: "revenue", label: "Revenue" },
+];
+
+function formatUsd(usd: number): string {
+    return `$${usd.toFixed(2)}`;
+}
+
+const labelCls = "font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground";
+const cellHead = "px-2 py-1.5 text-left font-medium text-muted-foreground";
+const cell = "px-2 py-1.5 align-top";
+
+/**
+ * 16:9 admin panel (spec §5) — a large dialog for admin/dev roles only (the
+ * trigger is role-gated by the caller, endpoints are gated server-side too).
+ * Tabs: Users (search/filter → row drill-in), AI calls, Webhook logs, Jobs +
+ * queue, Revenue. Each tab's query is enabled only while its tab is active so
+ * opening the panel doesn't fan out five requests at once.
+ */
+export function AdminPanelDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+    const [tab, setTab] = useState<AdminTab>("users");
+    const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                showCloseButton
+                className="flex aspect-[16/9] max-h-[85vh] w-[96vw] max-w-[min(96vw,960px)] flex-col gap-0 overflow-hidden bg-card p-0"
+                onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+                <div className="flex items-center gap-3 border-b border-white/8 px-4 py-3">
+                    <DialogTitle className="text-base">Admin</DialogTitle>
+                    <DialogDescription className="sr-only">
+                        Operational dashboard for admins and devs.
+                    </DialogDescription>
+                    <div className="ml-2 flex gap-1 overflow-x-auto rounded-lg border border-white/8 bg-black/20 p-1">
+                        {TABS.map((item) => (
+                            <button
+                                key={item.id}
+                                type="button"
+                                onClick={() => {
+                                    setTab(item.id);
+                                    setSelectedUserId(null);
+                                }}
+                                className={`h-7 shrink-0 rounded-md px-3 text-xs font-medium transition-colors ${
+                                    tab === item.id
+                                        ? "bg-white/10 text-foreground"
+                                        : "text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                {item.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto p-4">
+                    {tab === "users" ? (
+                        selectedUserId !== null ? (
+                            <UserProfile id={selectedUserId} onBack={() => setSelectedUserId(null)} />
+                        ) : (
+                            <UsersTab active={open} onSelectUser={setSelectedUserId} />
+                        )
+                    ) : tab === "ai-calls" ? (
+                        <AiCallsTab active={open} />
+                    ) : tab === "webhooks" ? (
+                        <WebhooksTab active={open} />
+                    ) : tab === "jobs" ? (
+                        <JobsTab active={open} />
+                    ) : (
+                        <RevenueTab active={open} />
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function Pending() {
+    return (
+        <div className="flex items-center justify-center py-10 text-muted-foreground">
+            <Loader2 className="size-5 animate-spin" />
+        </div>
+    );
+}
+
+function ErrorNote({ error }: { error: unknown }) {
+    return (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-2.5 text-sm">
+            <p className="break-words text-destructive/90">
+                {error instanceof Error ? error.message : "Something went wrong."}
+            </p>
+        </div>
+    );
+}
+
+function UsersTab({ active, onSelectUser }: { active: boolean; onSelectUser: (id: number) => void }) {
+    const [q, setQ] = useState("");
+    const [sort, setSort] = useState<"created" | "revenue" | "net" | "credits">("created");
+    const users = useAdminUsers({ q: q.trim() || undefined, sort, enabled: active });
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Input
+                    value={q}
+                    onChange={(e) => setQ(e.target.value)}
+                    placeholder="Search email…"
+                    className="h-8 w-52 text-sm"
+                    aria-label="Search users by email"
+                />
+                <select
+                    value={sort}
+                    onChange={(e) => setSort(e.target.value as typeof sort)}
+                    aria-label="Sort users"
+                    className="h-8 rounded-md border border-white/8 bg-black/20 px-2 text-xs text-foreground"
+                >
+                    <option value="created">Newest</option>
+                    <option value="revenue">Revenue</option>
+                    <option value="net">Net</option>
+                    <option value="credits">Diamonds</option>
+                </select>
+                {users.data ? <span className="text-xs text-muted-foreground">{users.data.total} users</span> : null}
+            </div>
+
+            {users.isPending ? (
+                <Pending />
+            ) : users.isError ? (
+                <ErrorNote error={users.error} />
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-white/8">
+                    <table className="w-full text-xs">
+                        <thead className="border-b border-white/8 bg-black/20">
+                            <tr>
+                                <th className={cellHead}>Email</th>
+                                <th className={cellHead}>Role</th>
+                                <th className={`${cellHead} text-right`}>Diamonds</th>
+                                <th className={`${cellHead} text-right`}>Revenue</th>
+                                <th className={`${cellHead} text-right`}>Cost</th>
+                                <th className={`${cellHead} text-right`}>Net</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {users.data.users.map((user) => (
+                                <tr
+                                    key={user.id}
+                                    tabIndex={0}
+                                    onClick={() => onSelectUser(user.id)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter") {
+                                            onSelectUser(user.id);
+                                        }
+                                    }}
+                                    className="cursor-pointer border-b border-white/5 outline-none last:border-0 hover:bg-white/5 focus-visible:bg-white/5"
+                                >
+                                    <td className={`${cell} max-w-[220px] truncate text-foreground/95`}>
+                                        {user.email}
+                                    </td>
+                                    <td className={cell}>
+                                        {user.role === "user" ? (
+                                            <span className="text-muted-foreground">user</span>
+                                        ) : (
+                                            <span className="text-primary">{user.role}</span>
+                                        )}
+                                    </td>
+                                    <td className={`${cell} text-right tabular-nums`}>
+                                        {formatDiamonds(user.credits)}
+                                    </td>
+                                    <td className={`${cell} text-right tabular-nums`}>
+                                        {formatUsd(user.revenueCents / 100)}
+                                    </td>
+                                    <td className={`${cell} text-right tabular-nums text-muted-foreground`}>
+                                        {formatUsd(user.aiCostUsd)}
+                                    </td>
+                                    <td
+                                        className={`${cell} text-right font-medium tabular-nums ${
+                                            user.netUsd >= 0 ? "text-primary" : "text-destructive"
+                                        }`}
+                                    >
+                                        {formatUsd(user.netUsd)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function UserProfile({ id, onBack }: { id: number; onBack: () => void }) {
+    const profile = useAdminUser(id);
+
+    return (
+        <div className="space-y-4">
+            <button
+                type="button"
+                onClick={onBack}
+                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+                <ArrowLeft className="size-4" /> Back to users
+            </button>
+
+            {profile.isPending ? (
+                <Pending />
+            ) : profile.isError ? (
+                <ErrorNote error={profile.error} />
+            ) : profile.data ? (
+                (() => {
+                    const data = profile.data;
+                    const buckets = computeCreditBuckets({
+                        credits: data.user.credits,
+                        subscription: data.billing.subscription,
+                    });
+
+                    return (
+                        <div className="space-y-4">
+                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                                <p className="text-sm font-semibold text-foreground/95">{data.user.email}</p>
+                                <span className="text-xs text-primary">{data.role}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    joined {formatRelativeTime(data.user.createdAt)}
+                                </span>
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                                <Stat label="Diamonds" value={formatDiamonds(data.user.credits)} />
+                                <Stat label="Revenue" value={formatUsd(data.totals.revenueCents / 100)} />
+                                <Stat label="AI cost" value={formatUsd(data.totals.aiCostUsd)} />
+                                <Stat
+                                    label="Net"
+                                    value={formatUsd(data.totals.netUsd)}
+                                    tone={data.totals.netUsd >= 0 ? "good" : "bad"}
+                                />
+                            </div>
+
+                            <Section title="Billing">
+                                <p className="text-sm text-muted-foreground">
+                                    {data.billing.subscription
+                                        ? `${data.billing.subscription.planId} · ${data.billing.subscription.status} · ${formatDiamonds(
+                                              buckets.allowanceRemaining
+                                          )}/${formatDiamonds(buckets.allowance)} allowance`
+                                        : "No subscription"}
+                                    {data.billing.lowBalance ? " · low balance" : ""}
+                                </p>
+                            </Section>
+
+                            <Section title={`Payments (${data.payments.length})`}>
+                                {data.payments.length === 0 ? (
+                                    <Empty />
+                                ) : (
+                                    <ul className="space-y-1">
+                                        {data.payments.slice(0, 10).map((payment) => (
+                                            <li
+                                                key={payment.id}
+                                                className="flex items-center justify-between gap-3 text-sm"
+                                            >
+                                                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                                                    {payment.kind} · {payment.status}
+                                                    {payment.packId ? ` · ${payment.packId}` : ""}
+                                                    {payment.planId ? ` · ${payment.planId}` : ""}
+                                                </span>
+                                                <span className="shrink-0 tabular-nums text-foreground/90">
+                                                    {payment.amountCents != null
+                                                        ? formatUsd(payment.amountCents / 100)
+                                                        : "—"}
+                                                </span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </Section>
+
+                            <Section title="Referral">
+                                <p className="text-sm text-muted-foreground">
+                                    {data.referral.code ? `Code ${data.referral.code}` : "No code"} ·{" "}
+                                    {data.referral.referees.length} invited · +
+                                    {formatDiamonds(data.referral.totalEarned)} earned
+                                    {data.referral.referredBy ? ` · invited by ${data.referral.referredBy.email}` : ""}
+                                </p>
+                            </Section>
+
+                            <Section title={`Recent ledger (${data.ledger.length})`}>
+                                {data.ledger.length === 0 ? (
+                                    <Empty />
+                                ) : (
+                                    <ul className="space-y-1">
+                                        {data.ledger.slice(0, 12).map((row) => (
+                                            <li
+                                                key={row.id}
+                                                className="flex items-center justify-between gap-3 text-sm"
+                                            >
+                                                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                                                    {formatLedgerReason(row.reason).label}
+                                                    {row.context ? ` · ${row.context}` : ""}
+                                                </span>
+                                                <span
+                                                    className={`shrink-0 tabular-nums ${
+                                                        row.delta < 0 ? "text-foreground/90" : "text-primary"
+                                                    }`}
+                                                >
+                                                    {row.delta < 0 ? "−" : "+"}
+                                                    {formatDiamonds(Math.abs(row.delta))}
+                                                </span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </Section>
+
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <Section title={`Watched (${data.activity.watched.length})`}>
+                                    {data.activity.watched.length === 0 ? (
+                                        <Empty />
+                                    ) : (
+                                        <ul className="space-y-1">
+                                            {data.activity.watched.slice(0, 8).map((watch) => (
+                                                <li key={watch.id} className="truncate text-sm text-muted-foreground">
+                                                    {watch.videoId} · {formatRelativeTime(watch.createdAt)}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </Section>
+                                <Section title={`Jobs (${data.jobs.length})`}>
+                                    {data.jobs.length === 0 ? (
+                                        <Empty />
+                                    ) : (
+                                        <ul className="space-y-1">
+                                            {data.jobs.slice(0, 8).map((job) => (
+                                                <li
+                                                    key={job.id}
+                                                    className="flex items-center justify-between gap-2 text-sm"
+                                                >
+                                                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                                                        #{job.id} · {job.target}
+                                                    </span>
+                                                    <span className="shrink-0 text-xs text-foreground/80">
+                                                        {job.status}
+                                                    </span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </Section>
+                            </div>
+                        </div>
+                    );
+                })()
+            ) : null}
+        </div>
+    );
+}
+
+function AiCallsTab({ active }: { active: boolean }) {
+    const [provider, setProvider] = useState("");
+    const [action, setAction] = useState("");
+    const calls = useAdminAiCalls({
+        provider: provider.trim() || undefined,
+        action: action.trim() || undefined,
+        enabled: active,
+    });
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Input
+                    value={provider}
+                    onChange={(e) => setProvider(e.target.value)}
+                    placeholder="provider"
+                    className="h-8 w-32 text-sm"
+                    aria-label="Filter by provider"
+                />
+                <Input
+                    value={action}
+                    onChange={(e) => setAction(e.target.value)}
+                    placeholder="action"
+                    className="h-8 w-32 text-sm"
+                    aria-label="Filter by action"
+                />
+                {calls.data ? <span className="text-xs text-muted-foreground">{calls.data.total} calls</span> : null}
+            </div>
+            {calls.isPending ? (
+                <Pending />
+            ) : calls.isError ? (
+                <ErrorNote error={calls.error} />
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-white/8">
+                    <table className="w-full text-xs">
+                        <thead className="border-b border-white/8 bg-black/20">
+                            <tr>
+                                <th className={cellHead}>Provider / model</th>
+                                <th className={cellHead}>Action</th>
+                                <th className={`${cellHead} text-right`}>Tokens</th>
+                                <th className={`${cellHead} text-right`}>Cost</th>
+                                <th className={`${cellHead} text-right`}>When</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {calls.data.aiCalls.map((call) => (
+                                <tr key={call.id} className="border-b border-white/5 last:border-0">
+                                    <td className={`${cell} text-foreground/90`}>
+                                        {call.provider}/{call.model}
+                                    </td>
+                                    <td className={`${cell} text-muted-foreground`}>{call.action}</td>
+                                    <td className={`${cell} text-right tabular-nums text-muted-foreground`}>
+                                        {call.inputTokens}/{call.outputTokens}
+                                    </td>
+                                    <td className={`${cell} text-right tabular-nums`}>
+                                        {call.costUsd != null ? formatUsd(call.costUsd) : "—"}
+                                    </td>
+                                    <td className={`${cell} text-right text-muted-foreground`}>
+                                        {formatRelativeTime(call.createdAt)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function WebhooksTab({ active }: { active: boolean }) {
+    const [outcome, setOutcome] = useState("");
+    const logs = useAdminWebhookLogs({ outcome: outcome || undefined, enabled: active });
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <select
+                    value={outcome}
+                    onChange={(e) => setOutcome(e.target.value)}
+                    aria-label="Filter webhook outcome"
+                    className="h-8 rounded-md border border-white/8 bg-black/20 px-2 text-xs text-foreground"
+                >
+                    <option value="">All outcomes</option>
+                    <option value="processed">processed</option>
+                    <option value="skipped">skipped</option>
+                    <option value="duplicate">duplicate</option>
+                    <option value="error">error</option>
+                </select>
+                {logs.data ? <span className="text-xs text-muted-foreground">{logs.data.total} events</span> : null}
+            </div>
+            {logs.isPending ? (
+                <Pending />
+            ) : logs.isError ? (
+                <ErrorNote error={logs.error} />
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-white/8">
+                    <table className="w-full text-xs">
+                        <thead className="border-b border-white/8 bg-black/20">
+                            <tr>
+                                <th className={cellHead}>Type</th>
+                                <th className={cellHead}>Outcome</th>
+                                <th className={cellHead}>Detail</th>
+                                <th className={`${cellHead} text-right`}>When</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {logs.data.webhookLogs.map((log) => (
+                                <tr key={log.id} className="border-b border-white/5 last:border-0">
+                                    <td className={`${cell} text-foreground/90`}>{log.type}</td>
+                                    <td className={cell}>
+                                        <span className={log.outcome === "error" ? "text-destructive" : "text-primary"}>
+                                            {log.outcome}
+                                        </span>
+                                    </td>
+                                    <td className={`${cell} max-w-[280px] truncate text-muted-foreground`}>
+                                        {log.detail ?? "—"}
+                                    </td>
+                                    <td className={`${cell} text-right text-muted-foreground`}>
+                                        {formatRelativeTime(log.createdAt)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function JobsTab({ active }: { active: boolean }) {
+    const [status, setStatus] = useState("");
+    const jobs = useAdminJobs({ status: status || undefined, enabled: active });
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <select
+                    value={status}
+                    onChange={(e) => setStatus(e.target.value)}
+                    aria-label="Filter job status"
+                    className="h-8 rounded-md border border-white/8 bg-black/20 px-2 text-xs text-foreground"
+                >
+                    <option value="">All statuses</option>
+                    <option value="pending">pending</option>
+                    <option value="running">running</option>
+                    <option value="completed">completed</option>
+                    <option value="failed">failed</option>
+                    <option value="cancelled">cancelled</option>
+                </select>
+                {jobs.data ? (
+                    <span className="text-xs text-muted-foreground">
+                        {jobs.data.queue.queued} queued · {jobs.data.queue.running} running
+                    </span>
+                ) : null}
+            </div>
+            {jobs.isPending ? (
+                <Pending />
+            ) : jobs.isError ? (
+                <ErrorNote error={jobs.error} />
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-white/8">
+                    <table className="w-full text-xs">
+                        <thead className="border-b border-white/8 bg-black/20">
+                            <tr>
+                                <th className={cellHead}>#</th>
+                                <th className={cellHead}>Target</th>
+                                <th className={cellHead}>Stages</th>
+                                <th className={cellHead}>Status</th>
+                                <th className={`${cellHead} text-right`}>When</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {jobs.data.jobs.map((job) => (
+                                <tr key={job.id} className="border-b border-white/5 last:border-0">
+                                    <td className={`${cell} tabular-nums text-muted-foreground`}>{job.id}</td>
+                                    <td className={`${cell} max-w-[180px] truncate text-foreground/90`}>
+                                        {job.target}
+                                    </td>
+                                    <td className={`${cell} text-muted-foreground`}>{(job.stages ?? []).join(", ")}</td>
+                                    <td className={cell}>
+                                        <span
+                                            className={
+                                                job.status === "failed"
+                                                    ? "text-destructive"
+                                                    : job.status === "completed"
+                                                      ? "text-primary"
+                                                      : "text-muted-foreground"
+                                            }
+                                        >
+                                            {job.status}
+                                        </span>
+                                    </td>
+                                    <td className={`${cell} text-right text-muted-foreground`}>
+                                        {formatRelativeTime(job.createdAt)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function RevenueTab({ active }: { active: boolean }) {
+    const revenue = useAdminRevenue(active);
+
+    if (revenue.isPending) {
+        return <Pending />;
+    }
+
+    if (revenue.isError) {
+        return <ErrorNote error={revenue.error} />;
+    }
+
+    if (!revenue.data) {
+        return null;
+    }
+
+    const { totals, daily } = revenue.data;
+    const maxRevenue = Math.max(1, ...daily.map((day) => day.revenueCents));
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                <Stat label="Revenue" value={formatUsd(totals.revenueCents / 100)} />
+                <Stat label="AI cost" value={formatUsd(totals.aiCostUsd)} />
+                <Stat label="Payments" value={String(totals.paymentsCount)} />
+                <Stat label="Active subs" value={String(totals.activeSubscriptions)} />
+            </div>
+
+            <div className="space-y-2">
+                <p className={labelCls}>revenue · last 30 days</p>
+                <div className="flex h-28 items-end gap-[3px]">
+                    {daily.map((day) => (
+                        <div
+                            key={day.day}
+                            title={`${day.day} · ${formatUsd(day.revenueCents / 100)}`}
+                            className={`min-w-0 flex-1 rounded-sm ${day.revenueCents === 0 ? "bg-white/5" : "bg-primary/50"}`}
+                            style={{ height: `${Math.max(4, (day.revenueCents / maxRevenue) * 100)}%` }}
+                        />
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "good" | "bad" }) {
+    return (
+        <div className="rounded-lg border border-white/8 bg-black/20 p-2.5">
+            <p className={labelCls}>{label}</p>
+            <p
+                className={`mt-1 text-base font-semibold tabular-nums ${
+                    tone === "good" ? "text-primary" : tone === "bad" ? "text-destructive" : "text-foreground"
+                }`}
+            >
+                {value}
+            </p>
+        </div>
+    );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <div className="space-y-1.5">
+            <p className={labelCls}>{title}</p>
+            {children}
+        </div>
+    );
+}
+
+function Empty() {
+    return <p className="text-sm text-muted-foreground">Nothing yet.</p>;
+}

--- a/src/youtube/extension/side-panel/channel-panel.tsx
+++ b/src/youtube/extension/side-panel/channel-panel.tsx
@@ -1,6 +1,14 @@
 import { Button } from "@app/utils/ui/components/button";
 import type { ChannelHandle } from "@app/youtube/lib/types";
-import { useAddChannel, useChannels, useChannelVideos, useConfig } from "@ext/api.hooks";
+import {
+    useAddChannel,
+    useChannels,
+    useChannelVideos,
+    useConfig,
+    useMe,
+    useToggleWatchlist,
+    useWatchlist,
+} from "@ext/api.hooks";
 import { Header } from "@ext/side-panel/header";
 import { ExternalLink, Plus } from "lucide-react";
 import { useState } from "react";
@@ -12,8 +20,13 @@ export function ChannelPanel({ handle }: { handle: string | null }) {
     const addChannel = useAddChannel();
     const videos = useChannelVideos(channelHandle, { limit: 20, includeShorts: true });
     const [collapsed, setCollapsed] = useState(false);
+    const me = useMe();
+    const watchlist = useWatchlist(Boolean(me.data?.user));
+    const toggleWatchlist = useToggleWatchlist();
 
     const tracked = channelHandle !== null && (channels.data ?? []).some((item) => item.handle === channelHandle);
+    const followed =
+        channelHandle !== null && (watchlist.data ?? []).some((entry) => entry.channelHandle === channelHandle);
     const rows = videos.data ?? [];
     const base = config.data?.apiBaseUrl.replace(/\/$/, "") ?? "";
     const webUrl = channelHandle ? `${base}/channels/${encodeURIComponent(channelHandle)}` : base;
@@ -44,6 +57,15 @@ export function ChannelPanel({ handle }: { handle: string | null }) {
                                 <Plus className="size-4" />
                                 {tracked ? "Tracked" : addChannel.isPending ? "Tracking…" : "Track this channel"}
                             </Button>
+                            {me.data?.user ? (
+                                <Button
+                                    variant={followed ? "cyber-secondary" : "default"}
+                                    disabled={toggleWatchlist.isPending}
+                                    onClick={() => toggleWatchlist.mutate({ handle: channelHandle, follow: !followed })}
+                                >
+                                    {followed ? "Following" : "Follow"}
+                                </Button>
+                            ) : null}
                             {base ? (
                                 <Button asChild variant="cyber-secondary">
                                     <a href={webUrl} target="_blank" rel="noopener noreferrer">
@@ -69,7 +91,9 @@ export function ChannelPanel({ handle }: { handle: string | null }) {
                             <p className="text-sm text-muted-foreground">Loading…</p>
                         ) : videos.isError ? (
                             <p className="rounded-2xl border border-dashed border-destructive/40 p-4 text-sm text-destructive/90">
-                                {videos.error instanceof Error ? videos.error.message : "Couldn't load this channel's videos."}
+                                {videos.error instanceof Error
+                                    ? videos.error.message
+                                    : "Couldn't load this channel's videos."}
                             </p>
                         ) : rows.length === 0 ? (
                             <p className="rounded-2xl border border-dashed border-primary/25 p-4 text-sm text-muted-foreground">

--- a/src/youtube/extension/side-panel/referral-section.tsx
+++ b/src/youtube/extension/side-panel/referral-section.tsx
@@ -1,0 +1,218 @@
+import { logger } from "@app/logger/client";
+import { Button } from "@app/utils/ui/components/button";
+import { Input } from "@app/utils/ui/components/input";
+import { Diamond, formatDiamonds } from "@app/utils/ui/components/youtube/diamond";
+import { copyText } from "@app/utils/ui/components/youtube/share-button";
+import { formatRelativeTime } from "@app/utils/ui/components/youtube/time";
+import { ApiError } from "@ext/api.bridge";
+import { useRedeemReferral, useReferral } from "@ext/api.hooks";
+import { Check, Copy, Gift, Loader2, Users } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Referral surface for the account hub (spec §4.4): the user's own invite code
+ * with a copy/share action, their referees + per-referral rewards + total
+ * earned, and a redeem entry for people arriving on an invite. Redeem errors
+ * are surfaced by the server's stable code (403 `offer_inactive`, 409 already
+ * redeemed) so the copy stays friendly instead of echoing raw messages.
+ */
+export function ReferralSection() {
+    const referral = useReferral();
+
+    if (referral.isError) {
+        return (
+            <div className="p-4">
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-2.5 text-sm">
+                    <p className="break-words text-destructive/90">
+                        {referral.error instanceof Error ? referral.error.message : "Failed to load referrals."}
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    const data = referral.data;
+
+    return (
+        <div className="space-y-4 p-4">
+            {referral.isPending || !data ? (
+                <div className="h-24 animate-pulse rounded-2xl bg-white/5" />
+            ) : (
+                <>
+                    <InviteCard code={data.code} totalEarned={data.totalEarned} />
+                    <RefereeList referees={data.referees} />
+                </>
+            )}
+            <RedeemCard />
+        </div>
+    );
+}
+
+function InviteCard({ code, totalEarned }: { code: string; totalEarned: number }) {
+    const [copied, setCopied] = useState(false);
+
+    async function copy() {
+        try {
+            await copyText(`Join me on the YouTube companion — redeem code ${code} for bonus diamonds.`);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (error) {
+            logger.warn({ error }, "referral-section: copy failed");
+        }
+    }
+
+    return (
+        <div className="relative overflow-hidden rounded-2xl border border-primary/25 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10 p-4">
+            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">your invite code</p>
+            <div className="mt-2 flex items-center gap-2">
+                <span className="select-all font-mono text-xl font-semibold tracking-[0.2em] text-foreground">
+                    {code}
+                </span>
+                <Button size="sm" variant="ghost" className="ml-auto text-muted-foreground" onClick={() => void copy()}>
+                    {copied ? (
+                        <>
+                            <Check className="size-4 text-primary" /> Copied
+                        </>
+                    ) : (
+                        <>
+                            <Copy className="size-4" /> Share invite
+                        </>
+                    )}
+                </Button>
+            </div>
+            <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                Earned so far:
+                <Diamond size={14} />
+                <span className="font-semibold tabular-nums text-foreground">{formatDiamonds(totalEarned)}</span>
+            </p>
+        </div>
+    );
+}
+
+function RefereeList({ referees }: { referees: Array<{ email: string; redeemedAt: string; reward: number }> }) {
+    return (
+        <div className="space-y-2">
+            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">friends invited</p>
+            {referees.length === 0 ? (
+                <div className="flex items-start gap-3 rounded-2xl border border-dashed border-primary/25 p-5">
+                    <Users className="mt-0.5 size-5 shrink-0 text-primary" />
+                    <p className="text-sm text-muted-foreground">
+                        No one's joined with your code yet — share it to earn diamonds when they do.
+                    </p>
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    {referees.map((referee) => (
+                        <div
+                            key={`${referee.email}-${referee.redeemedAt}`}
+                            className="flex items-center gap-3 rounded-2xl border border-white/8 bg-black/20 p-3"
+                        >
+                            <p className="min-w-0 flex-1 truncate text-sm text-foreground/95">{referee.email}</p>
+                            <span className="shrink-0 font-mono text-[12px] text-muted-foreground">
+                                {formatRelativeTime(referee.redeemedAt)}
+                            </span>
+                            <span className="flex shrink-0 items-center gap-1 text-sm font-semibold text-primary">
+                                +<Diamond size={13} />
+                                <span className="tabular-nums">{formatDiamonds(referee.reward)}</span>
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function redeemErrorCopy(error: unknown): string {
+    if (error instanceof ApiError) {
+        if (error.code === "offer_inactive") {
+            return "There's no active referral offer right now.";
+        }
+
+        const message = error.message.toLowerCase();
+
+        if (message.includes("already redeemed")) {
+            return "You've already redeemed a referral.";
+        }
+
+        if (message.includes("your own")) {
+            return "You can't redeem your own code.";
+        }
+
+        if (message.includes("unknown")) {
+            return "That code isn't valid.";
+        }
+
+        return error.message;
+    }
+
+    return error instanceof Error ? error.message : String(error);
+}
+
+function RedeemCard() {
+    const redeem = useRedeemReferral();
+    const [code, setCode] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [reward, setReward] = useState<number | null>(null);
+
+    async function submit() {
+        const trimmed = code.trim();
+
+        if (trimmed === "" || redeem.isPending) {
+            return;
+        }
+
+        setError(null);
+        try {
+            const result = await redeem.mutateAsync({ code: trimmed });
+            setReward(result.reward);
+            setCode("");
+        } catch (err) {
+            logger.warn({ error: err }, "referral-section: redeem failed");
+            setError(redeemErrorCopy(err));
+        }
+    }
+
+    if (reward !== null) {
+        return (
+            <div className="flex items-center gap-3 rounded-2xl border border-primary/25 bg-primary/5 p-3">
+                <Gift className="size-5 shrink-0 text-primary" />
+                <p className="text-sm text-foreground/95">
+                    Referral redeemed —{" "}
+                    <span className="inline-flex items-center gap-1 font-semibold text-primary">
+                        +<Diamond size={13} />
+                        <span className="tabular-nums">{formatDiamonds(reward)}</span>
+                    </span>{" "}
+                    added to your balance.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2 rounded-2xl border border-white/8 bg-black/20 p-3">
+            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                got an invite code?
+            </p>
+            <div className="flex items-center gap-2">
+                <Input
+                    value={code}
+                    onChange={(event) => setCode(event.target.value.toUpperCase())}
+                    placeholder="ABCD1234"
+                    maxLength={8}
+                    aria-label="Referral code"
+                    className="h-9 flex-1 font-mono uppercase tracking-[0.15em]"
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                            void submit();
+                        }
+                    }}
+                />
+                <Button size="sm" disabled={redeem.isPending || code.trim() === ""} onClick={() => void submit()}>
+                    {redeem.isPending ? <Loader2 className="size-4 animate-spin" /> : "Redeem"}
+                </Button>
+            </div>
+            {error ? <p className="break-words text-sm text-destructive/90">{error}</p> : null}
+        </div>
+    );
+}

--- a/src/youtube/extension/side-panel/settings-dialog.tsx
+++ b/src/youtube/extension/side-panel/settings-dialog.tsx
@@ -4,10 +4,12 @@ import { Button } from "@app/utils/ui/components/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@app/utils/ui/components/dialog";
 import { Input } from "@app/utils/ui/components/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@app/utils/ui/components/select";
+import { ActivityGraph } from "@app/utils/ui/components/youtube/activity-graph";
+import { Diamond, formatDiamonds } from "@app/utils/ui/components/youtube/diamond";
 import { OUTPUT_LANGS } from "@app/utils/ui/components/youtube/output-langs";
 import { formatRelativeTime } from "@app/utils/ui/components/youtube/time";
 import { DIAMOND_PACKS } from "@app/youtube/lib/billing.types";
-import type { PresetKind, PromptPreset, ShareSummary } from "@app/youtube/lib/types";
+import type { PresetKind, PromptPreset, ShareSummary, YtRole } from "@app/youtube/lib/types";
 import {
     useCheckout,
     useCreatePreset,
@@ -25,7 +27,23 @@ import {
     useUsageSummary,
 } from "@ext/api.hooks";
 import { persistUiLang, useT, useUiLang } from "@ext/shared/i18n";
-import { CreditCard, Gem, Loader2, LogOut, Pencil, Share2, Trash2, Wand2 } from "lucide-react";
+import type { AccountSection } from "@ext/side-panel/account-view";
+import { LowBalanceNudge, SubscriptionSection } from "@ext/side-panel/subscription-section";
+import {
+    CreditCard,
+    Gem,
+    Gift,
+    History,
+    Library,
+    Loader2,
+    LogOut,
+    Newspaper,
+    Pencil,
+    Share2,
+    ShieldCheck,
+    Trash2,
+    Wand2,
+} from "lucide-react";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 
 type AuthMode = "login" | "register";
@@ -34,15 +52,18 @@ export function SettingsDialog({
     open,
     onOpenChange,
     devMode,
-    onViewActivity,
+    onOpenAccount,
+    onOpenAdmin,
 }: {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     devMode?: boolean;
-    onViewActivity?: () => void;
+    onOpenAccount?: (section: AccountSection) => void;
+    onOpenAdmin?: () => void;
 }) {
     const me = useMe(open);
     const user = me.data?.user;
+    const role = me.data?.role;
     const t = useT();
 
     return (
@@ -66,7 +87,9 @@ export function SettingsDialog({
                         credits={user.credits}
                         outputLang={user.outputLang}
                         devMode={devMode}
-                        onViewActivity={onViewActivity}
+                        role={role}
+                        onOpenAccount={onOpenAccount}
+                        onOpenAdmin={onOpenAdmin}
                     />
                 ) : (
                     <AuthForm />
@@ -81,16 +104,21 @@ function SignedInView({
     credits,
     outputLang,
     devMode,
-    onViewActivity,
+    role,
+    onOpenAccount,
+    onOpenAdmin,
 }: {
     email: string;
     credits: number;
     outputLang: string | null;
     devMode?: boolean;
-    onViewActivity?: () => void;
+    role?: YtRole;
+    onOpenAccount?: (section: AccountSection) => void;
+    onOpenAdmin?: () => void;
 }) {
     const logout = useLogout();
     const t = useT();
+    const isPower = role === "admin" || role === "dev";
 
     return (
         <div className="space-y-3">
@@ -99,18 +127,35 @@ function SignedInView({
                     {t("settings.signedInAs")}
                 </p>
                 <p className="mt-1 break-all text-sm text-foreground/95">{email}</p>
-                <div className="mt-3 flex items-baseline gap-1.5">
-                    <span className="text-xl leading-none" aria-hidden>
-                        💎
+                <div className="mt-3 flex items-center gap-2">
+                    <Diamond size={22} glow />
+                    <span className="text-2xl font-semibold tabular-nums leading-none text-foreground">
+                        {formatDiamonds(credits)}
                     </span>
-                    <span className="text-2xl font-semibold tabular-nums leading-none text-foreground">{credits}</span>
                     <span className="text-xs text-muted-foreground">diamonds</span>
                 </div>
             </div>
 
+            <LowBalanceNudge />
+
+            <SubscriptionSection />
+
             <DiamondPacksSection devMode={devMode} />
 
-            {onViewActivity ? <ActivitySparkline onViewAll={onViewActivity} /> : null}
+            {onOpenAccount ? <ActivitySparkline onViewAll={() => onOpenAccount("activity")} /> : null}
+
+            {onOpenAccount ? <LibraryNav onOpen={onOpenAccount} /> : null}
+
+            {isPower && onOpenAdmin ? (
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    className="w-full justify-start text-muted-foreground"
+                    onClick={onOpenAdmin}
+                >
+                    <ShieldCheck className="size-4" /> Admin panel
+                </Button>
+            ) : null}
 
             <LanguageSection outputLang={outputLang} />
 
@@ -126,6 +171,46 @@ function SignedInView({
                 onClick={() => logout.mutate()}
             >
                 <LogOut className="size-4" /> {t("action.logOut")}
+            </Button>
+        </div>
+    );
+}
+
+function LibraryNav({ onOpen }: { onOpen: (section: AccountSection) => void }) {
+    return (
+        <div className="space-y-2">
+            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">your library</p>
+            <Button
+                size="sm"
+                variant="ghost"
+                className="w-full justify-start text-muted-foreground"
+                onClick={() => onOpen("history")}
+            >
+                <History className="size-4" /> History
+            </Button>
+            <Button
+                size="sm"
+                variant="ghost"
+                className="w-full justify-start text-muted-foreground"
+                onClick={() => onOpen("collections")}
+            >
+                <Library className="size-4" /> Collections
+            </Button>
+            <Button
+                size="sm"
+                variant="ghost"
+                className="w-full justify-start text-muted-foreground"
+                onClick={() => onOpen("digest")}
+            >
+                <Newspaper className="size-4" /> Digest
+            </Button>
+            <Button
+                size="sm"
+                variant="ghost"
+                className="w-full justify-start text-muted-foreground"
+                onClick={() => onOpen("referral")}
+            >
+                <Gift className="size-4" /> Referral
             </Button>
         </div>
     );
@@ -178,39 +263,10 @@ function LanguageSection({ outputLang }: { outputLang: string | null }) {
 
 function ActivitySparkline({ onViewAll }: { onViewAll: () => void }) {
     const summary = useUsageSummary();
-    const days = summary.data?.days ?? [];
-    const maxSpent = Math.max(1, ...days.map((d) => d.spent));
-
-    if (summary.isPending) {
-        return (
-            <div className="space-y-2">
-                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-                    activity · last 30 days
-                </p>
-                <div className="flex items-center justify-center py-4 text-muted-foreground">
-                    <Loader2 className="size-4 animate-spin" />
-                </div>
-            </div>
-        );
-    }
 
     return (
         <div className="space-y-2">
-            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-                activity · last 30 days
-            </p>
-            <div className="flex h-12 items-end gap-[2px]">
-                {days.map((day, i) => (
-                    <div
-                        key={day.date}
-                        title={`${day.date} · ${day.spent} 💎`}
-                        className={`flex-1 rounded-sm ${
-                            day.spent === 0 ? "bg-white/5" : i === days.length - 1 ? "bg-primary/70" : "bg-primary/30"
-                        }`}
-                        style={{ height: `${Math.max(8, (day.spent / maxSpent) * 100)}%` }}
-                    />
-                ))}
-            </div>
+            <ActivityGraph days={summary.data?.days ?? []} loading={summary.isPending} />
             <p className="text-sm text-muted-foreground">
                 This month:{" "}
                 <span className="font-semibold tabular-nums text-foreground">{summary.data?.month.spent ?? 0} 💎</span>{" "}
@@ -269,8 +325,8 @@ function DiamondPacksSection({ devMode }: { devMode?: boolean }) {
                             onClick={() => void buy(pack.id)}
                             className="rounded-2xl border border-white/8 bg-black/20 p-3 text-left transition-colors hover:border-primary/40 disabled:opacity-60"
                         >
-                            <p className="text-base font-semibold tabular-nums text-foreground">
-                                {pack.diamonds.toLocaleString("en-US").replace(",", " ")} 💎
+                            <p className="flex items-center gap-1 text-base font-semibold tabular-nums text-foreground">
+                                <Diamond size={15} /> {formatDiamonds(pack.diamonds)}
                             </p>
                             {pendingPack === pack.id ? (
                                 <p className="mt-0.5 flex items-center gap-1.5 text-sm text-muted-foreground">

--- a/src/youtube/extension/side-panel/side-panel.tsx
+++ b/src/youtube/extension/side-panel/side-panel.tsx
@@ -2,10 +2,20 @@ import { type PipelineProgress, type VideoDetailTab, VideoDetailTabs } from "@ap
 import type { PipelineJob } from "@app/youtube/lib/jobs.types";
 import type { JobStage, SummaryMode } from "@app/youtube/lib/types";
 import { send } from "@ext/api.bridge";
-import { buildAudioSrc, dataSource, useConfig, useMe, useModels, useStartPipeline, useSummary } from "@ext/api.hooks";
+import {
+    buildAudioSrc,
+    dataSource,
+    useConfig,
+    useMe,
+    useModels,
+    useQueueStats,
+    useStartPipeline,
+    useSummary,
+} from "@ext/api.hooks";
 import { loadUiLang } from "@ext/shared/i18n";
 import type { ExtensionEvent, PlayerChaptersMessage } from "@ext/shared/messages";
-import { ActivityView } from "@ext/side-panel/activity-view";
+import { type AccountSection, AccountView } from "@ext/side-panel/account-view";
+import { AdminPanelDialog } from "@ext/side-panel/admin-panel";
 import { ChannelPanel } from "@ext/side-panel/channel-panel";
 import { Header } from "@ext/side-panel/header";
 import { PlaylistPanel } from "@ext/side-panel/playlist-panel";
@@ -36,7 +46,9 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
     const [active, setActive] = useState<VideoDetailTab>("summary");
     const [collapsed, setCollapsed] = useState(false);
     const [settingsOpen, setSettingsOpen] = useState(false);
-    const [view, setView] = useState<"tabs" | "activity">("tabs");
+    const [adminOpen, setAdminOpen] = useState(false);
+    const [view, setView] = useState<"tabs" | "account">("tabs");
+    const [accountSection, setAccountSection] = useState<AccountSection>("activity");
     // `playerTime` is the throttled value handed to the tab subtree; the ref
     // holds the raw 1 Hz position so we can push an exact value the instant a
     // consumer that needs it (the transcript's follow-mode) becomes visible.
@@ -136,6 +148,9 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
     // while a job runs for THIS video) and query invalidation when a job
     // finishes (so "Fetch comments" etc. actually surface their data).
     const [pipelineProgress, setPipelineProgress] = useState<PipelineProgress | null>(null);
+    // Only poll the queue while a job is actually in flight — the transcript
+    // tab uses it to show how many jobs are ahead.
+    const queueStats = useQueueStats(pipelineProgress !== null);
     const activeJobIdsRef = useRef<Set<number>>(new Set());
     // Streaming summary:partial payloads (kept past job:completed so the
     // refetched query swaps content in without a flash of emptiness).
@@ -361,8 +376,14 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
                 hits its top/bottom. */}
             <div className="yt-body-collapsible flex min-h-0 flex-1 flex-col" data-collapsed={collapsed}>
                 <div className="yt-scroll min-h-0 flex-1 overflow-y-auto overscroll-contain">
-                    {view === "activity" ? (
-                        <ActivityView onBack={() => setView("tabs")} />
+                    {view === "account" ? (
+                        <AccountView
+                            section={accountSection}
+                            onSectionChange={setAccountSection}
+                            onBack={() => setView("tabs")}
+                            onRequireLogin={requireLogin}
+                            onOpenWatch={(id, t) => void send({ type: "nav:openWatch", id, t })}
+                        />
                     ) : (
                         <VideoDetailTabs
                             videoId={videoId}
@@ -376,7 +397,9 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
                             modelPresets={models.data?.presets ?? []}
                             modelDefaults={models.data?.defaults}
                             pipelineProgress={pipelineProgress}
+                            queueStats={queueStats.data?.queue}
                             onRequireLogin={requireLogin}
+                            onUpgrade={() => setSettingsOpen(true)}
                             onOpenWatch={(id, t) => void send({ type: "nav:openWatch", id, t })}
                             partialSummaries={partialSummaries}
                             streamingMode={streamingMode}
@@ -402,11 +425,17 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
                     }
                 }}
                 devMode={IS_DEV_BUILD}
-                onViewActivity={() => {
+                onOpenAccount={(accountSectionId) => {
                     setSettingsOpen(false);
-                    setView("activity");
+                    setAccountSection(accountSectionId);
+                    setView("account");
+                }}
+                onOpenAdmin={() => {
+                    setSettingsOpen(false);
+                    setAdminOpen(true);
                 }}
             />
+            <AdminPanelDialog open={adminOpen} onOpenChange={setAdminOpen} />
         </div>
     );
 }

--- a/src/youtube/extension/side-panel/subscription-section.tsx
+++ b/src/youtube/extension/side-panel/subscription-section.tsx
@@ -1,0 +1,207 @@
+import { logger } from "@app/logger/client";
+import { Button } from "@app/utils/ui/components/button";
+import { computeCreditBuckets, subscriptionRenewalCopy } from "@app/utils/ui/components/youtube/billing-ui";
+import { Diamond, formatDiamonds } from "@app/utils/ui/components/youtube/diamond";
+import { SUBSCRIPTION_PLANS } from "@app/youtube/lib/billing.types";
+import type { MeBillingContext, YtUser } from "@app/youtube/lib/types";
+import { useMe, useSubscribe } from "@ext/api.hooks";
+import { Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { useState } from "react";
+
+const PLAN = SUBSCRIPTION_PLANS[0];
+
+/**
+ * Subscription surface for the account/settings panel (spec §4.2): shows the
+ * active plan with a RESETTING allowance-vs-top-up split, renewal/cancel state
+ * — or a subscribe CTA when the user isn't a member. The allowance bucket
+ * claws back each period; the top-up bucket survives, and the split bar makes
+ * that visible so nobody expects diamonds to stack month over month.
+ */
+export function SubscriptionSection() {
+    const me = useMe();
+    const user = me.data?.user;
+    const billing = me.data?.billing;
+
+    if (!user || !billing) {
+        return null;
+    }
+
+    const subscription = billing.subscription;
+
+    if (subscription && subscription.status !== "canceled") {
+        return <ActivePlan user={user} subscription={subscription} />;
+    }
+
+    return <SubscribeCta />;
+}
+
+function ActivePlan({
+    user,
+    subscription,
+}: {
+    user: YtUser;
+    subscription: NonNullable<MeBillingContext["subscription"]>;
+}) {
+    const buckets = computeCreditBuckets({ credits: user.credits, subscription });
+    const renewal = subscriptionRenewalCopy(subscription);
+    const pastDue = subscription.status === "past_due";
+    // Bar segments are sized against the plan allowance so a fully-spent
+    // allowance visibly empties (top-up still shows beyond it).
+    const scale = Math.max(buckets.allowance, buckets.total, 1);
+    const allowancePct = (buckets.allowanceRemaining / scale) * 100;
+    const topupPct = (buckets.topup / scale) * 100;
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center justify-between">
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">subscription</p>
+                <span
+                    className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[11px] uppercase tracking-[0.18em] ${
+                        pastDue
+                            ? "border-destructive/40 text-destructive"
+                            : "border-primary/30 bg-primary/5 text-primary"
+                    }`}
+                >
+                    {pastDue ? "past due" : "active"}
+                </span>
+            </div>
+
+            <div className="rounded-2xl border border-white/8 bg-black/20 p-3">
+                <div className="flex items-center gap-2">
+                    <Diamond size={18} glow />
+                    <p className="text-sm font-semibold text-foreground/95">Monthly · ${PLAN.usd}/mo</p>
+                    {renewal ? (
+                        <span className="ml-auto inline-flex items-center gap-1 font-mono text-[12px] text-muted-foreground">
+                            <RefreshCw className="size-3" /> {renewal}
+                        </span>
+                    ) : null}
+                </div>
+
+                <div className="mt-3 flex h-2 overflow-hidden rounded-full bg-white/5">
+                    <div className="h-full bg-primary/70" style={{ width: `${allowancePct}%` }} />
+                    <div className="h-full bg-secondary/60" style={{ width: `${topupPct}%` }} />
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                    <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                        <span className="size-2 rounded-full bg-primary/70" aria-hidden />
+                        <span className="tabular-nums text-foreground">
+                            {formatDiamonds(buckets.allowanceRemaining)}
+                        </span>
+                        {" / "}
+                        {formatDiamonds(buckets.allowance)} allowance
+                    </span>
+                    {buckets.topup > 0 ? (
+                        <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                            <span className="size-2 rounded-full bg-secondary/60" aria-hidden />
+                            <span className="tabular-nums text-foreground">+{formatDiamonds(buckets.topup)}</span>{" "}
+                            top-up
+                        </span>
+                    ) : null}
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                    Allowance resets to {formatDiamonds(buckets.allowance)} each period. Top-up diamonds carry over.
+                </p>
+                {subscription.cancelAtPeriodEnd ? (
+                    <p className="mt-1 text-xs text-amber-300/80">
+                        Cancels at period end — you keep access until then.
+                    </p>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function SubscribeCta() {
+    const subscribe = useSubscribe();
+    const [error, setError] = useState<string | null>(null);
+
+    async function start() {
+        if (subscribe.isPending) {
+            return;
+        }
+
+        setError(null);
+        try {
+            await subscribe.mutateAsync({ planId: PLAN.id });
+        } catch (err) {
+            logger.warn({ error: err }, "subscription-section: subscribe failed");
+            setError(err instanceof Error ? err.message : String(err));
+        }
+    }
+
+    const unconfigured = error?.includes("not configured") || error?.includes("billing not configured");
+
+    return (
+        <div className="space-y-2">
+            <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">subscription</p>
+            {unconfigured ? (
+                <div className="flex items-start gap-3 rounded-2xl border border-dashed border-primary/25 p-4">
+                    <Sparkles className="mt-0.5 size-5 shrink-0 text-primary" />
+                    <p className="text-sm text-muted-foreground">Subscriptions aren't configured on this server yet.</p>
+                </div>
+            ) : (
+                <div className="relative overflow-hidden rounded-2xl border border-primary/25 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10 p-4">
+                    <div className="flex items-center gap-2">
+                        <Diamond size={20} glow />
+                        <p className="text-sm font-semibold text-foreground">
+                            {formatDiamonds(PLAN.allowance)} diamonds / month
+                        </p>
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        A fresh {formatDiamonds(PLAN.allowance)}-diamond allowance every period for ${PLAN.usd}/mo.
+                        Cancel anytime.
+                    </p>
+                    <Button
+                        size="sm"
+                        className="mt-3 w-full"
+                        disabled={subscribe.isPending}
+                        onClick={() => void start()}
+                    >
+                        {subscribe.isPending ? (
+                            <>
+                                <Loader2 className="size-4 animate-spin" /> Opening…
+                            </>
+                        ) : (
+                            <>
+                                <Sparkles className="size-4" /> Subscribe · ${PLAN.usd}/mo
+                            </>
+                        )}
+                    </Button>
+                </div>
+            )}
+            {error && !unconfigured ? (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-2.5 text-sm">
+                    <p className="break-words text-destructive/90">{error}</p>
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+/**
+ * Low-balance nudge banner (spec §4.3) — surfaces when the billing context
+ * flags `lowBalance`, steering the user to top-up/subscribe before an action
+ * bounces. Rendered near the top of the account surface.
+ */
+export function LowBalanceNudge({ onGetDiamonds }: { onGetDiamonds?: () => void }) {
+    const me = useMe();
+
+    if (!me.data?.user || !me.data.billing?.lowBalance) {
+        return null;
+    }
+
+    return (
+        <div className="flex items-center gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-3">
+            <Diamond size={20} glow />
+            <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-amber-100/95">Running low on diamonds</p>
+                <p className="text-xs text-amber-100/70">Top up or subscribe to keep summarizing and asking.</p>
+            </div>
+            {onGetDiamonds ? (
+                <Button size="sm" className="shrink-0" onClick={onGetDiamonds}>
+                    Get more
+                </Button>
+            ) : null}
+        </div>
+    );
+}

--- a/src/youtube/lib/db.ts
+++ b/src/youtube/lib/db.ts
@@ -7,6 +7,12 @@ import { deleteIfExists } from "@app/youtube/lib/cache";
 import type { Channel, ChannelHandle } from "@app/youtube/lib/channel.types";
 import type { FetchedComment, VideoComment } from "@app/youtube/lib/comments.types";
 import type {
+    AdminListAiCallsOpts,
+    AdminListUsersOpts,
+    AdminListWebhookLogsOpts,
+    AdminRevenueSummary,
+    AdminUserRow,
+    AdminUserTotals,
     AiCallRecord,
     AskMessageRecord,
     AskMessageRole,
@@ -1877,6 +1883,15 @@ export class YoutubeDatabase extends BaseDatabase {
         return row?.user_id ?? null;
     }
 
+    /** Read-only lookup of a user's existing referral code (never creates one). */
+    getReferralCodeForUser(userId: number): string | null {
+        const row = this.db
+            .query<{ code: string }, [number]>("SELECT code FROM referral_codes WHERE user_id = ?")
+            .get(userId);
+
+        return row?.code ?? null;
+    }
+
     createReferral(input: {
         code: string;
         referrerUserId: number;
@@ -2008,6 +2023,224 @@ export class YoutubeDatabase extends BaseDatabase {
         const row = this.db.query<UserRow, [string]>("SELECT * FROM users WHERE api_token = ?").get(apiToken);
 
         return row ? rowToUser(row) : null;
+    }
+
+    getUserById(userId: number): YtUser | null {
+        const row = this.db.query<UserRow, [number]>("SELECT * FROM users WHERE id = ?").get(userId);
+
+        return row ? rowToUser(row) : null;
+    }
+
+    /**
+     * Admin users table: one row per user with money aggregates joined from
+     * pre-aggregated subqueries (one row per user_id each) so payments × ai_calls
+     * never multiply. Role is config-derived and attached in the route, not here.
+     */
+    adminListUsers(opts: AdminListUsersOpts): { rows: AdminUserRow[]; total: number } {
+        const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+        const offset = Math.max(opts.offset ?? 0, 0);
+        const filters: string[] = [];
+        const params: Array<string> = [];
+
+        if (opts.search) {
+            filters.push("u.email LIKE ?");
+            params.push(`%${opts.search}%`);
+        }
+
+        if (opts.subscription === "none") {
+            filters.push("s.status IS NULL");
+        } else if (opts.subscription) {
+            filters.push("s.status = ?");
+            params.push(opts.subscription);
+        }
+
+        const where = filters.length > 0 ? `WHERE ${filters.join(" AND ")}` : "";
+        const orderCol = ADMIN_USER_SORTS[opts.sort ?? "created"] ?? ADMIN_USER_SORTS.created;
+        const dir = opts.dir === "asc" ? "ASC" : "DESC";
+        const base = `
+            FROM users u
+            LEFT JOIN (SELECT user_id, SUM(amount_cents) AS revenue_cents FROM payments WHERE status = 'succeeded' GROUP BY user_id) p ON p.user_id = u.id
+            LEFT JOIN (SELECT user_id, SUM(cost_usd) AS cost_usd FROM ai_calls GROUP BY user_id) a ON a.user_id = u.id
+            LEFT JOIN subscriptions s ON s.user_id = u.id
+            ${where}`;
+        const total = this.db.query<{ n: number }, string[]>(`SELECT COUNT(*) AS n ${base}`).get(...params)?.n ?? 0;
+        const rows = this.db
+            .query<AdminUserRowRaw, [...string[], number, number]>(
+                `SELECT u.id, u.email, u.credits, u.created_at, u.last_login_at,
+                        COALESCE(p.revenue_cents, 0) AS revenue_cents,
+                        COALESCE(a.cost_usd, 0) AS cost_usd,
+                        s.status AS sub_status, s.plan_id AS sub_plan_id
+                 ${base}
+                 ORDER BY ${orderCol} ${dir}, u.id DESC
+                 LIMIT ? OFFSET ?`
+            )
+            .all(...params, limit, offset);
+
+        return { rows: rows.map(rowToAdminUser), total };
+    }
+
+    /** Money aggregates + row counts for one user's admin profile header. */
+    adminUserTotals(userId: number): AdminUserTotals {
+        const row = this.db
+            .query<
+                { revenue_cents: number; cost_usd: number; payments_count: number; ai_calls_count: number },
+                [number, number, number, number]
+            >(
+                `SELECT
+                    (SELECT COALESCE(SUM(amount_cents), 0) FROM payments WHERE user_id = ? AND status = 'succeeded') AS revenue_cents,
+                    (SELECT COALESCE(SUM(cost_usd), 0) FROM ai_calls WHERE user_id = ?) AS cost_usd,
+                    (SELECT COUNT(*) FROM payments WHERE user_id = ?) AS payments_count,
+                    (SELECT COUNT(*) FROM ai_calls WHERE user_id = ?) AS ai_calls_count`
+            )
+            .get(userId, userId, userId, userId);
+
+        return {
+            revenueCents: row?.revenue_cents ?? 0,
+            aiCostUsd: row?.cost_usd ?? 0,
+            paymentsCount: row?.payments_count ?? 0,
+            aiCallsCount: row?.ai_calls_count ?? 0,
+        };
+    }
+
+    /** Paginated ai_calls for the admin ops view, filterable by provider/action/user. Newest first. */
+    adminListAiCalls(opts: AdminListAiCallsOpts = {}): { rows: AiCallRecord[]; total: number } {
+        const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+        const offset = Math.max(opts.offset ?? 0, 0);
+        const where: string[] = [];
+        const params: Array<string | number> = [];
+
+        if (opts.provider) {
+            where.push("provider = ?");
+            params.push(opts.provider);
+        }
+
+        if (opts.action) {
+            where.push("action = ?");
+            params.push(opts.action);
+        }
+
+        if (opts.userId !== undefined) {
+            where.push("user_id = ?");
+            params.push(opts.userId);
+        }
+
+        const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+        const total =
+            this.db
+                .query<{ n: number }, Array<string | number>>(`SELECT COUNT(*) AS n FROM ai_calls ${whereClause}`)
+                .get(...params)?.n ?? 0;
+        const rows = this.db
+            .query<AiCallRow, [...Array<string | number>, number, number]>(
+                `SELECT * FROM ai_calls ${whereClause} ORDER BY id DESC LIMIT ? OFFSET ?`
+            )
+            .all(...params, limit, offset);
+
+        return { rows: rows.map(rowToAiCall), total };
+    }
+
+    /** Paginated webhook_logs for the admin ops view, filterable by outcome. Newest first. */
+    adminListWebhookLogs(opts: AdminListWebhookLogsOpts = {}): { rows: WebhookLogRecord[]; total: number } {
+        const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+        const offset = Math.max(opts.offset ?? 0, 0);
+        const whereClause = opts.outcome ? "WHERE outcome = ?" : "";
+        const params: string[] = opts.outcome ? [opts.outcome] : [];
+        const total =
+            this.db
+                .query<{ n: number }, string[]>(`SELECT COUNT(*) AS n FROM webhook_logs ${whereClause}`)
+                .get(...params)?.n ?? 0;
+        const rows = this.db
+            .query<WebhookLogRow, [...string[], number, number]>(
+                `SELECT * FROM webhook_logs ${whereClause} ORDER BY id DESC LIMIT ? OFFSET ?`
+            )
+            .all(...params, limit, offset);
+
+        return { rows: rows.map(rowToWebhookLog), total };
+    }
+
+    /** Paginated jobs list for the admin ops view (reuses listJobs), plus the matching total. */
+    adminListJobs(opts: { status?: JobStatus; limit?: number; offset?: number } = {}): {
+        rows: PipelineJob[];
+        total: number;
+    } {
+        const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+        const offset = Math.max(opts.offset ?? 0, 0);
+        const whereClause = opts.status ? "WHERE status = ?" : "";
+        const params: string[] = opts.status ? [opts.status] : [];
+        const total =
+            this.db.query<{ n: number }, string[]>(`SELECT COUNT(*) AS n FROM jobs ${whereClause}`).get(...params)?.n ??
+            0;
+        const rows = this.listJobs({ status: opts.status, limit, offset });
+
+        return { rows, total };
+    }
+
+    /**
+     * Platform revenue summary: lifetime totals plus per-day revenue/AI-cost
+     * buckets over the last `days` (zero-filled, oldest→newest, UTC day keys).
+     */
+    adminRevenueSummary(opts: { days?: number } = {}): AdminRevenueSummary {
+        const days = Math.min(Math.max(opts.days ?? 30, 1), 365);
+        const totalsRow = this.db
+            .query<
+                {
+                    revenue_cents: number;
+                    cost_usd: number;
+                    payments_count: number;
+                    refunds_count: number;
+                    active_subscriptions: number;
+                },
+                []
+            >(
+                `SELECT
+                    (SELECT COALESCE(SUM(amount_cents), 0) FROM payments WHERE status = 'succeeded') AS revenue_cents,
+                    (SELECT COALESCE(SUM(cost_usd), 0) FROM ai_calls) AS cost_usd,
+                    (SELECT COUNT(*) FROM payments WHERE status = 'succeeded') AS payments_count,
+                    (SELECT COUNT(*) FROM payments WHERE status = 'refunded') AS refunds_count,
+                    (SELECT COUNT(*) FROM subscriptions WHERE status = 'active') AS active_subscriptions`
+            )
+            .get();
+
+        const now = Date.now();
+        const cutoff = new Date(now - (days - 1) * 86_400_000).toISOString().slice(0, 10);
+        const revenueByDay = new Map<string, number>();
+
+        for (const row of this.db
+            .query<{ day: string; revenue_cents: number }, [string]>(
+                `SELECT substr(created_at, 1, 10) AS day, COALESCE(SUM(amount_cents), 0) AS revenue_cents
+                 FROM payments WHERE status = 'succeeded' AND substr(created_at, 1, 10) >= ? GROUP BY day`
+            )
+            .all(cutoff)) {
+            revenueByDay.set(row.day, row.revenue_cents);
+        }
+
+        const costByDay = new Map<string, number>();
+
+        for (const row of this.db
+            .query<{ day: string; cost_usd: number }, [string]>(
+                `SELECT substr(created_at, 1, 10) AS day, COALESCE(SUM(cost_usd), 0) AS cost_usd
+                 FROM ai_calls WHERE substr(created_at, 1, 10) >= ? GROUP BY day`
+            )
+            .all(cutoff)) {
+            costByDay.set(row.day, row.cost_usd);
+        }
+
+        const daily: AdminRevenueSummary["daily"] = [];
+
+        for (let i = days - 1; i >= 0; i--) {
+            const day = new Date(now - i * 86_400_000).toISOString().slice(0, 10);
+            daily.push({ day, revenueCents: revenueByDay.get(day) ?? 0, aiCostUsd: costByDay.get(day) ?? 0 });
+        }
+
+        return {
+            totals: {
+                revenueCents: totalsRow?.revenue_cents ?? 0,
+                aiCostUsd: totalsRow?.cost_usd ?? 0,
+                paymentsCount: totalsRow?.payments_count ?? 0,
+                refundsCount: totalsRow?.refunds_count ?? 0,
+                activeSubscriptions: totalsRow?.active_subscriptions ?? 0,
+            },
+            daily,
+        };
     }
 
     touchUserLogin(id: number): void {
@@ -3726,6 +3959,40 @@ interface ReferralRow {
     offer_from: string;
     offer_to: string;
     created_at: string;
+}
+
+/** Fixed sort whitelist — never interpolate a raw sort key into SQL. */
+const ADMIN_USER_SORTS = {
+    created: "u.created_at",
+    revenue: "COALESCE(p.revenue_cents, 0)",
+    net: "(COALESCE(p.revenue_cents, 0) / 100.0 - COALESCE(a.cost_usd, 0))",
+    credits: "u.credits",
+} as const;
+
+interface AdminUserRowRaw {
+    id: number;
+    email: string;
+    credits: number;
+    created_at: string;
+    last_login_at: string | null;
+    revenue_cents: number;
+    cost_usd: number;
+    sub_status: string | null;
+    sub_plan_id: string | null;
+}
+
+function rowToAdminUser(row: AdminUserRowRaw): AdminUserRow {
+    return {
+        id: row.id,
+        email: row.email,
+        credits: row.credits,
+        revenueCents: row.revenue_cents,
+        aiCostUsd: row.cost_usd,
+        subStatus: row.sub_status,
+        subPlanId: row.sub_plan_id,
+        createdAt: row.created_at,
+        lastLoginAt: row.last_login_at,
+    };
 }
 
 function rowToReferral(row: ReferralRow): ReferralRecord {

--- a/src/youtube/lib/db.types.ts
+++ b/src/youtube/lib/db.types.ts
@@ -402,3 +402,62 @@ export interface ReferralRecord {
     offerTo: string;
     createdAt: string;
 }
+
+export interface AdminListUsersOpts {
+    /** Case-insensitive email substring. */
+    search?: string;
+    /** Subscription filter: a status ("active"|"past_due"|"canceled") or "none". */
+    subscription?: string;
+    sort?: "created" | "revenue" | "net" | "credits";
+    dir?: "asc" | "desc";
+    limit?: number;
+    offset?: number;
+}
+
+/** One row of the admin users table — per-user money aggregates (role attached in the route). */
+export interface AdminUserRow {
+    id: number;
+    email: string;
+    credits: number;
+    /** Sum of succeeded payments (cents). */
+    revenueCents: number;
+    /** Sum of ai_calls.cost_usd. */
+    aiCostUsd: number;
+    subStatus: string | null;
+    subPlanId: string | null;
+    createdAt: string;
+    lastLoginAt: string | null;
+}
+
+export interface AdminUserTotals {
+    revenueCents: number;
+    aiCostUsd: number;
+    paymentsCount: number;
+    aiCallsCount: number;
+}
+
+export interface AdminListAiCallsOpts {
+    provider?: string;
+    action?: string;
+    userId?: number;
+    limit?: number;
+    offset?: number;
+}
+
+export interface AdminListWebhookLogsOpts {
+    outcome?: string;
+    limit?: number;
+    offset?: number;
+}
+
+export interface AdminRevenueSummary {
+    totals: {
+        revenueCents: number;
+        aiCostUsd: number;
+        paymentsCount: number;
+        refundsCount: number;
+        activeSubscriptions: number;
+    };
+    /** Daily buckets, oldest→newest, gaps zero-filled, covering the requested window. */
+    daily: Array<{ day: string; revenueCents: number; aiCostUsd: number }>;
+}

--- a/src/youtube/lib/server/__tests__/admin-ops-route.test.ts
+++ b/src/youtube/lib/server/__tests__/admin-ops-route.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleAdminRoute } from "@app/youtube/lib/server/routes/admin";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "yt-admin-ops-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    await yt.config.update({ powerUsers: [{ email: "admin@example.com", type: "admin" }] });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function mkUser(email: string) {
+    return db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+}
+
+async function get(path: string, token: string | null) {
+    const url = new URL(`http://localhost${path}`);
+    const req = new Request(url, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+    const res = await handleAdminRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("admin ops gating", () => {
+    it("401 anon / 403 non-power on ai-calls", async () => {
+        mkUser("admin@example.com");
+        mkUser("plain@example.com");
+
+        expect((await get("/api/v1/admin/ai-calls", null)).status).toBe(401);
+        expect((await get("/api/v1/admin/ai-calls", "ytu_plain@example.com")).status).toBe(403);
+        expect((await get("/api/v1/admin/ai-calls", "ytu_admin@example.com")).status).toBe(200);
+    });
+});
+
+describe("GET /api/v1/admin/ai-calls", () => {
+    it("lists newest-first, filters by provider/action/user, paginates", async () => {
+        mkUser("admin@example.com");
+        const u = mkUser("u@example.com");
+        const v = mkUser("v@example.com");
+        db.recordAiCall({ provider: "xai", model: "grok", action: "summary", userId: u.id, costUsd: 0.1 });
+        db.recordAiCall({ provider: "openai", model: "gpt", action: "qa", userId: u.id, costUsd: 0.2 });
+        db.recordAiCall({ provider: "xai", model: "grok", action: "qa", userId: v.id, costUsd: 0.3 });
+
+        const all = await get("/api/v1/admin/ai-calls", "ytu_admin@example.com");
+
+        expect(all.status).toBe(200);
+        expect(all.json.total).toBe(3);
+        expect((all.json.aiCalls as Array<{ id: number }>)[0].id).toBe(3);
+
+        const byProvider = await get("/api/v1/admin/ai-calls?provider=xai", "ytu_admin@example.com");
+
+        expect(byProvider.json.total).toBe(2);
+
+        const byAction = await get("/api/v1/admin/ai-calls?action=qa", "ytu_admin@example.com");
+
+        expect(byAction.json.total).toBe(2);
+
+        const byUser = await get(`/api/v1/admin/ai-calls?userId=${u.id}`, "ytu_admin@example.com");
+
+        expect(byUser.json.total).toBe(2);
+
+        const paged = await get("/api/v1/admin/ai-calls?limit=1&offset=0", "ytu_admin@example.com");
+
+        expect(paged.json.aiCalls).toHaveLength(1);
+        expect(paged.json.total).toBe(3);
+    });
+});
+
+describe("GET /api/v1/admin/webhook-logs", () => {
+    it("lists and filters by outcome", async () => {
+        mkUser("admin@example.com");
+        db.recordWebhookLog({ stripeEventId: "evt_1", type: "checkout", payloadHash: "a", outcome: "processed" });
+        db.recordWebhookLog({ stripeEventId: "evt_2", type: "checkout", payloadHash: "b", outcome: "duplicate" });
+        db.recordWebhookLog({ stripeEventId: "evt_3", type: "invoice", payloadHash: "c", outcome: "error" });
+
+        const all = await get("/api/v1/admin/webhook-logs", "ytu_admin@example.com");
+
+        expect(all.json.total).toBe(3);
+        expect((all.json.webhookLogs as Array<{ stripeEventId: string }>)[0].stripeEventId).toBe("evt_3");
+
+        const errors = await get("/api/v1/admin/webhook-logs?outcome=error", "ytu_admin@example.com");
+
+        expect(errors.json.total).toBe(1);
+        expect((errors.json.webhookLogs as Array<{ type: string }>)[0].type).toBe("invoice");
+    });
+});
+
+describe("GET /api/v1/admin/jobs", () => {
+    it("lists jobs with queue stats and status filter", async () => {
+        mkUser("admin@example.com");
+        db.enqueueJob({ targetKind: "video", target: "vid1", stages: ["metadata"] });
+        db.enqueueJob({ targetKind: "video", target: "vid2", stages: ["summarize"] });
+
+        const res = await get("/api/v1/admin/jobs", "ytu_admin@example.com");
+
+        expect(res.status).toBe(200);
+        expect(res.json.total).toBe(2);
+        expect((res.json.jobs as unknown[]).length).toBe(2);
+        expect((res.json.queue as { queued: number }).queued).toBe(2);
+
+        const pending = await get("/api/v1/admin/jobs?status=pending", "ytu_admin@example.com");
+
+        expect(pending.json.total).toBe(2);
+
+        const running = await get("/api/v1/admin/jobs?status=running", "ytu_admin@example.com");
+
+        expect(running.json.total).toBe(0);
+    });
+});
+
+describe("GET /api/v1/admin/revenue", () => {
+    it("computes totals and zero-filled daily buckets", async () => {
+        mkUser("admin@example.com");
+        const u = mkUser("payer@example.com");
+        db.recordPayment({ userId: u.id, kind: "pack", stripeRef: "cs_a", amountCents: 499, status: "succeeded" });
+        db.recordPayment({
+            userId: u.id,
+            kind: "subscription",
+            stripeRef: "in_a",
+            amountCents: 999,
+            status: "succeeded",
+        });
+        db.recordPayment({
+            userId: u.id,
+            kind: "subscription",
+            stripeRef: "failed:x",
+            amountCents: 999,
+            status: "failed",
+        });
+        db.recordPayment({ userId: u.id, kind: "pack", stripeRef: "re_a", amountCents: 200, status: "refunded" });
+        db.recordAiCall({ provider: "xai", model: "grok", action: "summary", userId: u.id, costUsd: 0.4 });
+        db.upsertSubscription({ userId: u.id, planId: "sub-monthly", status: "active", allowance: 3000 });
+
+        const res = await get("/api/v1/admin/revenue?days=7", "ytu_admin@example.com");
+
+        expect(res.status).toBe(200);
+        const totals = res.json.totals as Record<string, number>;
+
+        expect(totals.revenueCents).toBe(1498);
+        expect(totals.aiCostUsd).toBeCloseTo(0.4, 5);
+        expect(totals.paymentsCount).toBe(2);
+        expect(totals.refundsCount).toBe(1);
+        expect(totals.activeSubscriptions).toBe(1);
+
+        const daily = res.json.daily as Array<{ day: string; revenueCents: number; aiCostUsd: number }>;
+
+        expect(daily).toHaveLength(7);
+        const today = new Date().toISOString().slice(0, 10);
+
+        expect(daily.at(-1)?.day).toBe(today);
+        expect(daily.at(-1)?.revenueCents).toBe(1498);
+        expect(daily.at(-1)?.aiCostUsd).toBeCloseTo(0.4, 5);
+        expect(daily.reduce((sum, d) => sum + d.revenueCents, 0)).toBe(1498);
+        expect(daily[0].revenueCents).toBe(0);
+    });
+});

--- a/src/youtube/lib/server/__tests__/admin-user-profile-route.test.ts
+++ b/src/youtube/lib/server/__tests__/admin-user-profile-route.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleAdminRoute } from "@app/youtube/lib/server/routes/admin";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "yt-admin-profile-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    await yt.config.update({ powerUsers: [{ email: "admin@example.com", type: "admin" }] });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function mkUser(email: string) {
+    return db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+}
+
+async function getProfile(token: string | null, id: number | string) {
+    const url = new URL(`http://localhost/api/v1/admin/users/${id}`);
+    const req = new Request(url, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+    const res = await handleAdminRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("GET /api/v1/admin/users/:id", () => {
+    it("403 for non-power, 404 for unknown id", async () => {
+        mkUser("admin@example.com");
+        const plain = mkUser("plain@example.com");
+
+        expect((await getProfile("ytu_plain@example.com", plain.id)).status).toBe(403);
+        expect((await getProfile("ytu_admin@example.com", 999_999)).status).toBe(404);
+    });
+
+    it("returns the full drill-in picture", async () => {
+        mkUser("admin@example.com");
+        const referrer = mkUser("referrer@example.com");
+        const u = mkUser("target@example.com");
+
+        db.grantCredits(u.id, 100, "register-grant");
+        db.grantCredits(u.id, 500, "stripe:cs_x");
+        db.recordPayment({ userId: u.id, kind: "subscription", stripeRef: "in_a", amountCents: 999, currency: "usd", credits: 3000, status: "succeeded" });
+        db.recordAiCall({ provider: "xai", model: "grok", action: "summary", userId: u.id, costUsd: 0.2 });
+        db.upsertSubscription({
+            userId: u.id,
+            planId: "sub-monthly",
+            status: "active",
+            allowance: 3000,
+            periodStart: new Date(Date.now() - 1000).toISOString(),
+            periodEnd: new Date(Date.now() + 2_000_000_000).toISOString(),
+            periodStartBalance: 600,
+        });
+        // u referred someone; u was also referred by `referrer`.
+        db.getOrCreateReferralCode(u.id, "MYCODE22");
+        const referee = mkUser("referee@example.com");
+        db.createReferral({ code: "MYCODE22", referrerUserId: u.id, refereeUserId: referee.id, reward: 25, offerFrom: "2026-01-01T00:00:00Z", offerTo: "2027-01-01T00:00:00Z" });
+        db.getOrCreateReferralCode(referrer.id, "REFR3333");
+        db.createReferral({ code: "REFR3333", referrerUserId: referrer.id, refereeUserId: u.id, reward: 25, offerFrom: "2026-01-01T00:00:00Z", offerTo: "2027-01-01T00:00:00Z" });
+        db.recordVideoWatch({ userId: u.id, videoId: "vid00000001" });
+        db.recordVideoLog({ kind: "summary:view", userId: u.id, videoId: "vid00000001" });
+        db.enqueueJob({ targetKind: "video", target: "vid00000001", stages: ["summarize"], userId: u.id });
+
+        const res = await getProfile("ytu_admin@example.com", u.id);
+
+        expect(res.status).toBe(200);
+        expect((res.json.user as { email: string }).email).toBe("target@example.com");
+        expect(res.json.role).toBe("user");
+
+        const billing = res.json.billing as { subscription: { allowanceRemaining: number } | null };
+
+        expect(billing.subscription).not.toBeNull();
+
+        const totals = res.json.totals as Record<string, number>;
+
+        expect(totals.revenueCents).toBe(999);
+        expect(totals.aiCostUsd).toBeCloseTo(0.2, 5);
+        expect(totals.paymentsCount).toBe(1);
+        expect(totals.aiCallsCount).toBe(1);
+
+        expect((res.json.ledger as unknown[]).length).toBeGreaterThanOrEqual(2);
+        expect((res.json.payments as unknown[]).length).toBe(1);
+
+        const referral = res.json.referral as {
+            code: string | null;
+            referees: Array<{ email: string; reward: number }>;
+            totalEarned: number;
+            referredBy: { email: string } | null;
+        };
+
+        expect(referral.code).toBe("MYCODE22");
+        expect(referral.referees).toHaveLength(1);
+        expect(referral.referees[0].email).toBe("referee@example.com");
+        expect(referral.totalEarned).toBe(25);
+        expect(referral.referredBy?.email).toBe("referrer@example.com");
+
+        const activity = res.json.activity as { watched: unknown[]; logs: unknown[] };
+
+        expect(activity.watched).toHaveLength(1);
+        expect(activity.logs).toHaveLength(1);
+        expect((res.json.jobs as unknown[]).length).toBe(1);
+    });
+});

--- a/src/youtube/lib/server/__tests__/admin-users-route.test.ts
+++ b/src/youtube/lib/server/__tests__/admin-users-route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+import { handleAdminRoute } from "@app/youtube/lib/server/routes/admin";
+import { Youtube } from "@app/youtube/lib/youtube";
+
+let dir: string;
+let db: YoutubeDatabase;
+let yt: Youtube;
+
+beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "yt-admin-users-"));
+    db = new YoutubeDatabase(":memory:");
+    yt = new Youtube({ baseDir: dir, db });
+    await yt.config.update({ powerUsers: [{ email: "admin@example.com", type: "admin" }] });
+});
+
+afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+});
+
+function mkUser(email: string) {
+    return db.createUser({ email, passwordHash: "h", apiToken: `ytu_${email}` });
+}
+
+async function getUsers(token: string | null, query = "") {
+    const url = new URL(`http://localhost/api/v1/admin/users${query}`);
+    const req = new Request(url, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+    const res = await handleAdminRoute(req, url, yt);
+
+    return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("GET /api/v1/admin/users gating", () => {
+    it("401 login_required for anonymous", async () => {
+        mkUser("admin@example.com");
+        const res = await getUsers(null);
+
+        expect(res.status).toBe(401);
+        expect(res.json.code).toBe("login_required");
+    });
+
+    it("403 forbidden for authed non-power user", async () => {
+        mkUser("admin@example.com");
+        mkUser("plain@example.com");
+        const res = await getUsers("ytu_plain@example.com");
+
+        expect(res.status).toBe(403);
+        expect(res.json.code).toBe("forbidden");
+    });
+
+    it("200 for admin", async () => {
+        mkUser("admin@example.com");
+        const res = await getUsers("ytu_admin@example.com");
+
+        expect(res.status).toBe(200);
+    });
+});
+
+describe("admin users aggregates", () => {
+    it("computes revenue, ai cost, net per user with role + subscription", async () => {
+        mkUser("admin@example.com");
+        const u = mkUser("payer@example.com");
+        db.recordPayment({ userId: u.id, kind: "pack", stripeRef: "cs_a", amountCents: 499, currency: "usd", credits: 500, status: "succeeded" });
+        db.recordPayment({ userId: u.id, kind: "subscription", stripeRef: "in_a", amountCents: 999, currency: "usd", credits: 3000, status: "succeeded" });
+        // failed payment must NOT count toward revenue.
+        db.recordPayment({ userId: u.id, kind: "subscription", stripeRef: "failed:in_b", amountCents: 999, status: "failed" });
+        db.recordAiCall({ provider: "xai", model: "grok", action: "summary", userId: u.id, costUsd: 0.1 });
+        db.recordAiCall({ provider: "xai", model: "grok", action: "qa", userId: u.id, costUsd: 0.25 });
+        db.upsertSubscription({ userId: u.id, planId: "sub-monthly", status: "active", allowance: 3000 });
+
+        const res = await getUsers("ytu_admin@example.com");
+
+        expect(res.status).toBe(200);
+        expect(res.json.total).toBe(2);
+        const users = res.json.users as Array<Record<string, unknown>>;
+        const payer = users.find((row) => row.email === "payer@example.com");
+
+        expect(payer?.revenueCents).toBe(1498);
+        expect(payer?.aiCostUsd).toBeCloseTo(0.35, 5);
+        expect(payer?.netUsd).toBeCloseTo(14.63, 5);
+        expect(payer?.subscription).toEqual({ planId: "sub-monthly", status: "active" });
+        expect(payer?.role).toBe("user");
+
+        const adminRow = users.find((row) => row.email === "admin@example.com");
+
+        expect(adminRow?.role).toBe("admin");
+        expect(adminRow?.revenueCents).toBe(0);
+        expect(adminRow?.aiCostUsd).toBe(0);
+        expect(adminRow?.subscription).toBeNull();
+    });
+
+    it("searches by email substring and paginates", async () => {
+        mkUser("admin@example.com");
+        mkUser("alice@example.com");
+        mkUser("bob@example.com");
+
+        const searched = await getUsers("ytu_admin@example.com", "?q=ali");
+
+        expect(searched.json.total).toBe(1);
+        expect((searched.json.users as Array<{ email: string }>)[0].email).toBe("alice@example.com");
+
+        const paged = await getUsers("ytu_admin@example.com", "?limit=1&offset=0");
+
+        expect(paged.json.users).toHaveLength(1);
+        expect(paged.json.total).toBe(3);
+    });
+});

--- a/src/youtube/lib/server/index.ts
+++ b/src/youtube/lib/server/index.ts
@@ -13,6 +13,7 @@ import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
 import { clearPid, registerSignalHandlers, writePid } from "@app/youtube/lib/server/daemon";
 import { toErrorResponse } from "@app/youtube/lib/server/error";
 import { clearPortFile, writePortFile } from "@app/youtube/lib/server/port-file";
+import { handleAdminRoute } from "@app/youtube/lib/server/routes/admin";
 import { handleCacheRoute } from "@app/youtube/lib/server/routes/cache";
 import { handleChannelsRoute } from "@app/youtube/lib/server/routes/channels";
 import { handleCollectionsRoute } from "@app/youtube/lib/server/routes/collections";
@@ -211,6 +212,10 @@ async function dispatchApiRoute(req: Request, url: URL, youtube: Youtube): Promi
 
     if (url.pathname.startsWith("/api/v1/collections")) {
         return handleCollectionsRoute(req, url, youtube);
+    }
+
+    if (url.pathname.startsWith("/api/v1/admin")) {
+        return handleAdminRoute(req, url, youtube);
     }
 
     if (url.pathname.startsWith("/api/v1/cache")) {

--- a/src/youtube/lib/server/openapi.ts
+++ b/src/youtube/lib/server/openapi.ts
@@ -1517,6 +1517,172 @@ function buildPaths(): Record<string, OpenApiPathItem> {
                 },
             },
         },
+        "/api/v1/admin/users": {
+            get: {
+                operationId: "adminListUsers",
+                summary: "Users table with per-user revenue/AI-cost/net aggregates (admin/dev only)",
+                tags: ["admin"],
+                parameters: [
+                    {
+                        name: "q",
+                        in: "query",
+                        required: false,
+                        description: "Email substring.",
+                        schema: { type: "string" },
+                    },
+                    { name: "subscription", in: "query", required: false, schema: { type: "string" } },
+                    {
+                        name: "sort",
+                        in: "query",
+                        required: false,
+                        schema: { type: "string", enum: ["created", "revenue", "net", "credits"] },
+                    },
+                    { name: "dir", in: "query", required: false, schema: { type: "string", enum: ["asc", "desc"] } },
+                    { name: "limit", in: "query", required: false, schema: { type: "integer" } },
+                    { name: "offset", in: "query", required: false, schema: { type: "integer" } },
+                ],
+                responses: {
+                    "200": jsonResponse("Users table", {
+                        type: "object",
+                        properties: {
+                            users: arrayOf({ type: "object" }),
+                            total: { type: "integer" },
+                            limit: { type: "integer" },
+                            offset: { type: "integer" },
+                        },
+                        required: ["users", "total"],
+                    }),
+                    "401": errorResponse,
+                    "403": errorResponse,
+                },
+            },
+        },
+        "/api/v1/admin/users/{id}": {
+            get: {
+                operationId: "adminGetUser",
+                summary:
+                    "Full user profile drill-in: role, billing, ledger, payments, referrals, activity, jobs (admin/dev only)",
+                tags: ["admin"],
+                parameters: [
+                    { name: "id", in: "path", required: true, description: "User id.", schema: { type: "integer" } },
+                ],
+                responses: {
+                    "200": jsonResponse("User profile", { type: "object" }),
+                    "401": errorResponse,
+                    "403": errorResponse,
+                    "404": errorResponse,
+                },
+            },
+        },
+        "/api/v1/admin/ai-calls": {
+            get: {
+                operationId: "adminListAiCalls",
+                summary: "Paginated AI calls, filterable by provider/action/user (admin/dev only)",
+                tags: ["admin"],
+                parameters: [
+                    { name: "provider", in: "query", required: false, schema: { type: "string" } },
+                    { name: "action", in: "query", required: false, schema: { type: "string" } },
+                    { name: "userId", in: "query", required: false, schema: { type: "integer" } },
+                    { name: "limit", in: "query", required: false, schema: { type: "integer" } },
+                    { name: "offset", in: "query", required: false, schema: { type: "integer" } },
+                ],
+                responses: {
+                    "200": jsonResponse("AI calls", {
+                        type: "object",
+                        properties: {
+                            aiCalls: arrayOf({ type: "object" }),
+                            total: { type: "integer" },
+                            limit: { type: "integer" },
+                            offset: { type: "integer" },
+                        },
+                        required: ["aiCalls", "total"],
+                    }),
+                    "401": errorResponse,
+                    "403": errorResponse,
+                },
+            },
+        },
+        "/api/v1/admin/webhook-logs": {
+            get: {
+                operationId: "adminListWebhookLogs",
+                summary: "Paginated Stripe webhook logs, filterable by outcome (admin/dev only)",
+                tags: ["admin"],
+                parameters: [
+                    { name: "outcome", in: "query", required: false, schema: { type: "string" } },
+                    { name: "limit", in: "query", required: false, schema: { type: "integer" } },
+                    { name: "offset", in: "query", required: false, schema: { type: "integer" } },
+                ],
+                responses: {
+                    "200": jsonResponse("Webhook logs", {
+                        type: "object",
+                        properties: {
+                            webhookLogs: arrayOf({ type: "object" }),
+                            total: { type: "integer" },
+                            limit: { type: "integer" },
+                            offset: { type: "integer" },
+                        },
+                        required: ["webhookLogs", "total"],
+                    }),
+                    "401": errorResponse,
+                    "403": errorResponse,
+                },
+            },
+        },
+        "/api/v1/admin/jobs": {
+            get: {
+                operationId: "adminListJobs",
+                summary: "Paginated pipeline jobs plus current queue stats, filterable by status (admin/dev only)",
+                tags: ["admin"],
+                parameters: [
+                    { name: "status", in: "query", required: false, schema: { type: "string" } },
+                    { name: "limit", in: "query", required: false, schema: { type: "integer" } },
+                    { name: "offset", in: "query", required: false, schema: { type: "integer" } },
+                ],
+                responses: {
+                    "200": jsonResponse("Jobs and queue", {
+                        type: "object",
+                        properties: {
+                            jobs: arrayOf({ type: "object" }),
+                            queue: { type: "object" },
+                            total: { type: "integer" },
+                            limit: { type: "integer" },
+                            offset: { type: "integer" },
+                        },
+                        required: ["jobs", "queue", "total"],
+                    }),
+                    "401": errorResponse,
+                    "403": errorResponse,
+                },
+            },
+        },
+        "/api/v1/admin/revenue": {
+            get: {
+                operationId: "adminRevenueSummary",
+                summary: "Platform revenue totals plus zero-filled daily revenue/cost buckets (admin/dev only)",
+                tags: ["admin"],
+                parameters: [
+                    {
+                        name: "days",
+                        in: "query",
+                        required: false,
+                        description: "Daily-bucket window length (1-365, default 30).",
+                        schema: { type: "integer" },
+                    },
+                ],
+                responses: {
+                    "200": jsonResponse("Revenue summary", {
+                        type: "object",
+                        properties: {
+                            totals: { type: "object" },
+                            daily: arrayOf({ type: "object" }),
+                        },
+                        required: ["totals", "daily"],
+                    }),
+                    "401": errorResponse,
+                    "403": errorResponse,
+                },
+            },
+        },
     };
 }
 

--- a/src/youtube/lib/server/routes/admin.ts
+++ b/src/youtube/lib/server/routes/admin.ts
@@ -1,0 +1,265 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { buildBillingContext } from "@app/youtube/lib/billing";
+import type { YoutubeDatabase } from "@app/youtube/lib/db";
+import type { AdminListAiCallsOpts, AdminListUsersOpts, AdminListWebhookLogsOpts } from "@app/youtube/lib/db.types";
+import type { JobStatus } from "@app/youtube/lib/jobs.types";
+import { getLedgerPage } from "@app/youtube/lib/ledger-views";
+import { isPowerRole, roleForEmail } from "@app/youtube/lib/roles";
+import { requireUser } from "@app/youtube/lib/server/auth";
+import { CORS_HEADERS } from "@app/youtube/lib/server/cors";
+import { toErrorResponse } from "@app/youtube/lib/server/error";
+import { matchRoute } from "@app/youtube/lib/server/match-route";
+import type { YtUser } from "@app/youtube/lib/users.types";
+import type { Youtube } from "@app/youtube/lib/youtube";
+
+const USER_SORTS = new Set(["created", "revenue", "net", "credits"]);
+
+/**
+ * Admin gate: 401 login_required for anonymous (via requireUser), then 403
+ * {code:"forbidden"} for authed non-power users. Returns the YtUser on success.
+ */
+async function requireAdmin(req: Request, url: URL, yt: Youtube): Promise<YtUser | Response> {
+    const user = requireUser(req, url, yt.db);
+
+    if (user instanceof Response) {
+        return user;
+    }
+
+    const role = roleForEmail(await yt.config.get("powerUsers"), user.email);
+
+    if (!isPowerRole(role)) {
+        logger.debug({ userId: user.id, role }, "admin route: rejected non-power user");
+
+        return jsonError("admin access required", 403, "forbidden");
+    }
+
+    return user;
+}
+
+export async function handleAdminRoute(req: Request, url: URL, yt: Youtube): Promise<Response> {
+    try {
+        if (matchRoute(req, "GET", "/api/v1/admin/users", url.pathname)) {
+            const user = await requireAdmin(req, url, yt);
+
+            if (user instanceof Response) {
+                return user;
+            }
+
+            const opts = parseListUsersOpts(url);
+            const { rows, total } = yt.db.adminListUsers(opts);
+            const powerUsers = await yt.config.get("powerUsers");
+            const users = rows.map((row) => ({
+                id: row.id,
+                email: row.email,
+                role: roleForEmail(powerUsers, row.email),
+                credits: row.credits,
+                revenueCents: row.revenueCents,
+                aiCostUsd: row.aiCostUsd,
+                netUsd: row.revenueCents / 100 - row.aiCostUsd,
+                subscription: row.subStatus ? { planId: row.subPlanId, status: row.subStatus } : null,
+                createdAt: row.createdAt,
+                lastLoginAt: row.lastLoginAt,
+            }));
+
+            return Response.json({ users, total, limit: opts.limit, offset: opts.offset }, { headers: CORS_HEADERS });
+        }
+
+        const profile = matchRoute(req, "GET", "/api/v1/admin/users/:id", url.pathname);
+
+        if (profile) {
+            const admin = await requireAdmin(req, url, yt);
+
+            if (admin instanceof Response) {
+                return admin;
+            }
+
+            const userId = parseId(profile.id);
+            const target = userId !== null ? yt.db.getUserById(userId) : null;
+
+            if (!target) {
+                return jsonError("user not found", 404);
+            }
+
+            const role = roleForEmail(await yt.config.get("powerUsers"), target.email);
+            const billing = await buildBillingContext({ db: yt.db, config: yt.config, user: target });
+            const totals = yt.db.adminUserTotals(target.id);
+
+            return Response.json(
+                {
+                    user: target,
+                    role,
+                    billing,
+                    totals: { ...totals, netUsd: totals.revenueCents / 100 - totals.aiCostUsd },
+                    ledger: getLedgerPage(yt.db, target.id, { limit: 25 }).rows,
+                    payments: yt.db.listPayments({ userId: target.id, limit: 50 }),
+                    referral: buildAdminReferral(yt.db, target.id),
+                    activity: {
+                        watched: yt.db.listWatchesByUser(target.id, 30),
+                        logs: yt.db.listVideoLogs({ userId: target.id, limit: 30 }),
+                    },
+                    jobs: yt.db.listJobs({ userId: target.id, limit: 20 }),
+                },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/admin/ai-calls", url.pathname)) {
+            const admin = await requireAdmin(req, url, yt);
+
+            if (admin instanceof Response) {
+                return admin;
+            }
+
+            const opts = parseListAiCallsOpts(url);
+            const { rows, total } = yt.db.adminListAiCalls(opts);
+
+            return Response.json(
+                { aiCalls: rows, total, limit: opts.limit, offset: opts.offset },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/admin/webhook-logs", url.pathname)) {
+            const admin = await requireAdmin(req, url, yt);
+
+            if (admin instanceof Response) {
+                return admin;
+            }
+
+            const opts = parseListWebhookLogsOpts(url);
+            const { rows, total } = yt.db.adminListWebhookLogs(opts);
+
+            return Response.json(
+                { webhookLogs: rows, total, limit: opts.limit, offset: opts.offset },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/admin/jobs", url.pathname)) {
+            const admin = await requireAdmin(req, url, yt);
+
+            if (admin instanceof Response) {
+                return admin;
+            }
+
+            const status = parseJobStatus(url.searchParams.get("status"));
+            const limit = clampInt(url.searchParams.get("limit"), 50, 1, 200);
+            const offset = clampInt(url.searchParams.get("offset"), 0, 0, Number.MAX_SAFE_INTEGER);
+            const { rows, total } = yt.db.adminListJobs({ status, limit, offset });
+
+            return Response.json(
+                { jobs: rows, queue: yt.db.getQueueStats(), total, limit, offset },
+                { headers: CORS_HEADERS }
+            );
+        }
+
+        if (matchRoute(req, "GET", "/api/v1/admin/revenue", url.pathname)) {
+            const admin = await requireAdmin(req, url, yt);
+
+            if (admin instanceof Response) {
+                return admin;
+            }
+
+            const days = clampInt(url.searchParams.get("days"), 30, 1, 365);
+
+            return Response.json(yt.db.adminRevenueSummary({ days }), { headers: CORS_HEADERS });
+        }
+
+        return jsonError("not found", 404);
+    } catch (err) {
+        return toErrorResponse(err);
+    }
+}
+
+/** Admin sees full (unmasked) emails on both referral sides — they inspect everything. */
+function buildAdminReferral(db: YoutubeDatabase, userId: number) {
+    const code = db.getReferralCodeForUser(userId);
+    const made = db.listReferralsByReferrer(userId);
+    const referees = made.map((referral) => ({
+        email: db.getUserEmailById(referral.refereeUserId) ?? "unknown",
+        reward: referral.reward,
+        redeemedAt: referral.createdAt,
+    }));
+    const totalEarned = made.reduce((sum, referral) => sum + referral.reward, 0);
+    const referred = db.getReferralByReferee(userId);
+    const referredBy = referred
+        ? {
+              email: db.getUserEmailById(referred.referrerUserId) ?? "unknown",
+              reward: referred.reward,
+              redeemedAt: referred.createdAt,
+          }
+        : null;
+
+    return { code, referees, totalEarned, referredBy };
+}
+
+function parseListUsersOpts(url: URL): AdminListUsersOpts & { limit: number; offset: number } {
+    const search = url.searchParams.get("q")?.trim() || undefined;
+    const subscription = url.searchParams.get("subscription")?.trim() || undefined;
+    const rawSort = url.searchParams.get("sort") ?? "";
+    const sort = (USER_SORTS.has(rawSort) ? rawSort : "created") as AdminListUsersOpts["sort"];
+    const dir = url.searchParams.get("dir") === "asc" ? "asc" : "desc";
+    const limit = clampInt(url.searchParams.get("limit"), 50, 1, 200);
+    const offset = clampInt(url.searchParams.get("offset"), 0, 0, Number.MAX_SAFE_INTEGER);
+
+    return { search, subscription, sort, dir, limit, offset };
+}
+
+function parseListAiCallsOpts(url: URL): AdminListAiCallsOpts & { limit: number; offset: number } {
+    const provider = url.searchParams.get("provider")?.trim() || undefined;
+    const action = url.searchParams.get("action")?.trim() || undefined;
+    const rawUser = url.searchParams.get("userId");
+    const userId = rawUser !== null && /^[1-9]\d*$/.test(rawUser) ? Number(rawUser) : undefined;
+    const limit = clampInt(url.searchParams.get("limit"), 50, 1, 200);
+    const offset = clampInt(url.searchParams.get("offset"), 0, 0, Number.MAX_SAFE_INTEGER);
+
+    return { provider, action, userId, limit, offset };
+}
+
+function parseListWebhookLogsOpts(url: URL): AdminListWebhookLogsOpts & { limit: number; offset: number } {
+    const outcome = url.searchParams.get("outcome")?.trim() || undefined;
+    const limit = clampInt(url.searchParams.get("limit"), 50, 1, 200);
+    const offset = clampInt(url.searchParams.get("offset"), 0, 0, Number.MAX_SAFE_INTEGER);
+
+    return { outcome, limit, offset };
+}
+
+const JOB_STATUSES = new Set<JobStatus>(["pending", "running", "completed", "failed", "cancelled", "interrupted"]);
+
+function parseJobStatus(raw: string | null): JobStatus | undefined {
+    if (raw !== null && JOB_STATUSES.has(raw as JobStatus)) {
+        return raw as JobStatus;
+    }
+
+    return undefined;
+}
+
+function clampInt(raw: string | null, fallback: number, min: number, max: number): number {
+    const parsed = raw === null ? Number.NaN : Number.parseInt(raw, 10);
+
+    if (Number.isNaN(parsed)) {
+        return fallback;
+    }
+
+    return Math.min(Math.max(parsed, min), max);
+}
+
+function parseId(value: string): number | null {
+    if (!/^[1-9]\d*$/.test(value)) {
+        return null;
+    }
+
+    const id = Number(value);
+
+    return Number.isSafeInteger(id) ? id : null;
+}
+
+function jsonError(error: string, status: number, code?: string): Response {
+    const body = code ? { error, code } : { error };
+
+    return new Response(SafeJSON.stringify(body, { strict: true }), {
+        status,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+}

--- a/src/youtube/ui/routes/collections.$id.tsx
+++ b/src/youtube/ui/routes/collections.$id.tsx
@@ -1,9 +1,8 @@
-import { SafeJSON } from "@app/utils/json";
 import { Badge } from "@app/utils/ui/components/badge";
 import { Button } from "@app/utils/ui/components/button";
 import { Card, CardContent } from "@app/utils/ui/components/card";
 import { CollectionAskPanel } from "@app/utils/ui/components/youtube/collection-ask-panel";
-import type { AskMessageRecord } from "@app/youtube/lib/types";
+import { optimisticUserMessage, ruleSummary } from "@app/utils/ui/components/youtube/collection-ui";
 import { useAskCollection, useCollection, useRemoveCollectionVideo, useThread, useThreads } from "@app/yt/api.hooks";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
@@ -11,32 +10,6 @@ import { useState } from "react";
 export const Route = createFileRoute("/collections/$id")({
     component: CollectionDetailPage,
 });
-
-function ruleSummary(ruleJson: string | null): string {
-    if (!ruleJson) {
-        return "Dynamic collection";
-    }
-
-    const rule = SafeJSON.parse(ruleJson) as { type?: string; sinceDays?: number } | null;
-
-    if (rule?.type === "watched" && typeof rule.sinceDays === "number") {
-        return `Videos you watched in the last ${rule.sinceDays} days`;
-    }
-
-    return "Dynamic collection";
-}
-
-function optimisticUserMessage(threadId: number | null, content: string): AskMessageRecord {
-    return {
-        id: -1,
-        threadId: threadId ?? -1,
-        role: "user",
-        content,
-        toolName: null,
-        toolArgsJson: null,
-        createdAt: new Date().toISOString(),
-    };
-}
 
 function CollectionDetailPage() {
     const params = Route.useParams();


### PR DESCRIPTION
## Summary

- Extension API bridge for collections, history, watchlist, digest; account hub with history section, collections section with multi-turn ask
- Admin users table endpoint (role-gated, per-user revenue/cost/net aggregates), admin user profile drill-in, admin ops endpoints (ai-calls, webhook-logs, jobs, revenue summary)
- Digest section + channel follow/unfollow toggle; glowing diamond credit component
- Subscription UI (resetting allowance vs top-up, subscribe CTA, low-balance nudge); interactive activity graph + friendly ledger reason copy
- Referral section (invite code, referees, redeem with friendly errors); friendly 402 upsell on quota/credit exhaustion
- Transcript progress bar + queue position + AI transcription cost gate; 16:9 admin panel (users/ai-calls/webhooks/jobs/revenue + user drill-in)

## Stack

1. feat(youtube): product surface base
2. fix(youtube): phase 0 — panel scroll, comments feedback, dialog rework, audit sweep
3. feat(youtube): phase 1 foundations — roles, ai task mapping, audit tables, typed auth, WS scoping, transcript fallback
4. feat(youtube): phase 3 web features — history, collections, collection-ask agent, watchlist + digest
5. feat(youtube): phase 2 billing — Stripe subscriptions, resetting allowance, free tier, referrals
6. **feat(youtube): phase 4 extension — feature port, monetization UI, 16:9 admin panel + admin API** ← you are here
7. feat(youtube): phase 5 customization + production polish — settings, sweep fixes, review-fix wave

Part of the #263 split; merge bottom-up.
