### PR TITLE
feat(claude): switcheroo-style table picker for cc run account selection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@ast-grep/napi": "^0.42.0",
         "@babel/core": "^7.28.6",
         "@babel/preset-typescript": "^7.28.5",
+        "@clack/core": "^1.4.3",
         "@clack/prompts": "^1.0.0",
         "@crawlee/utils": "^3.16.0",
         "@genesiscz/darwinkit": "0.7.5",
@@ -491,7 +492,7 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
-    "@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
 
     "@clack/prompts": ["@clack/prompts@1.0.0", "", { "dependencies": { "@clack/core": "1.0.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A=="],
 
@@ -2191,7 +2192,13 @@
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -3678,6 +3685,8 @@
     "@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@clack/prompts/@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
 
     "@crawlee/core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "@ast-grep/napi": "^0.42.0",
         "@babel/core": "^7.28.6",
         "@babel/preset-typescript": "^7.28.5",
+        "@clack/core": "^1.4.3",
         "@clack/prompts": "^1.0.0",
         "@crawlee/utils": "^3.16.0",
         "@genesiscz/darwinkit": "0.7.5",

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { type LaunchableModel, modelFamilyOf, resolveModelSpec } from "@app/claude/lib/models";
 import { type ScoredAccount, scoreAccounts } from "@app/claude/lib/usage/account-picker";
 import { getSharedAccountsUsage } from "@app/claude/lib/usage/shared-cache";
+import { tableSelectAccount } from "@app/claude/lib/usage/table-select";
+import { TIER_BADGE } from "@app/claude/lib/usage/usage-table";
 import * as p from "@clack/prompts";
 import { AIConfig } from "@genesiscz/utils/ai/AIConfig";
 import { findClaudeCommand } from "@genesiscz/utils/claude";
@@ -105,13 +107,6 @@ async function resolveModel(spec: string): Promise<string> {
     return picked as string;
 }
 
-const TIER_BADGE: Record<ScoredAccount["tier"], string> = {
-    ready: pc.green("●"),
-    "session-starved": pc.yellow("◐"),
-    "weekly-blocked": pc.red("○"),
-    "no-data": pc.dim("?"),
-};
-
 async function scoreTokenAccounts(
     withToken: AIAccountEntry[],
     modelId: string | undefined
@@ -211,26 +206,18 @@ async function pickAccount(
         return plainSelect(withToken, defaultName);
     }
 
-    const labelByName = new Map(withToken.map((a) => [a.name, a.label]));
-    const picked = await p.select({
-        message: "Launch Claude Code as which account? (best first)",
-        initialValue: scored[0].accountName,
-        options: scored.map((acc, i) => {
-            const label = labelByName.get(acc.accountName);
-            return {
-                value: acc.accountName,
-                label: `${TIER_BADGE[acc.tier]} ${acc.accountName}${label ? ` ${pc.dim(`(${label})`)}` : ""}${i === 0 ? pc.green(" ★") : ""}`,
-                hint: scoredHint(acc),
-            };
-        }),
+    const picked = await tableSelectAccount({
+        message: "Launch Claude Code as which account?",
+        scored,
+        accountsByName: new Map(withToken.map((a) => [a.name, a])),
     });
 
-    if (p.isCancel(picked)) {
+    if (picked === null) {
         p.cancel("Cancelled");
         process.exit(0);
     }
 
-    return picked as string;
+    return picked;
 }
 
 /**

--- a/src/claude/lib/usage/account-picker.ts
+++ b/src/claude/lib/usage/account-picker.ts
@@ -1,5 +1,6 @@
 import type { ClaudeModelFamily } from "@app/claude/lib/models";
 import type { AccountUsage, UsageBucket } from "./api";
+import { type CompactLimits, extractCompactLimits } from "./compact-limits";
 
 /**
  * Account-picking heuristic for `tools claude start --pick/--autopick`.
@@ -61,6 +62,8 @@ export interface ScoredAccount {
     why: string;
     /** Set when usage data came from a stale cache or failed entirely. */
     dataNote?: string;
+    /** Compact 5h / weekly / Fable readout for the table-picker columns. */
+    limits?: CompactLimits;
 }
 
 export interface ScoreOptions {
@@ -146,6 +149,7 @@ export function scoreAccounts(accounts: AccountUsage[], opts: ScoreOptions = {})
         const usage = account.usage;
         const session = viewBucket(usage.five_hour, SESSION_PERIOD_HOURS, now);
         const weekly = viewBucket(usage.seven_day, WEEKLY_PERIOD_HOURS, now);
+        const limits = extractCompactLimits(usage);
 
         // The binding weekly constraint: overall bucket, plus the model-specific
         // bucket when launching that family — whichever sustains the LOWER rate.
@@ -183,6 +187,7 @@ export function scoreAccounts(accounts: AccountUsage[], opts: ScoreOptions = {})
                 sessionUsableFraction: usableFraction,
                 why: `${bindingName} exhausted — refills in ${fmtHours(binding.hoursToReset)}`,
                 dataNote: staleNote,
+                limits,
             };
         }
 
@@ -196,6 +201,7 @@ export function scoreAccounts(accounts: AccountUsage[], opts: ScoreOptions = {})
                 sessionUsableFraction: usableFraction,
                 why: `would stall — ${sessionPhrase(session)}, needs ${Math.round(paceLine)}% to keep pace · ${weeklyPhrase(binding, bindingName)}`,
                 dataNote: staleNote,
+                limits,
             };
         }
 
@@ -209,6 +215,7 @@ export function scoreAccounts(accounts: AccountUsage[], opts: ScoreOptions = {})
             sessionUsableFraction: usableFraction,
             why: `${fmtRate(weeklyRate)} sustainable — ${weeklyPhrase(binding, bindingName)} · ${sessionPhrase(session)}${usableNote}`,
             dataNote: staleNote,
+            limits,
         };
     });
 

