### PR TITLE
feat(handoff): cross-agent task handoff MCP suite + dev-dashboard Agent-tasks tab

### DIFF
--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -49,6 +49,24 @@ import {
 } from "./tools/boards/schemas";
 import { handleWaitForWork } from "./tools/boards/wait-for-work";
 import { handleAttachAfter, handleHighlight, handleReply, handleSetStatus } from "./tools/boards/work-tools";
+import {
+    HANDOFF_ACTION_DESCRIPTION,
+    HANDOFF_ACTION_INPUT_SCHEMA,
+    HANDOFF_GET_DESCRIPTION,
+    HANDOFF_GET_INPUT_SCHEMA,
+    HANDOFF_LIST_DESCRIPTION,
+    HANDOFF_LIST_INPUT_SCHEMA,
+    HANDOFF_POST_DESCRIPTION,
+    HANDOFF_POST_INPUT_SCHEMA,
+    type HandoffActionArgs,
+    type HandoffGetArgs,
+    type HandoffListArgs,
+    type HandoffPostArgs,
+    handleHandoffAction,
+    handleHandoffGet,
+    handleHandoffList,
+    handleHandoffPost,
+} from "./tools/handoff";
 import { handleQuestionAnswer, QUESTION_ANSWER_INPUT_SCHEMA, type QuestionAnswerArgs } from "./tools/question-answer";
 
 const log = logger.child({ component: "claude:mcp" });
@@ -74,6 +92,13 @@ const SERVER_INSTRUCTIONS =
     "`tools question log` / `tools question tail`.\n\n" +
     "DO NOT use for: routine task instructions you simply execute, pure acknowledgements " +
     '("ok", "thanks", "continue"), or trivial lookups not worth preserving.\n\n' +
+    "HANDOFFS (cross-agent task handoff): `handoff_post` creates. `handoff_get` reads. `handoff_list` lists. " +
+    "`handoff_action` changes. To delegate work, handoff_post {title, tasks} → copy the returned `paste` block " +
+    "into the receiving agent's chat. Receiving agent: handoff_get {id} → claim (claim: true) → work the tasks " +
+    "→ handoff_action check_task with proof per task (deny_task with reason for tasks you can't do) → " +
+    "finish_handoff when all resolved. Poster edits anytime from its own session via handoff_action " +
+    "(add_tasks/modify_task/modify_handoff/cancel_handoff); from other sessions pass the editId. Progress is " +
+    'live on the dev-dashboard /qa "Agent tasks" tab.\n\n' +
     "BOARDS (dev-dashboard annotation boards):\n" +
     "- Boards live on the DEV-DASHBOARD server (base auto-resolved from its config; default " +
     "http://127.0.0.1:3042, override BOARDS_BASE_URL). Other local dashboards on other ports (e.g. the " +
@@ -123,6 +148,26 @@ function buildToolRegistry(): Record<string, ToolEntry> {
                 const r = await handleQuestionAnswer(args as unknown as QuestionAnswerArgs);
                 return r.summary;
             },
