### PR TITLE
feat(ai-proxy): realtime audio tunnel + batch STT (xAI + OpenAI)

### DIFF
--- a/src/ai-proxy/REALTIME.md
+++ b/src/ai-proxy/REALTIME.md
@@ -64,10 +64,27 @@ ZlibError. The xAI provider now strips stale framing headers on every relay.
 ## Provider support
 
 Realtime is a provider capability (`realtimeConnect` / `realtimeClientSecrets`
-on `ProxyProvider`); currently only `xai-api-key` implements it. The upstream
-WS base defaults to the account's `baseUrl` with `http(s)` swapped for
-`ws(s)`; set `realtimeBaseUrl` on the account to override (this is how tests
-point it at a mock server).
+on `ProxyProvider`), implemented by two providers. The upstream WS base
+defaults to the account's `baseUrl` with `http(s)` swapped for `ws(s)`; set
+`realtimeBaseUrl` on the account to override (this is how tests point it at a
+mock server).
+
+| Provider (config `provider`) | Upstream | Realtime models | Key |
+|---|---|---|---|
+| `xai-api-key` | `wss://api.x.ai/v1/realtime` | `grok-voice-latest` | `apiKeyEnv` (e.g. XAI_API_KEY) |
+| `openai` | `wss://api.openai.com/v1/realtime` | `gpt-realtime`, `gpt-realtime-mini`, `gpt-4o-realtime-preview` | `apiKeyEnv` (default OPENAI_API_KEY) |
+
+Example account for OpenAI realtime (routes `martin/openai/gpt-realtime`):
+
+```json
+{ "name": "martin", "provider": "openai", "providerSlug": "openai", "enabled": true, "apiKeyEnv": "OPENAI_API_KEY" }
+```
+
+`openai` (platform API key) is distinct from `openai-subscription`
+(ChatGPT/Codex OAuth); it also forwards `/chat/completions` and `/responses`,
+and being an api-key provider it is grantable to non-owner clients. Note:
+`openai` accounts don't appear in the `/v1/models` catalog (no model-meta
+integration) — use full ids.
 
 ## Usage / billing
 
@@ -103,9 +120,17 @@ Caveat: xAI's realtime `response.done` reports `usage` with all-zero token
 counts — the ledger records the session (frames/bytes/duration) but token
 usage stays 0 until xAI populates it.
 
+**OpenAI provider (same run):** the tunnel routed
+`live-oa/openai/gpt-realtime` to the real OpenAI upstream — WS opened, key
+accepted (mint returns 200 with an `ek_…` secret), and OpenAI's
+`insufficient_quota` error event + 1013 close relayed verbatim to the client.
+The identical error reproduces connecting to OpenAI directly (proxy bypassed),
+so the block is the OpenAI **account's billing**, not the tunnel; a funded
+account is the only missing piece for an OpenAI speech round trip.
+
 Earlier mock coverage remains in `lib/realtime.test.ts` (auth rejection, model
-routing, both-way text+binary piping, pre-open queueing, close propagation,
-usage capture, batch STT translation).
+routing incl. openai-account routing, both-way text+binary piping, pre-open
+queueing, close propagation, usage capture, batch STT translation).
 
 ## genesis-server note
 

