### PR TITLE
feat: add steerable Codex app-server sessions

### DIFF
--- a/plugins/genesis-tools/skills/agents-talk/SKILL.md
+++ b/plugins/genesis-tools/skills/agents-talk/SKILL.md
@@ -59,6 +59,10 @@ tools agents discover
 # 6. Watch the whole conversation in a separate terminal (human-friendly):
 tools agents listen
 
+# Keep a compact receiver stream without changing what senders publish:
+tools agents login --agent-name lead --kinds message,error,approval_request
+tools agents login --agent-name lead --filter '.op=="approval_request"'
+
 # Enable verbose lifecycle visibility for ALL peers (default: only main sees
 # stream-mode join/leave + real-failure logout; other peers see nothing):
 tools agents login --agent-main --agent-name lead --debug
@@ -123,7 +127,29 @@ tools agents message --from reviewer --reply 0001 \
 
 # E. Pure ack (no body):
 tools agents message --from reviewer --reply 0001
+
+# Send one request and block until a correlated --reply arrives:
+tools agents request --from reviewer --to lead --body 'Approve the auth change?'
 ```
+
+## Long-lived Codex teammates
+
+`tools codex spawn` creates a persistent app-server session and auto-registers `codex_<name>` on this same bus. Do
+not manually log that identity in from the orchestrator. The driver observes inbound controls; the model receives with
+the seeded `tools agents login --agent-name codex_<name> --once --session <id>` command.
+
+Sessions are read-only unless you deliberately choose a write policy:
+
+```bash
+# Supervised worker: untrusted commands and write approvals go to lead.
+tools codex spawn --name implementer --write ask --prompt 'Implement the bounded change'
+
+# Trusted bounded worker: workspace writes without approval prompts.
+tools codex spawn --name implementer --write allow --prompt 'Implement the bounded change'
+```
+
+Omit `--write` (or use `--write deny`) for reviewers. Use `--write ask` as the default when edits are needed; use
+`--write allow` only when the task and writable roots are tightly bounded.
 
 ## What you receive on the `login` stream
 
@@ -169,6 +195,8 @@ You normally don't pass `--session` — it's automatic.
 - **Don't expect mid-tool-call interrupts.** Stream-mode `login` delivers between tool calls (via Monitor), `login --once` returns when next called. Neither preempts a running tool.
 - **Don't expect an idle teammate to wake on an agents-channel message.** See the idle-teammates section above — pair every send to a possibly-idle teammate with a harness `SendMessage` nudge.
 - **One main per session.** A second `login --agent-main` errors. Use a different `--agent-name` for additional coordinators.
+- **Receiver filters intentionally advance that receiver's cursor past non-matches.** Use a dedicated monitor identity
+  when you may later need the unfiltered stream.
 
 ## Quick reference
 
@@ -183,6 +211,9 @@ You normally don't pass `--session` — it's automatic.
 | `tools agents message --from X --reply 0001 --body '...'` | Reply (auto-routes to the original sender) |
 | `tools agents message --from X --reply 0001` | Pure ack (no body) |
 | `tools agents message --from X --to Y --body-file <path>` | Long/multi-section body — write it to a file first (avoids shell-quoting breaks from embedded `'`/`` ` ``/`$(...)` truncating `--body`) |
+| `tools agents request --from X --to Y --body '...'` | Send and block until a correlated reply arrives |
+| `tools agents login --agent-name X --kinds message,error` | Receiver-side event/body-kind filter |
+| `tools agents login --agent-name X --filter '.op=="approval_request"'` | Receiver-side structured-body filter |
 | `tools agents discover` | List all agents in session |
 | `tools agents listen` | Human-facing color-formatted feed follower (sees everything) |
 

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -13,15 +13,18 @@ tools agents login --agent-name lead --agent-main              # auto-registers 
 tools agents login --agent-name researcher                     # auto-registers + attaches (stream mode)
 tools agents login --agent-id agt_xxx --agent-name X            # attach with a chosen id
 tools agents login --agent-name X --once                       # one-shot (poll loop)
+tools agents login --agent-name lead --kinds message,error     # receiver-side verbosity filter
+tools agents login --agent-name lead --filter '.op=="approval_request"'
 tools agents message --from X --to Y --body '...'
 tools agents message --from X --body '...'                     # broadcast (no --to)
 tools agents message --from X --reply 0001 --body '...'        # reply (auto-routes to original sender)
 tools agents message --from X --reply 0001                     # pure ack (no body)
