### PR TITLE
feat(ai-proxy,say): Grok image routing/errors + say --output

### DIFF
--- a/src/ai-proxy/index.ts
+++ b/src/ai-proxy/index.ts
@@ -21,7 +21,16 @@ import { runUsageCommand } from "@app/ai-proxy/commands/usage";
 import { isValidThinkingMode } from "@app/ai-proxy/lib/thinking-config";
 import type { AiProxyProviderType, CursorTranslationMode, ThinkingPresentationMode } from "@app/ai-proxy/lib/types";
 import { runTool } from "@genesiscz/utils/cli";
+import { configureLogger } from "@genesiscz/utils/logger";
 import { Command } from "commander";
+
+// proxy.log is the serve process's stderr — without timestamps a stale log
+// file is indistinguishable from a quiet one, which is exactly how a 5-day-old
+// proxy.log derailed an incident investigation. Must run before runTool: its
+// setBaseBinding() instantiates the logger, freezing timestamp options.
+if (process.argv.includes("serve")) {
+    configureLogger({ includeTimestamp: true, timestampFormat: "SYS:yyyy-mm-dd HH:MM:ss" });
+}
 
 const program = new Command()
     .name("ai-proxy")

--- a/src/ai-proxy/lib/providers/grok-errors.test.ts
+++ b/src/ai-proxy/lib/providers/grok-errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { mapGrokError } from "@app/ai-proxy/lib/providers/grok-errors";
+
+describe("mapGrokError", () => {
+    it("re-wraps Grok's string-error shape into the OpenAI envelope", () => {
+        // Actual body captured from the grok chat proxy when a client sent
+        // "data:image/jpeg;base64,[object Object]" (ai@7 + @ai-sdk/openai v2 compat).
+        const envelope = mapGrokError({
+            status: 400,
+            bodyText: '{"code":"invalid-argument","error":"Base64 string of provided image cannot be decoded."}',
+        });
+
+        expect(envelope.error.message).toBe("Base64 string of provided image cannot be decoded.");
+        expect(envelope.error.type).toBe("invalid_request_error");
+        expect(envelope.error.code).toBe("invalid-argument");
+    });
+
+    it("passes through an already OpenAI-shaped error", () => {
+        const envelope = mapGrokError({
+            status: 400,
+            bodyText: '{"error":{"message":"bad tool call","type":"invalid_request_error","code":"tool_error"}}',
+        });
+
+        expect(envelope.error.message).toBe("bad tool call");
+        expect(envelope.error.type).toBe("invalid_request_error");
+        expect(envelope.error.code).toBe("tool_error");
+    });
+
+    it("uses raw text for non-JSON bodies", () => {
+        const envelope = mapGrokError({ status: 502, bodyText: "upstream exploded" });
+
+        expect(envelope.error.message).toBe("upstream exploded");
+        expect(envelope.error.type).toBe("upstream_error");
+    });
+
+    it("falls back to a status message for empty bodies", () => {
+        const envelope = mapGrokError({ status: 500, bodyText: "" });
+
+        expect(envelope.error.message).toBe("Grok upstream returned 500");
+        expect(envelope.error.type).toBe("upstream_error");
+    });
+
+    it("maps 429 to rate_limit_error with a retry hint", () => {
+        const envelope = mapGrokError({
+            status: 429,
+            bodyText: '{"code":"resource-exhausted","error":"Too many requests."}',
+            retryAfterSec: 30,
+        });
+
+        expect(envelope.error.message).toBe("Too many requests. Retry after 30s.");
+        expect(envelope.error.type).toBe("rate_limit_error");
+        expect(envelope.error.code).toBe("resource-exhausted");
+    });
+});