--- a/src/ai-proxy/REALTIME.md
+++ b/src/ai-proxy/REALTIME.md
@@ -1,0 +1,76 @@
+# ai-proxy realtime audio (`/v1/realtime`)
+
+Real-time speech-to-speech through the proxy: a voice client opens ONE WebSocket
+to ai-proxy and the proxy tunnels every frame — JSON events and binary audio
+alike — to the upstream provider's OpenAI-Realtime-compatible WS (xAI
+`wss://api.x.ai/v1/realtime`). Routing, auth, logging, and usage go through the
+same machinery as the HTTP chat path; the protocol itself is not reinterpreted.
+
+## Client-facing surface
+
+```
+ws://127.0.0.1:8317/v1/realtime?model=martin/grok/grok-voice-latest
+```
+
+- **Auth**: `Authorization: Bearer <proxyApiKey or client key>` — same keys as
+  `/v1/chat/completions`. Browsers can't set WS headers; pass `?key=<key>`
+  instead (only consulted when the header is absent).
+- **Model**: the `model` query param takes a proxy model id
+  (`<account>/<provider>/<model>`, shorter forms allowed) resolved by the same
+  `resolveModel` as chat; the upstream leg gets the bare upstream id
+  (`grok-voice-latest`) and the ACCOUNT's API key — the client never holds
+  upstream credentials.
+- **Protocol**: transparent tunnel. Send `session.update`,
+  `input_audio_buffer.append`, `response.create`, binary PCM frames, …;
+  receive `response.output_audio.delta`, transcripts, etc. verbatim.
+- Client provider/quota rules apply exactly like chat (subscription providers
+  stay owner-only; monthly caps reject the upgrade with 429).
+
+Ephemeral-token mint for browsers that must talk to xAI directly:
+
+```
+POST http://127.0.0.1:8317/v1/realtime/client_secrets
+Authorization: Bearer <proxy key>
+{"session": {"type": "realtime", "model": "martin/grok/grok-voice-latest"}}
+```
+
+The proxy resolves the model, rewrites it (top-level `model` and
+`session.model`) to the upstream id, and forwards to the provider's
+`/realtime/client_secrets` with the account key. Note: a session opened with a
+minted secret connects to the upstream DIRECTLY — it bypasses the proxy's
+logging/usage. Prefer the WS tunnel when the client can reach the proxy.
+
+## Provider support
+
+Realtime is a provider capability (`realtimeConnect` / `realtimeClientSecrets`
+on `ProxyProvider`); currently only `xai-api-key` implements it. The upstream
+WS base defaults to the account's `baseUrl` with `http(s)` swapped for
+`ws(s)`; set `realtimeBaseUrl` on the account to override (this is how tests
+point it at a mock server).
+
+## Usage / billing
+
+Best-effort: the tunnel sniffs upstream `response.done` events and accumulates
+`response.usage.{input,output,total}_tokens` per session, recorded into the
+usage ledger on close (`path: "/v1/realtime"`, `status: 101`) plus a
+`realtime session closed` log line with frame/byte counters both directions.
+If the upstream omits usage events the session is still recorded, just without
+token counts — no local estimate is attempted for audio.
+
+## Verification status (2026-07-20)
+
+**Live xAI verification is pending credits** — the team's xAI credits are
+exhausted (`POST /v1/realtime/client_secrets` → 403 "team … used all available
+credits"). The tunnel is verified against a mock upstream WS instead
+(`lib/realtime.test.ts`): auth rejection, model routing (upstream saw
+`grok-voice-latest` + the account key), text and binary frames piped both ways,
+pre-upstream-open frames queued not dropped, upstream close propagated with
+code/reason, and usage capture from `response.done`. Once credits exist, a live
+check is just: connect the URL above with a real key and speak.
+
+## genesis-server note
+
+The ephemeral mint lives here (ai-proxy) so the account key stays in one
+place; if genesis-server has (or grows) a `/api/realtime/token` route it
+should proxy to `POST /v1/realtime/client_secrets` on ai-proxy rather than
+hold XAI_API_KEY itself.

--- a/src/ai-proxy/REALTIME.md
+++ b/src/ai-proxy/REALTIME.md
@@ -40,6 +40,27 @@ The proxy resolves the model, rewrites it (top-level `model` and
 minted secret connects to the upstream DIRECTLY — it bypasses the proxy's
 logging/usage. Prefer the WS tunnel when the client can reach the proxy.
 
+## Batch STT: `POST /v1/audio/transcriptions`
+
+OpenAI Whisper-compatible batch transcription for non-realtime use:
+
+```
+POST http://127.0.0.1:8317/v1/audio/transcriptions
+Authorization: Bearer <proxy key>
+multipart/form-data: model=martin/grok/grok-transcribe, file=<audio>, [language=…]
+```
+
+xAI has NO OpenAI-shape transcriptions route (404, verified live 2026-07-20) —
+its STT is `POST /v1/stt` (multipart, no model field, `file` appended last).
+The provider translates: `model` is consumed by proxy routing, remaining
+fields + file forward to `/stt`, and the response (`{text, language, duration,
+words}` — a superset of OpenAI's `json` format) passes through as-is. 25 MB
+body cap (OpenAI's Whisper limit).
+
+Relay gotcha fixed along the way: Bun's fetch decodes gzip upstream bodies but
+keeps `Content-Encoding` on the headers; relaying them verbatim gave clients a
+ZlibError. The xAI provider now strips stale framing headers on every relay.
+
 ## Provider support
 
 Realtime is a provider capability (`realtimeConnect` / `realtimeClientSecrets`
@@ -57,16 +78,34 @@ usage ledger on close (`path: "/v1/realtime"`, `status: 101`) plus a
 If the upstream omits usage events the session is still recorded, just without
 token counts — no local estimate is attempted for audio.
 
-## Verification status (2026-07-20)
+## Verification status (2026-07-20): LIVE-VERIFIED against real xAI
 
-**Live xAI verification is pending credits** — the team's xAI credits are
-exhausted (`POST /v1/realtime/client_secrets` → 403 "team … used all available
-credits"). The tunnel is verified against a mock upstream WS instead
-(`lib/realtime.test.ts`): auth rejection, model routing (upstream saw
-`grok-voice-latest` + the account key), text and binary frames piped both ways,
-pre-upstream-open frames queued not dropped, upstream close propagated with
-code/reason, and usage capture from `response.done`. Once credits exist, a live
-check is just: connect the URL above with a real key and speak.
+Credits were refilled and the full stack was verified against the real
+upstream via `scripts/verify-realtime-live.ts` (throwaway proxy, temp config,
+real `XAI_API_KEY`; spends ~a cent):
+
+- **WS tunnel, full speech-to-speech round trip**: spoke a `say`-synthesized
+  sample through `ws://…/v1/realtime?model=live/grok/grok-voice-latest`;
+  upstream transcribed the input ("Hello there, please tell me one fun fact."),
+  streamed 273 KB of `response.output_audio.delta` plus the output transcript
+  ("The world's largest snowflake was recorded in 1887 and measured 15 inches
+  wide!"), full GA event ladder through `response.done`, clean close.
+  Session shape mirrored the companion client: `session.update` with
+  `turn_detection: null`, `audio.input.format {audio/pcm, rate 24000}`,
+  `audio.input.transcription {model: grok-transcribe}`, then
+  `input_audio_buffer.append` (base64 PCM) → `commit` → `response.create`.
+- **Batch `/v1/audio/transcriptions`**: HTTP 200 with the exact transcript +
+  word timings through the proxy.
+- **Mint `/v1/realtime/client_secrets`**: HTTP 200 with a 107-char
+  `xai-realtime-client-secret-…` (was 403 credits-exhausted before refill).
+
+Caveat: xAI's realtime `response.done` reports `usage` with all-zero token
+counts — the ledger records the session (frames/bytes/duration) but token
+usage stays 0 until xAI populates it.
+
+Earlier mock coverage remains in `lib/realtime.test.ts` (auth rejection, model
+routing, both-way text+binary piping, pre-open queueing, close propagation,
+usage capture, batch STT translation).
 
 ## genesis-server note
 

--- a/src/ai-proxy/lib/account-config.ts
+++ b/src/ai-proxy/lib/account-config.ts
@@ -22,6 +22,7 @@ export function accountConfigFingerprint(account: AiProxyAccountConfig): string 
     return SafeJSON.stringify({
         provider: account.provider,
         baseUrl: account.baseUrl,
+        realtimeBaseUrl: account.realtimeBaseUrl,
         grok: account.grok,
         githubCopilot: account.githubCopilot,
         anthropicSub: account.anthropicSub,

--- a/src/ai-proxy/lib/audio.ts
+++ b/src/ai-proxy/lib/audio.ts
@@ -1,0 +1,99 @@
+import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { guardProxyRoute, jsonError } from "@app/ai-proxy/lib/route-guards";
+import type { AiProxyConfig } from "@app/ai-proxy/lib/types";
+import { scheduleBillingSync } from "@app/ai-proxy/lib/usage/billing-sync";
+import { recordUsageRequest } from "@app/ai-proxy/lib/usage/store";
+import { logger } from "@genesiscz/utils/logger";
+
+/** OpenAI's Whisper file limit — audio uploads are bigger than chat bodies. */
+const MAX_AUDIO_BODY_BYTES = 25 * 1024 * 1024;
+
+/**
+ * POST /v1/audio/transcriptions — OpenAI Whisper-compatible batch STT.
+ * Multipart body with `file` + `model` (proxy model id, e.g.
+ * martin/grok/grok-transcribe); the provider translates to its own STT API
+ * (xAI has no OpenAI-shape transcriptions route — it posts to /v1/stt).
+ */
+export async function handleAudioTranscriptions(input: {
+    req: Request;
+    config: AiProxyConfig;
+    providers: Map<string, ProxyProvider>;
+}): Promise<Response> {
+    const contentLength = input.req.headers.get("content-length");
+
+    if (contentLength) {
+        const declaredBytes = Number.parseInt(contentLength, 10);
+
+        if (Number.isFinite(declaredBytes) && declaredBytes > MAX_AUDIO_BODY_BYTES) {
+            return jsonError(413, "Audio body too large (max 25 MB)");
+        }
+    }
+
+    let form: FormData;
+    try {
+        form = await input.req.formData();
+    } catch {
+        return jsonError(400, "Body must be multipart/form-data with a file field");
+    }
+
+    const file = form.get("file");
+
+    if (!(file instanceof Blob)) {
+        return jsonError(400, "Missing file field");
+    }
+
+    const model = form.get("model");
+    const guarded = await guardProxyRoute({
+        authReq: input.req,
+        config: input.config,
+        providers: input.providers,
+        proxyModel: typeof model === "string" ? model : undefined,
+        logLabel: "transcriptions",
+    });
+
+    if (guarded instanceof Response) {
+        return guarded;
+    }
+
+    const { client, route, provider } = guarded;
+
+    if (typeof provider.audioTranscriptions !== "function") {
+        return jsonError(400, `Provider "${route.account.provider}" does not support audio transcriptions`);
+    }
+
+    const started = performance.now();
+    const response = await provider.audioTranscriptions(input.req, route.upstreamId, form);
+    const elapsedMs = Math.round(performance.now() - started);
+
+    logger.info(
+        {
+            path: "/v1/audio/transcriptions",
+            model,
+            upstreamModel: route.upstreamId,
+            status: response.status,
+            elapsedMs,
+            fileBytes: file.size,
+            client: client.name,
+        },
+        "ai-proxy: request"
+    );
+
+    // STT bills per audio-second, not tokens — record the request without usage.
+    recordUsageRequest({
+        ts: new Date().toISOString(),
+        account: route.accountName,
+        client: client.name,
+        provider: route.account.provider,
+        proxyModel: typeof model === "string" ? model : String(model),
+        upstreamModel: route.upstreamId,
+        path: "/v1/audio/transcriptions",
+        status: response.status,
+        elapsedMs,
+        stream: false,
+        rateLimited: response.status === 429,
+        error: response.status >= 400,
+    });
+    scheduleBillingSync(route.account, input.providers);
+
+    return response;
+}

--- a/src/ai-proxy/lib/providers/http-relay.ts
+++ b/src/ai-proxy/lib/providers/http-relay.ts
@@ -1,0 +1,40 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+
+/**
+ * Bun's fetch transparently decodes compressed upstream bodies but leaves
+ * Content-Encoding/Content-Length on the headers; relaying those verbatim
+ * makes the client try to gunzip already-plain bytes (ZlibError — bit the
+ * /stt relay live 2026-07-20). Strip the now-stale framing headers.
+ */
+export function relayHeaders(upstream: Response): Headers {
+    const headers = new Headers(upstream.headers);
+    headers.delete("content-encoding");
+    headers.delete("content-length");
+    headers.delete("transfer-encoding");
+    return headers;
+}
+
+/**
+ * client_secrets bodies nest the model under `session.model` (top-level `model`
+ * is handled by rewriteBodyModel in the provider's forward); rewrite the nested
+ * one here.
+ */
+export function rewriteSessionModel(bodyText: string, upstreamModel: string): string {
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true }) as Record<string, unknown>;
+        const session = parsed.session;
+
+        if (session && typeof session === "object" && "model" in session) {
+            return SafeJSON.stringify({ ...parsed, session: { ...session, model: upstreamModel } });
+        }
+
+        return bodyText;
+    } catch {
+        return bodyText;
+    }
+}
+
+/** http(s) base → ws(s) base for a provider's realtime endpoint. */
+export function toWsBase(httpOrWsBase: string): string {
+    return httpOrWsBase.replace(/\/$/, "").replace(/^http/, "ws");
+}

--- a/src/ai-proxy/lib/providers/openai-api-key.ts
+++ b/src/ai-proxy/lib/providers/openai-api-key.ts
@@ -1,0 +1,166 @@
+import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
+import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
+import { rewriteBodyModel } from "@app/ai-proxy/lib/rewrite-upstream-body";
+import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { fetchDirect } from "@genesiscz/utils/net/fetch-direct";
+
+export const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
+
+function maskKey(key: string): string {
+    if (key.length <= 8) {
+        return "****";
+    }
+
+    return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+/**
+ * OpenAI API-key provider (`https://api.openai.com/v1`, provider type
+ * "openai"). Bills the platform API key — distinct from openai-subscription
+ * (ChatGPT/Codex OAuth). Exists primarily for the realtime voice tunnel
+ * (gpt-realtime / gpt-realtime-mini / gpt-4o-realtime-preview); chat and
+ * responses forward too since the surface is identical.
+ */
+export class OpenAiApiKeyProvider implements ProxyProvider {
+    readonly id = "openai";
+    readonly accountFingerprint: string;
+    private readonly account: AiProxyAccountConfig;
+    private readonly apiKey: string;
+    private readonly baseUrl: string;
+
+    constructor(account: AiProxyAccountConfig, apiKey: string) {
+        this.account = account;
+        this.accountFingerprint = accountConfigFingerprint(account);
+        this.apiKey = apiKey;
+        this.baseUrl = (account.baseUrl ?? OPENAI_API_BASE_URL).replace(/\/$/, "");
+    }
+
+    static async create(account: AiProxyAccountConfig): Promise<OpenAiApiKeyProvider> {
+        const envName = account.apiKeyEnv ?? "OPENAI_API_KEY";
+        const apiKey = env.getTrimmed(envName as never);
+
+        if (!apiKey) {
+            throw new Error(`No OpenAI API key found (checked ${envName}).`);
+        }
+
+        return new OpenAiApiKeyProvider(account, apiKey);
+    }
+
+    async listModels(): Promise<OpenAiModel[]> {
+        try {
+            const response = await fetchDirect(`${this.baseUrl}/models`, {
+                headers: { Authorization: `Bearer ${this.apiKey}` },
+            });
+
+            if (!response.ok) {
+                return [];
+            }
+
+            const body = (await response.json()) as { data?: { id: string; created?: number; owned_by?: string }[] };
+
+            return (body.data ?? []).map((model) => ({
+                id: `${this.account.name}/${this.account.providerSlug}/${model.id}`,
+                object: "model" as const,
+                created: model.created ?? 0,
+                owned_by: model.owned_by ?? "openai",
+            }));
+        } catch (err) {
+            logger.warn({ err, account: this.account.name }, "ai-proxy: openai listModels failed");
+            return [];
+        }
+    }
+
+    async chatCompletions(req: Request, model: string, bodyText: string): Promise<Response> {
+        return this.forward("/chat/completions", model, bodyText, req);
+    }
+
+    async responses(req: Request, model: string, bodyText: string): Promise<Response> {
+        return this.forward("/responses", model, bodyText, req);
+    }
+
+    async getUsage(): Promise<UsageSummary> {
+        return {
+            accountName: this.account.name,
+            provider: "openai",
+            summary: `API key ${maskKey(this.apiKey)} present. Platform billing has no key-scoped usage endpoint.`,
+        };
+    }
+
+    /** Upstream realtime WS: `baseUrl` with ws(s) scheme unless `realtimeBaseUrl` overrides. */
+    realtimeConnect(model: string): RealtimeConnectTarget {
+        const wsBase = toWsBase(this.account.realtimeBaseUrl ?? this.baseUrl);
+
+        return {
+            url: `${wsBase}/realtime?model=${encodeURIComponent(model)}`,
+            headers: { Authorization: `Bearer ${this.apiKey}` },
+        };
+    }
+
+    /** Ephemeral client-secret mint — model is rewritten both top-level and in `session.model`. */
+    async realtimeClientSecrets(req: Request, model: string, bodyText: string): Promise<Response> {
+        return this.forward("/realtime/client_secrets", model, rewriteSessionModel(bodyText, model), req);
+    }
+
+    private async forward(path: string, upstreamModel: string, bodyText: string, req: Request): Promise<Response> {
+        const started = performance.now();
+        const upstreamBody = rewriteBodyModel(bodyText, upstreamModel);
+
+        try {
+            const upstream = await fetchDirect(`${this.baseUrl}${path}`, {
+                method: "POST",
+                body: upstreamBody,
+                signal: req.signal,
+                headers: {
+                    Authorization: `Bearer ${this.apiKey}`,
+                    "Content-Type": "application/json",
+                    Accept: req.headers.get("Accept") ?? "application/json",
+                },
+            });
+
+            const elapsedMs = Math.round(performance.now() - started);
+            logger[upstream.ok ? "debug" : "warn"](
+                { account: this.account.name, upstreamModel, path, status: upstream.status, elapsedMs },
+                `ai-proxy: openai upstream request ${upstream.ok ? "ok" : "failed"}`
+            );
+
+            return new Response(upstream.body, {
+                status: upstream.status,
+                headers: relayHeaders(upstream),
+            });
+        } catch (err) {
+            if (req.signal.aborted) {
+                logger.debug({ account: this.account.name, path }, "ai-proxy: openai client aborted");
+                return new Response(null, { status: 499 });
+            }
+
+            logger.warn(
+                {
+                    err,
+                    account: this.account.name,
+                    upstreamModel,
+                    path,
+                    elapsedMs: Math.round(performance.now() - started),
+                },
+                "ai-proxy: openai upstream fetch threw"
+            );
+
+            return new Response(
+                SafeJSON.stringify({
+                    error: {
+                        message: err instanceof Error ? err.message : String(err),
+                        type: "upstream_error",
+                        code: "openai_api_fetch_failed",
+                    },
+                }),
+                {
+                    status: 502,
+                    headers: { "Content-Type": "application/json" },
+                }
+            );
+        }
+    }
+}

--- a/src/ai-proxy/lib/providers/registry.ts
+++ b/src/ai-proxy/lib/providers/registry.ts
@@ -1,3 +1,4 @@
+import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { AnthropicSubscriptionProvider } from "@app/ai-proxy/lib/providers/anthropic-subscription";
 import { GithubCopilotSubscriptionProvider } from "@app/ai-proxy/lib/providers/github-copilot-subscription";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
@@ -72,6 +73,41 @@ export async function createProvider(account: AiProxyAccountConfig): Promise<Pro
     }
 
     throw new Error(`Provider not implemented yet: ${account.provider}`);
+}
+
+/**
+ * Fetch the cached provider for a resolved route, recreating it when the
+ * account config changed (fingerprint mismatch) or it was never built. Returns
+ * null when the provider cannot be created.
+ */
+export async function acquireProvider(
+    providers: Map<string, ProxyProvider>,
+    route: { accountName: string; providerSlug: string; account: AiProxyAccountConfig }
+): Promise<ProxyProvider | null> {
+    const key = routeProviderKey(route);
+    const fingerprint = accountConfigFingerprint(route.account);
+    let provider = providers.get(key);
+
+    if (provider && provider.accountFingerprint !== fingerprint) {
+        const refreshed = await tryCreateProvider(route.account);
+        if (refreshed) {
+            providers.set(key, refreshed);
+            provider = refreshed;
+        } else {
+            providers.delete(key);
+            provider = undefined;
+        }
+    }
+
+    if (!provider) {
+        const created = await tryCreateProvider(route.account);
+        if (created) {
+            providers.set(key, created);
+            provider = created;
+        }
+    }
+
+    return provider ?? null;
 }
 
 export async function tryCreateProvider(account: AiProxyAccountConfig): Promise<ProxyProvider | null> {

--- a/src/ai-proxy/lib/providers/registry.ts
+++ b/src/ai-proxy/lib/providers/registry.ts
@@ -2,6 +2,7 @@ import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { AnthropicSubscriptionProvider } from "@app/ai-proxy/lib/providers/anthropic-subscription";
 import { GithubCopilotSubscriptionProvider } from "@app/ai-proxy/lib/providers/github-copilot-subscription";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
+import { OpenAiApiKeyProvider } from "@app/ai-proxy/lib/providers/openai-api-key";
 import { OpenAiSubscriptionProvider } from "@app/ai-proxy/lib/providers/openai-subscription";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { XaiApiKeyProvider } from "@app/ai-proxy/lib/providers/xai-api-key";
@@ -22,7 +23,8 @@ export function isProviderImplemented(provider: AiProxyAccountConfig["provider"]
         provider === "github-copilot-subscription" ||
         provider === "anthropic-subscription" ||
         provider === "openai-subscription" ||
-        provider === "xai-api-key"
+        provider === "xai-api-key" ||
+        provider === "openai"
     );
 }
 
@@ -70,6 +72,10 @@ export async function createProvider(account: AiProxyAccountConfig): Promise<Pro
 
     if (account.provider === "xai-api-key") {
         return XaiApiKeyProvider.create(account);
+    }
+
+    if (account.provider === "openai") {
+        return OpenAiApiKeyProvider.create(account);
     }
 
     throw new Error(`Provider not implemented yet: ${account.provider}`);

--- a/src/ai-proxy/lib/providers/types.ts
+++ b/src/ai-proxy/lib/providers/types.ts
@@ -25,4 +25,6 @@ export interface ProxyProvider {
     realtimeConnect?(model: string): RealtimeConnectTarget;
     /** POST /realtime/client_secrets pass-through (ephemeral token mint); absent = unsupported. */
     realtimeClientSecrets?(req: Request, model: string, bodyText: string): Promise<Response>;
+    /** OpenAI-compatible batch STT (/v1/audio/transcriptions); absent = unsupported. */
+    audioTranscriptions?(req: Request, model: string, form: FormData): Promise<Response>;
 }

--- a/src/ai-proxy/lib/providers/types.ts
+++ b/src/ai-proxy/lib/providers/types.ts
@@ -8,6 +8,12 @@ export interface OpenAiModel {
     description?: string;
 }
 
+/** Upstream realtime WebSocket connect target resolved by a provider. */
+export interface RealtimeConnectTarget {
+    url: string;
+    headers: Record<string, string>;
+}
+
 export interface ProxyProvider {
     id: string;
     readonly accountFingerprint: string;
@@ -15,4 +21,8 @@ export interface ProxyProvider {
     chatCompletions(req: Request, model: string, bodyText: string): Promise<Response>;
     responses(req: Request, model: string, bodyText: string): Promise<Response>;
     getUsage(): Promise<UsageSummary>;
+    /** Providers with a realtime WS API return the upstream connect target; absent = unsupported. */
+    realtimeConnect?(model: string): RealtimeConnectTarget;
+    /** POST /realtime/client_secrets pass-through (ephemeral token mint); absent = unsupported. */
+    realtimeClientSecrets?(req: Request, model: string, bodyText: string): Promise<Response>;
 }

--- a/src/ai-proxy/lib/providers/xai-api-key.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key.ts
@@ -12,6 +12,20 @@ import { fetchDirect } from "@genesiscz/utils/net/fetch-direct";
 
 export { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
 
+/**
+ * Bun's fetch transparently decodes compressed upstream bodies but leaves
+ * Content-Encoding/Content-Length on the headers; relaying those verbatim
+ * makes the client try to gunzip already-plain bytes (ZlibError — bit the
+ * /stt relay live 2026-07-20). Strip the now-stale framing headers.
+ */
+function relayHeaders(upstream: Response): Headers {
+    const headers = new Headers(upstream.headers);
+    headers.delete("content-encoding");
+    headers.delete("content-length");
+    headers.delete("transfer-encoding");
+    return headers;
+}
+
 function maskKey(key: string): string {
     if (key.length <= 8) {
         return "****";
@@ -84,6 +98,82 @@ export class XaiApiKeyProvider implements ProxyProvider {
     /** Ephemeral client-secret mint — model is rewritten both top-level and in `session.model`. */
     async realtimeClientSecrets(req: Request, model: string, bodyText: string): Promise<Response> {
         return this.forward("/realtime/client_secrets", model, rewriteSessionModel(bodyText, model), req);
+    }
+
+    /**
+     * OpenAI Whisper-compatible in, xAI /stt out. xAI has no
+     * /audio/transcriptions route (404, verified 2026-07-20); its STT takes
+     * multipart WITHOUT a model field (routing consumed the proxy model) and
+     * requires `file` appended last. Response ({text, language, duration,
+     * words}) is a superset of OpenAI's json format — passed through as-is.
+     */
+    async audioTranscriptions(req: Request, upstreamModel: string, form: FormData): Promise<Response> {
+        const started = performance.now();
+        const upstream = new FormData();
+
+        for (const [key, value] of form.entries()) {
+            if (key === "model" || key === "file") {
+                continue;
+            }
+
+            upstream.append(key, value);
+        }
+
+        const file = form.get("file");
+
+        if (file instanceof Blob) {
+            upstream.append("file", file, file instanceof File ? file.name : "audio");
+        }
+
+        try {
+            const response = await fetchDirect(`${this.baseUrl}/stt`, {
+                method: "POST",
+                body: upstream,
+                signal: req.signal,
+                headers: { Authorization: `Bearer ${this.apiKey}` },
+            });
+
+            const elapsedMs = Math.round(performance.now() - started);
+            logger[response.ok ? "debug" : "warn"](
+                { account: this.account.name, upstreamModel, path: "/stt", status: response.status, elapsedMs },
+                `ai-proxy: xai-api-key upstream stt ${response.ok ? "ok" : "failed"}`
+            );
+
+            return new Response(response.body, {
+                status: response.status,
+                headers: relayHeaders(response),
+            });
+        } catch (err) {
+            if (req.signal.aborted) {
+                logger.debug({ account: this.account.name, path: "/stt" }, "ai-proxy: xai-api-key client aborted");
+                return new Response(null, { status: 499 });
+            }
+
+            logger.warn(
+                {
+                    err,
+                    account: this.account.name,
+                    upstreamModel,
+                    path: "/stt",
+                    elapsedMs: Math.round(performance.now() - started),
+                },
+                "ai-proxy: xai-api-key upstream stt threw"
+            );
+
+            return new Response(
+                SafeJSON.stringify({
+                    error: {
+                        message: err instanceof Error ? err.message : String(err),
+                        type: "upstream_error",
+                        code: "xai_api_fetch_failed",
+                    },
+                }),
+                {
+                    status: 502,
+                    headers: { "Content-Type": "application/json" },
+                }
+            );
+        }
     }
 
     async getUsage(): Promise<UsageSummary> {
@@ -177,7 +267,7 @@ export class XaiApiKeyProvider implements ProxyProvider {
 
             return new Response(upstream.body, {
                 status: upstream.status,
-                headers: upstream.headers,
+                headers: relayHeaders(upstream),
             });
         } catch (err) {
             if (req.signal.aborted) {

--- a/src/ai-proxy/lib/providers/xai-api-key.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key.ts
@@ -1,4 +1,5 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
 import { listXaiProxyModels } from "@app/ai-proxy/lib/model-meta";
 import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
@@ -11,20 +12,6 @@ import { logger } from "@genesiscz/utils/logger";
 import { fetchDirect } from "@genesiscz/utils/net/fetch-direct";
 
 export { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
-
-/**
- * Bun's fetch transparently decodes compressed upstream bodies but leaves
- * Content-Encoding/Content-Length on the headers; relaying those verbatim
- * makes the client try to gunzip already-plain bytes (ZlibError — bit the
- * /stt relay live 2026-07-20). Strip the now-stale framing headers.
- */
-function relayHeaders(upstream: Response): Headers {
-    const headers = new Headers(upstream.headers);
-    headers.delete("content-encoding");
-    headers.delete("content-length");
-    headers.delete("transfer-encoding");
-    return headers;
-}
 
 function maskKey(key: string): string {
     if (key.length <= 8) {
@@ -87,7 +74,7 @@ export class XaiApiKeyProvider implements ProxyProvider {
 
     /** Upstream realtime WS: `baseUrl` with ws(s) scheme unless `realtimeBaseUrl` overrides. */
     realtimeConnect(model: string): RealtimeConnectTarget {
-        const wsBase = (this.account.realtimeBaseUrl ?? this.baseUrl).replace(/\/$/, "").replace(/^http/, "ws");
+        const wsBase = toWsBase(this.account.realtimeBaseUrl ?? this.baseUrl);
 
         return {
             url: `${wsBase}/realtime?model=${encodeURIComponent(model)}`,
@@ -300,25 +287,6 @@ export class XaiApiKeyProvider implements ProxyProvider {
                 }
             );
         }
-    }
-}
-
-/**
- * client_secrets bodies nest the model under `session.model` (top-level `model`
- * is handled by rewriteBodyModel in forward()); rewrite the nested one here.
- */
-function rewriteSessionModel(bodyText: string, upstreamModel: string): string {
-    try {
-        const parsed = SafeJSON.parse(bodyText, { strict: true }) as Record<string, unknown>;
-        const session = parsed.session;
-
-        if (session && typeof session === "object" && "model" in session) {
-            return SafeJSON.stringify({ ...parsed, session: { ...session, model: upstreamModel } });
-        }
-
-        return bodyText;
-    } catch {
-        return bodyText;
     }
 }
 

--- a/src/ai-proxy/lib/providers/xai-api-key.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key.ts
@@ -1,6 +1,6 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { listXaiProxyModels } from "@app/ai-proxy/lib/model-meta";
-import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
 import { rewriteBodyModel } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
@@ -69,6 +69,21 @@ export class XaiApiKeyProvider implements ProxyProvider {
 
     async responses(req: Request, model: string, bodyText: string): Promise<Response> {
         return this.forward("/responses", model, bodyText, req);
+    }
+
+    /** Upstream realtime WS: `baseUrl` with ws(s) scheme unless `realtimeBaseUrl` overrides. */
+    realtimeConnect(model: string): RealtimeConnectTarget {
+        const wsBase = (this.account.realtimeBaseUrl ?? this.baseUrl).replace(/\/$/, "").replace(/^http/, "ws");
+
+        return {
+            url: `${wsBase}/realtime?model=${encodeURIComponent(model)}`,
+            headers: { Authorization: `Bearer ${this.apiKey}` },
+        };
+    }
+
+    /** Ephemeral client-secret mint — model is rewritten both top-level and in `session.model`. */
+    async realtimeClientSecrets(req: Request, model: string, bodyText: string): Promise<Response> {
+        return this.forward("/realtime/client_secrets", model, rewriteSessionModel(bodyText, model), req);
     }
 
     async getUsage(): Promise<UsageSummary> {
@@ -195,6 +210,25 @@ export class XaiApiKeyProvider implements ProxyProvider {
                 }
             );
         }
+    }
+}
+
+/**
+ * client_secrets bodies nest the model under `session.model` (top-level `model`
+ * is handled by rewriteBodyModel in forward()); rewrite the nested one here.
+ */
+function rewriteSessionModel(bodyText: string, upstreamModel: string): string {
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true }) as Record<string, unknown>;
+        const session = parsed.session;
+
+        if (session && typeof session === "object" && "model" in session) {
+            return SafeJSON.stringify({ ...parsed, session: { ...session, model: upstreamModel } });
+        }
+
+        return bodyText;
+    } catch {
+        return bodyText;
     }
 }
 

--- a/src/ai-proxy/lib/realtime.test.ts
+++ b/src/ai-proxy/lib/realtime.test.ts
@@ -1,0 +1,283 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAiProxyConfigStore, resetAiProxyConfigStore } from "@app/ai-proxy/lib/config-store";
+import { createRuntime, startAiProxyServer } from "@app/ai-proxy/lib/server";
+import { getAiProxyStorage, resetAiProxyStorage } from "@app/ai-proxy/lib/storage";
+import type { AiProxyConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+// Integration: real proxy server + mock upstream realtime WS (xAI credits are
+// exhausted, so live verification is pending — see REALTIME.md). The mock
+// stands in for wss://api.x.ai/v1/realtime via the account's realtimeBaseUrl.
+
+const PROXY_KEY = "test-proxy-key-0123456789abcdef";
+
+interface UpstreamSession {
+    authorization: string | null;
+    model: string | null;
+}
+
+const upstreamSessions: UpstreamSession[] = [];
+
+let mockUpstream: ReturnType<typeof Bun.serve>;
+let proxy: ReturnType<typeof startAiProxyServer>;
+let proxyUrl: string;
+
+const originalHome = env.get("GENESIS_TOOLS_HOME");
+const originalKey = env.get("AI_PROXY_TEST_XAI_KEY");
+
+function startMockUpstream() {
+    return Bun.serve<UpstreamSession, never>({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch(req, server) {
+            const url = new URL(req.url);
+
+            if (url.pathname !== "/realtime") {
+                return new Response("Not Found", { status: 404 });
+            }
+
+            const session: UpstreamSession = {
+                authorization: req.headers.get("Authorization"),
+                model: url.searchParams.get("model"),
+            };
+            upstreamSessions.push(session);
+
+            if (server.upgrade(req, { data: session })) {
+                return undefined;
+            }
+
+            return new Response("upgrade failed", { status: 426 });
+        },
+        websocket: {
+            open(ws) {
+                ws.send(SafeJSON.stringify({ type: "session.created", model: ws.data.model }));
+            },
+            message(ws, message) {
+                if (typeof message === "string") {
+                    if (message === "close-me") {
+                        ws.close(4321, "mock upstream bye");
+                        return;
+                    }
+
+                    if (message === "report-usage") {
+                        ws.send(
+                            SafeJSON.stringify({
+                                type: "response.done",
+                                response: { usage: { input_tokens: 7, output_tokens: 5, total_tokens: 12 } },
+                            })
+                        );
+                        return;
+                    }
+
+                    ws.send(`echo:${message}`);
+                    return;
+                }
+
+                // Binary frames echo back verbatim.
+                ws.send(message);
+            },
+        },
+    });
+}
+
+async function connectClient(query: string, headers?: Record<string, string>) {
+    const events: (string | ArrayBuffer)[] = [];
+    const opened = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<{ code: number; reason: string }>();
+    const ws = new WebSocket(`${proxyUrl}/v1/realtime${query}`, headers ? ({ headers } as never) : undefined);
+    ws.binaryType = "arraybuffer";
+    ws.onopen = () => opened.resolve();
+    ws.onerror = () => opened.reject(new Error("client WS errored"));
+    ws.onclose = (event) => closed.resolve({ code: event.code, reason: event.reason });
+    ws.onmessage = (event) => events.push(event.data as string | ArrayBuffer);
+
+    return { ws, events, opened: opened.promise, closed: closed.promise };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+    const started = Date.now();
+
+    while (!predicate()) {
+        if (Date.now() - started > timeoutMs) {
+            throw new Error("waitFor timed out");
+        }
+
+        await Bun.sleep(10);
+    }
+}
+
+beforeAll(async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "ai-proxy-realtime-"));
+    env.testing.set("GENESIS_TOOLS_HOME", tempDir);
+    env.testing.set("AI_PROXY_TEST_XAI_KEY", "xai-mock-key");
+    resetAiProxyConfigStore();
+    resetAiProxyStorage();
+
+    mockUpstream = startMockUpstream();
+
+    const config: AiProxyConfig = {
+        listen: { host: "127.0.0.1", port: 0 },
+        proxyApiKey: PROXY_KEY,
+        translation: { cursorAgent: "off", thinking: "raw" },
+        accounts: [
+            {
+                name: "martin",
+                provider: "xai-api-key",
+                providerSlug: "grok",
+                enabled: true,
+                apiKeyEnv: "AI_PROXY_TEST_XAI_KEY",
+                baseUrl: `http://127.0.0.1:${mockUpstream.port}`,
+                realtimeBaseUrl: `ws://127.0.0.1:${mockUpstream.port}`,
+            },
+        ],
+    };
+
+    mkdirSync(getAiProxyStorage().getBaseDir(), { recursive: true });
+    await getAiProxyConfigStore().save(config);
+
+    const runtime = await createRuntime(config);
+    proxy = startAiProxyServer(runtime);
+    proxyUrl = `ws://127.0.0.1:${proxy.port}`;
+});
+
+afterAll(() => {
+    proxy?.stop(true);
+    mockUpstream?.stop(true);
+    resetAiProxyConfigStore();
+    resetAiProxyStorage();
+
+    if (originalHome === undefined) {
+        env.testing.unset("GENESIS_TOOLS_HOME");
+    } else {
+        env.testing.set("GENESIS_TOOLS_HOME", originalHome);
+    }
+
+    if (originalKey === undefined) {
+        env.testing.unset("AI_PROXY_TEST_XAI_KEY");
+    } else {
+        env.testing.set("AI_PROXY_TEST_XAI_KEY", originalKey);
+    }
+});
+
+describe("realtime WS tunnel", () => {
+    it("rejects a bad proxy key with 401 before upgrading", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime?model=martin/grok/grok-voice-latest`, {
+            headers: { Authorization: "Bearer wrong-key" },
+        });
+
+        expect(res.status).toBe(401);
+        const body = (await res.json()) as { error: { type: string } };
+        expect(body.error.type).toBe("auth_error");
+    });
+
+    it("rejects a missing model with 400", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime`, {
+            headers: { Authorization: `Bearer ${PROXY_KEY}` },
+        });
+
+        expect(res.status).toBe(400);
+    });
+
+    it("rejects an unknown model with 400", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime?model=nope/nope/nope`, {
+            headers: { Authorization: `Bearer ${PROXY_KEY}` },
+        });
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error: { message: string } };
+        expect(body.error.message).toContain("No enabled account");
+    });
+
+    it("pipes text and binary frames both ways with routed model + upstream auth", async () => {
+        const sessionsBefore = upstreamSessions.length;
+        const client = await connectClient("?model=martin/grok/grok-voice-latest", {
+            Authorization: `Bearer ${PROXY_KEY}`,
+        });
+        await client.opened;
+
+        // Sent before the upstream leg opens — must be queued, not dropped.
+        client.ws.send(SafeJSON.stringify({ type: "session.update" }));
+        const audio = new Uint8Array([0, 1, 2, 250, 251, 252]);
+        client.ws.send(audio);
+
+        await waitFor(() => client.events.length >= 3);
+
+        // Upstream saw the resolved upstream model id + the ACCOUNT key (not the proxy key).
+        expect(upstreamSessions.length).toBe(sessionsBefore + 1);
+        const session = upstreamSessions[sessionsBefore];
+        expect(session.model).toBe("grok-voice-latest");
+        expect(session.authorization).toBe("Bearer xai-mock-key");
+
+        expect(client.events[0]).toBe('{"type":"session.created","model":"grok-voice-latest"}');
+        expect(client.events[1]).toBe('echo:{"type":"session.update"}');
+        expect(client.events[2]).toBeInstanceOf(ArrayBuffer);
+        expect(Array.from(new Uint8Array(client.events[2] as ArrayBuffer))).toEqual(Array.from(audio));
+
+        client.ws.close(1000);
+    });
+
+    it("accepts the proxy key via ?key= for browser clients", async () => {
+        const client = await connectClient(`?model=martin/grok/grok-voice-latest&key=${PROXY_KEY}`);
+        await client.opened;
+        await waitFor(() => client.events.length >= 1);
+        expect(client.events[0]).toBe('{"type":"session.created","model":"grok-voice-latest"}');
+        client.ws.close(1000);
+    });
+
+    it("closes the client when the upstream closes", async () => {
+        const client = await connectClient("?model=martin/grok/grok-voice-latest", {
+            Authorization: `Bearer ${PROXY_KEY}`,
+        });
+        await client.opened;
+        await waitFor(() => client.events.length >= 1);
+
+        client.ws.send("close-me");
+        const closeEvent = await client.closed;
+
+        expect(closeEvent.code).toBe(4321);
+        expect(closeEvent.reason).toBe("mock upstream bye");
+    });
+
+    it("records usage from response.done events without breaking the pipe", async () => {
+        const client = await connectClient("?model=martin/grok/grok-voice-latest", {
+            Authorization: `Bearer ${PROXY_KEY}`,
+        });
+        await client.opened;
+        await waitFor(() => client.events.length >= 1);
+
+        client.ws.send("report-usage");
+        await waitFor(() => client.events.length >= 2);
+
+        // The usage event is relayed verbatim to the client (transparent tunnel).
+        expect(client.events[1]).toContain('"response.done"');
+        client.ws.close(1000);
+    });
+});
+
+describe("realtime client_secrets mint", () => {
+    it("rejects a bad proxy key with 401", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime/client_secrets`, {
+            method: "POST",
+            headers: { Authorization: "Bearer wrong-key", "Content-Type": "application/json" },
+            body: SafeJSON.stringify({ session: { type: "realtime", model: "martin/grok/grok-voice-latest" } }),
+        });
+
+        expect(res.status).toBe(401);
+    });
+
+    it("requires a model in the body", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime/client_secrets`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${PROXY_KEY}`, "Content-Type": "application/json" },
+            body: SafeJSON.stringify({ session: { type: "realtime" } }),
+        });
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error: { message: string } };
+        expect(body.error.message).toContain("Missing model");
+    });
+});