+tools agents request --from X --to Y --body 'approve?'         # block for correlated reply
 tools agents discover                                          # list registry
 tools agents listen                                            # human-facing color follower
 ```
 
-There is no separate `register` command — `login` auto-registers on first use for a given `--agent-name`/`--agent-id`. There is no separate `respond` command — replies go through `message --reply <msg-id>`.
+There is no separate `register` command — `login` auto-registers on first use for a given `--agent-name`/`--agent-id`. There is no separate `respond` command — replies go through `message --reply <msg-id>`. `request` is a thin send-and-wait primitive over those same replies; it does not introduce a second channel.
 
 ## Session resolution
 
@@ -67,7 +70,7 @@ The registry (who's registered, logged in/out) is derived by replaying `feed.jso
 ## Build / test
 
 ```bash
-bunx tsgo --noEmit                                # type-check
+tsgo --noEmit                                     # type-check
 tools agents --help                               # show command tree
 tools agents login --agent-main --agent-name lead --once --session demo
 tools agents discover --session demo

--- a/src/agents/commands/login.ts
+++ b/src/agents/commands/login.ts
@@ -11,6 +11,7 @@ import { isVisibleToAgent } from "../lib/filter";
 import { formatEventPretty } from "../lib/format-pretty";
 import { deriveMainAgentId, isMainId } from "../lib/id-gen";
 import { onShutdown } from "../lib/lifecycle";
+import { createListenerFilter } from "../lib/listener-filter";
 import { ensureSessionDir, sessionPaths } from "../lib/paths";
 import { readSessionMeta, type SessionMeta } from "../lib/session-meta";
 import { resolveSession } from "../lib/session-resolve";
@@ -32,6 +33,8 @@ interface LoginOpts {
     session?: string;
     observer?: boolean;
     format?: "pretty" | "json";
+    kinds?: string;
+    filter?: string;
 }
 
 interface ActiveLogin {
@@ -43,6 +46,7 @@ interface ActiveLogin {
     observer: boolean;
     format: "pretty" | "json";
     cursorSeq: number;
+    listenerFilter: (event: FeedEvent) => boolean;
 }
 
 async function pickAgent(records: AgentRecord[]): Promise<AgentRecord | null> {
@@ -275,6 +279,10 @@ function emitVisibleEvent(event: FeedEvent, active: ActiveLogin): boolean {
         return false;
     }
 
+    if (!active.listenerFilter(event)) {
+        return false;
+    }
+
     if (active.format === "pretty") {
         out.println(formatEventPretty(event));
     } else {
@@ -413,6 +421,7 @@ async function runLoginImpl(opts: LoginOpts): Promise<void> {
             observer: Boolean(opts.observer),
             format,
             cursorSeq: readCursor(paths, record.agent_id),
+            listenerFilter: createListenerFilter({ kinds: opts.kinds, expression: opts.filter }),
         };
 
         await emitLoggedIn({ paths, record, mode });
@@ -501,6 +510,8 @@ export function registerLoginCommand(program: Command): void {
         .option("--session <id>", "Override session resolution")
         .option("--observer", "Read-only: bypass per-agent visibility filter and see ALL events")
         .option("--format <fmt>", "pretty | json (default: json; observer in TTY → pretty)")
+        .option("--kinds <csv>", "Only emit feed types or structured message op/event kinds")
+        .option("--filter <expr>", 'Filter structured bodies, e.g. .op=="approval_request"')
         .action(async (opts: LoginOpts) => {
             await runLogin(opts);
         });

--- a/src/agents/commands/request.ts
+++ b/src/agents/commands/request.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendRequest } from "../lib/request";
+import { resolveSession } from "../lib/session-resolve";
+
+interface RequestOptions {
+    from: string;
+    to: string;
+    body?: string;
+    bodyFile?: string;
+    timeout?: string;
+    session?: string;
+}
+
+export function registerRequestCommand(program: Command): void {
+    program
+        .command("request")
+        .description("Send a message and block until a correlated reply arrives")
+        .requiredOption("--from <token>", "Sender agent name or id")
+        .requiredOption("--to <token>", "Single recipient agent name or id")
+        .option("--body <text>", "Request body")
+        .option("--body-file <path>", "Read request body from a file")
+        .option("--timeout <seconds>", "Reply timeout in seconds", "300")
+        .option("--session <id>", "Override session resolution")
+        .action(async (options: RequestOptions) => {
+            if (options.body && options.bodyFile) {
+                throw new Error("--body and --body-file are mutually exclusive");
+            }
+
+            const body = options.bodyFile ? readFileSync(options.bodyFile, "utf8") : options.body;
+            if (!body) {
+                throw new Error("--body or --body-file is required");
+            }
+
+            const timeoutSeconds = Number.parseFloat(options.timeout ?? "300");
+            if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+                throw new Error("--timeout must be greater than zero");
+            }
+
+            const session = resolveSession(options.session).session;
+            const reply = await sendRequest({
+                session,
+                from: options.from,
+                to: options.to,
+                body,
+                timeoutMs: timeoutSeconds * 1_000,
+            });
+            out.result(SafeJSON.stringify(reply, { strict: true }));
+        });
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -7,6 +7,7 @@ import { registerDiscoverCommand } from "./commands/discover";
 import { registerListenCommand } from "./commands/listen";
 import { registerLoginCommand } from "./commands/login";
 import { registerMessageCommand } from "./commands/message";
+import { registerRequestCommand } from "./commands/request";
 
 handleReadmeFlag(import.meta.url);
 
@@ -19,6 +20,7 @@ program
 
 registerLoginCommand(program);
 registerMessageCommand(program);
+registerRequestCommand(program);
 registerDiscoverCommand(program);
 registerListenCommand(program);
 

--- a/src/agents/lib/listener-filter.ts
+++ b/src/agents/lib/listener-filter.ts
@@ -1,0 +1,84 @@
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { FeedEvent } from "./types";
+
+const log = logger.child({ component: "agents:listener-filter" });
+
+interface ListenerFilterOptions {
+    kinds?: string;
+    expression?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function messageBody(event: FeedEvent): Record<string, unknown> | null {
+    if (event.type !== "message" || !event.body.trim().startsWith("{")) {
+        return null;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(event.body, { strict: true });
+        return isRecord(parsed) ? parsed : null;
+    } catch (err) {
+        log.debug({ err, messageId: event.message_id }, "structured listener filter skipped invalid JSON body");
+        return null;
+    }
+}
+
+function valueAtPath(record: Record<string, unknown>, path: string[]): unknown {
+    let value: unknown = record;
+
+    for (const segment of path) {
+        if (!isRecord(value)) {
+            return undefined;
+        }
+
+        value = value[segment];
+    }
+
+    return value;
+}
+
+function compileExpression(expression: string): (event: FeedEvent) => boolean {
+    const match = expression.match(/^\.([A-Za-z_][\w.]*)\s*(==|!=)\s*"([^"]*)"$/);
+    if (!match?.[1] || !match[2]) {
+        throw new Error(
+            `Unsupported --filter expression: ${expression}. Supported form: .field=="value" or .field!="value"`
+        );
+    }
+
+    const path = match[1].split(".");
+    const operator = match[2];
+    const expected = match[3] ?? "";
+
+    return (event) => {
+        const source = messageBody(event) ?? (event as unknown as Record<string, unknown>);
+        const actual = valueAtPath(source, path);
+        return operator === "==" ? actual === expected : actual !== expected;
+    };
+}
+
+export function createListenerFilter(options: ListenerFilterOptions): (event: FeedEvent) => boolean {
+    const kinds = new Set(
+        (options.kinds ?? "")
+            .split(",")
+            .map((kind) => kind.trim())
+            .filter(Boolean)
+    );
+    const expressionFilter = options.expression ? compileExpression(options.expression) : null;
+
+    return (event) => {
+        if (kinds.size > 0) {
+            const body = messageBody(event);
+            const bodyKind =
+                typeof body?.op === "string" ? body.op : typeof body?.event === "string" ? body.event : null;
+            if (!kinds.has(event.type) && (!bodyKind || !kinds.has(bodyKind))) {
+                return false;
+            }
+        }
+
+        return expressionFilter ? expressionFilter(event) : true;
+    };
+}

--- a/src/agents/lib/request.ts
+++ b/src/agents/lib/request.ts
@@ -1,0 +1,54 @@
+import { deriveRegistry } from "./derived-registry";
+import { readFeedSince, withFeedLock } from "./feed";
+import { ensureSessionDir, sessionPaths } from "./paths";
+import { resolveMany, resolveOne } from "./resolve-token";
+import type { MessageEvent } from "./types";
+
+export async function sendRequest(options: {
+    session: string;
+    from: string;
+    to: string;
+    body: string;
+    timeoutMs: number;
+    meta?: Record<string, unknown>;
+}): Promise<MessageEvent> {
+    const paths = sessionPaths(options.session);
+    ensureSessionDir(paths);
+
+    const request = await withFeedLock(paths, ({ events, appendMessageEvent }) => {
+        const registry = deriveRegistry(events);
+        const sender = resolveOne(registry, options.from, "sender");
+        const recipients = resolveMany(registry, options.to, "recipient");
+        if (recipients.length !== 1) {
+            throw new Error("agents request requires exactly one recipient");
+        }
+
+        return appendMessageEvent({
+            type: "message",
+            from_agent_id: sender.agent_id,
+            from_agent_name: sender.agent_name,
+            to_agent_ids: recipients,
+            body: options.body,
+            meta: { ...options.meta, request: true },
+            private: false,
+        });
+    });
+
+    const deadline = Date.now() + options.timeoutMs;
+    while (Date.now() < deadline) {
+        const events = await readFeedSince(paths, request.seq);
+        const reply = events.find(
+            (event): event is MessageEvent =>
+                event.type === "message" &&
+                event.in_reply_to === request.message_id &&
+                event.to_agent_ids.includes(request.from_agent_id)
+        );
+        if (reply) {
+            return reply;
+        }
+
+        await Bun.sleep(20);
+    }
+
+    throw new Error(`agents request ${request.message_id} timed out after ${options.timeoutMs}ms`);
+}

--- a/src/agents/tests/listener-filter.test.ts
+++ b/src/agents/tests/listener-filter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { createListenerFilter } from "../lib/listener-filter";
+import type { FeedEvent, MessageEvent } from "../lib/types";
+
+function message(body: string): MessageEvent {
+    return {
+        type: "message",
+        seq: 1,
+        ts: "now",
+        message_id: "0001",
+        from_agent_id: "agt_0001",
+        from_agent_name: "worker",
+        to_agent_ids: ["main_test"],
+        body,
+        meta: {},
+        private: false,
+    };
+}
+
+describe("agents listener filter", () => {
+    test("matches feed types and structured body kinds", () => {
+        const filter = createListenerFilter({ kinds: "message,approval_request" });
+        const lifecycle: FeedEvent = {
+            type: "logged_in",
+            seq: 2,
+            ts: "now",
+            agent_id: "agt_0001",
+            agent_name: "worker",
+            mode: "stream",
+        };
+
+        expect(filter(message("plain text"))).toBe(true);
+        expect(filter(message('{"op":"approval_request"}'))).toBe(true);
+        expect(filter(message('{"event":"turn_completed"}'))).toBe(true);
+        expect(filter(lifecycle)).toBe(false);
+    });
+
+    test("supports the documented jq-ish equality expression", () => {
+        const filter = createListenerFilter({ expression: '.op=="approval_request"' });
+
+        expect(filter(message('{"op":"approval_request","requestId":"r1"}'))).toBe(true);
+        expect(filter(message('{"op":"steer"}'))).toBe(false);
+        expect(filter(message("plain text"))).toBe(false);
+    });
+
+    test("rejects unsupported expressions instead of evaluating code", () => {
+        expect(() => createListenerFilter({ expression: "process.exit(1)" })).toThrow(
+            "Unsupported --filter expression"
+        );
+    });
+});

--- a/src/agents/tests/request.test.ts
+++ b/src/agents/tests/request.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+import { appendFeed, appendMessage, readFeed } from "../lib/feed";
+import { ensureSessionDir, sessionPaths } from "../lib/paths";
+import { sendRequest } from "../lib/request";
+
+describe("agents request", () => {
+    test("blocks until a correlated reply arrives", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-agents-request-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const paths = sessionPaths("request-test");
+            ensureSessionDir(paths);
+            await appendFeed(paths, {
+                type: "registered",
+                agent_name: "lead",
+                agent_id: "main_test",
+                awaiting_login: false,
+                is_main: true,
+                role: null,
+                meta: {},
+            });
+            await appendFeed(paths, {
+                type: "registered",
+                agent_name: "worker",
+                agent_id: "agt_0001",
+                awaiting_login: false,
+                is_main: false,
+                role: null,
+                meta: {},
+            });
+
+            const pending = sendRequest({
+                session: "request-test",
+                from: "lead",
+                to: "worker",
+                body: "approve?",
+                timeoutMs: 1_000,
+            });
+            await Bun.sleep(30);
+            const request = (await readFeed(paths)).find((event) => event.type === "message");
+            expect(request?.type).toBe("message");
+
+            if (request?.type !== "message") {
+                throw new Error("request message missing");
+            }
+
+            await appendMessage(paths, {
+                type: "message",
+                from_agent_id: "agt_0001",
+                from_agent_name: "worker",
+                to_agent_ids: ["main_test"],
+                body: '{"op":"approve"}',
+                meta: {},
+                private: false,
+                in_reply_to: request.message_id,
+            });
+
+            await expect(pending).resolves.toMatchObject({
+                from_agent_name: "worker",
+                in_reply_to: request.message_id,
+                body: '{"op":"approve"}',
+            });
+        });
+    });
+
+    test("times out without a reply", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-agents-request-timeout-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const paths = sessionPaths("request-timeout");
+            ensureSessionDir(paths);
+            await appendFeed(paths, {
+                type: "registered",
+                agent_name: "lead",
+                agent_id: "main_test",
+                awaiting_login: false,
+                is_main: true,
+                role: null,
+                meta: {},
+            });
+            await appendFeed(paths, {
+                type: "registered",
+                agent_name: "worker",
+                agent_id: "agt_0001",
+                awaiting_login: false,
+                is_main: false,
+                role: null,
+                meta: {},
+            });
+
+            await expect(
+                sendRequest({
+                    session: "request-timeout",
+                    from: "lead",
+                    to: "worker",
+                    body: "approve?",
+                    timeoutMs: 20,
+                })
+            ).rejects.toThrow("timed out");
+        });
+    });
+});

--- a/src/codex/README.md
+++ b/src/codex/README.md
@@ -1,0 +1,30 @@
+# `tools codex`
+
+Spawn, monitor, and steer long-lived Codex app-server sessions from GenesisTools.
+
+```bash
+tools codex spawn \
+  --name reviewer \
+  --mode review \
+  --prompt "Review the current working tree"
+
+tools codex status --name reviewer
+tools codex tail --name reviewer --follow
+tools codex steer --name reviewer --body "Focus on the auth path"
+tools codex interrupt --name reviewer
+tools codex read --name reviewer
+tools codex review --name reviewer --scope working-tree
+tools codex review --name reviewer --base main --scope branch --adversarial auth rollback
+tools codex stop --name reviewer
+```
+
+Sessions are read-only by default. For implementation work, use `--write ask` for supervised approvals or
+`--write allow` for a trusted bounded worker. `--write deny` is explicitly read-only.
+
+With `--write ask`, Codex uses its `untrusted` approval policy: commands outside Codex's built-in trusted read-only
+set, sandbox escalations, and file-change approval requests pause and are forwarded to `lead` as `approval_request`
+messages. Resolve one with `tools codex approve --name <n> --request <id>` or `deny`. Codex 0.144.5 has no protocol
+mode that pauses its built-in trusted read-only commands; `untrusted` is its strictest supported command policy.
+
+The driver joins the parent Claude Code swarm through `tools agents`. Use `--no-agents` to disable that integration,
+or `--session <id>` when the parent session cannot be discovered from `CLAUDE_CODE_SESSION_ID`.

--- a/src/codex/commands/approve.ts
+++ b/src/codex/commands/approve.ts
@@ -1,0 +1,36 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+async function answerApproval(options: { name: string; request: string }, decision: "approve" | "deny"): Promise<void> {
+    const response = await sendControlRequest(options.name, {
+        op: decision,
+        requestId: options.request,
+    });
+    if (!response.ok) {
+        throw new Error(response.error);
+    }
+
+    out.result(SafeJSON.stringify(response.result ?? {}, null, 2));
+}
+
+export function registerApprovalCommands(program: Command): void {
+    program
+        .command("approve")
+        .description("Approve a pending Codex request")
+        .requiredOption("--name <name>", "Session name")
+        .requiredOption("--request <id>", "Approval request id")
+        .action(async (options: { name: string; request: string }) => {
+            await answerApproval(options, "approve");
+        });
+
+    program
+        .command("deny")
+        .description("Deny a pending Codex request")
+        .requiredOption("--name <name>", "Session name")
+        .requiredOption("--request <id>", "Approval request id")
+        .action(async (options: { name: string; request: string }) => {
+            await answerApproval(options, "deny");
+        });
+}

--- a/src/codex/commands/interrupt.ts
+++ b/src/codex/commands/interrupt.ts
@@ -1,0 +1,19 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+export function registerInterruptCommand(program: Command): void {
+    program
+        .command("interrupt")
+        .description("Interrupt the active Codex turn")
+        .requiredOption("--name <name>", "Session name")
+        .action(async (options: { name: string }) => {
+            const response = await sendControlRequest(options.name, { op: "interrupt" });
+            if (!response.ok) {
+                throw new Error(response.error);
+            }
+
+            out.result(SafeJSON.stringify(response.result ?? {}, null, 2));
+        });
+}

--- a/src/codex/commands/logs.ts
+++ b/src/codex/commands/logs.ts
@@ -1,0 +1,33 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { CodexSessionStore } from "../lib/store";
+
+export async function printLogs(options: { name: string; grep?: string; tail?: string }): Promise<void> {
+    const store = new CodexSessionStore();
+    let events = await store.readEvents(options.name);
+    if (options.grep) {
+        const pattern = new RegExp(options.grep);
+        events = events.filter((event) => pattern.test(SafeJSON.stringify(event, { strict: true })));
+    }
+
+    if (options.tail) {
+        const count = Number.parseInt(options.tail, 10);
+        events = events.slice(-count);
+    }
+
+    const body = events.map((event) => SafeJSON.stringify(event, { jsonl: true })).join("\n");
+    if (body) {
+        out.print(`${body}\n`);
+    }
+}
+
+export function registerLogsCommand(program: Command): void {
+    program
+        .command("logs")
+        .description("Read a Codex session event log")
+        .requiredOption("--name <name>", "Session name")
+        .option("--grep <pattern>", "Filter serialized events with a regular expression")
+        .option("--tail <count>", "Show the last N events")
+        .action(printLogs);
+}

--- a/src/codex/commands/read.ts
+++ b/src/codex/commands/read.ts
@@ -1,0 +1,19 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+export function registerReadCommand(program: Command): void {
+    program
+        .command("read")
+        .description("Read the current Codex thread snapshot")
+        .requiredOption("--name <name>", "Session name")
+        .action(async (options: { name: string }) => {
+            const response = await sendControlRequest(options.name, { op: "read" });
+            if (!response.ok) {
+                throw new Error(response.error);
+            }
+
+            out.result(SafeJSON.stringify(response.result ?? null, null, 2));
+        });
+}

--- a/src/codex/commands/review.ts
+++ b/src/codex/commands/review.ts
@@ -1,0 +1,41 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+type ReviewScope = "auto" | "working-tree" | "branch";
+
+export function registerReviewCommand(program: Command): void {
+    program
+        .command("review")
+        .description("Start a native or adversarial Codex review")
+        .requiredOption("--name <name>", "Session name")
+        .option("--base <ref>", "Base branch or ref")
+        .option("--scope <scope>", "auto | working-tree | branch", "auto")
+        .option("--adversarial [focus...]", "Run a skeptical turn instead of native review")
+        .action(
+            async (options: { name: string; base?: string; scope: ReviewScope; adversarial?: boolean | string[] }) => {
+                if (!(["auto", "working-tree", "branch"] as string[]).includes(options.scope)) {
+                    throw new Error("--scope must be auto, working-tree, or branch");
+                }
+
+                const adversarial =
+                    options.adversarial === true
+                        ? []
+                        : Array.isArray(options.adversarial)
+                          ? options.adversarial
+                          : undefined;
+                const response = await sendControlRequest(options.name, {
+                    op: "review",
+                    scope: options.scope,
+                    ...(options.base ? { base: options.base } : {}),
+                    ...(adversarial ? { adversarial } : {}),
+                });
+                if (!response.ok) {
+                    throw new Error(response.error);
+                }
+
+                out.result(SafeJSON.stringify(response.result ?? {}, null, 2));
+            }
+        );
+}

--- a/src/codex/commands/rollback.ts
+++ b/src/codex/commands/rollback.ts
@@ -1,0 +1,25 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+export function registerRollbackCommand(program: Command): void {
+    program
+        .command("rollback")
+        .description("Drop turns from the end of a Codex thread")
+        .requiredOption("--name <name>", "Session name")
+        .requiredOption("--turns <count>", "Number of turns to drop")
+        .action(async (options: { name: string; turns: string }) => {
+            const turns = Number.parseInt(options.turns, 10);
+            if (!Number.isInteger(turns) || turns < 1) {
+                throw new Error("--turns must be at least 1");
+            }
+
+            const response = await sendControlRequest(options.name, { op: "rollback", turns });
+            if (!response.ok) {
+                throw new Error(response.error);
+            }
+
+            out.result(SafeJSON.stringify(response.result ?? {}, null, 2));
+        });
+}

--- a/src/codex/commands/sessions.ts
+++ b/src/codex/commands/sessions.ts
@@ -1,0 +1,12 @@
+import type { Command } from "commander";
+import { printStatus } from "./status";
+
+export function registerSessionsCommand(program: Command): void {
+    program
+        .command("sessions")
+        .description("List Codex sessions")
+        .option("--json", "Emit machine-readable JSON")
+        .action(async (options: { json?: boolean }) => {
+            await printStatus(options);
+        });
+}

--- a/src/codex/commands/spawn.ts
+++ b/src/codex/commands/spawn.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { logger, out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { parseWritePolicy, schemaDriftWarning, spawnCodexSession } from "../lib/spawn";
+import type { CodexWritePolicy } from "../lib/store";
+
+const log = logger.child({ component: "codex:spawn" });
+
+interface SpawnCliOptions {
+    name: string;
+    cwd?: string;
+    home?: string;
+    model?: string;
+    effort?: string;
+    write?: CodexWritePolicy;
+    mode?: "review" | "task";
+    prompt?: string;
+    promptFile?: string;
+    agents?: boolean;
+    session?: string;
+    writableRoot?: string[];
+}
+
+export function registerSpawnCommand(program: Command): void {
+    program
+        .command("spawn")
+        .description("Spawn a long-lived Codex app-server session")
+        .requiredOption("--name <name>", "Unique session name")
+        .option("--cwd <path>", "Working directory")
+        .option("--home <path>", "CODEX_HOME override")
+        .option("--model <model>", "Codex model")
+        .option("--effort <effort>", "Reasoning effort")
+        .option("--write <policy>", "ask | allow | deny")
+        .option("--mode <mode>", "review | task", "task")
+        .option("--prompt <text>", "Start the first turn with this prompt")
+        .option("--prompt-file <path>", "Read the first prompt from a file")
+        .option("--no-agents", "Disable tools agents integration")
+        .option("--session <id>", "Parent tools agents session id")
+        .option("--writable-root <path...>", "Additional writable roots")
+        .action(async (options: SpawnCliOptions) => {
+            if (options.prompt && options.promptFile) {
+                throw new Error("--prompt and --prompt-file are mutually exclusive");
+            }
+
+            if (options.mode !== "review" && options.mode !== "task") {
+                throw new Error("--mode must be review or task");
+            }
+
+            const prompt = options.promptFile ? readFileSync(options.promptFile, "utf8") : options.prompt;
+            const meta = await spawnCodexSession({
+                ...options,
+                prompt,
+                write: parseWritePolicy(options.write),
+                rendezvousSession: options.session,
+                writableRoots: options.writableRoot,
+            });
+            const warning = schemaDriftWarning(meta.codexVersion);
+            if (warning) {
+                log.warn({ installed: meta.codexVersion }, warning);
+                out.log.warn(warning);
+            }
+
+            out.result(SafeJSON.stringify(meta, null, 2));
+        });
+}

--- a/src/codex/commands/status.ts
+++ b/src/codex/commands/status.ts
@@ -1,0 +1,42 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { CodexSessionStore, deriveSessionStatus } from "../lib/store";
+
+export async function printStatus(options: { name?: string; json?: boolean }): Promise<void> {
+    const store = new CodexSessionStore();
+    const names = options.name ? [options.name] : await store.listNames();
+    const sessions = [];
+
+    for (const name of names) {
+        const meta = await store.readMeta(name);
+        if (meta) {
+            sessions.push({ ...meta, derivedStatus: deriveSessionStatus(meta) });
+        }
+    }
+
+    if (options.json) {
+        out.result(SafeJSON.stringify(options.name ? (sessions[0] ?? null) : sessions, null, 2));
+        return;
+    }
+
+    if (sessions.length === 0) {
+        out.printlnErr("No Codex sessions found.");
+        return;
+    }
+
+    for (const session of sessions) {
+        out.printlnErr(
+            `${session.name.padEnd(24)} ${session.derivedStatus.padEnd(10)} pid=${session.daemonPid} thread=${session.threadId ?? "—"}`
+        );
+    }
+}
+
+export function registerStatusCommand(program: Command): void {
+    program
+        .command("status")
+        .description("Show Codex session state")
+        .option("--name <name>", "Session name; omit for all sessions")
+        .option("--json", "Emit machine-readable JSON")
+        .action(printStatus);
+}

--- a/src/codex/commands/steer.ts
+++ b/src/codex/commands/steer.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+export function registerSteerCommand(program: Command): void {
+    program
+        .command("steer")
+        .description("Inject input into a running Codex turn")
+        .requiredOption("--name <name>", "Session name")
+        .option("--body <text>", "Steering message")
+        .option("--body-file <path>", "Read steering message from a file")
+        .option("--force", "Interrupt then start if same-turn steering is rejected")
+        .action(async (options: { name: string; body?: string; bodyFile?: string; force?: boolean }) => {
+            if (options.body && options.bodyFile) {
+                throw new Error("--body and --body-file are mutually exclusive");
+            }
+
+            const body = options.bodyFile ? readFileSync(options.bodyFile, "utf8") : options.body;
+            if (!body) {
+                throw new Error("--body or --body-file is required");
+            }
+
+            const response = await sendControlRequest(options.name, {
+                op: "steer",
+                body,
+                force: Boolean(options.force),
+            });
+            if (!response.ok) {
+                throw new Error(response.error);
+            }
+
+            out.result(SafeJSON.stringify(response.result ?? {}, null, 2));
+        });
+}

--- a/src/codex/commands/stop.ts
+++ b/src/codex/commands/stop.ts
@@ -1,0 +1,19 @@
+import { out } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import type { Command } from "commander";
+import { sendControlRequest } from "../lib/control-channel";
+
+export function registerStopCommand(program: Command): void {
+    program
+        .command("stop")
+        .description("Stop a Codex session")
+        .requiredOption("--name <name>", "Session name")
+        .action(async (options: { name: string }) => {
+            const response = await sendControlRequest(options.name, { op: "stop" });
+            if (!response.ok) {
+                throw new Error(response.error);
+            }
+
+            out.result(SafeJSON.stringify(response.result ?? { stopped: true }, null, 2));
+        });
+}

--- a/src/codex/commands/tail.ts
+++ b/src/codex/commands/tail.ts
@@ -1,0 +1,43 @@
+import { existsSync, statSync } from "node:fs";
+import { out } from "@app/logger";
+import type { Command } from "commander";
+import { sessionEventsPath } from "../lib/paths";
+import { CodexSessionStore } from "../lib/store";
+import { printLogs } from "./logs";
+
+export function registerTailCommand(program: Command): void {
+    program
+        .command("tail")
+        .description("Show recent events and optionally follow")
+        .requiredOption("--name <name>", "Session name")
+        .option("--tail <count>", "Show the last N existing events", "20")
+        .option("--follow", "Follow until the session closes")
+        .action(async (options: { name: string; tail: string; follow?: boolean }) => {
+            await printLogs(options);
+            if (!options.follow) {
+                return;
+            }
+
+            const path = sessionEventsPath(options.name);
+            let offset = existsSync(path) ? statSync(path).size : 0;
+            const store = new CodexSessionStore();
+
+            for (;;) {
+                if (existsSync(path)) {
+                    const size = statSync(path).size;
+                    if (size > offset) {
+                        const text = await Bun.file(path).slice(offset, size).text();
+                        out.print(text);
+                        offset = size;
+                    }
+                }
+
+                const meta = await store.readMeta(options.name);
+                if (!meta || meta.status === "closed" || meta.status === "failed") {
+                    return;
+                }
+
+                await Bun.sleep(200);
+            }
+        });
+}

--- a/src/codex/daemon.ts
+++ b/src/codex/daemon.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env bun
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { AgentsBridge } from "./lib/agents-bridge";
+import { AppServerClient, type RpcNotification, spawnAppServer } from "./lib/app-server-client";
+import { readControlRequests, respondToControl } from "./lib/control-channel";
+import { sessionDaemonLogPath, sessionLaunchPath } from "./lib/paths";
+import { CodexSessionRuntime } from "./lib/session";
+import type { LaunchConfig } from "./lib/spawn";
+import { CodexSessionStore } from "./lib/store";
+
+const log = logger.child({ component: "codex:daemon" });
+
+function parseName(): string {
+    const index = Bun.argv.indexOf("--name");
+    const name = index >= 0 ? Bun.argv[index + 1] : undefined;
+    if (!name) {
+        throw new Error("codex daemon requires --name <session>");
+    }
+
+    return name;
+}
+
+async function run(): Promise<void> {
+    const name = parseName();
+    const store = new CodexSessionStore();
+    const meta = await store.readMeta(name);
+    if (!meta) {
+        throw new Error(`Codex session metadata not found: ${name}`);
+    }
+
+    const launch = SafeJSON.parse(readFileSync(sessionLaunchPath(name), "utf8"), { strict: true }) as LaunchConfig;
+    const config = [`sandbox_mode=${meta.sandbox}`];
+    if (launch.writableRoots.length > 0) {
+        config.push(
+            `sandbox_workspace_write.writable_roots=${SafeJSON.stringify(launch.writableRoots, { strict: true })}`
+        );
+    }
+
+    let runtime: CodexSessionRuntime | null = null;
+    let bridge: AgentsBridge | null = null;
+    let exiting = false;
+    const child = spawnAppServer({
+        cwd: meta.cwd,
+        home: meta.home,
+        config,
+        envOverrides: { GT_RENDEZVOUS_SESSION: meta.rendezvousSession },
+    });
+    await store.updateMeta(name, { appServerPid: child.pid, daemonPid: process.pid });
+
+    const client = new AppServerClient(child, {
+        onNotification: async (notification: RpcNotification) => {
+            await runtime?.handleNotification(notification);
+            void bridge?.publish(notification).catch((err) => {
+                log.warn({ err, method: notification.method }, "publishing Codex event to agents bus failed");
+            });
+        },
+        onStderr: (text) => {
+            appendFileSync(sessionDaemonLogPath(name), text);
+        },
+        onServerRequest: async (request) => {
+            if (!runtime) {
+                throw new Error(`Codex server request arrived before runtime initialization: ${request.method}`);
+            }
+
+            return runtime.handleServerRequest(request);
+        },
+        onExit: async (code) => {
+            if (!exiting) {
+                exiting = true;
+                await store.updateMeta(name, {
+                    status: code === 0 ? "closed" : "failed",
+                    exitCode: code,
+                    activeTurnId: undefined,
+                    lastEventAt: new Date().toISOString(),
+                });
+
+                try {
+                    await bridge?.publishEvent({
+                        event: "error",
+                        message: `Codex app-server exited with code ${code}`,
+                    });
+                } catch (err) {
+                    log.warn({ err, code }, "publishing app-server exit to agents bus failed");
+                }
+
+                await bridge?.close();
+            }
+        },
+    });
+    runtime = new CodexSessionRuntime({
+        client,
+        store,
+        meta: (await store.readMeta(name)) ?? meta,
+        onApprovalRequest: async (notice) => {
+            store.appendEvent(name, { source: "daemon", method: "approval_request", params: notice });
+            if (!meta.agentsEnabled) {
+                return;
+            }
+
+            const deadline = Date.now() + 5_000;
+            while (!bridge && Date.now() < deadline) {
+                await Bun.sleep(50);
+            }
+
+            if (!bridge) {
+                throw new Error("Agents bridge was not ready to forward an approval request");
+            }
+
+            await bridge.publishEvent(notice);
+        },
+    });
+
+    const shutdown = async (): Promise<void> => {
+        if (exiting) {
+            return;
+        }
+
+        exiting = true;
+        await bridge?.close();
+        await runtime?.close();
+    };
+
+    process.on("SIGINT", () => void shutdown());
+    process.on("SIGTERM", () => void shutdown());
+
+    try {
+        await runtime.start({ prompt: launch.prompt });
+
+        if (meta.agentsEnabled) {
+            bridge = new AgentsBridge({
+                agentName: meta.agentName,
+                rendezvousSession: meta.rendezvousSession,
+                afterSeq: meta.lastAgentSeq,
+                onSeq: async (seq) => {
+                    await store.updateMeta(name, { lastAgentSeq: seq });
+                },
+                onControl: async (control) => {
+                    try {
+                        const result = await runtime?.execute(control);
+                        await bridge?.publishEvent({ event: "control_result", op: control.op, result });
+                    } catch (err) {
+                        const message = err instanceof Error ? err.message : String(err);
+                        await bridge?.publishEvent({ event: "error", op: control.op, message });
+                    }
+                },
+            });
+            const agentId = await bridge.start();
+            await store.updateMeta(name, { agentId });
+        }
+
+        let lastControlSeq = 0;
+
+        while (!exiting) {
+            const requests = await readControlRequests(name, lastControlSeq);
+            for (const request of requests) {
+                lastControlSeq = request.seq;
+                store.appendEvent(name, { source: "control", method: request.control.op, params: request.control });
+
+                if (request.control.op === "stop") {
+                    respondToControl(name, request.id, { ok: true, result: { stopped: true } });
+                    await shutdown();
+                    break;
+                }
+
+                try {
+                    const result = await runtime.execute(request.control);
+                    respondToControl(name, request.id, { ok: true, result });
+                } catch (err) {
+                    respondToControl(name, request.id, {
+                        ok: false,
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                }
+            }
+
+            if (!exiting) {
+                await Bun.sleep(50);
+            }
+        }
+    } catch (err) {
+        log.error({ err, name }, "codex daemon failed");
+        try {
+            await shutdown();
+        } catch (shutdownError) {
+            log.warn({ err: shutdownError, name }, "codex daemon cleanup after failure failed");
+        }
+
+        await store.updateMeta(name, {
+            status: "failed",
+            activeTurnId: undefined,
+            lastEventAt: new Date().toISOString(),
+        });
+        throw err;
+    }
+}
+
+await run();

--- a/src/codex/index.ts
+++ b/src/codex/index.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+
+import { runTool } from "@app/utils/cli";
+import { Command } from "commander";
+import { registerApprovalCommands } from "./commands/approve";
+import { registerInterruptCommand } from "./commands/interrupt";
+import { registerLogsCommand } from "./commands/logs";
+import { registerReadCommand } from "./commands/read";
+import { registerReviewCommand } from "./commands/review";
+import { registerRollbackCommand } from "./commands/rollback";
+import { registerSessionsCommand } from "./commands/sessions";
+import { registerSpawnCommand } from "./commands/spawn";
+import { registerStatusCommand } from "./commands/status";
+import { registerSteerCommand } from "./commands/steer";
+import { registerStopCommand } from "./commands/stop";
+import { registerTailCommand } from "./commands/tail";
+
+const program = new Command();
+
+program.name("codex").description("Spawn, monitor, and steer Codex app-server sessions");
+
+registerSpawnCommand(program);
+registerSteerCommand(program);
+registerInterruptCommand(program);
+registerRollbackCommand(program);
+registerReadCommand(program);
+registerReviewCommand(program);
+registerApprovalCommands(program);
+registerStatusCommand(program);
+registerSessionsCommand(program);
+registerLogsCommand(program);
+registerTailCommand(program);
+registerStopCommand(program);
+
+await runTool(program, { tool: "codex" });

--- a/src/codex/lib/_generated/protocol.ts
+++ b/src/codex/lib/_generated/protocol.ts
@@ -1,0 +1,84 @@
+// GENERATED CODE SNAPSHOT — codex-cli 0.144.5 (`codex app-server generate-ts`).
+
+export const CODEX_SCHEMA_VERSION = "0.144.5";
+
+export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+export type AskForApproval =
+    | "untrusted"
+    | "on-request"
+    | {
+          granular: {
+              sandbox_approval: boolean;
+              rules: boolean;
+              skill_approval: boolean;
+              request_permissions: boolean;
+              mcp_elicitations: boolean;
+          };
+      }
+    | "never";
+
+export interface InitializeParams {
+    clientInfo: {
+        name: string;
+        title: string | null;
+        version: string;
+    };
+    capabilities: null;
+}
+
+export interface ThreadStartParams {
+    model?: string | null;
+    cwd?: string | null;
+    approvalPolicy?: AskForApproval | null;
+    sandbox?: SandboxMode | null;
+    config?: Record<string, JsonValue> | null;
+    serviceName?: string | null;
+    baseInstructions?: string | null;
+    developerInstructions?: string | null;
+    ephemeral?: boolean | null;
+}
+
+export type UserInput = {
+    type: "text";
+    text: string;
+    text_elements: [];
+};
+
+export interface TurnStartParams {
+    threadId: string;
+    input: UserInput[];
+    model?: string | null;
+    effort?: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+}
+
+export interface TurnInterruptParams {
+    threadId: string;
+    turnId: string;
+}
+
+export interface ThreadRollbackParams {
+    threadId: string;
+    numTurns: number;
+}
+
+export interface ThreadReadParams {
+    threadId: string;
+    includeTurns: boolean;
+}
+
+export interface ThreadUnsubscribeParams {
+    threadId: string;
+}
+
+export type ReviewTarget =
+    | { type: "uncommittedChanges" }
+    | { type: "baseBranch"; branch: string }
+    | { type: "commit"; sha: string; title: string | null }
+    | { type: "custom"; instructions: string };
+
+export interface ReviewStartParams {
+    threadId: string;
+    target: ReviewTarget;
+}
+
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };

--- a/src/codex/lib/agents-bridge.test.ts
+++ b/src/codex/lib/agents-bridge.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { AgentsBridge, type AgentsTransport, type AgentsTransportSubscription } from "./agents-bridge";
+import type { CodexControl } from "./control";
+
+class FakeAgentsTransport implements AgentsTransport {
+    readonly sent: Array<{ from: string; to: string; body: string; session: string }> = [];
+    lineHandler: ((line: string) => void | Promise<void>) | null = null;
+
+    async register(): Promise<string> {
+        return "agt_0002";
+    }
+
+    async send(options: { from: string; to: string; body: string; session: string }): Promise<void> {
+        this.sent.push(options);
+    }
+
+    async observe(
+        _session: string,
+        onLine: (line: string) => void | Promise<void>
+    ): Promise<AgentsTransportSubscription> {
+        this.lineHandler = onLine;
+        return { close: async () => {} };
+    }
+}
+
+describe("AgentsBridge", () => {
+    test("auto-registers and routes addressed controls", async () => {
+        const transport = new FakeAgentsTransport();
+        const controls: CodexControl[] = [];
+        const bridge = new AgentsBridge({
+            agentName: "codex_reviewer",
+            rendezvousSession: "parent-1",
+            transport,
+            onControl: async (control) => {
+                controls.push(control);
+            },
+        });
+
+        await expect(bridge.start()).resolves.toBe("agt_0002");
+        await transport.lineHandler?.(
+            '{"seq":7,"type":"message","from_agent_id":"main_parent","from_agent_name":"lead","to_agent_ids":["agt_0002"],"body":"{\\"op\\":\\"steer\\",\\"body\\":\\"focus\\"}","message_id":"0001","meta":{},"private":false,"ts":"now"}'
+        );
+        await transport.lineHandler?.(
+            '{"seq":8,"type":"message","from_agent_id":"agt_0003","from_agent_name":"other","to_agent_ids":["agt_0004"],"body":"ignore","message_id":"0002","meta":{},"private":false,"ts":"now"}'
+        );
+        await transport.lineHandler?.(
+            '{"seq":9,"type":"message","from_agent_id":"main_parent","from_agent_name":"lead","to_agent_ids":["agt_0002"],"body":"{bad","message_id":"0003","meta":{},"private":false,"ts":"now"}'
+        );
+        await transport.lineHandler?.(
+            '{"seq":10,"type":"message","from_agent_id":"main_parent","from_agent_name":"lead","to_agent_ids":["agt_0002"],"body":"{\\"op\\":\\"interrupt\\"}","message_id":"0004","meta":{},"private":false,"ts":"now"}'
+        );
+
+        expect(controls).toEqual([{ op: "steer", body: "focus", force: false }, { op: "interrupt" }]);
+        expect(transport.sent.at(-1)?.body).toContain('"event":"error"');
+        await bridge.close();
+    });
+
+    test("publishes milestone notifications to lead", async () => {
+        const transport = new FakeAgentsTransport();
+        const bridge = new AgentsBridge({
+            agentName: "codex_reviewer",
+            rendezvousSession: "parent-1",
+            transport,
+            onControl: async () => {},
+        });
+        await bridge.start();
+
+        await bridge.publish({ method: "turn/started", params: { turn: { id: "turn-1" } } });
+        await bridge.publish({
+            method: "item/completed",
+            params: {
+                item: {
+                    type: "commandExecution",
+                    id: "item-1",
+                    command: "tools agents message --to lead",
+                    exitCode: 0,
+                    aggregatedOutput: "private command output that must stay in the session log",
+                },
+            },
+        });
+
+        expect(transport.sent).toHaveLength(2);
+        expect(transport.sent[0]?.body).toContain('"event":"turn_started"');
+        expect(transport.sent[1]?.body).toContain('"event":"item"');
+        expect(transport.sent[1]?.body).toContain('"itemType":"commandExecution"');
+        expect(transport.sent[1]?.body).toContain('"summary":"tools agents message --to lead (exit 0)"');
+        expect(transport.sent[1]?.body).not.toContain("private command output");
+    });
+});

--- a/src/codex/lib/agents-bridge.ts
+++ b/src/codex/lib/agents-bridge.ts
@@ -1,0 +1,406 @@
+import { logger } from "@app/logger";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import type { RpcNotification } from "./app-server-client";
+import { type CodexControl, parseControlBody } from "./control";
+
+const log = logger.child({ component: "codex:agents-bridge" });
+
+export interface AgentsTransportSubscription {
+    close(): Promise<void>;
+}
+
+export interface AgentsTransport {
+    register(agentName: string, session: string): Promise<string>;
+    send(options: { from: string; to: string; body: string; session: string }): Promise<void>;
+    observe(session: string, onLine: (line: string) => void | Promise<void>): Promise<AgentsTransportSubscription>;
+}
+
+interface AgentsBridgeOptions {
+    agentName: string;
+    rendezvousSession: string;
+    transport?: AgentsTransport;
+    onControl: (control: CodexControl) => void | Promise<void>;
+    onSeq?: (seq: number) => void | Promise<void>;
+    afterSeq?: number;
+}
+
+interface MessageFeedEvent {
+    seq: number;
+    type: "message";
+    from_agent_id: string;
+    to_agent_ids: string[];
+    body: string;
+}
+
+interface AgentRecord {
+    agent_id: string;
+    agent_name: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseMessageEvent(line: string): MessageFeedEvent | null {
+    const parsed = SafeJSON.parse(line, { strict: true });
+    if (
+        !isRecord(parsed) ||
+        parsed.type !== "message" ||
+        typeof parsed.seq !== "number" ||
+        typeof parsed.from_agent_id !== "string" ||
+        typeof parsed.body !== "string" ||
+        !Array.isArray(parsed.to_agent_ids) ||
+        !parsed.to_agent_ids.every((id) => typeof id === "string")
+    ) {
+        return null;
+    }
+
+    return parsed as unknown as MessageFeedEvent;
+}
+
+function nestedRecord(value: unknown, key: string): Record<string, unknown> | null {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    return isRecord(value[key]) ? value[key] : null;
+}
+
+function compactText(value: unknown, maxLength = 400): string | null {
+    if (typeof value !== "string") {
+        return null;
+    }
+
+    const normalized = value.replace(/\s+/g, " ").trim();
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+
+    return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function itemSummary(item: Record<string, unknown>): string {
+    if (item.type === "agentMessage") {
+        return compactText(item.text) ?? "agent message";
+    }
+
+    if (item.type === "commandExecution") {
+        const command = compactText(item.command) ?? "command";
+        const outcome = typeof item.exitCode === "number" ? `exit ${item.exitCode}` : compactText(item.status);
+        return outcome ? `${command} (${outcome})` : command;
+    }
+
+    if (item.type === "fileChange") {
+        const changeCount = Array.isArray(item.changes) ? item.changes.length : 0;
+        return `${changeCount} file ${changeCount === 1 ? "change" : "changes"}`;
+    }
+
+    if (item.type === "todoList") {
+        const itemCount = Array.isArray(item.items) ? item.items.length : 0;
+        return `${itemCount} todo ${itemCount === 1 ? "item" : "items"}`;
+    }
+
+    if (item.type === "reasoning") {
+        return "reasoning update";
+    }
+
+    return compactText(item.type) ?? "Codex item";
+}
+
+function eventEnvelope(notification: RpcNotification): Record<string, unknown> | null {
+    if (notification.method === "turn/started") {
+        return { event: "turn_started", turnId: nestedRecord(notification.params, "turn")?.id };
+    }
+
+    if (notification.method === "turn/completed") {
+        return { event: "turn_completed", turnId: nestedRecord(notification.params, "turn")?.id };
+    }
+
+    if (notification.method === "turn/failed") {
+        return { event: "error", message: "Codex turn failed", detail: notification.params };
+    }
+
+    if (notification.method === "error") {
+        return { event: "error", detail: notification.params };
+    }
+
+    if (notification.method === "item/started" || notification.method === "item/completed") {
+        const item = nestedRecord(notification.params, "item");
+        if (!item) {
+            return null;
+        }
+
+        return {
+            event: "item",
+            phase: notification.method.split("/")[1],
+            itemId: item.id,
+            itemType: item.type,
+            summary: itemSummary(item),
+        };
+    }
+
+    return null;
+}
+
+export class AgentsBridge {
+    private readonly agentName: string;
+    private readonly session: string;
+    private readonly transport: AgentsTransport;
+    private readonly onControl: AgentsBridgeOptions["onControl"];
+    private readonly onSeq: AgentsBridgeOptions["onSeq"];
+    private subscription: AgentsTransportSubscription | null = null;
+    private agentId: string | null = null;
+    private lastSeq: number;
+    private outbound = Promise.resolve();
+
+    constructor(options: AgentsBridgeOptions) {
+        this.agentName = options.agentName;
+        this.session = options.rendezvousSession;
+        this.transport = options.transport ?? new CliAgentsTransport();
+        this.onControl = options.onControl;
+        this.onSeq = options.onSeq;
+        this.lastSeq = options.afterSeq ?? 0;
+    }
+
+    async start(): Promise<string> {
+        this.agentId = await this.transport.register(this.agentName, this.session);
+        this.subscription = await this.transport.observe(this.session, async (line) => {
+            await this.handleLine(line);
+        });
+        return this.agentId;
+    }
+
+    async publish(notification: RpcNotification): Promise<void> {
+        const envelope = eventEnvelope(notification);
+        if (!envelope) {
+            return;
+        }
+
+        await this.enqueue({
+            from: this.agentName,
+            to: "lead",
+            body: SafeJSON.stringify(envelope, { strict: true }),
+            session: this.session,
+        });
+    }
+
+    async publishEvent(event: Record<string, unknown>): Promise<void> {
+        await this.enqueue({
+            from: this.agentName,
+            to: "lead",
+            body: SafeJSON.stringify(event, { strict: true }),
+            session: this.session,
+        });
+    }
+
+    async close(): Promise<void> {
+        await this.subscription?.close();
+        this.subscription = null;
+        await this.outbound;
+    }
+
+    private async enqueue(options: { from: string; to: string; body: string; session: string }): Promise<void> {
+        const send = this.outbound.then(() => this.transport.send(options));
+        this.outbound = send.catch((err) => {
+            log.debug(
+                { err, session: this.session, to: options.to },
+                "agents outbound queue recovered after send failure"
+            );
+        });
+        await send;
+    }
+
+    private async handleLine(line: string): Promise<void> {
+        let event: MessageFeedEvent | null;
+        try {
+            event = parseMessageEvent(line);
+        } catch (err) {
+            log.debug({ err, line }, "ignoring non-feed agents observer line");
+            return;
+        }
+
+        if (!event || !this.agentId || event.seq <= this.lastSeq) {
+            return;
+        }
+
+        this.lastSeq = event.seq;
+        await this.onSeq?.(event.seq);
+
+        if (event.from_agent_id === this.agentId || !event.to_agent_ids.includes(this.agentId)) {
+            return;
+        }
+
+        let control: CodexControl;
+        try {
+            control = parseControlBody(event.body);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            log.warn({ err, seq: event.seq, from: event.from_agent_id }, "ignoring invalid Codex control message");
+            await this.publishEvent({ event: "error", message });
+            return;
+        }
+
+        await this.onControl(control);
+    }
+}
+
+async function runAgentsCommand(args: string[]): Promise<string> {
+    const proc = Bun.spawn({
+        cmd: ["tools", "agents", ...args],
+        env: env.getProcessEnv(),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    if (exitCode !== 0) {
+        throw new Error(`tools agents ${args[0] ?? "command"} failed: ${stderr.trim() || `exit ${exitCode}`}`);
+    }
+
+    return stdout;
+}
+
+export class CliAgentsTransport implements AgentsTransport {
+    async register(agentName: string, session: string): Promise<string> {
+        const login = Bun.spawn({
+            cmd: [
+                "tools",
+                "agents",
+                "login",
+                "--agent-name",
+                agentName,
+                "--once",
+                "--session",
+                session,
+                "--format",
+                "json",
+            ],
+            env: env.getProcessEnv(),
+            stdin: "ignore",
+            stdout: "ignore",
+            stderr: "ignore",
+        });
+        const deadline = Date.now() + 5_000;
+        let found: AgentRecord | undefined;
+
+        try {
+            while (Date.now() < deadline) {
+                const stdout = await runAgentsCommand(["discover", "--session", session, "--format", "json"]);
+                const records = SafeJSON.parse(stdout, { strict: true });
+                if (!Array.isArray(records)) {
+                    throw new Error("tools agents discover returned a non-array response");
+                }
+
+                found = records.find(
+                    (record): record is AgentRecord =>
+                        isRecord(record) && record.agent_name === agentName && typeof record.agent_id === "string"
+                );
+                if (found) {
+                    break;
+                }
+
+                await Bun.sleep(50);
+            }
+        } finally {
+            try {
+                login.kill("SIGTERM");
+            } catch (err) {
+                log.debug({ err, pid: login.pid }, "one-shot agents login already exited");
+            }
+
+            await login.exited;
+        }
+
+        if (!found) {
+            throw new Error(`tools agents did not register ${agentName} within 5 seconds`);
+        }
+
+        return found.agent_id;
+    }
+
+    async send(options: { from: string; to: string; body: string; session: string }): Promise<void> {
+        await runAgentsCommand([
+            "message",
+            "--from",
+            options.from,
+            "--to",
+            options.to,
+            "--body",
+            options.body,
+            "--session",
+            options.session,
+        ]);
+    }
+
+    async observe(
+        session: string,
+        onLine: (line: string) => void | Promise<void>
+    ): Promise<AgentsTransportSubscription> {
+        const proc = Bun.spawn({
+            cmd: ["tools", "agents", "listen", "--session", session, "--format", "json"],
+            env: env.getProcessEnv(),
+            stdin: "ignore",
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        void consumeLines(proc.stdout, onLine).catch((err) => {
+            log.error({ err, pid: proc.pid, session }, "agents observer stdout failed");
+        });
+        void new Response(proc.stderr)
+            .text()
+            .then((stderr) => {
+                if (stderr.trim()) {
+                    log.debug({ stderr, pid: proc.pid, session }, "agents observer stderr");
+                }
+            })
+            .catch((err) => {
+                log.debug({ err, pid: proc.pid, session }, "reading agents observer stderr failed");
+            });
+
+        return {
+            close: async () => {
+                try {
+                    proc.kill("SIGTERM");
+                } catch (err) {
+                    log.debug({ err, pid: proc.pid }, "agents observer already exited");
+                    // The observer may already have exited with its parent daemon.
+                }
+                await proc.exited;
+            },
+        };
+    }
+}
+
+async function consumeLines(
+    stream: ReadableStream<Uint8Array>,
+    onLine: (line: string) => void | Promise<void>
+): Promise<void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let partial = "";
+
+    try {
+        for (;;) {
+            const result = await reader.read();
+            if (result.done) {
+                break;
+            }
+
+            partial += decoder.decode(result.value, { stream: true });
+            const lines = partial.split("\n");
+            partial = lines.pop() ?? "";
+            for (const line of lines) {
+                if (line.trim()) {
+                    await onLine(line);
+                }
+            }
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}

--- a/src/codex/lib/app-server-client.test.ts
+++ b/src/codex/lib/app-server-client.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { SafeJSON } from "@app/utils/json";
+import { AppServerClient, type AppServerProcess } from "./app-server-client";
+
+function createProcessHarness(): {
+    process: AppServerProcess;
+    writes: string[];
+    push: (message: Record<string, unknown>) => void;
+} {
+    const writes: string[] = [];
+    let stdoutController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const encoder = new TextEncoder();
+    const stdout = new ReadableStream<Uint8Array>({
+        start(controller) {
+            stdoutController = controller;
+        },
+    });
+
+    return {
+        process: {
+            pid: 42,
+            stdin: {
+                write(value: string | Uint8Array) {
+                    writes.push(typeof value === "string" ? value : new TextDecoder().decode(value));
+                    return value.length;
+                },
+                end() {
+                    return undefined;
+                },
+            },
+            stdout,
+            stderr: new ReadableStream<Uint8Array>({ start() {} }),
+            exited: new Promise<number>(() => {}),
+            kill() {},
+        },
+        writes,
+        push(message) {
+            stdoutController?.enqueue(encoder.encode(`${SafeJSON.stringify(message, { strict: true })}\n`));
+        },
+    };
+}
+
+describe("AppServerClient", () => {
+    test("correlates request responses by id", async () => {
+        const harness = createProcessHarness();
+        const client = new AppServerClient(harness.process);
+        const resultPromise = client.request<{ thread: { id: string } }>("thread/read", { threadId: "thread-1" });
+
+        await Bun.sleep(0);
+        const request = SafeJSON.parse(harness.writes[0] ?? "", { strict: true }) as {
+            id: number;
+            method: string;
+        };
+        expect(request.method).toBe("thread/read");
+
+        harness.push({ id: request.id, result: { thread: { id: "thread-1" } } });
+
+        await expect(resultPromise).resolves.toEqual({ thread: { id: "thread-1" } });
+        await client.close();
+    });
+
+    test("dispatches notifications and server requests", async () => {
+        const harness = createProcessHarness();
+        const notifications: string[] = [];
+        const client = new AppServerClient(harness.process, {
+            onNotification: (notification) => {
+                notifications.push(notification.method);
+            },
+            onServerRequest: async (request) => ({
+                decision: request.method.includes("fileChange") ? "accept" : "decline",
+            }),
+        });
+
+        harness.push({ method: "turn/started", params: { turn: { id: "turn-1" } } });
+        harness.push({ id: "approval-1", method: "item/fileChange/requestApproval", params: { itemId: "item-1" } });
+        await Bun.sleep(10);
+
+        expect(notifications).toEqual(["turn/started"]);
+        const response = SafeJSON.parse(harness.writes[0] ?? "", { strict: true }) as {
+            id: string;
+            result: { decision: string };
+        };
+        expect(response).toEqual({ id: "approval-1", result: { decision: "accept" } });
+        await client.close();
+    });
+
+    test("continues reading responses while a server approval is pending", async () => {
+        const harness = createProcessHarness();
+        let resolveApproval: (decision: { decision: string }) => void = () => {};
+        const approval = new Promise<{ decision: string }>((resolve) => {
+            resolveApproval = resolve;
+        });
+        const client = new AppServerClient(harness.process, {
+            onServerRequest: () => approval,
+        });
+
+        harness.push({ id: "approval-1", method: "item/commandExecution/requestApproval", params: {} });
+        await Bun.sleep(0);
+        const read = client.request<{ thread: { id: string } }>("thread/read", { threadId: "thread-1" });
+        const request = SafeJSON.parse(harness.writes[0] ?? "", { strict: true }) as { id: number };
+        harness.push({ id: request.id, result: { thread: { id: "thread-1" } } });
+
+        await expect(
+            Promise.race([
+                read,
+                Bun.sleep(30).then(() => {
+                    throw new Error("response reader blocked behind approval");
+                }),
+            ])
+        ).resolves.toEqual({ thread: { id: "thread-1" } });
+
+        resolveApproval({ decision: "accept" });
+        await Bun.sleep(0);
+        expect(harness.writes).toHaveLength(2);
+        await client.close();
+    });
+
+    test("rejects pending requests when the child exits", async () => {
+        let resolveExit: (code: number) => void = () => {};
+        const harness = createProcessHarness();
+        harness.process.exited = new Promise<number>((resolve) => {
+            resolveExit = resolve;
+        });
+        const client = new AppServerClient(harness.process);
+        const pending = client.request("thread/read", { threadId: "thread-1" });
+
+        resolveExit(17);
+
+        await expect(pending).rejects.toThrow("exited with code 17");
+        await client.close();
+    });
+});

--- a/src/codex/lib/app-server-client.ts
+++ b/src/codex/lib/app-server-client.ts
@@ -1,0 +1,318 @@
+import { logger } from "@app/logger";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+
+const log = logger.child({ component: "codex:app-server-client" });
+
+export type RpcId = number | string;
+
+export interface RpcNotification {
+    method: string;
+    params?: unknown;
+}
+
+export interface RpcServerRequest extends RpcNotification {
+    id: RpcId;
+}
+
+export interface AppServerProcess {
+    pid: number;
+    stdin: {
+        write(value: string | Uint8Array): number | Promise<number>;
+        flush?: () => number | Promise<number>;
+        end(): number | undefined | Promise<number | undefined>;
+    };
+    stdout: ReadableStream<Uint8Array>;
+    stderr: ReadableStream<Uint8Array>;
+    exited: Promise<number>;
+    kill(signal?: number | NodeJS.Signals): void;
+}
+
+interface AppServerClientOptions {
+    onNotification?: (notification: RpcNotification) => void | Promise<void>;
+    onServerRequest?: (request: RpcServerRequest) => unknown | Promise<unknown>;
+    onStderr?: (text: string) => void;
+    onExit?: (code: number) => void | Promise<void>;
+}
+
+interface PendingRequest {
+    method: string;
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function responseError(value: unknown): Error {
+    if (isRecord(value) && typeof value.message === "string") {
+        return new Error(value.message);
+    }
+
+    return new Error("Codex app-server returned an unknown RPC error");
+}
+
+export class AppServerClient {
+    private readonly pending = new Map<RpcId, PendingRequest>();
+    private readonly options: AppServerClientOptions;
+    private nextId = 1;
+    private closed = false;
+
+    constructor(
+        readonly process: AppServerProcess,
+        options: AppServerClientOptions = {}
+    ) {
+        this.options = options;
+        void this.readStdout();
+        void this.readStderr();
+        void this.watchExit();
+    }
+
+    async request<T>(method: string, params?: unknown): Promise<T> {
+        if (this.closed) {
+            throw new Error("Codex app-server client is closed");
+        }
+
+        const id = this.nextId;
+        this.nextId += 1;
+
+        const result = new Promise<T>((resolve, reject) => {
+            this.pending.set(id, {
+                method,
+                resolve: (value) => resolve(value as T),
+                reject,
+            });
+        });
+
+        try {
+            await this.writeMessage({ id, method, ...(params === undefined ? {} : { params }) });
+        } catch (err) {
+            this.pending.delete(id);
+            throw err;
+        }
+
+        return result;
+    }
+
+    async notify(method: string, params?: unknown): Promise<void> {
+        await this.writeMessage({ method, ...(params === undefined ? {} : { params }) });
+    }
+
+    async close(): Promise<void> {
+        if (this.closed) {
+            return;
+        }
+
+        this.closed = true;
+        this.rejectPending(new Error("Codex app-server client closed"));
+
+        try {
+            await this.process.stdin.end();
+        } catch (err) {
+            log.debug({ err }, "closing app-server stdin failed");
+        }
+
+        try {
+            this.process.kill("SIGTERM");
+        } catch (err) {
+            log.debug({ err, pid: this.process.pid }, "terminating app-server failed");
+        }
+    }
+
+    private async writeMessage(message: Record<string, unknown>): Promise<void> {
+        const line = `${SafeJSON.stringify(message, { jsonl: true })}\n`;
+        await this.process.stdin.write(line);
+        await this.process.stdin.flush?.();
+    }
+
+    private async readStdout(): Promise<void> {
+        const reader = this.process.stdout.getReader();
+        const decoder = new TextDecoder();
+        let partial = "";
+
+        try {
+            for (;;) {
+                const result = await reader.read();
+                if (result.done) {
+                    break;
+                }
+
+                partial += decoder.decode(result.value, { stream: true });
+                const lines = partial.split("\n");
+                partial = lines.pop() ?? "";
+
+                for (const line of lines) {
+                    await this.handleLine(line);
+                }
+            }
+
+            partial += decoder.decode();
+            if (partial.trim()) {
+                await this.handleLine(partial);
+            }
+        } catch (err) {
+            if (!this.closed) {
+                log.error({ err }, "reading app-server stdout failed");
+                this.rejectPending(err instanceof Error ? err : new Error(String(err)));
+            }
+        } finally {
+            reader.releaseLock();
+        }
+    }
+
+    private async readStderr(): Promise<void> {
+        const reader = this.process.stderr.getReader();
+        const decoder = new TextDecoder();
+
+        try {
+            for (;;) {
+                const result = await reader.read();
+                if (result.done) {
+                    break;
+                }
+
+                const text = decoder.decode(result.value, { stream: true });
+                if (text) {
+                    this.options.onStderr?.(text);
+                }
+            }
+
+            const tail = decoder.decode();
+            if (tail) {
+                this.options.onStderr?.(tail);
+            }
+        } catch (err) {
+            if (!this.closed) {
+                log.warn({ err }, "reading app-server stderr failed");
+            }
+        } finally {
+            reader.releaseLock();
+        }
+    }
+
+    private async handleLine(line: string): Promise<void> {
+        if (!line.trim()) {
+            return;
+        }
+
+        let message: unknown;
+        try {
+            message = SafeJSON.parse(line, { strict: true });
+        } catch (err) {
+            log.warn({ err, line }, "ignoring invalid app-server JSON line");
+            return;
+        }
+
+        if (!isRecord(message)) {
+            log.warn({ message }, "ignoring non-object app-server message");
+            return;
+        }
+
+        const id = message.id;
+        const method = message.method;
+
+        if ((typeof id === "number" || typeof id === "string") && typeof method === "string") {
+            void this.handleServerRequest({ id, method, params: message.params }).catch((err) => {
+                log.error({ err, id, method }, "answering app-server request failed");
+            });
+            return;
+        }
+
+        if (typeof id === "number" || typeof id === "string") {
+            const pending = this.pending.get(id);
+            if (!pending) {
+                log.debug({ id }, "received response for unknown app-server request");
+                return;
+            }
+
+            this.pending.delete(id);
+            if ("error" in message) {
+                pending.reject(responseError(message.error));
+            } else {
+                pending.resolve(message.result);
+            }
+
+            return;
+        }
+
+        if (typeof method === "string") {
+            await this.options.onNotification?.({ method, params: message.params });
+        }
+    }
+
+    private async handleServerRequest(request: RpcServerRequest): Promise<void> {
+        if (!this.options.onServerRequest) {
+            await this.writeMessage({
+                id: request.id,
+                error: { code: -32_601, message: `No handler for server request ${request.method}` },
+            });
+            return;
+        }
+
+        try {
+            const result = await this.options.onServerRequest(request);
+            await this.writeMessage({ id: request.id, result });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            await this.writeMessage({ id: request.id, error: { code: -32_000, message } });
+        }
+    }
+
+    private async watchExit(): Promise<void> {
+        const code = await this.process.exited;
+        const wasClosed = this.closed;
+        this.closed = true;
+        this.rejectPending(new Error(`Codex app-server exited with code ${code}`));
+
+        if (!wasClosed) {
+            await this.options.onExit?.(code);
+        }
+    }
+
+    private rejectPending(error: Error): void {
+        for (const pending of this.pending.values()) {
+            pending.reject(error);
+        }
+
+        this.pending.clear();
+    }
+}
+
+export function spawnAppServer(options: {
+    cwd: string;
+    home?: string;
+    envOverrides?: Record<string, string>;
+    config?: string[];
+}): AppServerProcess {
+    const cmd = ["codex", "app-server"];
+
+    for (const config of options.config ?? []) {
+        cmd.push("-c", config);
+    }
+
+    const childEnv = { ...env.getProcessEnv(), ...options.envOverrides };
+    if (options.home) {
+        childEnv.CODEX_HOME = options.home;
+    }
+
+    const proc = Bun.spawn({
+        cmd,
+        cwd: options.cwd,
+        env: childEnv,
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+
+    return {
+        pid: proc.pid,
+        stdin: proc.stdin,
+        stdout: proc.stdout,
+        stderr: proc.stderr,
+        exited: proc.exited,
+        kill(signal) {
+            proc.kill(signal);
+        },
+    };
+}

--- a/src/codex/lib/control-channel.test.ts
+++ b/src/codex/lib/control-channel.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+import {
+    appendControlRequest,
+    readControlRequests,
+    respondToControl,
+    sendControlRequest,
+    waitForControlResponse,
+} from "./control-channel";
+import { CodexSessionStore } from "./store";
+
+describe("codex control channel", () => {
+    test("orders requests and round-trips responses", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-control-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const first = await appendControlRequest("reviewer", { op: "interrupt" });
+            const second = await appendControlRequest("reviewer", { op: "rollback", turns: 2 });
+
+            const requests = await readControlRequests("reviewer", 0);
+            expect(requests.map((request) => request.seq)).toEqual([1, 2]);
+            expect(requests.map((request) => request.control)).toEqual([
+                { op: "interrupt" },
+                { op: "rollback", turns: 2 },
+            ]);
+
+            const responsePromise = waitForControlResponse("reviewer", second.id, 1_000);
+            respondToControl("reviewer", second.id, { ok: true, result: { rolledBack: 2 } });
+            await expect(responsePromise).resolves.toEqual({ ok: true, result: { rolledBack: 2 } });
+            expect(first.seq).toBe(1);
+        });
+    });
+
+    test("times out when the daemon does not answer", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-control-timeout-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            await expect(waitForControlResponse("missing", "request-1", 20)).rejects.toThrow("Timed out");
+        });
+    });
+
+    test("rejects controls for closed sessions without waiting for a timeout", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-control-closed-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const now = new Date().toISOString();
+            store.writeMeta({
+                name: "reviewer",
+                daemonPid: 123,
+                cwd: "/repo",
+                sandbox: "read-only",
+                approvalPolicy: "never",
+                writePolicy: "deny",
+                status: "closed",
+                agentName: "codex_reviewer",
+                rendezvousSession: "parent",
+                agentsEnabled: false,
+                startedAt: now,
+                lastEventAt: now,
+                codexVersion: "0.144.5",
+                pendingApprovals: {},
+            });
+
+            await expect(sendControlRequest("reviewer", { op: "interrupt" }, 20)).rejects.toThrow(
+                'Codex session "reviewer" is closed'
+            );
+        });
+    });
+});

--- a/src/codex/lib/control-channel.ts
+++ b/src/codex/lib/control-channel.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { isProcessAlive } from "@app/task/lib/process-alive";
+import { SafeJSON } from "@app/utils/json";
+import { parseJsonl } from "@app/utils/jsonl";
+import { withFileLock } from "@app/utils/storage";
+import { atomicWriteFileSync } from "@app/utils/storage/storage";
+import type { CodexControl } from "./control";
+import { sessionControlPath, sessionResponsePath } from "./paths";
+import { CodexSessionStore } from "./store";
+
+export interface ControlRequest {
+    id: string;
+    seq: number;
+    ts: string;
+    control: CodexControl;
+}
+
+export type ControlResponse = { ok: true; result?: unknown } | { ok: false; error: string };
+
+function readRequests(path: string): ControlRequest[] {
+    if (!existsSync(path)) {
+        return [];
+    }
+
+    const text = readFileSync(path, "utf8");
+    return text.trim() ? parseJsonl<ControlRequest>(text) : [];
+}
+
+export async function appendControlRequest(name: string, control: CodexControl): Promise<ControlRequest> {
+    const path = sessionControlPath(name);
+    mkdirSync(dirname(path), { recursive: true });
+
+    return withFileLock(`${path}.lock`, async () => {
+        const existing = readRequests(path);
+        const request: ControlRequest = {
+            id: randomUUID(),
+            seq: (existing.at(-1)?.seq ?? 0) + 1,
+            ts: new Date().toISOString(),
+            control,
+        };
+        appendFileSync(path, `${SafeJSON.stringify(request, { jsonl: true })}\n`);
+        return request;
+    });
+}
+
+export async function readControlRequests(name: string, afterSeq: number): Promise<ControlRequest[]> {
+    return readRequests(sessionControlPath(name)).filter((request) => request.seq > afterSeq);
+}
+
+export function respondToControl(name: string, requestId: string, response: ControlResponse): void {
+    const path = sessionResponsePath(name, requestId);
+    mkdirSync(dirname(path), { recursive: true });
+    atomicWriteFileSync(path, SafeJSON.stringify(response, null, 2));
+}
+
+export async function waitForControlResponse(
+    name: string,
+    requestId: string,
+    timeoutMs = 30_000
+): Promise<ControlResponse> {
+    const path = sessionResponsePath(name, requestId);
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (existsSync(path)) {
+            return SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as ControlResponse;
+        }
+
+        await Bun.sleep(20);
+    }
+
+    throw new Error(`Timed out waiting for Codex session "${name}" to answer control request ${requestId}`);
+}
+
+export async function sendControlRequest(
+    name: string,
+    control: CodexControl,
+    timeoutMs = 30_000
+): Promise<ControlResponse> {
+    const meta = await new CodexSessionStore().readMeta(name);
+    if (!meta) {
+        throw new Error(`Codex session not found: ${name}`);
+    }
+
+    if (meta.status === "closed" || meta.status === "failed") {
+        throw new Error(`Codex session "${name}" is ${meta.status}`);
+    }
+
+    if (!isProcessAlive(meta.daemonPid)) {
+        throw new Error(`Codex session "${name}" daemon is not running (pid ${meta.daemonPid})`);
+    }
+
+    const request = await appendControlRequest(name, control);
+    return waitForControlResponse(name, request.id, timeoutMs);
+}

--- a/src/codex/lib/control.test.ts
+++ b/src/codex/lib/control.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { parseControlBody } from "./control";
+
+describe("parseControlBody", () => {
+    test("treats plain text as a steer", () => {
+        expect(parseControlBody("focus on auth")).toEqual({ op: "steer", body: "focus on auth", force: false });
+    });
+
+    test("parses structured ops", () => {
+        expect(parseControlBody('{"op":"rollback","turns":2}')).toEqual({ op: "rollback", turns: 2 });
+        expect(parseControlBody('{"op":"approve","requestId":"req-1"}')).toEqual({
+            op: "approve",
+            requestId: "req-1",
+        });
+    });
+
+    test("supports slash fallbacks", () => {
+        expect(parseControlBody("/interrupt")).toEqual({ op: "interrupt" });
+        expect(parseControlBody("/rollback 3")).toEqual({ op: "rollback", turns: 3 });
+        expect(parseControlBody("/stop")).toEqual({ op: "stop" });
+    });
+
+    test("rejects malformed structured controls", () => {
+        expect(() => parseControlBody('{"op":"rollback","turns":0}')).toThrow("turns must be at least 1");
+        expect(() => parseControlBody('{"op":"explode"}')).toThrow("Unsupported control op");
+    });
+});

--- a/src/codex/lib/control.ts
+++ b/src/codex/lib/control.ts
@@ -1,0 +1,104 @@
+import { SafeJSON } from "@app/utils/json";
+
+export type CodexControl =
+    | { op: "steer"; body: string; force: boolean }
+    | { op: "interrupt" }
+    | { op: "rollback"; turns: number }
+    | { op: "read" }
+    | { op: "review"; base?: string; scope?: "auto" | "working-tree" | "branch"; adversarial?: string[] }
+    | { op: "approve" | "deny"; requestId: string }
+    | { op: "stop" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredRequestId(value: unknown): string {
+    if (typeof value !== "string" || !value) {
+        throw new Error("requestId is required");
+    }
+
+    return value;
+}
+
+function rollbackTurns(value: unknown): number {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+        throw new Error("rollback turns must be at least 1");
+    }
+
+    return value;
+}
+
+function parseStructuredControl(value: Record<string, unknown>): CodexControl {
+    switch (value.op) {
+        case "steer":
+            if (typeof value.body !== "string" || !value.body.trim()) {
+                throw new Error("steer body is required");
+            }
+
+            return { op: "steer", body: value.body, force: Boolean(value.force) };
+        case "interrupt":
+            return { op: "interrupt" };
+        case "rollback":
+            return { op: "rollback", turns: rollbackTurns(value.turns) };
+        case "read":
+            return { op: "read" };
+        case "review": {
+            const scope = value.scope ?? "auto";
+            if (scope !== "auto" && scope !== "working-tree" && scope !== "branch") {
+                throw new Error(`Unsupported review scope: ${String(scope)}`);
+            }
+
+            const adversarial =
+                value.adversarial === true
+                    ? []
+                    : Array.isArray(value.adversarial)
+                      ? value.adversarial.filter((focus): focus is string => typeof focus === "string")
+                      : undefined;
+            return {
+                op: "review",
+                scope,
+                ...(typeof value.base === "string" ? { base: value.base } : {}),
+                ...(adversarial ? { adversarial } : {}),
+            };
+        }
+        case "approve":
+        case "deny":
+            return { op: value.op, requestId: requiredRequestId(value.requestId) };
+        case "stop":
+            return { op: "stop" };
+        default:
+            throw new Error(`Unsupported control op: ${String(value.op)}`);
+    }
+}
+
+export function parseControlBody(body: string): CodexControl {
+    const trimmed = body.trim();
+    if (!trimmed) {
+        throw new Error("Control body is empty");
+    }
+
+    if (trimmed === "/interrupt") {
+        return { op: "interrupt" };
+    }
+
+    if (trimmed === "/stop") {
+        return { op: "stop" };
+    }
+
+    const rollback = trimmed.match(/^\/rollback(?:\s+(\d+))?$/);
+    if (rollback) {
+        return { op: "rollback", turns: rollbackTurns(Number(rollback[1] ?? "1")) };
+    }
+
+    if (trimmed.startsWith("{")) {
+        const parsed = SafeJSON.parse(trimmed, { strict: true });
+        if (!isRecord(parsed)) {
+            throw new Error("Structured control body must be an object");
+        }
+
+        return parseStructuredControl(parsed);
+    }
+
+    return { op: "steer", body, force: false };
+}

--- a/src/codex/lib/paths.ts
+++ b/src/codex/lib/paths.ts
@@ -1,0 +1,45 @@
+import { join, resolve, sep } from "node:path";
+import { env } from "@app/utils/env";
+
+export function codexRoot(): string {
+    return join(env.tools.getHome(), ".genesis-tools", "codex");
+}
+
+export function sessionsDir(): string {
+    return join(codexRoot(), "sessions");
+}
+
+function safeSessionPath(name: string, suffix: string): string {
+    const root = sessionsDir();
+    const candidate = resolve(root, `${name}${suffix}`);
+    const validName = /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name);
+    if (!validName || !candidate.startsWith(`${root}${sep}`)) {
+        throw new Error(`Invalid session name: ${name}`);
+    }
+
+    return candidate;
+}
+
+export function sessionMetaPath(name: string): string {
+    return safeSessionPath(name, ".meta.json");
+}
+
+export function sessionEventsPath(name: string): string {
+    return safeSessionPath(name, ".jsonl");
+}
+
+export function sessionDaemonLogPath(name: string): string {
+    return safeSessionPath(name, ".daemon.log");
+}
+
+export function sessionControlPath(name: string): string {
+    return safeSessionPath(name, ".control.jsonl");
+}
+
+export function sessionLaunchPath(name: string): string {
+    return safeSessionPath(name, ".launch.json");
+}
+
+export function sessionResponsePath(name: string, requestId: string): string {
+    return safeSessionPath(name, `.response.${requestId}.json`);
+}

--- a/src/codex/lib/seed-instructions.test.ts
+++ b/src/codex/lib/seed-instructions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { buildAgentInstructions } from "./seed-instructions";
+
+describe("buildAgentInstructions", () => {
+    test("pins every agents command to the parent rendezvous session", () => {
+        const instructions = buildAgentInstructions({
+            agentName: "codex_reviewer",
+            rendezvousSession: "parent-123",
+            leadName: "lead",
+        });
+
+        expect(instructions).toContain("--from codex_reviewer --to lead");
+        expect(instructions).toContain("--agent-name codex_reviewer --once --session parent-123");
+        expect(instructions.match(/--session parent-123/g)?.length).toBeGreaterThanOrEqual(3);
+    });
+});

--- a/src/codex/lib/seed-instructions.ts
+++ b/src/codex/lib/seed-instructions.ts
@@ -1,0 +1,18 @@
+export function buildAgentInstructions(options: {
+    agentName: string;
+    rendezvousSession: string;
+    leadName: string;
+}): string {
+    const sessionFlag = `--session ${options.rendezvousSession}`;
+
+    return [
+        `You are \`${options.agentName}\`, a member of a Claude Code agent swarm. The lead agent is \`${options.leadName}\`.`,
+        "Report progress, findings, and questions with:",
+        `tools agents message --from ${options.agentName} --to ${options.leadName} --body '<text>' ${sessionFlag}`,
+        "Check for replies or steering from the lead with:",
+        `tools agents login --agent-name ${options.agentName} --once ${sessionFlag}`,
+        "Reply to a specific message with:",
+        `tools agents message --from ${options.agentName} --reply <id> --body '<text>' ${sessionFlag}`,
+        "Prefer one concise message per meaningful step.",
+    ].join("\n");
+}

