### PR TITLE
feat(scripts): guard bun test against a broken dependency tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,12 @@ tools <tool-name> --readme
 
 So when you write the end-of-task notification, you can typically rely on a saved `claude` profile and just call `tools say "<xxx> done" --app claude` — voice etc. come from the profile.
 
+### Running Tests
+
+**Use `bun run test` (or `bun scripts/test.ts <paths>`), never bare `bun test`.** The wrapper stat-checks the dependency tree first (~1ms) and reinstalls when it is missing, partial or stale, then hands off to `bun test` with argv, output and exit code untouched.
+
+This exists because inside a **git worktree** any `bunx` call creates a partial `node_modules/` that shadows the parent checkout's complete one. Bare `bun test` then fails across a hundred unrelated files with errors like `Cannot find module 'parse5/lib/common/doctype'`, which looks exactly like the branch broke the world. Logic lives in `scripts/test-deps.ts` (`diagnose()` / `lockStamp()`), covered by `scripts/test-deps.test.ts`.
+
 ### Installation & Setup
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         "dev:reas-dashboard": "bun --bun vite dev --strictPort -c src/Internal/commands/reas/ui/vite.config.ts",
         "clear-cache": "bun src/utils/clearCache.ts",
         "build:native": "cd native/ax-tool && swift build -c release",
-        "test": "bun test --parallel --path-ignore-patterns='**/dashboard/**' --path-ignore-patterns='**/dev-dashboard/**' --path-ignore-patterns='**/claude-history-dashboard/**' --path-ignore-patterns='**/Internal/**' --path-ignore-patterns='**/shops/**' --path-ignore-patterns='**/task/tests/**'",
-        "test:task": "bun test --parallel src/task/tests/",
+        "test": "bun scripts/test.ts --parallel --path-ignore-patterns='**/dashboard/**' --path-ignore-patterns='**/dev-dashboard/**' --path-ignore-patterns='**/claude-history-dashboard/**' --path-ignore-patterns='**/Internal/**' --path-ignore-patterns='**/shops/**' --path-ignore-patterns='**/task/tests/**'",
+        "test:task": "bun scripts/test.ts --parallel src/task/tests/",
         "test:coverage": "bun run test --coverage --coverage-reporter=lcov --coverage-dir=coverage",
         "postinstall": "bun scripts/apply-patches.ts"
     },

--- a/scripts/test-deps.test.ts
+++ b/scripts/test-deps.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CANARY_PACKAGES, diagnose, lockStamp, missingCanaries } from "./test-deps";
+
+const roots: string[] = [];
+
+function makeRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "test-deps-"));
+    roots.push(root);
+    return root;
+}
+
+function withPackages(root: string, packages: readonly string[]): void {
+    for (const pkg of packages) {
+        mkdirSync(join(root, "node_modules", pkg), { recursive: true });
+    }
+}
+
+afterEach(() => {
+    while (roots.length > 0) {
+        rmSync(roots.pop()!, { recursive: true, force: true });
+    }
+});
+
+describe("diagnose", () => {
+    test("a missing node_modules is reported", () => {
+        expect(diagnose(makeRoot())).toBe("node_modules is missing");
+    });
+
+    test("a complete tree is healthy", () => {
+        const root = makeRoot();
+        withPackages(root, CANARY_PACKAGES);
+
+        expect(diagnose(root)).toBeNull();
+    });
+
+    test("the worktree-shadowing case (partial tree) is caught and names what is missing", () => {
+        // What `bunx` leaves behind inside a worktree: a node_modules holding
+        // only whatever that one command needed.
+        const root = makeRoot();
+        withPackages(root, ["picocolors", ".bin"]);
+
+        const verdict = diagnose(root);
+
+        expect(verdict).toContain("incomplete");
+        expect(verdict).toContain("parse5");
+        expect(verdict).not.toContain("picocolors");
+    });
+
+    test("an empty node_modules is incomplete, not healthy", () => {
+        const root = makeRoot();
+        mkdirSync(join(root, "node_modules"), { recursive: true });
+
+        expect(diagnose(root)).toContain("incomplete");
+    });
+});
+
+describe("missingCanaries", () => {
+    test("lists only the absent packages", () => {
+        const root = makeRoot();
+        withPackages(root, ["picocolors", "commander"]);
+
+        expect(missingCanaries(root, ["picocolors", "commander", "parse5"])).toEqual(["parse5"]);
+    });
+
+    test("scoped package names resolve as directories", () => {
+        const root = makeRoot();
+        withPackages(root, ["@clack/prompts"]);
+
+        expect(missingCanaries(root, ["@clack/prompts"])).toEqual([]);
+    });
+});
+
+describe("lockStamp", () => {
+    test("reports no-lockfile when none exists", () => {
+        expect(lockStamp(makeRoot())).toBe("no-lockfile");
+    });
+
+    test("changes when the lockfile content changes", () => {
+        const root = makeRoot();
+        const lock = join(root, "bun.lock");
+
+        writeFileSync(lock, "one");
+        const before = lockStamp(root);
+
+        writeFileSync(lock, "one plus more bytes");
+        const after = lockStamp(root);
+
+        expect(before).not.toBe(after);
+        expect(after).toContain("bun.lock");
+    });
+
+    test("is stable across calls when nothing changes", () => {
+        const root = makeRoot();
+        writeFileSync(join(root, "bun.lock"), "stable");
+
+        expect(lockStamp(root)).toBe(lockStamp(root));
+    });
+});