+        },
+        handoff_post: {
+            description: HANDOFF_POST_DESCRIPTION,
+            inputSchema: HANDOFF_POST_INPUT_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) => handleHandoffPost(args as unknown as HandoffPostArgs),
+        },
+        handoff_get: {
+            description: HANDOFF_GET_DESCRIPTION,
+            inputSchema: HANDOFF_GET_INPUT_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) => handleHandoffGet(args as unknown as HandoffGetArgs),
+        },
+        handoff_list: {
+            description: HANDOFF_LIST_DESCRIPTION,
+            inputSchema: HANDOFF_LIST_INPUT_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) => handleHandoffList(args as unknown as HandoffListArgs),
+        },
+        handoff_action: {
+            description: HANDOFF_ACTION_DESCRIPTION,
+            inputSchema: HANDOFF_ACTION_INPUT_SCHEMA as unknown as Record<string, unknown>,
+            handler: async (args) => handleHandoffAction(args as unknown as HandoffActionArgs),
         },
         boards_list_boards: {
             description:
@@ -356,6 +401,7 @@ function buildToolRegistry(): Record<string, ToolEntry> {
 const CAPABILITY_PREFIXES: Record<string, string> = {
     question_answer: "question_answer",
     boards: "boards_",
+    handoff: "handoff_",
 };
 
 /**

--- a/src/claude/mcp/tools/handoff.ts
+++ b/src/claude/mcp/tools/handoff.ts
@@ -1,0 +1,275 @@
+import { executeHandoffActions, getHandoff, type HandoffDeps, listHandoffs, postHandoff } from "@app/handoff/executor";
+import type { HandoffActionInput, HandoffTarget, HandoffTaskInput } from "@app/handoff/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+export interface HandoffPostArgs {
+    title: string;
+    description?: string;
+    tasks: HandoffTaskInput[];
+    target?: HandoffTarget;
+    refs?: string[];
+}
+
+export interface HandoffGetArgs {
+    id: string;
+    claim?: boolean;
+    unclaim?: boolean;
+}
+
+export interface HandoffListArgs {
+    limit?: number;
+    offset?: number;
+    mine?: boolean;
+    open?: boolean;
+    project?: string;
+}
+
+export interface HandoffActionArgs {
+    id: string;
+    editId?: string;
+    actions: HandoffActionInput[];
+}
+
+function render(value: unknown): string {
+    return SafeJSON.stringify(value, { strict: true }, 2);
+}
+
+export async function handleHandoffPost(args: HandoffPostArgs, deps: HandoffDeps = {}): Promise<string> {
+    return render(postHandoff(args, deps));
+}
+
+export async function handleHandoffGet(args: HandoffGetArgs, deps: HandoffDeps = {}): Promise<string> {
+    return render(getHandoff(args, deps));
+}
+
+export async function handleHandoffList(args: HandoffListArgs, deps: HandoffDeps = {}): Promise<string> {
+    return render(listHandoffs(args, deps));
+}
+
+export async function handleHandoffAction(args: HandoffActionArgs, deps: HandoffDeps = {}): Promise<string> {
+    return render(executeHandoffActions(args, deps));
+}
+
+export const HANDOFF_POST_DESCRIPTION =
+    "Create a handoff — a task list for ANOTHER agent session (cross-repo/cross-project ok). Give title and " +
+    "tasks (each has text and optional acceptanceCriteria); optional description (context body), target " +
+    "{sessionId|sessionName}, and refs. Returns the handoff with final task ids, an editId (edit credential " +
+    "for other sessions — your own session edits without it), and a `paste` block: paste it into the " +
+    "receiving agent's chat. To change anything later, call handoff_action.";
+
+export const HANDOFF_GET_DESCRIPTION =
+    "Read a handoff by id (from a paste block or handoff_list). Pass claim: true to claim it for this " +
+    "session before working, unclaim: true to release it. Several sessions may claim the same handoff " +
+    "(co-owning). If your session IS the target sessionId it auto-claims (response says so; undo with " +
+    "unclaim: true). If this session posted the handoff (same sessionId — sessions are ephemeral, identity " +
+    "is per-session not per-human), the response also returns your editId; if the posting session is gone " +
+    "and the editId is lost, your user can read it on the dev-dashboard /qa Agent-tasks tab. info[] always " +
+    "states where you stand and the one next step. After claiming, record work via handoff_action check_task.";
+
+export const HANDOFF_LIST_DESCRIPTION =
+    "List recent handoffs, newest-updated first — ALL projects by default; project: '<name>' narrows. " +
+    "open: true → only unresolved (not done/cancelled); mine: true → posted by, claimed by, or targeted at " +
+    "this session; limit (default 20) + offset page through. Open rows are detailed, claimed rows concise. " +
+    "Use the id with handoff_get.";
+
+export const HANDOFF_ACTION_DESCRIPTION =
+    "Change a handoff — tasks and lifecycle (claim/unclaim also exist as a convenience on handoff_get; " +
+    'identical effect). Ordered actions array; every action is an object { action: "<verb>", …verb fields } ' +
+    "(payload-less verbs may be bare strings). Claimer verbs (be claimed, or start with {action:'claim'}): " +
+    "claim, unclaim, check_task {taskId, proof:{answer, commitIds?, context?}}, uncheck_task {taskId}, " +
+    "deny_task {taskId, reason}, undeny_task {taskId}, comment {text}, finish_handoff (rejected unless every " +
+    "task is checked or denied — force: true overrides; undo via reopen_handoff). Poster verbs (from the " +
+    "posting session, or with editId): add_tasks {tasks:[…]}, modify_task {taskId, text?, acceptanceCriteria?}, " +
+    "modify_handoff {title?, description?, target?, refs?}, deny_task, undeny_task, check_task, comment, " +
+    "cancel_handoff, reopen_handoff (undoes finish OR cancel; also allowed for the claimer whose own finish " +
+    "closed it). attach_file {path, taskId?, note?} attaches a local file (screenshot, log) to the handoff or " +
+    "a task. Common short forms are accepted as aliases (done/finish→finish_handoff, check→check_task, " +
+    "add→add_tasks, modify→modify_task, deny→deny_task, uncheck→uncheck_task). An unrecognized verb is " +
+    "rejected with the full valid-verb list.";
+
+const TASK_ITEM_SCHEMA = {
+    type: "object",
+    properties: {
+        id: {
+            type: "string",
+            description: "optional task id — auto-assigned t<n> when omitted; final ids ALWAYS in the response",
+        },
+        text: { type: "string", description: "what to do — imperative, self-contained" },
+        acceptanceCriteria: {
+            type: "string",
+            description: "how the worker knows the task is done — optional but strongly recommended",
+        },
+    },
+    required: ["text"],
+} as const;
+
+const TARGET_SCHEMA = {
+    type: "object",
+    description:
+        "address a specific session: exact sessionId auto-claims on its first get; sessionName only nudges (names aren't unique)",
+    properties: {
+        sessionId: { type: "string", description: "exact receiving sessionId — auto-claims on its first handoff_get" },
+        sessionName: { type: "string", description: "receiving session's name — nudge only, never auto-claims" },
+    },
+} as const;
+
+export const HANDOFF_POST_INPUT_SCHEMA = {
+    type: "object",
+    properties: {
+        title: { type: "string", description: "short imperative title of the work being handed off" },
+        description: { type: "string", description: "markdown body — the why/context the worker needs" },
+        tasks: { type: "array", minItems: 1, items: TASK_ITEM_SCHEMA, description: "the checkable task list (≥1)" },
+        target: TARGET_SCHEMA,
+        refs: {
+            type: "array",
+            items: { type: "string" },
+            description: "file paths / PR / board URLs the worker will need",
+        },
+    },
+    required: ["title", "tasks"],
+} as const;
+
+export const HANDOFF_GET_INPUT_SCHEMA = {
+    type: "object",
+    properties: {
+        id: {
+            type: "string",
+            description: "the handoff id from a paste block or handoff_list — h_ prefix optional, whitespace ok",
+        },
+        claim: {
+            type: "boolean",
+            description: "claim this handoff for the calling session before working (co-owning is allowed)",
+        },
+        unclaim: { type: "boolean", description: "release ONLY this session's claim (no-op if not claimed)" },
+    },
+    required: ["id"],
+} as const;
+
+export const HANDOFF_LIST_INPUT_SCHEMA = {
+    type: "object",
+    properties: {
+        limit: { type: "number", description: "max rows (default 20)" },
+        offset: { type: "number", description: "skip this many rows (paging)" },
+        mine: {
+            type: "boolean",
+            description: "only handoffs posted by, claimed by, or targeted at this session",
+        },
+        open: { type: "boolean", description: "only unresolved handoffs (status open or claimed)" },
+        project: { type: "string", description: "narrow to one project (default: all projects)" },
+    },
+} as const;
+
+export const HANDOFF_ACTION_INPUT_SCHEMA = {
+    type: "object",
+    properties: {
+        id: {
+            type: "string",
+            description: "the handoff id — h_ prefix optional, whitespace ok",
+        },
+        editId: {
+            type: "string",
+            description:
+                "poster edit credential from handoff_post — only needed for poster verbs from a session other than the posting one; your user can read it on the dev-dashboard /qa Agent-tasks tab",
+        },
+        actions: {
+            type: "array",
+            minItems: 1,
+            description:
+                'ordered — each action is { action: "<verb>", …verb fields } — e.g. { action: "check_task", taskId: "t1", proof: { answer: "…" } }; payload-less verbs may be plain strings',
+            items: {
+                anyOf: [
+                    { type: "string", description: 'bare payload-less verb, e.g. "claim" or "finish_handoff"' },
+                    {
+                        type: "object",
+                        properties: {
+                            action: {
+                                type: "string",
+                                description: "the verb — see the tool description for the full list",
+                            },
+                            taskId: {
+                                type: "string",
+                                description: "the task's id from the handoff you read (t1, t2, …)",
+                            },
+                            proof: {
+                                type: "object",
+                                description: "check_task evidence",
+                                properties: {
+                                    answer: {
+                                        type: "string",
+                                        description:
+                                            "what you did and how you verified it satisfies the acceptance criteria (tests run + results) — 1-3 sentences, markdown ok",
+                                    },
+                                    commitIds: {
+                                        type: "array",
+                                        items: { type: "string" },
+                                        description: "commit SHAs implementing it, e.g. ['a1b2c3d']",
+                                    },
+                                    context: { type: "string", description: "optional side effects, caveats, links" },
+                                    screenshots: {
+                                        type: "array",
+                                        items: { type: "string" },
+                                        description:
+                                            "absolute paths of screenshots proving it (e.g. the annotated PNG from tools control draw) — auto-ingested as attachments",
+                                    },
+                                    attachmentIds: {
+                                        type: "array",
+                                        items: { type: "string" },
+                                        description: "ids of already-ingested attachments to link to this proof",
+                                    },
+                                },
+                                required: ["answer"],
+                            },
+                            reason: {
+                                type: "string",
+                                description:
+                                    "deny_task: why this task won't be done — shown struck-through with the task while denied (undeny_task clears it)",
+                            },
+                            force: {
+                                type: "boolean",
+                                description:
+                                    "override cross-state guards: check a denied task, deny a checked task, or finish with unresolved tasks",
+                            },
+                            text: { type: "string", description: "comment text / modify_task replacement text" },
+                            path: {
+                                type: "string",
+                                description:
+                                    "attach_file: absolute path of the file to attach (screenshot, log, diff) — copied into the handoff's attachment store",
+                            },
+                            note: { type: "string", description: "attach_file: short caption for the attachment" },
+                            screenshots: {
+                                type: "array",
+                                items: { type: "string" },
+                                description:
+                                    "comment: absolute screenshot paths — auto-ingested and linked to the comment",
+                            },
+                            attachmentIds: {
+                                type: "array",
+                                items: { type: "string" },
+                                description: "comment: ids of already-ingested attachments to link",
+                            },
+                            tasks: {
+                                type: "array",
+                                items: TASK_ITEM_SCHEMA,
+                                description: "add_tasks: new tasks to append (ids auto-assigned)",
+                            },
+                            acceptanceCriteria: {
+                                type: "string",
+                                description: "modify_task: replacement acceptance criteria",
+                            },
+                            title: { type: "string", description: "modify_handoff: replacement title" },
+                            description: { type: "string", description: "modify_handoff: replacement description" },
+                            target: TARGET_SCHEMA,
+                            refs: {
+                                type: "array",
+                                items: { type: "string" },
+                                description: "modify_handoff: replacement refs list",
+                            },
+                        },
+                        required: ["action"],
+                    },
+                ],
+            },
+        },
+    },
+    required: ["id", "actions"],
+} as const;

--- a/src/dev-dashboard/lib/handoff-sse.ts
+++ b/src/dev-dashboard/lib/handoff-sse.ts
@@ -1,23 +1,50 @@
+import { existsSync, readFileSync } from "node:fs";
 import { todayHandoffLogFile } from "@app/handoff/log-store";
 import type { HandoffEvent } from "@app/handoff/types";
 import { FileTailer } from "@genesiscz/utils/fs/file-tailer";
+import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
+import { logger } from "@genesiscz/utils/logger";
+
+const log = logger.child({ component: "dev-dashboard:handoff-sse" });
 
 export interface HandoffStream {
     close(): void;
 }
 
-const ROLLOVER_CHECK_MS = 30_000;
+const ROLLOVER_CHECK_MS = 5_000;
 
 /**
  * Tail the handoff event log for SSE. Handoffs are multi-day, so the tailer
  * MUST survive midnight (§7.2): a periodic check re-tails the new date's file
  * when the day rolls over — a tailer pinned to one date file dies silently at
- * 00:00 (qa-sse.ts has exactly that bug; do not copy it).
+ * 00:00 (qa-sse.ts has exactly that bug at routes/qa.ts:132; do not copy it).
+ *
+ * FileTailer attaches at EOF and never replays, so an event written to the new
+ * day-file in the window before the rollover check would be missed. On switch
+ * we therefore replay the new file from byte 0 (§8.10). Frames are idempotent
+ * on the client (each just triggers a refetch), so any duplicate with the fresh
+ * tailer's first reads is harmless — replay eliminates the miss at zero cost.
  */
 export function createHandoffStream(onEvent: (e: HandoffEvent) => void): HandoffStream {
     let file = todayHandoffLogFile();
     let tailer = new FileTailer<HandoffEvent>(file, { onLine: (e) => onEvent(e) });
     tailer.start();
+
+    const replayFromStart = (path: string): void => {
+        if (!existsSync(path)) {
+            return;
+        }
+
+        try {
+            const { values } = parseJsonlChunk<HandoffEvent>(readFileSync(path));
+
+            for (const event of values) {
+                onEvent(event);
+            }
+        } catch (err) {
+            log.warn({ err, path }, "handoff rollover replay failed (new day file unparseable)");
+        }
+    };
 
     const rollover = setInterval(() => {
         const current = todayHandoffLogFile();
@@ -27,6 +54,8 @@ export function createHandoffStream(onEvent: (e: HandoffEvent) => void): Handoff
             file = current;
             tailer = new FileTailer<HandoffEvent>(file, { onLine: (e) => onEvent(e) });
             tailer.start();
+            // Emit anything already written to the new day's file before the tailer attached.
+            replayFromStart(file);
         }
     }, ROLLOVER_CHECK_MS);
 

--- a/src/dev-dashboard/lib/handoff-sse.ts
+++ b/src/dev-dashboard/lib/handoff-sse.ts
@@ -1,0 +1,39 @@
+import { todayHandoffLogFile } from "@app/handoff/log-store";
+import type { HandoffEvent } from "@app/handoff/types";
+import { FileTailer } from "@genesiscz/utils/fs/file-tailer";
+
+export interface HandoffStream {
+    close(): void;
+}
+
+const ROLLOVER_CHECK_MS = 30_000;
+
+/**
+ * Tail the handoff event log for SSE. Handoffs are multi-day, so the tailer
+ * MUST survive midnight (§7.2): a periodic check re-tails the new date's file
+ * when the day rolls over — a tailer pinned to one date file dies silently at
+ * 00:00 (qa-sse.ts has exactly that bug; do not copy it).
+ */
+export function createHandoffStream(onEvent: (e: HandoffEvent) => void): HandoffStream {
+    let file = todayHandoffLogFile();
+    let tailer = new FileTailer<HandoffEvent>(file, { onLine: (e) => onEvent(e) });
+    tailer.start();
+
+    const rollover = setInterval(() => {
+        const current = todayHandoffLogFile();
+
+        if (current !== file) {
+            tailer.stop();
+            file = current;
+            tailer = new FileTailer<HandoffEvent>(file, { onLine: (e) => onEvent(e) });
+            tailer.start();
+        }
+    }, ROLLOVER_CHECK_MS);
+
+    return {
+        close: () => {
+            clearInterval(rollover);
+            tailer.stop();
+        },
+    };
+}

--- a/src/dev-dashboard/lib/handoff-types.ts
+++ b/src/dev-dashboard/lib/handoff-types.ts
@@ -1,0 +1,50 @@
+import type { Handoff, HandoffActionResult, HandoffListRow } from "@app/handoff/types";
+
+export type {
+    Handoff,
+    HandoffActionInput,
+    HandoffActionResult,
+    HandoffAttachment,
+    HandoffComment,
+    HandoffListRow,
+    HandoffProof,
+    HandoffStatus,
+    HandoffTarget,
+    HandoffTask,
+    HandoffTaskInput,
+} from "@app/handoff/types";
+
+/** Route/tool response shape of a handoff: editId stripped, attachment paths resolved. */
+export type PublicHandoff = Omit<Handoff, "editId"> & {
+    attachments: (Handoff["attachments"][number] & { path?: string })[];
+};
+
+export interface HandoffListResponse {
+    handoffs: HandoffListRow[];
+    info: string[];
+}
+
+export interface HandoffGetResponse {
+    handoff: PublicHandoff;
+    editId?: string;
+    info: string[];
+}
+
+export interface HandoffActionResponse {
+    handoff: PublicHandoff;
+    results: HandoffActionResult[];
+    info: string[];
+}
+
+export interface HandoffPostResponse {
+    handoff: PublicHandoff;
+    editId: string;
+    paste: { _agent: string; id: string; title: string; tasks: string };
+    info: string[];
+}
+
+export interface HandoffStreamFrame {
+    id: string;
+    ev: string;
+    ts: string;
+}

--- a/src/dev-dashboard/server/registry.ts
+++ b/src/dev-dashboard/server/registry.ts
@@ -18,6 +18,7 @@ import { containersRoutes } from "@app/dev-dashboard/server/routes/containers";
 import { daemonRoutes } from "@app/dev-dashboard/server/routes/daemon";
 import { diskRoutes } from "@app/dev-dashboard/server/routes/disk";
 import { e2eRoutes } from "@app/dev-dashboard/server/routes/e2e";
+import { handoffRoutes } from "@app/dev-dashboard/server/routes/handoff";
 import { liveRoutes } from "@app/dev-dashboard/server/routes/live";
 import { netRoutes } from "@app/dev-dashboard/server/routes/net";
 import { obsidianRoutes } from "@app/dev-dashboard/server/routes/obsidian";
@@ -62,6 +63,7 @@ export function createDashboardRouter(): Router {
         ...liveRoutes(getLiveHub()),
         ...processesRoutes(),
         ...qaRoutes(),
+        ...handoffRoutes(),
         ...attentionRoutes(),
         ...todosRoutes(),
         ...obsidianRoutes(),

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -113,6 +113,16 @@ export function handoffRoutes(): RouteDef[] {
                     const filename = ctx.query.get("filename") ?? "pasted.bin";
                     const taskId = ctx.query.get("taskId") ?? undefined;
                     const note = ctx.query.get("note") ?? undefined;
+                    const contentLength = ctx.headers["content-length"];
+
+                    if (contentLength !== undefined && Number.parseInt(contentLength, 10) > MAX_ATTACHMENT_BYTES) {
+                        return {
+                            kind: "json",
+                            status: 413,
+                            body: { error: `attachment declares ${contentLength} bytes — the cap is 10 MB` },
+                        };
+                    }
+
                     const bytes = await ctx.readRawBody();
 
                     if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
@@ -151,6 +161,9 @@ export function handoffRoutes(): RouteDef[] {
                         };
                     }
 
+                    const safeName = resolved.filename.replace(/"/g, "");
+                    const disposition = resolved.mime.startsWith("image/") ? "inline" : "attachment";
+
                     return {
                         kind: "binary",
                         status: 200,
@@ -158,7 +171,8 @@ export function handoffRoutes(): RouteDef[] {
                         body: readFileSync(resolved.path),
                         headers: {
                             "Cache-Control": "public, max-age=31536000, immutable",
-                            "Content-Disposition": `inline; filename="${resolved.filename.replace(/"/g, "")}"`,
+                            "Content-Disposition": `${disposition}; filename="${safeName}"`,
+                            "X-Content-Type-Options": "nosniff",
                         },
                     };
                 } catch (err) {

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -1,0 +1,192 @@
+import { readFileSync } from "node:fs";
+import { createHandoffStream } from "@app/dev-dashboard/lib/handoff-sse";
+import { errorResult } from "@app/dev-dashboard/server/routes/error";
+import type { RouteDef } from "@app/dev-dashboard/server/types";
+import { MAX_ATTACHMENT_BYTES } from "@app/handoff/attachments";
+import {
+    attachHandoffBytes,
+    DASHBOARD_ACTOR,
+    executeHandoffActions,
+    getHandoff,
+    type HandoffDeps,
+    listHandoffs,
+    postHandoff,
+    resolveAttachment,
+} from "@app/handoff/executor";
+import type { HandoffActionInput, HandoffTarget, HandoffTaskInput } from "@app/handoff/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+/** Every UI-originated event runs with owner authority and is visibly attributed (§7.1). */
+const deps: HandoffDeps = { by: DASHBOARD_ACTOR };
+
+export function handoffRoutes(): RouteDef[] {
+    return [
+        {
+            method: "GET",
+            pattern: "/api/handoff/log",
+            handler: (ctx) => {
+                try {
+                    const limitRaw = ctx.query.get("limit");
+                    const offsetRaw = ctx.query.get("offset");
+                    const res = listHandoffs(
+                        {
+                            limit: limitRaw !== null ? Number.parseInt(limitRaw, 10) : 100,
+                            offset: offsetRaw !== null ? Number.parseInt(offsetRaw, 10) : undefined,
+                            open: ctx.query.get("open") === "1",
+                            project: ctx.query.get("project") ?? undefined,
+                        },
+                        deps
+                    );
+
+                    return { kind: "json", status: 200, body: res };
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
+            method: "GET",
+            pattern: "/api/handoff/get",
+            handler: (ctx) => {
+                try {
+                    const id = ctx.query.get("id") ?? "";
+                    const res = getHandoff({ id }, deps);
+
+                    return { kind: "json", status: 200, body: res };
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
+            method: "POST",
+            pattern: "/api/handoff/action",
+            handler: async (ctx) => {
+                try {
+                    const body = await ctx.readJson<{ id?: string; editId?: string; actions?: HandoffActionInput[] }>();
+                    const res = executeHandoffActions(
+                        { id: body.id ?? "", editId: body.editId, actions: body.actions ?? [] },
+                        deps
+                    );
+
+                    return { kind: "json", status: 200, body: res };
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
+            method: "POST",
+            pattern: "/api/handoff/post",
+            handler: async (ctx) => {
+                try {
+                    const body = await ctx.readJson<{
+                        title?: string;
+                        description?: string;
+                        tasks?: HandoffTaskInput[];
+                        target?: HandoffTarget;
+                        refs?: string[];
+                    }>();
+                    const res = postHandoff(
+                        {
+                            title: body.title ?? "",
+                            description: body.description,
+                            tasks: body.tasks ?? [],
+                            target: body.target,
+                            refs: body.refs,
+                        },
+                        deps
+                    );
+
+                    return { kind: "json", status: 200, body: res };
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
+            method: "POST",
+            pattern: "/api/handoff/attach",
+            handler: async (ctx) => {
+                try {
+                    const id = ctx.query.get("id") ?? "";
+                    const filename = ctx.query.get("filename") ?? "pasted.bin";
+                    const taskId = ctx.query.get("taskId") ?? undefined;
+                    const note = ctx.query.get("note") ?? undefined;
+                    const bytes = await ctx.readRawBody();
+
+                    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+                        return {
+                            kind: "json",
+                            status: 413,
+                            body: { error: `attachment is ${bytes.byteLength} bytes — the cap is 10 MB` },
+                        };
+                    }
+
+                    const res = attachHandoffBytes({ id, filename, bytes, taskId, note }, deps);
+
+                    return { kind: "json", status: 200, body: res };
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
+            method: "GET",
+            pattern: "/api/handoff/attachment",
+            handler: (ctx) => {
+                try {
+                    const attachmentId = ctx.query.get("id") ?? "";
+                    const resolved = resolveAttachment(attachmentId, deps);
+
+                    if (resolved === null) {
+                        return { kind: "json", status: 404, body: { error: `unknown attachment: ${attachmentId}` } };
+                    }
+
+                    if (resolved.missing) {
+                        return {
+                            kind: "json",
+                            status: 410,
+                            body: { error: `attachment file missing on disk: ${attachmentId}` },
+                        };
+                    }
+
+                    return {
+                        kind: "binary",
+                        status: 200,
+                        contentType: resolved.mime,
+                        body: readFileSync(resolved.path),
+                        headers: {
+                            "Cache-Control": "public, max-age=31536000, immutable",
+                            "Content-Disposition": `inline; filename="${resolved.filename.replace(/"/g, "")}"`,
+                        },
+                    };
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
+            method: "GET",
+            pattern: "/api/handoff/stream",
+            longLived: true,
+            handler: () => ({
+                kind: "sse",
+                start: (emit) => {
+                    emit.comment(" handoff stream open");
+                    const stream = createHandoffStream((event) =>
+                        emit.data(SafeJSON.stringify({ id: event.id, ev: event.ev, ts: event.ts }, { strict: true }))
+                    );
+                    const keepAlive = setInterval(() => emit.comment(" ping"), 12_000);
+
+                    return {
+                        close: () => {
+                            clearInterval(keepAlive);
+                            stream.close();
+                        },
+                    };
+                },
+            }),
+        },
+    ];
+}

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -162,7 +162,9 @@ export function handoffRoutes(): RouteDef[] {
                     }
 
                     const safeName = resolved.filename.replace(/"/g, "");
-                    const disposition = resolved.mime.startsWith("image/") ? "inline" : "attachment";
+                    // SVG is a scriptable same-origin document even with nosniff — force it to download.
+                    const inlineOk = resolved.mime.startsWith("image/") && resolved.mime !== "image/svg+xml";
+                    const disposition = inlineOk ? "inline" : "attachment";
 
                     return {
                         kind: "binary",

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
@@ -1,0 +1,104 @@
+import type { PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
+import { useState } from "react";
+import { attachmentUrl } from "./useHandoffApi";
+
+type AttachmentMeta = PublicHandoff["attachments"][number];
+
+function isImage(a: AttachmentMeta): boolean {
+    return a.mime.startsWith("image/");
+}
+
+function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose: () => void }) {
+    return (
+        <div
+            className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-black/85 p-8"
+            onClick={onClose}
+        >
+            <img
+                src={attachmentUrl(attachment.attachmentId)}
+                alt={attachment.filename}
+                className="max-h-[80vh] max-w-[90vw] rounded border border-[var(--dd-border)] object-contain"
+            />
+            <div className="flex items-center gap-3 font-mono text-xs text-[var(--dd-text-secondary)]">
+                <span>{attachment.filename}</span>
+                <span className="text-[var(--dd-text-muted)]">
+                    {attachment.by.sessionName ?? attachment.by.agent} · {new Date(attachment.ts).toLocaleString()}
+                </span>
+                <a
+                    href={attachmentUrl(attachment.attachmentId)}
+                    download={attachment.filename}
+                    className="dd-accent-text hover:opacity-80"
+                    onClick={(ev) => ev.stopPropagation()}
+                >
+                    download
+                </a>
+                <button type="button" className="dd-accent-text cursor-pointer hover:opacity-80" onClick={onClose}>
+                    close
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export function AttachmentChip({ attachment }: { attachment: AttachmentMeta }) {
+    const [open, setOpen] = useState(false);
+
+    if (attachment.missing === true) {
+        return (
+            <span
+                className="inline-flex items-center gap-1 rounded border border-dashed border-[var(--dd-border)] px-2 py-1 font-mono text-[10px] text-[var(--dd-text-muted)] line-through"
+                title="attachment file missing on disk"
+            >
+                ⚠ {attachment.filename}
+            </span>
+        );
+    }
+
+    if (isImage(attachment)) {
+        return (
+            <>
+                <button
+                    type="button"
+                    className="cursor-zoom-in rounded border border-[var(--dd-border)] bg-black/25 p-0.5 transition-opacity hover:opacity-80"
+                    onClick={() => setOpen(true)}
+                    title={`${attachment.filename}${attachment.note ? ` — ${attachment.note}` : ""}`}
+                >
+                    <img
+                        src={attachmentUrl(attachment.attachmentId)}
+                        alt={attachment.filename}
+                        className="h-16 w-24 rounded-sm object-cover"
+                        loading="lazy"
+                    />
+                </button>
+                {open ? <Lightbox attachment={attachment} onClose={() => setOpen(false)} /> : null}
+            </>
+        );
+    }
+
+    return (
+        <a
+            href={attachmentUrl(attachment.attachmentId)}
+            download={attachment.filename}
+            className="inline-flex items-center gap-1 rounded border border-[var(--dd-border)] bg-black/20 px-2 py-1 font-mono text-[10px] text-[var(--dd-text-secondary)] hover:border-primary/60"
+            title={attachment.note ?? attachment.filename}
+        >
+            📎 {attachment.filename}
+        </a>
+    );
+}
+
+export function AttachmentStrip({ attachments, ids }: { attachments: AttachmentMeta[]; ids?: string[] }) {
+    const visible = ids !== undefined ? attachments.filter((a) => ids.includes(a.attachmentId)) : attachments;
+
+    if (visible.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            {visible.map((a) => (
+                <AttachmentChip key={a.attachmentId} attachment={a} />
+            ))}
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
@@ -1,5 +1,5 @@
 import type { PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { attachmentUrl } from "./useHandoffApi";
 
 type AttachmentMeta = PublicHandoff["attachments"][number];
@@ -9,8 +9,27 @@ function isImage(a: AttachmentMeta): boolean {
 }
 
 function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose: () => void }) {
+    const closeRef = useRef<HTMLButtonElement | null>(null);
+
+    useEffect(() => {
+        closeRef.current?.focus();
+
+        const onKeyDown = (ev: KeyboardEvent): void => {
+            if (ev.key === "Escape") {
+                onClose();
+            }
+        };
+
+        document.addEventListener("keydown", onKeyDown);
+
+        return () => document.removeEventListener("keydown", onKeyDown);
+    }, [onClose]);
+
     return (
         <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`attachment preview: ${attachment.filename}`}
             className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-black/85 p-8"
             onClick={onClose}
         >
@@ -19,7 +38,10 @@ function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose
                 alt={attachment.filename}
                 className="max-h-[80vh] max-w-[90vw] rounded border border-[var(--dd-border)] object-contain"
             />
-            <div className="flex items-center gap-3 font-mono text-xs text-[var(--dd-text-secondary)]">
+            <div
+                className="flex items-center gap-3 font-mono text-xs text-[var(--dd-text-secondary)]"
+                onClick={(ev) => ev.stopPropagation()}
+            >
                 <span>{attachment.filename}</span>
                 <span className="text-[var(--dd-text-muted)]">
                     {attachment.by.sessionName ?? attachment.by.agent} · {new Date(attachment.ts).toLocaleString()}
@@ -28,11 +50,15 @@ function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose
                     href={attachmentUrl(attachment.attachmentId)}
                     download={attachment.filename}
                     className="dd-accent-text hover:opacity-80"
-                    onClick={(ev) => ev.stopPropagation()}
                 >
                     download
                 </a>
-                <button type="button" className="dd-accent-text cursor-pointer hover:opacity-80" onClick={onClose}>
+                <button
+                    ref={closeRef}
+                    type="button"
+                    className="dd-accent-text cursor-pointer hover:opacity-80"
+                    onClick={onClose}
+                >
                     close
                 </button>
             </div>

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
@@ -9,24 +9,51 @@ function isImage(a: AttachmentMeta): boolean {
 }
 
 function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose: () => void }) {
+    const dialogRef = useRef<HTMLDivElement | null>(null);
     const closeRef = useRef<HTMLButtonElement | null>(null);
 
     useEffect(() => {
+        const previouslyFocused = document.activeElement as HTMLElement | null;
         closeRef.current?.focus();
 
         const onKeyDown = (ev: KeyboardEvent): void => {
             if (ev.key === "Escape") {
                 onClose();
+                return;
+            }
+
+            if (ev.key !== "Tab" || dialogRef.current === null) {
+                return;
+            }
+
+            const focusable = dialogRef.current.querySelectorAll<HTMLElement>("a[href], button");
+            if (focusable.length === 0) {
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+
+            if (ev.shiftKey && document.activeElement === first) {
+                ev.preventDefault();
+                last.focus();
+            } else if (!ev.shiftKey && document.activeElement === last) {
+                ev.preventDefault();
+                first.focus();
             }
         };
 
         document.addEventListener("keydown", onKeyDown);
 
-        return () => document.removeEventListener("keydown", onKeyDown);
+        return () => {
+            document.removeEventListener("keydown", onKeyDown);
+            previouslyFocused?.focus();
+        };
     }, [onClose]);
 
     return (
         <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-label={`attachment preview: ${attachment.filename}`}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
@@ -75,11 +75,15 @@ export function HandoffDetail({ id }: { id: string }) {
     const uploadFiles = (files: File[], taskId?: string): void => {
         setUploadError(null);
 
-        for (const file of files) {
-            uploadHandoffAttachment({ id, file, taskId })
-                .then(() => detail.refetch())
-                .catch((err) => setUploadError(err instanceof Error ? err.message : String(err)));
-        }
+        Promise.allSettled(files.map((file) => uploadHandoffAttachment({ id, file, taskId }))).then((results) => {
+            const failure = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
+
+            if (failure !== undefined) {
+                setUploadError(failure.reason instanceof Error ? failure.reason.message : String(failure.reason));
+            }
+
+            void detail.refetch();
+        });
     };
 
     /** Paste anywhere (§7.3): task-row focus → that task; comment composer → pending chip; else the handoff. */
@@ -237,7 +241,11 @@ export function HandoffDetail({ id }: { id: string }) {
                     <button
                         type="button"
                         className="dd-accent-text cursor-pointer hover:opacity-80"
-                        onClick={() => void navigator.clipboard.writeText(detail.data?.editId ?? "")}
+                        onClick={() => {
+                            navigator.clipboard
+                                .writeText(detail.data?.editId ?? "")
+                                .catch((err) => console.error("copy editId failed", err));
+                        }}
                         title="click to copy"
                     >
                         {detail.data.editId} ⧉

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
@@ -1,0 +1,519 @@
+import type { HandoffActionInput, HandoffActionResult, PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
+import { renderMarkdown } from "@app/dev-dashboard/lib/obsidian/markdown";
+import { Button } from "@ui/components/button";
+import { Input } from "@ui/components/input";
+import { Textarea } from "@ui/components/textarea";
+import { type ClipboardEvent, type DragEvent, useMemo, useRef, useState } from "react";
+import { AttachmentStrip } from "./HandoffAttachments";
+import { HandoffTaskRow } from "./HandoffTaskRow";
+import { uploadHandoffAttachment, useHandoffAction, useHandoffDetail } from "./useHandoffApi";
+
+function md(text: string): string {
+    return renderMarkdown(text, { resolveWikilink: () => null }).html;
+}
+
+function statusBadgeClass(status: PublicHandoff["status"]): string {
+    if (status === "open") {
+        return "border-[#3f5530] text-[#a3e635]";
+    }
+
+    if (status === "claimed") {
+        return "border-[#4a3a5e] text-[#c792ea]";
+    }
+
+    if (status === "done") {
+        return "border-[var(--dd-border)] text-[var(--dd-text-muted)]";
+    }
+
+    return "border-[var(--dd-danger)]/50 text-[var(--dd-danger)]";
+}
+
+function actorLabel(by: { sessionName: string | null; agent: string; via?: string }): string {
+    if (by.agent === "human") {
+        return "Martin · dashboard";
+    }
+
+    return by.sessionName ?? by.agent;
+}
+
+export function HandoffDetail({ id }: { id: string }) {
+    const detail = useHandoffDetail(id);
+    const action = useHandoffAction(id);
+    const [editIdRevealed, setEditIdRevealed] = useState(false);
+    const [editingTitle, setEditingTitle] = useState(false);
+    const [titleDraft, setTitleDraft] = useState("");
+    const [editingDescription, setEditingDescription] = useState(false);
+    const [descriptionDraft, setDescriptionDraft] = useState("");
+    const [newTaskText, setNewTaskText] = useState("");
+    const [newTaskCriteria, setNewTaskCriteria] = useState("");
+    const [commentDraft, setCommentDraft] = useState("");
+    const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const composerRef = useRef<HTMLTextAreaElement | null>(null);
+    const handoff = detail.data?.handoff;
+    const lastResults: HandoffActionResult[] = action.data?.results ?? [];
+    const failures = lastResults.filter((r) => !r.ok);
+
+    const descriptionHtml = useMemo(
+        () => (handoff?.description !== undefined ? md(handoff.description) : ""),
+        [handoff?.description]
+    );
+
+    if (detail.isLoading || handoff === undefined) {
+        return (
+            <div className="dd-panel flex h-40 items-center justify-center text-sm text-[var(--dd-text-muted)]">
+                {detail.isError ? `Failed to load: ${String(detail.error)}` : "Loading handoff…"}
+            </div>
+        );
+    }
+
+    const terminal = handoff.status === "done" || handoff.status === "cancelled";
+    const resolved = handoff.tasks.filter((t) => t.checked || t.denied).length;
+    const allResolved = handoff.tasks.length > 0 && resolved === handoff.tasks.length;
+    const run = (actions: HandoffActionInput[]): void => action.mutate(actions);
+
+    const uploadFiles = (files: File[], taskId?: string): void => {
+        setUploadError(null);
+
+        for (const file of files) {
+            uploadHandoffAttachment({ id, file, taskId })
+                .then(() => detail.refetch())
+                .catch((err) => setUploadError(err instanceof Error ? err.message : String(err)));
+        }
+    };
+
+    /** Paste anywhere (§7.3): task-row focus → that task; comment composer → pending chip; else the handoff. */
+    const onPaste = (ev: ClipboardEvent<HTMLDivElement>): void => {
+        const files = [...ev.clipboardData.files];
+
+        if (files.length === 0) {
+            return;
+        }
+
+        ev.preventDefault();
+        const target = ev.target as HTMLElement;
+
+        if (target.closest("[data-comment-composer]") !== null) {
+            setPendingFiles((prev) => [...prev, ...files]);
+            return;
+        }
+
+        const taskRow = target.closest("[data-task-id]");
+        uploadFiles(files, taskRow?.getAttribute("data-task-id") ?? undefined);
+    };
+
+    const onDrop = (ev: DragEvent<HTMLDivElement>): void => {
+        const files = [...ev.dataTransfer.files];
+
+        if (files.length === 0) {
+            return;
+        }
+
+        ev.preventDefault();
+        const target = ev.target as HTMLElement;
+
+        if (target.closest("[data-comment-composer]") !== null) {
+            setPendingFiles((prev) => [...prev, ...files]);
+            return;
+        }
+
+        const taskRow = target.closest("[data-task-id]");
+        uploadFiles(files, taskRow?.getAttribute("data-task-id") ?? undefined);
+    };
+
+    const submitComment = async (): Promise<void> => {
+        const text = commentDraft.trim();
+
+        if (text.length === 0 && pendingFiles.length === 0) {
+            return;
+        }
+
+        setUploadError(null);
+
+        try {
+            const attachmentIds: string[] = [];
+
+            for (const file of pendingFiles) {
+                const res = await uploadHandoffAttachment({ id, file });
+                attachmentIds.push(res.attachmentId);
+            }
+
+            run([
+                {
+                    action: "comment",
+                    text: text.length > 0 ? text : "(attachment)",
+                    ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
+                },
+            ]);
+            setCommentDraft("");
+            setPendingFiles([]);
+        } catch (err) {
+            setUploadError(err instanceof Error ? err.message : String(err));
+        }
+    };
+
+    const handoffLevelAttachments = handoff.attachments.filter(
+        (a) =>
+            a.taskId === undefined && !handoff.comments.some((c) => c.attachmentIds?.includes(a.attachmentId) === true)
+    );
+
+    return (
+        <div
+            className="dd-panel flex flex-col gap-4 p-4"
+            onPaste={onPaste}
+            onDrop={onDrop}
+            onDragOver={(ev) => ev.preventDefault()}
+        >
+            <div className="flex flex-wrap items-center gap-2">
+                {editingTitle ? (
+                    <div className="flex flex-1 items-center gap-2">
+                        <Input
+                            value={titleDraft}
+                            onChange={(e) => setTitleDraft(e.target.value)}
+                            className="border-[var(--dd-border)] bg-black/25 text-base font-bold"
+                        />
+                        <button
+                            type="button"
+                            className="dd-accent-text cursor-pointer text-xs"
+                            onClick={() => {
+                                if (titleDraft.trim().length > 0 && titleDraft !== handoff.title) {
+                                    run([{ action: "modify_handoff", title: titleDraft }]);
+                                }
+
+                                setEditingTitle(false);
+                            }}
+                        >
+                            save
+                        </button>
+                        <button
+                            type="button"
+                            className="cursor-pointer text-xs text-[var(--dd-text-muted)]"
+                            onClick={() => setEditingTitle(false)}
+                        >
+                            cancel
+                        </button>
+                    </div>
+                ) : (
+                    <h2 className="flex-1 text-base font-bold text-[var(--dd-text-primary)]">
+                        {handoff.title}
+                        {!terminal ? (
+                            <button
+                                type="button"
+                                className="ml-2 cursor-pointer text-xs text-[var(--dd-text-muted)] transition-colors hover:text-[var(--dd-text-primary)]"
+                                onClick={() => {
+                                    setTitleDraft(handoff.title);
+                                    setEditingTitle(true);
+                                }}
+                                title="edit title"
+                            >
+                                ✎
+                            </button>
+                        ) : null}
+                    </h2>
+                )}
+                <span
+                    className={`rounded-full border px-2 py-[1px] font-mono text-[11px] uppercase ${statusBadgeClass(handoff.status)}`}
+                >
+                    {handoff.status}
+                </span>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] text-[var(--dd-text-muted)]">
+                <span className="text-[var(--dd-text-secondary)]">{handoff.id}</span>
+                <span>·</span>
+                <span>by {handoff.postedBy.sessionName ?? handoff.postedBy.sessionId ?? handoff.postedBy.agent}</span>
+                {handoff.project !== null ? (
+                    <>
+                        <span>·</span>
+                        <span>{handoff.project}</span>
+                    </>
+                ) : null}
+                <span>·</span>
+                <span>
+                    {resolved}/{handoff.tasks.length} resolved
+                </span>
+                <span>·</span>
+                {editIdRevealed && detail.data?.editId !== undefined ? (
+                    <button
+                        type="button"
+                        className="dd-accent-text cursor-pointer hover:opacity-80"
+                        onClick={() => void navigator.clipboard.writeText(detail.data?.editId ?? "")}
+                        title="click to copy"
+                    >
+                        {detail.data.editId} ⧉
+                    </button>
+                ) : (
+                    <button
+                        type="button"
+                        className="cursor-pointer transition-colors hover:text-[var(--dd-text-primary)]"
+                        onClick={() => setEditIdRevealed(true)}
+                        title="reveal the poster edit credential"
+                    >
+                        editId ••••••
+                    </button>
+                )}
+            </div>
+
+            {handoff.claimedBy.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+                    <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                        claimed by
+                    </span>
+                    {handoff.claimedBy.map((c) => (
+                        <span
+                            key={`${c.sessionId}-${c.claimedAt}`}
+                            className="rounded-full border border-[#4a3a5e] px-2 py-px text-[#c792ea]"
+                            title={`${c.sessionId ?? ""} · ${c.via} · ${new Date(c.claimedAt).toLocaleString()}`}
+                        >
+                            {c.sessionName ?? c.sessionId ?? "unnamed"}
+                        </span>
+                    ))}
+                </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-2">
+                {!terminal ? (
+                    <>
+                        <Button
+                            size="sm"
+                            disabled={action.isPending}
+                            className="transition-[filter] hover:brightness-110"
+                            onClick={() => {
+                                if (
+                                    allResolved ||
+                                    window.confirm(`${handoff.tasks.length - resolved} open task(s) — force finish?`)
+                                ) {
+                                    run([{ action: "finish_handoff", ...(allResolved ? {} : { force: true }) }]);
+                                }
+                            }}
+                        >
+                            Finish
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={action.isPending}
+                            className="border-[var(--dd-border)] text-[var(--dd-danger)] hover:border-[var(--dd-danger)]/60"
+                            onClick={() => {
+                                if (window.confirm("Cancel this handoff? Claimers will be told to stop work.")) {
+                                    run(["cancel_handoff"]);
+                                }
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                    </>
+                ) : (
+                    <Button size="sm" disabled={action.isPending} onClick={() => run(["reopen_handoff"])}>
+                        Reopen
+                    </Button>
+                )}
+            </div>
+
+            {handoff.description !== undefined ? (
+                <div>
+                    <div className="mb-1 flex items-center gap-2">
+                        <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                            description
+                        </span>
+                        {!terminal && !editingDescription ? (
+                            <button
+                                type="button"
+                                className="cursor-pointer text-xs text-[var(--dd-text-muted)] transition-colors hover:text-[var(--dd-text-primary)]"
+                                onClick={() => {
+                                    setDescriptionDraft(handoff.description ?? "");
+                                    setEditingDescription(true);
+                                }}
+                            >
+                                ✎
+                            </button>
+                        ) : null}
+                    </div>
+                    {editingDescription ? (
+                        <div className="flex flex-col gap-1.5">
+                            <Textarea
+                                value={descriptionDraft}
+                                onChange={(e) => setDescriptionDraft(e.target.value)}
+                                className="border-[var(--dd-border)] bg-black/25 text-sm"
+                                rows={4}
+                            />
+                            <div className="flex gap-2 text-xs">
+                                <button
+                                    type="button"
+                                    className="dd-accent-text cursor-pointer"
+                                    onClick={() => {
+                                        run([{ action: "modify_handoff", description: descriptionDraft }]);
+                                        setEditingDescription(false);
+                                    }}
+                                >
+                                    save
+                                </button>
+                                <button
+                                    type="button"
+                                    className="cursor-pointer text-[var(--dd-text-muted)]"
+                                    onClick={() => setEditingDescription(false)}
+                                >
+                                    cancel
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <article
+                            className="dd-markdown text-sm text-[var(--dd-text-secondary)]"
+                            dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+                        />
+                    )}
+                </div>
+            ) : null}
+
+            {handoff.refs !== undefined && handoff.refs.length > 0 ? (
+                <div className="font-mono text-[10px] text-[var(--dd-text-muted)]">
+                    refs: {handoff.refs.join(" · ")}
+                </div>
+            ) : null}
+
+            <AttachmentStrip attachments={handoffLevelAttachments} />
+
+            <div className="flex flex-col gap-1.5">
+                <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                    tasks
+                </span>
+                {handoff.tasks.map((task) => (
+                    <HandoffTaskRow
+                        key={task.id}
+                        task={task}
+                        attachments={handoff.attachments}
+                        disabled={terminal || action.isPending}
+                        onActions={run}
+                    />
+                ))}
+                {!terminal ? (
+                    <div className="flex items-center gap-2 rounded border border-dashed border-[var(--dd-border)]/60 px-3 py-2">
+                        <Input
+                            value={newTaskText}
+                            onChange={(e) => setNewTaskText(e.target.value)}
+                            className="h-7 border-[var(--dd-border)] bg-black/15 text-sm"
+                            placeholder="add a task…"
+                        />
+                        <Input
+                            value={newTaskCriteria}
+                            onChange={(e) => setNewTaskCriteria(e.target.value)}
+                            className="h-7 border-[var(--dd-border)] bg-black/10 text-xs"
+                            placeholder="acceptance criteria (optional)"
+                        />
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={newTaskText.trim().length === 0 || action.isPending}
+                            onClick={() => {
+                                run([
+                                    {
+                                        action: "add_tasks",
+                                        tasks: [
+                                            {
+                                                text: newTaskText.trim(),
+                                                ...(newTaskCriteria.trim().length > 0
+                                                    ? { acceptanceCriteria: newTaskCriteria.trim() }
+                                                    : {}),
+                                            },
+                                        ],
+                                    },
+                                ]);
+                                setNewTaskText("");
+                                setNewTaskCriteria("");
+                            }}
+                        >
+                            Add
+                        </Button>
+                    </div>
+                ) : null}
+            </div>
+
+            <div className="flex flex-col gap-2">
+                <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                    comments
+                </span>
+                {handoff.comments.length === 0 ? (
+                    <p className="text-xs text-[var(--dd-text-muted)]">No comments yet.</p>
+                ) : (
+                    handoff.comments.map((comment) => (
+                        <div
+                            key={`${comment.ts}-${comment.text.slice(0, 24)}`}
+                            className="rounded border border-[var(--dd-border)]/50 bg-black/10 px-3 py-2"
+                        >
+                            <div className="mb-1 flex items-center gap-2 font-mono text-[10px] text-[var(--dd-text-muted)]">
+                                <span className="text-[var(--dd-text-secondary)]">{actorLabel(comment.by)}</span>
+                                <span>{new Date(comment.ts).toLocaleString()}</span>
+                            </div>
+                            <p className="whitespace-pre-wrap text-sm text-[var(--dd-text-primary)]">{comment.text}</p>
+                            {comment.attachmentIds !== undefined && comment.attachmentIds.length > 0 ? (
+                                <div className="mt-1.5">
+                                    <AttachmentStrip attachments={handoff.attachments} ids={comment.attachmentIds} />
+                                </div>
+                            ) : null}
+                        </div>
+                    ))
+                )}
+                {!terminal ? (
+                    <div data-comment-composer className="flex flex-col gap-1.5">
+                        {pendingFiles.length > 0 ? (
+                            <div className="flex flex-wrap gap-1.5">
+                                {pendingFiles.map((file, index) => (
+                                    <span
+                                        key={index}
+                                        className="inline-flex items-center gap-1 rounded border border-primary/40 bg-primary/10 px-2 py-0.5 font-mono text-[10px] text-[var(--dd-text-secondary)]"
+                                    >
+                                        📎 {file.name || "pasted image"}
+                                        <button
+                                            type="button"
+                                            className="cursor-pointer hover:text-[var(--dd-danger)]"
+                                            onClick={() =>
+                                                setPendingFiles((prev) => prev.filter((_, i) => i !== index))
+                                            }
+                                        >
+                                            ×
+                                        </button>
+                                    </span>
+                                ))}
+                            </div>
+                        ) : null}
+                        <div className="flex items-end gap-2">
+                            <Textarea
+                                ref={composerRef}
+                                value={commentDraft}
+                                onChange={(e) => setCommentDraft(e.target.value)}
+                                className="min-h-[2.5rem] border-[var(--dd-border)] bg-black/15 text-sm"
+                                rows={2}
+                                placeholder="comment… (paste screenshots here to attach them)"
+                            />
+                            <Button
+                                size="sm"
+                                disabled={
+                                    (commentDraft.trim().length === 0 && pendingFiles.length === 0) || action.isPending
+                                }
+                                onClick={() => void submitComment()}
+                            >
+                                Send
+                            </Button>
+                        </div>
+                    </div>
+                ) : null}
+            </div>
+
+            {failures.length > 0 ? (
+                <div className="rounded border border-[var(--dd-danger)]/40 bg-[var(--dd-danger)]/10 px-3 py-2 text-xs text-[var(--dd-danger)]">
+                    {failures.map((f) => (
+                        <p key={`${f.action}-${f.error}`}>
+                            {f.action}: {f.error}
+                        </p>
+                    ))}
+                </div>
+            ) : null}
+            {uploadError !== null ? <p className="text-xs text-[var(--dd-danger)]">{uploadError}</p> : null}
+            {action.isError ? <p className="text-xs text-[var(--dd-danger)]">{String(action.error)}</p> : null}
+            {detail.data !== undefined && detail.data.info.length > 0 ? (
+                <p className="font-mono text-[10px] text-[var(--dd-text-muted)]">{detail.data.info.join(" · ")}</p>
+            ) : null}
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
@@ -1,0 +1,314 @@
+import type { HandoffPostResponse, HandoffTaskInput } from "@app/dev-dashboard/lib/handoff-types";
+import { Button } from "@ui/components/button";
+import {
+    GlassDialogBody,
+    GlassDialogContent,
+    GlassDialogFooter,
+    GlassDialogHeader,
+    GlassDialogScroll,
+    GlassDialogShell,
+    GlassDialogTitle,
+} from "@ui/components/glass-dialog";
+import { Input } from "@ui/components/input";
+import { Label } from "@ui/components/label";
+import { Textarea } from "@ui/components/textarea";
+import { useState } from "react";
+import { useHandoffCreate } from "./useHandoffApi";
+
+const DIALOG_PANEL_CLASS =
+    "dd-panel border-[var(--dd-border)] bg-[var(--dd-bg-panel)]/95 text-[var(--dd-text-primary)] shadow-[0_0_80px_rgba(0,0,0,0.55)]";
+const LABEL_CLASS = "text-xs uppercase tracking-wider text-[var(--dd-text-muted)]";
+const INPUT_CLASS = "mt-1.5 border-[var(--dd-border)] bg-black/20";
+
+export interface ProofDraft {
+    answer: string;
+    commitIds?: string[];
+    context?: string;
+}
+
+/** Check-a-task proof dialog (§7.3) — answer prefilled for the human owner. */
+export function HandoffProofDialog({
+    open,
+    taskText,
+    onOpenChange,
+    onSubmit,
+}: {
+    open: boolean;
+    taskText: string;
+    onOpenChange: (b: boolean) => void;
+    onSubmit: (proof: ProofDraft) => void;
+}) {
+    const [answer, setAnswer] = useState("Verified manually via dashboard");
+    const [commits, setCommits] = useState("");
+    const [context, setContext] = useState("");
+
+    const submit = (): void => {
+        const proof: ProofDraft = { answer: answer.trim() };
+        const commitIds = commits
+            .split(/[\s,]+/)
+            .map((c) => c.trim())
+            .filter((c) => c.length > 0);
+
+        if (commitIds.length > 0) {
+            proof.commitIds = commitIds;
+        }
+
+        if (context.trim().length > 0) {
+            proof.context = context.trim();
+        }
+
+        onSubmit(proof);
+        onOpenChange(false);
+    };
+
+    return (
+        <GlassDialogShell open={open} onOpenChange={onOpenChange}>
+            <GlassDialogContent size="md" showCloseButton className={DIALOG_PANEL_CLASS}>
+                <GlassDialogBody>
+                    <GlassDialogHeader className="text-left">
+                        <GlassDialogTitle className="dd-accent-text text-base font-bold">Check task</GlassDialogTitle>
+                        <p className="text-xs text-[var(--dd-text-secondary)]">{taskText}</p>
+                    </GlassDialogHeader>
+                    <div className="flex flex-col gap-3">
+                        <div>
+                            <Label className={LABEL_CLASS}>Proof / answer</Label>
+                            <Textarea
+                                value={answer}
+                                onChange={(e) => setAnswer(e.target.value)}
+                                className={INPUT_CLASS}
+                                rows={3}
+                            />
+                        </div>
+                        <div>
+                            <Label className={LABEL_CLASS}>Commit SHAs (optional, space/comma separated)</Label>
+                            <Input
+                                value={commits}
+                                onChange={(e) => setCommits(e.target.value)}
+                                className={INPUT_CLASS}
+                                placeholder="a1b2c3d e4f5a6b"
+                            />
+                        </div>
+                        <div>
+                            <Label className={LABEL_CLASS}>Context (optional)</Label>
+                            <Input
+                                value={context}
+                                onChange={(e) => setContext(e.target.value)}
+                                className={INPUT_CLASS}
+                                placeholder="side effects, caveats, links"
+                            />
+                        </div>
+                    </div>
+                    <GlassDialogFooter className="gap-2 sm:flex-row sm:justify-end">
+                        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                            Cancel
+                        </Button>
+                        <Button type="button" onClick={submit} disabled={answer.trim().length === 0}>
+                            Check task
+                        </Button>
+                    </GlassDialogFooter>
+                </GlassDialogBody>
+            </GlassDialogContent>
+        </GlassDialogShell>
+    );
+}
+
+interface TaskDraft {
+    text: string;
+    acceptanceCriteria: string;
+}
+
+/** New-handoff dialog (§7.3): title, description, task composer rows, target/refs. */
+export function HandoffCreateDialog({
+    open,
+    onOpenChange,
+    onCreated,
+}: {
+    open: boolean;
+    onOpenChange: (b: boolean) => void;
+    onCreated: (res: HandoffPostResponse) => void;
+}) {
+    const create = useHandoffCreate();
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [tasks, setTasks] = useState<TaskDraft[]>([{ text: "", acceptanceCriteria: "" }]);
+    const [targetName, setTargetName] = useState("");
+    const [refs, setRefs] = useState("");
+
+    const setTask = (index: number, patch: Partial<TaskDraft>): void => {
+        setTasks((prev) => prev.map((t, i) => (i === index ? { ...t, ...patch } : t)));
+    };
+
+    const validTasks = tasks.filter((t) => t.text.trim().length > 0);
+
+    const submit = (): void => {
+        const payload: {
+            title: string;
+            description?: string;
+            tasks: HandoffTaskInput[];
+            target?: { sessionName: string };
+            refs?: string[];
+        } = {
+            title: title.trim(),
+            tasks: validTasks.map((t) => {
+                const task: HandoffTaskInput = { text: t.text.trim() };
+
+                if (t.acceptanceCriteria.trim().length > 0) {
+                    task.acceptanceCriteria = t.acceptanceCriteria.trim();
+                }
+
+                return task;
+            }),
+        };
+
+        if (description.trim().length > 0) {
+            payload.description = description.trim();
+        }
+
+        if (targetName.trim().length > 0) {
+            payload.target = { sessionName: targetName.trim() };
+        }
+
+        const refList = refs
+            .split(/\n+/)
+            .map((r) => r.trim())
+            .filter((r) => r.length > 0);
+
+        if (refList.length > 0) {
+            payload.refs = refList;
+        }
+
+        create.mutate(payload, {
+            onSuccess: (res) => {
+                onCreated(res);
+                onOpenChange(false);
+                setTitle("");
+                setDescription("");
+                setTasks([{ text: "", acceptanceCriteria: "" }]);
+                setTargetName("");
+                setRefs("");
+            },
+        });
+    };
+
+    return (
+        <GlassDialogShell open={open} onOpenChange={onOpenChange}>
+            <GlassDialogContent size="lg" fixedHeight showCloseButton className={DIALOG_PANEL_CLASS}>
+                <GlassDialogBody className="gap-0 p-0 sm:p-0">
+                    <GlassDialogHeader className="shrink-0 border-b border-[var(--dd-border)]/80 px-5 py-4 text-left">
+                        <GlassDialogTitle className="dd-accent-text text-lg font-bold">New handoff</GlassDialogTitle>
+                        <p className="text-xs text-[var(--dd-text-secondary)]">
+                            A task list for an agent session — it claims, works, checks tasks off with proof.
+                        </p>
+                    </GlassDialogHeader>
+                    <GlassDialogScroll className="px-5 py-4">
+                        <div className="flex flex-col gap-4">
+                            <div>
+                                <Label className={LABEL_CLASS}>Title</Label>
+                                <Input
+                                    value={title}
+                                    onChange={(e) => setTitle(e.target.value)}
+                                    className={INPUT_CLASS}
+                                    placeholder="Fix e2e Active-filter semantics"
+                                />
+                            </div>
+                            <div>
+                                <Label className={LABEL_CLASS}>Description (markdown, optional)</Label>
+                                <Textarea
+                                    value={description}
+                                    onChange={(e) => setDescription(e.target.value)}
+                                    className={INPUT_CLASS}
+                                    rows={3}
+                                    placeholder="the why / context the worker needs"
+                                />
+                            </div>
+                            <div className="flex flex-col gap-2">
+                                <Label className={LABEL_CLASS}>Tasks</Label>
+                                {tasks.map((task, index) => (
+                                    <div
+                                        key={index}
+                                        className="flex flex-col gap-1 rounded border border-[var(--dd-border)]/70 bg-black/15 p-2"
+                                    >
+                                        <div className="flex items-center gap-2">
+                                            <span className="font-mono text-[10px] text-[var(--dd-text-muted)]">
+                                                t{index + 1}
+                                            </span>
+                                            <Input
+                                                value={task.text}
+                                                onChange={(e) => setTask(index, { text: e.target.value })}
+                                                className="border-[var(--dd-border)] bg-black/20"
+                                                placeholder="what to do"
+                                            />
+                                            {tasks.length > 1 ? (
+                                                <button
+                                                    type="button"
+                                                    className="cursor-pointer text-[var(--dd-text-muted)] hover:text-[var(--dd-danger)]"
+                                                    onClick={() =>
+                                                        setTasks((prev) => prev.filter((_, i) => i !== index))
+                                                    }
+                                                    title="remove row"
+                                                >
+                                                    ×
+                                                </button>
+                                            ) : null}
+                                        </div>
+                                        <Input
+                                            value={task.acceptanceCriteria}
+                                            onChange={(e) => setTask(index, { acceptanceCriteria: e.target.value })}
+                                            className="border-[var(--dd-border)] bg-black/10 text-xs"
+                                            placeholder="acceptance criteria (optional but recommended)"
+                                        />
+                                    </div>
+                                ))}
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="self-start"
+                                    onClick={() => setTasks((prev) => [...prev, { text: "", acceptanceCriteria: "" }])}
+                                >
+                                    + Add task row
+                                </Button>
+                            </div>
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <div>
+                                    <Label className={LABEL_CLASS}>Target session name (optional)</Label>
+                                    <Input
+                                        value={targetName}
+                                        onChange={(e) => setTargetName(e.target.value)}
+                                        className={INPUT_CLASS}
+                                        placeholder="gt-worker"
+                                    />
+                                </div>
+                                <div>
+                                    <Label className={LABEL_CLASS}>Refs (one per line, optional)</Label>
+                                    <Textarea
+                                        value={refs}
+                                        onChange={(e) => setRefs(e.target.value)}
+                                        className={INPUT_CLASS}
+                                        rows={2}
+                                        placeholder={"src/foo.ts\nhttps://github.com/...pull/1"}
+                                    />
+                                </div>
+                            </div>
+                            {create.isError ? (
+                                <p className="text-xs text-[var(--dd-danger)]">{String(create.error)}</p>
+                            ) : null}
+                        </div>
+                    </GlassDialogScroll>
+                    <GlassDialogFooter className="shrink-0 gap-2 border-t border-[var(--dd-border)]/80 px-5 py-4 sm:flex-row sm:justify-end">
+                        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                            Cancel
+                        </Button>
+                        <Button
+                            type="button"
+                            onClick={submit}
+                            disabled={create.isPending || title.trim().length === 0 || validTasks.length === 0}
+                        >
+                            {create.isPending ? "Posting…" : "Post handoff"}
+                        </Button>
+                    </GlassDialogFooter>
+                </GlassDialogBody>
+            </GlassDialogContent>
+        </GlassDialogShell>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
@@ -71,8 +71,11 @@ export function HandoffProofDialog({
                     </GlassDialogHeader>
                     <div className="flex flex-col gap-3">
                         <div>
-                            <Label className={LABEL_CLASS}>Proof / answer</Label>
+                            <Label className={LABEL_CLASS} htmlFor="handoff-proof-answer">
+                                Proof / answer
+                            </Label>
                             <Textarea
+                                id="handoff-proof-answer"
                                 value={answer}
                                 onChange={(e) => setAnswer(e.target.value)}
                                 className={INPUT_CLASS}
@@ -80,8 +83,11 @@ export function HandoffProofDialog({
                             />
                         </div>
                         <div>
-                            <Label className={LABEL_CLASS}>Commit SHAs (optional, space/comma separated)</Label>
+                            <Label className={LABEL_CLASS} htmlFor="handoff-proof-commits">
+                                Commit SHAs (optional, space/comma separated)
+                            </Label>
                             <Input
+                                id="handoff-proof-commits"
                                 value={commits}
                                 onChange={(e) => setCommits(e.target.value)}
                                 className={INPUT_CLASS}
@@ -89,8 +95,11 @@ export function HandoffProofDialog({
                             />
                         </div>
                         <div>
-                            <Label className={LABEL_CLASS}>Context (optional)</Label>
+                            <Label className={LABEL_CLASS} htmlFor="handoff-proof-context">
+                                Context (optional)
+                            </Label>
                             <Input
+                                id="handoff-proof-context"
                                 value={context}
                                 onChange={(e) => setContext(e.target.value)}
                                 className={INPUT_CLASS}
@@ -203,8 +212,11 @@ export function HandoffCreateDialog({
                     <GlassDialogScroll className="px-5 py-4">
                         <div className="flex flex-col gap-4">
                             <div>
-                                <Label className={LABEL_CLASS}>Title</Label>
+                                <Label className={LABEL_CLASS} htmlFor="handoff-create-title">
+                                    Title
+                                </Label>
                                 <Input
+                                    id="handoff-create-title"
                                     value={title}
                                     onChange={(e) => setTitle(e.target.value)}
                                     className={INPUT_CLASS}
@@ -212,8 +224,11 @@ export function HandoffCreateDialog({
                                 />
                             </div>
                             <div>
-                                <Label className={LABEL_CLASS}>Description (markdown, optional)</Label>
+                                <Label className={LABEL_CLASS} htmlFor="handoff-create-description">
+                                    Description (markdown, optional)
+                                </Label>
                                 <Textarea
+                                    id="handoff-create-description"
                                     value={description}
                                     onChange={(e) => setDescription(e.target.value)}
                                     className={INPUT_CLASS}
@@ -271,8 +286,11 @@ export function HandoffCreateDialog({
                             </div>
                             <div className="grid gap-4 sm:grid-cols-2">
                                 <div>
-                                    <Label className={LABEL_CLASS}>Target session name (optional)</Label>
+                                    <Label className={LABEL_CLASS} htmlFor="handoff-create-target">
+                                        Target session name (optional)
+                                    </Label>
                                     <Input
+                                        id="handoff-create-target"
                                         value={targetName}
                                         onChange={(e) => setTargetName(e.target.value)}
                                         className={INPUT_CLASS}
@@ -280,8 +298,11 @@ export function HandoffCreateDialog({
                                     />
                                 </div>
                                 <div>
-                                    <Label className={LABEL_CLASS}>Refs (one per line, optional)</Label>
+                                    <Label className={LABEL_CLASS} htmlFor="handoff-create-refs">
+                                        Refs (one per line, optional)
+                                    </Label>
                                     <Textarea
+                                        id="handoff-create-refs"
                                         value={refs}
                                         onChange={(e) => setRefs(e.target.value)}
                                         className={INPUT_CLASS}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
@@ -1,0 +1,228 @@
+import type { HandoffListRow, HandoffPostResponse, HandoffStreamFrame } from "@app/dev-dashboard/lib/handoff-types";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "@ui/components/button";
+import { useEffect, useMemo, useState } from "react";
+import { HandoffDetail } from "./HandoffDetail";
+import { HandoffCreateDialog } from "./HandoffDialogs";
+import { useHandoffList } from "./useHandoffApi";
+
+const STATUS_GROUPS: { key: string; label: string }[] = [
+    { key: "open", label: "Open" },
+    { key: "claimed", label: "Claimed" },
+    { key: "done", label: "Done" },
+    { key: "cancelled", label: "Cancelled" },
+];
+
+function statusDot(status: string): string {
+    if (status === "open") {
+        return "#a3e635";
+    }
+
+    if (status === "claimed") {
+        return "#c792ea";
+    }
+
+    if (status === "done") {
+        return "var(--dd-text-muted)";
+    }
+
+    return "var(--dd-danger)";
+}
+
+function HandoffRow({
+    row,
+    selected,
+    onSelect,
+}: {
+    row: HandoffListRow;
+    selected: boolean;
+    onSelect: (id: string) => void;
+}) {
+    return (
+        <button
+            type="button"
+            className={`flex w-full cursor-pointer flex-col gap-1 rounded border px-3 py-2 text-left transition-all duration-200 hover:-translate-y-px hover:border-primary/50 ${
+                selected ? "border-primary/60 bg-primary/10" : "border-[var(--dd-border)]/60 bg-black/10"
+            }`}
+            onClick={() => onSelect(row.id)}
+        >
+            <div className="flex items-center gap-2">
+                <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: statusDot(row.status) }}
+                />
+                <span className="min-w-0 flex-1 truncate text-sm text-[var(--dd-text-primary)]">{row.title}</span>
+                <span className="font-mono text-[10px] text-[var(--dd-text-secondary)]">
+                    {row.progress ?? row.tasks}
+                </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] text-[var(--dd-text-muted)]">
+                {row.project !== null ? <span>{row.project}</span> : null}
+                {row.postedBy.sessionName !== null ? <span>by {row.postedBy.sessionName}</span> : null}
+                {row.claimedBy !== undefined && row.claimedBy.length > 0 ? (
+                    <span className="text-[#c792ea]">
+                        → {row.claimedBy.map((c) => c.sessionName ?? c.sessionId ?? "unnamed").join(", ")}
+                    </span>
+                ) : null}
+                {row.target !== undefined ? (
+                    <span className="rounded border border-[var(--dd-border)] px-1 py-px">
+                        @{row.target.sessionName ?? row.target.sessionId}
+                    </span>
+                ) : null}
+                <span>{row.ageHours < 24 ? `${row.ageHours}h` : `${Math.round(row.ageHours / 24)}d`}</span>
+            </div>
+        </button>
+    );
+}
+
+export function HandoffTab() {
+    const list = useHandoffList();
+    const queryClient = useQueryClient();
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [openOnly, setOpenOnly] = useState(false);
+    const [project, setProject] = useState<string>("");
+    const [createOpen, setCreateOpen] = useState(false);
+    const [editIdToast, setEditIdToast] = useState<HandoffPostResponse | null>(null);
+    const rows = useMemo(() => list.data?.handoffs ?? [], [list.data]);
+
+    // SSE keeps every window live (§7.3): each frame → refetch that handoff + the list.
+    useEffect(() => {
+        const es = new EventSource("/api/handoff/stream");
+        es.onmessage = (ev) => {
+            try {
+                const frame = SafeJSON.parse(ev.data, { strict: true }) as HandoffStreamFrame;
+                void queryClient.invalidateQueries({ queryKey: ["handoff-log"] });
+                void queryClient.invalidateQueries({ queryKey: ["handoff", frame.id] });
+            } catch {
+                /* malformed frame — ignore */
+            }
+        };
+
+        return () => es.close();
+    }, [queryClient]);
+
+    const projects = useMemo(
+        () => [...new Set(rows.map((r) => r.project).filter((p): p is string => p !== null))].sort(),
+        [rows]
+    );
+    const filtered = rows.filter(
+        (r) => (!openOnly || r.status === "open" || r.status === "claimed") && (project === "" || r.project === project)
+    );
+
+    return (
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)]">
+            <div className="dd-panel flex flex-col gap-3 self-start p-3">
+                <div className="flex items-center gap-2">
+                    <Button
+                        size="sm"
+                        className="transition-[filter] hover:brightness-110"
+                        onClick={() => setCreateOpen(true)}
+                    >
+                        + New handoff
+                    </Button>
+                    <label className="flex cursor-pointer items-center gap-1.5 font-mono text-[10px] text-[var(--dd-text-muted)]">
+                        <input
+                            type="checkbox"
+                            checked={openOnly}
+                            onChange={(e) => setOpenOnly(e.target.checked)}
+                            className="accent-[var(--color-primary)]"
+                        />
+                        open only
+                    </label>
+                    <select
+                        value={project}
+                        onChange={(e) => setProject(e.target.value)}
+                        className="ml-auto rounded border border-[var(--dd-border)] bg-black/25 px-1.5 py-0.5 font-mono text-[10px] text-[var(--dd-text-secondary)]"
+                    >
+                        <option value="">all projects</option>
+                        {projects.map((p) => (
+                            <option key={p} value={p}>
+                                {p}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                {list.isLoading ? (
+                    <p className="py-6 text-center text-xs text-[var(--dd-text-muted)]">Loading handoffs…</p>
+                ) : list.isError ? (
+                    <p className="py-6 text-center text-xs text-[var(--dd-danger)]">{String(list.error)}</p>
+                ) : filtered.length === 0 ? (
+                    <p className="py-6 text-center text-xs text-[var(--dd-text-muted)]">
+                        No handoffs yet — post one from an agent (handoff_post) or the button above.
+                    </p>
+                ) : (
+                    STATUS_GROUPS.map((group) => {
+                        const groupRows = filtered.filter((r) => r.status === group.key);
+
+                        if (groupRows.length === 0) {
+                            return null;
+                        }
+
+                        return (
+                            <div key={group.key} className="flex flex-col gap-1.5">
+                                <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                                    {group.label} · {groupRows.length}
+                                </span>
+                                {groupRows.map((row) => (
+                                    <HandoffRow
+                                        key={row.id}
+                                        row={row}
+                                        selected={row.id === selectedId}
+                                        onSelect={setSelectedId}
+                                    />
+                                ))}
+                            </div>
+                        );
+                    })
+                )}
+            </div>
+
+            <div className="min-w-0">
+                {selectedId !== null ? (
+                    <HandoffDetail id={selectedId} />
+                ) : (
+                    <div className="dd-panel flex h-40 items-center justify-center text-sm text-[var(--dd-text-muted)]">
+                        Select a handoff to inspect and edit it.
+                    </div>
+                )}
+            </div>
+
+            <HandoffCreateDialog
+                open={createOpen}
+                onOpenChange={setCreateOpen}
+                onCreated={(res) => {
+                    setEditIdToast(res);
+                    setSelectedId(res.handoff.id);
+                }}
+            />
+
+            {editIdToast !== null ? (
+                <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-1.5 rounded border border-primary/50 bg-[var(--dd-bg-panel)] px-4 py-3 shadow-[0_0_40px_rgba(0,0,0,0.6)]">
+                    <p className="text-sm text-[var(--dd-text-primary)]">Posted {editIdToast.handoff.id}</p>
+                    <p className="font-mono text-[10px] text-[var(--dd-text-muted)]">
+                        editId (the dashboard can always re-reveal it):
+                    </p>
+                    <div className="flex items-center gap-2">
+                        <code className="dd-accent-text font-mono text-xs">{editIdToast.editId}</code>
+                        <button
+                            type="button"
+                            className="cursor-pointer font-mono text-[10px] text-[var(--dd-text-secondary)] hover:text-[var(--dd-text-primary)]"
+                            onClick={() => void navigator.clipboard.writeText(editIdToast.editId)}
+                        >
+                            copy
+                        </button>
+                        <button
+                            type="button"
+                            className="cursor-pointer font-mono text-[10px] text-[var(--dd-text-muted)] hover:text-[var(--dd-text-primary)]"
+                            onClick={() => setEditIdToast(null)}
+                        >
+                            dismiss
+                        </button>
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
@@ -209,7 +209,11 @@ export function HandoffTab() {
                         <button
                             type="button"
                             className="cursor-pointer font-mono text-[10px] text-[var(--dd-text-secondary)] hover:text-[var(--dd-text-primary)]"
-                            onClick={() => void navigator.clipboard.writeText(editIdToast.editId)}
+                            onClick={() => {
+                                navigator.clipboard
+                                    .writeText(editIdToast.editId)
+                                    .catch((err) => console.error("copy editId failed", err));
+                            }}
                         >
                             copy
                         </button>

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
@@ -10,7 +10,9 @@ function CommitChip({ sha }: { sha: string }) {
         <button
             type="button"
             className="cursor-pointer rounded border border-[var(--dd-border)] bg-black/25 px-1.5 py-px font-mono text-[10px] text-[var(--dd-text-secondary)] hover:border-primary/60"
-            onClick={() => void navigator.clipboard.writeText(sha)}
+            onClick={() => {
+                navigator.clipboard.writeText(sha).catch((err) => console.error("copy SHA failed", err));
+            }}
             title="copy SHA"
         >
             {sha}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
@@ -1,0 +1,293 @@
+import type { HandoffActionInput, HandoffTask, PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
+import { Checkbox } from "@ui/components/checkbox";
+import { Input } from "@ui/components/input";
+import { useState } from "react";
+import { AttachmentStrip } from "./HandoffAttachments";
+import { HandoffProofDialog } from "./HandoffDialogs";
+
+function CommitChip({ sha }: { sha: string }) {
+    return (
+        <button
+            type="button"
+            className="cursor-pointer rounded border border-[var(--dd-border)] bg-black/25 px-1.5 py-px font-mono text-[10px] text-[var(--dd-text-secondary)] hover:border-primary/60"
+            onClick={() => void navigator.clipboard.writeText(sha)}
+            title="copy SHA"
+        >
+            {sha}
+        </button>
+    );
+}
+
+export function HandoffTaskRow({
+    task,
+    attachments,
+    disabled,
+    onActions,
+}: {
+    task: HandoffTask;
+    attachments: PublicHandoff["attachments"];
+    disabled: boolean;
+    onActions: (actions: HandoffActionInput[]) => void;
+}) {
+    const [proofOpen, setProofOpen] = useState(false);
+    const [denyOpen, setDenyOpen] = useState(false);
+    const [denyReason, setDenyReason] = useState("");
+    const [editing, setEditing] = useState(false);
+    const [editText, setEditText] = useState(task.text);
+    const [editCriteria, setEditCriteria] = useState(task.acceptanceCriteria ?? "");
+    const [proofExpanded, setProofExpanded] = useState(false);
+    const taskAttachments = attachments.filter((a) => a.taskId === task.id);
+    const proofIds = task.proof?.attachmentIds ?? [];
+
+    const onToggle = (): void => {
+        if (task.checked) {
+            if (window.confirm("Uncheck this task? The current proof is cleared (history stays in the event log).")) {
+                onActions([{ action: "uncheck_task", taskId: task.id }]);
+            }
+
+            return;
+        }
+
+        if (task.denied) {
+            if (
+                window.confirm(
+                    `Task is denied ("${task.deniedReason ?? ""}") — force-check anyway (clears the denial)?`
+                )
+            ) {
+                setProofOpen(true);
+            }
+
+            return;
+        }
+
+        setProofOpen(true);
+    };
+
+    const submitDeny = (): void => {
+        const reason = denyReason.trim();
+
+        if (reason.length === 0) {
+            return;
+        }
+
+        if (task.checked && !window.confirm("Task is checked — force-deny anyway (proof stays visible)?")) {
+            return;
+        }
+
+        onActions([{ action: "deny_task", taskId: task.id, reason, ...(task.checked ? { force: true } : {}) }]);
+        setDenyOpen(false);
+        setDenyReason("");
+    };
+
+    const saveEdit = (): void => {
+        const patch: { action: string; taskId: string; text?: string; acceptanceCriteria?: string } = {
+            action: "modify_task",
+            taskId: task.id,
+        };
+
+        if (editText.trim().length > 0 && editText !== task.text) {
+            patch.text = editText;
+        }
+
+        if (editCriteria !== (task.acceptanceCriteria ?? "")) {
+            patch.acceptanceCriteria = editCriteria;
+        }
+
+        if (patch.text !== undefined || patch.acceptanceCriteria !== undefined) {
+            onActions([patch as HandoffActionInput]);
+        }
+
+        setEditing(false);
+    };
+
+    return (
+        <div
+            data-task-id={task.id}
+            tabIndex={0}
+            className="flex flex-col gap-1.5 rounded border border-[var(--dd-border)]/60 bg-black/10 px-3 py-2 focus-within:border-primary/40"
+        >
+            <div className="flex items-start gap-2.5">
+                <Checkbox
+                    checked={task.checked}
+                    disabled={disabled}
+                    onCheckedChange={onToggle}
+                    className="mt-0.5"
+                    aria-label={`check ${task.id}`}
+                />
+                <div className="min-w-0 flex-1">
+                    {editing ? (
+                        <div className="flex flex-col gap-1.5">
+                            <Input
+                                value={editText}
+                                onChange={(e) => setEditText(e.target.value)}
+                                className="border-[var(--dd-border)] bg-black/25 text-sm"
+                            />
+                            <Input
+                                value={editCriteria}
+                                onChange={(e) => setEditCriteria(e.target.value)}
+                                className="border-[var(--dd-border)] bg-black/15 text-xs"
+                                placeholder="acceptance criteria"
+                            />
+                            <div className="flex gap-2 text-xs">
+                                <button type="button" className="dd-accent-text cursor-pointer" onClick={saveEdit}>
+                                    save
+                                </button>
+                                <button
+                                    type="button"
+                                    className="cursor-pointer text-[var(--dd-text-muted)]"
+                                    onClick={() => setEditing(false)}
+                                >
+                                    cancel
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <>
+                            <p
+                                className={`text-sm text-[var(--dd-text-primary)]${task.denied ? " line-through opacity-60" : ""}`}
+                            >
+                                <span className="mr-1.5 font-mono text-[10px] text-[var(--dd-text-muted)]">
+                                    {task.id}
+                                </span>
+                                {task.text}
+                            </p>
+                            {task.acceptanceCriteria ? (
+                                <p className="mt-0.5 text-xs text-[var(--dd-text-muted)]">
+                                    ✓? {task.acceptanceCriteria}
+                                </p>
+                            ) : null}
+                        </>
+                    )}
+
+                    {task.denied ? (
+                        <p className="mt-1 inline-flex items-center gap-1.5 rounded border border-[var(--dd-danger)]/40 bg-[var(--dd-danger)]/10 px-2 py-0.5 text-[11px] text-[var(--dd-danger)]">
+                            denied: {task.deniedReason}
+                            <span className="text-[var(--dd-text-muted)]">
+                                — {task.deniedBy?.sessionName ?? task.deniedBy?.agent}
+                            </span>
+                        </p>
+                    ) : null}
+
+                    {task.checked && task.proof ? (
+                        <div className="mt-1">
+                            <button
+                                type="button"
+                                className="dd-accent-text cursor-pointer text-[11px] hover:opacity-80"
+                                onClick={() => setProofExpanded((v) => !v)}
+                            >
+                                {proofExpanded ? "▴ proof" : "▾ proof"}
+                                <span className="ml-1 text-[var(--dd-text-muted)]">
+                                    by {task.checkedBy?.sessionName ?? task.checkedBy?.agent}
+                                    {task.checkedBy?.via === "dashboard" ? " via dashboard" : ""}
+                                </span>
+                            </button>
+                            {proofExpanded ? (
+                                <div className="mt-1 flex flex-col gap-1.5 rounded border border-[var(--dd-border)]/50 bg-black/20 p-2 text-xs text-[var(--dd-text-secondary)]">
+                                    <p className="whitespace-pre-wrap">{task.proof.answer}</p>
+                                    {task.proof.commitIds !== undefined && task.proof.commitIds.length > 0 ? (
+                                        <div className="flex flex-wrap gap-1.5">
+                                            {task.proof.commitIds.map((sha) => (
+                                                <CommitChip key={sha} sha={sha} />
+                                            ))}
+                                        </div>
+                                    ) : null}
+                                    {task.proof.context ? (
+                                        <p className="text-[var(--dd-text-muted)]">{task.proof.context}</p>
+                                    ) : null}
+                                    <AttachmentStrip attachments={attachments} ids={proofIds} />
+                                </div>
+                            ) : null}
+                        </div>
+                    ) : null}
+
+                    <div className="mt-1">
+                        <AttachmentStrip
+                            attachments={taskAttachments.filter((a) => !proofIds.includes(a.attachmentId))}
+                        />
+                    </div>
+
+                    {denyOpen ? (
+                        <div className="mt-1.5 flex items-center gap-2">
+                            <Input
+                                value={denyReason}
+                                onChange={(e) => setDenyReason(e.target.value)}
+                                className="h-7 border-[var(--dd-border)] bg-black/25 text-xs"
+                                placeholder="reason (required)"
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                        submitDeny();
+                                    }
+                                }}
+                            />
+                            <button
+                                type="button"
+                                className={`cursor-pointer text-xs ${denyReason.trim().length === 0 ? "cursor-not-allowed text-[var(--dd-text-muted)]" : "text-[var(--dd-danger)]"}`}
+                                disabled={denyReason.trim().length === 0}
+                                onClick={submitDeny}
+                            >
+                                deny
+                            </button>
+                            <button
+                                type="button"
+                                className="cursor-pointer text-xs text-[var(--dd-text-muted)]"
+                                onClick={() => setDenyOpen(false)}
+                            >
+                                cancel
+                            </button>
+                        </div>
+                    ) : null}
+                </div>
+
+                {!disabled ? (
+                    <div className="flex shrink-0 items-center gap-2 text-[11px]">
+                        <button
+                            type="button"
+                            className="cursor-pointer text-[var(--dd-text-muted)] hover:text-[var(--dd-text-primary)]"
+                            onClick={() => {
+                                setEditText(task.text);
+                                setEditCriteria(task.acceptanceCriteria ?? "");
+                                setEditing((v) => !v);
+                            }}
+                            title="edit text / acceptance criteria"
+                        >
+                            ✎
+                        </button>
+                        {task.denied ? (
+                            <button
+                                type="button"
+                                className="dd-accent-text cursor-pointer hover:opacity-80"
+                                onClick={() => onActions([{ action: "undeny_task", taskId: task.id }])}
+                            >
+                                undeny
+                            </button>
+                        ) : (
+                            <button
+                                type="button"
+                                className="cursor-pointer text-[var(--dd-text-muted)] hover:text-[var(--dd-danger)]"
+                                onClick={() => setDenyOpen((v) => !v)}
+                            >
+                                deny
+                            </button>
+                        )}
+                    </div>
+                ) : null}
+            </div>
+
+            <HandoffProofDialog
+                open={proofOpen}
+                taskText={task.text}
+                onOpenChange={setProofOpen}
+                onSubmit={(proof) =>
+                    onActions([
+                        {
+                            action: "check_task",
+                            taskId: task.id,
+                            proof,
+                            ...(task.denied ? { force: true } : {}),
+                        },
+                    ])
+                }
+            />
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/handoff/useHandoffApi.ts
+++ b/src/dev-dashboard/ui/src/components/handoff/useHandoffApi.ts
@@ -1,0 +1,140 @@
+import type {
+    HandoffActionInput,
+    HandoffActionResponse,
+    HandoffGetResponse,
+    HandoffListResponse,
+    HandoffPostResponse,
+    HandoffTarget,
+    HandoffTaskInput,
+    PublicHandoff,
+} from "@app/dev-dashboard/lib/handoff-types";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(url, init);
+    const text = await res.text();
+
+    if (!res.ok) {
+        let message = text;
+
+        try {
+            const body = SafeJSON.parse(text, { strict: true }) as { error?: string };
+
+            if (typeof body.error === "string") {
+                message = body.error;
+            }
+        } catch {
+            /* non-JSON error body — use raw text */
+        }
+
+        throw new Error(message || `${res.status}`);
+    }
+
+    return SafeJSON.parse(text, { strict: true }) as T;
+}
+
+export function useHandoffList() {
+    return useQuery({
+        queryKey: ["handoff-log"],
+        queryFn: () => fetchJson<HandoffListResponse>("/api/handoff/log?limit=200"),
+        retry: false,
+    });
+}
+
+export function useHandoffDetail(id: string | null) {
+    return useQuery({
+        queryKey: ["handoff", id],
+        enabled: id !== null,
+        queryFn: () => fetchJson<HandoffGetResponse>(`/api/handoff/get?id=${encodeURIComponent(id ?? "")}`),
+        retry: false,
+    });
+}
+
+/**
+ * All mutations go through the one action language (§7.2). No optimistic
+ * updates — the POST response's folded handoff is authoritative (§7.3).
+ */
+export function useHandoffAction(id: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (actions: HandoffActionInput[]) =>
+            fetchJson<HandoffActionResponse>("/api/handoff/action", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify({ id, actions }, { strict: true }),
+            }),
+        onSuccess: (res) => {
+            queryClient.setQueryData<HandoffGetResponse>(["handoff", id], (prev) => ({
+                editId: prev?.editId,
+                handoff: res.handoff,
+                info: res.info,
+            }));
+            void queryClient.invalidateQueries({ queryKey: ["handoff-log"] });
+        },
+    });
+}
+
+export function useHandoffCreate() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (input: {
+            title: string;
+            description?: string;
+            tasks: HandoffTaskInput[];
+            target?: HandoffTarget;
+            refs?: string[];
+        }) =>
+            fetchJson<HandoffPostResponse>("/api/handoff/post", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: SafeJSON.stringify(input, { strict: true }),
+            }),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["handoff-log"] });
+        },
+    });
+}
+
+export async function uploadHandoffAttachment(input: {
+    id: string;
+    file: File;
+    taskId?: string;
+}): Promise<{ attachmentId: string; handoff: PublicHandoff }> {
+    const params = new URLSearchParams({ id: input.id, filename: input.file.name || "pasted.png" });
+
+    if (input.taskId !== undefined) {
+        params.set("taskId", input.taskId);
+    }
+
+    const res = await fetch(`/api/handoff/attach?${params.toString()}`, {
+        method: "POST",
+        headers: { "Content-Type": input.file.type || "application/octet-stream" },
+        body: input.file,
+    });
+    const text = await res.text();
+
+    if (!res.ok) {
+        let message = text;
+
+        try {
+            const body = SafeJSON.parse(text, { strict: true }) as { error?: string };
+
+            if (typeof body.error === "string") {
+                message = body.error;
+            }
+        } catch {
+            /* raw text */
+        }
+
+        throw new Error(message || `${res.status}`);
+    }
+
+    return SafeJSON.parse(text, { strict: true }) as { attachmentId: string; handoff: PublicHandoff };
+}
+
+export function attachmentUrl(attachmentId: string): string {
+    return `/api/handoff/attachment?id=${encodeURIComponent(attachmentId)}`;
+}

--- a/src/dev-dashboard/ui/src/routes/qa.tsx
+++ b/src/dev-dashboard/ui/src/routes/qa.tsx
@@ -9,6 +9,8 @@ import { useQuery } from "@tanstack/react-query";
 import { BlinkingBox } from "@ui/components/BlinkingBox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/tooltip";
 import { type KeyboardEvent, type MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { HandoffTab } from "@/components/handoff/HandoffTab";
+import { useHandoffList } from "@/components/handoff/useHandoffApi";
 import { QaClockProvider } from "@/components/QaClockProvider";
 import { QaCopyButtons } from "@/components/QaCopyButtons";
 import { QaReadTime } from "@/components/QaReadTime";
@@ -350,6 +352,55 @@ const QaCard = memo(function QaCard({
 });
 
 export function QaRoute() {
+    const [tab, setTab] = useState<"qa" | "tasks">(() =>
+        new URLSearchParams(window.location.search).get("tab") === "tasks" ? "tasks" : "qa"
+    );
+    const handoffList = useHandoffList();
+    const openCount = (handoffList.data?.handoffs ?? []).filter(
+        (h) => h.status === "open" || h.status === "claimed"
+    ).length;
+
+    const switchTab = (next: "qa" | "tasks"): void => {
+        setTab(next);
+        const url = new URL(window.location.href);
+
+        if (next === "tasks") {
+            url.searchParams.set("tab", "tasks");
+        } else {
+            url.searchParams.delete("tab");
+        }
+
+        window.history.replaceState(null, "", url.toString());
+    };
+
+    const tabClass = (active: boolean): string =>
+        `cursor-pointer rounded-t border-b-2 px-3 py-1.5 font-mono text-xs uppercase tracking-wider transition-colors ${
+            active
+                ? "dd-accent-text border-[var(--color-primary)]"
+                : "border-transparent text-[var(--dd-text-muted)] hover:text-[var(--dd-text-primary)]"
+        }`;
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-1 border-b border-[var(--dd-border)]/60">
+                <button type="button" className={tabClass(tab === "qa")} onClick={() => switchTab("qa")}>
+                    Q&amp;A
+                </button>
+                <button type="button" className={tabClass(tab === "tasks")} onClick={() => switchTab("tasks")}>
+                    Agent tasks
+                    {openCount > 0 ? (
+                        <span className="ml-1.5 rounded-full border border-[#3f5530] px-1.5 py-px text-[10px] text-[#a3e635]">
+                            {openCount}
+                        </span>
+                    ) : null}
+                </button>
+            </div>
+            {tab === "qa" ? <QaFeed /> : <HandoffTab />}
+        </div>
+    );
+}
+
+function QaFeed() {
     const urlPinnedId = useMemo(() => new URLSearchParams(window.location.search).get("id"), []);
     const [pinnedId] = useState<string | null>(urlPinnedId);
     const logQuery = useQuery({ queryKey: ["qa-log"], queryFn: fetchQaLog, retry: false });

--- a/src/handoff/attachments.ts
+++ b/src/handoff/attachments.ts
@@ -1,0 +1,108 @@
+import { copyFileSync, existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+import { generateAttachmentId } from "./ids";
+import { handoffLogDir } from "./log-store";
+
+const log = logger.child({ component: "handoff:attachments" });
+
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+const MIME_BY_EXT: Record<string, string> = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+    svg: "image/svg+xml",
+    pdf: "application/pdf",
+    txt: "text/plain",
+    log: "text/plain",
+    md: "text/markdown",
+    json: "application/json",
+    jsonl: "application/x-ndjson",
+    diff: "text/x-diff",
+    patch: "text/x-diff",
+    html: "text/html",
+    mp4: "video/mp4",
+    mov: "video/quicktime",
+    zip: "application/zip",
+};
+
+export function mimeForFilename(filename: string): string {
+    const ext = extname(filename).replace(/^\./, "").toLowerCase();
+    return MIME_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+export function attachmentsRoot(base?: string): string {
+    return join(handoffLogDir(base), "attachments");
+}
+
+/**
+ * §6.3 layout: attachments/<handoffId>/<attachmentId>.<ext>. The ext comes from
+ * the stored filename, so the path is derivable from the attach event alone
+ * (fold + routes never scan the directory).
+ */
+export function attachmentFilePath(handoffId: string, attachmentId: string, filename: string, base?: string): string {
+    const ext = extname(filename).replace(/^\./, "").toLowerCase() || "bin";
+    return join(attachmentsRoot(base), handoffId, `${attachmentId}.${ext}`);
+}
+
+export interface IngestedAttachment {
+    attachmentId: string;
+    filename: string;
+    mime: string;
+    bytes: number;
+}
+
+/** MCP attach_file path: copy a local file into the store (immutable once written). */
+export function ingestAttachmentFromPath(handoffId: string, sourcePath: string, base?: string): IngestedAttachment {
+    if (!existsSync(sourcePath)) {
+        throw new Error(`attach_file: no file at "${sourcePath}" — pass an absolute path on this machine.`);
+    }
+
+    const stats = statSync(sourcePath);
+
+    if (!stats.isFile()) {
+        throw new Error(`attach_file: "${sourcePath}" is not a regular file.`);
+    }
+
+    if (stats.size > MAX_ATTACHMENT_BYTES) {
+        throw new Error(
+            `attach_file: "${sourcePath}" is ${stats.size} bytes — the cap is ${MAX_ATTACHMENT_BYTES} (10 MB).`
+        );
+    }
+
+    const attachmentId = generateAttachmentId();
+    const filename = basename(sourcePath);
+    const dest = attachmentFilePath(handoffId, attachmentId, filename, base);
+    mkdirSync(join(attachmentsRoot(base), handoffId), { recursive: true });
+    copyFileSync(sourcePath, dest);
+    log.info({ handoffId, attachmentId, filename, bytes: stats.size, dest }, "attachment ingested from path");
+
+    return { attachmentId, filename, mime: mimeForFilename(filename), bytes: stats.size };
+}
+
+/** Dashboard upload path: write pasted/dropped bytes into the store. */
+export function ingestAttachmentBytes(
+    handoffId: string,
+    filename: string,
+    bytes: Uint8Array,
+    base?: string
+): IngestedAttachment {
+    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+        throw new Error(`attachment is ${bytes.byteLength} bytes — the cap is ${MAX_ATTACHMENT_BYTES} (10 MB).`);
+    }
+
+    const attachmentId = generateAttachmentId();
+    const safeName = basename(filename.trim() || "pasted.bin");
+    const dest = attachmentFilePath(handoffId, attachmentId, safeName, base);
+    mkdirSync(join(attachmentsRoot(base), handoffId), { recursive: true });
+    writeFileSync(dest, bytes);
+    log.info(
+        { handoffId, attachmentId, filename: safeName, bytes: bytes.byteLength, dest },
+        "attachment ingested from bytes"
+    );
+
+    return { attachmentId, filename: safeName, mime: mimeForFilename(safeName), bytes: bytes.byteLength };
+}

--- a/src/handoff/executor.test.ts
+++ b/src/handoff/executor.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DASHBOARD_ACTOR, executeHandoffActions, getHandoff, listHandoffs, postHandoff } from "./executor";
+import { byFor, freshEnv } from "./test-utils";
+
+const A = byFor("session-a", "poster-a");
+const B = byFor("session-b", "worker-b");
+const C = byFor("session-c", "gt-worker");
+const NULL1 = byFor(null, "headless-1");
+const NULL2 = byFor(null, "headless-2");
+
+describe("handoff_post (§8.1)", () => {
+    test("posts with auto ids, paste block, editId; own-session edit without editId", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            {
+                title: "Fix e2e Active-filter semantics",
+                tasks: [{ text: "task one" }, { text: "task two", acceptanceCriteria: "e2e green" }],
+                target: { sessionName: "gt-worker" },
+            },
+            env.depsFor(A)
+        );
+
+        expect(res.handoff.tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
+        expect(res.editId.startsWith("he_")).toBe(true);
+        expect(res.paste.id).toBe(res.handoff.id);
+        expect(res.paste._agent).toContain(res.handoff.id);
+        expect(res.paste.tasks).toBe("0/2");
+        expect(res.info.length).toBeGreaterThan(0);
+
+        // Own-session poster verb WITHOUT editId.
+        const edit = executeHandoffActions(
+            { id: res.handoff.id, actions: [{ action: "add_tasks", tasks: [{ text: "task three" }] }] },
+            env.depsFor(A)
+        );
+        expect(edit.results[0].ok).toBe(true);
+        expect(edit.results[0].assignedTaskIds).toEqual(["t3"]);
+        expect(edit.handoff.tasks).toHaveLength(3);
+    });
+
+    test("rejects empty input with copy-pasteable example", () => {
+        const env = freshEnv();
+        expect(() => postHandoff({ title: "", tasks: [] }, env.depsFor(A))).toThrow(/handoff_post needs title/);
+    });
+});
+
+describe("claims (§8.2, §8.3)", () => {
+    function posted(env: ReturnType<typeof freshEnv>) {
+        return postHandoff(
+            {
+                title: "T",
+                tasks: [{ text: "one" }, { text: "two" }],
+                target: { sessionId: "session-c", sessionName: "gt-worker" },
+            },
+            env.depsFor(A)
+        );
+    }
+
+    test("explicit claim recorded via explicit; unclaimed get says NOT claimed", () => {
+        const env = freshEnv();
+        const { handoff } = posted(env);
+
+        const readB = getHandoff({ id: handoff.id }, env.depsFor(B));
+        expect(readB.info.join(" ")).toContain("NOT claimed");
+        expect(readB.editId).toBeUndefined();
+
+        const claimed = getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+        expect(claimed.handoff.claimedBy).toHaveLength(1);
+        expect(claimed.handoff.claimedBy[0].via).toBe("explicit");
+        expect(claimed.handoff.status).toBe("claimed");
+    });
+
+    test("target sessionId auto-claims via target-match; co-owning traced individually", () => {
+        const env = freshEnv();
+        const { handoff } = posted(env);
+        getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+
+        const readC = getHandoff({ id: handoff.id }, env.depsFor(C));
+        expect(readC.info.join(" ")).toContain("Auto-claimed");
+        expect(readC.handoff.claimedBy).toHaveLength(2);
+        const viaBySession = Object.fromEntries(readC.handoff.claimedBy.map((c) => [c.sessionId, c.via]));
+        expect(viaBySession["session-b"]).toBe("explicit");
+        expect(viaBySession["session-c"]).toBe("target-match");
+    });
+
+    test("repeat claim dedupes with info; unclaim removes only caller; last unclaim → open", () => {
+        const env = freshEnv();
+        const { handoff } = posted(env);
+        getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+        const again = getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+        expect(again.info.join(" ")).toContain("Already claimed by you");
+        expect(again.handoff.claimedBy).toHaveLength(1);
+
+        const noopUnclaim = getHandoff({ id: handoff.id, unclaim: true }, env.depsFor(A));
+        expect(noopUnclaim.info.join(" ")).toContain("nothing to unclaim");
+
+        const released = getHandoff({ id: handoff.id, unclaim: true }, env.depsFor(B));
+        expect(released.handoff.claimedBy).toHaveLength(0);
+        expect(released.handoff.status).toBe("open");
+    });
+
+    test("claim+unclaim together rejected; sessionName target only nudges", () => {
+        const env = freshEnv();
+        const { handoff } = posted(env);
+        expect(() => getHandoff({ id: handoff.id, claim: true, unclaim: true }, env.depsFor(B))).toThrow(/not both/);
+
+        const nameMatch = getHandoff({ id: handoff.id }, env.depsFor(byFor("session-x", "gt-worker")));
+        expect(nameMatch.handoff.claimedBy).toHaveLength(0);
+        expect(nameMatch.info.join(" ")).toContain("names aren't unique");
+    });
+});
+
+describe("work loop (§8.4, §8.5)", () => {
+    test("check with proof → progress; deny sans reason rejected with example; finish; reopen; undeny", () => {
+        const env = freshEnv();
+        const { handoff } = postHandoff({ title: "T", tasks: [{ text: "one" }, { text: "two" }] }, env.depsFor(A));
+        getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+
+        const check = executeHandoffActions(
+            {
+                id: handoff.id,
+                actions: [
+                    {
+                        action: "check_task",
+                        taskId: "t1",
+                        proof: { answer: "done, tests green", commitIds: ["abc1234"] },
+                    },
+                ],
+            },
+            env.depsFor(B)
+        );
+        expect(check.results[0].ok).toBe(true);
+        expect(check.handoff.tasks[0].checked).toBe(true);
+        expect(check.handoff.tasks[0].proof?.commitIds).toEqual(["abc1234"]);
+
+        const list = listHandoffs({}, env.depsFor(A));
+        expect(list.handoffs[0].tasks).toBe("1/2");
+
+        const badDeny = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "deny_task", taskId: "t2" }] },
+            env.depsFor(B)
+        );
+        expect(badDeny.results[0].ok).toBe(false);
+        expect(badDeny.results[0].error).toContain('reason: "out of scope');
+
+        const deny = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "deny_task", taskId: "t2", reason: "cannot repro" }] },
+            env.depsFor(B)
+        );
+        expect(deny.results[0].ok).toBe(true);
+        expect(deny.handoff.tasks[1].denied).toBe(true);
+        expect(deny.info.join(" ")).toContain("finish_handoff");
+
+        const finish = executeHandoffActions({ id: handoff.id, actions: ["finish_handoff"] }, env.depsFor(B));
+        expect(finish.results[0].ok).toBe(true);
+        expect(finish.handoff.status).toBe("done");
+        expect(finish.handoff.finishedTs).toBeDefined();
+
+        const reopen = executeHandoffActions({ id: handoff.id, actions: ["reopen_handoff"] }, env.depsFor(A));
+        expect(reopen.results[0].ok).toBe(true);
+        expect(reopen.handoff.status).toBe("claimed");
+        expect(reopen.handoff.tasks[0].checked).toBe(true);
+
+        const undeny = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "undeny_task", taskId: "t2" }] },
+            env.depsFor(B)
+        );
+        expect(undeny.results[0].ok).toBe(true);
+        expect(undeny.handoff.tasks[1].denied).toBe(false);
+        expect(undeny.handoff.tasks[1].deniedReason).toBeUndefined();
+    });
+
+    test("finish gate lists unresolved ids; force overrides", () => {
+        const env = freshEnv();
+        const { handoff } = postHandoff({ title: "T", tasks: [{ text: "one" }, { text: "two" }] }, env.depsFor(A));
+        getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+
+        const gated = executeHandoffActions({ id: handoff.id, actions: ["finish_handoff"] }, env.depsFor(B));
+        expect(gated.results[0].ok).toBe(false);
+        expect(gated.results[0].error).toContain("t1, t2");
+
+        const forced = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "finish_handoff", force: true }] },
+            env.depsFor(B)
+        );
+        expect(forced.results[0].ok).toBe(true);
+        expect(forced.handoff.status).toBe("done");
+    });
+});
+
+describe("edit safety (§8.6)", () => {
+    test("modify_task protected fields ignored + named; deny checked needs force; cancel informs claimers", () => {
+        const env = freshEnv();
+        const { handoff } = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+        executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "check_task", taskId: "t1", proof: { answer: "ok" } }] },
+            env.depsFor(B)
+        );
+
+        const modify = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "modify_task", taskId: "t1", text: "renamed", checked: false }] },
+            env.depsFor(A)
+        );
+        expect(modify.results[0].ok).toBe(true);
+        expect(modify.results[0].info?.join(" ")).toContain("Protected field ignored: checked");
+        expect(modify.handoff.tasks[0].text).toBe("renamed");
+        expect(modify.handoff.tasks[0].checked).toBe(true);
+
+        const denyChecked = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "deny_task", taskId: "t1", reason: "nope" }] },
+            env.depsFor(B)
+        );
+        expect(denyChecked.results[0].ok).toBe(false);
+        expect(denyChecked.results[0].error).toContain("force: true");
+
+        const forceDeny = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "deny_task", taskId: "t1", reason: "nope", force: true }] },
+            env.depsFor(B)
+        );
+        expect(forceDeny.results[0].ok).toBe(true);
+        expect(forceDeny.handoff.tasks[0].proof?.answer).toBe("ok");
+
+        const cancel = executeHandoffActions({ id: handoff.id, actions: ["cancel_handoff"] }, env.depsFor(A));
+        expect(cancel.results[0].ok).toBe(true);
+
+        const bNext = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "comment", text: "hi" }] },
+            env.depsFor(B)
+        );
+        expect(bNext.results[0].ok).toBe(false);
+        expect(bNext.results[0].error).toContain("Cancelled by the poster");
+        expect(bNext.info.join(" ")).toContain("stop work");
+    });
+});
+
+describe("aliases + catalogs (§8.7)", () => {
+    test("done alias finishes; close → verb catalog; unknown taskId → task catalog; unknown id → list hint", () => {
+        const env = freshEnv();
+        const { handoff } = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        getHandoff({ id: handoff.id, claim: true }, env.depsFor(B));
+        executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "check", taskId: "t1", proof: { answer: "ok" } }] },
+            env.depsFor(B)
+        );
+
+        const done = executeHandoffActions({ id: handoff.id, actions: ["done"] }, env.depsFor(B));
+        expect(done.results[0].action).toBe("finish_handoff");
+        expect(done.results[0].ok).toBe(true);
+
+        const close = executeHandoffActions({ id: handoff.id, actions: ["close"] }, env.depsFor(B));
+        expect(close.results[0].ok).toBe(false);
+        expect(close.results[0].error).toContain("Valid actions:");
+        expect(close.results[0].error).toContain("reopen_handoff");
+
+        const reopen = executeHandoffActions({ id: handoff.id, actions: ["reopen_handoff"] }, env.depsFor(A));
+        expect(reopen.results[0].ok).toBe(true);
+
+        const badTask = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "check_task", taskId: "t9", proof: { answer: "x" } }] },
+            env.depsFor(B)
+        );
+        expect(badTask.results[0].ok).toBe(false);
+        expect(badTask.results[0].error).toContain("t1");
+
+        expect(() => getHandoff({ id: "zzz" }, env.depsFor(B))).toThrow(/handoff_list/);
+    });
+
+    test("id tolerance: h_ prefix optional, whitespace trimmed", () => {
+        const env = freshEnv();
+        const { handoff } = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const bare = handoff.id.replace(/^h_/, "");
+        const res = getHandoff({ id: `  ${bare} ` }, env.depsFor(B));
+        expect(res.handoff.id).toBe(handoff.id);
+    });
+});
+
+describe("null sessions (§8.8) + editId", () => {
+    test("null never matches null; editId is the only credential for id-less sessions", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(NULL1));
+
+        const denied = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "modify_handoff", title: "hijacked" }] },
+            env.depsFor(NULL2)
+        );
+        expect(denied.results[0].ok).toBe(false);
+        expect(denied.results[0].error).toContain("editId");
+
+        const allowed = executeHandoffActions(
+            { id: posted.handoff.id, editId: posted.editId, actions: [{ action: "modify_handoff", title: "renamed" }] },
+            env.depsFor(NULL2)
+        );
+        expect(allowed.results[0].ok).toBe(true);
+        expect(allowed.handoff.title).toBe("renamed");
+    });
+
+    test("null session cannot claim; editId never leaks to non-posters", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+
+        const claim = getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(NULL1));
+        expect(claim.handoff.claimedBy).toHaveLength(0);
+        expect(claim.info.join(" ")).toContain("cannot claim");
+        expect(claim.editId).toBeUndefined();
+
+        const posterRead = getHandoff({ id: posted.handoff.id }, env.depsFor(A));
+        expect(posterRead.editId).toBe(posted.editId);
+    });
+});
+
+describe("fold-after-append truthfulness (§8.9c)", () => {
+    test("claim+check batch reflects a cancel that landed first", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        executeHandoffActions({ id: posted.handoff.id, actions: ["cancel_handoff"] }, env.depsFor(A));
+
+        const b = executeHandoffActions(
+            {
+                id: posted.handoff.id,
+                actions: ["claim", { action: "check_task", taskId: "t1", proof: { answer: "x" } }],
+            },
+            env.depsFor(B)
+        );
+        expect(b.results[0].ok).toBe(false);
+        expect(b.results[1].ok).toBe(false);
+        expect(b.handoff.status).toBe("cancelled");
+    });
+
+    test("claim earlier in the same actions array counts for later verbs", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const b = executeHandoffActions(
+            {
+                id: posted.handoff.id,
+                actions: ["claim", { action: "check_task", taskId: "t1", proof: { answer: "x" } }, "finish_handoff"],
+            },
+            env.depsFor(B)
+        );
+        expect(b.results.map((r) => r.ok)).toEqual([true, true, true]);
+        expect(b.handoff.status).toBe("done");
+    });
+
+    test("unclaimed session using a claimer verb gets claim-first guidance", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const b = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "check_task", taskId: "t1", proof: { answer: "x" } }] },
+            env.depsFor(B)
+        );
+        expect(b.results[0].ok).toBe(false);
+        expect(b.results[0].error).toContain("claim first");
+    });
+});
+
+describe("handoff_list (§8.12)", () => {
+    test("mine includes targeted-but-never-claimed; open filters; paging info", () => {
+        const env = freshEnv();
+        postHandoff({ title: "other", tasks: [{ text: "x" }] }, env.depsFor(A));
+        const targeted = postHandoff(
+            { title: "for-c", tasks: [{ text: "x" }], target: { sessionId: "session-c" } },
+            env.depsFor(A)
+        );
+
+        const mineC = listHandoffs({ mine: true }, env.depsFor(C));
+        expect(mineC.handoffs.map((h) => h.id)).toEqual([targeted.handoff.id]);
+
+        const done = postHandoff({ title: "done-one", tasks: [{ text: "x" }] }, env.depsFor(A));
+        executeHandoffActions(
+            {
+                id: done.handoff.id,
+                actions: ["claim", { action: "check_task", taskId: "t1", proof: { answer: "y" } }, "done"],
+            },
+            env.depsFor(B)
+        );
+
+        const open = listHandoffs({ open: true }, env.depsFor(A));
+        expect(open.handoffs.every((h) => h.status === "open" || h.status === "claimed")).toBe(true);
+        expect(open.handoffs.some((h) => h.id === done.handoff.id)).toBe(false);
+    });
+});
+
+describe("reopen paths (§8.13)", () => {
+    test("finisher reopens own finish; a different claimer cannot; poster reopens cancelled", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(C));
+        executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "finish_handoff", force: true }] },
+            env.depsFor(B)
+        );
+
+        const cReopen = executeHandoffActions({ id: posted.handoff.id, actions: ["reopen_handoff"] }, env.depsFor(C));
+        expect(cReopen.results[0].ok).toBe(false);
+        expect(cReopen.results[0].error).toContain("whose own finish");
+
+        const bReopen = executeHandoffActions({ id: posted.handoff.id, actions: ["reopen_handoff"] }, env.depsFor(B));
+        expect(bReopen.results[0].ok).toBe(true);
+        expect(bReopen.handoff.status).toBe("claimed");
+
+        executeHandoffActions({ id: posted.handoff.id, actions: ["cancel_handoff"] }, env.depsFor(A));
+        const posterReopen = executeHandoffActions(
+            { id: posted.handoff.id, actions: ["reopen_handoff"] },
+            env.depsFor(A)
+        );
+        expect(posterReopen.results[0].ok).toBe(true);
+        expect(posterReopen.handoff.status).toBe("claimed");
+    });
+});
+
+describe("attachments + comments (§8.16b/16c agent side)", () => {
+    test("attach_file ingests; comment screenshots sugar; proof screenshots sugar; cap enforced", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+
+        const shot = join(env.base, "..", "shot.png");
+        writeFileSync(shot, new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3]));
+
+        const attach = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "attach_file", path: shot, taskId: "t1", note: "before" }] },
+            env.depsFor(B)
+        );
+        expect(attach.results[0].ok).toBe(true);
+        expect(attach.results[0].attachmentId).toBeDefined();
+        expect(attach.handoff.attachments).toHaveLength(1);
+        expect(attach.handoff.attachments[0].taskId).toBe("t1");
+        expect(attach.handoff.attachments[0].missing).toBeUndefined();
+        expect(attach.handoff.attachments[0].path).toBeDefined();
+
+        const comment = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "comment", text: "see shot", screenshots: [shot] }] },
+            env.depsFor(B)
+        );
+        expect(comment.results[0].ok).toBe(true);
+        expect(comment.handoff.comments[0].attachmentIds).toHaveLength(1);
+        expect(comment.handoff.attachments).toHaveLength(2);
+
+        const check = executeHandoffActions(
+            {
+                id: posted.handoff.id,
+                actions: [{ action: "check_task", taskId: "t1", proof: { answer: "done", screenshots: [shot] } }],
+            },
+            env.depsFor(B)
+        );
+        expect(check.results[0].ok).toBe(true);
+        expect(check.handoff.tasks[0].proof?.attachmentIds).toHaveLength(1);
+
+        const big = join(env.base, "..", "big.bin");
+        writeFileSync(big, new Uint8Array(10 * 1024 * 1024 + 1));
+        const over = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "attach_file", path: big }] },
+            env.depsFor(B)
+        );
+        expect(over.results[0].ok).toBe(false);
+        expect(over.results[0].error).toContain("10 MB");
+    });
+});
+
+describe("dashboard owner authority (§7.1)", () => {
+    test("human actor bypasses claim + poster credentials; stamped via dashboard", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+
+        const human = executeHandoffActions(
+            {
+                id: posted.handoff.id,
+                actions: [
+                    { action: "check_task", taskId: "t1", proof: { answer: "Verified manually via dashboard" } },
+                    { action: "add_tasks", tasks: [{ text: "follow-up" }] },
+                    { action: "comment", text: "looks good" },
+                ],
+            },
+            env.depsFor(DASHBOARD_ACTOR)
+        );
+        expect(human.results.map((r) => r.ok)).toEqual([true, true, true]);
+        expect(human.handoff.tasks[0].checkedBy?.agent).toBe("human");
+        expect(human.handoff.tasks[0].checkedBy?.via).toBe("dashboard");
+        expect(human.handoff.comments[0].by.agent).toBe("human");
+
+        // Human actor is NOT a session identity: it never becomes poster session.
+        const humanRead = getHandoff({ id: posted.handoff.id }, env.depsFor(DASHBOARD_ACTOR));
+        expect(humanRead.editId).toBe(posted.editId);
+    });
+});
+
+describe("actions[] item shape errors", () => {
+    test("malformed item gets the item-shape gloss; empty actions throws", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+
+        const bad = executeHandoffActions(
+            { id: posted.handoff.id, actions: [42 as unknown as string] },
+            env.depsFor(A)
+        );
+        expect(bad.results[0].ok).toBe(false);
+        expect(bad.results[0].error).toContain('{ action: "<verb>"');
+
+        expect(() => executeHandoffActions({ id: posted.handoff.id, actions: [] }, env.depsFor(A))).toThrow(
+            /actions array/
+        );
+    });
+});

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -1,8 +1,9 @@
 import type { Database } from "bun:sqlite";
 import type { AgentRuntimeContext } from "@genesiscz/utils/agent-runtime";
 import { getAgentRuntimeContext } from "@genesiscz/utils/agent-runtime";