--- a/src/codex/lib/session.test.ts
+++ b/src/codex/lib/session.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+import type { RpcClient } from "./session";
+import { CodexSessionRuntime } from "./session";
+import { type CodexSessionMeta, CodexSessionStore } from "./store";
+
+class FakeRpcClient implements RpcClient {
+    readonly requests: Array<{ method: string; params: unknown }> = [];
+    readonly notifications: Array<{ method: string; params: unknown }> = [];
+    private turn = 0;
+    rejectNextTurn: Error | null = null;
+
+    async request<T>(method: string, params?: unknown): Promise<T> {
+        this.requests.push({ method, params });
+
+        if (method === "initialize") {
+            return {} as T;
+        }
+
+        if (method === "thread/start") {
+            return { thread: { id: "thread-1" } } as T;
+        }
+
+        if (method === "turn/start") {
+            if (this.rejectNextTurn) {
+                const error = this.rejectNextTurn;
+                this.rejectNextTurn = null;
+                throw error;
+            }
+
+            this.turn += 1;
+            return { turn: { id: `turn-${this.turn}` } } as T;
+        }
+
+        if (method === "turn/interrupt" || method === "thread/rollback" || method === "thread/unsubscribe") {
+            return {} as T;
+        }
+
+        if (method === "thread/read") {
+            return { thread: { id: "thread-1", turns: [] } } as T;
+        }
+
+        if (method === "review/start") {
+            return { turn: { id: "review-turn-1" }, reviewThreadId: "thread-1" } as T;
+        }
+
+        throw new Error(`Unexpected request: ${method}`);
+    }
+
+    async notify(method: string, params?: unknown): Promise<void> {
+        this.notifications.push({ method, params });
+    }
+
+    async close(): Promise<void> {}
+}
+
+function makeMeta(home: string): CodexSessionMeta {
+    const now = new Date().toISOString();
+    return {
+        name: "reviewer",
+        daemonPid: 123,
+        cwd: "/repo",
+        sandbox: "workspace-write",
+        approvalPolicy: "never",
+        writePolicy: "allow",
+        status: "starting",
+        agentName: "codex_reviewer",
+        rendezvousSession: "parent-123",
+        agentsEnabled: true,
+        startedAt: now,
+        lastEventAt: now,
+        codexVersion: "0.144.5",
+        pendingApprovals: {},
+        home,
+    };
+}
+
+describe("CodexSessionRuntime", () => {
+    test("handshakes, starts a thread, and fires the first turn with exact v0.144 input", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(home);
+            store.writeMeta(meta);
+            const client = new FakeRpcClient();
+            const runtime = new CodexSessionRuntime({ client, store, meta });
+
+            await runtime.start({ prompt: "Review the auth path" });
+
+            expect(client.requests.map((request) => request.method)).toEqual([
+                "initialize",
+                "thread/start",
+                "turn/start",
+            ]);
+            expect(client.notifications).toEqual([{ method: "initialized", params: undefined }]);
+            expect(client.requests[1]?.params).toMatchObject({
+                cwd: "/repo",
+                sandbox: "workspace-write",
+                approvalPolicy: "never",
+                developerInstructions: expect.stringContaining("--session parent-123"),
+            });
+            expect(client.requests[2]?.params).toEqual({
+                threadId: "thread-1",
+                input: [{ type: "text", text: "Review the auth path", text_elements: [] }],
+            });
+
+            const persisted = await store.readMeta("reviewer");
+            expect(persisted?.threadId).toBe("thread-1");
+            expect(persisted?.activeTurnId).toBe("turn-1");
+            expect(persisted?.status).toBe("running");
+        });
+    });
+
+    test("tracks turn lifecycle and usage from notifications", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-events-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(home);
+            store.writeMeta(meta);
+            const runtime = new CodexSessionRuntime({ client: new FakeRpcClient(), store, meta });
+            await runtime.start({});
+
+            await runtime.handleNotification({ method: "turn/started", params: { turn: { id: "turn-9" } } });
+            await runtime.handleNotification({
+                method: "thread/tokenUsage/updated",
+                params: { tokenUsage: { total: { inputTokens: 10, outputTokens: 4, cachedInputTokens: 3 } } },
+            });
+            await runtime.handleNotification({ method: "turn/completed", params: { turn: { id: "turn-9" } } });
+
+            const persisted = await store.readMeta("reviewer");
+            expect(persisted?.status).toBe("ready");
+            expect(persisted?.activeTurnId).toBeUndefined();
+            expect(persisted?.usage).toEqual({ inputTokens: 10, outputTokens: 4, cachedInputTokens: 3 });
+            expect((await store.readEvents("reviewer")).map((event) => event.method)).toEqual([
+                "daemon/started",
+                "turn/started",
+                "thread/tokenUsage/updated",
+                "turn/completed",
+            ]);
+        });
+    });
+
+    test("steers the active turn by re-submitting turn/start", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-steer-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(home);
+            store.writeMeta(meta);
+            const client = new FakeRpcClient();
+            const runtime = new CodexSessionRuntime({ client, store, meta });
+            await runtime.start({ prompt: "Begin" });
+
+            const result = await runtime.execute({ op: "steer", body: "Focus on auth", force: false });
+
+            expect(result).toEqual({ turnId: "turn-2", queued: false });
+            expect(client.requests.at(-1)).toEqual({
+                method: "turn/start",
+                params: {
+                    threadId: "thread-1",
+                    input: [{ type: "text", text: "Focus on auth", text_elements: [] }],
+                },
+            });
+        });
+    });
+
+    test("queues a rejected same-turn steer and delivers it at the boundary", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-queue-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(home);
+            store.writeMeta(meta);
+            const client = new FakeRpcClient();
+            const runtime = new CodexSessionRuntime({ client, store, meta });
+            await runtime.start({ prompt: "Begin" });
+            client.rejectNextTurn = new Error("active turn cannot accept same-turn steering");
+
+            await expect(runtime.execute({ op: "steer", body: "Queued correction", force: false })).resolves.toEqual({
+                queued: true,
+            });
+            await runtime.handleNotification({ method: "turn/completed", params: { turn: { id: "turn-1" } } });
+
+            expect(client.requests.at(-1)?.method).toBe("turn/start");
+            expect(client.requests.at(-1)?.params).toMatchObject({
+                input: [{ type: "text", text: "Queued correction", text_elements: [] }],
+            });
+            expect((await store.readMeta("reviewer"))?.queuedSteers).toEqual([]);
+        });
+    });
+
+    test("interrupts, rolls back, and reads the thread", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-controls-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(home);
+            store.writeMeta(meta);
+            const client = new FakeRpcClient();
+            const runtime = new CodexSessionRuntime({ client, store, meta });
+            await runtime.start({ prompt: "Begin" });
+
+            await runtime.execute({ op: "interrupt" });
+            await runtime.execute({ op: "rollback", turns: 2 });
+            const snapshot = await runtime.execute({ op: "read" });
+
+            expect(client.requests.slice(-3)).toEqual([
+                { method: "turn/interrupt", params: { threadId: "thread-1", turnId: "turn-1" } },
+                { method: "thread/rollback", params: { threadId: "thread-1", numTurns: 2 } },
+                { method: "thread/read", params: { threadId: "thread-1", includeTurns: true } },
+            ]);
+            expect(snapshot).toEqual({ thread: { id: "thread-1", turns: [] } });
+        });
+    });
+
+    test("starts native and adversarial reviews", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-review-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(home);
+            store.writeMeta(meta);
+            const client = new FakeRpcClient();
+            const runtime = new CodexSessionRuntime({ client, store, meta });
+            await runtime.start({});
+
+            await runtime.execute({ op: "review", scope: "working-tree" });
+            await runtime.execute({ op: "review", scope: "branch", base: "main", adversarial: ["auth", "rollback"] });
+
+            expect(client.requests.at(-2)).toEqual({
+                method: "review/start",
+                params: { threadId: "thread-1", target: { type: "uncommittedChanges" } },
+            });
+            expect(client.requests.at(-1)?.method).toBe("turn/start");
+            expect(client.requests.at(-1)?.params).toMatchObject({
+                input: [
+                    {
+                        type: "text",
+                        text: expect.stringContaining("auth, rollback"),
+                        text_elements: [],
+                    },
+                ],
+            });
+        });
+    });
+
+    test("auto-answers approval requests for allow and deny policies", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-auto-approval-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const allowMeta = makeMeta(home);
+            store.writeMeta(allowMeta);
+            const allowRuntime = new CodexSessionRuntime({ client: new FakeRpcClient(), store, meta: allowMeta });
+            await expect(
+                allowRuntime.handleServerRequest({
+                    id: "allow-1",
+                    method: "item/fileChange/requestApproval",
+                    params: { itemId: "item-1" },
+                })
+            ).resolves.toEqual({ decision: "accept" });
+
+            const denyMeta = { ...makeMeta(home), name: "deny", writePolicy: "deny" as const };
+            store.writeMeta(denyMeta);
+            const denyRuntime = new CodexSessionRuntime({ client: new FakeRpcClient(), store, meta: denyMeta });
+            await expect(
+                denyRuntime.handleServerRequest({
+                    id: "deny-1",
+                    method: "item/commandExecution/requestApproval",
+                    params: { command: "touch x" },
+                })
+            ).resolves.toEqual({ decision: "decline" });
+        });
+    });
+
+    test("holds ask approvals until an approve control resolves them", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-ask-approval-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = {
+                ...makeMeta(home),
+                writePolicy: "ask" as const,
+                approvalPolicy: "untrusted" as const,
+            };
+            store.writeMeta(meta);
+            const notices: Array<Record<string, unknown>> = [];
+            const runtime = new CodexSessionRuntime({
+                client: new FakeRpcClient(),
+                store,
+                meta,
+                onApprovalRequest: async (notice) => {
+                    notices.push(notice);
+                },
+            });
+
+            const pending = runtime.handleServerRequest({
+                id: "request-1",
+                method: "item/fileChange/requestApproval",
+                params: { itemId: "item-1", reason: "write src/x.ts" },
+            });
+            await Bun.sleep(10);
+
+            expect(notices).toEqual([expect.objectContaining({ event: "approval_request", requestId: "request-1" })]);
+            expect((await store.readMeta("reviewer"))?.pendingApprovals["request-1"]).toMatchObject({
+                method: "item/fileChange/requestApproval",
+            });
+
+            await runtime.execute({ op: "approve", requestId: "request-1" });
+            await expect(pending).resolves.toEqual({ decision: "accept" });
+            expect((await store.readMeta("reviewer"))?.pendingApprovals).toEqual({});
+        });
+    });
+
+    test("declines and clears unresolved approvals while closing", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-runtime-close-approval-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = {
+                ...makeMeta(home),
+                writePolicy: "ask" as const,
+                approvalPolicy: "untrusted" as const,
+            };
+            store.writeMeta(meta);
+            const runtime = new CodexSessionRuntime({ client: new FakeRpcClient(), store, meta });
+            await runtime.start({});
+            const pending = runtime.handleServerRequest({
+                id: "request-1",
+                method: "item/commandExecution/requestApproval",
+                params: { command: "touch x" },
+            });
+            await Bun.sleep(0);
+
+            await runtime.close();
+
+            await expect(pending).resolves.toEqual({ decision: "decline" });
+            expect((await store.readMeta("reviewer"))?.pendingApprovals).toEqual({});
+        });
+    });
+});

