### PR TITLE
feat(cc): prettify session tools, Bun.mmap perf, search fixes

### DIFF
--- a/src/claude/commands/history.ts
+++ b/src/claude/commands/history.ts
@@ -15,15 +15,19 @@ import {
 } from "@app/claude/lib/history/search";
 import { getAgentRuntimeContext } from "@genesiscz/utils/agent-runtime";
 import { resolveProjectFilter } from "@genesiscz/utils/claude";
+import { formatSessionAge } from "@genesiscz/utils/claude/session-display";
 import { isInteractive } from "@genesiscz/utils/cli";
 import { buildViteDevCmd, defineDashboardApp } from "@genesiscz/utils/DashboardApp";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import { PROJECT_ROOT } from "@genesiscz/utils/paths";
 import * as p from "@genesiscz/utils/prompts/p";
+import { truncateText } from "@genesiscz/utils/string";
+import { createBoxTable, formatDotStatus, renderCliHeader } from "@genesiscz/utils/table";
 import { spawn } from "bun";
 import chalk from "chalk";
 import type { Command } from "commander";
+import pc from "picocolors";
 
 // =============================================================================
 // Output Formatting
@@ -135,6 +139,37 @@ function formatResultsAsMarkdown(results: SearchResult[], filters: SearchFilters
     }
 
     return lines.join("\n");
