### PR TITLE
feat(ai-proxy): account-stored credentials, key safety, grok OIDC self-refresh

### DIFF
--- a/src/ai-proxy/commands/accounts.test.ts
+++ b/src/ai-proxy/commands/accounts.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runAccountsAllowEnv, runAccountsSetKey } from "@app/ai-proxy/commands/accounts";
+import { loadConfig, saveConfig } from "@app/ai-proxy/lib/config";
+import { resetAiProxyConfigStore } from "@app/ai-proxy/lib/config-store";
+import { resetAiProxyStorage } from "@app/ai-proxy/lib/storage";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
+
+/**
+ * These cover the non-interactive halves of `accounts set-key` / `allow-env` —
+ * the ones that decide, without a human in the loop, whether an account may
+ * spend a billed key. The clack chooser itself is not driven here; every state
+ * it can leave behind is reachable through these two entry points.
+ *
+ * `isInteractive()` is false under the test runner (no TTY), which is exactly
+ * the branch a script or a daemon takes.
+ */
+
+const originalHome = env.get("GENESIS_TOOLS_HOME");
+let tempDir: string;
+
+function account(overrides: Partial<AiProxyAccountConfig> = {}): AiProxyAccountConfig {
+    return { name: "work", provider: "xai-api-key", providerSlug: "xai", enabled: true, ...overrides };
+}
+
+async function seed(...accounts: AiProxyAccountConfig[]): Promise<void> {
+    const config = await loadConfig();
+    config.accounts = accounts;
+    await saveConfig(config);
+}
+
+async function readAccount(name: string): Promise<AiProxyAccountConfig | undefined> {
+    return (await loadConfig()).accounts.find((item) => item.name === name);
+}
+
+beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "ai-proxy-accounts-"));
+    env.testing.set("GENESIS_TOOLS_HOME", tempDir);
+    resetAiProxyConfigStore();
+    resetAiProxyStorage();
+});
+
+afterEach(() => {
+    resetAiProxyConfigStore();
+    resetAiProxyStorage();
+    rmSync(tempDir, { recursive: true, force: true });
+
+    if (originalHome === undefined) {
+        env.testing.unset("GENESIS_TOOLS_HOME");
+    } else {
+        env.testing.set("GENESIS_TOOLS_HOME", originalHome);
+    }
+});
+
+describe("runAccountsSetKey", () => {
+    it("stores a key given on argv and drops any environment opt-in", async () => {
+        await seed(account({ allowEnvApiKey: true }));
+
+        await runAccountsSetKey("work", "xai-secret-value");
+
+        const stored = await readAccount("work");
+        expect(stored?.apiKey).toBe("xai-secret-value");
+        // Both fields set would claim two different intentions; the stored key
+        // wins at resolve time, so the opt-in has to go.
+        expect(stored?.allowEnvApiKey).toBeUndefined();
+    });
+
+    it("trims the key so a stray space cannot become part of the credential", async () => {
+        await seed(account());
+
+        await runAccountsSetKey("work", "  xai-secret-value  ");
+
+        expect((await readAccount("work"))?.apiKey).toBe("xai-secret-value");
+    });
+
+    it("changes nothing for an OAuth account, which has no api key to set", async () => {
+        await seed(account({ name: "grok", provider: "grok-subscription", providerSlug: "grok" }));
+
+        await runAccountsSetKey("grok", "should-not-land");
+
+        expect((await readAccount("grok"))?.apiKey).toBeUndefined();
+    });
+
+    it("changes nothing for an account that does not exist", async () => {
+        await seed(account());
+
+        await runAccountsSetKey("missing", "should-not-land");
+
+        expect((await loadConfig()).accounts).toHaveLength(1);
+        expect((await readAccount("work"))?.apiKey).toBeUndefined();
+    });
+
+    it("leaves the account untouched when no key is given and there is no terminal to ask on", async () => {
+        await seed(account({ apiKey: "existing-key" }));
+
+        await runAccountsSetKey("work", undefined);
+
+        expect((await readAccount("work"))?.apiKey).toBe("existing-key");
+    });
+});
+
+describe("runAccountsAllowEnv", () => {
+    it("opts the account in and removes a stored key that would have won anyway", async () => {
+        await seed(account({ apiKey: "stored-key" }));
+
+        await runAccountsAllowEnv("work", true);
+
+        const stored = await readAccount("work");
+        expect(stored?.allowEnvApiKey).toBe(true);
+        expect(stored?.apiKey).toBeUndefined();
+    });
+
+    it("revokes the opt-in, leaving the account with no credential at all", async () => {
+        await seed(account({ allowEnvApiKey: true }));
+
+        await runAccountsAllowEnv("work", false);
+
+        const stored = await readAccount("work");
+        expect(stored?.allowEnvApiKey).toBeUndefined();
+        expect(stored?.apiKey).toBeUndefined();
+    });
+
+    it("refuses to opt in an OAuth account", async () => {
+        await seed(account({ name: "grok", provider: "grok-subscription", providerSlug: "grok" }));
+
+        await runAccountsAllowEnv("grok", true);
+
+        expect((await readAccount("grok"))?.allowEnvApiKey).toBeUndefined();
+    });
+});

--- a/src/ai-proxy/commands/accounts.ts
+++ b/src/ai-proxy/commands/accounts.ts
@@ -1,10 +1,12 @@
 import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
 import { loadConfig, saveConfig } from "@app/ai-proxy/lib/config";
 import { type AccountListRow, displayAccountsTable, displayAccountTestResult } from "@app/ai-proxy/lib/display";
+import { apiKeyStatus, findEnvSourceFile } from "@app/ai-proxy/lib/providers/api-key-state";
 import { createProvider, isProviderImplemented } from "@app/ai-proxy/lib/providers/registry";
+import type { AiProxyAccountConfig, AiProxyProviderType } from "@app/ai-proxy/lib/types";
 import { AIConfig } from "@genesiscz/utils/ai/AIConfig";
 import { CODEX_AUTH_PATH, extractPlanType, readCodexAuthJson } from "@genesiscz/utils/ai/openai/codex-auth";
-import { suggestCommand } from "@genesiscz/utils/cli";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
 
 function cmd(replaceCommand: string[]): string {
@@ -165,6 +167,205 @@ export async function runAccountsSetEnabled(name: string, enabled: boolean): Pro
     await saveConfig(config);
     out.log.success(`${enabled ? "Enabled" : "Disabled"} account: ${name} (${account.provider})`);
     out.log.info("Restart the proxy to apply: tools ai-proxy down && tools ai-proxy up");
+}
+
+const API_KEY_PROVIDERS = new Set<AiProxyProviderType>(["xai-api-key", "openai"]);
+
+export async function runAccountsSetKey(name: string, key: string | undefined): Promise<void> {
+    const config = await loadConfig();
+    const account = config.accounts.find((item) => item.name === name);
+
+    if (!account) {
+        out.log.warn(`Account not found: ${name}`);
+        out.log.info(cmd(["accounts", "list"]));
+        return;
+    }
+
+    if (!API_KEY_PROVIDERS.has(account.provider)) {
+        out.log.warn(`Account "${name}" is ${account.provider} — it authenticates via OAuth, not an API key.`);
+        return;
+    }
+
+    const trimmed = key?.trim();
+
+    if (trimmed) {
+        // Passing the key as argv puts it in shell history and in `ps` for the
+        // lifetime of the command — kept for scripts, but say so.
+        out.log.warn("A key passed on the command line lands in shell history and is visible to `ps`.");
+        out.log.info(`Interactive, masked entry: ${cmd(["accounts", "set-key", name])}`);
+        applyStoredKey(account, trimmed);
+        await saveConfig(config);
+        reportStoredKey(name, account.provider);
+        return;
+    }
+
+    if (!isInteractive()) {
+        out.log.warn(`No key given for "${name}" and this is not a terminal, so nothing was changed.`);
+        out.log.info(`Pass the key as an argument, or opt in to the environment key: ${allowEnvHint(name)}`);
+        return;
+    }
+
+    await chooseCredential({ config, account, name });
+}
+
+function applyStoredKey(account: AiProxyAccountConfig, key: string): void {
+    account.apiKey = key;
+    // A stored key wins over the environment anyway; clearing the opt-in keeps
+    // the two fields from describing two different intentions.
+    delete account.allowEnvApiKey;
+}
+
+function reportStoredKey(name: string, provider: AiProxyProviderType): void {
+    out.log.success(`Stored API key for "${name}" (${provider}) in the ai-proxy config.`);
+    out.log.warn("This is a billed credential and it now lives in plain text in the ai-proxy config file.");
+    out.log.info(RESTART_HINT);
+}
+
+function allowEnvHint(name: string): string {
+    return cmd(["accounts", "allow-env", name]);
+}
+
+const RESTART_HINT = "Restart the proxy to apply: tools ai-proxy down && tools ai-proxy up";
+
+/** Print where the account stands today, then offer the four end states. */
+async function chooseCredential(input: {
+    config: Awaited<ReturnType<typeof loadConfig>>;
+    account: AiProxyAccountConfig;
+    name: string;
+}): Promise<void> {
+    const { account, name } = input;
+    const status = apiKeyStatus(account);
+    const sourceFile = await findEnvSourceFile(status.envName);
+    const envDetail = `${status.envName} is ${status.envPresent ? "set" : "not set"} in this environment · ${
+        sourceFile ? `exported from ${sourceFile}` : "source unknown"
+    }`;
+
+    out.log.info(
+        [
+            `Account "${name}" (${account.provider})`,
+            status.state === "override"
+                ? `  now: a key stored on the account (${status.maskedOverride}) — the environment is ignored`
+                : status.state === "env"
+                  ? `  now: spends the environment key ${status.envName}`
+                  : "  now: no usable credential — routes to this account are refused",
+            `  ${envDetail}`,
+        ].join("\n")
+    );
+
+    const options = [
+        {
+            value: "env" as const,
+            label: `Use the environment variable ${status.envName}`,
+            hint: status.envPresent ? (sourceFile ?? "source unknown") : "not currently set",
+        },
+        { value: "override" as const, label: "Override with a specific key (entered masked)" },
+        ...(status.state === "override"
+            ? [
+                  {
+                      value: "remove-override" as const,
+                      label: "Remove the stored key and fall back to the environment",
+                  },
+              ]
+            : []),
+        { value: "none" as const, label: "Use no key at all (account becomes unusable)" },
+    ];
+
+    const choice = await out.select({ message: `Credential for "${name}"`, options });
+
+    if (out.isCancel(choice)) {
+        out.log.warn("Cancelled — nothing changed.");
+        return;
+    }
+
+    if (choice === "override") {
+        const entered = await out.password({
+            message: `API key for "${name}"`,
+            validate: (value) => (value.trim().length > 0 ? undefined : "Enter a key, or cancel."),
+        });
+
+        if (out.isCancel(entered)) {
+            out.log.warn("Cancelled — nothing changed.");
+            return;
+        }
+
+        applyStoredKey(account, entered.trim());
+        await saveConfig(input.config);
+        reportStoredKey(name, account.provider);
+        return;
+    }
+
+    if (choice === "none") {
+        delete account.apiKey;
+        delete account.allowEnvApiKey;
+        await saveConfig(input.config);
+        out.log.success(`"${name}" now has no credential at all.`);
+        out.log.warn("The account will not load and every route to it is refused until you set one.");
+        out.log.info(RESTART_HINT);
+        return;
+    }
+
+    delete account.apiKey;
+    account.allowEnvApiKey = true;
+    await saveConfig(input.config);
+    out.log.success(
+        choice === "remove-override"
+            ? `Removed the stored key for "${name}" — it now spends ${status.envName}.`
+            : `"${name}" now spends the environment key ${status.envName}.`
+    );
+
+    if (!status.envPresent) {
+        out.log.warn(`${status.envName} is not set right now, so the account will not load until it is.`);
+    }
+
+    out.log.warn("Every call on this account spends metered money on whatever key the environment holds.");
+    out.log.info(RESTART_HINT);
+}
+
+export async function runAccountsAllowEnv(name: string, allow: boolean): Promise<void> {
+    const config = await loadConfig();
+    const account = config.accounts.find((item) => item.name === name);
+
+    if (!account) {
+        out.log.warn(`Account not found: ${name}`);
+        out.log.info(cmd(["accounts", "list"]));
+        return;
+    }
+
+    if (!API_KEY_PROVIDERS.has(account.provider)) {
+        out.log.warn(`Account "${name}" is ${account.provider} — it authenticates via OAuth, not an API key.`);
+        return;
+    }
+
+    const hadOverride = Boolean(account.apiKey);
+
+    if (allow) {
+        // A stored key would win anyway, so keeping both would leave the config
+        // claiming an intention the proxy does not act on.
+        delete account.apiKey;
+        account.allowEnvApiKey = true;
+    } else {
+        delete account.allowEnvApiKey;
+    }
+
+    await saveConfig(config);
+
+    if (allow) {
+        out.log.success(`"${name}" may now resolve its billed API key from the environment.`);
+
+        if (hadOverride) {
+            out.log.warn("Removed the key that was stored on the account — the environment key is used instead.");
+        }
+
+        out.log.warn("Every call on this account spends metered money on whatever key the environment holds.");
+    } else {
+        out.log.success(`"${name}" will no longer pick up a billed API key from the environment.`);
+
+        if (!account.apiKey) {
+            out.log.warn("It now has no credential at all and will not load until you set one.");
+        }
+    }
+
+    out.log.info(RESTART_HINT);
 }
 
 export async function runAccountsRemove(name: string): Promise<void> {

--- a/src/ai-proxy/index.ts
+++ b/src/ai-proxy/index.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env bun
 
 import {
+    runAccountsAllowEnv,
     runAccountsList,
     runAccountsRemove,
     runAccountsSetEnabled,
+    runAccountsSetKey,
     runAccountsStatus,
     runAccountsTest,
 } from "@app/ai-proxy/commands/accounts";
@@ -303,6 +305,21 @@ accountsCmd
     .description("Re-enable a disabled account")
     .action(async (name: string) => {
         await runAccountsSetEnabled(name, true);
+    });
+
+accountsCmd
+    .command("set-key <name> [key]")
+    .description("Choose an api-key account's credential (omit key for a masked interactive chooser)")
+    .action(async (name: string, key?: string) => {
+        await runAccountsSetKey(name, key);
+    });
+
+accountsCmd
+    .command("allow-env <name>")
+    .description("Non-interactive form of set-key's env choice (clears any stored key; --off revokes)")
+    .option("--off", "revoke the opt-in")
+    .action(async (name: string, options: { off?: boolean }) => {
+        await runAccountsAllowEnv(name, !options.off);
     });
 
 accountsCmd

--- a/src/ai-proxy/lib/account-config.ts
+++ b/src/ai-proxy/lib/account-config.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { defaultApiKeyEnvName } from "@app/ai-proxy/lib/providers/api-key-state";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { copilotDataDir } from "@genesiscz/utils/ai/github-copilot/paths";
 import type { CopilotAccountType } from "@genesiscz/utils/ai/github-copilot/types";
@@ -34,7 +35,7 @@ export interface AccountCredentialDescription {
  */
 export function describeAccountCredential(account: AiProxyAccountConfig): AccountCredentialDescription {
     if (account.provider === "xai-api-key" || account.provider === "openai") {
-        const envName = account.apiKeyEnv ?? (account.provider === "openai" ? "OPENAI_API_KEY" : "XAI_API_KEY");
+        const envName = defaultApiKeyEnvName(account);
         // Trimmed, because that is what the resolvers do: a whitespace-only
         // `apiKey` falls through to the env var, and this log must say so.
         const configured = account.apiKey?.trim();

--- a/src/ai-proxy/lib/account-config.ts
+++ b/src/ai-proxy/lib/account-config.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { copilotDataDir } from "@genesiscz/utils/ai/github-copilot/paths";
 import type { CopilotAccountType } from "@genesiscz/utils/ai/github-copilot/types";
@@ -18,7 +19,69 @@ export function resolveGithubCopilotDataDir(account: AiProxyAccountConfig): stri
     return copilotDataDir(account.githubCopilot?.dataDir);
 }
 
+export interface AccountCredentialDescription {
+    /** Where the credential comes from — never the credential itself. */
+    source: string;
+    /** True when using this account spends metered, per-token money. */
+    billed: boolean;
+}
+
+/**
+ * Describe (never resolve, never print) an account's credential so startup and
+ * per-request logs can say which door each account walks through. `billed`
+ * separates a subscription seat, which costs nothing extra per call, from a
+ * platform API key, which does.
+ */
+export function describeAccountCredential(account: AiProxyAccountConfig): AccountCredentialDescription {
+    if (account.provider === "xai-api-key" || account.provider === "openai") {
+        const envName = account.apiKeyEnv ?? (account.provider === "openai" ? "OPENAI_API_KEY" : "XAI_API_KEY");
+        // Trimmed, because that is what the resolvers do: a whitespace-only
+        // `apiKey` falls through to the env var, and this log must say so.
+        const configured = account.apiKey?.trim();
+
+        return {
+            source: configured ? "config apiKey" : `env ${envName}`,
+            billed: true,
+        };
+    }
+
+    if (account.provider === "grok-subscription") {
+        return {
+            source: account.grok?.accountName
+                ? `ai config account "${account.grok.accountName}" (OAuth)`
+                : `OAuth ${resolveGrokAuthPath(account)}`,
+            billed: false,
+        };
+    }
+
+    if (account.provider === "github-copilot-subscription") {
+        return { source: `OAuth ${resolveGithubCopilotDataDir(account)}`, billed: false };
+    }
+
+    if (account.provider === "anthropic-subscription") {
+        return {
+            source: account.anthropicSub?.accountName
+                ? `ai config account "${account.anthropicSub.accountName}" (OAuth)`
+                : "OAuth (anthropic subscription)",
+            billed: false,
+        };
+    }
+
+    if (account.provider === "openai-subscription") {
+        return {
+            source: account.openaiSub?.accountName
+                ? `ai config account "${account.openaiSub.accountName}" (OAuth)`
+                : "OAuth (codex auth.json)",
+            billed: false,
+        };
+    }
+
+    return { source: "unknown", billed: false };
+}
+
 export function accountConfigFingerprint(account: AiProxyAccountConfig): string {
+    const configuredKey = account.apiKey?.trim();
+
     return SafeJSON.stringify({
         provider: account.provider,
         baseUrl: account.baseUrl,
@@ -27,6 +90,8 @@ export function accountConfigFingerprint(account: AiProxyAccountConfig): string 
         githubCopilot: account.githubCopilot,
         anthropicSub: account.anthropicSub,
         openaiSub: account.openaiSub,
+        apiKey: configuredKey ? createHash("sha256").update(configuredKey).digest("hex").slice(0, 12) : undefined,
+        allowEnvApiKey: account.allowEnvApiKey,
         apiKeyEnv: account.apiKeyEnv,
         managementKeyEnv: account.managementKeyEnv,
         teamId: account.teamId,

--- a/src/ai-proxy/lib/config-store.test.ts
+++ b/src/ai-proxy/lib/config-store.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+    type ConfigPermissionOps,
+    checkConfigPermissions,
     getAiProxyConfigStore,
     isReadableByOthers,
     parseConfigJson,
@@ -99,14 +101,86 @@ describe("config-store migration", () => {
 
         await store.save(config);
 
-        // Written through a rename of a fresh umask'd temp file, so this has to
-        // be re-applied per save rather than once at creation.
+        // The mode is carried by the temp file through the rename, so it holds
+        // on the very first save rather than being applied after publication.
         expect(statSync(getAiProxyStorage().getConfigPath()).mode & 0o777).toBe(0o600);
 
         await store.save(config);
         expect(statSync(getAiProxyStorage().getConfigPath()).mode & 0o777).toBe(0o600);
 
         rmSync(tempDir, { recursive: true, force: true });
+    });
+});
+
+describe("checkConfigPermissions", () => {
+    // Never opened — every filesystem call is injected. It only has to look like
+    // a config path in the warning the function logs.
+    const fakeConfigPath = join(tmpdir(), "ai-proxy-permissions", "config.json");
+
+    function recordingOps(behaviour: { chmod?: () => Promise<void>; statMode?: () => Promise<number> }): {
+        ops: ConfigPermissionOps;
+        calls: { chmod: number[]; stat: number };
+    } {
+        const calls = { chmod: [] as number[], stat: 0 };
+
+        return {
+            calls,
+            ops: {
+                chmod: async (_path, mode) => {
+                    calls.chmod.push(mode);
+                    await behaviour.chmod?.();
+                },
+                statMode: async () => {
+                    calls.stat += 1;
+                    return (await behaviour.statMode?.()) ?? 0o600;
+                },
+            },
+        };
+    }
+
+    it("reports nothing when the file ends up owner-only", async () => {
+        const { ops, calls } = recordingOps({ statMode: async () => 0o600 });
+
+        expect(await checkConfigPermissions(fakeConfigPath, ops)).toBeUndefined();
+        expect(calls.chmod).toEqual([0o600]);
+    });
+
+    it("reports the RESULTING mode when chmod succeeded but changed nothing", async () => {
+        // The exFAT / network-mount case: chmod resolves, the mode is untouched.
+        // Reporting the requested 0600 here would tell the user the file is safe.
+        const { ops, calls } = recordingOps({ statMode: async () => 0o644 });
+
+        expect(await checkConfigPermissions(fakeConfigPath, ops)).toBe("644");
+        // A regression that stops re-reading the mode would make this 0.
+        expect(calls.stat).toBe(1);
+    });
+
+    it("reports a group-readable result too, not just world-readable", async () => {
+        const { ops } = recordingOps({ statMode: async () => 0o640 });
+
+        expect(await checkConfigPermissions(fakeConfigPath, ops)).toBe("640");
+    });
+
+    it("reports unknown when chmod is rejected", async () => {
+        const { ops, calls } = recordingOps({
+            chmod: async () => {
+                throw new Error("EPERM");
+            },
+        });
+
+        expect(await checkConfigPermissions(fakeConfigPath, ops)).toBe("unknown");
+        // The mode is unknowable, so it must not silently pass as owner-only.
+        expect(calls.stat).toBe(0);
+    });
+
+    it("reports unknown when the mode cannot be read back", async () => {
+        const { ops } = recordingOps({
+            statMode: async () => {
+                throw new Error("ENOENT");
+            },
+        });
+
+        expect(await checkConfigPermissions(fakeConfigPath, ops)).toBe("unknown");
     });
 });
 

--- a/src/ai-proxy/lib/config-store.test.ts
+++ b/src/ai-proxy/lib/config-store.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getAiProxyConfigStore, parseConfigJson, resetAiProxyConfigStore } from "@app/ai-proxy/lib/config-store";
+import {
+    getAiProxyConfigStore,
+    isReadableByOthers,
+    parseConfigJson,
+    resetAiProxyConfigStore,
+} from "@app/ai-proxy/lib/config-store";
 import { getAiProxyStorage, resetAiProxyStorage } from "@app/ai-proxy/lib/storage";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -102,5 +107,24 @@ describe("config-store migration", () => {
         expect(statSync(getAiProxyStorage().getConfigPath()).mode & 0o777).toBe(0o600);
 
         rmSync(tempDir, { recursive: true, force: true });
+    });
+});
+
+describe("isReadableByOthers", () => {
+    it("accepts owner-only modes", () => {
+        expect(isReadableByOthers(0o600)).toBe(false);
+        // Stricter than required is still fine — flagging 0o400 would send the
+        // user a `chmod 600` for a file that is already safe.
+        expect(isReadableByOthers(0o400)).toBe(false);
+        expect(isReadableByOthers(0o000)).toBe(false);
+    });
+
+    it("rejects anything a group or other user can reach", () => {
+        expect(isReadableByOthers(0o640)).toBe(true);
+        expect(isReadableByOthers(0o604)).toBe(true);
+        expect(isReadableByOthers(0o644)).toBe(true);
+        // Execute-only counts: it still grants a bit to somebody else.
+        expect(isReadableByOthers(0o601)).toBe(true);
+        expect(isReadableByOthers(0o610)).toBe(true);
     });
 });

--- a/src/ai-proxy/lib/config-store.test.ts
+++ b/src/ai-proxy/lib/config-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getAiProxyConfigStore, parseConfigJson, resetAiProxyConfigStore } from "@app/ai-proxy/lib/config-store";
@@ -76,6 +76,30 @@ describe("config-store migration", () => {
 
         const fresh = await store.loadFresh();
         expect(fresh.translation.thinking).toBe("raw");
+
+        rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("keeps the saved config owner-only, since it stores billed api keys in plain text", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "ai-proxy-config-mode-"));
+        env.testing.set("GENESIS_TOOLS_HOME", tempDir);
+        resetAiProxyConfigStore();
+        resetAiProxyStorage();
+
+        const store = getAiProxyConfigStore();
+        const config = await store.load();
+        config.accounts = [
+            { name: "work", provider: "xai-api-key", providerSlug: "xai", enabled: true, apiKey: "xai-secret-value" },
+        ];
+
+        await store.save(config);
+
+        // Written through a rename of a fresh umask'd temp file, so this has to
+        // be re-applied per save rather than once at creation.
+        expect(statSync(getAiProxyStorage().getConfigPath()).mode & 0o777).toBe(0o600);
+
+        await store.save(config);
+        expect(statSync(getAiProxyStorage().getConfigPath()).mode & 0o777).toBe(0o600);
 
         rmSync(tempDir, { recursive: true, force: true });
     });