--- a/src/ai-proxy/lib/providers/grok-errors.ts
+++ b/src/ai-proxy/lib/providers/grok-errors.ts
@@ -1,0 +1,70 @@
+import type { OpenAiErrorEnvelope } from "@app/ai-proxy/lib/providers/wham-errors";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * Grok's chat proxy reports errors as `{"code":"invalid-argument","error":"…"}`
+ * — the message is a STRING `error` field, not the OpenAI `{error:{message}}`
+ * envelope. OpenAI SDK clients that can't parse the envelope fall back to the
+ * bare statusText ("Bad Request"), hiding the actual reason.
+ */
+function parseGrokUpstreamError(bodyText: string): { message?: string; type?: string; code?: string } {
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true });
+
+        if (!isObject(parsed)) {
+            return {};
+        }
+
+        if (typeof parsed.error === "string") {
+            return {
+                message: parsed.error,
+                code: typeof parsed.code === "string" ? parsed.code : undefined,
+            };
+        }
+
+        const error = isObject(parsed.error) ? parsed.error : parsed;
+
+        return {
+            message: typeof error.message === "string" ? error.message : undefined,
+            type: typeof error.type === "string" ? error.type : undefined,
+            code: typeof error.code === "string" ? error.code : undefined,
+        };
+    } catch {
+        const trimmed = bodyText.trim();
+        return trimmed ? { message: trimmed.slice(0, 500) } : {};
+    }
+}
+
+/** Map a non-OK Grok upstream response to an OpenAI-shaped error envelope. */
+export function mapGrokError({
+    status,
+    bodyText,
+    retryAfterSec,
+}: {
+    status: number;
+    bodyText: string;
+    retryAfterSec?: number;
+}): OpenAiErrorEnvelope {
+    const upstream = parseGrokUpstreamError(bodyText);
+
+    if (status === 429) {
+        const hint = retryAfterSec != null ? ` Retry after ${retryAfterSec}s.` : " Retry later.";
+
+        return {
+            error: {
+                message: `${upstream.message ?? "Grok rate limit hit."}${hint}`,
+                type: "rate_limit_error",
+                code: upstream.code ?? "rate_limit_exceeded",
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: upstream.message ?? `Grok upstream returned ${status}`,
+            type: upstream.type ?? (status >= 500 ? "upstream_error" : "invalid_request_error"),
+            code: upstream.code,
+        },
+    };
+}

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -1,6 +1,8 @@
 import { accountConfigFingerprint, resolveGrokAuthPath } from "@app/ai-proxy/lib/account-config";
 import { listGrokProxyModels } from "@app/ai-proxy/lib/model-meta";
+import { mapGrokError } from "@app/ai-proxy/lib/providers/grok-errors";
 import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { parseRetryAfterSeconds } from "@app/ai-proxy/lib/providers/wham-errors";
 import { prepareGrokUpstreamBody } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
@@ -112,6 +114,7 @@ export class GrokSubscriptionProvider implements ProxyProvider {
 
             if (!upstream.ok) {
                 const retryAfter = upstream.headers.get("retry-after");
+                const errorBody = await upstream.text();
                 logger.warn(
                     {
                         account: this.account.name,
@@ -122,23 +125,42 @@ export class GrokSubscriptionProvider implements ProxyProvider {
                         status: upstream.status,
                         elapsedMs,
                         retryAfter,
+                        body: errorBody.slice(0, 500),
                     },
                     "ai-proxy: upstream request failed"
                 );
-            } else {
-                logger.debug(
-                    {
-                        account: this.account.name,
-                        upstreamModel: prepared.upstreamModel,
-                        requestedModel: upstreamModel,
-                        imageRouted: prepared.imageRouted,
-                        path,
-                        status: upstream.status,
-                        elapsedMs,
-                    },
-                    "ai-proxy: upstream request ok"
-                );
+
+                // Grok's `{"code":…,"error":"…"}` shape doesn't match the OpenAI
+                // error envelope, so SDK clients would only surface the bare
+                // statusText ("Bad Request") — re-wrap so the real message survives.
+                const envelope = mapGrokError({
+                    status: upstream.status,
+                    bodyText: errorBody,
+                    retryAfterSec: parseRetryAfterSeconds(upstream.headers),
+                });
+                const headers = new Headers({ "Content-Type": "application/json" });
+                if (retryAfter) {
+                    headers.set("retry-after", retryAfter);
+                }
+
+                return new Response(SafeJSON.stringify(envelope), {
+                    status: upstream.status,
+                    headers,
+                });
             }
+
+            logger.debug(
+                {
+                    account: this.account.name,
+                    upstreamModel: prepared.upstreamModel,
+                    requestedModel: upstreamModel,
+                    imageRouted: prepared.imageRouted,
+                    path,
+                    status: upstream.status,
+                    elapsedMs,
+                },
+                "ai-proxy: upstream request ok"
+            );
 
             return new Response(upstream.body, {
                 status: upstream.status,

--- a/src/ai-proxy/lib/rewrite-upstream-body.test.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+    findInvalidImageDataPayload,
     GROK_IMAGE_FALLBACK_MODEL,
     grokModelSupportsImages,
     latestUserTurnHasImages,
@@ -300,5 +301,81 @@ describe("rewrite-upstream-body", () => {
         expect(parsed.model).toBe("grok-build");
         expect(rewritten.imageRouted).toBe(false);
         expect(parsed.messages[0]?.content?.[0]?.type).toBe("image_url");
+    });
+});
+
+describe("findInvalidImageDataPayload", () => {
+    it("catches a stringified-object payload in chat messages", () => {
+        // ai@7 + @ai-sdk/openai v2 compat mode stringifies V4 tagged file data
+        // into "[object Object]" — the exact request shape eve sent.
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "text", text: "What do you see?" },
+                        { type: "image_url", image_url: { url: "data:image/jpeg;base64,[object Object]" } },
+                    ],
+                },
+            ],
+        });
+
+        expect(payload).toBe("[object Object]");
+    });
+
+    it("catches invalid payloads in responses input items", () => {
+        const payload = findInvalidImageDataPayload({
+            input: [
+                {
+                    role: "user",
+                    content: [{ type: "input_image", image_url: "data:image/png;base64,not valid!" }],
+                },
+            ],
+        });
+
+        expect(payload).toBe("not valid!");
+    });
+
+    it("catches empty base64 payloads", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                { role: "user", content: [{ type: "image_url", image_url: { url: "data:image/png;base64," } }] },
+            ],
+        });
+
+        expect(payload).toBe("");
+    });
+
+    it("accepts valid base64 payloads", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "image_url", image_url: { url: "data:image/png;base64,iVBORw0KGgo=" } }],
+                },
+            ],
+        });
+
+        expect(payload).toBeNull();
+    });
+
+    it("ignores remote URLs and non-base64 data URLs", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "image_url", image_url: { url: "https://example.com/cat.jpg" } },
+                        { type: "image_url", image_url: { url: "data:image/svg+xml,%3Csvg%3E%3C/svg%3E" } },
+                    ],
+                },
+            ],
+        });
+
+        expect(payload).toBeNull();
+    });
+
+    it("ignores bodies without image parts", () => {
+        expect(findInvalidImageDataPayload({ messages: [{ role: "user", content: "hi" }] })).toBeNull();
     });
 });