--- a/src/claude/lib/usage/compact-limits.ts
+++ b/src/claude/lib/usage/compact-limits.ts
@@ -1,0 +1,56 @@
+import type { UsageBucket, UsageResponse } from "./api";
+
+export interface CompactLimit {
+    /** 0–100, % of the bucket still LEFT (headroom). */
+    leftPct: number;
+    resetsAt: string | null;
+}
+
+/** The three numbers the picker shows: 5h session, weekly, Fable weekly. */
+export interface CompactLimits {
+    session?: CompactLimit;
+    weekly?: CompactLimit;
+    fable?: CompactLimit;
+}
+
+function fromUsed(percentUsed: number, resetsAt: string | null): CompactLimit {
+    return { leftPct: Math.min(100, Math.max(0, 100 - percentUsed)), resetsAt };
+}
+
+function fromBucket(bucket: UsageBucket | null | undefined): CompactLimit | undefined {
+    if (!bucket || typeof bucket.utilization !== "number") {
+        return undefined;
+    }
+
+    return fromUsed(bucket.utilization, bucket.resets_at);
+}
+
+/**
+ * Extract the compact 5h / weekly / Fable limits from a usage payload.
+ * Prefers the modern `limits[]` array (the only place the Fable-scoped
+ * weekly limit lives); falls back to the legacy flat buckets.
+ */
+export function extractCompactLimits(usage: UsageResponse): CompactLimits {
+    const compact: CompactLimits = {};
+
+    if (Array.isArray(usage.limits)) {
+        for (const raw of usage.limits) {
+            if (typeof raw?.percent !== "number") {
+                continue;
+            }
+
+            if (raw.kind === "session") {
+                compact.session = fromUsed(raw.percent, raw.resets_at);
+            } else if (raw.kind === "weekly_all") {
+                compact.weekly = fromUsed(raw.percent, raw.resets_at);
+            } else if (raw.kind === "weekly_scoped" && raw.scope?.model?.display_name?.toLowerCase() === "fable") {
+                compact.fable = fromUsed(raw.percent, raw.resets_at);
+            }
+        }
+    }
+
+    compact.session ??= fromBucket(usage.five_hour);
+    compact.weekly ??= fromBucket(usage.seven_day);
+
+    return compact;
+}

