### PR TITLE
feat(claude, dev-dashboard, youtube): ext panel visuals, token journal recovery + plan-expired label, share raw download

### DIFF
--- a/src/claude/commands/usage/components/overview/account-section.tsx
+++ b/src/claude/commands/usage/components/overview/account-section.tsx
@@ -10,6 +10,12 @@ import { Box, Text } from "ink";
 import { UsageBar } from "./usage-bar";
 
 function shortStaleReason(reason: string): string {
+    // 403 permission_error from an org whose subscription lapsed — the OAuth
+    // tokens are still perfectly valid, only the plan needs renewing.
+    if (reason.includes("not allowed for this organization")) {
+        return "plan expired";
+    }
+
     if (reason.includes("429")) {
         return "rate limited";
     }

--- a/src/dev-dashboard/lib/obsidian/share-template.ts
+++ b/src/dev-dashboard/lib/obsidian/share-template.ts
@@ -377,6 +377,8 @@ footer.dd-share-footer .dd-share-source {
     top: 16px;
     right: 16px;
     z-index: 100;
+    display: flex;
+    gap: 8px;
 }
 
 .dd-share-view-btn {
@@ -468,11 +470,14 @@ const FILE_CODE_ICON =
 const BOOK_OPEN_ICON =
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg>';
 
+const DOWNLOAD_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>';
+
 function embedSourceJson(source: string): string {
     return SafeJSON.stringify(source).replace(/</g, "\\u003c");
 }
 
-function buildViewToggleScript(): string {
+function buildViewToggleScript(downloadName: string): string {
     return `<script>
 (function () {
     var btn = document.getElementById("dd-share-view-btn");
@@ -483,6 +488,21 @@ function buildViewToggleScript(): string {
     }
 
     panel.textContent = JSON.parse(dataEl.textContent);
+
+    var downloadBtn = document.getElementById("dd-share-download-btn");
+    if (downloadBtn) {
+        downloadBtn.addEventListener("click", function () {
+            var blob = new Blob([panel.textContent], { type: "text/markdown;charset=utf-8" });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement("a");
+            a.href = url;
+            a.download = ${SafeJSON.stringify(downloadName)};
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        });
+    }
 
     var fileCodeIcon = ${SafeJSON.stringify(FILE_CODE_ICON)};
     var bookOpenIcon = ${SafeJSON.stringify(BOOK_OPEN_ICON)};
@@ -529,7 +549,10 @@ export function renderSharePage(options: ShareTemplateOptions): string {
         bodyExtras.push(buildMermaidScript());
     }
 
-    bodyExtras.push(buildViewToggleScript());
+    const baseName = sourcePath?.split("/").pop()?.replace(/\.md$/i, "") || title;
+    const downloadName = `${baseName.replace(/[\\/:*?"<>|]/g, "_")}.md`;
+
+    bodyExtras.push(buildViewToggleScript(downloadName));
 
     const sourceLine = sourcePath ? `<span class="dd-share-source">${escapeHtml(sourcePath)}</span>` : "";
 
@@ -546,6 +569,7 @@ ${headExtras.join("\n")}
 <body>
 <div class="dd-share-toolbar">
 <button type="button" class="dd-share-view-btn" id="dd-share-view-btn" aria-label="Show raw markdown source" title="Show raw markdown source">${FILE_CODE_ICON}</button>
+<button type="button" class="dd-share-view-btn" id="dd-share-download-btn" aria-label="Download raw markdown" title="Download raw markdown">${DOWNLOAD_ICON}</button>
 </div>
 <main>
 <article>${rendered.html}</article>

--- a/src/dev-dashboard/lib/qa-types.ts
+++ b/src/dev-dashboard/lib/qa-types.ts
@@ -6,7 +6,7 @@ export interface EnrichedQaEntry {
     questionHtml: string;
 }
 
-export interface QaRow extends QaEntry, EnrichedQaEntry {
+export interface QaRow extends QaEntry, Partial<EnrichedQaEntry> {
     supersededBy: string | null;
     readAt: number | null;
 }

--- a/src/dev-dashboard/server/routes/qa.ts
+++ b/src/dev-dashboard/server/routes/qa.ts
@@ -35,7 +35,7 @@ export function qaRoutes(): RouteDef[] {
                         limit: Number.parseInt(ctx.query.get("limit") ?? "100", 10),
                     });
 
-                    return { kind: "json", status: 200, body: { entries: rows.map((row) => enrichQaEntry(row)) } };
+                    return { kind: "json", status: 200, body: { entries: rows } };
                 } catch (err) {
                     return errorResult(err);
                 } finally {

--- a/src/dev-dashboard/ui/src/routes/qa.tsx
+++ b/src/dev-dashboard/ui/src/routes/qa.tsx
@@ -1,4 +1,5 @@
-import { isQaAnswerTruncated } from "@app/dev-dashboard/lib/qa-preview";
+import { isQaAnswerTruncated, QA_ANSWER_PREVIEW_LINES } from "@app/dev-dashboard/lib/qa-preview";
+import { renderQaAnswerHtml, renderQaQuestionHtml } from "@app/dev-dashboard/lib/qa-render";
 import { searchQa } from "@app/dev-dashboard/lib/qa-search";
 import type { QaRow } from "@app/dev-dashboard/lib/qa-types";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -36,7 +37,7 @@ async function fetchQaLog(): Promise<QaRow[]> {
 
     const body = SafeJSON.parse(await res.text(), { strict: true }) as { entries: QaRow[] };
 
-    return body.entries;
+    return body.entries.reverse();
 }
 
 function tagClass(tag: string): string {
@@ -179,21 +180,43 @@ const QaCard = memo(function QaCard({
     }, [unread, pinned]);
     const [saveDialogOpen, setSaveDialogOpen] = useState(false);
     const truncated = isQaAnswerTruncated(entry.answerMd);
-    const answerBase = open || !truncated ? entry.answerHtml : entry.answerHtmlPreview;
+
+    const renderedAnswerHtml = useMemo(
+        () => entry.answerHtml ?? renderQaAnswerHtml(entry.answerMd),
+        [entry.answerHtml, entry.answerMd]
+    );
+
+    const renderedAnswerPreview = useMemo(() => {
+        if (!truncated) {
+            return renderedAnswerHtml;
+        }
+
+        if (entry.answerHtmlPreview) {
+            return entry.answerHtmlPreview;
+        }
+
+        const previewMd = `${entry.answerMd.split("\n").slice(0, QA_ANSWER_PREVIEW_LINES).join("\n")}\n…`;
+        return renderQaAnswerHtml(previewMd);
+    }, [entry.answerHtmlPreview, entry.answerMd, renderedAnswerHtml, truncated]);
+
+    const renderedQuestionHtml = useMemo(
+        () => entry.questionHtml ?? renderQaQuestionHtml(entry.question),
+        [entry.questionHtml, entry.question]
+    );
+
+    const answerBase = open || !truncated ? renderedAnswerHtml : renderedAnswerPreview;
 
     const questionHtml = useMemo(() => {
         if (viewMode === "source") {
             return "";
         }
 
-        const html = entry.questionHtml;
-
         if (highlightTokens.length === 0) {
-            return html;
+            return renderedQuestionHtml;
         }
 
-        return highlightMatchesInHtml(html, highlightTokens);
-    }, [entry.questionHtml, highlightTokens, viewMode]);
+        return highlightMatchesInHtml(renderedQuestionHtml, highlightTokens);
+    }, [renderedQuestionHtml, highlightTokens, viewMode]);
 
     const answerHtml = useMemo(() => {
         if (viewMode === "source") {

--- a/src/utils/claude/subscription-auth.test.ts
+++ b/src/utils/claude/subscription-auth.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { readJournalRecovery } from "./subscription-auth";
+
+const HOME = join(tmpdir(), `sub-auth-test-${process.pid}`);
+const JOURNAL = join(HOME, ".genesis-tools", "ai", "token-journal.jsonl");
+
+function writeJournal(lines: object[]): void {
+    writeFileSync(JOURNAL, `${lines.map((l) => SafeJSON.stringify(l)).join("\n")}\n`);
+}
+
+describe("readJournalRecovery", () => {
+    beforeEach(() => {
+        mkdirSync(join(HOME, ".genesis-tools", "ai"), { recursive: true });
+        env.testing.set("GENESIS_TOOLS_HOME", HOME);
+    });
+
+    afterEach(() => {
+        env.testing.unset("GENESIS_TOOLS_HOME");
+        rmSync(HOME, { recursive: true, force: true });
+    });
+
+    it("returns the newest journaled pair when it differs from the consumed token", () => {
+        writeJournal([
+            { ts: "t1", account: "acc", newAccessToken: "at-old", newRefreshToken: "rt-old", newExpiresAt: 1 },
+            { ts: "t2", account: "other", newAccessToken: "x", newRefreshToken: "y", newExpiresAt: 2 },
+            { ts: "t3", account: "acc", newAccessToken: "at-new", newRefreshToken: "rt-new", newExpiresAt: 3 },
+        ]);
+
+        expect(readJournalRecovery("acc", "rt-consumed")).toEqual({
+            accessToken: "at-new",
+            refreshToken: "rt-new",
+            expiresAt: 3,
+        });
+    });
+
+    it("returns null when the newest journaled token IS the consumed one (grant genuinely dead)", () => {
+        writeJournal([{ ts: "t1", account: "acc", newAccessToken: "at", newRefreshToken: "rt-consumed" }]);
+
+        expect(readJournalRecovery("acc", "rt-consumed")).toBeNull();
+    });
+
+    it("returns null when the account has no journal entries", () => {
+        writeJournal([{ ts: "t1", account: "other", newRefreshToken: "rt" }]);
+
+        expect(readJournalRecovery("acc", "rt-consumed")).toBeNull();
+    });
+
+    it("returns null when the journal file does not exist", () => {
+        rmSync(JOURNAL, { force: true });
+
+        expect(readJournalRecovery("acc", "rt-consumed")).toBeNull();
+    });
+
+    it("skips malformed lines and still finds the newest valid entry", () => {
+        writeFileSync(
+            JOURNAL,
+            [
+                SafeJSON.stringify({
+                    ts: "t1",
+                    account: "acc",
+                    newAccessToken: "at",
+                    newRefreshToken: "rt-good",
+                    newExpiresAt: 9,
+                }),
+                "{not json",
+            ].join("\n")
+        );
+
+        expect(readJournalRecovery("acc", "rt-consumed")).toEqual({
+            accessToken: "at",
+            refreshToken: "rt-good",
+            expiresAt: 9,
+        });
+    });
+});

--- a/src/utils/claude/subscription-auth.ts
+++ b/src/utils/claude/subscription-auth.ts
@@ -1,9 +1,9 @@
-import { appendFileSync, chmodSync } from "node:fs";
+import { appendFileSync, chmodSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { retry } from "@genesiscz/utils/async";
 import { env } from "@genesiscz/utils/env";
-import { SafeJSON } from "@genesiscz/utils/json";
+import { parseJSON, SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import type { OAuthTokens } from "./auth";
 import { claudeOAuth } from "./auth";
@@ -76,8 +76,7 @@ const invalidGrantAt = new Map<string, number>();
  */
 function journalTokenRotation(account: string, oldTokens: Partial<OAuthTokens>, newTokens: OAuthTokens): void {
     try {
-        const dir = join(env.tools.getHome() || homedir(), ".genesis-tools", "ai");
-        const path = join(dir, "token-journal.jsonl");
+        const path = journalPath();
         appendFileSync(
             path,
             `${SafeJSON.stringify({
@@ -96,6 +95,59 @@ function journalTokenRotation(account: string, oldTokens: Partial<OAuthTokens>, 
     } catch (err) {
         logger.warn({ err, account }, "[token-refresh] journal append failed");
     }
+}
+
+function journalPath(): string {
+    return join(env.tools.getHome() || homedir(), ".genesis-tools", "ai", "token-journal.jsonl");
+}
+
+/**
+ * When a refresh dies with invalid_grant, the config's refresh token may be a
+ * stale, already-consumed one that a concurrent writer reverted (this bricked
+ * an account for 3 days on 2026-07-24 — the journal held the live pair the
+ * whole time). Returns the newest journaled pair for the account IF its
+ * refresh token differs from the one that just failed; one recovery attempt
+ * with it is safe because a journaled-but-unpersisted token was never sent to
+ * the server again.
+ */
+export function readJournalRecovery(
+    account: string,
+    consumedRefreshToken: string
+): { accessToken: string; refreshToken: string; expiresAt: number } | null {
+    let raw: string;
+    try {
+        raw = readFileSync(journalPath(), "utf8");
+    } catch (err) {
+        logger.debug({ err, account }, "[token-refresh] journal unreadable, no recovery candidate");
+        return null;
+    }
+
+    const lines = raw.trim().split("\n");
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const entry = parseJSON<{
+            account?: string;
+            newAccessToken?: string;
+            newRefreshToken?: string;
+            newExpiresAt?: number;
+        }>(lines[i]);
+
+        if (!entry || entry.account !== account) {
+            continue;
+        }
+
+        if (!entry.newRefreshToken || entry.newRefreshToken === consumedRefreshToken) {
+            return null;
+        }
+
+        return {
+            accessToken: entry.newAccessToken ?? "",
+            refreshToken: entry.newRefreshToken,
+            expiresAt: entry.newExpiresAt ?? 0,
+        };
+    }
+
+    return null;
 }
 
 /**
@@ -214,14 +266,36 @@ export async function resolveAccountToken(accountName?: string, options?: Resolv
             });
         } catch (err) {
             if (String(err).includes("invalid_grant")) {
-                invalidGrantAt.set(name, Date.now());
-                throw new Error(`Token expired (invalid_grant). Run: tools claude login ${name}`);
-            }
+                // The consumed token may be a stale revert of a journaled rotation —
+                // try the journal's newest pair once before declaring the grant dead.
+                const recovery = readJournalRecovery(name, diskAccount.tokens.refreshToken);
 
-            throw new Error(
-                `Failed to refresh token for "${name}": ${err instanceof Error ? err.message : err}. ` +
-                    `Run \`tools claude login ${name}\` if this persists.`
-            );
+                if (recovery) {
+                    logger.warn(
+                        `[token-refresh] ${name}: invalid_grant on stored token, ` +
+                            `attempting recovery with newer journaled refresh token`
+                    );
+                    try {
+                        newTokens = await claudeOAuth.refresh(recovery.refreshToken);
+                        logger.info(`[token-refresh] ${name}: journal recovery succeeded`);
+                    } catch (recoveryErr) {
+                        invalidGrantAt.set(name, Date.now());
+                        logger.warn(
+                            `[token-refresh] ${name}: journal recovery failed: ` +
+                                `${recoveryErr instanceof Error ? recoveryErr.message : recoveryErr}`
+                        );
+                        throw new Error(`Token expired (invalid_grant). Run: tools claude login ${name}`);
+                    }
+                } else {
+                    invalidGrantAt.set(name, Date.now());
+                    throw new Error(`Token expired (invalid_grant). Run: tools claude login ${name}`);
+                }
+            } else {
+                throw new Error(
+                    `Failed to refresh token for "${name}": ${err instanceof Error ? err.message : err}. ` +
+                        `Run \`tools claude login ${name}\` if this persists.`
+                );
+            }
         }
 
         journalTokenRotation(name, diskAccount.tokens, newTokens);

--- a/src/youtube/commands/__tests__/download.test.ts
+++ b/src/youtube/commands/__tests__/download.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { EnqueuePipelineResult } from "@app/youtube/lib/pipeline.types";
 import type { JobStage, PipelineJob } from "@app/youtube/lib/types";
 import { Command } from "commander";
 
@@ -18,7 +19,11 @@ mock.module("@app/youtube/commands/_shared/ensure-pipeline", () => ({
             },
         },
         pipeline: {
-            enqueue: (input: unknown) => {
+            // Typed as the real return so this mock can't silently drift from
+            // `Pipeline.enqueue` again — it used to hand back a bare job, while
+            // production destructures `{ job }`, so every command test threw
+            // "enqueue returned no job".
+            enqueue: (input: unknown): EnqueuePipelineResult => {
                 calls.enqueue.push(input);
                 const job: PipelineJob = {
                     id: jobs.length + 1,
@@ -43,7 +48,7 @@ mock.module("@app/youtube/commands/_shared/ensure-pipeline", () => ({
                 };
                 jobs.push(job);
 
-                return job;
+                return { job, reused: false, queuePosition: 1 };
             },
             start: async () => {
                 calls.start++;

--- a/src/youtube/commands/__tests__/pipeline.test.ts
+++ b/src/youtube/commands/__tests__/pipeline.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { EnqueuePipelineResult } from "@app/youtube/lib/pipeline.types";
 import type { JobStage, PipelineJob } from "@app/youtube/lib/types";
 import { Command } from "commander";
 
@@ -13,7 +14,11 @@ const calls = {
 mock.module("@app/youtube/commands/_shared/ensure-pipeline", () => ({
     getYoutube: async () => ({
         pipeline: {
-            enqueue: (input: unknown) => {
+            // Typed as the real return so this mock can't silently drift from
+            // `Pipeline.enqueue` again — it used to hand back a bare job, while
+            // production destructures `{ job }`, so every command test threw
+            // "enqueue returned no job".
+            enqueue: (input: unknown): EnqueuePipelineResult => {
                 calls.enqueue.push(input);
                 const job: PipelineJob = {
                     id: jobs.length + 1,
@@ -38,7 +43,7 @@ mock.module("@app/youtube/commands/_shared/ensure-pipeline", () => ({
                 };
                 jobs.push(job);
 
-                return job;
+                return { job, reused: false, queuePosition: jobs.length };
             },
             setGlobalConcurrencyOverride: (value: number | null) => {
                 calls.concurrency.push(value);

--- a/src/youtube/extension/__tests__/placement.test.ts
+++ b/src/youtube/extension/__tests__/placement.test.ts
@@ -4,6 +4,7 @@ import {
     isInFlowPosition,
     isUsableLiveChatStyle,
     rectsOverlapSubstantially,
+    shouldRecoverInline,
 } from "@ext/placement";
 
 describe("isUsableLiveChatStyle", () => {
@@ -38,6 +39,31 @@ describe("rectsOverlapSubstantially / full-bleed", () => {
         expect(rectsOverlapSubstantially(rail, player)).toBe(false);
         expect(isFullBleedOverPlayer(over, player)).toBe(true);
         expect(isFullBleedOverPlayer(rail, player)).toBe(false);
+    });
+});
+
+describe("shouldRecoverInline", () => {
+    const base = { placement: "fixed", slotAvailable: true, attempts: 0, maxAttempts: 3 } as const;
+
+    it("re-attempts inline once the rail becomes usable again", () => {
+        // The bug this pins: the fixed fallback had no watcher, so a panel that
+        // retreated during a theater toggle floated over the rail until the
+        // next navigation even after the rail was healthy.
+        expect(shouldRecoverInline(base)).toBe(true);
+    });
+
+    it("leaves a healthy inline panel alone", () => {
+        expect(shouldRecoverInline({ ...base, placement: "inline" })).toBe(false);
+    });
+
+    it("waits while the rail is still unusable", () => {
+        expect(shouldRecoverInline({ ...base, slotAvailable: false })).toBe(false);
+    });
+
+    it("stops once the attempt budget is spent, so a failing slot cannot remount forever", () => {
+        expect(shouldRecoverInline({ ...base, attempts: 2 })).toBe(true);
+        expect(shouldRecoverInline({ ...base, attempts: 3 })).toBe(false);
+        expect(shouldRecoverInline({ ...base, attempts: 9 })).toBe(false);
     });
 });
 

--- a/src/youtube/extension/__tests__/placement.test.ts
+++ b/src/youtube/extension/__tests__/placement.test.ts
@@ -3,6 +3,7 @@ import {
     isFullBleedOverPlayer,
     isInFlowPosition,
     isUsableLiveChatStyle,
+    isUsableRailStyle,
     rectsOverlapSubstantially,
     shouldRecoverInline,
 } from "@ext/placement";
@@ -39,6 +40,26 @@ describe("rectsOverlapSubstantially / full-bleed", () => {
         expect(rectsOverlapSubstantially(rail, player)).toBe(false);
         expect(isFullBleedOverPlayer(over, player)).toBe(true);
         expect(isFullBleedOverPlayer(rail, player)).toBe(false);
+    });
+});
+
+describe("isUsableRailStyle", () => {
+    const visible = { display: "block", visibility: "visible" };
+
+    it("accepts a normal painted rail", () => {
+        expect(isUsableRailStyle(visible, rect(1376, 68, 528, 900))).toBe(true);
+    });
+
+    it("rejects the rail YouTube hides on narrow layouts", () => {
+        // Below ~1000px #secondary becomes display:none. The panel is its
+        // child, so it inherited the hidden box and vanished at 0×0 rather
+        // than falling back to the fixed host.
+        expect(isUsableRailStyle({ display: "none", visibility: "visible" }, rect(0, 0, 0, 0))).toBe(false);
+        expect(isUsableRailStyle({ display: "block", visibility: "hidden" }, rect(1376, 68, 528, 900))).toBe(false);
+    });
+
+    it("rejects a hairline rail too narrow to hold the panel", () => {
+        expect(isUsableRailStyle(visible, rect(1376, 68, 40, 900))).toBe(false);
     });
 });
 

--- a/src/youtube/extension/__tests__/playlist-members.test.ts
+++ b/src/youtube/extension/__tests__/playlist-members.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { playlistVideoIdsFromHrefs, sameIds } from "@ext/playlist-members";
+
+const LIST = "PLjRFDDC_0VxgKQcBmF-DRwkGItt8xl_2F";
+
+describe("playlistVideoIdsFromHrefs", () => {
+    it("reads members from modern lockup hrefs", () => {
+        // The regression: detection queried ytd-playlist-video-renderer, but
+        // YouTube now renders playlist rows as yt-lockup-view-model, so the
+        // panel reported "0 videos detected" no matter how far you scrolled.
+        const hrefs = [
+            `/watch?v=tKzj-NaJoIc&list=${LIST}&index=1&pp=iAQB`,
+            `/watch?v=uFWrYzUX_wc&list=${LIST}&index=2&pp=iAQB`,
+            `/watch?v=EY8XjnATOU8&list=${LIST}&index=3&pp=iAQB`,
+        ];
+
+        expect(playlistVideoIdsFromHrefs(hrefs, LIST, 20)).toEqual(["tKzj-NaJoIc", "uFWrYzUX_wc", "EY8XjnATOU8"]);
+    });
+
+    it("ignores links belonging to a different playlist", () => {
+        const hrefs = [`/watch?v=keep0000001&list=${LIST}&index=1`, "/watch?v=drop0000001&list=PLotherlist&index=1"];
+
+        expect(playlistVideoIdsFromHrefs(hrefs, LIST, 20)).toEqual(["keep0000001"]);
+    });
+
+    it("skips the play-all link, which carries a list but no video", () => {
+        const hrefs = [`/playlist?list=${LIST}`, `/watch?v=vid00000001&list=${LIST}`];
+
+        expect(playlistVideoIdsFromHrefs(hrefs, LIST, 20)).toEqual(["vid00000001"]);
+    });
+
+    it("dedupes the thumbnail and title anchors of one row", () => {
+        const hrefs = [`/watch?v=vid00000001&list=${LIST}&index=1`, `/watch?v=vid00000001&list=${LIST}&index=1`];
+
+        expect(playlistVideoIdsFromHrefs(hrefs, LIST, 20)).toEqual(["vid00000001"]);
+    });
+
+    it("stops at the report cap", () => {
+        const hrefs = Array.from({ length: 40 }, (_, i) => `/watch?v=vid${String(i).padStart(8, "0")}&list=${LIST}`);
+
+        expect(playlistVideoIdsFromHrefs(hrefs, LIST, 20)).toHaveLength(20);
+    });
+
+    it("survives a malformed href instead of throwing", () => {
+        const hrefs = ["::::not a url", `/watch?v=vid00000001&list=${LIST}`];
+
+        expect(playlistVideoIdsFromHrefs(hrefs, LIST, 20)).toEqual(["vid00000001"]);
+    });
+});
+
+describe("sameIds", () => {
+    it("keeps the previous array identity when nothing changed", () => {
+        expect(sameIds(["a", "b"], ["a", "b"])).toBe(true);
+    });
+
+    it("detects appended and reordered members", () => {
+        expect(sameIds(["a"], ["a", "b"])).toBe(false);
+        expect(sameIds(["a", "b"], ["b", "a"])).toBe(false);
+    });
+});

--- a/src/youtube/extension/content-script.ts
+++ b/src/youtube/extension/content-script.ts
@@ -3,6 +3,7 @@ import {
     isFullBleedOverPlayer,
     isInFlowPosition,
     isUsableLiveChatStyle,
+    isUsableRailStyle,
     rectsOverlapSubstantially,
     shouldRecoverInline,
 } from "@ext/placement";
@@ -89,8 +90,10 @@ function isInFlowRail(el: HTMLElement): boolean {
     // width), so inserting our panel as its child paints it over the video.
     // Only flow inline when #secondary is a normal in-flow rail; otherwise the
     // caller uses the fixed host fallback, which pins us to the right clear of
-    // the player.
-    return isInFlowPosition(getComputedStyle(el).position);
+    // the player. It must also be painted — below ~1000px YouTube hides the
+    // rail outright, which used to take the panel down with it.
+    const style = getComputedStyle(el);
+    return isInFlowPosition(style.position) && isUsableRailStyle(style, el.getBoundingClientRect());
 }
 
 function findLiveChatFrame(): HTMLElement | null {
@@ -409,6 +412,12 @@ function scheduleMount(): void {
         window.clearTimeout(mountRetryTimer);
         mountRetryTimer = null;
     }
+
+    // Fresh recovery budget per navigation. Without this the counter only ever
+    // reset on a successful inline mount, so a few pages that legitimately fell
+    // back (narrow window, hidden rail) permanently exhausted it — every later
+    // video then stayed on the fixed overlay even with a perfectly good rail.
+    inlineRecoveryAttempts = 0;
 
     let attempts = 0;
     const tryMount = (): void => {

--- a/src/youtube/extension/content-script.ts
+++ b/src/youtube/extension/content-script.ts
@@ -193,7 +193,7 @@ function applyInlineStyles(host: HTMLElement): void {
         // non-flex rail parent.
         "flex: 0 0 auto",
         "height: auto",
-        "min-height: 120px",
+        // min-height lives in side-panel.css (:host) so collapsing can drop it.
         // Cap well below the viewport so recommendations stay visible; the
         // panel body scrolls inside. `overflow: hidden` so content can never
         // paint past the cap over the rail below.
@@ -215,7 +215,7 @@ function applyFixedStyles(host: HTMLElement): void {
         "top: 72px",
         "width: 400px",
         "height: auto",
-        "min-height: 120px",
+        // min-height lives in side-panel.css (:host) so collapsing can drop it.
         "max-height: min(calc(100vh - 96px), 900px)",
         "z-index: 2147483647",
         "pointer-events: auto",

--- a/src/youtube/extension/content-script.ts
+++ b/src/youtube/extension/content-script.ts
@@ -4,6 +4,7 @@ import {
     isInFlowPosition,
     isUsableLiveChatStyle,
     rectsOverlapSubstantially,
+    shouldRecoverInline,
 } from "@ext/placement";
 import { type ChapterTicksHandle, mountChapterTicks } from "@ext/player-chapters";
 import type { PlayerChaptersMessage, PlayerTimeMessage } from "@ext/shared/messages";
@@ -257,6 +258,9 @@ function attachHost(target: PanelTarget): { host: HTMLElement; placement: Placem
 let layoutWatchTimer: number | null = null;
 let layoutResizeObserver: ResizeObserver | null = null;
 let layoutMutationObserver: MutationObserver | null = null;
+/** Bounds fixed→inline recovery so a slot that keeps failing can't remount forever. */
+const MAX_INLINE_RECOVERY_ATTEMPTS = 3;
+let inlineRecoveryAttempts = 0;
 
 function stopLayoutWatch(): void {
     if (layoutWatchTimer !== null) {
@@ -288,10 +292,25 @@ function inlinePlacementStillValid(host: HTMLElement): boolean {
     return true;
 }
 
+/** Mirrors attachHost's inline conditions, but measures only — never inserts. */
+function inlineSlotAvailable(): boolean {
+    if (location.pathname !== "/watch") {
+        return false;
+    }
+
+    const chat = findLiveChatFrame();
+    if (chat?.parentElement && isUsableLiveChat(chat)) {
+        return true;
+    }
+
+    const secondary = findWatchSecondaryColumn();
+    return secondary !== null && isInFlowRail(secondary) && !secondaryOverlapsPlayer(secondary);
+}
+
 function startLayoutWatch(host: HTMLElement, placement: Placement): void {
     stopLayoutWatch();
 
-    if (placement !== "inline" || location.pathname !== "/watch") {
+    if (location.pathname !== "/watch") {
         return;
     }
 
@@ -308,7 +327,27 @@ function startLayoutWatch(host: HTMLElement, placement: Placement): void {
                 return;
             }
 
-            if (!inlinePlacementStillValid(liveHost)) {
+            if (placement === "inline") {
+                if (!inlinePlacementStillValid(liveHost)) {
+                    ensureSidePanel();
+                }
+
+                return;
+            }
+
+            // The fixed fallback used to be terminal: whatever made the rail
+            // unusable (theater mode, a mid-navigation reflow, a resize) kept
+            // the panel floating over the rail until the next navigation, even
+            // once the rail was healthy again. Watch that direction too.
+            const recover = shouldRecoverInline({
+                placement,
+                slotAvailable: inlineSlotAvailable(),
+                attempts: inlineRecoveryAttempts,
+                maxAttempts: MAX_INLINE_RECOVERY_ATTEMPTS,
+            });
+
+            if (recover) {
+                inlineRecoveryAttempts += 1;
                 ensureSidePanel();
             }
         }, 200);
@@ -334,6 +373,13 @@ function ensureSidePanel(): void {
     }
 
     const { host, placement } = attachHost(target);
+
+    // Landing inline is the goal state — give any later fallback a fresh
+    // recovery budget instead of spending the page's one allowance forever.
+    if (placement === "inline") {
+        inlineRecoveryAttempts = 0;
+    }
+
     const shadow = host.shadowRoot ?? host.attachShadow({ mode: "open" });
     mountSidePanel(shadow, target, placement);
     startLayoutWatch(host, placement);

--- a/src/youtube/extension/placement.ts
+++ b/src/youtube/extension/placement.ts
@@ -33,6 +33,32 @@ export function rectsOverlapSubstantially(a: RectLike, b: RectLike, minPx = 40):
     return horizontal > minPx && vertical > minPx;
 }
 
+/**
+ * Whether a panel currently on the fixed fallback should re-attempt inline.
+ *
+ * The fallback used to be terminal — nothing re-measured once we retreated, so
+ * a transient bad layout (theater mode, a mid-navigation reflow) left the panel
+ * floating over the rail until the next navigation. `attempts` bounds the
+ * retry so a slot that keeps failing can't remount the panel forever.
+ */
+export function shouldRecoverInline({
+    placement,
+    slotAvailable,
+    attempts,
+    maxAttempts,
+}: {
+    placement: "inline" | "fixed";
+    slotAvailable: boolean;
+    attempts: number;
+    maxAttempts: number;
+}): boolean {
+    if (placement !== "fixed") {
+        return false;
+    }
+
+    return slotAvailable && attempts < maxAttempts;
+}
+
 /** Full-bleed strip: host spans ~player width with nearly aligned left edges. */
 export function isFullBleedOverPlayer(host: RectLike, player: RectLike): boolean {
     if (host.width === 0 || player.width === 0) {

--- a/src/youtube/extension/placement.ts
+++ b/src/youtube/extension/placement.ts
@@ -22,6 +22,23 @@ export function isInFlowPosition(position: string): boolean {
     return position === "static" || position === "relative";
 }
 
+/**
+ * A rail is only usable if it is actually painted.
+ *
+ * On narrow layouts YouTube sets `#secondary` to `display: none` and stacks the
+ * rail's content elsewhere. Our host is a child of that rail, so it inherited
+ * the hidden box and the panel silently disappeared at 0×0 — visible in neither
+ * placement, with nothing to signal it had gone. Treat a hidden or hairline
+ * rail as unusable so the caller falls back to the fixed host.
+ */
+export function isUsableRailStyle(style: { display: string; visibility: string }, rect: RectLike): boolean {
+    if (style.display === "none" || style.visibility === "hidden") {
+        return false;
+    }
+
+    return rect.width >= 120;
+}
+
 /** True when `a` substantially overlaps `b` (same idea as coversPlayer). */
 export function rectsOverlapSubstantially(a: RectLike, b: RectLike, minPx = 40): boolean {
     if (a.width === 0 || b.width === 0) {

--- a/src/youtube/extension/playlist-members.ts
+++ b/src/youtube/extension/playlist-members.ts
@@ -1,0 +1,49 @@
+/** Pure playlist-membership helpers (testable without a YouTube page). */
+
+/**
+ * Pick the member video ids out of a playlist page's anchor hrefs.
+ *
+ * Matching on the URL rather than on a renderer tag is deliberate: detection
+ * used to query `ytd-playlist-video-renderer`, and when YouTube re-rendered
+ * playlists as `yt-lockup-view-model` the panel silently reported "0 videos
+ * detected" forever. Member links always carry `?v=…&list=<id>`, which survives
+ * those custom-element renames.
+ *
+ * Anchors for a *different* list (sidebar shelves, "next playlist" links) are
+ * skipped, so a stray recommendation can't inflate the report.
+ */
+export function playlistVideoIdsFromHrefs(hrefs: Iterable<string>, listId: string, max: number): string[] {
+    const ids: string[] = [];
+
+    for (const href of hrefs) {
+        let url: URL;
+
+        try {
+            url = new URL(href, "https://www.youtube.com");
+        } catch {
+            continue;
+        }
+
+        if (url.searchParams.get("list") !== listId) {
+            continue;
+        }
+
+        const id = url.searchParams.get("v");
+
+        if (!id || ids.includes(id)) {
+            continue;
+        }
+
+        ids.push(id);
+
+        if (ids.length >= max) {
+            break;
+        }
+    }
+
+    return ids;
+}
+
+export function sameIds(a: readonly string[], b: readonly string[]): boolean {
+    return a.length === b.length && a.every((id, i) => id === b[i]);
+}

--- a/src/youtube/extension/popup/popup.css
+++ b/src/youtube/extension/popup/popup.css
@@ -1,4 +1,6 @@
 @import 'tailwindcss';
+/* Same enter/exit utilities the panel needs — see side-panel.css. */
+@import 'tw-animate-css';
 @source '..';
 @source '../../../utils/ui/components';
 /* Shared youtube panel components live outside the extension dir; unscanned,

--- a/src/youtube/extension/popup/popup.css
+++ b/src/youtube/extension/popup/popup.css
@@ -1,6 +1,9 @@
 @import 'tailwindcss';
 @source '..';
 @source '../../../utils/ui/components';
+/* Shared youtube panel components live outside the extension dir; unscanned,
+   their unique class strings never reach the bundle. Same gap as side-panel.css. */
+@source '../../ui/components';
 
 :root,
 .cyberpunk {

--- a/src/youtube/extension/side-panel/playlist-panel.tsx
+++ b/src/youtube/extension/side-panel/playlist-panel.tsx
@@ -7,29 +7,52 @@ import { Header } from "@ext/side-panel/header";
 import { Button } from "@genesiscz/utils/ui/components/button";
 import { Markdown } from "@genesiscz/utils/ui/components/markdown";
 import { ChevronLeft, FileText, ListVideo, Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { playlistVideoIdsFromHrefs, sameIds } from "@ext/playlist-members";
+import { useEffect, useState } from "react";
 
 const MAX_REPORT_MEMBERS = 20;
 
 /** Scrape the playlist page's member video ids (content-script context — the
  *  shadow-DOM panel shares the page's document). Capped at the report limit. */
-function collectPlaylistVideoIds(): string[] {
-    const anchors = document.querySelectorAll<HTMLAnchorElement>(
-        'ytd-playlist-video-renderer a[href*="watch?v="], ytd-playlist-panel-video-renderer a[href*="watch?v="]'
+function collectPlaylistVideoIds(listId: string): string[] {
+    const anchors = document.querySelectorAll<HTMLAnchorElement>('a[href*="list="]');
+    return playlistVideoIdsFromHrefs(
+        Array.from(anchors, (a) => a.getAttribute("href") ?? ""),
+        listId,
+        MAX_REPORT_MEMBERS
     );
-    const ids: string[] = [];
+}
 
-    for (const anchor of anchors) {
-        const id = new URL(anchor.href, location.origin).searchParams.get("v");
+/**
+ * Playlist rows stream in after first paint and as the user scrolls, so the
+ * original one-shot `useMemo(…, [])` almost always measured an empty list —
+ * hence the old "reopen the panel" instruction. Re-scrape as the page fills in.
+ */
+function usePlaylistVideoIds(listId: string): string[] {
+    const [ids, setIds] = useState<string[]>(() => collectPlaylistVideoIds(listId));
 
-        if (id && !ids.includes(id)) {
-            ids.push(id);
-        }
+    useEffect(() => {
+        let timer = 0;
 
-        if (ids.length >= MAX_REPORT_MEMBERS) {
-            break;
-        }
-    }
+        const rescan = (): void => {
+            window.clearTimeout(timer);
+            timer = window.setTimeout(() => {
+                const next = collectPlaylistVideoIds(listId);
+                // Only swap identity when the set really changed, otherwise
+                // YouTube's constant DOM churn would re-render every 250ms.
+                setIds((prev) => (sameIds(prev, next) ? prev : next));
+            }, 250);
+        };
+
+        const observer = new MutationObserver(rescan);
+        observer.observe(document.body, { childList: true, subtree: true });
+        rescan();
+
+        return () => {
+            window.clearTimeout(timer);
+            observer.disconnect();
+        };
+    }, [listId]);
 
     return ids;
 }
@@ -38,7 +61,7 @@ export function PlaylistPanel({ listId }: { listId: string }) {
     const [collapsed, setCollapsed] = useState(false);
     const [confirmOpen, setConfirmOpen] = useState(false);
     const [reportId, setReportId] = useState<number | null>(null);
-    const memberIds = useMemo(() => collectPlaylistVideoIds(), []);
+    const memberIds = usePlaylistVideoIds(listId);
     const estimate = useReportEstimate(memberIds, confirmOpen);
     const create = useCreateReport();
     const report = useReport(reportId);
@@ -103,8 +126,8 @@ export function PlaylistPanel({ listId }: { listId: string }) {
                                 <div className="flex items-start gap-3 rounded-2xl border border-dashed border-primary/25 p-5">
                                     <ListVideo className="mt-0.5 size-5 shrink-0 text-primary" />
                                     <p className="text-sm text-muted-foreground">
-                                        Reports need at least 2 videos. Scroll the playlist so its entries render, then
-                                        reopen the panel.
+                                        Reports need at least 2 videos. Scroll the playlist so more entries load — the
+                                        count updates as they appear.
                                     </p>
                                 </div>
                             ) : (

--- a/src/youtube/extension/side-panel/playlist-panel.tsx
+++ b/src/youtube/extension/side-panel/playlist-panel.tsx
@@ -2,12 +2,12 @@ import type { VideoReport } from "@app/youtube/lib/types";
 import { LlmConfirmDialog } from "@app/youtube/ui/components/shared/llm-confirm-dialog";
 import { errorCodeOf } from "@app/youtube/ui/components/shared/login-required";
 import { useCreateReport, useReport, useReportEstimate } from "@ext/api.hooks";
+import { playlistVideoIdsFromHrefs, sameIds } from "@ext/playlist-members";
 import type { ReportMemberMeta } from "@ext/shared/messages";
 import { Header } from "@ext/side-panel/header";
 import { Button } from "@genesiscz/utils/ui/components/button";
 import { Markdown } from "@genesiscz/utils/ui/components/markdown";
 import { ChevronLeft, FileText, ListVideo, Loader2 } from "lucide-react";
-import { playlistVideoIdsFromHrefs, sameIds } from "@ext/playlist-members";
 import { useEffect, useState } from "react";
 
 const MAX_REPORT_MEMBERS = 20;

--- a/src/youtube/extension/side-panel/side-panel.css
+++ b/src/youtube/extension/side-panel/side-panel.css
@@ -226,9 +226,24 @@
 }
 
 .yt-body-collapsible[data-collapsed="true"] {
+    /* The body is a `flex-1` item, so flex-grow reclaimed exactly the space
+       `height: 0` freed and the panel never shrank — it just went blank at
+       full height. Stop it growing and the card collapses to its header. */
+    flex: 0 0 auto;
     height: 0;
     opacity: 0;
     pointer-events: none;
+}
+
+/* Floor lives here, not in the content script's inline style, so the collapsed
+   state can drop below it — an inline min-height would win over :host and hold
+   a ~120px empty box open under the header. */
+:host {
+    min-height: 120px;
+}
+
+:host([data-collapsed="true"]) {
+    min-height: 0;
 }
 
 /* Themed prose for LLM markdown (Ask answers). Rendered by the shared

--- a/src/youtube/extension/side-panel/side-panel.css
+++ b/src/youtube/extension/side-panel/side-panel.css
@@ -1,6 +1,11 @@
 @import 'tailwindcss';
 @source '..';
 @source '../../../utils/ui/components';
+/* The panel renders ~29 components from youtube/ui/components (tabs, summary,
+   the LLM confirm dialog, …). Without this, every class string that appears
+   ONLY in that tree is dropped from the bundle — which is why the confirm
+   dialog rendered full-bleed: its max-w-[min(94vw,560px)] was never generated. */
+@source '../../ui/components';
 
 /* Phase 5: the user's theme choice (system→resolved to light/dark by JS) sets
    data-theme on the extension roots. Light overrides the dark token defaults +

--- a/src/youtube/extension/side-panel/side-panel.css
+++ b/src/youtube/extension/side-panel/side-panel.css
@@ -1,4 +1,9 @@
 @import 'tailwindcss';
+/* Radix-driven enter/exit utilities (animate-in, fade-out-0, zoom-out-95, the
+   data-[state=…] variants). Every other dashboard imports this; the extension
+   did not, so its dialogs and popovers snapped in and out with no transition
+   while still carrying the animation classes. */
+@import 'tw-animate-css';
 @source '..';
 @source '../../../utils/ui/components';
 /* The panel renders ~29 components from youtube/ui/components (tabs, summary,

--- a/src/youtube/extension/side-panel/side-panel.tsx
+++ b/src/youtube/extension/side-panel/side-panel.tsx
@@ -106,6 +106,7 @@ function useApplyAppearance(settings: UserSettings | undefined, anchorRef: RefOb
 function VideoPanel({ videoId, placement }: { videoId: string; placement: Placement }) {
     const [active, setActive] = useState<VideoDetailTab>("summary");
     const [collapsed, setCollapsed] = useState(false);
+    const hostRef = useRef<HTMLDivElement>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [adminOpen, setAdminOpen] = useState(false);
     const [view, setView] = useState<"tabs" | "account">("tabs");
@@ -164,6 +165,17 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
             return next;
         });
     }, [settings.data, updateSettings]);
+
+    // Mirror the collapsed flag onto the shadow host so `:host([data-collapsed])`
+    // can drop the min-height floor. Without it the body collapses but the host
+    // stays 120px tall, leaving an empty box hanging under the header.
+    useEffect(() => {
+        const host = hostRef.current?.getRootNode();
+
+        if (host instanceof ShadowRoot) {
+            host.host.setAttribute("data-collapsed", String(collapsed));
+        }
+    }, [collapsed]);
 
     // Login-gated action retry: a 401'd action registers itself here before
     // the settings dialog opens; the moment `useMe` reports a user, the dialog
@@ -470,7 +482,7 @@ function VideoPanel({ videoId, placement }: { videoId: string; placement: Placem
             : `flex h-auto max-h-[min(70vh,720px)] min-h-0 flex-col overflow-hidden rounded-xl border border-white/10 bg-card shadow-2xl shadow-black/40 ${heightAnim}`;
 
     return (
-        <div className={containerClass}>
+        <div ref={hostRef} className={containerClass}>
             <Header
                 collapsed={collapsed}
                 onToggleCollapse={toggleCollapse}

--- a/src/youtube/lib/__tests__/legacy-schema-upgrade.test.ts
+++ b/src/youtube/lib/__tests__/legacy-schema-upgrade.test.ts
@@ -1,0 +1,102 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { YoutubeDatabase } from "@app/youtube/lib/db";
+
+const dirs: string[] = [];
+
+function legacyDbPath(build: (db: Database) => void): string {
+    const dir = mkdtempSync(join(tmpdir(), "yt-legacy-schema-"));
+    dirs.push(dir);
+    const path = join(dir, "youtube.db");
+    const seed = new Database(path);
+    build(seed);
+    seed.close();
+    return path;
+}
+
+afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe("opening a database written by an older build", () => {
+    it("upgrades a jobs table that predates the fingerprint column instead of throwing", () => {
+        // The regression: initSchema indexed jobs(fingerprint) directly. On an
+        // existing DB `CREATE TABLE IF NOT EXISTS jobs` is a no-op, so the
+        // column was still missing when the index ran — SQLiteError "no such
+        // column: fingerprint" escaped the constructor and killed the API
+        // server at startup for every user with a pre-existing database.
+        const path = legacyDbPath((seed) => {
+            // The jobs table exactly as it shipped before params/fingerprint/
+            // priority/user_id were introduced — those four are the only
+            // columns any migration adds to it.
+            seed.exec(`
+                CREATE TABLE jobs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    target_kind TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    stages TEXT NOT NULL,
+                    current_stage TEXT,
+                    status TEXT NOT NULL,
+                    error TEXT,
+                    progress REAL NOT NULL DEFAULT 0,
+                    progress_message TEXT,
+                    parent_job_id INTEGER,
+                    worker_id TEXT,
+                    claimed_at TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    completed_at TEXT
+                );
+            `);
+            seed.exec(
+                "INSERT INTO jobs (target_kind, target, stages, status) VALUES ('video', 'vid00000001', '[\"metadata\"]', 'done')"
+            );
+        });
+
+        const db = new YoutubeDatabase(path);
+
+        try {
+            const raw = db.getDb();
+            const columns = raw.query<{ name: string }, []>("PRAGMA table_info(jobs)").all().map((c) => c.name);
+
+            expect(columns).toContain("fingerprint");
+            expect(columns).toContain("priority");
+            expect(columns).toContain("params");
+
+            const index = raw
+                .query<{ name: string }, []>(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_jobs_fingerprint_active'"
+                )
+                .all();
+            expect(index).toHaveLength(1);
+
+            // The upgrade must not cost the user their existing rows.
+            const rows = raw.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM jobs").get();
+            expect(rows?.n).toBe(1);
+        } finally {
+            db.close();
+        }
+    });
+
+    it("still builds the fingerprint index on a fresh database", () => {
+        const db = new YoutubeDatabase(":memory:");
+
+        try {
+            const index = db
+                .getDb()
+                .query<{ name: string }, []>(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_jobs_fingerprint_active'"
+                )
+                .all();
+
+            expect(index).toHaveLength(1);
+        } finally {
+            db.close();
+        }
+    });
+});

--- a/src/youtube/lib/__tests__/legacy-schema-upgrade.test.ts
+++ b/src/youtube/lib/__tests__/legacy-schema-upgrade.test.ts
@@ -62,7 +62,10 @@ describe("opening a database written by an older build", () => {
 
         try {
             const raw = db.getDb();
-            const columns = raw.query<{ name: string }, []>("PRAGMA table_info(jobs)").all().map((c) => c.name);
+            const columns = raw
+                .query<{ name: string }, []>("PRAGMA table_info(jobs)")
+                .all()
+                .map((c) => c.name);
 
             expect(columns).toContain("fingerprint");
             expect(columns).toContain("priority");

--- a/src/youtube/lib/db.ts
+++ b/src/youtube/lib/db.ts
@@ -216,7 +216,12 @@ export class YoutubeDatabase extends BaseDatabase {
             CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status, current_stage);
             CREATE INDEX IF NOT EXISTS idx_jobs_target ON jobs(target_kind, target);
             CREATE INDEX IF NOT EXISTS idx_jobs_parent ON jobs(parent_job_id);
-            CREATE INDEX IF NOT EXISTS idx_jobs_fingerprint_active ON jobs(fingerprint) WHERE status IN ('pending','running');
+            /* No fingerprint index here: on a DB created before that column
+               existed, CREATE TABLE IF NOT EXISTS is a no-op, so indexing
+               jobs(fingerprint) throws "no such column" and takes the whole
+               server down at startup. The add-jobs-fingerprint-priority
+               migration below adds the column first, then creates this index
+               for legacy and fresh databases alike. */
 
             CREATE TABLE IF NOT EXISTS qa_chunks (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/youtube/ui/components/shared/insights-tab.tsx
+++ b/src/youtube/ui/components/shared/insights-tab.tsx
@@ -188,8 +188,9 @@ export function InsightsTab({
 
     return (
         <div className="space-y-4">
-            <div className="flex items-center justify-between gap-3">
-                <h3 className="min-w-0 truncate text-base font-semibold">Key insights</h3>
+            {/* Same wrap-don't-truncate rule as the summary tab header. */}
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+                <h3 className="min-w-0 grow basis-40 text-base font-semibold">Key insights</h3>
                 <Button
                     size="sm"
                     className="shrink-0"

--- a/src/youtube/ui/components/shared/summary-tab.tsx
+++ b/src/youtube/ui/components/shared/summary-tab.tsx
@@ -223,8 +223,12 @@ export function SummaryTab({
 
     return (
         <div className="space-y-4">
-            <div className="flex items-center justify-between gap-3">
-                <h3 className="min-w-0 truncate text-base font-semibold">Whole-video summary</h3>
+            {/* Wraps instead of truncating: in a ~330px extension rail the
+                title and the action button can't share a line, and
+                justify-between always sacrificed the title ("Whole-video
+                sum…"). Below the basis the buttons drop to their own row. */}
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+                <h3 className="min-w-0 grow basis-40 text-base font-semibold">Whole-video summary</h3>
                 <div className="flex shrink-0 items-center gap-1">
                     {createShare && long !== null ? (
                         <ShareButton


### PR DESCRIPTION
## YouTube extension panel visuals

- `ced05889d` scan shared youtube UI for Tailwind, and recover from the fixed-panel fallback
- `911de6a25` stop indexing jobs(fingerprint) before the migration adds it (killed server startup on existing databases)
- `5728245f0` detect playlist members by URL, and keep counting as rows stream in
- `d9310066f` keep the panel visible when YouTube hides the rail, and stop headers truncating in a narrow panel
- `67f5d1211` import tw-animate-css so dialogs actually animate instead of snapping
- `08c6ad9b8` collapsing the panel now shrinks it to the header instead of leaving an empty box

## Claude usage: token resilience

- `84189fb7e` fix(claude): recover invalid_grant accounts from the token journal, and label expired-plan orgs
  - On `invalid_grant`, `resolveAccountToken` now tries the newest journaled token pair once before declaring the grant dead. This auto-heals the lost-write case where a concurrent writer reverted the config to an already-consumed single-use refresh token (which bricked an account for 3 days; the live pair sat in `token-journal.jsonl` the whole time).
  - The usage overview now distinguishes a 403 `permission_error` ("OAuth authentication is currently not allowed for this organization", i.e. the org's plan lapsed) as `plan expired` instead of the misleading `fetch failing` / `needs re-login`. Tokens for those accounts are valid and are never touched.
  - 5 new tests for the journal recovery reader (newest-pair selection, consumed-token short-circuit, missing file, malformed lines).

## Dev-dashboard share pages

- `03a82ddc2` feat(dev-dashboard): download button on share pages saves the raw markdown
  - Second toolbar button next to the source-view toggle; downloads the embedded markdown source as a `.md` file named after the vault note (falls back to the page title).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Obsidian share pages now include a button to download the displayed source as a Markdown file.
  - Playlist panels now rescan automatically as more videos load.
  - YouTube side panels can recover inline placement when the rail becomes usable again.
- **Bug Fixes**
  - Improved handling for collapsed side panels and unusable page layouts.
  - Safer recovery from interrupted sign-ins/token refresh issues, including single-use refresh token rotation cases.
  - Updated stale-reason labeling to better match “plan expired”.
  - Q&A rendering is more reliable, with corrected feed ordering and improved preview behavior.
  - Legacy YouTube database upgrades now complete without losing existing jobs.
- **Style**
  - “Key insights” and “Whole-video summary” headers now wrap instead of truncating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->