--- a/src/ai-proxy/lib/rewrite-upstream-body.test.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.test.ts
@@ -378,4 +378,166 @@ describe("findInvalidImageDataPayload", () => {
     it("ignores bodies without image parts", () => {
         expect(findInvalidImageDataPayload({ messages: [{ role: "user", content: "hi" }] })).toBeNull();
     });
+
+    it("catches stringified-object data inside AI SDK file parts", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "file", mediaType: "image/jpeg", data: "[object Object]" }],
+                },
+            ],
+        });
+
+        expect(payload).toBe("[object Object]");
+    });
+});
+
+describe("AI SDK image part variants", () => {
+    const JPEG_B64 = "/9j/4AAQSkZJRg==";
+
+    function firstContentPart(bodyText: string): Record<string, unknown> {
+        const parsed = SafeJSON.parse(bodyText) as {
+            messages: Array<{ content: Array<Record<string, unknown>> }>;
+        };
+        const part = parsed.messages[0]?.content?.[0];
+        if (!part) {
+            throw new Error("no content part");
+        }
+        return part;
+    }
+
+    it("routes and normalizes image_url string form", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [
+                    { role: "user", content: [{ type: "image_url", image_url: `data:image/jpeg;base64,${JPEG_B64}` }] },
+                ],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(rewritten.upstreamModel).toBe(GROK_IMAGE_FALLBACK_MODEL);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes input_image parts", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [
+                    {
+                        role: "user",
+                        content: [{ type: "input_image", image_url: `data:image/png;base64,${JPEG_B64}` }],
+                    },
+                ],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/png;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes file parts with image mediaType and raw base64", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "file", mediaType: "image/jpeg", data: JPEG_B64 }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes file parts with a data URL and no mediaType", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "file", data: `data:image/jpeg;base64,${JPEG_B64}` }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("recovers ai@7 V4 tagged file data serialized to JSON", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [
+                    {
+                        role: "user",
+                        content: [{ type: "file", mediaType: "image/jpeg", data: { type: "data", data: JPEG_B64 } }],
+                    },
+                ],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes AI SDK core image parts (image field, raw base64)", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "image", image: JPEG_B64 }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("leaves non-image file parts untouched and unrouted", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "file", mediaType: "application/pdf", data: JPEG_B64 }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(false);
+        expect(rewritten.upstreamModel).toBe("grok-4.3");
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "file",
+            mediaType: "application/pdf",
+            data: JPEG_B64,
+        });
+    });
 });