--- a/scripts/test-deps.ts
+++ b/scripts/test-deps.ts
@@ -1,0 +1,73 @@
+import { statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Dependency-tree health checks for the `bun test` wrapper (`scripts/test.ts`).
+ *
+ * Split out from the runner so the decision logic is testable without spawning
+ * installs or test runs — everything here is pure apart from `stat`.
+ */
+
+/**
+ * Packages that must resolve for the suite to run at all. Deliberately a
+ * hand-picked spread — a types package, a leaf dep, a transitive-heavy one and
+ * the workspace link — rather than the whole dependency list, which would cost
+ * more to check than it saves.
+ */
+export const CANARY_PACKAGES = ["bun-types", "picocolors", "commander", "@clack/prompts", "parse5", "@genesiscz/utils"];
+
+export const STAMP_FILE = ".genesis-install-stamp";
+
+function statOrNull(path: string): ReturnType<typeof statSync> | null {
+    try {
+        return statSync(path);
+    } catch {
+        // Missing is the normal answer here, not an error worth logging.
+        return null;
+    }
+}
+
+/**
+ * Lockfile identity without reading it: any install rewrites size or mtime, so
+ * this is one `stat` instead of hashing a megabyte on every test run.
+ */
+export function lockStamp(root: string): string {
+    for (const name of ["bun.lock", "bun.lockb", "package-lock.json"]) {
+        const stat = statOrNull(join(root, name));
+
+        if (stat) {
+            return `${name}:${stat.size}:${Math.round(stat.mtimeMs)}`;
+        }
+    }
+
+    return "no-lockfile";
+}
+
+export function missingCanaries(root: string, canaries: readonly string[] = CANARY_PACKAGES): string[] {
+    const nodeModules = join(root, "node_modules");
+
+    return canaries.filter((pkg) => statOrNull(join(nodeModules, pkg)) === null);
+}
+
+/**
+ * Why the dependency tree is unusable, or null when it looks healthy.
+ *
+ * The case this exists for: inside a git worktree, any `bunx` call creates a
+ * PARTIAL `node_modules/` that shadows the parent checkout's complete one. Every
+ * later `bun test` then dies with resolution errors like
+ * `Cannot find module 'parse5/lib/common/doctype'` across a hundred unrelated
+ * files, which reads exactly like the branch broke the world.
+ */
+export function diagnose(root: string, canaries: readonly string[] = CANARY_PACKAGES): string | null {
+    if (statOrNull(join(root, "node_modules")) === null) {
+        return "node_modules is missing";
+    }
+
+    const missing = missingCanaries(root, canaries);
+
+    if (missing.length > 0) {
+        return `node_modules is incomplete (missing ${missing.join(", ")})`;
+    }
+
+    return null;
+}

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+import { dirname, join } from "node:path";
+import { diagnose, lockStamp, STAMP_FILE } from "./test-deps";
+
+/**
+ * `bun test` wrapper that refuses to run against a broken dependency tree.
+ *
+ * The failure this prevents: inside a git worktree, any `bunx` call creates a
+ * PARTIAL `node_modules/` that shadows the parent checkout's complete one. Every
+ * subsequent `bun test` then dies with resolution errors like
+ * `Cannot find module 'parse5/lib/common/doctype'` across a hundred unrelated
+ * files, which reads exactly like the branch broke the world. It cost a real
+ * debugging detour before anyone thought to look at `node_modules`.
+ *
+ * The guard is a handful of `stat` calls (~1ms), so it can sit in front of every
+ * run. argv, output and exit code pass straight through — this must be invisible
+ * when the tree is healthy.
+ */
+
+const ROOT = dirname(import.meta.dir);
+const STAMP = join(ROOT, "node_modules", STAMP_FILE);
+
+function warn(message: string): void {
+    process.stderr.write(`\x1b[33m[test] ${message}\x1b[0m\n`);
+}
+
+async function stampMatches(): Promise<boolean> {
+    const file = Bun.file(STAMP);
+
+    if (!(await file.exists())) {
+        return false;
+    }
+
+    return (await file.text()).trim() === lockStamp(ROOT);
+}
+
+async function install(reason: string): Promise<void> {
+    warn(`${reason} — running bun install`);
+
+    const proc = Bun.spawn(["bun", "install"], { cwd: ROOT, stdio: ["inherit", "inherit", "inherit"] });
+    const code = await proc.exited;
+
+    if (code === 0) {
+        await Bun.write(STAMP, lockStamp(ROOT));
+        return;
+    }
+
+    // A non-zero exit is usually a POSTINSTALL failing (puppeteer downloading a
+    // browser, a native build), which says nothing about whether the packages
+    // the tests import actually landed. Re-check the tree instead of assuming:
+    // blocking a green suite over an unrelated postinstall would make this guard
+    // worse than the problem it prevents.
+    const stillBroken = diagnose(ROOT);
+
+    if (stillBroken) {
+        process.stderr.write(`\x1b[31m[test] bun install failed (exit ${code}) and ${stillBroken}\x1b[0m\n`);
+        process.exit(code);
+    }
+
+    warn(`bun install exited ${code} (likely a postinstall), but the tree resolves — continuing`);
+    // No stamp after a partial install: re-verify next run rather than recording
+    // a state we are not sure about.
+}
+
+const broken = diagnose(ROOT);
+
+if (broken) {
+    await install(broken);
+} else if (!(await stampMatches())) {
+    // Lockfile moved since the last verified install (branch switch, pull).
+    await install("dependencies are stale");
+}
+
+const proc = Bun.spawn(["bun", "test", ...process.argv.slice(2)], {
+    cwd: ROOT,
+    stdio: ["inherit", "inherit", "inherit"],
+});
+
+process.exit(await proc.exited);

--- a/scripts/tv-verify-all.sh
+++ b/scripts/tv-verify-all.sh
@@ -51,8 +51,8 @@ if rg -l "sessionid=|sessionid_sign=" src/tradingview/lib/__fixtures__/ >/dev/nu
 else record V0.5 "$CMD_LABEL" PASS ""; fi
 
 echo "=== V1 Static ==="
-CMD_LABEL="bun test src/tradingview"
-if bun test src/tradingview 2>&1 | tee /tmp/tv-verify-V1.1.log | tail -5 | rg -q "0 fail"; then
+CMD_LABEL="bun scripts/test.ts src/tradingview"
+if bun scripts/test.ts src/tradingview 2>&1 | tee /tmp/tv-verify-V1.1.log | tail -5 | rg -q "0 fail"; then
   record V1.1 "$CMD_LABEL" PASS ""
 else record V1.1 "$CMD_LABEL" FAIL ""; fi
 
@@ -138,7 +138,7 @@ else
 fi
 
 CMD_LABEL="notify.test.ts"
-if bun test src/tradingview/lib/notify.test.ts 2>&1 | tail -3 | rg -q "0 fail"; then record V2.11 "$CMD_LABEL" PASS ""
+if bun scripts/test.ts src/tradingview/lib/notify.test.ts 2>&1 | tail -3 | rg -q "0 fail"; then record V2.11 "$CMD_LABEL" PASS ""
 else record V2.11 "$CMD_LABEL" FAIL ""; fi
 
 CMD_LABEL="quotes regression"
@@ -215,7 +215,7 @@ else record V5.3 "$CMD_LABEL" FAIL ""; fi
 
 echo "=== V6 Final ==="
 # V6.1 re-run V1 subset
-if bun test src/tradingview 2>&1 | tail -3 | rg -q "0 fail" && ! tsgo --noEmit 2>&1 | rg -q "src/tradingview"; then record V6.1 "re-run V1" PASS ""
+if bun scripts/test.ts src/tradingview 2>&1 | tail -3 | rg -q "0 fail" && ! tsgo --noEmit 2>&1 | rg -q "src/tradingview"; then record V6.1 "re-run V1" PASS ""
 else record V6.1 "re-run V1" FAIL ""; fi
 
 COMMITS=$(git log --oneline master..feat/tradingview 2>/dev/null | wc -l | tr -d ' ')

--- a/scripts/verify-task-tool.sh
+++ b/scripts/verify-task-tool.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-bun test src/utils/log-session/
-bun test src/task/lib/
-bun test src/task/tests/task.integration.test.ts
-bun test src/task/tests/dashboard.integration.test.ts
+bun scripts/test.ts src/utils/log-session/
+bun scripts/test.ts src/task/lib/
+bun scripts/test.ts src/task/tests/task.integration.test.ts
+bun scripts/test.ts src/task/tests/dashboard.integration.test.ts
 echo "✓ task tool verification passed"


### PR DESCRIPTION
Stops a failure mode that already cost a debugging detour: bare `bun test` running against a broken dependency tree.

## The failure

Inside a git worktree, any `bunx` call (biome, playwright, anything) creates a **partial** `node_modules/` that shadows the parent checkout's complete one. Every later `bun test` then dies like this:

```
error: Cannot find module 'parse5/lib/common/doctype' from
'.../node_modules/parse5-htmlparser2-tree-adapter/lib/index.js'

 0 pass
 164 fail
 164 errors
```

164 files erroring across unrelated subsystems reads exactly like the branch broke the world. It took a stash/re-run/compare-against-main detour before anyone thought to look at `node_modules`. `bun install` in the worktree fixes it instantly, once you know.

## The guard

`bun run test` now goes through `scripts/test.ts`:

1. `stat` `node_modules/` and a handful of canary packages (a types package, a leaf dep, a transitive-heavy one, the workspace link).
2. Compare a lockfile stamp (`name:size:mtime`, no read) against `node_modules/.genesis-install-stamp`.
3. Reinstall on missing / partial / stale, then `exec bun test` with argv, output and exit code untouched.

Roughly 1ms on a healthy tree, so it can sit in front of every run and stay invisible.

**A failing `bun install` does not block the suite** when the tree still resolves afterwards. A non-zero exit is usually an unrelated postinstall (puppeteer downloading a browser) and refusing to run a green suite over that would make the guard worse than the problem.

## Wired through

- `package.json` — `test` and `test:task`. `test:coverage` and CI already delegate to `bun run test`, so they inherit it.
- `scripts/verify-task-tool.sh`, `scripts/tv-verify-all.sh` — these are the ad-hoc ones run inside worktrees, which is exactly where the shadowing bites. They use `bun scripts/test.ts <paths>` directly, since the `package.json` script carries ignore-globs that would fight explicit path filters.
- `CLAUDE.md` — documents the rule and why.

## Verification

Each path exercised against a real tree:

- **Healthy**: `bun scripts/test.ts ./src/utils/format.test.ts` → 54 pass, `0.19s total`, no install, no extra output.
- **Partial tree** (hid `picocolors` to reproduce the shadowing): `[test] node_modules is incomplete (missing picocolors) — running bun install` → installed → 54 pass.
- **Stale lockfile** (`touch bun.lock`): `[test] dependencies are stale — running bun install` → installed → 54 pass.
- **Missing tree** (fresh worktree, no `node_modules`): detected, installed; `bun install` then exited 1 on puppeteer's postinstall and the guard continued because the tree resolved — which is the tolerance path doing its job.
- **Exit code**: a deliberately failing test through the wrapper returns `1`.

`scripts/test-deps.test.ts` covers the decision logic against temp dirs (9 tests): missing tree, complete tree, partial tree naming what is absent, empty `node_modules`, scoped package resolution, and lockfile stamp stability/change. `typecheck:all` clean, biome clean.

## Note

The logic lives in `scripts/test-deps.ts` rather than inside the runner so it is testable without spawning installs or test runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Improved test execution reliability by automatically checking and repairing incomplete or outdated dependencies before tests run.
  * Preserved existing test arguments, output, and exit codes.
  * Updated verification scripts to use the reliable test runner.

* **Documentation**
  * Added guidance for running tests through the project’s recommended commands.

* **Tests**
  * Added coverage for dependency health checks and lockfile change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->