+import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
-import { attachmentFilePath, ingestAttachmentFromPath } from "./attachments";
+import { attachmentFilePath, ingestAttachmentBytes, ingestAttachmentFromPath } from "./attachments";
 import { CANCELLED_INFO, DONE_INFO, isHumanOwner, sessionIdMatches } from "./fold";
 import { generateEditId, generateEventUid, generateHandoffId, normalizeEditId, normalizeHandoffId } from "./ids";
 import { appendHandoffEvents } from "./log-store";
@@ -1004,4 +1005,108 @@ function parseAction(
         default:
             return shapeFail(index, verb, `Unknown action "${requested}". ${VERB_CATALOG}`);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard helpers (routes share this executor — §7.2)
+// ---------------------------------------------------------------------------
+
+export interface AttachBytesInput {
+    id: string;
+    filename: string;
+    bytes: Uint8Array;
+    taskId?: string;
+    note?: string;
+}
+
+export interface AttachBytesResponse {
+    attachmentId: string;
+    handoff: PublicHandoff;
+    info: string[];
+}
+
+/** The dashboard /attach route: pasted/dropped bytes → store + attach event. */
+export function attachHandoffBytes(input: AttachBytesInput, deps: HandoffDeps = {}): AttachBytesResponse {
+    const id = normalizeHandoffId(String(input.id ?? ""));
+    const by = buildBy(deps);
+
+    return withDb(deps, (db) => {
+        catchUpHandoffs(db, deps.base);
+        const existing = getHandoffById(db, id);
+
+        if (existing === null) {
+            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
+        }
+
+        const ingested = ingestAttachmentBytes(id, input.filename, input.bytes, deps.base);
+        const event: HandoffEvent = {
+            ev: "attach",
+            ts: nowIso(deps),
+            uid: generateEventUid(),
+            id,
+            by,
+            attachmentId: ingested.attachmentId,
+            filename: ingested.filename,
+            mime: ingested.mime,
+            bytes: ingested.bytes,
+            ...(input.taskId !== undefined && input.taskId.length > 0 ? { taskId: input.taskId } : {}),
+            ...(input.note !== undefined && input.note.length > 0 ? { note: input.note } : {}),
+        };
+        appendHandoffEvents([event], deps.base);
+        catchUpHandoffs(db, deps.base);
+        const outcome = getEventOutcome(db, event.uid);
+
+        if (outcome !== null && !outcome.applied) {
+            throw new Error(outcome.error ?? "attach rejected by fold");
+        }
+
+        const handoff = getHandoffById(db, id);
+
+        if (handoff === null) {
+            throw new Error(`No handoff ${id} after fold — check ~/.genesis-tools/logs for details.`);
+        }
+
+        return {
+            attachmentId: ingested.attachmentId,
+            handoff: publicHandoff(handoff, deps.base),
+            info: stateInfo(handoff, by),
+        };
+    });
+}
+
+export interface ResolvedAttachment {
+    handoffId: string;
+    attachmentId: string;
+    filename: string;
+    mime: string;
+    path: string;
+    missing: boolean;
+}
+
+/** Locate an attachment by id across handoffs (dashboard /attachment route). */
+export function resolveAttachment(attachmentId: string, deps: HandoffDeps = {}): ResolvedAttachment | null {
+    return withDb(deps, (db) => {
+        catchUpHandoffs(db, deps.base);
+        const rows = db
+            .query("SELECT id, attachments FROM handoffs WHERE attachments LIKE ?")
+            .all(`%${attachmentId}%`) as { id: string; attachments: string }[];
+
+        for (const row of rows) {
+            const attachments = SafeJSON.parse(row.attachments, { strict: true }) as Handoff["attachments"];
+            const found = attachments.find((a) => a.attachmentId === attachmentId);
+
+            if (found !== undefined) {
+                return {
+                    handoffId: row.id,
+                    attachmentId,
+                    filename: found.filename,
+                    mime: found.mime,
+                    path: attachmentFilePath(row.id, attachmentId, found.filename, deps.base),
+                    missing: found.missing === true,
+                };
+            }
+        }
+
+        return null;
+    });
 }

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -1092,7 +1092,13 @@ export function resolveAttachment(attachmentId: string, deps: HandoffDeps = {}):
             .all(`%${attachmentId}%`) as { id: string; attachments: string }[];
 
         for (const row of rows) {
-            const attachments = SafeJSON.parse(row.attachments, { strict: true }) as Handoff["attachments"];
+            let attachments: Handoff["attachments"];
+            try {
+                attachments = SafeJSON.parse(row.attachments, { strict: true }) as Handoff["attachments"];
+            } catch (err) {
+                log.warn({ err, handoffId: row.id }, "handoff.attachments column is not valid JSON — skipping");
+                continue;
+            }
 
             if (!Array.isArray(attachments)) {
                 log.warn({ handoffId: row.id }, "handoff.attachments column is not an array — skipping");

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -1105,9 +1105,16 @@ export function resolveAttachment(attachmentId: string, deps: HandoffDeps = {}):
                 continue;
             }
 
-            const found = attachments.find((a) => a.attachmentId === attachmentId);
+            const found = attachments.find(
+                (a) => a !== null && typeof a === "object" && a.attachmentId === attachmentId
+            );
 
             if (found !== undefined) {
+                if (typeof found.filename !== "string" || typeof found.mime !== "string") {
+                    log.warn({ handoffId: row.id, attachmentId }, "attachment entry missing string filename/mime — skipping");
+                    continue;
+                }
+
                 return {
                     handoffId: row.id,
                     attachmentId,

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -1093,6 +1093,12 @@ export function resolveAttachment(attachmentId: string, deps: HandoffDeps = {}):
 
         for (const row of rows) {
             const attachments = SafeJSON.parse(row.attachments, { strict: true }) as Handoff["attachments"];
+
+            if (!Array.isArray(attachments)) {
+                log.warn({ handoffId: row.id }, "handoff.attachments column is not an array — skipping");
+                continue;
+            }
+
             const found = attachments.find((a) => a.attachmentId === attachmentId);
 
             if (found !== undefined) {

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -1,0 +1,1007 @@
+import type { Database } from "bun:sqlite";
+import type { AgentRuntimeContext } from "@genesiscz/utils/agent-runtime";
+import { getAgentRuntimeContext } from "@genesiscz/utils/agent-runtime";
+import { logger } from "@genesiscz/utils/logger";
+import { attachmentFilePath, ingestAttachmentFromPath } from "./attachments";
+import { CANCELLED_INFO, DONE_INFO, isHumanOwner, sessionIdMatches } from "./fold";
+import { generateEditId, generateEventUid, generateHandoffId, normalizeEditId, normalizeHandoffId } from "./ids";
+import { appendHandoffEvents } from "./log-store";
+import { catchUpHandoffs, getEventOutcome, getHandoffById, listHandoffRows, openHandoffModel } from "./read-model";
+import type {
+    Handoff,
+    HandoffActionInput,
+    HandoffActionResult,
+    HandoffEvent,
+    HandoffEventBy,
+    HandoffListRow,
+    HandoffProof,
+    HandoffTarget,
+    HandoffTaskInput,
+} from "./types";
+
+const log = logger.child({ component: "handoff:executor" });
+
+export interface HandoffDeps {
+    /** Log + attachment store base dir override (tests). */
+    base?: string;
+    /** qa.db path override (tests). */
+    dbPath?: string;
+    /** AgentRuntimeContext overrides (tests / explicit session). */
+    ctx?: Partial<AgentRuntimeContext>;
+    /** Full actor override — the dashboard's owner-authority human actor (§7.1). */
+    by?: HandoffEventBy;
+    nowIso?: () => string;
+}
+
+export const DASHBOARD_ACTOR: HandoffEventBy = {
+    sessionId: null,
+    sessionTitle: "dev-dashboard",
+    agent: "human",
+    aiAgent: null,
+    branch: null,
+    cwd: null,
+    repoRoot: null,
+    project: null,
+    commitSha: null,
+    isWorktree: false,
+    via: "dashboard",
+};
+
+function buildBy(deps: HandoffDeps): HandoffEventBy {
+    if (deps.by !== undefined) {
+        return deps.by;
+    }
+
+    const ctx = getAgentRuntimeContext(deps.ctx ?? {});
+    return {
+        sessionId: ctx.sessionId,
+        sessionTitle: ctx.sessionTitle,
+        agent: ctx.agent,
+        aiAgent: ctx.aiAgent,
+        branch: ctx.branch,
+        cwd: ctx.cwd,
+        repoRoot: ctx.repoRoot,
+        project: ctx.project,
+        commitSha: ctx.commitSha,
+        isWorktree: ctx.isWorktree,
+    };
+}
+
+function withDb<T>(deps: HandoffDeps, fn: (db: Database) => T): T {
+    const db = openHandoffModel(deps.dbPath);
+
+    try {
+        return fn(db);
+    } finally {
+        db.close();
+    }
+}
+
+function nowIso(deps: HandoffDeps): string {
+    return deps.nowIso !== undefined ? deps.nowIso() : new Date().toISOString();
+}
+
+/** The response-facing handoff: editId stripped (returned separately, only when entitled). */
+export type PublicHandoff = Omit<Handoff, "editId"> & {
+    attachments: (Handoff["attachments"][number] & { path?: string })[];
+};
+
+function publicHandoff(h: Handoff, base?: string): PublicHandoff {
+    const { editId: _editId, ...rest } = h;
+    return {
+        ...rest,
+        attachments: h.attachments.map((a) =>
+            a.missing === true ? { ...a } : { ...a, path: attachmentFilePath(h.id, a.attachmentId, a.filename, base) }
+        ),
+    };
+}
+
+function isClaimedBy(h: Handoff, by: HandoffEventBy): boolean {
+    return h.claimedBy.some((c) => sessionIdMatches(c.sessionId, by.sessionId));
+}
+
+function isPosterSession(h: Handoff, by: HandoffEventBy): boolean {
+    return sessionIdMatches(h.postedBy.sessionId, by.sessionId);
+}
+
+function progress(h: Handoff): { resolved: number; total: number; denied: number } {
+    const denied = h.tasks.filter((t) => t.denied).length;
+    const resolved = h.tasks.filter((t) => t.checked || t.denied).length;
+    return { resolved, total: h.tasks.length, denied };
+}
+
+function claimantNames(h: Handoff, excludeBy?: HandoffEventBy): string[] {
+    return h.claimedBy
+        .filter((c) => excludeBy === undefined || !sessionIdMatches(c.sessionId, excludeBy.sessionId))
+        .map((c) => c.sessionName ?? c.sessionId ?? "unnamed session");
+}
+
+/** State-aware info lines (§5) — every response gets ≥1 line ending in the ONE next step. */
+function stateInfo(h: Handoff, by: HandoffEventBy): string[] {
+    const lines: string[] = [];
+
+    if (h.status === "done") {
+        lines.push(DONE_INFO);
+        return lines;
+    }
+
+    if (h.status === "cancelled") {
+        lines.push(CANCELLED_INFO);
+        return lines;
+    }
+
+    const mine = isClaimedBy(h, by);
+
+    if (h.claimedBy.length === 0) {
+        lines.push(
+            `NOT claimed — claim it with handoff_get { id: "${h.id}", claim: true } (or include { action: "claim" } first in handoff_action) before working.`
+        );
+
+        if (
+            h.target?.sessionName != null &&
+            by.sessionTitle != null &&
+            h.target.sessionName === by.sessionTitle &&
+            !mine
+        ) {
+            lines.push(
+                `This handoff targets sessionName "${h.target.sessionName}" — that matches this session's name, but names aren't unique so it never auto-claims; claim explicitly.`
+            );
+        }
+    } else if (mine) {
+        const others = claimantNames(h, by);
+        lines.push(others.length === 0 ? "Claimed by you." : `Claimed by you and ${others.join(", ")} (co-owned).`);
+    } else {
+        lines.push(`Claimed by ${claimantNames(h).join(", ")} — claiming too will co-own it.`);
+    }
+
+    const p = progress(h);
+
+    if (p.total > 0 && p.resolved === p.total) {
+        lines.push('All tasks resolved — call handoff_action { actions: ["finish_handoff"] }.');
+    }
+
+    return lines;
+}
+
+function pasteAgentText(id: string): string {
+    return (
+        `You have been handed a task list. Call the genesis-tools MCP tool handoff_get with { id: "${id}" } to read it, ` +
+        `then claim it by calling handoff_get again with { id: "${id}", claim: true } before working. ` +
+        'Check each finished task off with handoff_action { id, actions: [{ action: "check_task", taskId, proof: { answer, commitIds } }] }. ' +
+        'To refuse a task you can\'t do, send { action: "deny_task", taskId, reason }. ' +
+        'When every task is checked or denied, send { action: "finish_handoff" }. ' +
+        "If the id doesn't resolve, call handoff_list to find it. " +
+        "If you don't have the genesis-tools MCP tools, tell your user to enable the genesis-tools MCP server."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// handoff_post
+// ---------------------------------------------------------------------------
+
+export interface PostHandoffInput {
+    title: string;
+    description?: string;
+    tasks: HandoffTaskInput[];
+    target?: HandoffTarget;
+    refs?: string[];
+}
+
+export interface PostHandoffResponse {
+    handoff: PublicHandoff;
+    editId: string;
+    paste: { _agent: string; id: string; title: string; tasks: string };
+    info: string[];
+}
+
+export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): PostHandoffResponse {
+    const title = typeof input.title === "string" ? input.title.trim() : "";
+    const tasks = Array.isArray(input.tasks) ? input.tasks : [];
+
+    if (
+        title.length === 0 ||
+        tasks.length === 0 ||
+        tasks.some((t) => typeof t.text !== "string" || t.text.trim().length === 0)
+    ) {
+        throw new Error(
+            'handoff_post needs title and ≥1 task with text — e.g. { title: "Fix e2e Active-filter semantics", tasks: [{ text: "Make the Active filter exclude archived rows", acceptanceCriteria: "e2e filters.spec green" }] }.'
+        );
+    }
+
+    const by = buildBy(deps);
+    const event: HandoffEvent = {
+        ev: "post",
+        ts: nowIso(deps),
+        uid: generateEventUid(),
+        id: generateHandoffId(),
+        editId: generateEditId(),
+        title,
+        tasks,
+        by,
+    };
+
+    if (input.description !== undefined && input.description.trim().length > 0) {
+        event.description = input.description;
+    }
+
+    if (
+        input.target !== undefined &&
+        (input.target.sessionId !== undefined || input.target.sessionName !== undefined)
+    ) {
+        event.target = input.target;
+    }
+
+    if (input.refs !== undefined && input.refs.length > 0) {
+        event.refs = input.refs;
+    }
+
+    appendHandoffEvents([event], deps.base);
+
+    return withDb(deps, (db) => {
+        catchUpHandoffs(db, deps.base);
+        const handoff = getHandoffById(db, event.id);
+
+        if (handoff === null) {
+            throw new Error(`handoff_post failed to fold ${event.id} — check ~/.genesis-tools/logs for details.`);
+        }
+
+        log.info({ id: handoff.id, tasks: handoff.tasks.length, by: by.sessionId }, "handoff posted");
+
+        return {
+            handoff: publicHandoff(handoff, deps.base),
+            editId: event.editId,
+            paste: {
+                _agent: pasteAgentText(handoff.id),
+                id: handoff.id,
+                title: handoff.title,
+                tasks: `0/${handoff.tasks.length}`,
+            },
+            info: [
+                "Posted. Copy `paste` into the target agent's chat.",
+                "You can edit from this session anytime via handoff_action (no editId needed).",
+            ],
+        };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// handoff_get
+// ---------------------------------------------------------------------------
+
+export interface GetHandoffInput {
+    id: string;
+    claim?: boolean;
+    unclaim?: boolean;
+}
+
+export interface GetHandoffResponse {
+    handoff: PublicHandoff;
+    editId?: string;
+    info: string[];
+}
+
+export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetHandoffResponse {
+    if (input.claim === true && input.unclaim === true) {
+        throw new Error(
+            `Pass either claim: true or unclaim: true, not both — e.g. handoff_get { id: "${input.id}", claim: true }.`
+        );
+    }
+
+    const id = normalizeHandoffId(String(input.id ?? ""));
+    const by = buildBy(deps);
+
+    return withDb(deps, (db) => {
+        catchUpHandoffs(db, deps.base);
+        const existing = getHandoffById(db, id);
+
+        if (existing === null) {
+            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
+        }
+
+        const events: HandoffEvent[] = [];
+        const extraInfo: string[] = [];
+        let autoClaimUid: string | undefined;
+        let claimUid: string | undefined;
+        let unclaimUid: string | undefined;
+
+        const autoClaim =
+            input.unclaim !== true &&
+            existing.target?.sessionId !== undefined &&
+            sessionIdMatches(existing.target.sessionId, by.sessionId) &&
+            !isClaimedBy(existing, by) &&
+            (existing.status === "open" || existing.status === "claimed");
+
+        if (autoClaim) {
+            autoClaimUid = generateEventUid();
+            events.push({ ev: "claim", ts: nowIso(deps), uid: autoClaimUid, id, via: "target-match", by });
+        }
+
+        if (input.claim === true && !autoClaim) {
+            claimUid = generateEventUid();
+            events.push({ ev: "claim", ts: nowIso(deps), uid: claimUid, id, via: "explicit", by });
+        }
+
+        if (input.unclaim === true) {
+            unclaimUid = generateEventUid();
+            events.push({ ev: "unclaim", ts: nowIso(deps), uid: unclaimUid, id, by });
+        }
+
+        if (events.length > 0) {
+            appendHandoffEvents(events, deps.base);
+            catchUpHandoffs(db, deps.base);
+        }
+
+        const handoff = getHandoffById(db, id);
+
+        if (handoff === null) {
+            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
+        }
+
+        if (autoClaimUid !== undefined) {
+            const outcome = getEventOutcome(db, autoClaimUid);
+
+            if (outcome?.applied === true) {
+                extraInfo.push(
+                    `Auto-claimed: this session IS the handoff's target sessionId. Undo with handoff_get { id: "${id}", unclaim: true }.`
+                );
+            } else if (outcome?.error !== undefined) {
+                extraInfo.push(outcome.error);
+            }
+        }
+
+        if (claimUid !== undefined) {
+            const outcome = getEventOutcome(db, claimUid);
+
+            if (outcome?.error !== undefined) {
+                extraInfo.push(outcome.error);
+            } else if (outcome?.info !== undefined) {
+                extraInfo.push(...outcome.info);
+            }
+        }
+
+        if (unclaimUid !== undefined) {
+            const outcome = getEventOutcome(db, unclaimUid);
+
+            if (outcome?.info !== undefined) {
+                extraInfo.push(...outcome.info);
+            }
+        }
+
+        const response: GetHandoffResponse = {
+            handoff: publicHandoff(handoff, deps.base),
+            info: [...extraInfo, ...stateInfo(handoff, by)],
+        };
+
+        // editId recovery: ONLY the posting session (or the dashboard owner) ever sees it (§3).
+        if (isPosterSession(handoff, by) || isHumanOwner(by)) {
+            response.editId = handoff.editId;
+        }
+
+        return response;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// handoff_list
+// ---------------------------------------------------------------------------
+
+export interface ListHandoffsInput {
+    limit?: number;
+    offset?: number;
+    mine?: boolean;
+    open?: boolean;
+    project?: string;
+}
+
+export interface ListHandoffsResponse {
+    handoffs: HandoffListRow[];
+    info: string[];
+}
+
+export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = {}): ListHandoffsResponse {
+    const by = buildBy(deps);
+    const limit = input.limit !== undefined && input.limit > 0 ? input.limit : 20;
+    const offset = input.offset !== undefined && input.offset > 0 ? input.offset : 0;
+
+    return withDb(deps, (db) => {
+        catchUpHandoffs(db, deps.base);
+        let rows = listHandoffRows(db, {
+            statuses: input.open === true ? ["open", "claimed"] : undefined,
+            project: input.project,
+        });
+
+        if (input.mine === true) {
+            rows = rows.filter(
+                (h) =>
+                    isPosterSession(h, by) ||
+                    isClaimedBy(h, by) ||
+                    sessionIdMatches(h.target?.sessionId ?? null, by.sessionId) ||
+                    (h.target?.sessionName != null &&
+                        by.sessionTitle != null &&
+                        h.target.sessionName === by.sessionTitle)
+            );
+        }
+
+        const total = rows.length;
+        const page = rows.slice(offset, offset + limit);
+        const now = Date.now();
+        const handoffs = page.map((h): HandoffListRow => {
+            const p = progress(h);
+            const row: HandoffListRow = {
+                id: h.id,
+                title: h.title,
+                status: h.status,
+                tasks: `${p.resolved}/${p.total}`,
+                postedBy: { sessionName: h.postedBy.sessionName },
+                project: h.project,
+                ageHours: Math.round(((now - new Date(h.createdTs).getTime()) / 3_600_000) * 10) / 10,
+            };
+
+            if (h.target !== undefined) {
+                row.target = h.target;
+            }
+
+            if (h.claimedBy.length > 0) {
+                row.claimedBy = h.claimedBy.map((c) => ({ sessionId: c.sessionId, sessionName: c.sessionName }));
+                row.progress = `${p.resolved}/${p.total}${p.denied > 0 ? ` (${p.denied} denied)` : ""}`;
+            }
+
+            return row;
+        });
+
+        const info: string[] = [`${total} handoff${total === 1 ? "" : "s"} matched; showing ${page.length}.`];
+
+        if (total > offset + page.length) {
+            info.push(`More available — pass offset: ${offset + page.length}.`);
+        }
+
+        return { handoffs, info };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// handoff_action
+// ---------------------------------------------------------------------------
+
+const ALIASES: Record<string, string> = {
+    done: "finish_handoff",
+    finish: "finish_handoff",
+    check: "check_task",
+    add: "add_tasks",
+    modify: "modify_task",
+    deny: "deny_task",
+    uncheck: "uncheck_task",
+};
+
+const VERBS = [
+    "claim",
+    "unclaim",
+    "check_task",
+    "uncheck_task",
+    "deny_task",
+    "undeny_task",
+    "comment",
+    "attach_file",
+    "add_tasks",
+    "modify_task",
+    "modify_handoff",
+    "finish_handoff",
+    "cancel_handoff",
+    "reopen_handoff",
+] as const;
+
+const VERB_CATALOG =
+    `Valid actions: ${VERBS.join(", ")}. ` +
+    "Aliases: done/finish→finish_handoff, check→check_task, add→add_tasks, modify→modify_task, deny→deny_task, uncheck→uncheck_task.";
+
+const PROTECTED_TASK_FIELDS = [
+    "checked",
+    "proof",
+    "checkedBy",
+    "checkedTs",
+    "denied",
+    "deniedReason",
+    "deniedBy",
+    "deniedTs",
+] as const;
+
+interface PendingAction {
+    index: number;
+    action: string;
+    result?: HandoffActionResult;
+    event?: HandoffEvent;
+    preEvents?: HandoffEvent[];
+    shapeInfo?: string[];
+    attachmentId?: string;
+}
+
+function shapeFail(index: number, action: string, error: string): PendingAction {
+    return { index, action, result: { action, ok: false, error } };
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+        return undefined;
+    }
+
+    return value;
+}
+
+export interface ExecuteActionsInput {
+    id: string;
+    editId?: string;
+    actions: HandoffActionInput[];
+}
+
+export interface ExecuteActionsResponse {
+    handoff: PublicHandoff;
+    results: HandoffActionResult[];
+    info: string[];
+}
+
+export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffDeps = {}): ExecuteActionsResponse {
+    if (!Array.isArray(input.actions) || input.actions.length === 0) {
+        throw new Error(
+            'handoff_action needs an actions array — e.g. handoff_action { id: "h_x1y2z3ab", actions: [{ action: "check_task", taskId: "t1", proof: { answer: "…" } }] }. ' +
+                VERB_CATALOG
+        );
+    }
+
+    const id = normalizeHandoffId(String(input.id ?? ""));
+    const editId = normalizeEditId(input.editId);
+    const by = buildBy(deps);
+
+    return withDb(deps, (db) => {
+        catchUpHandoffs(db, deps.base);
+        const existing = getHandoffById(db, id);
+
+        if (existing === null) {
+            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
+        }
+
+        const stamp = (): { ts: string; uid: string; id: string; by: HandoffEventBy; editId?: string } => ({
+            ts: nowIso(deps),
+            uid: generateEventUid(),
+            id,
+            by,
+            ...(editId !== undefined ? { editId } : {}),
+        });
+
+        const pending: PendingAction[] = input.actions.map((raw, index) =>
+            parseAction(raw, index, existing, stamp, deps)
+        );
+
+        const events = pending.flatMap((p) => [...(p.preEvents ?? []), ...(p.event !== undefined ? [p.event] : [])]);
+
+        if (events.length > 0) {
+            appendHandoffEvents(events, deps.base);
+            catchUpHandoffs(db, deps.base);
+        }
+
+        const handoff = getHandoffById(db, id);
+
+        if (handoff === null) {
+            throw new Error(`No handoff ${id} after fold — check ~/.genesis-tools/logs for details.`);
+        }
+
+        const results = pending.map((p): HandoffActionResult => {
+            if (p.result !== undefined) {
+                return p.result;
+            }
+
+            const event = p.event;
+
+            if (event === undefined) {
+                return { action: p.action, ok: false, error: "internal: no event built" };
+            }
+
+            const outcome = getEventOutcome(db, event.uid);
+
+            if (outcome === null) {
+                return { action: p.action, ok: false, error: "internal: fold outcome missing — see logs." };
+            }
+
+            const result: HandoffActionResult = { action: p.action, ok: outcome.applied };
+            const infoLines = [...(p.shapeInfo ?? []), ...(outcome.info ?? [])];
+
+            if (outcome.error !== undefined) {
+                result.error = outcome.error;
+            }
+
+            if (infoLines.length > 0) {
+                result.info = infoLines;
+            }
+
+            if (outcome.assignedTaskIds !== undefined) {
+                result.assignedTaskIds = outcome.assignedTaskIds;
+            }
+
+            if (p.attachmentId !== undefined) {
+                result.attachmentId = p.attachmentId;
+            }
+
+            return result;
+        });
+
+        log.info(
+            { id, actions: pending.map((p) => p.action), ok: results.filter((r) => r.ok).length, by: by.sessionId },
+            "handoff actions executed"
+        );
+
+        return {
+            handoff: publicHandoff(handoff, deps.base),
+            results,
+            info: stateInfo(handoff, by),
+        };
+    });
+}
+
+function ingestScreenshots(
+    paths: string[],
+    handoffId: string,
+    taskId: string | undefined,
+    stamp: () => { ts: string; uid: string; id: string; by: HandoffEventBy; editId?: string },
+    deps: HandoffDeps
+): { events: HandoffEvent[]; attachmentIds: string[] } {
+    const events: HandoffEvent[] = [];
+    const attachmentIds: string[] = [];
+
+    for (const path of paths) {
+        const ingested = ingestAttachmentFromPath(handoffId, path, deps.base);
+        const event: HandoffEvent = {
+            ev: "attach",
+            ...stamp(),
+            attachmentId: ingested.attachmentId,
+            filename: ingested.filename,
+            mime: ingested.mime,
+            bytes: ingested.bytes,
+        };
+
+        if (taskId !== undefined) {
+            event.taskId = taskId;
+        }
+
+        events.push(event);
+        attachmentIds.push(ingested.attachmentId);
+    }
+
+    return { events, attachmentIds };
+}
+
+function parseAction(
+    raw: HandoffActionInput,
+    index: number,
+    handoff: Handoff,
+    stamp: () => { ts: string; uid: string; id: string; by: HandoffEventBy; editId?: string },
+    deps: HandoffDeps
+): PendingAction {
+    let payload: { action: string } & Record<string, unknown>;
+
+    if (typeof raw === "string") {
+        payload = { action: raw };
+    } else if (raw !== null && typeof raw === "object" && typeof raw.action === "string") {
+        payload = raw;
+    } else {
+        return shapeFail(
+            index,
+            "(invalid)",
+            'Each actions[] item is { action: "<verb>", …verb fields } or a bare verb string — e.g. { action: "check_task", taskId: "t1", proof: { answer: "…" } }. ' +
+                VERB_CATALOG
+        );
+    }
+
+    const requested = payload.action.trim();
+    const verb = ALIASES[requested] ?? requested;
+
+    if (!(VERBS as readonly string[]).includes(verb)) {
+        return shapeFail(index, requested, `Unknown action "${requested}". ${VERB_CATALOG}`);
+    }
+
+    const taskId = typeof payload.taskId === "string" ? payload.taskId.trim() : undefined;
+
+    switch (verb) {
+        case "claim":
+            return { index, action: verb, event: { ev: "claim", ...stamp(), via: "explicit" } };
+
+        case "unclaim":
+            return { index, action: verb, event: { ev: "unclaim", ...stamp() } };
+
+        case "check_task": {
+            const proofRaw = payload.proof as Record<string, unknown> | undefined;
+            const answer = typeof proofRaw?.answer === "string" ? proofRaw.answer.trim() : "";
+
+            if (taskId === undefined || answer.length === 0) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'check_task needs taskId and proof.answer — e.g. { action: "check_task", taskId: "t1", proof: { answer: "Implemented + bun test green (12/12)", commitIds: ["a1b2c3d"] } }.'
+                );
+            }
+
+            const proof: HandoffProof = { answer };
+            const commitIds = asStringArray(proofRaw?.commitIds);
+
+            if (commitIds !== undefined && commitIds.length > 0) {
+                proof.commitIds = commitIds;
+            }
+
+            if (typeof proofRaw?.context === "string" && proofRaw.context.trim().length > 0) {
+                proof.context = proofRaw.context;
+            }
+
+            const existingIds = asStringArray(proofRaw?.attachmentIds) ?? [];
+            const screenshots = asStringArray(proofRaw?.screenshots) ?? [];
+            let preEvents: HandoffEvent[] = [];
+
+            if (screenshots.length > 0) {
+                try {
+                    const ingest = ingestScreenshots(screenshots, handoff.id, taskId, stamp, deps);
+                    preEvents = ingest.events;
+                    proof.attachmentIds = [...existingIds, ...ingest.attachmentIds];
+                } catch (err) {
+                    return shapeFail(index, verb, err instanceof Error ? err.message : String(err));
+                }
+            } else if (existingIds.length > 0) {
+                proof.attachmentIds = existingIds;
+            }
+
+            return {
+                index,
+                action: verb,
+                preEvents,
+                event: {
+                    ev: "check_task",
+                    ...stamp(),
+                    taskId,
+                    proof,
+                    ...(payload.force === true ? { force: true } : {}),
+                },
+            };
+        }
+
+        case "uncheck_task": {
+            if (taskId === undefined) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'uncheck_task needs taskId — e.g. { action: "uncheck_task", taskId: "t1" }.'
+                );
+            }
+
+            return { index, action: verb, event: { ev: "uncheck_task", ...stamp(), taskId } };
+        }
+
+        case "deny_task": {
+            const reason = typeof payload.reason === "string" ? payload.reason.trim() : "";
+
+            if (taskId === undefined || reason.length === 0) {
+                return shapeFail(
+                    index,
+                    verb,
+                    `deny_task needs taskId and reason — e.g. { action: "deny_task", taskId: "${taskId ?? "t1"}", reason: "out of scope for this repo" }.`
+                );
+            }
+
+            return {
+                index,
+                action: verb,
+                event: {
+                    ev: "deny_task",
+                    ...stamp(),
+                    taskId,
+                    reason,
+                    ...(payload.force === true ? { force: true } : {}),
+                },
+            };
+        }
+
+        case "undeny_task": {
+            if (taskId === undefined) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'undeny_task needs taskId — e.g. { action: "undeny_task", taskId: "t1" }.'
+                );
+            }
+
+            return { index, action: verb, event: { ev: "undeny_task", ...stamp(), taskId } };
+        }
+
+        case "comment": {
+            const text = typeof payload.text === "string" ? payload.text.trim() : "";
+
+            if (text.length === 0) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'comment needs text — e.g. { action: "comment", text: "starting on t2" }.'
+                );
+            }
+
+            const attachmentIds = asStringArray(payload.attachmentIds) ?? [];
+            const screenshots = asStringArray(payload.screenshots) ?? [];
+            let preEvents: HandoffEvent[] = [];
+            let allIds = attachmentIds;
+
+            if (screenshots.length > 0) {
+                try {
+                    const ingest = ingestScreenshots(screenshots, handoff.id, undefined, stamp, deps);
+                    preEvents = ingest.events;
+                    allIds = [...attachmentIds, ...ingest.attachmentIds];
+                } catch (err) {
+                    return shapeFail(index, verb, err instanceof Error ? err.message : String(err));
+                }
+            }
+
+            return {
+                index,
+                action: verb,
+                preEvents,
+                event: { ev: "comment", ...stamp(), text, ...(allIds.length > 0 ? { attachmentIds: allIds } : {}) },
+            };
+        }
+
+        case "attach_file": {
+            const path = typeof payload.path === "string" ? payload.path.trim() : "";
+
+            if (path.length === 0) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'attach_file needs path — e.g. { action: "attach_file", path: "/tmp/screenshot.png", taskId: "t1", note: "before state" }.'
+                );
+            }
+
+            try {
+                const ingested = ingestAttachmentFromPath(handoff.id, path, deps.base);
+                return {
+                    index,
+                    action: verb,
+                    attachmentId: ingested.attachmentId,
+                    event: {
+                        ev: "attach",
+                        ...stamp(),
+                        attachmentId: ingested.attachmentId,
+                        filename: ingested.filename,
+                        mime: ingested.mime,
+                        bytes: ingested.bytes,
+                        ...(taskId !== undefined ? { taskId } : {}),
+                        ...(typeof payload.note === "string" && payload.note.trim().length > 0
+                            ? { note: payload.note }
+                            : {}),
+                    },
+                };
+            } catch (err) {
+                return shapeFail(index, verb, err instanceof Error ? err.message : String(err));
+            }
+        }
+
+        case "add_tasks": {
+            const tasksRaw = payload.tasks;
+
+            if (!Array.isArray(tasksRaw) || tasksRaw.length === 0) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'add_tasks needs tasks — e.g. { action: "add_tasks", tasks: [{ text: "Update the README", acceptanceCriteria: "section exists" }] }.'
+                );
+            }
+
+            const tasks: HandoffTaskInput[] = [];
+
+            for (const t of tasksRaw) {
+                if (t !== null && typeof t === "object" && typeof (t as Record<string, unknown>).text === "string") {
+                    const item = t as Record<string, unknown>;
+                    const task: HandoffTaskInput = { text: item.text as string };
+
+                    if (typeof item.id === "string") {
+                        task.id = item.id;
+                    }
+
+                    if (typeof item.acceptanceCriteria === "string") {
+                        task.acceptanceCriteria = item.acceptanceCriteria;
+                    }
+
+                    tasks.push(task);
+                }
+            }
+
+            if (tasks.length === 0) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'add_tasks: every entry needs text — e.g. { action: "add_tasks", tasks: [{ text: "Update the README" }] }.'
+                );
+            }
+
+            return { index, action: verb, event: { ev: "add_tasks", ...stamp(), tasks } };
+        }
+
+        case "modify_task": {
+            const text = typeof payload.text === "string" && payload.text.trim().length > 0 ? payload.text : undefined;
+            const acceptanceCriteria =
+                typeof payload.acceptanceCriteria === "string" ? payload.acceptanceCriteria : undefined;
+
+            if (taskId === undefined || (text === undefined && acceptanceCriteria === undefined)) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'modify_task needs taskId plus text and/or acceptanceCriteria — e.g. { action: "modify_task", taskId: "t1", text: "…" }. Task status fields have their own verbs (check_task, deny_task, …).'
+                );
+            }
+
+            const shapeInfo: string[] = [];
+
+            for (const field of PROTECTED_TASK_FIELDS) {
+                if (field in payload) {
+                    shapeInfo.push(
+                        `Protected field ignored: ${field} — mutable only via its own verb (§check_task/deny_task family).`
+                    );
+                }
+            }
+
+            return {
+                index,
+                action: verb,
+                shapeInfo,
+                event: {
+                    ev: "modify_task",
+                    ...stamp(),
+                    taskId,
+                    ...(text !== undefined ? { text } : {}),
+                    ...(acceptanceCriteria !== undefined ? { acceptanceCriteria } : {}),
+                },
+            };
+        }
+
+        case "modify_handoff": {
+            const title =
+                typeof payload.title === "string" && payload.title.trim().length > 0 ? payload.title : undefined;
+            const description = typeof payload.description === "string" ? payload.description : undefined;
+            const target =
+                payload.target === null
+                    ? null
+                    : payload.target !== null && typeof payload.target === "object"
+                      ? (payload.target as HandoffTarget)
+                      : undefined;
+            const refs = asStringArray(payload.refs);
+
+            if (title === undefined && description === undefined && target === undefined && refs === undefined) {
+                return shapeFail(
+                    index,
+                    verb,
+                    'modify_handoff needs at least one of title/description/target/refs — e.g. { action: "modify_handoff", title: "…" }. Tasks are edited via modify_task/add_tasks.'
+                );
+            }
+
+            return {
+                index,
+                action: verb,
+                event: {
+                    ev: "modify_handoff",
+                    ...stamp(),
+                    ...(title !== undefined ? { title } : {}),
+                    ...(description !== undefined ? { description } : {}),
+                    ...(target !== undefined ? { target } : {}),
+                    ...(refs !== undefined ? { refs } : {}),
+                },
+            };
+        }
+
+        case "finish_handoff":
+            return {
+                index,
+                action: verb,
+                event: { ev: "finish", ...stamp(), ...(payload.force === true ? { force: true } : {}) },
+            };
+
+        case "cancel_handoff":
+            return { index, action: verb, event: { ev: "cancel", ...stamp() } };
+
+        case "reopen_handoff":
+            return { index, action: verb, event: { ev: "reopen", ...stamp() } };
+
+        default:
+            return shapeFail(index, verb, `Unknown action "${requested}". ${VERB_CATALOG}`);
+    }
+}