--- a/src/ai-proxy/lib/config-store.ts
+++ b/src/ai-proxy/lib/config-store.ts
@@ -1,5 +1,6 @@
 import { migrateAccountConfig } from "@app/ai-proxy/lib/account-config";
 import { normalizeBasePath } from "@app/ai-proxy/lib/path-prefix";
+import { maskApiKey } from "@app/ai-proxy/lib/providers/api-key-state";
 import { getAiProxyStorage } from "@app/ai-proxy/lib/storage";
 import type { AiProxyConfig, AiProxyPublicConfig } from "@app/ai-proxy/lib/types";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -154,9 +155,14 @@ export function resetAiProxyConfigStore(): void {
 }
 
 export function redactConfig(config: AiProxyConfig): AiProxyConfig {
+    // `maskApiKey` rather than a prefix slice: a short key is entirely inside its
+    // own first few characters, which is the one case redaction has to survive.
     return {
         ...config,
-        proxyApiKey: config.proxyApiKey ? `${config.proxyApiKey.slice(0, 8)}…` : "",
+        proxyApiKey: config.proxyApiKey ? maskApiKey(config.proxyApiKey) : "",
+        accounts: config.accounts.map((account) =>
+            account.apiKey ? { ...account, apiKey: maskApiKey(account.apiKey) } : account
+        ),
     };
 }
 