--- a/src/ai-proxy/lib/realtime.test.ts
+++ b/src/ai-proxy/lib/realtime.test.ts
@@ -22,6 +22,15 @@ interface UpstreamSession {
 
 const upstreamSessions: UpstreamSession[] = [];
 
+interface SttRequest {
+    authorization: string | null;
+    model: FormDataEntryValue | null;
+    language: FormDataEntryValue | null;
+    fileBytes: number;
+}
+
+const sttRequests: SttRequest[] = [];
+
 let mockUpstream: ReturnType<typeof Bun.serve>;
 let proxy: ReturnType<typeof startAiProxyServer>;
 let proxyUrl: string;
@@ -33,8 +42,23 @@ function startMockUpstream() {
     return Bun.serve<UpstreamSession, never>({
         hostname: "127.0.0.1",
         port: 0,
-        fetch(req, server) {
+        async fetch(req, server) {
             const url = new URL(req.url);
+
+            if (url.pathname === "/stt" && req.method === "POST") {
+                const form = await req.formData();
+                const file = form.get("file");
+                sttRequests.push({
+                    authorization: req.headers.get("Authorization"),
+                    model: form.get("model"),
+                    language: form.get("language"),
+                    fileBytes: file instanceof Blob ? file.size : -1,
+                });
+
+                return new Response(SafeJSON.stringify({ text: "mock transcript", language: "en", duration: 1.2 }), {
+                    headers: { "Content-Type": "application/json" },
+                });
+            }
 
             if (url.pathname !== "/realtime") {
                 return new Response("Not Found", { status: 404 });
@@ -279,5 +303,76 @@ describe("realtime client_secrets mint", () => {
         expect(res.status).toBe(400);
         const body = (await res.json()) as { error: { message: string } };
         expect(body.error.message).toContain("Missing model");
+    });
+});
+
+describe("audio transcriptions", () => {
+    function transcriptionForm(overrides?: { model?: string | null; file?: boolean }) {
+        const form = new FormData();
+
+        if (overrides?.model !== null) {
+            form.append("model", overrides?.model ?? "martin/grok/grok-transcribe");
+        }
+
+        form.append("language", "en");
+
+        if (overrides?.file !== false) {
+            form.append("file", new Blob([new Uint8Array([1, 2, 3, 4])], { type: "audio/wav" }), "sample.wav");
+        }
+
+        return form;
+    }
+
+    it("rejects a bad proxy key with 401", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/audio/transcriptions`, {
+            method: "POST",
+            headers: { Authorization: "Bearer wrong-key" },
+            body: transcriptionForm(),
+        });
+
+        expect(res.status).toBe(401);
+    });
+
+    it("rejects a missing file with 400", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/audio/transcriptions`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${PROXY_KEY}` },
+            body: transcriptionForm({ file: false }),
+        });
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error: { message: string } };
+        expect(body.error.message).toContain("Missing file");
+    });
+
+    it("rejects a missing model with 400", async () => {
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/audio/transcriptions`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${PROXY_KEY}` },
+            body: transcriptionForm({ model: null }),
+        });
+
+        expect(res.status).toBe(400);
+    });
+
+    it("routes to the upstream STT with the account key, dropping the model field", async () => {
+        const before = sttRequests.length;
+        const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/audio/transcriptions`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${PROXY_KEY}` },
+            body: transcriptionForm(),
+        });
+
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { text: string };
+        expect(body.text).toBe("mock transcript");
+
+        expect(sttRequests.length).toBe(before + 1);
+        const seen = sttRequests[before];
+        expect(seen.authorization).toBe("Bearer xai-mock-key");
+        // xAI /stt has no model concept — routing consumed it.
+        expect(seen.model).toBeNull();
+        expect(seen.language).toBe("en");
+        expect(seen.fileBytes).toBe(4);
     });
 });

--- a/src/ai-proxy/lib/realtime.test.ts
+++ b/src/ai-proxy/lib/realtime.test.ts
@@ -138,6 +138,7 @@ beforeAll(async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "ai-proxy-realtime-"));
     env.testing.set("GENESIS_TOOLS_HOME", tempDir);
     env.testing.set("AI_PROXY_TEST_XAI_KEY", "xai-mock-key");
+    env.testing.set("AI_PROXY_TEST_OPENAI_KEY", "openai-mock-key");
     resetAiProxyConfigStore();
     resetAiProxyStorage();
 
@@ -154,6 +155,15 @@ beforeAll(async () => {
                 providerSlug: "grok",
                 enabled: true,
                 apiKeyEnv: "AI_PROXY_TEST_XAI_KEY",
+                baseUrl: `http://127.0.0.1:${mockUpstream.port}`,
+                realtimeBaseUrl: `ws://127.0.0.1:${mockUpstream.port}`,
+            },
+            {
+                name: "martin",
+                provider: "openai",
+                providerSlug: "openai",
+                enabled: true,
+                apiKeyEnv: "AI_PROXY_TEST_OPENAI_KEY",
                 baseUrl: `http://127.0.0.1:${mockUpstream.port}`,
                 realtimeBaseUrl: `ws://127.0.0.1:${mockUpstream.port}`,
             },
@@ -185,6 +195,8 @@ afterAll(() => {
     } else {
         env.testing.set("AI_PROXY_TEST_XAI_KEY", originalKey);
     }
+
+    env.testing.unset("AI_PROXY_TEST_OPENAI_KEY");
 });
 
 describe("realtime WS tunnel", () => {
@@ -241,6 +253,22 @@ describe("realtime WS tunnel", () => {
         expect(client.events[2]).toBeInstanceOf(ArrayBuffer);
         expect(Array.from(new Uint8Array(client.events[2] as ArrayBuffer))).toEqual(Array.from(audio));
 
+        client.ws.close(1000);
+    });
+
+    it("routes an openai model to the openai account with its own key", async () => {
+        const sessionsBefore = upstreamSessions.length;
+        const client = await connectClient("?model=martin/openai/gpt-realtime", {
+            Authorization: `Bearer ${PROXY_KEY}`,
+        });
+        await client.opened;
+        await waitFor(() => client.events.length >= 1);
+
+        expect(upstreamSessions.length).toBe(sessionsBefore + 1);
+        const session = upstreamSessions[sessionsBefore];
+        expect(session.model).toBe("gpt-realtime");
+        expect(session.authorization).toBe("Bearer openai-mock-key");
+        expect(client.events[0]).toBe('{"type":"session.created","model":"gpt-realtime"}');
         client.ws.close(1000);
     });
 

--- a/src/ai-proxy/lib/realtime.ts
+++ b/src/ai-proxy/lib/realtime.ts
@@ -1,10 +1,7 @@
-import { clientProviderDenial, resolveClient } from "@app/ai-proxy/lib/clients";
-import { acquireProvider, routeProviderKey } from "@app/ai-proxy/lib/providers/registry";
 import type { ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
-import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
+import { guardProxyRoute, jsonError } from "@app/ai-proxy/lib/route-guards";
 import type { AiProxyConfig, ResolvedRoute } from "@app/ai-proxy/lib/types";
 import { scheduleBillingSync } from "@app/ai-proxy/lib/usage/billing-sync";
-import { checkClientQuota } from "@app/ai-proxy/lib/usage/client-ledger";
 import { recordUsageRequest } from "@app/ai-proxy/lib/usage/store";
 import type { TokenUsage } from "@app/ai-proxy/lib/usage/types";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -33,13 +30,6 @@ export interface RealtimeBridgeData {
     upstreamFrames: number;
     upstreamBytes: number;
     usage: TokenUsage | null;
-}
-
-function jsonError(status: number, message: string, extra?: { type?: string; code?: string }): Response {
-    return new Response(SafeJSON.stringify({ error: { message, ...extra } }), {
-        status,
-        headers: { "Content-Type": "application/json" },
-    });
 }
 
 /** Browsers cannot set WS headers — accept the proxy key via `?key=` too. */
@@ -121,44 +111,20 @@ export async function handleRealtimeUpgrade(input: {
     config: AiProxyConfig;
     providers: Map<string, ProxyProvider>;
 }): Promise<Response | undefined> {
-    const client = resolveClient(realtimeAuthRequest(input.req, input.url), input.config);
-
-    if (!client) {
-        return jsonError(401, "Invalid proxy API key", { type: "auth_error" });
-    }
-
     const proxyModel = input.url.searchParams.get("model");
+    const guarded = await guardProxyRoute({
+        authReq: realtimeAuthRequest(input.req, input.url),
+        config: input.config,
+        providers: input.providers,
+        proxyModel,
+        logLabel: "realtime",
+    });
 
-    if (!proxyModel) {
-        return jsonError(400, "Missing model query param");
+    if (guarded instanceof Response) {
+        return guarded;
     }
 
-    let route: ResolvedRoute;
-    try {
-        route = resolveModel(proxyModel, input.config.accounts);
-    } catch (err) {
-        return jsonError(400, err instanceof Error ? err.message : String(err));
-    }
-
-    const denial = clientProviderDenial(client, route.account.provider);
-
-    if (denial) {
-        logger.warn({ client: client.name, model: proxyModel, denial }, "ai-proxy: realtime provider denied");
-        return jsonError(403, denial, { type: "forbidden", code: "provider_not_allowed" });
-    }
-
-    const quota = checkClientQuota(client);
-
-    if (!quota.ok) {
-        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: realtime quota exceeded");
-        return jsonError(429, quota.reason, { type: "quota_exceeded", code: "monthly_quota_exceeded" });
-    }
-
-    const provider = await acquireProvider(input.providers, route);
-
-    if (!provider) {
-        return jsonError(500, `Provider not loaded: ${routeProviderKey(route)}`);
-    }
+    const { client, route, provider } = guarded;
 
     if (typeof provider.realtimeConnect !== "function") {
         return jsonError(400, `Provider "${route.account.provider}" does not support realtime`);
@@ -168,7 +134,7 @@ export async function handleRealtimeUpgrade(input: {
         target: provider.realtimeConnect(route.upstreamId),
         client: client.name,
         route,
-        proxyModel,
+        proxyModel: guarded.proxyModel,
         providers: input.providers,
         upstream: null,
         queue: [],
@@ -354,12 +320,6 @@ export async function handleRealtimeClientSecrets(input: {
     config: AiProxyConfig;
     providers: Map<string, ProxyProvider>;
 }): Promise<Response> {
-    const client = resolveClient(input.req, input.config);
-
-    if (!client) {
-        return jsonError(401, "Invalid proxy API key", { type: "auth_error" });
-    }
-
     const bodyText = await input.req.text();
 
     let parsed: { model?: string; session?: { model?: string } };
@@ -375,32 +335,19 @@ export async function handleRealtimeClientSecrets(input: {
         return jsonError(400, "Missing model (set session.model)");
     }
 
-    let route: ResolvedRoute;
-    try {
-        route = resolveModel(proxyModel, input.config.accounts);
-    } catch (err) {
-        return jsonError(400, err instanceof Error ? err.message : String(err));
+    const guarded = await guardProxyRoute({
+        authReq: input.req,
+        config: input.config,
+        providers: input.providers,
+        proxyModel,
+        logLabel: "realtime",
+    });
+
+    if (guarded instanceof Response) {
+        return guarded;
     }
 
-    const denial = clientProviderDenial(client, route.account.provider);
-
-    if (denial) {
-        logger.warn({ client: client.name, model: proxyModel, denial }, "ai-proxy: realtime provider denied");
-        return jsonError(403, denial, { type: "forbidden", code: "provider_not_allowed" });
-    }
-
-    const quota = checkClientQuota(client);
-
-    if (!quota.ok) {
-        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: realtime quota exceeded");
-        return jsonError(429, quota.reason, { type: "quota_exceeded", code: "monthly_quota_exceeded" });
-    }
-
-    const provider = await acquireProvider(input.providers, route);
-
-    if (!provider) {
-        return jsonError(500, `Provider not loaded: ${routeProviderKey(route)}`);
-    }
+    const { client, route, provider } = guarded;
 
     if (typeof provider.realtimeClientSecrets !== "function") {
         return jsonError(400, `Provider "${route.account.provider}" does not support realtime client secrets`);

--- a/src/ai-proxy/lib/realtime.ts
+++ b/src/ai-proxy/lib/realtime.ts
@@ -1,0 +1,425 @@
+import { clientProviderDenial, resolveClient } from "@app/ai-proxy/lib/clients";
+import { acquireProvider, routeProviderKey } from "@app/ai-proxy/lib/providers/registry";
+import type { ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
+import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
+import type { AiProxyConfig, ResolvedRoute } from "@app/ai-proxy/lib/types";
+import { scheduleBillingSync } from "@app/ai-proxy/lib/usage/billing-sync";
+import { checkClientQuota } from "@app/ai-proxy/lib/usage/client-ledger";
+import { recordUsageRequest } from "@app/ai-proxy/lib/usage/store";
+import type { TokenUsage } from "@app/ai-proxy/lib/usage/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import type { Server, ServerWebSocket, WebSocketHandler } from "bun";
+
+// Transparent client↔upstream WebSocket tunnel for OpenAI-Realtime-compatible
+// voice APIs (xAI grok-voice). The proxy only touches routing, auth, and
+// logging — every frame (JSON events and binary audio alike) is relayed as-is.
+
+/** Cap frames buffered before the upstream WS opens (audio floods fast). */
+const MAX_WS_QUEUE = 1024;
+
+export interface RealtimeBridgeData {
+    target: RealtimeConnectTarget;
+    client: string;
+    route: ResolvedRoute;
+    proxyModel: string;
+    providers: Map<string, ProxyProvider>;
+    upstream: WebSocket | null;
+    queue: (string | Buffer<ArrayBuffer>)[];
+    closed: boolean;
+    startedAt: number;
+    clientFrames: number;
+    clientBytes: number;
+    upstreamFrames: number;
+    upstreamBytes: number;
+    usage: TokenUsage | null;
+}
+
+function jsonError(status: number, message: string, extra?: { type?: string; code?: string }): Response {
+    return new Response(SafeJSON.stringify({ error: { message, ...extra } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+/** Browsers cannot set WS headers — accept the proxy key via `?key=` too. */
+function realtimeAuthRequest(req: Request, url: URL): Request {
+    if (req.headers.get("Authorization")) {
+        return req;
+    }
+
+    const key = url.searchParams.get("key");
+
+    if (!key) {
+        return req;
+    }
+
+    return new Request(req.url, { headers: { Authorization: `Bearer ${key}` } });
+}
+
+function normalizeCloseCode(code: number): number {
+    return code >= 1000 && code < 5000 && code !== 1005 && code !== 1006 ? code : 1000;
+}
+
+function frameByteLength(payload: string | ArrayBuffer | Buffer): number {
+    if (typeof payload === "string") {
+        return Buffer.byteLength(payload, "utf8");
+    }
+
+    return payload.byteLength;
+}
+
+/**
+ * Best-effort usage capture: OpenAI-Realtime upstreams report token usage on
+ * `response.done` events (`response.usage.{input,output,total}_tokens`).
+ * Accumulated per session and recorded on close; absent when upstream omits it.
+ */
+function sniffRealtimeUsage(data: RealtimeBridgeData, payload: string): void {
+    if (!payload.includes('"response.done"')) {
+        return;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(payload) as {
+            type?: string;
+            response?: { usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number } };
+        };
+
+        if (parsed.type !== "response.done") {
+            return;
+        }
+
+        const usage = parsed.response?.usage;
+
+        if (!usage || typeof usage !== "object") {
+            return;
+        }
+
+        const prompt = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+        const completion = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
+        const total = typeof usage.total_tokens === "number" ? usage.total_tokens : prompt + completion;
+        const acc = data.usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+
+        acc.prompt_tokens = (acc.prompt_tokens ?? 0) + prompt;
+        acc.completion_tokens = (acc.completion_tokens ?? 0) + completion;
+        acc.total_tokens = (acc.total_tokens ?? 0) + total;
+        data.usage = acc;
+    } catch {
+        // not JSON — an upstream is free to send arbitrary text frames
+    }
+}
+
+/**
+ * GET /v1/realtime?model=<proxy model id> — authenticated WS upgrade that
+ * resolves the model to an account exactly like the chat path, then tunnels to
+ * the provider's realtime endpoint. Returns undefined once upgraded.
+ */
+export async function handleRealtimeUpgrade(input: {
+    req: Request;
+    url: URL;
+    server: Server<RealtimeBridgeData>;
+    config: AiProxyConfig;
+    providers: Map<string, ProxyProvider>;
+}): Promise<Response | undefined> {
+    const client = resolveClient(realtimeAuthRequest(input.req, input.url), input.config);
+
+    if (!client) {
+        return jsonError(401, "Invalid proxy API key", { type: "auth_error" });
+    }
+
+    const proxyModel = input.url.searchParams.get("model");
+
+    if (!proxyModel) {
+        return jsonError(400, "Missing model query param");
+    }
+
+    let route: ResolvedRoute;
+    try {
+        route = resolveModel(proxyModel, input.config.accounts);
+    } catch (err) {
+        return jsonError(400, err instanceof Error ? err.message : String(err));
+    }
+
+    const denial = clientProviderDenial(client, route.account.provider);
+
+    if (denial) {
+        logger.warn({ client: client.name, model: proxyModel, denial }, "ai-proxy: realtime provider denied");
+        return jsonError(403, denial, { type: "forbidden", code: "provider_not_allowed" });
+    }
+
+    const quota = checkClientQuota(client);
+
+    if (!quota.ok) {
+        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: realtime quota exceeded");
+        return jsonError(429, quota.reason, { type: "quota_exceeded", code: "monthly_quota_exceeded" });
+    }
+
+    const provider = await acquireProvider(input.providers, route);
+
+    if (!provider) {
+        return jsonError(500, `Provider not loaded: ${routeProviderKey(route)}`);
+    }
+
+    if (typeof provider.realtimeConnect !== "function") {
+        return jsonError(400, `Provider "${route.account.provider}" does not support realtime`);
+    }
+
+    const data: RealtimeBridgeData = {
+        target: provider.realtimeConnect(route.upstreamId),
+        client: client.name,
+        route,
+        proxyModel,
+        providers: input.providers,
+        upstream: null,
+        queue: [],
+        closed: false,
+        startedAt: performance.now(),
+        clientFrames: 0,
+        clientBytes: 0,
+        upstreamFrames: 0,
+        upstreamBytes: 0,
+        usage: null,
+    };
+
+    if (input.server.upgrade(input.req, { data })) {
+        return undefined;
+    }
+
+    return jsonError(426, "WebSocket upgrade failed");
+}
+
+export const realtimeWebsocket: WebSocketHandler<RealtimeBridgeData> = {
+    idleTimeout: 240,
+    open(ws: ServerWebSocket<RealtimeBridgeData>) {
+        const data = ws.data;
+
+        let upstream: WebSocket;
+        try {
+            // Bun extension: headers on the client WebSocket constructor.
+            upstream = new WebSocket(data.target.url, { headers: data.target.headers } as never);
+        } catch (err) {
+            logger.warn({ err, model: data.proxyModel }, "ai-proxy: realtime upstream WS construct failed");
+            data.closed = true;
+
+            try {
+                ws.close(1011);
+            } catch {
+                // client already gone
+            }
+
+            return;
+        }
+
+        upstream.binaryType = "arraybuffer";
+        data.upstream = upstream;
+
+        logger.info(
+            {
+                model: data.proxyModel,
+                upstreamModel: data.route.upstreamId,
+                account: data.route.accountName,
+                client: data.client,
+            },
+            "ai-proxy: realtime session open"
+        );
+
+        upstream.onopen = () => {
+            for (const queued of data.queue) {
+                upstream.send(queued);
+            }
+
+            data.queue = [];
+        };
+
+        upstream.onmessage = (event: MessageEvent) => {
+            if (data.closed) {
+                return;
+            }
+
+            const payload = event.data as string | ArrayBuffer;
+            data.upstreamFrames += 1;
+            data.upstreamBytes += frameByteLength(payload);
+
+            if (typeof payload === "string") {
+                sniffRealtimeUsage(data, payload);
+            }
+
+            try {
+                ws.send(payload);
+            } catch {
+                // client closed between the check and the send
+            }
+        };
+
+        upstream.onclose = (event: CloseEvent) => {
+            data.closed = true;
+
+            try {
+                ws.close(normalizeCloseCode(event.code), event.reason);
+            } catch {
+                // client already gone
+            }
+        };
+
+        upstream.onerror = () => {
+            logger.warn({ model: data.proxyModel, target: data.target.url }, "ai-proxy: realtime upstream WS error");
+
+            try {
+                ws.close(1011);
+            } catch {
+                // client already gone
+            }
+        };
+    },
+    message(ws: ServerWebSocket<RealtimeBridgeData>, message) {
+        const data = ws.data;
+        data.clientFrames += 1;
+        data.clientBytes += frameByteLength(message);
+        const upstream = data.upstream;
+
+        if (!upstream || upstream.readyState !== WebSocket.OPEN) {
+            if (data.queue.length >= MAX_WS_QUEUE) {
+                // Upstream stalled while the client floods; cap memory.
+                ws.close(1013, "upstream not ready");
+                return;
+            }
+
+            data.queue.push(message);
+            return;
+        }
+
+        try {
+            upstream.send(message);
+        } catch {
+            // upstream closed between the readyState check and the send
+        }
+    },
+    close(ws: ServerWebSocket<RealtimeBridgeData>, code, _reason) {
+        const data = ws.data;
+        data.closed = true;
+        const upstream = data.upstream;
+
+        if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
+            try {
+                upstream.close(normalizeCloseCode(code), _reason);
+            } catch {
+                // upstream already gone
+            }
+        }
+
+        const elapsedMs = Math.round(performance.now() - data.startedAt);
+
+        logger.info(
+            {
+                model: data.proxyModel,
+                upstreamModel: data.route.upstreamId,
+                account: data.route.accountName,
+                client: data.client,
+                code,
+                elapsedMs,
+                clientFrames: data.clientFrames,
+                clientBytes: data.clientBytes,
+                upstreamFrames: data.upstreamFrames,
+                upstreamBytes: data.upstreamBytes,
+                usage: data.usage ?? undefined,
+            },
+            "ai-proxy: realtime session closed"
+        );
+
+        recordUsageRequest({
+            ts: new Date().toISOString(),
+            account: data.route.accountName,
+            client: data.client,
+            provider: data.route.account.provider,
+            proxyModel: data.proxyModel,
+            upstreamModel: data.route.upstreamId,
+            path: "/v1/realtime",
+            status: 101,
+            elapsedMs,
+            stream: true,
+            usage: data.usage ?? undefined,
+        });
+        scheduleBillingSync(data.route.account, data.providers);
+    },
+};
+
+/**
+ * POST /v1/realtime/client_secrets — ephemeral-token mint pass-through. The
+ * browser gets a short-lived upstream secret without ever seeing the account
+ * API key; note the minted secret is used to talk to the upstream DIRECTLY
+ * (the session itself bypasses the proxy — use the WS tunnel for full logging).
+ */
+export async function handleRealtimeClientSecrets(input: {
+    req: Request;
+    config: AiProxyConfig;
+    providers: Map<string, ProxyProvider>;
+}): Promise<Response> {
+    const client = resolveClient(input.req, input.config);
+
+    if (!client) {
+        return jsonError(401, "Invalid proxy API key", { type: "auth_error" });
+    }
+
+    const bodyText = await input.req.text();
+
+    let parsed: { model?: string; session?: { model?: string } };
+    try {
+        parsed = SafeJSON.parse(bodyText, { strict: true }) as { model?: string; session?: { model?: string } };
+    } catch {
+        return jsonError(400, "Invalid JSON body");
+    }
+
+    const proxyModel = parsed.session?.model ?? parsed.model;
+
+    if (!proxyModel || typeof proxyModel !== "string") {
+        return jsonError(400, "Missing model (set session.model)");
+    }
+
+    let route: ResolvedRoute;
+    try {
+        route = resolveModel(proxyModel, input.config.accounts);
+    } catch (err) {
+        return jsonError(400, err instanceof Error ? err.message : String(err));
+    }
+
+    const denial = clientProviderDenial(client, route.account.provider);
+
+    if (denial) {
+        logger.warn({ client: client.name, model: proxyModel, denial }, "ai-proxy: realtime provider denied");
+        return jsonError(403, denial, { type: "forbidden", code: "provider_not_allowed" });
+    }
+
+    const quota = checkClientQuota(client);
+
+    if (!quota.ok) {
+        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: realtime quota exceeded");
+        return jsonError(429, quota.reason, { type: "quota_exceeded", code: "monthly_quota_exceeded" });
+    }
+
+    const provider = await acquireProvider(input.providers, route);
+
+    if (!provider) {
+        return jsonError(500, `Provider not loaded: ${routeProviderKey(route)}`);
+    }
+
+    if (typeof provider.realtimeClientSecrets !== "function") {
+        return jsonError(400, `Provider "${route.account.provider}" does not support realtime client secrets`);
+    }
+
+    const started = performance.now();
+    const response = await provider.realtimeClientSecrets(input.req, route.upstreamId, bodyText);
+
+    logger.info(
+        {
+            path: "/v1/realtime/client_secrets",
+            model: proxyModel,
+            upstreamModel: route.upstreamId,
+            status: response.status,
+            elapsedMs: Math.round(performance.now() - started),
+            client: client.name,
+        },
+        "ai-proxy: request"
+    );
+
+    return response;
+}

--- a/src/ai-proxy/lib/route-guards.ts
+++ b/src/ai-proxy/lib/route-guards.ts
@@ -1,0 +1,79 @@
+import type { ResolvedClient } from "@app/ai-proxy/lib/clients";
+import { clientProviderDenial, resolveClient } from "@app/ai-proxy/lib/clients";
+import { acquireProvider, routeProviderKey } from "@app/ai-proxy/lib/providers/registry";
+import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
+import type { AiProxyConfig, ResolvedRoute } from "@app/ai-proxy/lib/types";
+import { checkClientQuota } from "@app/ai-proxy/lib/usage/client-ledger";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+export function jsonError(status: number, message: string, extra?: { type?: string; code?: string }): Response {
+    return new Response(SafeJSON.stringify({ error: { message, ...extra } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+export interface GuardedRoute {
+    client: ResolvedClient;
+    route: ResolvedRoute;
+    provider: ProxyProvider;
+    /** The validated (non-empty) proxy model id. */
+    proxyModel: string;
+}
+
+/**
+ * The shared auth → resolveModel → provider-denial → quota → acquireProvider
+ * sequence for endpoints that route a proxy model id to an upstream account.
+ * Returns a Response on any rejection, else the guarded route.
+ */
+export async function guardProxyRoute(input: {
+    authReq: Request;
+    config: AiProxyConfig;
+    providers: Map<string, ProxyProvider>;
+    proxyModel: string | null | undefined;
+    logLabel: string;
+}): Promise<GuardedRoute | Response> {
+    const client = resolveClient(input.authReq, input.config);
+
+    if (!client) {
+        return jsonError(401, "Invalid proxy API key", { type: "auth_error" });
+    }
+
+    if (!input.proxyModel || typeof input.proxyModel !== "string") {
+        return jsonError(400, "Missing model");
+    }
+
+    let route: ResolvedRoute;
+    try {
+        route = resolveModel(input.proxyModel, input.config.accounts);
+    } catch (err) {
+        return jsonError(400, err instanceof Error ? err.message : String(err));
+    }
+
+    const denial = clientProviderDenial(client, route.account.provider);
+
+    if (denial) {
+        logger.warn(
+            { client: client.name, model: input.proxyModel, denial },
+            `ai-proxy: ${input.logLabel} provider denied`
+        );
+        return jsonError(403, denial, { type: "forbidden", code: "provider_not_allowed" });
+    }
+
+    const quota = checkClientQuota(client);
+
+    if (!quota.ok) {
+        logger.warn({ client: client.name, reason: quota.reason }, `ai-proxy: ${input.logLabel} quota exceeded`);
+        return jsonError(429, quota.reason, { type: "quota_exceeded", code: "monthly_quota_exceeded" });
+    }
+
+    const provider = await acquireProvider(input.providers, route);
+
+    if (!provider) {
+        return jsonError(500, `Provider not loaded: ${routeProviderKey(route)}`);
+    }
+
+    return { client, route, provider, proxyModel: input.proxyModel };
+}

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -1,10 +1,10 @@
-import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
 import { clientProviderDenial, resolveClient, validateClients } from "@app/ai-proxy/lib/clients";
 import { loadConfigFresh } from "@app/ai-proxy/lib/config";
 import { stripBasePath } from "@app/ai-proxy/lib/path-prefix";
-import { buildProviderMap, routeProviderKey, tryCreateProvider } from "@app/ai-proxy/lib/providers/registry";
+import { acquireProvider, buildProviderMap, routeProviderKey } from "@app/ai-proxy/lib/providers/registry";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { handleRealtimeClientSecrets, handleRealtimeUpgrade, realtimeWebsocket } from "@app/ai-proxy/lib/realtime";
 import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
 import { findInvalidImageDataPayload } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import { resolveThinkingMode } from "@app/ai-proxy/lib/thinking-config";
@@ -116,7 +116,8 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
         hostname: listen.host,
         port: listen.port,
         idleTimeout: 120,
-        async fetch(req) {
+        websocket: realtimeWebsocket,
+        async fetch(req, server) {
             const url = new URL(req.url);
             const path = normalizePath(url.pathname, runtime.config.public?.basePath);
 
@@ -127,6 +128,14 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
             }
 
             const config = await loadConfigFresh();
+
+            if (path === "/v1/realtime" && req.method === "GET") {
+                return handleRealtimeUpgrade({ req, url, server, config, providers: runtime.providers });
+            }
+
+            if (path === "/v1/realtime/client_secrets" && req.method === "POST") {
+                return handleRealtimeClientSecrets({ req, config, providers: runtime.providers });
+            }
 
             if (path === "/v1/models" && req.method === "GET") {
                 const client = resolveClient(req, config);
@@ -259,34 +268,16 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         );
                     }
 
-                    const key = routeProviderKey(route);
-                    const fingerprint = accountConfigFingerprint(route.account);
-                    let provider = runtime.providers.get(key);
-
-                    if (provider && provider.accountFingerprint !== fingerprint) {
-                        const refreshed = await tryCreateProvider(route.account);
-                        if (refreshed) {
-                            runtime.providers.set(key, refreshed);
-                            provider = refreshed;
-                        } else {
-                            runtime.providers.delete(key);
-                            provider = undefined;
-                        }
-                    }
+                    const provider = await acquireProvider(runtime.providers, route);
 
                     if (!provider) {
-                        const created = await tryCreateProvider(route.account);
-                        if (created) {
-                            runtime.providers.set(key, created);
-                            provider = created;
-                        }
-                    }
-
-                    if (!provider) {
-                        return new Response(SafeJSON.stringify({ error: { message: `Provider not loaded: ${key}` } }), {
-                            status: 500,
-                            headers: { "Content-Type": "application/json" },
-                        });
+                        return new Response(
+                            SafeJSON.stringify({ error: { message: `Provider not loaded: ${routeProviderKey(route)}` } }),
+                            {
+                                status: 500,
+                                headers: { "Content-Type": "application/json" },
+                            }
+                        );
                     }
 
                     if (path === "/v1/responses") {

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -272,7 +272,9 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
 
                     if (!provider) {
                         return new Response(
-                            SafeJSON.stringify({ error: { message: `Provider not loaded: ${routeProviderKey(route)}` } }),
+                            SafeJSON.stringify({
+                                error: { message: `Provider not loaded: ${routeProviderKey(route)}` },
+                            }),
                             {
                                 status: 500,
                                 headers: { "Content-Type": "application/json" },

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -1,3 +1,4 @@
+import { handleAudioTranscriptions } from "@app/ai-proxy/lib/audio";
 import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
 import { clientProviderDenial, resolveClient, validateClients } from "@app/ai-proxy/lib/clients";
 import { loadConfigFresh } from "@app/ai-proxy/lib/config";
@@ -135,6 +136,10 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
 
             if (path === "/v1/realtime/client_secrets" && req.method === "POST") {
                 return handleRealtimeClientSecrets({ req, config, providers: runtime.providers });
+            }
+
+            if (path === "/v1/audio/transcriptions" && req.method === "POST") {
+                return handleAudioTranscriptions({ req, config, providers: runtime.providers });
             }
 
             if (path === "/v1/models" && req.method === "GET") {

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -122,6 +122,12 @@ export interface AiProxyAccountConfig {
     openaiSub?: AiProxyOpenAiSubAccountConfig;
     apiKeyEnv?: string;
     baseUrl?: string;
+    /**
+     * Override for the realtime WebSocket base (e.g. wss://api.x.ai/v1).
+     * Defaults to `baseUrl` with http(s):// swapped for ws(s)://. Point it at a
+     * local mock server in tests.
+     */
+    realtimeBaseUrl?: string;
     managementKeyEnv?: string;
     teamId?: string;
 }

--- a/src/ai-proxy/scripts/verify-realtime-live.ts
+++ b/src/ai-proxy/scripts/verify-realtime-live.ts
@@ -24,6 +24,7 @@ import { SafeJSON } from "@genesiscz/utils/json";
 
 const PROXY_KEY = `live-verify-${crypto.randomUUID()}`;
 const MODEL = "live/grok/grok-voice-latest";
+const OPENAI_MODEL = "live-oa/openai/gpt-realtime";
 
 function extractPcm(wavPath: string): Buffer {
     const wav = readFileSync(wavPath);
@@ -64,6 +65,13 @@ async function main() {
                 enabled: true,
                 apiKeyEnv: "XAI_API_KEY",
             },
+            {
+                name: "live-oa",
+                provider: "openai",
+                providerSlug: "openai",
+                enabled: true,
+                apiKeyEnv: "OPENAI_API_KEY",
+            },
         ],
     };
 
@@ -71,89 +79,100 @@ async function main() {
     await getAiProxyConfigStore().save(config);
 
     const proxy = startAiProxyServer(await createRuntime(config));
-    console.log(`throwaway proxy on 127.0.0.1:${proxy.port}\n--- 1. realtime WS tunnel ---`);
+    console.log(`throwaway proxy on 127.0.0.1:${proxy.port}`);
 
-    const eventCounts = new Map<string, number>();
-    let inputTranscript = "";
-    let outputTranscript = "";
-    let audioDeltaBytes = 0;
-    const done = Promise.withResolvers<string>();
+    async function runTunnel(model: string, transcriptionModel?: string) {
+        console.log(`--- realtime WS tunnel: ${model} ---`);
+        const eventCounts = new Map<string, number>();
+        let inputTranscript = "";
+        let outputTranscript = "";
+        let audioDeltaBytes = 0;
+        const done = Promise.withResolvers<string>();
 
-    const ws = new WebSocket(`ws://127.0.0.1:${proxy.port}/v1/realtime?model=${MODEL}`, {
-        headers: { Authorization: `Bearer ${PROXY_KEY}` },
-    } as never);
+        const ws = new WebSocket(`ws://127.0.0.1:${proxy.port}/v1/realtime?model=${encodeURIComponent(model)}`, {
+            headers: { Authorization: `Bearer ${PROXY_KEY}` },
+        } as never);
 
-    const deadline = setTimeout(() => done.resolve("timeout after 30s"), 30_000);
-    ws.onerror = () => done.resolve("client WS error");
-    ws.onclose = (event) => done.resolve(`closed code=${event.code} reason=${event.reason}`);
-    ws.onmessage = (event) => {
-        if (typeof event.data !== "string") {
-            return;
-        }
+        const deadline = setTimeout(() => done.resolve("timeout after 30s"), 30_000);
+        ws.onerror = () => done.resolve("client WS error");
+        ws.onclose = (event) => done.resolve(`closed code=${event.code} reason=${event.reason}`);
+        ws.onmessage = (event) => {
+            if (typeof event.data !== "string") {
+                return;
+            }
 
-        const parsed = SafeJSON.parse(event.data) as {
-            type?: string;
-            delta?: string;
-            transcript?: string;
-            error?: unknown;
-        };
-        const type = parsed.type ?? "?";
-        eventCounts.set(type, (eventCounts.get(type) ?? 0) + 1);
+            const parsed = SafeJSON.parse(event.data) as {
+                type?: string;
+                delta?: string;
+                transcript?: string;
+                error?: unknown;
+            };
+            const type = parsed.type ?? "?";
+            eventCounts.set(type, (eventCounts.get(type) ?? 0) + 1);
 
-        if (type === "error") {
-            console.log(`  upstream error event: ${event.data.slice(0, 400)}`);
-        }
+            if (type === "error") {
+                console.log(`  upstream error event: ${event.data.slice(0, 400)}`);
+            }
 
-        if (type === "session.created") {
-            ws.send(
-                SafeJSON.stringify({
-                    type: "session.update",
-                    session: {
-                        type: "realtime",
-                        instructions: "Reply with one short sentence.",
-                        audio: {
-                            input: {
-                                format: { type: "audio/pcm", rate: 24000 },
-                                turn_detection: null,
-                                transcription: { model: "grok-transcribe" },
+            if (type === "session.created") {
+                ws.send(
+                    SafeJSON.stringify({
+                        type: "session.update",
+                        session: {
+                            type: "realtime",
+                            instructions: "Reply with one short sentence.",
+                            audio: {
+                                input: {
+                                    format: { type: "audio/pcm", rate: 24000 },
+                                    turn_detection: null,
+                                    ...(transcriptionModel ? { transcription: { model: transcriptionModel } } : {}),
+                                },
                             },
                         },
-                    },
-                })
-            );
-        }
+                    })
+                );
+            }
 
-        if (type === "session.updated") {
-            ws.send(SafeJSON.stringify({ type: "input_audio_buffer.append", audio: pcm.toString("base64") }));
-            ws.send(SafeJSON.stringify({ type: "input_audio_buffer.commit" }));
-            ws.send(SafeJSON.stringify({ type: "response.create" }));
-        }
+            if (type === "session.updated") {
+                ws.send(SafeJSON.stringify({ type: "input_audio_buffer.append", audio: pcm.toString("base64") }));
+                ws.send(SafeJSON.stringify({ type: "input_audio_buffer.commit" }));
+                ws.send(SafeJSON.stringify({ type: "response.create" }));
+            }
 
-        if (type === "conversation.item.input_audio_transcription.completed") {
-            inputTranscript = parsed.transcript ?? "";
-        }
+            if (type === "conversation.item.input_audio_transcription.completed") {
+                inputTranscript = parsed.transcript ?? "";
+            }
 
-        if (type.endsWith("output_audio.delta") && typeof parsed.delta === "string") {
-            audioDeltaBytes += Buffer.from(parsed.delta, "base64").length;
-        }
+            if (type.endsWith("output_audio.delta") && typeof parsed.delta === "string") {
+                audioDeltaBytes += Buffer.from(parsed.delta, "base64").length;
+            }
 
-        if (type.endsWith("output_audio_transcript.delta") && typeof parsed.delta === "string") {
-            outputTranscript += parsed.delta;
-        }
+            if (type.endsWith("output_audio_transcript.delta") && typeof parsed.delta === "string") {
+                outputTranscript += parsed.delta;
+            }
 
-        if (type === "response.done") {
-            done.resolve("response.done");
-        }
-    };
+            if (type === "response.done") {
+                done.resolve("response.done");
+            }
+        };
 
-    const outcome = await done.promise;
-    clearTimeout(deadline);
-    ws.close(1000);
-    console.log(`outcome: ${outcome}`);
-    console.log(`events: ${[...eventCounts.entries()].map(([k, v]) => `${k}×${v}`).join(", ")}`);
-    console.log(`input transcript:  ${SafeJSON.stringify(inputTranscript)}`);
-    console.log(`output transcript: ${SafeJSON.stringify(outputTranscript)}`);
-    console.log(`output audio delta bytes: ${audioDeltaBytes}`);
+        const outcome = await done.promise;
+        clearTimeout(deadline);
+        ws.close(1000);
+        console.log(`outcome: ${outcome}`);
+        console.log(`events: ${[...eventCounts.entries()].map(([k, v]) => `${k}×${v}`).join(", ")}`);
+        console.log(`input transcript:  ${SafeJSON.stringify(inputTranscript)}`);
+        console.log(`output transcript: ${SafeJSON.stringify(outputTranscript)}`);
+        console.log(`output audio delta bytes: ${audioDeltaBytes}`);
+    }
+
+    await runTunnel(MODEL, "grok-transcribe");
+
+    if (process.env.OPENAI_API_KEY) {
+        await runTunnel(OPENAI_MODEL);
+    } else {
+        console.log("--- skipping OpenAI tunnel (no OPENAI_API_KEY) ---");
+    }
 
     console.log("--- 2. batch /v1/audio/transcriptions ---");
     const form = new FormData();

--- a/src/ai-proxy/scripts/verify-realtime-live.ts
+++ b/src/ai-proxy/scripts/verify-realtime-live.ts
@@ -1,0 +1,184 @@
+/**
+ * Live end-to-end verification of the ai-proxy realtime tunnel + batch STT
+ * against the REAL xAI upstream (spends a fraction of a cent of credits).
+ *
+ *   XAI_API_KEY=… bun src/ai-proxy/scripts/verify-realtime-live.ts <audio.wav>
+ *
+ * The wav must be LEI16 mono 24 kHz (e.g. `say -o x.wav --data-format=LEI16@24000 "hi"`).
+ * Boots a throwaway proxy on a random port with a temp GENESIS_TOOLS_HOME
+ * (never touches the user's running proxy/config), then:
+ *   1. WS tunnel: session.update (turn_detection null, pcm24k, grok-transcribe
+ *      input transcription) → input_audio_buffer.append/commit →
+ *      response.create → waits for transcripts/audio deltas.
+ *   2. POST /v1/audio/transcriptions with the same wav.
+ *   3. POST /v1/realtime/client_secrets mint.
+ */
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAiProxyConfigStore, resetAiProxyConfigStore } from "@app/ai-proxy/lib/config-store";
+import { createRuntime, startAiProxyServer } from "@app/ai-proxy/lib/server";
+import { getAiProxyStorage, resetAiProxyStorage } from "@app/ai-proxy/lib/storage";
+import type { AiProxyConfig } from "@app/ai-proxy/lib/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+const PROXY_KEY = `live-verify-${crypto.randomUUID()}`;
+const MODEL = "live/grok/grok-voice-latest";
+
+function extractPcm(wavPath: string): Buffer {
+    const wav = readFileSync(wavPath);
+    const dataAt = wav.indexOf(Buffer.from("data"));
+
+    if (dataAt < 0) {
+        throw new Error(`${wavPath}: no RIFF data chunk`);
+    }
+
+    return wav.subarray(dataAt + 8);
+}
+
+async function main() {
+    const wavPath = process.argv[2];
+
+    if (!wavPath || !process.env.XAI_API_KEY) {
+        console.error("usage: XAI_API_KEY=… bun verify-realtime-live.ts <audio-24k-lei16.wav>");
+        process.exit(2);
+    }
+
+    const pcm = extractPcm(wavPath);
+    console.log(`audio: ${wavPath} → ${pcm.length} PCM bytes (~${(pcm.length / 48000).toFixed(2)}s @24k)`);
+
+    const tempDir = mkdtempSync(join(tmpdir(), "ai-proxy-live-"));
+    process.env.GENESIS_TOOLS_HOME = tempDir;
+    resetAiProxyConfigStore();
+    resetAiProxyStorage();
+
+    const config: AiProxyConfig = {
+        listen: { host: "127.0.0.1", port: 0 },
+        proxyApiKey: PROXY_KEY,
+        translation: { cursorAgent: "off", thinking: "raw" },
+        accounts: [
+            {
+                name: "live",
+                provider: "xai-api-key",
+                providerSlug: "grok",
+                enabled: true,
+                apiKeyEnv: "XAI_API_KEY",
+            },
+        ],
+    };
+
+    mkdirSync(getAiProxyStorage().getBaseDir(), { recursive: true });
+    await getAiProxyConfigStore().save(config);
+
+    const proxy = startAiProxyServer(await createRuntime(config));
+    console.log(`throwaway proxy on 127.0.0.1:${proxy.port}\n--- 1. realtime WS tunnel ---`);
+
+    const eventCounts = new Map<string, number>();
+    let inputTranscript = "";
+    let outputTranscript = "";
+    let audioDeltaBytes = 0;
+    const done = Promise.withResolvers<string>();
+
+    const ws = new WebSocket(`ws://127.0.0.1:${proxy.port}/v1/realtime?model=${MODEL}`, {
+        headers: { Authorization: `Bearer ${PROXY_KEY}` },
+    } as never);
+
+    const deadline = setTimeout(() => done.resolve("timeout after 30s"), 30_000);
+    ws.onerror = () => done.resolve("client WS error");
+    ws.onclose = (event) => done.resolve(`closed code=${event.code} reason=${event.reason}`);
+    ws.onmessage = (event) => {
+        if (typeof event.data !== "string") {
+            return;
+        }
+
+        const parsed = SafeJSON.parse(event.data) as {
+            type?: string;
+            delta?: string;
+            transcript?: string;
+            error?: unknown;
+        };
+        const type = parsed.type ?? "?";
+        eventCounts.set(type, (eventCounts.get(type) ?? 0) + 1);
+
+        if (type === "error") {
+            console.log(`  upstream error event: ${event.data.slice(0, 400)}`);
+        }
+
+        if (type === "session.created") {
+            ws.send(
+                SafeJSON.stringify({
+                    type: "session.update",
+                    session: {
+                        type: "realtime",
+                        instructions: "Reply with one short sentence.",
+                        audio: {
+                            input: {
+                                format: { type: "audio/pcm", rate: 24000 },
+                                turn_detection: null,
+                                transcription: { model: "grok-transcribe" },
+                            },
+                        },
+                    },
+                })
+            );
+        }
+
+        if (type === "session.updated") {
+            ws.send(SafeJSON.stringify({ type: "input_audio_buffer.append", audio: pcm.toString("base64") }));
+            ws.send(SafeJSON.stringify({ type: "input_audio_buffer.commit" }));
+            ws.send(SafeJSON.stringify({ type: "response.create" }));
+        }
+
+        if (type === "conversation.item.input_audio_transcription.completed") {
+            inputTranscript = parsed.transcript ?? "";
+        }
+
+        if (type.endsWith("output_audio.delta") && typeof parsed.delta === "string") {
+            audioDeltaBytes += Buffer.from(parsed.delta, "base64").length;
+        }
+
+        if (type.endsWith("output_audio_transcript.delta") && typeof parsed.delta === "string") {
+            outputTranscript += parsed.delta;
+        }
+
+        if (type === "response.done") {
+            done.resolve("response.done");
+        }
+    };
+
+    const outcome = await done.promise;
+    clearTimeout(deadline);
+    ws.close(1000);
+    console.log(`outcome: ${outcome}`);
+    console.log(`events: ${[...eventCounts.entries()].map(([k, v]) => `${k}×${v}`).join(", ")}`);
+    console.log(`input transcript:  ${SafeJSON.stringify(inputTranscript)}`);
+    console.log(`output transcript: ${SafeJSON.stringify(outputTranscript)}`);
+    console.log(`output audio delta bytes: ${audioDeltaBytes}`);
+
+    console.log("--- 2. batch /v1/audio/transcriptions ---");
+    const form = new FormData();
+    form.append("model", "live/grok/grok-transcribe");
+    form.append("file", new Blob([readFileSync(wavPath)], { type: "audio/wav" }), "sample.wav");
+    const stt = await fetch(`http://127.0.0.1:${proxy.port}/v1/audio/transcriptions`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${PROXY_KEY}` },
+        body: form,
+    });
+    console.log(`HTTP ${stt.status}: ${(await stt.text()).slice(0, 300)}`);
+
+    console.log("--- 3. /v1/realtime/client_secrets mint ---");
+    const mint = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime/client_secrets`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${PROXY_KEY}`, "Content-Type": "application/json" },
+        body: SafeJSON.stringify({ session: { type: "realtime", model: MODEL } }),
+    });
+    const mintBody = (await mint.json()) as { value?: string; expires_at?: number };
+    console.log(
+        `HTTP ${mint.status}: secret=${mintBody.value ? `${mintBody.value.slice(0, 24)}… (${mintBody.value.length} chars)` : "none"} expires_at=${mintBody.expires_at}`
+    );
+
+    proxy.stop(true);
+    process.exit(0);
+}
+
+await main();

--- a/src/e2e/say.e2e.test.ts
+++ b/src/e2e/say.e2e.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { execTool, getOutput } from "@genesiscz/utils/e2e/helpers";
 import { skip } from "@genesiscz/utils/test/skip";
 
@@ -18,7 +21,7 @@ describe.skipIf(skip.integration)("tools say", () => {
 
         it("--help shows all options", async () => {
             const r = await execTool(["say", "--help"]);
-            for (const flag of ["--volume", "--voice", "--rate", "--wait", "--app", "--mute", "--unmute"]) {
+            for (const flag of ["--volume", "--voice", "--rate", "--wait", "--app", "--mute", "--unmute", "--output"]) {
                 expect(r.stdout).toContain(flag);
             }
         });
@@ -114,6 +117,27 @@ describe.skipIf(skip.integration)("tools say", () => {
             const r = await execTool(["say", "--help"]);
             expect(r.stdout).toContain("--volume");
             expect(r.stdout).toContain("--rate");
+        });
+    });
+
+    describe("--output", () => {
+        // `say -o` writes AIFF without needing a speaker/TTY audio session.
+        it("writes AIFF to the given path and does not hang", async () => {
+            const dir = mkdtempSync(join(tmpdir(), "say-e2e-"));
+            const outPath = join(dir, "hello.aiff");
+            const r = await execTool(["say", "hello", "--output", outPath, "--provider", "macos", "--no-fallback"]);
+            expect(r.exitCode).toBe(0);
+            expect(getOutput(r).toLowerCase()).toContain("wrote");
+            expect(existsSync(outPath)).toBe(true);
+            expect(statSync(outPath).size).toBeGreaterThan(100);
+        });
+
+        it("appends .aiff when path has no extension (macos)", async () => {
+            const dir = mkdtempSync(join(tmpdir(), "say-e2e-"));
+            const base = join(dir, "noext");
+            const r = await execTool(["say", "hi", "--output", base, "--provider", "macos", "--no-fallback"]);
+            expect(r.exitCode).toBe(0);
+            expect(existsSync(`${base}.aiff`)).toBe(true);
         });
     });
 });

--- a/src/say/README.md
+++ b/src/say/README.md
@@ -24,6 +24,10 @@ tools say "x done" --app claude
 # Override one field on a single run (does NOT persist)
 tools say "x done" --app claude --voice Daniel
 
+# Save speech to a file (no playback; blocks until written)
+tools say "Deploy done" --output /tmp/done.aiff --provider macos
+tools say "Hello" --output /tmp/hello.mp3 --provider xai --format mp3
+
 # Manage profiles interactively
 tools say config
 ```
@@ -201,7 +205,8 @@ In a non-TTY context both entry points fail fast — pass `--app <name> --save` 
 | `--language <bcp47>` | Language hint (xAI) |
 | `--format <codec>` | `mp3` or `wav` |
 | `--file <path>` | Read text from a file |
-| `--stream` / `--no-stream` | Force streaming mode on/off |
+| `--output <path>` | Write audio to a file instead of playing. Blocks until written. macOS → AIFF; cloud → mp3/wav per `--format`. Mute is ignored. No extension → appends the correct one. |
+| `--stream` / `--no-stream` | Force streaming mode on/off (ignored with `--output`, which always buffers fully) |
 | `--model <id>` | Provider-specific model (OpenAI: `tts-1`, `gpt-4o-mini-tts`) |
 | `--save` | Persist explicitly-passed flags to `--app`'s profile |
 | `--unset <fields>` | Comma-separated profile fields to ignore (or remove with `--save`) |

--- a/src/say/index.ts
+++ b/src/say/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, extname, resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { AI } from "@genesiscz/utils/ai/index.ts";
 import { getModelsForTask } from "@genesiscz/utils/ai/ModelManager";
@@ -42,6 +42,7 @@ interface SayOptions {
     language?: string;
     format?: "mp3" | "wav";
     file?: string;
+    output?: string;
     stream?: boolean;
     noStream?: boolean;
     model?: string;
@@ -72,6 +73,10 @@ const program = new Command()
     .option("--language <bcp47>", "Language hint (xai only; defaults to 'auto')")
     .option("--format <codec>", "Output codec: mp3 or wav")
     .option("--file <path>", "Read text from a file instead of args")
+    .option(
+        "--output <path>",
+        "Write synthesized audio to a file instead of playing (macOS: AIFF; cloud: mp3/wav per --format). Blocks until written. Mute is ignored."
+    )
     .option("--stream", "Force streaming path")
     .option("--no-stream", "Force REST/non-streaming path")
     .option("--model <id>", "Provider-specific model (e.g. tts-1, gpt-4o-mini-tts for openai)")
@@ -133,9 +138,10 @@ const program = new Command()
         // If --save is requesting a mute change, don't short-circuit on the
         // existing mute state — otherwise --unmute --save / --unset mute --save
         // can never be persisted from a currently-muted profile.
+        // --output still synthesizes (mute only silences speaker playback).
         const wantsMuteWrite = opts.save === true && (opts.unmute === true || unsetList.includes("mute"));
 
-        if (!wantsMuteWrite && (await mgr.isMuted(opts.app))) {
+        if (!wantsMuteWrite && !opts.output && (await mgr.isMuted(opts.app))) {
             process.stderr.write("[say] muted\n");
             return;
         }
@@ -146,9 +152,9 @@ const program = new Command()
         // --wait so the child performs the (possibly network-bound for cloud
         // providers) synth + playback in its own process group, then return
         // immediately. --wait opts back into blocking; it is also the recursion
-        // guard since this branch only triggers without it. --save runs inline
-        // so its confirmation output is preserved.
-        if (!opts.wait && !opts.save) {
+        // guard since this branch only triggers without it. --save / --output
+        // run inline so confirmation text and the audio file are ready before exit.
+        if (!opts.wait && !opts.save && !opts.output) {
             spawnDetachedSpeaker();
             return;
         }
@@ -388,16 +394,22 @@ interface SpeakCachedArgs {
  * cloud providers, hash the request — on a hit, play the cached audio
  * directly; on a miss, synthesize, play, and record the miss so the Nth
  * occurrence persists.
+ *
+ * With `--output`, never plays: synthesizes (or serves cache), writes the
+ * full buffer to the path, then returns. Streaming is ignored because a
+ * complete file is required.
  */
 async function speakCached(args: SpeakCachedArgs): Promise<void> {
     const { mgr, text, provider, effective, opts, stream } = args;
+    const outputPath = opts.output ? resolve(opts.output) : undefined;
 
     // Bypass the cache when:
     //   - provider is macos (local & free)
     //   - the user explicitly asked for streaming — caching needs the whole
     //     buffer up front, which would silently negate `--stream` for cloud
     //     providers. Honor the flag instead.
-    if (provider === "macos" || stream === true) {
+    // `--output` needs a full buffer, so it never takes the stream-only path.
+    if ((provider === "macos" || stream === true) && !outputPath) {
         await AI.speak(text, {
             provider,
             voice: effective.voice ?? undefined,
@@ -409,6 +421,20 @@ async function speakCached(args: SpeakCachedArgs): Promise<void> {
             wait: opts.wait,
             model: effective.model ?? undefined,
         });
+        return;
+    }
+
+    // macos + --output, or cloud (with optional cache): need the buffer.
+    if (provider === "macos") {
+        const result = await AI.synthesize(text, {
+            provider,
+            voice: effective.voice ?? undefined,
+            language: effective.language ?? undefined,
+            format: effective.format ?? undefined,
+            rate: effective.rate ?? undefined,
+            model: effective.model ?? undefined,
+        });
+        writeAudioFile(outputPath as string, result.audio, result.contentType);
         return;
     }
 
@@ -443,6 +469,12 @@ async function speakCached(args: SpeakCachedArgs): Promise<void> {
 
     if (hit) {
         logger.debug(`[say] cache hit (${provider}, ${hit.audio.byteLength}B)`);
+
+        if (outputPath) {
+            writeAudioFile(outputPath, hit.audio, hit.contentType);
+            return;
+        }
+
         await playBuffer(hit.audio, hit.contentType, {
             volume: effective.volume ?? undefined,
             wait: opts.wait,
@@ -472,10 +504,60 @@ async function speakCached(args: SpeakCachedArgs): Promise<void> {
         logger.warn(`[say/cache] recordMiss() failed, audio not cached: ${err}`);
     }
 
+    if (outputPath) {
+        writeAudioFile(outputPath, result.audio, result.contentType);
+        return;
+    }
+
     await playBuffer(result.audio, result.contentType, {
         volume: effective.volume ?? undefined,
         wait: opts.wait,
     });
+}
+
+/** MIME → preferred extension when the user path has none. */
+const CONTENT_TYPE_EXT: Record<string, string> = {
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/wave": ".wav",
+    "audio/aiff": ".aiff",
+    "audio/x-aiff": ".aiff",
+};
+
+/**
+ * Write TTS bytes to disk. Creates parent directories. If `path` has no
+ * extension, appends one derived from `contentType`. Does not convert
+ * codecs — macos always yields AIFF; cloud yields mp3/wav per `--format`.
+ */
+function writeAudioFile(path: string, audio: Buffer, contentType: string): void {
+    let dest = path;
+    const preferred = CONTENT_TYPE_EXT[contentType.toLowerCase()];
+
+    if (!extname(dest) && preferred) {
+        dest = `${dest}${preferred}`;
+    }
+
+    const parent = dirname(dest);
+
+    if (parent && parent !== ".") {
+        mkdirSync(parent, { recursive: true });
+    }
+
+    writeFileSync(dest, audio);
+
+    const ext = extname(dest).toLowerCase();
+    if (preferred && ext && ext !== preferred) {
+        out.println(
+            pc.yellow(
+                `[say] wrote ${dest} (${audio.byteLength}B, ${contentType}) — extension ${ext} does not match payload; use ${preferred} for this provider/format`
+            )
+        );
+        return;
+    }
+
+    out.println(pc.green(`[say] wrote ${dest} (${audio.byteLength}B, ${contentType})`));
 }
 
 function isVoiceNotFoundError(message: string): boolean {
@@ -662,7 +744,10 @@ async function main(): Promise<void> {
     }
 }
 
-main();
+// Top-level await keeps the event loop alive for the full synth path.
+// A floating `main()` lets Bun exit early during `AI.synthesize` (Bun.spawn
+// for `say -o` does not always hold a process ref the way `say` playback does).
+await main();
 
 // ============================================
 // `tools say config` — unified app/profile manager


### PR DESCRIPTION
## ai-proxy realtime audio + batch STT (xAI + OpenAI)

Adds real-time audio transport to `tools ai-proxy` so the Genesis F6 companion can stream voice through the proxy (one-brain: transcript still relays to eve).

### What landed
- **`/v1/realtime` WS tunnel** + ephemeral `client_secrets` mint — transparent frame tunnel to the upstream realtime API.
- **`/v1/audio/transcriptions`** batch STT (OpenAI Whisper-compatible; translates to xAI `/v1/stt`).
- **Two providers**, shared `lib/providers/http-relay.ts` helpers (relayHeaders / rewriteSessionModel / toWsBase):
  - **xAI grok** — `live/grok/grok-voice-latest`.
  - **OpenAI** — `<account>/openai/gpt-realtime` → `wss://api.openai.com/v1/realtime`, `OPENAI_API_KEY`.
- **REALTIME.md** — provider table, model ids (`gpt-realtime`/`gpt-realtime-mini`/`gpt-4o-realtime-preview`), example account JSON.
- Caught + fixed a gzip `Content-Encoding` relay bug (Bun pre-decodes; stale framing headers now stripped on all relays).

### Live verification
- **xAI — full pass:** tunnel round trip → input "Hello there, please tell me one fun fact." → output "The shortest war in history lasted just 38 minutes!", 176KB audio, `response.done`. Batch STT 200, mint 200.
- **OpenAI — routing/auth proven, account quota-blocked:** mint 200 with `ek_…` secret (key valid); data plane returns `insufficient_quota` + 1013, relayed verbatim. Direct-to-OpenAI control test reproduced the identical error → account billing, not code. Funds the account → tunnel works, no code change.

### Tests
206 pass / 0 fail (+14 realtime/audio incl. OpenAI-routing regression), tsgo clean.

Includes prior `feat(say): --output` commit (b8b6b17b7) already on the branch.
