### PR TITLE
feat(handoff): Agent Tasks tab redesign — activity, unified SSE, include scoping

### DIFF
--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -95,11 +95,14 @@ const SERVER_INSTRUCTIONS =
     '("ok", "thanks", "continue"), or trivial lookups not worth preserving.\n\n' +
     "HANDOFFS (cross-agent task handoff): `handoff_post` creates. `handoff_get` reads. `handoff_list` lists. " +
     "`handoff_action` changes. To delegate work, handoff_post {title, tasks} → copy the returned `paste` block " +
-    "into the receiving agent's chat. Receiving agent: handoff_get {id} → claim (claim: true) → work the tasks " +
-    "→ handoff_action check_task with proof per task (deny_task with reason for tasks you can't do) → " +
-    "finish_handoff when all resolved. Poster edits anytime from its own session via handoff_action " +
+    'into the receiving agent\'s chat. Receiving agent: handoff_get {id} (default include:["tasks"] — full task ' +
+    "array) → claim (claim: true) → work the tasks " +
+    "→ handoff_action check_task with proof per task (deny_task with reason for tasks you can't do; " +
+    "uncheck_task keeps prior proof) → " +
+    'finish_handoff when all resolved. Pass include:["events"] on handoff_get for a bare {events, info} ' +
+    "activity trace (editId-free). Poster edits anytime from its own session via handoff_action " +
     "(add_tasks/modify_task/modify_handoff/cancel_handoff); from other sessions pass the editId. Progress is " +
-    'live on the dev-dashboard /qa "Agent tasks" tab.\n\n' +
+    'live on the dev-dashboard /qa "Agent tasks" tab (SSE via /api/qa/stream type=handoff).\n\n' +
     "BOARDS (dev-dashboard annotation boards):\n" +
     "- Boards live on the DEV-DASHBOARD server (base auto-resolved from its config; default " +
     "http://127.0.0.1:3042, override BOARDS_BASE_URL). Other local dashboards on other ports (e.g. the " +

--- a/src/claude/mcp/tools/handoff.ts
+++ b/src/claude/mcp/tools/handoff.ts
@@ -14,6 +14,7 @@ export interface HandoffGetArgs {
     id: string;
     claim?: boolean;
     unclaim?: boolean;
+    include?: string[];
 }
 
 export interface HandoffListArgs {
@@ -22,24 +23,28 @@ export interface HandoffListArgs {
     mine?: boolean;
     open?: boolean;
     project?: string;
+    include?: string[];
 }
 
 export interface HandoffActionArgs {
     id: string;
     editId?: string;
     actions: HandoffActionInput[];
+    include?: string[];
 }
 
 function render(value: unknown): string {
     return SafeJSON.stringify(value, { strict: true }, 2);
 }
 
+const DEFAULT_MCP_INCLUDE = ["tasks"];
+
 export async function handleHandoffPost(args: HandoffPostArgs, deps: HandoffDeps = {}): Promise<string> {
     return render(postHandoff(args, deps));
 }
 
 export async function handleHandoffGet(args: HandoffGetArgs, deps: HandoffDeps = {}): Promise<string> {
-    return render(getHandoff(args, deps));
+    return render(getHandoff({ ...args, include: args.include ?? DEFAULT_MCP_INCLUDE }, deps));
 }
 
 export async function handleHandoffList(args: HandoffListArgs, deps: HandoffDeps = {}): Promise<string> {
@@ -47,7 +52,7 @@ export async function handleHandoffList(args: HandoffListArgs, deps: HandoffDeps
 }
 
 export async function handleHandoffAction(args: HandoffActionArgs, deps: HandoffDeps = {}): Promise<string> {
-    return render(executeHandoffActions(args, deps));
+    return render(executeHandoffActions({ ...args, include: args.include ?? DEFAULT_MCP_INCLUDE }, deps));
 }
 
 export const HANDOFF_POST_DESCRIPTION =
@@ -64,19 +69,24 @@ export const HANDOFF_GET_DESCRIPTION =
     "unclaim: true). If this session posted the handoff (same sessionId — sessions are ephemeral, identity " +
     "is per-session not per-human), the response also returns your editId; if the posting session is gone " +
     "and the editId is lost, your user can read it on the dev-dashboard /qa Agent-tasks tab. info[] always " +
-    "states where you stand and the one next step. After claiming, record work via handoff_action check_task.";
+    "states where you stand and the one next step. After claiming, record work via handoff_action check_task. " +
+    'Optional include: string[] scopes the response (default ["tasks"] — full task array). Sections: tasks, ' +
+    'claimedBy, comments, attachments, events, postedBy, postedByContext. Special: include:["events"] alone ' +
+    "returns {events, info} without the handoff envelope.";
 
 export const HANDOFF_LIST_DESCRIPTION =
     "List recent handoffs, newest-updated first — ALL projects by default; project: '<name>' narrows. " +
     "open: true → only unresolved (not done/cancelled); mine: true → posted by, claimed by, or targeted at " +
     "this session; limit (default 20) + offset page through. Open rows are detailed, claimed rows concise. " +
+    'Optional include: ["tasks"] adds the full task array per row (other include values are ignored with an info line). ' +
     "Use the id with handoff_get.";
 
 export const HANDOFF_ACTION_DESCRIPTION =
     "Change a handoff — tasks and lifecycle (claim/unclaim also exist as a convenience on handoff_get; " +
     'identical effect). Ordered actions array; every action is an object { action: "<verb>", …verb fields } ' +
     "(payload-less verbs may be bare strings). Claimer verbs (be claimed, or start with {action:'claim'}): " +
-    "claim, unclaim, check_task {taskId, proof:{answer, commitIds?, context?}}, uncheck_task {taskId}, " +
+    "claim, unclaim, check_task {taskId, proof:{answer, commitIds?, context?}}, uncheck_task {taskId} " +
+    "(keeps prior proof on the task; clears checkedBy/checkedTs), " +
     "deny_task {taskId, reason}, undeny_task {taskId}, comment {text}, finish_handoff (rejected unless every " +
     "task is checked or denied — force: true overrides; undo via reopen_handoff). Poster verbs (from the " +
     "posting session, or with editId): add_tasks {tasks:[…]}, modify_task {taskId, text?, acceptanceCriteria?}, " +
@@ -85,7 +95,16 @@ export const HANDOFF_ACTION_DESCRIPTION =
     "closed it). attach_file {path, taskId?, note?} attaches a local file (screenshot, log) to the handoff or " +
     "a task. Common short forms are accepted as aliases (done/finish→finish_handoff, check→check_task, " +
     "add→add_tasks, modify→modify_task, deny→deny_task, uncheck→uncheck_task). An unrecognized verb is " +
-    "rejected with the full valid-verb list.";
+    'rejected with the full valid-verb list. Optional include: string[] scopes the returned handoff (default ["tasks"]; ' +
+    'same sections as handoff_get; include:["events"] alone is not special here — events are added on the handoff object).';
+
+const INCLUDE_PROP = {
+    type: "array",
+    items: { type: "string" },
+    description:
+        "optional response sections — tasks | claimedBy | comments | attachments | events | postedBy | postedByContext. " +
+        'Default on get/action: ["tasks"]. Unknown names → error listing valid sections.',
+} as const;
 
 const TASK_ITEM_SCHEMA = {
     type: "object",
@@ -141,6 +160,7 @@ export const HANDOFF_GET_INPUT_SCHEMA = {
             description: "claim this handoff for the calling session before working (co-owning is allowed)",
         },
         unclaim: { type: "boolean", description: "release ONLY this session's claim (no-op if not claimed)" },
+        include: INCLUDE_PROP,
     },
     required: ["id"],
 } as const;
@@ -156,6 +176,11 @@ export const HANDOFF_LIST_INPUT_SCHEMA = {
         },
         open: { type: "boolean", description: "only unresolved handoffs (status open or claimed)" },
         project: { type: "string", description: "narrow to one project (default: all projects)" },
+        include: {
+            type: "array",
+            items: { type: "string" },
+            description: 'optional — only "tasks" is honored on list rows (adds full task array as taskList)',
+        },
     },
 } as const;
 
@@ -171,6 +196,7 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
             description:
                 "poster edit credential from handoff_post — only needed for poster verbs from a session other than the posting one; your user can read it on the dev-dashboard /qa Agent-tasks tab",
         },
