### PR TITLE
feat(ai-proxy): Codex/WHAM subscription hardening — usage, resilience, login UX, probe-backed param fidelity, catalog, observability

### DIFF
--- a/src/ai-proxy/README.md
+++ b/src/ai-proxy/README.md
@@ -93,7 +93,9 @@ Speaks OpenAI (`/v1/chat/completions`) to proxy clients and forwards the Claude 
 
 ### OpenAI (ChatGPT/Codex) subscription
 
-Speaks OpenAI to proxy clients on both `/v1/chat/completions` and `/v1/responses`, converting to/from the ChatGPT backend's Responses-only WHAM API (`chatgpt.com/backend-api/wham/responses`, streaming-only — non-streaming callers get the SSE accumulated into a single JSON response). No interactive `accounts login` flow yet — add the account by hand:
+Speaks OpenAI to proxy clients on both `/v1/chat/completions` and `/v1/responses`, converting to/from the ChatGPT backend's Responses-only WHAM API (`chatgpt.com/backend-api/wham/responses`, streaming-only — non-streaming callers get the SSE accumulated into a single JSON response).
+
+**Login** (recommended): `tools ai-proxy accounts login codex` — browser OAuth, saves an `openai-sub` account into `~/.genesis-tools/ai/config.json` and points (or creates) a proxy account at it. `tools ai-proxy accounts status` shows auth source, token expiry, and ChatGPT plan. Manual config (advanced):
 
 ```json
 {
@@ -102,7 +104,10 @@ Speaks OpenAI to proxy clients on both `/v1/chat/completions` and `/v1/responses
   "providerSlug": "codex",
   "enabled": true,
   "openaiSub": {
-    "accountName": "codex-account"
+    "accountName": "codex-account",
+    "failoverAccountNames": ["codex-backup"],
+    "defaultReasoningEffort": "low",
+    "aliases": { "fast": "gpt-5.4-mini" }
   }
 }
 ```
@@ -110,6 +115,13 @@ Speaks OpenAI to proxy clients on both `/v1/chat/completions` and `/v1/responses
 Two token sources, tried in order:
 - `openaiSub.accountName` set → the named `openai-sub` account in `~/.genesis-tools/ai/config.json` (refreshed via Codex OAuth and persisted).
 - `openaiSub.accountName` omitted → the Codex CLI's own cache (`~/.codex/auth.json`, read-only; run `codex login` to refresh it). Override the path with `openaiSub.codexAuthPath`.
+
+Behavior notes:
+- **Rate limits / failover:** a 429 puts the account on an in-memory cooldown (honours `Retry-After`, else exponential backoff); `failoverAccountNames` (additional `openai-sub` AI-config accounts) are tried in order within the same request. A 401 triggers one forced token refresh + retry before the account is marked unhealthy for 15 minutes.
+- **Parameters:** WHAM rejects `max_output_tokens`, `temperature`, and `top_p` — the proxy strips them (warned once per process, surfaced in the `x-ai-proxy-dropped` response header). Client `reasoning` passes through (unknown efforts clamp to `low`); when omitted, `openaiSub.defaultReasoningEffort` applies (`"none"` omits the field, default `low`).
+- **Aliases:** built-ins `latest`, `codex`, `mini` resolve against the catalog; `openaiSub.aliases` adds per-account ones. Unknown ids pass through so WHAM's own 400 surfaces.
+- **Usage:** `tools ai-proxy usage` reports proxy-observed token counts from the local store — ChatGPT exposes no plan-quota endpoint, so weekly-limit numbers are never claimed.
+- **Local health checks:** shell proxies break localhost curls — use `curl --noproxy '*' http://127.0.0.1:<port>/…` (or unset `http_proxy`/`https_proxy`).
 
 ### xAI API key
 

--- a/src/ai-proxy/commands/accounts-login.ts
+++ b/src/ai-proxy/commands/accounts-login.ts
@@ -6,19 +6,32 @@ import {
     saveConfig,
 } from "@app/ai-proxy/lib/config";
 import { clearCopilotModelsCache } from "@app/ai-proxy/lib/copilot-models-cache";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import * as p from "@clack/prompts";
+import { AIConfig } from "@genesiscz/utils/ai/AIConfig";
 import {
     clearGithubCopilotTokenResolutionCache,
     clearSessionCache,
     fetchGithubUserLogin,
 } from "@genesiscz/utils/ai/github-copilot";
 import { copilotDataDir, copilotGhoTokenAuthKey, githubTokenPath } from "@genesiscz/utils/ai/github-copilot/paths";
+import { codexOAuth, extractEmail, extractPlanType } from "@genesiscz/utils/ai/openai/codex-auth";
+import { Browser } from "@genesiscz/utils/browser";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { logger, out } from "@genesiscz/utils/logger";
 import { runGitHubDeviceLogin } from "@genesiscz/utils/oauth";
 import { authStorageBackend, setAuthSecret } from "@genesiscz/utils/storage";
 
