### PR TITLE
test(youtube,ai-proxy): drop leaking billing mock, fix yt-dlp mock kill (remainder of #244)

### DIFF
--- a/src/youtube/lib/__tests__/call-llm-structured.test.ts
+++ b/src/youtube/lib/__tests__/call-llm-structured.test.ts
@@ -26,10 +26,6 @@ mock.module("@genesiscz/utils/ask/types/provider", () => ({
     getLanguageModel: () => "MOCK_MODEL",
 }));
 
-mock.module("@genesiscz/utils/claude/subscription-billing", () => ({
-    applySystemPromptPrefix: (_prefix: string | undefined, system: string) => system,
-}));
-
 mock.module("@genesiscz/utils/ai/prompt-caching", () => ({
     buildProviderOptions: () => ({}),
 }));

--- a/src/youtube/lib/__tests__/yt-dlp.test.ts
+++ b/src/youtube/lib/__tests__/yt-dlp.test.ts
@@ -32,7 +32,8 @@ function mockProcess(stdout: string, stderr = "", exitCode = 0): ReturnType<type
         stderr: textStream(stderr),
         exited: Promise.resolve(exitCode),
         exitCode,
-    } as ReturnType<typeof Bun.spawn>;
+        kill: () => {},
+    } as unknown as ReturnType<typeof Bun.spawn>;
 }
 
 afterEach(() => {


### PR DESCRIPTION
Surviving remainder of closed PR #244 (`ask-cache-hit-billing`), rebased onto the post-cutover master.

## What survived and why it's small

The original branch had 11 commits. During the rebase, 8 were proven **already upstream** via independent master commits (AI SDK v5→v7, zod v3→v4, youtube OpenAPI + comments backend, eve foundation, ai-proxy subscription providers, VPS deploy templates) — and the headline billing bug itself (double-billing on 100% cache-hit input) was already fixed on master (`src/ask/utils/helpers.ts` `Math.max(0, derived)` + `cachedInputTokens: usageCacheReadTokens(...)` in `src/ask/index.ts`). Replaying those would have regressed newer master code, so they were dropped with per-commit verification.

What genuinely remained — two test-hygiene fixes (`ab2feca84`):

- `src/youtube/lib/__tests__/call-llm-structured.test.ts` — drop a leaking `mock.module(...subscription-billing...)` that polluted other test files via bun:test's global module mocking (verified `applySystemPromptPrefix` is side-effect-free for this fixture, so the mock was unnecessary)
- `src/youtube/lib/__tests__/yt-dlp.test.ts` — give the mocked spawn return a `kill: () => {}` so teardown doesn't throw

## Gates (at rebase time, 2026-07-18)

- `tsgo --noEmit`: 0 errors; boundary + logging guards green; biome clean
- `bun test src/ask src/ai-proxy`: 237 pass / 0 fail; the 2 touched files: 20 pass / 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI and media-processing test mocks to reflect current runtime behavior.
  * Improved test reliability when handling provider options and terminating mocked processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->