### PR TITLE
chore(mcp): migrate to @modelcontextprotocol/* 2.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,9 @@
         "@jmespath-community/jmespath": "^1.3.0",
         "@lancedb/lancedb": "^0.27.1",
         "@mdit/plugin-alert": "^0.22.4",
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "@modelcontextprotocol/server-github": "^2025.4.8",
         "@mozilla/readability": "^0.6.0",
         "@nanocollective/get-md": "1.1.0-beta.1",
@@ -167,6 +169,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-code": "^2.1.45",
         "@biomejs/biome": "^2.5.0",
+        "@modelcontextprotocol/codemod": "2.0.0",
         "@playwright/test": "1.57.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -627,8 +630,6 @@
 
     "@hlidac-shopu/lib": ["@hlidac-shopu/lib@1.5.3", "", { "dependencies": { "chart.js": "4.5.1", "chartjs-adapter-date-fns": "3.0.0", "date-fns": "4.1.0", "lit": "3.3.2" } }, "sha512-a/9TZyimXhIayiezEgeRCPR2/Sgyr3qWkE3Jjz4+6EwpjxZ7pYVwbv2vuxQ7aBLVVsp/qdUl2M3OyNhbwJ8auQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
-
     "@huggingface/inference": ["@huggingface/inference@4.13.15", "", { "dependencies": { "@huggingface/jinja": "^0.5.5", "@huggingface/tasks": "^0.19.90" } }, "sha512-V7B13KFDVhYkQqgx8vpMcmtEG+PoePlh65IUvpphTTItHAq6zRLcsS4torh1QavUaT+6nEwho4wFXzBQNGBwKQ=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.5", "", {}, "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ=="],
@@ -839,7 +840,15 @@
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/codemod": ["@modelcontextprotocol/codemod@2.0.0", "", { "dependencies": { "commander": "^13.0.0", "fast-glob": "^3.3.3", "ts-morph": "^28.0.0" }, "bin": { "mcp-codemod": "dist/cli.mjs" } }, "sha512-VZMKhuAGMhST/T8XLcVmK92b5MrKeadBiuE0xsSoE8pV6Js1xzJacTI9g412FqXHSsVKPd7eVzz9dIgVr6c8JA=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.0.1", "", { "dependencies": { "content-type": "^1.0.5", "raw-body": "^3.0.0", "zod": "^3.23.8" } }, "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@modelcontextprotocol/server-github": ["@modelcontextprotocol/server-github@2025.4.8", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.0.1", "@types/node": "^22", "@types/node-fetch": "^2.6.12", "node-fetch": "^3.3.2", "universal-user-agent": "^7.0.2", "zod": "^3.22.4", "zod-to-json-schema": "^3.23.5" }, "bin": { "mcp-server-github": "dist/index.js" } }, "sha512-8N43bQw9MlUB0piTZHK2JMh8kYPKxH57d4Z7Wb8PS4by2MkZ0FzI5xPImg3xumpev82VZw2VWHQJJJYp+WkwEw=="],
 
@@ -1579,8 +1588,6 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -1594,8 +1601,6 @@
     "ai": ["ai@7.0.22", "", { "dependencies": { "@ai-sdk/gateway": "4.0.16", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
@@ -1724,8 +1729,6 @@
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
-
-    "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
 
     "bonjour-service": ["bonjour-service@1.4.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "multicast-dns": "^7.2.5" } }, "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w=="],
 
@@ -1897,21 +1900,13 @@
 
     "console-polyfill": ["console-polyfill@0.3.0", "", {}, "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ=="],
 
-    "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
-
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
@@ -2047,15 +2042,11 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
     "electron": ["electron@23.3.13", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^16.11.26", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-BaXtHEb+KYKLouUXlUVDa/lj9pj4F5kiE0kwFdJV84Y2EU7euIDgPthfKtchhr5MVHmjtavRMIV/zAwEiSQ9rQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.277", "", {}, "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-japanese": ["encoding-japanese@2.2.0", "", {}, "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="],
 
@@ -2107,8 +2098,6 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "escodegen": ["escodegen@1.14.3", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^4.2.0", "esutils": "^2.0.2", "optionator": "^0.8.1" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw=="],
@@ -2147,8 +2136,6 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
     "event-emitter": ["event-emitter@0.3.5", "", { "dependencies": { "d": "1", "es5-ext": "~0.10.14" } }, "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA=="],
 
     "event-stream": ["event-stream@3.3.4", "", { "dependencies": { "duplexer": "~0.1.1", "from": "~0", "map-stream": "~0.1.0", "pause-stream": "0.0.11", "split": "0.3", "stream-combiner": "~0.0.4", "through": "~2.3.1" } }, "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g=="],
@@ -2163,15 +2150,11 @@
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
     "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
-
-    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
-
-    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -2229,8 +2212,6 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
-
     "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
 
     "find-replace": ["find-replace@3.0.0", "", { "dependencies": { "array-back": "^3.0.1" } }, "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ=="],
@@ -2255,11 +2236,7 @@
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
     "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "from": ["from@0.1.7", "", {}, "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="],
 
@@ -2307,7 +2284,7 @@
 
     "glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
 
-    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
@@ -2370,8 +2347,6 @@
     "hogan.js": ["hogan.js@3.0.2", "", { "dependencies": { "mkdirp": "0.3.0", "nopt": "1.0.10" }, "bin": { "hulk": "./bin/hulk" } }, "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
-
-    "hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
@@ -2505,8 +2480,6 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "is-redirect": ["is-redirect@1.0.0", "", {}, "sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
@@ -2576,8 +2549,6 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -2733,11 +2704,7 @@
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
     "memory-stream": ["memory-stream@1.0.0", "", { "dependencies": { "readable-stream": "^3.4.0" } }, "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -2747,9 +2714,9 @@
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
 
@@ -2778,8 +2745,6 @@
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
-
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
@@ -2849,8 +2814,6 @@
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
@@ -2913,8 +2876,6 @@
 
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
@@ -2928,8 +2889,6 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
-
-    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -2999,8 +2958,6 @@
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -3024,8 +2981,6 @@
     "quick-lru": ["quick-lru@7.3.0", "", {}, "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
-
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "rate-limiter-flexible": ["rate-limiter-flexible@7.4.0", "", {}, "sha512-IJopePGO6HnMWVdeLCihnxXZ0WCW0mxXiU5LE3bZ00GHESsCaAvgD8hN/ATIJeZhnrVdU5cfRyS1uV63Vmc4zg=="],
 
@@ -3133,8 +3088,6 @@
 
     "rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
@@ -3167,8 +3120,6 @@
 
     "semver-diff": ["semver-diff@2.1.0", "", { "dependencies": { "semver": "^5.0.3" } }, "sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw=="],
 
-    "send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
-
     "seqproto": ["seqproto@0.2.3", "", {}, "sha512-HpNyPYl7DJa2a6XQJ+MJAc6ft6Y9ZU+zRiuvTHFpLPeqvapcTAGFJyhMEIN7Y7VXhWT6NEdNVhbXFHwtaCOfCw=="],
 
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
@@ -3176,8 +3127,6 @@
     "seroval": ["seroval@1.5.1", "", {}, "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.1", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw=="],
-
-    "serve-static": ["serve-static@2.2.0", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
@@ -3281,7 +3230,7 @@
 
     "static-eval": ["static-eval@2.0.2", "", { "dependencies": { "escodegen": "^1.8.1" } }, "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg=="],
 
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+    "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -3439,8 +3388,6 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
-
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
@@ -3514,8 +3461,6 @@
     "vali-date": ["vali-date@1.0.0", "", {}, "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@6.0.2", "", {}, "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
@@ -3619,11 +3564,9 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
-
-    "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
@@ -3632,8 +3575,6 @@
     "@clack/prompts/@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
 
     "@crawlee/core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@crawlee/memory-storage/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "@electron/get/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -3705,13 +3646,13 @@
 
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@modelcontextprotocol/server-github/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.0.1", "", { "dependencies": { "content-type": "^1.0.5", "raw-body": "^3.0.0", "zod": "^3.23.8" } }, "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w=="],
+    "@modelcontextprotocol/codemod/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@modelcontextprotocol/server-github/@types/node": ["@types/node@22.18.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg=="],
 
     "@modelcontextprotocol/server-github/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@modelcontextprotocol/server-github/zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "@nanocollective/get-md/cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
@@ -3943,6 +3884,8 @@
 
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "eslint/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
@@ -3961,13 +3904,11 @@
 
     "eslint-plugin-react/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "eventsource/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
-    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
     "flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -3996,8 +3937,6 @@
     "happy-dom-without-node/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "html-to-text/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
-
-    "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "http2-wrapper/quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
@@ -4195,8 +4134,6 @@
 
     "@crawlee/core/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "@crawlee/memory-storage/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
@@ -4270,8 +4207,6 @@
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
-
-    "@tanstack/router-plugin/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -4382,8 +4317,6 @@
     "eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "eslint/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
@@ -4559,8 +4492,6 @@
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "apify-client/axios/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "babel-plugin-module-resolver/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "babel-plugin-module-resolver/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -4640,8 +4571,6 @@
     "update-notifier/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "apify-client/axios/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,8 +3,8 @@ preload = ["./src/utils/bun/preload-solid-scoped.ts", "./src/utils/search/stores
 [install]
 # Supply-chain delay: refuse package versions younger than 7 days (604800s)
 minimumReleaseAge = 604800
-# Vercel AI SDK line is exempt: we track its latest majors closely (v7 upgrade,
-# eve compatibility) and it releases multiple times per day. Exact-match only.
+# Exact-match only. AI SDK: we track latest majors closely. MCP: authorized
+# 2026-07-28 for SDK v2 migration (packages published 2026-07-27).
 minimumReleaseAgeExcludes = [
     "ai",
     "@ai-sdk/anthropic",
@@ -17,6 +17,10 @@ minimumReleaseAgeExcludes = [
     "@ai-sdk/provider-utils",
     "@ai-sdk/gateway",
     "@openrouter/ai-sdk-provider",
+    "@modelcontextprotocol/client",
+    "@modelcontextprotocol/server",
+    "@modelcontextprotocol/core",
+    "@modelcontextprotocol/codemod",
 ]
 
 [test]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,8 +3,9 @@ preload = ["./src/utils/bun/preload-solid-scoped.ts", "./src/utils/search/stores
 [install]
 # Supply-chain delay: refuse package versions younger than 7 days (604800s)
 minimumReleaseAge = 604800
-# Exact-match only. AI SDK: we track latest majors closely. MCP: authorized
-# 2026-07-28 for SDK v2 migration (packages published 2026-07-27).
+# Exact-match only, and a standing bypass for every future version of the listed
+# package. Nothing goes in here that does not need permanent latest-tracking.
+# AI SDK: we track latest majors closely.
 minimumReleaseAgeExcludes = [
     "ai",
     "@ai-sdk/anthropic",
@@ -17,10 +18,6 @@ minimumReleaseAgeExcludes = [
     "@ai-sdk/provider-utils",
     "@ai-sdk/gateway",
     "@openrouter/ai-sdk-provider",
-    "@modelcontextprotocol/client",
-    "@modelcontextprotocol/server",
-    "@modelcontextprotocol/core",
-    "@modelcontextprotocol/codemod",
 ]
 
 [test]

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "devDependencies": {
         "@anthropic-ai/claude-code": "^2.1.45",
         "@biomejs/biome": "^2.5.0",
+        "@modelcontextprotocol/codemod": "2.0.0",
         "@playwright/test": "1.57.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -109,7 +110,9 @@
         "@jmespath-community/jmespath": "^1.3.0",
         "@lancedb/lancedb": "^0.27.1",
         "@mdit/plugin-alert": "^0.22.4",
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/core": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "@modelcontextprotocol/server-github": "^2025.4.8",
         "@mozilla/readability": "^0.6.0",
         "@nanocollective/get-md": "1.1.0-beta.1",

--- a/src/Internal/mcp-client/index.ts
+++ b/src/Internal/mcp-client/index.ts
@@ -3,8 +3,8 @@
  */
 
 import { out } from "@genesiscz/utils/logger";
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 const transport = new StdioClientTransport({
     command: "bunx",

--- a/src/Internal/mcp-client/index.ts
+++ b/src/Internal/mcp-client/index.ts
@@ -3,8 +3,8 @@
  */
 
 import { out } from "@genesiscz/utils/logger";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { Client } from "@modelcontextprotocol/client";
 
 const transport = new StdioClientTransport({
     command: "bunx",

--- a/src/claude/mcp/boards.e2e.test.ts
+++ b/src/claude/mcp/boards.e2e.test.ts
@@ -8,8 +8,8 @@ import { tarGz } from "@app/dev-dashboard/lib/boards/tar";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { findFreePort } from "@genesiscz/utils/net/free-port";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { Client } from "@modelcontextprotocol/client";
 
 // A minimal valid 1x1 transparent PNG — importSet only creates cards for files that
 // parse as images (width > 0 && height > 0), so a real PNG header is required.

--- a/src/claude/mcp/boards.e2e.test.ts
+++ b/src/claude/mcp/boards.e2e.test.ts
@@ -8,8 +8,8 @@ import { tarGz } from "@app/dev-dashboard/lib/boards/tar";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { findFreePort } from "@genesiscz/utils/net/free-port";
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 // A minimal valid 1x1 transparent PNG — importSet only creates cards for files that
 // parse as images (width > 0 && height > 0), so a real PNG header is required.

--- a/src/claude/mcp/server.e2e.test.ts
+++ b/src/claude/mcp/server.e2e.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 describe("genesis-tools MCP server (stdio e2e)", () => {
     it("advertises question_answer and records via a real JSON-RPC call", async () => {

--- a/src/claude/mcp/server.e2e.test.ts
+++ b/src/claude/mcp/server.e2e.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { Client } from "@modelcontextprotocol/client";
 
 describe("genesis-tools MCP server (stdio e2e)", () => {
     it("advertises question_answer and records via a real JSON-RPC call", async () => {

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -1,8 +1,7 @@
 import { env } from "@genesiscz/utils/env/envVariables";
 import { logger } from "@genesiscz/utils/logger";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import { ANNOTATE_IMAGE_INPUT_SCHEMA, type AnnotateImageArgs, handleAnnotateImage } from "./tools/annotate-image";
 import {
     handleArrange,
@@ -450,27 +449,27 @@ export async function startMcpServer(): Promise<void> {
         { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS }
     );
 
-    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
         tools: Object.entries(registry).map(([name, t]) => ({
             name,
             description: t.description,
-            inputSchema: t.inputSchema,
+            inputSchema: t.inputSchema as ListToolsResult["tools"][number]["inputSchema"],
         })),
     }));
 
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
         const entry = registry[request.params.name];
         if (!entry) {
-            return { content: [{ type: "text", text: `Unknown tool: ${request.params.name}` }], isError: true };
+            return { content: [{ type: "text" as const, text: `Unknown tool: ${request.params.name}` }], isError: true };
         }
 
         try {
             const text = await entry.handler((request.params.arguments ?? {}) as Record<string, unknown>);
-            return { content: [{ type: "text", text }] };
+            return { content: [{ type: "text" as const, text }] };
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             log.warn({ err, tool: request.params.name }, "mcp tool handler failed");
-            return { content: [{ type: "text", text: `${request.params.name} failed: ${message}` }], isError: true };
+            return { content: [{ type: "text" as const, text: `${request.params.name} failed: ${message}` }], isError: true };
         }
     });
 

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -1,7 +1,7 @@
 import { env } from "@genesiscz/utils/env/envVariables";
 import { logger } from "@genesiscz/utils/logger";
+import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import { ANNOTATE_IMAGE_INPUT_SCHEMA, type AnnotateImageArgs, handleAnnotateImage } from "./tools/annotate-image";
 import {
     handleArrange,
@@ -449,18 +449,24 @@ export async function startMcpServer(): Promise<void> {
         { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS }
     );
 
-    server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
-        tools: Object.entries(registry).map(([name, t]) => ({
-            name,
-            description: t.description,
-            inputSchema: t.inputSchema as ListToolsResult["tools"][number]["inputSchema"],
-        })),
-    }));
+    server.setRequestHandler(
+        "tools/list",
+        async (): Promise<ListToolsResult> => ({
+            tools: Object.entries(registry).map(([name, t]) => ({
+                name,
+                description: t.description,
+                inputSchema: t.inputSchema as ListToolsResult["tools"][number]["inputSchema"],
+            })),
+        })
+    );
 
-    server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
+    server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
         const entry = registry[request.params.name];
         if (!entry) {
-            return { content: [{ type: "text" as const, text: `Unknown tool: ${request.params.name}` }], isError: true };
+            return {
+                content: [{ type: "text" as const, text: `Unknown tool: ${request.params.name}` }],
+                isError: true,
+            };
         }
 
         try {
@@ -469,7 +475,10 @@ export async function startMcpServer(): Promise<void> {
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             log.warn({ err, tool: request.params.name }, "mcp tool handler failed");
-            return { content: [{ type: "text" as const, text: `${request.params.name} failed: ${message}` }], isError: true };
+            return {
+                content: [{ type: "text" as const, text: `${request.params.name} failed: ${message}` }],
+                isError: true,
+            };
         }
     });
 

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -1,6 +1,12 @@
 import { env } from "@genesiscz/utils/env/envVariables";
 import { logger } from "@genesiscz/utils/logger";
-import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import {
+    type CallToolResult,
+    type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { ANNOTATE_IMAGE_INPUT_SCHEMA, type AnnotateImageArgs, handleAnnotateImage } from "./tools/annotate-image";
 import {
@@ -463,10 +469,7 @@ export async function startMcpServer(): Promise<void> {
     server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
         const entry = registry[request.params.name];
         if (!entry) {
-            return {
-                content: [{ type: "text" as const, text: `Unknown tool: ${request.params.name}` }],
-                isError: true,
-            };
+            throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${request.params.name}`);
         }
 
         try {

--- a/src/dashboard/apps/web/package.json
+++ b/src/dashboard/apps/web/package.json
@@ -22,7 +22,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@modelcontextprotocol/sdk": "^1.17.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/dashboard/apps/web/src/lib/mcp/server.ts
+++ b/src/dashboard/apps/web/src/lib/mcp/server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { registerTaskTools } from "./tools/tasks";
 import { registerTimerTools } from "./tools/timers";
 

--- a/src/dashboard/apps/web/src/lib/mcp/tools/tasks.ts
+++ b/src/dashboard/apps/web/src/lib/mcp/tools/tasks.ts
@@ -13,12 +13,12 @@ export function registerTaskTools(server: McpServer, userId: string) {
         {
             description: "List the owner's assistant tasks. Optionally filter by status.",
             inputSchema: z.object({
-                            status: z
-                                .enum(["backlog", "in-progress", "blocked", "completed"])
-                                .optional()
-                                .describe("Filter by task status"),
-                            limit: z.number().min(1).max(200).default(50),
-                        }),
+                status: z
+                    .enum(["backlog", "in-progress", "blocked", "completed"])
+                    .optional()
+                    .describe("Filter by task status"),
+                limit: z.number().min(1).max(200).default(50),
+            }),
         },
         async ({ status, limit }) => {
             const tasks = db
@@ -45,11 +45,11 @@ export function registerTaskTools(server: McpServer, userId: string) {
         {
             description: "Create a new assistant task for the owner.",
             inputSchema: z.object({
-                            title: z.string().describe("Task title"),
-                            description: z.string().optional().describe("Task description"),
-                            status: z.enum(["backlog", "in-progress", "blocked", "completed"]).default("backlog"),
-                            urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).default("nice-to-have"),
-                        }),
+                title: z.string().describe("Task title"),
+                description: z.string().optional().describe("Task description"),
+                status: z.enum(["backlog", "in-progress", "blocked", "completed"]).default("backlog"),
+                urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).default("nice-to-have"),
+            }),
         },
         async ({ title, description, status, urgencyLevel }) => {
             const now = new Date().toISOString();
@@ -81,12 +81,12 @@ export function registerTaskTools(server: McpServer, userId: string) {
         {
             description: "Update one of the owner's assistant tasks.",
             inputSchema: z.object({
-                            id: z.string().describe("Task ID to update"),
-                            title: z.string().optional(),
-                            description: z.string().optional(),
-                            status: z.enum(["backlog", "in-progress", "blocked", "completed"]).optional(),
-                            urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).optional(),
-                        }),
+                id: z.string().describe("Task ID to update"),
+                title: z.string().optional(),
+                description: z.string().optional(),
+                status: z.enum(["backlog", "in-progress", "blocked", "completed"]).optional(),
+                urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).optional(),
+            }),
         },
         async ({ id, ...patch }) => {
             const result = db
@@ -108,8 +108,8 @@ export function registerTaskTools(server: McpServer, userId: string) {
         {
             description: "Delete one of the owner's assistant tasks by ID.",
             inputSchema: z.object({
-                            id: z.string().describe("Task ID to delete"),
-                        }),
+                id: z.string().describe("Task ID to delete"),
+            }),
         },
         async ({ id }) => {
             const result = db

--- a/src/dashboard/apps/web/src/lib/mcp/tools/tasks.ts
+++ b/src/dashboard/apps/web/src/lib/mcp/tools/tasks.ts
@@ -1,5 +1,5 @@
 import { SafeJSON } from "@dashboard/shared";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { assistantTasks, db } from "@/drizzle";
@@ -12,13 +12,13 @@ export function registerTaskTools(server: McpServer, userId: string) {
         "list_tasks",
         {
             description: "List the owner's assistant tasks. Optionally filter by status.",
-            inputSchema: {
-                status: z
-                    .enum(["backlog", "in-progress", "blocked", "completed"])
-                    .optional()
-                    .describe("Filter by task status"),
-                limit: z.number().min(1).max(200).default(50),
-            },
+            inputSchema: z.object({
+                            status: z
+                                .enum(["backlog", "in-progress", "blocked", "completed"])
+                                .optional()
+                                .describe("Filter by task status"),
+                            limit: z.number().min(1).max(200).default(50),
+                        }),
         },
         async ({ status, limit }) => {
             const tasks = db
@@ -44,12 +44,12 @@ export function registerTaskTools(server: McpServer, userId: string) {
         "create_task",
         {
             description: "Create a new assistant task for the owner.",
-            inputSchema: {
-                title: z.string().describe("Task title"),
-                description: z.string().optional().describe("Task description"),
-                status: z.enum(["backlog", "in-progress", "blocked", "completed"]).default("backlog"),
-                urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).default("nice-to-have"),
-            },
+            inputSchema: z.object({
+                            title: z.string().describe("Task title"),
+                            description: z.string().optional().describe("Task description"),
+                            status: z.enum(["backlog", "in-progress", "blocked", "completed"]).default("backlog"),
+                            urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).default("nice-to-have"),
+                        }),
         },
         async ({ title, description, status, urgencyLevel }) => {
             const now = new Date().toISOString();
@@ -80,13 +80,13 @@ export function registerTaskTools(server: McpServer, userId: string) {
         "update_task",
         {
             description: "Update one of the owner's assistant tasks.",
-            inputSchema: {
-                id: z.string().describe("Task ID to update"),
-                title: z.string().optional(),
-                description: z.string().optional(),
-                status: z.enum(["backlog", "in-progress", "blocked", "completed"]).optional(),
-                urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).optional(),
-            },
+            inputSchema: z.object({
+                            id: z.string().describe("Task ID to update"),
+                            title: z.string().optional(),
+                            description: z.string().optional(),
+                            status: z.enum(["backlog", "in-progress", "blocked", "completed"]).optional(),
+                            urgencyLevel: z.enum(["critical", "important", "nice-to-have"]).optional(),
+                        }),
         },
         async ({ id, ...patch }) => {
             const result = db
@@ -107,9 +107,9 @@ export function registerTaskTools(server: McpServer, userId: string) {
         "delete_task",
         {
             description: "Delete one of the owner's assistant tasks by ID.",
-            inputSchema: {
-                id: z.string().describe("Task ID to delete"),
-            },
+            inputSchema: z.object({
+                            id: z.string().describe("Task ID to delete"),
+                        }),
         },
         async ({ id }) => {
             const result = db

--- a/src/dashboard/apps/web/src/lib/mcp/tools/timers.ts
+++ b/src/dashboard/apps/web/src/lib/mcp/tools/timers.ts
@@ -1,5 +1,5 @@
 import { SafeJSON } from "@dashboard/shared";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db, timers } from "@/drizzle";
@@ -10,7 +10,7 @@ export function registerTimerTools(server: McpServer, userId: string) {
         "list_timers",
         {
             description: "List the owner's timers.",
-            inputSchema: {},
+            inputSchema: z.object({}),
         },
         async () => {
             const timerList = db.select().from(timers).where(eq(timers.userId, userId)).all();
@@ -30,12 +30,12 @@ export function registerTimerTools(server: McpServer, userId: string) {
         "upsert_timer",
         {
             description: "Create or update a timer for the owner. Omit id to let the server generate one.",
-            inputSchema: {
-                id: z.string().optional().describe("Timer ID (omit to create new)"),
-                label: z.string().describe("Timer label / name"),
-                duration: z.number().optional().describe("Target duration in seconds (for countdown)"),
-                mode: z.enum(["stopwatch", "countdown", "pomodoro"]).default("stopwatch"),
-            },
+            inputSchema: z.object({
+                            id: z.string().optional().describe("Timer ID (omit to create new)"),
+                            label: z.string().describe("Timer label / name"),
+                            duration: z.number().optional().describe("Target duration in seconds (for countdown)"),
+                            mode: z.enum(["stopwatch", "countdown", "pomodoro"]).default("stopwatch"),
+                        }),
         },
         async ({ id: inputId, label, duration, mode }) => {
             const timerId = inputId ?? crypto.randomUUID();
@@ -94,9 +94,9 @@ export function registerTimerTools(server: McpServer, userId: string) {
         "delete_timer",
         {
             description: "Delete one of the owner's timers by ID.",
-            inputSchema: {
-                timerId: z.string().describe("Timer ID to delete"),
-            },
+            inputSchema: z.object({
+                            timerId: z.string().describe("Timer ID to delete"),
+                        }),
         },
         async ({ timerId }) => {
             const result = db

--- a/src/dashboard/apps/web/src/lib/mcp/tools/timers.ts
+++ b/src/dashboard/apps/web/src/lib/mcp/tools/timers.ts
@@ -31,11 +31,11 @@ export function registerTimerTools(server: McpServer, userId: string) {
         {
             description: "Create or update a timer for the owner. Omit id to let the server generate one.",
             inputSchema: z.object({
-                            id: z.string().optional().describe("Timer ID (omit to create new)"),
-                            label: z.string().describe("Timer label / name"),
-                            duration: z.number().optional().describe("Target duration in seconds (for countdown)"),
-                            mode: z.enum(["stopwatch", "countdown", "pomodoro"]).default("stopwatch"),
-                        }),
+                id: z.string().optional().describe("Timer ID (omit to create new)"),
+                label: z.string().describe("Timer label / name"),
+                duration: z.number().optional().describe("Target duration in seconds (for countdown)"),
+                mode: z.enum(["stopwatch", "countdown", "pomodoro"]).default("stopwatch"),
+            }),
         },
         async ({ id: inputId, label, duration, mode }) => {
             const timerId = inputId ?? crypto.randomUUID();
@@ -95,8 +95,8 @@ export function registerTimerTools(server: McpServer, userId: string) {
         {
             description: "Delete one of the owner's timers by ID.",
             inputSchema: z.object({
-                            timerId: z.string().describe("Timer ID to delete"),
-                        }),
+                timerId: z.string().describe("Timer ID to delete"),
+            }),
         },
         async ({ timerId }) => {
             const result = db

--- a/src/dashboard/apps/web/src/utils/mcp-handler.test.ts
+++ b/src/dashboard/apps/web/src/utils/mcp-handler.test.ts
@@ -1,0 +1,107 @@
+import { SafeJSON } from "@dashboard/shared";
+import { McpServer } from "@modelcontextprotocol/server";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { handleMcpRequest } from "./mcp-handler";
+
+interface JsonRpcResponse {
+    jsonrpc: "2.0";
+    id: number | string | null;
+    result?: Record<string, unknown>;
+    error?: { code: number; message: string };
+}
+
+/** A server shaped like createMcpServer() but with one tool and no database. */
+function buildServer(): McpServer {
+    const server = new McpServer({ name: "nexus-dashboard-test", version: "0.1.0" });
+    server.registerTool(
+        "echo",
+        { description: "Echo the given text", inputSchema: z.object({ text: z.string() }) },
+        async (args: { text: string }) => ({ content: [{ type: "text" as const, text: args.text }] })
+    );
+    return server;
+}
+
+async function post(body: unknown): Promise<{ status: number; frame: JsonRpcResponse }> {
+    const request = new Request("http://localhost/api/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: SafeJSON.stringify(body),
+    });
+    const response = await handleMcpRequest(request, buildServer());
+    return { status: response.status, frame: (await response.json()) as JsonRpcResponse };
+}
+
+const INITIALIZE = {
+    jsonrpc: "2.0" as const,
+    id: 1,
+    method: "initialize",
+    params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "handler-test", version: "1.0.0" },
+    },
+};
+
+describe("handleMcpRequest", () => {
+    it("answers initialize with a negotiated protocol version", async () => {
+        const { status, frame } = await post(INITIALIZE);
+
+        expect(status).toBe(200);
+        expect(frame.jsonrpc).toBe("2.0");
+        expect(frame.id).toBe(1);
+        expect(frame.error).toBeUndefined();
+        expect(frame.result?.protocolVersion).toBeDefined();
+    });
+
+    it("returns a JSON-RPC error frame when the payload is not valid JSON", async () => {
+        const request = new Request("http://localhost/api/mcp", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "not json",
+        });
+
+        const response = await handleMcpRequest(request, buildServer());
+        const frame = (await response.json()) as JsonRpcResponse;
+
+        expect(response.status).toBe(500);
+        expect(frame.error?.code).toBe(-32603);
+        expect(frame.id).toBeNull();
+    });
+
+    // Each POST builds its own server and transport pair, so tools/list and
+    // tools/call arrive on a connection that never saw an initialize handshake.
+    // The v2 server answers them anyway, which is what makes this route work.
+    it("lists tools on a fresh per-request server", async () => {
+        const { frame } = await post({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+
+        expect(frame.error).toBeUndefined();
+        expect(frame.id).toBe(2);
+        const tools = frame.result?.tools as Array<{ name: string }>;
+        expect(tools.map((t) => t.name)).toEqual(["echo"]);
+    });
+
+    it("runs a tool and returns its content", async () => {
+        const { frame } = await post({
+            jsonrpc: "2.0",
+            id: 3,
+            method: "tools/call",
+            params: { name: "echo", arguments: { text: "hello" } },
+        });
+
+        expect(frame.error).toBeUndefined();
+        expect(frame.id).toBe(3);
+        expect(frame.result?.content).toEqual([{ type: "text", text: "hello" }]);
+    });
+
+    it("reports a tool argument that fails schema validation", async () => {
+        const { frame } = await post({
+            jsonrpc: "2.0",
+            id: 4,
+            method: "tools/call",
+            params: { name: "echo", arguments: { text: 42 } },
+        });
+
+        expect(frame.result?.isError).toBe(true);
+    });
+});

--- a/src/dashboard/apps/web/src/utils/mcp-handler.ts
+++ b/src/dashboard/apps/web/src/utils/mcp-handler.ts
@@ -1,5 +1,5 @@
+import type { JSONRPCMessage, McpServer } from "@modelcontextprotocol/server";
 import { InMemoryTransport } from "@modelcontextprotocol/server";
-import type { McpServer, JSONRPCMessage } from "@modelcontextprotocol/server";
 
 export async function handleMcpRequest(request: Request, server: McpServer): Promise<Response> {
     try {

--- a/src/dashboard/apps/web/src/utils/mcp-handler.ts
+++ b/src/dashboard/apps/web/src/utils/mcp-handler.ts
@@ -1,7 +1,5 @@
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { InMemoryTransport } from "@modelcontextprotocol/server";
+import type { McpServer, JSONRPCMessage } from "@modelcontextprotocol/server";
 
 export async function handleMcpRequest(request: Request, server: McpServer): Promise<Response> {
     try {

--- a/src/dashboard/bun.lock
+++ b/src/dashboard/bun.lock
@@ -17,7 +17,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@modelcontextprotocol/sdk": "^1.17.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -335,7 +335,11 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@0.6.3", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA=="],
 
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1149,7 +1153,7 @@
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "env-runner": ["env-runner@0.1.9", "", { "dependencies": { "crossws": "^0.4.5", "exsolve": "^1.0.8", "httpxy": "^0.5.3", "srvx": "^0.11.15" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": "^0.2.0", "miniflare": "^4.20260515.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-W9AiZlPx0uXtghAJiTBkeZOgyQdecVvoln3cHoOEZswPq0cVMi+WBhUQjdUn+JcZFAFgOt+i5fcO7C2zniZoCg=="],
+    "env-runner": ["env-runner@0.1.16", "", { "dependencies": { "crossws": "^0.4.8", "exsolve": "^1.1.0", "httpxy": "^0.5.4", "srvx": "^0.11.19" }, "peerDependencies": { "@netlify/runtime": "^4.1.23", "@vercel/queue": ">=0.2.0", "miniflare": "^4.20260515.0", "wrangler": "^4.0.0" }, "optionalPeers": ["@netlify/runtime", "@vercel/queue", "miniflare", "wrangler"], "bin": { "env-runner": "dist/cli.mjs" } }, "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -1321,7 +1325,7 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "httpxy": ["httpxy@0.5.3", "", {}, "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw=="],
+    "httpxy": ["httpxy@0.5.5", "", {}, "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1591,7 +1595,7 @@
 
     "nf3": ["nf3@0.3.17", "", {}, "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ=="],
 
-    "nitro": ["nitro@3.0.260522-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.9", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.2", "srvx": "^0.11.15", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.2.0", "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.3", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-L/z2eOWgkiQHc65kv+SEMgau505afSRF7NJlbooaaZEZscFrNSD7rXZzeVubQlgIzPbhOG8o73bk9soIiGTHRA=="],
+    "nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
     "node-abi": ["node-abi@3.85.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg=="],
 
@@ -1609,7 +1613,7 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "ocache": ["ocache@0.1.4", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ=="],
+    "ocache": ["ocache@0.1.5", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w=="],
 
     "ofetch": ["ofetch@2.0.0-alpha.3", "", {}, "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA=="],
 
@@ -2247,6 +2251,12 @@
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "env-runner/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
+
+    "env-runner/exsolve": ["exsolve@1.1.0", "", {}, "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="],
+
+    "env-runner/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
+
     "h3-v2/rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
     "h3-v2/srvx": ["srvx@0.10.0", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-NqIsR+wQCfkvvwczBh8J8uM4wTZx41K2lLSEp/3oMp917ODVVMtW5Me4epCmQ3gH8D+0b+/t4xxkUKutyhimTA=="],
@@ -2259,7 +2269,11 @@
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
-    "nitro/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
+    "nitro/crossws": ["crossws@0.4.10", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA=="],
+
+    "nitro/rolldown": ["rolldown@1.2.0", "", { "dependencies": { "@oxc-project/types": "=0.140.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.0", "@rolldown/binding-darwin-arm64": "1.2.0", "@rolldown/binding-darwin-x64": "1.2.0", "@rolldown/binding-freebsd-x64": "1.2.0", "@rolldown/binding-linux-arm-gnueabihf": "1.2.0", "@rolldown/binding-linux-arm64-gnu": "1.2.0", "@rolldown/binding-linux-arm64-musl": "1.2.0", "@rolldown/binding-linux-ppc64-gnu": "1.2.0", "@rolldown/binding-linux-s390x-gnu": "1.2.0", "@rolldown/binding-linux-x64-gnu": "1.2.0", "@rolldown/binding-linux-x64-musl": "1.2.0", "@rolldown/binding-openharmony-arm64": "1.2.0", "@rolldown/binding-wasm32-wasi": "1.2.0", "@rolldown/binding-win32-arm64-msvc": "1.2.0", "@rolldown/binding-win32-x64-msvc": "1.2.0" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA=="],
+
+    "nitro/srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
 
     "node-abi/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -2447,37 +2461,37 @@
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
-    "nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
+    "nitro/rolldown/@oxc-project/types": ["@oxc-project/types@0.140.0", "", {}, "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ=="],
 
-    "nitro/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.2", "", { "os": "android", "cpu": "arm64" }, "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ=="],
+    "nitro/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.0", "", { "os": "android", "cpu": "arm64" }, "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw=="],
 
-    "nitro/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w=="],
+    "nitro/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg=="],
 
-    "nitro/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA=="],
+    "nitro/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw=="],
 
-    "nitro/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA=="],
+    "nitro/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w=="],
+    "nitro/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.0", "", { "os": "linux", "cpu": "arm" }, "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig=="],
+    "nitro/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw=="],
+    "nitro/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA=="],
+    "nitro/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ=="],
+    "nitro/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ=="],
+    "nitro/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ=="],
 
-    "nitro/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw=="],
+    "nitro/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw=="],
 
-    "nitro/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w=="],
+    "nitro/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.0", "", { "os": "none", "cpu": "arm64" }, "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA=="],
 
-    "nitro/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.2", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ=="],
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.0", "", { "dependencies": { "@emnapi/core": "1.11.2", "@emnapi/runtime": "1.11.2", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g=="],
 
-    "nitro/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A=="],
+    "nitro/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA=="],
 
-    "nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ=="],
+    "nitro/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
@@ -2771,6 +2785,12 @@
 
     "@vitest/mocker/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
     "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
@@ -2978,5 +2998,9 @@
     "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "nitro/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
   }
 }

--- a/src/dashboard/bunfig.toml
+++ b/src/dashboard/bunfig.toml
@@ -1,8 +1,5 @@
+# Supply-chain delay: refuse package versions younger than 7 days (604800s).
+# No minimumReleaseAgeExcludes on purpose: the MCP v2 packages resolve from the
+# committed bun.lock, which the age gate does not re-check.
 [install]
 minimumReleaseAge = 604800
-minimumReleaseAgeExcludes = [
-    "@modelcontextprotocol/client",
-    "@modelcontextprotocol/server",
-    "@modelcontextprotocol/core",
-    "@modelcontextprotocol/codemod",
-]

--- a/src/dashboard/bunfig.toml
+++ b/src/dashboard/bunfig.toml
@@ -1,0 +1,8 @@
+[install]
+minimumReleaseAge = 604800
+minimumReleaseAgeExcludes = [
+    "@modelcontextprotocol/client",
+    "@modelcontextprotocol/server",
+    "@modelcontextprotocol/core",
+    "@modelcontextprotocol/codemod",
+]

--- a/src/har-analyzer/mcp/server.ts
+++ b/src/har-analyzer/mcp/server.ts
@@ -8,8 +8,8 @@ import type { EntryFilter, HarFile, HarSession } from "@app/har-analyzer/types";
 import { isInterestingMimeType } from "@app/har-analyzer/types";
 import { formatBytes, formatDuration } from "@genesiscz/utils/format";
 import { logger } from "@genesiscz/utils/logger";
+import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 
 export async function startMcpServer(): Promise<void> {
     const sm = new SessionManager();
@@ -31,104 +31,107 @@ export async function startMcpServer(): Promise<void> {
 
     const server = new Server({ name: "har-analyzer", version: "1.0.0" }, { capabilities: { tools: {} } });
 
-    server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
-        tools: [
-            {
-                name: "har_load",
-                description: "Load a HAR file and show the dashboard overview",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: { file: { type: "string", description: "Path to the HAR file" } },
-                    required: ["file"],
-                },
-            },
-            {
-                name: "har_overview",
-                description: "Show dashboard overview of the currently loaded HAR",
-                inputSchema: { type: "object" as const, properties: {} },
-            },
-            {
-                name: "har_list",
-                description: "List entries with optional filters",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: {
-                        domain: { type: "string", description: "Filter by domain" },
-                        status: { type: "string", description: "Filter by status (e.g. 4xx, 200)" },
-                        method: { type: "string", description: "Filter by HTTP method" },
-                        url: { type: "string", description: "Filter by URL pattern" },
-                        limit: { type: "number", description: "Max entries to show" },
+    server.setRequestHandler(
+        "tools/list",
+        async (): Promise<ListToolsResult> => ({
+            tools: [
+                {
+                    name: "har_load",
+                    description: "Load a HAR file and show the dashboard overview",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: { file: { type: "string", description: "Path to the HAR file" } },
+                        required: ["file"],
                     },
                 },
-            },
-            {
-                name: "har_detail",
-                description: "Show detail for a specific entry",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: {
-                        entry: { type: "number", description: "Entry index" },
-                        raw: { type: "boolean", description: "Show full body/headers" },
-                        section: { type: "string", description: "Filter section: body, headers, cookies" },
-                        full: { type: "boolean", description: "Bypass ref system" },
-                    },
-                    required: ["entry"],
+                {
+                    name: "har_overview",
+                    description: "Show dashboard overview of the currently loaded HAR",
+                    inputSchema: { type: "object" as const, properties: {} },
                 },
-            },
-            {
-                name: "har_expand",
-                description: "Expand a reference to see full content",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: { ref: { type: "string", description: "Reference ID (e.g. e14.rs.body)" } },
-                    required: ["ref"],
-                },
-            },
-            {
-                name: "har_search",
-                description: "Search across entries",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: {
-                        query: { type: "string", description: "Search query" },
-                        scope: { type: "string", description: "Search scope: url, body, header, all" },
-                        domain: { type: "string", description: "Filter by domain" },
-                    },
-                    required: ["query"],
-                },
-            },
-            {
-                name: "har_analyze",
-                description: "Run analysis: errors, security",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: {
-                        type: {
-                            type: "string",
-                            enum: ["errors", "security"],
-                            description: "Analysis type: errors, security",
+                {
+                    name: "har_list",
+                    description: "List entries with optional filters",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: {
+                            domain: { type: "string", description: "Filter by domain" },
+                            status: { type: "string", description: "Filter by status (e.g. 4xx, 200)" },
+                            method: { type: "string", description: "Filter by HTTP method" },
+                            url: { type: "string", description: "Filter by URL pattern" },
+                            limit: { type: "number", description: "Max entries to show" },
                         },
                     },
-                    required: ["type"],
                 },
-            },
-            {
-                name: "har_export",
-                description: "Export filtered/sanitized HAR subset",
-                inputSchema: {
-                    type: "object" as const,
-                    properties: {
-                        domain: { type: "string", description: "Filter by domain" },
-                        status: { type: "string", description: "Filter by status" },
-                        sanitize: { type: "boolean", description: "Redact sensitive data" },
-                        stripBodies: { type: "boolean", description: "Remove body content" },
+                {
+                    name: "har_detail",
+                    description: "Show detail for a specific entry",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: {
+                            entry: { type: "number", description: "Entry index" },
+                            raw: { type: "boolean", description: "Show full body/headers" },
+                            section: { type: "string", description: "Filter section: body, headers, cookies" },
+                            full: { type: "boolean", description: "Bypass ref system" },
+                        },
+                        required: ["entry"],
                     },
                 },
-            },
-        ],
-    }));
+                {
+                    name: "har_expand",
+                    description: "Expand a reference to see full content",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: { ref: { type: "string", description: "Reference ID (e.g. e14.rs.body)" } },
+                        required: ["ref"],
+                    },
+                },
+                {
+                    name: "har_search",
+                    description: "Search across entries",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: {
+                            query: { type: "string", description: "Search query" },
+                            scope: { type: "string", description: "Search scope: url, body, header, all" },
+                            domain: { type: "string", description: "Filter by domain" },
+                        },
+                        required: ["query"],
+                    },
+                },
+                {
+                    name: "har_analyze",
+                    description: "Run analysis: errors, security",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: {
+                            type: {
+                                type: "string",
+                                enum: ["errors", "security"],
+                                description: "Analysis type: errors, security",
+                            },
+                        },
+                        required: ["type"],
+                    },
+                },
+                {
+                    name: "har_export",
+                    description: "Export filtered/sanitized HAR subset",
+                    inputSchema: {
+                        type: "object" as const,
+                        properties: {
+                            domain: { type: "string", description: "Filter by domain" },
+                            status: { type: "string", description: "Filter by status" },
+                            sanitize: { type: "boolean", description: "Redact sensitive data" },
+                            stripBodies: { type: "boolean", description: "Remove body content" },
+                        },
+                    },
+                },
+            ],
+        })
+    );
 
-    server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
+    server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
         const { name, arguments: args } = request.params;
         const a = (args ?? {}) as Record<string, unknown>;
 
@@ -142,13 +145,17 @@ export async function startMcpServer(): Promise<void> {
                     sm.cleanExpiredSessions().catch((err) =>
                         logger.debug({ err }, "[har-analyzer] expired-session cleanup failed")
                     );
-                    return { content: [{ type: "text" as const, text: formatDashboard(session.stats, session.sourceFile) }] };
+                    return {
+                        content: [{ type: "text" as const, text: formatDashboard(session.stats, session.sourceFile) }],
+                    };
                 }
 
                 case "har_overview": {
                     const ctx = await ensureSession();
                     return {
-                        content: [{ type: "text" as const, text: formatDashboard(ctx.session.stats, ctx.session.sourceFile) }],
+                        content: [
+                            { type: "text" as const, text: formatDashboard(ctx.session.stats, ctx.session.sourceFile) },
+                        ],
                     };
                 }
 
@@ -272,7 +279,9 @@ export async function startMcpServer(): Promise<void> {
                             break;
                     }
 
-                    return { content: [{ type: "text" as const, text: content ?? `No content found for ref "${refId}".` }] };
+                    return {
+                        content: [{ type: "text" as const, text: content ?? `No content found for ref "${refId}".` }],
+                    };
                 }
 
                 case "har_search": {
@@ -369,7 +378,10 @@ export async function startMcpServer(): Promise<void> {
 
                     return {
                         content: [
-                            { type: "text" as const, text: `Unknown analysis type: ${type}. Supported: errors, security` },
+                            {
+                                type: "text" as const,
+                                text: `Unknown analysis type: ${type}. Supported: errors, security`,
+                            },
                         ],
                     };
                 }

--- a/src/har-analyzer/mcp/server.ts
+++ b/src/har-analyzer/mcp/server.ts
@@ -8,7 +8,13 @@ import type { EntryFilter, HarFile, HarSession } from "@app/har-analyzer/types";
 import { isInterestingMimeType } from "@app/har-analyzer/types";
 import { formatBytes, formatDuration } from "@genesiscz/utils/format";
 import { logger } from "@genesiscz/utils/logger";
-import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import {
+    type CallToolResult,
+    type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 
 export async function startMcpServer(): Promise<void> {
@@ -404,10 +410,15 @@ export async function startMcpServer(): Promise<void> {
                 }
 
                 default:
-                    return { content: [{ type: "text" as const, text: `Unknown tool: ${name}` }], isError: true };
+                    throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${name}`);
             }
         } catch (error) {
+            if (error instanceof ProtocolError) {
+                throw error;
+            }
+
             const message = error instanceof Error ? error.message : String(error);
+            logger.warn({ error, tool: name }, "[har-analyzer] MCP tool call failed");
             return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
         }
     });

--- a/src/har-analyzer/mcp/server.ts
+++ b/src/har-analyzer/mcp/server.ts
@@ -8,9 +8,8 @@ import type { EntryFilter, HarFile, HarSession } from "@app/har-analyzer/types";
 import { isInterestingMimeType } from "@app/har-analyzer/types";
 import { formatBytes, formatDuration } from "@genesiscz/utils/format";
 import { logger } from "@genesiscz/utils/logger";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 
 export async function startMcpServer(): Promise<void> {
     const sm = new SessionManager();
@@ -32,7 +31,7 @@ export async function startMcpServer(): Promise<void> {
 
     const server = new Server({ name: "har-analyzer", version: "1.0.0" }, { capabilities: { tools: {} } });
 
-    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
         tools: [
             {
                 name: "har_load",
@@ -129,7 +128,7 @@ export async function startMcpServer(): Promise<void> {
         ],
     }));
 
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
         const { name, arguments: args } = request.params;
         const a = (args ?? {}) as Record<string, unknown>;
 
@@ -143,13 +142,13 @@ export async function startMcpServer(): Promise<void> {
                     sm.cleanExpiredSessions().catch((err) =>
                         logger.debug({ err }, "[har-analyzer] expired-session cleanup failed")
                     );
-                    return { content: [{ type: "text", text: formatDashboard(session.stats, session.sourceFile) }] };
+                    return { content: [{ type: "text" as const, text: formatDashboard(session.stats, session.sourceFile) }] };
                 }
 
                 case "har_overview": {
                     const ctx = await ensureSession();
                     return {
-                        content: [{ type: "text", text: formatDashboard(ctx.session.stats, ctx.session.sourceFile) }],
+                        content: [{ type: "text" as const, text: formatDashboard(ctx.session.stats, ctx.session.sourceFile) }],
                     };
                 }
 
@@ -164,14 +163,14 @@ export async function startMcpServer(): Promise<void> {
                     };
                     const entries = filterEntries(ctx.session.entries, filter);
                     const lines = entries.map(formatEntryLine);
-                    return { content: [{ type: "text", text: lines.join("\n") || "No entries match." }] };
+                    return { content: [{ type: "text" as const, text: lines.join("\n") || "No entries match." }] };
                 }
 
                 case "har_detail": {
                     const ctx = await ensureSession();
                     const idx = a.entry as number;
                     if (idx < 0 || idx >= ctx.session.entries.length) {
-                        return { content: [{ type: "text", text: `Entry e${idx} not found.` }] };
+                        return { content: [{ type: "text" as const, text: `Entry e${idx} not found.` }] };
                     }
                     const entry = ctx.harFile.log.entries[idx];
                     const ie = ctx.session.entries[idx];
@@ -215,7 +214,7 @@ export async function startMcpServer(): Promise<void> {
                             }
                         }
 
-                        return { content: [{ type: "text", text: lines.join("\n") }] };
+                        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
                     }
 
                     // L2 detail
@@ -236,7 +235,7 @@ export async function startMcpServer(): Promise<void> {
                         `Response Body: ${formatBytes(entry.response.content.size)} (${entry.response.content.mimeType})`
                     );
 
-                    return { content: [{ type: "text", text: lines.join("\n") }] };
+                    return { content: [{ type: "text" as const, text: lines.join("\n") }] };
                 }
 
                 case "har_expand": {
@@ -244,11 +243,11 @@ export async function startMcpServer(): Promise<void> {
                     const refId = a.ref as string;
                     const match = refId.match(/^e(\d+)\./);
                     if (!match) {
-                        return { content: [{ type: "text", text: `Invalid ref format: "${refId}"` }] };
+                        return { content: [{ type: "text" as const, text: `Invalid ref format: "${refId}"` }] };
                     }
                     const entryIdx = Number.parseInt(match[1], 10);
                     if (entryIdx < 0 || entryIdx >= ctx.session.entries.length) {
-                        return { content: [{ type: "text", text: `Entry e${entryIdx} not found.` }] };
+                        return { content: [{ type: "text" as const, text: `Entry e${entryIdx} not found.` }] };
                     }
 
                     const entry = ctx.harFile.log.entries[entryIdx];
@@ -273,7 +272,7 @@ export async function startMcpServer(): Promise<void> {
                             break;
                     }
 
-                    return { content: [{ type: "text", text: content ?? `No content found for ref "${refId}".` }] };
+                    return { content: [{ type: "text" as const, text: content ?? `No content found for ref "${refId}".` }] };
                 }
 
                 case "har_search": {
@@ -319,7 +318,7 @@ export async function startMcpServer(): Promise<void> {
                     return {
                         content: [
                             {
-                                type: "text",
+                                type: "text" as const,
                                 text: results.length > 0 ? results.join("\n") : `No matches for "${a.query}".`,
                             },
                         ],
@@ -333,14 +332,14 @@ export async function startMcpServer(): Promise<void> {
                     if (type === "errors") {
                         const errors = ctx.session.entries.filter((e) => e.isError);
                         if (errors.length === 0) {
-                            return { content: [{ type: "text", text: "No errors found." }] };
+                            return { content: [{ type: "text" as const, text: "No errors found." }] };
                         }
                         const lines = errors.map((e) => {
                             const raw = ctx.harFile.log.entries[e.index];
                             const body = raw.response.content.text?.slice(0, 80) ?? "";
                             return `e${e.index}  ${e.status}  ${e.method}  ${truncatePath(e.path, 40)}  ${formatDuration(e.timeMs)}${body ? `\n  ${body}` : ""}`;
                         });
-                        return { content: [{ type: "text", text: lines.join("\n") }] };
+                        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
                     }
 
                     if (type === "security") {
@@ -361,7 +360,7 @@ export async function startMcpServer(): Promise<void> {
                         return {
                             content: [
                                 {
-                                    type: "text",
+                                    type: "text" as const,
                                     text: findings.length > 0 ? findings.join("\n") : "No security findings.",
                                 },
                             ],
@@ -370,7 +369,7 @@ export async function startMcpServer(): Promise<void> {
 
                     return {
                         content: [
-                            { type: "text", text: `Unknown analysis type: ${type}. Supported: errors, security` },
+                            { type: "text" as const, text: `Unknown analysis type: ${type}. Supported: errors, security` },
                         ],
                     };
                 }
@@ -385,7 +384,7 @@ export async function startMcpServer(): Promise<void> {
                     return {
                         content: [
                             {
-                                type: "text",
+                                type: "text" as const,
                                 text: `Would export ${filtered.length} entries. Use CLI: tools har-analyzer export [--domain X] [--sanitize] [-o file]`,
                             },
                         ],
@@ -393,11 +392,11 @@ export async function startMcpServer(): Promise<void> {
                 }
 
                 default:
-                    return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
+                    return { content: [{ type: "text" as const, text: `Unknown tool: ${name}` }], isError: true };
             }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+            return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
         }
     });
 

--- a/src/indexer/mcp-server.ts
+++ b/src/indexer/mcp-server.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { out } from "@genesiscz/utils/logger";
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { McpServer } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { shutdownManager } from "./mcp/shared";
 import { registerGraphTools } from "./mcp/tools/graph";
 import { registerIndexTools } from "./mcp/tools/index";

--- a/src/indexer/mcp-server.ts
+++ b/src/indexer/mcp-server.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { out } from "@genesiscz/utils/logger";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { McpServer } from "@modelcontextprotocol/server";
 import { shutdownManager } from "./mcp/shared";
 import { registerGraphTools } from "./mcp/tools/graph";
 import { registerIndexTools } from "./mcp/tools/index";

--- a/src/indexer/mcp/shared.test.ts
+++ b/src/indexer/mcp/shared.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/client";
+import { InMemoryTransport, McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import { type McpTextResult, registerTool } from "./shared";
+
+interface CallToolTextResult {
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+}
+
+/** Register the given tools on a real McpServer and return a Client wired to it in memory. */
+async function connectClient(register: (server: McpServer) => void): Promise<Client> {
+    const server = new McpServer({ name: "indexer-test", version: "1.0.0" });
+    register(server);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "indexer-test-client", version: "1.0.0" });
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    return client;
+}
+
+const searchShape = {
+    query: z.string().describe("what to look for"),
+    limit: z.number().optional(),
+};
+
+describe("indexer registerTool adapter", () => {
+    it("advertises the raw shape as an object JSON Schema with the required keys", async () => {
+        const client = await connectClient((server) => {
+            registerTool(server, "indexer_search", "Search the index", searchShape, async () => ({
+                content: [{ type: "text", text: "" }],
+            }));
+        });
+
+        const { tools } = await client.listTools();
+        expect(tools).toHaveLength(1);
+        expect(tools[0].name).toBe("indexer_search");
+        expect(tools[0].description).toBe("Search the index");
+        expect(tools[0].inputSchema.type).toBe("object");
+        expect(Object.keys(tools[0].inputSchema.properties ?? {}).sort()).toEqual(["limit", "query"]);
+        expect(tools[0].inputSchema.required).toEqual(["query"]);
+
+        await client.close();
+    });
+
+    it("delivers validated arguments to the handler and returns its content", async () => {
+        const received: Array<{ query: string; limit?: number }> = [];
+        const client = await connectClient((server) => {
+            registerTool(server, "indexer_search", "Search the index", searchShape, async (args) => {
+                received.push(args);
+                return { content: [{ type: "text", text: `hit:${args.query}:${args.limit ?? 0}` }] };
+            });
+        });
+
+        const result = (await client.callTool({
+            name: "indexer_search",
+            arguments: { query: "chunker", limit: 5 },
+        })) as CallToolTextResult;
+
+        expect(received).toEqual([{ query: "chunker", limit: 5 }]);
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toBe("hit:chunker:5");
+
+        await client.close();
+    });
+
+    it("rejects arguments that violate the shape without invoking the handler", async () => {
+        let invoked = false;
+        const client = await connectClient((server) => {
+            registerTool(
+                server,
+                "indexer_search",
+                "Search the index",
+                searchShape,
+                async (): Promise<McpTextResult> => {
+                    invoked = true;
+                    return { content: [{ type: "text", text: "should not run" }] };
+                }
+            );
+        });
+
+        const result = (await client.callTool({
+            name: "indexer_search",
+            arguments: { limit: 5 },
+        })) as CallToolTextResult;
+
+        expect(invoked).toBe(false);
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("query");
+
+        await client.close();
+    });
+});

--- a/src/indexer/mcp/shared.ts
+++ b/src/indexer/mcp/shared.ts
@@ -1,18 +1,12 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
 import { IndexerManager } from "../lib/manager";
 
 export type McpTextResult = { content: Array<{ type: "text"; text: string }> };
 
 /**
  * Register an MCP tool whose argument schema is a zod v4 raw shape.
- *
- * The MCP SDK resolves its own (nested) copy of zod for the `ZodRawShapeCompat`
- * type it exposes on `server.tool`. A shape built from our top-level zod v4 is
- * therefore not nominally assignable at that boundary even though it is
- * structurally identical and parses correctly at runtime (the SDK duck-types
- * v3/v4 schemas). This wrapper is the single place that reconciles the two zod
- * instances; every call site stays fully typed through `Shape`.
+ * Wraps the shape with z.object() for the v2 registerTool Standard Schema API.
  */
 export function registerTool<Shape extends z.ZodRawShape>(
     server: McpServer,
@@ -21,13 +15,15 @@ export function registerTool<Shape extends z.ZodRawShape>(
     shape: Shape,
     handler: (args: z.infer<z.ZodObject<Shape>>) => Promise<McpTextResult>
 ): void {
-    const register = server.tool.bind(server) as (
-        name: string,
-        description: string,
-        shape: Shape,
-        handler: (args: z.infer<z.ZodObject<Shape>>) => Promise<McpTextResult>
-    ) => void;
-    register(name, description, shape, handler);
+    server.registerTool(
+        name,
+        {
+            description,
+            inputSchema: z.object(shape),
+        },
+        // Handler args are typed from our shape; SDK callback typing is looser.
+        handler as (args: z.infer<z.ZodObject<Shape>>) => Promise<McpTextResult>
+    );
 }
 
 let manager: IndexerManager | null = null;

--- a/src/indexer/mcp/tools/graph.ts
+++ b/src/indexer/mcp/tools/graph.ts
@@ -1,5 +1,5 @@
 import { buildCodeGraph, getGraphStats, toMermaidDiagram } from "@app/indexer/lib/code-graph";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { formatError, getManager, registerTool } from "../shared";
 

--- a/src/indexer/mcp/tools/index.ts
+++ b/src/indexer/mcp/tools/index.ts
@@ -1,6 +1,6 @@
 import { basename, resolve } from "node:path";
 import type { IndexConfig } from "@app/indexer/lib/types";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { formatError, getManager, registerTool } from "../shared";
 

--- a/src/indexer/mcp/tools/manage.ts
+++ b/src/indexer/mcp/tools/manage.ts
@@ -1,5 +1,5 @@
 import { formatBytes, formatDuration, formatRelativeTime } from "@genesiscz/utils/format";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { formatError, getManager, registerTool } from "../shared";
 

--- a/src/indexer/mcp/tools/models.ts
+++ b/src/indexer/mcp/tools/models.ts
@@ -1,5 +1,5 @@
 import { getModelsForType, MODEL_REGISTRY } from "@app/indexer/lib/model-registry";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { registerTool } from "../shared";
 

--- a/src/indexer/mcp/tools/search.ts
+++ b/src/indexer/mcp/tools/search.ts
@@ -1,6 +1,6 @@
 import { detectMode } from "@app/indexer/lib/search-mode";
 import type { ChunkRecord } from "@app/indexer/lib/types";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { formatError, getManager, registerTool } from "../shared";
 

--- a/src/jenkins-mcp/lib/errors.test.ts
+++ b/src/jenkins-mcp/lib/errors.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { extractErrors } from "./errors";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { AxiosError, AxiosHeaders, type AxiosResponse } from "axios";
+import pino from "pino";
+import { axiosLogFields, extractErrors } from "./errors";
 
 describe("extractErrors", () => {
     it("finds FAIL lines with ±5 context for short logs", () => {
@@ -85,5 +88,47 @@ describe("extractErrors (agnostic patterns)", () => {
         const errs = extractErrors(text);
         expect(errs.length).toBeGreaterThan(0);
         expect(errs[0].matched).toContain(line.slice(0, 10));
+    });
+});
+
+describe("axiosLogFields", () => {
+    const TOKEN = "SUPER_SECRET_JENKINS_TOKEN";
+
+    function jenkinsAxiosError(): AxiosError {
+        const headers = new AxiosHeaders();
+        const config = {
+            url: "/job/deploy/42/api/json",
+            method: "get",
+            baseURL: "https://jenkins.example.com",
+            auth: { username: "ci-user", password: TOKEN },
+            headers,
+        };
+        return new AxiosError("Request failed with status code 500", "ERR_BAD_RESPONSE", config, {}, {
+            status: 500,
+            statusText: "Internal Server Error",
+            data: {},
+            headers,
+            config,
+        } as AxiosResponse);
+    }
+
+    it("keeps the fields needed to reconstruct a failed call", () => {
+        const fields = axiosLogFields(jenkinsAxiosError());
+
+        expect(fields.message).toBe("Request failed with status code 500");
+        expect(fields.code).toBe("ERR_BAD_RESPONSE");
+        expect(fields.status).toBe(500);
+        expect(fields.method).toBe("get");
+        expect(fields.url).toBe("/job/deploy/42/api/json");
+        expect(fields.stack).toBeDefined();
+    });
+
+    it("drops the basic-auth credentials that pino would otherwise serialize", () => {
+        const error = jenkinsAxiosError();
+
+        // Control: the raw error really does leak, so this test is load-bearing.
+        expect(SafeJSON.stringify(pino.stdSerializers.err(error))).toContain(TOKEN);
+
+        expect(SafeJSON.stringify(axiosLogFields(error))).not.toContain(TOKEN);
     });
 });

--- a/src/jenkins-mcp/lib/errors.ts
+++ b/src/jenkins-mcp/lib/errors.ts
@@ -1,3 +1,5 @@
+import type { AxiosError } from "axios";
+
 // Tool-agnostic failure markers. Each term should appear across at least two
 // unrelated build/package/language ecosystems so the pattern doesn't bias
 // toward one stack. Case-insensitive so we catch `Failed`, `error:`, etc.
@@ -58,4 +60,32 @@ export function extractErrors(text: string, opts: ExtractOpts = {}): ErrorBlock[
         matched: lines[r.matchIdx],
         window: lines.slice(r.from, r.to + 1),
     }));
+}
+
+export interface AxiosLogFields {
+    message: string;
+    stack?: string;
+    code?: string;
+    status?: number;
+    method?: string;
+    url?: string;
+}
+
+/**
+ * Flatten an AxiosError into log-safe fields.
+ *
+ * Never hand the AxiosError itself to the logger: pino's error serializer copies
+ * the error's own enumerable properties, and `AxiosError.config` carries
+ * `auth: { username, password }` populated by createClient() with the Jenkins API
+ * token in plaintext, so the token would land in the day-stamped log file.
+ */
+export function axiosLogFields(error: AxiosError): AxiosLogFields {
+    return {
+        message: error.message,
+        stack: error.stack,
+        code: error.code,
+        status: error.response?.status,
+        method: error.config?.method,
+        url: error.config?.url,
+    };
 }

--- a/src/jenkins-mcp/mcp.ts
+++ b/src/jenkins-mcp/mcp.ts
@@ -12,7 +12,7 @@ import {
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import axios, { type AxiosInstance } from "axios";
 import { createClient, readEnvAuth } from "./lib/client";
-import { extractErrors } from "./lib/errors";
+import { axiosLogFields, extractErrors } from "./lib/errors";
 import { formatDuration, formatStageLine, statusBody } from "./lib/format";
 import { fetchLog, grepLog } from "./lib/log";
 import { type BuildMeta, findFailingLeaf, flattenBuildMeta, getStages } from "./lib/pipeline";
@@ -436,15 +436,7 @@ class JenkinsServer {
                 }
 
                 if (axios.isAxiosError(error)) {
-                    logger.warn(
-                        {
-                            error,
-                            tool: request.params.name,
-                            status: error.response?.status,
-                            url: error.config?.url,
-                        },
-                        "Jenkins API call failed"
-                    );
+                    logger.warn({ ...axiosLogFields(error), tool: request.params.name }, "Jenkins API call failed");
                     throw new ProtocolError(
                         ProtocolErrorCode.InternalError,
                         `Jenkins API error: ${error.response?.data?.message || error.message}`

--- a/src/jenkins-mcp/mcp.ts
+++ b/src/jenkins-mcp/mcp.ts
@@ -2,9 +2,8 @@
 
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, ProtocolError, ProtocolErrorCode, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import axios, { type AxiosInstance } from "axios";
 import { createClient, readEnvAuth } from "./lib/client";
 import { extractErrors } from "./lib/errors";
@@ -84,7 +83,7 @@ function buildRef(raw: unknown, toolName: string): BuildRefArgs {
 
 function parseArgs<T>(raw: unknown, schema: ArgSchema, toolName: string): T {
     if (raw === null || typeof raw !== "object") {
-        throw new McpError(ErrorCode.InvalidParams, `${toolName}: arguments must be an object`);
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, `${toolName}: arguments must be an object`);
     }
 
     const args = raw as Record<string, unknown>;
@@ -93,11 +92,11 @@ function parseArgs<T>(raw: unknown, schema: ArgSchema, toolName: string): T {
         const value = args[field];
 
         if (type === "string" && (typeof value !== "string" || value === "")) {
-            throw new McpError(ErrorCode.InvalidParams, `${toolName}: '${field}' must be a non-empty string`);
+            throw new ProtocolError(ProtocolErrorCode.InvalidParams, `${toolName}: '${field}' must be a non-empty string`);
         }
 
         if (type !== "string" && typeof value !== type) {
-            throw new McpError(ErrorCode.InvalidParams, `${toolName}: '${field}' must be a ${type}`);
+            throw new ProtocolError(ProtocolErrorCode.InvalidParams, `${toolName}: '${field}' must be a ${type}`);
         }
     }
 
@@ -109,7 +108,7 @@ function parseArgs<T>(raw: unknown, schema: ArgSchema, toolName: string): T {
         }
 
         if (typeof value !== type) {
-            throw new McpError(ErrorCode.InvalidParams, `${toolName}: '${field}' must be a ${type}`);
+            throw new ProtocolError(ProtocolErrorCode.InvalidParams, `${toolName}: '${field}' must be a ${type}`);
         }
     }
 
@@ -143,13 +142,13 @@ class JenkinsServer {
     }
 
     private setupToolHandlers() {
-        this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+        this.server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
             tools: [
                 {
                     name: "get_build_status",
                     description: "Get the status of a Jenkins build",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
@@ -161,11 +160,11 @@ class JenkinsServer {
                     name: "trigger_build",
                     description: "Trigger a new Jenkins build",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             parameters: {
-                                type: "object",
+                                type: "object" as const,
                                 description: "Build parameters (optional)",
                                 additionalProperties: true,
                             },
@@ -178,7 +177,7 @@ class JenkinsServer {
                     description:
                         "Fetch a build's console log (or a single node's log when nodeId is set), strip HTML timestamp wrappers, and save to /tmp/jenkins-mcp/. Returns the file path + summary. If `grep` is set, also returns matching lines formatted as 'L<lineno>: <text>' (caps at 200 matches). Token-efficient: bytes never enter the response unless you grep.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
@@ -199,7 +198,7 @@ class JenkinsServer {
                     name: "list_jobs",
                     description: "List Jenkins jobs in a folder or at root",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             folderPath: {
                                 type: "string",
@@ -215,7 +214,7 @@ class JenkinsServer {
                     description:
                         "Get build history for a Jenkins job. With expand=true (default), each entry also has displayName, causes (who/what triggered), parameters, branch, SCM revision, and estimatedDuration.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             limit: { type: "number", description: "Number of recent builds (default 10)" },
@@ -232,7 +231,7 @@ class JenkinsServer {
                     name: "stop_build",
                     description: "Stop a running Jenkins build",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
@@ -244,7 +243,7 @@ class JenkinsServer {
                     name: "get_queue",
                     description: "Get the current Jenkins build queue",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             limit: { type: "number", description: "Max queue items to return" },
                         },
@@ -255,7 +254,7 @@ class JenkinsServer {
                     name: "get_job_config",
                     description: "Get the configuration of a Jenkins job",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                         },
@@ -267,7 +266,7 @@ class JenkinsServer {
                     description:
                         "Get the pipeline stage tree for a build (wfapi/describe). With expand=true, includes parallel branch flow nodes. Answers 'what is ?selected-node=N?'.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: "Build number" },
@@ -284,7 +283,7 @@ class JenkinsServer {
                     description:
                         "Find the failing stage (and innermost failing flow node) for a build, fetch its log, and return regex-extracted error windows. One-shot 'what failed and why'.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: "Build number" },
@@ -297,7 +296,7 @@ class JenkinsServer {
                     description:
                         "Extended build info: parameters, causes (who/what triggered), builtOn (agent), executor, estimated duration.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: "Build number" },
@@ -309,7 +308,7 @@ class JenkinsServer {
                     name: "get_build_changes",
                     description: "SCM changeSet (commits, authors) + build trigger causes for a build.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: "Build number" },
@@ -322,7 +321,7 @@ class JenkinsServer {
                     description:
                         "Snapshot current build state with full stage list + durations, then suggest the CLI 'monitor' command to background via Bash for live JSONL events and click-to-Brave notifications. Does NOT poll itself.",
                     inputSchema: {
-                        type: "object",
+                        type: "object" as const,
                         properties: {
                             jobPath: { type: "string", description: JOB_PATH_DESC },
                             buildNumber: { type: "string", description: "Build number" },
@@ -333,7 +332,7 @@ class JenkinsServer {
             ],
         }));
 
-        this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+        this.server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
             try {
                 const raw = request.params.arguments ?? {};
                 const name = request.params.name;
@@ -417,21 +416,21 @@ class JenkinsServer {
                     case "wait_for_build":
                         return await this.waitForBuild(buildRef(raw, name));
                     default:
-                        throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+                        throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${name}`);
                 }
             } catch (error) {
-                if (error instanceof McpError) {
+                if (error instanceof ProtocolError) {
                     throw error;
                 }
 
                 if (axios.isAxiosError(error)) {
-                    throw new McpError(
-                        ErrorCode.InternalError,
+                    throw new ProtocolError(
+                        ProtocolErrorCode.InternalError,
                         `Jenkins API error: ${error.response?.data?.message || error.message}`
                     );
                 }
 
-                throw new McpError(ErrorCode.InternalError, error instanceof Error ? error.message : "Unknown error");
+                throw new ProtocolError(ProtocolErrorCode.InternalError, error instanceof Error ? error.message : "Unknown error");
             }
         });
     }
@@ -440,7 +439,7 @@ class JenkinsServer {
         return {
             content: [
                 {
-                    type: "text",
+                    type: "text" as const,
                     text: typeof value === "string" ? value : SafeJSON.stringify(value, null, 2),
                 },
             ],

--- a/src/jenkins-mcp/mcp.ts
+++ b/src/jenkins-mcp/mcp.ts
@@ -436,12 +436,22 @@ class JenkinsServer {
                 }
 
                 if (axios.isAxiosError(error)) {
+                    logger.warn(
+                        {
+                            error,
+                            tool: request.params.name,
+                            status: error.response?.status,
+                            url: error.config?.url,
+                        },
+                        "Jenkins API call failed"
+                    );
                     throw new ProtocolError(
                         ProtocolErrorCode.InternalError,
                         `Jenkins API error: ${error.response?.data?.message || error.message}`
                     );
                 }
 
+                logger.error({ error, tool: request.params.name }, "Jenkins MCP tool call failed");
                 throw new ProtocolError(
                     ProtocolErrorCode.InternalError,
                     error instanceof Error ? error.message : "Unknown error"

--- a/src/jenkins-mcp/mcp.ts
+++ b/src/jenkins-mcp/mcp.ts
@@ -2,8 +2,14 @@
 
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
+import {
+    type CallToolResult,
+    type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, ProtocolError, ProtocolErrorCode, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import axios, { type AxiosInstance } from "axios";
 import { createClient, readEnvAuth } from "./lib/client";
 import { extractErrors } from "./lib/errors";
@@ -92,7 +98,10 @@ function parseArgs<T>(raw: unknown, schema: ArgSchema, toolName: string): T {
         const value = args[field];
 
         if (type === "string" && (typeof value !== "string" || value === "")) {
-            throw new ProtocolError(ProtocolErrorCode.InvalidParams, `${toolName}: '${field}' must be a non-empty string`);
+            throw new ProtocolError(
+                ProtocolErrorCode.InvalidParams,
+                `${toolName}: '${field}' must be a non-empty string`
+            );
         }
 
         if (type !== "string" && typeof value !== type) {
@@ -142,197 +151,200 @@ class JenkinsServer {
     }
 
     private setupToolHandlers() {
-        this.server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
-            tools: [
-                {
-                    name: "get_build_status",
-                    description: "Get the status of a Jenkins build",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
-                        },
-                        required: ["jobPath"],
-                    },
-                },
-                {
-                    name: "trigger_build",
-                    description: "Trigger a new Jenkins build",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            parameters: {
-                                type: "object" as const,
-                                description: "Build parameters (optional)",
-                                additionalProperties: true,
+        this.server.setRequestHandler(
+            "tools/list",
+            async (): Promise<ListToolsResult> => ({
+                tools: [
+                    {
+                        name: "get_build_status",
+                        description: "Get the status of a Jenkins build",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
                             },
+                            required: ["jobPath"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "get_build_log",
-                    description:
-                        "Fetch a build's console log (or a single node's log when nodeId is set), strip HTML timestamp wrappers, and save to /tmp/jenkins-mcp/. Returns the file path + summary. If `grep` is set, also returns matching lines formatted as 'L<lineno>: <text>' (caps at 200 matches). Token-efficient: bytes never enter the response unless you grep.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
-                            nodeId: {
-                                type: "string",
-                                description: "Pipeline node id (selected-node) — fetch just this node's log",
+                    {
+                        name: "trigger_build",
+                        description: "Trigger a new Jenkins build",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                parameters: {
+                                    type: "object" as const,
+                                    description: "Build parameters (optional)",
+                                    additionalProperties: true,
+                                },
                             },
-                            grep: {
-                                type: "string",
-                                description:
-                                    "Regex to filter lines. Returns up to 200 matches as 'L<n>: <text>' strings.",
+                            required: ["jobPath"],
+                        },
+                    },
+                    {
+                        name: "get_build_log",
+                        description:
+                            "Fetch a build's console log (or a single node's log when nodeId is set), strip HTML timestamp wrappers, and save to /tmp/jenkins-mcp/. Returns the file path + summary. If `grep` is set, also returns matching lines formatted as 'L<lineno>: <text>' (caps at 200 matches). Token-efficient: bytes never enter the response unless you grep.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
+                                nodeId: {
+                                    type: "string",
+                                    description: "Pipeline node id (selected-node) — fetch just this node's log",
+                                },
+                                grep: {
+                                    type: "string",
+                                    description:
+                                        "Regex to filter lines. Returns up to 200 matches as 'L<n>: <text>' strings.",
+                                },
                             },
+                            required: ["jobPath"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "list_jobs",
-                    description: "List Jenkins jobs in a folder or at root",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            folderPath: {
-                                type: "string",
-                                description: 'Folder path (e.g. "job/Foo"); empty for root',
+                    {
+                        name: "list_jobs",
+                        description: "List Jenkins jobs in a folder or at root",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                folderPath: {
+                                    type: "string",
+                                    description: 'Folder path (e.g. "job/Foo"); empty for root',
+                                },
+                                limit: { type: "number", description: "Max jobs to return" },
                             },
-                            limit: { type: "number", description: "Max jobs to return" },
+                            required: [],
                         },
-                        required: [],
                     },
-                },
-                {
-                    name: "get_build_history",
-                    description:
-                        "Get build history for a Jenkins job. With expand=true (default), each entry also has displayName, causes (who/what triggered), parameters, branch, SCM revision, and estimatedDuration.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            limit: { type: "number", description: "Number of recent builds (default 10)" },
-                            expand: {
-                                type: "boolean",
-                                description:
-                                    "Include richer per-build fields (default true). Pass false for a minimal status-only listing.",
+                    {
+                        name: "get_build_history",
+                        description:
+                            "Get build history for a Jenkins job. With expand=true (default), each entry also has displayName, causes (who/what triggered), parameters, branch, SCM revision, and estimatedDuration.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                limit: { type: "number", description: "Number of recent builds (default 10)" },
+                                expand: {
+                                    type: "boolean",
+                                    description:
+                                        "Include richer per-build fields (default true). Pass false for a minimal status-only listing.",
+                                },
                             },
+                            required: ["jobPath"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "stop_build",
-                    description: "Stop a running Jenkins build",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
-                        },
-                        required: ["jobPath", "buildNumber"],
-                    },
-                },
-                {
-                    name: "get_queue",
-                    description: "Get the current Jenkins build queue",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            limit: { type: "number", description: "Max queue items to return" },
-                        },
-                        required: [],
-                    },
-                },
-                {
-                    name: "get_job_config",
-                    description: "Get the configuration of a Jenkins job",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                        },
-                        required: ["jobPath"],
-                    },
-                },
-                {
-                    name: "get_pipeline_stages",
-                    description:
-                        "Get the pipeline stage tree for a build (wfapi/describe). With expand=true, includes parallel branch flow nodes. Answers 'what is ?selected-node=N?'.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: "Build number" },
-                            expand: {
-                                type: "boolean",
-                                description: "Include stageFlowNodes (parallel branches inside each stage)",
+                    {
+                        name: "stop_build",
+                        description: "Stop a running Jenkins build",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: 'Build number (or "lastBuild")' },
                             },
+                            required: ["jobPath", "buildNumber"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "get_failing_node",
-                    description:
-                        "Find the failing stage (and innermost failing flow node) for a build, fetch its log, and return regex-extracted error windows. One-shot 'what failed and why'.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: "Build number" },
+                    {
+                        name: "get_queue",
+                        description: "Get the current Jenkins build queue",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                limit: { type: "number", description: "Max queue items to return" },
+                            },
+                            required: [],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "get_build_info",
-                    description:
-                        "Extended build info: parameters, causes (who/what triggered), builtOn (agent), executor, estimated duration.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: "Build number" },
+                    {
+                        name: "get_job_config",
+                        description: "Get the configuration of a Jenkins job",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                            },
+                            required: ["jobPath"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "get_build_changes",
-                    description: "SCM changeSet (commits, authors) + build trigger causes for a build.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: "Build number" },
+                    {
+                        name: "get_pipeline_stages",
+                        description:
+                            "Get the pipeline stage tree for a build (wfapi/describe). With expand=true, includes parallel branch flow nodes. Answers 'what is ?selected-node=N?'.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: "Build number" },
+                                expand: {
+                                    type: "boolean",
+                                    description: "Include stageFlowNodes (parallel branches inside each stage)",
+                                },
+                            },
+                            required: ["jobPath"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-                {
-                    name: "wait_for_build",
-                    description:
-                        "Snapshot current build state with full stage list + durations, then suggest the CLI 'monitor' command to background via Bash for live JSONL events and click-to-Brave notifications. Does NOT poll itself.",
-                    inputSchema: {
-                        type: "object" as const,
-                        properties: {
-                            jobPath: { type: "string", description: JOB_PATH_DESC },
-                            buildNumber: { type: "string", description: "Build number" },
+                    {
+                        name: "get_failing_node",
+                        description:
+                            "Find the failing stage (and innermost failing flow node) for a build, fetch its log, and return regex-extracted error windows. One-shot 'what failed and why'.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: "Build number" },
+                            },
+                            required: ["jobPath"],
                         },
-                        required: ["jobPath"],
                     },
-                },
-            ],
-        }));
+                    {
+                        name: "get_build_info",
+                        description:
+                            "Extended build info: parameters, causes (who/what triggered), builtOn (agent), executor, estimated duration.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: "Build number" },
+                            },
+                            required: ["jobPath"],
+                        },
+                    },
+                    {
+                        name: "get_build_changes",
+                        description: "SCM changeSet (commits, authors) + build trigger causes for a build.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: "Build number" },
+                            },
+                            required: ["jobPath"],
+                        },
+                    },
+                    {
+                        name: "wait_for_build",
+                        description:
+                            "Snapshot current build state with full stage list + durations, then suggest the CLI 'monitor' command to background via Bash for live JSONL events and click-to-Brave notifications. Does NOT poll itself.",
+                        inputSchema: {
+                            type: "object" as const,
+                            properties: {
+                                jobPath: { type: "string", description: JOB_PATH_DESC },
+                                buildNumber: { type: "string", description: "Build number" },
+                            },
+                            required: ["jobPath"],
+                        },
+                    },
+                ],
+            })
+        );
 
-        this.server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
+        this.server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
             try {
                 const raw = request.params.arguments ?? {};
                 const name = request.params.name;
@@ -430,7 +442,10 @@ class JenkinsServer {
                     );
                 }
 
-                throw new ProtocolError(ProtocolErrorCode.InternalError, error instanceof Error ? error.message : "Unknown error");
+                throw new ProtocolError(
+                    ProtocolErrorCode.InternalError,
+                    error instanceof Error ? error.message : "Unknown error"
+                );
             }
         });
     }

--- a/src/mcp-doctor/lib/probe.ts
+++ b/src/mcp-doctor/lib/probe.ts
@@ -1,8 +1,8 @@
 import { withTimeout } from "@genesiscz/utils/async";
 import { logger } from "@genesiscz/utils/logger";
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
-import { Client, SSEClientTransport, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import type { Transport } from "@modelcontextprotocol/client";
+import { Client, SSEClientTransport, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { classifyResult } from "./report";
 import type { NormalizedServer, ProbeResult, StdioServer } from "./types";
 import { isInvalidServer } from "./types";

--- a/src/mcp-doctor/lib/probe.ts
+++ b/src/mcp-doctor/lib/probe.ts
@@ -1,10 +1,8 @@
 import { withTimeout } from "@genesiscz/utils/async";
 import { logger } from "@genesiscz/utils/logger";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { Client, SSEClientTransport, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import type { Transport } from "@modelcontextprotocol/client";
 import { classifyResult } from "./report";
 import type { NormalizedServer, ProbeResult, StdioServer } from "./types";
 import { isInvalidServer } from "./types";

--- a/src/mcp-doctor/unknown-tool.contract.test.ts
+++ b/src/mcp-doctor/unknown-tool.contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import { Client, ProtocolErrorCode } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+
+const SRC_ROOT = join(import.meta.dir, "..");
+
+interface ServerUnderTest {
+    name: string;
+    /** Path relative to src/. */
+    entry: string;
+    args: string[];
+    /**
+     * True when the unknown-tool branch sits inside a try whose catch flattens
+     * exceptions into an isError result. Those catches must re-throw
+     * ProtocolError or they silently convert the protocol error back into a
+     * tool error, which typechecks and looks fine in review.
+     */
+    catchWrapped: boolean;
+}
+
+const SERVERS: ServerUnderTest[] = [
+    { name: "shops", entry: "shops/index.ts", args: ["mcp"], catchWrapped: false },
+    { name: "claude", entry: "claude/index.ts", args: ["mcp"], catchWrapped: false },
+    { name: "har-analyzer", entry: "har-analyzer/index.ts", args: ["mcp"], catchWrapped: true },
+    { name: "mcp-web-reader", entry: "mcp-web-reader/index.ts", args: ["--server"], catchWrapped: true },
+    { name: "mcp-ripgrep", entry: "mcp-ripgrep/index.ts", args: [], catchWrapped: false },
+];
+
+async function callUnknownTool(server: ServerUnderTest): Promise<{ code?: number; message: string }> {
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ["run", join(SRC_ROOT, server.entry), ...server.args],
+    });
+    const client = new Client({ name: "unknown-tool-contract", version: "1.0.0" });
+    await client.connect(transport);
+
+    try {
+        await client.callTool({ name: "definitely_not_a_tool", arguments: {} });
+        return { message: "__no_error_thrown__" };
+    } catch (error) {
+        const protocolError = error as { code?: number; message: string };
+        return { code: protocolError.code, message: protocolError.message };
+    } finally {
+        await client.close();
+    }
+}
+
+// A tool the server never advertised is a lookup failure, so it belongs in the
+// JSON-RPC error channel, not in an isError CallToolResult. Every in-repo server
+// implements this independently, so it is asserted per server rather than once.
+describe("MCP servers reject unknown tools with MethodNotFound", () => {
+    for (const server of SERVERS) {
+        const label = server.catchWrapped ? `${server.name} (catch-wrapped)` : server.name;
+
+        it(label, async () => {
+            const { code, message } = await callUnknownTool(server);
+
+            expect(code).toBe(ProtocolErrorCode.MethodNotFound);
+            expect(message).toContain("definitely_not_a_tool");
+        }, 30_000);
+    }
+});

--- a/src/mcp-doctor/unknown-tool.contract.test.ts
+++ b/src/mcp-doctor/unknown-tool.contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
 import { Client, ProtocolErrorCode } from "@modelcontextprotocol/client";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
@@ -17,6 +18,8 @@ interface ServerUnderTest {
      * tool error, which typechecks and looks fine in review.
      */
     catchWrapped: boolean;
+    /** Extra env needed to boot. Never real credentials: no tool call leaves the process. */
+    env?: Record<string, string>;
 }
 
 const SERVERS: ServerUnderTest[] = [
@@ -25,12 +28,39 @@ const SERVERS: ServerUnderTest[] = [
     { name: "har-analyzer", entry: "har-analyzer/index.ts", args: ["mcp"], catchWrapped: true },
     { name: "mcp-web-reader", entry: "mcp-web-reader/index.ts", args: ["--server"], catchWrapped: true },
     { name: "mcp-ripgrep", entry: "mcp-ripgrep/index.ts", args: [], catchWrapped: false },
+    {
+        name: "jenkins-mcp",
+        entry: "jenkins-mcp/index.ts",
+        args: [],
+        catchWrapped: true,
+        // readEnvAuth() throws unless all three are set, but it only reads them.
+        // An unknown-tool call is rejected before any HTTP request is issued.
+        env: {
+            JENKINS_URL: "http://jenkins.invalid",
+            JENKINS_USER: "contract-test",
+            JENKINS_TOKEN: "not-a-real-token",
+        },
+    },
 ];
+
+/** StdioClientTransport wants Record<string, string>; the process env is sparser than that. */
+function definedEnv(): Record<string, string> {
+    const result: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(env.getProcessEnv())) {
+        if (value !== undefined) {
+            result[key] = value;
+        }
+    }
+
+    return result;
+}
 
 async function callUnknownTool(server: ServerUnderTest): Promise<{ code?: number; message: string }> {
     const transport = new StdioClientTransport({
         command: process.execPath,
         args: ["run", join(SRC_ROOT, server.entry), ...server.args],
+        env: { ...definedEnv(), ...server.env },
     });
     const client = new Client({ name: "unknown-tool-contract", version: "1.0.0" });
     await client.connect(transport);
@@ -47,8 +77,13 @@ async function callUnknownTool(server: ServerUnderTest): Promise<{ code?: number
 }
 
 // A tool the server never advertised is a lookup failure, so it belongs in the
-// JSON-RPC error channel, not in an isError CallToolResult. Every in-repo server
-// implements this independently, so it is asserted per server rather than once.
+// JSON-RPC error channel, not in an isError CallToolResult. Every server below
+// implements that branch independently, so it is asserted per server.
+//
+// This covers every in-repo stdio MCP server that can be booted hermetically.
+// The one omission is mcp-tsc, whose MCP command builds a TypeScript LSP server
+// bound to a cwd and tsconfig, so spawning it means starting a full LSP over the
+// repo to assert a single throw.
 describe("MCP servers reject unknown tools with MethodNotFound", () => {
     for (const server of SERVERS) {
         const label = server.catchWrapped ? `${server.name} (catch-wrapped)` : server.name;

--- a/src/mcp-ripgrep/index.ts
+++ b/src/mcp-ripgrep/index.ts
@@ -5,9 +5,8 @@ import { wrapArray } from "@genesiscz/utils/array";
 import { logger } from "@genesiscz/utils/logger";
 import { handleReadmeFlag } from "@genesiscz/utils/readme";
 import { escapeShellArg, stripAnsi } from "@genesiscz/utils/string";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 
 // stdio MCP server: stdout carries JSON-RPC frames, so all diagnostics MUST go
 // to the logger (file + stderr via the gated stream), never console.log.
@@ -140,14 +139,14 @@ if (rootArgIndex !== -1 && process.argv.length > rootArgIndex + 1) {
 }
 
 // List available tools
-server.setRequestHandler(ListToolsRequestSchema, async () => {
+server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
     return {
         tools: [
             {
                 name: "search",
                 description: "Search files for patterns using ripgrep (rg)",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         pattern: schemaProperties.pattern,
                         path: schemaProperties.path,
@@ -164,7 +163,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 name: "advanced-search",
                 description: "Advanced search with ripgrep with more options",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         pattern: schemaProperties.pattern,
                         path: schemaProperties.path,
@@ -189,7 +188,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 name: "count-matches",
                 description: "Count matches in files using ripgrep",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         pattern: schemaProperties.pattern,
                         path: schemaProperties.path,
@@ -205,7 +204,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 name: "list-files",
                 description: "List files that would be searched by ripgrep without actually searching them",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         path: schemaProperties.pathForListing,
                         filePattern: schemaProperties.filePattern,
@@ -219,21 +218,23 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 name: "list-file-types",
                 description: "List all supported file types in ripgrep",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {},
                 },
             },
         ],
-    };
+    } as ListToolsResult;
 });
 
 // Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
+server.setRequestHandler('tools/call', async (request, _ctx): Promise<CallToolResult> => {
     const toolName = request.params.name;
 
     if (!["search", "advanced-search", "count-matches", "list-files", "list-file-types"].includes(toolName)) {
-        // Return ServerResult.NEXT to allow the next handler to process the request
-        return Object.create(null);
+        return {
+            content: [{ type: "text" as const, text: `Unknown tool: ${toolName}` }],
+            isError: true,
+        };
     }
 
     try {
@@ -252,7 +253,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 if (!pattern) {
                     return {
                         isError: true,
-                        content: [{ type: "text", text: "Error: Pattern is required" }],
+                        content: [{ type: "text" as const, text: "Error: Pattern is required" }],
                     };
                 }
 
@@ -306,11 +307,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 return {
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: command,
                         },
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: processOutput(stdout, false) || "No matches found",
                         },
                     ],
@@ -338,7 +339,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 if (!pattern) {
                     return {
                         isError: true,
-                        content: [{ type: "text", text: "Error: Pattern is required" }],
+                        content: [{ type: "text" as const, text: "Error: Pattern is required" }],
                     };
                 }
 
@@ -434,7 +435,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 return {
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: processOutput(stdout, useColors) || "No matches found",
                         },
                     ],
@@ -452,7 +453,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 if (!pattern) {
                     return {
                         isError: true,
-                        content: [{ type: "text", text: "Error: Pattern is required" }],
+                        content: [{ type: "text" as const, text: "Error: Pattern is required" }],
                     };
                 }
 
@@ -500,7 +501,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 return {
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: processOutput(stdout, useColors) || "No matches found",
                         },
                     ],
@@ -553,7 +554,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 return {
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: stripAnsi(stdout) || "No files found",
                         },
                     ],
@@ -575,7 +576,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 return {
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: stripAnsi(stdout) || "Failed to get file types",
                         },
                     ],
@@ -586,7 +587,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
                 // This shouldn't happen due to the initial check, but TypeScript doesn't know that
                 return {
                     isError: true,
-                    content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
+                    content: [{ type: "text" as const, text: `Unknown tool: ${toolName}` }],
                 };
         }
     } catch (error) {
@@ -598,7 +599,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
             return {
                 content: [
                     {
-                        type: "text",
+                        type: "text" as const,
                         text: "No matches found.",
                     },
                 ],
@@ -610,7 +611,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
             isError: true,
             content: [
                 {
-                    type: "text",
+                    type: "text" as const,
                     text: stripAnsi(`Error: ${execError.message}\n${execError.stderr || ""}`),
                 },
             ],

--- a/src/mcp-ripgrep/index.ts
+++ b/src/mcp-ripgrep/index.ts
@@ -5,8 +5,8 @@ import { wrapArray } from "@genesiscz/utils/array";
 import { logger } from "@genesiscz/utils/logger";
 import { handleReadmeFlag } from "@genesiscz/utils/readme";
 import { escapeShellArg, stripAnsi } from "@genesiscz/utils/string";
+import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 
 // stdio MCP server: stdout carries JSON-RPC frames, so all diagnostics MUST go
 // to the logger (file + stderr via the gated stream), never console.log.
@@ -139,7 +139,7 @@ if (rootArgIndex !== -1 && process.argv.length > rootArgIndex + 1) {
 }
 
 // List available tools
-server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
+server.setRequestHandler("tools/list", async (): Promise<ListToolsResult> => {
     return {
         tools: [
             {
@@ -227,7 +227,7 @@ server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
 });
 
 // Handle tool calls
-server.setRequestHandler('tools/call', async (request, _ctx): Promise<CallToolResult> => {
+server.setRequestHandler("tools/call", async (request, _ctx): Promise<CallToolResult> => {
     const toolName = request.params.name;
 
     if (!["search", "advanced-search", "count-matches", "list-files", "list-file-types"].includes(toolName)) {

--- a/src/mcp-ripgrep/index.ts
+++ b/src/mcp-ripgrep/index.ts
@@ -5,7 +5,13 @@ import { wrapArray } from "@genesiscz/utils/array";
 import { logger } from "@genesiscz/utils/logger";
 import { handleReadmeFlag } from "@genesiscz/utils/readme";
 import { escapeShellArg, stripAnsi } from "@genesiscz/utils/string";
-import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import {
+    type CallToolResult,
+    type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 
 // stdio MCP server: stdout carries JSON-RPC frames, so all diagnostics MUST go
@@ -231,10 +237,7 @@ server.setRequestHandler("tools/call", async (request, _ctx): Promise<CallToolRe
     const toolName = request.params.name;
 
     if (!["search", "advanced-search", "count-matches", "list-files", "list-file-types"].includes(toolName)) {
-        return {
-            content: [{ type: "text" as const, text: `Unknown tool: ${toolName}` }],
-            isError: true,
-        };
+        throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${toolName}`);
     }
 
     try {

--- a/src/mcp-tsc/README.md
+++ b/src/mcp-tsc/README.md
@@ -314,7 +314,7 @@ For very large projects, the LSP may timeout waiting for diagnostics. This is co
 
 - `typescript`: TypeScript compiler
 - `ts-lsp-client`: LSP client library
-- `@modelcontextprotocol/sdk`: MCP server SDK
+- `@modelcontextprotocol/server` (2.0.0): MCP server SDK
 - `glob`: File pattern matching
 
 ## Related Tools

--- a/src/mcp-tsc/protocols/McpAdapter.ts
+++ b/src/mcp-tsc/protocols/McpAdapter.ts
@@ -6,8 +6,8 @@ import { filterByTsconfig, resolveFiles } from "@app/mcp-tsc/utils/FileResolver.
 import { normalizeFilePaths } from "@app/mcp-tsc/utils/normalize-file-paths.js";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
+import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import ts from "typescript";
 
 export interface McpAdapterOptions {
@@ -52,7 +52,7 @@ export class McpAdapter {
 
     private setupHandlers(): void {
         // Register tool list
-        this.mcpServer.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
+        this.mcpServer.setRequestHandler("tools/list", async (): Promise<ListToolsResult> => {
             return {
                 tools: [
                     {
@@ -130,7 +130,7 @@ export class McpAdapter {
         });
 
         // Register tool call handler
-        this.mcpServer.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
+        this.mcpServer.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
             const toolName = request.params.name;
             const args = request.params.arguments || {};
 
@@ -309,7 +309,10 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
                 return {
                     isError: true,
                     content: [
-                        { type: "text" as const, text: `Error: Line ${line} is out of range (file has ${lines.length} lines)` },
+                        {
+                            type: "text" as const,
+                            text: `Error: Line ${line} is out of range (file has ${lines.length} lines)`,
+                        },
                     ],
                 };
             }

--- a/src/mcp-tsc/protocols/McpAdapter.ts
+++ b/src/mcp-tsc/protocols/McpAdapter.ts
@@ -6,9 +6,8 @@ import { filterByTsconfig, resolveFiles } from "@app/mcp-tsc/utils/FileResolver.
 import { normalizeFilePaths } from "@app/mcp-tsc/utils/normalize-file-paths.js";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import ts from "typescript";
 
 export interface McpAdapterOptions {
@@ -53,7 +52,7 @@ export class McpAdapter {
 
     private setupHandlers(): void {
         // Register tool list
-        this.mcpServer.setRequestHandler(ListToolsRequestSchema, async () => {
+        this.mcpServer.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
             return {
                 tools: [
                     {
@@ -61,7 +60,7 @@ export class McpAdapter {
                         description:
                             "Get TypeScript diagnostics for files matching the specified patterns. Use instead of running any 'tsc' command which isnt for the full project",
                         inputSchema: {
-                            type: "object",
+                            type: "object" as const,
                             properties: {
                                 files: {
                                     oneOf: [
@@ -93,7 +92,7 @@ export class McpAdapter {
                         description:
                             "Get TypeScript hover information (type definitions, documentation) for a specific location in a TypeScript file. Useful for introspecting types, function signatures, and variable definitions. Returns JSDoc comments, parameter descriptions, return types, and examples.",
                         inputSchema: {
-                            type: "object",
+                            type: "object" as const,
                             properties: {
                                 file: {
                                     type: "string",
@@ -131,7 +130,7 @@ export class McpAdapter {
         });
 
         // Register tool call handler
-        this.mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+        this.mcpServer.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
             const toolName = request.params.name;
             const args = request.params.arguments || {};
 
@@ -145,7 +144,7 @@ export class McpAdapter {
 
             return {
                 isError: true,
-                content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
+                content: [{ type: "text" as const, text: `Unknown tool: ${toolName}` }],
             };
         });
     }
@@ -162,7 +161,7 @@ export class McpAdapter {
             if (filePatterns.length === 0) {
                 return {
                     isError: true,
-                    content: [{ type: "text", text: "Error: files parameter is required" }],
+                    content: [{ type: "text" as const, text: "Error: files parameter is required" }],
                 };
             }
 
@@ -173,7 +172,7 @@ export class McpAdapter {
                     isError: true,
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: `No files found matching the specified patterns.\nSearched in: ${
                                 this.cwd
                             }\nPatterns: ${SafeJSON.stringify(filePatterns)}`,
@@ -189,7 +188,7 @@ export class McpAdapter {
                     isError: true,
                     content: [
                         {
-                            type: "text",
+                            type: "text" as const,
                             text: `None of the matched files are included in tsconfig.json.\nFound ${
                                 targetFiles.length
                             } file(s) but they are not in the TypeScript project.\nFiles found: ${targetFiles
@@ -217,7 +216,7 @@ export class McpAdapter {
                         isError: true,
                         content: [
                             {
-                                type: "text",
+                                type: "text" as const,
                                 text: `Timeout waiting for diagnostics (${timeoutMs}ms).
 
 Missing diagnostics for the following file(s):
@@ -252,7 +251,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
             return {
                 content: [
                     {
-                        type: "text",
+                        type: "text" as const,
                         text: summary + diagnosticsText,
                     },
                 ],
@@ -262,7 +261,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
                 isError: true,
                 content: [
                     {
-                        type: "text",
+                        type: "text" as const,
                         text: `Error: ${error instanceof Error ? error.message : String(error)}`,
                     },
                 ],
@@ -284,14 +283,14 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
             if (!filePath) {
                 return {
                     isError: true,
-                    content: [{ type: "text", text: "Error: file parameter is required" }],
+                    content: [{ type: "text" as const, text: "Error: file parameter is required" }],
                 };
             }
 
             if (!line) {
                 return {
                     isError: true,
-                    content: [{ type: "text", text: "Error: line parameter is required" }],
+                    content: [{ type: "text" as const, text: "Error: line parameter is required" }],
                 };
             }
 
@@ -299,7 +298,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
             if (!ts.sys.fileExists(absolutePath)) {
                 return {
                     isError: true,
-                    content: [{ type: "text", text: `Error: File not found: ${filePath}` }],
+                    content: [{ type: "text" as const, text: `Error: File not found: ${filePath}` }],
                 };
             }
 
@@ -310,7 +309,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
                 return {
                     isError: true,
                     content: [
-                        { type: "text", text: `Error: Line ${line} is out of range (file has ${lines.length} lines)` },
+                        { type: "text" as const, text: `Error: Line ${line} is out of range (file has ${lines.length} lines)` },
                     ],
                 };
             }
@@ -324,7 +323,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
                 if (index === -1) {
                     return {
                         isError: true,
-                        content: [{ type: "text", text: `Error: Text "${text}" not found on line ${line}` }],
+                        content: [{ type: "text" as const, text: `Error: Text "${text}" not found on line ${line}` }],
                     };
                 }
                 character = index + 1;
@@ -356,7 +355,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
             return {
                 content: [
                     {
-                        type: "text",
+                        type: "text" as const,
                         text: `\`\`\`json\n${SafeJSON.stringify(response, null, 2)}\n\`\`\``,
                     },
                 ],
@@ -366,7 +365,7 @@ Please retry with a lower timeout (e.g., timeout=${retryTimeoutSeconds}) to get 
                 isError: true,
                 content: [
                     {
-                        type: "text",
+                        type: "text" as const,
                         text: `Error: ${error instanceof Error ? error.message : String(error)}`,
                     },
                 ],

--- a/src/mcp-tsc/protocols/McpAdapter.ts
+++ b/src/mcp-tsc/protocols/McpAdapter.ts
@@ -6,7 +6,13 @@ import { filterByTsconfig, resolveFiles } from "@app/mcp-tsc/utils/FileResolver.
 import { normalizeFilePaths } from "@app/mcp-tsc/utils/normalize-file-paths.js";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
-import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import {
+    type CallToolResult,
+    type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import ts from "typescript";
 
@@ -142,10 +148,7 @@ export class McpAdapter {
                 return await this.handleGetDiagnostics(args as unknown as GetTsDiagnosticsArgs);
             }
 
-            return {
-                isError: true,
-                content: [{ type: "text" as const, text: `Unknown tool: ${toolName}` }],
-            };
+            throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${toolName}`);
         });
     }
 

--- a/src/mcp-tsc/stress-test.ts
+++ b/src/mcp-tsc/stress-test.ts
@@ -14,8 +14,8 @@
 import { writeFileSync } from "node:fs";
 import path from "node:path";
 import { out } from "@genesiscz/utils/logger";
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 // Configuration
 const CONFIG = {

--- a/src/mcp-tsc/stress-test.ts
+++ b/src/mcp-tsc/stress-test.ts
@@ -14,8 +14,8 @@
 import { writeFileSync } from "node:fs";
 import path from "node:path";
 import { out } from "@genesiscz/utils/logger";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { Client } from "@modelcontextprotocol/client";
 
 // Configuration
 const CONFIG = {

--- a/src/mcp-web-reader/index.ts
+++ b/src/mcp-web-reader/index.ts
@@ -7,10 +7,10 @@ import { Command } from "commander";
 handleReadmeFlag(import.meta.url);
 
 import { runTool } from "@genesiscz/utils/cli";
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
+import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { checkLLMModel, downloadLLMModel } from "@nanocollective/get-md";
 import { type EngineName, getEngine, listEngines } from "./engines/index.js";
 import {
@@ -137,7 +137,7 @@ const server = new Server(
     { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
+server.setRequestHandler("tools/list", async (): Promise<ListToolsResult> => {
     return {
         tools: [
             {
@@ -215,7 +215,7 @@ server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
     };
 });
 
-server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
+server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
     const name = request.params.name;
     const args = (request.params.arguments || {}) as Record<string, unknown>;
 

--- a/src/mcp-web-reader/index.ts
+++ b/src/mcp-web-reader/index.ts
@@ -9,7 +9,13 @@ handleReadmeFlag(import.meta.url);
 import { runTool } from "@genesiscz/utils/cli";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
-import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import {
+    type CallToolResult,
+    type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import { checkLLMModel, downloadLLMModel } from "@nanocollective/get-md";
 import { type EngineName, getEngine, listEngines } from "./engines/index.js";
@@ -232,9 +238,14 @@ server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> 
             return (await handleFetchWebMarkdown(args)) as CallToolResult;
         }
 
-        return { content: [{ type: "text" as const, text: `Unknown tool: ${name}` }], isError: true };
+        throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${name}`);
     } catch (e: unknown) {
+        if (e instanceof ProtocolError) {
+            throw e;
+        }
+
         const message = e instanceof Error ? e.message : String(e);
+        logger.warn({ error: e, tool: name }, "mcp-web-reader tool call failed");
         return {
             isError: true,
             content: [{ type: "text" as const, text: `Error: ${message}` }],

--- a/src/mcp-web-reader/index.ts
+++ b/src/mcp-web-reader/index.ts
@@ -7,11 +7,10 @@ import { Command } from "commander";
 handleReadmeFlag(import.meta.url);
 
 import { runTool } from "@genesiscz/utils/cli";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, type CallToolResult, type ListToolsResult } from "@modelcontextprotocol/server";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { checkLLMModel, downloadLLMModel } from "@nanocollective/get-md";
 import { type EngineName, getEngine, listEngines } from "./engines/index.js";
 import {
@@ -138,17 +137,17 @@ const server = new Server(
     { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
+server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => {
     return {
         tools: [
             {
                 name: "FetchWebRaw",
                 description: "Fetch raw HTML of a URL (depth, save_tokens, tokens)",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         url: { type: "string" },
-                        headers: { type: "object", description: "Optional headers" },
+                        headers: { type: "object" as const, description: "Optional headers" },
                         depth: { type: "string", enum: ["basic", "advanced"], description: "Extraction depth" },
                         save_tokens: {
                             type: "number",
@@ -165,7 +164,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 description:
                     "Fetch Markdown via Jina Reader (https://r.jina.ai/http://...) (depth, save_tokens, tokens)",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         url: { type: "string" },
                         depth: {
@@ -188,7 +187,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 description:
                     "Extract Markdown locally using pluggable engines (turndown, mdream, readerlm). Supports depth, engine selection, save_tokens, and token limits.",
                 inputSchema: {
-                    type: "object",
+                    type: "object" as const,
                     properties: {
                         url: { type: "string", description: "URL to fetch and convert" },
                         engine: {
@@ -216,29 +215,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     };
 });
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
     const name = request.params.name;
     const args = (request.params.arguments || {}) as Record<string, unknown>;
 
     try {
         if (name === "FetchWebRaw") {
-            return await handleFetchWebRaw(args);
+            return (await handleFetchWebRaw(args)) as CallToolResult;
         }
 
         if (name === "FetchJina") {
-            return await handleFetchJina(args);
+            return (await handleFetchJina(args)) as CallToolResult;
         }
 
         if (name === "FetchWebMarkdown") {
-            return await handleFetchWebMarkdown(args);
+            return (await handleFetchWebMarkdown(args)) as CallToolResult;
         }
 
-        return Object.create(null);
+        return { content: [{ type: "text" as const, text: `Unknown tool: ${name}` }], isError: true };
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
         return {
             isError: true,
-            content: [{ type: "text", text: `Error: ${message}` }],
+            content: [{ type: "text" as const, text: `Error: ${message}` }],
         };
     }
 });

--- a/src/shops/mcp/server.ts
+++ b/src/shops/mcp/server.ts
@@ -2,8 +2,14 @@ import { getShopsDatabase, type ShopsDatabase } from "@app/shops/db/ShopsDatabas
 import { buildRegistry, getAdvertisedTools, getHandler, type ToolEntry } from "@app/shops/mcp/registry";
 import { listResources, readResource } from "@app/shops/mcp/resources";
 import { logger } from "@genesiscz/utils/logger";
+import {
+    type CallToolResult,
+    type ListResourcesResult,
+    type ListToolsResult,
+    type ReadResourceResult,
+    Server,
+} from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, type CallToolResult, type ListToolsResult, type ListResourcesResult, type ReadResourceResult } from "@modelcontextprotocol/server";
 
 const log = logger.child({ component: "shops:mcp-server" });
 
@@ -19,15 +25,18 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
 
     const server = new Server({ name: "shops", version: "1.0.0" }, { capabilities: { tools: {}, resources: {} } });
 
-    server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
-        tools: getAdvertisedTools(registry, allowWrite).map((t: ToolEntry) => ({
-            name: t.name,
-            description: t.description,
-            inputSchema: t.inputSchema as unknown as ListToolsResult["tools"][number]["inputSchema"],
-        })),
-    }));
+    server.setRequestHandler(
+        "tools/list",
+        async (): Promise<ListToolsResult> => ({
+            tools: getAdvertisedTools(registry, allowWrite).map((t: ToolEntry) => ({
+                name: t.name,
+                description: t.description,
+                inputSchema: t.inputSchema as unknown as ListToolsResult["tools"][number]["inputSchema"],
+            })),
+        })
+    );
 
-    server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
+    server.setRequestHandler("tools/call", async (request): Promise<CallToolResult> => {
         const name = request.params.name;
         const lookup = getHandler(registry, name, allowWrite);
         if (lookup.kind === "notFound") {
@@ -54,15 +63,18 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
         return { content: result.content, isError: result.isError };
     });
 
-    server.setRequestHandler('resources/list', async (): Promise<ListResourcesResult> => ({
-        resources: listResources().map((r) => ({
-            uri: r.uri,
-            name: r.name,
-            mimeType: r.mimeType,
-        })),
-    }));
+    server.setRequestHandler(
+        "resources/list",
+        async (): Promise<ListResourcesResult> => ({
+            resources: listResources().map((r) => ({
+                uri: r.uri,
+                name: r.name,
+                mimeType: r.mimeType,
+            })),
+        })
+    );
 
-    server.setRequestHandler('resources/read', async (request): Promise<ReadResourceResult> => {
+    server.setRequestHandler("resources/read", async (request): Promise<ReadResourceResult> => {
         const uri = request.params.uri;
         try {
             const content = await readResource(uri, shopsDb);

--- a/src/shops/mcp/server.ts
+++ b/src/shops/mcp/server.ts
@@ -2,14 +2,8 @@ import { getShopsDatabase, type ShopsDatabase } from "@app/shops/db/ShopsDatabas
 import { buildRegistry, getAdvertisedTools, getHandler, type ToolEntry } from "@app/shops/mcp/registry";
 import { listResources, readResource } from "@app/shops/mcp/resources";
 import { logger } from "@genesiscz/utils/logger";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-    CallToolRequestSchema,
-    ListResourcesRequestSchema,
-    ListToolsRequestSchema,
-    ReadResourceRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, type CallToolResult, type ListToolsResult, type ListResourcesResult, type ReadResourceResult } from "@modelcontextprotocol/server";
 
 const log = logger.child({ component: "shops:mcp-server" });
 
@@ -25,20 +19,20 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
 
     const server = new Server({ name: "shops", version: "1.0.0" }, { capabilities: { tools: {}, resources: {} } });
 
-    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    server.setRequestHandler('tools/list', async (): Promise<ListToolsResult> => ({
         tools: getAdvertisedTools(registry, allowWrite).map((t: ToolEntry) => ({
             name: t.name,
             description: t.description,
-            inputSchema: t.inputSchema,
+            inputSchema: t.inputSchema as unknown as ListToolsResult["tools"][number]["inputSchema"],
         })),
     }));
 
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler('tools/call', async (request): Promise<CallToolResult> => {
         const name = request.params.name;
         const lookup = getHandler(registry, name, allowWrite);
         if (lookup.kind === "notFound") {
             return {
-                content: [{ type: "text", text: `Unknown tool: ${name}` }],
+                content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
                 isError: true,
             };
         }
@@ -47,7 +41,7 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
             return {
                 content: [
                     {
-                        type: "text",
+                        type: "text" as const,
                         text: `Tool ${name} requires --allow-write flag. Re-run server with --allow-write to enable.`,
                     },
                 ],
@@ -60,7 +54,7 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
         return { content: result.content, isError: result.isError };
     });
 
-    server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    server.setRequestHandler('resources/list', async (): Promise<ListResourcesResult> => ({
         resources: listResources().map((r) => ({
             uri: r.uri,
             name: r.name,
@@ -68,7 +62,7 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
         })),
     }));
 
-    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    server.setRequestHandler('resources/read', async (request): Promise<ReadResourceResult> => {
         const uri = request.params.uri;
         try {
             const content = await readResource(uri, shopsDb);

--- a/src/shops/mcp/server.ts
+++ b/src/shops/mcp/server.ts
@@ -6,6 +6,8 @@ import {
     type CallToolResult,
     type ListResourcesResult,
     type ListToolsResult,
+    ProtocolError,
+    ProtocolErrorCode,
     type ReadResourceResult,
     Server,
 } from "@modelcontextprotocol/server";
@@ -40,10 +42,7 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
         const name = request.params.name;
         const lookup = getHandler(registry, name, allowWrite);
         if (lookup.kind === "notFound") {
-            return {
-                content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
-                isError: true,
-            };
+            throw new ProtocolError(ProtocolErrorCode.MethodNotFound, `Unknown tool: ${name}`);
         }
 
         if (lookup.kind === "writeBlocked") {

--- a/src/shops/mcp/stdio.smoke.test.ts
+++ b/src/shops/mcp/stdio.smoke.test.ts
@@ -8,26 +8,7 @@ interface JsonRpcResponse {
     error?: { code: number; message: string };
 }
 
-interface JsonRpcRequest {
-    jsonrpc: "2.0";
-    id: number;
-    method: string;
-    params?: Record<string, unknown>;
-}
-
-const INITIALIZE: JsonRpcRequest = {
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {
-        protocolVersion: "2024-11-05",
-        capabilities: {},
-        clientInfo: { name: "smoke-test", version: "1.0.0" },
-    },
-};
-
-/** Boot the stdio server, write every frame, and return the responses keyed by request id. */
-async function exchange(requests: JsonRpcRequest[]): Promise<Map<number, JsonRpcResponse>> {
+async function runInitializeAndListTools(): Promise<{ initialize: JsonRpcResponse; listTools: JsonRpcResponse }> {
     const proc = Bun.spawn(["bun", "src/shops/index.ts", "mcp"], {
         cwd: process.cwd(),
         stdin: "pipe",
@@ -35,62 +16,61 @@ async function exchange(requests: JsonRpcRequest[]): Promise<Map<number, JsonRpc
         stderr: "pipe",
     });
 
-    for (const request of requests) {
-        proc.stdin.write(`${SafeJSON.stringify(request)}\n`);
-    }
+    const initRequest = {
+        jsonrpc: "2.0" as const,
+        id: 1,
+        method: "initialize",
+        params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "smoke-test", version: "1.0.0" },
+        },
+    };
+    const listRequest = {
+        jsonrpc: "2.0" as const,
+        id: 2,
+        method: "tools/list",
+    };
 
+    proc.stdin.write(`${SafeJSON.stringify(initRequest)}\n`);
+    proc.stdin.write(`${SafeJSON.stringify(listRequest)}\n`);
     proc.stdin.end();
 
-    const stdoutText = await new Response(proc.stdout).text();
+    // Both pipes must be drained concurrently. The server logs to stderr, so
+    // reading stdout alone would deadlock once the stderr pipe buffer fills:
+    // the child blocks on write, never exits, and stdout never reaches EOF.
+    const [stdoutText, stderrText] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+    ]);
     proc.kill();
     await proc.exited;
 
     const lines = stdoutText.split("\n").filter((l) => l.trim().length > 0);
-    if (lines.length < requests.length) {
+    if (lines.length < 2) {
         throw new Error(
-            `Expected ${requests.length} JSON-RPC frames on stdout, got ${lines.length}: ${stdoutText.slice(0, 500)}`
+            `Expected at least 2 JSON-RPC frames on stdout, got ${lines.length}.\n` +
+                `stdout: ${stdoutText.slice(0, 500)}\nstderr: ${stderrText.slice(0, 500)}`
         );
     }
 
-    const byId = new Map<number, JsonRpcResponse>();
-    for (const line of lines) {
-        const frame = SafeJSON.parse(line) as JsonRpcResponse;
-        byId.set(Number(frame.id), frame);
-    }
-
-    return byId;
+    const initialize = SafeJSON.parse(lines[0]) as JsonRpcResponse;
+    const listTools = SafeJSON.parse(lines[1]) as JsonRpcResponse;
+    return { initialize, listTools };
 }
 
 describe("MCP stdio smoke", () => {
     it("boots the server, returns valid JSON-RPC frames, no stdout pollution", async () => {
-        const responses = await exchange([INITIALIZE, { jsonrpc: "2.0", id: 2, method: "tools/list" }]);
+        const { initialize, listTools } = await runInitializeAndListTools();
+        expect(initialize.jsonrpc).toBe("2.0");
+        expect(initialize.id).toBe(1);
+        expect(initialize.result).toBeDefined();
+        expect(initialize.result?.protocolVersion).toBeDefined();
 
-        const initialize = responses.get(1);
-        expect(initialize?.jsonrpc).toBe("2.0");
-        expect(initialize?.result).toBeDefined();
-        expect(initialize?.result?.protocolVersion).toBeDefined();
-
-        const listTools = responses.get(2);
-        expect(listTools?.jsonrpc).toBe("2.0");
-        const tools = (listTools?.result as unknown as { tools: Array<{ name: string }> }).tools;
+        expect(listTools.jsonrpc).toBe("2.0");
+        expect(listTools.id).toBe(2);
+        const tools = (listTools.result as unknown as { tools: Array<{ name: string }> }).tools;
         expect(tools.length).toBe(8);
         expect(tools.every((t) => !t.name.startsWith("shops_ingest"))).toBe(true);
-    }, 15_000);
-
-    it("answers an unknown tool with a MethodNotFound protocol error, not an isError result", async () => {
-        const responses = await exchange([
-            INITIALIZE,
-            {
-                jsonrpc: "2.0",
-                id: 2,
-                method: "tools/call",
-                params: { name: "shops_definitely_not_a_tool", arguments: {} },
-            },
-        ]);
-
-        const call = responses.get(2);
-        expect(call?.result).toBeUndefined();
-        expect(call?.error?.code).toBe(-32601);
-        expect(call?.error?.message).toContain("shops_definitely_not_a_tool");
     }, 15_000);
 });

--- a/src/shops/mcp/stdio.smoke.test.ts
+++ b/src/shops/mcp/stdio.smoke.test.ts
@@ -8,7 +8,26 @@ interface JsonRpcResponse {
     error?: { code: number; message: string };
 }
 
-async function runInitializeAndListTools(): Promise<{ initialize: JsonRpcResponse; listTools: JsonRpcResponse }> {
+interface JsonRpcRequest {
+    jsonrpc: "2.0";
+    id: number;
+    method: string;
+    params?: Record<string, unknown>;
+}
+
+const INITIALIZE: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "smoke-test", version: "1.0.0" },
+    },
+};
+
+/** Boot the stdio server, write every frame, and return the responses keyed by request id. */
+async function exchange(requests: JsonRpcRequest[]): Promise<Map<number, JsonRpcResponse>> {
     const proc = Bun.spawn(["bun", "src/shops/index.ts", "mcp"], {
         cwd: process.cwd(),
         stdin: "pipe",
@@ -16,24 +35,10 @@ async function runInitializeAndListTools(): Promise<{ initialize: JsonRpcRespons
         stderr: "pipe",
     });
 
-    const initRequest = {
-        jsonrpc: "2.0" as const,
-        id: 1,
-        method: "initialize",
-        params: {
-            protocolVersion: "2024-11-05",
-            capabilities: {},
-            clientInfo: { name: "smoke-test", version: "1.0.0" },
-        },
-    };
-    const listRequest = {
-        jsonrpc: "2.0" as const,
-        id: 2,
-        method: "tools/list",
-    };
+    for (const request of requests) {
+        proc.stdin.write(`${SafeJSON.stringify(request)}\n`);
+    }
 
-    proc.stdin.write(`${SafeJSON.stringify(initRequest)}\n`);
-    proc.stdin.write(`${SafeJSON.stringify(listRequest)}\n`);
     proc.stdin.end();
 
     const stdoutText = await new Response(proc.stdout).text();
@@ -41,29 +46,51 @@ async function runInitializeAndListTools(): Promise<{ initialize: JsonRpcRespons
     await proc.exited;
 
     const lines = stdoutText.split("\n").filter((l) => l.trim().length > 0);
-    if (lines.length < 2) {
+    if (lines.length < requests.length) {
         throw new Error(
-            `Expected at least 2 JSON-RPC frames on stdout, got ${lines.length}: ${stdoutText.slice(0, 500)}`
+            `Expected ${requests.length} JSON-RPC frames on stdout, got ${lines.length}: ${stdoutText.slice(0, 500)}`
         );
     }
 
-    const initialize = SafeJSON.parse(lines[0]) as JsonRpcResponse;
-    const listTools = SafeJSON.parse(lines[1]) as JsonRpcResponse;
-    return { initialize, listTools };
+    const byId = new Map<number, JsonRpcResponse>();
+    for (const line of lines) {
+        const frame = SafeJSON.parse(line) as JsonRpcResponse;
+        byId.set(Number(frame.id), frame);
+    }
+
+    return byId;
 }
 
 describe("MCP stdio smoke", () => {
     it("boots the server, returns valid JSON-RPC frames, no stdout pollution", async () => {
-        const { initialize, listTools } = await runInitializeAndListTools();
-        expect(initialize.jsonrpc).toBe("2.0");
-        expect(initialize.id).toBe(1);
-        expect(initialize.result).toBeDefined();
-        expect(initialize.result?.protocolVersion).toBeDefined();
+        const responses = await exchange([INITIALIZE, { jsonrpc: "2.0", id: 2, method: "tools/list" }]);
 
-        expect(listTools.jsonrpc).toBe("2.0");
-        expect(listTools.id).toBe(2);
-        const tools = (listTools.result as unknown as { tools: Array<{ name: string }> }).tools;
+        const initialize = responses.get(1);
+        expect(initialize?.jsonrpc).toBe("2.0");
+        expect(initialize?.result).toBeDefined();
+        expect(initialize?.result?.protocolVersion).toBeDefined();
+
+        const listTools = responses.get(2);
+        expect(listTools?.jsonrpc).toBe("2.0");
+        const tools = (listTools?.result as unknown as { tools: Array<{ name: string }> }).tools;
         expect(tools.length).toBe(8);
         expect(tools.every((t) => !t.name.startsWith("shops_ingest"))).toBe(true);
+    }, 15_000);
+
+    it("answers an unknown tool with a MethodNotFound protocol error, not an isError result", async () => {
+        const responses = await exchange([
+            INITIALIZE,
+            {
+                jsonrpc: "2.0",
+                id: 2,
+                method: "tools/call",
+                params: { name: "shops_definitely_not_a_tool", arguments: {} },
+            },
+        ]);
+
+        const call = responses.get(2);
+        expect(call?.result).toBeUndefined();
+        expect(call?.error?.code).toBe(-32601);
+        expect(call?.error?.message).toContain("shops_definitely_not_a_tool");
     }, 15_000);
 });

--- a/src/shops/mcp/stdio.smoke.test.ts
+++ b/src/shops/mcp/stdio.smoke.test.ts
@@ -8,6 +8,12 @@ interface JsonRpcResponse {
     error?: { code: number; message: string };
 }
 
+interface JsonRpcFrame {
+    jsonrpc?: string;
+    id?: number | string;
+    method?: string;
+}
+
 async function runInitializeAndListTools(): Promise<{ initialize: JsonRpcResponse; listTools: JsonRpcResponse }> {
     const proc = Bun.spawn(["bun", "src/shops/index.ts", "mcp"], {
         cwd: process.cwd(),
@@ -46,16 +52,40 @@ async function runInitializeAndListTools(): Promise<{ initialize: JsonRpcRespons
     proc.kill();
     await proc.exited;
 
+    const context = `\nstdout: ${stdoutText.slice(0, 500)}\nstderr: ${stderrText.slice(0, 500)}`;
     const lines = stdoutText.split("\n").filter((l) => l.trim().length > 0);
-    if (lines.length < 2) {
-        throw new Error(
-            `Expected at least 2 JSON-RPC frames on stdout, got ${lines.length}.\n` +
-                `stdout: ${stdoutText.slice(0, 500)}\nstderr: ${stderrText.slice(0, 500)}`
-        );
+
+    // Every stdout line must be a JSON-RPC frame. This is the "no stdout
+    // pollution" half of the contract: one stray console.log anywhere in the
+    // server or its imports corrupts the stream for every client.
+    const byId = new Map<number | string, JsonRpcResponse>();
+    for (const [index, line] of lines.entries()) {
+        let frame: JsonRpcFrame;
+
+        try {
+            frame = SafeJSON.parse(line) as JsonRpcFrame;
+        } catch {
+            throw new Error(`stdout line ${index + 1} is not JSON, so something polluted the stream: ${line}`);
+        }
+
+        if (frame.jsonrpc !== "2.0") {
+            throw new Error(`stdout line ${index + 1} is not a JSON-RPC 2.0 frame: ${line}`);
+        }
+
+        // Notifications carry no id and need no correlation.
+        if (frame.id === undefined) {
+            continue;
+        }
+
+        byId.set(frame.id, frame as JsonRpcResponse);
     }
 
-    const initialize = SafeJSON.parse(lines[0]) as JsonRpcResponse;
-    const listTools = SafeJSON.parse(lines[1]) as JsonRpcResponse;
+    const initialize = byId.get(1);
+    const listTools = byId.get(2);
+    if (!initialize || !listTools) {
+        throw new Error(`Missing responses for ids 1 and 2, got ids [${[...byId.keys()].join(", ")}].${context}`);
+    }
+
     return { initialize, listTools };
 }
 

--- a/src/youtube/lib/devtools/frame-grid.ts
+++ b/src/youtube/lib/devtools/frame-grid.ts
@@ -1,8 +1,9 @@
+import type { Client } from "@modelcontextprotocol/client";
+
 // Copied from .claude/skills/chrome-extension-dev/scripts/devtools-frame-grid.ts
 // at 2026-07-17T19:10:00Z, commit 376aa1d59e451bcca57bee553220a1eae08e4b00.
 // Moved into the package so src/youtube doesn't import from a dotfile
 // directory outside the repo's shipped source tree.
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 export interface FrameGridOpts {
     /** Crop region in the SCREENSHOT's own pixel space: "x,y,w,h". Omit for the full viewport. */

--- a/src/youtube/lib/devtools/mcp-client.ts
+++ b/src/youtube/lib/devtools/mcp-client.ts
@@ -1,10 +1,11 @@
 // Copied from .claude/skills/chrome-extension-dev/scripts/devtools-mcp-client.ts
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { Client } from "@modelcontextprotocol/client";
+
 // at 2026-07-17T19:10:00Z, commit 376aa1d59e451bcca57bee553220a1eae08e4b00.
 // Moved into the package so src/youtube doesn't import from a dotfile
 // directory outside the repo's shipped source tree.
 import { env } from "@genesiscz/utils/env.client";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 export interface DevtoolsClientOpts {
     /** CDP endpoint of an already-running, extension-loaded browser (see browser.ts). */

--- a/src/youtube/lib/devtools/mcp-client.ts
+++ b/src/youtube/lib/devtools/mcp-client.ts
@@ -1,11 +1,11 @@
 // Copied from .claude/skills/chrome-extension-dev/scripts/devtools-mcp-client.ts
-import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
-import { Client } from "@modelcontextprotocol/client";
 
 // at 2026-07-17T19:10:00Z, commit 376aa1d59e451bcca57bee553220a1eae08e4b00.
 // Moved into the package so src/youtube doesn't import from a dotfile
 // directory outside the repo's shipped source tree.
 import { env } from "@genesiscz/utils/env.client";
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 export interface DevtoolsClientOpts {
     /** CDP endpoint of an already-running, extension-loaded browser (see browser.ts). */


### PR DESCRIPTION
## Summary

Migrate GenesisTools from monolithic `@modelcontextprotocol/sdk@1.25.2` to the stable v2 package split:

- `@modelcontextprotocol/client@2.0.0`
- `@modelcontextprotocol/server@2.0.0`
- `@modelcontextprotocol/core@2.0.0`

Also exempt those packages (and the codemod) from Bun's 7-day `minimumReleaseAge` gate so install works while the packages are still young (published 2026-07-27).

**Not in this PR:** forcing protocol 2026-07-28 wire. v2 clients/servers still speak 2025-era (`initialize`) by default, which matches current hosts (Claude Code, Cursor, Codex). Dual-era / MRTR is a follow-up.

Research note: `GenesisBrain/Dev/MCP/ModelContextProtocolV2.md`

## What changed

- Official `mcp-codemod v1-to-v2` rewrote imports, `setRequestHandler` method strings, `McpError` → `ProtocolError`, `.tool()` → `registerTool` where applicable
- Manual burn-down: indexer `registerTool` via `server.registerTool` + `z.object`, dashboard `InMemoryTransport` from server package only, low-level handlers annotated `ListToolsResult` / `CallToolResult`, `type: "text"|"object" as const`
- Dashboard workspace: `apps/web` dep + local `bunfig.toml` excludes for the same age gate
- Root `bunfig.toml`: add MCP packages to `minimumReleaseAgeExcludes` (does **not** lower `minimumReleaseAge`)

## Verification

### BEFORE (worktree at master tip `9b4e946f2`, pre-migration)

```text
bun scripts/test.ts src/shops/mcp/ src/mcp-doctor/mcp-doctor.test.ts src/claude/mcp/ src/jenkins-mcp/lib/ src/mcp-manager/commands/__tests__/
→ 274 pass, 0 fail, EXIT 0

mcp-scripting: servers (25 enabled), tools genesis-tools.*, call handoff_list → EXIT 0
```

### AFTER (this branch)

```text
same test suite → 274 pass, 0 fail, EXIT 0
bun scripts/test.ts src/claude/mcp/server.e2e.test.ts src/shops/mcp/stdio.smoke.test.ts → 2 pass, EXIT 0
tsgo --noEmit → EXIT 0
rg '@modelcontextprotocol/sdk' src (non-md) → only dashboard lock transitive peer via @google/genai optional peer
bun pm ls → client/server/core/codemod @2.0.0; no root sdk dep
mcp-scripting call genesis-tools.handoff_list → EXIT 0
```

## Risk / residual

- `@modelcontextprotocol/server-github` remains as an install-string / optional dep and still pulls v1 sdk transitively; no object flow between v1/v2
- mcp-scripting skill itself still depends on sdk v1 + mcporter (out of scope)
- Protocol 2026 dual-era (`versionNegotiation`, `serveStdio` factory, MRTR) deferred on purpose

## Test plan

- [x] Unit/e2e MCP suite green before and after
- [x] `tsgo --noEmit` clean
- [x] Stdio smoke: genesis-tools MCP + shops MCP
- [x] Live mcp-scripting handoff_list
- [ ] CI on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated MCP integrations across the application to the latest protocol package structure.
  * Preserved existing tool, resource, client, and transport behavior.

* **Bug Fixes**
  * Improved MCP response typing and error handling for unknown tools, invalid inputs, and failed requests.
  * Standardized validation for task and timer tool inputs.

* **Tests**
  * Updated MCP end-to-end and stress-test integrations to use the current client interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->