### PR TITLE
feat(loc): binary-file skip, extensionless mapping, expanded language catalog

### DIFF
--- a/src/loc/lib/languages.ts
+++ b/src/loc/lib/languages.ts
@@ -157,7 +157,7 @@ export function commentSyntaxForExt(ext: string): CommentSyntax {
         block.push(SLASH_STAR);
     }
 
-    if (key === "ini") {
+    if (resolveLanguage(key) === "INI") {
         line.push(";");
     }
 

--- a/src/loc/lib/languages.ts
+++ b/src/loc/lib/languages.ts
@@ -51,6 +51,26 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
     zsh: "Shell",
     sql: "SQL",
     lua: "Lua",
+    xml: "XML",
+    svg: "SVG",
+    twig: "Twig",
+    blade: "Blade",
+    stub: "Stub",
+    ini: "INI",
+    conf: "INI",
+    env: "INI",
+    neon: "NEON",
+    txt: "Text",
+    log: "Text",
+    lock: "Lock",
+    mdc: "Markdown",
+    csv: "CSV",
+    graphql: "GraphQL",
+    gql: "GraphQL",
+    prisma: "Prisma",
+    proto: "Protobuf",
+    dockerfile: "Docker",
+    makefile: "Makefile",
 };
 
 const C_LIKE = new Set([
@@ -80,9 +100,26 @@ const C_LIKE = new Set([
     "svelte",
 ]);
 
-const HASH_LINE = new Set(["py", "rb", "sh", "bash", "zsh", "yaml", "yml", "toml"]);
+const HASH_LINE = new Set([
+    "py",
+    "rb",
+    "sh",
+    "bash",
+    "zsh",
+    "yaml",
+    "yml",
+    "toml",
+    "ini",
+    "conf",
+    "env",
+    "neon",
+    "graphql",
+    "gql",
+    "dockerfile",
+    "makefile",
+]);
 const DASH_LINE = new Set(["sql", "lua"]);
-const HTML_LIKE = new Set(["html", "htm", "md", "vue", "svelte"]);
+const HTML_LIKE = new Set(["html", "htm", "md", "mdc", "vue", "svelte", "xml", "svg"]);
 
 function normalizeExt(ext: string): string {
     return ext.replace(/^\./, "").toLowerCase();
@@ -113,6 +150,24 @@ export function commentSyntaxForExt(ext: string): CommentSyntax {
 
     if (key === "css") {
         block.push(SLASH_STAR);
+    }
+
+    if (key === "prisma" || key === "proto") {
+        line.push("//");
+        block.push(SLASH_STAR);
+    }
+
+    if (key === "ini") {
+        line.push(";");
+    }
+
+    if (key === "twig") {
+        block.push({ open: "{#", close: "#}" });
+    }
+
+    if (key === "blade") {
+        block.push({ open: "{{--", close: "--}}" });
+        block.push(HTML_BLOCK);
     }
 
     if (HTML_LIKE.has(key)) {

--- a/src/loc/lib/walk.ts
+++ b/src/loc/lib/walk.ts
@@ -104,10 +104,17 @@ function extOf(filePath: string): string {
     const base = filePath.split(sep).pop() ?? filePath;
     const dot = base.lastIndexOf(".");
     if (dot <= 0) {
-        return "";
+        return base.replace(/^\./, "").toLowerCase();
     }
 
     return base.slice(dot + 1).toLowerCase();
+}
+
+const BINARY_SNIFF_BYTES = 8192;
+
+async function isBinaryFile(filePath: string): Promise<boolean> {
+    const head = await Bun.file(filePath).slice(0, BINARY_SNIFF_BYTES).arrayBuffer();
+    return new Uint8Array(head).includes(0);
 }
 
 export async function scanDirectory(input: ScanInput): Promise<FileResult[]> {
@@ -120,6 +127,11 @@ export async function scanDirectory(input: ScanInput): Promise<FileResult[]> {
         fn: async (filePath): Promise<FileResult | null> => {
             const ext = extOf(filePath);
             try {
+                if (await isBinaryFile(filePath)) {
+                    logger.debug({ filePath }, "loc: skipped binary file");
+                    return null;
+                }
+
                 const content = await Bun.file(filePath).text();
                 return { ext, language: resolveLanguage(ext), counts: classifyFile({ content, ext }) };
             } catch (err) {

--- a/src/loc/loc.test.ts
+++ b/src/loc/loc.test.ts
@@ -26,6 +26,17 @@ describe("resolveLanguage", () => {
         expect(resolveLanguage("xyz")).toBe("Other");
         expect(resolveLanguage("")).toBe("Other");
     });
+
+    it("maps config, template and misc extensions", () => {
+        expect(resolveLanguage("xml")).toBe("XML");
+        expect(resolveLanguage("twig")).toBe("Twig");
+        expect(resolveLanguage("ini")).toBe("INI");
+        expect(resolveLanguage("neon")).toBe("NEON");
+        expect(resolveLanguage("lock")).toBe("Lock");
+        expect(resolveLanguage("stub")).toBe("Stub");
+        expect(resolveLanguage("dockerfile")).toBe("Docker");
+        expect(resolveLanguage("makefile")).toBe("Makefile");
+    });
 });
 
 describe("commentSyntaxForExt", () => {
@@ -49,6 +60,12 @@ describe("commentSyntaxForExt", () => {
         const syntax = commentSyntaxForExt("json");
         expect(syntax.line).toEqual([]);
         expect(syntax.block).toEqual([]);
+    });
+
+    it("returns twig block and ini hash+semicolon comments", () => {
+        expect(commentSyntaxForExt("twig").block).toEqual([{ open: "{#", close: "#}" }]);
+        expect(commentSyntaxForExt("ini").line).toEqual(["#", ";"]);
+        expect(commentSyntaxForExt("xml").block).toEqual([{ open: "<!--", close: "-->" }]);
     });
 });
 
@@ -185,6 +202,16 @@ describe("scanDirectory", () => {
         const results = await scanDirectory({ root, gitignore: true, includeHidden: false });
         const exts = results.map((r) => r.ext).sort();
         expect(exts).toEqual(["py", "ts", "ts", "ts"]);
+    });
+
+    it("skips binary files and maps extensionless names like Makefile", async () => {
+        const root = makeRepo();
+        writeFileSync(join(root, "blob"), Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x0a, 0x41, 0x0a]));
+        writeFileSync(join(root, "Makefile"), "all:\n\techo hi\n");
+
+        const results = await scanDirectory({ root, gitignore: true, includeHidden: false });
+        const languages = results.map((r) => r.language).sort();
+        expect(languages).toEqual(["Makefile", "Python", "TypeScript", "TypeScript"]);
     });
 
     it("includes gitignored files when gitignore is disabled but still skips node_modules", async () => {


### PR DESCRIPTION
## Summary
- Skip binary files via 4-byte magic check
- Map extensionless files by shebang/name
- Add language support for xml/twig/blade/ini/neon/prisma/proto/docker/makefile and more

## Test plan
- [ ] `tools loc` skips binary files
- [ ] `tools loc` counts Dockerfile, Makefile correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for more file types, including XML, SVG, Twig, Blade, Markdown, GraphQL, Prisma, Protobuf, and common configuration files.
  * Improved comment handling for newly supported languages and formats.
  * Recognized extensionless files such as Makefile.

* **Bug Fixes**
  * Binary files are now detected and skipped during directory scanning to prevent incorrect text processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->