--- a/src/ai-proxy/lib/rewrite-upstream-body.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.ts
@@ -147,7 +147,98 @@ function isImageContentPart(part: unknown): boolean {
         return true;
     }
 
+    // AI SDK file parts carrying an image (only when the image payload is
+    // actually extractable — non-image file parts must stay untouched).
+    if (part.type === "file") {
+        return fileImageDataUrl(part) !== null;
+    }
+
     return false;
+}
+
+const IMAGE_MEDIA_TYPE_KEYS = ["mediaType", "media_type", "mimeType", "mime_type"] as const;
+
+function imageMediaTypeFromPart(part: JsonObject): string | null {
+    for (const key of IMAGE_MEDIA_TYPE_KEYS) {
+        const value = part[key];
+
+        if (typeof value === "string" && value.startsWith("image/")) {
+            return value;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Inline payload of an AI SDK `file` part. Covers the plain-string `data`
+ * form, UI-message `url`, and ai@7's V4 tagged objects
+ * ({type:'data', data} / {type:'url', url}) — when a client serializes the V4
+ * prompt shape straight to JSON, the base64 is still recoverable here.
+ */
+function filePartInlineData(part: JsonObject): string | null {
+    if (typeof part.data === "string") {
+        return part.data;
+    }
+
+    if (isObject(part.data)) {
+        if (part.data.type === "data" && typeof part.data.data === "string") {
+            return part.data.data;
+        }
+
+        if (part.data.type === "url" && typeof part.data.url === "string") {
+            return part.data.url;
+        }
+    }
+
+    if (typeof part.url === "string") {
+        return part.url;
+    }
+
+    return null;
+}
+
+/** Data/remote URL of a `file` part when it carries an image; null otherwise. */
+function fileImageDataUrl(part: JsonObject): string | null {
+    if (part.type !== "file") {
+        return null;
+    }
+
+    const mediaType = imageMediaTypeFromPart(part);
+    const raw = filePartInlineData(part);
+
+    if (!raw) {
+        return null;
+    }
+
+    if (raw.startsWith("data:")) {
+        return raw.startsWith("data:image/") || mediaType ? raw : null;
+    }
+
+    if (/^https?:/.test(raw)) {
+        return mediaType ? raw : null;
+    }
+
+    // Raw base64 — only an image when the part declares an image media type.
+    return mediaType ? `data:${mediaType};base64,${raw}` : null;
+}
+
+/** Data/remote URL of an AI SDK core image part ({type:'image', image: …}). */
+function imageFieldDataUrl(part: JsonObject): string | null {
+    const image = part.image;
+    const raw = typeof image === "string" ? image : isObject(image) && typeof image.url === "string" ? image.url : null;
+
+    if (!raw) {
+        return null;
+    }
+
+    if (raw.startsWith("data:") || /^https?:/.test(raw)) {
+        return raw;
+    }
+
+    // Raw base64 with no declared media type — jpeg is the pragmatic default
+    // (matches AI SDK's own image/* fallback behavior).
+    return `data:${imageMediaTypeFromPart(part) ?? "image/jpeg"};base64,${raw}`;
 }
 
 function imageDataUrlFromPart(part: JsonObject): string | null {
@@ -178,6 +269,14 @@ function imageDataUrlFromPart(part: JsonObject): string | null {
         if (data) {
             return `data:${mediaType};base64,${data}`;
         }
+    }
+
+    if (part.type === "image") {
+        return imageFieldDataUrl(part);
+    }
+
+    if (part.type === "file") {
+        return fileImageDataUrl(part);
     }
 
     return null;

--- a/src/ai-proxy/lib/rewrite-upstream-body.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.ts
@@ -183,6 +183,73 @@ function imageDataUrlFromPart(part: JsonObject): string | null {
     return null;
 }
 
+const BASE64_MARKER = ";base64,";
+
+/**
+ * Returns the (truncated) offending payload when an image part carries a
+ * base64 data URL whose payload cannot be base64 — e.g. a client stringified
+ * an object into the data slot ("[object Object]", seen from ai@7 running
+ * @ai-sdk/openai v2 in compatibility mode). The image bytes never reached the
+ * proxy in that case, so rejecting early with a clear message beats burning an
+ * upstream call on a cryptic 400.
+ */
+export function findInvalidImageDataPayload(body: JsonObject): string | null {
+    const partsToCheck: JsonObject[] = [];
+
+    if (Array.isArray(body.messages)) {
+        for (const message of body.messages) {
+            if (isObject(message) && Array.isArray(message.content)) {
+                for (const part of message.content) {
+                    if (isObject(part) && isImageContentPart(part)) {
+                        partsToCheck.push(part);
+                    }
+                }
+            }
+        }
+    }
+
+    if (Array.isArray(body.input)) {
+        for (const item of body.input) {
+            if (!isObject(item)) {
+                continue;
+            }
+
+            if (isImageContentPart(item)) {
+                partsToCheck.push(item);
+            } else if (Array.isArray(item.content)) {
+                for (const part of item.content) {
+                    if (isObject(part) && isImageContentPart(part)) {
+                        partsToCheck.push(part);
+                    }
+                }
+            }
+        }
+    }
+
+    for (const part of partsToCheck) {
+        const dataUrl = imageDataUrlFromPart(part);
+
+        if (!dataUrl?.startsWith("data:")) {
+            continue;
+        }
+
+        const markerIndex = dataUrl.indexOf(BASE64_MARKER);
+
+        if (markerIndex === -1) {
+            continue;
+        }
+
+        const payload = dataUrl.slice(markerIndex + BASE64_MARKER.length);
+        const stripped = payload.replace(/\s+/g, "");
+
+        if (stripped.length === 0 || /[^A-Za-z0-9+/=_-]/.test(stripped)) {
+            return payload.slice(0, 100);
+        }
+    }
+
+    return null;
+}
+
 function normalizeImagePartForChat(part: JsonObject): JsonObject {
     const dataUrl = imageDataUrlFromPart(part);
 

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -6,6 +6,7 @@ import { stripBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { buildProviderMap, routeProviderKey, tryCreateProvider } from "@app/ai-proxy/lib/providers/registry";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
+import { findInvalidImageDataPayload } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import { resolveThinkingMode } from "@app/ai-proxy/lib/thinking-config";
 import { resolveTranslationMode } from "@app/ai-proxy/lib/translation-config";
 import { handleChatCompletions } from "@app/ai-proxy/lib/translators";
@@ -203,6 +204,28 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         status: 400,
                         headers: { "Content-Type": "application/json" },
                     });
+                }
+
+                const invalidImagePayload = findInvalidImageDataPayload(parsed as Record<string, unknown>);
+
+                if (invalidImagePayload !== null) {
+                    logger.warn(
+                        { path, model: parsed.model, payloadPreview: invalidImagePayload },
+                        "ai-proxy: rejecting image content with invalid base64 payload"
+                    );
+                    return new Response(
+                        SafeJSON.stringify({
+                            error: {
+                                message:
+                                    `Image content part carries an invalid base64 payload (${SafeJSON.stringify(invalidImagePayload)}) — ` +
+                                    "the image bytes never reached the proxy. This usually means the client stringified an object " +
+                                    'into the data URL (e.g. AI SDK v2-compat file parts becoming "[object Object]").',
+                                type: "invalid_request_error",
+                                code: "invalid_image_data",
+                            },
+                        }),
+                        { status: 400, headers: { "Content-Type": "application/json" } }
+                    );
                 }
 
                 try {

--- a/src/e2e/say.e2e.test.ts
+++ b/src/e2e/say.e2e.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { execTool, getOutput } from "@genesiscz/utils/e2e/helpers";
 import { skip } from "@genesiscz/utils/test/skip";
 
@@ -18,7 +21,7 @@ describe.skipIf(skip.integration)("tools say", () => {
 
         it("--help shows all options", async () => {
             const r = await execTool(["say", "--help"]);
-            for (const flag of ["--volume", "--voice", "--rate", "--wait", "--app", "--mute", "--unmute"]) {
+            for (const flag of ["--volume", "--voice", "--rate", "--wait", "--app", "--mute", "--unmute", "--output"]) {
                 expect(r.stdout).toContain(flag);
             }
         });
@@ -114,6 +117,27 @@ describe.skipIf(skip.integration)("tools say", () => {
             const r = await execTool(["say", "--help"]);
             expect(r.stdout).toContain("--volume");
             expect(r.stdout).toContain("--rate");
+        });
+    });
+
+    describe("--output", () => {
+        // `say -o` writes AIFF without needing a speaker/TTY audio session.
+        it("writes AIFF to the given path and does not hang", async () => {
+            const dir = mkdtempSync(join(tmpdir(), "say-e2e-"));
+            const outPath = join(dir, "hello.aiff");
+            const r = await execTool(["say", "hello", "--output", outPath, "--provider", "macos", "--no-fallback"]);
+            expect(r.exitCode).toBe(0);
+            expect(getOutput(r).toLowerCase()).toContain("wrote");
+            expect(existsSync(outPath)).toBe(true);
+            expect(statSync(outPath).size).toBeGreaterThan(100);
+        });
+
+        it("appends .aiff when path has no extension (macos)", async () => {
+            const dir = mkdtempSync(join(tmpdir(), "say-e2e-"));
+            const base = join(dir, "noext");
+            const r = await execTool(["say", "hi", "--output", base, "--provider", "macos", "--no-fallback"]);
+            expect(r.exitCode).toBe(0);
+            expect(existsSync(`${base}.aiff`)).toBe(true);
         });
     });
 });

--- a/src/say/README.md
+++ b/src/say/README.md
@@ -24,6 +24,10 @@ tools say "x done" --app claude
 # Override one field on a single run (does NOT persist)
 tools say "x done" --app claude --voice Daniel
 
+# Save speech to a file (no playback; blocks until written)
+tools say "Deploy done" --output /tmp/done.aiff --provider macos
+tools say "Hello" --output /tmp/hello.mp3 --provider xai --format mp3
+
 # Manage profiles interactively
 tools say config
 ```
@@ -201,7 +205,8 @@ In a non-TTY context both entry points fail fast — pass `--app <name> --save` 
 | `--language <bcp47>` | Language hint (xAI) |
 | `--format <codec>` | `mp3` or `wav` |
 | `--file <path>` | Read text from a file |
-| `--stream` / `--no-stream` | Force streaming mode on/off |
+| `--output <path>` | Write audio to a file instead of playing. Blocks until written. macOS → AIFF; cloud → mp3/wav per `--format`. Mute is ignored. No extension → appends the correct one. |
+| `--stream` / `--no-stream` | Force streaming mode on/off (ignored with `--output`, which always buffers fully) |
 | `--model <id>` | Provider-specific model (OpenAI: `tts-1`, `gpt-4o-mini-tts`) |
 | `--save` | Persist explicitly-passed flags to `--app`'s profile |
 | `--unset <fields>` | Comma-separated profile fields to ignore (or remove with `--save`) |

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, extname, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { AI } from "@genesiscz/utils/ai/index.ts";
 import { getModelsForTask } from "@genesiscz/utils/ai/ModelManager";
@@ -42,6 +42,7 @@ interface SayOptions {
     language?: string;
     format?: "mp3" | "wav";
     file?: string;
+    output?: string;
     stream?: boolean;
     noStream?: boolean;
     model?: string;
@@ -72,6 +73,10 @@ const program = new Command()
     .option("--language <bcp47>", "Language hint (xai only; defaults to 'auto')")
     .option("--format <codec>", "Output codec: mp3 or wav")
     .option("--file <path>", "Read text from a file instead of args")
+    .option(
+        "--output <path>",
+        "Write synthesized audio to a file instead of playing (macOS: AIFF; cloud: mp3/wav per --format). Blocks until written. Mute is ignored."
+    )
     .option("--stream", "Force streaming path")
     .option("--no-stream", "Force REST/non-streaming path")
     .option("--model <id>", "Provider-specific model (e.g. tts-1, gpt-4o-mini-tts for openai)")
@@ -133,9 +138,10 @@ const program = new Command()
         // If --save is requesting a mute change, don't short-circuit on the
         // existing mute state — otherwise --unmute --save / --unset mute --save
         // can never be persisted from a currently-muted profile.
+        // --output still synthesizes (mute only silences speaker playback).
         const wantsMuteWrite = opts.save === true && (opts.unmute === true || unsetList.includes("mute"));
 
-        if (!wantsMuteWrite && (await mgr.isMuted(opts.app))) {
+        if (!wantsMuteWrite && !opts.output && (await mgr.isMuted(opts.app))) {
             process.stderr.write("[say] muted\n");
             return;
         }
@@ -146,9 +152,9 @@ const program = new Command()
         // --wait so the child performs the (possibly network-bound for cloud
         // providers) synth + playback in its own process group, then return
         // immediately. --wait opts back into blocking; it is also the recursion
-        // guard since this branch only triggers without it. --save runs inline
-        // so its confirmation output is preserved.
-        if (!opts.wait && !opts.save) {
+        // guard since this branch only triggers without it. --save / --output
+        // run inline so confirmation text and the audio file are ready before exit.
+        if (!opts.wait && !opts.save && !opts.output) {
             spawnDetachedSpeaker();
             return;
         }
@@ -388,16 +394,22 @@ interface SpeakCachedArgs {
  * cloud providers, hash the request — on a hit, play the cached audio
  * directly; on a miss, synthesize, play, and record the miss so the Nth
  * occurrence persists.
+ *
+ * With `--output`, never plays: synthesizes (or serves cache), writes the
+ * full buffer to the path, then returns. Streaming is ignored because a
+ * complete file is required.
  */
 async function speakCached(args: SpeakCachedArgs): Promise<void> {
     const { mgr, text, provider, effective, opts, stream } = args;
+    const outputPath = opts.output ? resolve(opts.output) : undefined;
 
     // Bypass the cache when:
     //   - provider is macos (local & free)
     //   - the user explicitly asked for streaming — caching needs the whole
     //     buffer up front, which would silently negate `--stream` for cloud
     //     providers. Honor the flag instead.
-    if (provider === "macos" || stream === true) {
+    // `--output` needs a full buffer, so it never takes the stream-only path.
+    if ((provider === "macos" || stream === true) && !outputPath) {
         await AI.speak(text, {
             provider,
             voice: effective.voice ?? undefined,
@@ -409,6 +421,20 @@ async function speakCached(args: SpeakCachedArgs): Promise<void> {
             wait: opts.wait,
             model: effective.model ?? undefined,
         });
+        return;
+    }
+
+    // macos + --output, or cloud (with optional cache): need the buffer.
+    if (provider === "macos") {
+        const result = await AI.synthesize(text, {
+            provider,
+            voice: effective.voice ?? undefined,
+            language: effective.language ?? undefined,
+            format: effective.format ?? undefined,
+            rate: effective.rate ?? undefined,
+            model: effective.model ?? undefined,
+        });
+        writeAudioFile(outputPath as string, result.audio, result.contentType);
         return;
     }
 
@@ -443,6 +469,12 @@ async function speakCached(args: SpeakCachedArgs): Promise<void> {
 
     if (hit) {
         logger.debug(`[say] cache hit (${provider}, ${hit.audio.byteLength}B)`);
+
+        if (outputPath) {
+            writeAudioFile(outputPath, hit.audio, hit.contentType);
+            return;
+        }
+
         await playBuffer(hit.audio, hit.contentType, {
             volume: effective.volume ?? undefined,
             wait: opts.wait,
@@ -472,10 +504,60 @@ async function speakCached(args: SpeakCachedArgs): Promise<void> {
         logger.warn(`[say/cache] recordMiss() failed, audio not cached: ${err}`);
     }
 
+    if (outputPath) {
+        writeAudioFile(outputPath, result.audio, result.contentType);
+        return;
+    }
+
     await playBuffer(result.audio, result.contentType, {
         volume: effective.volume ?? undefined,
         wait: opts.wait,
     });
+}
+
+/** MIME → preferred extension when the user path has none. */
+const CONTENT_TYPE_EXT: Record<string, string> = {
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/wave": ".wav",
+    "audio/aiff": ".aiff",
+    "audio/x-aiff": ".aiff",
+};
+
+/**
+ * Write TTS bytes to disk. Creates parent directories. If `path` has no
+ * extension, appends one derived from `contentType`. Does not convert
+ * codecs — macos always yields AIFF; cloud yields mp3/wav per `--format`.
+ */
+function writeAudioFile(path: string, audio: Buffer, contentType: string): void {
+    let dest = path;
+    const preferred = CONTENT_TYPE_EXT[contentType.toLowerCase()];
+
+    if (!extname(dest) && preferred) {
+        dest = `${dest}${preferred}`;
+    }
+
+    const parent = dirname(dest);
+
+    if (parent && parent !== ".") {
+        mkdirSync(parent, { recursive: true });
+    }
+
+    writeFileSync(dest, audio);
+
+    const ext = extname(dest).toLowerCase();
+    if (preferred && ext && ext !== preferred) {
+        out.println(
+            pc.yellow(
+                `[say] wrote ${dest} (${audio.byteLength}B, ${contentType}) — extension ${ext} does not match payload; use ${preferred} for this provider/format`
+            )
+        );
+        return;
+    }
+
+    out.println(pc.green(`[say] wrote ${dest} (${audio.byteLength}B, ${contentType})`));
 }
 
 function isVoiceNotFoundError(message: string): boolean {
@@ -662,7 +744,10 @@ async function main(): Promise<void> {
     }
 }
 
-main();
+// Top-level await keeps the event loop alive for the full synth path.
+// A floating `main()` lets Bun exit early during `AI.synthesize` (Bun.spawn
+// for `say -o` does not always hold a process ref the way `say` playback does).
+await main();
 
 // ============================================
 // `tools say config` — unified app/profile manager


### PR DESCRIPTION
## Summary

- **ai-proxy / Grok images:** accept every AI SDK image part shape (image_url object/string, input_image, file parts, ai@7 V4 tagged data, core `{type:'image'}`) so companion/eve screenshot turns route correctly; leave non-image file parts alone.
- **ai-proxy / Grok errors:** map Grok `{code,error}` bodies to OpenAI-style envelopes; reject unrecoverable base64 payloads (e.g. `[object Object]`) with a clear 400 before they hit upstream; timestamp proxy serve logs.
- **say:** add `--output <path>` to write synthesized speech to a file (no playback, blocks until written); fix floating `main()` so Bun does not exit mid-`AI.synthesize`.

## Test plan

- [ ] `tools say "hello" --output /tmp/t.aiff --provider macos --no-fallback` → file exists, AIFF, prints `[say] wrote …`
- [ ] `tools say "hi" --output /tmp/noext --provider macos` → writes `/tmp/noext.aiff`
- [ ] Mute does not block `--output`; fire-and-forget still works without `--output`
- [ ] ai-proxy: image part variants tests green (`rewrite-upstream-body.test.ts`, grok-errors tests)
- [ ] ai-proxy: invalid base64 data URL returns 400 `invalid_image_data` without upstream call
- [ ] ai-proxy: non-OK Grok body surfaces real message in OpenAI envelope (not bare "Bad Request")



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--output <path>` to save synthesized speech to audio files, with automatic format extensions.
  * Added support for image inputs represented by additional AI SDK formats.
  * Improved Grok error responses with clearer messages, rate-limit details, and retry guidance.

* **Bug Fixes**
  * Added validation for invalid image data, returning actionable request errors.
  * Serve logs now include timestamps to distinguish current and older entries.
  * Preserved upstream retry information in proxy responses.

* **Documentation**
  * Documented speech output file usage and related option behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->