### PR TITLE
fix(monorepo): resolve @genesiscz/utils/* subpath imports in vite dev

### DIFF
--- a/src/ai-proxy/index.ts
+++ b/src/ai-proxy/index.ts
@@ -21,7 +21,16 @@ import { runUsageCommand } from "@app/ai-proxy/commands/usage";
 import { isValidThinkingMode } from "@app/ai-proxy/lib/thinking-config";
 import type { AiProxyProviderType, CursorTranslationMode, ThinkingPresentationMode } from "@app/ai-proxy/lib/types";
 import { runTool } from "@genesiscz/utils/cli";
+import { configureLogger } from "@genesiscz/utils/logger";
 import { Command } from "commander";
+
+// proxy.log is the serve process's stderr — without timestamps a stale log
+// file is indistinguishable from a quiet one, which is exactly how a 5-day-old
+// proxy.log derailed an incident investigation. Must run before runTool: its
+// setBaseBinding() instantiates the logger, freezing timestamp options.
+if (process.argv.includes("serve")) {
+    configureLogger({ includeTimestamp: true, timestampFormat: "SYS:yyyy-mm-dd HH:MM:ss" });
+}
 
 const program = new Command()
     .name("ai-proxy")

--- a/src/ai-proxy/lib/providers/grok-errors.test.ts
+++ b/src/ai-proxy/lib/providers/grok-errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { mapGrokError } from "@app/ai-proxy/lib/providers/grok-errors";
+
+describe("mapGrokError", () => {
+    it("re-wraps Grok's string-error shape into the OpenAI envelope", () => {
+        // Actual body captured from the grok chat proxy when a client sent
+        // "data:image/jpeg;base64,[object Object]" (ai@7 + @ai-sdk/openai v2 compat).
+        const envelope = mapGrokError({
+            status: 400,
+            bodyText: '{"code":"invalid-argument","error":"Base64 string of provided image cannot be decoded."}',
+        });
+
+        expect(envelope.error.message).toBe("Base64 string of provided image cannot be decoded.");
+        expect(envelope.error.type).toBe("invalid_request_error");
+        expect(envelope.error.code).toBe("invalid-argument");
+    });
+
+    it("passes through an already OpenAI-shaped error", () => {
+        const envelope = mapGrokError({
+            status: 400,
+            bodyText: '{"error":{"message":"bad tool call","type":"invalid_request_error","code":"tool_error"}}',
+        });
+
+        expect(envelope.error.message).toBe("bad tool call");
+        expect(envelope.error.type).toBe("invalid_request_error");
+        expect(envelope.error.code).toBe("tool_error");
+    });
+
+    it("uses raw text for non-JSON bodies", () => {
+        const envelope = mapGrokError({ status: 502, bodyText: "upstream exploded" });
+
+        expect(envelope.error.message).toBe("upstream exploded");
+        expect(envelope.error.type).toBe("upstream_error");
+    });
+
+    it("falls back to a status message for empty bodies", () => {
+        const envelope = mapGrokError({ status: 500, bodyText: "" });
+
+        expect(envelope.error.message).toBe("Grok upstream returned 500");
+        expect(envelope.error.type).toBe("upstream_error");
+    });
+
+    it("maps 429 to rate_limit_error with a retry hint", () => {
+        const envelope = mapGrokError({
+            status: 429,
+            bodyText: '{"code":"resource-exhausted","error":"Too many requests."}',
+            retryAfterSec: 30,
+        });
+
+        expect(envelope.error.message).toBe("Too many requests. Retry after 30s.");
+        expect(envelope.error.type).toBe("rate_limit_error");
+        expect(envelope.error.code).toBe("resource-exhausted");
+    });
+});

--- a/src/ai-proxy/lib/providers/grok-errors.ts
+++ b/src/ai-proxy/lib/providers/grok-errors.ts
@@ -1,0 +1,70 @@
+import type { OpenAiErrorEnvelope } from "@app/ai-proxy/lib/providers/wham-errors";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * Grok's chat proxy reports errors as `{"code":"invalid-argument","error":"…"}`
+ * — the message is a STRING `error` field, not the OpenAI `{error:{message}}`
+ * envelope. OpenAI SDK clients that can't parse the envelope fall back to the
+ * bare statusText ("Bad Request"), hiding the actual reason.
+ */
+function parseGrokUpstreamError(bodyText: string): { message?: string; type?: string; code?: string } {
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true });
+
+        if (!isObject(parsed)) {
+            return {};
+        }
+
+        if (typeof parsed.error === "string") {
+            return {
+                message: parsed.error,
+                code: typeof parsed.code === "string" ? parsed.code : undefined,
+            };
+        }
+
+        const error = isObject(parsed.error) ? parsed.error : parsed;
+
+        return {
+            message: typeof error.message === "string" ? error.message : undefined,
+            type: typeof error.type === "string" ? error.type : undefined,
+            code: typeof error.code === "string" ? error.code : undefined,
+        };
+    } catch {
+        const trimmed = bodyText.trim();
+        return trimmed ? { message: trimmed.slice(0, 500) } : {};
+    }
+}
+
+/** Map a non-OK Grok upstream response to an OpenAI-shaped error envelope. */
+export function mapGrokError({
+    status,
+    bodyText,
+    retryAfterSec,
+}: {
+    status: number;
+    bodyText: string;
+    retryAfterSec?: number;
+}): OpenAiErrorEnvelope {
+    const upstream = parseGrokUpstreamError(bodyText);
+
+    if (status === 429) {
+        const hint = retryAfterSec != null ? ` Retry after ${retryAfterSec}s.` : " Retry later.";
+
+        return {
+            error: {
+                message: `${upstream.message ?? "Grok rate limit hit."}${hint}`,
+                type: "rate_limit_error",
+                code: upstream.code ?? "rate_limit_exceeded",
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: upstream.message ?? `Grok upstream returned ${status}`,
+            type: upstream.type ?? (status >= 500 ? "upstream_error" : "invalid_request_error"),
+            code: upstream.code,
+        },
+    };
+}

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -1,6 +1,8 @@
 import { accountConfigFingerprint, resolveGrokAuthPath } from "@app/ai-proxy/lib/account-config";
 import { listGrokProxyModels } from "@app/ai-proxy/lib/model-meta";
+import { mapGrokError } from "@app/ai-proxy/lib/providers/grok-errors";
 import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { parseRetryAfterSeconds } from "@app/ai-proxy/lib/providers/wham-errors";
 import { prepareGrokUpstreamBody } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
@@ -112,6 +114,7 @@ export class GrokSubscriptionProvider implements ProxyProvider {
 
             if (!upstream.ok) {
                 const retryAfter = upstream.headers.get("retry-after");
+                const errorBody = await upstream.text();
                 logger.warn(
                     {
                         account: this.account.name,
@@ -122,23 +125,42 @@ export class GrokSubscriptionProvider implements ProxyProvider {
                         status: upstream.status,
                         elapsedMs,
                         retryAfter,
+                        body: errorBody.slice(0, 500),
                     },
                     "ai-proxy: upstream request failed"
                 );
-            } else {
-                logger.debug(
-                    {
-                        account: this.account.name,
-                        upstreamModel: prepared.upstreamModel,
-                        requestedModel: upstreamModel,
-                        imageRouted: prepared.imageRouted,
-                        path,
-                        status: upstream.status,
-                        elapsedMs,
-                    },
-                    "ai-proxy: upstream request ok"
-                );
+
+                // Grok's `{"code":…,"error":"…"}` shape doesn't match the OpenAI
+                // error envelope, so SDK clients would only surface the bare
+                // statusText ("Bad Request") — re-wrap so the real message survives.
+                const envelope = mapGrokError({
+                    status: upstream.status,
+                    bodyText: errorBody,
+                    retryAfterSec: parseRetryAfterSeconds(upstream.headers),
+                });
+                const headers = new Headers({ "Content-Type": "application/json" });
+                if (retryAfter) {
+                    headers.set("retry-after", retryAfter);
+                }
+
+                return new Response(SafeJSON.stringify(envelope), {
+                    status: upstream.status,
+                    headers,
+                });
             }
+
+            logger.debug(
+                {
+                    account: this.account.name,
+                    upstreamModel: prepared.upstreamModel,
+                    requestedModel: upstreamModel,
+                    imageRouted: prepared.imageRouted,
+                    path,
+                    status: upstream.status,
+                    elapsedMs,
+                },
+                "ai-proxy: upstream request ok"
+            );
 
             return new Response(upstream.body, {
                 status: upstream.status,

--- a/src/ai-proxy/lib/rewrite-upstream-body.test.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+    findInvalidImageDataPayload,
     GROK_IMAGE_FALLBACK_MODEL,
     grokModelSupportsImages,
     latestUserTurnHasImages,
@@ -300,5 +301,81 @@ describe("rewrite-upstream-body", () => {
         expect(parsed.model).toBe("grok-build");
         expect(rewritten.imageRouted).toBe(false);
         expect(parsed.messages[0]?.content?.[0]?.type).toBe("image_url");
+    });
+});
+
+describe("findInvalidImageDataPayload", () => {
+    it("catches a stringified-object payload in chat messages", () => {
+        // ai@7 + @ai-sdk/openai v2 compat mode stringifies V4 tagged file data
+        // into "[object Object]" — the exact request shape eve sent.
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "text", text: "What do you see?" },
+                        { type: "image_url", image_url: { url: "data:image/jpeg;base64,[object Object]" } },
+                    ],
+                },
+            ],
+        });
+
+        expect(payload).toBe("[object Object]");
+    });
+
+    it("catches invalid payloads in responses input items", () => {
+        const payload = findInvalidImageDataPayload({
+            input: [
+                {
+                    role: "user",
+                    content: [{ type: "input_image", image_url: "data:image/png;base64,not valid!" }],
+                },
+            ],
+        });
+
+        expect(payload).toBe("not valid!");
+    });
+
+    it("catches empty base64 payloads", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                { role: "user", content: [{ type: "image_url", image_url: { url: "data:image/png;base64," } }] },
+            ],
+        });
+
+        expect(payload).toBe("");
+    });
+
+    it("accepts valid base64 payloads", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "image_url", image_url: { url: "data:image/png;base64,iVBORw0KGgo=" } }],
+                },
+            ],
+        });
+
+        expect(payload).toBeNull();
+    });
+
+    it("ignores remote URLs and non-base64 data URLs", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "image_url", image_url: { url: "https://example.com/cat.jpg" } },
+                        { type: "image_url", image_url: { url: "data:image/svg+xml,%3Csvg%3E%3C/svg%3E" } },
+                    ],
+                },
+            ],
+        });
+
+        expect(payload).toBeNull();
+    });
+
+    it("ignores bodies without image parts", () => {
+        expect(findInvalidImageDataPayload({ messages: [{ role: "user", content: "hi" }] })).toBeNull();
     });
 });