+const CODEX_PROVIDER_ALIASES = new Set(["codex", "openai", "chatgpt"]);
+
 export async function runAccountsLogin(provider: string, options?: { dataDir?: string }): Promise<void> {
+    if (CODEX_PROVIDER_ALIASES.has(provider)) {
+        await runCodexLogin();
+        return;
+    }
+
     if (provider !== "github-copilot") {
-        out.log.error(`Unknown provider: ${provider}. Supported: github-copilot`);
+        out.log.error(`Unknown provider: ${provider}. Supported: github-copilot, codex`);
         return;
     }
 
@@ -81,4 +94,112 @@ export async function runAccountsLogin(provider: string, options?: { dataDir?: s
 
     await saveConfig(config);
     out.log.info(`Suggested model: ${report.suggestedModel ?? `${detected.name}/github-copilot/claude-sonnet-4`}`);
+}
+
+/**
+ * Browser PKCE login for the ChatGPT/Codex subscription. Persists the tokens
+ * as an `openai-sub` account in the unified AI config, then points (or creates)
+ * an ai-proxy `openai-subscription` account at it.
+ */
+async function runCodexLogin(): Promise<void> {
+    if (!isInteractive()) {
+        out.log.error("Codex login needs a TTY (browser OAuth + code paste).");
+        out.log.info(suggestCommand("tools ai-proxy", { replaceCommand: ["accounts", "login", "codex"] }));
+        out.log.info("Alternative: run `codex login` and configure openaiSub.codexAuthPath (CLI-cache mode).");
+        return;
+    }
+
+    const authUrl = await codexOAuth.startLogin();
+
+    p.note(
+        [
+            "1. Open the URL below in your browser",
+            "2. Sign in with your ChatGPT account",
+            "3. Authorize Codex",
+            "4. Copy the code from the callback page/URL",
+        ].join("\n"),
+        "OpenAI OAuth Login"
+    );
+
+    out.println();
+    out.println(`  ${authUrl}`);
+    out.println();
+
+    const openBrowser = await p.confirm({ message: "Open URL in browser?", initialValue: true });
+
+    if (p.isCancel(openBrowser)) {
+        return;
+    }
+
+    if (openBrowser) {
+        await Browser.open(authUrl);
+    }
+
+    const code = await p.text({
+        message: "Paste the authorization code:",
+        validate: (val) => {
+            if (!val?.trim()) {
+                return "Code is required";
+            }
+        },
+    });
+
+    if (p.isCancel(code)) {
+        return;
+    }
+
+    const spinner = p.spinner();
+    spinner.start("Exchanging code for tokens...");
+
+    let tokens: Awaited<ReturnType<typeof codexOAuth.exchangeCode>>;
+    try {
+        tokens = await codexOAuth.exchangeCode((code as string).trim());
+        spinner.stop("Tokens received.");
+    } catch (err) {
+        spinner.stop(`Token exchange failed: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+    }
+
+    const email = extractEmail(tokens.accessToken);
+    const planType = extractPlanType(tokens.accessToken);
+    const accountName = email?.split("@")[0]?.toLowerCase() || "codex";
+
+    const aiConfig = await AIConfig.load();
+    await aiConfig.addAccount({
+        name: accountName,
+        provider: "openai-sub",
+        tokens: {
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            expiresAt: tokens.expiresAt,
+        },
+        label: planType ?? "codex",
+        apps: ["ask", "ai-proxy"],
+    });
+    out.log.success(`AI-config account "${accountName}" (openai-sub${planType ? `, ${planType}` : ""}) saved.`);
+
+    const config = await loadConfig();
+    const existing = config.accounts.find(
+        (item) => item.provider === "openai-subscription" && item.openaiSub?.accountName === accountName
+    );
+
+    if (existing) {
+        existing.enabled = true;
+        out.log.info(`Proxy account "${existing.name}" already references it.`);
+    } else {
+        const proxyName = config.accounts.some((item) => item.name === "codex") ? `codex-${accountName}` : "codex";
+        const proxyAccount: AiProxyAccountConfig = {
+            name: proxyName,
+            label: planType ? `Codex (${planType})` : "Codex",
+            provider: "openai-subscription",
+            providerSlug: "codex",
+            enabled: true,
+            openaiSub: { accountName },
+        };
+        config.accounts.push(proxyAccount);
+        out.log.info(`Added proxy account: ${proxyName}`);
+    }
+
+    await saveConfig(config);
+    out.log.info(`Try: ${suggestCommand("tools ai-proxy", { replaceCommand: ["models"] })}`);
 }

--- a/src/ai-proxy/commands/accounts.ts
+++ b/src/ai-proxy/commands/accounts.ts
@@ -2,6 +2,8 @@ import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
 import { loadConfig, saveConfig } from "@app/ai-proxy/lib/config";
 import { type AccountListRow, displayAccountsTable, displayAccountTestResult } from "@app/ai-proxy/lib/display";
 import { createProvider, isProviderImplemented } from "@app/ai-proxy/lib/providers/registry";
+import { AIConfig } from "@genesiscz/utils/ai/AIConfig";
+import { CODEX_AUTH_PATH, extractPlanType, readCodexAuthJson } from "@genesiscz/utils/ai/openai/codex-auth";
 import { suggestCommand } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
 
@@ -77,6 +79,70 @@ export async function runAccountsTest(name: string): Promise<void> {
         out.println(`  ${cmd(["config", "show"])}`);
         out.println(`  ${cmd(["status"])}`);
         out.println();
+    }
+}
+
+/**
+ * Auth detail for codex (openai-subscription) accounts: where the token comes
+ * from, when it expires, and the ChatGPT plan when the JWT carries it.
+ */
+export async function runAccountsStatus(): Promise<void> {
+    const config = await loadConfig();
+    const codexAccounts = config.accounts.filter((account) => account.provider === "openai-subscription");
+
+    if (codexAccounts.length === 0) {
+        out.log.info("No openai-subscription accounts configured.");
+        out.log.info(cmd(["accounts", "login", "codex"]));
+        return;
+    }
+
+    const aiConfig = await AIConfig.load();
+
+    for (const account of codexAccounts) {
+        const accountName = account.openaiSub?.accountName;
+        let source: string;
+        let accessToken: string | undefined;
+        let expiresAt: number | undefined;
+
+        if (accountName) {
+            const entry = aiConfig.getAccount(accountName);
+
+            if (!entry) {
+                out.log.warn(`${account.name}: AI-config account "${accountName}" not found`);
+                continue;
+            }
+
+            if (entry.tokens.authFile) {
+                source = `codex-auth.json (${entry.tokens.authFile})`;
+                const tokens = await readCodexAuthJson(entry.tokens.authFile);
+                accessToken = tokens?.accessToken;
+                expiresAt = tokens?.expiresAt;
+            } else {
+                source = `ai-config (${accountName})`;
+                accessToken = entry.tokens.accessToken;
+                expiresAt = entry.tokens.expiresAt;
+            }
+        } else {
+            const path = account.openaiSub?.codexAuthPath ?? CODEX_AUTH_PATH;
+            source = `codex-auth.json (${path})`;
+            const tokens = await readCodexAuthJson(path);
+            accessToken = tokens?.accessToken;
+            expiresAt = tokens?.expiresAt;
+        }
+
+        const plan = accessToken ? extractPlanType(accessToken) : undefined;
+        const failover = account.openaiSub?.failoverAccountNames;
+        const expiry = expiresAt
+            ? `${new Date(expiresAt).toLocaleString()}${expiresAt < Date.now() ? " (EXPIRED)" : ""}`
+            : "unknown";
+
+        out.log.info(`${account.name}${plan ? ` (${plan})` : ""}${account.enabled ? "" : " [disabled]"}`);
+        out.log.info(`  auth:    ${accessToken ? source : `${source} — NO TOKEN`}`);
+        out.log.info(`  expires: ${expiry}`);
+
+        if (failover && failover.length > 0) {
+            out.log.info(`  failover: ${failover.join(", ")}`);
+        }
     }
 }
 

--- a/src/ai-proxy/commands/usage.ts
+++ b/src/ai-proxy/commands/usage.ts
@@ -4,6 +4,7 @@ import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import { maybeSyncBilling } from "@app/ai-proxy/lib/usage/billing-sync";
 import {
+    getModelUsageBreakdownSince,
     getTodayUsageSummary,
     readBillingStore,
     readRecentRequestsForAccount,
@@ -15,9 +16,12 @@ import { out } from "@genesiscz/utils/logger";
 
 export interface UsageCommandOptions {
     account?: string;
+    provider?: string;
     json?: boolean;
     recent?: number;
     paths?: boolean;
+    /** Show per-model aggregates over the trailing 30 days. */
+    breakdown?: boolean;
 }
 
 interface UsageCommandResult {
@@ -30,6 +34,7 @@ interface UsageCommandResult {
     today: ReturnType<typeof getTodayUsageSummary>;
     last?: UsageRequestRecord;
     recent?: UsageRequestRecord[];
+    breakdown?: ReturnType<typeof getModelUsageBreakdownSince>;
     storePaths?: ReturnType<typeof usageStorePaths>;
 }
 
@@ -53,9 +58,10 @@ function formatLastRequest(record: UsageRequestRecord): string {
 
 function formatTodaySummary(today: ReturnType<typeof getTodayUsageSummary>): string {
     const tokenSummary = today.total_tokens > 0 ? `, ${formatTokens(today.total_tokens)} tokens` : "";
+    const estimated = today.estimated_requests ? `, ${today.estimated_requests} estimated` : "";
     const rateLimits = today.rate_limits > 0 ? ` (${today.rate_limits} rate limits)` : "";
 
-    return `${today.requests} requests${tokenSummary}${rateLimits}`;
+    return `${today.requests} requests${tokenSummary}${estimated}${rateLimits}`;
 }
 
 function billingSnapshot(snapshot?: AccountBillingSnapshot): UsageCommandResult["billing"] {
@@ -74,7 +80,8 @@ async function fetchLiveUsage(account: AiProxyAccountConfig): Promise<UsageSumma
     if (
         account.provider === "grok-subscription" ||
         account.provider === "github-copilot-subscription" ||
-        account.provider === "xai-api-key"
+        account.provider === "xai-api-key" ||
+        account.provider === "openai-subscription"
     ) {
         const provider = await createProvider(account);
         return provider.getUsage();
@@ -115,13 +122,24 @@ async function buildAccountUsage(
         today,
         last,
         recent: options.recent ? accountRecent : undefined,
+        breakdown: options.breakdown ? getModelUsageBreakdownSince(30, account.name) : undefined,
         storePaths: options.paths ? usageStorePaths() : undefined,
     };
 }
 
 export async function runUsageCommand(options: UsageCommandOptions): Promise<void> {
     const config = await loadConfig();
-    const accounts = config.accounts.filter((item) => (options.account ? item.name === options.account : item.enabled));
+    const accounts = config.accounts.filter((item) => {
+        if (options.account) {
+            return item.name === options.account;
+        }
+
+        if (options.provider && item.provider !== options.provider && item.providerSlug !== options.provider) {
+            return false;
+        }
+
+        return item.enabled;
+    });
 
     if (accounts.length === 0) {
         out.log.error("No matching accounts in config");
@@ -157,6 +175,22 @@ export async function runUsageCommand(options: UsageCommandOptions): Promise<voi
 
         if (summary.last) {
             out.log.info(`  last: ${formatLastRequest(summary.last)}`);
+        }
+
+        if (summary.breakdown) {
+            const entries = Object.entries(summary.breakdown).sort((a, b) => b[1].total_tokens - a[1].total_tokens);
+
+            if (entries.length === 0) {
+                out.log.info("  30d: no tracked requests");
+            }
+
+            for (const [model, stats] of entries) {
+                const shortModel = model.split("/").slice(2).join("/") || model;
+                const rateLimits = stats.rate_limits > 0 ? `, ${stats.rate_limits} rate limits` : "";
+                out.log.info(
+                    `  30d ${shortModel}: ${stats.requests} req, ${formatTokens(stats.total_tokens)} tok${rateLimits}`
+                );
+            }
         }
     }
 }

--- a/src/ai-proxy/index.ts
+++ b/src/ai-proxy/index.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env bun
 
-import { runAccountsList, runAccountsRemove, runAccountsTest } from "@app/ai-proxy/commands/accounts";
+import {
+    runAccountsList,
+    runAccountsRemove,
+    runAccountsStatus,
+    runAccountsTest,
+} from "@app/ai-proxy/commands/accounts";
 import { runAccountsLogin } from "@app/ai-proxy/commands/accounts-login";
 import { clientsAdd, clientsList, clientsUsage } from "@app/ai-proxy/commands/clients";
 import { runConfigDetect, runConfigInit, runConfigSet, runConfigShow } from "@app/ai-proxy/commands/config";
@@ -195,8 +200,10 @@ program
     .command("usage")
     .description("Show subscription or Management API usage")
     .option("--account <name>", "Limit to one account")
+    .option("--provider <type>", "Filter by provider type or slug (e.g. openai-subscription, codex)")
     .option("--json", "Machine-readable output")
     .option("--recent <n>", "Include last N local request records", (value) => Number.parseInt(value, 10))
+    .option("--breakdown", "Per-model aggregates over the trailing 30 days")
     .option("--paths", "Print local usage store file paths")
     .action(async (options) => {
         await runUsageCommand(options);
@@ -206,9 +213,16 @@ const accountsCmd = program.command("accounts").description("Manage configured a
 
 accountsCmd
     .command("login <provider>")
-    .description("OAuth login for a provider (github-copilot)")
+    .description("OAuth login for a provider (github-copilot, codex)")
     .action(async (provider: string) => {
         await runAccountsLogin(provider);
+    });
+
+accountsCmd
+    .command("status")
+    .description("Auth detail for codex accounts (source, expiry, plan)")
+    .action(async () => {
+        await runAccountsStatus();
     });
 
 accountsCmd

--- a/src/ai-proxy/lib/chat-to-responses-body.test.ts
+++ b/src/ai-proxy/lib/chat-to-responses-body.test.ts
@@ -14,6 +14,30 @@ describe("chat-to-responses-body", () => {
         ]);
     });
 
+    it("converts chat image_url parts to flat Responses input_image parts", () => {
+        const input = convertMessagesToInput([
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "what is this?" },
+                    { type: "image_url", image_url: { url: "data:image/png;base64,AAA", detail: "high" } },
+                    { type: "image_url", image_url: "https://example.com/x.png" },
+                ],
+            },
+        ]);
+
+        expect(input).toEqual([
+            {
+                role: "user",
+                content: [
+                    { type: "input_text", text: "what is this?" },
+                    { type: "input_image", image_url: "data:image/png;base64,AAA", detail: "high" },
+                    { type: "input_image", image_url: "https://example.com/x.png", detail: "auto" },
+                ],
+            },
+        ]);
+    });
+
     it("ensures responses bodies have input instead of messages", () => {
         const body = ensureResponsesInput({
             model: "grok-composer-2.5-fast",

--- a/src/ai-proxy/lib/chat-to-responses-body.ts
+++ b/src/ai-proxy/lib/chat-to-responses-body.ts
@@ -26,6 +26,21 @@ function contentToParts(content: unknown, textType: "input_text" | "output_text"
             return part;
         }
 
+        // Chat image parts nest the url ({image_url:{url,detail}}); the
+        // Responses API wants a flat input_image part with a string image_url.
+        if (part.type === "image_url" && textType === "input_text") {
+            const nested = isObject(part.image_url) ? part.image_url : undefined;
+            const url = nested ? nested.url : part.image_url;
+
+            if (typeof url === "string") {
+                return {
+                    type: "input_image",
+                    image_url: url,
+                    detail: nested && typeof nested.detail === "string" ? nested.detail : "auto",
+                };
+            }
+        }
+
         return part;
     });
 }

--- a/src/ai-proxy/lib/debug-capture.ts
+++ b/src/ai-proxy/lib/debug-capture.ts
@@ -1,0 +1,37 @@
+import { join } from "node:path";
+import { getAiProxyStorage } from "@app/ai-proxy/lib/storage";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * Opt-in (AI_PROXY_DEBUG_CAPTURE=1) dump of the last failing upstream exchange.
+ * The capture carries the upstream request BODY and response text only — never
+ * Authorization headers, tokens, or the proxy API key.
+ */
+export function captureUpstreamFailure(input: {
+    provider: string;
+    account: string;
+    model: string;
+    status: number;
+    requestBody: string;
+    responseBody: string;
+}): void {
+    if (!env.aiProxy.getDebugCapture()) {
+        return;
+    }
+
+    const path = join(getAiProxyStorage().getBaseDir(), "debug", `last-${input.provider}-failure.json`);
+    const capture = {
+        ts: new Date().toISOString(),
+        ...input,
+    };
+
+    void Bun.write(path, `${SafeJSON.stringify(capture, null, 2)}\n`)
+        .then(() => {
+            logger.info({ path, status: input.status }, "ai-proxy: captured failing upstream exchange");
+        })
+        .catch((err) => {
+            logger.debug({ err, path }, "ai-proxy: debug capture write failed");
+        });
+}

--- a/src/ai-proxy/lib/display.ts
+++ b/src/ai-proxy/lib/display.ts
@@ -82,6 +82,15 @@ function formatContextWindow(tokens: number | undefined): string {
     return pc.white(formatTokens(tokens));
 }
 
+function formatModalities(modalities: string[] | undefined): string {
+    if (!modalities || modalities.length === 0) {
+        return pc.dim("—");
+    }
+
+    const short = modalities.map((modality) => modality.slice(0, 1)).join("+");
+    return pc.white(short);
+}
+
 function formatEnabled(enabled: boolean): string {
     if (enabled) {
         return formatDotStatus("ok", "yes");
@@ -131,7 +140,7 @@ export function displayModelsTable(models: ProxyModelMeta[]): void {
         return;
     }
 
-    const table = createBoxTable(["PROXY ID", "VIS", "SPEED", "THINK", "CTX", "PROBE"]);
+    const table = createBoxTable(["PROXY ID", "VIS", "SPEED", "THINK", "CTX", "MODAL", "PROBE"]);
 
     for (const model of models) {
         table.push([
@@ -140,6 +149,7 @@ export function displayModelsTable(models: ProxyModelMeta[]): void {
             formatSpeed(model.speed),
             formatThinking(model.thinking),
             formatContextWindow(model.contextWindow),
+            formatModalities(model.inputModalities),
             formatProbeStatus(model.probeStatus),
         ]);
     }
@@ -158,6 +168,7 @@ export function displayModelsTable(models: ProxyModelMeta[]): void {
     renderCliKeyRow("SPEED", "relative latency class (not a hard SLA)");
     renderCliKeyRow("THINK", "reasoning mode: none | optional | reasoning | multi-agent");
     renderCliKeyRow("CTX", "context window in tokens (— if unknown)");
+    renderCliKeyRow("MODAL", "input modalities upstream advertises (t=text, i=image; — if unknown)");
     renderCliKeyRow(
         "PROBE",
         "ok=upstream advertises it (or Grok chat-probe ok) · fail=Grok dead id · skip=static fallback · n/a=no signal"

--- a/src/ai-proxy/lib/model-meta.ts
+++ b/src/ai-proxy/lib/model-meta.ts
@@ -19,7 +19,9 @@ import type { GrokModelRecord } from "@genesiscz/utils/ai/grok";
 import { GROK_STATIC_CATALOG, inferModelSpeed, inferModelThinking, toProxyId } from "@genesiscz/utils/ai/grok";
 import { WHAM_BASE_URL } from "@genesiscz/utils/ai/openai/codex-auth";
 import {
+    OPENAI_SUB_BUILTIN_ALIAS_NAMES,
     OPENAI_SUB_STATIC_CATALOG,
+    resolveOpenAiSubModel,
     tryFetchWhamModels,
     type WhamModelRecord,
 } from "@genesiscz/utils/ai/openai/sub-models";
@@ -255,8 +257,8 @@ export async function listOpenAiSubProxyModels(account: AiProxyAccountConfig): P
         logger.debug({ err, account: account.name }, "ai-proxy: codex catalog auth/list failed — static fallback");
     }
 
-    return records.map((record) => ({
-        proxyId: toProxyId(account.name, account.providerSlug, record.slug),
+    const toMeta = (id: string, record: WhamModelRecord, description: string): ProxyModelMeta => ({
+        proxyId: toProxyId(account.name, account.providerSlug, id),
         accountName: account.name,
         providerSlug: account.providerSlug,
         upstreamId: record.slug,
@@ -267,14 +269,37 @@ export async function listOpenAiSubProxyModels(account: AiProxyAccountConfig): P
         thinking: "reasoning" as const,
         contextWindow: record.contextWindow,
         supportsTools: true,
+        inputModalities: record.inputModalities,
+        supportsParallelToolCalls: record.supportsParallelToolCalls,
         billingPlane: "subscription" as const,
         source,
         probeStatus,
-        description: `${record.displayName} via ChatGPT/Codex subscription`,
+        description,
         object: "model" as const,
         created: 1_740_960_000,
         owned_by: providerKey(account),
-    }));
+    });
+
+    // Aliases (builtin + per-account config) advertised when they resolve to a
+    // record on this plan's list.
+    const aliasNames = [...OPENAI_SUB_BUILTIN_ALIAS_NAMES, ...Object.keys(account.openaiSub?.aliases ?? {})];
+    const aliases: ProxyModelMeta[] = [];
+
+    for (const alias of aliasNames) {
+        const concrete = resolveOpenAiSubModel(alias, account.openaiSub?.aliases);
+        const record = records.find((item) => item.slug === concrete);
+
+        if (concrete === alias || !record) {
+            continue;
+        }
+
+        aliases.push(toMeta(alias, record, `Codex ${alias} alias (${concrete})`));
+    }
+
+    return [
+        ...aliases,
+        ...records.map((record) => toMeta(record.slug, record, `${record.displayName} via ChatGPT/Codex subscription`)),
+    ];
 }
 
 function catalogCopilotRecords(account: AiProxyAccountConfig): CopilotModelRecord[] {

--- a/src/ai-proxy/lib/providers/cooldown.test.ts
+++ b/src/ai-proxy/lib/providers/cooldown.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+    cooldownRemainingMs,
+    markRateLimited,
+    markSuccess,
+    markUnhealthy,
+    resetCooldowns,
+} from "@app/ai-proxy/lib/providers/cooldown";
+
+describe("cooldown", () => {
+    beforeEach(() => {
+        resetCooldowns();
+    });
+
+    it("honours Retry-After and reports remaining time", () => {
+        const applied = markRateLimited("acct", 60);
+
+        expect(applied).toBe(60_000);
+        expect(cooldownRemainingMs("acct")).toBeGreaterThan(55_000);
+        expect(cooldownRemainingMs("other")).toBe(0);
+    });
+
+    it("backs off exponentially on consecutive strikes without Retry-After", () => {
+        const first = markRateLimited("acct");
+        const second = markRateLimited("acct");
+        const third = markRateLimited("acct");
+
+        expect(first).toBe(30_000);
+        expect(second).toBe(60_000);
+        expect(third).toBe(120_000);
+    });
+
+    it("resets on success", () => {
+        markRateLimited("acct", 60);
+        markSuccess("acct");
+
+        expect(cooldownRemainingMs("acct")).toBe(0);
+        expect(markRateLimited("acct")).toBe(30_000);
+    });
+
+    it("marks unhealthy accounts for a fixed window", () => {
+        markUnhealthy("acct", 5_000);
+        expect(cooldownRemainingMs("acct")).toBeGreaterThan(4_000);
+    });
+});

--- a/src/ai-proxy/lib/providers/cooldown.ts
+++ b/src/ai-proxy/lib/providers/cooldown.ts
@@ -1,0 +1,63 @@
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * In-memory per-account cooldown registry, shared by subscription providers.
+ * Keys are account names (or token fingerprints). Rate limits back off
+ * exponentially on consecutive strikes; any success resets the state.
+ */
+interface CooldownState {
+    until: number;
+    strikes: number;
+}
+
+const BASE_BACKOFF_MS = 30_000;
+const MAX_BACKOFF_MS = 10 * 60_000;
+export const UNHEALTHY_COOLDOWN_MS = 15 * 60_000;
+
+const cooldowns = new Map<string, CooldownState>();
+
+/** Apply a 429 cooldown. Honours Retry-After when given; else exponential backoff. Returns the window in ms. */
+export function markRateLimited(key: string, retryAfterSec?: number): number {
+    const previous = cooldowns.get(key);
+    const strikes = (previous?.strikes ?? 0) + 1;
+    const backoffMs =
+        retryAfterSec != null && Number.isFinite(retryAfterSec) && retryAfterSec > 0
+            ? retryAfterSec * 1000
+            : Math.min(BASE_BACKOFF_MS * 2 ** (strikes - 1), MAX_BACKOFF_MS);
+
+    cooldowns.set(key, { until: Date.now() + backoffMs, strikes });
+    logger.warn({ key, strikes, backoffMs }, "ai-proxy cooldown: rate limited, cooling down");
+
+    return backoffMs;
+}
+
+/** Mark an account unusable (e.g. auth dead after refresh) for a fixed window. */
+export function markUnhealthy(key: string, ms: number = UNHEALTHY_COOLDOWN_MS): void {
+    const previous = cooldowns.get(key);
+    cooldowns.set(key, { until: Date.now() + ms, strikes: previous?.strikes ?? 0 });
+    logger.warn({ key, ms }, "ai-proxy cooldown: account marked unhealthy");
+}
+
+export function markSuccess(key: string): void {
+    cooldowns.delete(key);
+}
+
+export function cooldownRemainingMs(key: string): number {
+    const state = cooldowns.get(key);
+
+    if (!state) {
+        return 0;
+    }
+
+    const remaining = state.until - Date.now();
+    if (remaining <= 0) {
+        return 0;
+    }
+
+    return remaining;
+}
+
+/** Test hook: wipe all cooldown state. */
+export function resetCooldowns(): void {
+    cooldowns.clear();
+}

--- a/src/ai-proxy/lib/providers/openai-sub-token.ts
+++ b/src/ai-proxy/lib/providers/openai-sub-token.ts
@@ -23,14 +23,34 @@ export interface OpenAiSubToken {
  *  - otherwise → the Codex CLI cache (`~/.codex/auth.json`), read-only. The CLI
  *    keeps this fresh; the local proxy piggybacks on the machine's `codex login`.
  */
-export async function resolveOpenAiSubToken(account: AiProxyAccountConfig): Promise<OpenAiSubToken> {
+export async function resolveOpenAiSubToken(
+    account: AiProxyAccountConfig,
+    options?: { forceRefresh?: boolean }
+): Promise<OpenAiSubToken> {
     const accountName = account.openaiSub?.accountName;
 
     if (accountName) {
-        return resolveCodexAccountToken(accountName);
+        return resolveCodexAccountToken(accountName, options);
+    }
+
+    if (options?.forceRefresh) {
+        throw new Error(
+            "openai-subscription account uses the Codex CLI cache — the proxy cannot refresh it. Run `codex login`."
+        );
     }
 
     return resolveFromCodexCli(account.openaiSub?.codexAuthPath);
+}
+
+/**
+ * Resolve a token for one of `openaiSub.failoverAccountNames` — always a named
+ * `openai-sub` account in the unified AI config.
+ */
+export async function resolveOpenAiSubFailoverToken(
+    accountName: string,
+    options?: { forceRefresh?: boolean }
+): Promise<OpenAiSubToken> {
+    return resolveCodexAccountToken(accountName, options);
 }
 
 async function resolveFromCodexCli(authPath?: string): Promise<OpenAiSubToken> {

--- a/src/ai-proxy/lib/providers/openai-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.test.ts
@@ -1,12 +1,40 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { resetCooldowns } from "@app/ai-proxy/lib/providers/cooldown";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { SafeJSON } from "@genesiscz/utils/json";
 
 const TEST_TOKEN = "codex-access-token";
 const TEST_ACCOUNT_ID = "acct-123";
 
+let primaryResolver: (options?: { forceRefresh?: boolean }) => Promise<{ token: string; accountId?: string }> =
+    async () => ({ token: TEST_TOKEN, accountId: TEST_ACCOUNT_ID });
+let failoverResolver: (
+    name: string,
+    options?: { forceRefresh?: boolean }
+) => Promise<{ token: string; accountId?: string }> = async (name) => ({ token: `${name}-token` });
+
 mock.module("@app/ai-proxy/lib/providers/openai-sub-token", () => ({
-    resolveOpenAiSubToken: async () => ({ token: TEST_TOKEN, accountId: TEST_ACCOUNT_ID }),
+    resolveOpenAiSubToken: async (_account: unknown, options?: { forceRefresh?: boolean }) => primaryResolver(options),
+    resolveOpenAiSubFailoverToken: async (name: string, options?: { forceRefresh?: boolean }) =>
+        failoverResolver(name, options),
+}));
+
+interface StubWhamModel {
+    slug: string;
+    displayName: string;
+    contextWindow: number;
+    visibility: "list" | "hide";
+    inputModalities?: string[];
+}
+
+let whamModelsStub: StubWhamModel[] | null = null;
+
+mock.module("@genesiscz/utils/ai/openai/sub-models", () => ({
+    OPENAI_SUB_STATIC_CATALOG: [],
+    OPENAI_SUB_BUILTIN_ALIAS_NAMES: ["latest", "codex", "mini"],
+    resolveOpenAiSubModel: (id: string, aliases?: Record<string, string>) => aliases?.[id] ?? id,
+    tryFetchWhamModels: async () => whamModelsStub,
+    fetchWhamModels: async () => whamModelsStub ?? [],
 }));
 
 const account: AiProxyAccountConfig = {
@@ -37,6 +65,13 @@ function whamStreamResponse(): Response {
 
 const realFetch = globalThis.fetch;
 
+beforeEach(() => {
+    resetCooldowns();
+    primaryResolver = async () => ({ token: TEST_TOKEN, accountId: TEST_ACCOUNT_ID });
+    failoverResolver = async (name) => ({ token: `${name}-token` });
+    whamModelsStub = null;
+});
+
 afterEach(() => {
     globalThis.fetch = realFetch;
 });
@@ -44,7 +79,7 @@ afterEach(() => {
 describe("buildWhamResponsesBody", () => {
     it("extracts system→instructions, maps messages→input, forces stream", async () => {
         const { buildWhamResponsesBody } = await import("./openai-subscription");
-        const body = buildWhamResponsesBody(
+        const { body, dropped } = buildWhamResponsesBody(
             {
                 model: "codex/codex/gpt-5.5",
                 messages: [
@@ -64,11 +99,12 @@ describe("buildWhamResponsesBody", () => {
         // WHAM rejects max_output_tokens ("Unsupported parameter"), so the
         // caller's max_tokens cap must NOT be forwarded (verified live 2026-07-12).
         expect(body.max_output_tokens).toBeUndefined();
+        expect(dropped).toContain("max_tokens");
     });
 
     it("maps chat function tools to flat Responses tools", async () => {
         const { buildWhamResponsesBody } = await import("./openai-subscription");
-        const body = buildWhamResponsesBody(
+        const { body } = buildWhamResponsesBody(
             {
                 messages: [{ role: "user", content: "go" }],
                 tools: [
@@ -84,6 +120,57 @@ describe("buildWhamResponsesBody", () => {
         expect(body.tools).toEqual([
             { type: "function", name: "search", description: "d", parameters: { type: "object" } },
         ]);
+    });
+
+    it("records dropped sampling params and unsupported tool types", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+        const { body, dropped } = buildWhamResponsesBody(
+            {
+                messages: [{ role: "user", content: "go" }],
+                temperature: 0.2,
+                top_p: 0.9,
+                tools: [{ type: "web_search" }, { type: "function", function: { name: "f", parameters: {} } }],
+            },
+            "gpt-5.5"
+        );
+
+        expect(dropped).toContain("temperature");
+        expect(dropped).toContain("top_p");
+        expect(dropped).toContain("tools[type=web_search]");
+        expect(body.tools).toEqual([{ type: "function", name: "f", description: undefined, parameters: {} }]);
+    });
+
+    it("passes client reasoning through and clamps unknown efforts", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+
+        const passthrough = buildWhamResponsesBody(
+            { messages: [{ role: "user", content: "x" }], reasoning: { effort: "high" } },
+            "gpt-5.5"
+        );
+        expect(passthrough.body.reasoning).toEqual({ effort: "high" });
+
+        const clamped = buildWhamResponsesBody(
+            { messages: [{ role: "user", content: "x" }], reasoning: { effort: "ultra-max" } },
+            "gpt-5.5"
+        );
+        expect(clamped.body.reasoning).toEqual({ effort: "low" });
+    });
+
+    it("honours defaultReasoningEffort config, including none=omit", async () => {
+        const { buildWhamResponsesBody } = await import("./openai-subscription");
+
+        const highDefault = buildWhamResponsesBody({ messages: [{ role: "user", content: "x" }] }, "gpt-5.5", {
+            defaultReasoningEffort: "high",
+        });
+        expect(highDefault.body.reasoning).toEqual({ effort: "high" });
+
+        const omitted = buildWhamResponsesBody({ messages: [{ role: "user", content: "x" }] }, "gpt-5.5", {
+            defaultReasoningEffort: "none",
+        });
+        expect(omitted.body.reasoning).toBeUndefined();
+
+        const fallback = buildWhamResponsesBody({ messages: [{ role: "user", content: "x" }] }, "gpt-5.5");
+        expect(fallback.body.reasoning).toEqual({ effort: "low" });
     });
 });
 
@@ -115,9 +202,15 @@ describe("OpenAiSubscriptionProvider", () => {
         const completion = (await res.json()) as {
             object: string;
             choices: Array<{ message: { content: string } }>;
+            usage?: Record<string, unknown>;
         };
         expect(completion.object).toBe("chat.completion");
         expect(completion.choices[0]?.message.content).toBe("CODEX_OK");
+        expect(completion.usage).toEqual({
+            prompt_tokens: 10,
+            completion_tokens: 3,
+            total_tokens: 13,
+        });
 
         // upstream targeted WHAM with the Codex token + account id
         expect(capturedUrl).toBe("https://chatgpt.com/backend-api/wham/responses");
@@ -159,6 +252,9 @@ describe("OpenAiSubscriptionProvider", () => {
         expect(text).toContain('"object":"chat.completion.chunk"');
         expect(text).toContain("CODEX");
         expect(text).toContain("[DONE]");
+        // WHAM's response.completed usage must survive into the chat stream.
+        expect(text).toContain('"prompt_tokens":10');
+        expect(text).toContain('"completion_tokens":3');
     });
 
     it("returns 400 (not a 502) for a non-object JSON body", async () => {
@@ -198,7 +294,275 @@ describe("OpenAiSubscriptionProvider", () => {
         const res = await provider.responses(req, "gpt-5.5", bodyText);
 
         expect(res.status).toBe(502);
-        const errorBody = (await res.json()) as { error: { message: string } };
+        const errorBody = (await res.json()) as { error: { message: string; type?: string } };
         expect(errorBody.error.message).toBe("upstream boom");
+        expect(errorBody.error.type).toBe("upstream_error");
+    });
+
+    it("surfaces x-ai-proxy-dropped through the chat translation path", async () => {
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) =>
+            whamStreamResponse()) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+            max_tokens: 32,
+            temperature: 0.5,
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("x-ai-proxy-dropped")).toBe("max_tokens,temperature");
+    });
+
+    it("fails over to the next account on 429 within one request", async () => {
+        const authHeaders: Array<string | null> = [];
+        let call = 0;
+
+        globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+            authHeaders.push(new Headers(init?.headers).get("authorization"));
+            call += 1;
+
+            if (call === 1) {
+                return new Response('{"error":{"message":"slow down"}}', {
+                    status: 429,
+                    headers: { "retry-after": "60" },
+                });
+            }
+
+            return whamStreamResponse();
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create({
+            ...account,
+            openaiSub: { failoverAccountNames: ["backup"] },
+        });
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(200);
+        expect(authHeaders).toEqual([`Bearer ${TEST_TOKEN}`, "Bearer backup-token"]);
+    });
+
+    it("returns a rate_limit_error envelope with Retry-After when every account is limited", async () => {
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) =>
+            new Response('{"error":{"message":"slow down"}}', {
+                status: 429,
+                headers: { "retry-after": "45" },
+            })) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/responses", { method: "POST", body: bodyText });
+        const res = await provider.responses(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get("retry-after")).toBe("45");
+        const body = (await res.json()) as { error: { type: string; message: string } };
+        expect(body.error.type).toBe("rate_limit_error");
+    });
+
+    it("skips a cooling account on the next request instead of hitting upstream", async () => {
+        let upstreamCalls = 0;
+
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => {
+            upstreamCalls += 1;
+            return new Response('{"error":{"message":"slow down"}}', {
+                status: 429,
+                headers: { "retry-after": "60" },
+            });
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+        });
+
+        const first = await provider.responses(
+            new Request("http://localhost/v1/responses", { method: "POST", body: bodyText }),
+            "gpt-5.5",
+            bodyText
+        );
+        expect(first.status).toBe(429);
+        expect(upstreamCalls).toBe(1);
+
+        const second = await provider.responses(
+            new Request("http://localhost/v1/responses", { method: "POST", body: bodyText }),
+            "gpt-5.5",
+            bodyText
+        );
+        expect(second.status).toBe(502);
+        expect(upstreamCalls).toBe(1);
+        const body = (await second.json()) as { error: { message: string } };
+        expect(body.error.message).toContain("cooling down");
+    });
+
+    it("force-refreshes once on 401 and succeeds on retry", async () => {
+        const refreshCalls: Array<boolean | undefined> = [];
+        primaryResolver = async (options) => {
+            refreshCalls.push(options?.forceRefresh);
+            return {
+                token: options?.forceRefresh ? "fresh-token" : "stale-token",
+                accountId: TEST_ACCOUNT_ID,
+            };
+        };
+
+        const authHeaders: Array<string | null> = [];
+        globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+            const auth = new Headers(init?.headers).get("authorization");
+            authHeaders.push(auth);
+
+            if (auth === "Bearer stale-token") {
+                return new Response('{"detail":"Unauthorized"}', { status: 401 });
+            }
+
+            return whamStreamResponse();
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const req = new Request("http://localhost/v1/chat/completions", { method: "POST", body: bodyText });
+        const res = await provider.chatCompletions(req, "gpt-5.5", bodyText);
+
+        expect(res.status).toBe(200);
+        expect(refreshCalls).toEqual([undefined, true]);
+        expect(authHeaders).toEqual(["Bearer stale-token", "Bearer fresh-token"]);
+    });
+
+    it("rejects image input for models known to lack the image modality", async () => {
+        whamModelsStub = [
+            {
+                slug: "gpt-5.5",
+                displayName: "GPT-5.5",
+                contextWindow: 272_000,
+                visibility: "list",
+                inputModalities: ["text"],
+            },
+            {
+                slug: "gpt-5.6-sol",
+                displayName: "GPT-5.6-Sol",
+                contextWindow: 372_000,
+                visibility: "list",
+                inputModalities: ["text", "image"],
+            },
+        ];
+
+        let upstreamCalled = false;
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => {
+            upstreamCalled = true;
+            return whamStreamResponse();
+        }) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "text", text: "what is this?" },
+                        { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+                    ],
+                },
+            ],
+        });
+        const res = await provider.responses(
+            new Request("http://localhost/v1/responses", { method: "POST", body: bodyText }),
+            "gpt-5.5",
+            bodyText
+        );
+
+        expect(res.status).toBe(400);
+        expect(upstreamCalled).toBe(false);
+        const body = (await res.json()) as { error: { code: string; message: string } };
+        expect(body.error.code).toBe("unsupported_modality");
+        expect(body.error.message).toContain("gpt-5.6-sol");
+    });
+
+    it("lets image input pass when modalities are unknown", async () => {
+        whamModelsStub = null;
+
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) =>
+            whamStreamResponse()) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [
+                { role: "user", content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AAA" } }] },
+            ],
+        });
+        const res = await provider.responses(
+            new Request("http://localhost/v1/responses", { method: "POST", body: bodyText }),
+            "gpt-5.5",
+            bodyText
+        );
+
+        expect(res.status).toBe(200);
+    });
+
+    it("marks the account unhealthy after a second 401 and returns authentication_error", async () => {
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) =>
+            new Response('{"detail":"Unauthorized"}', { status: 401 })) as typeof fetch;
+
+        const { OpenAiSubscriptionProvider } = await import("./openai-subscription");
+        const provider = await OpenAiSubscriptionProvider.create(account);
+
+        const bodyText = SafeJSON.stringify({
+            model: "codex/codex/gpt-5.5",
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const res = await provider.responses(
+            new Request("http://localhost/v1/responses", { method: "POST", body: bodyText }),
+            "gpt-5.5",
+            bodyText
+        );
+
+        expect(res.status).toBe(401);
+        const body = (await res.json()) as { error: { type: string; message: string } };
+        expect(body.error.type).toBe("authentication_error");
+        expect(body.error.message).toContain("accounts login codex");
+
+        // Account is now cooling — next request short-circuits without upstream.
+        let upstreamCalled = false;
+        globalThis.fetch = (async (_url: RequestInfo | URL, _init?: RequestInit) => {
+            upstreamCalled = true;
+            return whamStreamResponse();
+        }) as typeof fetch;
+
+        const second = await provider.responses(
+            new Request("http://localhost/v1/responses", { method: "POST", body: bodyText }),
+            "gpt-5.5",
+            bodyText
+        );
+        expect(second.status).toBe(502);
+        expect(upstreamCalled).toBe(false);
     });
 });

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -1,12 +1,22 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { convertMessagesToInput } from "@app/ai-proxy/lib/chat-to-responses-body";
+import { captureUpstreamFailure } from "@app/ai-proxy/lib/debug-capture";
 import { clientAbortResponse } from "@app/ai-proxy/lib/providers/client-abort";
-import { resolveOpenAiSubToken } from "@app/ai-proxy/lib/providers/openai-sub-token";
+import { cooldownRemainingMs, markRateLimited, markSuccess, markUnhealthy } from "@app/ai-proxy/lib/providers/cooldown";
+import { resolveOpenAiSubFailoverToken, resolveOpenAiSubToken } from "@app/ai-proxy/lib/providers/openai-sub-token";
 import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { mapWhamError, parseRetryAfterSeconds } from "@app/ai-proxy/lib/providers/wham-errors";
 import { responsesToChat } from "@app/ai-proxy/lib/translators/responses-to-chat";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
-import { WHAM_BASE_URL } from "@genesiscz/utils/ai/openai/codex-auth";
-import { fetchWhamModels, resolveOpenAiSubModel } from "@genesiscz/utils/ai/openai/sub-models";
+import { getTodayUsageSummary, getUsageSummarySince } from "@app/ai-proxy/lib/usage/store";
+import { extractPlanType, WHAM_BASE_URL } from "@genesiscz/utils/ai/openai/codex-auth";
+import {
+    fetchWhamModels,
+    resolveOpenAiSubModel,
+    tryFetchWhamModels,
+    type WhamModelRecord,
+} from "@genesiscz/utils/ai/openai/sub-models";
+import { formatTokens } from "@genesiscz/utils/format";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { isObject } from "@genesiscz/utils/object";
@@ -21,10 +31,14 @@ const WHAM_RESPONSES_URL = `${WHAM_BASE_URL}/responses`;
  * translator (which calls `responses()` and maps the Responses output back to
  * chat.completion / chat.completion.chunk).
  */
+const MODALITY_CACHE_TTL_MS = 10 * 60_000;
+
 export class OpenAiSubscriptionProvider implements ProxyProvider {
     readonly id = "openai-subscription";
     readonly accountFingerprint: string;
     private readonly account: AiProxyAccountConfig;
+    private modalityRecords: WhamModelRecord[] | null = null;
+    private modalityFetchedAt = 0;
 
     constructor(account: AiProxyAccountConfig) {
         this.account = account;
@@ -56,8 +70,84 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
         return response;
     }
 
+    /**
+     * Token candidates tried in order: the primary account source, then any
+     * `openaiSub.failoverAccountNames`. Each has its own cooldown key.
+     */
+    private tokenCandidates(): Array<{
+        key: string;
+        resolve: (options?: { forceRefresh?: boolean }) => Promise<{ token: string; accountId?: string }>;
+    }> {
+        const candidates: Array<{
+            key: string;
+            resolve: (options?: { forceRefresh?: boolean }) => Promise<{ token: string; accountId?: string }>;
+        }> = [
+            {
+                key: this.account.name,
+                resolve: (options) => resolveOpenAiSubToken(this.account, options),
+            },
+        ];
+
+        for (const failoverName of this.account.openaiSub?.failoverAccountNames ?? []) {
+            candidates.push({
+                key: `${this.account.name}:${failoverName}`,
+                resolve: (options) => resolveOpenAiSubFailoverToken(failoverName, options),
+            });
+        }
+
+        return candidates;
+    }
+
+    /**
+     * Advertised input modalities for a model, from the live WHAM list (cached
+     * 10 min). Returns undefined when unknown — the guard only blocks when it
+     * KNOWS the model lacks image input; unknown models pass through so WHAM's
+     * own error surfaces.
+     */
+    private async lookupInputModalities(concreteModel: string): Promise<string[] | undefined> {
+        if (!this.modalityRecords || Date.now() - this.modalityFetchedAt > MODALITY_CACHE_TTL_MS) {
+            try {
+                const { token, accountId } = await resolveOpenAiSubToken(this.account);
+                this.modalityRecords = await tryFetchWhamModels(token, accountId);
+                this.modalityFetchedAt = Date.now();
+            } catch (err) {
+                logger.debug({ err, account: this.account.name }, "ai-proxy: modality lookup failed — skipping guard");
+                return undefined;
+            }
+        }
+
+        return this.modalityRecords?.find((record) => record.slug === concreteModel)?.inputModalities;
+    }
+
+    private async fetchWham({
+        token,
+        accountId,
+        whamBodyText,
+        signal,
+    }: {
+        token: string;
+        accountId?: string;
+        whamBodyText: string;
+        signal: AbortSignal;
+    }): Promise<Response> {
+        return fetch(WHAM_RESPONSES_URL, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "chatgpt-account-id": accountId ?? "",
+                "Content-Type": "application/json",
+                "OpenAI-Beta": "responses=experimental",
+                originator: "codex_cli_rs",
+                session_id: crypto.randomUUID(),
+                Accept: "text/event-stream",
+            },
+            body: whamBodyText,
+            signal,
+        });
+    }
+
     async responses(req: Request, model: string, bodyText: string): Promise<Response> {
-        const concreteModel = resolveOpenAiSubModel(model);
+        const concreteModel = resolveOpenAiSubModel(model, this.account.openaiSub?.aliases);
 
         let parsed: Record<string, unknown>;
         try {
@@ -72,80 +162,181 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
             return jsonError(400, "Invalid JSON body");
         }
 
-        const wantStream = parsed.stream === true;
-        const whamBody = buildWhamResponsesBody(parsed, concreteModel);
+        if (bodyContainsImageInput(parsed)) {
+            const modalities = await this.lookupInputModalities(concreteModel);
 
-        let token: string;
-        let accountId: string | undefined;
-        try {
-            ({ token, accountId } = await resolveOpenAiSubToken(this.account));
-        } catch (err) {
-            logger.warn({ err, account: this.account.name }, "ai-proxy: openai-subscription token resolution failed");
-            return jsonError(
-                502,
-                `Codex subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`
-            );
+            if (modalities && !modalities.includes("image")) {
+                const visionModels = (this.modalityRecords ?? [])
+                    .filter((record) => record.visibility === "list" && record.inputModalities?.includes("image"))
+                    .map((record) => record.slug);
+                const hint = visionModels.length > 0 ? ` Vision-capable: ${visionModels.join(", ")}.` : "";
+
+                return new Response(
+                    SafeJSON.stringify({
+                        error: {
+                            message: `Model ${concreteModel} does not accept image input.${hint}`,
+                            type: "invalid_request_error",
+                            code: "unsupported_modality",
+                        },
+                    }),
+                    { status: 400, headers: { "Content-Type": "application/json" } }
+                );
+            }
         }
 
+        const wantStream = parsed.stream === true;
+        const { body: whamBody, dropped } = buildWhamResponsesBody(parsed, concreteModel, {
+            defaultReasoningEffort: this.account.openaiSub?.defaultReasoningEffort,
+        });
+        warnDroppedParamsOnce(dropped);
+        const whamBodyText = SafeJSON.stringify(whamBody);
+
         const started = performance.now();
-        let upstream: Response;
-        try {
-            upstream = await fetch(WHAM_RESPONSES_URL, {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "chatgpt-account-id": accountId ?? "",
-                    "Content-Type": "application/json",
-                    "OpenAI-Beta": "responses=experimental",
-                    originator: "codex_cli_rs",
-                    session_id: crypto.randomUUID(),
-                    Accept: "text/event-stream",
-                },
-                body: SafeJSON.stringify(whamBody),
-                signal: req.signal,
-            });
-        } catch (err) {
-            const aborted = clientAbortResponse(err, { err, account: this.account.name });
-            if (aborted) {
-                return aborted;
+        let upstream: Response | undefined;
+        let servedBy: string | undefined;
+        let lastFailure: Response | undefined;
+
+        for (const candidate of this.tokenCandidates()) {
+            const coolingMs = cooldownRemainingMs(candidate.key);
+            if (coolingMs > 0) {
+                logger.debug(
+                    { key: candidate.key, coolingMs, model: concreteModel },
+                    "ai-proxy: skipping cooling codex account"
+                );
+                continue;
             }
 
-            logger.warn({ err, account: this.account.name }, "ai-proxy: WHAM upstream fetch failed");
-            return jsonError(
-                502,
-                `Failed to reach ChatGPT upstream: ${err instanceof Error ? err.message : String(err)}`
-            );
+            let token: string;
+            let accountId: string | undefined;
+            try {
+                ({ token, accountId } = await candidate.resolve());
+            } catch (err) {
+                logger.warn({ err, key: candidate.key }, "ai-proxy: openai-subscription token resolution failed");
+                lastFailure = jsonError(
+                    502,
+                    `Codex subscription token unavailable: ${err instanceof Error ? err.message : String(err)}`
+                );
+                continue;
+            }
+
+            let attempt: Response;
+            try {
+                attempt = await this.fetchWham({ token, accountId, whamBodyText, signal: req.signal });
+            } catch (err) {
+                const aborted = clientAbortResponse(err, { err, account: this.account.name });
+                if (aborted) {
+                    return aborted;
+                }
+
+                logger.warn({ err, key: candidate.key }, "ai-proxy: WHAM upstream fetch failed");
+                lastFailure = jsonError(
+                    502,
+                    `Failed to reach ChatGPT upstream: ${err instanceof Error ? err.message : String(err)}`
+                );
+                continue;
+            }
+
+            if (attempt.status === 401) {
+                // One forced refresh, then one retry. A second 401 means the
+                // grant is dead — cool the account and move to the next one.
+                void attempt.body?.cancel();
+                try {
+                    ({ token, accountId } = await candidate.resolve({ forceRefresh: true }));
+                    attempt = await this.fetchWham({ token, accountId, whamBodyText, signal: req.signal });
+                } catch (err) {
+                    const aborted = clientAbortResponse(err, { err, account: this.account.name });
+                    if (aborted) {
+                        return aborted;
+                    }
+
+                    logger.warn({ err, key: candidate.key }, "ai-proxy: codex 401 refresh-retry failed");
+                    markUnhealthy(candidate.key);
+                    lastFailure = whamErrorResponse({ status: 401, bodyText: "" });
+                    continue;
+                }
+
+                if (attempt.status === 401) {
+                    const errorText = await attempt.text();
+                    logger.warn(
+                        { key: candidate.key, body: errorText.slice(0, 300) },
+                        "ai-proxy: codex account still 401 after refresh — marking unhealthy"
+                    );
+                    markUnhealthy(candidate.key);
+                    lastFailure = whamErrorResponse({ status: 401, bodyText: errorText });
+                    continue;
+                }
+            }
+
+            if (attempt.status === 429) {
+                const retryAfterSec = parseRetryAfterSeconds(attempt.headers);
+                const errorText = await attempt.text();
+                const backoffMs = markRateLimited(candidate.key, retryAfterSec);
+                lastFailure = whamErrorResponse({
+                    status: 429,
+                    bodyText: errorText,
+                    retryAfterSec: retryAfterSec ?? Math.ceil(backoffMs / 1000),
+                });
+                continue;
+            }
+
+            if (!attempt.ok) {
+                const errorText = await attempt.text();
+                logger.warn(
+                    {
+                        key: candidate.key,
+                        model: concreteModel,
+                        status: attempt.status,
+                        body: errorText.slice(0, 500),
+                    },
+                    "ai-proxy: WHAM upstream request failed"
+                );
+                captureUpstreamFailure({
+                    provider: "openai-subscription",
+                    account: this.account.name,
+                    model: concreteModel,
+                    status: attempt.status,
+                    requestBody: whamBodyText,
+                    responseBody: errorText,
+                });
+
+                return whamErrorResponse({ status: attempt.status, bodyText: errorText });
+            }
+
+            markSuccess(candidate.key);
+            upstream = attempt;
+            servedBy = candidate.key;
+            break;
+        }
+
+        if (!upstream) {
+            return lastFailure ?? jsonError(502, "All codex accounts are cooling down or unavailable.");
         }
 
         const elapsedMs = Math.round(performance.now() - started);
-
-        if (!upstream.ok) {
-            const errorText = await upstream.text();
-            logger.warn(
-                {
-                    account: this.account.name,
-                    model: concreteModel,
-                    status: upstream.status,
-                    elapsedMs,
-                    body: errorText.slice(0, 500),
-                },
-                "ai-proxy: WHAM upstream request failed"
-            );
-
-            return new Response(errorText, {
-                status: upstream.status,
-                headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
-            });
-        }
+        const reasoning = isObject(whamBody.reasoning) ? whamBody.reasoning : undefined;
 
         logger.debug(
-            { account: this.account.name, model: concreteModel, wantStream, elapsedMs },
+            {
+                provider: "openai-subscription",
+                account: this.account.name,
+                servedBy,
+                proxyModel: model,
+                upstreamModel: concreteModel,
+                reasoningEffort: reasoning && typeof reasoning.effort === "string" ? reasoning.effort : undefined,
+                stream: wantStream,
+                status: upstream.status,
+                elapsedMs,
+                dropped: dropped.length > 0 ? dropped : undefined,
+                authSource: this.account.openaiSub?.accountName ? "ai-config" : "codex-auth.json",
+            },
             "ai-proxy: WHAM upstream request ok"
         );
 
         if (!upstream.body) {
             return jsonError(502, "WHAM upstream returned no body");
         }
+
+        const droppedHeader = dropped.length > 0 ? { "x-ai-proxy-dropped": dropped.join(",") } : undefined;
 
         if (wantStream) {
             return new Response(upstream.body, {
@@ -159,6 +350,7 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
                     // eve tool-loop. curl tolerates it; undici does not. Close per stream.
                     Connection: "close",
                     "X-Accel-Buffering": "no",
+                    ...droppedHeader,
                 },
             });
         }
@@ -187,22 +379,77 @@ export class OpenAiSubscriptionProvider implements ProxyProvider {
                 { account: this.account.name, model: concreteModel, error: accumulated.error },
                 "ai-proxy: WHAM stream reported response.failed"
             );
-            return jsonError(502, accumulated.error);
+            captureUpstreamFailure({
+                provider: "openai-subscription",
+                account: this.account.name,
+                model: concreteModel,
+                status: 502,
+                requestBody: whamBodyText,
+                responseBody: accumulated.error,
+            });
+            return new Response(
+                SafeJSON.stringify({
+                    error: {
+                        message: accumulated.error,
+                        type: "upstream_error",
+                        ...(accumulated.errorCode ? { code: accumulated.errorCode } : {}),
+                    },
+                }),
+                { status: 502, headers: { "Content-Type": "application/json" } }
+            );
         }
 
         return new Response(accumulated.body, {
             status: 200,
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...droppedHeader },
         });
     }
 
     async getUsage(): Promise<UsageSummary> {
+        // ChatGPT exposes no plan-quota endpoint we can trust, so this reports
+        // proxy-observed traffic from the local usage store — never claim
+        // upstream weekly-limit numbers here.
+        const today = getTodayUsageSummary(this.account.name);
+        const month = getUsageSummarySince(30, this.account.name);
+        const summary =
+            `proxy-observed: today ${today.requests} req / ${formatTokens(today.total_tokens)} tok · ` +
+            `30d ${month.requests} req / ${formatTokens(month.total_tokens)} tok (not ChatGPT plan quota)`;
+
+        let tier: string | undefined;
+        try {
+            const { token } = await resolveOpenAiSubToken(this.account);
+            tier = extractPlanType(token);
+        } catch (err) {
+            logger.debug(
+                { err, account: this.account.name },
+                "ai-proxy: getUsage could not resolve codex token for tier"
+            );
+        }
+
         return {
             accountName: this.account.name,
             provider: "openai-subscription",
-            summary: "subscription (usage not exposed by the ChatGPT backend)",
+            tier,
+            summary,
         };
     }
+}
+
+function partIsImage(part: unknown): boolean {
+    return isObject(part) && (part.type === "image_url" || part.type === "input_image");
+}
+
+function messageHasImage(entry: unknown): boolean {
+    return isObject(entry) && Array.isArray(entry.content) && entry.content.some(partIsImage);
+}
+
+/** True when the chat `messages` or Responses `input` carry image parts. */
+export function bodyContainsImageInput(parsed: Record<string, unknown>): boolean {
+    if (Array.isArray(parsed.messages) && parsed.messages.some(messageHasImage)) {
+        return true;
+    }
+
+    return Array.isArray(parsed.input) && parsed.input.some(messageHasImage);
 }
 
 function extractText(content: unknown): string {
@@ -217,7 +464,7 @@ function extractText(content: unknown): string {
     return "";
 }
 
-function mapChatToolsToResponses(tools: unknown): unknown[] | undefined {
+function mapChatToolsToResponses(tools: unknown, dropped?: string[]): unknown[] | undefined {
     if (!Array.isArray(tools)) {
         return undefined;
     }
@@ -244,20 +491,71 @@ function mapChatToolsToResponses(tools: unknown): unknown[] | undefined {
                 description: typeof fn.description === "string" ? fn.description : undefined,
                 parameters: fn.parameters ?? { type: "object", properties: {} },
             });
+            continue;
         }
+
+        // WHAM only accepts flat function tools — anything else is stripped.
+        dropped?.push(`tools[type=${typeof tool.type === "string" ? tool.type : "unknown"}]`);
     }
 
     return mapped.length > 0 ? mapped : undefined;
 }
 
+/** Filter an already-Responses-shaped tools array down to what WHAM accepts. */
+function mapResponsesTools(tools: unknown, dropped: string[]): unknown[] | undefined {
+    if (!Array.isArray(tools)) {
+        return undefined;
+    }
+
+    const kept: unknown[] = [];
+
+    for (const tool of tools) {
+        if (isObject(tool) && tool.type === "function") {
+            kept.push(tool);
+            continue;
+        }
+
+        dropped.push(`tools[type=${isObject(tool) && typeof tool.type === "string" ? tool.type : "unknown"}]`);
+    }
+
+    return kept.length > 0 ? kept : undefined;
+}
+
+const WHAM_REASONING_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh"]);
+
+export interface WhamBodyBuildResult {
+    body: Record<string, unknown>;
+    /** Client-sent parameters WHAM cannot enforce, silently stripped from the upstream body. */
+    dropped: string[];
+}
+
+const warnedDroppedParams = new Set<string>();
+
+/** Log each dropped-parameter name once per process so agent traffic doesn't spam the log. */
+export function warnDroppedParamsOnce(dropped: string[]): void {
+    for (const param of dropped) {
+        if (warnedDroppedParams.has(param)) {
+            continue;
+        }
+
+        warnedDroppedParams.add(param);
+        logger.warn({ param }, "ai-proxy: WHAM does not accept this parameter — dropped (logged once per process)");
+    }
+}
+
 /** Convert a chat- or responses-shaped body into a WHAM Responses request. */
-export function buildWhamResponsesBody(parsed: Record<string, unknown>, model: string): Record<string, unknown> {
+export function buildWhamResponsesBody(
+    parsed: Record<string, unknown>,
+    model: string,
+    options?: { defaultReasoningEffort?: "none" | "low" | "medium" | "high" }
+): WhamBodyBuildResult {
     const body: Record<string, unknown> = {
         model,
         stream: true,
         store: false,
         include: [],
     };
+    const dropped: string[] = [];
 
     if (Array.isArray(parsed.input)) {
         // Already a Responses body.
@@ -267,7 +565,13 @@ export function buildWhamResponsesBody(parsed: Record<string, unknown>, model: s
             body.instructions = parsed.instructions;
         }
 
-        if (parsed.tools) {
+        if (Array.isArray(parsed.tools)) {
+            const kept = mapResponsesTools(parsed.tools, dropped);
+
+            if (kept) {
+                body.tools = kept;
+            }
+        } else if (parsed.tools) {
             body.tools = parsed.tools;
         }
     } else {
@@ -290,33 +594,61 @@ export function buildWhamResponsesBody(parsed: Record<string, unknown>, model: s
             body.instructions = instructions.join("\n\n");
         }
 
-        const tools = mapChatToolsToResponses(parsed.tools);
+        const tools = mapChatToolsToResponses(parsed.tools, dropped);
 
         if (tools) {
             body.tools = tools;
         }
     }
 
-    // WHAM rejects max_output_tokens outright ("Unsupported parameter"), so a
-    // caller's max_tokens cap is intentionally dropped rather than forwarded.
-
-    if (isObject(parsed.reasoning)) {
-        body.reasoning = parsed.reasoning;
-    } else {
-        body.reasoning = { effort: "low" };
+    // WHAM allowlist probed live 2026-07-19 (Plus plan): max_output_tokens,
+    // temperature, top_p, previous_response_id all 400 "Unsupported parameter";
+    // store must stay false ("Store must be set to false"). Dropped rather than
+    // forwarded — recorded in `dropped` so callers can surface it honestly.
+    if (parsed.max_tokens != null || parsed.max_output_tokens != null) {
+        dropped.push("max_tokens");
     }
 
-    return body;
+    for (const param of ["temperature", "top_p", "previous_response_id"] as const) {
+        if (parsed[param] != null) {
+            dropped.push(param);
+        }
+    }
+
+    if (parsed.store === true) {
+        dropped.push("store");
+    }
+
+    if (isObject(parsed.reasoning)) {
+        // Pass the client's reasoning through, clamping unknown efforts.
+        const reasoning = { ...parsed.reasoning };
+
+        if (typeof reasoning.effort === "string" && !WHAM_REASONING_EFFORTS.has(reasoning.effort)) {
+            logger.debug({ effort: reasoning.effort }, "ai-proxy: clamped unknown reasoning effort to low");
+            reasoning.effort = "low";
+        }
+
+        body.reasoning = reasoning;
+    } else {
+        const effort = options?.defaultReasoningEffort ?? "low";
+
+        if (effort !== "none") {
+            body.reasoning = { effort };
+        }
+    }
+
+    return { body, dropped };
 }
 
 async function accumulateResponsesJson(
     stream: ReadableStream<Uint8Array>
-): Promise<{ failed: false; body: string } | { failed: true; error: string }> {
+): Promise<{ failed: false; body: string } | { failed: true; error: string; errorCode?: string }> {
     const raw = await new Response(stream).text();
     let text = "";
     const functionCalls: unknown[] = [];
     let completed: Record<string, unknown> = {};
     let failure: string | undefined;
+    let failureCode: string | undefined;
 
     for (const line of raw.split("\n")) {
         const trimmed = line.trimStart();
@@ -362,11 +694,12 @@ async function accumulateResponsesJson(
             const response = isObject(event.response) ? event.response : undefined;
             const error = response && isObject(response.error) ? response.error : undefined;
             failure = error && typeof error.message === "string" ? error.message : "WHAM response.failed";
+            failureCode = error && typeof error.code === "string" ? error.code : undefined;
         }
     }
 
     if (failure) {
-        return { failed: true, error: failure };
+        return { failed: true, error: failure, errorCode: failureCode };
     }
 
     const output: unknown[] = [];
@@ -390,4 +723,24 @@ function jsonError(status: number, message: string): Response {
         status,
         headers: { "Content-Type": "application/json" },
     });
+}
+
+/** OpenAI-shaped error response for a failed WHAM request, with Retry-After on 429. */
+function whamErrorResponse({
+    status,
+    bodyText,
+    retryAfterSec,
+}: {
+    status: number;
+    bodyText: string;
+    retryAfterSec?: number;
+}): Response {
+    const envelope = mapWhamError({ status, bodyText, retryAfterSec });
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+    if (status === 429 && retryAfterSec != null) {
+        headers["Retry-After"] = String(retryAfterSec);
+    }
+
+    return new Response(SafeJSON.stringify(envelope), { status, headers });
 }

--- a/src/ai-proxy/lib/providers/wham-errors.test.ts
+++ b/src/ai-proxy/lib/providers/wham-errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { mapWhamError, parseRetryAfterSeconds } from "@app/ai-proxy/lib/providers/wham-errors";
+
+describe("mapWhamError", () => {
+    it("maps 401 to an actionable authentication_error", () => {
+        const envelope = mapWhamError({ status: 401, bodyText: '{"detail":"Unauthorized"}' });
+
+        expect(envelope.error.type).toBe("authentication_error");
+        expect(envelope.error.code).toBe("codex_auth_expired");
+        expect(envelope.error.message).toContain("accounts login codex");
+    });
+
+    it("maps 429 with a retry hint", () => {
+        const envelope = mapWhamError({
+            status: 429,
+            bodyText: '{"error":{"message":"Too many requests","code":"rate_limit"}}',
+            retryAfterSec: 30,
+        });
+
+        expect(envelope.error.type).toBe("rate_limit_error");
+        expect(envelope.error.code).toBe("rate_limit");
+        expect(envelope.error.message).toContain("Too many requests");
+        expect(envelope.error.message).toContain("Retry after 30s");
+    });
+
+    it("keeps the upstream message for 400s and tolerates non-JSON bodies", () => {
+        const bad = mapWhamError({
+            status: 400,
+            bodyText: '{"error":{"message":"Unsupported parameter: max_output_tokens","type":"invalid_request_error"}}',
+        });
+        expect(bad.error.message).toBe("Unsupported parameter: max_output_tokens");
+        expect(bad.error.type).toBe("invalid_request_error");
+
+        const html = mapWhamError({ status: 502, bodyText: "<html>bad gateway</html>" });
+        expect(html.error.type).toBe("upstream_error");
+        expect(html.error.message).toBe("ChatGPT upstream returned 502");
+    });
+});
+
+describe("parseRetryAfterSeconds", () => {
+    it("parses numeric Retry-After", () => {
+        expect(parseRetryAfterSeconds(new Headers({ "retry-after": "42" }))).toBe(42);
+    });
+
+    it("returns undefined when absent or garbage", () => {
+        expect(parseRetryAfterSeconds(new Headers())).toBeUndefined();
+        expect(parseRetryAfterSeconds(new Headers({ "retry-after": "soon" }))).toBeUndefined();
+    });
+});

--- a/src/ai-proxy/lib/providers/wham-errors.ts
+++ b/src/ai-proxy/lib/providers/wham-errors.ts
@@ -1,0 +1,100 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isObject } from "@genesiscz/utils/object";
+
+export interface OpenAiErrorEnvelope {
+    error: {
+        message: string;
+        type: string;
+        code?: string;
+    };
+}
+
+/** Pull message/type/code out of a WHAM error body when it is JSON; else use the raw text. */
+function parseUpstreamError(bodyText: string): { message?: string; type?: string; code?: string } {
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true });
+
+        if (!isObject(parsed)) {
+            return {};
+        }
+
+        const error = isObject(parsed.error) ? parsed.error : parsed;
+
+        return {
+            message: typeof error.message === "string" ? error.message : undefined,
+            type: typeof error.type === "string" ? error.type : undefined,
+            code: typeof error.code === "string" ? error.code : undefined,
+        };
+    } catch (err) {
+        logger.debug({ err, bodyPreview: bodyText.slice(0, 200) }, "ai-proxy: WHAM error body is not JSON");
+        return {};
+    }
+}
+
+/**
+ * Map a non-OK WHAM response to an OpenAI-shaped error envelope. 401 and 429
+ * get actionable copy; everything else keeps the upstream message when parseable.
+ */
+export function mapWhamError({
+    status,
+    bodyText,
+    retryAfterSec,
+}: {
+    status: number;
+    bodyText: string;
+    retryAfterSec?: number;
+}): OpenAiErrorEnvelope {
+    const upstream = parseUpstreamError(bodyText);
+
+    if (status === 401) {
+        return {
+            error: {
+                message:
+                    "Codex auth expired or invalid — run `tools ai-proxy accounts login codex` (or `codex login` when using the CLI cache).",
+                type: "authentication_error",
+                code: upstream.code ?? "codex_auth_expired",
+            },
+        };
+    }
+
+    if (status === 429) {
+        const hint = retryAfterSec != null ? ` Retry after ${retryAfterSec}s.` : " Retry later.";
+
+        return {
+            error: {
+                message: `${upstream.message ?? "ChatGPT subscription rate limit hit."}${hint}`,
+                type: "rate_limit_error",
+                code: upstream.code ?? "rate_limit_exceeded",
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: upstream.message ?? `ChatGPT upstream returned ${status}`,
+            type: upstream.type ?? (status >= 500 ? "upstream_error" : "invalid_request_error"),
+            code: upstream.code,
+        },
+    };
+}
+
+export function parseRetryAfterSeconds(headers: Headers): number | undefined {
+    const raw = headers.get("retry-after");
+
+    if (!raw) {
+        return undefined;
+    }
+
+    const seconds = Number(raw);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+        return seconds;
+    }
+
+    const dateMs = Date.parse(raw);
+    if (Number.isFinite(dateMs)) {
+        return Math.max(0, Math.round((dateMs - Date.now()) / 1000));
+    }
+
+    return undefined;
+}

--- a/src/ai-proxy/lib/translators/responses-to-chat-json.ts
+++ b/src/ai-proxy/lib/translators/responses-to-chat-json.ts
@@ -176,6 +176,7 @@ export async function responsesToChatJson({
     }
 
     const rawText = await upstream.text();
+    const droppedHeader = upstream.headers.get("x-ai-proxy-dropped");
 
     try {
         const parsed = SafeJSON.parse(rawText, { strict: true }) as JsonObject;
@@ -185,7 +186,10 @@ export async function responsesToChatJson({
         return pipelineResult(
             new Response(responseText, {
                 status: upstream.status,
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                    "Content-Type": "application/json",
+                    ...(droppedHeader ? { "x-ai-proxy-dropped": droppedHeader } : {}),
+                },
             }),
             responseText
         );

--- a/src/ai-proxy/lib/translators/responses-to-chat-sse.ts
+++ b/src/ai-proxy/lib/translators/responses-to-chat-sse.ts
@@ -223,6 +223,8 @@ export async function responsesToChatSse({
         },
     });
 
+    const droppedHeader = upstream.headers.get("x-ai-proxy-dropped");
+
     return pipelineResult(
         new Response(stream, {
             status: 200,
@@ -233,6 +235,7 @@ export async function responsesToChatSse({
                 // close per stream (see providers/anthropic-subscription.ts).
                 Connection: "close",
                 "X-Accel-Buffering": "no",
+                ...(droppedHeader ? { "x-ai-proxy-dropped": droppedHeader } : {}),
             },
         }),
         responseBody

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -96,6 +96,18 @@ export interface AiProxyOpenAiSubAccountConfig {
     accountName?: string;
     /** Override path to the Codex CLI auth.json (defaults to ~/.codex/auth.json). */
     codexAuthPath?: string;
+    /**
+     * Additional `openai-sub` AI-config account names tried in order when the
+     * primary is rate-limited (429) or its auth dies (401 after refresh).
+     */
+    failoverAccountNames?: string[];
+    /**
+     * Reasoning effort sent to WHAM when the client omits `reasoning`.
+     * "none" omits the field entirely. Default: "low".
+     */
+    defaultReasoningEffort?: "none" | "low" | "medium" | "high";
+    /** Extra model aliases for this account, e.g. { "fast": "gpt-5.4-mini" }. */
+    aliases?: Record<string, string>;
 }
 
 export interface AiProxyAccountConfig {
@@ -155,6 +167,9 @@ export interface ProxyModelMeta {
     agentType?: string;
     apiBackend?: string;
     supportsTools?: boolean;
+    /** Input modalities upstream advertises (e.g. ["text","image"]); absent = unknown. */
+    inputModalities?: string[];
+    supportsParallelToolCalls?: boolean;
     billingPlane: "subscription" | "api-key";
     source: GrokModelRecord["source"];
     probeStatus?: GrokModelRecord["probeStatus"];

--- a/src/ai-proxy/lib/usage/extract.test.ts
+++ b/src/ai-proxy/lib/usage/extract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import {
+    estimateUsageFromExchange,
+    extractLatestUsageFromSse,
+    extractUsageFromJsonBody,
+} from "@app/ai-proxy/lib/usage/extract";
+
+describe("extractLatestUsageFromSse", () => {
+    it("reads top-level usage from chat completion chunks", () => {
+        const sse =
+            'data: {"object":"chat.completion.chunk","choices":[{"delta":{"content":"hi"}}]}\n\n' +
+            'data: {"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}\n\n' +
+            "data: [DONE]\n\n";
+
+        expect(extractLatestUsageFromSse(sse)).toEqual({
+            prompt_tokens: 5,
+            completion_tokens: 2,
+            total_tokens: 7,
+        });
+    });
+
+    it("reads nested response.usage from Responses response.completed events (WHAM shape)", () => {
+        const sse =
+            'data: {"type":"response.output_text.delta","delta":"CODEX_OK"}\n\n' +
+            'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":10,"output_tokens":3,"total_tokens":13}}}\n\n';
+
+        expect(extractLatestUsageFromSse(sse)).toEqual({
+            prompt_tokens: 10,
+            completion_tokens: 3,
+            total_tokens: 13,
+        });
+    });
+
+    it("returns undefined when no event carries usage", () => {
+        const sse = 'data: {"type":"response.output_text.delta","delta":"x"}\n\n';
+        expect(extractLatestUsageFromSse(sse)).toBeUndefined();
+    });
+});
+
+describe("extractUsageFromJsonBody", () => {
+    it("normalizes Responses-style input/output token names", () => {
+        const body = '{"usage":{"input_tokens":4,"output_tokens":6}}';
+
+        expect(extractUsageFromJsonBody(body)).toEqual({
+            prompt_tokens: 4,
+            completion_tokens: 6,
+            total_tokens: 10,
+        });
+    });
+});
+
+describe("estimateUsageFromExchange", () => {
+    it("estimates from message text and chat SSE deltas, tagged estimated", () => {
+        const bodyText = '{"messages":[{"role":"user","content":"tell me a story about a dragon"}],"stream":true}';
+        const responseBody =
+            'data: {"object":"chat.completion.chunk","choices":[{"delta":{"content":"Once upon a time"}}]}\n\n' +
+            'data: {"object":"chat.completion.chunk","choices":[{"delta":{"content":" there was a dragon."}}]}\n\n' +
+            "data: [DONE]\n\n";
+
+        const usage = estimateUsageFromExchange({ bodyText, responseBody, stream: true });
+
+        expect(usage.source).toBe("estimated");
+        // "tell me a story about a dragon" = 31 chars → ceil(31/4) = 8
+        expect(usage.prompt_tokens).toBe(8);
+        // "Once upon a time there was a dragon." = 36 chars → 9
+        expect(usage.completion_tokens).toBe(9);
+        expect(usage.total_tokens).toBe(17);
+    });
+
+    it("estimates from non-stream chat completion message content", () => {
+        const bodyText = '{"messages":[{"role":"user","content":"hi"}]}';
+        const responseBody =
+            '{"object":"chat.completion","choices":[{"message":{"role":"assistant","content":"hello there"}}]}';
+
+        const usage = estimateUsageFromExchange({ bodyText, responseBody, stream: false });
+
+        expect(usage.source).toBe("estimated");
+        expect(usage.prompt_tokens).toBe(1);
+        expect(usage.completion_tokens).toBe(3);
+    });
+});

--- a/src/ai-proxy/lib/usage/extract.ts
+++ b/src/ai-proxy/lib/usage/extract.ts
@@ -85,7 +85,16 @@ export function extractLatestUsageFromSse(buffer: string): TokenUsage | undefine
 
         try {
             const parsed = SafeJSON.parse(payload, { strict: true }) as JsonObject;
-            const usage = normalizeUsage(parsed.usage);
+
+            if (!parsed) {
+                continue;
+            }
+
+            // Responses SSE (WHAM included) nests usage on `response.completed`
+            // events as `response.usage`; chat SSE carries it at the event root.
+            const usage =
+                normalizeUsage(parsed.usage) ??
+                (isObject(parsed.response) ? normalizeUsage(parsed.response.usage) : undefined);
 
             if (usage) {
                 latest = usage;
@@ -96,6 +105,175 @@ export function extractLatestUsageFromSse(buffer: string): TokenUsage | undefine
     }
 
     return latest;
+}
+
+function collectTextFromContent(content: unknown, sink: string[]): void {
+    if (typeof content === "string") {
+        sink.push(content);
+        return;
+    }
+
+    if (!Array.isArray(content)) {
+        return;
+    }
+
+    for (const part of content) {
+        if (isObject(part) && typeof part.text === "string") {
+            sink.push(part.text);
+        }
+    }
+}
+
+function estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+}
+
+/** Prompt-side text from a chat or Responses request body (messages/input/instructions). */
+function promptTextFromRequestBody(bodyText: string): string {
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true }) as JsonObject;
+
+        if (!parsed) {
+            return bodyText;
+        }
+
+        const sink: string[] = [];
+
+        if (typeof parsed.instructions === "string") {
+            sink.push(parsed.instructions);
+        }
+
+        for (const entry of [
+            ...(Array.isArray(parsed.messages) ? parsed.messages : []),
+            ...(Array.isArray(parsed.input) ? parsed.input : []),
+        ]) {
+            if (isObject(entry)) {
+                collectTextFromContent(entry.content, sink);
+            }
+        }
+
+        if (sink.length > 0) {
+            return sink.join("\n");
+        }
+
+        return bodyText;
+    } catch (err) {
+        logger.debug({ err }, "ai-proxy usage: prompt estimate fell back to raw body");
+        return bodyText;
+    }
+}
+
+/** Completion-side text from the outbound response (chat SSE, Responses SSE, or JSON). */
+function completionTextFromResponseBody(responseBody: string, stream: boolean): string {
+    if (!stream) {
+        try {
+            const parsed = SafeJSON.parse(responseBody, { strict: true }) as JsonObject;
+
+            if (!parsed) {
+                return responseBody;
+            }
+
+            const sink: string[] = [];
+
+            if (Array.isArray(parsed.choices)) {
+                for (const choice of parsed.choices) {
+                    if (isObject(choice) && isObject(choice.message)) {
+                        collectTextFromContent(choice.message.content, sink);
+                    }
+                }
+            }
+
+            if (Array.isArray(parsed.output)) {
+                for (const item of parsed.output) {
+                    if (isObject(item)) {
+                        collectTextFromContent(item.content, sink);
+                    }
+                }
+            }
+
+            if (sink.length > 0) {
+                return sink.join("");
+            }
+
+            return responseBody;
+        } catch (err) {
+            logger.debug({ err }, "ai-proxy usage: completion estimate fell back to raw body");
+            return responseBody;
+        }
+    }
+
+    const sink: string[] = [];
+
+    for (const line of responseBody.split("\n")) {
+        if (!line.startsWith("data:")) {
+            continue;
+        }
+
+        const payload = line.slice(5).trim();
+        if (!payload || payload === "[DONE]") {
+            continue;
+        }
+
+        try {
+            const parsed = SafeJSON.parse(payload, { strict: true }) as JsonObject;
+
+            if (!parsed) {
+                continue;
+            }
+
+            // Responses SSE text deltas.
+            if (typeof parsed.delta === "string") {
+                sink.push(parsed.delta);
+                continue;
+            }
+
+            // Chat completion chunks.
+            if (Array.isArray(parsed.choices)) {
+                for (const choice of parsed.choices) {
+                    if (!isObject(choice) || !isObject(choice.delta)) {
+                        continue;
+                    }
+
+                    if (typeof choice.delta.content === "string") {
+                        sink.push(choice.delta.content);
+                    }
+
+                    if (typeof choice.delta.reasoning_content === "string") {
+                        sink.push(choice.delta.reasoning_content);
+                    }
+                }
+            }
+        } catch (err) {
+            logger.debug({ err }, "ai-proxy usage: skipped SSE line in completion estimate");
+        }
+    }
+
+    return sink.length > 0 ? sink.join("") : responseBody;
+}
+
+/**
+ * Char-heuristic (~4 chars/token) usage estimate for successful exchanges where
+ * upstream sent no usage. Always tagged `source: "estimated"` — never presented
+ * as upstream-reported numbers.
+ */
+export function estimateUsageFromExchange({
+    bodyText,
+    responseBody,
+    stream,
+}: {
+    bodyText: string;
+    responseBody: string;
+    stream: boolean;
+}): TokenUsage {
+    const promptTokens = estimateTokens(promptTextFromRequestBody(bodyText));
+    const completionTokens = estimateTokens(completionTextFromResponseBody(responseBody, stream));
+
+    return {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: promptTokens + completionTokens,
+        source: "estimated",
+    };
 }
 
 export function bodyWantsStream(bodyText: string): boolean {

--- a/src/ai-proxy/lib/usage/store.ts
+++ b/src/ai-proxy/lib/usage/store.ts
@@ -182,6 +182,10 @@ function bumpDailyAggregate(record: UsageRequestRecord): void {
         current.rate_limits += 1;
     }
 
+    if (record.usage?.source === "estimated") {
+        current.estimated_requests = (current.estimated_requests ?? 0) + 1;
+    }
+
     store.days[day][key] = current;
     void saveDailyStoreAsync();
 }
@@ -343,10 +347,8 @@ export function readRecentRequestsForAccount(account: string, limit = 20): Usage
     return collectTailJsonlRecords(path, limit, (record) => record.account === account);
 }
 
-export function getTodayUsageSummary(account?: string): DailyModelUsage {
-    const store = readDailyStore();
-    const today = store.days[dayKey()] ?? {};
-    const summary: DailyModelUsage = {
+function emptyDailyModelUsage(): DailyModelUsage {
+    return {
         requests: 0,
         prompt_tokens: 0,
         completion_tokens: 0,
@@ -354,8 +356,10 @@ export function getTodayUsageSummary(account?: string): DailyModelUsage {
         errors: 0,
         rate_limits: 0,
     };
+}
 
-    for (const [key, stats] of Object.entries(today)) {
+function addDayIntoSummary(day: Record<string, DailyModelUsage>, summary: DailyModelUsage, account?: string): void {
+    for (const [key, stats] of Object.entries(day)) {
         if (account && !key.startsWith(`${account}/`)) {
             continue;
         }
@@ -366,9 +370,65 @@ export function getTodayUsageSummary(account?: string): DailyModelUsage {
         summary.total_tokens += stats.total_tokens;
         summary.errors += stats.errors;
         summary.rate_limits += stats.rate_limits;
+
+        if (stats.estimated_requests) {
+            summary.estimated_requests = (summary.estimated_requests ?? 0) + stats.estimated_requests;
+        }
+    }
+}
+
+export function getTodayUsageSummary(account?: string): DailyModelUsage {
+    const store = readDailyStore();
+    const today = store.days[dayKey()] ?? {};
+    const summary = emptyDailyModelUsage();
+    addDayIntoSummary(today, summary, account);
+
+    return summary;
+}
+
+/** Aggregate daily usage over the trailing N days (today included). */
+export function getUsageSummarySince(daysBack: number, account?: string): DailyModelUsage {
+    const store = readDailyStore();
+    const summary = emptyDailyModelUsage();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - daysBack);
+
+    for (const [day, stats] of Object.entries(store.days)) {
+        if (day < dayKey(cutoff)) {
+            continue;
+        }
+
+        addDayIntoSummary(stats, summary, account);
     }
 
     return summary;
+}
+
+/** Per-model aggregate over the trailing N days for one account (today included). */
+export function getModelUsageBreakdownSince(daysBack: number, account: string): Record<string, DailyModelUsage> {
+    const store = readDailyStore();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - daysBack);
+    const breakdown: Record<string, DailyModelUsage> = {};
+
+    for (const [day, stats] of Object.entries(store.days)) {
+        if (day < dayKey(cutoff)) {
+            continue;
+        }
+
+        for (const [key, usage] of Object.entries(stats)) {
+            if (!key.startsWith(`${account}/`)) {
+                continue;
+            }
+
+            const model = key.slice(account.length + 1);
+            const current = breakdown[model] ?? emptyDailyModelUsage();
+            addDayIntoSummary({ [key]: usage }, current);
+            breakdown[model] = current;
+        }
+    }
+
+    return breakdown;
 }
 
 export function usageStorePaths(): { billing: string; daily: string; requests: string } {

--- a/src/ai-proxy/lib/usage/track-response.ts
+++ b/src/ai-proxy/lib/usage/track-response.ts
@@ -1,6 +1,11 @@
 import type { ResolvedRoute } from "@app/ai-proxy/lib/types";
 import { recordClientUsage } from "@app/ai-proxy/lib/usage/client-ledger";
-import { bodyWantsStream, extractLatestUsageFromSse, extractUsageFromJsonBody } from "@app/ai-proxy/lib/usage/extract";
+import {
+    bodyWantsStream,
+    estimateUsageFromExchange,
+    extractLatestUsageFromSse,
+    extractUsageFromJsonBody,
+} from "@app/ai-proxy/lib/usage/extract";
 import { recordUsageRequest } from "@app/ai-proxy/lib/usage/store";
 import { logger } from "@genesiscz/utils/logger";
 
@@ -18,7 +23,21 @@ export function trackCompletedRequest(input: {
     thinking?: string;
 }): void {
     const stream = input.stream ?? bodyWantsStream(input.bodyText);
-    const usage = stream ? extractLatestUsageFromSse(input.responseBody) : extractUsageFromJsonBody(input.responseBody);
+    let usage = stream ? extractLatestUsageFromSse(input.responseBody) : extractUsageFromJsonBody(input.responseBody);
+
+    // Upstream sent no usage on a successful exchange — record a local estimate,
+    // explicitly tagged so it is never mistaken for upstream-reported numbers.
+    if (!usage && input.status < 400 && input.responseBody.length > 0) {
+        usage = estimateUsageFromExchange({
+            bodyText: input.bodyText,
+            responseBody: input.responseBody,
+            stream,
+        });
+        logger.debug(
+            { model: input.proxyModel, usage },
+            "ai-proxy usage: upstream omitted usage — recorded local estimate"
+        );
+    }
 
     const record = {
         ts: new Date().toISOString(),

--- a/src/ai-proxy/lib/usage/types.ts
+++ b/src/ai-proxy/lib/usage/types.ts
@@ -6,6 +6,8 @@ export interface TokenUsage {
     completion_tokens?: number;
     total_tokens?: number;
     cost_in_usd_ticks?: number;
+    /** "estimated" = local char-heuristic because upstream omitted usage; absent = upstream-reported. */
+    source?: "estimated";
 }
 
 export interface UsageRequestRecord {
@@ -47,6 +49,8 @@ export interface DailyModelUsage {
     total_tokens: number;
     errors: number;
     rate_limits: number;
+    /** Requests whose tokens were locally estimated (upstream sent no usage). */
+    estimated_requests?: number;
 }
 
 export interface DailyUsageStore {

--- a/src/utils/ai/openai/codex-auth.ts
+++ b/src/utils/ai/openai/codex-auth.ts
@@ -302,7 +302,10 @@ export interface ResolvedCodexToken {
  * the cross-process AI-config lock, re-read inside the lock, and
  * short-circuits if another caller/process already refreshed while waiting.
  */
-export async function resolveCodexAccountToken(accountName: string): Promise<ResolvedCodexToken> {
+export async function resolveCodexAccountToken(
+    accountName: string,
+    options?: { forceRefresh?: boolean }
+): Promise<ResolvedCodexToken> {
     const { AIConfig } = await import("../AIConfig");
     const config = await AIConfig.load();
     const entry = config.getAccount(accountName);
@@ -315,6 +318,12 @@ export async function resolveCodexAccountToken(accountName: string): Promise<Res
     // (~/.codex/auth.json). Live-read, never copied — the CLI owns refresh.
     // An explicit reference wins over any stored (possibly stale) tokens.
     if (entry.tokens.authFile) {
+        if (options?.forceRefresh) {
+            throw new Error(
+                `openai-sub account "${accountName}" references the Codex CLI cache — the proxy cannot refresh it. Run \`codex login\`.`
+            );
+        }
+
         const tokens = await readCodexAuthJson(entry.tokens.authFile);
 
         if (!tokens?.accessToken) {
@@ -337,7 +346,12 @@ export async function resolveCodexAccountToken(accountName: string): Promise<Res
         throw new Error(`No access token for openai-sub account "${accountName}". Run \`tools ask config\`.`);
     }
 
-    if (entry.tokens.expiresAt && codexOAuth.needsRefresh(entry.tokens.expiresAt)) {
+    const staleToken = accessToken;
+    const wantsRefresh =
+        options?.forceRefresh === true ||
+        (entry.tokens.expiresAt != null && codexOAuth.needsRefresh(entry.tokens.expiresAt));
+
+    if (wantsRefresh) {
         accessToken = await config.withLock(async (data) => {
             const acc = data.accounts.find((a) => a.name === accountName);
 
@@ -345,7 +359,16 @@ export async function resolveCodexAccountToken(accountName: string): Promise<Res
                 throw new Error(`openai-sub account "${accountName}" not found in AI config.`);
             }
 
-            if (acc.tokens.expiresAt && !codexOAuth.needsRefresh(acc.tokens.expiresAt) && acc.tokens.accessToken) {
+            // Another caller/process already rotated the token while we waited
+            // for the lock — use theirs. On forceRefresh (upstream said 401),
+            // "already rotated" means a token DIFFERENT from the one that failed.
+            const alreadyFresh =
+                acc.tokens.accessToken &&
+                acc.tokens.expiresAt &&
+                !codexOAuth.needsRefresh(acc.tokens.expiresAt) &&
+                (!options?.forceRefresh || acc.tokens.accessToken !== staleToken);
+
+            if (alreadyFresh && acc.tokens.accessToken) {
                 return acc.tokens.accessToken;
             }
 

--- a/src/utils/ai/openai/sub-models.test.ts
+++ b/src/utils/ai/openai/sub-models.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { OPENAI_SUB_STATIC_CATALOG, resolveOpenAiSubModel } from "./sub-models";
+
+describe("resolveOpenAiSubModel", () => {
+    it("passes concrete ids and unknown values through unchanged", () => {
+        expect(resolveOpenAiSubModel("gpt-5.5")).toBe("gpt-5.5");
+        expect(resolveOpenAiSubModel("made-up-model")).toBe("made-up-model");
+    });
+
+    it("resolves builtin aliases against the static catalog", () => {
+        const firstListed = OPENAI_SUB_STATIC_CATALOG.find((record) => record.visibility === "list");
+        expect(resolveOpenAiSubModel("latest")).toBe(firstListed?.slug ?? "latest");
+
+        const codex = resolveOpenAiSubModel("codex");
+        expect(codex).not.toBe("codex");
+
+        const mini = resolveOpenAiSubModel("mini");
+        expect(mini).toContain("mini");
+    });
+
+    it("prefers config aliases over builtins", () => {
+        expect(resolveOpenAiSubModel("latest", { latest: "gpt-5.4" })).toBe("gpt-5.4");
+        expect(resolveOpenAiSubModel("fast", { fast: "gpt-5.4-mini" })).toBe("gpt-5.4-mini");
+    });
+});

--- a/src/utils/ai/openai/sub-models.ts
+++ b/src/utils/ai/openai/sub-models.ts
@@ -27,8 +27,34 @@ export const OPENAI_SUB_STATIC_CATALOG: WhamModelRecord[] = [
     { slug: "gpt-5-codex", displayName: "GPT-5-Codex", contextWindow: 272_000, visibility: "list" },
 ];
 
-/** Codex model ids are already concrete; unknown values pass through unchanged. */
-export function resolveOpenAiSubModel(id: string): string {
+/**
+ * Built-in aliases resolved against the static catalog (first list-visible
+ * match). Config aliases (per proxy account) win over built-ins; unknown ids
+ * pass through unchanged so WHAM's own 400 surfaces for bad slugs.
+ */
+export const OPENAI_SUB_BUILTIN_ALIAS_NAMES = ["latest", "codex", "mini"] as const;
+
+const OPENAI_SUB_BUILTIN_ALIASES: Record<string, (catalog: WhamModelRecord[]) => string | undefined> = {
+    latest: (catalog) => catalog.find((record) => record.visibility === "list")?.slug,
+    codex: (catalog) =>
+        catalog.find((record) => record.visibility === "list" && record.slug.includes("codex"))?.slug ??
+        catalog.find((record) => record.visibility === "list")?.slug,
+    mini: (catalog) => catalog.find((record) => record.visibility === "list" && record.slug.includes("mini"))?.slug,
+};
+
+export function resolveOpenAiSubModel(id: string, aliases?: Record<string, string>): string {
+    const fromConfig = aliases?.[id];
+
+    if (fromConfig) {
+        return fromConfig;
+    }
+
+    const builtin = OPENAI_SUB_BUILTIN_ALIASES[id];
+
+    if (builtin) {
+        return builtin(OPENAI_SUB_STATIC_CATALOG) ?? id;
+    }
+
     return id;
 }
 

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -72,6 +72,11 @@ export const env = {
         getApiHomeEnvKey: () => (isNonEmpty("COPILOT_API_HOME") ? "COPILOT_API_HOME" : undefined),
     },
 
+    aiProxy: {
+        /** Save the last failing WHAM request/response (redacted, no tokens) under ~/.genesis-tools/ai-proxy/debug/. */
+        getDebugCapture: () => isFlag("AI_PROXY_DEBUG_CAPTURE"),
+    },
+
     github: {
         getToken: () => getFirstValue(GITHUB_TOKEN_KEYS),
         getTokenEnvKey: () => getFirstEnvKey(GITHUB_TOKEN_KEYS),


### PR DESCRIPTION
Implements Track A of `.claude/plans/2026-07-19-AIProxy.spec.md` (Codex/WHAM + subscription hardening), including all optional items, with live verification on the owner machine.

## Phases

**P1 — Usage correctness**
- `extractLatestUsageFromSse` reads nested `response.usage` from Responses `response.completed` events (WHAM shape), not just top-level.
- Chat JSON + stream paths assert usage survival end-to-end.
- `getUsage` for `openai-subscription` reports **proxy-observed** today/30d counts from the local store + plan tier from the JWT — never claims ChatGPT plan quota.
- **P1.4 estimate fallback:** when upstream omits usage on a successful exchange, a char-heuristic estimate is recorded, tagged `usage.source: "estimated"` (+ `estimated_requests` daily counter, shown in `usage` output). Never presented as upstream numbers.

**P2 — Resilience**
- Non-OK WHAM responses map to OpenAI-shaped envelopes (`authentication_error` / `rate_limit_error` / `upstream_error`) with actionable copy.
- Per-account in-memory cooldown on 429 (honours `Retry-After`, else exponential backoff 30s→10min); unhealthy accounts cool 15 min.
- 401 → one forced token refresh (rotation-safe under the AI-config lock) + one retry; second 401 marks the account unhealthy.
- `openaiSub.failoverAccountNames`: additional `openai-sub` accounts tried in order within the same request.

**P3 — Auth UX**
- `tools ai-proxy accounts login codex` — PKCE browser flow, persists an `openai-sub` AI-config account and points/creates a proxy account at it.
- `tools ai-proxy accounts status` — auth source (ai-config vs codex-auth.json), token expiry, ChatGPT plan.
- README rewritten for the codex provider.

**P4 — Parameter fidelity (probe-backed)**
- **Live probe matrix (2026-07-19, Plus plan)** documented in the spec: `max_output_tokens`/`temperature`/`top_p`/`previous_response_id` all 400 "Unsupported parameter"; `store` must stay `false`; omitting `reasoning` and `effort: medium` both accepted.
- Dropped params recorded and surfaced via `x-ai-proxy-dropped` response header (propagated through the chat translation path too — found in live smoke) + once-per-process warn.
- Client `reasoning` passes through (unknown efforts clamp to `low`); `openaiSub.defaultReasoningEffort` config (`"none"` omits — probe-validated).

**P5 — Catalog**
- Aliases: builtin `latest`/`codex`/`mini` + per-account `openaiSub.aliases`, advertised in the catalog when resolvable.
- `models` table gains MODAL column (input modalities); context window + parallel-tool metadata carried on `ProxyModelMeta`.
- Image input to a model that provably lacks the image modality → 400 `unsupported_modality` naming vision-capable models (unknown modalities pass through).

**P6 — Translation edges**
- Chat `image_url` parts → Responses `input_image` (detail preserved).
- Non-function tool types stripped + recorded (WHAM accepts flat function tools only).
- `response.failed` → structured error envelope with upstream code.

**P7 — Observability**
- Structured request log fields (servedBy, reasoningEffort, dropped, authSource, elapsedMs…).
- `usage --provider <type> --breakdown` per-model 30d aggregates.
- `AI_PROXY_DEBUG_CAPTURE=1` saves the last failing upstream exchange (redacted — no tokens) under `~/.genesis-tools/ai-proxy/debug/`.

**P8 — resolved impossible:** WHAM rejects `store:true` ("Store must be set to false") and `previous_response_id` ("Unsupported parameter") — probed live. `store:false` stays forced; both recorded as dropped when clients send them.

**Track B** — design doc only (`.claude/plans/2026-07-19-AIProxy-TrackB-design.md`); build stays gated on demand.

Also carried on this branch: `feat(loc)` — user's concurrent loc-tool improvements (binary-file skip, expanded language catalog), split into its own commit.

## Verification

- 173 ai-proxy tests + openai-utils/loc suites green (`bun test`), `tsgo --noEmit` clean on every commit (pre-commit CI mirror).
- **Live WHAM probes** (9 controlled requests, Plus plan) — results table in spec §4.
- **Live proxy smoke** (branch code, port 8377, `curl --noproxy`):
  - non-stream chat: 200, `CODEX_OK`, upstream usage `13/18/31`, `x-ai-proxy-dropped: max_tokens` header present;
  - streamed alias `codex/codex/latest`: 200 with usage in stream;
  - `usage --account codex --breakdown`: rows recorded per model incl. the alias.
- `accounts status` live: shows `codex (plus)`, source `~/.codex/auth.json`, expiry.

Not verified here: end-to-end browser login flow, failover with two real accounts, Cursor agent tool round-trip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive Codex/OpenAI subscription login, account status, failover, aliases, and model capability details.
  - Added usage filtering and 30-day per-model breakdowns, including estimated usage reporting.
  - Added Claude session agent targeting, timestamps, improved search ranking, and compact table displays.
  - Expanded language detection and safely skips binary files during scanning.

- **Bug Fixes**
  - Improved image input conversion, upstream error handling, rate-limit retries, token refresh, and account failover.
  - Preserved notices when unsupported parameters are removed from requests.
  - Improved session metadata recovery for large history files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->