--- a/src/ai-proxy/lib/config-store.ts
+++ b/src/ai-proxy/lib/config-store.ts
@@ -1,9 +1,14 @@
+import { chmod } from "node:fs/promises";
 import { migrateAccountConfig } from "@app/ai-proxy/lib/account-config";
 import { normalizeBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { maskApiKey } from "@app/ai-proxy/lib/providers/api-key-state";
 import { getAiProxyStorage } from "@app/ai-proxy/lib/storage";
 import type { AiProxyConfig, AiProxyPublicConfig } from "@app/ai-proxy/lib/types";
 import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+/** Owner-only: the config carries the proxy bearer key and billed vendor keys. */
+const CONFIG_FILE_MODE = 0o600;
 
 export function getDefaultConfig(): AiProxyConfig {
     return {
@@ -114,7 +119,25 @@ export class AiProxyConfigStore {
         const normalized = mergeConfig(config);
         await this.storage.ensureDirs();
         await this.storage.setConfig(normalized);
+        await this.restrictConfigPermissions();
         this.cached = normalized;
+    }
+
+    /**
+     * Re-applied on every save, not once: the atomic write renames a fresh temp
+     * file over the config, so the new inode carries the process umask (0644 in
+     * practice) and any earlier tightening is gone. The file holds the proxy
+     * bearer key and, since `accounts[].apiKey`, billed vendor credentials in
+     * plain text — other local accounts have no business reading either.
+     */
+    private async restrictConfigPermissions(): Promise<void> {
+        const path = this.storage.getConfigPath();
+
+        try {
+            await chmod(path, CONFIG_FILE_MODE);
+        } catch (err) {
+            logger.warn({ err, path }, "ai-proxy: could not restrict config file permissions to owner-only");
+        }
     }
 
     async update(patch: Partial<AiProxyConfig>): Promise<AiProxyConfig> {

--- a/src/ai-proxy/lib/config-store.ts
+++ b/src/ai-proxy/lib/config-store.ts
@@ -10,6 +10,16 @@ import { logger, out } from "@genesiscz/utils/logger";
 /** Owner-only: the config carries the proxy bearer key and billed vendor keys. */
 const CONFIG_FILE_MODE = 0o600;
 
+/**
+ * Whether any group or other bit survived on the config's mode. Split out so the
+ * mask itself is pinned by tests: narrowing it to `0o007` would stop catching a
+ * group-readable file, and comparing against `0o600` instead would report a
+ * stricter 0o400 as a problem. Both are silent failures of a security check.
+ */
+export function isReadableByOthers(mode: number): boolean {
+    return (mode & 0o077) !== 0;
+}
+
 export function getDefaultConfig(): AiProxyConfig {
     return {
         listen: { host: "127.0.0.1", port: 8317 },
@@ -141,7 +151,7 @@ export class AiProxyConfigStore {
             // believed otherwise.
             const mode = (await stat(path)).mode & 0o777;
 
-            if ((mode & 0o077) !== 0) {
+            if (isReadableByOthers(mode)) {
                 this.warnConfigReadable(path, mode.toString(8));
             }
         } catch (err) {

--- a/src/ai-proxy/lib/config-store.ts
+++ b/src/ai-proxy/lib/config-store.ts
@@ -2,13 +2,13 @@ import { chmod, stat } from "node:fs/promises";
 import { migrateAccountConfig } from "@app/ai-proxy/lib/account-config";
 import { normalizeBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { maskApiKey } from "@app/ai-proxy/lib/providers/api-key-state";
-import { getAiProxyStorage } from "@app/ai-proxy/lib/storage";
+import { AI_PROXY_CONFIG_FILE_MODE, getAiProxyStorage } from "@app/ai-proxy/lib/storage";
 import type { AiProxyConfig, AiProxyPublicConfig } from "@app/ai-proxy/lib/types";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
 
 /** Owner-only: the config carries the proxy bearer key and billed vendor keys. */
-const CONFIG_FILE_MODE = 0o600;
+const CONFIG_FILE_MODE = AI_PROXY_CONFIG_FILE_MODE;
 
 /**
  * Whether any group or other bit survived on the config's mode. Split out so the
@@ -166,9 +166,10 @@ export class AiProxyConfigStore {
     async save(config: AiProxyConfig): Promise<void> {
         const normalized = mergeConfig(config);
         await this.storage.ensureDirs();
-        // The mode travels with the temp file through the rename, so the key is
-        // never published at the umask default even for an instant.
-        await this.storage.setConfig(normalized, { mode: CONFIG_FILE_MODE });
+        // Mode comes from the storage instance (AI_PROXY_CONFIG_FILE_MODE) and
+        // travels with the temp file through the rename, so the key is never
+        // published at the umask default even for an instant.
+        await this.storage.setConfig(normalized);
         await this.restrictConfigPermissions();
         this.cached = normalized;
     }

--- a/src/ai-proxy/lib/config-store.ts
+++ b/src/ai-proxy/lib/config-store.ts
@@ -1,11 +1,11 @@
-import { chmod } from "node:fs/promises";
+import { chmod, stat } from "node:fs/promises";
 import { migrateAccountConfig } from "@app/ai-proxy/lib/account-config";
 import { normalizeBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { maskApiKey } from "@app/ai-proxy/lib/providers/api-key-state";
 import { getAiProxyStorage } from "@app/ai-proxy/lib/storage";
 import type { AiProxyConfig, AiProxyPublicConfig } from "@app/ai-proxy/lib/types";
 import { SafeJSON } from "@genesiscz/utils/json";
-import { logger } from "@genesiscz/utils/logger";
+import { logger, out } from "@genesiscz/utils/logger";
 
 /** Owner-only: the config carries the proxy bearer key and billed vendor keys. */
 const CONFIG_FILE_MODE = 0o600;
@@ -135,9 +135,33 @@ export class AiProxyConfigStore {
 
         try {
             await chmod(path, CONFIG_FILE_MODE);
+            // Verified, not assumed: on a filesystem without POSIX permissions
+            // (exFAT, some network mounts) chmod returns success and changes
+            // nothing, which would leave the key readable while this code
+            // believed otherwise.
+            const mode = (await stat(path)).mode & 0o777;
+
+            if ((mode & 0o077) !== 0) {
+                this.warnConfigReadable(path, mode.toString(8));
+            }
         } catch (err) {
             logger.warn({ err, path }, "ai-proxy: could not restrict config file permissions to owner-only");
+            this.warnConfigReadable(path, "unknown");
         }
+    }
+
+    /**
+     * Deliberately does not throw. The config, key included, is already on disk
+     * by the time this runs, so failing the save would report "nothing was
+     * saved" about a file that now holds the credential. What the caller can
+     * actually act on is the path and the command that fixes it.
+     */
+    private warnConfigReadable(path: string, mode: string): void {
+        logger.warn(
+            { path, mode, fix: `chmod 600 ${path}` },
+            "ai-proxy: config file with billed api keys is readable by other local accounts"
+        );
+        out.log.warn(`${path} holds billed API keys and is readable by other local accounts. Fix: chmod 600 ${path}`);
     }
 
     async update(patch: Partial<AiProxyConfig>): Promise<AiProxyConfig> {

--- a/src/ai-proxy/lib/config-store.ts
+++ b/src/ai-proxy/lib/config-store.ts
@@ -20,6 +20,44 @@ export function isReadableByOthers(mode: number): boolean {
     return (mode & 0o077) !== 0;
 }
 
+/**
+ * The filesystem calls the permission check makes, injectable so both failure
+ * shapes can be driven from a test without mocking `node:fs` process-wide.
+ */
+export interface ConfigPermissionOps {
+    chmod: (path: string, mode: number) => Promise<void>;
+    statMode: (path: string) => Promise<number>;
+}
+
+const realPermissionOps: ConfigPermissionOps = {
+    chmod: (path, mode) => chmod(path, mode),
+    statMode: async (path) => (await stat(path)).mode & 0o777,
+};
+
+/**
+ * Enforce owner-only on the config and report what actually stuck: the octal
+ * mode when the file is still reachable by somebody else, `"unknown"` when the
+ * filesystem refused to answer, and undefined when it is owner-only.
+ *
+ * It reports the RESULTING mode rather than the requested one on purpose — the
+ * whole point is to catch a chmod that claimed success without doing anything.
+ */
+export async function checkConfigPermissions(
+    path: string,
+    ops: ConfigPermissionOps = realPermissionOps
+): Promise<string | undefined> {
+    try {
+        await ops.chmod(path, CONFIG_FILE_MODE);
+        const mode = await ops.statMode(path);
+
+        return isReadableByOthers(mode) ? mode.toString(8) : undefined;
+    } catch (err) {
+        logger.warn({ err, path }, "ai-proxy: could not restrict config file permissions to owner-only");
+
+        return "unknown";
+    }
+}
+
 export function getDefaultConfig(): AiProxyConfig {
     return {
         listen: { host: "127.0.0.1", port: 8317 },
@@ -128,35 +166,27 @@ export class AiProxyConfigStore {
     async save(config: AiProxyConfig): Promise<void> {
         const normalized = mergeConfig(config);
         await this.storage.ensureDirs();
-        await this.storage.setConfig(normalized);
+        // The mode travels with the temp file through the rename, so the key is
+        // never published at the umask default even for an instant.
+        await this.storage.setConfig(normalized, { mode: CONFIG_FILE_MODE });
         await this.restrictConfigPermissions();
         this.cached = normalized;
     }
 
     /**
-     * Re-applied on every save, not once: the atomic write renames a fresh temp
-     * file over the config, so the new inode carries the process umask (0644 in
-     * practice) and any earlier tightening is gone. The file holds the proxy
-     * bearer key and, since `accounts[].apiKey`, billed vendor credentials in
-     * plain text — other local accounts have no business reading either.
+     * Defence in depth behind `save`'s birth-mode: that closes the disclosure
+     * window, this catches the case where the mode never took effect at all —
+     * on a filesystem without POSIX permissions (exFAT, some network mounts)
+     * every chmod succeeds and changes nothing. The file holds the proxy bearer
+     * key and, since `accounts[].apiKey`, billed vendor credentials in plain
+     * text, so a silent no-op there must not read as success.
      */
     private async restrictConfigPermissions(): Promise<void> {
         const path = this.storage.getConfigPath();
+        const insecureMode = await checkConfigPermissions(path);
 
-        try {
-            await chmod(path, CONFIG_FILE_MODE);
-            // Verified, not assumed: on a filesystem without POSIX permissions
-            // (exFAT, some network mounts) chmod returns success and changes
-            // nothing, which would leave the key readable while this code
-            // believed otherwise.
-            const mode = (await stat(path)).mode & 0o777;
-
-            if (isReadableByOthers(mode)) {
-                this.warnConfigReadable(path, mode.toString(8));
-            }
-        } catch (err) {
-            logger.warn({ err, path }, "ai-proxy: could not restrict config file permissions to owner-only");
-            this.warnConfigReadable(path, "unknown");
+        if (insecureMode) {
+            this.warnConfigReadable(path, insecureMode);
         }
     }
 

--- a/src/ai-proxy/lib/model-meta.ts
+++ b/src/ai-proxy/lib/model-meta.ts
@@ -1,5 +1,7 @@
 import { loadCatalogFile } from "@app/ai-proxy/lib/catalog-file";
 import { resolveCopilotModelRecords } from "@app/ai-proxy/lib/copilot-models-cache";
+import { assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
+import { defaultApiKeyEnvName } from "@app/ai-proxy/lib/providers/api-key-state";
 import { resolveOpenAiSubToken } from "@app/ai-proxy/lib/providers/openai-sub-token";
 import { providerKey } from "@app/ai-proxy/lib/providers/registry";
 import { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
@@ -443,17 +445,31 @@ function listXaiStaticProxyModels(account: AiProxyAccountConfig, baseUrl: string
  */
 export async function listXaiProxyModels(account: AiProxyAccountConfig): Promise<ProxyModelMeta[]> {
     const baseUrl = (account.baseUrl ?? XAI_API_BASE_URL).replace(/\/$/, "");
-    const apiKey = resolveXaiApiKey(account);
+    const resolved = resolveXaiApiKey(account);
 
-    if (!apiKey) {
+    if (!resolved) {
         logger.debug({ account: account.name }, "ai-proxy: xai catalog using static fallback (no API key)");
+        return listXaiStaticProxyModels(account, baseUrl);
+    }
+
+    // Building the catalog is still spending the key, so it walks through the
+    // same guard as provider construction — otherwise an account without
+    // `allowEnvApiKey` would burn an ambient XAI_API_KEY here anyway.
+    try {
+        assertApiKeySourceAllowed({ account, source: resolved.source, envName: defaultApiKeyEnvName(account) });
+    } catch (err) {
+        logger.warn(
+            { err, account: account.name },
+            "ai-proxy: xai catalog refused the ambient environment key — static fallback"
+        );
+
         return listXaiStaticProxyModels(account, baseUrl);
     }
 
     try {
         const response = await fetchDirect(`${baseUrl}/models`, {
             headers: {
-                Authorization: `Bearer ${apiKey}`,
+                Authorization: `Bearer ${resolved.key}`,
                 Accept: "application/json",
             },
         });

--- a/src/ai-proxy/lib/providers/api-key-guard.test.ts
+++ b/src/ai-proxy/lib/providers/api-key-guard.test.ts
@@ -86,6 +86,30 @@ describe("resolveAccountApiKey", () => {
         ).toEqual({ key: "default-key", source: "defaultEnv" });
     });
 
+    it("falls through when the named var is exported but empty", () => {
+        // `export XAI_API_KEY=` in a shell rc is the realistic footgun here: the
+        // variable exists, so a `has()`-style check would accept it and hand the
+        // provider an empty bearer token.
+        env.testing.set("MY_NAMED_KEY", "   ");
+
+        try {
+            expect(
+                resolveAccountApiKey({
+                    account: { ...account, apiKeyEnv: "MY_NAMED_KEY" },
+                    defaultEnvKey: () => "default-key",
+                })
+            ).toEqual({ key: "default-key", source: "defaultEnv" });
+        } finally {
+            env.testing.unset("MY_NAMED_KEY");
+        }
+    });
+
+    it("ignores a whitespace-only stored key the same way", () => {
+        expect(
+            resolveAccountApiKey({ account: { ...account, apiKey: "  " }, defaultEnvKey: () => "default-key" })
+        ).toEqual({ key: "default-key", source: "defaultEnv" });
+    });
+
     it("returns undefined when nothing carries a key", () => {
         expect(resolveAccountApiKey({ account, defaultEnvKey: () => undefined })).toBeUndefined();
     });

--- a/src/ai-proxy/lib/providers/api-key-guard.test.ts
+++ b/src/ai-proxy/lib/providers/api-key-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
+import { assertApiKeySourceAllowed, resolveAccountApiKey } from "@app/ai-proxy/lib/providers/api-key-guard";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
 
 const account: AiProxyAccountConfig = {
     name: "work",
@@ -34,5 +35,58 @@ describe("assertApiKeySourceAllowed", () => {
                 envName: "XAI_API_KEY",
             })
         ).not.toThrow();
+    });
+
+    it("still allows a stored key when the account ALSO opted in to the environment", () => {
+        // Both fields set is a config the CLI never writes, but a hand-edited
+        // file can carry it. The stored key wins, so the guard sees "config".
+        const both: AiProxyAccountConfig = { ...account, apiKey: "config-key", allowEnvApiKey: true };
+        const resolved = resolveAccountApiKey({ account: both, defaultEnvKey: () => "env-key" });
+
+        expect(resolved).toEqual({ key: "config-key", source: "config" });
+        expect(() =>
+            assertApiKeySourceAllowed({ account: both, source: "config", envName: "XAI_API_KEY" })
+        ).not.toThrow();
+    });
+});
+
+describe("resolveAccountApiKey", () => {
+    it("labels the provider default as defaultEnv, not as the account's named var", () => {
+        // The mislabel this replaces mattered: an account with no `apiKeyEnv`
+        // reported "configEnv" for a key that came from the provider default.
+        expect(resolveAccountApiKey({ account, defaultEnvKey: () => "default-key" })).toEqual({
+            key: "default-key",
+            source: "defaultEnv",
+        });
+    });
+
+    it("prefers the env var the account names over the provider default", () => {
+        env.testing.set("MY_NAMED_KEY", "named-key");
+
+        try {
+            expect(
+                resolveAccountApiKey({
+                    account: { ...account, apiKeyEnv: "MY_NAMED_KEY" },
+                    defaultEnvKey: () => "default-key",
+                })
+            ).toEqual({ key: "named-key", source: "configEnv" });
+        } finally {
+            env.testing.unset("MY_NAMED_KEY");
+        }
+    });
+
+    it("falls through to the provider default when the named var is unset", () => {
+        env.testing.unset("MY_NAMED_KEY");
+
+        expect(
+            resolveAccountApiKey({
+                account: { ...account, apiKeyEnv: "MY_NAMED_KEY" },
+                defaultEnvKey: () => "default-key",
+            })
+        ).toEqual({ key: "default-key", source: "defaultEnv" });
+    });
+
+    it("returns undefined when nothing carries a key", () => {
+        expect(resolveAccountApiKey({ account, defaultEnvKey: () => undefined })).toBeUndefined();
     });
 });

--- a/src/ai-proxy/lib/providers/api-key-guard.test.ts
+++ b/src/ai-proxy/lib/providers/api-key-guard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+
+const account: AiProxyAccountConfig = {
+    name: "work",
+    provider: "xai-api-key",
+    providerSlug: "xai",
+    enabled: true,
+};
+
+describe("assertApiKeySourceAllowed", () => {
+    it("allows a key stored on the account", () => {
+        expect(() => assertApiKeySourceAllowed({ account, source: "config", envName: "XAI_API_KEY" })).not.toThrow();
+    });
+
+    it("refuses an environment key that was never opted in to", () => {
+        expect(() => assertApiKeySourceAllowed({ account, source: "defaultEnv", envName: "XAI_API_KEY" })).toThrow(
+            /Refusing to spend the ambient XAI_API_KEY/
+        );
+    });
+
+    it("refuses the config-named env var too", () => {
+        expect(() => assertApiKeySourceAllowed({ account, source: "configEnv", envName: "MY_XAI_KEY" })).toThrow(
+            /MY_XAI_KEY/
+        );
+    });
+
+    it("allows an environment key once the account opts in", () => {
+        expect(() =>
+            assertApiKeySourceAllowed({
+                account: { ...account, allowEnvApiKey: true },
+                source: "defaultEnv",
+                envName: "XAI_API_KEY",
+            })
+        ).not.toThrow();
+    });
+});

--- a/src/ai-proxy/lib/providers/api-key-guard.ts
+++ b/src/ai-proxy/lib/providers/api-key-guard.ts
@@ -1,0 +1,46 @@
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { logger } from "@genesiscz/utils/logger";
+
+/** Where an api-key account's credential came from — logged, never the key itself. */
+export type ApiKeySource = "config" | "configEnv" | "defaultEnv";
+
+export interface ResolvedApiKey {
+    key: string;
+    source: ApiKeySource;
+}
+
+/**
+ * Guard for the one credential path that costs metered money: an api-key
+ * account picking a key out of the ambient environment.
+ *
+ * A key stored on the account (`apiKey`) is a deliberate act, so it is always
+ * allowed. A key that merely happens to sit in the shell env is not: it is how
+ * a rotated or borrowed `XAI_API_KEY` gets spent by surprise, and it is exactly
+ * what the proxy is supposed to make impossible. Using one now requires
+ * `allowEnvApiKey` on the account, and even then it is logged loudly.
+ */
+export function assertApiKeySourceAllowed(input: {
+    account: AiProxyAccountConfig;
+    source: ApiKeySource;
+    envName: string;
+}): void {
+    if (input.source === "config") {
+        return;
+    }
+
+    if (input.account.allowEnvApiKey) {
+        logger.warn(
+            { account: input.account.name, provider: input.account.provider, apiKeyEnv: input.envName },
+            "ai-proxy: account is opted in to spending the ambient environment API key"
+        );
+
+        return;
+    }
+
+    throw new Error(
+        `Refusing to spend the ambient ${input.envName} for billed account "${input.account.name}": ` +
+            "an environment key is never used implicitly. Store the key on the account with " +
+            `\`tools ai-proxy accounts set-key ${input.account.name}\`, or opt in explicitly with ` +
+            `\`tools ai-proxy accounts allow-env ${input.account.name}\`.`
+    );
+}

--- a/src/ai-proxy/lib/providers/api-key-guard.ts
+++ b/src/ai-proxy/lib/providers/api-key-guard.ts
@@ -1,4 +1,5 @@
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
 import { logger } from "@genesiscz/utils/logger";
 
 /** Where an api-key account's credential came from — logged, never the key itself. */
@@ -7,6 +8,39 @@ export type ApiKeySource = "config" | "configEnv" | "defaultEnv";
 export interface ResolvedApiKey {
     key: string;
     source: ApiKeySource;
+}
+
+/**
+ * The single precedence rule for every api-key account: a key stored on the
+ * account, then the env var the account names, then the provider's default.
+ *
+ * It lives beside the guard because the guard's whole decision is a function of
+ * the `source` this returns — a provider that resolved a key its own way could
+ * hand the guard a `source` that does not describe where the key actually came
+ * from, and the refusal would then be wrong in either direction. Only the last
+ * step differs per provider, so that one is injected.
+ */
+export function resolveAccountApiKey(input: {
+    account: AiProxyAccountConfig;
+    defaultEnvKey: () => string | undefined;
+}): ResolvedApiKey | undefined {
+    const configured = input.account.apiKey?.trim();
+
+    if (configured) {
+        return { key: configured, source: "config" };
+    }
+
+    if (input.account.apiKeyEnv) {
+        const named = env.getTrimmed(input.account.apiKeyEnv as never);
+
+        if (named) {
+            return { key: named, source: "configEnv" };
+        }
+    }
+
+    const fallback = input.defaultEnvKey();
+
+    return fallback ? { key: fallback, source: "defaultEnv" } : undefined;
 }
 
 /**

--- a/src/ai-proxy/lib/providers/api-key-state.test.ts
+++ b/src/ai-proxy/lib/providers/api-key-state.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { apiKeyStatus, defaultApiKeyEnvName, maskApiKey } from "@app/ai-proxy/lib/providers/api-key-state";
+import {
+    apiKeyStatus,
+    defaultApiKeyEnvName,
+    findEnvSourceFile,
+    maskApiKey,
+} from "@app/ai-proxy/lib/providers/api-key-state";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { env } from "@genesiscz/utils/env";
 
@@ -50,5 +55,13 @@ describe("apiKeyStatus", () => {
 
     it("never reveals a short key", () => {
         expect(maskApiKey("short")).toBe("****");
+    });
+});
+
+describe("findEnvSourceFile", () => {
+    it("treats a regex-shaped env name as literal instead of throwing", async () => {
+        // `apiKeyEnv` is an unvalidated config value, and this runs inside the
+        // interactive `accounts set-key` prompt where a throw is user-visible.
+        expect(await findEnvSourceFile("KEY(")).toBeUndefined();
     });
 });

--- a/src/ai-proxy/lib/providers/api-key-state.test.ts
+++ b/src/ai-proxy/lib/providers/api-key-state.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { apiKeyStatus, defaultApiKeyEnvName, maskApiKey } from "@app/ai-proxy/lib/providers/api-key-state";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
+
+const account: AiProxyAccountConfig = {
+    name: "work",
+    provider: "xai-api-key",
+    providerSlug: "xai",
+    enabled: true,
+};
+
+describe("apiKeyStatus", () => {
+    it("reports a stored key as an override, masked", () => {
+        const status = apiKeyStatus({ ...account, apiKey: "xai-abcdefghijklmnop" });
+
+        expect(status.state).toBe("override");
+        expect(status.maskedOverride).toBe("xai-…mnop");
+    });
+
+    it("reports the env state once the account opts in", () => {
+        env.testing.set("XAI_API_KEY", "from-env");
+
+        try {
+            const status = apiKeyStatus({ ...account, allowEnvApiKey: true });
+
+            expect(status.state).toBe("env");
+            expect(status.envName).toBe("XAI_API_KEY");
+            expect(status.envPresent).toBe(true);
+        } finally {
+            env.testing.unset("XAI_API_KEY");
+        }
+    });
+
+    it("reports no credential when neither is configured, and still names the env var", () => {
+        env.testing.unset("XAI_API_KEY");
+        const status = apiKeyStatus(account);
+
+        expect(status.state).toBe("none");
+        expect(status.envName).toBe("XAI_API_KEY");
+        expect(status.envPresent).toBe(false);
+        expect(status.maskedOverride).toBeUndefined();
+    });
+
+    it("names the provider's default env var, or the configured one", () => {
+        expect(defaultApiKeyEnvName(account)).toBe("XAI_API_KEY");
+        expect(defaultApiKeyEnvName({ ...account, provider: "openai" })).toBe("OPENAI_API_KEY");
+        expect(defaultApiKeyEnvName({ ...account, apiKeyEnv: "MY_KEY" })).toBe("MY_KEY");
+    });
+
+    it("never reveals a short key", () => {
+        expect(maskApiKey("short")).toBe("****");
+    });
+});

--- a/src/ai-proxy/lib/providers/api-key-state.test.ts
+++ b/src/ai-proxy/lib/providers/api-key-state.test.ts
@@ -38,7 +38,10 @@ describe("apiKeyStatus", () => {
     });
 
     it("reports no credential when neither is configured, and still names the env var", () => {
+        // BOTH aliases: the name is now alias-aware, so leaving a stray
+        // `X_AI_API_KEY` in the ambient environment would decide this assertion.
         env.testing.unset("XAI_API_KEY");
+        env.testing.unset("X_AI_API_KEY");
         const status = apiKeyStatus(account);
 
         expect(status.state).toBe("none");
@@ -48,9 +51,25 @@ describe("apiKeyStatus", () => {
     });
 
     it("names the provider's default env var, or the configured one", () => {
+        env.testing.unset("XAI_API_KEY");
+        env.testing.unset("X_AI_API_KEY");
+
         expect(defaultApiKeyEnvName(account)).toBe("XAI_API_KEY");
         expect(defaultApiKeyEnvName({ ...account, provider: "openai" })).toBe("OPENAI_API_KEY");
         expect(defaultApiKeyEnvName({ ...account, apiKeyEnv: "MY_KEY" })).toBe("MY_KEY");
+    });
+
+    it("names the legacy alias when that is the variable actually carrying the key", () => {
+        // Reporting "XAI_API_KEY" here would send the user to a variable they
+        // never set, while the guard spends the one they did.
+        env.testing.unset("XAI_API_KEY");
+        env.testing.set("X_AI_API_KEY", "legacy-alias-key");
+
+        try {
+            expect(defaultApiKeyEnvName(account)).toBe("X_AI_API_KEY");
+        } finally {
+            env.testing.unset("X_AI_API_KEY");
+        }
     });
 
     it("never reveals a short key", () => {

--- a/src/ai-proxy/lib/providers/api-key-state.ts
+++ b/src/ai-proxy/lib/providers/api-key-state.ts
@@ -59,6 +59,10 @@ export function apiKeyStatus(account: AiProxyAccountConfig): ApiKeyStatus {
     };
 }
 
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 const SHELL_RC_FILES = [".zshrc", ".zprofile", ".zshenv", ".bashrc", ".bash_profile", ".profile"];
 
 async function shellConfigCandidates(): Promise<string[]> {
@@ -83,7 +87,10 @@ async function shellConfigCandidates(): Promise<string[]> {
  * variable may come from a keychain helper, a launch agent, or a parent shell).
  */
 export async function findEnvSourceFile(envName: string): Promise<string | undefined> {
-    const pattern = new RegExp(`^\\s*(export\\s+)?${envName}\\s*=`, "m");
+    // `envName` is a config value (`apiKeyEnv`), so it reaches here unvalidated:
+    // unescaped, a `(` would throw SyntaxError out of an interactive prompt and
+    // a `.` would match a variable the account does not actually read.
+    const pattern = new RegExp(`^\\s*(export\\s+)?${escapeRegExp(envName)}\\s*=`, "m");
 
     for (const file of await shellConfigCandidates()) {
         try {

--- a/src/ai-proxy/lib/providers/api-key-state.ts
+++ b/src/ai-proxy/lib/providers/api-key-state.ts
@@ -31,12 +31,24 @@ export interface ApiKeyStatus {
     maskedOverride?: string;
 }
 
+/**
+ * The env var to NAME in guards, errors and status output.
+ *
+ * Alias-aware on purpose: xAI resolves through `XAI_API_KEY` or the legacy
+ * `X_AI_API_KEY`, so an account relying on the alias must be told the variable
+ * that was actually read. Every site that reports an env var goes through here,
+ * or the name in the message disagrees with the key that was resolved.
+ */
 export function defaultApiKeyEnvName(account: AiProxyAccountConfig): string {
     if (account.apiKeyEnv) {
         return account.apiKeyEnv;
     }
 
-    return account.provider === "openai" ? "OPENAI_API_KEY" : "XAI_API_KEY";
+    if (account.provider === "openai") {
+        return "OPENAI_API_KEY";
+    }
+
+    return env.x.getApiEnvKey() ?? "XAI_API_KEY";
 }
 
 export function maskApiKey(key: string): string {

--- a/src/ai-proxy/lib/providers/api-key-state.ts
+++ b/src/ai-proxy/lib/providers/api-key-state.ts
@@ -1,0 +1,99 @@
+/**
+ * Where an api-key account currently stands, for the CLI to show before it asks
+ * the user to change anything.
+ *
+ * The three states come straight from the two config fields the guard reads
+ * (`apiKey`, `allowEnvApiKey`), so what the CLI prints and what the proxy will
+ * actually do cannot drift apart.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+
+export type ApiKeyState =
+    /** A key is stored on the account; the environment is ignored. */
+    | "override"
+    /** No stored key, but the account may spend the environment's key. */
+    | "env"
+    /** No stored key and no opt-in: the account has no usable credential. */
+    | "none";
+
+export interface ApiKeyStatus {
+    state: ApiKeyState;
+    /** Env var the account would read, whether or not it is set. */
+    envName: string;
+    /** Whether that variable is present in this process's environment. */
+    envPresent: boolean;
+    /** Masked form of the stored key, if any. Never the value. */
+    maskedOverride?: string;
+}
+
+export function defaultApiKeyEnvName(account: AiProxyAccountConfig): string {
+    if (account.apiKeyEnv) {
+        return account.apiKeyEnv;
+    }
+
+    return account.provider === "openai" ? "OPENAI_API_KEY" : "XAI_API_KEY";
+}
+
+export function maskApiKey(key: string): string {
+    if (key.length <= 8) {
+        return "****";
+    }
+
+    return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+export function apiKeyStatus(account: AiProxyAccountConfig): ApiKeyStatus {
+    const envName = defaultApiKeyEnvName(account);
+    const stored = account.apiKey?.trim();
+
+    return {
+        state: stored ? "override" : account.allowEnvApiKey ? "env" : "none",
+        envName,
+        envPresent: Boolean(env.ai.getByEnvKey(envName)),
+        maskedOverride: stored ? maskApiKey(stored) : undefined,
+    };
+}
+
+const SHELL_RC_FILES = [".zshrc", ".zprofile", ".zshenv", ".bashrc", ".bash_profile", ".profile"];
+
+async function shellConfigCandidates(): Promise<string[]> {
+    const home = homedir();
+    const candidates = SHELL_RC_FILES.map((file) => join(home, file));
+    const shellDir = join(home, ".config", "shell");
+
+    try {
+        for (const entry of await readdir(shellDir)) {
+            candidates.push(join(shellDir, entry));
+        }
+    } catch (err) {
+        logger.debug({ err, shellDir }, "ai-proxy: no ~/.config/shell directory to scan");
+    }
+
+    return candidates;
+}
+
+/**
+ * Best-effort answer to "where does this env var come from?" — returns the FILE
+ * that exports it, never the value, and undefined when it cannot be found (the
+ * variable may come from a keychain helper, a launch agent, or a parent shell).
+ */
+export async function findEnvSourceFile(envName: string): Promise<string | undefined> {
+    const pattern = new RegExp(`^\\s*(export\\s+)?${envName}\\s*=`, "m");
+
+    for (const file of await shellConfigCandidates()) {
+        try {
+            if (pattern.test(await readFile(file, "utf-8"))) {
+                return file;
+            }
+        } catch (err) {
+            logger.debug({ err, file }, "ai-proxy: shell config candidate unreadable");
+        }
+    }
+
+    return undefined;
+}

--- a/src/ai-proxy/lib/providers/openai-api-key.ts
+++ b/src/ai-proxy/lib/providers/openai-api-key.ts
@@ -1,5 +1,5 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
-import { type ApiKeySource, assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
+import { assertApiKeySourceAllowed, resolveAccountApiKey } from "@app/ai-proxy/lib/providers/api-key-guard";
 import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { rewriteBodyModel } from "@app/ai-proxy/lib/rewrite-upstream-body";
@@ -42,27 +42,28 @@ export class OpenAiApiKeyProvider implements ProxyProvider {
 
     static async create(account: AiProxyAccountConfig): Promise<OpenAiApiKeyProvider> {
         const envName = account.apiKeyEnv ?? "OPENAI_API_KEY";
-        const configured = account.apiKey?.trim();
-        const apiKey = configured || env.getTrimmed(envName as never);
+        const resolved = resolveAccountApiKey({
+            account,
+            defaultEnvKey: () => env.getTrimmed("OPENAI_API_KEY" as never),
+        });
 
-        if (!apiKey) {
+        if (!resolved) {
             throw new Error(`No OpenAI API key found (checked config apiKey, ${envName}).`);
         }
 
-        const source: ApiKeySource = configured ? "config" : "configEnv";
-        assertApiKeySourceAllowed({ account, source, envName });
+        assertApiKeySourceAllowed({ account, source: resolved.source, envName });
 
         logger.info(
             {
                 account: account.name,
                 provider: account.provider,
-                keySource: source,
+                keySource: resolved.source,
                 apiKeyEnv: envName,
             },
             "ai-proxy: openai account using a billed API key"
         );
 
-        return new OpenAiApiKeyProvider(account, apiKey);
+        return new OpenAiApiKeyProvider(account, resolved.key);
     }
 
     async listModels(): Promise<OpenAiModel[]> {

--- a/src/ai-proxy/lib/providers/openai-api-key.ts
+++ b/src/ai-proxy/lib/providers/openai-api-key.ts
@@ -1,5 +1,6 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { assertApiKeySourceAllowed, resolveAccountApiKey } from "@app/ai-proxy/lib/providers/api-key-guard";
+import { defaultApiKeyEnvName } from "@app/ai-proxy/lib/providers/api-key-state";
 import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { rewriteBodyModel } from "@app/ai-proxy/lib/rewrite-upstream-body";
@@ -41,14 +42,15 @@ export class OpenAiApiKeyProvider implements ProxyProvider {
     }
 
     static async create(account: AiProxyAccountConfig): Promise<OpenAiApiKeyProvider> {
-        const envName = account.apiKeyEnv ?? "OPENAI_API_KEY";
-        const resolved = resolveAccountApiKey({
-            account,
-            defaultEnvKey: () => env.getTrimmed("OPENAI_API_KEY" as never),
-        });
+        const envName = defaultApiKeyEnvName(account);
+        const resolved = resolveAccountApiKey({ account, defaultEnvKey: () => env.ai.openai.getKey() });
 
         if (!resolved) {
-            throw new Error(`No OpenAI API key found (checked config apiKey, ${envName}).`);
+            // Name both: the fallback is always consulted, so an account with a
+            // custom `apiKeyEnv` would otherwise be told only half of what failed.
+            const checked = envName === "OPENAI_API_KEY" ? envName : `${envName} / OPENAI_API_KEY`;
+
+            throw new Error(`No OpenAI API key found (checked config apiKey, ${checked}).`);
         }
 
         assertApiKeySourceAllowed({ account, source: resolved.source, envName });

--- a/src/ai-proxy/lib/providers/openai-api-key.ts
+++ b/src/ai-proxy/lib/providers/openai-api-key.ts
@@ -1,4 +1,5 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { type ApiKeySource, assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
 import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { rewriteBodyModel } from "@app/ai-proxy/lib/rewrite-upstream-body";
@@ -41,11 +42,25 @@ export class OpenAiApiKeyProvider implements ProxyProvider {
 
     static async create(account: AiProxyAccountConfig): Promise<OpenAiApiKeyProvider> {
         const envName = account.apiKeyEnv ?? "OPENAI_API_KEY";
-        const apiKey = env.getTrimmed(envName as never);
+        const configured = account.apiKey?.trim();
+        const apiKey = configured || env.getTrimmed(envName as never);
 
         if (!apiKey) {
-            throw new Error(`No OpenAI API key found (checked ${envName}).`);
+            throw new Error(`No OpenAI API key found (checked config apiKey, ${envName}).`);
         }
+
+        const source: ApiKeySource = configured ? "config" : "configEnv";
+        assertApiKeySourceAllowed({ account, source, envName });
+
+        logger.info(
+            {
+                account: account.name,
+                provider: account.provider,
+                keySource: source,
+                apiKeyEnv: envName,
+            },
+            "ai-proxy: openai account using a billed API key"
+        );
 
         return new OpenAiApiKeyProvider(account, apiKey);
     }

--- a/src/ai-proxy/lib/providers/openai-subscription.ts
+++ b/src/ai-proxy/lib/providers/openai-subscription.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { convertMessagesToInput } from "@app/ai-proxy/lib/chat-to-responses-body";
 import { captureUpstreamFailure } from "@app/ai-proxy/lib/debug-capture";
@@ -705,7 +706,9 @@ async function accumulateResponsesJson(
     const output: unknown[] = [];
 
     if (text.length > 0) {
+        // Responses API clients (Vercel AI SDK) require an id on every output item; WHAM omits it.
         output.push({
+            id: `msg_${randomUUID().replace(/-/g, "")}`,
             type: "message",
             role: "assistant",
             status: "completed",
@@ -713,7 +716,14 @@ async function accumulateResponsesJson(
         });
     }
 
-    output.push(...functionCalls);
+    for (const call of functionCalls) {
+        if (isObject(call) && typeof call.id !== "string") {
+            output.push({ ...call, id: `fc_${randomUUID().replace(/-/g, "")}` });
+            continue;
+        }
+
+        output.push(call);
+    }
 
     return { failed: false, body: SafeJSON.stringify({ ...completed, object: "response", output }) };
 }

--- a/src/ai-proxy/lib/providers/registry.test.ts
+++ b/src/ai-proxy/lib/providers/registry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import {
+    lastProviderFailure,
+    providerUnavailableResponse,
+    tryCreateProvider,
+} from "@app/ai-proxy/lib/providers/registry";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { env } from "@genesiscz/utils/env";
+
+const account: AiProxyAccountConfig = {
+    name: "work",
+    provider: "xai-api-key",
+    providerSlug: "xai",
+    enabled: true,
+    apiKeyEnv: "AI_PROXY_REGISTRY_TEST_KEY",
+};
+
+describe("provider construction failures", () => {
+    it("remembers why an account could not be built and answers 503 with the reason", async () => {
+        env.testing.unset("AI_PROXY_REGISTRY_TEST_KEY");
+        env.testing.unset("XAI_API_KEY");
+        env.testing.unset("X_AI_API_KEY");
+
+        const provider = await tryCreateProvider(account);
+        expect(provider).toBeNull();
+        expect(lastProviderFailure("work/xai")).toContain("No xAI API key found");
+
+        const response = providerUnavailableResponse({ accountName: "work", providerSlug: "xai" });
+        expect(response.status).toBe(503);
+
+        const body = (await response.json()) as { error: { message: string; code: string } };
+        expect(body.error.code).toBe("provider_not_loaded");
+        expect(body.error.message).toContain("Provider not loaded: work/xai");
+        expect(body.error.message).toContain("No xAI API key found");
+    });
+
+    it("reports the opt-in refusal as the reason when the key only exists in the environment", async () => {
+        env.testing.set("AI_PROXY_REGISTRY_TEST_KEY", "billed-key");
+
+        try {
+            expect(await tryCreateProvider(account)).toBeNull();
+            expect(lastProviderFailure("work/xai")).toContain("Refusing to spend the ambient");
+        } finally {
+            env.testing.unset("AI_PROXY_REGISTRY_TEST_KEY");
+        }
+    });
+});

--- a/src/ai-proxy/lib/providers/registry.ts
+++ b/src/ai-proxy/lib/providers/registry.ts
@@ -1,4 +1,5 @@
-import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
+import { homedir } from "node:os";
+import { accountConfigFingerprint, describeAccountCredential } from "@app/ai-proxy/lib/account-config";
 import { AnthropicSubscriptionProvider } from "@app/ai-proxy/lib/providers/anthropic-subscription";
 import { GithubCopilotSubscriptionProvider } from "@app/ai-proxy/lib/providers/github-copilot-subscription";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
@@ -7,6 +8,7 @@ import { OpenAiSubscriptionProvider } from "@app/ai-proxy/lib/providers/openai-s
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { XaiApiKeyProvider } from "@app/ai-proxy/lib/providers/xai-api-key";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 
 export function providerKey(account: { name: string; providerSlug: string }): string {
@@ -116,17 +118,100 @@ export async function acquireProvider(
     return provider ?? null;
 }
 
+/**
+ * Why each provider failed to construct, keyed like `providerKey()`. Without it
+ * a route to a broken account could only answer "Provider not loaded: <key>",
+ * which says nothing about the missing credential that actually caused it.
+ */
+const providerFailures = new Map<string, string>();
+
+export function lastProviderFailure(key: string): string | undefined {
+    return providerFailures.get(key);
+}
+
 export async function tryCreateProvider(account: AiProxyAccountConfig): Promise<ProxyProvider | null> {
+    const key = providerKey(account);
+
     if (!account.enabled || !isProviderImplemented(account.provider)) {
         if (account.enabled && !isProviderImplemented(account.provider)) {
             logger.warn(
                 { account: account.name, provider: account.provider },
                 "ai-proxy: skipping unimplemented provider at runtime"
             );
+            providerFailures.set(key, `provider "${account.provider}" is not implemented`);
         }
 
         return null;
     }
 
-    return createProvider(account);
+    try {
+        const provider = await createProvider(account);
+        providerFailures.delete(key);
+        const credential = describeAccountCredential(account);
+
+        logger.info(
+            {
+                account: account.name,
+                provider: account.provider,
+                credentialSource: credential.source,
+                billed: credential.billed,
+            },
+            credential.billed
+                ? "ai-proxy: account ready on a BILLED api key — every call costs metered money"
+                : "ai-proxy: account ready on a subscription login"
+        );
+
+        return provider;
+    } catch (err) {
+        // One unusable account (missing key env var, expired auth) must not take
+        // down the whole proxy — routes to healthy accounts keep serving.
+        const message = err instanceof Error ? err.message : String(err);
+        providerFailures.set(key, message);
+        logger.warn(
+            { err, account: account.name, provider: account.provider, reason: message },
+            "ai-proxy: account unavailable — skipping"
+        );
+
+        return null;
+    }
+}
+
+/**
+ * The api-key constructors say only which account and env var are missing, which
+ * is exactly what the caller needs. The OAuth/file-based ones can name local
+ * paths, so home directories are collapsed and the text is bounded before it
+ * leaves the process — the full error is already in the server log.
+ */
+function publicFailureReason(reason: string | undefined): string | undefined {
+    if (!reason) {
+        return undefined;
+    }
+
+    const withoutHome = reason.replaceAll(homedir(), "~");
+
+    return withoutHome.length > 300 ? `${withoutHome.slice(0, 300)}…` : withoutHome;
+}
+
+/**
+ * 503 (not 500) for a route whose account never constructed: the proxy is fine,
+ * that one account's credentials are not. The construction error is echoed so
+ * the caller sees WHICH credential is missing.
+ */
+export function providerUnavailableResponse(route: { accountName: string; providerSlug: string }): Response {
+    const key = routeProviderKey(route);
+    const reason = publicFailureReason(lastProviderFailure(key));
+
+    return new Response(
+        SafeJSON.stringify({
+            error: {
+                message: reason ? `Provider not loaded: ${key} — ${reason}` : `Provider not loaded: ${key}`,
+                type: "provider_unavailable",
+                code: "provider_not_loaded",
+            },
+        }),
+        {
+            status: 503,
+            headers: { "Content-Type": "application/json", "retry-after": "30" },
+        }
+    );
 }

--- a/src/ai-proxy/lib/providers/xai-api-key-auth.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key-auth.ts
@@ -1,34 +1,14 @@
-import type { ResolvedApiKey } from "@app/ai-proxy/lib/providers/api-key-guard";
+import { type ResolvedApiKey, resolveAccountApiKey } from "@app/ai-proxy/lib/providers/api-key-guard";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { env } from "@genesiscz/utils/env";
 
 export const XAI_API_BASE_URL = "https://api.x.ai/v1";
 
 /**
- * Resolve the inference API key for an xai-api-key account.
- * Config `apiKey` wins so the account survives an environment without the shell
- * vars, then the env var named in config (`apiKeyEnv`), then the XAI aliases.
+ * Resolve the inference API key for an xai-api-key account: the shared
+ * precedence, with the XAI aliases (`XAI_API_KEY` / `X_AI_API_KEY`) as this
+ * provider's default step.
  */
 export function resolveXaiApiKey(account: AiProxyAccountConfig): ResolvedApiKey | undefined {
-    const configured = account.apiKey?.trim();
-
-    if (configured) {
-        return { key: configured, source: "config" };
-    }
-
-    if (account.apiKeyEnv) {
-        const named = env.getTrimmed(account.apiKeyEnv as never);
-
-        if (named) {
-            return { key: named, source: "configEnv" };
-        }
-    }
-
-    const fallback = env.x.getApiKey();
-
-    if (fallback) {
-        return { key: fallback, source: "defaultEnv" };
-    }
-
-    return undefined;
+    return resolveAccountApiKey({ account, defaultEnvKey: () => env.x.getApiKey() });
 }

--- a/src/ai-proxy/lib/providers/xai-api-key-auth.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key-auth.ts
@@ -1,3 +1,4 @@
+import type { ResolvedApiKey } from "@app/ai-proxy/lib/providers/api-key-guard";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { env } from "@genesiscz/utils/env";
 
@@ -5,16 +6,29 @@ export const XAI_API_BASE_URL = "https://api.x.ai/v1";
 
 /**
  * Resolve the inference API key for an xai-api-key account.
- * Prefers the env var named in config (`apiKeyEnv`), then the standard XAI aliases.
+ * Config `apiKey` wins so the account survives an environment without the shell
+ * vars, then the env var named in config (`apiKeyEnv`), then the XAI aliases.
  */
-export function resolveXaiApiKey(account: AiProxyAccountConfig): string | undefined {
+export function resolveXaiApiKey(account: AiProxyAccountConfig): ResolvedApiKey | undefined {
+    const configured = account.apiKey?.trim();
+
+    if (configured) {
+        return { key: configured, source: "config" };
+    }
+
     if (account.apiKeyEnv) {
         const named = env.getTrimmed(account.apiKeyEnv as never);
 
         if (named) {
-            return named;
+            return { key: named, source: "configEnv" };
         }
     }
 
-    return env.x.getApiKey();
+    const fallback = env.x.getApiKey();
+
+    if (fallback) {
+        return { key: fallback, source: "defaultEnv" };
+    }
+
+    return undefined;
 }

--- a/src/ai-proxy/lib/providers/xai-api-key.test.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key.test.ts
@@ -17,7 +17,7 @@ describe("resolveXaiApiKey", () => {
         env.testing.unset("X_AI_API_KEY");
 
         try {
-            expect(resolveXaiApiKey(account)).toBe("test-key-from-named");
+            expect(resolveXaiApiKey(account)).toEqual({ key: "test-key-from-named", source: "configEnv" });
         } finally {
             env.testing.unset("XAI_API_KEY");
         }
@@ -28,9 +28,34 @@ describe("resolveXaiApiKey", () => {
         env.testing.set("X_AI_API_KEY", "legacy-alias-key");
 
         try {
-            expect(resolveXaiApiKey({ ...account, apiKeyEnv: "XAI_API_KEY" })).toBe("legacy-alias-key");
+            expect(resolveXaiApiKey({ ...account, apiKeyEnv: "XAI_API_KEY" })).toEqual({
+                key: "legacy-alias-key",
+                source: "defaultEnv",
+            });
         } finally {
             env.testing.unset("X_AI_API_KEY");
         }
+    });
+
+    it("prefers the key stored on the account over any environment variable", () => {
+        env.testing.set("XAI_API_KEY", "env-key");
+        env.testing.set("X_AI_API_KEY", "alias-key");
+
+        try {
+            expect(resolveXaiApiKey({ ...account, apiKey: "config-key" })).toEqual({
+                key: "config-key",
+                source: "config",
+            });
+        } finally {
+            env.testing.unset("XAI_API_KEY");
+            env.testing.unset("X_AI_API_KEY");
+        }
+    });
+
+    it("returns undefined when neither config nor env carries a key", () => {
+        env.testing.unset("XAI_API_KEY");
+        env.testing.unset("X_AI_API_KEY");
+
+        expect(resolveXaiApiKey(account)).toBeUndefined();
     });
 });

--- a/src/ai-proxy/lib/providers/xai-api-key.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key.ts
@@ -1,5 +1,6 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { listXaiProxyModels } from "@app/ai-proxy/lib/model-meta";
+import { assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
 import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
@@ -40,16 +41,23 @@ export class XaiApiKeyProvider implements ProxyProvider {
     }
 
     static async create(account: AiProxyAccountConfig): Promise<XaiApiKeyProvider> {
-        const apiKey = resolveXaiApiKey(account);
+        const resolved = resolveXaiApiKey(account);
         const envName = account.apiKeyEnv ?? env.x.getApiEnvKey() ?? "XAI_API_KEY";
 
-        if (!apiKey) {
+        if (!resolved) {
             throw new Error(
-                `No xAI API key found (checked ${envName} / X_AI_API_KEY). Get one at https://console.x.ai/team/default/api-keys`
+                `No xAI API key found (checked config apiKey, ${envName} / X_AI_API_KEY). Set it on the account with \`tools ai-proxy accounts set-key ${account.name}\` or get one at https://console.x.ai/team/default/api-keys`
             );
         }
 
-        return new XaiApiKeyProvider(account, apiKey);
+        assertApiKeySourceAllowed({ account, source: resolved.source, envName });
+
+        logger.info(
+            { account: account.name, provider: account.provider, keySource: resolved.source, apiKeyEnv: envName },
+            "ai-proxy: xai account using a billed API key"
+        );
+
+        return new XaiApiKeyProvider(account, resolved.key);
     }
 
     async listModels(): Promise<OpenAiModel[]> {

--- a/src/ai-proxy/lib/providers/xai-api-key.ts
+++ b/src/ai-proxy/lib/providers/xai-api-key.ts
@@ -1,6 +1,7 @@
 import { accountConfigFingerprint } from "@app/ai-proxy/lib/account-config";
 import { listXaiProxyModels } from "@app/ai-proxy/lib/model-meta";
 import { assertApiKeySourceAllowed } from "@app/ai-proxy/lib/providers/api-key-guard";
+import { defaultApiKeyEnvName } from "@app/ai-proxy/lib/providers/api-key-state";
 import { relayHeaders, rewriteSessionModel, toWsBase } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/providers/types";
 import { resolveXaiApiKey, XAI_API_BASE_URL } from "@app/ai-proxy/lib/providers/xai-api-key-auth";
@@ -42,7 +43,7 @@ export class XaiApiKeyProvider implements ProxyProvider {
 
     static async create(account: AiProxyAccountConfig): Promise<XaiApiKeyProvider> {
         const resolved = resolveXaiApiKey(account);
-        const envName = account.apiKeyEnv ?? env.x.getApiEnvKey() ?? "XAI_API_KEY";
+        const envName = defaultApiKeyEnvName(account);
 
         if (!resolved) {
             throw new Error(

--- a/src/ai-proxy/lib/realtime.test.ts
+++ b/src/ai-proxy/lib/realtime.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getAiProxyConfigStore, resetAiProxyConfigStore } from "@app/ai-proxy/lib/config-store";
@@ -31,6 +31,7 @@ interface SttRequest {
 
 const sttRequests: SttRequest[] = [];
 
+let baseConfig: AiProxyConfig;
 let mockUpstream: ReturnType<typeof Bun.serve>;
 let proxy: ReturnType<typeof startAiProxyServer>;
 let proxyUrl: string;
@@ -144,16 +145,18 @@ beforeAll(async () => {
 
     mockUpstream = startMockUpstream();
 
-    const config: AiProxyConfig = {
+    baseConfig = {
         listen: { host: "127.0.0.1", port: 0 },
         proxyApiKey: PROXY_KEY,
         translation: { cursorAgent: "off", thinking: "raw" },
+        realtime: { allowClientSecrets: true },
         accounts: [
             {
                 name: "martin",
                 provider: "xai-api-key",
                 providerSlug: "grok",
                 enabled: true,
+                allowEnvApiKey: true,
                 apiKeyEnv: "AI_PROXY_TEST_XAI_KEY",
                 baseUrl: `http://127.0.0.1:${mockUpstream.port}`,
                 realtimeBaseUrl: `ws://127.0.0.1:${mockUpstream.port}`,
@@ -163,6 +166,7 @@ beforeAll(async () => {
                 provider: "openai",
                 providerSlug: "openai",
                 enabled: true,
+                allowEnvApiKey: true,
                 apiKeyEnv: "AI_PROXY_TEST_OPENAI_KEY",
                 baseUrl: `http://127.0.0.1:${mockUpstream.port}`,
                 realtimeBaseUrl: `ws://127.0.0.1:${mockUpstream.port}`,
@@ -171,9 +175,9 @@ beforeAll(async () => {
     };
 
     mkdirSync(getAiProxyStorage().getBaseDir(), { recursive: true });
-    await getAiProxyConfigStore().save(config);
+    await getAiProxyConfigStore().save(baseConfig);
 
-    const runtime = await createRuntime(config);
+    const runtime = await createRuntime(baseConfig);
     proxy = startAiProxyServer(runtime);
     proxyUrl = `ws://127.0.0.1:${proxy.port}`;
 });
@@ -294,6 +298,41 @@ describe("realtime WS tunnel", () => {
         expect(closeEvent.reason).toBe("mock upstream bye");
     });
 
+    it("writes a transcript with the text events and counts the audio it skipped", async () => {
+        const client = await connectClient("?model=martin/grok/grok-voice-latest", {
+            Authorization: `Bearer ${PROXY_KEY}`,
+            "x-gt-session": "realtime-transcript-test",
+        });
+        await client.opened;
+        await waitFor(() => client.events.length >= 1);
+
+        client.ws.send(SafeJSON.stringify({ type: "session.update", session: { voice: "ara" } }));
+        // A delta frame carrying base64 audio: counted, never stored.
+        client.ws.send(SafeJSON.stringify({ type: "response.audio.delta", delta: "A".repeat(5_000) }));
+        client.ws.send(new Uint8Array([1, 2, 3, 4]));
+        await waitFor(() => client.events.length >= 4);
+
+        client.ws.close(1000);
+        await client.closed;
+
+        const file = join(
+            getAiProxyStorage().getBaseDir(),
+            "transcripts",
+            new Date().toISOString().slice(0, 10),
+            "realtime-transcript-test.jsonl"
+        );
+        await waitFor(() => existsSync(file) && readFileSync(file, "utf-8").includes("realtime session closed"));
+
+        const contents = readFileSync(file, "utf-8");
+        expect(contents).toContain("session.update");
+        expect(contents).toContain("session.created");
+        // The delta frame was counted, not stored…
+        expect(contents).toContain('"response.audio.delta":1');
+        expect(contents).not.toContain("[client] response.audio.delta");
+        // …and the binary frame only shows up as a byte count.
+        expect(contents).toContain('"binaryFrames"');
+    });
+
     it("records usage from response.done events without breaking the pipe", async () => {
         const client = await connectClient("?model=martin/grok/grok-voice-latest", {
             Authorization: `Bearer ${PROXY_KEY}`,
@@ -331,6 +370,27 @@ describe("realtime client_secrets mint", () => {
         expect(res.status).toBe(400);
         const body = (await res.json()) as { error: { message: string } };
         expect(body.error.message).toContain("Missing model");
+    });
+
+    it("refuses to mint when realtime.allowClientSecrets is off", async () => {
+        // The server re-reads the config per request (`loadConfigFresh`), so
+        // flipping the stored flag is what actually exercises the guard.
+        await getAiProxyConfigStore().save({ ...baseConfig, realtime: { allowClientSecrets: false } });
+
+        try {
+            const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/realtime/client_secrets`, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${PROXY_KEY}`, "Content-Type": "application/json" },
+                body: SafeJSON.stringify({ session: { type: "realtime", model: "martin/grok/grok-voice-latest" } }),
+            });
+
+            expect(res.status).toBe(403);
+            const body = (await res.json()) as { error: { code: string; message: string } };
+            expect(body.error.code).toBe("client_secrets_disabled");
+            expect(body.error.message).toContain("never reach this proxy's logs");
+        } finally {
+            await getAiProxyConfigStore().save(baseConfig);
+        }
     });
 });
 

--- a/src/ai-proxy/lib/realtime.ts
+++ b/src/ai-proxy/lib/realtime.ts
@@ -404,8 +404,55 @@ export async function handleRealtimeClientSecrets(input: {
         );
     }
 
+    const mintTags = readRequestTags(input.req.headers);
     const started = performance.now();
-    const response = await provider.realtimeClientSecrets(input.req, route.upstreamId, bodyText);
+
+    // This route is dispatched before server.ts's try/catch, so an expired
+    // subscription auth or a network failure here would surface as an unhandled
+    // rejection instead of the error envelope every other route returns.
+    let response: Response;
+    try {
+        response = await provider.realtimeClientSecrets(input.req, route.upstreamId, bodyText);
+    } catch (err) {
+        const elapsedMs = Math.round(performance.now() - started);
+        logger.warn(
+            {
+                err,
+                path: "/v1/realtime/client_secrets",
+                model: proxyModel,
+                upstreamModel: route.upstreamId,
+                account: route.accountName,
+                client: client.name,
+                elapsedMs,
+            },
+            "ai-proxy: realtime client secret mint failed before a response was received"
+        );
+
+        recordUsageRequest({
+            ts: new Date().toISOString(),
+            account: route.accountName,
+            client: client.name,
+            provider: route.account.provider,
+            proxyModel,
+            upstreamModel: route.upstreamId,
+            path: "/v1/realtime/client_secrets",
+            status: 502,
+            elapsedMs,
+            stream: false,
+            error: true,
+            tags: mintTags,
+        });
+
+        return jsonError(
+            502,
+            `Realtime client secret mint failed: ${err instanceof Error ? err.message : String(err)}`,
+            {
+                type: "upstream_error",
+                code: "client_secrets_failed",
+            }
+        );
+    }
+
     const elapsedMs = Math.round(performance.now() - started);
     const minted = await response.text();
 
@@ -440,6 +487,7 @@ export async function handleRealtimeClientSecrets(input: {
         elapsedMs,
         stream: false,
         error: response.status >= 400,
+        tags: mintTags,
     });
 
     // `response.text()` already decoded the body, so upstream's framing headers

--- a/src/ai-proxy/lib/realtime.ts
+++ b/src/ai-proxy/lib/realtime.ts
@@ -2,8 +2,10 @@ import type { ProxyProvider, RealtimeConnectTarget } from "@app/ai-proxy/lib/pro
 import { guardProxyRoute, jsonError } from "@app/ai-proxy/lib/route-guards";
 import type { AiProxyConfig, ResolvedRoute } from "@app/ai-proxy/lib/types";
 import { scheduleBillingSync } from "@app/ai-proxy/lib/usage/billing-sync";
+import { RealtimeTranscript } from "@app/ai-proxy/lib/usage/realtime-transcript";
 import { recordUsageRequest } from "@app/ai-proxy/lib/usage/store";
-import type { TokenUsage } from "@app/ai-proxy/lib/usage/types";
+import { readRequestTags } from "@app/ai-proxy/lib/usage/transcripts";
+import type { RequestTags, TokenUsage } from "@app/ai-proxy/lib/usage/types";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import type { Server, ServerWebSocket, WebSocketHandler } from "bun";
@@ -30,6 +32,8 @@ export interface RealtimeBridgeData {
     upstreamFrames: number;
     upstreamBytes: number;
     usage: TokenUsage | null;
+    transcript: RealtimeTranscript;
+    tags?: RequestTags;
 }
 
 /** Browsers cannot set WS headers — accept the proxy key via `?key=` too. */
@@ -130,6 +134,7 @@ export async function handleRealtimeUpgrade(input: {
         return jsonError(400, `Provider "${route.account.provider}" does not support realtime`);
     }
 
+    const tags = readRequestTags(input.req.headers);
     const data: RealtimeBridgeData = {
         target: provider.realtimeConnect(route.upstreamId),
         client: client.name,
@@ -145,6 +150,16 @@ export async function handleRealtimeUpgrade(input: {
         upstreamFrames: 0,
         upstreamBytes: 0,
         usage: null,
+        tags,
+        transcript: new RealtimeTranscript({
+            ts: new Date().toISOString(),
+            account: route.accountName,
+            provider: route.account.provider,
+            proxyModel: guarded.proxyModel,
+            upstreamModel: route.upstreamId,
+            client: client.name,
+            tags,
+        }),
     };
 
     if (input.server.upgrade(input.req, { data })) {
@@ -205,6 +220,7 @@ export const realtimeWebsocket: WebSocketHandler<RealtimeBridgeData> = {
             const payload = event.data as string | ArrayBuffer;
             data.upstreamFrames += 1;
             data.upstreamBytes += frameByteLength(payload);
+            data.transcript.recordFrame("upstream", payload);
 
             if (typeof payload === "string") {
                 sniffRealtimeUsage(data, payload);
@@ -241,6 +257,7 @@ export const realtimeWebsocket: WebSocketHandler<RealtimeBridgeData> = {
         const data = ws.data;
         data.clientFrames += 1;
         data.clientBytes += frameByteLength(message);
+        data.transcript.recordFrame("client", message);
         const upstream = data.upstream;
 
         if (!upstream || upstream.readyState !== WebSocket.OPEN) {
@@ -292,6 +309,16 @@ export const realtimeWebsocket: WebSocketHandler<RealtimeBridgeData> = {
             "ai-proxy: realtime session closed"
         );
 
+        const transcript = data.transcript.finish({
+            elapsedMs,
+            closeCode: code,
+            usage: data.usage ?? undefined,
+            clientFrames: data.clientFrames,
+            clientBytes: data.clientBytes,
+            upstreamFrames: data.upstreamFrames,
+            upstreamBytes: data.upstreamBytes,
+        });
+
         recordUsageRequest({
             ts: new Date().toISOString(),
             account: data.route.accountName,
@@ -304,6 +331,8 @@ export const realtimeWebsocket: WebSocketHandler<RealtimeBridgeData> = {
             elapsedMs,
             stream: true,
             usage: data.usage ?? undefined,
+            tags: data.tags,
+            transcript,
         });
         scheduleBillingSync(data.route.account, data.providers);
     },
@@ -353,20 +382,92 @@ export async function handleRealtimeClientSecrets(input: {
         return jsonError(400, `Provider "${route.account.provider}" does not support realtime client secrets`);
     }
 
+    if (!input.config.realtime?.allowClientSecrets) {
+        logger.warn(
+            {
+                path: "/v1/realtime/client_secrets",
+                model: proxyModel,
+                upstreamModel: route.upstreamId,
+                account: route.accountName,
+                client: client.name,
+            },
+            "ai-proxy: refused to mint a realtime client secret (realtime.allowClientSecrets is off)"
+        );
+
+        return jsonError(
+            403,
+            "Minting realtime client secrets is disabled: the minted secret talks to the vendor directly, " +
+                "so that session's usage and content never reach this proxy's logs. Use the logged WS tunnel " +
+                "(GET /v1/realtime?model=…), or set realtime.allowClientSecrets = true in the ai-proxy config " +
+                "to accept the blind spot.",
+            { type: "forbidden", code: "client_secrets_disabled" }
+        );
+    }
+
     const started = performance.now();
     const response = await provider.realtimeClientSecrets(input.req, route.upstreamId, bodyText);
+    const elapsedMs = Math.round(performance.now() - started);
+    const minted = await response.text();
 
-    logger.info(
+    logger.warn(
         {
             path: "/v1/realtime/client_secrets",
             model: proxyModel,
             upstreamModel: route.upstreamId,
+            account: route.accountName,
+            provider: route.account.provider,
             status: response.status,
-            elapsedMs: Math.round(performance.now() - started),
+            elapsedMs,
             client: client.name,
+            expiresAt: readSecretExpiry(minted),
         },
-        "ai-proxy: request"
+        response.ok
+            ? "ai-proxy: minted a realtime client secret — that session bypasses this proxy and is NOT logged"
+            : "ai-proxy: realtime client secret mint was refused upstream"
     );
 
-    return response;
+    // The grant is on record even though the session it authorizes is not, so
+    // vendor-side usage can at least be attributed to a client and a moment.
+    recordUsageRequest({
+        ts: new Date().toISOString(),
+        account: route.accountName,
+        client: client.name,
+        provider: route.account.provider,
+        proxyModel,
+        upstreamModel: route.upstreamId,
+        path: "/v1/realtime/client_secrets",
+        status: response.status,
+        elapsedMs,
+        stream: false,
+        error: response.status >= 400,
+    });
+
+    // `response.text()` already decoded the body, so upstream's framing headers
+    // now describe a payload that no longer exists — clients would misdecode it.
+    const headers = new Headers(response.headers);
+    headers.delete("content-encoding");
+    headers.delete("content-length");
+    headers.delete("transfer-encoding");
+
+    return new Response(minted, { status: response.status, headers });
+}
+
+/** Pull the expiry out of a mint response so the grant's lifetime is on record. */
+function readSecretExpiry(body: string): string | undefined {
+    try {
+        const parsed = SafeJSON.parse(body, { strict: true }) as {
+            expires_at?: number | string;
+            client_secret?: { expires_at?: number | string };
+        };
+        const raw = parsed.client_secret?.expires_at ?? parsed.expires_at;
+
+        if (typeof raw === "number") {
+            return new Date(raw * 1000).toISOString();
+        }
+
+        return typeof raw === "string" ? raw : undefined;
+    } catch (err) {
+        logger.debug({ err }, "ai-proxy: realtime mint response was not JSON — no expiry recorded");
+        return undefined;
+    }
 }

--- a/src/ai-proxy/lib/route-guards.ts
+++ b/src/ai-proxy/lib/route-guards.ts
@@ -1,6 +1,6 @@
 import type { ResolvedClient } from "@app/ai-proxy/lib/clients";
 import { clientProviderDenial, resolveClient } from "@app/ai-proxy/lib/clients";
-import { acquireProvider, routeProviderKey } from "@app/ai-proxy/lib/providers/registry";
+import { acquireProvider, providerUnavailableResponse } from "@app/ai-proxy/lib/providers/registry";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
 import type { AiProxyConfig, ResolvedRoute } from "@app/ai-proxy/lib/types";
@@ -72,7 +72,7 @@ export async function guardProxyRoute(input: {
     const provider = await acquireProvider(input.providers, route);
 
     if (!provider) {
-        return jsonError(500, `Provider not loaded: ${routeProviderKey(route)}`);
+        return providerUnavailableResponse(route);
     }
 
     return { client, route, provider, proxyModel: input.proxyModel };

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -36,12 +36,6 @@ function mapProxyRequestError(err: unknown): { status: number; message: string }
 
     const message = err instanceof Error ? err.message : String(err);
 
-    // The account exists but its credentials did not resolve — a configuration
-    // problem on the proxy host, retryable once fixed, so 503 rather than 400.
-    if (message.startsWith("Provider not loaded:")) {
-        return { status: 503, message };
-    }
-
     if (
         message.startsWith("Model id must be") ||
         message.startsWith("No enabled account for model") ||

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -3,7 +3,7 @@ import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
 import { clientProviderDenial, resolveClient, validateClients } from "@app/ai-proxy/lib/clients";
 import { loadConfigFresh } from "@app/ai-proxy/lib/config";
 import { stripBasePath } from "@app/ai-proxy/lib/path-prefix";
-import { acquireProvider, buildProviderMap, routeProviderKey } from "@app/ai-proxy/lib/providers/registry";
+import { acquireProvider, buildProviderMap, providerUnavailableResponse } from "@app/ai-proxy/lib/providers/registry";
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { handleRealtimeClientSecrets, handleRealtimeUpgrade, realtimeWebsocket } from "@app/ai-proxy/lib/realtime";
 import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
@@ -36,10 +36,15 @@ function mapProxyRequestError(err: unknown): { status: number; message: string }
 
     const message = err instanceof Error ? err.message : String(err);
 
+    // The account exists but its credentials did not resolve — a configuration
+    // problem on the proxy host, retryable once fixed, so 503 rather than 400.
+    if (message.startsWith("Provider not loaded:")) {
+        return { status: 503, message };
+    }
+
     if (
         message.startsWith("Model id must be") ||
         message.startsWith("No enabled account for model") ||
-        message.startsWith("Provider not loaded:") ||
         message.startsWith("Ambiguous model")
     ) {
         return { status: 400, message };
@@ -288,15 +293,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                     const provider = await acquireProvider(runtime.providers, route);
 
                     if (!provider) {
-                        return new Response(
-                            SafeJSON.stringify({
-                                error: { message: `Provider not loaded: ${routeProviderKey(route)}` },
-                            }),
-                            {
-                                status: 500,
-                                headers: { "Content-Type": "application/json" },
-                            }
-                        );
+                        return providerUnavailableResponse(route);
                     }
 
                     if (path === "/v1/responses") {

--- a/src/ai-proxy/lib/storage.ts
+++ b/src/ai-proxy/lib/storage.ts
@@ -3,9 +3,17 @@ import { Storage } from "@genesiscz/utils/storage/storage";
 
 const TOOL_NAME = "ai-proxy";
 
+/**
+ * Owner-only: this config carries the proxy bearer key and, since
+ * `accounts[].apiKey`, billed vendor credentials in plain text. Declared on the
+ * storage instance so every writer of config.json honours it, not just the one
+ * `AiProxyConfigStore.save` happens to call.
+ */
+export const AI_PROXY_CONFIG_FILE_MODE = 0o600;
+
 export class AiProxyStorage extends Storage {
     constructor() {
-        super(TOOL_NAME);
+        super(TOOL_NAME, { configFileMode: AI_PROXY_CONFIG_FILE_MODE });
     }
 
     runtimePath(): string {

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -120,6 +120,19 @@ export interface AiProxyAccountConfig {
     githubCopilot?: AiProxyGithubCopilotAccountConfig;
     anthropicSub?: AiProxyAnthropicSubAccountConfig;
     openaiSub?: AiProxyOpenAiSubAccountConfig;
+    /**
+     * Literal API key for api-key providers, stored in config instead of the
+     * environment. Takes precedence over `apiKeyEnv` so the account keeps
+     * working when the proxy runs without the user's shell env (launchd, cron).
+     * This is a real billed credential — `redactConfig` masks it.
+     */
+    apiKey?: string;
+    /**
+     * Opt in to resolving this account's billed key from the environment. Off by
+     * default: an ambient `XAI_API_KEY` must never be spent just because the
+     * shell happens to export it.
+     */
+    allowEnvApiKey?: boolean;
     apiKeyEnv?: string;
     baseUrl?: string;
     /**
@@ -142,12 +155,23 @@ export interface AiProxyClientConfig {
     disabled?: boolean;
 }
 
+export interface AiProxyRealtimeConfig {
+    /**
+     * Allow POST /v1/realtime/client_secrets. Off by default: the minted secret
+     * is spent talking to the vendor DIRECTLY, so the session itself never
+     * passes through the proxy and cannot be logged. The WS tunnel
+     * (GET /v1/realtime) is the observable path.
+     */
+    allowClientSecrets?: boolean;
+}
+
 export interface AiProxyConfig {
     listen: AiProxyListenConfig;
     proxyApiKey: string;
     /** Per-user keys for multi-client (VPS) mode. proxyApiKey remains the owner key. */
     clients?: AiProxyClientConfig[];
     translation: AiProxyTranslationConfig;
+    realtime?: AiProxyRealtimeConfig;
     public?: AiProxyPublicConfig;
     accounts: AiProxyAccountConfig[];
 }

--- a/src/ai-proxy/lib/usage/realtime-transcript.test.ts
+++ b/src/ai-proxy/lib/usage/realtime-transcript.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+// The transcript store writes into ~/.genesis-tools/ai-proxy, so it is replaced
+// with a collector: these tests are about what the writer decides to keep.
+
+const appended: string[] = [];
+
+mock.module("@app/ai-proxy/lib/usage/transcripts", () => ({
+    transcriptsEnabled: () => true,
+    transcriptFile: (day: string, session?: string) => `${day}/${session ?? "_untagged"}.jsonl`,
+    appendTranscriptLines: (_file: string, _day: string, lines: string[]) => {
+        appended.push(...lines);
+    },
+}));
+
+import { MAX_RETAINED_EVENTS, RealtimeTranscript } from "@app/ai-proxy/lib/usage/realtime-transcript";
+
+function newTranscript(): RealtimeTranscript {
+    return new RealtimeTranscript({
+        ts: "2026-07-29T04:00:00.000Z",
+        account: "acct",
+        provider: "openai",
+        proxyModel: "openai/gpt-realtime",
+        upstreamModel: "gpt-realtime",
+        client: "cli",
+    });
+}
+
+function closingSummary() {
+    return {
+        elapsedMs: 1_000,
+        closeCode: 1000,
+        clientFrames: 1,
+        clientBytes: 10,
+        upstreamFrames: 1,
+        upstreamBytes: 10,
+    };
+}
+
+interface Entry {
+    eventType?: string;
+    realtime?: { retainedEvents?: number; cappedEvents?: number };
+}
+
+function entries(): Entry[] {
+    return appended.map((line) => SafeJSON.parse(line, { strict: true }) as Entry);
+}
+
+beforeEach(() => {
+    appended.length = 0;
+});
+
+describe("RealtimeTranscript", () => {
+    it("counts stream fragments instead of storing them", () => {
+        const transcript = newTranscript();
+
+        transcript.recordFrame("upstream", SafeJSON.stringify({ type: "response.audio.delta", delta: "AAAA" }));
+        transcript.recordFrame("client", SafeJSON.stringify({ type: "session.update", session: {} }));
+        transcript.finish(closingSummary());
+
+        const recorded = entries();
+        expect(recorded.filter((entry) => entry.eventType === "response.audio.delta")).toHaveLength(0);
+        expect(recorded.filter((entry) => entry.eventType === "session.update")).toHaveLength(1);
+    });
+
+    it("stops retaining events at the ceiling and counts the rest in the summary", () => {
+        const transcript = newTranscript();
+        const overshoot = 100;
+
+        for (let index = 0; index < MAX_RETAINED_EVENTS + overshoot; index += 1) {
+            transcript.recordFrame("client", SafeJSON.stringify({ type: "conversation.item.create", index }));
+        }
+
+        transcript.finish(closingSummary());
+
+        const recorded = entries();
+        expect(recorded.filter((entry) => entry.eventType === "conversation.item.create")).toHaveLength(
+            MAX_RETAINED_EVENTS
+        );
+
+        const summary = recorded[recorded.length - 1];
+        expect(summary?.realtime?.retainedEvents).toBe(MAX_RETAINED_EVENTS);
+        expect(summary?.realtime?.cappedEvents).toBe(overshoot);
+    });
+});

--- a/src/ai-proxy/lib/usage/realtime-transcript.test.ts
+++ b/src/ai-proxy/lib/usage/realtime-transcript.test.ts
@@ -40,7 +40,8 @@ function closingSummary() {
 
 interface Entry {
     eventType?: string;
-    realtime?: { retainedEvents?: number; cappedEvents?: number };
+    realtime?: { retainedEvents?: number; cappedEvents?: number; skippedEvents?: Record<string, number> };
+    message?: { content?: { text?: string }[] };
 }
 
 function entries(): Entry[] {
@@ -62,6 +63,36 @@ describe("RealtimeTranscript", () => {
         const recorded = entries();
         expect(recorded.filter((entry) => entry.eventType === "response.audio.delta")).toHaveLength(0);
         expect(recorded.filter((entry) => entry.eventType === "session.update")).toHaveLength(1);
+    });
+
+    it("reports every skipped high-volume type and its count in the closing summary", () => {
+        // Dropping the frames is only half the contract: the summary is the only
+        // record that a voice session carried audio at all, so the counts have to
+        // survive both in the structured field and in the human-readable text.
+        const transcript = newTranscript();
+
+        for (let index = 0; index < 10_000; index += 1) {
+            transcript.recordFrame("upstream", SafeJSON.stringify({ type: "response.audio.delta", delta: "AAAA" }));
+        }
+
+        for (let index = 0; index < 42; index += 1) {
+            transcript.recordFrame("client", SafeJSON.stringify({ type: "input_audio_buffer.append", audio: "BBBB" }));
+        }
+
+        transcript.finish(closingSummary());
+
+        const recorded = entries();
+        // 10_042 frames in, one summary line out.
+        expect(recorded).toHaveLength(1);
+
+        const summary = recorded[0];
+        expect(summary?.realtime?.skippedEvents).toEqual({
+            "response.audio.delta": 10_000,
+            "input_audio_buffer.append": 42,
+        });
+        expect(summary?.realtime?.retainedEvents).toBe(0);
+        expect(summary?.message?.content?.[0]?.text).toContain("response.audio.delta x10000");
+        expect(summary?.message?.content?.[0]?.text).toContain("input_audio_buffer.append x42");
     });
 
     it("stops retaining events at the ceiling and counts the rest in the summary", () => {

--- a/src/ai-proxy/lib/usage/realtime-transcript.ts
+++ b/src/ai-proxy/lib/usage/realtime-transcript.ts
@@ -1,0 +1,269 @@
+/**
+ * Transcript writer for realtime WebSocket sessions.
+ *
+ * The chat path can serialize one exchange after the fact (`writeTranscript`),
+ * but a realtime session is a minutes-long stream of events in both directions,
+ * so this records as it goes and closes with a summary entry. The JSONL shape is
+ * the same one `tools ai-proxy calls --show` already reads: entries sharing a
+ * `callId`, each carrying `message.content` text blocks.
+ *
+ * Volume is the whole problem. A voice session is mostly `*.delta` frames and
+ * base64 PCM; inlining them would write megabytes per minute and bury the parts
+ * a human actually wants to read. So delta frames and binary frames are counted,
+ * not stored, and any oversized string inside a kept event is replaced by a note
+ * of how many characters were dropped.
+ */
+import {
+    appendTranscriptLines,
+    type TranscriptRef,
+    transcriptFile,
+    transcriptsEnabled,
+} from "@app/ai-proxy/lib/usage/transcripts";
+import type { RequestTags, TokenUsage } from "@app/ai-proxy/lib/usage/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+/** Longest string kept inside a recorded event before it becomes a note. */
+const MAX_FIELD_CHARS = 2_000;
+/** Longest serialized event kept in one entry. */
+const MAX_EVENT_CHARS = 8_000;
+/** Entries buffered before hitting the disk. */
+const FLUSH_EVERY = 20;
+/**
+ * Retained events per session. `FLUSH_EVERY` only bounds memory: without this a
+ * session that stays open for hours (or a client that just keeps sending
+ * non-delta frames) writes to disk forever. Past the ceiling events are counted
+ * in the summary the same way high-volume deltas already are.
+ */
+export const MAX_RETAINED_EVENTS = 5_000;
+/** Retained event bytes per session, for the same reason. */
+const MAX_RETAINED_BYTES = 32 * 1_024 * 1_024;
+
+export type RealtimeDirection = "client" | "upstream";
+
+export interface RealtimeTranscriptOptions {
+    ts: string;
+    account: string;
+    provider: string;
+    proxyModel: string;
+    upstreamModel: string;
+    client: string;
+    tags?: RequestTags;
+}
+
+export interface RealtimeTranscriptSummary {
+    elapsedMs: number;
+    closeCode: number;
+    usage?: TokenUsage;
+    clientFrames: number;
+    clientBytes: number;
+    upstreamFrames: number;
+    upstreamBytes: number;
+}
+
+/** Events whose payload is a stream fragment: counted, never stored. */
+function isHighVolumeEvent(type: string): boolean {
+    return type.endsWith(".delta") || type === "input_audio_buffer.append";
+}
+
+/** Replace long strings (base64 audio, giant instructions) but keep the structure. */
+function truncateStrings(value: unknown, depth = 0): unknown {
+    if (typeof value === "string") {
+        return value.length > MAX_FIELD_CHARS ? `<omitted ${value.length} chars>` : value;
+    }
+
+    if (value === null || typeof value !== "object" || depth >= 8) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item) => truncateStrings(item, depth + 1));
+    }
+
+    return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, truncateStrings(item, depth + 1)])
+    );
+}
+
+function compactEvent(event: unknown): string {
+    const json = SafeJSON.stringify(truncateStrings(event), { strict: true });
+
+    return json.length > MAX_EVENT_CHARS ? `${json.slice(0, MAX_EVENT_CHARS)}…` : json;
+}
+
+export class RealtimeTranscript {
+    private readonly file: string;
+    private readonly day: string;
+    private readonly sessionId: string;
+    private readonly callId = crypto.randomUUID();
+    private readonly options: RealtimeTranscriptOptions;
+    private readonly enabled: boolean;
+    private readonly skipped = new Map<string, number>();
+    private pending: string[] = [];
+    private parentUuid: string | null = null;
+    private binaryFrames = { client: 0, upstream: 0 };
+    private binaryBytes = { client: 0, upstream: 0 };
+    private retainedEvents = 0;
+    private retainedBytes = 0;
+    private cappedEvents = 0;
+
+    constructor(options: RealtimeTranscriptOptions) {
+        this.options = options;
+        this.enabled = transcriptsEnabled();
+        this.day = options.ts.slice(0, 10);
+        this.sessionId = options.tags?.session ?? "_untagged";
+        this.file = transcriptFile(this.day, options.tags?.session);
+    }
+
+    recordFrame(direction: RealtimeDirection, payload: string | ArrayBuffer | Buffer): void {
+        if (!this.enabled) {
+            return;
+        }
+
+        if (typeof payload !== "string") {
+            this.binaryFrames[direction] += 1;
+            this.binaryBytes[direction] += payload.byteLength;
+            return;
+        }
+
+        let event: { type?: string } | undefined;
+        try {
+            event = SafeJSON.parse(payload, { strict: true }) as { type?: string };
+        } catch (err) {
+            logger.debug({ err, direction }, "ai-proxy realtime transcript: non-JSON frame kept verbatim");
+        }
+
+        if (!event || typeof event !== "object") {
+            this.push(direction, "text", payload.slice(0, MAX_EVENT_CHARS));
+            return;
+        }
+
+        const type = typeof event.type === "string" ? event.type : "unknown";
+
+        if (isHighVolumeEvent(type)) {
+            this.skipped.set(type, (this.skipped.get(type) ?? 0) + 1);
+            return;
+        }
+
+        this.push(direction, type, compactEvent(event));
+    }
+
+    /** Close the session out with a summary entry and return its ref. */
+    finish(summary: RealtimeTranscriptSummary): TranscriptRef | undefined {
+        if (!this.enabled) {
+            return undefined;
+        }
+
+        const uuid = crypto.randomUUID();
+        this.pending.push(
+            SafeJSON.stringify(
+                {
+                    parentUuid: this.parentUuid,
+                    sessionId: this.sessionId,
+                    uuid,
+                    timestamp: new Date(new Date(this.options.ts).getTime() + summary.elapsedMs).toISOString(),
+                    type: "assistant",
+                    callId: this.callId,
+                    tags: this.options.tags ?? {},
+                    elapsedMs: summary.elapsedMs,
+                    status: 101,
+                    stream: true,
+                    account: this.options.account,
+                    provider: this.options.provider,
+                    path: "/v1/realtime",
+                    realtime: {
+                        closeCode: summary.closeCode,
+                        clientFrames: summary.clientFrames,
+                        clientBytes: summary.clientBytes,
+                        upstreamFrames: summary.upstreamFrames,
+                        upstreamBytes: summary.upstreamBytes,
+                        binaryFrames: { ...this.binaryFrames },
+                        binaryBytes: { ...this.binaryBytes },
+                        skippedEvents: Object.fromEntries(this.skipped),
+                        retainedEvents: this.retainedEvents,
+                        cappedEvents: this.cappedEvents,
+                    },
+                    message: {
+                        role: "assistant",
+                        model: this.options.upstreamModel,
+                        proxyModel: this.options.proxyModel,
+                        content: [{ type: "text", text: this.summaryText(summary) }],
+                        usage: summary.usage,
+                    },
+                },
+                { strict: true }
+            )
+        );
+
+        this.flush();
+
+        return { file: this.file, uuid };
+    }
+
+    private summaryText(summary: RealtimeTranscriptSummary): string {
+        const skipped = [...this.skipped.entries()].map(([type, count]) => `${type} x${count}`).join(", ");
+
+        return [
+            `realtime session closed (code ${summary.closeCode}) after ${Math.round(summary.elapsedMs / 1000)}s`,
+            `client ${summary.clientFrames} frames / ${summary.clientBytes} bytes · upstream ${summary.upstreamFrames} frames / ${summary.upstreamBytes} bytes`,
+            `binary frames not stored: client ${this.binaryFrames.client} (${this.binaryBytes.client} bytes), upstream ${this.binaryFrames.upstream} (${this.binaryBytes.upstream} bytes)`,
+            skipped ? `stream fragments counted only: ${skipped}` : "no stream fragments",
+            this.cappedEvents > 0
+                ? `retention ceiling reached after ${this.retainedEvents} events: ${this.cappedEvents} later events counted only`
+                : `${this.retainedEvents} events retained`,
+        ].join("\n");
+    }
+
+    private push(direction: RealtimeDirection, type: string, body: string): void {
+        if (this.retainedEvents >= MAX_RETAINED_EVENTS || this.retainedBytes >= MAX_RETAINED_BYTES) {
+            this.cappedEvents += 1;
+
+            if (this.cappedEvents === 1) {
+                logger.warn(
+                    { file: this.file, retainedEvents: this.retainedEvents, retainedBytes: this.retainedBytes },
+                    "ai-proxy realtime transcript: session hit its retention ceiling, later events are counted only"
+                );
+            }
+
+            return;
+        }
+
+        const uuid = crypto.randomUUID();
+        const line = SafeJSON.stringify(
+            {
+                parentUuid: this.parentUuid,
+                sessionId: this.sessionId,
+                uuid,
+                timestamp: new Date().toISOString(),
+                type: direction === "client" ? "user" : "assistant",
+                callId: this.callId,
+                direction,
+                eventType: type,
+                message: {
+                    role: direction === "client" ? "user" : "assistant",
+                    content: [{ type: "text", text: `[${direction}] ${type}\n${body}` }],
+                },
+            },
+            { strict: true }
+        );
+
+        this.pending.push(line);
+        this.parentUuid = uuid;
+        this.retainedEvents += 1;
+        this.retainedBytes += line.length;
+
+        if (this.pending.length >= FLUSH_EVERY) {
+            this.flush();
+        }
+    }
+
+    private flush(): void {
+        if (this.pending.length === 0) {
+            return;
+        }
+
+        const lines = this.pending;
+        this.pending = [];
+        appendTranscriptLines(this.file, this.day, lines);
+    }
+}

--- a/src/ai-proxy/lib/usage/transcripts.ts
+++ b/src/ai-proxy/lib/usage/transcripts.ts
@@ -102,6 +102,24 @@ function queueAppend(file: string, day: string, payload: string): void {
     });
 }
 
+/** Transcripts are opt-out; a realtime session must honour the same switch. */
+export function transcriptsEnabled(): boolean {
+    return env.aiProxy.getTranscripts();
+}
+
+/**
+ * Append already-serialized JSONL entries to a session file. Realtime sessions
+ * stream for minutes, so they write as they go instead of building one exchange
+ * up front the way `writeTranscript` does.
+ */
+export function appendTranscriptLines(file: string, day: string, lines: string[]): void {
+    if (lines.length === 0) {
+        return;
+    }
+
+    queueAppend(file, day, `${lines.join("\n")}\n`);
+}
+
 function sanitize(part: string | undefined, fallback: string): string {
     const cleaned = (part ?? "").replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
     return cleaned || fallback;

--- a/src/ask/providers/ProviderManager.test.ts
+++ b/src/ask/providers/ProviderManager.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// Every collaborator of `detectProviders` is a dynamic import or a network probe,
+// so this replaces them with the smallest fixture that exercises the cache
+// semantics: no env-key providers at all, one grok-sub and one openai-sub account.
+
+const ACCOUNTS_BY_PROVIDER: Record<string, { name: string }[]> = {
+    "grok-sub": [{ name: "grok-cli" }],
+    "openai-sub": [{ name: "codex" }],
+};
+
+function stubProvider(name: string) {
+    return {
+        name,
+        type: name,
+        key: "stub",
+        provider: {},
+        models: [],
+        config: { name, type: name, envKey: "STUB", priority: 1 },
+        subscription: true,
+    };
+}
+
+mock.module("@genesiscz/utils/ask/providers/providers", () => ({
+    getProviderConfigs: () => [],
+    KNOWN_MODELS: {},
+}));
+
+mock.module("@ask/config", () => ({
+    loadAskConfig: async () => ({}),
+}));
+
+mock.module("@genesiscz/utils/ai/AIConfig", () => ({
+    AIConfig: {
+        load: async () => ({
+            isProviderEnabled: () => true,
+            getProviderApiKey: () => undefined,
+            getAccountsByProvider: (provider: string) => ACCOUNTS_BY_PROVIDER[provider] ?? [],
+            getDefaultAccount: () => undefined,
+        }),
+    },
+}));
+
+mock.module("@genesiscz/utils/ai/resolvers", () => ({
+    ensureResolversInitialized: async () => {},
+    getResolver: (kind: string) => ({
+        resolve: async () => stubProvider(kind === "grok-sub" ? "grok" : "openai"),
+    }),
+}));
+
+import { ProviderManager } from "@ask/providers/ProviderManager";
+
+describe("ProviderManager.detectProviders", () => {
+    it("includes an earlier targeted scan's provider in the first full-catalog result", async () => {
+        const manager = new ProviderManager();
+
+        expect((await manager.detectProviders("grok")).map((provider) => provider.name)).toEqual(["grok"]);
+
+        // The full scan skips the grok probe because it is already cached, so
+        // returning only what THIS call discovered would serve an openai-only
+        // catalog to the first caller that asked for everything.
+        const full = await manager.detectProviders();
+        expect(full.map((provider) => provider.name).sort()).toEqual(["grok", "openai"]);
+    });
+
+    it("serves the same complete catalog from the cache on later calls", async () => {
+        const manager = new ProviderManager();
+        await manager.detectProviders();
+
+        expect((await manager.detectProviders()).map((provider) => provider.name).sort()).toEqual(["grok", "openai"]);
+    });
+});

--- a/src/ask/providers/ProviderManager.ts
+++ b/src/ask/providers/ProviderManager.ts
@@ -31,10 +31,19 @@ interface ModelMetadata {
 
 export class ProviderManager {
     private detectedProviders: Map<string, DetectedProvider> = new Map();
-    private initialized = false;
+    /**
+     * Set only by a scan that was allowed to look at EVERY provider. A targeted
+     * scan skips the subscription probes for the other providers (see the
+     * `!targetProvider ||` guards below), so marking its result complete would
+     * hide anthropic-sub / openai-sub / grok-sub for the rest of the process.
+     * That is exactly what happened in the long-lived youtube server: one
+     * `resolveProviderChoice({fallbackSpec: "xai/…"})` — a cost estimate was
+     * enough — left `/api/v1/models` serving an xai-only catalog until restart.
+     */
+    private scannedAll = false;
 
     async detectProviders(targetProvider?: string): Promise<DetectedProvider[]> {
-        if (this.initialized) {
+        if (this.scannedAll || (targetProvider && this.detectedProviders.has(targetProvider))) {
             return Array.from(this.detectedProviders.values());
         }
 
@@ -106,14 +115,22 @@ export class ProviderManager {
             await this.detectGrokSubscription(detected);
         }
 
-        this.initialized = true;
+        // Only a full scan may be cached as complete.
+        if (!targetProvider) {
+            this.scannedAll = true;
+        }
 
-        if (detected.length === 0) {
+        // The map, not the local `detected` array: this scan skipped every probe
+        // an earlier targeted scan already cached, so returning only what THIS
+        // call found would hand the first full-catalog caller a short list.
+        const all = Array.from(this.detectedProviders.values());
+
+        if (all.length === 0) {
             logger.warn("No AI providers detected. Please set API keys in environment variables.");
             logger.info(`Supported providers: ${configs.map((c) => c.envKey).join(", ")}`);
         }
 
-        return detected;
+        return all;
     }
 
     private async detectAnthropicSubscription(askConfig: AskConfig, detected: DetectedProvider[]): Promise<void> {

--- a/src/utils/ai/grok/account.test.ts
+++ b/src/utils/ai/grok/account.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AIAccountEntry } from "@genesiscz/utils/config/ai.types";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+// Tokens are synthetic unsigned JWTs carrying only an `exp`, and `fetch` is
+// replaced per test, so nothing here reaches auth.x.ai or the user's real
+// ~/.genesis-tools/ai/config.json.
+
+const ISSUER = "https://auth.example.test";
+const ENTRY_KEY = `${ISSUER}::11111111-2222-3333-4444-555555555555`;
+
+let account: AIAccountEntry | undefined;
+
+mock.module("@genesiscz/utils/ai/AIConfig", () => ({
+    AIConfig: {
+        load: async () => ({
+            getAccount: (name: string) => (account?.name === name ? account : undefined),
+            getAccountsByProvider: (provider: string) => (account && account.provider === provider ? [account] : []),
+        }),
+    },
+}));
+
+import { resolveGrokSubToken } from "./account";
+import { GrokAuthExpiredError } from "./auth-errors";
+import type { GrokAuthEntry } from "./types";
+
+function jwt(expSecondsFromNow: number): string {
+    const payload = Buffer.from(SafeJSON.stringify({ exp: Math.floor(Date.now() / 1000) + expSecondsFromNow }), "utf-8")
+        .toString("base64url")
+        .replace(/=+$/, "");
+
+    return `e30.${payload}.sig`;
+}
+
+const EXPIRED = jwt(-3_600);
+const FRESH = jwt(3_600);
+
+let authPath: string;
+const originalFetch = globalThis.fetch;
+
+function writeAuth(entries: Record<string, GrokAuthEntry>): void {
+    writeFileSync(authPath, SafeJSON.stringify(entries, { strict: true }, 2), { mode: 0o600 });
+}
+
+function readAuth(): Record<string, GrokAuthEntry> {
+    return SafeJSON.parse(readFileSync(authPath, "utf-8"), { strict: true }) as Record<string, GrokAuthEntry>;
+}
+
+function expiredEntries(overrides: Partial<GrokAuthEntry> = {}): Record<string, GrokAuthEntry> {
+    return {
+        [ENTRY_KEY]: {
+            key: EXPIRED,
+            refresh_token: "refresh-one",
+            expires_at: "2020-01-01T00:00:00.000Z",
+            oidc_issuer: ISSUER,
+            oidc_client_id: "client-abc",
+            auth_mode: "oidc",
+            ...overrides,
+        },
+    };
+}
+
+/** Records every request; the token endpoint answers with `token` when given. */
+function stubFetch(options: { calls: string[]; token?: { status?: number; body?: string } }): void {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        options.calls.push(url);
+
+        if (url.endsWith("/.well-known/openid-configuration")) {
+            return new Response("no", { status: 404 });
+        }
+
+        const token = options.token ?? {};
+
+        return new Response(token.body ?? SafeJSON.stringify({ access_token: FRESH, refresh_token: "refresh-two" }), {
+            status: token.status ?? 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }) as typeof fetch;
+}
+
+beforeEach(() => {
+    authPath = join(mkdtempSync(join(tmpdir(), "grok-account-")), "auth.json");
+    account = { name: "grok", provider: "grok-sub", tokens: { authFile: authPath } };
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+describe("resolveGrokSubToken", () => {
+    it("refreshes an expired token instead of throwing, and persists it", async () => {
+        writeAuth(expiredEntries());
+        const calls: string[] = [];
+        stubFetch({ calls });
+
+        const resolved = await resolveGrokSubToken("grok");
+
+        expect(resolved.token).toBe(FRESH);
+        expect(resolved.authPath).toBe(authPath);
+        expect(calls.some((url) => url === `${ISSUER}/oauth2/token`)).toBe(true);
+
+        const entry = readAuth()[ENTRY_KEY];
+        expect(entry?.key).toBe(FRESH);
+        expect(entry?.refresh_token).toBe("refresh-two");
+        expect(Date.parse(entry?.expires_at ?? "")).toBeGreaterThan(Date.now());
+    });
+
+    it("does not touch the network when the on-disk token is still fresh", async () => {
+        writeAuth(expiredEntries({ key: FRESH }));
+        const calls: string[] = [];
+        stubFetch({ calls });
+
+        const resolved = await resolveGrokSubToken("grok");
+
+        expect(resolved.token).toBe(FRESH);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("throws when the issuer rejects the refresh grant", async () => {
+        writeAuth(expiredEntries());
+        stubFetch({ calls: [], token: { status: 400, body: '{"error":"invalid_grant"}' } });
+
+        await expect(resolveGrokSubToken("grok")).rejects.toThrow(GrokAuthExpiredError);
+    });
+
+    it("returns a still-valid stored accessToken without touching the network", async () => {
+        account = { name: "grok", provider: "grok-sub", tokens: { accessToken: FRESH } };
+        const calls: string[] = [];
+        stubFetch({ calls });
+
+        expect((await resolveGrokSubToken("grok")).token).toBe(FRESH);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("refuses an expired stored accessToken rather than refreshing the default auth file", async () => {
+        account = { name: "grok", provider: "grok-sub", tokens: { accessToken: EXPIRED } };
+        const calls: string[] = [];
+        stubFetch({ calls });
+
+        // The default ~/.grok/auth.json holds whichever account the Grok CLI
+        // logged in last, so refreshing from it would cross a billing boundary.
+        await expect(resolveGrokSubToken("grok")).rejects.toThrow(GrokAuthExpiredError);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("throws when the entry carries no refresh token to spend", async () => {
+        writeAuth(expiredEntries({ refresh_token: undefined }));
+        const calls: string[] = [];
+        stubFetch({ calls });
+
+        await expect(resolveGrokSubToken("grok")).rejects.toThrow(GrokAuthExpiredError);
+        expect(calls).toHaveLength(0);
+    });
+});

--- a/src/utils/ai/grok/account.ts
+++ b/src/utils/ai/grok/account.ts
@@ -4,7 +4,7 @@ import { logger } from "@genesiscz/utils/logger";
 import { decodeJwtClaims, getActiveAuthEntry, isTokenExpired, readAuthFileAsync } from "./auth";
 import { GrokAuthExpiredError } from "./auth-errors";
 import { grokAuthPath } from "./paths";
-import { refreshGrokAuth } from "./refresh";
+import { refreshGrokAuthOrThrow } from "./refresh";
 
 export interface ResolvedGrokSubToken {
     token: string;
@@ -88,16 +88,12 @@ async function ensureFreshToken(token: string, authPath: string): Promise<string
         return token;
     }
 
-    const refreshed = await refreshGrokAuth({ path: authPath });
-
-    if (!refreshed || isTokenExpired(decodeJwtClaims(refreshed))) {
-        logger.warn({ authPath }, "grok: OIDC refresh did not yield a usable token for the grok-sub account");
-        throw new GrokAuthExpiredError(authPath);
-    }
-
-    logger.info({ authPath }, "grok: refreshed the expired grok-sub token via OIDC");
-
-    return refreshed;
+    return refreshGrokAuthOrThrow({
+        authPath,
+        context: {},
+        onSuccess: "grok: refreshed the expired grok-sub token via OIDC",
+        onFailure: "grok: OIDC refresh did not yield a usable token for the grok-sub account",
+    });
 }
 
 function pick(account: AIAccountEntry): { name: string; label?: string } {

--- a/src/utils/ai/grok/account.ts
+++ b/src/utils/ai/grok/account.ts
@@ -1,8 +1,10 @@
 import { AIConfig } from "@genesiscz/utils/ai/AIConfig";
 import type { AIAccountEntry } from "@genesiscz/utils/config/ai.types";
+import { logger } from "@genesiscz/utils/logger";
 import { decodeJwtClaims, getActiveAuthEntry, isTokenExpired, readAuthFileAsync } from "./auth";
 import { GrokAuthExpiredError } from "./auth-errors";
 import { grokAuthPath } from "./paths";
+import { refreshGrokAuth } from "./refresh";
 
 export interface ResolvedGrokSubToken {
     token: string;
@@ -47,7 +49,19 @@ export async function resolveGrokSubToken(accountName?: string): Promise<Resolve
     // An explicit `authFile` reference wins over stored tokens (which can go
     // stale on their own — the referenced file is CLI-refreshed).
     if (account.tokens.accessToken && !account.tokens.authFile) {
-        assertNotExpired(account.tokens.accessToken, authPath);
+        // A stored token carries no refresh metadata of its own, and `authPath`
+        // here is only the CLI's default file — whoever the CLI happens to be
+        // logged in as. Refreshing from it would hand back a DIFFERENT account's
+        // token and quietly cross a billing boundary, so expiry is fatal instead.
+        if (isTokenExpired(decodeJwtClaims(account.tokens.accessToken))) {
+            logger.warn(
+                { account: account.name },
+                "grok: stored accessToken expired and the account references no authFile to refresh from"
+            );
+
+            throw new GrokAuthExpiredError(authPath);
+        }
+
         return { token: account.tokens.accessToken, authPath, account: pick(account) };
     }
 
@@ -58,14 +72,32 @@ export async function resolveGrokSubToken(accountName?: string): Promise<Resolve
         throw new GrokAuthExpiredError(authPath);
     }
 
-    assertNotExpired(active.key, authPath);
-    return { token: active.key, authPath, account: pick(account) };
+    const token = await ensureFreshToken(active.key, authPath);
+    return { token, authPath, account: pick(account) };
 }
 
-function assertNotExpired(token: string, authPath: string): void {
-    if (isTokenExpired(decodeJwtClaims(token))) {
+/**
+ * An expired token is recoverable on its own: the auth file carries the OIDC
+ * `refresh_token` / issuer / client id, so perform the grant rather than telling
+ * the caller to run the `grok` CLI by hand — impossible for a background daemon,
+ * and the reason provider detection used to fail outright. Only a refresh that
+ * cannot be attempted (no refresh fields) or that the issuer rejects is fatal.
+ */
+async function ensureFreshToken(token: string, authPath: string): Promise<string> {
+    if (!isTokenExpired(decodeJwtClaims(token))) {
+        return token;
+    }
+
+    const refreshed = await refreshGrokAuth({ path: authPath });
+
+    if (!refreshed || isTokenExpired(decodeJwtClaims(refreshed))) {
+        logger.warn({ authPath }, "grok: OIDC refresh did not yield a usable token for the grok-sub account");
         throw new GrokAuthExpiredError(authPath);
     }
+
+    logger.info({ authPath }, "grok: refreshed the expired grok-sub token via OIDC");
+
+    return refreshed;
 }
 
 function pick(account: AIAccountEntry): { name: string; label?: string } {

--- a/src/utils/ai/grok/auth.ts
+++ b/src/utils/ai/grok/auth.ts
@@ -5,6 +5,21 @@ import { logger } from "@genesiscz/utils/logger";
 import { grokAuthPath } from "./paths";
 import type { GrokAuthEntry, GrokJwtClaims } from "./types";
 
+/**
+ * The one rule for "is this top-level value a usable auth entry?". Exported
+ * because a writer has to apply the SAME rule in reverse: everything this
+ * rejects is still someone else's data in a file we do not own.
+ */
+export function isAuthEntry(value: unknown): value is GrokAuthEntry {
+    if (typeof value !== "object" || value === null) {
+        return false;
+    }
+
+    const entry = value as GrokAuthEntry;
+
+    return typeof entry.key === "string" && entry.key.length > 0;
+}
+
 function parseAuthEntries(raw: unknown): Map<string, GrokAuthEntry> {
     const entries = new Map<string, GrokAuthEntry>();
 
@@ -13,13 +28,8 @@ function parseAuthEntries(raw: unknown): Map<string, GrokAuthEntry> {
     }
 
     for (const [key, value] of Object.entries(raw)) {
-        if (typeof value !== "object" || value === null) {
-            continue;
-        }
-
-        const entry = value as GrokAuthEntry;
-        if (typeof entry.key === "string" && entry.key.length > 0) {
-            entries.set(key, entry);
+        if (isAuthEntry(value)) {
+            entries.set(key, value);
         }
     }
 

--- a/src/utils/ai/grok/client.test.ts
+++ b/src/utils/ai/grok/client.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { GrokAuthExpiredError } from "./auth-errors";
+import { GrokSubscriptionClient } from "./client";
+import type { GrokAuthEntry } from "./types";
+
+// Synthetic unsigned JWTs and a replaced `fetch`: nothing here reaches
+// cli-chat-proxy.grok.com or the user's real ~/.grok/auth.json.
+
+const ISSUER = "https://auth.example.test";
+const ENTRY_KEY = `${ISSUER}::11111111-2222-3333-4444-555555555555`;
+const BASE_URL = "https://cli-chat-proxy.example.test/v1";
+
+function jwt(expSecondsFromNow: number): string {
+    const payload = Buffer.from(SafeJSON.stringify({ exp: Math.floor(Date.now() / 1000) + expSecondsFromNow }), "utf-8")
+        .toString("base64url")
+        .replace(/=+$/, "");
+
+    return `e30.${payload}.sig`;
+}
+
+/** Time-valid, so nothing on the expiry path fires — only upstream's 401 does. */
+const FRESH = jwt(3_600);
+const ROTATED = jwt(7_200);
+
+let authPath: string;
+const originalFetch = globalThis.fetch;
+
+function writeAuth(key: string): void {
+    const entries: Record<string, GrokAuthEntry> = {
+        [ENTRY_KEY]: {
+            key,
+            refresh_token: "refresh-one",
+            expires_at: "2020-01-01T00:00:00.000Z",
+            oidc_issuer: ISSUER,
+            oidc_client_id: "client-abc",
+            auth_mode: "oidc",
+        },
+    };
+
+    writeFileSync(authPath, SafeJSON.stringify(entries, { strict: true }, 2), { mode: 0o600 });
+}
+
+function readAuth(): Record<string, GrokAuthEntry> {
+    return SafeJSON.parse(readFileSync(authPath, "utf-8"), { strict: true }) as Record<string, GrokAuthEntry>;
+}
+
+/**
+ * `apiStatuses` is consumed one per `/models` request, so a `[401, 200]` script
+ * says "reject the first attempt, accept the retry". `grantedToken` is what the
+ * OIDC token endpoint hands back.
+ */
+function stubFetch(options: { calls: string[]; apiStatuses: number[]; grantedToken?: string }): void {
+    let apiCall = 0;
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        options.calls.push(url);
+
+        if (url.endsWith("/.well-known/openid-configuration")) {
+            return new Response("no", { status: 404 });
+        }
+
+        if (url.endsWith("/oauth2/token")) {
+            return new Response(
+                SafeJSON.stringify({ access_token: options.grantedToken ?? ROTATED, refresh_token: "refresh-two" }),
+                { status: 200, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        const status = options.apiStatuses[apiCall] ?? 200;
+        apiCall += 1;
+
+        return new Response(SafeJSON.stringify({ data: [] }), {
+            status,
+            headers: { "Content-Type": "application/json" },
+        });
+    }) as typeof fetch;
+}
+
+beforeEach(() => {
+    authPath = join(mkdtempSync(join(tmpdir(), "grok-client-")), "auth.json");
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+describe("GrokSubscriptionClient 401 recovery", () => {
+    it("forces an OIDC grant and retries once when upstream rejects a still-valid token", async () => {
+        writeAuth(FRESH);
+        const calls: string[] = [];
+        stubFetch({ calls, apiStatuses: [401, 200] });
+
+        const client = new GrokSubscriptionClient({ token: FRESH, authPath, baseUrl: BASE_URL });
+        await client.getModels();
+
+        // The whole point: a revoked token is normally still inside its `exp`, so
+        // an unforced refresh would return it unchanged and skip the retry.
+        expect(client.getToken()).toBe(ROTATED);
+        expect(calls.filter((url) => url === `${BASE_URL}/models`)).toHaveLength(2);
+        expect(calls).toContain(`${ISSUER}/oauth2/token`);
+        expect(readAuth()[ENTRY_KEY]?.key).toBe(ROTATED);
+    });
+
+    it("throws GrokAuthExpiredError without retrying when the grant returns the rejected token", async () => {
+        writeAuth(FRESH);
+        const calls: string[] = [];
+        stubFetch({ calls, apiStatuses: [401, 401], grantedToken: FRESH });
+
+        const client = new GrokSubscriptionClient({ token: FRESH, authPath, baseUrl: BASE_URL });
+
+        await expect(client.getModels()).rejects.toThrow(GrokAuthExpiredError);
+        expect(calls.filter((url) => url === `${BASE_URL}/models`)).toHaveLength(1);
+    });
+});

--- a/src/utils/ai/grok/client.ts
+++ b/src/utils/ai/grok/client.ts
@@ -4,6 +4,7 @@ import { decodeJwtClaims, getActiveAuthEntry, isTokenExpired, readAuthFileAsync 
 import { GrokAuthExpiredError, isAuthHttpStatus } from "./auth-errors";
 import { buildCliProxyHeaders } from "./headers";
 import { GROK_CLI_CHAT_PROXY_BASE_URL, grokAuthPath } from "./paths";
+import { refreshGrokAuth } from "./refresh";
 import type { GrokBillingConfig, GrokProbeResult, GrokSettings } from "./types";
 
 export interface GrokSubscriptionClientOptions {
@@ -77,8 +78,25 @@ export class GrokSubscriptionClient {
         }
 
         if (isTokenExpired(decodeJwtClaims(this.token))) {
+            await this.refreshToken("expired in memory and on disk");
+        }
+    }
+
+    /**
+     * Last resort before giving up on an expired token: perform the OIDC
+     * refresh-token grant ourselves instead of telling the user to run the
+     * `grok` CLI, which a background daemon cannot do.
+     */
+    private async refreshToken(reason: string): Promise<void> {
+        const refreshed = await refreshGrokAuth({ path: this.authPath });
+
+        if (!refreshed || isTokenExpired(decodeJwtClaims(refreshed))) {
+            logger.warn({ authPath: this.authPath, reason }, "grok: OIDC refresh did not yield a usable token");
             throw new GrokAuthExpiredError(this.authPath);
         }
+
+        this.token = refreshed;
+        logger.info({ authPath: this.authPath, reason }, "grok: recovered the session with an OIDC refresh");
     }
 
     async fetch(path: string, init?: RequestInit & { modelOverride?: string }): Promise<Response> {
@@ -93,6 +111,18 @@ export class GrokSubscriptionClient {
             if (reloaded && reloaded !== previousToken) {
                 logger.debug("grok: reloaded auth.json after 401, retrying once");
                 response = await this.doFetch(path, init);
+            } else {
+                // Same token the upstream just rejected — force the grant rather
+                // than retrying the identical credential. A rejected token is
+                // usually still inside its `exp`, so an unforced refresh would
+                // hand back that same credential and skip the retry entirely.
+                const refreshed = await refreshGrokAuth({ path: this.authPath, force: true });
+
+                if (refreshed && refreshed !== previousToken) {
+                    this.token = refreshed;
+                    logger.info({ authPath: this.authPath }, "grok: refreshed auth after 401, retrying once");
+                    response = await this.doFetch(path, init);
+                }
             }
         }
 

--- a/src/utils/ai/grok/client.ts
+++ b/src/utils/ai/grok/client.ts
@@ -4,7 +4,7 @@ import { decodeJwtClaims, getActiveAuthEntry, isTokenExpired, readAuthFileAsync 
 import { GrokAuthExpiredError, isAuthHttpStatus } from "./auth-errors";
 import { buildCliProxyHeaders } from "./headers";
 import { GROK_CLI_CHAT_PROXY_BASE_URL, grokAuthPath } from "./paths";
-import { refreshGrokAuth } from "./refresh";
+import { refreshGrokAuth, refreshGrokAuthOrThrow } from "./refresh";
 import type { GrokBillingConfig, GrokProbeResult, GrokSettings } from "./types";
 
 export interface GrokSubscriptionClientOptions {
@@ -88,15 +88,12 @@ export class GrokSubscriptionClient {
      * `grok` CLI, which a background daemon cannot do.
      */
     private async refreshToken(reason: string): Promise<void> {
-        const refreshed = await refreshGrokAuth({ path: this.authPath });
-
-        if (!refreshed || isTokenExpired(decodeJwtClaims(refreshed))) {
-            logger.warn({ authPath: this.authPath, reason }, "grok: OIDC refresh did not yield a usable token");
-            throw new GrokAuthExpiredError(this.authPath);
-        }
-
-        this.token = refreshed;
-        logger.info({ authPath: this.authPath, reason }, "grok: recovered the session with an OIDC refresh");
+        this.token = await refreshGrokAuthOrThrow({
+            authPath: this.authPath,
+            context: { reason },
+            onSuccess: "grok: recovered the session with an OIDC refresh",
+            onFailure: "grok: OIDC refresh did not yield a usable token",
+        });
     }
 
     async fetch(path: string, init?: RequestInit & { modelOverride?: string }): Promise<Response> {

--- a/src/utils/ai/grok/index.ts
+++ b/src/utils/ai/grok/index.ts
@@ -9,4 +9,5 @@ export * from "./management-api";
 export * from "./models";
 export * from "./paths";
 export * from "./probe";
+export * from "./refresh";
 export * from "./types";

--- a/src/utils/ai/grok/refresh.test.ts
+++ b/src/utils/ai/grok/refresh.test.ts
@@ -227,6 +227,35 @@ describe("refreshGrokAuth", () => {
         expect(entries[ENTRY_KEY]?.key).toBe(FRESH);
     });
 
+    it("preserves top-level fields that are not auth entries", async () => {
+        // `parseAuthEntries` keeps only objects carrying a non-empty `key`, so a
+        // rewrite built from that map alone would silently delete whatever else
+        // the `grok` CLI stores beside the entries in a file we do not own.
+        writeFileSync(
+            authPath,
+            SafeJSON.stringify(
+                {
+                    ...defaultEntries(),
+                    version: 2,
+                    settings: { theme: "dark" },
+                    "https://auth.x.ai::logged-out": { auth_mode: "oidc", key: "" },
+                },
+                { strict: true },
+                2
+            ),
+            { mode: 0o600 }
+        );
+        stubFetch({ calls: [] });
+
+        await refreshGrokAuth({ path: authPath });
+
+        const raw = SafeJSON.parse(readFileSync(authPath, "utf-8"), { strict: true }) as Record<string, unknown>;
+        expect(raw.version).toBe(2);
+        expect(raw.settings).toEqual({ theme: "dark" });
+        expect(raw["https://auth.x.ai::logged-out"]).toEqual({ auth_mode: "oidc", key: "" });
+        expect((raw[ENTRY_KEY] as GrokAuthEntry).key).toBe(FRESH);
+    });
+
     it("keeps a concurrent refresh of the SAME entry rather than clobbering it", async () => {
         writeAuth(defaultEntries());
         stubFetch({

--- a/src/utils/ai/grok/refresh.test.ts
+++ b/src/utils/ai/grok/refresh.test.ts
@@ -256,24 +256,69 @@ describe("refreshGrokAuth", () => {
         expect((raw[ENTRY_KEY] as GrokAuthEntry).key).toBe(FRESH);
     });
 
-    it("leaves no temp file behind when the atomic write cannot complete", async () => {
-        // The temp file carries the access AND refresh tokens, so a write that
-        // fails partway must not leave one on disk. The directory is revoked
-        // mid-grant, after the initial read has already succeeded.
-        writeAuth(defaultEntries());
+    // Revoking directory write access does not stop root, so under a root CI
+    // image the write would succeed and this would fail for the wrong reason.
+    it.skipIf(process.getuid?.() === 0)(
+        "leaves no temp file behind when the atomic write cannot complete",
+        async () => {
+            // The temp file carries the access AND refresh tokens, so a write that
+            // fails partway must not leave one on disk. The directory is revoked
+            // mid-grant, after the initial read has already succeeded.
+            writeAuth(defaultEntries());
+            stubFetch({
+                calls: [],
+                onToken: () => {
+                    chmodSync(dir, 0o500);
+                },
+            });
+
+            expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+
+            chmodSync(dir, 0o700);
+            expect(readdirSync(dir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+            // The original token is untouched, so the account is no worse off.
+            expect(readAuth()[ENTRY_KEY]?.key).toBe(EXPIRED);
+        }
+    );
+
+    it("preserves sibling data in a file the lenient reader accepts but strict JSON rejects", async () => {
+        // The reader (`readAuthFileAsync`) parses leniently, so a trailing comma
+        // is a file this code happily refreshes. If the rewrite re-parsed it
+        // strictly it would fall back and delete everything else — the very data
+        // loss this rewrite path exists to prevent.
+        writeFileSync(
+            authPath,
+            `{
+                "version": 2,
+                ${SafeJSON.stringify(ENTRY_KEY, { strict: true })}: ${SafeJSON.stringify(defaultEntries()[ENTRY_KEY], { strict: true })},
+            }`,
+            { mode: 0o600 }
+        );
+        stubFetch({ calls: [] });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBe(FRESH);
+
+        const raw = SafeJSON.parse(readFileSync(authPath, "utf-8"), { strict: true }) as Record<string, unknown>;
+        expect(raw.version).toBe(2);
+        expect((raw[ENTRY_KEY] as GrokAuthEntry).key).toBe(FRESH);
+    });
+
+    it("keeps every other entry when the file turns unparseable mid-grant", async () => {
+        const otherKey = `${ISSUER}::99999999-8888-7777-6666-555555555555`;
+        writeAuth({ ...defaultEntries(), [otherKey]: { key: FRESH, refresh_token: "other-refresh" } });
         stubFetch({
             calls: [],
             onToken: () => {
-                chmodSync(dir, 0o500);
+                writeFileSync(authPath, "{ this is not json at all", { mode: 0o600 });
             },
         });
 
-        expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+        await refreshGrokAuth({ path: authPath });
 
-        chmodSync(dir, 0o700);
-        expect(readdirSync(dir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
-        // The original token is untouched, so the account is no worse off.
-        expect(readAuth()[ENTRY_KEY]?.key).toBe(EXPIRED);
+        // Falling back to an empty document would have dropped the other account.
+        const entries = readAuth();
+        expect(entries[otherKey]?.key).toBe(FRESH);
+        expect(entries[ENTRY_KEY]?.key).toBe(FRESH);
     });
 
     it("keeps a concurrent refresh of the SAME entry rather than clobbering it", async () => {

--- a/src/utils/ai/grok/refresh.test.ts
+++ b/src/utils/ai/grok/refresh.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { refreshGrokAuth } from "./refresh";
+import type { GrokAuthEntry } from "./types";
+
+// Every token here is synthetic: an unsigned JWT whose payload carries only an
+// `exp`, plus placeholder refresh tokens. Nothing in this file touches
+// auth.x.ai — `fetch` is replaced for the duration of each test.
+
+const ISSUER = "https://auth.example.test";
+const ENTRY_KEY = `${ISSUER}::11111111-2222-3333-4444-555555555555`;
+
+function jwt(expSecondsFromNow: number): string {
+    const payload = Buffer.from(SafeJSON.stringify({ exp: Math.floor(Date.now() / 1000) + expSecondsFromNow }), "utf-8")
+        .toString("base64url")
+        .replace(/=+$/, "");
+
+    return `e30.${payload}.sig`;
+}
+
+const EXPIRED = jwt(-3_600);
+const FRESH = jwt(3_600);
+/** A second usable token, so "which one came back?" is answerable. */
+const ROTATED = jwt(7_200);
+
+let dir: string;
+let authPath: string;
+const originalFetch = globalThis.fetch;
+
+interface FetchCall {
+    url: string;
+    body?: string;
+}
+
+function writeAuth(entries: Record<string, GrokAuthEntry>): void {
+    writeFileSync(authPath, SafeJSON.stringify(entries, { strict: true }, 2), { mode: 0o600 });
+}
+
+function readAuth(): Record<string, GrokAuthEntry> {
+    return SafeJSON.parse(readFileSync(authPath, "utf-8"), { strict: true }) as Record<string, GrokAuthEntry>;
+}
+
+function defaultEntries(): Record<string, GrokAuthEntry> {
+    return {
+        [ENTRY_KEY]: {
+            key: EXPIRED,
+            refresh_token: "refresh-one",
+            expires_at: "2020-01-01T00:00:00.000Z",
+            oidc_issuer: ISSUER,
+            oidc_client_id: "client-abc",
+            auth_mode: "oidc",
+        },
+    };
+}
+
+/**
+ * Replace fetch with a recorder. `discovery` decides what the well-known
+ * endpoint answers; `token` builds the token-endpoint response; `onToken` runs
+ * while the token request is in flight, which is where a concurrent `grok` CLI
+ * write is simulated.
+ */
+function stubFetch(options: {
+    calls: FetchCall[];
+    discovery?: { ok: boolean; tokenEndpoint?: string };
+    token?: { status?: number; body?: string };
+    onToken?: () => void;
+}): void {
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        options.calls.push({ url, body: typeof init?.body === "string" ? init.body : undefined });
+
+        if (url.endsWith("/.well-known/openid-configuration")) {
+            const discovery = options.discovery ?? { ok: false };
+
+            if (!discovery.ok) {
+                return new Response("no", { status: 404 });
+            }
+
+            return Response.json({ token_endpoint: discovery.tokenEndpoint });
+        }
+
+        options.onToken?.();
+        const token = options.token ?? {};
+
+        return new Response(token.body ?? SafeJSON.stringify({ access_token: FRESH, refresh_token: "refresh-two" }), {
+            status: token.status ?? 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }) as typeof fetch;
+}
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "grok-refresh-"));
+    mkdirSync(dir, { recursive: true });
+    authPath = join(dir, "auth.json");
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+describe("refreshGrokAuth", () => {
+    it("performs exactly one token request for concurrent callers and hands them the same token", async () => {
+        writeAuth(defaultEntries());
+        const calls: FetchCall[] = [];
+        stubFetch({ calls });
+
+        const results = await Promise.all(Array.from({ length: 5 }, () => refreshGrokAuth({ path: authPath })));
+
+        expect(results).toEqual([FRESH, FRESH, FRESH, FRESH, FRESH]);
+        // Burning a single-use refresh token twice can invalidate the grant, so
+        // this count is the point of the whole single-flight design.
+        expect(calls.filter((call) => !call.url.includes(".well-known")).length).toBe(1);
+        expect(calls[calls.length - 1]?.body).toContain("grant_type=refresh_token");
+        expect(calls[calls.length - 1]?.body).toContain("refresh_token=refresh-one");
+    });
+
+    it("rewrites auth.json with the rotated tokens, leaving no temp file behind", async () => {
+        writeAuth(defaultEntries());
+        stubFetch({ calls: [] });
+
+        await refreshGrokAuth({ path: authPath });
+
+        const entries = readAuth();
+        expect(entries[ENTRY_KEY]?.key).toBe(FRESH);
+        expect(entries[ENTRY_KEY]?.refresh_token).toBe("refresh-two");
+        expect(entries[ENTRY_KEY]?.oidc_client_id).toBe("client-abc");
+        expect(new Date(entries[ENTRY_KEY]?.expires_at ?? 0).getTime()).toBeGreaterThan(Date.now());
+        expect(readdirSync(dir)).toEqual(["auth.json"]);
+    });
+
+    it("keeps the rewritten file owner-only", async () => {
+        writeAuth(defaultEntries());
+        stubFetch({ calls: [] });
+
+        await refreshGrokAuth({ path: authPath });
+
+        expect(statSync(authPath).mode & 0o777).toBe(0o600);
+    });
+
+    it("falls back to {issuer}/oauth2/token when discovery is unusable", async () => {
+        writeAuth(defaultEntries());
+        const calls: FetchCall[] = [];
+        stubFetch({ calls, discovery: { ok: false } });
+
+        await refreshGrokAuth({ path: authPath });
+
+        expect(calls[0]?.url).toBe(`${ISSUER}/.well-known/openid-configuration`);
+        expect(calls[1]?.url).toBe(`${ISSUER}/oauth2/token`);
+    });
+
+    it("uses the token_endpoint that discovery advertises", async () => {
+        writeAuth(defaultEntries());
+        const calls: FetchCall[] = [];
+        stubFetch({ calls, discovery: { ok: true, tokenEndpoint: `${ISSUER}/custom/token` } });
+
+        await refreshGrokAuth({ path: authPath });
+
+        expect(calls[1]?.url).toBe(`${ISSUER}/custom/token`);
+    });
+
+    it("returns null and leaves the file untouched when the token endpoint rejects the grant", async () => {
+        writeAuth(defaultEntries());
+        stubFetch({ calls: [], token: { status: 400, body: '{"error":"invalid_grant"}' } });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+        expect(readAuth()[ENTRY_KEY]?.key).toBe(EXPIRED);
+        expect(readdirSync(dir)).toEqual(["auth.json"]);
+    });
+
+    it("returns null on a malformed token response instead of writing a corrupt file", async () => {
+        writeAuth(defaultEntries());
+        stubFetch({ calls: [], token: { body: "not json at all" } });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+        expect(readAuth()[ENTRY_KEY]?.key).toBe(EXPIRED);
+    });
+
+    it("returns null when the response carries no access_token", async () => {
+        writeAuth(defaultEntries());
+        stubFetch({ calls: [], token: { body: '{"refresh_token":"refresh-two"}' } });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+        expect(readAuth()[ENTRY_KEY]?.key).toBe(EXPIRED);
+    });
+
+    it("does not attempt a grant when the entry lacks the OIDC fields", async () => {
+        writeAuth({ [ENTRY_KEY]: { key: EXPIRED, oidc_issuer: ISSUER } });
+        const calls: FetchCall[] = [];
+        stubFetch({ calls });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+        expect(calls).toHaveLength(0);
+    });
+
+    it("returns the on-disk token without a network call when it is already fresh", async () => {
+        writeAuth({ [ENTRY_KEY]: { ...defaultEntries()[ENTRY_KEY], key: FRESH } as GrokAuthEntry });
+        const calls: FetchCall[] = [];
+        stubFetch({ calls });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBe(FRESH);
+        expect(calls).toHaveLength(0);
+    });
+
+    it("preserves what another writer added to auth.json while the grant was in flight", async () => {
+        const otherKey = `${ISSUER}::99999999-8888-7777-6666-555555555555`;
+        writeAuth(defaultEntries());
+        stubFetch({
+            calls: [],
+            onToken: () => {
+                // Stand-in for the `grok` CLI writing the file mid-refresh.
+                writeAuth({
+                    ...defaultEntries(),
+                    [otherKey]: { key: FRESH, refresh_token: "other-refresh" },
+                });
+            },
+        });
+
+        await refreshGrokAuth({ path: authPath });
+
+        const entries = readAuth();
+        expect(entries[otherKey]?.key).toBe(FRESH);
+        expect(entries[otherKey]?.refresh_token).toBe("other-refresh");
+        expect(entries[ENTRY_KEY]?.key).toBe(FRESH);
+    });
+
+    it("keeps a concurrent refresh of the SAME entry rather than clobbering it", async () => {
+        writeAuth(defaultEntries());
+        stubFetch({
+            calls: [],
+            onToken: () => {
+                // The `grok` CLI wins the race and rotates the active entry. Its
+                // refresh token is the one the issuer now expects, so ours must lose.
+                writeAuth({
+                    [ENTRY_KEY]: {
+                        ...defaultEntries()[ENTRY_KEY],
+                        key: ROTATED,
+                        refresh_token: "cli-refresh",
+                    } as GrokAuthEntry,
+                });
+            },
+        });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBe(ROTATED);
+
+        const entry = readAuth()[ENTRY_KEY];
+        expect(entry?.key).toBe(ROTATED);
+        expect(entry?.refresh_token).toBe("cli-refresh");
+    });
+
+    it("still performs the grant for an unexpired on-disk token when forced", async () => {
+        writeAuth({ [ENTRY_KEY]: { ...defaultEntries()[ENTRY_KEY], key: FRESH } as GrokAuthEntry });
+        const calls: FetchCall[] = [];
+        stubFetch({
+            calls,
+            token: { body: SafeJSON.stringify({ access_token: ROTATED, refresh_token: "refresh-two" }) },
+        });
+
+        // Without `force` this returns FRESH untouched (see the test above); a 401
+        // recovery needs the grant to happen anyway.
+        expect(await refreshGrokAuth({ path: authPath, force: true })).toBe(ROTATED);
+        expect(calls.filter((call) => !call.url.includes(".well-known"))).toHaveLength(1);
+        expect(readAuth()[ENTRY_KEY]?.key).toBe(ROTATED);
+    });
+});

--- a/src/utils/ai/grok/refresh.test.ts
+++ b/src/utils/ai/grok/refresh.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -254,6 +254,26 @@ describe("refreshGrokAuth", () => {
         expect(raw.settings).toEqual({ theme: "dark" });
         expect(raw["https://auth.x.ai::logged-out"]).toEqual({ auth_mode: "oidc", key: "" });
         expect((raw[ENTRY_KEY] as GrokAuthEntry).key).toBe(FRESH);
+    });
+
+    it("leaves no temp file behind when the atomic write cannot complete", async () => {
+        // The temp file carries the access AND refresh tokens, so a write that
+        // fails partway must not leave one on disk. The directory is revoked
+        // mid-grant, after the initial read has already succeeded.
+        writeAuth(defaultEntries());
+        stubFetch({
+            calls: [],
+            onToken: () => {
+                chmodSync(dir, 0o500);
+            },
+        });
+
+        expect(await refreshGrokAuth({ path: authPath })).toBeNull();
+
+        chmodSync(dir, 0o700);
+        expect(readdirSync(dir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+        // The original token is untouched, so the account is no worse off.
+        expect(readAuth()[ENTRY_KEY]?.key).toBe(EXPIRED);
     });
 
     it("keeps a concurrent refresh of the SAME entry rather than clobbering it", async () => {

--- a/src/utils/ai/grok/refresh.ts
+++ b/src/utils/ai/grok/refresh.ts
@@ -18,7 +18,7 @@ import { chmod, rename, writeFile } from "node:fs/promises";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { decodeJwt } from "@genesiscz/utils/jwt";
 import { logger } from "@genesiscz/utils/logger";
-import { decodeJwtClaims, isTokenExpired, readAuthFileAsync } from "./auth";
+import { decodeJwtClaims, isAuthEntry, isTokenExpired, readAuthFileAsync } from "./auth";
 import { grokAuthPath } from "./paths";
 import type { GrokAuthEntry } from "./types";
 
@@ -70,9 +70,32 @@ async function resolveTokenEndpoint(issuer: string): Promise<string> {
     return `${base}/oauth2/token`;
 }
 
-async function writeAuthFileAtomically(authPath: string, entries: Map<string, GrokAuthEntry>): Promise<void> {
+/**
+ * The parsed entry map is a filtered VIEW of auth.json: `parseAuthEntries` drops
+ * every top-level value that is not a live entry (a logged-out slot with an
+ * empty `key`, a `settings` object, a scalar version marker). Rebuilding the
+ * file from that map would delete all of it, so the rewrite patches the raw
+ * document and the map is used only to reason about entries.
+ */
+async function readAuthDocument(authPath: string): Promise<Record<string, unknown>> {
+    try {
+        const parsed = SafeJSON.parse(await Bun.file(authPath).text(), { strict: true });
+
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+
+        logger.warn({ authPath }, "grok refresh: auth file is not a JSON object, rewriting it with entries only");
+    } catch (err) {
+        logger.warn({ err, authPath }, "grok refresh: auth file unreadable before rewrite, keeping entries only");
+    }
+
+    return {};
+}
+
+async function writeAuthFileAtomically(authPath: string, document: Record<string, unknown>): Promise<void> {
     const temp = `${authPath}.${process.pid}.${Date.now()}.tmp`;
-    const payload = `${SafeJSON.stringify(Object.fromEntries(entries), { strict: true }, 2)}\n`;
+    const payload = `${SafeJSON.stringify(document, { strict: true }, 2)}\n`;
 
     await writeFile(temp, payload, { mode: AUTH_FILE_MODE });
     await chmod(temp, AUTH_FILE_MODE);
@@ -167,8 +190,9 @@ async function performRefresh(authPath: string, force: boolean): Promise<string 
 
     // Re-read right before writing: whatever the CLI wrote in the meantime keeps
     // its other entries, and only this entry's tokens are replaced.
-    const current = await readAuthFileAsync(authPath);
-    const target = current.get(id) ?? entry;
+    const document = await readAuthDocument(authPath);
+    const onDisk = document[id];
+    const target = isAuthEntry(onDisk) ? onDisk : entry;
 
     // …unless the CLI refreshed THIS entry while the grant was in flight. Its
     // rotated refresh token is the one the issuer now expects, so overwriting it
@@ -186,21 +210,22 @@ async function performRefresh(authPath: string, force: boolean): Promise<string 
               ? Math.floor(Date.now() / 1000) + payload.expires_in
               : undefined;
 
-    current.set(id, {
+    const next: GrokAuthEntry = {
         ...target,
         key: payload.access_token,
         refresh_token: payload.refresh_token ?? target.refresh_token,
         expires_at: expSec ? new Date(expSec * 1000).toISOString() : target.expires_at,
-    });
+    };
 
-    await writeAuthFileAtomically(authPath, current);
+    document[id] = next;
+    await writeAuthFileAtomically(authPath, document);
 
     logger.info(
         {
             authPath,
             endpoint,
             rotatedRefreshToken: Boolean(payload.refresh_token),
-            expiresAt: current.get(id)?.expires_at,
+            expiresAt: next.expires_at,
         },
         "grok refresh: access token refreshed via OIDC and auth.json rewritten"
     );

--- a/src/utils/ai/grok/refresh.ts
+++ b/src/utils/ai/grok/refresh.ts
@@ -19,6 +19,7 @@ import { SafeJSON } from "@genesiscz/utils/json";
 import { decodeJwt } from "@genesiscz/utils/jwt";
 import { logger } from "@genesiscz/utils/logger";
 import { decodeJwtClaims, isAuthEntry, isTokenExpired, readAuthFileAsync } from "./auth";
+import { GrokAuthExpiredError } from "./auth-errors";
 import { grokAuthPath } from "./paths";
 import type { GrokAuthEntry } from "./types";
 
@@ -77,20 +78,29 @@ async function resolveTokenEndpoint(issuer: string): Promise<string> {
  * file from that map would delete all of it, so the rewrite patches the raw
  * document and the map is used only to reason about entries.
  */
-async function readAuthDocument(authPath: string): Promise<Record<string, unknown>> {
+async function readAuthDocument(
+    authPath: string,
+    knownEntries: Map<string, GrokAuthEntry>
+): Promise<Record<string, unknown>> {
     try {
-        const parsed = SafeJSON.parse(await Bun.file(authPath).text(), { strict: true });
+        // Lenient, matching `readAuthFileAsync`. A stricter parse here would
+        // reject files the reader accepted (a trailing comma is enough), fall
+        // through to the fallback, and drop everything this function exists to
+        // keep — the exact data loss it was written to prevent.
+        const parsed = SafeJSON.parse(await Bun.file(authPath).text());
 
         if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
             return parsed as Record<string, unknown>;
         }
 
-        logger.warn({ authPath }, "grok refresh: auth file is not a JSON object, rewriting it with entries only");
+        logger.warn({ authPath }, "grok refresh: auth file is not a JSON object, rewriting it from known entries");
     } catch (err) {
-        logger.warn({ err, authPath }, "grok refresh: auth file unreadable before rewrite, keeping entries only");
+        logger.warn({ err, authPath }, "grok refresh: auth file unreadable before rewrite, keeping known entries");
     }
 
-    return {};
+    // Still every entry the initial read saw, rather than an empty document:
+    // losing the non-entry fields is bad, losing the other accounts is worse.
+    return Object.fromEntries(knownEntries);
 }
 
 async function writeAuthFileAtomically(authPath: string, document: Record<string, unknown>): Promise<void> {
@@ -204,7 +214,7 @@ async function performRefresh(authPath: string, force: boolean): Promise<string 
 
     // Re-read right before writing: whatever the CLI wrote in the meantime keeps
     // its other entries, and only this entry's tokens are replaced.
-    const document = await readAuthDocument(authPath);
+    const document = await readAuthDocument(authPath, entries);
     const onDisk = document[id];
     const target = isAuthEntry(onDisk) ? onDisk : entry;
 
@@ -245,6 +255,35 @@ async function performRefresh(authPath: string, force: boolean): Promise<string 
     );
 
     return payload.access_token;
+}
+
+/**
+ * Refresh and insist on a usable result: the shared "a refresh that cannot be
+ * attempted or that the issuer rejects is fatal" contract.
+ *
+ * Both callers (`resolveGrokSubToken` and `GrokSubscriptionClient`) need exactly
+ * this and only differ in what they log and what they do with the token, so the
+ * rule about when an expired token becomes a `GrokAuthExpiredError` lives here
+ * rather than in two places that can disagree.
+ */
+export async function refreshGrokAuthOrThrow(options: {
+    authPath: string;
+    force?: boolean;
+    /** Included in both log lines so a caller's context survives into the log. */
+    context: Record<string, unknown>;
+    onSuccess: string;
+    onFailure: string;
+}): Promise<string> {
+    const refreshed = await refreshGrokAuth({ path: options.authPath, force: options.force });
+
+    if (!refreshed || isTokenExpired(decodeJwtClaims(refreshed))) {
+        logger.warn({ authPath: options.authPath, ...options.context }, options.onFailure);
+        throw new GrokAuthExpiredError(options.authPath);
+    }
+
+    logger.info({ authPath: options.authPath, ...options.context }, options.onSuccess);
+
+    return refreshed;
 }
 
 export interface RefreshGrokAuthOptions {

--- a/src/utils/ai/grok/refresh.ts
+++ b/src/utils/ai/grok/refresh.ts
@@ -14,7 +14,7 @@
  * the same moment, so refreshes are single-flighted per auth path — one network
  * call, one rotation, no burnt refresh tokens.
  */
-import { chmod, rename, writeFile } from "node:fs/promises";
+import { chmod, rename, unlink, writeFile } from "node:fs/promises";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { decodeJwt } from "@genesiscz/utils/jwt";
 import { logger } from "@genesiscz/utils/logger";
@@ -97,9 +97,23 @@ async function writeAuthFileAtomically(authPath: string, document: Record<string
     const temp = `${authPath}.${process.pid}.${Date.now()}.tmp`;
     const payload = `${SafeJSON.stringify(document, { strict: true }, 2)}\n`;
 
-    await writeFile(temp, payload, { mode: AUTH_FILE_MODE });
-    await chmod(temp, AUTH_FILE_MODE);
-    await rename(temp, authPath);
+    // The temp file holds the access AND refresh tokens, so a failure after it
+    // exists must not leave it lying around at whatever mode it got. `writeFile`
+    // mode is masked by umask (umask 0600 yields a 000 file), which is why the
+    // chmod follows rather than being redundant with it.
+    try {
+        await writeFile(temp, payload, { mode: AUTH_FILE_MODE });
+        await chmod(temp, AUTH_FILE_MODE);
+        await rename(temp, authPath);
+    } catch (err) {
+        try {
+            await unlink(temp);
+        } catch (cleanupErr) {
+            logger.warn({ err: cleanupErr, temp }, "grok refresh: could not remove the temp auth file after a failure");
+        }
+
+        throw err;
+    }
 }
 
 /** Token-shaped runs, which some issuers echo back inside their error payloads. */

--- a/src/utils/ai/grok/refresh.ts
+++ b/src/utils/ai/grok/refresh.ts
@@ -1,0 +1,251 @@
+/**
+ * OIDC refresh-token grant for `~/.grok/auth.json`.
+ *
+ * The auth file already carries everything the grant needs (`refresh_token`,
+ * `oidc_issuer`, `oidc_client_id`), but nothing ever used them: an expired
+ * access token could only be fixed by running the `grok` CLI by hand, which is
+ * unusable for a background daemon. This performs the refresh itself.
+ *
+ * Two hazards shape the implementation. The `grok` CLI may be refreshing the
+ * same file concurrently, so the rewrite is temp-file + rename (a reader sees
+ * either the old file or the new one, never a torn one) and the file is re-read
+ * immediately before writing so a fresher token from the CLI wins instead of
+ * being clobbered. And several in-flight proxy requests can notice the expiry at
+ * the same moment, so refreshes are single-flighted per auth path — one network
+ * call, one rotation, no burnt refresh tokens.
+ */
+import { chmod, rename, writeFile } from "node:fs/promises";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { decodeJwt } from "@genesiscz/utils/jwt";
+import { logger } from "@genesiscz/utils/logger";
+import { decodeJwtClaims, isTokenExpired, readAuthFileAsync } from "./auth";
+import { grokAuthPath } from "./paths";
+import type { GrokAuthEntry } from "./types";
+
+const AUTH_FILE_MODE = 0o600;
+/** Both calls sit on the request path of live proxy requests, so neither may hang. */
+const DISCOVERY_TIMEOUT_MS = 5_000;
+const TOKEN_TIMEOUT_MS = 15_000;
+
+const inflight = new Map<string, Promise<string | null>>();
+
+interface TokenResponse {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+}
+
+function activeEntryId(entries: Map<string, GrokAuthEntry>): string | undefined {
+    for (const [id, entry] of entries) {
+        if (entry.key.length > 0) {
+            return id;
+        }
+    }
+
+    return undefined;
+}
+
+/** Ask the issuer where its token endpoint is; fall back to the conventional path. */
+async function resolveTokenEndpoint(issuer: string): Promise<string> {
+    const base = issuer.replace(/\/$/, "");
+
+    try {
+        const response = await fetch(`${base}/.well-known/openid-configuration`, {
+            signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+        });
+
+        if (response.ok) {
+            const discovery = SafeJSON.parse(await response.text(), { strict: true }) as { token_endpoint?: string };
+
+            if (typeof discovery.token_endpoint === "string" && discovery.token_endpoint.length > 0) {
+                return discovery.token_endpoint;
+            }
+        }
+
+        logger.debug({ issuer, status: response.status }, "grok refresh: discovery unusable, using default endpoint");
+    } catch (err) {
+        logger.debug({ err, issuer }, "grok refresh: discovery request failed, using default endpoint");
+    }
+
+    return `${base}/oauth2/token`;
+}
+
+async function writeAuthFileAtomically(authPath: string, entries: Map<string, GrokAuthEntry>): Promise<void> {
+    const temp = `${authPath}.${process.pid}.${Date.now()}.tmp`;
+    const payload = `${SafeJSON.stringify(Object.fromEntries(entries), { strict: true }, 2)}\n`;
+
+    await writeFile(temp, payload, { mode: AUTH_FILE_MODE });
+    await chmod(temp, AUTH_FILE_MODE);
+    await rename(temp, authPath);
+}
+
+/** Token-shaped runs, which some issuers echo back inside their error payloads. */
+function redactTokens(text: string): string {
+    return text.replace(/[A-Za-z0-9._~+/-]{20,}={0,2}/g, "<redacted>");
+}
+
+/**
+ * A refusal is worth logging, the raw body is not: OAuth error payloads
+ * sometimes quote the submitted `refresh_token` back at you.
+ */
+function describeTokenError(body: string): string {
+    try {
+        const parsed = SafeJSON.parse(body, { strict: true }) as { error?: unknown; error_description?: unknown };
+        const parts = [parsed.error, parsed.error_description].filter(
+            (part): part is string => typeof part === "string"
+        );
+
+        if (parts.length > 0) {
+            return redactTokens(parts.join(": "));
+        }
+    } catch (err) {
+        logger.debug({ err }, "grok refresh: token endpoint error body is not JSON");
+    }
+
+    return redactTokens(body).slice(0, 200);
+}
+
+async function performRefresh(authPath: string, force: boolean): Promise<string | null> {
+    const entries = await readAuthFileAsync(authPath);
+    const id = activeEntryId(entries);
+    const entry = id ? entries.get(id) : undefined;
+
+    if (!id || !entry) {
+        logger.warn({ authPath }, "grok refresh: no auth entry to refresh");
+        return null;
+    }
+
+    // The CLI (or another process) may already have refreshed while we queued.
+    // `force` skips this: a token the upstream just rejected is usually still
+    // time-valid, and an undecodable token reads as "fresh" here too.
+    if (!force && !isTokenExpired(decodeJwtClaims(entry.key))) {
+        logger.debug({ authPath }, "grok refresh: on-disk token is already fresh");
+        return entry.key;
+    }
+
+    if (!entry.refresh_token || !entry.oidc_issuer || !entry.oidc_client_id) {
+        logger.warn(
+            {
+                authPath,
+                hasRefreshToken: Boolean(entry.refresh_token),
+                hasIssuer: Boolean(entry.oidc_issuer),
+                hasClientId: Boolean(entry.oidc_client_id),
+            },
+            "grok refresh: auth entry lacks the fields an OIDC refresh needs"
+        );
+
+        return null;
+    }
+
+    const endpoint = await resolveTokenEndpoint(entry.oidc_issuer);
+    const response = await fetch(endpoint, {
+        method: "POST",
+        signal: AbortSignal.timeout(TOKEN_TIMEOUT_MS),
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+        body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: entry.refresh_token,
+            client_id: entry.oidc_client_id,
+        }).toString(),
+    });
+
+    if (!response.ok) {
+        logger.warn(
+            { authPath, endpoint, status: response.status, reason: describeTokenError(await response.text()) },
+            "grok refresh: token endpoint rejected the refresh grant"
+        );
+
+        return null;
+    }
+
+    const payload = SafeJSON.parse(await response.text(), { strict: true }) as TokenResponse;
+
+    if (!payload.access_token) {
+        logger.warn({ authPath, endpoint }, "grok refresh: token endpoint returned no access_token");
+        return null;
+    }
+
+    // Re-read right before writing: whatever the CLI wrote in the meantime keeps
+    // its other entries, and only this entry's tokens are replaced.
+    const current = await readAuthFileAsync(authPath);
+    const target = current.get(id) ?? entry;
+
+    // …unless the CLI refreshed THIS entry while the grant was in flight. Its
+    // rotated refresh token is the one the issuer now expects, so overwriting it
+    // with ours would break the next refresh. Its access token is usable, so use it.
+    if (target.key !== entry.key && !isTokenExpired(decodeJwtClaims(target.key))) {
+        logger.info({ authPath }, "grok refresh: another writer refreshed this entry mid-grant, keeping its token");
+        return target.key;
+    }
+
+    const claims = decodeJwt(payload.access_token);
+    const expSec =
+        claims.ok && typeof (claims.payload as { exp?: number }).exp === "number"
+            ? (claims.payload as { exp?: number }).exp
+            : payload.expires_in
+              ? Math.floor(Date.now() / 1000) + payload.expires_in
+              : undefined;
+
+    current.set(id, {
+        ...target,
+        key: payload.access_token,
+        refresh_token: payload.refresh_token ?? target.refresh_token,
+        expires_at: expSec ? new Date(expSec * 1000).toISOString() : target.expires_at,
+    });
+
+    await writeAuthFileAtomically(authPath, current);
+
+    logger.info(
+        {
+            authPath,
+            endpoint,
+            rotatedRefreshToken: Boolean(payload.refresh_token),
+            expiresAt: current.get(id)?.expires_at,
+        },
+        "grok refresh: access token refreshed via OIDC and auth.json rewritten"
+    );
+
+    return payload.access_token;
+}
+
+export interface RefreshGrokAuthOptions {
+    /** Auth file to refresh. Defaults to the Grok CLI's `~/.grok/auth.json`. */
+    path?: string;
+    /**
+     * Refresh even when the on-disk token still looks unexpired. The 401-recovery
+     * path needs this: a revoked token is normally still inside its `exp`, and a
+     * token whose claims cannot be decoded also reads as "not expired".
+     */
+    force?: boolean;
+}
+
+/**
+ * Refresh the Grok access token in `auth.json` and return the new one, or null
+ * when the file cannot be refreshed (missing fields, issuer refused). Concurrent
+ * callers on the same path share one refresh.
+ */
+export function refreshGrokAuth(options?: RefreshGrokAuthOptions): Promise<string | null> {
+    const authPath = options?.path ?? grokAuthPath();
+    const force = options?.force ?? false;
+    // A soft refresh in flight may return the very token a forced caller was
+    // just rejected for, so the two kinds never share a promise.
+    const key = `${force ? "force" : "soft"}::${authPath}`;
+    const existing = inflight.get(key);
+
+    if (existing) {
+        return existing;
+    }
+
+    const next = performRefresh(authPath, force)
+        .catch((err: unknown) => {
+            logger.warn({ err, authPath, force }, "grok refresh: refresh attempt failed");
+            return null;
+        })
+        .finally(() => {
+            inflight.delete(key);
+        });
+
+    inflight.set(key, next);
+
+    return next;
+}

--- a/src/utils/storage/storage.test.ts
+++ b/src/utils/storage/storage.test.ts
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/plugin: test fixture intentionally uses /tmp/ or /Users/ string literals — production plugins do not apply to test code
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
@@ -191,17 +191,16 @@ describe("atomicWriteFileSync mode", () => {
         expect(readdirSync(dir)).toEqual(["target"]);
     });
 
-    // Same caveat as the grok refresh suite: a 0500 directory does not stop root.
-    it.skipIf(process.getuid?.() === 0)("leaves no temp file behind when the data cannot be written at all", () => {
-        const readOnly = join(dir, "read-only");
-        mkdirSync(readOnly, { mode: 0o500 });
+    it("leaves no temp file behind when the data cannot be written at all", () => {
+        // ENOTDIR via a regular file as a parent component, rather than a 0500
+        // directory: permission bits are bypassed by root and not enforced the
+        // same way on Windows, so a mode-based denial is not a dependable
+        // failure. A file is never a directory, on any host, for any user.
+        const notADirectory = join(dir, "not-a-directory");
+        writeFileSync(notADirectory, "x");
 
-        try {
-            expect(() => atomicWriteFileSync(join(readOnly, "x.json"), "{}", { mode: 0o600 })).toThrow();
-            expect(readdirSync(readOnly)).toEqual([]);
-        } finally {
-            chmodSync(readOnly, 0o700);
-        }
+        expect(() => atomicWriteFileSync(join(notADirectory, "x.json"), "{}", { mode: 0o600 })).toThrow();
+        expect(readdirSync(dir)).toEqual(["not-a-directory"]);
     });
 
     it("leaves the mode to the umask when none is requested", () => {

--- a/src/utils/storage/storage.test.ts
+++ b/src/utils/storage/storage.test.ts
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/plugin: test fixture intentionally uses /tmp/ or /Users/ string literals — production plugins do not apply to test code
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
@@ -134,6 +134,30 @@ describe("atomicWriteFileSync mode", () => {
         }
 
         expect(statSync(target).mode & 0o777).toBe(0o600);
+    });
+
+    it("leaves no temp file behind when the write cannot be published", () => {
+        // Renaming onto a non-empty directory fails with EISDIR *after* the temp
+        // file has been written and chmod'd, which is the only reachable way to
+        // land in the cleanup path with a temp file actually on disk.
+        const target = join(dir, "target");
+        mkdirSync(target);
+        writeFileSync(join(target, "child"), "x");
+
+        expect(() => atomicWriteFileSync(target, "{}", { mode: 0o600 })).toThrow(/Atomic rename failed/);
+        expect(readdirSync(dir)).toEqual(["target"]);
+    });
+
+    it("leaves no temp file behind when the data cannot be written at all", () => {
+        const readOnly = join(dir, "read-only");
+        mkdirSync(readOnly, { mode: 0o500 });
+
+        try {
+            expect(() => atomicWriteFileSync(join(readOnly, "x.json"), "{}", { mode: 0o600 })).toThrow();
+            expect(readdirSync(readOnly)).toEqual([]);
+        } finally {
+            chmodSync(readOnly, 0o700);
+        }
     });
 
     it("leaves the mode to the umask when none is requested", () => {

--- a/src/utils/storage/storage.test.ts
+++ b/src/utils/storage/storage.test.ts
@@ -100,6 +100,49 @@ describe("Storage GENESIS_TOOLS_HOME override", () => {
     });
 });
 
+describe("Storage configFileMode", () => {
+    let home: string;
+
+    beforeEach(() => {
+        home = mkdtempSync(join(tmpdir(), "storage-mode-"));
+        env.testing.set("GENESIS_TOOLS_HOME", home);
+    });
+
+    afterEach(() => {
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    it("applies the instance mode to every config writer, not just setConfig", async () => {
+        // setConfigValue and atomicConfigUpdate rewrite the SAME config.json, so
+        // a mode that only setConfig honoured would be undone by either of them.
+        const storage = new Storage("secret-tool", { configFileMode: 0o600 });
+
+        await storage.setConfig({ a: 1 });
+        expect(statSync(storage.getConfigPath()).mode & 0o777).toBe(0o600);
+
+        await storage.setConfigValue("b", 2);
+        expect(statSync(storage.getConfigPath()).mode & 0o777).toBe(0o600);
+
+        await storage.atomicConfigUpdate<{ c?: number }>((config) => {
+            config.c = 3;
+        });
+        expect(statSync(storage.getConfigPath()).mode & 0o777).toBe(0o600);
+    });
+
+    it("leaves the mode to the umask for tools that store no secrets", async () => {
+        const storage = new Storage("plain-tool");
+        const previous = process.umask(0o022);
+
+        try {
+            await storage.setConfig({ a: 1 });
+        } finally {
+            process.umask(previous);
+        }
+
+        expect(statSync(storage.getConfigPath()).mode & 0o777).toBe(0o644);
+    });
+});
+
 describe("atomicWriteFileSync mode", () => {
     let dir: string;
 
@@ -148,7 +191,8 @@ describe("atomicWriteFileSync mode", () => {
         expect(readdirSync(dir)).toEqual(["target"]);
     });
 
-    it("leaves no temp file behind when the data cannot be written at all", () => {
+    // Same caveat as the grok refresh suite: a 0500 directory does not stop root.
+    it.skipIf(process.getuid?.() === 0)("leaves no temp file behind when the data cannot be written at all", () => {
         const readOnly = join(dir, "read-only");
         mkdirSync(readOnly, { mode: 0o500 });
 

--- a/src/utils/storage/storage.test.ts
+++ b/src/utils/storage/storage.test.ts
@@ -1,9 +1,10 @@
 // biome-ignore-all lint/plugin: test fixture intentionally uses /tmp/ or /Users/ string literals — production plugins do not apply to test code
-import { afterEach, describe, expect, it } from "bun:test";
-import { homedir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
-import { Storage } from "./storage";
+import { atomicWriteFileSync, Storage } from "./storage";
 
 describe("Storage.parseTTL", () => {
     const storage = new Storage("test-tool");
@@ -96,5 +97,57 @@ describe("Storage GENESIS_TOOLS_HOME override", () => {
         expect(new Storage("ask").getConfigPath()).toBe(join(home, ".genesis-tools", "ask", "config.json"));
         env.testing.set("GENESIS_TOOLS_HOME", "");
         expect(new Storage("ask").getConfigPath()).toBe(join(home, ".genesis-tools", "ask", "config.json"));
+    });
+});
+
+describe("atomicWriteFileSync mode", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "atomic-mode-"));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("leaves the published file at the requested mode, never at the umask default", () => {
+        const target = join(dir, "secret.json");
+        atomicWriteFileSync(target, "{}", { mode: 0o600 });
+
+        // The mode rides the rename, so the file is never briefly visible at
+        // 0644 under its real name — a post-rename chmod could not promise that.
+        expect(statSync(target).mode & 0o777).toBe(0o600);
+        expect(readdirSync(dir)).toEqual(["secret.json"]);
+    });
+
+    it("survives a umask that would otherwise strip the requested bits", () => {
+        // writeFileSync's own `mode` is masked by umask: with umask 0600 it
+        // produces a 000 file, so the mode has to be re-applied before rename.
+        const target = join(dir, "hostile-umask.json");
+        const previous = process.umask(0o600);
+
+        try {
+            atomicWriteFileSync(target, "{}", { mode: 0o600 });
+        } finally {
+            process.umask(previous);
+        }
+
+        expect(statSync(target).mode & 0o777).toBe(0o600);
+    });
+
+    it("leaves the mode to the umask when none is requested", () => {
+        // Existing callers (todo, task, mcp-tsc) must keep their old behaviour;
+        // umask is pinned here so the expectation does not depend on the host.
+        const target = join(dir, "plain.json");
+        const previous = process.umask(0o022);
+
+        try {
+            atomicWriteFileSync(target, "{}");
+        } finally {
+            process.umask(previous);
+        }
+
+        expect(statSync(target).mode & 0o777).toBe(0o644);
     });
 });

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -22,6 +22,15 @@ import { withFileLock as acquireFileLock, LockTimeoutError } from "./file-lock";
  */
 export type TTLString = string;
 
+/** Best-effort removal of an abandoned temp file; never masks the failure that caused it. */
+function removeTempFile(tmp: string): void {
+    try {
+        unlinkSync(tmp);
+    } catch (cleanupErr) {
+        logger.debug({ err: cleanupErr, tmp }, "[storage] tmp-file cleanup after a failed atomic write");
+    }
+}
+
 /**
  * Write data to a file atomically via write-to-sibling-tmp + renameSync.
  * Safe under concurrent writers — each gets a unique tmp name and rename is atomic on POSIX.
@@ -40,21 +49,25 @@ export function atomicWriteFileSync(filePath: string, data: string, options?: { 
     }
 
     const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmp, data, options?.mode === undefined ? undefined : { mode: options.mode });
 
-    if (options?.mode !== undefined) {
-        chmodSync(tmp, options.mode);
+    // Every step after the temp path may exist shares one cleanup path: a
+    // half-written or unchmod'd temp file must never be left behind, least of
+    // all when it holds the secret `mode` was requested for.
+    try {
+        writeFileSync(tmp, data, options?.mode === undefined ? undefined : { mode: options.mode });
+
+        if (options?.mode !== undefined) {
+            chmodSync(tmp, options.mode);
+        }
+    } catch (err) {
+        removeTempFile(tmp);
+        throw err;
     }
 
     try {
         renameSync(tmp, filePath);
     } catch {
-        try {
-            unlinkSync(tmp);
-        } catch (cleanupErr) {
-            logger.debug({ err: cleanupErr, tmp }, "[storage] tmp-file cleanup after failed rename");
-        }
-
+        removeTempFile(tmp);
         throw new Error(`Atomic rename failed: ${tmp} → ${filePath}`);
     }
 }
@@ -212,6 +225,11 @@ export class Storage {
     /**
      * Set the entire config object
      * @param config - The config object to save
+     * @param options.mode - Octal file mode (e.g. `0o600`) for the config file.
+     * Pass it whenever the config holds credentials: the mode is applied to the
+     * temp file BEFORE it is renamed into place, so the file is never briefly
+     * readable at the umask default. Omit it and the mode is left to the umask,
+     * which is what every non-secret config wants.
      */
     async setConfig<T extends object>(config: T, options?: { mode?: number }): Promise<void> {
         await this.ensureDirs();

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+    chmodSync,
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    renameSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { env } from "@genesiscz/utils/env";
@@ -16,8 +25,14 @@ export type TTLString = string;
 /**
  * Write data to a file atomically via write-to-sibling-tmp + renameSync.
  * Safe under concurrent writers — each gets a unique tmp name and rename is atomic on POSIX.
+ *
+ * `mode` applies from the temp file's birth, so a file holding secrets is never
+ * briefly published at the umask default: the rename carries the restricted mode
+ * with it. Chmod'ing after the rename cannot close that window, and `writeFileSync`'s
+ * own `mode` is masked by umask (umask 0600 yields a 000 file), so it is re-applied
+ * to the temp file before it becomes visible under the real name.
  */
-export function atomicWriteFileSync(filePath: string, data: string): void {
+export function atomicWriteFileSync(filePath: string, data: string, options?: { mode?: number }): void {
     const dir = dirname(filePath);
 
     if (!existsSync(dir)) {
@@ -25,7 +40,11 @@ export function atomicWriteFileSync(filePath: string, data: string): void {
     }
 
     const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tmp, data);
+    writeFileSync(tmp, data, options?.mode === undefined ? undefined : { mode: options.mode });
+
+    if (options?.mode !== undefined) {
+        chmodSync(tmp, options.mode);
+    }
 
     try {
         renameSync(tmp, filePath);
@@ -194,9 +213,9 @@ export class Storage {
      * Set the entire config object
      * @param config - The config object to save
      */
-    async setConfig<T extends object>(config: T): Promise<void> {
+    async setConfig<T extends object>(config: T, options?: { mode?: number }): Promise<void> {
         await this.ensureDirs();
-        this.atomicWrite(this.configPath, SafeJSON.stringify(config, null, 2));
+        this.atomicWrite(this.configPath, SafeJSON.stringify(config, null, 2), options);
         logger.debug(`Config saved`);
     }
 
@@ -422,8 +441,8 @@ export class Storage {
     // Safe I/O
     // ============================================
 
-    private atomicWrite(filePath: string, data: string): void {
-        atomicWriteFileSync(filePath, data);
+    private atomicWrite(filePath: string, data: string, options?: { mode?: number }): void {
+        atomicWriteFileSync(filePath, data, options);
     }
 
     // ============================================

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -66,10 +66,24 @@ export function atomicWriteFileSync(filePath: string, data: string, options?: { 
 
     try {
         renameSync(tmp, filePath);
-    } catch {
+    } catch (err) {
         removeTempFile(tmp);
-        throw new Error(`Atomic rename failed: ${tmp} → ${filePath}`);
+        // The errno is the whole diagnosis here: EXDEV (tmp and target on
+        // different mounts), ENOSPC, EACCES and ENOTEMPTY all need different
+        // answers and would otherwise collapse into one opaque message.
+        throw new Error(`Atomic rename failed: ${tmp} → ${filePath}`, { cause: err });
     }
+}
+
+export interface StorageOptions {
+    /**
+     * Octal mode (e.g. `0o600`) applied to `config.json` by EVERY writer on this
+     * instance. Set it once here when a tool's config holds credentials, rather
+     * than per call: `setConfigValue` and `atomicConfigUpdate` write the same
+     * file as `setConfig`, so a per-call option is one forgotten argument away
+     * from republishing the secret at the umask default.
+     */
+    configFileMode?: number;
 }
 
 export class Storage {
@@ -77,13 +91,16 @@ export class Storage {
     private baseDir: string;
     private cacheDir: string;
     private configPath: string;
+    private configFileMode?: number;
 
     /**
      * Create a Storage instance for a tool
      * @param toolName - Name of the tool (e.g., "timely", "ask")
+     * @param options - See {@link StorageOptions}
      */
-    constructor(toolName: string) {
+    constructor(toolName: string, options?: StorageOptions) {
         this.toolName = toolName;
+        this.configFileMode = options?.configFileMode;
         // GENESIS_TOOLS_HOME overrides the storage root. Purely additive: unset
         // in production → identical to `homedir()`. Tests set it to a fresh
         // tmp dir so the suite can never write a user's real ~/.genesis-tools
@@ -225,15 +242,18 @@ export class Storage {
     /**
      * Set the entire config object
      * @param config - The config object to save
-     * @param options.mode - Octal file mode (e.g. `0o600`) for the config file.
-     * Pass it whenever the config holds credentials: the mode is applied to the
+     * @param options.mode - Octal file mode (e.g. `0o600`) for the config file,
+     * overriding the instance's `configFileMode`. The mode is applied to the
      * temp file BEFORE it is renamed into place, so the file is never briefly
-     * readable at the umask default. Omit it and the mode is left to the umask,
-     * which is what every non-secret config wants.
+     * readable at the umask default. With neither set, the mode is left to the
+     * umask, which is what every non-secret config wants. Prefer setting
+     * `configFileMode` once on the instance — see {@link StorageOptions}.
      */
     async setConfig<T extends object>(config: T, options?: { mode?: number }): Promise<void> {
         await this.ensureDirs();
-        this.atomicWrite(this.configPath, SafeJSON.stringify(config, null, 2), options);
+        this.atomicWrite(this.configPath, SafeJSON.stringify(config, null, 2), {
+            mode: options?.mode ?? this.configFileMode,
+        });
         logger.debug(`Config saved`);
     }
 
@@ -601,7 +621,9 @@ export class Storage {
                 }
 
                 updater(config);
-                this.atomicWrite(this.configPath, SafeJSON.stringify(config, null, 2));
+                this.atomicWrite(this.configPath, SafeJSON.stringify(config, null, 2), {
+                    mode: this.configFileMode,
+                });
                 logger.debug("Atomic config update complete");
 
                 return config;


### PR DESCRIPTION
## What

Credential-safety work on `ai-proxy`, plus the Grok OIDC self-refresh that unblocks `grok-sub` accounts.

**ai-proxy**

- Runs as a **launchd daemon via `DashboardApp`** instead of a bespoke daemon, and survives accounts it cannot use rather than failing to start.
- **API-key credentials are stored on the account**, so the proxy no longer depends on ambient process env for billed keys.
- **Refuses ambient billed keys** outright, **gates the client-secret mint**, and **logs realtime sessions** so a session can be reconstructed after the fact.
- **Interactive credential chooser** for `accounts set-key`.

**grok**

- Refreshes the **OIDC token itself** instead of erroring out and demanding the user run the `grok` CLI by hand.
- The refresh now happens in **account resolution**, not only in the HTTP client — an expired sub token was previously repaired for requests but still surfaced as expired everywhere else.
- Test coverage for the refresh grant.

**ask**

- A targeted provider scan no longer **caches itself as the full catalog**, which previously made a one-provider probe shrink the model list for every later call.

## Why

The proxy could bill against whatever key happened to be in the environment, which is the wrong default for a component that mints client secrets. Moving credentials onto the account makes the billing subject explicit and auditable.

## Scope

`src/ai-proxy/**`, `src/utils/ai/grok/**`, `src/ask/providers/ProviderManager.ts`.

Split out of #296. File-disjoint from the sibling PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account commands for setting API keys and allowing or disabling environment-based credentials.
  - Added realtime session transcripts with frame counts, summaries, tags, and usage details.
  - Added automatic Grok authentication refresh and recovery after expired or rejected tokens.
- **Bug Fixes**
  - Improved provider error reporting with clearer unavailable-service responses.
  - Improved provider discovery caching and credential selection.
- **Security**
  - Strengthened config file permissions and API-key masking.
  - Added controls to disable realtime client-secret creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->