--- a/src/codex/lib/session.ts
+++ b/src/codex/lib/session.ts
@@ -1,0 +1,429 @@
+import { logger } from "@app/logger";
+import type {
+    InitializeParams,
+    ReviewStartParams,
+    ReviewTarget,
+    ThreadReadParams,
+    ThreadRollbackParams,
+    ThreadStartParams,
+    ThreadUnsubscribeParams,
+    TurnInterruptParams,
+    TurnStartParams,
+} from "./_generated/protocol";
+import type { RpcNotification, RpcServerRequest } from "./app-server-client";
+import type { CodexControl } from "./control";
+import { buildAgentInstructions } from "./seed-instructions";
+import type { CodexSessionMeta, CodexSessionStore } from "./store";
+
+const log = logger.child({ component: "codex:session" });
+
+export interface RpcClient {
+    request<T>(method: string, params?: unknown): Promise<T>;
+    notify(method: string, params?: unknown): Promise<void>;
+    close(): Promise<void>;
+}
+
+interface RuntimeOptions {
+    client: RpcClient;
+    store: CodexSessionStore;
+    meta: CodexSessionMeta;
+    onApprovalRequest?: (notice: Record<string, unknown>) => void | Promise<void>;
+}
+
+interface ThreadStartResult {
+    thread: { id: string };
+}
+
+interface TurnStartResult {
+    turn: { id: string };
+}
+
+interface ReviewStartResult {
+    turn: { id: string };
+    reviewThreadId: string;
+}
+
+interface PendingApprovalDecision {
+    method: string;
+    resolve: (response: unknown) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nestedRecord(value: unknown, key: string): Record<string, unknown> | null {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const nested = value[key];
+    return isRecord(nested) ? nested : null;
+}
+
+function turnIdFromParams(params: unknown): string | undefined {
+    const turn = nestedRecord(params, "turn");
+    return typeof turn?.id === "string" ? turn.id : undefined;
+}
+
+function usageFromParams(params: unknown): Record<string, number> | undefined {
+    const tokenUsage = nestedRecord(params, "tokenUsage");
+    const total = nestedRecord(tokenUsage, "total");
+    if (!total) {
+        return undefined;
+    }
+
+    const usage: Record<string, number> = {};
+    for (const [key, value] of Object.entries(total)) {
+        if (typeof value === "number") {
+            usage[key] = value;
+        }
+    }
+
+    return usage;
+}
+
+export class CodexSessionRuntime {
+    private readonly client: RpcClient;
+    private readonly store: CodexSessionStore;
+    private meta: CodexSessionMeta;
+    private readonly onApprovalRequest: RuntimeOptions["onApprovalRequest"];
+    private readonly pendingApprovalDecisions = new Map<string, PendingApprovalDecision>();
+
+    constructor(options: RuntimeOptions) {
+        this.client = options.client;
+        this.store = options.store;
+        this.meta = options.meta;
+        this.onApprovalRequest = options.onApprovalRequest;
+    }
+
+    async start(options: { prompt?: string }): Promise<void> {
+        this.store.appendEvent(this.meta.name, { source: "daemon", method: "daemon/started" });
+
+        const initialize: InitializeParams = {
+            clientInfo: {
+                name: "genesis-tools-codex",
+                title: "GenesisTools Codex",
+                version: "0.1.0",
+            },
+            capabilities: null,
+        };
+        await this.client.request("initialize", initialize);
+        await this.client.notify("initialized");
+
+        const threadParams: ThreadStartParams = {
+            cwd: this.meta.cwd,
+            sandbox: this.meta.sandbox,
+            approvalPolicy: this.meta.approvalPolicy,
+            ...(this.meta.model ? { model: this.meta.model } : {}),
+            ...(this.meta.agentsEnabled
+                ? {
+                      developerInstructions: buildAgentInstructions({
+                          agentName: this.meta.agentName,
+                          rendezvousSession: this.meta.rendezvousSession,
+                          leadName: "lead",
+                      }),
+                  }
+                : {}),
+        };
+        const thread = await this.client.request<ThreadStartResult>("thread/start", threadParams);
+        await this.updateMeta({ threadId: thread.thread.id, status: "ready" });
+
+        if (options.prompt) {
+            await this.startTurn(options.prompt);
+        }
+    }
+
+    async startTurn(body: string): Promise<string> {
+        if (!this.meta.threadId) {
+            throw new Error("Codex thread is not initialized");
+        }
+
+        const params: TurnStartParams = {
+            threadId: this.meta.threadId,
+            input: [{ type: "text", text: body, text_elements: [] }],
+            ...(this.meta.model ? { model: this.meta.model } : {}),
+            ...(this.meta.effort ? { effort: this.meta.effort as TurnStartParams["effort"] } : {}),
+        };
+        const result = await this.client.request<TurnStartResult>("turn/start", params);
+        await this.updateMeta({ activeTurnId: result.turn.id, status: "running" });
+        return result.turn.id;
+    }
+
+    async handleNotification(notification: RpcNotification): Promise<void> {
+        this.store.appendEvent(this.meta.name, {
+            source: "app-server",
+            method: notification.method,
+            params: notification.params,
+        });
+
+        const lastEventAt = new Date().toISOString();
+
+        if (notification.method === "turn/started") {
+            await this.updateMeta({
+                activeTurnId: turnIdFromParams(notification.params),
+                status: "running",
+                lastEventAt,
+            });
+            return;
+        }
+
+        if (notification.method === "turn/completed") {
+            await this.updateMeta({ activeTurnId: undefined, status: "ready", lastEventAt });
+            await this.deliverQueuedSteer();
+            return;
+        }
+
+        if (notification.method === "turn/failed") {
+            await this.updateMeta({ activeTurnId: undefined, status: "ready", lastEventAt });
+            return;
+        }
+
+        if (notification.method === "thread/tokenUsage/updated") {
+            await this.updateMeta({ usage: usageFromParams(notification.params), lastEventAt });
+            return;
+        }
+
+        await this.updateMeta({ lastEventAt });
+    }
+
+    async execute(control: CodexControl): Promise<unknown> {
+        switch (control.op) {
+            case "steer":
+                return this.steer(control.body, control.force);
+            case "interrupt":
+                return this.interrupt();
+            case "rollback":
+                return this.rollback(control.turns);
+            case "read":
+                return this.read();
+            case "review":
+                return this.review(control);
+            case "approve":
+            case "deny":
+                return this.resolveApproval(control.requestId, control.op === "approve");
+            case "stop":
+                throw new Error(`Control op ${control.op} is not available in this runtime phase`);
+        }
+    }
+
+    async handleServerRequest(request: RpcServerRequest): Promise<unknown> {
+        if (!isApprovalMethod(request.method)) {
+            throw new Error(`Unsupported Codex server request: ${request.method}`);
+        }
+
+        if (this.meta.writePolicy === "allow") {
+            return approvalResponse(request.method, true);
+        }
+
+        if (this.meta.writePolicy === "deny") {
+            return approvalResponse(request.method, false);
+        }
+
+        const requestId = String(request.id);
+        const pendingApprovals = {
+            ...this.meta.pendingApprovals,
+            [requestId]: {
+                rpcId: request.id,
+                method: request.method,
+                detail: approvalDetail(request.params),
+                requestedAt: new Date().toISOString(),
+            },
+        };
+        await this.updateMeta({ pendingApprovals });
+
+        const response = new Promise<unknown>((resolve) => {
+            this.pendingApprovalDecisions.set(requestId, { method: request.method, resolve });
+        });
+        await this.onApprovalRequest?.({
+            event: "approval_request",
+            op: "approval_request",
+            requestId,
+            method: request.method,
+            detail: approvalDetail(request.params),
+        });
+        return response;
+    }
+
+    async close(): Promise<void> {
+        for (const pending of this.pendingApprovalDecisions.values()) {
+            pending.resolve(approvalResponse(pending.method, false));
+        }
+        this.pendingApprovalDecisions.clear();
+
+        if (this.meta.threadId) {
+            const params: ThreadUnsubscribeParams = { threadId: this.meta.threadId };
+            try {
+                await this.client.request("thread/unsubscribe", params);
+            } catch (err) {
+                log.debug({ err, threadId: this.meta.threadId }, "thread unsubscribe failed during close");
+                // The child may already be gone; close still needs to release local resources.
+            }
+        }
+
+        await this.client.close();
+        await this.updateMeta({
+            activeTurnId: undefined,
+            status: "closed",
+            lastEventAt: new Date().toISOString(),
+            pendingApprovals: {},
+        });
+    }
+
+    private async updateMeta(update: Partial<CodexSessionMeta>): Promise<void> {
+        this.meta = await this.store.updateMeta(this.meta.name, update);
+    }
+
+    private threadId(): string {
+        if (!this.meta.threadId) {
+            throw new Error("Codex thread is not initialized");
+        }
+
+        return this.meta.threadId;
+    }
+
+    private async steer(body: string, force: boolean): Promise<{ turnId?: string; queued: boolean }> {
+        try {
+            const turnId = await this.startTurn(body);
+            return { turnId, queued: false };
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (!/same-turn steer|same-turn steering|cannot accept/i.test(message)) {
+                throw err;
+            }
+
+            if (force) {
+                await this.interrupt();
+                const turnId = await this.startTurn(body);
+                return { turnId, queued: false };
+            }
+
+            const queuedSteers = [...(this.meta.queuedSteers ?? []), { body, force: false }];
+            await this.updateMeta({ queuedSteers });
+            return { queued: true };
+        }
+    }
+
+    private async interrupt(): Promise<{ interrupted: boolean }> {
+        if (!this.meta.activeTurnId) {
+            return { interrupted: false };
+        }
+
+        const params: TurnInterruptParams = {
+            threadId: this.threadId(),
+            turnId: this.meta.activeTurnId,
+        };
+        await this.client.request("turn/interrupt", params);
+        return { interrupted: true };
+    }
+
+    private async rollback(turns: number): Promise<{ rolledBack: number }> {
+        const params: ThreadRollbackParams = { threadId: this.threadId(), numTurns: turns };
+        await this.client.request("thread/rollback", params);
+        return { rolledBack: turns };
+    }
+
+    private async read(): Promise<unknown> {
+        const params: ThreadReadParams = { threadId: this.threadId(), includeTurns: true };
+        return this.client.request("thread/read", params);
+    }
+
+    private async deliverQueuedSteer(): Promise<void> {
+        const [next, ...rest] = this.meta.queuedSteers ?? [];
+        if (!next) {
+            return;
+        }
+
+        await this.startTurn(next.body);
+        await this.updateMeta({ queuedSteers: rest });
+    }
+
+    private async review(control: Extract<CodexControl, { op: "review" }>): Promise<unknown> {
+        if (control.adversarial) {
+            const focus = control.adversarial.length > 0 ? control.adversarial.join(", ") : "all material risks";
+            const target = control.base ? `changes against ${control.base}` : "the current working tree";
+            return this.startTurn(buildAdversarialReviewPrompt({ target, focus }));
+        }
+
+        const target = reviewTarget(control);
+        const params: ReviewStartParams = { threadId: this.threadId(), target };
+        const result = await this.client.request<ReviewStartResult>("review/start", params);
+        await this.updateMeta({ activeTurnId: result.turn.id, status: "running" });
+        return { turnId: result.turn.id, reviewThreadId: result.reviewThreadId };
+    }
+
+    private async resolveApproval(requestId: string, approved: boolean): Promise<{ resolved: boolean }> {
+        const pending = this.pendingApprovalDecisions.get(requestId);
+        if (!pending) {
+            throw new Error(`Pending approval not found: ${requestId}`);
+        }
+
+        this.pendingApprovalDecisions.delete(requestId);
+        const pendingApprovals = { ...this.meta.pendingApprovals };
+        delete pendingApprovals[requestId];
+        await this.updateMeta({ pendingApprovals });
+        pending.resolve(approvalResponse(pending.method, approved));
+        return { resolved: true };
+    }
+}
+
+function isApprovalMethod(method: string): boolean {
+    return (
+        method === "item/commandExecution/requestApproval" ||
+        method === "item/fileChange/requestApproval" ||
+        method === "applyPatchApproval" ||
+        method === "execCommandApproval"
+    );
+}
+
+function approvalResponse(method: string, approved: boolean): { decision: string } {
+    if (method === "applyPatchApproval" || method === "execCommandApproval") {
+        return { decision: approved ? "approved" : "denied" };
+    }
+
+    return { decision: approved ? "accept" : "decline" };
+}
+
+function approvalDetail(params: unknown): string {
+    if (!isRecord(params)) {
+        return "Codex requested approval";
+    }
+
+    for (const key of ["reason", "command", "grantRoot", "itemId"]) {
+        if (typeof params[key] === "string" && params[key]) {
+            return params[key];
+        }
+    }
+
+    return "Codex requested approval";
+}
+
+function reviewTarget(control: Extract<CodexControl, { op: "review" }>): ReviewTarget {
+    if (control.scope === "branch") {
+        if (!control.base) {
+            throw new Error("--base is required for --scope branch");
+        }
+
+        return { type: "baseBranch", branch: control.base };
+    }
+
+    if (control.base && control.scope !== "working-tree") {
+        return { type: "baseBranch", branch: control.base };
+    }
+
+    return { type: "uncommittedChanges" };
+}
+
+function buildAdversarialReviewPrompt(options: { target: string; focus: string }): string {
+    return `<role>
+You are Codex performing an adversarial software review. Your job is to break confidence in the change, not validate it.
+</role>
+
+<task>
+Review ${options.target}. User focus: ${options.focus}.
+</task>
+
+Default to skepticism. Prioritize auth and trust boundaries, data loss, rollback and retry safety, races, stale state,
+timeouts, schema drift, and observability gaps. Actively try to disprove the change. Report only material, grounded,
+actionable findings tied to concrete files and lines. Prefer one strong finding over several weak ones.`;
+}

--- a/src/codex/lib/spawn.test.ts
+++ b/src/codex/lib/spawn.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { parseWritePolicy, resolveWritePolicy } from "./spawn";
+
+describe("resolveWritePolicy", () => {
+    test("defaults to a read-only reviewer", () => {
+        expect(resolveWritePolicy()).toEqual({
+            writePolicy: "deny",
+            sandbox: "read-only",
+            approvalPolicy: "never",
+        });
+    });
+
+    test("maps allow and ask to workspace-write with different approvals", () => {
+        expect(resolveWritePolicy("allow")).toEqual({
+            writePolicy: "allow",
+            sandbox: "workspace-write",
+            approvalPolicy: "never",
+        });
+        expect(resolveWritePolicy("ask")).toEqual({
+            writePolicy: "ask",
+            sandbox: "workspace-write",
+            approvalPolicy: "untrusted",
+        });
+    });
+
+    test("rejects unknown write policies instead of silently using deny", () => {
+        expect(parseWritePolicy(undefined)).toBeUndefined();
+        expect(parseWritePolicy("ask")).toBe("ask");
+        expect(() => parseWritePolicy("sometimes")).toThrow("--write must be ask, allow, or deny");
+    });
+
+    test("keeps explicit deny read-only", () => {
+        expect(resolveWritePolicy("deny")).toEqual({
+            writePolicy: "deny",
+            sandbox: "read-only",
+            approvalPolicy: "never",
+        });
+    });
+});

--- a/src/codex/lib/spawn.ts
+++ b/src/codex/lib/spawn.ts
@@ -1,0 +1,157 @@
+import { closeSync, openSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { isProcessAlive } from "@app/task/lib/process-alive";
+import { env } from "@app/utils/env";
+import { SafeJSON } from "@app/utils/json";
+import { atomicWriteFileSync } from "@app/utils/storage/storage";
+import { CODEX_SCHEMA_VERSION } from "./_generated/protocol";
+import { sessionDaemonLogPath, sessionLaunchPath } from "./paths";
+import { type CodexSessionMeta, CodexSessionStore, type CodexWritePolicy } from "./store";
+import { detectCodexVersion } from "./version";
+
+export interface SpawnOptions {
+    name: string;
+    cwd?: string;
+    home?: string;
+    model?: string;
+    effort?: string;
+    write?: CodexWritePolicy;
+    mode?: "review" | "task";
+    prompt?: string;
+    agents?: boolean;
+    rendezvousSession?: string;
+    writableRoots?: string[];
+}
+
+export interface LaunchConfig {
+    name: string;
+    prompt?: string;
+    mode: "review" | "task";
+    writableRoots: string[];
+}
+
+export function parseWritePolicy(value: string | undefined): CodexWritePolicy | undefined {
+    if (value === undefined || value === "ask" || value === "allow" || value === "deny") {
+        return value;
+    }
+
+    throw new Error("--write must be ask, allow, or deny");
+}
+
+export function resolveWritePolicy(
+    write?: CodexWritePolicy
+): Pick<CodexSessionMeta, "writePolicy" | "sandbox" | "approvalPolicy"> {
+    if (write === "ask") {
+        return { writePolicy: "ask", sandbox: "workspace-write", approvalPolicy: "untrusted" };
+    }
+
+    if (write === "allow") {
+        return { writePolicy: "allow", sandbox: "workspace-write", approvalPolicy: "never" };
+    }
+
+    return { writePolicy: "deny", sandbox: "read-only", approvalPolicy: "never" };
+}
+
+export async function spawnCodexSession(options: SpawnOptions): Promise<CodexSessionMeta> {
+    const store = new CodexSessionStore();
+    const existing = await store.readMeta(options.name);
+    if (
+        existing &&
+        existing.status !== "closed" &&
+        existing.status !== "failed" &&
+        isProcessAlive(existing.daemonPid)
+    ) {
+        throw new Error(`Codex session "${options.name}" is already active (pid ${existing.daemonPid})`);
+    }
+
+    const rendezvousSession =
+        options.rendezvousSession ??
+        env.ai.getByEnvKey("CLAUDE_CODE_SESSION_ID") ??
+        env.getTrimmed("GT_RENDEZVOUS_SESSION");
+    const agentsEnabled = options.agents ?? true;
+    if (agentsEnabled && !rendezvousSession) {
+        throw new Error("A parent agents session is required. Run from Claude Code or pass --session <id>.");
+    }
+
+    const codexVersion = await detectCodexVersion();
+    const now = new Date().toISOString();
+    const cwd = resolve(options.cwd ?? process.cwd());
+    const policy = resolveWritePolicy(options.write);
+    const writableRoots = [...(options.writableRoots ?? [])];
+
+    if (agentsEnabled && policy.sandbox === "workspace-write") {
+        writableRoots.push(join(env.tools.getHome(), ".genesis-tools"));
+    }
+
+    const launch: LaunchConfig = {
+        name: options.name,
+        mode: options.mode ?? "task",
+        writableRoots: [...new Set(writableRoots.map((path) => resolve(path)))],
+        ...(options.prompt ? { prompt: options.prompt } : {}),
+    };
+    atomicWriteFileSync(sessionLaunchPath(options.name), SafeJSON.stringify(launch, null, 2));
+
+    const daemonEntry = resolve(import.meta.dir, "../daemon.ts");
+    const logFd = openSync(sessionDaemonLogPath(options.name), "a");
+    const meta: CodexSessionMeta = {
+        name: options.name,
+        daemonPid: 0,
+        cwd,
+        ...(options.home ? { home: resolve(options.home) } : {}),
+        ...(options.model ? { model: options.model } : {}),
+        ...(options.effort ? { effort: options.effort } : {}),
+        ...policy,
+        status: "starting",
+        agentName: `codex_${options.name}`,
+        rendezvousSession: rendezvousSession ?? `codex-${options.name}`,
+        agentsEnabled,
+        startedAt: now,
+        lastEventAt: now,
+        codexVersion,
+        pendingApprovals: {},
+    };
+    store.writeMeta(meta);
+
+    const proc = (() => {
+        try {
+            return Bun.spawn({
+                cmd: [process.execPath, daemonEntry, "--name", options.name],
+                cwd,
+                env: {
+                    ...env.getProcessEnv(),
+                    ...(rendezvousSession ? { GT_RENDEZVOUS_SESSION: rendezvousSession } : {}),
+                },
+                stdin: "ignore",
+                stdout: logFd,
+                stderr: logFd,
+                detached: true,
+            });
+        } finally {
+            closeSync(logFd);
+        }
+    })();
+    proc.unref();
+    store.writeMeta({ ...meta, daemonPid: proc.pid });
+
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+        const current = await store.readMeta(options.name);
+        if (current?.status === "ready" || current?.status === "running") {
+            return current;
+        }
+
+        if (current?.status === "failed" || current?.status === "closed") {
+            throw new Error(`Codex daemon failed to start. See ${sessionDaemonLogPath(options.name)}`);
+        }
+
+        await Bun.sleep(50);
+    }
+
+    throw new Error(`Timed out starting Codex session. See ${sessionDaemonLogPath(options.name)}`);
+}
+
+export function schemaDriftWarning(version: string): string | null {
+    return version === CODEX_SCHEMA_VERSION
+        ? null
+        : `Installed codex ${version} differs from generated app-server schema ${CODEX_SCHEMA_VERSION}`;
+}

--- a/src/codex/lib/store.test.ts
+++ b/src/codex/lib/store.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@app/utils/env";
+import { type CodexSessionMeta, CodexSessionStore, deriveSessionStatus } from "./store";
+
+function makeMeta(now: number): CodexSessionMeta {
+    return {
+        name: "reviewer",
+        daemonPid: 123,
+        cwd: "/repo",
+        sandbox: "read-only",
+        approvalPolicy: "never",
+        writePolicy: "deny",
+        status: "running",
+        agentName: "codex_reviewer",
+        rendezvousSession: "parent-session",
+        agentsEnabled: true,
+        startedAt: new Date(now - 5_000).toISOString(),
+        lastEventAt: new Date(now - 1_000).toISOString(),
+        codexVersion: "0.144.5",
+        pendingApprovals: {},
+    };
+}
+
+describe("CodexSessionStore", () => {
+    test("persists metadata atomically and lists sessions", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-store-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            const meta = makeMeta(Date.now());
+            store.writeMeta(meta);
+
+            await expect(store.readMeta("reviewer")).resolves.toEqual(meta);
+            await expect(store.listNames()).resolves.toEqual(["reviewer"]);
+        });
+    });
+
+    test("appends structured events in order", async () => {
+        const home = mkdtempSync(join(tmpdir(), "gt-codex-events-"));
+
+        await env.testing.withOverrides({ GENESIS_TOOLS_HOME: home }, async () => {
+            const store = new CodexSessionStore();
+            store.appendEvent("reviewer", { source: "app-server", method: "turn/started", params: { id: "t1" } });
+            store.appendEvent("reviewer", { source: "control", method: "steer", params: { body: "focus" } });
+
+            const events = await store.readEvents("reviewer");
+            expect(events.map((event) => event.seq)).toEqual([1, 2]);
+            expect(events.map((event) => event.method)).toEqual(["turn/started", "steer"]);
+        });
+    });
+
+    test("derives stalled and closed states without mutating persisted state", () => {
+        const now = Date.now();
+        const meta = makeMeta(now);
+        expect(deriveSessionStatus(meta, now, 10_000)).toBe("running");
+        expect(deriveSessionStatus({ ...meta, lastEventAt: new Date(now - 20_000).toISOString() }, now, 10_000)).toBe(
+            "stalled"
+        );
+        expect(deriveSessionStatus({ ...meta, status: "closed" }, now, 10_000)).toBe("closed");
+    });
+
+    test("rejects unsafe session names", async () => {
+        const store = new CodexSessionStore();
+        await expect(store.readMeta("../escape")).rejects.toThrow("Invalid session name");
+        await expect(store.readMeta("nested/name")).rejects.toThrow("Invalid session name");
+    });
+});