--- a/src/claude/lib/usage/table-select.test.ts
+++ b/src/claude/lib/usage/table-select.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import type { AIAccountEntry } from "@genesiscz/utils/config/ai.types";
+import { stripAnsi } from "@genesiscz/utils/string";
+import type { ScoredAccount } from "./account-picker";
+import { buildFrameParts, renderFrame } from "./table-select";
+
+const NOW = new Date("2026-07-18T12:00:00");
+const in2h = new Date(NOW.getTime() + 2 * 3600e3).toISOString();
+const in38h = new Date(NOW.getTime() + 38 * 3600e3).toISOString();
+
+function scoredAccount(name: string, tier: ScoredAccount["tier"], limits: ScoredAccount["limits"]): ScoredAccount {
+    return {
+        accountName: name,
+        tier,
+        weeklyRatePctPerHour: 1,
+        sessionHeadroomPct: 50,
+        weeklyHeadroomPct: 50,
+        sessionUsableFraction: 1,
+        why: "why-line",
+        limits,
+    };
+}
+
+const SCORED: ScoredAccount[] = [
+    scoredAccount("ohfixit", "ready", {
+        session: { leftPct: 100, resetsAt: in2h },
+        weekly: { leftPct: 99, resetsAt: in38h },
+        fable: { leftPct: 98, resetsAt: in38h },
+    }),
+    scoredAccount("lpreservine", "weekly-blocked", {
+        session: { leftPct: 100, resetsAt: null },
+        weekly: { leftPct: 20, resetsAt: in38h },
+        fable: { leftPct: 0, resetsAt: null },
+    }),
+];
+
+const ACCOUNTS = new Map<string, AIAccountEntry>([
+    [
+        "ohfixit",
+        {
+            name: "ohfixit",
+            provider: "anthropic-sub",
+            tokens: {},
+            label: "max",
+            secondary: {
+                accessToken: "at",
+                refreshToken: "rt",
+                emailAddress: "ohfixit@gmail.com",
+            },
+        },
+    ],
+]);
+
+const OPTS = { message: "Launch as?", scored: SCORED, accountsByName: ACCOUNTS };
+
+describe("renderFrame", () => {
+    test("active frame: labeled headers, coarse resets, focus pointer", () => {
+        const parts = buildFrameParts(OPTS, NOW);
+        const frame = stripAnsi(renderFrame(OPTS, parts, "active", 0));
+
+        expect(frame).toContain("RESETS 5H·WL");
+        expect(frame).toContain("2h · 38h");
+        expect(frame).toContain("— · 38h");
+        expect(frame).toContain("❯");
+    });
+
+    test("detail zone: identity, plan + why line, 3-column limit table", () => {
+        const parts = buildFrameParts(OPTS, NOW);
+        const frame = stripAnsi(renderFrame(OPTS, parts, "active", 0));
+
+        expect(frame).toContain("ohfixit@gmail.com");
+        expect(frame).toContain("Max subscription · why-line");
+        expect(frame).toContain("5 Hour");
+        expect(frame).toContain("Weekly");
+        expect(frame).toContain("Fable");
+        expect(frame).toContain("in 2h"); // 5h reset
+        expect(frame).toContain("= weekly"); // fable shares the weekly reset
+        expect(frame).toContain("█"); // headroom bars
+    });
+
+    test("detail zone follows the cursor with fixed height", () => {
+        const parts = buildFrameParts(OPTS, NOW);
+        const frame0 = stripAnsi(renderFrame(OPTS, parts, "active", 0));
+        const frame1 = stripAnsi(renderFrame(OPTS, parts, "active", 1));
+
+        expect(frame1).not.toContain("ohfixit@gmail.com");
+        expect(frame1).toContain("Subscription · why-line");
+        expect(frame0.split("\n").length).toBe(frame1.split("\n").length);
+    });
+
+    test("focused row name carries the accent color", () => {
+        const parts = buildFrameParts(OPTS, NOW);
+        const frame = renderFrame(OPTS, parts, "active", 1);
+        expect(frame).toContain("\x1b[1;38;5;75mlpreservine\x1b[22;39m");
+    });
+
+    test("submit frame collapses to the picked name", () => {
+        const parts = buildFrameParts(OPTS, NOW);
+        const frame = stripAnsi(renderFrame(OPTS, parts, "submit", 1));
+        expect(frame).toContain("lpreservine");
+        expect(frame).not.toContain("RESETS");
+    });
+});