--- a/src/handoff/fold.ts
+++ b/src/handoff/fold.ts
@@ -1,0 +1,655 @@
+import { existsSync } from "node:fs";
+import { attachmentFilePath } from "./attachments";
+import type {
+    FoldOutcome,
+    Handoff,
+    HandoffActor,
+    HandoffEvent,
+    HandoffEventBy,
+    HandoffTask,
+    HandoffTaskInput,
+} from "./types";
+
+export interface FoldConfig {
+    /** Log/attachments base dir override (tests). */
+    base?: string;
+}
+
+/** Null never establishes identity and never matches another null (spec §3). */
+export function sessionIdMatches(a: string | null | undefined, b: string | null | undefined): boolean {
+    return a != null && b != null && a === b;
+}
+
+/** Dashboard owner authority (§7.1): a distinct actor kind, never a session identity. */
+export function isHumanOwner(by: HandoffEventBy): boolean {
+    return by.agent === "human" && by.via === "dashboard";
+}
+
+export function actorOf(by: HandoffEventBy): HandoffActor {
+    const actor: HandoffActor = {
+        sessionId: by.sessionId,
+        sessionName: by.sessionTitle,
+        agent: by.agent,
+    };
+
+    if (by.via !== undefined) {
+        actor.via = by.via;
+    }
+
+    return actor;
+}
+
+function isPoster(state: Handoff, event: HandoffEvent): boolean {
+    if (isHumanOwner(event.by)) {
+        return true;
+    }
+
+    if (sessionIdMatches(event.by.sessionId, state.postedBy.sessionId)) {
+        return true;
+    }
+
+    return event.editId != null && event.editId === state.editId;
+}
+
+function isClaimer(state: Handoff, event: HandoffEvent): boolean {
+    if (isHumanOwner(event.by)) {
+        return true;
+    }
+
+    return state.claimedBy.some((c) => sessionIdMatches(c.sessionId, event.by.sessionId));
+}
+
+function taskIdCatalog(state: Handoff): string {
+    return state.tasks.map((t) => t.id).join(", ") || "(none)";
+}
+
+function nextFreeTaskId(taken: Set<string>): string {
+    let n = 1;
+
+    while (taken.has(`t${n}`)) {
+        n++;
+    }
+
+    return `t${n}`;
+}
+
+/**
+ * Fold-time auto id assignment (§6.1 rule 3). `rejectExplicitCollisions` is the
+ * add_tasks behavior (§2: supplied colliding id → item rejected, rest applies);
+ * post reassigns instead (§1.1: final ids ALWAYS in the response).
+ */
+function assignTaskIds(
+    inputs: HandoffTaskInput[],
+    existing: HandoffTask[],
+    opts: { rejectExplicitCollisions: boolean }
+): { tasks: HandoffTask[]; assignedIds: string[]; rejected: string[] } {
+    const taken = new Set(existing.map((t) => t.id));
+    const tasks: HandoffTask[] = [];
+    const assignedIds: string[] = [];
+    const rejected: string[] = [];
+
+    for (const input of inputs) {
+        const text = typeof input.text === "string" ? input.text.trim() : "";
+
+        if (text.length === 0) {
+            rejected.push("(task with empty text)");
+            continue;
+        }
+
+        let id: string;
+
+        if (input.id !== undefined && input.id.trim().length > 0) {
+            const wanted = input.id.trim();
+
+            if (taken.has(wanted)) {
+                if (opts.rejectExplicitCollisions) {
+                    rejected.push(wanted);
+                    continue;
+                }
+
+                id = nextFreeTaskId(taken);
+            } else {
+                id = wanted;
+            }
+        } else {
+            id = nextFreeTaskId(taken);
+        }
+
+        taken.add(id);
+        assignedIds.push(id);
+        const task: HandoffTask = { id, text, checked: false, denied: false };
+
+        if (input.acceptanceCriteria !== undefined && input.acceptanceCriteria.trim().length > 0) {
+            task.acceptanceCriteria = input.acceptanceCriteria;
+        }
+
+        tasks.push(task);
+    }
+
+    return { tasks, assignedIds, rejected };
+}
+
+function rejected(error: string): { state: null; outcome: FoldOutcome } {
+    return { state: null, outcome: { applied: false, error } };
+}
+
+const CLAIM_FIRST =
+    'Not a claimer of this handoff — claim first: include { action: "claim" } as the first action, or call handoff_get with claim: true.';
+
+const NOT_POSTER =
+    "Poster credential required (same session that posted, or editId). Pass editId at the top level: " +
+    'handoff_action { id, editId: "he_…", actions: […] }. Your user can read the editId on the dev-dashboard /qa Agent-tasks tab.';
+
+export const DONE_INFO =
+    'Handoff is done — reopen with handoff_action { actions: ["reopen_handoff"] } (poster, or the claimer whose own finish closed it).';
+
+export const CANCELLED_INFO = "Cancelled by the poster — stop work, revert if asked. The poster can reopen_handoff.";
+
+/**
+ * Pure, deterministic fold of one event onto one handoff's current state
+ * (spec §6.1). Same log → same state, always; every accept/reject decision is
+ * derived from (state, event) only, so rebuilds converge (attachment `missing`
+ * deliberately reflects current disk truth — §6.3).
+ */
+export function applyHandoffEvent(
+    state: Handoff | null,
+    event: HandoffEvent,
+    cfg: FoldConfig = {}
+): { state: Handoff | null; outcome: FoldOutcome } {
+    if (event.ev === "post") {
+        if (state !== null) {
+            // First-wins (§6.1 rule 5) — caller logs loudly; never clobber.
+            return {
+                state,
+                outcome: { applied: false, error: `Handoff ${event.id} already exists — post ignored (first wins).` },
+            };
+        }
+
+        const {
+            tasks,
+            assignedIds,
+            rejected: rejectedIds,
+        } = assignTaskIds(event.tasks, [], {
+            rejectExplicitCollisions: false,
+        });
+
+        if (tasks.length === 0) {
+            return rejected("post rejected: no valid tasks (each task needs non-empty text).");
+        }
+
+        const next: Handoff = {
+            id: event.id,
+            title: event.title,
+            status: "open",
+            tasks,
+            postedBy: actorOf(event.by),
+            postedByContext: event.by,
+            project: event.by.project,
+            claimedBy: [],
+            comments: [],
+            attachments: [],
+            editId: event.editId,
+            createdTs: event.ts,
+            updatedTs: event.ts,
+        };
+
+        if (event.description !== undefined) {
+            next.description = event.description;
+        }
+
+        if (event.target !== undefined) {
+            next.target = event.target;
+        }
+
+        if (event.refs !== undefined) {
+            next.refs = event.refs;
+        }
+
+        const outcome: FoldOutcome = { applied: true, assignedTaskIds: assignedIds };
+
+        if (rejectedIds.length > 0) {
+            outcome.info = [`Skipped invalid task entries: ${rejectedIds.join(", ")}.`];
+        }
+
+        return { state: next, outcome };
+    }
+
+    if (state === null) {
+        return rejected(`No handoff ${event.id} — re-check the paste block or call handoff_list to find it.`);
+    }
+
+    // Terminal-state gate: done/cancelled reject every mutation except reopen (§3).
+    if ((state.status === "done" || state.status === "cancelled") && event.ev !== "reopen") {
+        return { state, outcome: { applied: false, error: state.status === "done" ? DONE_INFO : CANCELLED_INFO } };
+    }
+
+    const next: Handoff = {
+        ...state,
+        tasks: state.tasks.map((t) => ({ ...t })),
+        claimedBy: state.claimedBy.map((c) => ({ ...c })),
+        comments: [...state.comments],
+        attachments: [...state.attachments],
+    };
+    next.updatedTs = event.ts;
+
+    const findTask = (taskId: string): HandoffTask | undefined => next.tasks.find((t) => t.id === taskId);
+
+    switch (event.ev) {
+        case "claim": {
+            if (event.by.sessionId == null && !isHumanOwner(event.by)) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: "This session has no sessionId — it cannot claim. Ask the posting session to act, or run from a real agent session (the poster can act with editId).",
+                    },
+                };
+            }
+
+            const mine = next.claimedBy.find((c) => sessionIdMatches(c.sessionId, event.by.sessionId));
+
+            if (mine) {
+                mine.claimedAt = event.ts;
+                return { state: next, outcome: { applied: true, noop: true, info: ["Already claimed by you."] } };
+            }
+
+            next.claimedBy.push({
+                sessionId: event.by.sessionId,
+                sessionName: event.by.sessionTitle,
+                branch: event.by.branch,
+                cwd: event.by.cwd,
+                claimedAt: event.ts,
+                via: event.via,
+            });
+
+            if (next.status === "open") {
+                next.status = "claimed";
+            }
+
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "unclaim": {
+            const before = next.claimedBy.length;
+            next.claimedBy = next.claimedBy.filter((c) => !sessionIdMatches(c.sessionId, event.by.sessionId));
+
+            if (next.claimedBy.length === before) {
+                return {
+                    state: next,
+                    outcome: {
+                        applied: true,
+                        noop: true,
+                        info: ["You had no claim on this handoff — nothing to unclaim."],
+                    },
+                };
+            }
+
+            if (next.claimedBy.length === 0 && next.status === "claimed") {
+                next.status = "open";
+            }
+
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "check_task": {
+            if (!isClaimer(next, event) && !isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            const task = findTask(event.taskId);
+
+            if (!task) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Unknown taskId "${event.taskId}" — this handoff's tasks are: ${taskIdCatalog(next)}.`,
+                    },
+                };
+            }
+
+            if (task.denied && event.force !== true) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Task ${task.id} is denied ("${task.deniedReason ?? ""}") — pass force: true to check it anyway (clears the denial).`,
+                    },
+                };
+            }
+
+            if (task.denied) {
+                task.denied = false;
+                delete task.deniedReason;
+                delete task.deniedBy;
+                delete task.deniedTs;
+            }
+
+            task.checked = true;
+            task.proof = event.proof;
+            task.checkedBy = actorOf(event.by);
+            task.checkedTs = event.ts;
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "uncheck_task": {
+            if (!isClaimer(next, event) && !isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            const task = findTask(event.taskId);
+
+            if (!task) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Unknown taskId "${event.taskId}" — this handoff's tasks are: ${taskIdCatalog(next)}.`,
+                    },
+                };
+            }
+
+            // Current-state proof cleared deliberately — the full trace survives in the event log (§2).
+            task.checked = false;
+            delete task.proof;
+            delete task.checkedBy;
+            delete task.checkedTs;
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "deny_task": {
+            if (!isClaimer(next, event) && !isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            const task = findTask(event.taskId);
+
+            if (!task) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Unknown taskId "${event.taskId}" — this handoff's tasks are: ${taskIdCatalog(next)}.`,
+                    },
+                };
+            }
+
+            if (typeof event.reason !== "string" || event.reason.trim().length === 0) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `deny_task needs a reason — e.g. { action: "deny_task", taskId: "${task.id}", reason: "out of scope for this repo" }.`,
+                    },
+                };
+            }
+
+            if (task.checked && event.force !== true) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Task ${task.id} is checked — pass force: true to deny anyway (proof stays visible).`,
+                    },
+                };
+            }
+
+            // checked + proof stay as-is under a forced deny (§4 rule 4); undeny returns to them.
+            task.denied = true;
+            task.deniedReason = event.reason;
+            task.deniedBy = actorOf(event.by);
+            task.deniedTs = event.ts;
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "undeny_task": {
+            if (!isClaimer(next, event) && !isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            const task = findTask(event.taskId);
+
+            if (!task) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Unknown taskId "${event.taskId}" — this handoff's tasks are: ${taskIdCatalog(next)}.`,
+                    },
+                };
+            }
+
+            if (!task.denied) {
+                return {
+                    state: next,
+                    outcome: { applied: true, noop: true, info: [`Task ${task.id} is not denied.`] },
+                };
+            }
+
+            task.denied = false;
+            delete task.deniedReason;
+            delete task.deniedBy;
+            delete task.deniedTs;
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "comment": {
+            if (!isClaimer(next, event) && !isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            const comment = { text: event.text, by: actorOf(event.by), ts: event.ts } as Handoff["comments"][number];
+
+            if (event.attachmentIds !== undefined && event.attachmentIds.length > 0) {
+                comment.attachmentIds = event.attachmentIds;
+            }
+
+            next.comments.push(comment);
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "attach": {
+            if (!isClaimer(next, event) && !isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            if (event.taskId !== undefined && !findTask(event.taskId)) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Unknown taskId "${event.taskId}" — this handoff's tasks are: ${taskIdCatalog(next)}.`,
+                    },
+                };
+            }
+
+            const filePath = attachmentFilePath(next.id, event.attachmentId, event.filename, cfg.base);
+            const attachment: Handoff["attachments"][number] = {
+                attachmentId: event.attachmentId,
+                filename: event.filename,
+                mime: event.mime,
+                bytes: event.bytes,
+                by: actorOf(event.by),
+                ts: event.ts,
+            };
+
+            if (event.taskId !== undefined) {
+                attachment.taskId = event.taskId;
+            }
+
+            if (event.note !== undefined) {
+                attachment.note = event.note;
+            }
+
+            if (!existsSync(filePath)) {
+                attachment.missing = true;
+            }
+
+            next.attachments.push(attachment);
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "add_tasks": {
+            if (!isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: NOT_POSTER } };
+            }
+
+            const {
+                tasks,
+                assignedIds,
+                rejected: rejectedIds,
+            } = assignTaskIds(event.tasks, next.tasks, {
+                rejectExplicitCollisions: true,
+            });
+
+            if (tasks.length === 0) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `add_tasks: no valid tasks to add${rejectedIds.length > 0 ? ` (rejected: ${rejectedIds.join(", ")})` : ""}. Each task needs non-empty text; supplied ids must not collide (existing: ${taskIdCatalog(next)}).`,
+                    },
+                };
+            }
+
+            next.tasks.push(...tasks);
+            const outcome: FoldOutcome = { applied: true, assignedTaskIds: assignedIds };
+
+            if (rejectedIds.length > 0) {
+                outcome.info = [
+                    `Rejected colliding/invalid task entries: ${rejectedIds.join(", ")} — the rest applied.`,
+                ];
+            }
+
+            return { state: next, outcome };
+        }
+
+        case "modify_task": {
+            if (!isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: NOT_POSTER } };
+            }
+
+            const task = findTask(event.taskId);
+
+            if (!task) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Unknown taskId "${event.taskId}" — this handoff's tasks are: ${taskIdCatalog(next)}.`,
+                    },
+                };
+            }
+
+            if (event.text !== undefined && event.text.trim().length > 0) {
+                task.text = event.text;
+            }
+
+            if (event.acceptanceCriteria !== undefined) {
+                if (event.acceptanceCriteria.trim().length === 0) {
+                    delete task.acceptanceCriteria;
+                } else {
+                    task.acceptanceCriteria = event.acceptanceCriteria;
+                }
+            }
+
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "modify_handoff": {
+            if (!isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: NOT_POSTER } };
+            }
+
+            if (event.title !== undefined && event.title.trim().length > 0) {
+                next.title = event.title;
+            }
+
+            if (event.description !== undefined) {
+                if (event.description.length === 0) {
+                    delete next.description;
+                } else {
+                    next.description = event.description;
+                }
+            }
+
+            if (event.target !== undefined) {
+                if (event.target === null) {
+                    delete next.target;
+                } else {
+                    next.target = event.target;
+                }
+            }
+
+            if (event.refs !== undefined) {
+                next.refs = event.refs;
+            }
+
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "finish": {
+            if (!isClaimer(next, event)) {
+                return { state, outcome: { applied: false, error: CLAIM_FIRST } };
+            }
+
+            const openTasks = next.tasks.filter((t) => !t.checked && !t.denied).map((t) => t.id);
+
+            if (openTasks.length > 0 && event.force !== true) {
+                return {
+                    state,
+                    outcome: {
+                        applied: false,
+                        error: `Cannot finish — unresolved tasks: ${openTasks.join(", ")}. Check or deny them, or pass force: true.`,
+                    },
+                };
+            }
+
+            next.status = "done";
+            next.finishedTs = event.ts;
+            next.finishedBy = actorOf(event.by);
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "cancel": {
+            if (!isPoster(next, event)) {
+                return { state, outcome: { applied: false, error: NOT_POSTER } };
+            }
+
+            next.status = "cancelled";
+            return { state: next, outcome: { applied: true } };
+        }
+
+        case "reopen": {
+            if (next.status !== "done" && next.status !== "cancelled") {
+                return {
+                    state,
+                    outcome: { applied: true, noop: true, info: [`Handoff is ${next.status} — nothing to reopen.`] },
+                };
+            }
+
+            const finisherReopens =
+                next.status === "done" && sessionIdMatches(next.finishedBy?.sessionId ?? null, event.by.sessionId);
+
+            if (!isPoster(next, event) && !finisherReopens) {
+                const who =
+                    next.status === "done" ? "the poster or the claimer whose own finish closed it" : "the poster";
+                return {
+                    state,
+                    outcome: { applied: false, error: `Only ${who} can reopen this handoff.` },
+                };
+            }
+
+            // Status flip ONLY — per-task checked/denied state untouched (§2).
+            next.status = next.claimedBy.length > 0 ? "claimed" : "open";
+            delete next.finishedTs;
+            delete next.finishedBy;
+            return { state: next, outcome: { applied: true } };
+        }
+
+        default: {
+            const unknown = event as { ev: string };
+            return { state, outcome: { applied: false, error: `Unknown event "${unknown.ev}" — ignored.` } };
+        }
+    }
+}