--- a/src/codex/lib/store.ts
+++ b/src/codex/lib/store.ts
@@ -1,0 +1,150 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { logger } from "@app/logger";
+import { SafeJSON } from "@app/utils/json";
+import { parseJsonl } from "@app/utils/jsonl";
+import { JsonlWriter } from "@app/utils/log-session/jsonl-writer";
+import { atomicWriteFileSync } from "@app/utils/storage/storage";
+import { sessionEventsPath, sessionMetaPath, sessionsDir } from "./paths";
+
+const log = logger.child({ component: "codex:store" });
+
+export type CodexWritePolicy = "ask" | "allow" | "deny";
+export type CodexSandbox = "read-only" | "workspace-write";
+export type CodexApprovalPolicy = "never" | "untrusted";
+export type PersistedCodexStatus = "starting" | "ready" | "running" | "closed" | "failed";
+export type CodexStatus = PersistedCodexStatus | "stalled";
+
+export interface PendingApproval {
+    rpcId: string | number;
+    method: string;
+    detail: string;
+    requestedAt: string;
+}
+
+export interface CodexSessionMeta {
+    name: string;
+    daemonPid: number;
+    appServerPid?: number;
+    threadId?: string;
+    activeTurnId?: string;
+    cwd: string;
+    home?: string;
+    model?: string;
+    effort?: string;
+    sandbox: CodexSandbox;
+    approvalPolicy: CodexApprovalPolicy;
+    writePolicy: CodexWritePolicy;
+    status: PersistedCodexStatus;
+    agentName: string;
+    agentId?: string;
+    rendezvousSession: string;
+    agentsEnabled: boolean;
+    startedAt: string;
+    lastEventAt: string;
+    codexVersion: string;
+    exitCode?: number;
+    usage?: Record<string, number>;
+    pendingApprovals: Record<string, PendingApproval>;
+    queuedSteers?: Array<{ body: string; force: boolean }>;
+    lastAgentSeq?: number;
+}
+
+export interface CodexEventRecord {
+    seq: number;
+    ts: string;
+    source: "app-server" | "control" | "agents" | "daemon";
+    method: string;
+    params?: unknown;
+}
+
+export function deriveSessionStatus(meta: CodexSessionMeta, now = Date.now(), stallMs = 120_000): CodexStatus {
+    if (meta.status !== "running") {
+        return meta.status;
+    }
+
+    const lastEventAt = Date.parse(meta.lastEventAt);
+    if (Number.isFinite(lastEventAt) && now - lastEventAt > stallMs) {
+        return "stalled";
+    }
+
+    return "running";
+}
+
+export class CodexSessionStore {
+    private readonly lastEventSeq = new Map<string, number>();
+
+    ensureSessionsDir(): string {
+        const path = sessionsDir();
+        mkdirSync(path, { recursive: true });
+        return path;
+    }
+
+    async readMeta(name: string): Promise<CodexSessionMeta | null> {
+        const path = sessionMetaPath(name);
+        if (!existsSync(path)) {
+            return null;
+        }
+
+        try {
+            return SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as CodexSessionMeta;
+        } catch (err) {
+            log.warn({ err, path, name }, "failed to read codex session metadata");
+            return null;
+        }
+    }
+
+    writeMeta(meta: CodexSessionMeta): void {
+        this.ensureSessionsDir();
+        atomicWriteFileSync(sessionMetaPath(meta.name), SafeJSON.stringify(meta, null, 2));
+    }
+
+    async updateMeta(name: string, update: Partial<CodexSessionMeta>): Promise<CodexSessionMeta> {
+        const current = await this.readMeta(name);
+        if (!current) {
+            throw new Error(`Codex session not found: ${name}`);
+        }
+
+        const next = { ...current, ...update };
+        this.writeMeta(next);
+        return next;
+    }
+
+    async listNames(): Promise<string[]> {
+        const dir = this.ensureSessionsDir();
+        return readdirSync(dir)
+            .filter((file) => file.endsWith(".meta.json"))
+            .map((file) => file.slice(0, -".meta.json".length))
+            .sort();
+    }
+
+    appendEvent(name: string, event: Omit<CodexEventRecord, "seq" | "ts">): CodexEventRecord {
+        this.ensureSessionsDir();
+        const path = sessionEventsPath(name);
+        let previousSeq = this.lastEventSeq.get(name);
+
+        if (previousSeq === undefined && existsSync(path)) {
+            const text = readFileSync(path, "utf8");
+            const records = text.trim() ? parseJsonl<CodexEventRecord>(text) : [];
+            previousSeq = records.at(-1)?.seq ?? 0;
+        }
+
+        const record: CodexEventRecord = {
+            ...event,
+            seq: (previousSeq ?? 0) + 1,
+            ts: new Date().toISOString(),
+        };
+        new JsonlWriter(path).append({ ...record });
+        this.lastEventSeq.set(name, record.seq);
+        return record;
+    }
+
+    async readEvents(name: string): Promise<CodexEventRecord[]> {
+        const path = sessionEventsPath(name);
+        if (!existsSync(path)) {
+            return [];
+        }
+
+        const text = await Bun.file(path).text();
+        return text.trim() ? parseJsonl<CodexEventRecord>(text) : [];
+    }
+}