+        include: INCLUDE_PROP,
         actions: {
             type: "array",
             minItems: 1,

--- a/src/dev-dashboard/contract/client.ts
+++ b/src/dev-dashboard/contract/client.ts
@@ -166,7 +166,17 @@ export function createDashboardClient(opts: DashboardClientOptions) {
                 const source = opts.eventSourceFactory(`${baseUrl}${QA_STREAM_PATH}`);
                 source.onmessage = (ev) => {
                     try {
-                        onEntry(SafeJSON.parse(ev.data, { strict: true }) as EnrichedQaEntry);
+                        const frame = SafeJSON.parse(ev.data, { strict: true }) as {
+                            type?: string;
+                        } & EnrichedQaEntry;
+
+                        // Multiplexed /api/qa/stream: only qa frames; ignore handoff.
+                        if (frame.type === "handoff") {
+                            return;
+                        }
+
+                        const { type: _type, ...entry } = frame;
+                        onEntry(entry as EnrichedQaEntry);
                     } catch {
                         // A malformed data frame is non-actionable client-side and must not kill the
                         // stream; keep-alive comment frames never reach onmessage. Skip and continue.

--- a/src/dev-dashboard/lib/handoff-sse.ts
+++ b/src/dev-dashboard/lib/handoff-sse.ts
@@ -1,68 +1,15 @@
-import { existsSync, readFileSync } from "node:fs";
 import { todayHandoffLogFile } from "@app/handoff/log-store";
 import type { HandoffEvent } from "@app/handoff/types";
-import { FileTailer } from "@genesiscz/utils/fs/file-tailer";
-import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
-import { logger } from "@genesiscz/utils/logger";
-
-const log = logger.child({ component: "dev-dashboard:handoff-sse" });
+import { createRollingJsonlStream } from "./rolling-jsonl-stream";
 
 export interface HandoffStream {
     close(): void;
 }
 
-const ROLLOVER_CHECK_MS = 5_000;
-
-/**
- * Tail the handoff event log for SSE. Handoffs are multi-day, so the tailer
- * MUST survive midnight (§7.2): a periodic check re-tails the new date's file
- * when the day rolls over — a tailer pinned to one date file dies silently at
- * 00:00 (qa-sse.ts has exactly that bug at routes/qa.ts:132; do not copy it).
- *
- * FileTailer attaches at EOF and never replays, so an event written to the new
- * day-file in the window before the rollover check would be missed. On switch
- * we therefore replay the new file from byte 0 (§8.10). Frames are idempotent
- * on the client (each just triggers a refetch), so any duplicate with the fresh
- * tailer's first reads is harmless — replay eliminates the miss at zero cost.
- */
+/** Tail the handoff event log for SSE — midnight-safe via createRollingJsonlStream. */
 export function createHandoffStream(onEvent: (e: HandoffEvent) => void): HandoffStream {
-    let file = todayHandoffLogFile();
-    let tailer = new FileTailer<HandoffEvent>(file, { onLine: (e) => onEvent(e) });
-    tailer.start();
-
-    const replayFromStart = (path: string): void => {
-        if (!existsSync(path)) {
-            return;
-        }
-
-        try {
-            const { values } = parseJsonlChunk<HandoffEvent>(readFileSync(path));
-
-            for (const event of values) {
-                onEvent(event);
-            }
-        } catch (err) {
-            log.warn({ err, path }, "handoff rollover replay failed (new day file unparseable)");
-        }
-    };
-
-    const rollover = setInterval(() => {
-        const current = todayHandoffLogFile();
-
-        if (current !== file) {
-            tailer.stop();
-            file = current;
-            tailer = new FileTailer<HandoffEvent>(file, { onLine: (e) => onEvent(e) });
-            tailer.start();
-            // Emit anything already written to the new day's file before the tailer attached.
-            replayFromStart(file);
-        }
-    }, ROLLOVER_CHECK_MS);
-
-    return {
-        close: () => {
-            clearInterval(rollover);
-            tailer.stop();
-        },
-    };
+    return createRollingJsonlStream<HandoffEvent>({
+        fileForNow: () => todayHandoffLogFile(),
+        onLine: onEvent,
+    });
 }

--- a/src/dev-dashboard/lib/handoff-types.ts
+++ b/src/dev-dashboard/lib/handoff-types.ts
@@ -5,6 +5,7 @@ export type {
     HandoffActionInput,
     HandoffActionResult,
     HandoffAttachment,
+    HandoffClaim,
     HandoffComment,
     HandoffListRow,
     HandoffProof,
@@ -44,7 +45,32 @@ export interface HandoffPostResponse {
 }
 
 export interface HandoffStreamFrame {
+    type?: "handoff";
     id: string;
     ev: string;
     ts: string;
 }
+
+export interface HandoffEventsResponse {
+    events: HandoffPublicEvent[];
+    total: number;
+}
+
+/** editId-stripped event from GET /api/handoff/events */
+export type HandoffPublicEvent = {
+    uid: string;
+    id: string;
+    ts: string;
+    ev: string;
+    by: {
+        sessionId: string | null;
+        sessionTitle: string | null;
+        agent: string;
+        via?: string;
+        branch?: string | null;
+        cwd?: string | null;
+        repoRoot?: string | null;
+        commitSha?: string | null;
+    };
+    [key: string]: unknown;
+};

--- a/src/dev-dashboard/lib/live/producers.ts
+++ b/src/dev-dashboard/lib/live/producers.ts
@@ -5,7 +5,7 @@ import type { LiveHub } from "@app/dev-dashboard/lib/live/hub";
 import type { LiveChannel } from "@app/dev-dashboard/lib/live/types";
 import { classifyListeningPorts, listListeningPorts } from "@app/dev-dashboard/lib/ports/scanner";
 import { enrichQaEntry } from "@app/dev-dashboard/lib/qa-render";
-import { createQaStream, todayLogFile } from "@app/dev-dashboard/lib/qa-sse";
+import { createQaStream } from "@app/dev-dashboard/lib/qa-sse";
 import { getCachedPulse, markPulseClientSeen } from "@app/dev-dashboard/lib/system/poller";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
@@ -104,7 +104,7 @@ export function startLiveProducers(hub: LiveHub): { stop: () => void } {
         }
 
         try {
-            qaStream = createQaStream(todayLogFile(), (entry) => {
+            qaStream = createQaStream((entry) => {
                 hub.publish({
                     v: 1,
                     channel: "qa",

--- a/src/dev-dashboard/lib/net/status.ts
+++ b/src/dev-dashboard/lib/net/status.ts
@@ -16,6 +16,6 @@ export function deriveNetStatus({ pulse, pingMs, activeTransport }: DeriveNetSta
         return { transport: activeTransport, latencyMs: null, quality: "down", ssid, publicIp };
     }
 
-    const quality = pingMs <= LATENCY_HEALTHY_MS ? "healthy" : pingMs <= LATENCY_DEGRADED_MS ? "degraded" : "down";
+    const quality = pingMs <= LATENCY_HEALTHY_MS ? "healthy" : "degraded";
     return { transport: activeTransport, latencyMs: pingMs, quality, ssid, publicIp };
 }

--- a/src/dev-dashboard/lib/qa-sse.test.ts
+++ b/src/dev-dashboard/lib/qa-sse.test.ts
@@ -10,7 +10,7 @@ describe("createQaStream", () => {
         const f = join(mkdtempSync(join(tmpdir(), "qa-sse-")), "2026-05-25.jsonl");
         appendFileSync(f, `${SafeJSON.stringify({ id: "old" })}\n`);
         const got: string[] = [];
-        const stream = createQaStream(f, (e) => got.push((e as { id: string }).id));
+        const stream = createQaStream((e) => got.push((e as { id: string }).id), { fileForNow: () => f });
         appendFileSync(f, `${SafeJSON.stringify({ id: "live" })}\n`);
         await Bun.sleep(500);
         stream.close();

--- a/src/dev-dashboard/lib/qa-sse.ts
+++ b/src/dev-dashboard/lib/qa-sse.ts
@@ -1,17 +1,20 @@
 import { logFilePathFor } from "@app/question/lib/log-store";
 import type { QaEntry } from "@app/question/lib/types";
-import { FileTailer } from "@genesiscz/utils/fs/file-tailer";
+import { createRollingJsonlStream, type RollingJsonlStream } from "./rolling-jsonl-stream";
 
 export function todayLogFile(): string {
     return logFilePathFor({ ts: Date.now() });
 }
 
-export interface QaStream {
-    close(): void;
-}
+export type QaStream = RollingJsonlStream;
 
-export function createQaStream(file: string, onEntry: (e: QaEntry) => void): QaStream {
-    const t = new FileTailer<QaEntry>(file, { onLine: (e) => onEntry(e) });
-    t.start();
-    return { close: () => t.stop() };
+/**
+ * Tail today's QA JSONL with midnight rollover. Pass `fileForNow` in tests to
+ * pin a fixed path (rollover never fires when the path is constant).
+ */
+export function createQaStream(onEntry: (e: QaEntry) => void, opts?: { fileForNow?: () => string }): QaStream {
+    return createRollingJsonlStream<QaEntry>({
+        fileForNow: opts?.fileForNow ?? todayLogFile,
+        onLine: onEntry,
+    });
 }

--- a/src/dev-dashboard/lib/rolling-jsonl-stream.test.ts
+++ b/src/dev-dashboard/lib/rolling-jsonl-stream.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { appendFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { createRollingJsonlStream } from "./rolling-jsonl-stream";
+
+describe("createRollingJsonlStream", () => {
+    it("swaps to the new day file on rollover and replays entries written before attach", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "rolling-jsonl-"));
+        const day1 = join(dir, "2026-05-25.jsonl");
+        const day2 = join(dir, "2026-05-26.jsonl");
+        appendFileSync(day1, `${SafeJSON.stringify({ id: "d1-old" })}\n`);
+
+        let current = day1;
+        const got: string[] = [];
+        const stream = createRollingJsonlStream<{ id: string }>({
+            fileForNow: () => current,
+            onLine: (v) => got.push(v.id),
+            checkIntervalMs: 25,
+        });
+
+        // Let the tailer attach at EOF of day1 (initial file is NOT replayed).
+        await Bun.sleep(120);
+        appendFileSync(day1, `${SafeJSON.stringify({ id: "d1-live" })}\n`);
+        await Bun.sleep(120);
+
+        // Write day2 BEFORE rollover fires, so replay-from-start must pick it up.
+        appendFileSync(day2, `${SafeJSON.stringify({ id: "d2-pre-attach" })}\n`);
+        current = day2;
+        await Bun.sleep(180);
+
+        // Append after the swap — the new tailer must see it too.
+        appendFileSync(day2, `${SafeJSON.stringify({ id: "d2-live" })}\n`);
+        await Bun.sleep(180);
+        stream.close();
+
+        // Initial file is attached at EOF (no replay) — d1-old must not appear.
+        expect(got).not.toContain("d1-old");
+        expect(got).toContain("d1-live");
+        // Rollover replays the new day file from byte 0.
+        expect(got).toContain("d2-pre-attach");
+        expect(got).toContain("d2-live");
+    });
+});

--- a/src/dev-dashboard/lib/rolling-jsonl-stream.ts
+++ b/src/dev-dashboard/lib/rolling-jsonl-stream.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { FileTailer } from "@genesiscz/utils/fs/file-tailer";
+import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
+import { logger } from "@genesiscz/utils/logger";
+
+const log = logger.child({ component: "dev-dashboard:rolling-jsonl" });
+
+const ROLLOVER_CHECK_MS = 5_000;
+
+export interface RollingJsonlStream {
+    close(): void;
+}
+
+/**
+ * Midnight-safe JSONL tailer: periodic re-check of `fileForNow()`, swap the
+ * FileTailer on path change, and replay the new file from byte 0 so events
+ * written before attach are not missed (handoff-sse §8.10 mechanism).
+ */
+export function createRollingJsonlStream<T>({
+    fileForNow,
+    onLine,
+}: {
+    fileForNow: () => string;
+    onLine: (value: T) => void;
+}): RollingJsonlStream {
+    let file = fileForNow();
+    let tailer = new FileTailer<T>(file, { onLine });
+    tailer.start();
+
+    const replayFromStart = (path: string): void => {
+        if (!existsSync(path)) {
+            return;
+        }
+
+        try {
+            const { values } = parseJsonlChunk<T>(readFileSync(path));
+
+            for (const value of values) {
+                onLine(value);
+            }
+        } catch (err) {
+            log.warn({ err, path }, "rollover replay failed (new day file unparseable)");
+        }
+    };
+
+    const rollover = setInterval(() => {
+        const current = fileForNow();
+
+        if (current !== file) {
+            tailer.stop();
+            file = current;
+            tailer = new FileTailer<T>(file, { onLine });
+            tailer.start();
+            replayFromStart(file);
+        }
+    }, ROLLOVER_CHECK_MS);
+
+    return {
+        close: () => {
+            clearInterval(rollover);
+            tailer.stop();
+        },
+    };
+}

--- a/src/dev-dashboard/lib/rolling-jsonl-stream.ts
+++ b/src/dev-dashboard/lib/rolling-jsonl-stream.ts
@@ -19,9 +19,11 @@ export interface RollingJsonlStream {
 export function createRollingJsonlStream<T>({
     fileForNow,
     onLine,
+    checkIntervalMs = ROLLOVER_CHECK_MS,
 }: {
     fileForNow: () => string;
     onLine: (value: T) => void;
+    checkIntervalMs?: number;
 }): RollingJsonlStream {
     let file = fileForNow();
     let tailer = new FileTailer<T>(file, { onLine });
@@ -53,7 +55,7 @@ export function createRollingJsonlStream<T>({
             tailer.start();
             replayFromStart(file);
         }
-    }, ROLLOVER_CHECK_MS);
+    }, checkIntervalMs);
 
     return {
         close: () => {

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { createHandoffStream } from "@app/dev-dashboard/lib/handoff-sse";
+import { getConfig } from "@app/dev-dashboard/config";
 import { errorResult } from "@app/dev-dashboard/server/routes/error";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
 import { MAX_ATTACHMENT_BYTES } from "@app/handoff/attachments";
@@ -13,19 +13,37 @@ import {
     postHandoff,
     resolveAttachment,
 } from "@app/handoff/executor";
-import type { HandoffActionInput, HandoffTarget, HandoffTaskInput } from "@app/handoff/types";
-import { SafeJSON } from "@genesiscz/utils/json";
+import { normalizeHandoffId } from "@app/handoff/ids";
+import { catchUpHandoffs, getHandoffById, listHandoffEvents, openHandoffModel } from "@app/handoff/read-model";
+import type { HandoffActionInput, HandoffEventBy, HandoffTarget, HandoffTaskInput } from "@app/handoff/types";
 
-/** Every UI-originated event runs with owner authority and is visibly attributed (§7.1). */
-const deps: HandoffDeps = { by: DASHBOARD_ACTOR };
+/**
+ * Dashboard actor (G7): sessionTitle = configured Basic Auth username;
+ * fallback "dev-dashboard" when auth is disabled. Keep agent/via for isHumanOwner.
+ */
+export function dashboardActor(sessionTitle?: string): HandoffEventBy {
+    return {
+        ...DASHBOARD_ACTOR,
+        sessionTitle:
+            sessionTitle !== undefined && sessionTitle.trim().length > 0 ? sessionTitle.trim() : "dev-dashboard",
+    };
+}
+
+async function dashboardDeps(): Promise<HandoffDeps> {
+    const config = await getConfig();
+    const title =
+        config.auth.enabled && config.auth.username.trim().length > 0 ? config.auth.username : "dev-dashboard";
+    return { by: dashboardActor(title) };
+}
 
 export function handoffRoutes(): RouteDef[] {
     return [
         {
             method: "GET",
             pattern: "/api/handoff/log",
-            handler: (ctx) => {
+            handler: async (ctx) => {
                 try {
+                    const deps = await dashboardDeps();
                     const limitRaw = ctx.query.get("limit");
                     const offsetRaw = ctx.query.get("offset");
                     const res = listHandoffs(
@@ -47,8 +65,9 @@ export function handoffRoutes(): RouteDef[] {
         {
             method: "GET",
             pattern: "/api/handoff/get",
-            handler: (ctx) => {
+            handler: async (ctx) => {
                 try {
+                    const deps = await dashboardDeps();
                     const id = ctx.query.get("id") ?? "";
                     const res = getHandoff({ id }, deps);
 
@@ -59,10 +78,48 @@ export function handoffRoutes(): RouteDef[] {
             },
         },
         {
+            method: "GET",
+            pattern: "/api/handoff/events",
+            handler: (ctx) => {
+                try {
+                    const id = normalizeHandoffId(ctx.query.get("id") ?? "");
+                    const limitRaw = ctx.query.get("limit");
+                    const limit = limitRaw !== null ? Number.parseInt(limitRaw, 10) : 200;
+                    const before = ctx.query.get("before") ?? undefined;
+
+                    if (id.length === 0) {
+                        return { kind: "json", status: 400, body: { error: "id query param required" } };
+                    }
+
+                    const db = openHandoffModel();
+
+                    try {
+                        catchUpHandoffs(db);
+
+                        if (getHandoffById(db, id) === null) {
+                            return {
+                                kind: "json",
+                                status: 404,
+                                body: { error: `No handoff ${id} — re-check the paste block or call handoff_list` },
+                            };
+                        }
+
+                        const body = listHandoffEvents({ db, handoffId: id, limit, before });
+                        return { kind: "json", status: 200, body };
+                    } finally {
+                        db.close();
+                    }
+                } catch (err) {
+                    return errorResult(err);
+                }
+            },
+        },
+        {
             method: "POST",
             pattern: "/api/handoff/action",
             handler: async (ctx) => {
                 try {
+                    const deps = await dashboardDeps();
                     const body = await ctx.readJson<{ id?: string; editId?: string; actions?: HandoffActionInput[] }>();
                     const res = executeHandoffActions(
                         { id: body.id ?? "", editId: body.editId, actions: body.actions ?? [] },
@@ -80,6 +137,7 @@ export function handoffRoutes(): RouteDef[] {
             pattern: "/api/handoff/post",
             handler: async (ctx) => {
                 try {
+                    const deps = await dashboardDeps();
                     const body = await ctx.readJson<{
                         title?: string;
                         description?: string;
@@ -109,6 +167,7 @@ export function handoffRoutes(): RouteDef[] {
             pattern: "/api/handoff/attach",
             handler: async (ctx) => {
                 try {
+                    const deps = await dashboardDeps();
                     const id = ctx.query.get("id") ?? "";
                     const filename = ctx.query.get("filename") ?? "pasted.bin";
                     const taskId = ctx.query.get("taskId") ?? undefined;
@@ -144,8 +203,9 @@ export function handoffRoutes(): RouteDef[] {
         {
             method: "GET",
             pattern: "/api/handoff/attachment",
-            handler: (ctx) => {
+            handler: async (ctx) => {
                 try {
+                    const deps = await dashboardDeps();
                     const attachmentId = ctx.query.get("id") ?? "";
                     const resolved = resolveAttachment(attachmentId, deps);
 
@@ -181,28 +241,6 @@ export function handoffRoutes(): RouteDef[] {
                     return errorResult(err);
                 }
             },
-        },
-        {
-            method: "GET",
-            pattern: "/api/handoff/stream",
-            longLived: true,
-            handler: () => ({
-                kind: "sse",
-                start: (emit) => {
-                    emit.comment(" handoff stream open");
-                    const stream = createHandoffStream((event) =>
-                        emit.data(SafeJSON.stringify({ id: event.id, ev: event.ev, ts: event.ts }, { strict: true }))
-                    );
-                    const keepAlive = setInterval(() => emit.comment(" ping"), 12_000);
-
-                    return {
-                        close: () => {
-                            clearInterval(keepAlive);
-                            stream.close();
-                        },
-                    };
-                },
-            }),
         },
     ];
 }

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -86,6 +86,7 @@ export function handoffRoutes(): RouteDef[] {
                     const limitRaw = ctx.query.get("limit");
                     const limit = limitRaw !== null ? Number.parseInt(limitRaw, 10) : 200;
                     const before = ctx.query.get("before") ?? undefined;
+                    const beforeUid = ctx.query.get("beforeUid") ?? undefined;
 
                     if (id.length === 0) {
                         return { kind: "json", status: 400, body: { error: "id query param required" } };
@@ -104,7 +105,7 @@ export function handoffRoutes(): RouteDef[] {
                             };
                         }
 
-                        const body = listHandoffEvents({ db, handoffId: id, limit, before });
+                        const body = listHandoffEvents({ db, handoffId: id, limit, before, beforeUid });
                         return { kind: "json", status: 200, body };
                     } finally {
                         db.close();

--- a/src/dev-dashboard/server/routes/qa.ts
+++ b/src/dev-dashboard/server/routes/qa.ts
@@ -1,8 +1,9 @@
 import { getConfig } from "@app/dev-dashboard/config";
+import { createHandoffStream } from "@app/dev-dashboard/lib/handoff-sse";
 import { saveToObsidianUnique } from "@app/dev-dashboard/lib/obsidian-save";
 import { formatQaAsMarkdown } from "@app/dev-dashboard/lib/qa-clipboard";
 import { enrichQaEntry } from "@app/dev-dashboard/lib/qa-render";
-import { createQaStream, todayLogFile } from "@app/dev-dashboard/lib/qa-sse";
+import { createQaStream } from "@app/dev-dashboard/lib/qa-sse";
 import { errorResult } from "@app/dev-dashboard/server/routes/error";
 import type { RouteDef } from "@app/dev-dashboard/server/types";
 import { defaultDbPath } from "@app/question/commands/log";
@@ -128,16 +129,25 @@ export function qaRoutes(): RouteDef[] {
             handler: () => ({
                 kind: "sse",
                 start: (emit) => {
-                    emit.comment(" qa stream open");
-                    const stream = createQaStream(todayLogFile(), (entry) =>
-                        emit.data(SafeJSON.stringify(enrichQaEntry(entry)))
+                    emit.comment(" qa+handoff multiplexed stream open");
+                    const qaStream = createQaStream((entry) =>
+                        emit.data(SafeJSON.stringify({ type: "qa", ...enrichQaEntry(entry) }, { strict: true }))
+                    );
+                    const handoffStream = createHandoffStream((event) =>
+                        emit.data(
+                            SafeJSON.stringify(
+                                { type: "handoff", id: event.id, ev: event.ev, ts: event.ts },
+                                { strict: true }
+                            )
+                        )
                     );
                     const keepAlive = setInterval(() => emit.comment(" ping"), 12_000);
 
                     return {
                         close: () => {
                             clearInterval(keepAlive);
-                            stream.close();
+                            qaStream.close();
+                            handoffStream.close();
                         },
                     };
                 },

--- a/src/dev-dashboard/ui/src/components/handoff/ActivityPanel.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/ActivityPanel.tsx
@@ -1,0 +1,269 @@
+import type { HandoffPublicEvent } from "@app/dev-dashboard/lib/handoff-types";
+import { ChevronsRight } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useActivityPanel } from "@/hooks/useActivityPanel";
+import { fetchHandoffEvents, useHandoffEvents } from "@/hooks/useHandoffEvents";
+import { actorChipLabel, relativeTime } from "./handoff-format";
+
+const VERB_COLOR: Record<string, string> = {
+    post: "#60a5fa",
+    claim: "#22d3ee",
+    unclaim: "#22d3ee",
+    check_task: "#4ade80",
+    uncheck_task: "#4ade80",
+    deny_task: "#fbbf24",
+    undeny_task: "#fbbf24",
+    comment: "var(--dd-text-secondary)",
+    attach: "var(--dd-text-secondary)",
+    add_tasks: "#c792ea",
+    modify_task: "#c792ea",
+    modify_handoff: "#c792ea",
+    finish: "#facc15",
+    cancel: "var(--dd-text-muted)",
+    reopen: "#22d3ee",
+};
+
+function str(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+    if (typeof value !== "object" || value === null || !(key in value)) {
+        return undefined;
+    }
+
+    return (value as Record<string, unknown>)[key];
+}
+
+function describeEvent(event: HandoffPublicEvent): string {
+    const taskId = str(field(event, "taskId"));
+
+    switch (event.ev) {
+        case "post":
+            return "posted the handoff";
+        case "claim":
+            return "claimed the handoff";
+        case "unclaim":
+            return "released the claim";
+        case "check_task":
+            return `checked ${taskId ?? "a task"}`;
+        case "uncheck_task":
+            return `unchecked ${taskId ?? "a task"}`;
+        case "deny_task": {
+            const reason = str(field(event, "reason"));
+            return `denied ${taskId ?? "a task"}${reason !== undefined ? ` — ${reason}` : ""}`;
+        }
+        case "undeny_task":
+            return `un-denied ${taskId ?? "a task"}`;
+        case "comment":
+            return "commented";
+        case "attach":
+            return `attached ${str(field(event, "filename")) ?? "a file"}`;
+        case "add_tasks": {
+            const tasksField = field(event, "tasks");
+            const tasks = Array.isArray(tasksField) ? tasksField.length : undefined;
+            return `added ${tasks ?? ""} task${tasks === 1 ? "" : "s"}`.trim();
+        }
+        case "modify_task":
+            return `modified ${taskId ?? "a task"}`;
+        case "modify_handoff":
+            return "modified the handoff";
+        case "finish":
+            return "finished the handoff";
+        case "cancel":
+            return "cancelled the handoff";
+        case "reopen":
+            return "reopened the handoff";
+        default:
+            return event.ev;
+    }
+}
+
+function eventDetail(event: HandoffPublicEvent): string | null {
+    switch (event.ev) {
+        case "check_task":
+            return str(field(field(event, "proof"), "answer")) ?? null;
+        case "deny_task":
+            return str(field(event, "reason")) ?? null;
+        case "comment":
+            return str(field(event, "text")) ?? null;
+        case "modify_task": {
+            const parts: string[] = [];
+            const text = str(field(event, "text"));
+            const criteria = str(field(event, "acceptanceCriteria"));
+
+            if (text !== undefined) {
+                parts.push(`text: ${text}`);
+            }
+
+            if (criteria !== undefined) {
+                parts.push(`criteria: ${criteria}`);
+            }
+
+            return parts.length > 0 ? parts.join("\n") : null;
+        }
+        case "modify_handoff": {
+            const title = str(field(event, "title"));
+            const description = str(field(event, "description"));
+            const parts: string[] = [];
+
+            if (title !== undefined) {
+                parts.push(`title: ${title}`);
+            }
+
+            if (description !== undefined) {
+                parts.push(`description: ${description}`);
+            }
+
+            return parts.length > 0 ? parts.join("\n") : null;
+        }
+        case "attach": {
+            const mime = str(field(event, "mime"));
+            return mime !== undefined ? `mime: ${mime}` : null;
+        }
+        default:
+            return null;
+    }
+}
+
+function EventEntry({ event, index }: { event: HandoffPublicEvent; index: number }) {
+    const [expanded, setExpanded] = useState(false);
+    const color = VERB_COLOR[event.ev] ?? "var(--dd-text-muted)";
+    const detail = eventDetail(event);
+
+    return (
+        <div
+            className="dd-activity-entry flex flex-col gap-1 rounded border-l-2 bg-black/10 px-2.5 py-2 text-[11px] transition-colors duration-150 hover:bg-black/20"
+            style={{ borderLeftColor: color, animationDelay: `${Math.min(index, 10) * 24}ms` }}
+        >
+            <div className="flex items-center gap-2">
+                <span className="shrink-0 rounded-full border border-[var(--dd-border)] px-1.5 py-px font-mono text-[10px] text-[var(--dd-text-secondary)]">
+                    {actorChipLabel(event.by)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[var(--dd-text-primary)]">{describeEvent(event)}</span>
+                <span className="shrink-0 font-mono text-[10px] text-[var(--dd-text-muted)]">
+                    {relativeTime(event.ts)}
+                </span>
+            </div>
+            {detail !== null ? (
+                <>
+                    <button
+                        type="button"
+                        className="cursor-pointer self-start font-mono text-[10px] text-[var(--dd-text-muted)] hover:text-[var(--dd-text-primary)]"
+                        onClick={() => setExpanded((v) => !v)}
+                    >
+                        {expanded ? "▴ details" : "▾ details"}
+                    </button>
+                    {expanded ? (
+                        <p className="whitespace-pre-wrap rounded border border-[var(--dd-border)]/50 bg-black/20 p-1.5 text-[var(--dd-text-secondary)]">
+                            {detail}
+                        </p>
+                    ) : null}
+                </>
+            ) : null}
+        </div>
+    );
+}
+
+export function ActivityPanel({ id }: { id: string | null }) {
+    const panel = useActivityPanel();
+    const collapsed = panel.state === "collapsed";
+    const events = useHandoffEvents(id);
+    const [olderEvents, setOlderEvents] = useState<HandoffPublicEvent[]>([]);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+
+    useEffect(() => {
+        setOlderEvents([]);
+        setLoadMoreError(null);
+    }, [id]);
+
+    const firstPage = events.data?.events ?? [];
+    const total = events.data?.total ?? 0;
+    const seen = new Set(firstPage.map((e) => e.uid));
+    const allEvents = [...firstPage, ...olderEvents.filter((e) => !seen.has(e.uid))];
+    const hasMore = allEvents.length < total;
+
+    const loadMore = (): void => {
+        if (id === null || allEvents.length === 0 || loadingMore) {
+            return;
+        }
+
+        const oldest = allEvents[allEvents.length - 1];
+        setLoadingMore(true);
+        setLoadMoreError(null);
+
+        fetchHandoffEvents({ id, before: oldest.ts })
+            .then((res) => setOlderEvents((prev) => [...prev, ...res.events]))
+            .catch((err) => setLoadMoreError(err instanceof Error ? err.message : String(err)))
+            .finally(() => setLoadingMore(false));
+    };
+
+    if (collapsed) {
+        return (
+            <button
+                type="button"
+                className="dd-panel flex w-full flex-col items-center justify-start gap-2 self-start py-3 transition-colors duration-150 hover:border-primary/40 lg:h-full"
+                onClick={() => panel.setState("expanded")}
+                title="expand activity"
+            >
+                <span className="[writing-mode:vertical-rl] font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                    Activity
+                </span>
+                {total > 0 ? (
+                    <span className="rounded-full border border-[var(--dd-border)] px-1.5 py-0.5 font-mono text-[9px] text-[var(--dd-text-secondary)]">
+                        {total}
+                    </span>
+                ) : null}
+            </button>
+        );
+    }
+
+    return (
+        <div className="dd-panel flex min-h-0 flex-col gap-2 self-start p-3 lg:h-full">
+            <div className="flex items-center justify-between">
+                <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                    Activity{total > 0 ? ` · ${total}` : ""}
+                </span>
+                <button
+                    type="button"
+                    className="cursor-pointer text-[var(--dd-text-muted)] transition-colors hover:text-[var(--dd-text-primary)]"
+                    onClick={() => panel.setState("collapsed")}
+                    title="collapse activity"
+                >
+                    <ChevronsRight className="h-3.5 w-3.5" />
+                </button>
+            </div>
+            {id === null ? (
+                <p className="py-6 text-center text-xs text-[var(--dd-text-muted)]">
+                    Select a handoff to see its activity.
+                </p>
+            ) : events.isLoading ? (
+                <p className="py-6 text-center text-xs text-[var(--dd-text-muted)]">Loading…</p>
+            ) : events.isError ? (
+                <p className="py-6 text-center text-xs text-[var(--dd-danger)]">{String(events.error)}</p>
+            ) : allEvents.length === 0 ? (
+                <p className="py-6 text-center text-xs text-[var(--dd-text-muted)]">No activity yet.</p>
+            ) : (
+                <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+                    {allEvents.map((event, index) => (
+                        <EventEntry key={event.uid} event={event} index={index} />
+                    ))}
+                    {hasMore ? (
+                        <button
+                            type="button"
+                            disabled={loadingMore}
+                            className="cursor-pointer self-center font-mono text-[10px] text-[var(--dd-text-muted)] hover:text-[var(--dd-text-primary)] disabled:cursor-not-allowed"
+                            onClick={loadMore}
+                        >
+                            {loadingMore ? "loading…" : "load more"}
+                        </button>
+                    ) : null}
+                    {loadMoreError !== null ? (
+                        <p className="text-center text-[10px] text-[var(--dd-danger)]">{loadMoreError}</p>
+                    ) : null}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/dev-dashboard/ui/src/components/handoff/ActivityPanel.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/ActivityPanel.tsx
@@ -1,6 +1,6 @@
 import type { HandoffPublicEvent } from "@app/dev-dashboard/lib/handoff-types";
 import { ChevronsRight } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useActivityPanel } from "@/hooks/useActivityPanel";
 import { fetchHandoffEvents, useHandoffEvents } from "@/hooks/useHandoffEvents";
 import { actorChipLabel, relativeTime } from "./handoff-format";
@@ -172,9 +172,12 @@ export function ActivityPanel({ id }: { id: string | null }) {
     const [olderEvents, setOlderEvents] = useState<HandoffPublicEvent[]>([]);
     const [loadingMore, setLoadingMore] = useState(false);
     const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+    const requestedIdRef = useRef<string | null>(id);
 
     useEffect(() => {
+        requestedIdRef.current = id;
         setOlderEvents([]);
+        setLoadingMore(false);
         setLoadMoreError(null);
     }, [id]);
 
@@ -190,13 +193,32 @@ export function ActivityPanel({ id }: { id: string | null }) {
         }
 
         const oldest = allEvents[allEvents.length - 1];
+        const reqId = id;
         setLoadingMore(true);
         setLoadMoreError(null);
 
-        fetchHandoffEvents({ id, before: oldest.ts })
-            .then((res) => setOlderEvents((prev) => [...prev, ...res.events]))
-            .catch((err) => setLoadMoreError(err instanceof Error ? err.message : String(err)))
-            .finally(() => setLoadingMore(false));
+        fetchHandoffEvents({ id, before: oldest.ts, beforeUid: oldest.uid })
+            .then((res) => {
+                if (requestedIdRef.current !== reqId) {
+                    return;
+                }
+
+                setOlderEvents((prev) => [...prev, ...res.events]);
+            })
+            .catch((err) => {
+                if (requestedIdRef.current !== reqId) {
+                    return;
+                }
+
+                setLoadMoreError(err instanceof Error ? err.message : String(err));
+            })
+            .finally(() => {
+                if (requestedIdRef.current !== reqId) {
+                    return;
+                }
+
+                setLoadingMore(false);
+            });
     };
 
     if (collapsed) {

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
@@ -16,11 +16,15 @@ const FILE_CHIP_PATTERN = /\[File#(a_[a-z0-9]+)\]/g;
  * leaving unknown ids as literal text. Plain-text segments render as-is
  * unless `renderSegment` (e.g. markdown) is supplied (G10).
  */
-export function renderWithFileChips(
-    text: string,
-    attachments: AttachmentMeta[],
-    renderSegment: (segment: string, key: string) => ReactNode = (segment) => segment
-): ReactNode[] {
+export function renderWithFileChips({
+    text,
+    attachments,
+    renderSegment = (segment) => segment,
+}: {
+    text: string;
+    attachments: AttachmentMeta[];
+    renderSegment?: (segment: string, key: string) => ReactNode;
+}): ReactNode[] {
     const byId = new Map(attachments.map((a) => [a.attachmentId, a]));
     const pattern = new RegExp(FILE_CHIP_PATTERN);
     const parts: ReactNode[] = [];

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffAttachments.tsx
@@ -1,5 +1,5 @@
 import type { PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { attachmentUrl } from "./useHandoffApi";
 
 type AttachmentMeta = PublicHandoff["attachments"][number];
@@ -8,9 +8,63 @@ function isImage(a: AttachmentMeta): boolean {
     return a.mime.startsWith("image/");
 }
 
+const FILE_CHIP_PATTERN = /\[File#(a_[a-z0-9]+)\]/g;
+
+/**
+ * Splits `text` on `[File#id]` refs, rendering known ids as inline attachment
+ * chips (interactive — reuses `AttachmentChip`, incl. onError fallback) and
+ * leaving unknown ids as literal text. Plain-text segments render as-is
+ * unless `renderSegment` (e.g. markdown) is supplied (G10).
+ */
+export function renderWithFileChips(
+    text: string,
+    attachments: AttachmentMeta[],
+    renderSegment: (segment: string, key: string) => ReactNode = (segment) => segment
+): ReactNode[] {
+    const byId = new Map(attachments.map((a) => [a.attachmentId, a]));
+    const pattern = new RegExp(FILE_CHIP_PATTERN);
+    const parts: ReactNode[] = [];
+    let lastIndex = 0;
+    let n = 0;
+    let match = pattern.exec(text);
+
+    while (match !== null) {
+        const [full, id] = match;
+
+        if (match.index > lastIndex) {
+            parts.push(renderSegment(text.slice(lastIndex, match.index), `t-${n}`));
+            n += 1;
+        }
+
+        const attachment = byId.get(id);
+        parts.push(attachment !== undefined ? <AttachmentChip key={`c-${n}`} attachment={attachment} /> : full);
+        n += 1;
+        lastIndex = match.index + full.length;
+        match = pattern.exec(text);
+    }
+
+    if (lastIndex < text.length) {
+        parts.push(renderSegment(text.slice(lastIndex), `t-${n}`));
+    }
+
+    return parts;
+}
+
+function BrokenFileChip({ filename }: { filename: string }) {
+    return (
+        <span
+            className="inline-flex items-center gap-1 rounded border border-dashed border-[var(--dd-border)] px-2 py-1 font-mono text-[10px] text-[var(--dd-text-muted)] line-through"
+            title="attachment file missing on disk"
+        >
+            ⚠ {filename}
+        </span>
+    );
+}
+
 function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose: () => void }) {
     const dialogRef = useRef<HTMLDivElement | null>(null);
     const closeRef = useRef<HTMLButtonElement | null>(null);
+    const [broken, setBroken] = useState(false);
 
     useEffect(() => {
         const previouslyFocused = document.activeElement as HTMLElement | null;
@@ -60,11 +114,16 @@ function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose
             className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-black/85 p-8"
             onClick={onClose}
         >
-            <img
-                src={attachmentUrl(attachment.attachmentId)}
-                alt={attachment.filename}
-                className="max-h-[80vh] max-w-[90vw] rounded border border-[var(--dd-border)] object-contain"
-            />
+            {broken ? (
+                <BrokenFileChip filename={attachment.filename} />
+            ) : (
+                <img
+                    src={attachmentUrl(attachment.attachmentId)}
+                    alt={attachment.filename}
+                    className="max-h-[80vh] max-w-[90vw] rounded border border-[var(--dd-border)] object-contain"
+                    onError={() => setBroken(true)}
+                />
+            )}
             <div
                 className="flex items-center gap-3 font-mono text-xs text-[var(--dd-text-secondary)]"
                 onClick={(ev) => ev.stopPropagation()}
@@ -95,16 +154,10 @@ function Lightbox({ attachment, onClose }: { attachment: AttachmentMeta; onClose
 
 export function AttachmentChip({ attachment }: { attachment: AttachmentMeta }) {
     const [open, setOpen] = useState(false);
+    const [broken, setBroken] = useState(false);
 
-    if (attachment.missing === true) {
-        return (
-            <span
-                className="inline-flex items-center gap-1 rounded border border-dashed border-[var(--dd-border)] px-2 py-1 font-mono text-[10px] text-[var(--dd-text-muted)] line-through"
-                title="attachment file missing on disk"
-            >
-                ⚠ {attachment.filename}
-            </span>
-        );
+    if (attachment.missing === true || broken) {
+        return <BrokenFileChip filename={attachment.filename} />;
     }
 
     if (isImage(attachment)) {
@@ -121,6 +174,7 @@ export function AttachmentChip({ attachment }: { attachment: AttachmentMeta }) {
                         alt={attachment.filename}
                         className="h-16 w-24 rounded-sm object-cover"
                         loading="lazy"
+                        onError={() => setBroken(true)}
                     />
                 </button>
                 {open ? <Lightbox attachment={attachment} onClose={() => setOpen(false)} /> : null}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
@@ -1,11 +1,17 @@
-import type { HandoffActionInput, HandoffActionResult, PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
+import type {
+    HandoffActionInput,
+    HandoffActionResult,
+    HandoffClaim,
+    PublicHandoff,
+} from "@app/dev-dashboard/lib/handoff-types";
 import { renderMarkdown } from "@app/dev-dashboard/lib/obsidian/markdown";
 import { Button } from "@ui/components/button";
 import { Input } from "@ui/components/input";
 import { Textarea } from "@ui/components/textarea";
 import { type ClipboardEvent, type DragEvent, useMemo, useRef, useState } from "react";
-import { AttachmentStrip } from "./HandoffAttachments";
-import { HandoffTaskRow } from "./HandoffTaskRow";
+import { AttachmentStrip, renderWithFileChips } from "./HandoffAttachments";
+import { CommitChip, HandoffTaskRow } from "./HandoffTaskRow";
+import { actorChipLabel, basename, relativeTime, shortSha, truncateMiddle } from "./handoff-format";
 import { uploadHandoffAttachment, useHandoffAction, useHandoffDetail } from "./useHandoffApi";
 
 function md(text: string): string {
@@ -28,12 +34,47 @@ function statusBadgeClass(status: PublicHandoff["status"]): string {
     return "border-[var(--dd-danger)]/50 text-[var(--dd-danger)]";
 }
 
-function actorLabel(by: { sessionName: string | null; agent: string; via?: string }): string {
-    if (by.agent === "human") {
-        return "Martin · dashboard";
-    }
+function ClaimerRow({ claim }: { claim: HandoffClaim }) {
+    const [expanded, setExpanded] = useState(false);
+    const [cwdExpanded, setCwdExpanded] = useState(false);
 
-    return by.sessionName ?? by.agent;
+    return (
+        <div className="flex flex-col gap-1 rounded border border-[#4a3a5e]/40 bg-black/10 px-2 py-1.5">
+            <button
+                type="button"
+                className="flex w-full cursor-pointer items-center gap-1.5 text-left"
+                onClick={() => setExpanded((v) => !v)}
+            >
+                <span className="rounded-full border border-[#4a3a5e] px-2 py-px text-[11px] text-[#c792ea]">
+                    {claim.sessionName ?? claim.sessionId ?? "unnamed"}
+                </span>
+                <span className="text-[10px] text-[var(--dd-text-muted)]">{expanded ? "▴" : "▾"}</span>
+            </button>
+            {expanded ? (
+                <div className="flex flex-col gap-1 pl-1 font-mono text-[10px] text-[var(--dd-text-secondary)]">
+                    {claim.branch !== null ? <span>branch: {claim.branch}</span> : null}
+                    {claim.repoRoot !== null ? <span>repo: {basename(claim.repoRoot)}</span> : null}
+                    {claim.commitSha !== null ? (
+                        <span className="flex items-center gap-1.5">
+                            sha:
+                            <CommitChip sha={claim.commitSha} label={shortSha(claim.commitSha)} />
+                        </span>
+                    ) : null}
+                    {claim.cwd !== null ? (
+                        <button
+                            type="button"
+                            className="cursor-pointer text-left hover:text-[var(--dd-text-primary)]"
+                            onClick={() => setCwdExpanded((v) => !v)}
+                            title="click to expand"
+                        >
+                            cwd: {cwdExpanded ? claim.cwd : truncateMiddle(claim.cwd, 48)}
+                        </button>
+                    ) : null}
+                    <span>claimed {relativeTime(claim.claimedAt)}</span>
+                </div>
+            ) : null}
+        </div>
+    );
 }
 
 export function HandoffDetail({ id }: { id: string }) {
@@ -70,7 +111,15 @@ export function HandoffDetail({ id }: { id: string }) {
     const terminal = handoff.status === "done" || handoff.status === "cancelled";
     const resolved = handoff.tasks.filter((t) => t.checked || t.denied).length;
     const allResolved = handoff.tasks.length > 0 && resolved === handoff.tasks.length;
+    // Owner-claim detection mirrors fold G11: the human owner's claim identity is agent === "human".
+    const humanClaim = handoff.claimedBy.find((c) => c.agent === "human");
     const run = (actions: HandoffActionInput[]): void => action.mutate(actions);
+
+    const pasteFileIntoTask = async (file: File, taskId: string): Promise<string> => {
+        const res = await uploadHandoffAttachment({ id, file, taskId });
+        void detail.refetch();
+        return res.attachmentId;
+    };
 
     const uploadFiles = (files: File[], taskId?: string): void => {
         setUploadError(null);
@@ -263,25 +312,30 @@ export function HandoffDetail({ id }: { id: string }) {
             </div>
 
             {handoff.claimedBy.length > 0 ? (
-                <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+                <div className="flex flex-col gap-1.5">
                     <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
                         claimed by
                     </span>
-                    {handoff.claimedBy.map((c) => (
-                        <span
-                            key={`${c.sessionId}-${c.claimedAt}`}
-                            className="rounded-full border border-[#4a3a5e] px-2 py-px text-[#c792ea]"
-                            title={`${c.sessionId ?? ""} · ${c.via} · ${new Date(c.claimedAt).toLocaleString()}`}
-                        >
-                            {c.sessionName ?? c.sessionId ?? "unnamed"}
-                        </span>
-                    ))}
+                    <div className="flex flex-wrap gap-1.5">
+                        {handoff.claimedBy.map((c) => (
+                            <ClaimerRow key={`${c.sessionId}-${c.claimedAt}`} claim={c} />
+                        ))}
+                    </div>
                 </div>
             ) : null}
 
             <div className="flex flex-wrap gap-2">
                 {!terminal ? (
                     <>
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={action.isPending}
+                            className="border-[#4a3a5e] text-[#c792ea] transition-[filter] hover:brightness-110"
+                            onClick={() => run([{ action: humanClaim !== undefined ? "unclaim" : "claim" }])}
+                        >
+                            {humanClaim !== undefined ? "Unclaim" : "Claim"}
+                        </Button>
                         <Button
                             size="sm"
                             disabled={action.isPending}
@@ -393,46 +447,72 @@ export function HandoffDetail({ id }: { id: string }) {
                         attachments={handoff.attachments}
                         disabled={terminal || action.isPending}
                         onActions={run}
+                        onPasteFile={(file) => pasteFileIntoTask(file, task.id)}
                     />
                 ))}
                 {!terminal ? (
-                    <div className="flex items-center gap-2 rounded border border-dashed border-[var(--dd-border)]/60 px-3 py-2">
-                        <Input
+                    <div className="flex flex-col gap-1.5 rounded border border-dashed border-[var(--dd-border)]/60 px-3 py-2">
+                        <Textarea
                             value={newTaskText}
                             onChange={(e) => setNewTaskText(e.target.value)}
-                            className="h-7 border-[var(--dd-border)] bg-black/15 text-sm"
+                            className="min-h-[2rem] border-[var(--dd-border)] bg-black/15 text-sm"
+                            rows={2}
                             placeholder="add a task…"
                         />
-                        <Input
-                            value={newTaskCriteria}
-                            onChange={(e) => setNewTaskCriteria(e.target.value)}
-                            className="h-7 border-[var(--dd-border)] bg-black/10 text-xs"
-                            placeholder="acceptance criteria (optional)"
-                        />
-                        <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={newTaskText.trim().length === 0 || action.isPending}
-                            onClick={() => {
-                                run([
-                                    {
-                                        action: "add_tasks",
-                                        tasks: [
-                                            {
-                                                text: newTaskText.trim(),
-                                                ...(newTaskCriteria.trim().length > 0
-                                                    ? { acceptanceCriteria: newTaskCriteria.trim() }
-                                                    : {}),
-                                            },
-                                        ],
-                                    },
-                                ]);
-                                setNewTaskText("");
-                                setNewTaskCriteria("");
-                            }}
-                        >
-                            Add
-                        </Button>
+                        <div className="flex items-center gap-2">
+                            <Input
+                                value={newTaskCriteria}
+                                onChange={(e) => setNewTaskCriteria(e.target.value)}
+                                className="h-7 border-[var(--dd-border)] bg-black/10 text-xs"
+                                placeholder="acceptance criteria (optional)"
+                                onKeyDown={(e) => {
+                                    if (e.key !== "Enter" || newTaskText.trim().length === 0) {
+                                        return;
+                                    }
+
+                                    e.preventDefault();
+                                    run([
+                                        {
+                                            action: "add_tasks",
+                                            tasks: [
+                                                {
+                                                    text: newTaskText.trim(),
+                                                    ...(newTaskCriteria.trim().length > 0
+                                                        ? { acceptanceCriteria: newTaskCriteria.trim() }
+                                                        : {}),
+                                                },
+                                            ],
+                                        },
+                                    ]);
+                                    setNewTaskText("");
+                                    setNewTaskCriteria("");
+                                }}
+                            />
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={newTaskText.trim().length === 0 || action.isPending}
+                                onClick={() => {
+                                    run([
+                                        {
+                                            action: "add_tasks",
+                                            tasks: [
+                                                {
+                                                    text: newTaskText.trim(),
+                                                    ...(newTaskCriteria.trim().length > 0
+                                                        ? { acceptanceCriteria: newTaskCriteria.trim() }
+                                                        : {}),
+                                                },
+                                            ],
+                                        },
+                                    ]);
+                                    setNewTaskText("");
+                                    setNewTaskCriteria("");
+                                }}
+                            >
+                                Add
+                            </Button>
+                        </div>
                     </div>
                 ) : null}
             </div>
@@ -450,10 +530,14 @@ export function HandoffDetail({ id }: { id: string }) {
                             className="rounded border border-[var(--dd-border)]/50 bg-black/10 px-3 py-2"
                         >
                             <div className="mb-1 flex items-center gap-2 font-mono text-[10px] text-[var(--dd-text-muted)]">
-                                <span className="text-[var(--dd-text-secondary)]">{actorLabel(comment.by)}</span>
+                                <span className="text-[var(--dd-text-secondary)]">{actorChipLabel(comment.by)}</span>
                                 <span>{new Date(comment.ts).toLocaleString()}</span>
                             </div>
-                            <p className="whitespace-pre-wrap text-sm text-[var(--dd-text-primary)]">{comment.text}</p>
+                            <div className="dd-markdown text-sm text-[var(--dd-text-primary)]">
+                                {renderWithFileChips(comment.text, handoff.attachments, (segment, key) => (
+                                    <span key={key} dangerouslySetInnerHTML={{ __html: md(segment) }} />
+                                ))}
+                            </div>
                             {comment.attachmentIds !== undefined && comment.attachmentIds.length > 0 ? (
                                 <div className="mt-1.5">
                                     <AttachmentStrip attachments={handoff.attachments} ids={comment.attachmentIds} />
@@ -492,7 +576,13 @@ export function HandoffDetail({ id }: { id: string }) {
                                 onChange={(e) => setCommentDraft(e.target.value)}
                                 className="min-h-[2.5rem] border-[var(--dd-border)] bg-black/15 text-sm"
                                 rows={2}
-                                placeholder="comment… (paste screenshots here to attach them)"
+                                placeholder="comment… (paste screenshots here to attach them, ⌘⏎ to send)"
+                                onKeyDown={(e) => {
+                                    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                                        e.preventDefault();
+                                        void submitComment();
+                                    }
+                                }}
                             />
                             <Button
                                 size="sm"

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
@@ -135,6 +135,38 @@ export function HandoffDetail({ id }: { id: string }) {
         });
     };
 
+    /**
+     * Paste into a text composer (new-task or comment) → upload the file(s) at handoff
+     * level and insert `[File#id]` at the cursor, so the ref renders as an inline chip
+     * (same pattern as editing an existing task's text). stopPropagation keeps the
+     * container paste handler from also grabbing the file.
+     */
+    const pasteFilesIntoDraft = (
+        ev: ClipboardEvent<HTMLTextAreaElement>,
+        setDraft: (updater: (prev: string) => string) => void
+    ): void => {
+        const files = [...ev.clipboardData.files];
+
+        if (files.length === 0) {
+            return;
+        }
+
+        ev.preventDefault();
+        ev.stopPropagation();
+        setUploadError(null);
+        const el = ev.target as HTMLTextAreaElement;
+        const cursor = el.selectionStart ?? el.value.length;
+
+        Promise.all(files.map((file) => uploadHandoffAttachment({ id, file }))).then(
+            (uploads) => {
+                const tokens = uploads.map((u) => `[File#${u.attachmentId}]`).join(" ");
+                setDraft((prev) => `${prev.slice(0, cursor)}${tokens}${prev.slice(cursor)}`);
+                void detail.refetch();
+            },
+            (err) => setUploadError(err instanceof Error ? err.message : String(err))
+        );
+    };
+
     /** Paste anywhere (§7.3): task-row focus → that task; comment composer → pending chip; else the handoff. */
     const onPaste = (ev: ClipboardEvent<HTMLDivElement>): void => {
         const files = [...ev.clipboardData.files];
@@ -455,9 +487,10 @@ export function HandoffDetail({ id }: { id: string }) {
                         <Textarea
                             value={newTaskText}
                             onChange={(e) => setNewTaskText(e.target.value)}
+                            onPaste={(e) => pasteFilesIntoDraft(e, setNewTaskText)}
                             className="min-h-[2rem] border-[var(--dd-border)] bg-black/15 text-sm"
                             rows={2}
-                            placeholder="add a task…"
+                            placeholder="add a task… (paste an image to insert a [File#id] ref)"
                         />
                         <div className="flex items-center gap-2">
                             <Input
@@ -574,9 +607,10 @@ export function HandoffDetail({ id }: { id: string }) {
                                 ref={composerRef}
                                 value={commentDraft}
                                 onChange={(e) => setCommentDraft(e.target.value)}
+                                onPaste={(e) => pasteFilesIntoDraft(e, setCommentDraft)}
                                 className="min-h-[2.5rem] border-[var(--dd-border)] bg-black/15 text-sm"
                                 rows={2}
-                                placeholder="comment… (paste screenshots here to attach them, ⌘⏎ to send)"
+                                placeholder="comment… (paste an image to insert a [File#id] ref, ⌘⏎ to send)"
                                 onKeyDown={(e) => {
                                     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
                                         e.preventDefault();

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDetail.tsx
@@ -12,6 +12,7 @@ import { type ClipboardEvent, type DragEvent, useMemo, useRef, useState } from "
 import { AttachmentStrip, renderWithFileChips } from "./HandoffAttachments";
 import { CommitChip, HandoffTaskRow } from "./HandoffTaskRow";
 import { actorChipLabel, basename, relativeTime, shortSha, truncateMiddle } from "./handoff-format";
+import { collectUploadTokens, insertAtCursor } from "./handoff-paste";
 import { uploadHandoffAttachment, useHandoffAction, useHandoffDetail } from "./useHandoffApi";
 
 function md(text: string): string {
@@ -20,11 +21,11 @@ function md(text: string): string {
 
 function statusBadgeClass(status: PublicHandoff["status"]): string {
     if (status === "open") {
-        return "border-[#3f5530] text-[#a3e635]";
+        return "border-[var(--dd-status-open-border)] text-[var(--dd-status-open-text)]";
     }
 
     if (status === "claimed") {
-        return "border-[#4a3a5e] text-[#c792ea]";
+        return "border-[var(--dd-status-claimed-border)] text-[var(--dd-status-claimed-text)]";
     }
 
     if (status === "done") {
@@ -39,13 +40,13 @@ function ClaimerRow({ claim }: { claim: HandoffClaim }) {
     const [cwdExpanded, setCwdExpanded] = useState(false);
 
     return (
-        <div className="flex flex-col gap-1 rounded border border-[#4a3a5e]/40 bg-black/10 px-2 py-1.5">
+        <div className="flex flex-col gap-1 rounded border border-[var(--dd-status-claimed-border)]/40 bg-black/10 px-2 py-1.5">
             <button
                 type="button"
                 className="flex w-full cursor-pointer items-center gap-1.5 text-left"
                 onClick={() => setExpanded((v) => !v)}
             >
-                <span className="rounded-full border border-[#4a3a5e] px-2 py-px text-[11px] text-[#c792ea]">
+                <span className="rounded-full border border-[var(--dd-status-claimed-border)] px-2 py-px text-[11px] text-[var(--dd-status-claimed-text)]">
                     {claim.sessionName ?? claim.sessionId ?? "unnamed"}
                 </span>
                 <span className="text-[10px] text-[var(--dd-text-muted)]">{expanded ? "▴" : "▾"}</span>
@@ -115,6 +116,22 @@ export function HandoffDetail({ id }: { id: string }) {
     const humanClaim = handoff.claimedBy.find((c) => c.agent === "human");
     const run = (actions: HandoffActionInput[]): void => action.mutate(actions);
 
+    const submitNewTask = (): void => {
+        run([
+            {
+                action: "add_tasks",
+                tasks: [
+                    {
+                        text: newTaskText.trim(),
+                        ...(newTaskCriteria.trim().length > 0 ? { acceptanceCriteria: newTaskCriteria.trim() } : {}),
+                    },
+                ],
+            },
+        ]);
+        setNewTaskText("");
+        setNewTaskCriteria("");
+    };
+
     const pasteFileIntoTask = async (file: File, taskId: string): Promise<string> => {
         const res = await uploadHandoffAttachment({ id, file, taskId });
         void detail.refetch();
@@ -157,14 +174,19 @@ export function HandoffDetail({ id }: { id: string }) {
         const el = ev.target as HTMLTextAreaElement;
         const cursor = el.selectionStart ?? el.value.length;
 
-        Promise.all(files.map((file) => uploadHandoffAttachment({ id, file }))).then(
-            (uploads) => {
-                const tokens = uploads.map((u) => `[File#${u.attachmentId}]`).join(" ");
-                setDraft((prev) => `${prev.slice(0, cursor)}${tokens}${prev.slice(cursor)}`);
-                void detail.refetch();
-            },
-            (err) => setUploadError(err instanceof Error ? err.message : String(err))
-        );
+        Promise.allSettled(files.map((file) => uploadHandoffAttachment({ id, file }))).then((results) => {
+            const { tokens, failure } = collectUploadTokens(results);
+
+            if (tokens.length > 0) {
+                setDraft((prev) => insertAtCursor(prev, tokens, cursor));
+            }
+
+            if (failure !== undefined) {
+                setUploadError(failure.reason instanceof Error ? failure.reason.message : String(failure.reason));
+            }
+
+            void detail.refetch();
+        });
     };
 
     /** Paste anywhere (§7.3): task-row focus → that task; comment composer → pending chip; else the handoff. */
@@ -363,7 +385,7 @@ export function HandoffDetail({ id }: { id: string }) {
                             size="sm"
                             variant="outline"
                             disabled={action.isPending}
-                            className="border-[#4a3a5e] text-[#c792ea] transition-[filter] hover:brightness-110"
+                            className="border-[var(--dd-status-claimed-border)] text-[var(--dd-status-claimed-text)] transition-[filter] hover:brightness-110"
                             onClick={() => run([{ action: humanClaim !== undefined ? "unclaim" : "claim" }])}
                         >
                             {humanClaim !== undefined ? "Unclaim" : "Claim"}
@@ -504,44 +526,14 @@ export function HandoffDetail({ id }: { id: string }) {
                                     }
 
                                     e.preventDefault();
-                                    run([
-                                        {
-                                            action: "add_tasks",
-                                            tasks: [
-                                                {
-                                                    text: newTaskText.trim(),
-                                                    ...(newTaskCriteria.trim().length > 0
-                                                        ? { acceptanceCriteria: newTaskCriteria.trim() }
-                                                        : {}),
-                                                },
-                                            ],
-                                        },
-                                    ]);
-                                    setNewTaskText("");
-                                    setNewTaskCriteria("");
+                                    submitNewTask();
                                 }}
                             />
                             <Button
                                 size="sm"
                                 variant="outline"
                                 disabled={newTaskText.trim().length === 0 || action.isPending}
-                                onClick={() => {
-                                    run([
-                                        {
-                                            action: "add_tasks",
-                                            tasks: [
-                                                {
-                                                    text: newTaskText.trim(),
-                                                    ...(newTaskCriteria.trim().length > 0
-                                                        ? { acceptanceCriteria: newTaskCriteria.trim() }
-                                                        : {}),
-                                                },
-                                            ],
-                                        },
-                                    ]);
-                                    setNewTaskText("");
-                                    setNewTaskCriteria("");
-                                }}
+                                onClick={submitNewTask}
                             >
                                 Add
                             </Button>
@@ -567,9 +559,13 @@ export function HandoffDetail({ id }: { id: string }) {
                                 <span>{new Date(comment.ts).toLocaleString()}</span>
                             </div>
                             <div className="dd-markdown text-sm text-[var(--dd-text-primary)]">
-                                {renderWithFileChips(comment.text, handoff.attachments, (segment, key) => (
-                                    <span key={key} dangerouslySetInnerHTML={{ __html: md(segment) }} />
-                                ))}
+                                {renderWithFileChips({
+                                    text: comment.text,
+                                    attachments: handoff.attachments,
+                                    renderSegment: (segment, key) => (
+                                        <span key={key} dangerouslySetInnerHTML={{ __html: md(segment) }} />
+                                    ),
+                                })}
                             </div>
                             {comment.attachmentIds !== undefined && comment.attachmentIds.length > 0 ? (
                                 <div className="mt-1.5">

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
@@ -12,7 +12,8 @@ import {
 import { Input } from "@ui/components/input";
 import { Label } from "@ui/components/label";
 import { Textarea } from "@ui/components/textarea";
-import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { type KeyboardEvent, useState } from "react";
 import { useHandoffCreate } from "./useHandoffApi";
 
 const DIALOG_PANEL_CLASS =
@@ -147,6 +148,10 @@ export function HandoffCreateDialog({
         setTasks((prev) => prev.map((t, i) => (i === index ? { ...t, ...patch } : t)));
     };
 
+    const addTaskRow = (): void => {
+        setTasks((prev) => [...prev, { text: "", acceptanceCriteria: "" }]);
+    };
+
     const validTasks = tasks.filter((t) => t.text.trim().length > 0);
 
     const submit = (): void => {
@@ -199,9 +204,25 @@ export function HandoffCreateDialog({
         });
     };
 
+    const onDialogKeyDown = (e: KeyboardEvent<HTMLDivElement>): void => {
+        if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+
+            if (!create.isPending && title.trim().length > 0 && validTasks.length > 0) {
+                submit();
+            }
+        }
+    };
+
     return (
         <GlassDialogShell open={open} onOpenChange={onOpenChange}>
-            <GlassDialogContent size="lg" fixedHeight showCloseButton className={DIALOG_PANEL_CLASS}>
+            <GlassDialogContent
+                size="lg"
+                fixedHeight
+                showCloseButton
+                className={DIALOG_PANEL_CLASS}
+                onKeyDown={onDialogKeyDown}
+            >
                 <GlassDialogBody className="gap-0 p-0 sm:p-0">
                     <GlassDialogHeader className="shrink-0 border-b border-[var(--dd-border)]/80 px-5 py-4 text-left">
                         <GlassDialogTitle className="dd-accent-text text-lg font-bold">New handoff</GlassDialogTitle>
@@ -241,36 +262,50 @@ export function HandoffCreateDialog({
                                 {tasks.map((task, index) => (
                                     <div
                                         key={index}
-                                        className="flex flex-col gap-1 rounded border border-[var(--dd-border)]/70 bg-black/15 p-2"
+                                        className="flex flex-col gap-1.5 rounded border border-[var(--dd-border)]/70 bg-black/15 p-2"
                                     >
-                                        <div className="flex items-center gap-2">
-                                            <span className="font-mono text-[10px] text-[var(--dd-text-muted)]">
-                                                t{index + 1}
+                                        <div className="flex items-start gap-2">
+                                            <span className="mt-2 text-xs text-[var(--dd-text-muted)]">
+                                                #{index + 1}
                                             </span>
-                                            <Input
+                                            <Textarea
                                                 value={task.text}
                                                 onChange={(e) => setTask(index, { text: e.target.value })}
-                                                className="border-[var(--dd-border)] bg-black/20"
+                                                className="min-h-[2.25rem] border-[var(--dd-border)] bg-black/20"
+                                                rows={2}
                                                 placeholder="what to do"
                                             />
                                             {tasks.length > 1 ? (
                                                 <button
                                                     type="button"
-                                                    className="cursor-pointer text-[var(--dd-text-muted)] hover:text-[var(--dd-danger)]"
+                                                    className="mt-1.5 cursor-pointer text-[var(--dd-text-muted)] hover:text-[var(--dd-danger)]"
                                                     onClick={() =>
                                                         setTasks((prev) => prev.filter((_, i) => i !== index))
                                                     }
                                                     title="remove row"
                                                 >
-                                                    ×
+                                                    <Trash2 className="h-3.5 w-3.5" />
                                                 </button>
                                             ) : null}
                                         </div>
                                         <Input
                                             value={task.acceptanceCriteria}
                                             onChange={(e) => setTask(index, { acceptanceCriteria: e.target.value })}
-                                            className="border-[var(--dd-border)] bg-black/10 text-xs"
+                                            className="ml-6 border-[var(--dd-border)] bg-black/10 text-xs"
                                             placeholder="acceptance criteria (optional but recommended)"
+                                            onKeyDown={(e) => {
+                                                if (
+                                                    e.key !== "Enter" ||
+                                                    e.metaKey ||
+                                                    e.ctrlKey ||
+                                                    index !== tasks.length - 1
+                                                ) {
+                                                    return;
+                                                }
+
+                                                e.preventDefault();
+                                                addTaskRow();
+                                            }}
                                         />
                                     </div>
                                 ))}
@@ -279,7 +314,7 @@ export function HandoffCreateDialog({
                                     variant="outline"
                                     size="sm"
                                     className="self-start"
-                                    onClick={() => setTasks((prev) => [...prev, { text: "", acceptanceCriteria: "" }])}
+                                    onClick={addTaskRow}
                                 >
                                     + Add task row
                                 </Button>

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
@@ -1,8 +1,11 @@
-import type { HandoffListRow, HandoffPostResponse, HandoffStreamFrame } from "@app/dev-dashboard/lib/handoff-types";
-import { SafeJSON } from "@genesiscz/utils/json";
+import type { HandoffListRow, HandoffPostResponse } from "@app/dev-dashboard/lib/handoff-types";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@ui/components/button";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { useActivityPanel } from "@/hooks/useActivityPanel";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useQaStream } from "@/hooks/useQaStream";
+import { ActivityPanel } from "./ActivityPanel";
 import { HandoffDetail } from "./HandoffDetail";
 import { HandoffCreateDialog } from "./HandoffDialogs";
 import { useHandoffList } from "./useHandoffApi";
@@ -32,10 +35,12 @@ function statusDot(status: string): string {
 
 function HandoffRow({
     row,
+    ordinal,
     selected,
     onSelect,
 }: {
     row: HandoffListRow;
+    ordinal: number;
     selected: boolean;
     onSelect: (id: string) => void;
 }) {
@@ -52,6 +57,7 @@ function HandoffRow({
                     className="h-1.5 w-1.5 shrink-0 rounded-full"
                     style={{ backgroundColor: statusDot(row.status) }}
                 />
+                <span className="font-mono text-[10px] text-[var(--dd-text-muted)]">#{ordinal}</span>
                 <span className="min-w-0 flex-1 truncate text-sm text-[var(--dd-text-primary)]">{row.title}</span>
                 <span className="font-mono text-[10px] text-[var(--dd-text-secondary)]">
                     {row.progress ?? row.tasks}
@@ -79,6 +85,8 @@ function HandoffRow({
 export function HandoffTab() {
     const list = useHandoffList();
     const queryClient = useQueryClient();
+    const activityPanel = useActivityPanel();
+    const isDesktop = useMediaQuery("(min-width: 1024px)");
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const [openOnly, setOpenOnly] = useState(false);
     const [project, setProject] = useState<string>("");
@@ -86,21 +94,16 @@ export function HandoffTab() {
     const [editIdToast, setEditIdToast] = useState<HandoffPostResponse | null>(null);
     const rows = useMemo(() => list.data?.handoffs ?? [], [list.data]);
 
-    // SSE keeps every window live (§7.3): each frame → refetch that handoff + the list.
-    useEffect(() => {
-        const es = new EventSource("/api/handoff/stream");
-        es.onmessage = (ev) => {
-            try {
-                const frame = SafeJSON.parse(ev.data, { strict: true }) as HandoffStreamFrame;
-                void queryClient.invalidateQueries({ queryKey: ["handoff-log"] });
-                void queryClient.invalidateQueries({ queryKey: ["handoff", frame.id] });
-            } catch {
-                /* malformed frame — ignore */
-            }
-        };
+    // Unified /api/qa/stream — handoff frames invalidate list + detail (+ events when selected).
+    useQaStream((frame) => {
+        if (frame.type !== "handoff") {
+            return;
+        }
 
-        return () => es.close();
-    }, [queryClient]);
+        void queryClient.invalidateQueries({ queryKey: ["handoff-log"] });
+        void queryClient.invalidateQueries({ queryKey: ["handoff", frame.id] });
+        void queryClient.invalidateQueries({ queryKey: ["handoff-events", frame.id] });
+    });
 
     const projects = useMemo(
         () => [...new Set(rows.map((r) => r.project).filter((p): p is string => p !== null))].sort(),
@@ -109,9 +112,14 @@ export function HandoffTab() {
     const filtered = rows.filter(
         (r) => (!openOnly || r.status === "open" || r.status === "claimed") && (project === "" || r.project === project)
     );
+    const ordinalById = new Map(filtered.map((row, index) => [row.id, index + 1]));
+    const activityColumn = activityPanel.state === "collapsed" ? "44px" : "340px";
 
     return (
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)]">
+        <div
+            className="grid grid-cols-1 gap-4 transition-[grid-template-columns] duration-200 ease-out"
+            style={isDesktop ? { gridTemplateColumns: `minmax(0,0.7fr) minmax(0,1.6fr) ${activityColumn}` } : undefined}
+        >
             <div className="dd-panel flex flex-col gap-3 self-start p-3">
                 <div className="flex items-center gap-2">
                     <Button
@@ -169,6 +177,7 @@ export function HandoffTab() {
                                     <HandoffRow
                                         key={row.id}
                                         row={row}
+                                        ordinal={ordinalById.get(row.id) ?? 0}
                                         selected={row.id === selectedId}
                                         onSelect={setSelectedId}
                                     />
@@ -188,6 +197,8 @@ export function HandoffTab() {
                     </div>
                 )}
             </div>
+
+            <ActivityPanel id={selectedId} />
 
             <HandoffCreateDialog
                 open={createOpen}

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
@@ -190,7 +190,7 @@ export function HandoffTab() {
 
             <div className="min-w-0">
                 {selectedId !== null ? (
-                    <HandoffDetail id={selectedId} />
+                    <HandoffDetail key={selectedId} id={selectedId} />
                 ) : (
                     <div className="dd-panel flex h-40 items-center justify-center text-sm text-[var(--dd-text-muted)]">
                         Select a handoff to inspect and edit it.

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
@@ -5,6 +5,7 @@ import { type ClipboardEvent, useState } from "react";
 import { AttachmentStrip, renderWithFileChips } from "./HandoffAttachments";
 import { HandoffProofDialog } from "./HandoffDialogs";
 import { splitCriteria } from "./handoff-format";
+import { insertAtCursor } from "./handoff-paste";
 
 export function CommitChip({ sha, label }: { sha: string; label?: string }) {
     return (
@@ -37,6 +38,31 @@ function CriteriaList({ raw }: { raw: string }) {
                 </li>
             ))}
         </ul>
+    );
+}
+
+function ProofBody({
+    proof,
+    attachments,
+    proofIds,
+}: {
+    proof: NonNullable<HandoffTask["proof"]>;
+    attachments: PublicHandoff["attachments"];
+    proofIds: string[];
+}) {
+    return (
+        <>
+            <p className="whitespace-pre-wrap">{proof.answer}</p>
+            {proof.commitIds !== undefined && proof.commitIds.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                    {proof.commitIds.map((sha) => (
+                        <CommitChip key={sha} sha={sha} />
+                    ))}
+                </div>
+            ) : null}
+            {proof.context ? <p className="text-[var(--dd-text-muted)]">{proof.context}</p> : null}
+            <AttachmentStrip attachments={attachments} ids={proofIds} />
+        </>
     );
 }
 
@@ -139,7 +165,7 @@ export function HandoffTaskRow({
         onPasteFile(files[0])
             .then((attachmentId) => {
                 const token = `[File#${attachmentId}]`;
-                setEditText((prev) => `${prev.slice(0, cursor)}${token}${prev.slice(cursor)}`);
+                setEditText((prev) => insertAtCursor(prev, token, cursor));
             })
             .catch((err) => setPasteError(err instanceof Error ? err.message : String(err)));
     };
@@ -197,7 +223,7 @@ export function HandoffTaskRow({
                                 <span className="mr-1.5 font-mono text-[10px] text-[var(--dd-text-muted)]">
                                     {task.id}
                                 </span>
-                                {renderWithFileChips(task.text, attachments)}
+                                {renderWithFileChips({ text: task.text, attachments })}
                             </p>
                             {task.acceptanceCriteria ? <CriteriaList raw={task.acceptanceCriteria} /> : null}
                         </>
@@ -227,18 +253,7 @@ export function HandoffTaskRow({
                             </button>
                             {proofExpanded ? (
                                 <div className="mt-1 flex flex-col gap-1.5 rounded border border-[var(--dd-border)]/50 bg-black/20 p-2 text-xs text-[var(--dd-text-secondary)]">
-                                    <p className="whitespace-pre-wrap">{task.proof.answer}</p>
-                                    {task.proof.commitIds !== undefined && task.proof.commitIds.length > 0 ? (
-                                        <div className="flex flex-wrap gap-1.5">
-                                            {task.proof.commitIds.map((sha) => (
-                                                <CommitChip key={sha} sha={sha} />
-                                            ))}
-                                        </div>
-                                    ) : null}
-                                    {task.proof.context ? (
-                                        <p className="text-[var(--dd-text-muted)]">{task.proof.context}</p>
-                                    ) : null}
-                                    <AttachmentStrip attachments={attachments} ids={proofIds} />
+                                    <ProofBody proof={task.proof} attachments={attachments} proofIds={proofIds} />
                                 </div>
                             ) : null}
                         </div>
@@ -249,15 +264,7 @@ export function HandoffTaskRow({
                             <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
                                 previous proof
                             </span>
-                            <p className="whitespace-pre-wrap">{task.proof.answer}</p>
-                            {task.proof.commitIds !== undefined && task.proof.commitIds.length > 0 ? (
-                                <div className="flex flex-wrap gap-1.5">
-                                    {task.proof.commitIds.map((sha) => (
-                                        <CommitChip key={sha} sha={sha} />
-                                    ))}
-                                </div>
-                            ) : null}
-                            <AttachmentStrip attachments={attachments} ids={proofIds} />
+                            <ProofBody proof={task.proof} attachments={attachments} proofIds={proofIds} />
                         </div>
                     ) : null}
 

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTaskRow.tsx
@@ -1,11 +1,12 @@
 import type { HandoffActionInput, HandoffTask, PublicHandoff } from "@app/dev-dashboard/lib/handoff-types";
 import { Checkbox } from "@ui/components/checkbox";
 import { Input } from "@ui/components/input";
-import { useState } from "react";
-import { AttachmentStrip } from "./HandoffAttachments";
+import { type ClipboardEvent, useState } from "react";
+import { AttachmentStrip, renderWithFileChips } from "./HandoffAttachments";
 import { HandoffProofDialog } from "./HandoffDialogs";
+import { splitCriteria } from "./handoff-format";
 
-function CommitChip({ sha }: { sha: string }) {
+export function CommitChip({ sha, label }: { sha: string; label?: string }) {
     return (
         <button
             type="button"
@@ -13,10 +14,29 @@ function CommitChip({ sha }: { sha: string }) {
             onClick={() => {
                 navigator.clipboard.writeText(sha).catch((err) => console.error("copy SHA failed", err));
             }}
-            title="copy SHA"
+            title="click to copy full SHA"
         >
-            {sha}
+            {label ?? sha}
         </button>
+    );
+}
+
+function CriteriaList({ raw }: { raw: string }) {
+    const items = splitCriteria(raw);
+
+    if (items.length === 0) {
+        return null;
+    }
+
+    return (
+        <ul className="mt-0.5 flex flex-col gap-0.5 text-xs text-[var(--dd-text-muted)]">
+            {items.map((item, index) => (
+                <li key={`${index}-${item}`} className="flex items-start gap-1">
+                    <span className="dd-accent-text shrink-0">✓</span>
+                    <span>{item}</span>
+                </li>
+            ))}
+        </ul>
     );
 }
 
@@ -25,11 +45,13 @@ export function HandoffTaskRow({
     attachments,
     disabled,
     onActions,
+    onPasteFile,
 }: {
     task: HandoffTask;
     attachments: PublicHandoff["attachments"];
     disabled: boolean;
     onActions: (actions: HandoffActionInput[]) => void;
+    onPasteFile: (file: File) => Promise<string>;
 }) {
     const [proofOpen, setProofOpen] = useState(false);
     const [denyOpen, setDenyOpen] = useState(false);
@@ -38,15 +60,13 @@ export function HandoffTaskRow({
     const [editText, setEditText] = useState(task.text);
     const [editCriteria, setEditCriteria] = useState(task.acceptanceCriteria ?? "");
     const [proofExpanded, setProofExpanded] = useState(false);
+    const [pasteError, setPasteError] = useState<string | null>(null);
     const taskAttachments = attachments.filter((a) => a.taskId === task.id);
     const proofIds = task.proof?.attachmentIds ?? [];
 
     const onToggle = (): void => {
         if (task.checked) {
-            if (window.confirm("Uncheck this task? The current proof is cleared (history stays in the event log).")) {
-                onActions([{ action: "uncheck_task", taskId: task.id }]);
-            }
-
+            onActions([{ action: "uncheck_task", taskId: task.id }]);
             return;
         }
 
@@ -102,6 +122,28 @@ export function HandoffTaskRow({
         setEditing(false);
     };
 
+    /** Task 12: pasting a file while editing the task text inserts `[File#id]` at the cursor. */
+    const onEditTextPaste = (ev: ClipboardEvent<HTMLInputElement>): void => {
+        const files = [...ev.clipboardData.files];
+
+        if (files.length === 0) {
+            return;
+        }
+
+        ev.preventDefault();
+        ev.stopPropagation();
+        setPasteError(null);
+        const input = ev.target as HTMLInputElement;
+        const cursor = input.selectionStart ?? editText.length;
+
+        onPasteFile(files[0])
+            .then((attachmentId) => {
+                const token = `[File#${attachmentId}]`;
+                setEditText((prev) => `${prev.slice(0, cursor)}${token}${prev.slice(cursor)}`);
+            })
+            .catch((err) => setPasteError(err instanceof Error ? err.message : String(err)));
+    };
+
     return (
         <div
             data-task-id={task.id}
@@ -122,6 +164,7 @@ export function HandoffTaskRow({
                             <Input
                                 value={editText}
                                 onChange={(e) => setEditText(e.target.value)}
+                                onPaste={onEditTextPaste}
                                 className="border-[var(--dd-border)] bg-black/25 text-sm"
                             />
                             <Input
@@ -130,6 +173,9 @@ export function HandoffTaskRow({
                                 className="border-[var(--dd-border)] bg-black/15 text-xs"
                                 placeholder="acceptance criteria"
                             />
+                            {pasteError !== null ? (
+                                <p className="text-[11px] text-[var(--dd-danger)]">{pasteError}</p>
+                            ) : null}
                             <div className="flex gap-2 text-xs">
                                 <button type="button" className="dd-accent-text cursor-pointer" onClick={saveEdit}>
                                     save
@@ -151,13 +197,9 @@ export function HandoffTaskRow({
                                 <span className="mr-1.5 font-mono text-[10px] text-[var(--dd-text-muted)]">
                                     {task.id}
                                 </span>
-                                {task.text}
+                                {renderWithFileChips(task.text, attachments)}
                             </p>
-                            {task.acceptanceCriteria ? (
-                                <p className="mt-0.5 text-xs text-[var(--dd-text-muted)]">
-                                    ✓? {task.acceptanceCriteria}
-                                </p>
-                            ) : null}
+                            {task.acceptanceCriteria ? <CriteriaList raw={task.acceptanceCriteria} /> : null}
                         </>
                     )}
 
@@ -199,6 +241,23 @@ export function HandoffTaskRow({
                                     <AttachmentStrip attachments={attachments} ids={proofIds} />
                                 </div>
                             ) : null}
+                        </div>
+                    ) : null}
+
+                    {!task.checked && task.proof ? (
+                        <div className="mt-1 flex flex-col gap-1.5 rounded border border-[var(--dd-border)]/40 bg-black/15 p-2 text-xs text-[var(--dd-text-secondary)] opacity-60">
+                            <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--dd-text-muted)]">
+                                previous proof
+                            </span>
+                            <p className="whitespace-pre-wrap">{task.proof.answer}</p>
+                            {task.proof.commitIds !== undefined && task.proof.commitIds.length > 0 ? (
+                                <div className="flex flex-wrap gap-1.5">
+                                    {task.proof.commitIds.map((sha) => (
+                                        <CommitChip key={sha} sha={sha} />
+                                    ))}
+                                </div>
+                            ) : null}
+                            <AttachmentStrip attachments={attachments} ids={proofIds} />
                         </div>
                     ) : null}
 

--- a/src/dev-dashboard/ui/src/components/handoff/handoff-format.ts
+++ b/src/dev-dashboard/ui/src/components/handoff/handoff-format.ts
@@ -1,0 +1,73 @@
+/** A short relative time ("now", "5m", "3h", "2d") from an ISO timestamp or epoch-ms number. */
+export function relativeTime(input: string | number): string {
+    const ms = typeof input === "number" ? input : Date.parse(input);
+
+    if (Number.isNaN(ms)) {
+        return "—";
+    }
+
+    const sec = Math.max(0, Math.round((Date.now() - ms) / 1000));
+
+    if (sec < 45) {
+        return "now";
+    }
+
+    const min = Math.round(sec / 60);
+
+    if (min < 60) {
+        return `${min}m`;
+    }
+
+    const hr = Math.round(min / 60);
+
+    if (hr < 24) {
+        return `${hr}h`;
+    }
+
+    const day = Math.round(hr / 24);
+    return `${day}d`;
+}
+
+export function shortSha(sha: string): string {
+    return sha.slice(0, 7);
+}
+
+export function basename(path: string): string {
+    const trimmed = path.replace(/\/+$/, "");
+    const idx = trimmed.lastIndexOf("/");
+    return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
+export function truncateMiddle(value: string, max: number): string {
+    if (value.length <= max) {
+        return value;
+    }
+
+    const keep = Math.floor((max - 1) / 2);
+    return `${value.slice(0, keep)}…${value.slice(value.length - keep)}`;
+}
+
+/** G12: presentation-only criteria split — newline-separated, trimmed, empties dropped, leading -/* stripped. */
+export function splitCriteria(raw: string): string[] {
+    return raw
+        .split(/\r?\n/)
+        .map((line) => line.trim().replace(/^[-*]\s*/, ""))
+        .filter((line) => line.length > 0);
+}
+
+/** Actor chip text for both compact `HandoffActor` (sessionName) and event `by` stamps (sessionTitle). */
+export function actorChipLabel(by: {
+    sessionName?: string | null;
+    sessionTitle?: string | null;
+    sessionId?: string | null;
+    agent: string;
+    via?: string;
+}): string {
+    const name = by.sessionName ?? by.sessionTitle ?? by.sessionId;
+
+    if (name !== null && name !== undefined) {
+        return by.via === "dashboard" ? `${name} · dashboard` : name;
+    }
+
+    return by.agent;
+}

--- a/src/dev-dashboard/ui/src/components/handoff/handoff-paste.test.ts
+++ b/src/dev-dashboard/ui/src/components/handoff/handoff-paste.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { collectUploadTokens, insertAtCursor, type UploadedAttachment } from "./handoff-paste";
+
+function fulfilled(attachmentId: string): PromiseFulfilledResult<UploadedAttachment> {
+    return { status: "fulfilled", value: { attachmentId } };
+}
+
+function rejected(reason: unknown): PromiseRejectedResult {
+    return { status: "rejected", reason };
+}
+
+describe("collectUploadTokens", () => {
+    it("joins a [File#id] token for every fulfilled upload with no failure", () => {
+        const { tokens, failure } = collectUploadTokens([fulfilled("a_1"), fulfilled("a_2")]);
+        expect(tokens).toBe("[File#a_1] [File#a_2]");
+        expect(failure).toBeUndefined();
+    });
+
+    it("keeps tokens for the successful uploads and surfaces the first rejection on mixed results", () => {
+        const err = new Error("upload failed");
+        const { tokens, failure } = collectUploadTokens([fulfilled("a_1"), rejected(err), fulfilled("a_2")]);
+        expect(tokens).toBe("[File#a_1] [File#a_2]");
+        expect(failure?.reason).toBe(err);
+    });
+
+    it("returns empty tokens and the failure when all uploads reject", () => {
+        const err = new Error("boom");
+        const { tokens, failure } = collectUploadTokens([rejected(err)]);
+        expect(tokens).toBe("");
+        expect(failure?.reason).toBe(err);
+    });
+});
+
+describe("insertAtCursor", () => {
+    it("splices the insert at the cursor", () => {
+        expect(insertAtCursor("abcd", "X", 2)).toBe("abXcd");
+    });
+
+    it("clamps a stale cursor past the end of a shrunken draft (typed/submitted/switched mid-upload)", () => {
+        // Draft was longer when the cursor was captured, then shrank while the
+        // upload was in flight — the token must land at the end, not out of range.
+        expect(insertAtCursor("ab", "[File#a_1]", 10)).toBe("ab[File#a_1]");
+    });
+
+    it("clamps a negative cursor to the start", () => {
+        expect(insertAtCursor("ab", "X", -5)).toBe("Xab");
+    });
+});

--- a/src/dev-dashboard/ui/src/components/handoff/handoff-paste.ts
+++ b/src/dev-dashboard/ui/src/components/handoff/handoff-paste.ts
@@ -1,0 +1,29 @@
+export interface UploadedAttachment {
+    attachmentId: string;
+}
+
+/**
+ * Insert `insert` into `prev` at `cursor`, clamping the cursor to the current
+ * length. The clamp matters when the draft shrank during the async upload gap
+ * (user edited/cleared it, or the composer remounted for another handoff) — a
+ * stale cursor past the end would otherwise splice text at the wrong offset.
+ */
+export function insertAtCursor(prev: string, insert: string, cursor: number): string {
+    const at = Math.min(Math.max(0, cursor), prev.length);
+    return `${prev.slice(0, at)}${insert}${prev.slice(at)}`;
+}
+
+/**
+ * Fold `Promise.allSettled` upload results into the `[File#id]` token string for
+ * every fulfilled upload plus the first rejection (if any). Successful uploads
+ * still produce their tokens even when a sibling upload fails.
+ */
+export function collectUploadTokens(results: PromiseSettledResult<UploadedAttachment>[]): {
+    tokens: string;
+    failure: PromiseRejectedResult | undefined;
+} {
+    const fulfilled = results.filter((r): r is PromiseFulfilledResult<UploadedAttachment> => r.status === "fulfilled");
+    const failure = results.find((r): r is PromiseRejectedResult => r.status === "rejected");
+    const tokens = fulfilled.map((r) => `[File#${r.value.attachmentId}]`).join(" ");
+    return { tokens, failure };
+}

--- a/src/dev-dashboard/ui/src/hooks/useActivityPanel.ts
+++ b/src/dev-dashboard/ui/src/hooks/useActivityPanel.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type ActivityPanelState = "collapsed" | "expanded";
+
+// Same-tab localStorage writes do NOT emit a `storage` event (cross-tab
+// only), so this custom event keeps every useActivityPanel consumer in sync
+// within the tab — mirrors useLayoutMode.ts.
+const ACTIVITY_PANEL_CHANGE_EVENT = "dd:activity-panel-change";
+const STORAGE_KEY = "dd:handoff:activity-panel";
+
+function readStored(): ActivityPanelState | null {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return value === "collapsed" || value === "expanded" ? value : null;
+}
+
+export function useActivityPanel(): {
+    state: ActivityPanelState;
+    setState: (next: ActivityPanelState) => void;
+} {
+    const [stored, setStored] = useState<ActivityPanelState | null>(() => readStored());
+
+    const setState = useCallback((next: ActivityPanelState) => {
+        setStored(next);
+        window.localStorage.setItem(STORAGE_KEY, next);
+        window.dispatchEvent(new Event(ACTIVITY_PANEL_CHANGE_EVENT));
+    }, []);
+
+    useEffect(() => {
+        const sync = () => setStored(readStored());
+
+        sync();
+        window.addEventListener(ACTIVITY_PANEL_CHANGE_EVENT, sync);
+
+        return () => window.removeEventListener(ACTIVITY_PANEL_CHANGE_EVENT, sync);
+    }, []);
+
+    return { state: stored ?? "collapsed", setState };
+}

--- a/src/dev-dashboard/ui/src/hooks/useHandoffEvents.ts
+++ b/src/dev-dashboard/ui/src/hooks/useHandoffEvents.ts
@@ -1,0 +1,50 @@
+import type { HandoffEventsResponse } from "@app/dev-dashboard/lib/handoff-types";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { useQuery } from "@tanstack/react-query";
+
+async function fetchJson<T>(url: string): Promise<T> {
+    const res = await fetch(url);
+    const text = await res.text();
+
+    if (!res.ok) {
+        let message = text;
+
+        try {
+            const body = SafeJSON.parse(text, { strict: true }) as { error?: string };
+
+            if (typeof body.error === "string") {
+                message = body.error;
+            }
+        } catch {
+            /* non-JSON error body — use raw text */
+        }
+
+        throw new Error(message || `${res.status}`);
+    }
+
+    return SafeJSON.parse(text, { strict: true }) as T;
+}
+
+export async function fetchHandoffEvents(input: {
+    id: string;
+    limit?: number;
+    before?: string;
+}): Promise<HandoffEventsResponse> {
+    const params = new URLSearchParams({ id: input.id, limit: String(input.limit ?? 200) });
+
+    if (input.before !== undefined) {
+        params.set("before", input.before);
+    }
+
+    return fetchJson<HandoffEventsResponse>(`/api/handoff/events?${params.toString()}`);
+}
+
+/** First page of a handoff's activity trace; ActivityPanel pages further back via `fetchHandoffEvents`. */
+export function useHandoffEvents(id: string | null) {
+    return useQuery({
+        queryKey: ["handoff-events", id],
+        enabled: id !== null,
+        queryFn: () => fetchHandoffEvents({ id: id ?? "" }),
+        retry: false,
+    });
+}

--- a/src/dev-dashboard/ui/src/hooks/useHandoffEvents.ts
+++ b/src/dev-dashboard/ui/src/hooks/useHandoffEvents.ts
@@ -15,8 +15,8 @@ async function fetchJson<T>(url: string): Promise<T> {
             if (typeof body.error === "string") {
                 message = body.error;
             }
-        } catch {
-            /* non-JSON error body — use raw text */
+        } catch (err) {
+            console.debug("fetchJson: non-JSON error body", err);
         }
 
         throw new Error(message || `${res.status}`);
@@ -29,11 +29,16 @@ export async function fetchHandoffEvents(input: {
     id: string;
     limit?: number;
     before?: string;
+    beforeUid?: string;
 }): Promise<HandoffEventsResponse> {
     const params = new URLSearchParams({ id: input.id, limit: String(input.limit ?? 200) });
 
     if (input.before !== undefined) {
         params.set("before", input.before);
+    }
+
+    if (input.beforeUid !== undefined) {
+        params.set("beforeUid", input.beforeUid);
     }
 
     return fetchJson<HandoffEventsResponse>(`/api/handoff/events?${params.toString()}`);

--- a/src/dev-dashboard/ui/src/hooks/useQaStream.ts
+++ b/src/dev-dashboard/ui/src/hooks/useQaStream.ts
@@ -1,0 +1,100 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { useEffect, useRef } from "react";
+
+export type QaStreamQaFrame = { type: "qa"; id: string } & Record<string, unknown>;
+
+export type QaStreamHandoffFrame = {
+    type: "handoff";
+    id: string;
+    ev: string;
+    ts: string;
+};
+
+export type QaStreamFrame = QaStreamQaFrame | QaStreamHandoffFrame;
+
+type FrameHandler = (frame: QaStreamFrame) => void;
+type StatusHandler = (down: boolean) => void;
+
+const frameHandlers = new Set<FrameHandler>();
+const statusHandlers = new Set<StatusHandler>();
+let sharedSource: EventSource | null = null;
+let refCount = 0;
+
+function notifyStatus(down: boolean): void {
+    for (const handler of statusHandlers) {
+        handler(down);
+    }
+}
+
+function ensureSharedSource(): void {
+    if (sharedSource !== null) {
+        return;
+    }
+
+    const es = new EventSource("/api/qa/stream");
+    sharedSource = es;
+
+    es.onopen = () => notifyStatus(false);
+    es.onmessage = (ev) => {
+        notifyStatus(false);
+
+        try {
+            const frame = SafeJSON.parse(ev.data, { strict: true }) as QaStreamFrame;
+
+            if (frame.type !== "qa" && frame.type !== "handoff") {
+                return;
+            }
+
+            for (const handler of frameHandlers) {
+                handler(frame);
+            }
+        } catch {
+            /* malformed frame — ignore */
+        }
+    };
+    es.onerror = () => {
+        if (es.readyState === EventSource.CLOSED) {
+            notifyStatus(true);
+        }
+    };
+}
+
+function releaseSharedSource(): void {
+    if (refCount > 0 || sharedSource === null) {
+        return;
+    }
+
+    sharedSource.close();
+    sharedSource = null;
+}
+
+/**
+ * One shared EventSource to `/api/qa/stream`. Consumers filter by `frame.type`.
+ * Multiplexes QA + handoff (D7); midnight-safe on the server.
+ */
+export function useQaStream(
+    onFrame: (frame: QaStreamFrame) => void,
+    opts?: { onStatus?: (down: boolean) => void }
+): void {
+    const onFrameRef = useRef(onFrame);
+    onFrameRef.current = onFrame;
+    const onStatusRef = useRef(opts?.onStatus);
+    onStatusRef.current = opts?.onStatus;
+
+    useEffect(() => {
+        const frameHandler: FrameHandler = (frame) => onFrameRef.current(frame);
+        const statusHandler: StatusHandler = (down) => onStatusRef.current?.(down);
+
+        frameHandlers.add(frameHandler);
+        statusHandlers.add(statusHandler);
+        refCount += 1;
+        ensureSharedSource();
+
+        return () => {
+            frameHandlers.delete(frameHandler);
+            statusHandlers.delete(statusHandler);
+            refCount -= 1;
+            releaseSharedSource();
+        };
+    }, []);
+}

--- a/src/dev-dashboard/ui/src/hooks/useQaStream.ts
+++ b/src/dev-dashboard/ui/src/hooks/useQaStream.ts
@@ -1,16 +1,10 @@
+import type { HandoffStreamFrame } from "@app/dev-dashboard/lib/handoff-types";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { useEffect, useRef } from "react";
 
 export type QaStreamQaFrame = { type: "qa"; id: string } & Record<string, unknown>;
 
-export type QaStreamHandoffFrame = {
-    type: "handoff";
-    id: string;
-    ev: string;
-    ts: string;
-};
-
-export type QaStreamFrame = QaStreamQaFrame | QaStreamHandoffFrame;
+export type QaStreamFrame = QaStreamQaFrame | HandoffStreamFrame;
 
 type FrameHandler = (frame: QaStreamFrame) => void;
 type StatusHandler = (down: boolean) => void;
@@ -48,14 +42,12 @@ function ensureSharedSource(): void {
             for (const handler of frameHandlers) {
                 handler(frame);
             }
-        } catch {
-            /* malformed frame — ignore */
+        } catch (err) {
+            console.debug("useQaStream: malformed frame", err);
         }
     };
     es.onerror = () => {
-        if (es.readyState === EventSource.CLOSED) {
-            notifyStatus(true);
-        }
+        notifyStatus(true);
     };
 }
 

--- a/src/dev-dashboard/ui/src/routes/qa.tsx
+++ b/src/dev-dashboard/ui/src/routes/qa.tsx
@@ -10,6 +10,7 @@ import { BlinkingBox } from "@ui/components/BlinkingBox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/tooltip";
 import { type KeyboardEvent, type MouseEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { HandoffTab } from "@/components/handoff/HandoffTab";
+import { truncateMiddle } from "@/components/handoff/handoff-format";
 import { useHandoffList } from "@/components/handoff/useHandoffApi";
 import { QaClockProvider } from "@/components/QaClockProvider";
 import { QaCopyButtons } from "@/components/QaCopyButtons";
@@ -48,17 +49,6 @@ function tagClass(tag: string): string {
     }
 
     return "border-[var(--dd-border)] text-[var(--dd-text-secondary)]";
-}
-
-function truncateMiddle(text: string, maxLen: number): string {
-    if (text.length <= maxLen) {
-        return text;
-    }
-
-    const head = Math.ceil((maxLen - 1) / 2);
-    const tail = Math.floor((maxLen - 1) / 2);
-
-    return `${text.slice(0, head)}…${text.slice(text.length - tail)}`;
 }
 
 function shortSessionId(sessionId: string): string {

--- a/src/dev-dashboard/ui/src/routes/qa.tsx
+++ b/src/dev-dashboard/ui/src/routes/qa.tsx
@@ -21,6 +21,7 @@ import { QaSearchBox } from "@/components/QaSearchBox";
 import { QaSectionHeading } from "@/components/QaSectionHeading";
 import { QaSourceToggle, type QaViewMode } from "@/components/QaSourceToggle";
 import { QaTopBar } from "@/components/QaTopBar";
+import { useQaStream } from "@/hooks/useQaStream";
 import { prependQaLiveEntry } from "./qa-live-cap";
 
 const READ_PERSIST_DEBOUNCE_MS = 400;
@@ -591,44 +592,28 @@ function QaFeed() {
         readAtByIdRef.current = readAtById;
     }, [readAtById]);
 
-    useEffect(() => {
-        const es = new EventSource("/api/qa/stream");
-        es.onopen = () => setSseDown(false);
-        es.onmessage = (ev) => {
-            setSseDown(false);
-
-            try {
-                const entry = SafeJSON.parse(ev.data, { strict: true }) as QaRow;
-
-                if (seen.current.has(entry.id)) {
-                    return;
-                }
-
-                seen.current.add(entry.id);
-                setLive((prev) => {
-                    const evicted = prependQaLiveEntry(
-                        prev,
-                        entry,
-                        seenIdsRef.current,
-                        readAtByIdRef.current,
-                        Date.now()
-                    );
-                    setSeenIds(evicted.seen);
-                    setReadAtById(evicted.readAtById);
-                    return evicted.live;
-                });
-            } catch {
-                /* ignore malformed frame */
+    useQaStream(
+        (frame) => {
+            if (frame.type !== "qa") {
+                return;
             }
-        };
-        es.onerror = () => {
-            if (es.readyState === EventSource.CLOSED) {
-                setSseDown(true);
-            }
-        };
 
-        return () => es.close();
-    }, []);
+            const entry = frame as unknown as QaRow;
+
+            if (seen.current.has(entry.id)) {
+                return;
+            }
+
+            seen.current.add(entry.id);
+            setLive((prev) => {
+                const evicted = prependQaLiveEntry(prev, entry, seenIdsRef.current, readAtByIdRef.current, Date.now());
+                setSeenIds(evicted.seen);
+                setReadAtById(evicted.readAtById);
+                return evicted.live;
+            });
+        },
+        { onStatus: setSseDown }
+    );
 
     const persisted = (logQuery.data ?? []).filter((r) => !seen.current.has(r.id));
     const all = [...live, ...persisted];

--- a/src/dev-dashboard/ui/src/slate-grid.css
+++ b/src/dev-dashboard/ui/src/slate-grid.css
@@ -1191,3 +1191,19 @@
     text-transform: uppercase;
     font-weight: 600;
 }
+
+@keyframes dd-activity-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.dd-activity-entry {
+    animation: dd-activity-fade-in 220ms ease both;
+}

--- a/src/dev-dashboard/ui/src/slate-grid.css
+++ b/src/dev-dashboard/ui/src/slate-grid.css
@@ -13,6 +13,10 @@
     --dd-warning: #fbbf24;
     --dd-danger: #f87171;
     --dd-accent-glow: rgba(52, 211, 153, 0.35);
+    --dd-status-open-border: #3f5530;
+    --dd-status-open-text: #a3e635;
+    --dd-status-claimed-border: #4a3a5e;
+    --dd-status-claimed-text: #c792ea;
 }
 
 .dd-grid-bg {
@@ -1206,4 +1210,10 @@
 
 .dd-activity-entry {
     animation: dd-activity-fade-in 220ms ease both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dd-activity-entry {
+        animation: none;
+    }
 }

--- a/src/handoff/executor.test.ts
+++ b/src/handoff/executor.test.ts
@@ -503,3 +503,68 @@ describe("actions[] item shape errors", () => {
         );
     });
 });
+
+describe("fold redesign (G5/G8/G11)", () => {
+    test("uncheck keeps proof and clears checkedBy/checkedTs", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+        executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "check_task", taskId: "t1", proof: { answer: "done" } }] },
+            env.depsFor(B)
+        );
+
+        const unchecked = executeHandoffActions(
+            { id: posted.handoff.id, actions: [{ action: "uncheck_task", taskId: "t1" }] },
+            env.depsFor(B)
+        );
+        expect(unchecked.results[0].ok).toBe(true);
+        expect(unchecked.handoff.tasks[0].checked).toBe(false);
+        expect(unchecked.handoff.tasks[0].proof?.answer).toBe("done");
+        expect(unchecked.handoff.tasks[0].checkedBy).toBeUndefined();
+        expect(unchecked.handoff.tasks[0].checkedTs).toBeUndefined();
+    });
+
+    test("claim copies repoRoot/commitSha/agent; dashboard claim/unclaim by human identity", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+
+        const claimed = getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+        const agentClaim = claimed.handoff.claimedBy.find((c) => c.sessionId === B.sessionId);
+        expect(agentClaim?.repoRoot).toBe(B.repoRoot);
+        expect(agentClaim?.commitSha).toBe(B.commitSha);
+        expect(agentClaim?.agent).toBe(B.agent);
+
+        const dashClaim = executeHandoffActions(
+            { id: posted.handoff.id, actions: ["claim"] },
+            env.depsFor(DASHBOARD_ACTOR)
+        );
+        expect(dashClaim.results[0].ok).toBe(true);
+        expect(dashClaim.handoff.claimedBy.some((c) => c.agent === "human")).toBe(true);
+
+        const dashUnclaim = executeHandoffActions(
+            { id: posted.handoff.id, actions: ["unclaim"] },
+            env.depsFor(DASHBOARD_ACTOR)
+        );
+        expect(dashUnclaim.results[0].ok).toBe(true);
+        expect(dashUnclaim.handoff.claimedBy.some((c) => c.agent === "human")).toBe(false);
+        // Agent claim untouched.
+        expect(dashUnclaim.handoff.claimedBy.some((c) => c.sessionId === B.sessionId)).toBe(true);
+    });
+
+    test("two null-sessionId non-human claims never match each other", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const nullA = byFor(null, "cron-a");
+        const nullB = byFor(null, "cron-b");
+
+        const aTry = executeHandoffActions({ id: posted.handoff.id, actions: ["claim"] }, env.depsFor(nullA));
+        expect(aTry.results[0].ok).toBe(false);
+        expect(aTry.results[0].error).toContain("sessionId");
+
+        const bTry = executeHandoffActions({ id: posted.handoff.id, actions: ["claim"] }, env.depsFor(nullB));
+        expect(bTry.results[0].ok).toBe(false);
+        expect(posted.handoff.claimedBy?.length ?? 0).toBe(0);
+        expect(bTry.handoff.claimedBy).toHaveLength(0);
+    });
+});

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -4,10 +4,18 @@ import { getAgentRuntimeContext } from "@genesiscz/utils/agent-runtime";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { attachmentFilePath, ingestAttachmentBytes, ingestAttachmentFromPath } from "./attachments";
-import { CANCELLED_INFO, DONE_INFO, isHumanOwner, sessionIdMatches } from "./fold";
+import { CANCELLED_INFO, claimMatches, DONE_INFO, isHumanOwner, sessionIdMatches } from "./fold";
 import { generateEditId, generateEventUid, generateHandoffId, normalizeEditId, normalizeHandoffId } from "./ids";
 import { appendHandoffEvents } from "./log-store";
-import { catchUpHandoffs, getEventOutcome, getHandoffById, listHandoffRows, openHandoffModel } from "./read-model";
+import { isEventsOnlyInclude, type ProjectedHandoff, parseIncludeSections, projectHandoff } from "./project";
+import {
+    catchUpHandoffs,
+    getEventOutcome,
+    getHandoffById,
+    listHandoffEvents,
+    listHandoffRows,
+    openHandoffModel,
+} from "./read-model";
 import type {
     Handoff,
     HandoffActionInput,
@@ -16,6 +24,7 @@ import type {
     HandoffEventBy,
     HandoffListRow,
     HandoffProof,
+    HandoffPublicEvent,
     HandoffTarget,
     HandoffTaskInput,
 } from "./types";
@@ -98,7 +107,7 @@ function publicHandoff(h: Handoff, base?: string): PublicHandoff {
 }
 
 function isClaimedBy(h: Handoff, by: HandoffEventBy): boolean {
-    return h.claimedBy.some((c) => sessionIdMatches(c.sessionId, by.sessionId));
+    return h.claimedBy.some((c) => claimMatches(c, by));
 }
 
 function isPosterSession(h: Handoff, by: HandoffEventBy): boolean {
@@ -273,14 +282,34 @@ export interface GetHandoffInput {
     id: string;
     claim?: boolean;
     unclaim?: boolean;
+    /** MCP section scoping. Omit → full PublicHandoff (HTTP). MCP handlers default to ["tasks"]. */
+    include?: string[];
 }
 
-export interface GetHandoffResponse {
+export type GetHandoffFullResponse = {
     handoff: PublicHandoff;
     editId?: string;
     info: string[];
-}
+};
 
+export type GetHandoffScopedResponse =
+    | {
+          handoff: ProjectedHandoff;
+          editId?: string;
+          info: string[];
+      }
+    | {
+          events: HandoffPublicEvent[];
+          info: string[];
+      };
+
+export type GetHandoffResponse = GetHandoffFullResponse | GetHandoffScopedResponse;
+
+export function getHandoff(
+    input: GetHandoffInput & { include: string[] },
+    deps?: HandoffDeps
+): GetHandoffScopedResponse;
+export function getHandoff(input: Omit<GetHandoffInput, "include">, deps?: HandoffDeps): GetHandoffFullResponse;
 export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetHandoffResponse {
     if (input.claim === true && input.unclaim === true) {
         throw new Error(
@@ -288,6 +317,7 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         );
     }
 
+    const sections = input.include !== undefined ? parseIncludeSections(input.include) : null;
     const id = normalizeHandoffId(String(input.id ?? ""));
     const by = buildBy(deps);
 
@@ -368,10 +398,24 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
             }
         }
 
-        const response: GetHandoffResponse = {
-            handoff: publicHandoff(handoff, deps.base),
-            info: [...extraInfo, ...stateInfo(handoff, by)],
-        };
+        const info = [...extraInfo, ...stateInfo(handoff, by)];
+
+        if (sections !== null && isEventsOnlyInclude(sections)) {
+            const { events: publicEvents } = listHandoffEvents({ db, handoffId: id });
+            return { events: publicEvents, info };
+        }
+
+        const full = publicHandoff(handoff, deps.base);
+        let projectedEvents: HandoffPublicEvent[] | undefined;
+
+        if (sections?.includes("events")) {
+            projectedEvents = listHandoffEvents({ db, handoffId: id }).events;
+        }
+
+        const response = {
+            handoff: sections === null ? full : projectHandoff({ handoff: full, sections, events: projectedEvents }),
+            info,
+        } as GetHandoffFullResponse | Extract<GetHandoffScopedResponse, { handoff: unknown }>;
 
         // editId recovery: ONLY the posting session (or the dashboard owner) ever sees it (§3).
         if (isPosterSession(handoff, by) || isHumanOwner(by)) {
@@ -392,10 +436,12 @@ export interface ListHandoffsInput {
     mine?: boolean;
     open?: boolean;
     project?: string;
+    /** Only `"tasks"` is honored on list rows; other values no-op with an info line. */
+    include?: string[];
 }
 
 export interface ListHandoffsResponse {
-    handoffs: HandoffListRow[];
+    handoffs: (HandoffListRow & { taskList?: Handoff["tasks"] })[];
     info: string[];
 }
 
@@ -403,6 +449,9 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
     const by = buildBy(deps);
     const limit = input.limit !== undefined && input.limit > 0 ? input.limit : 20;
     const offset = input.offset !== undefined && input.offset > 0 ? input.offset : 0;
+    const sections = input.include !== undefined ? parseIncludeSections(input.include) : [];
+    const wantTasks = sections.includes("tasks");
+    const ignored = sections.filter((s) => s !== "tasks");
 
     return withDb(deps, (db) => {
         catchUpHandoffs(db, deps.base);
@@ -426,9 +475,9 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
         const total = rows.length;
         const page = rows.slice(offset, offset + limit);
         const now = Date.now();
-        const handoffs = page.map((h): HandoffListRow => {
+        const handoffs = page.map((h): HandoffListRow & { taskList?: Handoff["tasks"] } => {
             const p = progress(h);
-            const row: HandoffListRow = {
+            const row: HandoffListRow & { taskList?: Handoff["tasks"] } = {
                 id: h.id,
                 title: h.title,
                 status: h.status,
@@ -447,6 +496,10 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
                 row.progress = `${p.resolved}/${p.total}${p.denied > 0 ? ` (${p.denied} denied)` : ""}`;
             }
 
+            if (wantTasks) {
+                row.taskList = h.tasks;
+            }
+
             return row;
         });
 
@@ -454,6 +507,10 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
 
         if (total > offset + page.length) {
             info.push(`More available — pass offset: ${offset + page.length}.`);
+        }
+
+        if (ignored.length > 0) {
+            info.push(`include sections ignored on list (only "tasks" applies): ${ignored.join(", ")}.`);
         }
 
         return { handoffs, info };
@@ -532,14 +589,32 @@ export interface ExecuteActionsInput {
     id: string;
     editId?: string;
     actions: HandoffActionInput[];
+    /** MCP section scoping. Omit → full PublicHandoff (HTTP). MCP handlers default to ["tasks"]. */
+    include?: string[];
 }
 
-export interface ExecuteActionsResponse {
+export type ExecuteActionsFullResponse = {
     handoff: PublicHandoff;
     results: HandoffActionResult[];
     info: string[];
-}
+};
 
+export type ExecuteActionsScopedResponse = {
+    handoff: ProjectedHandoff;
+    results: HandoffActionResult[];
+    info: string[];
+};
+
+export type ExecuteActionsResponse = ExecuteActionsFullResponse | ExecuteActionsScopedResponse;
+
+export function executeHandoffActions(
+    input: ExecuteActionsInput & { include: string[] },
+    deps?: HandoffDeps
+): ExecuteActionsScopedResponse;
+export function executeHandoffActions(
+    input: Omit<ExecuteActionsInput, "include">,
+    deps?: HandoffDeps
+): ExecuteActionsFullResponse;
 export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffDeps = {}): ExecuteActionsResponse {
     if (!Array.isArray(input.actions) || input.actions.length === 0) {
         throw new Error(
@@ -548,6 +623,7 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
         );
     }
 
+    const sections = input.include !== undefined ? parseIncludeSections(input.include) : null;
     const id = normalizeHandoffId(String(input.id ?? ""));
     const editId = normalizeEditId(input.editId);
     const by = buildBy(deps);
@@ -629,11 +705,18 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
             "handoff actions executed"
         );
 
+        const full = publicHandoff(handoff, deps.base);
+        let projectedEvents: HandoffPublicEvent[] | undefined;
+
+        if (sections?.includes("events")) {
+            projectedEvents = listHandoffEvents({ db, handoffId: id }).events;
+        }
+
         return {
-            handoff: publicHandoff(handoff, deps.base),
+            handoff: sections === null ? full : projectHandoff({ handoff: full, sections, events: projectedEvents }),
             results,
             info: stateInfo(handoff, by),
-        };
+        } as ExecuteActionsResponse;
     });
 }
 

--- a/src/handoff/fold.ts
+++ b/src/handoff/fold.ts
@@ -25,6 +25,22 @@ export function isHumanOwner(by: HandoffEventBy): boolean {
     return by.agent === "human" && by.via === "dashboard";
 }
 
+/**
+ * Claim identity (G11): sessionId match when non-null; else human-owner match
+ * (`agent === "human"` on the claim, mirrored by isHumanOwner on the event).
+ */
+export function claimMatches(claim: { sessionId: string | null; agent: string }, by: HandoffEventBy): boolean {
+    if (sessionIdMatches(claim.sessionId, by.sessionId)) {
+        return true;
+    }
+
+    if (by.sessionId == null && isHumanOwner(by) && claim.agent === "human") {
+        return true;
+    }
+
+    return false;
+}
+
 export function actorOf(by: HandoffEventBy): HandoffActor {
     const actor: HandoffActor = {
         sessionId: by.sessionId,
@@ -246,7 +262,7 @@ export function applyHandoffEvent(
                 };
             }
 
-            const mine = next.claimedBy.find((c) => sessionIdMatches(c.sessionId, event.by.sessionId));
+            const mine = next.claimedBy.find((c) => claimMatches(c, event.by));
 
             if (mine) {
                 mine.claimedAt = event.ts;
@@ -260,6 +276,9 @@ export function applyHandoffEvent(
                 cwd: event.by.cwd,
                 claimedAt: event.ts,
                 via: event.via,
+                repoRoot: event.by.repoRoot,
+                commitSha: event.by.commitSha,
+                agent: event.by.agent,
             });
 
             if (next.status === "open") {
@@ -271,7 +290,7 @@ export function applyHandoffEvent(
 
         case "unclaim": {
             const before = next.claimedBy.length;
-            next.claimedBy = next.claimedBy.filter((c) => !sessionIdMatches(c.sessionId, event.by.sessionId));
+            next.claimedBy = next.claimedBy.filter((c) => !claimMatches(c, event.by));
 
             if (next.claimedBy.length === before) {
                 return {
@@ -349,9 +368,9 @@ export function applyHandoffEvent(
                 };
             }
 
-            // Current-state proof cleared deliberately — the full trace survives in the event log (§2).
+            // Keep proof on uncheck (redesign G8) — activity trace shows the uncheck;
+            // UI renders surviving proof as a dimmed "previous proof" block.
             task.checked = false;
-            delete task.proof;
             delete task.checkedBy;
             delete task.checkedTs;
             return { state: next, outcome: { applied: true } };

--- a/src/handoff/project.test.ts
+++ b/src/handoff/project.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { executeHandoffActions, getHandoff, listHandoffs, postHandoff } from "./executor";
+import { HANDOFF_INCLUDE_SECTIONS, isEventsOnlyInclude, parseIncludeSections, projectHandoff } from "./project";
+import { byFor, freshEnv } from "./test-utils";
+
+const A = byFor("session-a", "poster-a");
+const B = byFor("session-b", "worker-b");
+
+describe("include scoping (G4)", () => {
+    test("parseIncludeSections rejects unknown names with catalog", () => {
+        expect(() => parseIncludeSections(["tasks", "nope"])).toThrow(/Unknown include/);
+        expect(() => parseIncludeSections(["tasks", "nope"])).toThrow(HANDOFF_INCLUDE_SECTIONS[0]);
+        expect(isEventsOnlyInclude(["events"])).toBe(true);
+        expect(isEventsOnlyInclude(["events", "tasks"])).toBe(false);
+    });
+
+    test("default MCP lean shape has tasks + core; omits comments/claimedBy", () => {
+        const env = freshEnv();
+        const posted = postHandoff(
+            { title: "T", description: "why", tasks: [{ text: "one" }, { text: "two" }] },
+            env.depsFor(A)
+        );
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+        executeHandoffActions({ id: posted.handoff.id, actions: [{ action: "comment", text: "hi" }] }, env.depsFor(B));
+
+        const lean = getHandoff({ id: posted.handoff.id, include: ["tasks"] }, env.depsFor(B));
+        expect("handoff" in lean).toBe(true);
+
+        if (!("handoff" in lean)) {
+            throw new Error("expected handoff envelope");
+        }
+
+        expect(lean.handoff.tasks).toHaveLength(2);
+        expect("tasksSummary" in lean.handoff).toBe(true);
+        expect("comments" in lean.handoff).toBe(false);
+        expect("claimedBy" in lean.handoff).toBe(false);
+        expect("postedByContext" in lean.handoff).toBe(false);
+    });
+
+    test("omit include → full PublicHandoff (HTTP path)", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const full = getHandoff({ id: posted.handoff.id }, env.depsFor(A));
+        expect("handoff" in full).toBe(true);
+
+        if (!("handoff" in full)) {
+            throw new Error("expected handoff envelope");
+        }
+
+        expect(full.handoff.tasks).toHaveLength(1);
+        expect("claimedBy" in full.handoff).toBe(true);
+        expect("comments" in full.handoff).toBe(true);
+        expect("attachments" in full.handoff).toBe(true);
+        expect("postedBy" in full.handoff).toBe(true);
+        expect("tasksSummary" in full.handoff).toBe(false);
+    });
+
+    test("include:[events] alone → bare {events, info}, no editId in payloads", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const bare = getHandoff({ id: posted.handoff.id, include: ["events"] }, env.depsFor(A));
+        expect("events" in bare).toBe(true);
+        expect("handoff" in bare).toBe(false);
+
+        if (!("events" in bare)) {
+            throw new Error("expected events");
+        }
+
+        expect(bare.events.length).toBeGreaterThanOrEqual(1);
+        expect(bare.events.some((e) => e.ev === "post")).toBe(true);
+
+        for (const event of bare.events) {
+            expect("editId" in event).toBe(false);
+        }
+    });
+
+    test("list include tasks adds taskList; other sections info-no-op", () => {
+        const env = freshEnv();
+        postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const listed = listHandoffs({ include: ["tasks", "comments"] }, env.depsFor(A));
+        expect(listed.handoffs[0].taskList).toHaveLength(1);
+        expect(listed.info.some((line) => line.includes("ignored"))).toBe(true);
+    });
+
+    test("projectHandoff full sections ≈ public shape keys", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const full = getHandoff({ id: posted.handoff.id }, env.depsFor(A));
+
+        if (!("handoff" in full)) {
+            throw new Error("expected handoff");
+        }
+
+        const projected = projectHandoff({
+            handoff: full.handoff as Parameters<typeof projectHandoff>[0]["handoff"],
+            sections: [...HANDOFF_INCLUDE_SECTIONS].filter((s) => s !== "events"),
+        });
+        expect(projected.tasks).toHaveLength(1);
+        expect(projected.claimedBy).toEqual([]);
+        expect(projected.comments).toEqual([]);
+        expect(projected.tasksSummary).toBe("0/1");
+    });
+});

--- a/src/handoff/project.ts
+++ b/src/handoff/project.ts
@@ -1,0 +1,152 @@
+import type { Handoff, HandoffPublicEvent } from "./types";
+
+/** Canonical MCP `include` section names (Architecture). */
+export const HANDOFF_INCLUDE_SECTIONS = [
+    "tasks",
+    "claimedBy",
+    "comments",
+    "attachments",
+    "events",
+    "postedBy",
+    "postedByContext",
+] as const;
+
+export type HandoffIncludeSection = (typeof HANDOFF_INCLUDE_SECTIONS)[number];
+
+const SECTION_SET = new Set<string>(HANDOFF_INCLUDE_SECTIONS);
+
+/** editId-stripped handoff as returned to callers (matches PublicHandoff). */
+export type PublicHandoffLike = Omit<Handoff, "editId"> & {
+    attachments: (Handoff["attachments"][number] & { path?: string })[];
+};
+
+export function parseIncludeSections(raw: unknown): HandoffIncludeSection[] {
+    if (!Array.isArray(raw)) {
+        throw new Error(`include must be an array of section names — valid: ${HANDOFF_INCLUDE_SECTIONS.join(", ")}.`);
+    }
+
+    const out: HandoffIncludeSection[] = [];
+    const unknown: string[] = [];
+
+    for (const item of raw) {
+        if (typeof item !== "string" || !SECTION_SET.has(item)) {
+            unknown.push(typeof item === "string" ? item : String(item));
+        } else if (!out.includes(item as HandoffIncludeSection)) {
+            out.push(item as HandoffIncludeSection);
+        }
+    }
+
+    if (unknown.length > 0) {
+        throw new Error(
+            `Unknown include section(s): ${unknown.join(", ")}. Valid: ${HANDOFF_INCLUDE_SECTIONS.join(", ")}.`
+        );
+    }
+
+    return out;
+}
+
+/** Always-present cheap core fields (not gated by include). */
+export type HandoffCoreProjection = {
+    id: string;
+    title: string;
+    description?: string;
+    status: Handoff["status"];
+    project: string | null;
+    target?: Handoff["target"];
+    refs?: string[];
+    tasksSummary: string;
+    createdTs: string;
+    updatedTs: string;
+    finishedTs?: string;
+};
+
+export type ProjectedHandoff = HandoffCoreProjection & {
+    tasks?: Handoff["tasks"];
+    claimedBy?: Handoff["claimedBy"];
+    comments?: Handoff["comments"];
+    attachments?: PublicHandoffLike["attachments"];
+    postedBy?: Handoff["postedBy"];
+    postedByContext?: Handoff["postedByContext"];
+    events?: HandoffPublicEvent[];
+};
+
+/** `progress()` string form — always on projected responses. */
+export function tasksSummaryOf(h: Pick<Handoff, "tasks">): string {
+    const total = h.tasks.length;
+    const resolved = h.tasks.filter((t) => t.checked || t.denied).length;
+    return `${resolved}/${total}`;
+}
+
+export function projectHandoff({
+    handoff,
+    sections,
+    events,
+}: {
+    handoff: PublicHandoffLike;
+    sections: HandoffIncludeSection[];
+    events?: HandoffPublicEvent[];
+}): ProjectedHandoff {
+    const core: HandoffCoreProjection = {
+        id: handoff.id,
+        title: handoff.title,
+        status: handoff.status,
+        project: handoff.project,
+        tasksSummary: tasksSummaryOf(handoff),
+        createdTs: handoff.createdTs,
+        updatedTs: handoff.updatedTs,
+    };
+
+    if (handoff.description !== undefined) {
+        core.description = handoff.description;
+    }
+
+    if (handoff.target !== undefined) {
+        core.target = handoff.target;
+    }
+
+    if (handoff.refs !== undefined) {
+        core.refs = handoff.refs;
+    }
+
+    if (handoff.finishedTs !== undefined) {
+        core.finishedTs = handoff.finishedTs;
+    }
+
+    const want = new Set(sections);
+    const out: ProjectedHandoff = { ...core };
+
+    if (want.has("tasks")) {
+        out.tasks = handoff.tasks;
+    }
+
+    if (want.has("claimedBy")) {
+        out.claimedBy = handoff.claimedBy;
+    }
+
+    if (want.has("comments")) {
+        out.comments = handoff.comments;
+    }
+
+    if (want.has("attachments")) {
+        out.attachments = handoff.attachments;
+    }
+
+    if (want.has("postedBy")) {
+        out.postedBy = handoff.postedBy;
+    }
+
+    if (want.has("postedByContext")) {
+        out.postedByContext = handoff.postedByContext;
+    }
+
+    if (want.has("events") && events !== undefined) {
+        out.events = events;
+    }
+
+    return out;
+}
+
+/** True when include is exactly `["events"]` — bare `{events, info}` response (D5). */
+export function isEventsOnlyInclude(sections: HandoffIncludeSection[]): boolean {
+    return sections.length === 1 && sections[0] === "events";
+}

--- a/src/handoff/project.ts
+++ b/src/handoff/project.ts
@@ -58,6 +58,7 @@ export type HandoffCoreProjection = {
     createdTs: string;
     updatedTs: string;
     finishedTs?: string;
+    finishedBy?: Handoff["finishedBy"];
 };
 
 export type ProjectedHandoff = HandoffCoreProjection & {
@@ -110,6 +111,10 @@ export function projectHandoff({
 
     if (handoff.finishedTs !== undefined) {
         core.finishedTs = handoff.finishedTs;
+    }
+
+    if (handoff.finishedBy !== undefined) {
+        core.finishedBy = handoff.finishedBy;
     }
 
     const want = new Set(sections);

--- a/src/handoff/read-model.test.ts
+++ b/src/handoff/read-model.test.ts
@@ -10,6 +10,7 @@ import {
     applyHandoffBatch,
     catchUpHandoffs,
     getHandoffById,
+    listHandoffEvents,
     listHandoffRows,
     openHandoffModel,
     rebuildHandoffModel,
@@ -217,5 +218,95 @@ describe("log layout", () => {
         const files = readdirSync(handoffLogDir(env.base)).filter((f) => f.endsWith(".jsonl"));
         expect(files).toHaveLength(1);
         expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}\.jsonl$/);
+    });
+});
+
+describe("handoff_events read-model (G1/G3)", () => {
+    test("events land on ingest, uid-idempotent, payloads never contain editId", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }] }, env.depsFor(A));
+        const db = openHandoffModel(env.dbPath);
+
+        try {
+            catchUpHandoffs(db, env.base);
+            const { events, total } = listHandoffEvents({ db, handoffId: posted.handoff.id });
+            expect(total).toBeGreaterThanOrEqual(1);
+            expect(events.some((e) => e.ev === "post")).toBe(true);
+
+            for (const event of events) {
+                expect("editId" in event).toBe(false);
+                const raw = SafeJSON.stringify(event, { strict: true });
+                expect(raw.includes('"editId"')).toBe(false);
+            }
+
+            const postRow = db
+                .query("SELECT payload FROM handoff_events WHERE handoff_id = ? AND ev = 'post'")
+                .get(posted.handoff.id) as { payload: string };
+            expect(postRow.payload.includes('"editId"')).toBe(false);
+
+            // Double-apply same batch via CAS-skipped path leaves uid count stable.
+            const countBefore = (
+                db.query("SELECT COUNT(*) AS n FROM handoff_events WHERE handoff_id = ?").get(posted.handoff.id) as {
+                    n: number;
+                }
+            ).n;
+            catchUpHandoffs(db, env.base);
+            const countAfter = (
+                db.query("SELECT COUNT(*) AS n FROM handoff_events WHERE handoff_id = ?").get(posted.handoff.id) as {
+                    n: number;
+                }
+            ).n;
+            expect(countAfter).toBe(countBefore);
+        } finally {
+            db.close();
+        }
+    });
+
+    test("rebuild produces identical handoff_events content", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "T", tasks: [{ text: "one" }, { text: "two" }] }, env.depsFor(A));
+        getHandoff({ id: posted.handoff.id, claim: true }, env.depsFor(B));
+        executeHandoffActions(
+            {
+                id: posted.handoff.id,
+                actions: [
+                    { action: "check_task", taskId: "t1", proof: { answer: "done" } },
+                    { action: "comment", text: "note" },
+                ],
+            },
+            env.depsFor(B)
+        );
+
+        const db = openHandoffModel(env.dbPath);
+
+        try {
+            catchUpHandoffs(db, env.base);
+            const before = (
+                db.query("SELECT uid, handoff_id, ts, ev, payload FROM handoff_events ORDER BY uid").all() as {
+                    uid: string;
+                    handoff_id: string;
+                    ts: string;
+                    ev: string;
+                    payload: string;
+                }[]
+            ).map((r) => ({ ...r }));
+            rebuildHandoffModel(db, env.base);
+            const after = (
+                db.query("SELECT uid, handoff_id, ts, ev, payload FROM handoff_events ORDER BY uid").all() as {
+                    uid: string;
+                    handoff_id: string;
+                    ts: string;
+                    ev: string;
+                    payload: string;
+                }[]
+            ).map((r) => ({ ...r }));
+            expect(after).toEqual(before);
+
+            for (const row of after) {
+                expect(row.payload.includes('"editId"')).toBe(false);
+            }
+        } finally {
+            db.close();
+        }
     });
 });

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -7,7 +7,7 @@ import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
 import { logger } from "@genesiscz/utils/logger";
 import { applyHandoffEvent } from "./fold";
 import { handoffLogDir } from "./log-store";
-import type { FoldOutcome, Handoff, HandoffEvent } from "./types";
+import type { FoldOutcome, Handoff, HandoffEvent, HandoffPublicEvent } from "./types";
 
 const log = logger.child({ component: "handoff:read-model" });
 
@@ -24,7 +24,22 @@ function ensureColumn(db: Database, table: string, column: string, ddl: string):
     }
 }
 
-function createTables(db: Database): void {
+function tableExists(db: Database, name: string): boolean {
+    const row = db.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name) as {
+        name: string;
+    } | null;
+    return row != null;
+}
+
+/** Strip editId before any events read-model persistence or public return (G3). */
+export function toPublicEvent(event: HandoffEvent): HandoffPublicEvent {
+    const { editId: _editId, ...rest } = event;
+    return rest;
+}
+
+function createTables(db: Database): { eventsTableCreated: boolean } {
+    const hadEventsTable = tableExists(db, "handoff_events");
+
     db.exec(`CREATE TABLE IF NOT EXISTS handoffs (
         id                     TEXT PRIMARY KEY,
         title                  TEXT NOT NULL,
@@ -61,6 +76,14 @@ function createTables(db: Database): void {
         extra      TEXT,
         ts         TEXT
     );`);
+    db.exec(`CREATE TABLE IF NOT EXISTS handoff_events (
+        uid        TEXT PRIMARY KEY,
+        handoff_id TEXT NOT NULL,
+        ts         TEXT NOT NULL,
+        ev         TEXT NOT NULL,
+        payload    TEXT NOT NULL
+    );`);
+    db.exec("CREATE INDEX IF NOT EXISTS idx_handoff_events_handoff ON handoff_events(handoff_id, ts);");
     ensureColumn(
         db,
         "handoffs",
@@ -69,6 +92,8 @@ function createTables(db: Database): void {
     );
     // Who finished it — needed for the reopen-by-finisher credential (§2 reopen_handoff).
     ensureColumn(db, "handoffs", "finished_by", "ALTER TABLE handoffs ADD COLUMN finished_by TEXT");
+
+    return { eventsTableCreated: !hadEventsTable && tableExists(db, "handoff_events") };
 }
 
 export function openHandoffModel(dbPath?: string): Database {
@@ -77,7 +102,18 @@ export function openHandoffModel(dbPath?: string): Database {
     const db = new Database(path);
     db.exec("PRAGMA journal_mode = WAL;");
     db.exec("PRAGMA busy_timeout = 5000;");
-    createTables(db);
+    const { eventsTableCreated } = createTables(db);
+
+    // One-time migration: table born under a non-empty handoffs → backfill via rebuild (G1).
+    if (eventsTableCreated && tableExists(db, "handoffs")) {
+        const count = (db.query("SELECT COUNT(*) AS n FROM handoffs").get() as { n: number }).n;
+
+        if (count > 0) {
+            log.info({ count }, "handoff_events table created under existing handoffs — rebuilding to backfill");
+            rebuildHandoffModel(db);
+        }
+    }
+
     log.debug({ path }, "handoff read-model opened");
     return db;
 }
@@ -106,6 +142,28 @@ interface HandoffRow {
 
 function rowToHandoff(row: HandoffRow): Handoff {
     const postedByContext = SafeJSON.parse(row.posted_by_context, { strict: true }) as Handoff["postedByContext"];
+    const claimedRaw = SafeJSON.parse(row.claimed_by, { strict: true }) as Array<{
+        sessionId: string | null;
+        sessionName: string | null;
+        branch: string | null;
+        cwd: string | null;
+        claimedAt: string;
+        via: Handoff["claimedBy"][number]["via"];
+        repoRoot?: string | null;
+        commitSha?: string | null;
+        agent?: string;
+    }>;
+    const claimedBy = claimedRaw.map((c) => ({
+        sessionId: c.sessionId,
+        sessionName: c.sessionName,
+        branch: c.branch,
+        cwd: c.cwd,
+        claimedAt: c.claimedAt,
+        via: c.via,
+        repoRoot: c.repoRoot ?? null,
+        commitSha: c.commitSha ?? null,
+        agent: c.agent ?? "unknown",
+    }));
     const handoff: Handoff = {
         id: row.id,
         title: row.title,
@@ -119,7 +177,7 @@ function rowToHandoff(row: HandoffRow): Handoff {
         },
         postedByContext,
         project: row.project,
-        claimedBy: SafeJSON.parse(row.claimed_by, { strict: true }) as Handoff["claimedBy"],
+        claimedBy,
         comments: SafeJSON.parse(row.comments, { strict: true }) as Handoff["comments"],
         attachments: SafeJSON.parse(row.attachments, { strict: true }) as Handoff["attachments"],
         editId: row.edit_id ?? "",
@@ -222,6 +280,43 @@ export function getEventOutcome(db: Database, uid: string): FoldOutcome | null {
     }
 
     return outcome;
+}
+
+export function listHandoffEvents({
+    db,
+    handoffId,
+    limit = 200,
+    before,
+}: {
+    db: Database;
+    handoffId: string;
+    limit?: number;
+    before?: string;
+}): { events: HandoffPublicEvent[]; total: number } {
+    const clamped = Math.min(1000, Math.max(1, Math.floor(limit)));
+    const total = (
+        db.query("SELECT COUNT(*) AS n FROM handoff_events WHERE handoff_id = ?").get(handoffId) as { n: number }
+    ).n;
+
+    const rows =
+        before !== undefined
+            ? (db
+                  .query(
+                      `SELECT payload FROM handoff_events
+                       WHERE handoff_id = ? AND ts < ?
+                       ORDER BY ts DESC LIMIT ?`
+                  )
+                  .all(handoffId, before, clamped) as { payload: string }[])
+            : (db
+                  .query(
+                      `SELECT payload FROM handoff_events
+                       WHERE handoff_id = ?
+                       ORDER BY ts DESC LIMIT ?`
+                  )
+                  .all(handoffId, clamped) as { payload: string }[]);
+
+    const events = rows.map((row) => SafeJSON.parse(row.payload, { strict: true }) as HandoffPublicEvent);
+    return { events, total };
 }
 
 /**
@@ -350,6 +445,9 @@ export function applyHandoffBatch({ db, file, prevOffset, events, consumed, base
     const putOutcome = db.prepare(
         "INSERT OR REPLACE INTO handoff_event_results (uid, handoff_id, ev, ok, error, extra, ts) VALUES (?,?,?,?,?,?,?)"
     );
+    const putEvent = db.prepare(
+        "INSERT OR IGNORE INTO handoff_events (uid, handoff_id, ts, ev, payload) VALUES (?,?,?,?,?)"
+    );
     let applied = false;
 
     const tx = db.transaction(() => {
@@ -398,6 +496,15 @@ export function applyHandoffBatch({ db, file, prevOffset, events, consumed, base
                 Object.keys(extra).length > 0 ? SafeJSON.stringify(extra, { strict: true }) : null,
                 event.ts
             );
+
+            // editId stripped at insert — never stored in handoff_events (G3).
+            putEvent.run(
+                event.uid,
+                event.id,
+                event.ts,
+                event.ev,
+                SafeJSON.stringify(toPublicEvent(event), { strict: true })
+            );
         }
 
         for (const state of states.values()) {
@@ -418,11 +525,12 @@ export function applyHandoffBatch({ db, file, prevOffset, events, consumed, base
     return applied;
 }
 
-/** Drop + full re-fold (§6.1 rule 6). */
+/** Drop + full re-fold (§6.1 rule 6). Also clears + refills handoff_events (G1). */
 export function rebuildHandoffModel(db: Database, base?: string): void {
     db.exec("DROP TABLE IF EXISTS handoffs;");
     db.exec("DROP TABLE IF EXISTS handoff_ingest_offsets;");
     db.exec("DROP TABLE IF EXISTS handoff_event_results;");
+    db.exec("DROP TABLE IF EXISTS handoff_events;");
     createTables(db);
     catchUpHandoffs(db, base);
     log.info("handoff read-model rebuilt from JSONL");

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -287,33 +287,49 @@ export function listHandoffEvents({
     handoffId,
     limit = 200,
     before,
+    beforeUid,
 }: {
     db: Database;
     handoffId: string;
     limit?: number;
     before?: string;
+    beforeUid?: string;
 }): { events: HandoffPublicEvent[]; total: number } {
-    const clamped = Math.min(1000, Math.max(1, Math.floor(limit)));
+    const safeLimit = Number.isFinite(limit) && limit > 0 ? limit : 200;
+    const clamped = Math.min(1000, Math.max(1, Math.floor(safeLimit)));
     const total = (
         db.query("SELECT COUNT(*) AS n FROM handoff_events WHERE handoff_id = ?").get(handoffId) as { n: number }
     ).n;
 
-    const rows =
-        before !== undefined
-            ? (db
-                  .query(
-                      `SELECT payload FROM handoff_events
-                       WHERE handoff_id = ? AND ts < ?
-                       ORDER BY ts DESC LIMIT ?`
-                  )
-                  .all(handoffId, before, clamped) as { payload: string }[])
-            : (db
-                  .query(
-                      `SELECT payload FROM handoff_events
-                       WHERE handoff_id = ?
-                       ORDER BY ts DESC LIMIT ?`
-                  )
-                  .all(handoffId, clamped) as { payload: string }[]);
+    let rows: { payload: string }[];
+
+    if (before !== undefined && beforeUid !== undefined) {
+        // Composite (ts, uid) cursor: a same-ms group split across a page boundary
+        // keeps its remainder instead of being permanently skipped.
+        rows = db
+            .query(
+                `SELECT payload FROM handoff_events
+                 WHERE handoff_id = ? AND (ts < ? OR (ts = ? AND uid < ?))
+                 ORDER BY ts DESC, uid DESC LIMIT ?`
+            )
+            .all(handoffId, before, before, beforeUid, clamped) as { payload: string }[];
+    } else if (before !== undefined) {
+        rows = db
+            .query(
+                `SELECT payload FROM handoff_events
+                 WHERE handoff_id = ? AND ts < ?
+                 ORDER BY ts DESC, uid DESC LIMIT ?`
+            )
+            .all(handoffId, before, clamped) as { payload: string }[];
+    } else {
+        rows = db
+            .query(
+                `SELECT payload FROM handoff_events
+                 WHERE handoff_id = ?
+                 ORDER BY ts DESC, uid DESC LIMIT ?`
+            )
+            .all(handoffId, clamped) as { payload: string }[];
+    }
 
     const events = rows.map((row) => SafeJSON.parse(row.payload, { strict: true }) as HandoffPublicEvent);
     return { events, total };

--- a/src/handoff/types.ts
+++ b/src/handoff/types.ts
@@ -47,6 +47,11 @@ export interface HandoffClaim {
     cwd: string | null;
     claimedAt: string;
     via: "target-match" | "explicit";
+    /** Copied from claim event `by` at fold — null on historical rows until rebuild. */
+    repoRoot: string | null;
+    commitSha: string | null;
+    /** Copied from claim event `by` — enables human-owner claim identity (agent === "human"). */
+    agent: string;
 }
 
 export interface HandoffComment {
@@ -144,6 +149,9 @@ export type HandoffEvent =
 
 export type HandoffEventName = HandoffEvent["ev"];
 
+/** Event as returned to HTTP/MCP — `editId` never leaves the read path (G3). */
+export type HandoffPublicEvent = Omit<HandoffEvent, "editId">;
+
 /** Fully folded current state of one handoff (read-model row, deserialized). */
 export interface Handoff {
     id: string;
@@ -195,7 +203,13 @@ export interface HandoffListRow {
     progress?: string;
     target?: HandoffTarget;
     postedBy: { sessionName: string | null };
-    claimedBy?: { sessionId: string | null; sessionName: string | null }[];
+    claimedBy?: {
+        sessionId: string | null;
+        sessionName: string | null;
+        agent?: string;
+        repoRoot?: string | null;
+        commitSha?: string | null;
+    }[];
     project: string | null;
     ageHours: number;
 }


### PR DESCRIPTION
## Summary
- Index handoff JSONL into `handoff_events` (editId stripped); fold keeps proof on uncheck and copies claimer repo/sha/agent with human-owner claim identity
- Unify live updates on `/api/qa/stream` (typed qa|handoff frames, midnight-safe rolling tailers); add `GET /api/handoff/events`; remove `/api/handoff/stream`
- MCP `include` scoping (default `["tasks"]`; events-only bare shape) + three-pane Agent Tasks UI (activity panel, Claim/Unclaim, criteria checklist, file chips, create-dialog polish)

## Test plan
- [ ] Restart dev-dashboard so the new routes/UI load
- [ ] `bun test src/handoff` green
- [ ] `curl` `/api/handoff/events?id=<id>` — events present, no `editId`; `/api/handoff/stream` → 404
- [ ] `curl -N /api/qa/stream` — both `type:"qa"` and `type:"handoff"` frames
- [ ] Browser `/qa` Agent tasks: 3-pane + activity live updates; Claim/Unclaim; criteria list; preserved proof; Cmd+Enter; create dialog keyboard flow; broken-image fallback
- [ ] MCP: `handoff_get` default lean with tasks; `include:["events"]` bare shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a handoff activity panel with event history, pagination, timestamps, actor details, and expandable event information.
  * Added scoped handoff responses, including task-focused and events-only views.
  * Added inline file references for comments and tasks, with paste-to-upload support and clearer missing-file indicators.
  * Improved task and handoff creation workflows with keyboard shortcuts and enhanced claim details.
  * Unified live QA and handoff updates through a shared activity stream.

* **Bug Fixes**
  * Improved stream reliability across log rotation and midnight rollover.
  * Preserved task proofs when tasks are unchecked.
  * Improved claim matching for dashboard and agent identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->