### PR TITLE
feat(claude,ai-proxy): quiet headless launches, CLAUDE_CONFIG_DIR fix, grok-4.5 catalog

### DIFF
--- a/src/ai-proxy/data/models-catalog.json
+++ b/src/ai-proxy/data/models-catalog.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-14T01:34:01.758Z",
-  "grokVersion": "0.2.99",
+  "updatedAt": "2026-07-21T17:58:05.989Z",
+  "grokVersion": "0.2.106",
   "accounts": [
     {
       "accountName": "martin",
@@ -8,20 +8,11 @@
       "baseUrl": "https://cli-chat-proxy.grok.com/v1",
       "pickerModels": [
         {
-          "id": "grok-build",
+          "id": "grok-4.5",
           "source": "picker",
           "visibility": "high",
-          "speed": "slow",
-          "thinking": "reasoning",
-          "probeStatus": "ok",
-          "httpCode": 200
-        },
-        {
-          "id": "grok-composer-2.5-fast",
-          "source": "picker",
-          "visibility": "high",
-          "speed": "fast",
-          "thinking": "reasoning",
+          "speed": "medium",
+          "thinking": "optional",
           "probeStatus": "ok",
           "httpCode": 200
         }
@@ -217,7 +208,25 @@
           "httpCode": 200
         },
         {
+          "id": "grok-build",
+          "source": "probe",
+          "visibility": "high",
+          "speed": "slow",
+          "thinking": "reasoning",
+          "probeStatus": "ok",
+          "httpCode": 200
+        },
+        {
           "id": "grok-build-0.1",
+          "source": "probe",
+          "visibility": "medium",
+          "speed": "slow",
+          "thinking": "reasoning",
+          "probeStatus": "ok",
+          "httpCode": 200
+        },
+        {
+          "id": "grok-build-latest",
           "source": "probe",
           "visibility": "medium",
           "speed": "slow",
@@ -249,6 +258,24 @@
           "visibility": "medium",
           "speed": "fast",
           "thinking": "none",
+          "probeStatus": "ok",
+          "httpCode": 200
+        },
+        {
+          "id": "grok-composer-2.5",
+          "source": "probe",
+          "visibility": "medium",
+          "speed": "fast",
+          "thinking": "reasoning",
+          "probeStatus": "ok",
+          "httpCode": 200
+        },
+        {
+          "id": "grok-composer-2.5-fast",
+          "source": "probe",
+          "visibility": "high",
+          "speed": "fast",
+          "thinking": "reasoning",
           "probeStatus": "ok",
           "httpCode": 200
         },

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -68,6 +68,55 @@ function shellQuote(arg: string): string {
     return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
+/** Headless launch (`-p`/`--print`): claude prints a result and exits, no TUI. */
+function isHeadlessPassthrough(passthrough: string[]): boolean {
+    return passthrough.some((arg) => arg === "-p" || arg === "--print");
+}
+
+/**
+ * The interactive shell (`-ic`) we spawn to pick up the user's ccc/claude wrappers
+ * emits `(eval):N: can't change option: zle` during rc init when a plugin toggles
+ * the ZLE option without a usable line editor. It's cosmetic. In headless mode the
+ * shell's stderr carries only diagnostics (no TUI), so drop just those benign lines
+ * and forward everything else through.
+ */
+async function forwardStderrDroppingZleNoise(stream: ReadableStream<Uint8Array>): Promise<void> {
+    const decoder = new TextDecoder();
+    const isZleNoise = (line: string) => /can't change option: zle/.test(line);
+    const reader = stream.getReader();
+    let buffer = "";
+
+    const flushLine = (line: string) => {
+        if (!isZleNoise(line)) {
+            process.stderr.write(line);
+        }
+    };
+
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+                break;
+            }
+
+            buffer += decoder.decode(value, { stream: true });
+            let newlineIndex = buffer.indexOf("\n");
+            while (newlineIndex !== -1) {
+                flushLine(buffer.slice(0, newlineIndex + 1));
+                buffer = buffer.slice(newlineIndex + 1);
+                newlineIndex = buffer.indexOf("\n");
+            }
+        }
+
+        buffer += decoder.decode();
+        if (buffer) {
+            flushLine(buffer);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
 function modelOption(model: LaunchableModel) {
     return { value: model.id, label: model.id, hint: model.label };
 }
@@ -404,8 +453,12 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
         .join(" ");
 
     const mode = opts.keychain ? "keychain login" : "long-lived token";
-    out.printlnErr(pc.dim(`Starting Claude as ${pc.cyan(accountName)} (${mode})${detail ? ` ${detail}` : ""}...`));
-    logger.debug({ cmd, accountName, modelId, resumeArgs, passthrough, mode }, "Spawning claude");
+    const headless = isHeadlessPassthrough(passthrough);
+    if (!headless) {
+        out.printlnErr(pc.dim(`Starting Claude as ${pc.cyan(accountName)} (${mode})${detail ? ` ${detail}` : ""}...`));
+    }
+
+    logger.debug({ cmd, accountName, modelId, resumeArgs, passthrough, mode, headless }, "Spawning claude");
 
     let launchEnv: Record<string, string | undefined>;
 
@@ -444,11 +497,16 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
 
     const proc = Bun.spawn({
         cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
-        stdio: ["inherit", "inherit", "inherit"],
+        stdio: ["inherit", "inherit", headless ? "pipe" : "inherit"],
         env: launchEnv,
     });
 
+    const stderrPump = headless && proc.stderr ? forwardStderrDroppingZleNoise(proc.stderr) : null;
+
     const exitCode = await proc.exited;
+    if (stderrPump) {
+        await stderrPump;
+    }
 
     if (opts.keychain) {
         try {

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -18,7 +18,14 @@ import pc from "picocolors";
 import { finishKeychainSession, injectSecondaryLogin, inspectKeychainBeforeInject } from "../lib/keychain-session";
 import { pickSessionForResume } from "./resume";
 
-const CLAUDE_JSON = join(homedir(), ".claude.json");
+/**
+ * Claude Code reads `.claude.json` from `$CLAUDE_CONFIG_DIR/.claude.json` when that
+ * env var is set (else `~/.claude.json`). The onboarding patch must target the same
+ * file the launched claude will read, or it silently patches the wrong config.
+ */
+function claudeJsonPath(): string {
+    return join(env.paths.getClaudeConfigDir() ?? homedir(), ".claude.json");
+}
 
 interface StartOptions {
     pick?: boolean;
@@ -37,18 +44,15 @@ interface StartOptions {
 async function ensureOnboardingSkippedForOAuthToken(): Promise<void> {
     // Best-effort by contract: any fs/parse failure here (permissions, disk, foreign
     // ~/.claude.json) must log and return — never abort the actual claude launch.
+    const claudeJson = claudeJsonPath();
     try {
-        const file = Bun.file(CLAUDE_JSON);
-        if (!(await file.exists())) {
-            return;
-        }
-
-        const text = await file.text();
+        const file = Bun.file(claudeJson);
+        const text = (await file.exists()) ? await file.text() : "{}";
         if (/"hasCompletedOnboarding"\s*:\s*true/.test(text)) {
             return;
         }
 
-        let updated = text;
+        let updated: string;
         if (/"hasCompletedOnboarding"\s*:\s*false/.test(text)) {
             updated = text.replace(/"hasCompletedOnboarding"\s*:\s*false/, '"hasCompletedOnboarding": true');
         } else {
@@ -57,10 +61,10 @@ async function ensureOnboardingSkippedForOAuthToken(): Promise<void> {
             updated = SafeJSON.stringify(config, null, 2);
         }
 
-        await Bun.write(CLAUDE_JSON, updated);
-        logger.debug({ path: CLAUDE_JSON }, "Set hasCompletedOnboarding for CLAUDE_CODE_OAUTH_TOKEN launch");
+        await Bun.write(claudeJson, updated);
+        logger.debug({ path: claudeJson }, "Set hasCompletedOnboarding for CLAUDE_CODE_OAUTH_TOKEN launch");
     } catch (error) {
-        logger.warn({ error, path: CLAUDE_JSON }, "Could not patch hasCompletedOnboarding in ~/.claude.json");
+        logger.warn({ error, path: claudeJson }, "Could not patch hasCompletedOnboarding");
     }
 }
 

--- a/src/utils/ai/grok/models.ts
+++ b/src/utils/ai/grok/models.ts
@@ -22,6 +22,7 @@ function seed(
 }
 
 export const GROK_STATIC_CATALOG: GrokModelRecord[] = [
+    seed("grok-4.5", "high", "medium", "optional", "ok"),
     seed("grok-build", "high", "slow", "reasoning", "ok"),
     seed("grok-composer-2.5-fast", "high", "fast", "reasoning", "ok"),
     seed("grok-build-0.1", "medium", "slow", "reasoning", "ok"),

--- a/src/utils/claude/index.ts
+++ b/src/utils/claude/index.ts
@@ -8,10 +8,12 @@ export * from "./projects";
 export { extractToolInputSummary, extractToolResultText, isAssistantEndTurn } from "./session-helpers";
 export * from "./types";
 
-import { createReadStream, existsSync } from "node:fs";
+import { createReadStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
 
 /**
  * Parse a JSONL transcript file into an array of message objects.
@@ -62,10 +64,115 @@ export function _setFindClaudeCommandTestHooks(hooks: FindClaudeCommandTestHooks
     findClaudeCommandTestHooks = hooks;
 }
 
+/**
+ * Resolving the command probes an interactive shell (~350-480ms) to pick up the
+ * user's `ccc`/`cc`/`claude` wrapper functions from their rc file. The winner
+ * changes only when they edit that rc file, so cache it keyed on shell + rc mtime
+ * — editing the wrapper invalidates it, and a 7-day TTL is a belt-and-suspenders
+ * fallback. Every `tools claude start/run` launch would otherwise pay the probe.
+ */
+interface ResolvedCommandCache {
+    command: string;
+    shell: string;
+    rcPath: string | null;
+    rcMtimeMs: number | null;
+    cachedAt: number;
+}
+
+const RESOLVED_COMMAND_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function resolvedCommandCachePath(): string {
+    return join(env.paths.getHome(), ".genesis-tools", "claude", "resolved-command.json");
+}
+
+/** The interactive rc file that defines the wrapper functions, for cache invalidation. */
+function interactiveRcPath(shell: string): string | null {
+    const base = shell.split("/").pop() ?? "";
+    const home = env.paths.getHome();
+    if (base.includes("zsh")) {
+        return join(home, ".zshrc");
+    }
+
+    if (base.includes("bash")) {
+        return join(home, ".bashrc");
+    }
+
+    return null;
+}
+
+function rcMtimeMs(rcPath: string | null): number | null {
+    if (!rcPath) {
+        return null;
+    }
+
+    try {
+        return statSync(rcPath).mtimeMs;
+    } catch {
+        return null;
+    }
+}
+
+function readResolvedCommandCache(shell: string): string | null {
+    try {
+        const path = resolvedCommandCachePath();
+        if (!existsSync(path)) {
+            return null;
+        }
+
+        const cache = SafeJSON.parse(readFileSync(path, "utf8")) as ResolvedCommandCache;
+
+        if (cache.shell !== shell) {
+            return null;
+        }
+
+        if (Date.now() - cache.cachedAt > RESOLVED_COMMAND_CACHE_TTL_MS) {
+            return null;
+        }
+
+        const currentMtime = rcMtimeMs(interactiveRcPath(shell));
+        if (currentMtime !== cache.rcMtimeMs) {
+            return null;
+        }
+
+        logger.debug({ command: cache.command, shell }, "[findClaudeCommand] cache hit");
+        return cache.command;
+    } catch (error) {
+        logger.debug({ error }, "[findClaudeCommand] cache read failed");
+        return null;
+    }
+}
+
+function writeResolvedCommandCache(command: string, shell: string): void {
+    try {
+        const path = resolvedCommandCachePath();
+        mkdirSync(dirname(path), { recursive: true });
+        const rcPath = interactiveRcPath(shell);
+        const cache: ResolvedCommandCache = {
+            command,
+            shell,
+            rcPath,
+            rcMtimeMs: rcMtimeMs(rcPath),
+            cachedAt: Date.now(),
+        };
+        writeFileSync(path, SafeJSON.stringify(cache, null, 2));
+        logger.debug({ command, shell }, "[findClaudeCommand] cached resolved command");
+    } catch (error) {
+        logger.debug({ error }, "[findClaudeCommand] cache write failed");
+    }
+}
+
 export async function findClaudeCommand(): Promise<string> {
     const shell = env.paths.getShell("/bin/sh");
     const candidates = findClaudeCommandTestHooks?.candidates ?? ["ccc", "cc", "claude"];
     const timeoutMs = findClaudeCommandTestHooks?.timeoutMs ?? 3000;
+
+    // Test hooks force a live probe; production reads the mtime-keyed cache first.
+    if (!findClaudeCommandTestHooks) {
+        const cached = readResolvedCommandCache(shell);
+        if (cached) {
+            return cached;
+        }
+    }
 
     for (const candidate of candidates) {
         const proc = findClaudeCommandTestHooks?.spawnProbe
@@ -83,6 +190,10 @@ export async function findClaudeCommand(): Promise<string> {
             await proc.exited;
 
             if (proc.exitCode === 0 && stdout.includes("Claude Code")) {
+                if (!findClaudeCommandTestHooks) {
+                    writeResolvedCommandCache(candidate, shell);
+                }
+
                 return candidate;
             }
         } catch {

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -141,6 +141,8 @@ export const env = {
         getHome: () => getTrimmed("HOME") ?? homedir(),
         getUserProfile: () => getTrimmed("USERPROFILE"),
         getShell: (fallback = "/bin/sh") => getWithDefault("SHELL", fallback),
+        /** Claude Code's config dir override; when set, `.claude.json` lives at `<dir>/.claude.json`. */
+        getClaudeConfigDir: () => getTrimmed("CLAUDE_CONFIG_DIR"),
         getHistfile: () => getTrimmed("HISTFILE"),
         getClarityProjectCwd: () => getTrimmed("CLARITY_PROJECT_CWD") ?? cwd(),
         getAppData: () => getTrimmed("APPDATA"),


### PR DESCRIPTION
## Summary

Two areas: the `tools claude` launcher and the ai-proxy grok catalog.

### `tools claude` launcher
- **perf**: cache the resolved `claude` command so we skip the interactive-shell probe on every invocation.
- **feat**: quiet headless launches (`-p` / `--print`) — suppress launcher chatter when running non-interactively.
- **fix**: honor `CLAUDE_CONFIG_DIR` when skipping onboarding (previously the onboarding-skip path ignored the configured config dir).

### ai-proxy
- **fix**: add `grok-4.5` to the grok-subscription catalog so it's callable through the proxy.

## Commits
- `fix(claude): honor CLAUDE_CONFIG_DIR when skipping onboarding`
- `feat(claude): quiet headless launches (-p/--print)`
- `perf(claude): cache resolved claude command to skip interactive-shell probe`
- `fix(ai-proxy): add grok-4.5 to grok-subscription catalog`
