### PR TITLE
fix(claude): warmup fails fast on credential-less accounts

### DIFF
--- a/src/claude/lib/warmup/service.ts
+++ b/src/claude/lib/warmup/service.ts
@@ -47,8 +47,21 @@ function shouldWarmWeekly(usage: UsageResponse): boolean {
 export async function sendWarmupMessage(accountName: string): Promise<boolean> {
     try {
         const { AIAccount } = await import("@genesiscz/utils/ai/AIAccount");
+        const { AIConfig } = await import("@genesiscz/utils/ai/AIConfig");
         const { ChatEngine } = await import("@ask/chat/ChatEngine");
         const { AnthropicModelCategory } = await import("@genesiscz/utils/ask/providers/ModelResolver");
+
+        // Fail fast on credential-less entries (e.g. an aborted login left an
+        // account with empty tokens) instead of spinning through token-refresh
+        // retries and an API call that can only return "Invalid bearer token".
+        const aiConfig = await AIConfig.load();
+        const tokens = aiConfig.getAccount(accountName)?.tokens;
+        if (tokens && !tokens.accessToken && !tokens.refreshToken && !tokens.longLivedToken && !tokens.authFile) {
+            logger.warn(
+                `Warmup skipped for "${accountName}": no credentials stored. Run: tools claude login ${accountName}`
+            );
+            return false;
+        }
 
         const account = AIAccount.chooseClaude(accountName);
         await ChatEngine.oneShot({


### PR DESCRIPTION
An aborted login can leave an account entry with empty `tokens` (real case: `olivia.handerson`, a typo'd duplicate of `olivia.henderson`). `tools claude warmup` still attempted it: 3× `[token-refresh] no refresh token available` warnings, then an API call that can only fail with "Invalid bearer token".

`sendWarmupMessage` now checks the stored tokens first (`accessToken`/`refreshToken`/`longLivedToken`/`authFile` all absent) and fails fast with a single actionable warning: `Warmup skipped … Run: tools claude login <name>`.

Verified live: `tools claude warmup olivia.handerson` now fails instantly with the skip message, zero token-refresh spam, no API roundtrip. tsgo + biome clean.