--- a/src/ai-proxy/lib/rewrite-upstream-body.test.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.test.ts
@@ -378,4 +378,166 @@ describe("findInvalidImageDataPayload", () => {
     it("ignores bodies without image parts", () => {
         expect(findInvalidImageDataPayload({ messages: [{ role: "user", content: "hi" }] })).toBeNull();
     });
+
+    it("catches stringified-object data inside AI SDK file parts", () => {
+        const payload = findInvalidImageDataPayload({
+            messages: [
+                {
+                    role: "user",
+                    content: [{ type: "file", mediaType: "image/jpeg", data: "[object Object]" }],
+                },
+            ],
+        });
+
+        expect(payload).toBe("[object Object]");
+    });
+});
+
+describe("AI SDK image part variants", () => {
+    const JPEG_B64 = "/9j/4AAQSkZJRg==";
+
+    function firstContentPart(bodyText: string): Record<string, unknown> {
+        const parsed = SafeJSON.parse(bodyText) as {
+            messages: Array<{ content: Array<Record<string, unknown>> }>;
+        };
+        const part = parsed.messages[0]?.content?.[0];
+        if (!part) {
+            throw new Error("no content part");
+        }
+        return part;
+    }
+
+    it("routes and normalizes image_url string form", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [
+                    { role: "user", content: [{ type: "image_url", image_url: `data:image/jpeg;base64,${JPEG_B64}` }] },
+                ],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(rewritten.upstreamModel).toBe(GROK_IMAGE_FALLBACK_MODEL);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes input_image parts", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [
+                    {
+                        role: "user",
+                        content: [{ type: "input_image", image_url: `data:image/png;base64,${JPEG_B64}` }],
+                    },
+                ],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/png;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes file parts with image mediaType and raw base64", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "file", mediaType: "image/jpeg", data: JPEG_B64 }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes file parts with a data URL and no mediaType", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "file", data: `data:image/jpeg;base64,${JPEG_B64}` }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("recovers ai@7 V4 tagged file data serialized to JSON", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [
+                    {
+                        role: "user",
+                        content: [{ type: "file", mediaType: "image/jpeg", data: { type: "data", data: JPEG_B64 } }],
+                    },
+                ],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("routes and normalizes AI SDK core image parts (image field, raw base64)", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "image", image: JPEG_B64 }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(true);
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${JPEG_B64}` },
+        });
+    });
+
+    it("leaves non-image file parts untouched and unrouted", () => {
+        const rewritten = prepareGrokUpstreamBody(
+            SafeJSON.stringify({
+                model: "martin/grok/grok-4.3",
+                messages: [{ role: "user", content: [{ type: "file", mediaType: "application/pdf", data: JPEG_B64 }] }],
+            }),
+            "grok-4.3",
+            "chat"
+        );
+
+        expect(rewritten.imageRouted).toBe(false);
+        expect(rewritten.upstreamModel).toBe("grok-4.3");
+        expect(firstContentPart(rewritten.bodyText)).toEqual({
+            type: "file",
+            mediaType: "application/pdf",
+            data: JPEG_B64,
+        });
+    });
 });

--- a/src/ai-proxy/lib/rewrite-upstream-body.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.ts
@@ -147,7 +147,98 @@ function isImageContentPart(part: unknown): boolean {
         return true;
     }
 
+    // AI SDK file parts carrying an image (only when the image payload is
+    // actually extractable — non-image file parts must stay untouched).
+    if (part.type === "file") {
+        return fileImageDataUrl(part) !== null;
+    }
+
     return false;
+}
+
+const IMAGE_MEDIA_TYPE_KEYS = ["mediaType", "media_type", "mimeType", "mime_type"] as const;
+
+function imageMediaTypeFromPart(part: JsonObject): string | null {
+    for (const key of IMAGE_MEDIA_TYPE_KEYS) {
+        const value = part[key];
+
+        if (typeof value === "string" && value.startsWith("image/")) {
+            return value;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Inline payload of an AI SDK `file` part. Covers the plain-string `data`
+ * form, UI-message `url`, and ai@7's V4 tagged objects
+ * ({type:'data', data} / {type:'url', url}) — when a client serializes the V4
+ * prompt shape straight to JSON, the base64 is still recoverable here.
+ */
+function filePartInlineData(part: JsonObject): string | null {
+    if (typeof part.data === "string") {
+        return part.data;
+    }
+
+    if (isObject(part.data)) {
+        if (part.data.type === "data" && typeof part.data.data === "string") {
+            return part.data.data;
+        }
+
+        if (part.data.type === "url" && typeof part.data.url === "string") {
+            return part.data.url;
+        }
+    }
+
+    if (typeof part.url === "string") {
+        return part.url;
+    }
+
+    return null;
+}
+
+/** Data/remote URL of a `file` part when it carries an image; null otherwise. */
+function fileImageDataUrl(part: JsonObject): string | null {
+    if (part.type !== "file") {
+        return null;
+    }
+
+    const mediaType = imageMediaTypeFromPart(part);
+    const raw = filePartInlineData(part);
+
+    if (!raw) {
+        return null;
+    }
+
+    if (raw.startsWith("data:")) {
+        return raw.startsWith("data:image/") || mediaType ? raw : null;
+    }
+
+    if (/^https?:/.test(raw)) {
+        return mediaType ? raw : null;
+    }
+
+    // Raw base64 — only an image when the part declares an image media type.
+    return mediaType ? `data:${mediaType};base64,${raw}` : null;
+}
+
+/** Data/remote URL of an AI SDK core image part ({type:'image', image: …}). */
+function imageFieldDataUrl(part: JsonObject): string | null {
+    const image = part.image;
+    const raw = typeof image === "string" ? image : isObject(image) && typeof image.url === "string" ? image.url : null;
+
+    if (!raw) {
+        return null;
+    }
+
+    if (raw.startsWith("data:") || /^https?:/.test(raw)) {
+        return raw;
+    }
+
+    // Raw base64 with no declared media type — jpeg is the pragmatic default
+    // (matches AI SDK's own image/* fallback behavior).
+    return `data:${imageMediaTypeFromPart(part) ?? "image/jpeg"};base64,${raw}`;
 }
 
 function imageDataUrlFromPart(part: JsonObject): string | null {
@@ -178,6 +269,14 @@ function imageDataUrlFromPart(part: JsonObject): string | null {
         if (data) {
             return `data:${mediaType};base64,${data}`;
         }
+    }
+
+    if (part.type === "image") {
+        return imageFieldDataUrl(part);
+    }
+
+    if (part.type === "file") {
+        return fileImageDataUrl(part);
     }
 
     return null;

--- a/src/ai-proxy/lib/rewrite-upstream-body.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.ts
@@ -183,6 +183,73 @@ function imageDataUrlFromPart(part: JsonObject): string | null {
     return null;
 }
 
+const BASE64_MARKER = ";base64,";
+
+/**
+ * Returns the (truncated) offending payload when an image part carries a
+ * base64 data URL whose payload cannot be base64 — e.g. a client stringified
+ * an object into the data slot ("[object Object]", seen from ai@7 running
+ * @ai-sdk/openai v2 in compatibility mode). The image bytes never reached the
+ * proxy in that case, so rejecting early with a clear message beats burning an
+ * upstream call on a cryptic 400.
+ */
+export function findInvalidImageDataPayload(body: JsonObject): string | null {
+    const partsToCheck: JsonObject[] = [];
+
+    if (Array.isArray(body.messages)) {
+        for (const message of body.messages) {
+            if (isObject(message) && Array.isArray(message.content)) {
+                for (const part of message.content) {
+                    if (isObject(part) && isImageContentPart(part)) {
+                        partsToCheck.push(part);
+                    }
+                }
+            }
+        }
+    }
+
+    if (Array.isArray(body.input)) {
+        for (const item of body.input) {
+            if (!isObject(item)) {
+                continue;
+            }
+
+            if (isImageContentPart(item)) {
+                partsToCheck.push(item);
+            } else if (Array.isArray(item.content)) {
+                for (const part of item.content) {
+                    if (isObject(part) && isImageContentPart(part)) {
+                        partsToCheck.push(part);
+                    }
+                }
+            }
+        }
+    }
+
+    for (const part of partsToCheck) {
+        const dataUrl = imageDataUrlFromPart(part);
+
+        if (!dataUrl?.startsWith("data:")) {
+            continue;
+        }
+
+        const markerIndex = dataUrl.indexOf(BASE64_MARKER);
+
+        if (markerIndex === -1) {
+            continue;
+        }
+
+        const payload = dataUrl.slice(markerIndex + BASE64_MARKER.length);
+        const stripped = payload.replace(/\s+/g, "");
+
+        if (stripped.length === 0 || /[^A-Za-z0-9+/=_-]/.test(stripped)) {
+            return payload.slice(0, 100);
+        }
+    }
+
+    return null;
+}
+
 function normalizeImagePartForChat(part: JsonObject): JsonObject {
     const dataUrl = imageDataUrlFromPart(part);
 

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -6,6 +6,7 @@ import { stripBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { buildProviderMap, routeProviderKey, tryCreateProvider } from "@app/ai-proxy/lib/providers/registry";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
+import { findInvalidImageDataPayload } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import { resolveThinkingMode } from "@app/ai-proxy/lib/thinking-config";
 import { resolveTranslationMode } from "@app/ai-proxy/lib/translation-config";
 import { handleChatCompletions } from "@app/ai-proxy/lib/translators";
@@ -203,6 +204,28 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         status: 400,
                         headers: { "Content-Type": "application/json" },
                     });
+                }
+
+                const invalidImagePayload = findInvalidImageDataPayload(parsed as Record<string, unknown>);
+
+                if (invalidImagePayload !== null) {
+                    logger.warn(
+                        { path, model: parsed.model, payloadPreview: invalidImagePayload },
+                        "ai-proxy: rejecting image content with invalid base64 payload"
+                    );
+                    return new Response(
+                        SafeJSON.stringify({
+                            error: {
+                                message:
+                                    `Image content part carries an invalid base64 payload (${SafeJSON.stringify(invalidImagePayload)}) — ` +
+                                    "the image bytes never reached the proxy. This usually means the client stringified an object " +
+                                    'into the data URL (e.g. AI SDK v2-compat file parts becoming "[object Object]").',
+                                type: "invalid_request_error",
+                                code: "invalid_image_data",
+                            },
+                        }),
+                        { status: 400, headers: { "Content-Type": "application/json" } }
+                    );
                 }
 
                 try {

--- a/src/utils/package.json
+++ b/src/utils/package.json
@@ -327,6 +327,11 @@
             "types": "./ui/index.ts",
             "default": "./ui/index.ts"
         },
+        "./ui/vite.base": {
+            "bun": "./ui/vite.base.ts",
+            "types": "./ui/vite.base.ts",
+            "default": "./ui/vite.base.ts"
+        },
         "./url": {
             "bun": "./url.ts",
             "types": "./url.ts",

--- a/src/utils/ui/vite.base.ts
+++ b/src/utils/ui/vite.base.ts
@@ -38,6 +38,19 @@ export interface DashboardViteConfig {
 const BROWSER_ASYNC_HOOKS_POLYFILL = resolve(__dirname, "browser-async-hooks.ts");
 
 /**
+ * Absolute path to the published `@genesiscz/utils` package root (src/utils).
+ *
+ * This file lives at `src/utils/ui/vite.base.ts`, so the package root is its
+ * parent directory — resolved from `__dirname` exactly like the `@ui` alias
+ * below (`resolve(__dirname, ".")`). Anchoring on `__dirname` (not the passed
+ * `root`, which is the dashboard's UI dir) makes the alias authoritative and
+ * correct in both the main repo and any git worktree, so browser resolution of
+ * `@genesiscz/utils/*` subpaths never depends on the package's `exports` map
+ * being complete.
+ */
+const UTILS_PACKAGE_ROOT = resolve(__dirname, "..");
+
+/**
  * Vite plugin that pins ALL bare-module resolution to the dashboard's own
  * directory tree (walking up to its nearest `node_modules/`).
  *
@@ -229,7 +242,7 @@ export function createDashboardViteConfig({
     const { plugins: _ignored, resolve: _resolveIgnored, optimizeDeps: overrideOptimizeDeps, ...rest } = overrides;
     const allAliases: Record<string, string> = {
         "@app": resolve(root, "src"),
-        "@genesiscz/utils": resolve(root, "src/utils"),
+        "@genesiscz/utils": UTILS_PACKAGE_ROOT,
         ...aliases,
     };
     const appDir = allAliases["@app"];


### PR DESCRIPTION
## Summary
- `@genesiscz/utils` intra-package self-imports (e.g. `dialog.tsx` → `@genesiscz/utils/ui/components/select`) fail to resolve in vite dev — the alias in `src/utils/ui/vite.base.ts` was anchored on the *consuming* dashboard's dir instead of the utils package dir, so it silently fell through to the incomplete `exports` map (69 explicit subpaths, no wildcards) and failed for anything not listed.
- Fixes the alias to anchor on `__dirname` (mirrors the working `@ui` alias), making it authoritative for all `@genesiscz/utils/*` subpaths regardless of which app loads the config.
- Adds one `exports` entry (`./ui/vite.base`) needed by a static rolldown-time import in `shops/ui/vite.config.ts`.

## Verified
- Booted in vite dev, all mount with zero import-analysis errors: dev-dashboard, clarity, youtube, shops, reas.
- `tsgo --noEmit` clean; `bun test src/utils` passes.

## Test plan
- [x] dev-dashboard `/qa` mounts (no "STARTING" stall, no import-analysis overlay)
- [x] clarity / youtube / shops / reas boot in dev
- [x] tsgo clean, bun test src/utils green