--- a/src/claude/lib/usage/table-select.ts
+++ b/src/claude/lib/usage/table-select.ts
@@ -1,0 +1,106 @@
+import { isCancel, SelectPrompt } from "@clack/core";
+import type { AIAccountEntry } from "@genesiscz/utils/config/ai.types";
+import pc from "picocolors";
+import type { ScoredAccount } from "./account-picker";
+import {
+    detailBlock,
+    padVisible,
+    TIER_BADGE,
+    tableHeaderRow,
+    tableRow,
+    tableWidths,
+    visibleWidth,
+} from "./usage-table";
+
+const S_ACTIVE = pc.cyan("◆");
+const S_SUBMIT = pc.green("◇");
+const S_CANCEL = pc.red("■");
+const BAR = pc.gray("│");
+const BAR_END = pc.gray("└");
+
+interface TableSelectOptions {
+    message: string;
+    scored: ScoredAccount[];
+    accountsByName: Map<string, AIAccountEntry>;
+}
+
+/** Pre-rendered static parts of the frame; only cursor/state vary per redraw. */
+export function buildFrameParts(opts: TableSelectOptions, now: Date = new Date()) {
+    const { scored, accountsByName } = opts;
+    const widths = tableWidths(scored);
+    const rows = scored.map((acc) => tableRow(acc, widths, now));
+    const rowsFocused = scored.map((acc) => tableRow(acc, widths, now, true));
+    const details = scored.map((acc) => detailBlock(acc, accountsByName.get(acc.accountName), now));
+    const detailWidth = Math.max(...details.flat().map(visibleWidth));
+    return { widths, rows, rowsFocused, details, detailWidth };
+}
+
+/**
+ * Pure frame renderer: question, FIXED-HEIGHT detail zone that follows the
+ * focused row, header row, then aligned table rows (which never wrap or
+ * move). Extracted from the prompt for testability.
+ */
+export function renderFrame(
+    opts: TableSelectOptions,
+    parts: ReturnType<typeof buildFrameParts>,
+    state: string,
+    cursor: number
+): string {
+    const { scored } = opts;
+    const { widths, rows, rowsFocused, details, detailWidth } = parts;
+    const title = `${pc.gray("│")}\n${S_ACTIVE}  ${opts.message} ${pc.dim("(best first, % left)")}`;
+
+    if (state === "submit") {
+        return `${title.replace(S_ACTIVE, S_SUBMIT)}\n${BAR}  ${pc.dim(scored[cursor].accountName)}`;
+    }
+
+    if (state === "cancel") {
+        return `${title.replace(S_ACTIVE, S_CANCEL)}\n${BAR}  ${pc.strikethrough(pc.dim("cancelled"))}`;
+    }
+
+    const detail = details[cursor];
+    const lines: string[] = [title];
+
+    // Fixed-height detail zone (padded so redraws never shrink or shift)
+    for (const [i, line] of detail.entries()) {
+        const gutter = i === 0 ? "┌" : i === detail.length - 1 ? "└" : "│";
+        lines.push(`${BAR}  ${pc.gray(gutter)} ${padVisible(line, detailWidth)}`);
+    }
+
+    lines.push(BAR);
+    lines.push(`${BAR}      ${tableHeaderRow(widths)}`);
+
+    for (const [i, acc] of scored.entries()) {
+        const focused = i === cursor;
+        const pointer = focused ? pc.cyan("❯") : " ";
+        lines.push(`${BAR}  ${pointer} ${TIER_BADGE[acc.tier]} ${focused ? rowsFocused[i] : rows[i]}`);
+    }
+
+    lines.push(BAR_END);
+    return lines.join("\n");
+}
+
+/**
+ * Custom @clack/core select that renders a real table (header row, aligned
+ * columns) plus a fixed-height detail zone above it. Returns the picked
+ * account name, or null on cancel.
+ */
+export async function tableSelectAccount(opts: TableSelectOptions): Promise<string | null> {
+    const parts = buildFrameParts(opts);
+
+    const prompt = new SelectPrompt({
+        options: opts.scored.map((acc) => ({ value: acc.accountName })),
+        initialValue: opts.scored[0].accountName,
+        render() {
+            return renderFrame(opts, parts, this.state, this.cursor);
+        },
+    });
+
+    const result = await prompt.prompt();
+
+    if (isCancel(result)) {
+        return null;
+    }
+
+    return result as string;
+}