--- a/src/codex/lib/version.ts
+++ b/src/codex/lib/version.ts
@@ -1,0 +1,27 @@
+import { env } from "@app/utils/env";
+
+export async function detectCodexVersion(): Promise<string> {
+    const proc = Bun.spawn({
+        cmd: ["codex", "--version"],
+        env: env.getProcessEnv(),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+
+    if (exitCode !== 0) {
+        throw new Error(`Unable to run codex --version: ${stderr.trim() || `exit ${exitCode}`}`);
+    }
+
+    const match = stdout.match(/codex-cli\s+([^\s]+)/);
+    if (!match?.[1]) {
+        throw new Error(`Unexpected codex --version output: ${stdout.trim()}`);
+    }
+
+    return match[1];
+}


### PR DESCRIPTION
## Summary

- Add long-lived `tools codex` sessions backed by a version-pinned Codex app-server client, persistent event logs, lifecycle commands, same-turn steering, interrupt/rollback/read controls, and native or adversarial reviews.
- Bridge Codex sessions to `tools agents` with automatic registration, compact milestone events, bidirectional control messages, correlated requests, and receiver-side filters.
- Keep sessions read-only by default and add supervised or trusted write policies, bus-forwarded approvals, stall detection, clean pending-approval shutdown, schema-drift warnings, and crash cleanup.

## Compatibility note

Codex CLI 0.144.5 has no policy that pauses its built-in trusted read-only commands. `--write ask` therefore uses `untrusted`, the strictest supported policy, and forwards every approval the app-server emits.

## Test plan

- [x] `bun test src/codex/ src/agents/tests/listener-filter.test.ts src/agents/tests/request.test.ts src/agents/tests/filter.test.ts src/agents/tests/id-gen.test.ts` — 61 passed
- [x] `tsgo --noEmit`
- [x] Biome on all touched TypeScript and the repository logging guard
- [x] Live same-turn steering, driver-to-model bus steering, and model-to-lead messaging
- [x] Live native review RPC and approval request/reply/write round-trip
- [x] Live stop during a pending approval and app-server crash cleanup
- [ ] Repository-wide `bun run lint` remains blocked by unchanged base-branch issues in `MoodTrendChart.tsx`, three markdown components, and `src/utils/index.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Codex session CLI for spawning, monitoring, steering, reviewing, interrupting, rolling back, approving, and stopping sessions.
  * Added session status, event logs, tailing, JSON output, and long-lived session management.
  * Added agent request-and-reply messaging with configurable receiver-side event and body filters.
  * Added configurable read-only, approval-based, and workspace-write policies.
* **Documentation**
  * Expanded guidance for Codex teammates, agent workflows, filtering, approvals, and common usage pitfalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->