+}
+
+function formatResultsAsTable(results: SearchResult[], filters: SearchFilters): void {
+    const queryDesc = filters.query ? `matching "${filters.query}"` : "recent sessions";
+    renderCliHeader("History", queryDesc);
+
+    const table = createBoxTable(["ID", "TITLE", "BRANCH", "DATE", "STATUS"]);
+
+    for (const result of results) {
+        const title = result.customTitle || result.summary || "(unnamed)";
+        const shortId = result.sessionId.slice(0, 8);
+
+        table.push([
+            pc.white(pc.bold(shortId)),
+            pc.white(truncateText(title, 36)),
+            result.gitBranch ? pc.magenta(truncateText(result.gitBranch, 18)) : pc.dim("—"),
+            formatSessionAge(result.timestamp.toISOString()),
+            result.isSubagent ? formatDotStatus("dim", "agent") : formatDotStatus("ok", "main"),
+        ]);
+    }
+
+    out.println(table.toString());
+    out.println();
+
+    const parts = [
+        pc.dim(`${results.length} result${results.length !== 1 ? "s" : ""}`),
+        filters.sortByRelevance ? pc.dim("sorted by relevance") : "",
+        filters.summaryOnly ? pc.dim("summary-only") : "",
+    ].filter(Boolean);
+    out.println(`  ${parts.join(pc.dim("  ·  "))}`);
+    out.println();
 }
 
 function formatResultsAsJson(results: SearchResult[]): string {
@@ -287,6 +322,8 @@ export function registerHistoryCommand(program: Command): void {
 
                 if (options.format === "json") {
                     out.println(formatResultsAsJson(results));
+                } else if (process.stdout.isTTY && !filters.context) {
+                    formatResultsAsTable(results, filters);
                 } else {
                     out.println(formatResultsAsMarkdown(results, filters));
                 }

--- a/src/claude/commands/resume.ts
+++ b/src/claude/commands/resume.ts
@@ -9,15 +9,15 @@ import {
 import * as p from "@clack/prompts";
 import { findClaudeCommand, resolveProjectFilter } from "@genesiscz/utils/claude";
 import { getSessionMetadata } from "@genesiscz/utils/claude/history-cache";
-import { formatDateTime } from "@genesiscz/utils/date";
+import { buildSessionTableOpts } from "@genesiscz/utils/claude/session-display";
+import { isInteractive } from "@genesiscz/utils/cli";
 import { env } from "@genesiscz/utils/env";
+import { tableSelect } from "@genesiscz/utils/prompts/clack/table-select";
 import type { Command } from "commander";
 import pc from "picocolors";
 
 // --- Constants ---
 
-const NAME_MAX_LEN = 45;
-const ID_PREFIX_LEN = 8;
 const PROMPT_PREVIEW_LEN = 60;
 
 // --- Types ---
@@ -66,13 +66,6 @@ function toDisplay(
         firstPrompt: opts.firstPrompt || "",
         matchSnippet: opts.matchSnippet,
     };
-}
-
-function formatDate(iso: string): string {
-    if (!iso) {
-        return "";
-    }
-    return formatDateTime(iso, { relative: "always-relative-short" });
 }
 
 function dedup(sessions: DisplaySession[]): DisplaySession[] {
@@ -139,6 +132,47 @@ async function loadSessions(allProjects: boolean, spinner: Spinner): Promise<Loa
     };
 }
 
+function normalizeAlphanumeric(s: string): string {
+    return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function scoreContentMatch(s: DisplaySession, query: string): number {
+    const q = query.toLowerCase();
+    const qNorm = normalizeAlphanumeric(q);
+    let score = 0;
+
+    if (s.name.toLowerCase().includes(q)) {
+        score += 100;
+    } else if (qNorm.length >= 3 && normalizeAlphanumeric(s.name).includes(qNorm)) {
+        score += 80;
+    }
+
+    if (s.firstPrompt.toLowerCase().includes(q)) {
+        score += 50;
+    } else if (qNorm.length >= 3 && normalizeAlphanumeric(s.firstPrompt).includes(qNorm)) {
+        score += 40;
+    }
+
+    if (s.branch.toLowerCase().includes(q)) {
+        score += 30;
+    }
+
+    if (s.project.toLowerCase().includes(q)) {
+        score += 20;
+    } else if (qNorm.length >= 3 && normalizeAlphanumeric(s.project).includes(qNorm)) {
+        score += 15;
+    }
+
+    if (s.modified) {
+        const ageDays = (Date.now() - new Date(s.modified).getTime()) / (1000 * 60 * 60 * 24);
+        if (ageDays < 7) {
+            score += Math.round(20 * (1 - ageDays / 7));
+        }
+    }
+
+    return score;
+}
+
 function matchByIdOrName(all: DisplaySession[], query: string): DisplaySession[] {
     const q = query.toLowerCase();
     const byId = all.filter((s) => s.sessionId.toLowerCase().startsWith(q));
@@ -146,13 +180,27 @@ function matchByIdOrName(all: DisplaySession[], query: string): DisplaySession[]
         return byId;
     }
 
-    return all.filter(
+    const exact = all.filter(
         (s) =>
             s.name.toLowerCase().includes(q) ||
             s.branch.toLowerCase().includes(q) ||
             s.project.toLowerCase().includes(q) ||
             s.firstPrompt.toLowerCase().includes(q)
     );
+    if (exact.length > 0) {
+        return exact;
+    }
+
+    // Normalized match: strip non-alphanumeric, retry substring.
+    // Catches "last24h" matching "last 24 hours", "devdashboard" matching "dev-dashboard", etc.
+    const qNorm = normalizeAlphanumeric(q);
+    if (qNorm.length >= 3) {
+        return all.filter((s) =>
+            [s.name, s.branch, s.project, s.firstPrompt].some((f) => normalizeAlphanumeric(f).includes(qNorm))
+        );
+    }
+
+    return [];
 }
 
 interface ContentSearchResult {
@@ -231,68 +279,33 @@ async function searchByContent(query: string, spinner: Spinner, project?: string
 
 // --- UI ---
 
-const EXCERPT_MAX_LEN = 120;
-
-function buildExcerpt(s: DisplaySession): string | undefined {
-    if (s.matchSnippet) {
-        return s.matchSnippet;
-    }
-
-    const nameNorm = s.name.toLowerCase().trim();
-
-    if (s.summary && s.summary.toLowerCase().trim() !== nameNorm) {
-        return s.summary;
-    }
-
-    const promptPreview = s.firstPrompt.slice(0, PROMPT_PREVIEW_LEN);
-    if (s.firstPrompt && promptPreview.toLowerCase().trim() !== nameNorm) {
-        return s.firstPrompt;
-    }
-
-    return undefined;
-}
-
-function sessionOption(s: DisplaySession) {
-    const hints = [
-        pc.dim(s.sessionId.slice(0, ID_PREFIX_LEN)),
-        s.branch ? pc.magenta(s.branch) : "",
-        s.project ? pc.blue(s.project) : "",
-        pc.dim(formatDate(s.modified)),
-        s.source === "search" ? pc.yellow("[search]") : "",
-    ].filter(Boolean);
-
-    const excerpt = buildExcerpt(s);
-    let label = s.name.slice(0, NAME_MAX_LEN);
-    if (excerpt) {
-        const cleaned = excerpt.slice(0, EXCERPT_MAX_LEN).replace(/\n/g, " ").trim();
-        label += `\n  ${pc.dim(cleaned)}`;
-    }
-
-    return {
-        value: s,
-        label,
-        hint: hints.join(" "),
-    };
-}
-
-async function selectSession(candidates: DisplaySession[]): Promise<DisplaySession> {
+async function selectSession(candidates: DisplaySession[], query?: string): Promise<DisplaySession> {
     if (candidates.length === 1) {
         const s = candidates[0];
         p.log.info(
-            `${pc.bold(s.name)} ${pc.dim(s.sessionId.slice(0, ID_PREFIX_LEN))} ${pc.magenta(s.branch)} ${pc.dim(formatDate(s.modified))}`
+            `${pc.bold(s.name)} ${pc.dim(s.sessionId.slice(0, 8))} ${pc.magenta(s.branch)} ${s.project ? pc.blue(s.project) : ""}`
         );
         return s;
     }
 
-    const result = await p.select({
+    if (!isInteractive()) {
+        const s = candidates[0];
+        p.log.info(`Auto-selected: ${pc.bold(s.name)} ${pc.dim(s.sessionId.slice(0, 8))}`);
+        return s;
+    }
+
+    const opts = buildSessionTableOpts(candidates, {
         message: "Select session to resume:",
-        options: candidates.map(sessionOption),
+        query,
     });
 
-    if (p.isCancel(result)) {
+    const result = await tableSelect(opts);
+
+    if (!result) {
         p.cancel("Cancelled");
         process.exit(0);
     }
+
     return result;
 }
 
@@ -369,6 +382,7 @@ export async function pickSessionForResume(
         candidates = matchByIdOrName(sessions, query);
 
         if (candidates.length > 0) {
+            candidates.sort((a, b) => scoreContentMatch(b, query) - scoreContentMatch(a, query));
             p.log.info(
                 pc.dim(`index: ${candidates.length} match${candidates.length !== 1 ? "es" : ""} `) +
                     pc.dim(`(name/branch/project/prompt)`)
@@ -394,6 +408,9 @@ export async function pickSessionForResume(
                         return cached ? { ...cached, source: "search" as const, matchSnippet: h.matchSnippet } : h;
                     })
                 );
+                // Rank by metadata relevance so sessions whose name/prompt matches
+                // sort above sessions where the query only appears in tool output
+                candidates.sort((a, b) => scoreContentMatch(b, query) - scoreContentMatch(a, query));
             }
         }
 
@@ -403,7 +420,7 @@ export async function pickSessionForResume(
         }
     }
 
-    return selectSession(candidates);
+    return selectSession(candidates, query);
 }
 
 async function main(query: string | undefined, opts: ResumeOptions) {

--- a/src/claude/commands/tail.ts
+++ b/src/claude/commands/tail.ts
@@ -51,6 +51,8 @@ interface TailOptions {
     output?: string;
     outputCli: boolean;
     project?: string;
+    agent?: string;
+    timestamps: boolean;
     listSessions: number;
 }
 
@@ -72,6 +74,8 @@ export function registerTailCommand(program: Command): void {
         .option("-o, --output <file>", "Write formatted output to file")
         .option("--output-cli", "Also print to CLI when using -o", false)
         .option("-p, --project <path>", "Search in specific project directory")
+        .option("-a, --agent <id>", "Tail a specific agent by ID prefix (searches subagents/ dirs)")
+        .option("--timestamps", "Show timestamps on each line", false)
         .option("-l, --list-sessions", "List recent sessions (-l compact, -ll verbose)", increaseCount, 0)
         .combineFlagAndOptionalValue(false)
         .addHelpText("after", `\n${INCLUDE_HELP}`)
@@ -86,6 +90,28 @@ export function registerTailCommand(program: Command): void {
                     project: projectPath,
                     colors: useColors,
                 });
+                return;
+            }
+
+            if (opts.agent) {
+                const agents = ClaudeSession.findSubagents({
+                    query: opts.agent,
+                    project: projectPath,
+                    allProjects: !projectPath,
+                });
+
+                if (agents.length === 0) {
+                    out.error(pc.red(`No agent matching "${opts.agent}" found.`));
+                    process.exit(1);
+                }
+
+                const target = agents.length === 1 ? agents[0] : await promptSelectTarget(agents);
+
+                if (!target) {
+                    process.exit(0);
+                }
+
+                await startTailing(target, opts);
                 return;
             }
 
@@ -166,6 +192,7 @@ async function startTailing(target: TailTarget, opts: TailOptions): Promise<void
         outputFile: opts.output,
         cliOutput,
         raw: opts.raw,
+        timestamps: opts.timestamps,
     });
 
     if (!opts.raw) {
@@ -482,10 +509,6 @@ async function resolveIncludeSpec(opts: TailOptions): Promise<IncludeSpec> {
 
     if (opts.interactive) {
         return await runInteractiveSetup(true);
-    }
-
-    if (opts.follow && process.stdout.isTTY) {
-        return await runInteractiveSetup(false);
     }
 
     return IncludeSpec.defaults();

--- a/src/claude/lib/history/search.ts
+++ b/src/claude/lib/history/search.ts
@@ -1457,6 +1457,10 @@ function applyMetadataLine(line: string, state: MetadataScanState): void {
     try {
         const obj = SafeJSON.parse(line, { strict: true });
 
+        if (!obj || typeof obj !== "object") {
+            return;
+        }
+
         if (obj.type === "summary" && obj.summary) {
             state.summary = obj.summary;
         }

--- a/src/claude/lib/history/search.ts
+++ b/src/claude/lib/history/search.ts
@@ -1404,6 +1404,213 @@ export async function getSessionListing(options: SessionListingOptions = {}): Pr
 // resolveProjectDir and findConversationFilesInDir are now in shared modules
 // (imported at top of file)
 
+const METADATA_USER_TEXT_CAP = 5000;
+const METADATA_LINE_LIMIT = 200;
+const METADATA_TAIL_BYTES = 64 * 1024;
+const NEWLINE_BYTE = 0x0a;
+
+interface MetadataScanState {
+    sessionId: string | null;
+    customTitle: string | null;
+    summary: string | null;
+    firstPrompt: string | null;
+    gitBranch: string | null;
+    cwd: string | null;
+    firstTimestamp: string | null;
+    userTexts: string[];
+    userTextLen: number;
+}
+
+function createMetadataScanState(): MetadataScanState {
+    return {
+        sessionId: null,
+        customTitle: null,
+        summary: null,
+        firstPrompt: null,
+        gitBranch: null,
+        cwd: null,
+        firstTimestamp: null,
+        userTexts: [],
+        userTextLen: 0,
+    };
+}
+
+function isMetadataScanComplete(state: MetadataScanState): boolean {
+    return Boolean(
+        state.summary &&
+            state.customTitle &&
+            state.sessionId &&
+            state.gitBranch &&
+            state.cwd &&
+            state.firstTimestamp &&
+            state.userTextLen >= METADATA_USER_TEXT_CAP
+    );
+}
+
+// Applies one JSONL line to the scan state. custom-title/summary are "latest wins"
+// (they're rewritten late in a session); everything else is "first wins".
+function applyMetadataLine(line: string, state: MetadataScanState): void {
+    if (!line.trim()) {
+        return;
+    }
+
+    try {
+        const obj = SafeJSON.parse(line, { strict: true });
+
+        if (obj.type === "summary" && obj.summary) {
+            state.summary = obj.summary;
+        }
+        if (obj.type === "custom-title" && obj.customTitle) {
+            state.customTitle = obj.customTitle;
+        }
+        if (obj.sessionId && !state.sessionId) {
+            state.sessionId = obj.sessionId;
+        }
+        if (obj.gitBranch && !state.gitBranch) {
+            state.gitBranch = obj.gitBranch;
+        }
+        if (obj.cwd && !state.cwd) {
+            state.cwd = obj.cwd;
+        }
+        if (obj.timestamp && !state.firstTimestamp) {
+            state.firstTimestamp = obj.timestamp;
+        }
+
+        if (obj.type === "user" && state.userTextLen < METADATA_USER_TEXT_CAP) {
+            let text = "";
+            if (typeof obj.message?.content === "string") {
+                text = obj.message.content;
+            } else if (Array.isArray(obj.message?.content)) {
+                const textBlock = obj.message.content.find((b: { type: string }) => b.type === "text");
+                if (textBlock?.text) {
+                    text = textBlock.text;
+                }
+            }
+            if (text) {
+                if (!state.firstPrompt) {
+                    state.firstPrompt = text;
+                }
+                const remaining = METADATA_USER_TEXT_CAP - state.userTextLen;
+                state.userTexts.push(text.slice(0, remaining));
+                state.userTextLen += text.length;
+            }
+        }
+    } catch {
+        // Skip unparseable lines
+    }
+}
+
+function findNthNewlineOffset(bytes: Uint8Array, n: number): number | null {
+    let count = 0;
+    for (let i = 0; i < bytes.length; i++) {
+        if (bytes[i] === NEWLINE_BYTE) {
+            count++;
+            if (count === n) {
+                return i;
+            }
+        }
+    }
+    return null;
+}
+
+// Scans metadata straight out of a mmap'd Uint8Array — only the pages actually
+// sliced/decoded get paged in by the OS, so large files stay cheap.
+function scanMetadataFromMmap(mapped: Uint8Array, isLargeFile: boolean): MetadataScanState {
+    const state = createMetadataScanState();
+    const decoder = new TextDecoder();
+
+    let headEnd = mapped.length;
+    let hitLimit = false;
+
+    if (isLargeFile) {
+        const offset = findNthNewlineOffset(mapped, METADATA_LINE_LIMIT);
+        if (offset !== null && offset < mapped.length - 1) {
+            headEnd = offset;
+            hitLimit = true;
+        }
+    }
+
+    const headLines = decoder.decode(mapped.subarray(0, headEnd)).split("\n");
+    for (const line of headLines) {
+        applyMetadataLine(line, state);
+        if (isMetadataScanComplete(state)) {
+            break;
+        }
+    }
+
+    // For large files where we hit the line limit, scan the tail for
+    // custom-title and summary — they're written late in the session
+    if (isLargeFile && hitLimit && (!state.customTitle || !state.summary)) {
+        const tailStart = Math.max(0, mapped.length - METADATA_TAIL_BYTES);
+        const tailLines = decoder.decode(mapped.subarray(tailStart)).split("\n");
+
+        // Skip the first (possibly partial) line when reading mid-file
+        const linesToScan = tailStart > 0 ? tailLines.slice(1) : tailLines;
+        for (const line of linesToScan) {
+            applyMetadataLine(line, state);
+        }
+    }
+
+    return state;
+}
+
+// Fallback path for filesystems where Bun.mmap throws (e.g. network mounts).
+async function scanMetadataFromStream(
+    filePath: string,
+    fileSize: number,
+    isLargeFile: boolean
+): Promise<MetadataScanState> {
+    const state = createMetadataScanState();
+    const fileStream = createReadStream(filePath);
+    const rl = createInterface({ input: fileStream, crlfDelay: Number.POSITIVE_INFINITY });
+
+    const LINE_LIMIT = isLargeFile ? METADATA_LINE_LIMIT : Number.POSITIVE_INFINITY;
+    let lineCount = 0;
+    let hitLimit = false;
+
+    for await (const line of rl) {
+        if (!line.trim()) {
+            continue;
+        }
+
+        lineCount++;
+        if (lineCount > LINE_LIMIT) {
+            hitLimit = true;
+            break;
+        }
+
+        applyMetadataLine(line, state);
+
+        if (isMetadataScanComplete(state)) {
+            fileStream.destroy();
+            break;
+        }
+    }
+
+    if (isLargeFile && hitLimit && (!state.customTitle || !state.summary)) {
+        try {
+            const tailStart = Math.max(0, fileSize - METADATA_TAIL_BYTES);
+            const tailStream = createReadStream(filePath, { start: tailStart });
+            const tailRl = createInterface({ input: tailStream, crlfDelay: Number.POSITIVE_INFINITY });
+            let firstLine = tailStart > 0;
+
+            for await (const line of tailRl) {
+                // Skip the first (possibly partial) line when reading mid-file
+                if (firstLine) {
+                    firstLine = false;
+                    continue;
+                }
+
+                applyMetadataLine(line, state);
+            }
+        } catch {
+            // Tail scan is best-effort
+        }
+    }
+
+    return state;
+}
+
 /**
  * Extract session metadata by reading the entire JSONL file.
  * Captures: summary, custom-title, sessionId, gitBranch, cwd,
@@ -1421,112 +1628,41 @@ export async function extractSessionMetadataFromFile(
         const fileStat = await stat(filePath);
         const isLargeFile = fileStat.size > 10 * 1024 * 1024;
 
-        const fileStream = createReadStream(filePath);
-        const rl = createInterface({ input: fileStream, crlfDelay: Number.POSITIVE_INFINITY });
+        let state: MetadataScanState | null = null;
 
-        let sessionId: string | null = null;
-        let customTitle: string | null = null;
-        let summary: string | null = null;
-        let firstPrompt: string | null = null;
-        let gitBranch: string | null = null;
-        let cwd: string | null = null;
-        let firstTimestamp: string | null = null;
-        const userTexts: string[] = [];
-        let userTextLen = 0;
-        const USER_TEXT_CAP = 5000;
-        const LINE_LIMIT = isLargeFile ? 200 : Number.POSITIVE_INFINITY;
-        let lineCount = 0;
-
-        for await (const line of rl) {
-            if (!line.trim()) {
-                continue;
-            }
-
-            lineCount++;
-            if (lineCount > LINE_LIMIT) {
-                break;
-            }
-
+        // Bun.mmap doesn't support empty files (throws EINVAL) — skip straight to the stream fallback
+        if (fileStat.size > 0) {
             try {
-                const obj = SafeJSON.parse(line, { strict: true });
-
-                // Always capture summary/custom-title (latest wins)
-                if (obj.type === "summary" && obj.summary) {
-                    summary = obj.summary;
-                }
-                if (obj.type === "custom-title" && obj.customTitle) {
-                    customTitle = obj.customTitle;
-                }
-                if (obj.sessionId && !sessionId) {
-                    sessionId = obj.sessionId;
-                }
-                if (obj.gitBranch && !gitBranch) {
-                    gitBranch = obj.gitBranch;
-                }
-                if (obj.cwd && !cwd) {
-                    cwd = obj.cwd;
-                }
-                if (obj.timestamp && !firstTimestamp) {
-                    firstTimestamp = obj.timestamp;
-                }
-
-                // Collect ALL user messages
-                if (obj.type === "user" && userTextLen < USER_TEXT_CAP) {
-                    let text = "";
-                    if (typeof obj.message?.content === "string") {
-                        text = obj.message.content;
-                    } else if (Array.isArray(obj.message?.content)) {
-                        const textBlock = obj.message.content.find((b: { type: string }) => b.type === "text");
-                        if (textBlock?.text) {
-                            text = textBlock.text;
-                        }
-                    }
-                    if (text) {
-                        if (!firstPrompt) {
-                            firstPrompt = text;
-                        }
-                        const remaining = USER_TEXT_CAP - userTextLen;
-                        userTexts.push(text.slice(0, remaining));
-                        userTextLen += text.length;
-                    }
-                }
-
-                // Early exit: all metadata found and user text cap reached
-                if (
-                    summary &&
-                    customTitle &&
-                    sessionId &&
-                    gitBranch &&
-                    cwd &&
-                    firstTimestamp &&
-                    userTextLen >= USER_TEXT_CAP
-                ) {
-                    fileStream.destroy();
-                    break;
-                }
-            } catch {
-                // Skip unparseable lines
+                let mapped: Uint8Array | null = Bun.mmap(filePath);
+                state = scanMetadataFromMmap(mapped, isLargeFile);
+                mapped = null;
+            } catch (err) {
+                logger.debug(
+                    { err, filePath },
+                    "Bun.mmap failed for session metadata scan, falling back to stream read"
+                );
             }
         }
 
-        // Fall back to filename as sessionId
-        if (!sessionId) {
-            sessionId = basename(filePath, ".jsonl");
+        if (!state) {
+            state = await scanMetadataFromStream(filePath, fileStat.size, isLargeFile);
         }
+
+        const sessionId = state.sessionId ?? basename(filePath, ".jsonl");
 
         return {
             filePath,
             sessionId,
-            customTitle,
-            summary,
-            firstPrompt,
-            gitBranch,
+            customTitle: state.customTitle,
+            summary: state.summary,
+            firstPrompt: state.firstPrompt,
+            gitBranch: state.gitBranch,
             project,
-            cwd,
+            cwd: state.cwd,
             mtime,
-            firstTimestamp,
+            firstTimestamp: state.firstTimestamp,
             isSubagent,
-            allUserText: userTexts.length > 0 ? userTexts.join(" ") : null,
+            allUserText: state.userTexts.length > 0 ? state.userTexts.join(" ") : null,
         };
     } catch {
         return null;

--- a/src/claude/lib/tail-list.ts
+++ b/src/claude/lib/tail-list.ts
@@ -17,6 +17,7 @@ import { formatRelativeTime } from "@genesiscz/utils/format";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import { truncateText } from "@genesiscz/utils/string";
+import { renderCliHeader } from "@genesiscz/utils/table";
 import pc from "picocolors";
 
 const STATUSLINE_DIR = resolve(homedir(), ".claude", "statusline");
@@ -77,12 +78,13 @@ export async function renderSessionList(options: ListSessionsOptions): Promise<v
 
     const activeIds = getActiveSessionIds();
     sortByRecency(sessions);
-    printSuggestHeader(sessions[0], options);
 
-    for (const session of sessions) {
-        if (options.level === 1) {
-            await renderCompactSession(session, activeIds, options);
-        } else {
+    if (options.level === 1) {
+        renderCliHeader("Sessions", "recent Claude Code sessions");
+        await renderCompactList(sessions, activeIds);
+    } else {
+        printSuggestHeader(sessions[0], options);
+        for (const session of sessions) {
             await renderVerboseSession(session, activeIds, options);
         }
     }
@@ -94,7 +96,7 @@ export async function renderSessionList(options: ListSessionsOptions): Promise<v
 export async function renderActiveSessionList(
     activeSessions: SessionInfo[],
     activeIds: Set<string>,
-    options: ListSessionsOptions
+    _options: ListSessionsOptions
 ): Promise<void> {
     if (activeSessions.length === 0) {
         return;
@@ -102,45 +104,76 @@ export async function renderActiveSessionList(
 
     sortByRecency(activeSessions);
 
-    out.println(
-        options.colors
-            ? pc.yellow(`⚠️ ${activeSessions.length} active sessions — pick one:`)
-            : `⚠️ ${activeSessions.length} active sessions — pick one:`
-    );
-    out.println();
-
-    printSuggestHeader(activeSessions[0], options);
-
-    for (const session of activeSessions) {
-        await renderCompactSession(session, activeIds, options);
-    }
+    renderCliHeader("Active Sessions", `${activeSessions.length} running — pick one`);
+    await renderCompactList(activeSessions, activeIds);
 }
 
-// ─── Compact List (-l) ──────────────────────────────────────────────────────
+// ─── Compact Table (-l) ─────────────────────────────────────────────────────
 
-async function renderCompactSession(
-    session: SessionInfo,
-    activeIds: Set<string>,
-    options: ListSessionsOptions
-): Promise<void> {
-    const c = options.colors;
-    renderSessionHeader(session, activeIds, options);
-
-    const preview = await extractSessionPreview(session.filePath);
-
-    if (preview.lastUserMessage) {
-        const collapsed = preview.lastUserMessage.replace(/\n+/g, " ");
-        const truncated = truncateText(collapsed, 120);
-        out.println(c ? `   ${pc.dim("›")} ${pc.green(truncated)}` : `   › ${truncated}`);
+function formatAge(date: Date | null | undefined): string {
+    if (!date) {
+        return pc.dim("—");
     }
 
-    for (const excerpt of preview.assistantExcerpts) {
-        const collapsed = excerpt.replace(/\n+/g, " ");
-        const truncated = truncateText(collapsed, 200);
-        out.println(c ? `   ${pc.dim("│")} ${pc.dim(truncated)}` : `   │ ${truncated}`);
+    const text = formatRelativeTime(date, { compact: true });
+    const ms = Date.now() - date.getTime();
+    const hours = ms / 3_600_000;
+
+    if (hours < 1) {
+        return pc.green(text);
     }
 
-    out.println();
+    if (hours < 12) {
+        return pc.yellow(text);
+    }
+
+    return pc.dim(text);
+}
+
+async function renderCompactList(sessions: SessionInfo[], activeIds: Set<string>): Promise<void> {
+    for (const session of sessions) {
+        const isActive = session.sessionId ? activeIds.has(session.sessionId) : false;
+        const shortId = (session.sessionId ?? "unknown").slice(0, 8);
+        const displayTime = session.lastTimestamp ?? session.startDate;
+        const branch = session.gitBranch ?? "";
+        const status = isActive ? pc.green("●") : pc.dim("●");
+        const title = session.title || session.summary || "";
+
+        const header = [
+            `${status} ${pc.bold(pc.white(shortId))}`,
+            formatAge(displayTime),
+            branch ? pc.magenta(branch) : "",
+            title ? pc.white(truncateText(title, 40)) : "",
+        ]
+            .filter(Boolean)
+            .join("  ");
+        out.println(`  ${header}`);
+
+        const preview = await extractSessionPreview(session.filePath);
+
+        if (preview.lastUserMessage) {
+            const collapsed = preview.lastUserMessage.replace(/\n+/g, " ");
+            out.println(`   ${pc.dim("›")} ${pc.green(truncateText(collapsed, 100))}`);
+        }
+
+        for (const excerpt of preview.assistantExcerpts.slice(-2)) {
+            const collapsed = excerpt.replace(/\n+/g, " ");
+            out.println(`   ${pc.dim("│")} ${pc.dim(truncateText(collapsed, 100))}`);
+        }
+
+        out.println();
+    }
+
+    if (sessions[0]?.sessionId) {
+        const hint = suggestCommand("tools claude", {
+            replaceCommand: ["tail", sessions[0].sessionId.slice(0, 8)],
+            keepFlags: ["-p", "--project"],
+        });
+        out.println(
+            `  ${pc.dim(`${sessions.length} session${sessions.length === 1 ? "" : "s"}  ·  `)}${pc.cyan(hint)}${pc.dim(" to tail")}`
+        );
+        out.println();
+    }
 }
 
 function renderSessionHeader(session: SessionInfo, activeIds: Set<string>, options: ListSessionsOptions): void {
@@ -226,8 +259,6 @@ async function extractSessionPreview(filePath: string): Promise<SessionPreview> 
                 }
 
                 let text = extractUserText(msg.message?.content ?? "");
-
-                // Strip system-reminder blocks and task-notification XML
                 text = text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "");
                 text = text.replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "");
                 text = text.trim();

--- a/src/utils/claude/ClaudeSessionFormatter.ts
+++ b/src/utils/claude/ClaudeSessionFormatter.ts
@@ -88,6 +88,7 @@ export class ClaudeSessionFormatter {
     private activeAgentId: string | null = null;
     private agentStartTime = new Map<string, number>();
     private fileStream: WriteStream | null = null;
+    private lastRecordType: string | null = null;
 
     constructor(private options: FormatterOptions) {
         if (options.outputFile) {
@@ -108,7 +109,7 @@ export class ClaudeSessionFormatter {
     }
 
     private get showTimestamps(): boolean {
-        return this.options.timestamps ?? !this.isMini;
+        return this.options.timestamps ?? false;
     }
 
     private get maxChars(): number {
@@ -132,6 +133,22 @@ export class ClaudeSessionFormatter {
         }
 
         const timestamp = "timestamp" in record && typeof record.timestamp === "string" ? record.timestamp : "";
+
+        const recordType = (record as { type: string }).type;
+
+        if (!this.isMini && this.lastRecordType && recordType !== this.lastRecordType) {
+            const isTurnBoundary =
+                (this.lastRecordType === "user" && (recordType === "assistant" || recordType === "A")) ||
+                ((this.lastRecordType === "assistant" || this.lastRecordType === "A") && recordType === "user");
+
+            if (isTurnBoundary) {
+                this.writeLine("");
+            }
+        }
+
+        if (recordType === "user" || recordType === "assistant" || recordType === "A") {
+            this.lastRecordType = recordType;
+        }
 
         switch (record.type) {
             case "user":
@@ -278,9 +295,16 @@ export class ClaudeSessionFormatter {
                         const maxChars = this.options.includeSpec.truncationLength("tools:out");
                         const isError = block.is_error;
                         const truncated = truncateText(result.trim(), maxChars);
-                        const line = `  ⎿ ${truncated}`;
-                        const formatted = this.options.colors ? (isError ? pc.red(line) : pc.dim(line)) : line;
-                        this.writeLine(formatted);
+
+                        if (this.options.colors && !isError) {
+                            const rendered = renderMarkdown(truncated);
+                            for (const line of rendered.split("\n")) {
+                                this.writeLine(`  ${pc.dim("⎿")} ${pc.dim(line)}`);
+                            }
+                        } else {
+                            const line = `  ⎿ ${truncated}`;
+                            this.writeLine(isError ? pc.red(line) : pc.dim(line));
+                        }
                     }
                 }
             }
@@ -484,9 +508,16 @@ export class ClaudeSessionFormatter {
                         if (result) {
                             const truncated = truncateText(result.trim(), maxChars);
                             const prefix = this.agentLinePrefix(agentId);
-                            const line = `${prefix}  ⎿ ${truncated}`;
-                            const formatted = this.options.colors ? (isError ? pc.red(line) : pc.dim(line)) : line;
-                            this.writeLine(formatted);
+
+                            if (this.options.colors && !isError) {
+                                const rendered = renderMarkdown(truncated);
+                                for (const line of rendered.split("\n")) {
+                                    this.writeLine(`${prefix}  ${pc.dim("⎿")} ${pc.dim(line)}`);
+                                }
+                            } else {
+                                const line = `${prefix}  ⎿ ${truncated}`;
+                                this.writeLine(isError ? pc.red(line) : pc.dim(line));
+                            }
                         }
                     }
                 }

--- a/src/utils/claude/cli/dsl.ts
+++ b/src/utils/claude/cli/dsl.ts
@@ -31,7 +31,7 @@ export class IncludeSpec {
     agentsThinking: boolean;
 
     static DEFAULT_SPEC =
-        "thinking,tools:in:500,tools:out:500,agents:input,agents:tools:in:50,agents:tools:out:500,agents:result";
+        "thinking,tools:in:2000,tools:out:2000,agents:input,agents:tools:in:2000,agents:tools:out:2000,agents:result,agents:thinking";
 
     constructor(spec?: string) {
         this.thinking = false;

--- a/src/utils/claude/session-display.ts
+++ b/src/utils/claude/session-display.ts
@@ -1,0 +1,197 @@
+import type { TableSelectOptions } from "@genesiscz/utils/prompts/clack/table-select";
+import { accent } from "@genesiscz/utils/prompts/clack/table-select";
+import { formatDotStatus, renderCliHeader } from "@genesiscz/utils/table";
+import pc from "picocolors";
+
+export interface SessionDisplayItem {
+    sessionId: string;
+    name: string;
+    summary: string;
+    branch: string;
+    project: string;
+    modified: string;
+    source: "cache" | "search";
+    firstPrompt: string;
+    matchSnippet?: string;
+}
+
+const NAME_COL_WIDTH = 42;
+const DETAIL_LINE_WIDTH = 72;
+const DETAIL_PROMPT_LINES = 6;
+
+export function formatSessionAge(iso: string): string {
+    if (!iso) {
+        return pc.dim("—");
+    }
+
+    const ms = Date.now() - new Date(iso).getTime();
+    const minutes = Math.floor(ms / 60_000);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    let text: string;
+    if (minutes < 1) {
+        text = "now";
+    } else if (minutes < 60) {
+        text = `${minutes}m`;
+    } else if (hours < 48) {
+        text = `${hours}h`;
+    } else {
+        text = `${days}d`;
+    }
+
+    if (minutes < 30) {
+        return pc.green(text);
+    }
+
+    if (hours < 6) {
+        return pc.yellow(text);
+    }
+
+    return pc.dim(text);
+}
+
+export function formatSessionBadge(source: "cache" | "search", isActive = false): string {
+    if (isActive) {
+        return pc.green("●");
+    }
+
+    if (source === "search") {
+        return pc.yellow("●");
+    }
+
+    return pc.dim("●");
+}
+
+function truncateSession(text: string, max: number): string {
+    if (text.length <= max) {
+        return text;
+    }
+
+    return `${text.slice(0, max - 1)}…`;
+}
+
+function sessionSnippet(s: SessionDisplayItem): string {
+    if (s.matchSnippet) {
+        return s.matchSnippet.replace(/\n/g, " ").trim();
+    }
+
+    const nameNorm = s.name.toLowerCase().trim();
+
+    if (s.summary && s.summary.toLowerCase().trim() !== nameNorm) {
+        return s.summary;
+    }
+
+    if (s.firstPrompt && s.firstPrompt.slice(0, 60).toLowerCase().trim() !== nameNorm) {
+        return s.firstPrompt;
+    }
+
+    return "";
+}
+
+function wrapText(text: string, width: number, maxLines: number): string[] {
+    const clean = text.replace(/\n+/g, " ").trim();
+
+    if (!clean) {
+        return [];
+    }
+
+    const lines: string[] = [];
+    let remaining = clean;
+
+    while (remaining.length > 0 && lines.length < maxLines) {
+        if (remaining.length <= width) {
+            lines.push(remaining);
+            break;
+        }
+
+        let breakAt = remaining.lastIndexOf(" ", width);
+
+        if (breakAt <= 0) {
+            breakAt = width;
+        }
+
+        lines.push(remaining.slice(0, breakAt));
+        remaining = remaining.slice(breakAt).trimStart();
+    }
+
+    if (remaining.length > 0 && lines.length === maxLines) {
+        const last = lines[maxLines - 1];
+        lines[maxLines - 1] = `${last.slice(0, last.length - 1)}…`;
+    }
+
+    return lines;
+}
+
+function buildDetailLines(s: SessionDisplayItem): string[] {
+    const header = [
+        accent(s.sessionId.slice(0, 8)),
+        s.project ? pc.blue(s.project) : "",
+        s.source === "search" ? pc.yellow("[search]") : "",
+    ]
+        .filter(Boolean)
+        .join(pc.dim(" · "));
+
+    const lines: string[] = [header];
+
+    const promptText = sessionSnippet(s) || s.firstPrompt;
+
+    if (promptText) {
+        const wrapped = wrapText(promptText, DETAIL_LINE_WIDTH, DETAIL_PROMPT_LINES);
+
+        for (const line of wrapped) {
+            lines.push(pc.dim(line));
+        }
+    }
+
+    // Pad to fixed height so the detail zone doesn't jump
+    while (lines.length < DETAIL_PROMPT_LINES + 1) {
+        lines.push("");
+    }
+
+    return lines;
+}
+
+export function buildSessionTableOpts(
+    sessions: SessionDisplayItem[],
+    opts: { message: string; query?: string }
+): TableSelectOptions<SessionDisplayItem> {
+    const hasMultipleProjects = new Set(sessions.map((s) => s.project).filter(Boolean)).size > 1;
+
+    const columns = [
+        { label: "NAME", minWidth: NAME_COL_WIDTH },
+        { label: "BRANCH", minWidth: 10 },
+        ...(hasMultipleProjects ? [{ label: "PROJECT", minWidth: 8 }] : []),
+        { label: "AGE", align: "right" as const, minWidth: 4 },
+    ];
+
+    return {
+        message: opts.message,
+        hint: opts.query ? `matching "${opts.query}"` : undefined,
+        columns,
+        rows: sessions.map((s) => {
+            const cells = [
+                truncateSession(s.name, NAME_COL_WIDTH),
+                s.branch ? pc.magenta(truncateSession(s.branch, 18)) : pc.dim("—"),
+                ...(hasMultipleProjects ? [s.project ? pc.blue(truncateSession(s.project, 14)) : pc.dim("—")] : []),
+                formatSessionAge(s.modified),
+            ];
+
+            const detail = buildDetailLines(s);
+
+            return {
+                value: s,
+                badge: formatSessionBadge(s.source),
+                cells,
+                detail,
+            };
+        }),
+        formatSubmitted: (row) => row.value.name,
+    };
+}
+
+export function renderSessionListHeader(title: string, subtitle: string): void {
+    renderCliHeader(title, subtitle);
+}
+
+export { formatDotStatus, renderCliHeader };

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -440,12 +440,13 @@ export class ClaudeSession {
                 // Derive session ID from parent directory name
                 const parentDir = basename(dirname(subagentsDir));
 
-                // Match against query
+                // Match against query (id, name, or description)
                 if (lowerQuery) {
-                    const idMatch = agentId.toLowerCase().startsWith(lowerQuery);
+                    const idMatch = agentId.toLowerCase().includes(lowerQuery);
+                    const nameMatch = meta?.name?.toLowerCase().includes(lowerQuery) ?? false;
                     const descMatch = meta?.description?.toLowerCase().includes(lowerQuery) ?? false;
 
-                    if (!idMatch && !descMatch) {
+                    if (!idMatch && !nameMatch && !descMatch) {
                         continue;
                     }
                 }

--- a/src/utils/claude/session.ts
+++ b/src/utils/claude/session.ts
@@ -443,8 +443,9 @@ export class ClaudeSession {
                 // Match against query (id, name, or description)
                 if (lowerQuery) {
                     const idMatch = agentId.toLowerCase().includes(lowerQuery);
-                    const nameMatch = meta?.name?.toLowerCase().includes(lowerQuery) ?? false;
-                    const descMatch = meta?.description?.toLowerCase().includes(lowerQuery) ?? false;
+                    const nameMatch = typeof meta?.name === "string" && meta.name.toLowerCase().includes(lowerQuery);
+                    const descMatch =
+                        typeof meta?.description === "string" && meta.description.toLowerCase().includes(lowerQuery);
 
                     if (!idMatch && !nameMatch && !descMatch) {
                         continue;

--- a/src/utils/claude/session.types.ts
+++ b/src/utils/claude/session.types.ts
@@ -138,4 +138,5 @@ export interface TailTarget {
 export interface AgentMeta {
     agentType: string;
     description: string;
+    name?: string;
 }


### PR DESCRIPTION
## Summary
Prettify Claude Code session tools + search improvements + Bun.mmap performance.

- **Search**: normalized matching ("last24h" finds "last 24 hours"), tail-scan for titles in large files, content search ranking
- **Resume picker**: tableSelect with columns/badges/6-line wrapped detail zone
- **Tail -l**: styled list with content excerpts + renderCliHeader
- **History**: box table for TTY output
- **Tail**: skip interactive prompt, markdown tool results, --agent flag, timestamps off, turn spacing
- **Shared** session-display.ts in src/utils/claude/
- **Perf**: Bun.mmap for session metadata extraction (469 MB/s, 213 files in 1.67s)
- **Agent search**: find by meta.name, not just ID prefix

## Test plan
- [ ] `tools claude tail -l` shows styled list with content
- [ ] `tools claude history --all --limit 5` shows box table
- [ ] `tools claude tail --agent <name>` finds agent by name
- [ ] `tools cc run --resume <query>` shows tableSelect picker
- [ ] `tools claude tail <session>` skips interactive prompt