--- a/src/handoff/ids.ts
+++ b/src/handoff/ids.ts
@@ -1,0 +1,56 @@
+import { randomBytes } from "node:crypto";
+
+const ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomSuffix(length: number): string {
+    const bytes = randomBytes(length);
+    let out = "";
+
+    for (let i = 0; i < length; i++) {
+        out += ALPHABET[bytes[i] % ALPHABET.length];
+    }
+
+    return out;
+}
+
+export function generateHandoffId(): string {
+    return `h_${randomSuffix(8)}`;
+}
+
+export function generateEditId(): string {
+    return `he_${randomSuffix(8)}`;
+}
+
+export function generateAttachmentId(): string {
+    return `a_${randomSuffix(8)}`;
+}
+
+export function generateEventUid(): string {
+    return randomSuffix(12);
+}
+
+/** Id tolerance (§5): `h_` prefix optional, whitespace trimmed. */
+export function normalizeHandoffId(raw: string): string {
+    const trimmed = raw.trim();
+
+    if (trimmed.length === 0) {
+        return trimmed;
+    }
+
+    return trimmed.startsWith("h_") ? trimmed : `h_${trimmed}`;
+}
+
+/** Same tolerance for edit credentials (`he_` prefix optional). */
+export function normalizeEditId(raw: string | undefined): string | undefined {
+    if (raw === undefined) {
+        return undefined;
+    }
+
+    const trimmed = raw.trim();
+
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    return trimmed.startsWith("he_") ? trimmed : `he_${trimmed}`;
+}