--- a/src/claude/lib/usage/usage-table.ts
+++ b/src/claude/lib/usage/usage-table.ts
@@ -1,0 +1,239 @@
+import type { AIAccountEntry } from "@genesiscz/utils/config/ai.types";
+import { stripAnsi } from "@genesiscz/utils/string";
+import pc from "picocolors";
+import type { ScoredAccount } from "./account-picker";
+import type { CompactLimit } from "./compact-limits";
+
+/**
+ * Focus highlight: 256-color 75 (#5fafff), bold — a light azure with strong
+ * contrast on dark terminal backgrounds, distinct from the cyan frame.
+ */
+export function accent(text: string): string {
+    return `\x1b[1;38;5;75m${text}\x1b[22;39m`;
+}
+
+export function visibleWidth(text: string): number {
+    return stripAnsi(text).length;
+}
+
+/** Pad an ANSI-colored string to a visible width. */
+export function padVisible(text: string, width: number, align: "left" | "right" = "left"): string {
+    const pad = Math.max(0, width - visibleWidth(text));
+    return align === "left" ? text + " ".repeat(pad) : " ".repeat(pad) + text;
+}
+
+export const TIER_BADGE: Record<ScoredAccount["tier"], string> = {
+    ready: pc.green("●"),
+    "session-starved": pc.yellow("◐"),
+    "weekly-blocked": pc.red("○"),
+    "no-data": pc.dim("?"),
+};
+
+function colorByPct(pct: number, text: string): string {
+    if (pct < 20) {
+        return pc.red(text);
+    }
+
+    if (pct <= 50) {
+        return pc.yellow(text);
+    }
+
+    return pc.green(text);
+}
+
+function pctCell(limit: CompactLimit | undefined): string {
+    if (!limit) {
+        return pc.dim("   —");
+    }
+
+    const pct = Math.round(limit.leftPct);
+    return colorByPct(pct, `${String(pct).padStart(3)}%`);
+}
+
+function hoursUntil(resetsAt: string | null | undefined, now: Date): number | null {
+    if (!resetsAt) {
+        return null;
+    }
+
+    const ms = new Date(resetsAt).getTime() - now.getTime();
+    if (!Number.isFinite(ms) || ms <= 0) {
+        return null;
+    }
+
+    return ms / 3_600_000;
+}
+
+/** Coarse duration for the RESETS column: "45m", "24h", "5d". */
+function fmtCoarse(hours: number | null): string {
+    if (hours === null) {
+        return "—";
+    }
+
+    if (hours < 1) {
+        return `${Math.max(1, Math.round(hours * 60))}m`;
+    }
+
+    if (hours < 48) {
+        return `${Math.round(hours)}h`;
+    }
+
+    return `${Math.round(hours / 24)}d`;
+}
+
+/** Compact relative distance for the detail zone: "2d 10h", "5h 20m", "12m". */
+function fmtRelative(from: Date, to: Date): string {
+    const totalMinutes = Math.max(0, Math.round((to.getTime() - from.getTime()) / 60_000));
+    const days = Math.floor(totalMinutes / 1440);
+    const hours = Math.floor((totalMinutes % 1440) / 60);
+    const minutes = totalMinutes % 60;
+
+    if (days > 0) {
+        return `${days}d ${hours}h`;
+    }
+
+    if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+    }
+
+    return `${Math.max(1, minutes)}m`;
+}
+
+export interface TableWidths {
+    name: number;
+}
+
+export function tableWidths(scored: ScoredAccount[]): TableWidths {
+    return { name: Math.max(7, ...scored.map((s) => s.accountName.length)) + 2 };
+}
+
+const PCT_W = 4;
+const GAP = "  ";
+const RESETS_W = 12;
+
+/** `  ACCOUNT      5H    WL    FB   RESETS 5H·WL` (dim). */
+export function tableHeaderRow(widths: TableWidths): string {
+    return pc.dim(
+        `${padVisible("ACCOUNT", widths.name)}${GAP}${padVisible("5H", PCT_W, "right")}${GAP}` +
+            `${padVisible("WL", PCT_W, "right")}${GAP}${padVisible("FB", PCT_W, "right")}${GAP} ${padVisible("RESETS 5H·WL", RESETS_W)}`
+    );
+}
+
+/** `ohfixit         100%   99%   98%   2h · 38h` — badge NOT included. */
+export function tableRow(scored: ScoredAccount, widths: TableWidths, now: Date = new Date(), focused = false): string {
+    const limits = scored.limits;
+    const resets = limits
+        ? `${fmtCoarse(hoursUntil(limits.session?.resetsAt, now))} · ${fmtCoarse(hoursUntil(limits.weekly?.resetsAt, now))}`
+        : "—";
+    const name = focused
+        ? padVisible(accent(scored.accountName), widths.name)
+        : padVisible(scored.accountName, widths.name);
+
+    return (
+        `${name}${GAP}${padVisible(pctCell(limits?.session), PCT_W, "right")}${GAP}` +
+        `${padVisible(pctCell(limits?.weekly), PCT_W, "right")}${GAP}${padVisible(pctCell(limits?.fable), PCT_W, "right")}${GAP} ` +
+        padVisible(pc.dim(resets), RESETS_W)
+    );
+}
+
+const DETAIL_LABEL_W = 8;
+const BAR_W = 10;
+const WHY_MAX_W = 66;
+
+/** `████████░░ 78%` — colored by headroom. */
+function barCell(limit: CompactLimit | undefined): string {
+    if (!limit) {
+        return pc.dim("—");
+    }
+
+    const pct = Math.round(limit.leftPct);
+    const filled = Math.round((pct / 100) * BAR_W);
+    const bar = "█".repeat(filled) + pc.dim("░".repeat(BAR_W - filled));
+    return `${colorByPct(pct, bar)} ${colorByPct(pct, `${pct}%`)}`;
+}
+
+/** `in 2h 5m` / `in 4d 10h` / `—` for a limit's reset. */
+function resetCell(limit: CompactLimit | undefined, now: Date): string {
+    if (!limit?.resetsAt) {
+        return "—";
+    }
+
+    const reset = new Date(limit.resetsAt);
+    if (!Number.isFinite(reset.getTime()) || reset.getTime() <= now.getTime()) {
+        return "—";
+    }
+
+    return `in ${fmtRelative(now, reset)}`;
+}
+
+/** Same reset moment at minute granularity (the API's timestamps differ by µs). */
+function sameResetMoment(a: string | null | undefined, b: string | null | undefined): boolean {
+    if (!a || !b) {
+        return false;
+    }
+
+    const diff = Math.abs(new Date(a).getTime() - new Date(b).getTime());
+    return Number.isFinite(diff) && diff < 60_000;
+}
+
+function capitalize(text: string): string {
+    return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+/** Cap the ranking explanation so the detail zone never wraps (wrap breaks the fixed-height redraw). */
+function truncateWhy(why: string): string {
+    return why.length > WHY_MAX_W ? `${why.slice(0, WHY_MAX_W - 1)}…` : why;
+}
+
+/** `Weekly   ████░░░░░░  20%  in 7h 29m` — one narrow row per limit. */
+function limitRow(label: string, limit: CompactLimit | undefined, reset: string): string {
+    return `${pc.dim(padVisible(label, DETAIL_LABEL_W))} ${padVisible(barCell(limit), BAR_W + 5, "left")} ${pc.dim(reset)}`;
+}
+
+/**
+ * The fixed-height (5-line) detail zone for the focused account, kept narrow
+ * for quarter-screen terminals:
+ *   1. name (accent-highlighted) · email
+ *   2. subscription plan · ranking explanation (why this position)
+ *   3-5. one row per limit: full name, headroom bar, reset countdown.
+ */
+export function detailBlock(
+    scored: ScoredAccount,
+    account: AIAccountEntry | undefined,
+    now: Date = new Date()
+): string[] {
+    const identity = [accent(scored.accountName)];
+
+    if (account?.secondary?.emailAddress) {
+        identity.push(pc.dim(account.secondary.emailAddress));
+    }
+
+    if (scored.dataNote) {
+        identity.push(pc.yellow(`[${scored.dataNote}]`));
+    }
+
+    const plan = account?.label ? `${capitalize(account.label)} subscription` : "Subscription";
+    const subscription = pc.dim(`${plan} · ${truncateWhy(scored.why)}`);
+
+    const limits = scored.limits;
+
+    if (!limits) {
+        return [
+            identity.join(" · "),
+            subscription,
+            limitRow("5 Hour", undefined, "—"),
+            limitRow("Weekly", undefined, "—"),
+            limitRow("Fable", undefined, "—"),
+        ];
+    }
+
+    const fableSameAsWeekly = sameResetMoment(limits.fable?.resetsAt, limits.weekly?.resetsAt);
+    const fableReset = fableSameAsWeekly ? "= weekly" : resetCell(limits.fable, now);
+
+    return [
+        identity.join(" · "),
+        subscription,
+        limitRow("5 Hour", limits.session, resetCell(limits.session, now)),
+        limitRow("Weekly", limits.weekly, resetCell(limits.weekly, now)),
+        limitRow("Fable", limits.fable, fableReset),
+    ];
+}


### PR DESCRIPTION
Ports the table-style account picker UI from [claude-switcheroo](https://github.com/LEFTEQ/claude-switcheroo) back into `tools cc run` / `tools claude start`. Switcheroo's ranking heuristic was originally ported from our `account-picker.ts`; this brings its superior rendering home.

## Before
Plain `p.select` with one long wrapping hint string per account — no columns, no alignment.

## After
Custom `@clack/core` select frame:
- aligned column table: `ACCOUNT  5H  WL  FB  RESETS 5H·WL`, pct cells colored by headroom
- fixed-height detail zone following the cursor: name · email, plan · ranking-why, and one `████████░░ 78%` bar row per limit (5 Hour / Weekly / Fable) with reset countdowns
- Fable-scoped weekly limit extracted from the modern `limits[]` API array (previously invisible)

## Changes
- `src/claude/lib/usage/compact-limits.ts` — extract 5h / weekly / Fable-scoped limits (`limits[]` first, legacy flat buckets fallback)
- `src/claude/lib/usage/usage-table.ts` — table rows, colored pct cells, headroom bars, 5-line detail block
- `src/claude/lib/usage/table-select.ts` — `@clack/core` SelectPrompt frame renderer (pure `renderFrame` for testability)
- `account-picker.ts` — `ScoredAccount.limits` populated via `extractCompactLimits`
- `start.ts` — scored path uses `tableSelectAccount`; plain fallback + `--autopick` unchanged; local `TIER_BADGE` deduped into usage-table
- new dep `@clack/core@1.4.3`; 5 ported `renderFrame` tests

Adaptations vs switcheroo: `AIAccountEntry` instead of its config type (email from `secondary.emailAddress`), no subscription-end line (no Stripe anchor stored) — ranking `why` shown instead, truncated at 66 chars so the fixed-height zone never wraps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive table-based account picker with subscription tiers, usage headroom, reset times, and account details.
  * Added visual indicators for session, weekly, and Fable-specific usage limits.
  * Supports modern and legacy usage data formats for consistent limit display.

* **Bug Fixes**
  * Improved account selection clarity by highlighting the currently focused account and presenting relevant usage details.

* **Tests**
  * Added coverage for table rendering, account details, focus behavior, reset information, and submission states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->