--- a/src/handoff/log-store.ts
+++ b/src/handoff/log-store.ts
@@ -1,11 +1,19 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import type { HandoffEvent } from "./types";
 
+/** Handoffs share the question family's storage root (§6.2) — honor its override too. */
+function questionRoot(): string {
+    const logBase = env.question.getLogBase();
+
+    return logBase !== undefined ? dirname(logBase) : join(homedir(), ".genesis-tools", "question");
+}
+
 export function handoffLogDir(base?: string): string {
-    return base ?? join(homedir(), ".genesis-tools", "question", "handoff");
+    return base ?? join(questionRoot(), "handoff");
 }
 
 export function logFilePathForTs(tsIso: string, base?: string): string {

--- a/src/handoff/log-store.ts
+++ b/src/handoff/log-store.ts
@@ -1,0 +1,50 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import type { HandoffEvent } from "./types";
+
+export function handoffLogDir(base?: string): string {
+    return base ?? join(homedir(), ".genesis-tools", "question", "handoff");
+}
+
+export function logFilePathForTs(tsIso: string, base?: string): string {
+    const d = new Date(tsIso);
+    const day = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    return join(handoffLogDir(base), `${day}.jsonl`);
+}
+
+export function todayHandoffLogFile(base?: string): string {
+    return logFilePathForTs(new Date().toISOString(), base);
+}
+
+/**
+ * Append a batch of events. One appendFileSync per target file (O_APPEND: the
+ * whole write lands atomically, so a multi-action call's events stay contiguous
+ * within this process's write — though interleaving with OTHER processes'
+ * appends between calls is legal and handled by the fold, spec §6.1).
+ */
+export function appendHandoffEvents(events: HandoffEvent[], base?: string): string[] {
+    if (events.length === 0) {
+        return [];
+    }
+
+    mkdirSync(handoffLogDir(base), { recursive: true });
+    const byFile = new Map<string, HandoffEvent[]>();
+
+    for (const event of events) {
+        const file = logFilePathForTs(event.ts, base);
+        const bucket = byFile.get(file) ?? [];
+        bucket.push(event);
+        byFile.set(file, bucket);
+    }
+
+    const files: string[] = [];
+
+    for (const [file, bucket] of byFile) {
+        appendFileSync(file, `${bucket.map((e) => SafeJSON.stringify(e, { strict: true })).join("\n")}\n`);
+        files.push(file);
+    }
+
+    return files;
+}

--- a/src/handoff/read-model.test.ts
+++ b/src/handoff/read-model.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { attachmentFilePath } from "./attachments";
+import { executeHandoffActions, getHandoff, postHandoff } from "./executor";
+import { generateEventUid } from "./ids";
+import { appendHandoffEvents, handoffLogDir } from "./log-store";
+import {
+    applyHandoffBatch,
+    catchUpHandoffs,
+    getHandoffById,
+    listHandoffRows,
+    openHandoffModel,
+    rebuildHandoffModel,
+} from "./read-model";
+import { byFor, freshEnv } from "./test-utils";
+import type { Handoff, HandoffEvent } from "./types";
+
+const A = byFor("session-a", "poster-a");
+const B = byFor("session-b", "worker-b");
+
+function addTasksEvent(id: string, texts: string[], explicitId?: string): HandoffEvent {
+    return {
+        ev: "add_tasks",
+        ts: new Date().toISOString(),
+        uid: generateEventUid(),
+        id,
+        by: A,
+        tasks: texts.map((text) => (explicitId !== undefined ? { id: explicitId, text } : { text })),
+    };
+}
+
+describe("CAS fold idempotency (§8.9a)", () => {
+    test("a batch folded by a racing process is skipped by the stale one — no double apply", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const id = posted.handoff.id;
+
+        // Delta event appended but not yet folded.
+        const event = addTasksEvent(id, ["delta task"]);
+        const [file] = appendHandoffEvents([event], env.base);
+        const size = statSync(file).size;
+
+        const db1 = openHandoffModel(env.dbPath);
+        const db2 = openHandoffModel(env.dbPath);
+
+        try {
+            const prev = (
+                db1.query("SELECT byte_offset FROM handoff_ingest_offsets WHERE file = ?").get(file) as {
+                    byte_offset: number;
+                }
+            ).byte_offset;
+
+            // Process 1 folds the batch first.
+            catchUpHandoffs(db1, env.base);
+            expect(getHandoffById(db1, id)?.tasks).toHaveLength(2);
+
+            // Process 2 read `prev` OUTSIDE its tx before process 1 committed —
+            // the CAS re-read inside the tx must skip the whole batch.
+            const applied = applyHandoffBatch({
+                db: db2,
+                file,
+                prevOffset: prev,
+                events: [event],
+                consumed: size - prev,
+                base: env.base,
+            });
+            expect(applied).toBe(false);
+            expect(getHandoffById(db2, id)?.tasks).toHaveLength(2);
+        } finally {
+            db1.close();
+            db2.close();
+        }
+    });
+
+    test("concurrent auto-id add_tasks fold to distinct ids; explicit collision rejected (§8.9b)", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const id = posted.handoff.id;
+
+        appendHandoffEvents([addTasksEvent(id, ["from p1"]), addTasksEvent(id, ["from p2"])], env.base);
+        const db = openHandoffModel(env.dbPath);
+
+        try {
+            catchUpHandoffs(db, env.base);
+            const tasks = getHandoffById(db, id)?.tasks ?? [];
+            expect(tasks.map((t) => t.id)).toEqual(["t1", "t2", "t3"]);
+
+            appendHandoffEvents(
+                [addTasksEvent(id, ["explicit t9"], "t9"), addTasksEvent(id, ["colliding t9"], "t9")],
+                env.base
+            );
+            catchUpHandoffs(db, env.base);
+            const after = getHandoffById(db, id)?.tasks ?? [];
+            expect(after.map((t) => t.id)).toEqual(["t1", "t2", "t3", "t9"]);
+        } finally {
+            db.close();
+        }
+    });
+});
+
+describe("rebuild (§8.11)", () => {
+    test("drop + re-fold deep-equals the incrementally folded state", () => {
+        const env = freshEnv();
+        const posted = postHandoff(
+            { title: "T", description: "body", tasks: [{ text: "one" }, { text: "two" }], refs: ["src/x.ts"] },
+            env.depsFor(A)
+        );
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+        executeHandoffActions(
+            {
+                id: posted.handoff.id,
+                actions: [
+                    { action: "check_task", taskId: "t1", proof: { answer: "done", commitIds: ["abc"] } },
+                    { action: "deny_task", taskId: "t2", reason: "wontfix" },
+                    { action: "comment", text: "note" },
+                    "finish_handoff",
+                ],
+            },
+            env.depsFor(B)
+        );
+        postHandoff({ title: "second", tasks: [{ text: "x" }] }, env.depsFor(B));
+
+        const db = openHandoffModel(env.dbPath);
+
+        try {
+            catchUpHandoffs(db, env.base);
+            const before = normalize(listHandoffRows(db));
+            rebuildHandoffModel(db, env.base);
+            const after = normalize(listHandoffRows(db));
+            expect(after).toEqual(before);
+        } finally {
+            db.close();
+        }
+    });
+});
+
+function normalize(rows: Handoff[]): unknown {
+    return SafeJSON.parse(
+        SafeJSON.stringify(
+            rows
+                .map((h) => ({
+                    ...h,
+                    claimedBy: [...h.claimedBy].sort((a, b) => a.claimedAt.localeCompare(b.claimedAt)),
+                    tasks: [...h.tasks].sort((a, b) => a.id.localeCompare(b.id)),
+                }))
+                .sort((a, b) => a.id.localeCompare(b.id)),
+            { strict: true }
+        ),
+        { strict: true }
+    );
+}
+
+describe("duplicate post ids (§6.1 rule 5)", () => {
+    test("first wins; second post never clobbers", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "original", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const dupe: HandoffEvent = {
+            ev: "post",
+            ts: new Date().toISOString(),
+            uid: generateEventUid(),
+            id: posted.handoff.id,
+            editId: "he_stolen00",
+            title: "clobber attempt",
+            tasks: [{ text: "evil" }],
+            by: B,
+        };
+        appendHandoffEvents([dupe], env.base);
+
+        const db = openHandoffModel(env.dbPath);
+
+        try {
+            catchUpHandoffs(db, env.base);
+            const h = getHandoffById(db, posted.handoff.id);
+            expect(h?.title).toBe("original");
+            expect(h?.editId).toBe(posted.editId);
+        } finally {
+            db.close();
+        }
+    });
+});
+
+describe("attachment resilience (§8.16b rebuild slice)", () => {
+    test("deleted file folds with missing: true after rebuild; nothing crashes", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const shot = join(env.base, "..", "shot.png");
+        writeFileSync(shot, new Uint8Array([1, 2, 3]));
+
+        const res = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "attach_file", path: shot }] },
+            env.depsFor(A)
+        );
+        const attachmentId = res.results[0].attachmentId;
+        expect(attachmentId).toBeDefined();
+        expect(res.handoff.attachments[0].missing).toBeUndefined();
+
+        rmSync(attachmentFilePath(posted.handoff.id, attachmentId as string, "shot.png", env.base));
+
+        const db = openHandoffModel(env.dbPath);
+
+        try {
+            rebuildHandoffModel(db, env.base);
+            const h = getHandoffById(db, posted.handoff.id);
+            expect(h?.attachments[0].missing).toBe(true);
+        } finally {
+            db.close();
+        }
+    });
+});
+
+describe("log layout", () => {
+    test("events land in day-stamped jsonl under the handoff dir", () => {
+        const env = freshEnv();
+        postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const files = readdirSync(handoffLogDir(env.base)).filter((f) => f.endsWith(".jsonl"));
+        expect(files).toHaveLength(1);
+        expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}\.jsonl$/);
+    });
+});

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -309,14 +309,24 @@ function readSuffix(file: string, start: number, size: number): Buffer {
     const length = size - start;
     const buf = Buffer.allocUnsafe(length);
     const fd = openSync(file, "r");
+    let total = 0;
 
     try {
-        readSync(fd, buf, 0, length, start);
+        // readSync may return short; the file may also have been truncated/replaced
+        // since statSync. Loop until the snapshot is filled or EOF (bytesRead 0).
+        while (total < length) {
+            const bytesRead = readSync(fd, buf, total, length - total, start + total);
+            if (bytesRead === 0) {
+                break;
+            }
+
+            total += bytesRead;
+        }
     } finally {
         closeSync(fd);
     }
 
-    return buf;
+    return total === length ? buf : buf.subarray(0, total);
 }
 
 export interface ApplyBatchInput {

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -231,7 +231,9 @@ export function getEventOutcome(db: Database, uid: string): FoldOutcome | null {
  * transaction (compare-and-set): if another process already advanced it past
  * this batch's start, the whole batch is skipped — delta events can never
  * double-apply (§6.1 rule 2; deliberate divergence from the question store's
- * read-offset-outside-tx idiom).
+ * read-offset-outside-tx idiom). A CAS skip only proves *some* batch reached
+ * the offset it landed on, not that it reached THIS read's end, so each file
+ * is retried from the freshly committed offset until it is fully caught up.
  */
 export function catchUpHandoffs(db: Database, base?: string): void {
     const dir = handoffLogDir(base);
@@ -246,34 +248,75 @@ export function catchUpHandoffs(db: Database, base?: string): void {
         .filter((f) => f.endsWith(".jsonl"))
         .sort()) {
         const file = join(dir, name);
-        const size = statSync(file).size;
-        const prev = (getOff.get(file) as { byte_offset: number } | null)?.byte_offset ?? 0;
 
-        if (size <= prev) {
-            continue;
+        for (;;) {
+            let size: number;
+
+            try {
+                size = statSync(file).size;
+            } catch (err) {
+                log.warn({ err, file }, "skipping handoff log file — stat failed (likely removed concurrently)");
+                break;
+            }
+
+            const prev = (getOff.get(file) as { byte_offset: number } | null)?.byte_offset ?? 0;
+
+            if (size <= prev) {
+                break;
+            }
+
+            let buf: Buffer;
+
+            try {
+                buf = readSuffix(file, prev, size);
+            } catch (err) {
+                log.warn({ err, file }, "skipping handoff log file — read failed (likely removed concurrently)");
+                break;
+            }
+
+            let events: HandoffEvent[];
+            let remainder: Buffer;
+
+            try {
+                const parsed = parseJsonlChunk<HandoffEvent>(buf);
+                events = parsed.values;
+                remainder = parsed.remainder;
+            } catch (err) {
+                log.warn({ err, file }, "skipping unparseable handoff JSONL tail");
+                break;
+            }
+
+            const consumed = buf.length - remainder.length;
+
+            if (events.length === 0) {
+                break;
+            }
+
+            const applied = applyHandoffBatch({ db, file, prevOffset: prev, events, consumed, base });
+
+            if (applied) {
+                break;
+            }
+
+            // CAS skip: another process advanced the offset concurrently — loop and
+            // retry from wherever it landed instead of dropping the remainder.
         }
-
-        const buf = readFileSync(file).subarray(prev);
-        let events: HandoffEvent[];
-        let remainder: Buffer;
-
-        try {
-            const parsed = parseJsonlChunk<HandoffEvent>(buf);
-            events = parsed.values;
-            remainder = parsed.remainder;
-        } catch (err) {
-            log.warn({ err, file }, "skipping unparseable handoff JSONL tail");
-            continue;
-        }
-
-        const consumed = buf.length - remainder.length;
-
-        if (events.length === 0) {
-            continue;
-        }
-
-        applyHandoffBatch({ db, file, prevOffset: prev, events, consumed, base });
     }
+}
+
+/** Read only the unconsumed suffix of a file — avoids reloading the whole day-log on every fold. */
+function readSuffix(file: string, start: number, size: number): Buffer {
+    const length = size - start;
+    const buf = Buffer.allocUnsafe(length);
+    const fd = openSync(file, "r");
+
+    try {
+        readSync(fd, buf, 0, length, start);
+    } finally {
+        closeSync(fd);
+    }
+
+    return buf;
 }
 
 export interface ApplyBatchInput {

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -1,0 +1,376 @@
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
+import { logger } from "@genesiscz/utils/logger";
+import { applyHandoffEvent } from "./fold";
+import { handoffLogDir } from "./log-store";
+import type { FoldOutcome, Handoff, HandoffEvent } from "./types";
+
+const log = logger.child({ component: "handoff:read-model" });
+
+/** Same db the /qa dashboard opens — handoffs ARE the QA family (spec §6.2). */
+export function handoffDbPath(): string {
+    return join(homedir(), ".genesis-tools", "question", "qa.db");
+}
+
+function ensureColumn(db: Database, table: string, column: string, ddl: string): void {
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[];
+
+    if (!cols.some((c) => c.name === column)) {
+        db.exec(ddl);
+    }
+}
+
+function createTables(db: Database): void {
+    db.exec(`CREATE TABLE IF NOT EXISTS handoffs (
+        id                     TEXT PRIMARY KEY,
+        title                  TEXT NOT NULL,
+        description            TEXT,
+        status                 TEXT NOT NULL DEFAULT 'open',
+        tasks                  TEXT NOT NULL,
+        target                 TEXT,
+        refs                   TEXT,
+        posted_by_context      TEXT NOT NULL,
+        posted_by_session_id   TEXT,
+        posted_by_session_name TEXT,
+        project                TEXT,
+        claimed_by             TEXT NOT NULL DEFAULT '[]',
+        comments               TEXT NOT NULL DEFAULT '[]',
+        edit_id                TEXT,
+        created_ts             TEXT NOT NULL,
+        updated_ts             TEXT NOT NULL,
+        finished_ts            TEXT
+    );`);
+    db.exec("CREATE INDEX IF NOT EXISTS idx_handoffs_status  ON handoffs(status);");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_handoffs_updated ON handoffs(updated_ts);");
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS handoff_ingest_offsets ( file TEXT PRIMARY KEY, byte_offset INTEGER NOT NULL );"
+    );
+    // Fold outcomes keyed by event uid: lets the appending process report truthful
+    // per-action results even when a concurrent process folded its batch first
+    // (§6.1 rules 2+4 — the CAS skip would otherwise lose the outcomes).
+    db.exec(`CREATE TABLE IF NOT EXISTS handoff_event_results (
+        uid        TEXT PRIMARY KEY,
+        handoff_id TEXT,
+        ev         TEXT,
+        ok         INTEGER NOT NULL,
+        error      TEXT,
+        extra      TEXT,
+        ts         TEXT
+    );`);
+    ensureColumn(
+        db,
+        "handoffs",
+        "attachments",
+        "ALTER TABLE handoffs ADD COLUMN attachments TEXT NOT NULL DEFAULT '[]'"
+    );
+    // Who finished it — needed for the reopen-by-finisher credential (§2 reopen_handoff).
+    ensureColumn(db, "handoffs", "finished_by", "ALTER TABLE handoffs ADD COLUMN finished_by TEXT");
+}
+
+export function openHandoffModel(dbPath?: string): Database {
+    const path = dbPath ?? handoffDbPath();
+    mkdirSync(dirname(path), { recursive: true });
+    const db = new Database(path);
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA busy_timeout = 5000;");
+    createTables(db);
+    log.debug({ path }, "handoff read-model opened");
+    return db;
+}
+
+interface HandoffRow {
+    id: string;
+    title: string;
+    description: string | null;
+    status: string;
+    tasks: string;
+    target: string | null;
+    refs: string | null;
+    posted_by_context: string;
+    posted_by_session_id: string | null;
+    posted_by_session_name: string | null;
+    project: string | null;
+    claimed_by: string;
+    comments: string;
+    edit_id: string | null;
+    created_ts: string;
+    updated_ts: string;
+    finished_ts: string | null;
+    attachments: string;
+    finished_by: string | null;
+}
+
+function rowToHandoff(row: HandoffRow): Handoff {
+    const postedByContext = SafeJSON.parse(row.posted_by_context, { strict: true }) as Handoff["postedByContext"];
+    const handoff: Handoff = {
+        id: row.id,
+        title: row.title,
+        status: row.status as Handoff["status"],
+        tasks: SafeJSON.parse(row.tasks, { strict: true }) as Handoff["tasks"],
+        postedBy: {
+            sessionId: row.posted_by_session_id,
+            sessionName: row.posted_by_session_name,
+            agent: postedByContext.agent,
+            ...(postedByContext.via !== undefined ? { via: postedByContext.via } : {}),
+        },
+        postedByContext,
+        project: row.project,
+        claimedBy: SafeJSON.parse(row.claimed_by, { strict: true }) as Handoff["claimedBy"],
+        comments: SafeJSON.parse(row.comments, { strict: true }) as Handoff["comments"],
+        attachments: SafeJSON.parse(row.attachments, { strict: true }) as Handoff["attachments"],
+        editId: row.edit_id ?? "",
+        createdTs: row.created_ts,
+        updatedTs: row.updated_ts,
+    };
+
+    if (row.description !== null) {
+        handoff.description = row.description;
+    }
+
+    if (row.target !== null) {
+        handoff.target = SafeJSON.parse(row.target, { strict: true }) as Handoff["target"];
+    }
+
+    if (row.refs !== null) {
+        handoff.refs = SafeJSON.parse(row.refs, { strict: true }) as string[];
+    }
+
+    if (row.finished_ts !== null) {
+        handoff.finishedTs = row.finished_ts;
+    }
+
+    if (row.finished_by !== null) {
+        handoff.finishedBy = SafeJSON.parse(row.finished_by, { strict: true }) as Handoff["finishedBy"];
+    }
+
+    return handoff;
+}
+
+const UPSERT_SQL = `INSERT OR REPLACE INTO handoffs
+    (id, title, description, status, tasks, target, refs, posted_by_context, posted_by_session_id,
+     posted_by_session_name, project, claimed_by, comments, edit_id, created_ts, updated_ts,
+     finished_ts, attachments, finished_by)
+    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
+
+function upsertHandoff(db: Database, h: Handoff): void {
+    db.prepare(UPSERT_SQL).run(
+        h.id,
+        h.title,
+        h.description ?? null,
+        h.status,
+        SafeJSON.stringify(h.tasks, { strict: true }),
+        h.target !== undefined ? SafeJSON.stringify(h.target, { strict: true }) : null,
+        h.refs !== undefined ? SafeJSON.stringify(h.refs, { strict: true }) : null,
+        SafeJSON.stringify(h.postedByContext, { strict: true }),
+        h.postedBy.sessionId,
+        h.postedBy.sessionName,
+        h.project,
+        SafeJSON.stringify(h.claimedBy, { strict: true }),
+        SafeJSON.stringify(h.comments, { strict: true }),
+        h.editId,
+        h.createdTs,
+        h.updatedTs,
+        h.finishedTs ?? null,
+        SafeJSON.stringify(h.attachments, { strict: true }),
+        h.finishedBy !== undefined ? SafeJSON.stringify(h.finishedBy, { strict: true }) : null
+    );
+}
+
+export function getHandoffById(db: Database, id: string): Handoff | null {
+    const row = db.query("SELECT * FROM handoffs WHERE id = ?").get(id) as HandoffRow | null;
+    return row ? rowToHandoff(row) : null;
+}
+
+export function listHandoffRows(db: Database, opts: { statuses?: string[]; project?: string } = {}): Handoff[] {
+    const where: string[] = [];
+    const params: string[] = [];
+
+    if (opts.statuses !== undefined && opts.statuses.length > 0) {
+        where.push(`status IN (${opts.statuses.map(() => "?").join(",")})`);
+        params.push(...opts.statuses);
+    }
+
+    if (opts.project !== undefined) {
+        where.push("project = ?");
+        params.push(opts.project);
+    }
+
+    const sql = `SELECT * FROM handoffs${where.length > 0 ? ` WHERE ${where.join(" AND ")}` : ""} ORDER BY updated_ts DESC`;
+    return (db.query(sql).all(...params) as HandoffRow[]).map(rowToHandoff);
+}
+
+export function getEventOutcome(db: Database, uid: string): FoldOutcome | null {
+    const row = db.query("SELECT ok, error, extra FROM handoff_event_results WHERE uid = ?").get(uid) as {
+        ok: number;
+        error: string | null;
+        extra: string | null;
+    } | null;
+
+    if (!row) {
+        return null;
+    }
+
+    const extra = row.extra !== null ? (SafeJSON.parse(row.extra, { strict: true }) as Partial<FoldOutcome>) : {};
+    const outcome: FoldOutcome = { applied: row.ok === 1, ...extra };
+
+    if (row.error !== null) {
+        outcome.error = row.error;
+    }
+
+    return outcome;
+}
+
+/**
+ * Lazily ingest JSONL bytes newer than the stored offsets and fold them into the
+ * handoffs table. Deterministic order: files sorted by name (date), lines by
+ * position (§6.1 rule 1). The ingest offset is re-read INSIDE the write
+ * transaction (compare-and-set): if another process already advanced it past
+ * this batch's start, the whole batch is skipped — delta events can never
+ * double-apply (§6.1 rule 2; deliberate divergence from the question store's
+ * read-offset-outside-tx idiom).
+ */
+export function catchUpHandoffs(db: Database, base?: string): void {
+    const dir = handoffLogDir(base);
+
+    if (!existsSync(dir)) {
+        return;
+    }
+
+    const getOff = db.prepare("SELECT byte_offset FROM handoff_ingest_offsets WHERE file = ?");
+
+    for (const name of readdirSync(dir)
+        .filter((f) => f.endsWith(".jsonl"))
+        .sort()) {
+        const file = join(dir, name);
+        const size = statSync(file).size;
+        const prev = (getOff.get(file) as { byte_offset: number } | null)?.byte_offset ?? 0;
+
+        if (size <= prev) {
+            continue;
+        }
+
+        const buf = readFileSync(file).subarray(prev);
+        let events: HandoffEvent[];
+        let remainder: Buffer;
+
+        try {
+            const parsed = parseJsonlChunk<HandoffEvent>(buf);
+            events = parsed.values;
+            remainder = parsed.remainder;
+        } catch (err) {
+            log.warn({ err, file }, "skipping unparseable handoff JSONL tail");
+            continue;
+        }
+
+        const consumed = buf.length - remainder.length;
+
+        if (events.length === 0) {
+            continue;
+        }
+
+        applyHandoffBatch({ db, file, prevOffset: prev, events, consumed, base });
+    }
+}
+
+export interface ApplyBatchInput {
+    db: Database;
+    file: string;
+    /** The offset read OUTSIDE the transaction — the CAS compare value. */
+    prevOffset: number;
+    events: HandoffEvent[];
+    consumed: number;
+    base?: string;
+}
+
+/**
+ * One CAS-guarded fold batch (§6.1 rule 2). Returns false when skipped because
+ * another process advanced the offset first — the batch then already folded
+ * elsewhere and its outcomes are readable via getEventOutcome.
+ */
+export function applyHandoffBatch({ db, file, prevOffset, events, consumed, base }: ApplyBatchInput): boolean {
+    const getOff = db.prepare("SELECT byte_offset FROM handoff_ingest_offsets WHERE file = ?");
+    const setOff = db.prepare("INSERT OR REPLACE INTO handoff_ingest_offsets (file, byte_offset) VALUES (?, ?)");
+    const putOutcome = db.prepare(
+        "INSERT OR REPLACE INTO handoff_event_results (uid, handoff_id, ev, ok, error, extra, ts) VALUES (?,?,?,?,?,?,?)"
+    );
+    let applied = false;
+
+    const tx = db.transaction(() => {
+        // CAS: another fold may have raced us between the outside read and here.
+        const current = (getOff.get(file) as { byte_offset: number } | null)?.byte_offset ?? 0;
+
+        if (current !== prevOffset) {
+            log.debug({ file, prevOffset, current }, "handoff fold batch skipped — offset advanced concurrently (CAS)");
+            return;
+        }
+
+        const states = new Map<string, Handoff | null>();
+
+        for (const event of events) {
+            if (!states.has(event.id)) {
+                states.set(event.id, getHandoffById(db, event.id));
+            }
+
+            const { state, outcome } = applyHandoffEvent(states.get(event.id) ?? null, event, { base });
+            states.set(event.id, state);
+
+            if (event.ev === "post" && !outcome.applied) {
+                log.error({ id: event.id, file }, "duplicate handoff post id — first wins, event skipped");
+            }
+
+            const extra: Partial<FoldOutcome> = {};
+
+            if (outcome.info !== undefined) {
+                extra.info = outcome.info;
+            }
+
+            if (outcome.noop !== undefined) {
+                extra.noop = outcome.noop;
+            }
+
+            if (outcome.assignedTaskIds !== undefined) {
+                extra.assignedTaskIds = outcome.assignedTaskIds;
+            }
+
+            putOutcome.run(
+                event.uid,
+                event.id,
+                event.ev,
+                outcome.applied ? 1 : 0,
+                outcome.error ?? null,
+                Object.keys(extra).length > 0 ? SafeJSON.stringify(extra, { strict: true }) : null,
+                event.ts
+            );
+        }
+
+        for (const state of states.values()) {
+            if (state !== null) {
+                upsertHandoff(db, state);
+            }
+        }
+
+        setOff.run(file, prevOffset + consumed);
+        applied = true;
+    });
+    tx();
+
+    if (applied) {
+        log.debug({ file, events: events.length, consumed }, "handoff fold batch applied");
+    }
+
+    return applied;
+}
+
+/** Drop + full re-fold (§6.1 rule 6). */
+export function rebuildHandoffModel(db: Database, base?: string): void {
+    db.exec("DROP TABLE IF EXISTS handoffs;");
+    db.exec("DROP TABLE IF EXISTS handoff_ingest_offsets;");
+    db.exec("DROP TABLE IF EXISTS handoff_event_results;");
+    createTables(db);
+    catchUpHandoffs(db, base);
+    log.info("handoff read-model rebuilt from JSONL");
+}

--- a/src/handoff/test-utils.ts
+++ b/src/handoff/test-utils.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HandoffDeps } from "./executor";
+import type { HandoffEventBy } from "./types";
+
+export function byFor(sessionId: string | null, sessionName: string | null = null): HandoffEventBy {
+    return {
+        sessionId,
+        sessionTitle: sessionName,
+        agent: sessionId === null ? "unknown" : "claude-code",
+        aiAgent: null,
+        branch: "test-branch",
+        cwd: "/tmp/test",
+        repoRoot: "/tmp/test",
+        project: "TestProj",
+        commitSha: null,
+        isWorktree: false,
+    };
+}
+
+export interface TestEnv {
+    base: string;
+    dbPath: string;
+    depsFor: (by: HandoffEventBy) => HandoffDeps;
+}
+
+export function freshEnv(): TestEnv {
+    const dir = mkdtempSync(join(tmpdir(), "handoff-test-"));
+    const base = join(dir, "log");
+    const dbPath = join(dir, "qa.db");
+    return { base, dbPath, depsFor: (by) => ({ base, dbPath, by }) };
+}

--- a/src/handoff/types.ts
+++ b/src/handoff/types.ts
@@ -1,0 +1,201 @@
+export type HandoffStatus = "open" | "claimed" | "done" | "cancelled";
+
+export interface HandoffTarget {
+    sessionId?: string;
+    sessionName?: string;
+}
+
+export interface HandoffTaskInput {
+    id?: string;
+    text: string;
+    acceptanceCriteria?: string;
+}
+
+export interface HandoffProof {
+    answer: string;
+    commitIds?: string[];
+    context?: string;
+    attachmentIds?: string[];
+}
+
+/** Compact who-did-it stamp kept on tasks/comments/claims (full context lives on the event). */
+export interface HandoffActor {
+    sessionId: string | null;
+    sessionName: string | null;
+    agent: string;
+    via?: string;
+}
+
+export interface HandoffTask {
+    id: string;
+    text: string;
+    acceptanceCriteria?: string;
+    checked: boolean;
+    proof?: HandoffProof;
+    checkedBy?: HandoffActor;
+    checkedTs?: string;
+    denied: boolean;
+    deniedReason?: string;
+    deniedBy?: HandoffActor;
+    deniedTs?: string;
+}
+
+export interface HandoffClaim {
+    sessionId: string | null;
+    sessionName: string | null;
+    branch: string | null;
+    cwd: string | null;
+    claimedAt: string;
+    via: "target-match" | "explicit";
+}
+
+export interface HandoffComment {
+    text: string;
+    attachmentIds?: string[];
+    by: HandoffActor;
+    ts: string;
+}
+
+export interface HandoffAttachment {
+    attachmentId: string;
+    filename: string;
+    mime: string;
+    bytes: number;
+    taskId?: string;
+    note?: string;
+    by: HandoffActor;
+    ts: string;
+    missing?: boolean;
+}
+
+/**
+ * The `by` stamp on every event — AgentContext subset per spec §6.1, plus
+ * `via: "dashboard"` for owner-authority UI events (agent: "human").
+ */
+export interface HandoffEventBy {
+    sessionId: string | null;
+    sessionTitle: string | null;
+    agent: string;
+    aiAgent: string | null;
+    branch: string | null;
+    cwd: string | null;
+    repoRoot: string | null;
+    project: string | null;
+    commitSha: string | null;
+    isWorktree: boolean;
+    via?: "dashboard";
+}
+
+interface HandoffEventBase {
+    ts: string;
+    /**
+     * Per-event correlation nonce: fold outcomes are persisted keyed by uid so the
+     * appending process can report truthful results even when a CONCURRENT process
+     * folded its batch first (spec §6.1 rules 2+4). Semantically inert for the fold.
+     */
+    uid: string;
+    id: string;
+    by: HandoffEventBy;
+    /**
+     * Poster credential echo for editId-authorized mutations — must live in the
+     * event so a rebuild folds to the same accept/reject decisions (§6.1 rules 1+6).
+     */
+    editId?: string;
+}
+
+export type HandoffEvent =
+    | (HandoffEventBase & {
+          ev: "post";
+          editId: string;
+          title: string;
+          description?: string;
+          tasks: HandoffTaskInput[];
+          target?: HandoffTarget;
+          refs?: string[];
+      })
+    | (HandoffEventBase & { ev: "claim"; via: "target-match" | "explicit" })
+    | (HandoffEventBase & { ev: "unclaim" })
+    | (HandoffEventBase & { ev: "check_task"; taskId: string; proof: HandoffProof; force?: boolean })
+    | (HandoffEventBase & { ev: "uncheck_task"; taskId: string })
+    | (HandoffEventBase & { ev: "deny_task"; taskId: string; reason: string; force?: boolean })
+    | (HandoffEventBase & { ev: "undeny_task"; taskId: string })
+    | (HandoffEventBase & { ev: "comment"; text: string; attachmentIds?: string[] })
+    | (HandoffEventBase & {
+          ev: "attach";
+          attachmentId: string;
+          filename: string;
+          mime: string;
+          bytes: number;
+          taskId?: string;
+          note?: string;
+      })
+    | (HandoffEventBase & { ev: "add_tasks"; tasks: HandoffTaskInput[] })
+    | (HandoffEventBase & { ev: "modify_task"; taskId: string; text?: string; acceptanceCriteria?: string })
+    | (HandoffEventBase & {
+          ev: "modify_handoff";
+          title?: string;
+          description?: string;
+          target?: HandoffTarget | null;
+          refs?: string[];
+      })
+    | (HandoffEventBase & { ev: "finish"; force?: boolean })
+    | (HandoffEventBase & { ev: "cancel" })
+    | (HandoffEventBase & { ev: "reopen" });
+
+export type HandoffEventName = HandoffEvent["ev"];
+
+/** Fully folded current state of one handoff (read-model row, deserialized). */
+export interface Handoff {
+    id: string;
+    title: string;
+    description?: string;
+    status: HandoffStatus;
+    tasks: HandoffTask[];
+    target?: HandoffTarget;
+    refs?: string[];
+    postedBy: HandoffActor;
+    postedByContext: HandoffEventBy;
+    project: string | null;
+    claimedBy: HandoffClaim[];
+    comments: HandoffComment[];
+    attachments: HandoffAttachment[];
+    editId: string;
+    createdTs: string;
+    updatedTs: string;
+    finishedTs?: string;
+    finishedBy?: HandoffActor;
+}
+
+/** What the fold decided for one event — persisted by uid (see HandoffEventBase.uid). */
+export interface FoldOutcome {
+    applied: boolean;
+    error?: string;
+    info?: string[];
+    noop?: boolean;
+    assignedTaskIds?: string[];
+}
+
+/** One entry of handoff_action's `actions` array: bare verb string or object. */
+export type HandoffActionInput = string | ({ action: string } & Record<string, unknown>);
+
+export interface HandoffActionResult {
+    action: string;
+    ok: boolean;
+    error?: string;
+    info?: string[];
+    assignedTaskIds?: string[];
+    attachmentId?: string;
+}
+
+export interface HandoffListRow {
+    id: string;
+    title: string;
+    status: HandoffStatus;
+    tasks: string;
+    progress?: string;
+    target?: HandoffTarget;
+    postedBy: { sessionName: string | null };
+    claimedBy?: { sessionId: string | null; sessionName: string | null }[];
+    project: string | null;
+    ageHours: number;
+}


### PR DESCRIPTION
## Summary
Part 2 of the annotate + handoff campaign — **cross-agent task handoff**.

A `handoff_post/get/list/action` MCP suite (sibling to `question_answer`) for durable, proof-checkable task handoff between agents, plus an interactive **"Agent tasks"** tab in the dev-dashboard `/qa` page.

### MCP suite (`src/handoff/`)
- **Event-sourced store** — append-only JSONL events + a sqlite read-model fold. CAS ingest-offset **inside** the write transaction (deliberately diverges from the question store, which reads the offset outside the tx and double-applies deltas).
- **Fold rules** — fold-after-append responses; deterministic auto task-id assignment at fold time; null `sessionId` never establishes identity; terminal-state gate.
- **One action language** — `handoff_action` with self-describing verbs (`add_tasks`, `modify_task`, `check_task`, `uncheck_task`, `deny_task`, `undeny_task`, `comment`, `claim`, `unclaim`, `finish_handoff`, `cancel_handoff`, `reopen_handoff`, `attach_file`) + an alias map + catalog errors for unknown verb/id/taskId.
- **Attachments** — disk files + metadata-only attach events, 10 MB cap, `missing:true` fold resilience, proof/comment screenshot sugar.

### Dashboard tab (`src/dev-dashboard/`)
- Two-pane list/detail Agent-tasks tab (open-count badge), owner-authority actor model (`by: {agent:"human", via:"dashboard"}`), POST `/action` + `/post` + `/attach` sharing the same MCP executor.
- Per-task controls (check w/ proof dialog, deny+reason, undeny, edit, add-task), comment composer with paste-anywhere screenshot chips, attachment lightbox, editId click-to-reveal.
- SSE stream that survives midnight rollover (replays the new day-file from byte 0 so no frame is missed).

## Test plan
- [x] `bun test src/handoff` — 27/27 green (CAS idempotency, null-session, aliases, catalogs, force symmetry, reopen paths, rebuild deep-equal, attachments missing:true, 10 MB cap, dashboard owner-authority)
- [x] `tsgo --noEmit` clean
- [x] Live browser sweep of `/qa?tab=tasks` — tab render, owner-authority proof, editId reveal, attachment lightbox+download, comment paste composer, per-task controls all verified
- [x] Functional HTTP sweep — post→id+editId, owner-authority check_task, attach round-trip byte-identical, 413 on 10 MB+

## Notes
Independent of the sibling **control-annotate** PR (only `src/claude/mcp/server.ts` is shared — this PR registers `handoff_*`, that one registers `annotate_image`).
