### PR TITLE
feat(du): Disk usage utility with clonefile checks

### DIFF
--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -611,3 +611,51 @@ Carryover verified directly against the file header rather than inferred: `nrecs
 at offset 24 read **4** after a cold parent scan of 4 files, then **5** after a
 scan of only the 2-file subdirectory. Truncation to the scanned subtree would have
 left 2.
+
+---
+
+## 2026-07-29 05:10 — Review round 2 (PR #302): the eviction gap, answered
+
+Still no C change, so still no benchmark owed (`clonesize.c` byte-identical since
+`03a7ded22`).
+
+Round 1 recorded `CACHE_MAX_RECS` eviction as an untested gap because crossing
+2,000,000 records means creating two million shared files. The review asked the
+obvious follow-up: can the branch be reached by forging the header's record count
+instead of writing the files?
+
+**No, and the reason is a guard worth knowing about.** `cache_open` computes the
+bytes the header implies and refuses the file when they exceed its actual size:
+
+```c
+size_t need = sizeof(CacheHeader) + h->nrecs * sizeof(CacheEnt) + h->nexts * sizeof(CacheExt);
+if (h->magic != CACHE_MAGIC || h->version != CACHE_VERSION || h->fsid != g_fsid ||
+    need > (size_t)st.st_size) { munmap(...); return; }
+```
+
+Measured on the 3-file fixture: the real cache is **376 bytes** with `nrecs = 3`.
+Forging `nrecs = 1,999,999` (offset 24) implies ~96 MB of records, so the whole
+cache is dropped and the scan falls back to reading the filesystem:
+
+| | files_opened | files_cached | unique_bytes |
+|---|---|---|---|
+| warm, real header | 0 | 3 | 4,194,304 |
+| warm, `nrecs` forged to 1,999,999 | 3 | 0 | 4,194,304 |
+
+So the forged-count route is closed by corruption detection, not by luck, and the
+totals stay correct either way. Genuine eviction still needs 2M real records and
+remains untested. `cache.test.ts` now pins the rejection.
+
+### Also closed this round
+
+`renderVolume` and `renderPartners` had zero coverage. Both are branch-heavy
+(allocated-vs-mapped selection, `UNACCOUNTED` vs `over-counted`, cloud/mount/denial
+sections, the 8-mount truncation, left-truncated paths), and one branch turned out
+to be genuinely surprising: **`renderPartners` returns early when `partner_dirs` is
+empty**, so a fixture with only `partner_files` never renders any file rows. A test
+written without checking that passes for the wrong reason.
+
+Worth recording for anyone extending `PartnersResult`: `clonesize_partners_json`
+emits `denied_dirs` and `denied_files` but **never `denied_paths`**, so the partner
+report's denial warning stands on counts alone and prints
+`(N further denial(s) not listed)`.

--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -690,3 +690,95 @@ and the full du + format suite still runs in well under a second.
 The distinction worth keeping: the size check protects against an **inconsistent or
 truncated** cache (out-of-bounds reads), and nothing more. It is not a bound on
 `nrecs`, and it should not be described as one.
+
+---
+
+## 2026-07-29 07:44 — Review round 4 (PR #302): integer overflow in the cache header check
+
+**This round DID change `clonesize.c`,** so unlike rounds 1-3 it gets measured. The
+change is a security fix in `cache_open`, which runs **once per scan** (called from
+`run_scan`, one call site), not in the per-file path. `cache_lookup` — the function
+actually in the hot loop — is untouched.
+
+### The bug
+
+`cache_open` validated the header by multiplying the counts out first:
+
+```c
+size_t need = sizeof(CacheHeader) + (size_t)h->nrecs * sizeof(CacheEnt) + (size_t)h->nexts * sizeof(CacheExt);
+if (... || need > (size_t)st.st_size) { munmap(...); return; }
+```
+
+`h->nrecs` is a `uint64_t` read straight off disk, and the product wraps a 64-bit
+`size_t`. `sizeof(CacheEnt)` is 48, and **48 · 2^60 = 3 · 2^64 ≡ 0 (mod 2^64)** — so
+`nrecs = 2^60` makes the record term exactly zero, `need` collapses to the 40-byte
+header, the size check passes, and `g_cache_nents` becomes 1.15e18. `cache_lookup`
+then binary-searches that many entries across a 280-byte mapping.
+
+Verified on the pre-fix binary, four forged headers, same fixture:
+
+| forged header | pre-fix | post-fix |
+|---|---|---|
+| `nrecs = 2^60` | **exit 139 (SIGSEGV)** | rejected, totals correct |
+| `nrecs = UINT64_MAX` | rejected | rejected |
+| `nexts = UINT64_MAX` | rejected | rejected |
+| `nrecs = 2^60`, `nexts = UINT64_MAX` | **exit 139 (SIGSEGV)** | rejected, totals correct |
+
+Two of four bypassed. `UINT64_MAX` alone does **not**: `(2^64−1)·48 mod 2^64` is
+huge, so the sum stays over the file size. The dangerous shapes are the ones whose
+product wraps *near zero*, which needs a count that is a multiple of 2^60 (for
+`nrecs`) or a companion term that pulls the total back down.
+
+### The fix
+
+Bound each count by **division** against the bytes that are actually present, before
+anything is scaled:
+
+```c
+size_t avail = (size_t)st.st_size - sizeof(CacheHeader);
+if (... || h->nrecs > avail / sizeof(CacheEnt)) { munmap(...); return; }
+size_t after_ents = avail - (size_t)h->nrecs * sizeof(CacheEnt);
+if (h->nexts > after_ents / sizeof(CacheExt)) { munmap(...); return; }
+```
+
+Division cannot overflow, and the multiplication that remains is provably in range.
+The earlier `st.st_size >= sizeof(CacheHeader)` check keeps `avail` from underflowing.
+
+### Correctness
+
+Byte totals on `node_modules`, pre-fix binary vs fixed, **all identical**:
+`files_scanned` 94696 · `files_opened` 94691 · `extents` 95834 ·
+`naive_bytes` 2461622272 · `unique_bytes` 2061258070 ·
+`unique_allocated_bytes` 2289090560 · `shared_bytes` 400364202 ·
+`outside_shared_bytes` 2257260544.
+
+The padded-cache eviction test from round 3 still passes, which is the check that
+matters for false rejection: a *legitimate* header claiming 1,999,999 records with
+the bytes to back it up is still accepted.
+
+### Benchmark, and why the numbers say nothing
+
+T2 (`node_modules`), `--warmup 2 --runs 7`. Load average at run time: **54-65**.
+
+| | Wall mean ± σ | Wall min | System CPU |
+|---|---|---|---|
+| OLD (multiply-then-compare) | 2.894 s ± 0.787 s | 2.084 s | 24.772 s |
+| NEW (divide-then-bound) | 3.113 s ± 0.446 s | 2.564 s | 29.027 s |
+
+Read naively that is a 23% regression on minima — which would be impossible, since
+the change is two divisions executed **once per scan**. So the control was run: the
+**same old binary against itself**, back to back.
+
+| | Wall mean ± σ | Wall min | System CPU |
+|---|---|---|---|
+| CONTROL A (old binary) | 3.212 s ± 0.820 s | 2.141 s | 32.131 s |
+| CONTROL B (same old binary) | 3.137 s ± 0.379 s | 2.543 s | 31.006 s |
+
+**Identical code shows a 19% spread on minima and its own system CPU moved 24.8 s →
+32.1 s across runs.** The OLD-vs-NEW difference is smaller than the noise floor of
+the machine at this load, so the benchmark cannot resolve this change and no
+conclusion should be drawn from it in either direction.
+
+**Methodology note worth keeping:** when a measurement disagrees with the structure
+of the change, run the same binary against itself before believing the measurement.
+This log has twice recorded a "regression" that a control would have dismissed.

--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -782,3 +782,97 @@ conclusion should be drawn from it in either direction.
 **Methodology note worth keeping:** when a measurement disagrees with the structure
 of the change, run the same binary against itself before believing the measurement.
 This log has twice recorded a "regression" that a control would have dismissed.
+
+---
+
+## 2026-07-29 08:11 — Review round 5 (PR #302): the same overflow, at two more sites
+
+Round 4 fixed the header counts in `cache_open`. Review then found the identical
+class one function away, and grepping for it found a third site nobody had
+reported. **`cache_lookup` runs once per shared file, so this one IS in the hot
+loop** and is measured below.
+
+### The three sites
+
+`off` and `count` are read straight out of the cache file, so `off + count` wraps
+a 64-bit unsigned and lands back under the limit:
+
+| site | check | status |
+|---|---|---|
+| `cache_open` header counts | `nrecs * sizeof(CacheEnt)` overflowed | fixed round 4, now routed through the helper |
+| `cache_lookup` per entry | `e->ext_off + e->ext_count > g_cache_nexts` | **reported** (CodeRabbit, Critical) |
+| `cache_write` carryover | `&g_cache_exts[g_cache_ents[oi].ext_off]`, **no check at all** | **found by grep, unreported** |
+
+All three now go through one helper, per the repo's fix-at-the-root rule:
+
+```c
+static inline int range_within(uint64_t off, uint64_t count, uint64_t limit) {
+    return off <= limit && count <= limit - off;
+}
+```
+
+Call sites divide rather than multiply when the limit is in bytes, so nothing is
+ever scaled before it is bounded.
+
+### What the per-entry bug actually did (it does not crash)
+
+Worth recording precisely, because the obvious guess is wrong. Forging one
+record's `ext_off` to `UINT64_MAX` on the 3-clone fixture:
+
+| | files_cached | files_opened | unique_bytes |
+|---|---|---|---|
+| pre-fix | 3 | 0 | **7,667,827,374,364,295,172** |
+| post-fix | 2 | 1 | 4,194,304 |
+
+**7.7 exabytes reported from 12 MB of files, silently, exit 0.** It does not
+segfault because the pointer arithmetic wraps too: `ext_off * sizeof(CacheExt)`
+lands just *before* `g_cache_exts`, which is still inside the mapping, so the
+scan reads whatever bytes are there and believes them. On a large cache the same
+wrap can reach past the end of the mapping. Silent wrong output is the realistic
+failure, not a crash.
+
+The fix degrades gracefully: only the poisoned record is dropped (`cached` 3 → 2)
+and its file is re-read from disk (`opened` 0 → 1). Rejecting one entry never
+throws the whole cache away.
+
+### Correctness
+
+Round-4 binary vs round-5 on `node_modules`, all ten totals identical:
+`files_scanned` 94696 · `files_opened` 94691 · `files_cached` 0 · `extents` 95834 ·
+`naive_bytes` 2461622272 · `unique_bytes` 2061258070 ·
+`unique_allocated_bytes` 2289090560 · `shared_bytes` 400364202 ·
+`outside_shared_bytes` 2257260544 · `private_sum_bytes` 282624.
+
+### Benchmark: warm-cache path, where `cache_lookup` is hottest
+
+T2 (`node_modules`) against a pre-warmed cache so every timed run is a pure
+`cache_lookup` workload. `--warmup 2 --runs 7`, load average **54**. The control
+(the R4 binary run a second time under a different label) is included in the same
+invocation, which is the only way to read these numbers honestly:
+
+| | Wall mean ± σ | Wall min | System CPU |
+|---|---|---|---|
+| R4 (add-then-compare) | 352.6 ms ± 23.9 ms | 332.7 ms | 4093.6 ms |
+| R5 (`range_within`) | 341.9 ms ± 20.1 ms | 319.0 ms | 3558.0 ms |
+| **CONTROL (R4 again)** | 298.3 ms ± 10.2 ms | 283.9 ms | 3054.9 ms |
+
+**R4 disagrees with itself by 18% on the mean and 34% on system CPU, and R5 lands
+between R4's two measurements.** The change swaps one add-and-compare for a
+compare-subtract-compare once per cache hit; it is far below what this machine can
+resolve. No regression, and no claim of an improvement either.
+
+### `bench.sh` fixes from the same round
+
+- **The caller's label no longer reaches a benched command.** `LABEL` (`$1`) was
+  interpolated into `CACHE_DIR`, which is pasted into the single-quoted hyperfine
+  command strings — a label containing `'` broke out and ran arbitrary commands.
+  Verified: the old construction executed an injected `touch`, the new `mktemp -d`
+  path does not. The label still appears in the human header, where it is echoed.
+- **`uptime` is printed at start, after the matrix, and at the end.** The doc has
+  required the load average since the first entry and the script never captured
+  it. Immediately useful: the verification run started at load **14.48** and hit
+  **87.64** by the end of the matrix, which is precisely the swing that makes
+  single-sided wall-time numbers worthless.
+- **The correctness cross-check prints the real totals**, not `head -c 600` of the
+  JSON — a fixed byte prefix is arbitrary once `groups[]` grows, so a "correctness
+  diff" could silently compare nothing.

--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -567,3 +567,47 @@ reached the line after the pipe. **Every `bench.sh` run since the extent-cache
 section was added therefore skipped that section entirely.** Both pipes now
 capture into a variable first and truncate from a herestring, verified to run
 through to the end.
+
+---
+
+## 2026-07-29 06:57 — Review round (PR #302): tests only, native core untouched
+
+**No benchmark was run, and none was needed.** This round changed no C: `git diff`
+touches `src/du/lib/options.ts` (new), `src/du/lib/options.test.ts` (new),
+`src/du/lib/cache.test.ts` (new), `src/du/index.ts` (imports), `src/du/lib/engine.ts`
+(comment) and `src/utils/format.ts` (comment). `clonesize.c` is byte-identical, so
+the hot loop cannot have moved. The rule in CLAUDE.md exists to catch unmeasured
+*features*; recording the absence here keeps the log honest either way.
+
+### What the new cache tests actually pin
+
+eve's review thread t3 was right that the extent cache had ~200 lines of C and a
+performance harness but no correctness suite. `src/du/lib/cache.test.ts` closes
+that, darwin-gated (the fixture needs `cp -c`/clonefile(2)). Measured on a fixture
+of one 4 MB file plus two clones:
+
+| step | files_opened | files_cached | unique_bytes |
+|---|---|---|---|
+| cold (`--no-cache`, writes) | 3 | 0 | 4,194,304 |
+| warm | 0 | 3 | 4,194,304 |
+| after rewriting one clone in place | 0 | 2 | 8,388,608 |
+| ground truth for that state (cache read off) | 2 | 0 | 8,388,608 |
+| after corrupting the cache file | 3 | 0 | 4,194,304 |
+
+Two things worth knowing for anyone extending these tests:
+
+- **The rewritten clone is not re-opened, it is skipped.** Once it stops sharing
+  blocks it becomes fully private, and the private-file skip
+  (`priv >= alloc && nlink <= 1 && alloc >= dlen`) means it never gets opened at
+  all. So the invalidation assertion has to be "totals track the no-cache ground
+  truth", not "the file was re-opened".
+- **A fully-warm scan skips the cache rewrite entirely** (`opened == 0` early
+  return in `cache_write`). A carryover test that scans a subtree whose files are
+  all already cached therefore never exercises the merge and passes vacuously. The
+  test forces a miss by adding an unseen file first, then asserts
+  `files_opened > 0` before checking the parent's records survived.
+
+Carryover verified directly against the file header rather than inferred: `nrecs`
+at offset 24 read **4** after a cold parent scan of 4 files, then **5** after a
+scan of only the 2-file subdirectory. Truncation to the scanned subtree would have
+left 2.

--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -614,7 +614,7 @@ left 2.
 
 ---
 
-## 2026-07-29 05:10 — Review round 2 (PR #302): the eviction gap, answered
+## 2026-07-29 07:05 — Review round 2 (PR #302): the eviction gap, answered
 
 Still no C change, so still no benchmark owed (`clonesize.c` byte-identical since
 `03a7ded22`).

--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -659,3 +659,34 @@ Worth recording for anyone extending `PartnersResult`: `clonesize_partners_json`
 emits `denied_dirs` and `denied_files` but **never `denied_paths`**, so the partner
 report's denial warning stands on counts alone and prints
 `(N further denial(s) not listed)`.
+
+---
+
+## 2026-07-29 07:14 — Review round 3 (PR #302): eviction is reachable after all
+
+Still no C change. This section exists to correct the one above, which overstated
+its own result.
+
+Round 2 claimed a forged record count "cannot reach the eviction branch". That is
+wrong as written, and the review caught it. `cache_open`'s
+`need > (size_t)st.st_size` is a **consistency** check, not a ceiling on the count:
+it only rejects a cache too small for what its header claims. A file that claims
+1,999,999 records **and is padded to actually hold them** passes it.
+
+So eviction is testable in fixture time after all:
+
+- header keeps the real magic / version / fsid, sets `nrecs = 1,999,999`, `nexts = 0`
+- body is 1,999,999 zeroed `CacheEnt` records (48 bytes each) → 95,999,992 bytes
+- the zeroed records have `fileid = 0`, so they match no real file: the scan opens
+  all 3 fixture files and the byte totals stay correct
+- `cache_write` then merges 1,999,999 carried-over records with this run's 3,
+  reaching 2,000,002, which trips `n > CACHE_MAX_RECS` and the recency truncation
+
+Result, measured: the rewritten cache holds **exactly 2,000,000** records, and the
+whole scan takes **0.26s**. The eviction branch is now covered by
+`cache.test.ts` ("evicts down to CACHE_MAX_RECS when the merged set overflows"),
+and the full du + format suite still runs in well under a second.
+
+The distinction worth keeping: the size check protects against an **inconsistent or
+truncated** cache (out-of-bounds reads), and nothing more. It is not a bound on
+`nrecs`, and it should not be described as one.

--- a/.claude/docs/benchmarks-du.md
+++ b/.claude/docs/benchmarks-du.md
@@ -1,0 +1,569 @@
+# `tools du` — performance log
+
+`src/du` exists for one reason: to be fast enough that a clone-aware scan of a
+huge tree is worth running at all (a 22.7M-file home scan took 618s). Every
+feature added to the native core sits in the hot loop, so an unmeasured feature
+is a silent regression waiting to happen.
+
+**Hard rule: read this file before touching `src/du/`, and append a section to it
+for every feature you add.** No exceptions, including "this can't possibly cost
+anything".
+
+## How to measure
+
+```bash
+src/du/native/bench.sh <label>
+```
+
+The script rebuilds `native/clonesize.c` with `clang -O2 -pthread`, then runs
+hyperfine (`--warmup 1 --runs 5`) over a fixed matrix:
+
+| Name | Target | Mode |
+|---|---|---|
+| `T1 flat` | repo root | no `--depth` |
+| `T1 depth2` | repo root | `--depth 2` |
+| `T2 flat` | repo `node_modules` | no `--depth` |
+| `T2 depth2` | repo `node_modules` | `--depth 2` |
+
+It finishes by printing the `--json` totals for T1 so byte-level output can be
+diffed across commits.
+
+### Read the numbers correctly
+
+- **System CPU time is the primary metric, not wall time.** The scan is
+  syscall-bound (`getattrlistbulk` + `openat` + `fcntl`), and this machine is
+  frequently under heavy load — the baseline below was taken at load average
+  **109**, which inflates and destabilises wall time (σ ≈ 7%). System CPU time
+  moves far less with unrelated load.
+- **Treat < 15% wall-time movement as noise** unless system CPU time moved with
+  it in the same direction.
+- **Always record the load average** (`uptime`) next to the numbers.
+- A run that changes `naive_bytes` / `unique_bytes` / `files_scanned` on an
+  unchanged tree is a correctness bug, not a benchmark result. Check that first.
+
+## Machine
+
+- Mac16,5 · Apple M4 Max · 16 cores · macOS 26.3.1
+- APFS, 995 GB Data volume
+
+---
+
+## 2026-07-27 23:05 — Baseline (before the 9-task feature wave)
+
+Baseline commit state: `src/du/` as of `acb76f91f` (feature work stashed away for
+this measurement). Load average at run time: **109.39** (heavily loaded machine).
+
+| Benchmark | Wall mean ± σ | User | System |
+|---|---|---|---|
+| T1 flat | 14.150 s ± 0.914 s | 0.540 s | 76.359 s |
+| T1 depth2 | 14.158 s ± 1.039 s | 0.540 s | 66.895 s |
+| T2 flat | 1.356 s ± 0.180 s | 0.051 s | 6.455 s |
+| T2 depth2 | 1.385 s ± 0.131 s | 0.052 s | 7.132 s |
+
+Correctness totals for T1 (repo root), to diff against after every change:
+
+```json
+{
+  "files_scanned": 711959,
+  "files_listed": 713388,
+  "files_opened": 468222,
+  "extents": 472445,
+  "threads": 16,
+  "naive_bytes": 19616407552,
+  "unique_bytes": 12157453308,
+  "shared_bytes": 7458954244,
+  "shared_pct": 38.02,
+  "cross_group_shared_bytes": 253217023
+}
+```
+
+Notes:
+
+- `--depth 2` costs nothing measurable over flat — the per-file `FileRec` push
+  and the node post-pass are both cheap next to the syscall load.
+- 468k of 712k files get opened + extent-scanned; the private-file skip
+  (`priv >= alloc && nlink <= 1 && alloc >= dlen`) avoids ~34% of the opens.
+- `du -sh` on T1 runs in ~10 s and reports 18 GB against clonesize's 11.32 GB
+  real unique, i.e. plain `du` overstates this tree by ~6.9 GB.
+
+### Cross-engine reference (`tools du bench .`, same session)
+
+| tool | wall | files/s | reported |
+|---|---|---|---|
+| `du -sh` | 10.01 s | - | 18G |
+| clonesize (C ffi) | 12.73 s | 55,949 | 11.32 GB |
+| clonesize (C proc) | 15.85 s | 44,907 | 11.32 GB |
+| clonesize (Bun) | 19.84 s | 35,885 | 11.32 GB |
+
+C-ffi and the Bun engine agreed byte-for-byte
+(`naive=19616395264 unique=12157444559`) on a quiesced run.
+
+---
+
+## 2026-07-27 23:30 — Step 1: native-core feature wave (handoff h_c4x0xc9a t1/t3/t5/t7 + entry points for t2/t8)
+
+What landed in `native/clonesize.c`:
+
+- **Denial tracking** — every `open()`/`openat()` that fails with EACCES/EPERM is
+  counted and the first 64 paths kept (`denied_dirs`, `denied_files`,
+  `denied_paths[]`). Costs one `errno` check on an already-failing syscall.
+- **`ATTR_CMN_MODTIME` added to the attrlist** (for `--changed-since`). This is
+  the only change that touches the per-file hot path: the entry grew from 80 to
+  96 bytes, so `getattrlistbulk` returns fewer entries per 64 KB buffer and the
+  walk issues marginally more syscalls.
+- **Sparse accounting** — `apparent_bytes`, `sparse_bytes`, `sparse_files`
+  (per-node too). Two compares and two adds per file.
+- **Second, block-aligned merge pass** — the cluster merge was extracted into
+  `merge_pass(align)` and now runs twice over the same sorted extent array:
+  raw (mapped bytes, unchanged semantics) and rounded out to 4096-byte
+  allocation blocks (`unique_allocated_bytes`). This is the only added *pass*,
+  and it is O(extents) with no extra sort.
+- **`clonesize_volume_json`** (ATTR_VOL_SPACEUSED) and
+  **`clonesize_partners_json`** (two-phase clone-partner query) — new entry
+  points, zero cost to the normal scan path.
+
+### A/B, same machine, binaries built from the same clang invocation
+
+Baseline binary rebuilt from `git show HEAD:src/du/native/clonesize.c`, so this
+is a true before/after rather than a comparison against yesterday's conditions.
+Load average during the run: **79** (T2) / **~75** (T1).
+
+T2 (`node_modules`), `--warmup 2 --runs 10`:
+
+| | Wall mean ± σ | System CPU |
+|---|---|---|
+| BASE | 1.438 s ± 0.447 s | 5.856 s |
+| NEW | 1.209 s ± 0.098 s | 6.233 s |
+
+T1 (repo root, 712k files), `--warmup 1 --runs 5`:
+
+| | Wall mean ± σ | System CPU |
+|---|---|---|
+| BASE | 13.242 s ± 1.574 s | 67.409 s |
+| NEW | 12.700 s ± 0.475 s | 61.567 s |
+
+**Verdict: no regression.** Wall time is flat-to-slightly-better on both targets
+(inside σ either way). System CPU moved +6.4% on T2 and −8.7% on T1, i.e. the
+two figures disagree in sign, which is the signature of machine load rather than
+code. The added work (one extra O(extents) pass, a 16-byte-wider attribute entry)
+is small next to the syscall floor.
+
+An earlier single-sided run of `bench.sh` showed T2 flat at +21% wall; the direct
+A/B above disproves it. **This is exactly why the A/B has to rebuild the baseline
+binary rather than compare against a stored number.**
+
+### Correctness (T1, unchanged tree semantics)
+
+`unique_bytes`, `naive_bytes`, `extents` and `files_opened` all track the
+baseline (the small drift is the live repo, ±130 KB across runs):
+
+```
+naive_bytes            19616546816
+unique_bytes           12157523815   <- mapped, same definition as baseline
+unique_allocated_bytes 13371289600   <- NEW: +1.21 GB the mapped figure was dropping
+apparent_bytes         17448549166
+private_sum_bytes       9956433920   <- "deleting this frees >= " floor
+extents                     472443
+files_opened                468220
+```
+
+The 1.21 GB gap between mapped and allocated on a single 712k-file repo is the
+concrete evidence for handoff task t7: summing mapped extents understates real
+consumption by the per-file sub-block slack, ~10% here.
+
+---
+
+## 2026-07-27 23:45 — Step 2: extent cache (`--no-cache` to bypass)
+
+### Why this and not something else
+
+Measured first, as the rule requires:
+
+```
+[profile] walk+scan 13.415s · merge 0.002s · sort+cluster 0.029s · total 13.445s
+          (opened 468220/711981 files, 472443 extents)
+```
+
+**99.8% of a scan is the walk.** Merge, sort and clustering together are 0.03 s —
+caching *those* would buy nothing. So the question is what inside the walk costs
+the most, answered with the built-in `NOSKIP=1` escape hatch, which forces every
+file open instead of only the shared ones:
+
+| | files opened | walk+scan |
+|---|---|---|
+| normal | 468,220 | 13.781 s |
+| `NOSKIP=1` | 711,981 | 17.969 s |
+
++243,761 opens cost +4.188 s → **~17.2 µs per `open()` + `fcntl(F_LOG2PHYS_EXT)`
+loop + `close()`**. The 468,220 opens in a normal run are therefore ≈ **8.0 s of
+the 13.8 s**. That is the thing worth caching, and nothing else is.
+
+### What the cache stores
+
+A file's physical extent list, keyed by `(fileid, mtime_ns, datalength, allocsize)`.
+Anything that rewrites a file bumps its mtime; anything that changes its length
+changes dlen/alloc. So an exact match means the extents cannot have moved and the
+syscalls are skipped. `ATTR_CMN_FILEID` was added to the attrlist for the key
+(entry size 96 → 104 bytes).
+
+- One file per **volume**, `~/.genesis-tools/du/cache/extents-<fsid>.bin`, because
+  fileids are volume-wide — one cache serves every scan root on that volume.
+- mmap'd read-only and binary-searched, so worker threads share it lock-free.
+- Written to a temp path and `rename(2)`d, so a killed scan cannot corrupt it.
+- Records the previous run never saw are **carried over**, not dropped. Verified:
+  scanning only `node_modules` against a whole-repo cache left the file at 29.8 MB
+  rather than truncating it to the subtree.
+- A fully-warm run (zero opens) **skips the rewrite entirely** — visible below as
+  the merge phase going 0.500 s → 0.002 s.
+- Not covered: an in-place rewrite that restores the exact mtime *and* size, and
+  APFS relocating blocks without touching file metadata. `--no-cache` exists for
+  both.
+
+`--no-cache` suppresses reading only. The cache is still WRITTEN, so the run after
+a `--no-cache` run is warm.
+
+### Numbers (T1 = repo root, 712k files, 468k shared)
+
+Phase timings from `PROFILE=1`, same session, back to back:
+
+| run | walk+scan | merge | total | opened | cached |
+|---|---|---|---|---|---|
+| cold (`--no-cache`, writes) | 12.356 s | 0.487 s | 12.960 s | 468,220 | 0 |
+| warm | 4.811 s | 0.198 s | 5.037 s | 0 | 468,220 |
+| warm again | 4.194 s | 0.190 s | 4.413 s | 0 | 468,220 |
+
+**~2.9× on a warm repeat scan** (12.96 s → 4.41 s), which lands within 15% of the
+8.0 s the NOSKIP measurement predicted was removable.
+
+End to end through the CLI (`tools du clonesize .`), including bun startup:
+
+```
+--no-cache   13.80s
+(warm)        4.59s
+```
+
+Cache file: **29,815,928 bytes** for 468,220 records + 472,443 extents.
+
+A later repeat under heavy load (load average ~90) measured 21.7 s → 6.6 s, i.e.
+the ratio holds even when the absolute numbers do not.
+
+### Cost when the cache is OFF
+
+`--warmup 2 --runs 7`, step-1 binary vs step-2 binary, both without `--cache-dir`:
+
+| | Wall mean ± σ | Wall min | System CPU |
+|---|---|---|---|
+| step1 (no cache code) | 23.106 s ± 3.085 s | **19.857 s** | 72.329 s |
+| step2 (cache code, off) | 24.775 s ± 4.576 s | **19.827 s** | 67.290 s |
+
+The means are useless here (σ > 3 s — a whole-volume scan was running alongside),
+but the **minima are identical to 30 ms**, and system CPU is lower for step 2. The
+cache code costs nothing when disabled.
+
+⚠️ Methodology note learned the hard way: this run was polluted because a
+`tools du volume` scan of the whole disk was running in the background. Never
+benchmark while another scan is in flight — check `uptime` first, and compare
+minima, not means, when the machine is busy.
+
+### Correctness
+
+Cold vs warm on `node_modules --depth 2`:
+
+- every scalar total byte-identical (`naive_bytes`, `unique_bytes`,
+  `unique_allocated_bytes`, `apparent_bytes`, `shared_bytes`,
+  `cross_group_shared_bytes`, `private_sum_bytes`, `extents`, `files_scanned`)
+- all **3,142 tree nodes identical** once sorted by path (the `nodes[]` array
+  order and `parent` indices are thread-interning order and have never been
+  stable across runs — that predates this change)
+- only `files_opened` / `files_cached` differ, which is the point
+
+Invalidation, on a fixture with three clones of one 4 MB file:
+
+```
+cold                        4 opened, 0 cached   unique 10.0 MB
+warm                        0 opened, 4 cached   unique 10.0 MB
+(rewrite one clone in place)
+warm                        0 opened, 3 cached   unique 14.0 MB
+--no-cache (ground truth)   3 opened, 0 cached   unique 14.0 MB
+```
+
+The rewritten file drops out of the cache and the total tracks the ground truth.
+
+### Bug this caught
+
+Adding `ATTR_CMN_FILEID` shifted every field after it in the `getattrlistbulk`
+entry. The parser was updated but the *request* was not, so the scan read `dlen`
+where `alloc` should be: `naive_bytes` silently became the old `apparent_bytes`
+value and `files_opened` fell from 468,220 to 248,942. Nothing crashed; the output
+just quietly lied. It was caught in one command by diffing against the correctness
+totals recorded in this file — which is the entire reason the rule to record them
+exists.
+
+---
+
+## 2026-07-28 00:45 — Step 3: filesystem and cloud-provider boundaries
+
+Not a performance feature, but it changes what a scan measures, so it belongs in
+this log.
+
+### Foreign mounts
+
+The walk now prunes mount points of *other* filesystems (`du -x` semantics),
+collected once from `getmntinfo()` before the walk starts. Two spellings are
+pruned, because macOS firmlinks mean the mount table records a network mount as
+`/Users/<user>/<mount>` while a scan rooted at `/System/Volumes/Data` reaches the
+same directory as `/System/Volumes/Data/Users/<user>/<mount>`. (Observed with an
+NFS export published by a local container runtime.)
+The second spelling is only generated when the scan root is under
+`/System/Volumes/Data`, so ordinary scans get an empty list and pay nothing.
+
+Cost: one `getmntinfo()` per scan, plus a string compare per directory push
+against a list that is empty for normal roots.
+
+### Cloud-provider roots — the one that actually mattered
+
+`~/Library/CloudStorage/<provider>` and `~/Library/Mobile Documents` are **not
+mounts** (same device id as everything else), so mount pruning cannot see them.
+
+Measured failure, on the native binary directly, no bun wrapper involved: a
+whole-volume scan reached 32 CPU-minutes and then stopped making progress. All 16
+workers were parked in `getattrlistbulk`, and `lsof` on the process showed every
+one of them sitting on a directory under
+`~/Library/CloudStorage/<provider>/…`. The File Provider extension answers those
+enumerations, and it was not answering.
+
+Skipping them is also the correct measurement: the contents are largely dataless
+placeholders whose bytes are on someone else's disk, and reading a placeholder can
+trigger a download. A disk-usage tool must never quietly pull gigabytes over the
+network in order to measure them. `--include-cloud` opts back in.
+
+Detection is a name check (`CloudStorage` / `Mobile Documents`) plus an
+8-character suffix compare on the parent (`…/Library`) — no `stat`, because
+`stat`ing the provider root is itself a call that can block.
+
+### The whole-volume reconcile this unlocked (handoff task t2)
+
+```
+Volume reconcile — /System/Volumes/Data
+27,028,294 files  •  16 threads  •  804.2s
+
+  Volume size                    994.7 GB
+  Volume used (APFS)             953.2 GB  = diskutil 'Volume Used Space'
+  Volume free                     14.9 GB
+  Scanned unique (alloc)         897.0 GB
+  UNACCOUNTED                     56.2 GB  (5.9% of used)
+
+  ⚠ 2 cloud-provider root(s) were NOT walked
+  12 mount point(s) of other filesystems were skipped
+  ⚠ 276 unreadable path(s) — the prime suspect for the gap
+     /System/Volumes/Data/.Spotlight-V100
+     /System/Volumes/Data/.fseventsd
+     /System/Volumes/Data/.DocumentRevisions-V100
+     …
+```
+
+`diskutil info` read 953.7 GB immediately afterwards, against the 953.2 GB the
+tool read at scan start — the volume is live and grew during the 13-minute scan.
+
+The hand-rolled audit that produced this handoff had a **132 GB** unexplained
+hole. It is now **56.2 GB**, and every remaining contributor is named on screen
+instead of being invisible.
+
+### Known limitation, unfixed
+
+Parallelism is per-directory: one directory is one queue item, taken by one
+worker. So a single pathological directory serialises the tail of a scan — the
+other 15 threads finish and idle while one enumerates.
+
+This run spent its last minutes exactly that way, inside a single application's
+log directory under `/Library/Application Support/` that had accumulated **3.1M
+files in one flat directory** (a crash-reporting loop writing ~36 files/minute for
+60 days, 38 GB).
+
+To be precise about what "big" means: the *directory itself* measured 99,184,928
+bytes per `stat` — that is its entry storage, not any file inside it. Nothing read
+a 99 MB file; a worker was calling `getattrlistbulk` in a loop over an enormous
+entry list. For scale, `ls` on that directory never completed, and the cheapest
+possible enumeration (name + type only) needed **357.8s at 8,671 entries/s**.
+
+Splitting one directory's entries across workers would fix the serialisation, and
+is not implemented.
+
+**This is a case `tools du` should make easy to spot, and currently does not.**
+A directory whose own `stat` size is tens of MB, or whose file count is in the
+millions, is worth flagging on sight: it is both a scan bottleneck and almost
+always a runaway-writer bug. Two cheap additions would surface it:
+
+- a `--top-dirs-by-entry-count` style report, or simply flagging any single
+  directory over ~100k entries in the `--depth` tree
+- including the directory's own `stat` size in node output, since that is an O(1)
+  proxy for entry count and needs no extra syscall
+
+Until then the manual check is `stat -f '%z' <dir>` on anything that makes a scan
+stall, and `tools du clonesize <dir> --changed-within 24h` to see whether it is
+actively growing.
+
+### Methodology warning that cost real time here
+
+`tools <name>` runs the tool in a **child** bun process. Sampling or reading
+`%CPU` from the process that `pgrep` finds first shows the *parent*, which sits in
+`kevent64` at 0% CPU for the entire run and looks exactly like a hang. Two
+"hangs" were diagnosed from that before the mistake was caught. Always resolve the
+child (`pgrep -P <parent>`) before concluding anything about a running scan, and
+prefer running `src/du/native/clonesize` directly when investigating.
+
+---
+
+## 2026-07-28 01:20 — Step 4: outside-scan sharing (handoff t10/t11)
+
+### The bug being fixed
+
+Scanning ONE SIDE of a clone pair reported the clone at full size with `0 B`
+shared, because clone-dedup is only computed *within the scanned set* and nothing
+in the output said so. `cp -Rcp orig clone` then scanning `clone` alone printed
+naive 300 MB / unique 300 MB / shared 0 B — a free clone presented as a 300 MB
+cost.
+
+### Why the obvious detection does not work
+
+The handoff suggested summing `allocsize − privatesize` per file. That fires just
+as hard when BOTH sides are scanned (every file there is shared too), so it cannot
+distinguish "shared with something I also counted" from "shared with something
+outside". Working through the block algebra, the aggregate totals are degenerate:
+`Σ(alloc − priv) − unique_shared − (naive − unique_alloc) ≡ 0` identically, so no
+combination of existing scalars recovers the answer. It needs per-cluster file
+identity.
+
+### What was added
+
+- `Ext` carries a `uint32 file` id, minted per worker without atomics (6 bits
+  thread index, 26 bits sequence). **This grew the extent record from 24 to 32
+  bytes**, which is the only reason this step needed a benchmark.
+- The block-aligned merge pass sums the length of clusters touched by exactly ONE
+  scanned file (`single_file`). Such a block was collected only because its file
+  shares with *something* (fully private files are never opened), yet nothing else
+  inside the scan references it.
+- Those clusters also contain the file's own private blocks, so
+  `outside_shared = single_file − Σ privatesize(opened files)`.
+
+Human output now leads with `Deleting this frees ≥`, labels the unique figure
+`(deduped WITHIN this scan only)`, and prints a yellow warning when
+`outside_shared_bytes > 0`.
+
+### Verification (the exact repro from the task)
+
+```
+scan PARENT (both sides)      naive 612.9 MB  unique 300.0 MB  shared 312.9 MB   no OUTSIDE line
+scan ONE SIDE (clone only)    naive 300.0 MB  unique 300.0 MB  Shared OUTSIDE 300.0 MB + warning
+```
+
+Both halves of the acceptance hold: the one-sided scan surfaces ~300 MB, the
+parent scan stays silent.
+
+Incidentally, this repo reports **550 MB** of outside-scan sharing against the
+wider volume — blocks shared with worktrees and the bun cache that a scan rooted
+here counts as its own.
+
+### Benchmark: the wider extent record
+
+`--warmup 2 --runs 7`, T1 = repo root, previous commit's binary vs this one:
+
+| | Wall mean ± σ | Wall min | System CPU |
+|---|---|---|---|
+| prev (`Ext` 24 B) | 12.117 s ± 0.751 s | 11.328 s | 66.506 s |
+| now (`Ext` 32 B + file ids) | 13.271 s ± 2.489 s | **11.256 s** | 64.272 s |
+
+The `now` mean carries an 18.6 s outlier (σ 2.489 s vs 0.751 s) from background
+load. Judged the documented way — minima under load, and system CPU as the
+tiebreak — the two are the same: minima differ by 0.6% in *favour* of the new
+binary, and system CPU is 3% lower. No regression.
+
+Correctness unchanged on T1: `extents` 472,443 and `files_opened` 468,220 are
+byte-identical to the step-1 reference; byte totals track the live repo's drift.
+
+Memory cost is real though unmeasured here: +8 bytes per extent is +3.8 MB on this
+repo, but a whole-volume scan collects far more extents, so expect tens to
+hundreds of MB more resident. Worth watching if a volume scan ever OOMs.
+
+---
+
+## 2026-07-29 06:14 — Review fix: file ids strided instead of bit-split
+
+Not a feature. PR #296 review threads t23/t35 both flagged the same real defect in
+the id minted by `next_file_id`, and the fix lands in the per-file hot path, so it
+gets measured like everything else here.
+
+### The defect
+
+Ids were `(tid << 26) | (seq++ & 0x03FFFFFF)`: 6 bits of thread index, 26 bits of
+sequence. `64 << 26` is 2^32, which is zero in a `uint32_t`, so worker 64 mints
+exactly the same id sequence as worker 0. `--threads` accepts up to 1024
+(`intOpt("--threads", { min: 1, max: 1024 })` in `src/du/index.ts`), so the
+invariant the id scheme needed was never enforced anywhere. When two colliding
+workers each hold a file whose blocks land in the same merged cluster,
+`merge_pass` sees one file id instead of two, counts the cluster as single-file,
+and inflates `outside_shared_bytes`. The 26-bit sequence was a second, softer
+ceiling: 67M files per worker.
+
+### The fix
+
+Ids are now strided by the walk's worker count: worker `t` of `N` hands out
+`t, t+N, t+2N, …`, so uniqueness holds at any thread count and the per-worker
+file ceiling disappears. `spawn_walk` publishes `g_walk_threads` before creating
+the workers; nothing else reads it, and `merge_pass` only ever compares ids for
+equality, so no caller depended on the bit layout. The space still wraps at 2^32
+ids, which is unreachable: every id owns at least one 32-byte `Ext`, so 4.3e9
+files would be >137 GB of extent array and the scan dies on malloc first.
+
+### Correctness
+
+Old binary rebuilt from the pre-fix source into the scratchpad, so this is a true
+A/B rather than a comparison against a stored number.
+
+`node_modules`, `--json`, both thread counts, old vs new:
+
+```
+OLD t=16   extents 48483  unique_bytes 3318947018  outside_shared_bytes 361316352
+OLD t=100  extents 48483  unique_bytes 3318947018  outside_shared_bytes 361316352
+NEW t=16   extents 48483  unique_bytes 3318947018  outside_shared_bytes 361316352
+NEW t=100  extents 48483  unique_bytes 3318947018  outside_shared_bytes 361316352
+```
+
+Byte-identical, i.e. the swap is output-neutral on the normal path. Note that the
+100-thread OLD run did **not** diverge here: a collision additionally needs the
+two colliding workers to hold files sharing one cluster AND to be at the same
+sequence index, which is rare rather than impossible. The defect is proven by the
+arithmetic, not by this run.
+
+On a purpose-built fixture (40 x 2 MB files, `cp -Rc` clone, scanning ONE side)
+the new binary returns `outside_shared_bytes = 83,886,080` identically at
+`--threads` 1, 4, 16, 64, 100 and 300. Under the old scheme the 300-thread case
+had no defined behaviour at all.
+
+### Benchmark
+
+`--warmup 2 --runs 7`, T2 = repo `node_modules`. Load average at run time:
+**35.44** (busy machine).
+
+| | Wall mean ± σ | Wall min | System CPU |
+|---|---|---|---|
+| OLD (bitfield id) | 1.717 s ± 0.261 s | 1.511 s | 9.773 s |
+| NEW (strided id) | 1.619 s ± 0.056 s | **1.537 s** | 8.321 s |
+
+**No regression.** Minima differ by 1.7%, far inside the documented 15% noise
+band, and system CPU moved 15% in the new binary's favour. The change swaps a
+shift+or for a multiply+add once per opened file, which is nothing next to the
+~17 µs `open()` + `fcntl(F_LOG2PHYS_EXT)` + `close()` loop that the same file
+pays for.
+
+### `bench.sh` was aborting halfway (review thread t34)
+
+Worth recording because it invalidates how the script's own output should be
+read: `"$BIN" --json "$T1" | head -c 600` under `set -euo pipefail` killed the
+run. The T1 JSON is ~213 KB (the `groups[]` array), far over the 64 KB pipe
+buffer, so `head` closes the pipe, `clonesize` dies with SIGPIPE (141), and
+`pipefail` propagates 141 into `set -e`. Reproduced directly: the script never
+reached the line after the pipe. **Every `bench.sh` run since the extent-cache
+section was added therefore skipped that section entirely.** Both pipes now
+capture into a variable first and truncate from a herestring, verified to run
+through to the end.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ See `.claude/docs/tool-template.md` for complete templates (@inquirer + @clack/p
 
 ## Working on `tools du` (`src/du/`)
 
-**Before touching ANYTHING under `src/du/`, read `.claude/docs/benchmarks-du.md`, and append a new dated section to it for every feature you add.** The native core (`src/du/native/clonesize.c`) is syscall-bound and runs in the hot loop of multi-million-file scans, so an unmeasured feature is a silent regression. Measure with `src/du/native/bench.sh <label>` (fixed target matrix + hyperfine), record system CPU time as the primary metric (wall time on this machine swings with load average — always note `uptime`), and diff the `--json` byte totals to prove the change was performance-only.
+**Before touching ANYTHING under `src/du/`, read `.claude/docs/benchmarks-du.md`, and append a new dated section to it for every feature you add.** The native core (`src/du/native/clonesize.c`) is syscall-bound and runs in the hot loop of multi-million-file scans, so an unmeasured feature is a silent regression. Measure with `src/du/native/bench.sh <label>` (fixed target matrix + hyperfine), record system CPU time as the primary metric (wall time on this machine swings with load average — always note `uptime`), and diff the `--json` byte totals. **Identical totals are required only when the change is meant to preserve scan semantics** (refactors, performance work, validation hardening). Features that deliberately change what is counted — `--changed-within` filtering, cloud-boundary pruning, allocation-vs-mapped reporting — must instead state which totals move, by how much, and why. Unexplained movement is a bug either way.
 
 ## Code Style Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,10 @@ See `.claude/docs/tool-template.md` for complete templates (@inquirer + @clack/p
 
 **Before writing or restyling ANY web UI** (`src/<tool>/ui`, `src/dashboard`, `src/dev-dashboard/ui`), read `.claude/docs/design-system.md`. It is the single shared-UI contract: theme tokens + `@ui/components/*` primitives + `wow-components.css` looks. Hard rules: no raw `zinc-*`/`white/NN` palette in app code (use theme tokens), never override a `<Card>`'s surface, pick a rich Button/Card variant on purpose, wrap routes in the shared shell/auth-layout. This doc exists because clarity & shops drifted "flat" by ignoring it while the dashboard didn't — don't repeat that. For per-dashboard design lineage (all 8 dashboards categorized into design families; why youtube/dev-dashboard diverge) see `.claude/docs/design-system-dashboards.md`; for the canonical ports/launch registry + conflict detection see `src/utils/ui/dashboards.ts`.
 
+## Working on `tools du` (`src/du/`)
+
+**Before touching ANYTHING under `src/du/`, read `.claude/docs/benchmarks-du.md`, and append a new dated section to it for every feature you add.** The native core (`src/du/native/clonesize.c`) is syscall-bound and runs in the hot loop of multi-million-file scans, so an unmeasured feature is a silent regression. Measure with `src/du/native/bench.sh <label>` (fixed target matrix + hyperfine), record system CPU time as the primary metric (wall time on this machine swings with load average — always note `uptime`), and diff the `--json` byte totals to prove the change was performance-only.
+
 ## Code Style Rules
 
 - **Fix bugs at the root, not at every call site.** When the same issue appears in multiple places because of a shared function, fix the shared function — don't patch each caller individually. One fix at the source beats N fixes at the edges.

--- a/src/du/index.ts
+++ b/src/du/index.ts
@@ -1,17 +1,30 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { runTool } from "@genesiscz/utils/cli";
-import { out } from "@genesiscz/utils/logger";
+import { parseDuration } from "@genesiscz/utils/format";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger, out } from "@genesiscz/utils/logger";
+import { Storage } from "@genesiscz/utils/storage";
 import { Command, InvalidArgumentError, Option } from "commander";
 import pc from "picocolors";
 import { scanWithBun } from "./lib/bun-scan";
-import { scanWithC, scanWithCFfi } from "./lib/engine";
-import { humanBytes, renderHuman, renderTree } from "./lib/format";
+import { readVolumeInfo, scanPartners, scanWithC, scanWithCFfi } from "./lib/engine";
+import { diffScans, humanBytes, renderDiff, renderHuman, renderPartners, renderTree, renderVolume } from "./lib/format";
 import type { ClonesizeResult, Engine, ScanOptions } from "./lib/types";
 import { detectWorktreeExcludes } from "./lib/worktrees";
 
 const program = new Command();
+const storage = new Storage("du");
+
+/**
+ * Extent-cache directory. One file per volume lives here, keyed by fsid, so a
+ * single cache serves every scan root on that volume (fileids are volume-wide).
+ */
+async function cacheDir(): Promise<string> {
+    await storage.ensureDirs();
+    return storage.getCacheDir();
+}
 
 program
     .name("tools du")
@@ -39,6 +52,18 @@ function intOpt(name: string, opts: { min?: number; max?: number } = {}) {
         }
 
         return n;
+    };
+}
+
+/** `--changed-within 7d` → the epoch-second cutoff the native core filters on. */
+function durationToCutoff(name: string) {
+    return (v: string): number => {
+        const ms = parseDuration(v);
+        if (ms <= 0) {
+            throw new InvalidArgumentError(`${name} must be a duration like 24h, 7d or 30m (got "${v}").`);
+        }
+
+        return Math.floor((Date.now() - ms) / 1000);
     };
 }
 
@@ -91,6 +116,18 @@ program
     .option("--depth <n>", "Per-directory tree down to depth N (du -d N style)", intOpt("--depth", { min: 0 }))
     .option("--freeable-tree", "Per-node ATTR_CMNEXT_PRIVATESIZE in the --depth tree (implies --depth 1)")
     .option("--ignore-worktrees", "Auto-detect and exclude git worktrees + .worktrees/ dirs")
+    .option(
+        "--changed-within <duration>",
+        "Only count files modified within this window (7d, 24h, 30m) — 'what grew', not 'what is big'",
+        durationToCutoff("--changed-within")
+    )
+    .option("--no-cache", "Ignore the extent cache when reading. It is still written, so the NEXT run is warm.")
+    .option(
+        "--include-cloud",
+        "Also walk ~/Library/CloudStorage and iCloud Drive. Slow, and reading a placeholder can download it."
+    )
+    .option("--save <file>", "Write the raw JSON result to a file (pairs with --diff on a later run)")
+    .option("--diff <file>", "Compare against a previously --saved scan and print the per-directory delta")
     .addHelpText(
         "after",
         [
@@ -100,6 +137,13 @@ program
             "  tools du clonesize ~/repo --ignore-worktrees  # skip sibling worktrees",
             "  tools du clonesize ~/repo --format json       # machine-readable",
             "  tools du clonesize ~/repo --engine bun        # independent Bun impl",
+            "  tools du clonesize ~ --depth 1 --changed-within 7d   # what actually grew this week",
+            "  tools du clonesize ~ --depth 2 --save mon.json       # ... then, days later:",
+            "  tools du clonesize ~ --depth 2 --diff mon.json       # per-dir grown/shrunk/new/gone",
+            "",
+            "Repeat scans are served from an extent cache in ~/.genesis-tools/du/cache: a file",
+            "whose (id, mtime, size, allocation) is unchanged cannot have moved blocks, so its",
+            "extent map is reused instead of re-opened. On this repo that is ~3x faster.",
             "",
             "Point it at the PARENT of several worktrees to see how much they clone-share.",
             "Key truth: deleting a worktree frees only its *unique* blocks — blocks it",
@@ -119,6 +163,11 @@ program
                 depth?: number;
                 freeableTree?: boolean;
                 ignoreWorktrees?: boolean;
+                changedWithin?: number;
+                cache: boolean;
+                includeCloud?: boolean;
+                save?: string;
+                diff?: string;
             }
         ) => {
             const root = assertDir(dir);
@@ -136,7 +185,13 @@ program
                 process.exit(2);
             }
 
-            const depth = o.freeableTree && o.depth === undefined ? 1 : o.depth;
+            if (o.changedWithin !== undefined && o.engine === "bun") {
+                out.error("--changed-within is only supported by the C engines (--engine c-ffi or c).");
+                process.exit(2);
+            }
+
+            // A diff is per-directory, so it needs the tree on both sides.
+            const depth = (o.freeableTree || o.diff !== undefined) && o.depth === undefined ? 1 : o.depth;
 
             const exclude = o.ignoreWorktrees ? await detectWorktreeExcludes(root) : [];
             if (o.ignoreWorktrees && exclude.length > 0) {
@@ -154,9 +209,53 @@ program
                 depth,
                 freeableTree: o.freeableTree,
                 exclude,
+                changedSince: o.changedWithin,
+                cacheDir: o.engine === "bun" ? undefined : await cacheDir(),
+                noCache: !o.cache,
+                includeCloud: o.includeCloud,
             };
 
             const { result, ms } = await runScan(scanOpts, o.engine);
+
+            if (o.save) {
+                const savePath = resolve(o.save);
+                await Bun.write(savePath, SafeJSON.stringify(result, null, 2));
+                logger.debug({ savePath, nodes: result.nodes?.length ?? 0 }, "du: saved scan snapshot");
+                out.log.success(`Saved scan to ${savePath}`);
+            }
+
+            if (o.diff) {
+                const diffPath = resolve(o.diff);
+                if (!existsSync(diffPath)) {
+                    out.error(`No such snapshot: ${diffPath}`);
+                    process.exit(1);
+                }
+
+                const before = SafeJSON.parse(await Bun.file(diffPath).text()) as ClonesizeResult;
+
+                // Rows are matched on absolute node path, so a snapshot of another root
+                // (or one saved without --depth) diffs to "everything is new", not to an
+                // error. Both are meaningless numbers presented as a real delta.
+                if (before.path !== result.path) {
+                    out.error(
+                        `${diffPath} is a scan of ${before.path}, not ${result.path}. A diff needs the same root on both sides.`
+                    );
+                    process.exit(2);
+                }
+
+                if (!before.nodes || before.nodes.length === 0) {
+                    out.error(`${diffPath} has no per-directory tree. Re-save it with --depth N to diff against it.`);
+                    process.exit(2);
+                }
+
+                const rows = diffScans(before, result);
+                if (o.format === "json") {
+                    out.result({ before: before.path, after: result.path, rows });
+                } else {
+                    out.println(renderDiff(before, result, rows));
+                }
+                return;
+            }
 
             if (o.format === "json") {
                 out.result({ ...result, engine: o.engine, elapsed_ms: Math.round(ms) });
@@ -167,6 +266,113 @@ program
             }
         }
     );
+
+// ---------------------------------------------------------------------------
+// volume
+// ---------------------------------------------------------------------------
+program
+    .command("volume")
+    .description("Reconcile a whole volume: APFS used-bytes vs what a scan can actually see")
+    .argument("[mount]", "Volume mount point", "/System/Volumes/Data")
+    .addOption(new Option("--format <fmt>", "Output format").choices(["human", "json"]).default("human"))
+    .option("--threads <n>", "Worker threads (default: number of CPUs)", intOpt("--threads", { min: 1, max: 1024 }))
+    .option("--depth <n>", "Also print a per-directory tree down to depth N", intOpt("--depth", { min: 0 }))
+    .option("--include-cloud", "Also walk cloud-provider roots (slow; reading a placeholder can download it)")
+    .addHelpText(
+        "after",
+        [
+            "",
+            "Answers 'my disk says 97% full — where is it?'. The scan is compared against",
+            "ATTR_VOL_SPACEUSED, the same number diskutil prints as 'Volume Used Space',",
+            "so anything the walk could not read shows up as an explicit UNACCOUNTED line",
+            "instead of silently vanishing from the total.",
+            "",
+            "  tools du volume                       # the Data volume",
+            "  sudo tools du volume                  # ... including root-only subtrees",
+        ].join("\n")
+    )
+    .action(
+        async (
+            mount: string,
+            o: { format: "human" | "json"; threads?: number; depth?: number; includeCloud?: boolean }
+        ) => {
+            const root = assertDir(mount);
+            const vol = readVolumeInfo(root);
+            logger.debug({ mount: root, used: vol.used_bytes }, "du: read volume attributes");
+
+            out.log.info(`Scanning ${root} — a whole volume takes minutes, not seconds.`);
+            const { result, ms } = await runScan(
+                {
+                    path: root,
+                    threads: o.threads,
+                    depth: o.depth,
+                    cacheDir: await cacheDir(),
+                    includeCloud: o.includeCloud,
+                },
+                "c-ffi"
+            );
+
+            if (o.format === "json") {
+                const scanned = result.unique_allocated_bytes ?? result.unique_bytes;
+                out.result({ volume: vol, scan: result, unaccounted_bytes: vol.used_bytes - scanned });
+                return;
+            }
+
+            out.println(renderVolume(vol, result, ms));
+            if (o.depth !== undefined && result.nodes && result.nodes.length > 0) {
+                out.println("");
+                out.println(renderTree(result, "c-ffi", ms));
+            }
+        }
+    );
+
+// ---------------------------------------------------------------------------
+// clones
+// ---------------------------------------------------------------------------
+program
+    .command("clones")
+    .description("Find WHERE ELSE a directory's blocks live — the concrete clone partners")
+    .argument("<dir>", "Directory whose shared blocks to trace")
+    .option("--against <root>", "Where to search for partners (default: the dir's parent)")
+    .addOption(new Option("--format <fmt>", "Output format").choices(["human", "json"]).default("human"))
+    .option("--threads <n>", "Worker threads (default: number of CPUs)", intOpt("--threads", { min: 1, max: 1024 }))
+    .option("--top <n>", "Rows to show (default 30)", intOpt("--top", { min: 1 }))
+    .addHelpText(
+        "after",
+        [
+            "",
+            "`clonesize` tells you a dir shares N bytes with something. This tells you WITH WHAT.",
+            "That is the question that decides whether a package-manager cache is safe to delete:",
+            "blocks a live node_modules still references are not freed by deleting the cache.",
+            "",
+            "  tools du clones ~/.bun --against ~/Projects",
+            "  tools du clones ~/repo/.worktrees/feat-x --against ~/repo",
+        ].join("\n")
+    )
+    .action(async (dir: string, o: { against?: string; format: "human" | "json"; threads?: number; top?: number }) => {
+        const target = assertDir(dir);
+        const searchRoot = assertDir(o.against ?? resolve(target, ".."));
+
+        // Not a prefix compare: /tmp/root is a prefix of the unrelated /tmp/root-other.
+        const rel = relative(searchRoot, target);
+        const contained = rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
+        if (!contained) {
+            out.error(`--against ${searchRoot} does not contain ${target}.`);
+            process.exit(2);
+        }
+
+        const t0 = performance.now();
+        const result = scanPartners({ target, root: searchRoot, threads: o.threads, top: o.top });
+        const ms = performance.now() - t0;
+        logger.debug({ target, searchRoot, partners: result.partner_files_total }, "du: partner scan complete");
+
+        if (o.format === "json") {
+            out.result({ ...result, elapsed_ms: Math.round(ms) });
+            return;
+        }
+
+        out.println(renderPartners(result, ms));
+    });
 
 // ---------------------------------------------------------------------------
 // bench

--- a/src/du/index.ts
+++ b/src/du/index.ts
@@ -2,15 +2,15 @@ import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import { runTool } from "@genesiscz/utils/cli";
-import { parseDuration } from "@genesiscz/utils/format";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
 import { Storage } from "@genesiscz/utils/storage";
-import { Command, InvalidArgumentError, Option } from "commander";
+import { Command, Option } from "commander";
 import pc from "picocolors";
 import { scanWithBun } from "./lib/bun-scan";
 import { readVolumeInfo, scanPartners, scanWithC, scanWithCFfi } from "./lib/engine";
 import { diffScans, humanBytes, renderDiff, renderHuman, renderPartners, renderTree, renderVolume } from "./lib/format";
+import { durationToCutoff, intOpt } from "./lib/options";
 import type { ClonesizeResult, Engine, ScanOptions } from "./lib/types";
 import { detectWorktreeExcludes } from "./lib/worktrees";
 
@@ -35,37 +35,6 @@ program
             "its full size even though clones share physical blocks."
     )
     .version("0.1.0");
-
-function intOpt(name: string, opts: { min?: number; max?: number } = {}) {
-    return (v: string): number => {
-        const n = Number.parseInt(v, 10);
-        if (!Number.isFinite(n) || String(n) !== v.trim()) {
-            throw new InvalidArgumentError(`${name} must be an integer (got "${v}").`);
-        }
-
-        if (opts.min !== undefined && n < opts.min) {
-            throw new InvalidArgumentError(`${name} must be >= ${opts.min}.`);
-        }
-
-        if (opts.max !== undefined && n > opts.max) {
-            throw new InvalidArgumentError(`${name} must be <= ${opts.max}.`);
-        }
-
-        return n;
-    };
-}
-
-/** `--changed-within 7d` → the epoch-second cutoff the native core filters on. */
-function durationToCutoff(name: string) {
-    return (v: string): number => {
-        const ms = parseDuration(v);
-        if (ms <= 0) {
-            throw new InvalidArgumentError(`${name} must be a duration like 24h, 7d or 30m (got "${v}").`);
-        }
-
-        return Math.floor((Date.now() - ms) / 1000);
-    };
-}
 
 function assertDir(dir: string): string {
     const root = resolve(dir);

--- a/src/du/lib/cache.test.ts
+++ b/src/du/lib/cache.test.ts
@@ -25,6 +25,10 @@ const NRECS_OFFSET = 24;
 const NEXTS_OFFSET = 32;
 /** CacheEnt: fileid, mtime_ns, dlen, alloc, ext_off (8 each) + ext_count, last_seen (4 each). */
 const CACHE_ENT_BYTES = 48;
+/** Offset of `ext_off` within a CacheEnt, and of the first record within the file. */
+const ENT_EXT_OFF_OFFSET = 32;
+const FIRST_RECORD_OFFSET = HEADER_BYTES;
+const UINT64_MAX = (1n << 64n) - 1n;
 /** Mirrors CACHE_MAX_RECS in clonesize.c. */
 const CACHE_MAX_RECS = 2_000_000;
 const FORGED_RECS = CACHE_MAX_RECS - 1;
@@ -221,6 +225,35 @@ describe.skipIf(!isDarwin)("extent cache", () => {
             expect(after.unique_bytes).toBe(CLONE_BYTES);
         }, 60_000);
     }
+
+    it("rejects an entry whose extent range wraps past the end of the blob", () => {
+        // Per-ENTRY counterpart to the header checks above. `ext_off + ext_count`
+        // wraps a 64-bit sum back under g_cache_nexts, so the old check accepted a
+        // forged offset and read extents from outside the declared region. It did
+        // not crash — the pointer arithmetic wrapped too and landed inside the
+        // mapping — it just reported garbage: this exact fixture came back with
+        // unique_bytes = 7,667,827,374,364,295,172 (7.7 EB from 12 MB of files).
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+
+        scan(fixture, cacheDir, true);
+        const cacheFile = join(cacheDir, readdirSync(cacheDir).find((f) => f.startsWith("extents-"))!);
+
+        // Leave the identity fields intact so the lookup still matches this record
+        // and reaches the bounds check that is under test.
+        const buf = readFileSync(cacheFile);
+        buf.writeBigUInt64LE(UINT64_MAX, FIRST_RECORD_OFFSET + ENT_EXT_OFF_OFFSET);
+        writeFileSync(cacheFile, buf);
+
+        const after = scan(fixture, cacheDir);
+
+        // Only the poisoned record is dropped: its file is re-read from disk while
+        // the other two are still served from the cache. Rejecting one entry must
+        // not throw the whole cache away.
+        expect(after.files_cached).toBe(2);
+        expect(after.files_opened).toBe(1);
+        expect(after.unique_bytes).toBe(CLONE_BYTES);
+    }, 60_000);
 
     it("keeps records for files outside the scanned subtree when it rewrites", () => {
         // The cache is per VOLUME, so a scan of one subtree must merge its records

--- a/src/du/lib/cache.test.ts
+++ b/src/du/lib/cache.test.ts
@@ -132,11 +132,11 @@ describe.skipIf(!isDarwin)("extent cache", () => {
     }, 60_000);
 
     it("rejects a record count the file is too small to hold", () => {
-        // cache_open multiplies the header's counts back out and drops the cache when
-        // they exceed the file, so an inconsistent or truncated file can never be
-        // trusted into an out-of-bounds read. Note this is a CONSISTENCY check, not a
-        // ceiling on the count itself — see the eviction test below for a header that
-        // claims just as much and is padded to back it up.
+        // cache_open bounds each count by DIVIDING the space that is actually there,
+        // so an inconsistent or truncated file is dropped. This is a CONSISTENCY
+        // check, not a ceiling on the count itself — see the eviction test below for
+        // a header that claims just as much and is padded to back it up. For counts
+        // large enough to overflow the arithmetic, see the overflow tests after it.
         const fixture = makeCloneFixture();
         const cacheDir = makeTmp("du-cache-dir-");
 
@@ -185,6 +185,42 @@ describe.skipIf(!isDarwin)("extent cache", () => {
         // 1,999,999 carried over + 3 fresh = 2,000,002, truncated back to the cap.
         expect(readFileSync(cacheFile).readBigUInt64LE(NRECS_OFFSET)).toBe(BigInt(CACHE_MAX_RECS));
     }, 60_000);
+
+    // Counts big enough to wrap the size arithmetic. Before cache_open validated by
+    // division, `nrecs * sizeof(CacheEnt)` was computed first and wrapped a 64-bit
+    // size_t, so these headers passed the check and cache_lookup binary-searched far
+    // past the end of the mapping — `nrecs = 2^60` segfaulted the scan (exit 139).
+    // Each case must now be rejected, leaving the scan to read the filesystem.
+    const OVERFLOW_HEADERS: [name: string, nrecs: bigint, nexts: bigint][] = [
+        // 48 * 2^60 == 3 * 2^64, i.e. the record term wraps to EXACTLY zero.
+        ["record count wrapping to zero", 1n << 60n, 0n],
+        ["record count at UINT64_MAX", (1n << 64n) - 1n, 0n],
+        ["extent count at UINT64_MAX", 3n, (1n << 64n) - 1n],
+        ["both counts oversized", 1n << 60n, (1n << 64n) - 1n],
+    ];
+
+    for (const [name, nrecs, nexts] of OVERFLOW_HEADERS) {
+        it(`rejects a ${name} instead of reading past the mapping`, () => {
+            const fixture = makeCloneFixture();
+            const cacheDir = makeTmp("du-cache-dir-");
+
+            scan(fixture, cacheDir, true);
+            const cacheFile = join(cacheDir, readdirSync(cacheDir).find((f) => f.startsWith("extents-"))!);
+
+            const buf = readFileSync(cacheFile);
+            buf.writeBigUInt64LE(nrecs, NRECS_OFFSET);
+            buf.writeBigUInt64LE(nexts, NEXTS_OFFSET);
+            writeFileSync(cacheFile, buf);
+
+            // Reaching this line at all is most of the assertion: the pre-fix binary
+            // died with SIGSEGV here rather than returning a result.
+            const after = scan(fixture, cacheDir);
+
+            expect(after.files_cached).toBe(0);
+            expect(after.files_opened).toBe(3);
+            expect(after.unique_bytes).toBe(CLONE_BYTES);
+        }, 60_000);
+    }
 
     it("keeps records for files outside the scanned subtree when it rewrites", () => {
         // The cache is per VOLUME, so a scan of one subtree must merge its records

--- a/src/du/lib/cache.test.ts
+++ b/src/du/lib/cache.test.ts
@@ -1,0 +1,150 @@
+// Extent-cache correctness. The cache skips open()+fcntl(F_LOG2PHYS_EXT) for any
+// file whose (fileid, mtime, dlen, alloc) is unchanged, which is ~60% of a scan's
+// cost — so a stale hit would silently report wrong bytes rather than fail. These
+// tests pin the hit/miss/invalidate/corrupt paths against ground truth taken with
+// the cache read disabled.
+//
+// Darwin-only: the fixture needs clonefile(2) (`cp -c`) and the engine needs
+// getattrlistbulk + F_LOG2PHYS_EXT. CI runs ubuntu, where these are skipped.
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanWithCFfi } from "./engine";
+import type { ClonesizeResult } from "./types";
+
+const isDarwin = process.platform === "darwin";
+const CLONE_MB = 4;
+const CLONE_BYTES = CLONE_MB * 1024 * 1024;
+
+const tmpDirs: string[] = [];
+
+function makeTmp(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+}
+
+/** One 4 MB file plus two APFS clones of it — 12 MB naive, 4 MB real. */
+function makeCloneFixture(): string {
+    const fixture = makeTmp("du-cache-fix-");
+    const orig = join(fixture, "orig.bin");
+    writeFileSync(orig, Buffer.alloc(CLONE_BYTES, "x"));
+    execFileSync("cp", ["-c", orig, join(fixture, "clone1.bin")]);
+    execFileSync("cp", ["-c", orig, join(fixture, "clone2.bin")]);
+    return fixture;
+}
+
+function scan(path: string, cacheDir: string, noCache = false): ClonesizeResult {
+    return scanWithCFfi({ path, cacheDir, noCache });
+}
+
+/** What the scan reports with the cache read disabled — the reference answer. */
+function groundTruth(path: string): ClonesizeResult {
+    return scanWithCFfi({ path });
+}
+
+afterAll(() => {
+    for (const dir of tmpDirs) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe.skipIf(!isDarwin)("extent cache", () => {
+    it("writes on a cold run and serves every file from the cache on the next one", () => {
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+
+        // --no-cache writes the cache but never reads it: the honest cold run.
+        const cold = scan(fixture, cacheDir, true);
+        expect(cold.files_scanned).toBe(3);
+        expect(cold.files_opened).toBe(3);
+        expect(cold.files_cached).toBe(0);
+        // Guards the fixture itself: if `cp -c` had fallen back to a full copy,
+        // unique would equal naive and every assertion below would be vacuous.
+        expect(cold.naive_bytes).toBe(3 * CLONE_BYTES);
+        expect(cold.unique_bytes).toBe(CLONE_BYTES);
+
+        const warm = scan(fixture, cacheDir);
+        expect(warm.files_opened).toBe(0);
+        expect(warm.files_cached).toBe(3);
+
+        // The point of the cache is that skipping the syscalls changes nothing.
+        expect(warm.unique_bytes).toBe(cold.unique_bytes);
+        expect(warm.naive_bytes).toBe(cold.naive_bytes);
+        expect(warm.unique_allocated_bytes).toBe(cold.unique_allocated_bytes);
+        expect(warm.shared_bytes).toBe(cold.shared_bytes);
+        expect(warm.extents).toBe(cold.extents);
+        expect(warm.files_scanned).toBe(cold.files_scanned);
+    }, 60_000);
+
+    it("drops a file that was rewritten in place and re-reads the truth", () => {
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+
+        scan(fixture, cacheDir, true);
+        expect(scan(fixture, cacheDir).files_cached).toBe(3);
+
+        // Rewriting a clone breaks its block sharing AND bumps its mtime, so its
+        // cache entry must not be trusted: real unique bytes go 4 MB -> 8 MB.
+        writeFileSync(join(fixture, "clone1.bin"), Buffer.alloc(CLONE_BYTES, "y"));
+
+        const warm = scan(fixture, cacheDir);
+        const truth = groundTruth(fixture);
+
+        expect(warm.files_cached).toBe(2);
+        expect(warm.unique_bytes).toBe(truth.unique_bytes);
+        expect(warm.unique_bytes).toBe(2 * CLONE_BYTES);
+        expect(warm.naive_bytes).toBe(truth.naive_bytes);
+        expect(warm.unique_allocated_bytes).toBe(truth.unique_allocated_bytes);
+    }, 60_000);
+
+    it("ignores a corrupted cache file instead of trusting or crashing on it", () => {
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+
+        scan(fixture, cacheDir, true);
+        const files = readdirSync(cacheDir).filter((f) => f.startsWith("extents-"));
+        expect(files.length).toBe(1);
+
+        // Garbage fails the magic/version/fsid/size header check in cache_open.
+        writeFileSync(join(cacheDir, files[0]!), "GARBAGE".repeat(64));
+
+        const after = scan(fixture, cacheDir);
+        const truth = groundTruth(fixture);
+
+        expect(after.files_cached).toBe(0);
+        expect(after.files_opened).toBe(3);
+        expect(after.unique_bytes).toBe(truth.unique_bytes);
+        expect(after.naive_bytes).toBe(truth.naive_bytes);
+    }, 60_000);
+
+    it("keeps records for files outside the scanned subtree when it rewrites", () => {
+        // The cache is per VOLUME, so a scan of one subtree must merge its records
+        // into the existing file rather than truncating it to that subtree —
+        // otherwise alternating scan roots would never stay warm.
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+        const sub = join(fixture, "sub");
+        mkdirSync(sub);
+        execFileSync("cp", ["-c", join(fixture, "orig.bin"), join(sub, "deep.bin")]);
+
+        scan(fixture, cacheDir, true);
+
+        // A fully-warm scan skips the rewrite entirely (clonesize.c: `opened == 0`),
+        // which would make this test vacuous. Add an unseen file so the subtree scan
+        // takes a miss, opens it, and genuinely rewrites the cache.
+        execFileSync("cp", ["-c", join(fixture, "orig.bin"), join(sub, "fresh.bin")]);
+
+        const subScan = scan(sub, cacheDir);
+        expect(subScan.files_opened).toBeGreaterThan(0);
+
+        // The parent's three records were NOT part of that scan; they must survive.
+        const warmParent = scan(fixture, cacheDir);
+        expect(warmParent.files_scanned).toBe(5);
+        expect(warmParent.files_opened).toBe(0);
+        expect(warmParent.files_cached).toBe(5);
+    }, 60_000);
+});

--- a/src/du/lib/cache.test.ts
+++ b/src/du/lib/cache.test.ts
@@ -193,14 +193,14 @@ describe.skipIf(!isDarwin)("extent cache", () => {
     // Each case must now be rejected, leaving the scan to read the filesystem.
     const OVERFLOW_HEADERS: [name: string, nrecs: bigint, nexts: bigint][] = [
         // 48 * 2^60 == 3 * 2^64, i.e. the record term wraps to EXACTLY zero.
-        ["record count wrapping to zero", 1n << 60n, 0n],
-        ["record count at UINT64_MAX", (1n << 64n) - 1n, 0n],
-        ["extent count at UINT64_MAX", 3n, (1n << 64n) - 1n],
+        ["a record count wrapping to zero", 1n << 60n, 0n],
+        ["a record count at UINT64_MAX", (1n << 64n) - 1n, 0n],
+        ["an extent count at UINT64_MAX", 3n, (1n << 64n) - 1n],
         ["both counts oversized", 1n << 60n, (1n << 64n) - 1n],
     ];
 
     for (const [name, nrecs, nexts] of OVERFLOW_HEADERS) {
-        it(`rejects a ${name} instead of reading past the mapping`, () => {
+        it(`rejects ${name} instead of reading past the mapping`, () => {
             const fixture = makeCloneFixture();
             const cacheDir = makeTmp("du-cache-dir-");
 

--- a/src/du/lib/cache.test.ts
+++ b/src/du/lib/cache.test.ts
@@ -9,7 +9,7 @@
 
 import { afterAll, describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { scanWithCFfi } from "./engine";
@@ -18,6 +18,9 @@ import type { ClonesizeResult } from "./types";
 const isDarwin = process.platform === "darwin";
 const CLONE_MB = 4;
 const CLONE_BYTES = CLONE_MB * 1024 * 1024;
+
+/** Byte offset of `nrecs` in CacheHeader: magic(8) version(4) reserved(4) fsid(8). */
+const NRECS_OFFSET = 24;
 
 const tmpDirs: string[] = [];
 
@@ -119,6 +122,31 @@ describe.skipIf(!isDarwin)("extent cache", () => {
         expect(after.files_opened).toBe(3);
         expect(after.unique_bytes).toBe(truth.unique_bytes);
         expect(after.naive_bytes).toBe(truth.naive_bytes);
+    }, 60_000);
+
+    it("rejects a forged record count instead of reading past the end of the file", () => {
+        // A header claiming more records than the file can hold is the cheap way to
+        // try to reach the CACHE_MAX_RECS eviction branch without writing 2M files.
+        // It does not work, and that is the point: cache_open computes the bytes the
+        // header implies and drops the whole cache when they exceed the file size, so
+        // a bloated count can never be trusted into an out-of-bounds read.
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+
+        scan(fixture, cacheDir, true);
+        const cacheFile = join(cacheDir, readdirSync(cacheDir).find((f) => f.startsWith("extents-"))!);
+
+        const buf = readFileSync(cacheFile);
+        expect(buf.readBigUInt64LE(NRECS_OFFSET)).toBe(3n);
+        buf.writeBigUInt64LE(1_999_999n, NRECS_OFFSET);
+        writeFileSync(cacheFile, buf);
+
+        const after = scan(fixture, cacheDir);
+        const truth = groundTruth(fixture);
+
+        expect(after.files_cached).toBe(0);
+        expect(after.files_opened).toBe(3);
+        expect(after.unique_bytes).toBe(truth.unique_bytes);
     }, 60_000);
 
     it("keeps records for files outside the scanned subtree when it rewrites", () => {

--- a/src/du/lib/cache.test.ts
+++ b/src/du/lib/cache.test.ts
@@ -19,8 +19,15 @@ const isDarwin = process.platform === "darwin";
 const CLONE_MB = 4;
 const CLONE_BYTES = CLONE_MB * 1024 * 1024;
 
-/** Byte offset of `nrecs` in CacheHeader: magic(8) version(4) reserved(4) fsid(8). */
+// CacheHeader layout: magic(8) version(4) reserved(4) fsid(8) nrecs(8) nexts(8).
+const HEADER_BYTES = 40;
 const NRECS_OFFSET = 24;
+const NEXTS_OFFSET = 32;
+/** CacheEnt: fileid, mtime_ns, dlen, alloc, ext_off (8 each) + ext_count, last_seen (4 each). */
+const CACHE_ENT_BYTES = 48;
+/** Mirrors CACHE_MAX_RECS in clonesize.c. */
+const CACHE_MAX_RECS = 2_000_000;
+const FORGED_RECS = CACHE_MAX_RECS - 1;
 
 const tmpDirs: string[] = [];
 
@@ -124,12 +131,12 @@ describe.skipIf(!isDarwin)("extent cache", () => {
         expect(after.naive_bytes).toBe(truth.naive_bytes);
     }, 60_000);
 
-    it("rejects a forged record count instead of reading past the end of the file", () => {
-        // A header claiming more records than the file can hold is the cheap way to
-        // try to reach the CACHE_MAX_RECS eviction branch without writing 2M files.
-        // It does not work, and that is the point: cache_open computes the bytes the
-        // header implies and drops the whole cache when they exceed the file size, so
-        // a bloated count can never be trusted into an out-of-bounds read.
+    it("rejects a record count the file is too small to hold", () => {
+        // cache_open multiplies the header's counts back out and drops the cache when
+        // they exceed the file, so an inconsistent or truncated file can never be
+        // trusted into an out-of-bounds read. Note this is a CONSISTENCY check, not a
+        // ceiling on the count itself — see the eviction test below for a header that
+        // claims just as much and is padded to back it up.
         const fixture = makeCloneFixture();
         const cacheDir = makeTmp("du-cache-dir-");
 
@@ -147,6 +154,36 @@ describe.skipIf(!isDarwin)("extent cache", () => {
         expect(after.files_cached).toBe(0);
         expect(after.files_opened).toBe(3);
         expect(after.unique_bytes).toBe(truth.unique_bytes);
+    }, 60_000);
+
+    it("evicts down to CACHE_MAX_RECS when the merged set overflows", () => {
+        // Reaching eviction by writing 2M real files would take minutes. A cache that
+        // *claims* 1,999,999 records and is padded to actually hold them passes
+        // cache_open's size check, so the merge (1,999,999 carried over + this run's
+        // records) crosses CACHE_MAX_RECS and the recency truncation has to fire.
+        const fixture = makeCloneFixture();
+        const cacheDir = makeTmp("du-cache-dir-");
+
+        scan(fixture, cacheDir, true);
+        const cacheFile = join(cacheDir, readdirSync(cacheDir).find((f) => f.startsWith("extents-"))!);
+
+        // Keep the real magic/version/fsid so the file is accepted, then claim 1,999,999
+        // zeroed records (fileid 0, last_seen 0) and no extents.
+        const header = readFileSync(cacheFile).subarray(0, HEADER_BYTES);
+        header.writeBigUInt64LE(BigInt(FORGED_RECS), NRECS_OFFSET);
+        header.writeBigUInt64LE(0n, NEXTS_OFFSET);
+        writeFileSync(cacheFile, Buffer.concat([header, Buffer.alloc(FORGED_RECS * CACHE_ENT_BYTES)]));
+
+        const after = scan(fixture, cacheDir);
+
+        // The forged records match no real file, so everything is read from disk and
+        // the totals stay correct through the whole exercise.
+        expect(after.files_cached).toBe(0);
+        expect(after.files_opened).toBe(3);
+        expect(after.unique_bytes).toBe(CLONE_BYTES);
+
+        // 1,999,999 carried over + 3 fresh = 2,000,002, truncated back to the cap.
+        expect(readFileSync(cacheFile).readBigUInt64LE(NRECS_OFFSET)).toBe(BigInt(CACHE_MAX_RECS));
     }, 60_000);
 
     it("keeps records for files outside the scanned subtree when it rewrites", () => {

--- a/src/du/lib/engine.ts
+++ b/src/du/lib/engine.ts
@@ -104,6 +104,15 @@ function openLib() {
         //                          int depth, int freeable_tree,
         //                          unsigned long long changed_since,
         //                          const char* cache_dir, int cache_read, int include_cloud)
+        //
+        // Sentinels the C side expects, none of which are valid values:
+        //   threads       0  => auto (ncpu)
+        //   min_bytes     0  => keep every file
+        //   depth        -1  => no per-directory tree
+        //   changed_since 0  => mtime filter OFF (g_mtime_min in clonesize.c). NOT
+        //                       "epoch zero": a real cutoff is always > 0, and the
+        //                       CLI rejects a zero-length window before reaching here.
+        //   cache_dir  NULL  => extent cache disabled entirely
         clonesize_run_json: {
             args: [
                 FFIType.ptr,

--- a/src/du/lib/engine.ts
+++ b/src/du/lib/engine.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { profiler } from "@genesiscz/utils/profile";
-import type { ClonesizeResult, ScanOptions } from "./types";
+import type { ClonesizeResult, PartnersResult, ScanOptions, VolumeInfo } from "./types";
 
 const prof = profiler.scope("du.engine");
 
@@ -101,7 +101,9 @@ function openLib() {
         // char* clonesize_run_json(const char* path, int threads, int freeable,
         //                          unsigned long long min_bytes,
         //                          const char* const* excludes, int nexcludes,
-        //                          int depth, int freeable_tree)
+        //                          int depth, int freeable_tree,
+        //                          unsigned long long changed_since,
+        //                          const char* cache_dir, int cache_read, int include_cloud)
         clonesize_run_json: {
             args: [
                 FFIType.ptr,
@@ -112,7 +114,18 @@ function openLib() {
                 FFIType.i32,
                 FFIType.i32,
                 FFIType.i32,
+                FFIType.u64,
+                FFIType.ptr,
+                FFIType.i32,
+                FFIType.i32,
             ],
+            returns: FFIType.ptr,
+        },
+        // char* clonesize_volume_json(const char* mount)
+        clonesize_volume_json: { args: [FFIType.ptr], returns: FFIType.ptr },
+        // char* clonesize_partners_json(const char* target, const char* root, int threads, int topn)
+        clonesize_partners_json: {
+            args: [FFIType.ptr, FFIType.ptr, FFIType.i32, FFIType.i32],
             returns: FFIType.ptr,
         },
         clonesize_free: { args: [FFIType.ptr], returns: FFIType.void },
@@ -145,6 +158,7 @@ export function scanWithCFfi(opts: ScanOptions): ClonesizeResult {
     }
 
     const pathBuf = Buffer.from(`${opts.path}\0`, "utf8");
+    const cacheBuf = opts.cacheDir ? Buffer.from(`${opts.cacheDir}\0`, "utf8") : null;
 
     const end = prof.start("c-ffi.run");
     const resPtr = symbols.clonesize_run_json(
@@ -155,7 +169,11 @@ export function scanWithCFfi(opts: ScanOptions): ClonesizeResult {
         exBufs.length > 0 ? ptr(exPtrs) : null,
         exBufs.length,
         opts.depth !== undefined && opts.depth >= 0 ? opts.depth : -1,
-        opts.freeableTree ? 1 : 0
+        opts.freeableTree ? 1 : 0,
+        BigInt(opts.changedSince && opts.changedSince > 0 ? opts.changedSince : 0),
+        cacheBuf ? ptr(cacheBuf) : null,
+        opts.noCache ? 0 : 1,
+        opts.includeCloud ? 1 : 0
     );
     end();
 
@@ -165,9 +183,51 @@ export function scanWithCFfi(opts: ScanOptions): ClonesizeResult {
 
     const json = new CString(resPtr).toString();
     symbols.clonesize_free(resPtr);
-    // keep exBufs alive until here
+    // keep the arg buffers alive until here
     void exBufs;
+    void cacheBuf;
     return SafeJSON.parse(json) as ClonesizeResult;
+}
+
+/** Read the volume's authoritative used/free bytes (ATTR_VOL_*) for a mount point. */
+export function readVolumeInfo(mount: string): VolumeInfo {
+    const { symbols } = getLib();
+    const buf = Buffer.from(`${mount}\0`, "utf8");
+    const resPtr = symbols.clonesize_volume_json(ptr(buf));
+    if (!resPtr) {
+        throw new Error(`Could not read volume attributes for ${mount} (is it a mount point?)`);
+    }
+
+    const json = new CString(resPtr).toString();
+    symbols.clonesize_free(resPtr);
+    return SafeJSON.parse(json) as VolumeInfo;
+}
+
+/**
+ * Two-phase clone-partner query: scan `target` for the blocks it shares, then
+ * scan `root` for every other file holding those same blocks.
+ */
+export function scanPartners(opts: { target: string; root: string; threads?: number; top?: number }): PartnersResult {
+    const { symbols } = getLib();
+    const targetBuf = Buffer.from(`${opts.target}\0`, "utf8");
+    const rootBuf = Buffer.from(`${opts.root}\0`, "utf8");
+
+    const end = prof.start("c-ffi.partners");
+    const resPtr = symbols.clonesize_partners_json(
+        ptr(targetBuf),
+        ptr(rootBuf),
+        opts.threads && opts.threads > 0 ? opts.threads : 0,
+        opts.top && opts.top > 0 ? opts.top : 30
+    );
+    end();
+
+    if (!resPtr) {
+        throw new Error("clonesize dylib returned NULL (partner scan failed)");
+    }
+
+    const json = new CString(resPtr).toString();
+    symbols.clonesize_free(resPtr);
+    return SafeJSON.parse(json) as PartnersResult;
 }
 
 /** Run the C engine as a subprocess and return the parsed result. */
@@ -188,6 +248,18 @@ export function scanWithC(opts: ScanOptions): ClonesizeResult {
     }
     if (opts.freeableTree) {
         args.push("--freeable-tree");
+    }
+    if (opts.changedSince && opts.changedSince > 0) {
+        args.push("--changed-since", String(opts.changedSince));
+    }
+    if (opts.cacheDir) {
+        args.push("--cache-dir", opts.cacheDir);
+    }
+    if (opts.noCache) {
+        args.push("--no-cache");
+    }
+    if (opts.includeCloud) {
+        args.push("--include-cloud");
     }
     for (const ex of opts.exclude ?? []) {
         args.push("--exclude", ex);

--- a/src/du/lib/format.test.ts
+++ b/src/du/lib/format.test.ts
@@ -2,8 +2,17 @@ import { describe, expect, it } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import pc from "picocolors";
-import { diffScans, humanBytes, humanBytesDecimal, renderDenied, renderHuman, renderTree } from "./format";
-import type { ClonesizeResult, NodeResult } from "./types";
+import {
+    diffScans,
+    humanBytes,
+    humanBytesDecimal,
+    renderDenied,
+    renderHuman,
+    renderPartners,
+    renderTree,
+    renderVolume,
+} from "./format";
+import type { ClonesizeResult, NodeResult, PartnersResult, VolumeInfo } from "./types";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escapes for assertions
 const stripAnsi = (s: string): string => s.replace(/\[[0-9;]*m/g, "");
@@ -221,5 +230,173 @@ describe("renderHuman ordering and scope warnings", () => {
     it("stays silent about outside sharing when there is none", () => {
         const out = stripAnsi(renderHuman(flat({ outside_shared_bytes: 0 }), "c-ffi"));
         expect(out).not.toContain("OUTSIDE");
+    });
+});
+
+describe("renderVolume", () => {
+    const volume = (over: Partial<VolumeInfo> = {}): VolumeInfo => ({
+        mount: "/System/Volumes/Data",
+        size_bytes: 1_000_000_000_000,
+        used_bytes: 900_000_000_000,
+        free_bytes: 100_000_000_000,
+        available_bytes: 100_000_000_000,
+        ...over,
+    });
+
+    const scanned = (over: Partial<ClonesizeResult> = {}): ClonesizeResult => ({
+        ...baseResult([]),
+        nodes: undefined,
+        depth: undefined,
+        unique_allocated_bytes: 800_000_000_000,
+        ...over,
+    });
+
+    it("reports the gap between APFS used-bytes and what the walk could see", () => {
+        const text = stripAnsi(renderVolume(volume(), scanned()));
+
+        expect(text).toContain("Volume reconcile — /System/Volumes/Data");
+        expect(text).toContain("Volume used (APFS)");
+        // 900 GB used - 800 GB scanned = 100 GB the walk never accounted for.
+        expect(text).toContain("UNACCOUNTED");
+        expect(text).toContain("100.0 GB");
+        expect(text).toContain("(11.1% of used)");
+    });
+
+    it("prefers allocated bytes over mapped bytes as the scanned figure", () => {
+        // unique_bytes understates real consumption by each file's sub-block slack,
+        // so the reconcile must use unique_allocated_bytes when it is present.
+        const text = stripAnsi(
+            renderVolume(volume(), scanned({ unique_bytes: 500_000_000_000, unique_allocated_bytes: 800_000_000_000 }))
+        );
+
+        expect(text).toContain("800.0 GB");
+        expect(text).not.toContain("500.0 GB");
+    });
+
+    it("falls back to mapped bytes when the scan has no allocated figure", () => {
+        const text = stripAnsi(
+            renderVolume(volume(), scanned({ unique_bytes: 700_000_000_000, unique_allocated_bytes: undefined }))
+        );
+
+        expect(text).toContain("700.0 GB");
+        expect(text).toContain("200.0 GB");
+    });
+
+    it("labels a scan that exceeds volume used-bytes as over-counted, not negative", () => {
+        const text = stripAnsi(renderVolume(volume(), scanned({ unique_allocated_bytes: 950_000_000_000 })));
+
+        expect(text).toContain("over-counted");
+        expect(text).not.toContain("UNACCOUNTED");
+        expect(text).toContain("50.0 GB");
+    });
+
+    it("names skipped cloud roots, which are a silent hole in the total", () => {
+        const text = stripAnsi(
+            renderVolume(volume(), scanned({ skipped_cloud: ["/Users/x/Library/CloudStorage/Dropbox"] }))
+        );
+
+        expect(text).toContain("1 cloud-provider root(s) were NOT walked");
+        expect(text).toContain("/Users/x/Library/CloudStorage/Dropbox");
+        expect(text).toContain("--include-cloud");
+    });
+
+    it("truncates a long skipped-mount list instead of flooding the report", () => {
+        const mounts = Array.from({ length: 12 }, (_v, i) => `/mnt/vol${i}`);
+        const text = stripAnsi(renderVolume(volume(), scanned({ skipped_mounts: mounts })));
+
+        expect(text).toContain("12 mount point(s) of other filesystems were skipped");
+        expect(text).toContain("/mnt/vol7");
+        expect(text).not.toContain("/mnt/vol8");
+        expect(text).toContain("... and 4 more");
+    });
+
+    it("blames denials for the gap and offers the sudo rerun", () => {
+        const text = stripAnsi(
+            renderVolume(volume(), scanned({ denied_dirs: 3, denied_files: 1, denied_paths: ["/private/var/db/x"] }))
+        );
+
+        expect(text).toContain("4 unreadable path(s) — the prime suspect for the gap");
+        expect(text).toContain("/private/var/db/x");
+        expect(text).toContain("sudo tools du volume /System/Volumes/Data");
+    });
+
+    it("says the gap is metadata when nothing was denied", () => {
+        const text = stripAnsi(renderVolume(volume(), scanned()));
+
+        expect(text).toContain("volume metadata, snapshots, or purgeable space");
+        expect(text).not.toContain("unreadable path(s)");
+    });
+});
+
+describe("renderPartners", () => {
+    const partners = (over: Partial<PartnersResult> = {}): PartnersResult => ({
+        target: "/repo/.worktrees/feat-x",
+        root: "/repo",
+        target_shared_bytes: 300 * 1024 * 1024,
+        partner_bytes: 600 * 1024 * 1024,
+        partner_files_total: 12,
+        files_opened: 40,
+        denied_dirs: 0,
+        denied_files: 0,
+        partner_dirs: [],
+        partner_files: [],
+        ...over,
+    });
+
+    it("says so plainly when nothing under the search root holds the blocks", () => {
+        const text = stripAnsi(renderPartners(partners()));
+
+        expect(text).toContain("Clone partners of /repo/.worktrees/feat-x");
+        expect(text).toContain("No partners under /repo");
+        expect(text).not.toContain("Partner directories:");
+    });
+
+    it("lists partner dirs and files with their shared bytes", () => {
+        const text = stripAnsi(
+            renderPartners(
+                partners({
+                    partner_dirs: [{ path: "/repo/node_modules", shared_bytes: 200 * 1024 * 1024, files: 7 }],
+                    partner_files: [{ path: "/repo/node_modules/a.bin", shared_bytes: 50 * 1024 * 1024 }],
+                })
+            )
+        );
+
+        expect(text).toContain("Partner directories:");
+        expect(text).toContain("/repo/node_modules");
+        expect(text).toContain("200.0 MB");
+        expect(text).toContain("Partner files:");
+        expect(text).toContain("/repo/node_modules/a.bin");
+        expect(text).toContain("50.0 MB");
+        // The whole point of the command: these blocks are not freed by deleting.
+        expect(text).toContain("Deleting the target frees nothing that a partner still references");
+    });
+
+    it("truncates long paths from the left so the filename stays readable", () => {
+        const deep = `/repo/${"nested/".repeat(20)}leaf.bin`;
+        const text = stripAnsi(
+            renderPartners(
+                partners({
+                    // An empty partner_dirs list short-circuits before the file rows,
+                    // so a dir has to be present for this path to be exercised at all.
+                    partner_dirs: [{ path: "/repo/node_modules", shared_bytes: 1024, files: 1 }],
+                    partner_files: [{ path: deep, shared_bytes: 1024 * 1024 }],
+                })
+            )
+        );
+
+        expect(text).toContain("leaf.bin");
+        expect(text).toContain("…");
+        expect(text).not.toContain(deep);
+    });
+
+    it("surfaces denials, since unreadable dirs mean partners may be missing", () => {
+        // The partners JSON carries counts only — clonesize_partners_json emits
+        // denied_dirs/denied_files and never denied_paths — so the warning has to
+        // stand on the count alone.
+        const text = stripAnsi(renderPartners(partners({ denied_dirs: 2, denied_files: 1 })));
+
+        expect(text).toContain("2 directories and 1 file(s) could not be read");
+        expect(text).toContain("every total above is INCOMPLETE");
+        expect(text).toContain("(3 further denial(s) not listed)");
     });
 });

--- a/src/du/lib/format.test.ts
+++ b/src/du/lib/format.test.ts
@@ -320,6 +320,31 @@ describe("renderVolume", () => {
         expect(text).toContain("sudo tools du volume /System/Volumes/Data");
     });
 
+    it("still reports denials when the scan over-counts instead of under-counting", () => {
+        // A volume can exceed used_bytes (clones counted on both sides, purgeable
+        // churn) and still be missing hundreds of unreadable paths. Gating the
+        // denial block on a positive gap hid them in exactly that case.
+        const text = stripAnsi(
+            renderVolume(
+                volume(),
+                scanned({
+                    unique_allocated_bytes: 950_000_000_000,
+                    denied_dirs: 7,
+                    denied_files: 2,
+                    denied_paths: ["/private/var/db/locked"],
+                })
+            )
+        );
+
+        expect(text).toContain("over-counted");
+        expect(text).toContain("9 unreadable path(s)");
+        expect(text).toContain("every total above is INCOMPLETE");
+        expect(text).toContain("/private/var/db/locked");
+        expect(text).toContain("sudo tools du volume /System/Volumes/Data");
+        // The gap framing only applies when there actually is a gap.
+        expect(text).not.toContain("prime suspect");
+    });
+
     it("says the gap is metadata when nothing was denied", () => {
         const text = stripAnsi(renderVolume(volume(), scanned()));
 

--- a/src/du/lib/format.test.ts
+++ b/src/du/lib/format.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import pc from "picocolors";
-import { humanBytes, renderTree } from "./format";
+import { diffScans, humanBytes, humanBytesDecimal, renderDenied, renderHuman, renderTree } from "./format";
 import type { ClonesizeResult, NodeResult } from "./types";
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escapes for assertions
@@ -100,5 +100,126 @@ describe("renderTree", () => {
         if (pc.isColorSupported) {
             expect(raw).toContain(pc.yellow("dupe"));
         }
+    });
+});
+
+describe("humanBytesDecimal", () => {
+    it("uses base-10 units so the volume reconcile lines up with diskutil", () => {
+        expect(humanBytesDecimal(1000)).toBe("1.0 KB");
+        expect(humanBytesDecimal(1_000_000_000)).toBe("1.0 GB");
+        // The exact figure diskutil printed for this machine's Data volume.
+        expect(humanBytesDecimal(942_235_377_664)).toBe("942.2 GB");
+    });
+
+    it("differs from the binary formatter, which is why both exist", () => {
+        expect(humanBytes(1_000_000_000)).not.toBe(humanBytesDecimal(1_000_000_000));
+    });
+});
+
+describe("renderDenied", () => {
+    it("prints nothing when the scan read everything", () => {
+        expect(renderDenied({ denied_dirs: 0, denied_files: 0, denied_paths: [] })).toEqual([]);
+        expect(renderDenied({})).toEqual([]);
+    });
+
+    it("names the unreadable paths and offers a sudo command", () => {
+        const lines = stripAnsi(
+            renderDenied({
+                denied_dirs: 1,
+                denied_files: 0,
+                denied_paths: ["/System/Volumes/Data/.fseventsd"],
+            }).join("\n")
+        );
+        expect(lines).toContain("INCOMPLETE");
+        expect(lines).toContain("/System/Volumes/Data/.fseventsd");
+        expect(lines).toContain("sudo tools du clonesize /System/Volumes/Data/.fseventsd");
+    });
+
+    it("reports denials it could not keep a path for", () => {
+        const lines = stripAnsi(renderDenied({ denied_dirs: 100, denied_files: 0, denied_paths: ["/a"] }).join("\n"));
+        expect(lines).toContain("99 further denial(s) not listed");
+    });
+});
+
+describe("diffScans", () => {
+    const scan = (nodes: NodeResult[]): ClonesizeResult => baseResult(nodes);
+
+    it("returns no rows for two identical scans", () => {
+        const nodes = [node({ path: ROOT, parent: -1, unique_allocated_bytes: 4096 })];
+        expect(diffScans(scan(nodes), scan(nodes))).toEqual([]);
+    });
+
+    it("reports a new directory with its full size as the delta", () => {
+        const before = scan([node({ path: ROOT, parent: -1, unique_allocated_bytes: 4096 })]);
+        const after = scan([
+            node({ path: ROOT, parent: -1, unique_allocated_bytes: 8192 }),
+            node({ path: BIG, depth: 1, parent: 0, unique_allocated_bytes: 4096 }),
+        ]);
+        const rows = diffScans(before, after);
+        expect(rows.map((r) => r.path)).toEqual([ROOT, BIG]);
+        expect(rows.find((r) => r.path === BIG)).toMatchObject({ status: "new", delta: 4096, before: 0 });
+        expect(rows.find((r) => r.path === ROOT)).toMatchObject({ status: "grown", delta: 4096 });
+    });
+
+    it("reports a removed directory as gone with a negative delta", () => {
+        const before = scan([
+            node({ path: ROOT, parent: -1, unique_allocated_bytes: 8192 }),
+            node({ path: SMALL, depth: 1, parent: 0, unique_allocated_bytes: 4096 }),
+        ]);
+        const after = scan([node({ path: ROOT, parent: -1, unique_allocated_bytes: 4096 })]);
+        const rows = diffScans(before, after);
+        expect(rows.find((r) => r.path === SMALL)).toMatchObject({ status: "gone", delta: -4096, after: 0 });
+    });
+
+    it("falls back to mapped bytes when a snapshot predates unique_allocated_bytes", () => {
+        const before = scan([node({ path: ROOT, parent: -1, unique_bytes: 1000 })]);
+        const after = scan([node({ path: ROOT, parent: -1, unique_bytes: 3000 })]);
+        expect(diffScans(before, after)[0]).toMatchObject({ delta: 2000, status: "grown" });
+    });
+
+    it("sorts the biggest absolute change first, shrink or grow", () => {
+        const before = scan([
+            node({ path: ROOT, parent: -1, unique_allocated_bytes: 100 }),
+            node({ path: SMALL, depth: 1, parent: 0, unique_allocated_bytes: 10_000 }),
+            node({ path: BIG, depth: 1, parent: 0, unique_allocated_bytes: 100 }),
+        ]);
+        const after = scan([
+            node({ path: ROOT, parent: -1, unique_allocated_bytes: 150 }),
+            node({ path: SMALL, depth: 1, parent: 0, unique_allocated_bytes: 0 }),
+            node({ path: BIG, depth: 1, parent: 0, unique_allocated_bytes: 200 }),
+        ]);
+        expect(diffScans(before, after)[0]).toMatchObject({ path: SMALL, status: "shrunk", delta: -10_000 });
+    });
+});
+
+describe("renderHuman ordering and scope warnings", () => {
+    const flat = (over: Partial<ClonesizeResult>): ClonesizeResult => ({
+        ...baseResult([]),
+        naive_bytes: 314572800,
+        unique_bytes: 314572800,
+        unique_allocated_bytes: 314572800,
+        private_sum_bytes: 0,
+        ...over,
+    });
+
+    it("puts the freeable figure above 'Real unique on disk'", () => {
+        const out = stripAnsi(renderHuman(flat({}), "c-ffi"));
+        expect(out.indexOf("Deleting this frees")).toBeLessThan(out.indexOf("Real unique on disk"));
+    });
+
+    it("labels unique as scan-scoped so it cannot be read as volume-wide", () => {
+        expect(stripAnsi(renderHuman(flat({}), "c-ffi"))).toContain("deduped WITHIN this scan only");
+    });
+
+    it("warns when blocks are also referenced outside the scan root", () => {
+        const out = stripAnsi(renderHuman(flat({ outside_shared_bytes: 314572800 }), "c-ffi"));
+        expect(out).toContain("Shared OUTSIDE this scan");
+        expect(out).toContain("ALSO referenced outside the scan root");
+        expect(out).toContain("Scan the parent directory");
+    });
+
+    it("stays silent about outside sharing when there is none", () => {
+        const out = stripAnsi(renderHuman(flat({ outside_shared_bytes: 0 }), "c-ffi"));
+        expect(out).not.toContain("OUTSIDE");
     });
 });

--- a/src/du/lib/format.ts
+++ b/src/du/lib/format.ts
@@ -353,10 +353,19 @@ export function renderVolume(vol: VolumeInfo, scan: ClonesizeResult, elapsedMs?:
         }
     }
 
+    // Denials are reported whenever they happened, never gated on the sign of the
+    // gap. A volume can over-count (clones counted on both sides, purgeable churn)
+    // and still have hundreds of unreadable paths; gating on `unaccounted > 0` hid
+    // them in exactly that case, which is the silence this report exists to break.
+    // Only the "prime suspect for the gap" framing depends on there being a gap.
     const denied = (scan.denied_dirs ?? 0) + (scan.denied_files ?? 0);
-    if (unaccounted > 0 && denied > 0) {
+    if (denied > 0) {
         L.push("");
-        L.push(pc.yellow(`  ⚠ ${denied} unreadable path(s) — the prime suspect for the gap.`));
+        L.push(
+            unaccounted > 0
+                ? pc.yellow(`  ⚠ ${denied} unreadable path(s) — the prime suspect for the gap.`)
+                : pc.yellow(`  ⚠ ${denied} unreadable path(s) — every total above is INCOMPLETE.`)
+        );
         for (const p of (scan.denied_paths ?? []).slice(0, 10)) {
             L.push(pc.dim(`     ${p}`));
         }

--- a/src/du/lib/format.ts
+++ b/src/du/lib/format.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import type { ClonesizeResult, Engine } from "./types";
+import type { ClonesizeResult, Engine, NodeResult, PartnersResult, VolumeInfo } from "./types";
 
 export function humanBytes(b: number): string {
     const KB = 1024,
@@ -21,12 +21,78 @@ export function humanBytes(b: number): string {
     return `${b} B`;
 }
 
+/**
+ * Decimal (SI) bytes. `diskutil` and the Finder both report base-10, so the
+ * volume reconcile has to as well — quoting 885 GiB next to diskutil's 950 GB
+ * looks like a 65 GB discrepancy that does not exist.
+ */
+export function humanBytesDecimal(b: number): string {
+    const KB = 1000,
+        MB = KB * 1000,
+        GB = MB * 1000,
+        TB = GB * 1000;
+    if (b >= TB) {
+        return `${(b / TB).toFixed(2)} TB`;
+    }
+    if (b >= GB) {
+        return `${(b / GB).toFixed(1)} GB`;
+    }
+    if (b >= MB) {
+        return `${(b / MB).toFixed(1)} MB`;
+    }
+    if (b >= KB) {
+        return `${(b / KB).toFixed(1)} KB`;
+    }
+    return `${b} B`;
+}
+
 function pad(s: string, n: number): string {
     return s.length >= n ? s : s + " ".repeat(n - s.length);
 }
 
 function padStart(s: string, n: number): string {
     return s.length >= n ? s : " ".repeat(n - s.length) + s;
+}
+
+/**
+ * Warn about subtrees the scan could not read, and hand back the exact command
+ * that would close the gap. A silent skip here is how a 132 GB hole hid inside a
+ * "complete" home scan.
+ */
+export function renderDenied(r: { denied_dirs?: number; denied_files?: number; denied_paths?: string[] }): string[] {
+    const dirs = r.denied_dirs ?? 0;
+    const files = r.denied_files ?? 0;
+    if (dirs === 0 && files === 0) {
+        return [];
+    }
+
+    const L: string[] = [""];
+    const what = [dirs > 0 ? `${dirs} director${dirs === 1 ? "y" : "ies"}` : "", files > 0 ? `${files} file(s)` : ""]
+        .filter(Boolean)
+        .join(" and ");
+    L.push(pc.yellow(`  ⚠ ${what} could not be read — every total above is INCOMPLETE.`));
+
+    const paths = r.denied_paths ?? [];
+    for (const p of paths.slice(0, 10)) {
+        L.push(pc.dim(`     ${p}`));
+    }
+    if (paths.length > 10) {
+        L.push(pc.dim(`     ... and ${paths.length - 10} more`));
+    }
+    if (dirs + files > paths.length) {
+        L.push(pc.dim(`     (${dirs + files - paths.length} further denial(s) not listed)`));
+    }
+    if (paths.length > 0) {
+        L.push("");
+        L.push(pc.dim("  Re-run as root to resolve them:"));
+        L.push(`     sudo tools du clonesize ${shellQuote(paths[0]!)}`);
+    }
+    return L;
+}
+
+/** Quote a path for copy-paste into a shell. */
+function shellQuote(p: string): string {
+    return /^[\w./@:-]+$/.test(p) ? p : `'${p.replaceAll("'", `'\\''`)}'`;
 }
 
 /** Pretty, human-first rendering of a scan result. */
@@ -42,8 +108,30 @@ export function renderHuman(r: ClonesizeResult, engine: Engine, elapsedMs?: numb
     L.push(pc.dim(meta.join("  •  ")));
     L.push("");
 
+    // Freeable leads. It is the only line that answers the question people
+    // actually ask ("what do I get back if I delete this"), and reading top-down
+    // past "Real unique on disk" is how a free clone gets mistaken for a full copy.
+    if (r.private_sum_bytes !== undefined) {
+        L.push(
+            `  ${pad("Deleting this frees \u2265", 26)} ${pc.bold(
+                pc.cyan(padStart(humanBytes(r.private_sum_bytes), 12))
+            )}  ${pc.dim("(blocks nothing else on the volume references)")}`
+        );
+    }
+    L.push(
+        `  ${pad("Real unique on disk", 26)} ${padStart(
+            humanBytes(r.unique_allocated_bytes ?? r.unique_bytes),
+            12
+        )}  ${pc.dim("(deduped WITHIN this scan only)")}`
+    );
+    if (r.unique_allocated_bytes !== undefined && r.unique_allocated_bytes !== r.unique_bytes) {
+        L.push(
+            `  ${pad("  ... mapped bytes only", 26)} ${padStart(humanBytes(r.unique_bytes), 12)}  ${pc.dim(
+                "(excludes per-file block slack)"
+            )}`
+        );
+    }
     L.push(`  ${pad("Naive (what du reports)", 26)} ${padStart(humanBytes(r.naive_bytes), 12)}`);
-    L.push(`  ${pad("Real unique on disk", 26)} ${pc.bold(padStart(humanBytes(r.unique_bytes), 12))}`);
     L.push(
         `  ${pad("Shared via CoW clones", 26)} ${pc.green(padStart(humanBytes(r.shared_bytes), 12))}  ${pc.dim(
             `(${savedPct}% of naive collapses)`
@@ -52,12 +140,32 @@ export function renderHuman(r: ClonesizeResult, engine: Engine, elapsedMs?: numb
     if (r.cross_group_shared_bytes > 0) {
         L.push(`  ${pad("Shared across marked dirs", 26)} ${padStart(humanBytes(r.cross_group_shared_bytes), 12)}`);
     }
-    if (r.private_sum_bytes !== undefined) {
+    if (r.outside_shared_bytes !== undefined && r.outside_shared_bytes > 0) {
         L.push(
-            `  ${pad("Σ per-file private", 26)} ${padStart(humanBytes(r.private_sum_bytes), 12)}  ${pc.dim(
-                "(exclusive to one file volume-wide)"
+            `  ${pad("Shared OUTSIDE this scan", 26)} ${pc.yellow(
+                padStart(humanBytes(r.outside_shared_bytes), 12)
+            )}  ${pc.dim("(also referenced by files above/outside the root)")}`
+        );
+    }
+    if (r.sparse_files !== undefined && r.sparse_files > 0) {
+        L.push(
+            `  ${pad("Sparse (never written)", 26)} ${padStart(humanBytes(r.sparse_bytes ?? 0), 12)}  ${pc.dim(
+                `(${r.sparse_files.toLocaleString()} sparse file(s); apparent ${humanBytes(r.apparent_bytes ?? 0)})`
             )}`
         );
+    }
+
+    // The scope-limited-uniqueness trap: scanning ONE side of a clone pair shows
+    // "unique == naive, 0% shared", which reads as "this cost me full size".
+    if (r.outside_shared_bytes !== undefined && r.outside_shared_bytes > 0) {
+        L.push("");
+        L.push(
+            pc.yellow(
+                `  \u26a0 ${humanBytes(r.outside_shared_bytes)} of this tree's blocks are ALSO referenced outside the scan root.`
+            )
+        );
+        L.push(pc.dim(`     "Real unique on disk" counts them; deleting this tree would not free them.`));
+        L.push(pc.dim("     Scan the parent directory to see the true sharing."));
     }
 
     // Marked-dir table (only the interesting rows: sizeable + any clone-flagged).
@@ -94,6 +202,8 @@ export function renderHuman(r: ClonesizeResult, engine: Engine, elapsedMs?: numb
         }
     }
 
+    L.push(...renderDenied(r));
+
     return L.join("\n");
 }
 
@@ -116,8 +226,18 @@ export function renderTree(r: ClonesizeResult, engine: Engine, elapsedMs?: numbe
     if (elapsedMs !== undefined) {
         meta.push(`${(elapsedMs / 1000).toFixed(2)}s`);
     }
+    if (r.changed_since !== undefined) {
+        meta.push(`changed since ${new Date(r.changed_since * 1000).toISOString().slice(0, 16).replace("T", " ")}`);
+    }
     L.push(pc.dim(meta.join("  •  ")));
-    L.push(pc.dim(`  ${pad("dir", 40)}${padStart("naive", 11)}${padStart("unique", 11)}${padStart("x-shared", 11)}`));
+    L.push(
+        pc.dim(
+            `  ${pad("dir", 40)}${padStart("naive", 11)}${padStart("unique", 11)}${padStart(
+                "x-shared",
+                11
+            )}${padStart("frees ≥", 11)}`
+        )
+    );
 
     // Index children by parent for a depth-first, unique-desc walk.
     const byParent = new Map<number, number[]>();
@@ -131,17 +251,28 @@ export function renderTree(r: ClonesizeResult, engine: Engine, elapsedMs?: numbe
     });
 
     const rootIdx = nodes.findIndex((n) => n.parent < 0);
+    const sparse = (n: NodeResult): boolean => (n.sparse_files ?? 0) > 0;
     const emit = (idx: number, indent: number) => {
         const n = nodes[idx]!;
-        const label = indent === 0 ? n.path : n.path.slice(n.path.lastIndexOf("/") + 1);
-        const name = `${"  ".repeat(indent)}${n.clone_flagged ? pc.yellow(label) : label}`;
-        const namePlain = `${"  ".repeat(indent)}${label}`;
+        const base = indent === 0 ? n.path : n.path.slice(n.path.lastIndexOf("/") + 1);
+        const name = `${"  ".repeat(indent)}${n.clone_flagged ? pc.yellow(base) : base}${
+            sparse(n) ? ` ${pc.magenta("sparse")}` : ""
+        }`;
+        const namePlain = `${"  ".repeat(indent)}${sparse(n) ? `${base} sparse` : base}`;
         L.push(
             `  ${pad(name + " ".repeat(Math.max(0, 40 - namePlain.length)), 40 + (name.length - namePlain.length))}` +
-                `${padStart(humanBytes(n.naive_bytes), 11)}${padStart(humanBytes(n.unique_bytes), 11)}` +
-                `${padStart(n.cross_shared_bytes > 0 ? humanBytes(n.cross_shared_bytes) : "-", 11)}`
+                `${padStart(humanBytes(n.naive_bytes), 11)}` +
+                `${padStart(humanBytes(n.unique_allocated_bytes ?? n.unique_bytes), 11)}` +
+                `${padStart(n.cross_shared_bytes > 0 ? humanBytes(n.cross_shared_bytes) : "-", 11)}` +
+                `${padStart(n.freeable_floor_bytes !== undefined ? humanBytes(n.freeable_floor_bytes) : "-", 11)}`
         );
-        const kids = (byParent.get(idx) ?? []).slice().sort((a, b) => nodes[b]!.unique_bytes - nodes[a]!.unique_bytes);
+        const kids = (byParent.get(idx) ?? [])
+            .slice()
+            .sort(
+                (a, b) =>
+                    (nodes[b]!.unique_allocated_bytes ?? nodes[b]!.unique_bytes) -
+                    (nodes[a]!.unique_allocated_bytes ?? nodes[a]!.unique_bytes)
+            );
         for (const k of kids) {
             emit(k, indent + 1);
         }
@@ -153,9 +284,219 @@ export function renderTree(r: ClonesizeResult, engine: Engine, elapsedMs?: numbe
     L.push("");
     L.push(
         pc.dim(
-            `  unique = clone-deduped bytes within the subtree · x-shared = bytes shared with dirs OUTSIDE it` +
-                ` · deleting a dir frees ~ (unique − x-shared).`
+            `  unique = clone-deduped allocated bytes within the subtree · x-shared = bytes shared with dirs OUTSIDE it`
         )
     );
+    L.push(
+        pc.dim(
+            `  frees ≥ = Σ per-file blocks private volume-wide (a floor: a dir cloned entirely within itself reads 0)`
+        )
+    );
+    if (nodes.some(sparse)) {
+        L.push(pc.dim(`  ${pc.magenta("sparse")} = holds sparse files; apparent size far exceeds allocated blocks`));
+    }
+    L.push(...renderDenied(r));
+    return L.join("\n");
+}
+
+/**
+ * Volume reconcile (`tools du volume`). The whole point is the last line: what
+ * the volume says it spent, minus what the scan could see, equals the hole.
+ */
+export function renderVolume(vol: VolumeInfo, scan: ClonesizeResult, elapsedMs?: number): string {
+    const L: string[] = [];
+    const scanned = scan.unique_allocated_bytes ?? scan.unique_bytes;
+    const unaccounted = vol.used_bytes - scanned;
+
+    L.push(pc.bold(`Volume reconcile — ${vol.mount}`));
+    const meta = [`${scan.files_scanned.toLocaleString()} files`, `${scan.threads} threads`];
+    if (elapsedMs !== undefined) {
+        meta.push(`${(elapsedMs / 1000).toFixed(1)}s`);
+    }
+    L.push(pc.dim(meta.join("  •  ")));
+    L.push("");
+    L.push(`  ${pad("Volume size", 26)} ${padStart(humanBytesDecimal(vol.size_bytes), 12)}`);
+    L.push(
+        `  ${pad("Volume used (APFS)", 26)} ${pc.bold(padStart(humanBytesDecimal(vol.used_bytes), 12))}  ${pc.dim(
+            "= diskutil 'Volume Used Space'"
+        )}`
+    );
+    L.push(`  ${pad("Volume free", 26)} ${padStart(humanBytesDecimal(vol.free_bytes), 12)}`);
+    L.push(`  ${pad("Scanned unique (alloc)", 26)} ${padStart(humanBytesDecimal(scanned), 12)}`);
+
+    const pct = vol.used_bytes > 0 ? (Math.abs(unaccounted) / vol.used_bytes) * 100 : 0;
+    const deltaLabel = unaccounted >= 0 ? "UNACCOUNTED" : "over-counted";
+    const deltaText = `${padStart(humanBytesDecimal(Math.abs(unaccounted)), 12)}  ${pc.dim(`(${pct.toFixed(1)}% of used)`)}`;
+    L.push(`  ${pad(deltaLabel, 26)} ${pct >= 1 ? pc.yellow(deltaText) : pc.green(deltaText)}`);
+
+    const cloud = scan.skipped_cloud ?? [];
+    if (cloud.length > 0) {
+        L.push("");
+        L.push(pc.yellow(`  ⚠ ${cloud.length} cloud-provider root(s) were NOT walked:`));
+        for (const c of cloud) {
+            L.push(pc.dim(`     ${c}`));
+        }
+        L.push(pc.dim("  Their contents are mostly placeholders that live on someone else's disk, and reading"));
+        L.push(pc.dim("  one can download it. Pass --include-cloud to walk them anyway."));
+    }
+
+    const mounts = scan.skipped_mounts ?? [];
+    if (mounts.length > 0) {
+        L.push("");
+        L.push(pc.dim(`  ${mounts.length} mount point(s) of other filesystems were skipped — their bytes belong to`));
+        L.push(pc.dim("  another volume, and walking an autofs or network mount can hang the scan:"));
+        for (const m of mounts.slice(0, 8)) {
+            L.push(pc.dim(`     ${m}`));
+        }
+        if (mounts.length > 8) {
+            L.push(pc.dim(`     ... and ${mounts.length - 8} more`));
+        }
+    }
+
+    const denied = (scan.denied_dirs ?? 0) + (scan.denied_files ?? 0);
+    if (unaccounted > 0 && denied > 0) {
+        L.push("");
+        L.push(pc.yellow(`  ⚠ ${denied} unreadable path(s) — the prime suspect for the gap.`));
+        for (const p of (scan.denied_paths ?? []).slice(0, 10)) {
+            L.push(pc.dim(`     ${p}`));
+        }
+        L.push("");
+        L.push(pc.dim("  Resolve it with:"));
+        L.push(`     sudo tools du volume ${shellQuote(vol.mount)}`);
+    } else if (unaccounted > 0) {
+        L.push("");
+        L.push(
+            pc.dim(
+                "  No denials, so the gap is volume metadata, snapshots, or purgeable space —" +
+                    " none of which a directory walk can see."
+            )
+        );
+    }
+    return L.join("\n");
+}
+
+/** `tools du clones <dir>`: the concrete paths holding the target's blocks. */
+export function renderPartners(p: PartnersResult, elapsedMs?: number): string {
+    const L: string[] = [];
+    L.push(pc.bold(`Clone partners of ${p.target}`));
+    const meta = [`searched ${p.root}`, `${p.files_opened.toLocaleString()} shared files opened`];
+    if (elapsedMs !== undefined) {
+        meta.push(`${(elapsedMs / 1000).toFixed(1)}s`);
+    }
+    L.push(pc.dim(meta.join("  •  ")));
+    L.push("");
+    L.push(`  ${pad("Target blocks shared", 26)} ${padStart(humanBytes(p.target_shared_bytes), 12)}`);
+    L.push(
+        `  ${pad("Held by other files", 26)} ${padStart(p.partner_files_total.toLocaleString(), 12)}  ${pc.dim(
+            `(${humanBytes(p.partner_bytes)} counted per partner)`
+        )}`
+    );
+
+    if (p.partner_dirs.length === 0) {
+        L.push("");
+        L.push(
+            pc.dim(`  No partners under ${p.root} — the shared blocks live outside it, or the target shares nothing.`)
+        );
+        return [...L, ...renderDenied(p)].join("\n");
+    }
+
+    L.push("");
+    L.push(pc.bold("  Partner directories:"));
+    L.push(pc.dim(`  ${pad("dir", 60)}${padStart("shared", 11)}${padStart("files", 8)}`));
+    for (const d of p.partner_dirs) {
+        L.push(
+            `  ${pad(d.path.length > 59 ? `…${d.path.slice(-58)}` : d.path, 60)}${padStart(humanBytes(d.shared_bytes), 11)}${padStart(String(d.files ?? 0), 8)}`
+        );
+    }
+
+    L.push("");
+    L.push(pc.bold("  Partner files:"));
+    for (const f of p.partner_files) {
+        L.push(
+            `  ${pad(f.path.length > 67 ? `…${f.path.slice(-66)}` : f.path, 68)}${padStart(humanBytes(f.shared_bytes), 11)}`
+        );
+    }
+
+    L.push("");
+    L.push(
+        pc.dim(
+            "  These paths hold the SAME physical blocks. Deleting the target frees nothing that a partner still references."
+        )
+    );
+    return L.join("\n");
+}
+
+export interface DiffRow {
+    path: string;
+    before: number;
+    after: number;
+    delta: number;
+    status: "grown" | "shrunk" | "new" | "gone";
+}
+
+/** Per-directory delta between two saved scans of the same tree. */
+export function diffScans(before: ClonesizeResult, after: ClonesizeResult): DiffRow[] {
+    const key = (n: NodeResult): number => n.unique_allocated_bytes ?? n.unique_bytes;
+    const prev = new Map<string, number>((before.nodes ?? []).map((n) => [n.path, key(n)]));
+    const next = new Map<string, number>((after.nodes ?? []).map((n) => [n.path, key(n)]));
+
+    const rows: DiffRow[] = [];
+    for (const [path, afterBytes] of next) {
+        const beforeBytes = prev.get(path);
+        if (beforeBytes === undefined) {
+            rows.push({ path, before: 0, after: afterBytes, delta: afterBytes, status: "new" });
+        } else if (beforeBytes !== afterBytes) {
+            rows.push({
+                path,
+                before: beforeBytes,
+                after: afterBytes,
+                delta: afterBytes - beforeBytes,
+                status: afterBytes > beforeBytes ? "grown" : "shrunk",
+            });
+        }
+    }
+    for (const [path, beforeBytes] of prev) {
+        if (!next.has(path)) {
+            rows.push({ path, before: beforeBytes, after: 0, delta: -beforeBytes, status: "gone" });
+        }
+    }
+
+    return rows.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+}
+
+export function renderDiff(before: ClonesizeResult, after: ClonesizeResult, rows: DiffRow[]): string {
+    const L: string[] = [];
+    L.push(pc.bold(`Scan diff — ${after.path}`));
+    const beforeTotal = before.unique_allocated_bytes ?? before.unique_bytes;
+    const afterTotal = after.unique_allocated_bytes ?? after.unique_bytes;
+    const delta = afterTotal - beforeTotal;
+    L.push(
+        pc.dim(
+            `${humanBytes(beforeTotal)} → ${humanBytes(afterTotal)}  •  ${
+                delta >= 0 ? "+" : "−"
+            }${humanBytes(Math.abs(delta))} total`
+        )
+    );
+
+    if (rows.length === 0) {
+        L.push("");
+        L.push(pc.green("  No per-directory change."));
+        return L.join("\n");
+    }
+
+    L.push("");
+    L.push(pc.dim(`  ${pad("dir", 52)}${padStart("before", 11)}${padStart("after", 11)}${padStart("delta", 12)}`));
+    for (const r of rows) {
+        const sign = r.delta >= 0 ? "+" : "−";
+        const deltaText = `${sign}${humanBytes(Math.abs(r.delta))}`;
+        const colored = r.delta >= 0 ? pc.red(deltaText) : pc.green(deltaText);
+        const tag = r.status === "new" ? " (new)" : r.status === "gone" ? " (gone)" : "";
+        const room = 51 - tag.length;
+        const label = `${r.path.length > room ? `…${r.path.slice(-(room - 1))}` : r.path}${tag}`;
+        L.push(
+            `  ${pad(label, 52)}` +
+                `${padStart(humanBytes(r.before), 11)}${padStart(humanBytes(r.after), 11)}${padStart(colored, 12 + (colored.length - deltaText.length))}`
+        );
+    }
     return L.join("\n");
 }

--- a/src/du/lib/options.test.ts
+++ b/src/du/lib/options.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { InvalidArgumentError } from "commander";
+import { durationToCutoff, intOpt } from "./options";
+
+describe("durationToCutoff", () => {
+    const parse = durationToCutoff("--changed-within");
+
+    it("returns SECONDS, not milliseconds", () => {
+        // The native core compares the cutoff against st_mtime (epoch seconds).
+        // Returning ms would land ~50,000 years in the future and exclude every
+        // file, so pin the magnitude against a seconds-scale clock.
+        const nowSec = Math.floor(Date.now() / 1000);
+        const cutoff = parse("24h");
+
+        expect(cutoff).toBeGreaterThan(nowSec - 86400 - 5);
+        expect(cutoff).toBeLessThanOrEqual(nowSec);
+    });
+
+    it("subtracts the window from now", () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+
+        // Allow a couple of seconds of slack for clock movement during the call.
+        expect(nowSec - parse("7d")).toBeGreaterThanOrEqual(604800 - 2);
+        expect(nowSec - parse("7d")).toBeLessThanOrEqual(604800 + 2);
+        expect(nowSec - parse("30m")).toBeGreaterThanOrEqual(1800 - 2);
+        expect(nowSec - parse("30m")).toBeLessThanOrEqual(1800 + 2);
+    });
+
+    it("orders windows so a longer one reaches further back", () => {
+        expect(parse("30d")).toBeLessThan(parse("7d"));
+        expect(parse("7d")).toBeLessThan(parse("24h"));
+        expect(parse("24h")).toBeLessThan(parse("30m"));
+    });
+
+    it("accepts compound durations", () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const elapsed = nowSec - parse("2d6h");
+
+        expect(elapsed).toBeGreaterThanOrEqual(2 * 86400 + 6 * 3600 - 2);
+        expect(elapsed).toBeLessThanOrEqual(2 * 86400 + 6 * 3600 + 2);
+    });
+
+    it("rejects unparseable durations with the flag name in the message", () => {
+        expect(() => parse("nonsense")).toThrow(InvalidArgumentError);
+        expect(() => parse("nonsense")).toThrow(/--changed-within must be a duration/);
+        expect(() => parse("")).toThrow(InvalidArgumentError);
+        expect(() => parse("7 lightyears")).toThrow(InvalidArgumentError);
+    });
+
+    it("rejects a zero-length window instead of returning 'now'", () => {
+        // parseDuration returns 0 for these, which would make the cutoff `now` and
+        // silently match nothing.
+        expect(() => parse("0")).toThrow(InvalidArgumentError);
+        expect(() => parse("0h")).toThrow(InvalidArgumentError);
+    });
+});
+
+describe("intOpt", () => {
+    it("parses integers", () => {
+        expect(intOpt("--threads")("16")).toBe(16);
+    });
+
+    it("enforces min and max", () => {
+        const threads = intOpt("--threads", { min: 1, max: 1024 });
+
+        expect(threads("1")).toBe(1);
+        expect(threads("1024")).toBe(1024);
+        expect(() => threads("0")).toThrow(/--threads must be >= 1/);
+        expect(() => threads("1025")).toThrow(/--threads must be <= 1024/);
+    });
+
+    it("rejects non-integers rather than silently truncating", () => {
+        expect(() => intOpt("--depth")("2.5")).toThrow(InvalidArgumentError);
+        expect(() => intOpt("--depth")("abc")).toThrow(InvalidArgumentError);
+        expect(() => intOpt("--depth")("")).toThrow(InvalidArgumentError);
+    });
+});

--- a/src/du/lib/options.ts
+++ b/src/du/lib/options.ts
@@ -1,0 +1,44 @@
+// Commander option coercers. They live here rather than in index.ts because that
+// file ends in `runTool(program)` — importing it from a test would parse argv and
+// run the CLI, so anything that needs coverage has to sit outside it.
+
+import { parseDuration } from "@genesiscz/utils/format";
+import { InvalidArgumentError } from "commander";
+
+export function intOpt(name: string, opts: { min?: number; max?: number } = {}) {
+    return (v: string): number => {
+        const n = Number.parseInt(v, 10);
+        if (!Number.isFinite(n) || String(n) !== v.trim()) {
+            throw new InvalidArgumentError(`${name} must be an integer (got "${v}").`);
+        }
+
+        if (opts.min !== undefined && n < opts.min) {
+            throw new InvalidArgumentError(`${name} must be >= ${opts.min}.`);
+        }
+
+        if (opts.max !== undefined && n > opts.max) {
+            throw new InvalidArgumentError(`${name} must be <= ${opts.max}.`);
+        }
+
+        return n;
+    };
+}
+
+/**
+ * `--changed-within 7d` → the epoch-SECOND cutoff the native core filters on.
+ *
+ * The unit change is the whole point: `parseDuration` returns milliseconds, and
+ * the C side compares against `st_mtime`, which is seconds. Returning ms here
+ * would put the cutoff ~50,000 years in the future and silently exclude every
+ * file, so the `/ 1000` is load-bearing and pinned by options.test.ts.
+ */
+export function durationToCutoff(name: string) {
+    return (v: string): number => {
+        const ms = parseDuration(v);
+        if (ms <= 0) {
+            throw new InvalidArgumentError(`${name} must be a duration like 24h, 7d or 30m (got "${v}").`);
+        }
+
+        return Math.floor((Date.now() - ms) / 1000);
+    };
+}

--- a/src/du/lib/types.ts
+++ b/src/du/lib/types.ts
@@ -20,15 +20,28 @@ export interface NodeResult {
     /** Parent node index in the `nodes` array; -1 for the root. */
     parent: number;
     naive_bytes: number;
-    /** Clone-deduped unique bytes WITHIN this subtree. */
+    /** Clone-deduped unique MAPPED bytes within this subtree (excludes block slack). */
     unique_bytes: number;
+    /** Same dedup, rounded to allocation blocks — what the volume actually spends. */
+    unique_allocated_bytes?: number;
     /** Bytes this subtree shares with directories OUTSIDE it. */
     cross_shared_bytes: number;
+    /** Same, block-aligned. */
+    cross_shared_allocated_bytes?: number;
     shared_pct: number;
     files: number;
     clone_flagged: boolean;
-    /** Σ per-file ATTR_CMNEXT_PRIVATESIZE in this subtree (only with --freeable-tree). */
+    /** Σ per-file ATTR_CMNEXT_PRIVATESIZE in this subtree. */
     private_bytes?: number;
+    /** Lower bound on bytes freed by deleting this subtree (== private_bytes). */
+    freeable_floor_bytes?: number;
+    /** Upper bound: allocated unique minus what it shares with dirs outside itself. */
+    freeable_ceiling_bytes?: number;
+    /** Σ datalength — exceeds naive_bytes when the subtree holds sparse files. */
+    apparent_bytes?: number;
+    /** Σ (datalength − allocsize) over sparse files here. */
+    sparse_bytes?: number;
+    sparse_files?: number;
 }
 
 export interface ClonesizeResult {
@@ -37,18 +50,78 @@ export interface ClonesizeResult {
     files_listed: number;
     /** Files actually opened + extent-scanned (< files_scanned when clones are skipped). */
     files_opened?: number;
+    /** Shared files whose extent map came from the cache instead of open()+fcntl(). */
+    files_cached?: number;
     /** Present with --depth: the per-directory tree (flat, ordered root-first). */
     depth?: number;
     nodes?: NodeResult[];
     extents: number;
     threads: number;
     naive_bytes: number;
+    /** Clone-deduped MAPPED bytes (extent scan stops at datalength — no block slack). */
     unique_bytes: number;
+    /** Clone-deduped ALLOCATED bytes — the figure the volume's used-space counter agrees with. */
+    unique_allocated_bytes?: number;
+    /** Σ datalength. Exceeds naive_bytes exactly when sparse files are present. */
+    apparent_bytes?: number;
+    /** Σ (datalength − allocsize) over sparse files: apparent size never written to disk. */
+    sparse_bytes?: number;
+    sparse_files?: number;
     shared_bytes: number;
     shared_pct: number;
     cross_group_shared_bytes: number;
+    /** Σ per-file ATTR_CMNEXT_PRIVATESIZE — the conservative floor on what deleting frees. */
     private_sum_bytes?: number;
+    /**
+     * Blocks inside this scan that are ALSO referenced by files outside the scan root.
+     * Non-zero means `unique_bytes` is scope-limited: scanning one side of a clone
+     * pair reports the clone at full size even though it cost nothing.
+     */
+    outside_shared_bytes?: number;
+    /** Directories the scan could not open (EACCES/EPERM) — their bytes are MISSING from every total. */
+    denied_dirs?: number;
+    denied_files?: number;
+    /** First 64 denied paths, for the report and the sudo hint. */
+    denied_paths?: string[];
+    /** Mount points of OTHER filesystems inside the scan root, pruned before the walk. */
+    skipped_mounts?: string[];
+    /** Cloud-provider roots (~/Library/CloudStorage, iCloud Drive) skipped unless --include-cloud. */
+    skipped_cloud?: string[];
+    /** Epoch seconds cutoff when the scan ran with --changed-within. */
+    changed_since?: number;
     groups: GroupResult[];
+}
+
+/** Authoritative volume figures straight from the APFS layer (ATTR_VOL_*). */
+export interface VolumeInfo {
+    mount: string;
+    size_bytes: number;
+    /** Matches `diskutil info <mount>` → "Volume Used Space". */
+    used_bytes: number;
+    free_bytes: number;
+    available_bytes: number;
+}
+
+export interface PartnerEntry {
+    path: string;
+    shared_bytes: number;
+    files?: number;
+}
+
+/** Result of `tools du clones <dir>`: who else holds this directory's blocks. */
+export interface PartnersResult {
+    target: string;
+    root: string;
+    /** Bytes of the target that live in blocks shared with something else. */
+    target_shared_bytes: number;
+    /** Σ over partner files (double-counts a block held by several partners). */
+    partner_bytes: number;
+    partner_files_total: number;
+    files_opened: number;
+    denied_dirs: number;
+    denied_files: number;
+    partner_dirs: PartnerEntry[];
+    partner_files: PartnerEntry[];
 }
 
 export type Engine = "c" | "c-ffi" | "bun";
@@ -68,4 +141,12 @@ export interface ScanOptions {
     depth?: number;
     /** --freeable-tree: per-node ATTR_CMNEXT_PRIVATESIZE (implies depth>=1). */
     freeableTree?: boolean;
+    /** --changed-within: only account files with mtime >= this epoch-second cutoff. */
+    changedSince?: number;
+    /** Directory holding the per-volume extent cache. Undefined disables it entirely. */
+    cacheDir?: string;
+    /** --no-cache: ignore the cache when reading. It is still WRITTEN, so the next run is warm. */
+    noCache?: boolean;
+    /** --include-cloud: walk cloud-provider roots too (slow, and can trigger downloads). */
+    includeCloud?: boolean;
 }

--- a/src/du/native/bench.sh
+++ b/src/du/native/bench.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fixed benchmark harness for the clonesize native core.
+#
+# Every feature added to clonesize.c must be measured with THIS script, before
+# and after, and the numbers appended to .claude/docs/benchmarks-du.md. The point
+# is a like-for-like comparison across commits: same targets, same modes, same
+# hyperfine settings.
+#
+# Usage:  src/du/native/bench.sh [label]
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+BIN="$HERE/clonesize"
+LABEL="${1:-unlabeled}"
+
+# Rebuild from source so the measurement always matches the working tree.
+clang -O2 -pthread -o "$BIN" "$HERE/clonesize.c"
+
+T1="$REPO"
+T2="$REPO/node_modules"
+
+echo "clonesize bench — label: $LABEL"
+echo "binary:  $BIN"
+echo "targets: T1=$T1"
+echo "         T2=$T2"
+echo
+
+hyperfine --warmup 1 --runs 5 --style basic \
+    -n "T1 flat"      "'$BIN' --quiet '$T1'" \
+    -n "T1 depth2"    "'$BIN' --quiet --depth 2 '$T1'" \
+    -n "T2 flat"      "'$BIN' --quiet '$T2'" \
+    -n "T2 depth2"    "'$BIN' --quiet --depth 2 '$T2'"
+
+echo
+echo "--- byte totals (T1 flat, for correctness diffing) ---"
+# Captured, then truncated. Piping the scan straight into `head` lets head close
+# the pipe first, which kills clonesize with SIGPIPE (141) and, under
+# `set -o pipefail -e`, aborts the script before the cache section below.
+T1_JSON="$("$BIN" --json "$T1")"
+head -c 600 <<<"$T1_JSON"
+echo
+
+# --- extent cache (added 2026-07-27) -----------------------------------------
+# Two phases, in order, because the cache is a stateful feature:
+#   1. --no-cache : writes the cache, never reads it (the honest "cold" number)
+#   2. warm       : same scan, extents served from the cache
+# The plain matrix above runs WITHOUT --cache-dir, so it stays comparable to
+# every pre-cache measurement in benchmarks-du.md.
+CACHE_DIR="${TMPDIR:-/tmp}/clonesize-bench-cache-$LABEL"
+mkdir -p "$CACHE_DIR"
+
+echo
+echo "--- extent cache ---"
+hyperfine --warmup 1 --runs 3 --style basic \
+    -n "T1 cache-cold" "'$BIN' --quiet --cache-dir '$CACHE_DIR' --no-cache '$T1'" \
+    -n "T1 cache-warm" "'$BIN' --quiet --cache-dir '$CACHE_DIR' '$T1'"
+
+echo
+echo "cache file:"
+ls -la "$CACHE_DIR"
+WARM_OUT="$("$BIN" --quiet --cache-dir "$CACHE_DIR" "$T1")"
+head -2 <<<"$WARM_OUT"

--- a/src/du/native/bench.sh
+++ b/src/du/native/bench.sh
@@ -20,10 +20,18 @@ clang -O2 -pthread -o "$BIN" "$HERE/clonesize.c"
 T1="$REPO"
 T2="$REPO/node_modules"
 
+# benchmarks-du.md requires the load average next to every number: wall time on
+# this machine swings hard with it, so a run without it cannot be interpreted.
+# Printed before AND after, because a long run can start quiet and end loaded.
+show_load() {
+    echo "load ($1): $(uptime)"
+}
+
 echo "clonesize bench — label: $LABEL"
 echo "binary:  $BIN"
 echo "targets: T1=$T1"
 echo "         T2=$T2"
+show_load "start"
 echo
 
 hyperfine --warmup 1 --runs 5 --style basic \
@@ -33,13 +41,17 @@ hyperfine --warmup 1 --runs 5 --style basic \
     -n "T2 depth2"    "'$BIN' --quiet --depth 2 '$T2'"
 
 echo
+show_load "after matrix"
+echo
 echo "--- byte totals (T1 flat, for correctness diffing) ---"
-# Captured, then truncated. Piping the scan straight into `head` lets head close
-# the pipe first, which kills clonesize with SIGPIPE (141) and, under
+# Captured, never piped. Piping the scan straight into `head` lets head close the
+# pipe first, which kills clonesize with SIGPIPE (141) and, under
 # `set -o pipefail -e`, aborts the script before the cache section below.
 T1_JSON="$("$BIN" --json "$T1")"
-head -c 600 <<<"$T1_JSON"
-echo
+# Print the scalar totals benchmarks-du.md actually diffs across commits. A fixed
+# byte prefix of the JSON was arbitrary — the groups[] array can push any field
+# past the cut, so a "correctness diff" could silently compare nothing.
+grep -oE '"(files_scanned|files_listed|files_opened|files_cached|extents|threads|naive_bytes|unique_bytes|unique_allocated_bytes|apparent_bytes|sparse_bytes|sparse_files|shared_bytes|cross_group_shared_bytes|private_sum_bytes|outside_shared_bytes)": [0-9]+' <<<"$T1_JSON"
 
 # --- extent cache (added 2026-07-27) -----------------------------------------
 # Two phases, in order, because the cache is a stateful feature:
@@ -47,11 +59,16 @@ echo
 #   2. warm       : same scan, extents served from the cache
 # The plain matrix above runs WITHOUT --cache-dir, so it stays comparable to
 # every pre-cache measurement in benchmarks-du.md.
-CACHE_DIR="${TMPDIR:-/tmp}/clonesize-bench-cache-$LABEL"
-mkdir -p "$CACHE_DIR"
+# The label is NEVER interpolated into a path. It is caller-supplied ($1) and the
+# cache dir is pasted into the single-quoted hyperfine command strings below, so a
+# label containing a quote would break out of the quoting and run arbitrary
+# commands. mktemp keeps the path generated and quote-free; the label stays in the
+# human header, where it is only ever echoed.
+CACHE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/clonesize-bench-cache.XXXXXX")"
 
 echo
 echo "--- extent cache ---"
+echo "cache dir: $CACHE_DIR"
 hyperfine --warmup 1 --runs 3 --style basic \
     -n "T1 cache-cold" "'$BIN' --quiet --cache-dir '$CACHE_DIR' --no-cache '$T1'" \
     -n "T1 cache-warm" "'$BIN' --quiet --cache-dir '$CACHE_DIR' '$T1'"
@@ -61,3 +78,5 @@ echo "cache file:"
 ls -la "$CACHE_DIR"
 WARM_OUT="$("$BIN" --quiet --cache-dir "$CACHE_DIR" "$T1")"
 head -2 <<<"$WARM_OUT"
+echo
+show_load "end"

--- a/src/du/native/clonesize.c
+++ b/src/du/native/clonesize.c
@@ -991,9 +991,24 @@ static void cache_open(const char *target) {
     if (map == MAP_FAILED) return;
 
     const CacheHeader *h = map;
-    size_t need = sizeof(CacheHeader) + (size_t)h->nrecs * sizeof(CacheEnt) + (size_t)h->nexts * sizeof(CacheExt);
+
+    // Validate the counts by DIVIDING the space that is actually there, never by
+    // multiplying the counts out first. The counts are attacker-influenceable
+    // (they are just bytes in an on-disk file), and `nrecs * sizeof(CacheEnt)`
+    // wraps a 64-bit size_t: nrecs = 2^60 makes that product exactly 0, so a
+    // "total > st_size" test passes and cache_lookup then binary-searches 2^60
+    // entries across a 280-byte mapping. That segfaults (verified: exit 139).
+    // Dividing cannot overflow, so each count is bounded before it is ever scaled.
+    size_t avail = (size_t)st.st_size - sizeof(CacheHeader);
     if (h->magic != CACHE_MAGIC || h->version != CACHE_VERSION || h->fsid != g_fsid ||
-        need > (size_t)st.st_size) {
+        h->nrecs > avail / sizeof(CacheEnt)) {
+        munmap(map, (size_t)st.st_size);
+        return;
+    }
+
+    // Safe to scale now: nrecs is known to fit, so this cannot wrap or underflow.
+    size_t after_ents = avail - (size_t)h->nrecs * sizeof(CacheEnt);
+    if (h->nexts > after_ents / sizeof(CacheExt)) {
         munmap(map, (size_t)st.st_size);
         return;
     }

--- a/src/du/native/clonesize.c
+++ b/src/du/native/clonesize.c
@@ -117,6 +117,20 @@ static const CacheEnt *g_cache_ents = NULL;
 static const CacheExt *g_cache_exts = NULL;
 static uint64_t    g_cache_nents = 0, g_cache_nexts = 0;
 
+/**
+ * True when `count` items starting at index `off` fit inside `limit` items.
+ *
+ * Every bounds check against the cache MUST go through this. `off` and `count`
+ * are read straight out of the cache file, so the obvious `off + count > limit`
+ * is wrong: the sum wraps a 64-bit unsigned and lands back under `limit`, so the
+ * check passes for a range nowhere near inside the mapping. Subtracting from the
+ * limit instead is exact for every input, and dividing (rather than multiplying)
+ * at the call site keeps byte-sized limits safe the same way.
+ */
+static inline int range_within(uint64_t off, uint64_t count, uint64_t limit) {
+    return off <= limit && count <= limit - off;
+}
+
 /** Per-file record of what to write back — one per accounted shared file. */
 typedef struct {
     uint64_t fileid, mtime_ns, dlen, alloc;
@@ -417,7 +431,7 @@ static const CacheEnt *cache_lookup(uint64_t fileid, uint64_t mtime_ns, uint64_t
     if (lo >= g_cache_nents || g_cache_ents[lo].fileid != fileid) return NULL;
     const CacheEnt *e = &g_cache_ents[lo];
     if (e->mtime_ns != mtime_ns || e->dlen != dlen || e->alloc != alloc) return NULL;
-    if (e->ext_off + e->ext_count > g_cache_nexts) return NULL;   // corrupt/truncated
+    if (!range_within(e->ext_off, e->ext_count, g_cache_nexts)) return NULL;   // corrupt/truncated
     return e;
 }
 
@@ -992,23 +1006,22 @@ static void cache_open(const char *target) {
 
     const CacheHeader *h = map;
 
-    // Validate the counts by DIVIDING the space that is actually there, never by
-    // multiplying the counts out first. The counts are attacker-influenceable
-    // (they are just bytes in an on-disk file), and `nrecs * sizeof(CacheEnt)`
-    // wraps a 64-bit size_t: nrecs = 2^60 makes that product exactly 0, so a
-    // "total > st_size" test passes and cache_lookup then binary-searches 2^60
-    // entries across a 280-byte mapping. That segfaults (verified: exit 139).
-    // Dividing cannot overflow, so each count is bounded before it is ever scaled.
+    // Bound each count against the space that is actually there, DIVIDING the
+    // available bytes into elements rather than multiplying the counts out.
+    // Multiplying first wraps a 64-bit size_t — nrecs = 2^60 makes
+    // nrecs * sizeof(CacheEnt) exactly 0, so a "total > st_size" test passes and
+    // cache_lookup then binary-searches 2^60 entries across a 280-byte mapping
+    // (verified: SIGSEGV, exit 139). Division cannot overflow.
     size_t avail = (size_t)st.st_size - sizeof(CacheHeader);
     if (h->magic != CACHE_MAGIC || h->version != CACHE_VERSION || h->fsid != g_fsid ||
-        h->nrecs > avail / sizeof(CacheEnt)) {
+        !range_within(0, h->nrecs, avail / sizeof(CacheEnt))) {
         munmap(map, (size_t)st.st_size);
         return;
     }
 
     // Safe to scale now: nrecs is known to fit, so this cannot wrap or underflow.
     size_t after_ents = avail - (size_t)h->nrecs * sizeof(CacheEnt);
-    if (h->nexts > after_ents / sizeof(CacheExt)) {
+    if (!range_within(0, h->nexts, after_ents / sizeof(CacheExt))) {
         munmap(map, (size_t)st.st_size);
         return;
     }
@@ -1112,6 +1125,12 @@ static void cache_write(int nthreads) {
         uint64_t fid = g_cache_ents[oi].fileid;
         while (ni < n && pend[ni].ent.fileid < fid) ni++;
         if (ni < n && pend[ni].ent.fileid == fid) { oi++; continue; }
+        // Carrying a record over means reading its extents back out of the old
+        // mapping, so it needs the same bound cache_lookup applies. Nothing had
+        // checked this one: a forged ext_off reached the fwrite loop below and
+        // read outside the mapping even when the header itself was consistent.
+        if (!range_within(g_cache_ents[oi].ext_off, g_cache_ents[oi].ext_count, g_cache_nexts)) { oi++; continue; }
+
         pend[merged].ent = g_cache_ents[oi];
         pend[merged].ent.ext_off = 0;
         pend[merged].from_scan = NULL;

--- a/src/du/native/clonesize.c
+++ b/src/du/native/clonesize.c
@@ -36,6 +36,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/attr.h>
+#include <sys/mman.h>
+#include <sys/mount.h>
+#include <sys/param.h>
 #include <sys/vnode.h>
 #include <time.h>
 
@@ -48,6 +51,78 @@ static int    g_nthreads   = 0;      // 0 => auto (ncpu)
 static int    g_freeable   = 0;      // sum ATTR_CMNEXT_PRIVATESIZE (now always available; gates output only)
 static size_t g_min_blocks = 0;      // skip files with alloc < this (bytes) — 0 = keep all
 static double g_clone_pct  = 0.30;   // group "clone-flagged" if >= this frac of its bytes is cross-group shared
+
+// --changed-within: when > 0, only files with st_mtime >= this epoch second are
+// accounted (the walk still descends every directory — a fresh file can live in
+// an untouched dir). 0 disables the filter.
+static uint64_t g_mtime_min = 0;
+
+// APFS allocation block. `alloc` (ATTR_FILE_ALLOCSIZE) is always a multiple of
+// this, so rounding extent ranges out to it converts the mapped-byte extent scan
+// into an allocated-block one (see merge_pass).
+#define BLK 4096ULL
+
+// ---------------------------------------------------------------------------
+// Extent cache.
+//
+// Profiling says 99.8% of a scan is the walk, and inside it each shared file
+// costs ~17µs of open()+fcntl(F_LOG2PHYS_EXT)+close() — 8.0s of a 13.8s
+// 712k-file scan. Everything else (merge, sort, cluster) is 0.03s.
+//
+// So the cache stores exactly that: a file's physical extent list, keyed by
+// identity that cannot change without the extents changing. A hit on
+// (fileid, mtime, datalength, allocsize) means the file was not written since we
+// last mapped it, so its extents still are what we recorded — and we skip the
+// syscalls entirely. Anything that rewrites a file bumps its mtime; anything
+// that changes its length changes dlen/alloc.
+//
+// Not covered: an in-place rewrite that restores the exact mtime AND size (i.e.
+// deliberate `touch -m` forgery), and APFS defragmenting blocks under a file
+// without touching its metadata. `--no-cache` exists for both.
+// ---------------------------------------------------------------------------
+#define CACHE_MAGIC     0x48434143455A4C43ULL   // "CLZECACH"
+#define CACHE_VERSION   1u
+#define CACHE_MAX_RECS  2000000u                // ~96 MB of records + extents
+
+typedef struct {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t reserved;
+    uint64_t fsid;
+    uint64_t nrecs;
+    uint64_t nexts;
+} CacheHeader;
+
+typedef struct {
+    uint64_t fileid;
+    uint64_t mtime_ns;
+    uint64_t dlen;
+    uint64_t alloc;
+    uint64_t ext_off;      // index into the extent blob
+    uint32_t ext_count;
+    uint32_t last_seen;    // epoch seconds, for eviction when over CACHE_MAX_RECS
+} CacheEnt;
+
+typedef struct { uint64_t dev, len; } CacheExt;
+
+static const char *g_cache_dir = NULL;   // NULL disables the cache entirely
+static int         g_cache_read = 1;     // --no-cache: still WRITE, just never READ
+static char        g_cache_file[4096];
+static uint64_t    g_fsid = 0;
+
+// The mmap'd previous cache (read-only, shared by every worker thread).
+static void       *g_cache_map = NULL;
+static size_t      g_cache_map_len = 0;
+static const CacheEnt *g_cache_ents = NULL;
+static const CacheExt *g_cache_exts = NULL;
+static uint64_t    g_cache_nents = 0, g_cache_nexts = 0;
+
+/** Per-file record of what to write back — one per accounted shared file. */
+typedef struct {
+    uint64_t fileid, mtime_ns, dlen, alloc;
+    size_t   ext_start;    // index into the owning thread's ext array
+    uint32_t ext_count;
+} CacheRec;
 
 // PROFILE: when the env var PROFILE is set (any value), phase timings go to stderr.
 static int    g_profile    = 0;
@@ -67,9 +142,15 @@ typedef struct {
     int      depth;       // 0 = root
     char    *name;        // basename (root uses the scan-root path)
     uint64_t naive, files, priv;   // rolled up to whole subtree in the post-pass
-    uint64_t private_dlen;         // Σ dlen of fully-private files (their unique contribution)
-    uint64_t unique_shared;        // unique bytes from shared extents (post-pass)
-    uint64_t cross;                // bytes shared with dirs OUTSIDE this subtree
+    uint64_t private_dlen;         // Σ dlen of fully-private files (their MAPPED unique contribution)
+    uint64_t private_alloc;        // Σ alloc of fully-private files (their ALLOCATED contribution)
+    uint64_t apparent;             // Σ dlen of every accounted file (sparse files count full)
+    uint64_t sparse_extra;         // Σ (dlen - alloc) over files where dlen > alloc
+    uint64_t sparse_files;         // count of those files
+    uint64_t unique_shared;        // unique MAPPED bytes from shared extents (post-pass)
+    uint64_t cross;                // mapped bytes shared with dirs OUTSIDE this subtree
+    uint64_t unique_shared_alloc;  // same as unique_shared, block-aligned
+    uint64_t cross_alloc;          // same as cross, block-aligned
 } Node;
 static Node  *g_nodes = NULL;
 static int    g_nnodes = 0, g_node_cap = 0;
@@ -93,7 +174,7 @@ static int intern_node(int parent, const char *name, int depth) {
 }
 
 // Per-file record emitted by the parallel scan in --depth mode; node accounting
-// (naive/files/priv/private-unique) is done single-threaded in the post-pass.
+// (naive/files/priv/private-unique/sparse) is done single-threaded in the post-pass.
 typedef struct { int node; uint64_t alloc, dlen, priv; int is_private; } FileRec;
 
 // ---------------------------------------------------------------------------
@@ -115,10 +196,87 @@ static uint64_t g_group_private[MAX_GROUPS];
 #define MAX_EXCLUDES 256
 static const char *g_excludes[MAX_EXCLUDES];
 static int g_nexcludes = 0;
+
+// Mount points of OTHER filesystems inside the scan root, pruned before the walk
+// can touch them (`du -x` semantics). Two reasons:
+//   1. Accounting: another volume's bytes are not this volume's used space, so
+//      counting them makes the volume reconcile wrong by construction.
+//   2. Robustness: /System/Volumes/Data on this machine contains an autofs trigger
+//      (`map auto_home` at /System/Volumes/Data/home) and an NFS export (OrbStack
+//      at ~/OrbStack). Descending into either can block a worker thread in an
+//      uninterruptible syscall for as long as the server takes to answer.
+// Pruning by PATH from getmntinfo() — before any open() — is what keeps that
+// unreachable; deciding by the child's fsid would mean stat'ing the mount point,
+// which is the very call that can block.
+#define MAX_FOREIGN_MOUNTS 512
+static char *g_foreign_mounts[MAX_FOREIGN_MOUNTS];
+static int   g_nforeign = 0;
+
+// ---------------------------------------------------------------------------
+// Cloud-provider roots (macOS File Provider): ~/Library/CloudStorage/<provider>
+// and ~/Library/Mobile Documents (iCloud Drive).
+//
+// These are NOT mount points — they sit on the same device as everything else,
+// so the mount pruning above cannot see them — but reading them goes through the
+// provider's extension. Measured here: all 16 workers parked in getattrlistbulk
+// inside ~/Library/CloudStorage/Tresorit-*, zero progress, for minutes.
+//
+// Skipping them is also the CORRECT accounting. Their contents are largely
+// dataless placeholders whose bytes live on someone else's disk, and touching a
+// placeholder can trigger a download — a disk-usage tool must never quietly pull
+// gigabytes over the network to measure them. `--include-cloud` opts back in.
+// ---------------------------------------------------------------------------
+#define MAX_CLOUD_ROOTS 128
+static char *g_cloud_roots[MAX_CLOUD_ROOTS];
+static int   g_ncloud = 0;
+static int   g_skip_cloud = 1;
+static pthread_mutex_t g_cloud_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+/** True when `dirpath` is a `Library` whose child `name` is a cloud-provider root. */
+static int is_cloud_root(const char *dirpath, const char *name) {
+    if (!g_skip_cloud) return 0;
+    if (strcmp(name, "CloudStorage") != 0 && strcmp(name, "Mobile Documents") != 0) return 0;
+    size_t dl = strlen(dirpath);
+    return dl >= 8 && strcmp(dirpath + dl - 8, "/Library") == 0;
+}
+
+static void note_cloud_root(const char *path) {
+    pthread_mutex_lock(&g_cloud_mtx);
+    if (g_ncloud < MAX_CLOUD_ROOTS) {
+        char *c = strdup(path);
+        if (c) g_cloud_roots[g_ncloud++] = c;
+    }
+    pthread_mutex_unlock(&g_cloud_mtx);
+}
+
 static int is_excluded(const char *path) {
     for (int i = 0; i < g_nexcludes; i++)
         if (strcmp(g_excludes[i], path) == 0) return 1;
+    for (int i = 0; i < g_nforeign; i++)
+        if (strcmp(g_foreign_mounts[i], path) == 0) return 1;
     return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Permission denials. A tree the scanner cannot open is a silent hole in the
+// total (on this machine .DocumentRevisions-V100 / .Spotlight-V100 / .fseventsd
+// hid ~132 GB), so every EACCES/EPERM is counted and the first MAX_DENIED paths
+// are kept for the report.
+// ---------------------------------------------------------------------------
+#define MAX_DENIED 64
+static char    *g_denied_paths[MAX_DENIED];
+static int      g_denied_kept = 0;
+static uint64_t g_denied_dirs = 0, g_denied_files = 0;
+static pthread_mutex_t g_denied_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+static void note_denied(const char *path, int is_dir) {
+    pthread_mutex_lock(&g_denied_mtx);
+    if (is_dir) g_denied_dirs++; else g_denied_files++;
+    if (g_denied_kept < MAX_DENIED) {
+        char *c = strdup(path);
+        if (c) g_denied_paths[g_denied_kept++] = c;
+    }
+    pthread_mutex_unlock(&g_denied_mtx);
 }
 
 static int intern_group(const char *name) {
@@ -141,25 +299,70 @@ out:
 // Extent record (per thread, then merged globally). `node` is the file's leaf
 // tree-node (its directory clamped to --depth), used only in --depth tree mode.
 // ---------------------------------------------------------------------------
-typedef struct { uint64_t dev; uint64_t len; int group; int node; } Ext;
+typedef struct { uint64_t dev; uint64_t len; int group; int node; uint32_t file; } Ext;
+
+// ---------------------------------------------------------------------------
+// Partner mode (`tools du clones`): phase 1 scans the TARGET and merges its
+// extents into g_tgt_ranges; phase 2 re-walks the wider ROOT and, for every
+// shared file outside the target, reports how many of its bytes land inside
+// those ranges — i.e. which concrete paths the target's blocks also live at.
+// ---------------------------------------------------------------------------
+typedef struct { char *path; uint64_t bytes; } PartnerRec;
+typedef struct { uint64_t start, end; } Range;
+static Range   *g_tgt_ranges = NULL;
+static size_t   g_ntgt_ranges = 0;
+static int      g_partner_mode = 0;
+static const char *g_partner_target = NULL;   // absolute path, no trailing slash
+static size_t   g_partner_target_len = 0;
 
 typedef struct {
     Ext     *exts;
     size_t   n, cap;
     uint64_t naive;                     // sum alloc for this thread's files
-    uint64_t unique_private;            // sum alloc of fully-private (skipped) files
+    uint64_t unique_private;            // sum dlen of fully-private (skipped) files — MAPPED
+    uint64_t unique_private_alloc;      // sum alloc of the same files — ALLOCATED blocks
     uint64_t priv_sum;                  // sum of privatesize across all files
+    uint64_t apparent;                  // sum dlen of accounted files (sparse count full)
+    uint64_t sparse_extra;              // sum (dlen - alloc) over files where dlen > alloc
+    uint64_t sparse_files;              // count of those files
     uint64_t group_naive[MAX_GROUPS];
     uint64_t group_files[MAX_GROUPS];
     uint64_t group_private[MAX_GROUPS];
     uint64_t files_listed;              // all regular files seen
     uint64_t files_accounted;           // alloc>0 && >=min  (private + shared)
     uint64_t files_opened;              // shared files actually opened+scanned
+    uint64_t files_cached;              // shared files served from the extent cache
+    uint64_t priv_opened;               // sum privatesize over files whose extents we collected
+    int      tid;                       // thread index, for minting globally unique file ids
+    uint32_t file_seq;
     FileRec *recs;                      // --depth mode: per-file node records
     size_t   nrecs, rec_cap;
+    PartnerRec *partners;               // partner mode: files overlapping the target
+    size_t   npartners, partner_cap;
+    CacheRec *crecs;                    // cache write-back records
+    size_t   ncrecs, crec_cap;
 } ThreadOut;
 
-static void ext_push(ThreadOut *t, uint64_t dev, uint64_t len, int group, int node) {
+/** Worker count of the walk in flight; the stride next_file_id mints ids on. */
+static int g_walk_threads = 1;
+
+/**
+ * A globally unique id for one scanned file, minted per worker so no atomics are
+ * needed: worker t hands out t, t+N, t+2N, … for N workers, so no two workers can
+ * produce the same id at any thread count. (A bit-field split cannot say that: it
+ * fixes a ceiling on the thread index, and --threads accepts up to 1024.) Only
+ * files whose extents we actually collect get one, which is what the
+ * outside-sharing detection below needs, see merge_pass's single-file clusters.
+ *
+ * Ids wrap after 2^32, which is unreachable: every id owns at least one 32-byte
+ * Ext, so 4.3e9 files is >137 GB of extent array and the scan dies on malloc long
+ * before an id repeats.
+ */
+static uint32_t next_file_id(ThreadOut *t) {
+    return t->file_seq++ * (uint32_t)g_walk_threads + (uint32_t)t->tid;
+}
+
+static void ext_push(ThreadOut *t, uint64_t dev, uint64_t len, int group, int node, uint32_t file) {
     if (t->n == t->cap) {
         t->cap = t->cap ? t->cap * 2 : 8192;
         t->exts = realloc(t->exts, t->cap * sizeof(Ext));
@@ -169,6 +372,7 @@ static void ext_push(ThreadOut *t, uint64_t dev, uint64_t len, int group, int no
     t->exts[t->n].len = len;
     t->exts[t->n].group = group;
     t->exts[t->n].node = node;
+    t->exts[t->n].file = file;
     t->n++;
 }
 
@@ -186,10 +390,79 @@ static void rec_push(ThreadOut *t, int node, uint64_t alloc, uint64_t dlen, uint
     t->nrecs++;
 }
 
+static void crec_push(ThreadOut *t, uint64_t fileid, uint64_t mtime_ns, uint64_t dlen, uint64_t alloc,
+                      size_t ext_start, uint32_t ext_count) {
+    if (t->ncrecs == t->crec_cap) {
+        t->crec_cap = t->crec_cap ? t->crec_cap * 2 : 8192;
+        t->crecs = realloc(t->crecs, t->crec_cap * sizeof(CacheRec));
+        if (!t->crecs) { perror("realloc crecs"); exit(1); }
+    }
+    t->crecs[t->ncrecs].fileid = fileid;
+    t->crecs[t->ncrecs].mtime_ns = mtime_ns;
+    t->crecs[t->ncrecs].dlen = dlen;
+    t->crecs[t->ncrecs].alloc = alloc;
+    t->crecs[t->ncrecs].ext_start = ext_start;
+    t->crecs[t->ncrecs].ext_count = ext_count;
+    t->ncrecs++;
+}
+
+/** Binary search the mmap'd cache. Returns NULL on miss or when the identity moved. */
+static const CacheEnt *cache_lookup(uint64_t fileid, uint64_t mtime_ns, uint64_t dlen, uint64_t alloc) {
+    if (!g_cache_ents || g_cache_nents == 0) return NULL;
+    uint64_t lo = 0, hi = g_cache_nents;
+    while (lo < hi) {
+        uint64_t mid = lo + (hi - lo) / 2;
+        if (g_cache_ents[mid].fileid < fileid) lo = mid + 1; else hi = mid;
+    }
+    if (lo >= g_cache_nents || g_cache_ents[lo].fileid != fileid) return NULL;
+    const CacheEnt *e = &g_cache_ents[lo];
+    if (e->mtime_ns != mtime_ns || e->dlen != dlen || e->alloc != alloc) return NULL;
+    if (e->ext_off + e->ext_count > g_cache_nexts) return NULL;   // corrupt/truncated
+    return e;
+}
+
+static void partner_push(ThreadOut *t, const char *path, uint64_t bytes) {
+    if (t->npartners == t->partner_cap) {
+        t->partner_cap = t->partner_cap ? t->partner_cap * 2 : 256;
+        t->partners = realloc(t->partners, t->partner_cap * sizeof(PartnerRec));
+        if (!t->partners) { perror("realloc partners"); exit(1); }
+    }
+    t->partners[t->npartners].path = strdup(path);
+    if (!t->partners[t->npartners].path) { perror("strdup partner path"); exit(1); }
+    t->partners[t->npartners].bytes = bytes;
+    t->npartners++;
+}
+
+// Bytes of [s,e) that fall inside the merged target ranges (binary search to the
+// first range that can overlap, then walk forward while ranges still start before e).
+static uint64_t range_overlap(uint64_t s, uint64_t e) {
+    if (g_ntgt_ranges == 0 || e <= s) return 0;
+    size_t lo = 0, hi = g_ntgt_ranges;
+    while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        if (g_tgt_ranges[mid].end <= s) lo = mid + 1; else hi = mid;
+    }
+    uint64_t sum = 0;
+    for (size_t i = lo; i < g_ntgt_ranges && g_tgt_ranges[i].start < e; i++) {
+        uint64_t a = g_tgt_ranges[i].start > s ? g_tgt_ranges[i].start : s;
+        uint64_t b = g_tgt_ranges[i].end   < e ? g_tgt_ranges[i].end   : e;
+        if (b > a) sum += b - a;
+    }
+    return sum;
+}
+
+/** True when `path` is the partner target itself or lives inside it. */
+static int under_partner_target(const char *path) {
+    if (!g_partner_target) return 0;
+    if (strncmp(path, g_partner_target, g_partner_target_len) != 0) return 0;
+    char after = path[g_partner_target_len];
+    return after == '\0' || after == '/';
+}
+
 // ---------------------------------------------------------------------------
 // Extent scan of ONE already-open shared file.
 // ---------------------------------------------------------------------------
-static void scan_shared_file(ThreadOut *t, int fd, off_t size, int group, int node) {
+static void scan_shared_file(ThreadOut *t, int fd, off_t size, int group, int node, uint32_t file) {
     off_t off = 0;
     while (off < size) {
         struct log2phys l2p;
@@ -200,9 +473,28 @@ static void scan_shared_file(ThreadOut *t, int fd, off_t size, int group, int no
         off_t contig = l2p.l2p_contigbytes; // OUT: contiguous bytes at this offset
         if (contig <= 0) break;
         if ((uint64_t)l2p.l2p_devoffset != (uint64_t)-1) // (off_t)-1 => sparse hole, skip
-            ext_push(t, (uint64_t)l2p.l2p_devoffset, (uint64_t)contig, group, node);
+            ext_push(t, (uint64_t)l2p.l2p_devoffset, (uint64_t)contig, group, node, file);
         off += contig;
     }
+}
+
+/** Partner mode: same walk, but sum the file's overlap with the target ranges. */
+static uint64_t overlap_shared_file(int fd, off_t size) {
+    off_t off = 0;
+    uint64_t sum = 0;
+    while (off < size) {
+        struct log2phys l2p;
+        memset(&l2p, 0, sizeof(l2p));
+        l2p.l2p_contigbytes = size - off;
+        l2p.l2p_devoffset   = off;
+        if (fcntl(fd, F_LOG2PHYS_EXT, &l2p) < 0) break;
+        off_t contig = l2p.l2p_contigbytes;
+        if (contig <= 0) break;
+        if ((uint64_t)l2p.l2p_devoffset != (uint64_t)-1)
+            sum += range_overlap((uint64_t)l2p.l2p_devoffset, (uint64_t)l2p.l2p_devoffset + (uint64_t)contig);
+        off += contig;
+    }
+    return sum;
 }
 
 // ---------------------------------------------------------------------------
@@ -234,15 +526,22 @@ static void q_push(char *path, int group, int node, int depth) {
     pthread_mutex_unlock(&g_qmtx);
 }
 
-// getattrlistbulk entry layout (4-byte packed, FSOPT_PACK_INVAL_ATTRS):
+// getattrlistbulk entry layout (4-byte packed, FSOPT_PACK_INVAL_ATTRS). Fields
+// appear in sys/attr.h BIT order, not request order, so inserting an attribute
+// shifts everything after it — verified empirically against fstatat() each time
+// one was added here:
 //   0  u32 length | 4 returned_attrs(20) | 24 name attrref(8) | 32 objtype(4)
-//   36 linkcount u32(4) | 40 alloc off_t(8) | 48 datalength off_t(8) | 56 privatesize off_t(8)
+//   36 modtime timespec(16) | 52 fileid u64(8) | 60 linkcount u32(4)
+//   64 alloc off_t(8) | 72 datalength off_t(8) | 80 privatesize off_t(8)
 static struct attrlist g_al;
 static uint64_t g_alopt;
 
 static void process_dir(ThreadOut *t, const char *dirpath, int dirgroup, int dirnode, int depth) {
     int dfd = open(dirpath, O_RDONLY | O_DIRECTORY | O_NONBLOCK);
-    if (dfd < 0) return;
+    if (dfd < 0) {
+        if (errno == EACCES || errno == EPERM) note_denied(dirpath, 1);
+        return;
+    }
     char buf[64 * 1024];
     for (;;) {
         int n = getattrlistbulk(dfd, &g_al, buf, sizeof buf, g_alopt);
@@ -256,6 +555,11 @@ static void process_dir(ThreadOut *t, const char *dirpath, int dirgroup, int dir
             const char *name = entry + off + nameoff;
             off += 8;
             uint32_t objtype; memcpy(&objtype, entry + off, 4); off += 4;
+            int64_t  mtime, mnsec;
+            memcpy(&mtime, entry + off, 8);
+            memcpy(&mnsec, entry + off + 8, 8);
+            off += 16;                                                    // timespec: sec + nsec
+            uint64_t fileid;  memcpy(&fileid,  entry + off, 8); off += 8;
             uint32_t nlink;   memcpy(&nlink,   entry + off, 4); off += 4;
             off_t alloc; memcpy(&alloc, entry + off, 8); off += 8;
             off_t dlen;  memcpy(&dlen,  entry + off, 8); off += 8;
@@ -268,7 +572,8 @@ static void process_dir(ThreadOut *t, const char *dirpath, int dirgroup, int dir
                 size_t pl = strlen(dirpath), nl = strlen(name);
                 char *sub = malloc(pl + 1 + nl + 1);
                 memcpy(sub, dirpath, pl); sub[pl] = '/'; memcpy(sub + pl + 1, name, nl + 1);
-                if (g_nexcludes && is_excluded(sub)) { free(sub); continue; }
+                if ((g_nexcludes || g_nforeign) && is_excluded(sub)) { free(sub); continue; }
+                if (is_cloud_root(dirpath, name)) { note_cloud_root(sub); free(sub); continue; }
                 // --depth: a child at depth<=maxdepth is its own node; deeper dirs
                 // inherit their depth-maxdepth ancestor's node.
                 int childnode = dirnode;
@@ -280,6 +585,9 @@ static void process_dir(ThreadOut *t, const char *dirpath, int dirgroup, int dir
 
             int g = (dirgroup < 0) ? intern_group(name) : dirgroup;
             t->files_listed++;
+            // --changed-within: attribute only files touched inside the window.
+            // Directories are still descended — a fresh file can sit in an old dir.
+            if (g_mtime_min && (uint64_t)mtime < g_mtime_min) continue;
             t->priv_sum += (uint64_t)priv;
             if (alloc == 0 || (size_t)alloc < g_min_blocks) continue;
 
@@ -289,6 +597,34 @@ static void process_dir(ThreadOut *t, const char *dirpath, int dirgroup, int dir
             t->group_files[g] += 1;
             t->group_private[g] += (uint64_t)priv;
             t->files_accounted++;
+            t->apparent += (uint64_t)dlen;
+            if ((uint64_t)dlen > a) {
+                t->sparse_extra += (uint64_t)dlen - a;
+                t->sparse_files++;
+            }
+
+            // Partner mode: only shared files can host another file's blocks, so
+            // the private-file skip below doubles as the partner-mode filter.
+            if (g_partner_mode) {
+                if ((uint64_t)priv >= a && nlink <= 1 && a >= (uint64_t)dlen) continue;
+                size_t pl = strlen(dirpath), nl = strlen(name);
+                char *full = malloc(pl + 1 + nl + 1);
+                if (!full) { perror("malloc partner path"); exit(1); }
+                memcpy(full, dirpath, pl); full[pl] = '/'; memcpy(full + pl + 1, name, nl + 1);
+                if (under_partner_target(full)) { free(full); continue; }
+                int pfd = openat(dfd, name, O_RDONLY | O_NONBLOCK);
+                if (pfd < 0) {
+                    if (errno == EACCES || errno == EPERM) note_denied(full, 0);
+                    free(full);
+                    continue;
+                }
+                t->files_opened++;
+                uint64_t ov = overlap_shared_file(pfd, dlen);
+                close(pfd);
+                if (ov > 0) partner_push(t, full, ov);
+                free(full);
+                continue;
+            }
 
             // NOSKIP=1 (env) disables the skip optimization below — every file is
             // opened + extent-scanned, matching the pre-skip engine. Intentional
@@ -307,16 +643,54 @@ static void process_dir(ThreadOut *t, const char *dirpath, int dirgroup, int dir
             //  - alloc<dlen: sparse file (holes); its mapped bytes < dlen, so scan it.
             if (!noskip && (uint64_t)priv >= a && nlink <= 1 && a >= (uint64_t)dlen) {
                 t->unique_private += (uint64_t)dlen;
+                t->unique_private_alloc += a;
                 if (g_maxdepth >= 0) rec_push(t, dirnode, a, (uint64_t)dlen, (uint64_t)priv, 1);
                 continue;
             }
-            // Shares some blocks — open by leaf (dfd is the parent) and extent-scan.
+            // Shares some blocks. Its extent map is the expensive part (~17µs of
+            // open+fcntl+close), so try the cache before paying for it.
+            uint64_t mtime_ns = (uint64_t)mtime * 1000000000ULL + (uint64_t)mnsec;
+            size_t ext_start = t->n;
+            if (g_cache_read) {
+                const CacheEnt *hit = cache_lookup(fileid, mtime_ns, (uint64_t)dlen, a);
+                if (hit) {
+                    uint32_t fid = next_file_id(t);
+                    for (uint32_t x = 0; x < hit->ext_count; x++) {
+                        const CacheExt *ce = &g_cache_exts[hit->ext_off + x];
+                        ext_push(t, ce->dev, ce->len, g, g_maxdepth >= 0 ? dirnode : -1, fid);
+                    }
+                    t->priv_opened += (uint64_t)priv;
+                    t->files_cached++;
+                    if (g_cache_dir) {
+                        crec_push(t, fileid, mtime_ns, (uint64_t)dlen, a, ext_start, hit->ext_count);
+                    }
+                    if (g_maxdepth >= 0) rec_push(t, dirnode, a, (uint64_t)dlen, (uint64_t)priv, 0);
+                    continue;
+                }
+            }
+
+            // Open by leaf (dfd is the parent) and extent-scan.
             int ffd = openat(dfd, name, O_RDONLY | O_NONBLOCK);
-            if (ffd < 0) continue;
+            if (ffd < 0) {
+                if (errno == EACCES || errno == EPERM) {
+                    size_t pl = strlen(dirpath), nl = strlen(name);
+                    char *full = malloc(pl + 1 + nl + 1);
+                    if (full) {
+                        memcpy(full, dirpath, pl); full[pl] = '/'; memcpy(full + pl + 1, name, nl + 1);
+                        note_denied(full, 0);
+                        free(full);
+                    }
+                }
+                continue;
+            }
             t->files_opened++;
-            scan_shared_file(t, ffd, dlen, g, g_maxdepth >= 0 ? dirnode : -1);
-            if (g_maxdepth >= 0) rec_push(t, dirnode, a, (uint64_t)dlen, (uint64_t)priv, 0);
+            scan_shared_file(t, ffd, dlen, g, g_maxdepth >= 0 ? dirnode : -1, next_file_id(t));
+            t->priv_opened += (uint64_t)priv;
             close(ffd);
+            if (g_cache_dir) {
+                crec_push(t, fileid, mtime_ns, (uint64_t)dlen, a, ext_start, (uint32_t)(t->n - ext_start));
+            }
+            if (g_maxdepth >= 0) rec_push(t, dirnode, a, (uint64_t)dlen, (uint64_t)priv, 0);
         }
     }
     close(dfd);
@@ -357,111 +731,37 @@ static int cmp_ext(const void *a, const void *b) {
 }
 
 // ---------------------------------------------------------------------------
-// Computed result
+// Cluster merge over the sorted extent array.
+//
+// Run TWICE over the same sorted array:
+//   align=0 — raw ranges. The extent scan stops at datalength, so this sums the
+//             MAPPED bytes: exact against the extents, but short of what the
+//             volume actually spends by each file's sub-block tail slack.
+//   align=1 — every range rounded out to an APFS allocation block. That tail
+//             slack is recovered, so the total is the ALLOCATED bytes, which is
+//             what `du`, `diskutil` and the free-space counter agree on.
+// Aligning starts DOWN preserves the sort order, so one qsort feeds both passes.
 // ---------------------------------------------------------------------------
 typedef struct {
-    uint64_t naive, unique, shared, cross_shared, priv_sum;
-    uint64_t files_listed, files_accounted, files_opened, extents;
-    int      threads;
-    double   pct;
+    uint64_t unique_shared, cross_shared;
+    /**
+     * Bytes in clusters touched by exactly ONE scanned file. Such a block was
+     * collected because the file shares with something (fully private files are
+     * never opened), yet nothing else inside the scan references it — so the
+     * sharing partner lies OUTSIDE the scan root. Subtracting the private bytes
+     * of those same files turns this into the outside-shared figure.
+     */
+    uint64_t single_file;
     uint64_t group_shared[MAX_GROUPS];
-} Result;
+} MergeOut;
 
-static double now_s(void) {
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return ts.tv_sec + ts.tv_nsec / 1e9;
-}
+static int merge_pass(const Ext *all, size_t total_exts, int align, int do_groups, MergeOut *M) {
+    memset(M, 0, sizeof *M);
 
-// Runs the full scan; fills *R. Returns 0 on success.
-static int run_scan(const char *target, Result *R) {
-    memset(R, 0, sizeof *R);
-
-    // Set up the shared attrlist for every getattrlistbulk call.
-    memset(&g_al, 0, sizeof g_al);
-    g_al.bitmapcount = ATTR_BIT_MAP_COUNT;
-    g_al.commonattr  = ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_NAME | ATTR_CMN_OBJTYPE;
-    g_al.fileattr    = ATTR_FILE_LINKCOUNT | ATTR_FILE_ALLOCSIZE | ATTR_FILE_DATALENGTH;
-    g_al.forkattr    = ATTR_CMNEXT_PRIVATESIZE;
-    g_alopt = FSOPT_PACK_INVAL_ATTRS | FSOPT_ATTR_CMN_EXTENDED | FSOPT_NOFOLLOW;
-
-    int nthreads = g_nthreads;
-    if (nthreads <= 0) {
-        long nc = sysconf(_SC_NPROCESSORS_ONLN);
-        nthreads = (nc > 0) ? (int)nc : 4;
-    }
-
-    double t0 = now_s();
-
-    // Fused parallel walk + shared-file extent scan.
-    g_outs = calloc(nthreads, sizeof(ThreadOut));
-    pthread_t *th = calloc(nthreads, sizeof(pthread_t));
-    // --depth: root is node 0 (depth 0). Files loose in the root belong to it.
-    int rootnode = (g_maxdepth >= 0) ? intern_node(-1, target, 0) : -1;
-    q_push(strdup(target), -1, rootnode, 0);
-    for (int i = 0; i < nthreads; i++) pthread_create(&th[i], NULL, worker, &g_outs[i]);
-    for (int i = 0; i < nthreads; i++) pthread_join(th[i], NULL);
-
-    double t1 = now_s();
-
-    // Merge thread outputs.
-    size_t total_exts = 0;
-    uint64_t naive = 0, unique_private = 0, priv_sum = 0;
-    uint64_t files_listed = 0, files_accounted = 0, files_opened = 0;
-    for (int i = 0; i < nthreads; i++) {
-        total_exts      += g_outs[i].n;
-        naive           += g_outs[i].naive;
-        unique_private  += g_outs[i].unique_private;
-        priv_sum        += g_outs[i].priv_sum;
-        files_listed    += g_outs[i].files_listed;
-        files_accounted += g_outs[i].files_accounted;
-        files_opened    += g_outs[i].files_opened;
-        for (int g = 0; g < g_ngroups; g++) {
-            g_group_naive[g]   += g_outs[i].group_naive[g];
-            g_group_files[g]   += g_outs[i].group_files[g];
-            g_group_private[g] += g_outs[i].group_private[g];
-        }
-        // --depth: accumulate per-leaf-node naive/files/priv/private-unique.
-        for (size_t r = 0; r < g_outs[i].nrecs; r++) {
-            FileRec *fr = &g_outs[i].recs[r];
-            Node *nd = &g_nodes[fr->node];
-            nd->naive += fr->alloc;
-            nd->files += 1;
-            nd->priv  += fr->priv;
-            if (fr->is_private) nd->private_dlen += fr->dlen;
-        }
-        free(g_outs[i].recs);
-    }
-
-    Ext *all = malloc((total_exts ? total_exts : 1) * sizeof(Ext));
-    if (!all) { perror("malloc merge"); return 1; }
-    size_t k = 0;
-    for (int i = 0; i < nthreads; i++) {
-        if (g_outs[i].n) memcpy(all + k, g_outs[i].exts, g_outs[i].n * sizeof(Ext));
-        k += g_outs[i].n;
-        free(g_outs[i].exts);
-    }
-    free(g_outs); g_outs = NULL;
-    free(th);
-
-    double t2 = now_s();
-
-    // Sort by device offset, merge overlapping clusters. For each merged cluster,
-    // collect its DISTINCT groups by scanning the cluster's own extents. This
-    // replaces the old uint64 group bitmask (which capped groups at 64 and made a
-    // scan root with >64 immediate children fold everything past the 63rd into one
-    // bogus overflow bucket) — there is no 64-group limit here.
-    qsort(all, total_exts, sizeof(Ext), cmp_ext);
-    for (int i = 0; i < MAX_GROUPS; i++) g_uf[i] = i;
-
-    uint64_t unique_shared = 0, cross_shared = 0;
-    uint64_t group_shared[MAX_GROUPS]; memset(group_shared, 0, sizeof group_shared);
-
-    // Per-cluster distinct-group dedup via epoch marks (O(cluster size), no reset).
     int gcap = g_ngroups > 0 ? g_ngroups : 1;
     int *seen_epoch = malloc((size_t)gcap * sizeof(int));
     int *dg = malloc((size_t)gcap * sizeof(int));
-    if (!seen_epoch || !dg) { perror("malloc groups"); return 1; }
+    if (!seen_epoch || !dg) { perror("malloc groups"); free(seen_epoch); free(dg); return 1; }
     for (int g = 0; g < gcap; g++) seen_epoch[g] = -1;
 
     // --depth node accounting scratch (epoch-marked, no reset between clusters).
@@ -477,18 +777,28 @@ static int run_scan(const char *target, Result *R) {
         for (int a = 0; a < ncap; a++) { leaf_seen[a] = -1; cov_epoch[a] = -1; }
     }
 
+    #define RSTART(x) (align ? ((x).dev & ~(BLK - 1)) : (x).dev)
+    #define REND(x)   (align ? (((x).dev + (x).len + BLK - 1) & ~(BLK - 1)) : (x).dev + (x).len)
+
     size_t i = 0;
     int epoch = 0;
     while (i < total_exts) {
-        uint64_t cs = all[i].dev, ce = all[i].dev + all[i].len;
+        uint64_t cs = RSTART(all[i]), ce = REND(all[i]);
         size_t j = i + 1;
-        while (j < total_exts && all[j].dev < ce) {
-            uint64_t en = all[j].dev + all[j].len;
+        while (j < total_exts && RSTART(all[j]) < ce) {
+            uint64_t en = REND(all[j]);
             if (en > ce) ce = en;
             j++;
         }
         uint64_t clen = ce - cs;
-        unique_shared += clen;
+        M->unique_shared += clen;
+
+        uint32_t f0 = all[i].file;
+        int single_file = 1;
+        for (size_t k = i + 1; k < j; k++) {
+            if (all[k].file != f0) { single_file = 0; break; }
+        }
+        if (single_file) M->single_file += clen;
 
         // Distinct groups touching this cluster, in first-appearance order.
         int ndg = 0;
@@ -506,11 +816,11 @@ static int run_scan(const char *target, Result *R) {
                 while (b >= 0 && dg[b] > v) { dg[b + 1] = dg[b]; b--; }
                 dg[b + 1] = v;
             }
-            cross_shared += clen;
+            M->cross_shared += clen;
             int first = dg[0];
             for (int m = 0; m < ndg; m++) {
-                group_shared[dg[m]] += clen;
-                if (m > 0) uf_union(first, dg[m]);
+                M->group_shared[dg[m]] += clen;
+                if (m > 0 && do_groups) uf_union(first, dg[m]);
             }
         }
 
@@ -533,48 +843,450 @@ static int run_scan(const char *target, Result *R) {
             }
             for (int ti = 0; ti < ntouch; ti++) {
                 int a = touched[ti];
-                g_nodes[a].unique_shared += clen;
-                if (cov_count[a] < nleaf) g_nodes[a].cross += clen;
+                if (align) {
+                    g_nodes[a].unique_shared_alloc += clen;
+                    if (cov_count[a] < nleaf) g_nodes[a].cross_alloc += clen;
+                } else {
+                    g_nodes[a].unique_shared += clen;
+                    if (cov_count[a] < nleaf) g_nodes[a].cross += clen;
+                }
             }
         }
         epoch++;
         i = j;
     }
+
+    #undef RSTART
+    #undef REND
+
     free(seen_epoch);
     free(dg);
     if (g_maxdepth >= 0) { free(leaf_seen); free(cov_epoch); free(cov_count); free(leaves); free(touched); }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Computed result
+// ---------------------------------------------------------------------------
+typedef struct {
+    uint64_t naive, unique, shared, cross_shared, priv_sum;
+    uint64_t unique_alloc;                  // same dedup, block-aligned (what the disk loses)
+    uint64_t outside_shared;                // blocks also referenced by files OUTSIDE the scan root
+    uint64_t apparent, sparse_extra, sparse_files;
+    uint64_t files_listed, files_accounted, files_opened, files_cached, extents;
+    int      threads;
+    double   pct;
+    uint64_t group_shared[MAX_GROUPS];
+} Result;
+
+static double now_s(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec / 1e9;
+}
+
+/**
+ * Collect every mount point inside `target` that belongs to a DIFFERENT
+ * filesystem, so the walk can prune them by path without ever opening them.
+ */
+static void collect_foreign_mounts(const char *target) {
+    for (int i = 0; i < g_nforeign; i++) { free(g_foreign_mounts[i]); g_foreign_mounts[i] = NULL; }
+    g_nforeign = 0;
+
+    struct statfs root;
+    if (statfs(target, &root) < 0) return;
+
+    struct statfs *mnts = NULL;
+    int n = getmntinfo(&mnts, MNT_NOWAIT);
+    size_t tlen = strlen(target);
+    while (tlen > 1 && target[tlen - 1] == '/') tlen--;
+
+    // Only a scan rooted at (or inside) the Data volume sees firmlinked mount paths.
+    const char *DATA = "/System/Volumes/Data";
+    size_t dlen_ = strlen(DATA);
+    int firmlink_root = strncmp(target, DATA, dlen_) == 0 && (target[dlen_] == '\0' || target[dlen_] == '/');
+
+    for (int i = 0; i < n && g_nforeign < MAX_FOREIGN_MOUNTS; i++) {
+        const char *mp = mnts[i].f_mntonname;
+        if (mnts[i].f_fsid.val[0] == root.f_fsid.val[0] &&
+            mnts[i].f_fsid.val[1] == root.f_fsid.val[1]) continue;   // same filesystem
+
+        // Spelling 1: the mount path as reported, when it sits inside the scan root.
+        int inside = strncmp(mp, target, tlen) == 0 && mp[tlen] == '/';
+        if (inside) {
+            char *c = strdup(mp);
+            if (c) g_foreign_mounts[g_nforeign++] = c;
+        }
+
+        // Spelling 2: <target><mp>, but ONLY under the Data volume. macOS firmlinks
+        // /Users, /Library, /private … from /System/Volumes/Data, so the mount table
+        // records OrbStack's NFS export as /Users/Martin/OrbStack while a scan rooted
+        // at /System/Volumes/Data reaches the very same directory as
+        // /System/Volumes/Data/Users/Martin/OrbStack. Spelling 1 never matches that,
+        // so without this the whole-volume scan walks straight into the NFS export.
+        if (!inside && firmlink_root && strcmp(mp, "/") != 0 && mp[0] == '/' &&
+            g_nforeign < MAX_FOREIGN_MOUNTS) {
+            size_t mlen = strlen(mp);
+            char *c = malloc(tlen + mlen + 1);
+            if (c) {
+                memcpy(c, target, tlen);
+                memcpy(c + tlen, mp, mlen + 1);
+                g_foreign_mounts[g_nforeign++] = c;
+            }
+        }
+    }
+}
+
+/** The attribute set every getattrlistbulk call requests. See the layout note above. */
+static void setup_attrlist(void) {
+    memset(&g_al, 0, sizeof g_al);
+    g_al.bitmapcount = ATTR_BIT_MAP_COUNT;
+    g_al.commonattr  = ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_NAME | ATTR_CMN_OBJTYPE |
+                       ATTR_CMN_MODTIME | ATTR_CMN_FILEID;
+    g_al.fileattr    = ATTR_FILE_LINKCOUNT | ATTR_FILE_ALLOCSIZE | ATTR_FILE_DATALENGTH;
+    g_al.forkattr    = ATTR_CMNEXT_PRIVATESIZE;
+    g_alopt = FSOPT_PACK_INVAL_ATTRS | FSOPT_ATTR_CMN_EXTENDED | FSOPT_NOFOLLOW;
+}
+
+/** Fused parallel walk + inline extent scan. Leaves g_outs for the caller to drain. */
+static void spawn_walk(const char *target, int nthreads, int rootnode) {
+    setup_attrlist();
+    collect_foreign_mounts(target);
+    g_walk_threads = nthreads > 0 ? nthreads : 1;
+    g_outs = calloc(nthreads, sizeof(ThreadOut));
+    pthread_t *th = calloc(nthreads, sizeof(pthread_t));
+    if (!g_outs || !th) { perror("calloc walk"); exit(1); }
+    for (int i = 0; i < nthreads; i++) g_outs[i].tid = i;
+    q_push(strdup(target), -1, rootnode, 0);
+    for (int i = 0; i < nthreads; i++) pthread_create(&th[i], NULL, worker, &g_outs[i]);
+    for (int i = 0; i < nthreads; i++) pthread_join(th[i], NULL);
+    free(th);
+}
+
+// ---------------------------------------------------------------------------
+// Extent cache I/O. One file per volume under the caller-supplied directory, so
+// a single cache serves every scan root on that volume (fileids are volume-wide).
+// ---------------------------------------------------------------------------
+static void cache_open(const char *target) {
+    g_cache_map = NULL; g_cache_map_len = 0;
+    g_cache_ents = NULL; g_cache_exts = NULL;
+    g_cache_nents = 0; g_cache_nexts = 0;
+    if (!g_cache_dir) return;
+
+    struct statfs sfs;
+    if (statfs(target, &sfs) < 0) { g_cache_dir = NULL; return; }
+    g_fsid = ((uint64_t)(uint32_t)sfs.f_fsid.val[0] << 32) | (uint32_t)sfs.f_fsid.val[1];
+    snprintf(g_cache_file, sizeof g_cache_file, "%s/extents-%016llx.bin",
+             g_cache_dir, (unsigned long long)g_fsid);
+
+    if (!g_cache_read) return;
+
+    int fd = open(g_cache_file, O_RDONLY);
+    if (fd < 0) return;
+    struct stat st;
+    if (fstat(fd, &st) < 0 || (size_t)st.st_size < sizeof(CacheHeader)) { close(fd); return; }
+
+    void *map = mmap(NULL, (size_t)st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if (map == MAP_FAILED) return;
+
+    const CacheHeader *h = map;
+    size_t need = sizeof(CacheHeader) + (size_t)h->nrecs * sizeof(CacheEnt) + (size_t)h->nexts * sizeof(CacheExt);
+    if (h->magic != CACHE_MAGIC || h->version != CACHE_VERSION || h->fsid != g_fsid ||
+        need > (size_t)st.st_size) {
+        munmap(map, (size_t)st.st_size);
+        return;
+    }
+
+    g_cache_map = map;
+    g_cache_map_len = (size_t)st.st_size;
+    g_cache_ents = (const CacheEnt *)((const char *)map + sizeof(CacheHeader));
+    g_cache_exts = (const CacheExt *)(g_cache_ents + h->nrecs);
+    g_cache_nents = h->nrecs;
+    g_cache_nexts = h->nexts;
+}
+
+static void cache_close(void) {
+    if (g_cache_map) munmap(g_cache_map, g_cache_map_len);
+    g_cache_map = NULL; g_cache_map_len = 0;
+    g_cache_ents = NULL; g_cache_exts = NULL;
+    g_cache_nents = 0; g_cache_nexts = 0;
+}
+
+// A record staged for the new cache file. Its extents live either in one of this
+// run's thread arrays (stride sizeof(Ext)) or in the previous mmap'd cache
+// (stride sizeof(CacheExt)) — exactly one of the two pointers is set.
+typedef struct {
+    CacheEnt        ent;
+    const Ext      *from_scan;
+    const CacheExt *from_old;
+} PendEnt;
+
+static int cmp_pend(const void *a, const void *b) {
+    const PendEnt *x = a, *y = b;
+    if (x->ent.fileid < y->ent.fileid) return -1;
+    if (x->ent.fileid > y->ent.fileid) return 1;
+    return 0;
+}
+
+static int cmp_pend_recency(const void *a, const void *b) {
+    const PendEnt *x = a, *y = b;
+    if (x->ent.last_seen > y->ent.last_seen) return -1;   // newest first
+    if (x->ent.last_seen < y->ent.last_seen) return 1;
+    return 0;
+}
+
+/**
+ * Merge this run's records with whatever the previous cache still holds and
+ * rewrite the file. Written to a temp path then rename(2)'d, so a killed scan
+ * can never leave a half-written cache behind.
+ *
+ * Must run BEFORE the thread extent arrays are freed — the records point into them.
+ */
+static void cache_write(int nthreads) {
+    if (!g_cache_dir || g_cache_file[0] == '\0') return;
+
+    size_t nnew = 0, opened = 0;
+    for (int i = 0; i < nthreads; i++) {
+        nnew += g_outs[i].ncrecs;
+        opened += g_outs[i].files_opened;
+    }
+
+    // A miss always leads to an open(), so zero opens means every record we would
+    // write is already on disk byte-for-byte. Skip the rewrite: on a fully warm
+    // repeat scan this saves rewriting tens of MB to learn nothing. The cost is
+    // that `last_seen` is not refreshed, which only matters once the cache is over
+    // CACHE_MAX_RECS and eviction starts caring about recency.
+    if (opened == 0 && g_cache_nents > 0) return;
+
+    size_t cap = nnew + (size_t)g_cache_nents;
+    PendEnt *pend = malloc((cap ? cap : 1) * sizeof(PendEnt));
+    if (!pend) return;
+
+    uint32_t now = (uint32_t)time(NULL);
+    size_t n = 0;
+    for (int i = 0; i < nthreads; i++) {
+        for (size_t r = 0; r < g_outs[i].ncrecs; r++) {
+            const CacheRec *cr = &g_outs[i].crecs[r];
+            pend[n].ent.fileid    = cr->fileid;
+            pend[n].ent.mtime_ns  = cr->mtime_ns;
+            pend[n].ent.dlen      = cr->dlen;
+            pend[n].ent.alloc     = cr->alloc;
+            pend[n].ent.ext_off   = 0;
+            pend[n].ent.ext_count = cr->ext_count;
+            pend[n].ent.last_seen = now;
+            pend[n].from_scan     = g_outs[i].exts + cr->ext_start;
+            pend[n].from_old      = NULL;
+            n++;
+        }
+    }
+
+    // Sort by fileid and collapse hardlink duplicates (one inode, many dentries).
+    qsort(pend, n, sizeof(PendEnt), cmp_pend);
+    size_t uniq = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (uniq > 0 && pend[uniq - 1].ent.fileid == pend[i].ent.fileid) continue;
+        pend[uniq++] = pend[i];
+    }
+    n = uniq;
+
+    // Carry over previous entries this run never saw — they belong to scan roots
+    // outside this one, and dropping them would make the cache root-scoped.
+    size_t oi = 0, ni = 0, merged = n;
+    while (oi < g_cache_nents) {
+        uint64_t fid = g_cache_ents[oi].fileid;
+        while (ni < n && pend[ni].ent.fileid < fid) ni++;
+        if (ni < n && pend[ni].ent.fileid == fid) { oi++; continue; }
+        pend[merged].ent = g_cache_ents[oi];
+        pend[merged].ent.ext_off = 0;
+        pend[merged].from_scan = NULL;
+        pend[merged].from_old = &g_cache_exts[g_cache_ents[oi].ext_off];
+        merged++;
+        oi++;
+    }
+    n = merged;
+
+    // Over the cap, keep the most recently seen records (this run's are all `now`).
+    if (n > CACHE_MAX_RECS) {
+        qsort(pend, n, sizeof(PendEnt), cmp_pend_recency);
+        n = CACHE_MAX_RECS;
+    }
+    qsort(pend, n, sizeof(PendEnt), cmp_pend);
+
+    uint64_t total_exts = 0;
+    for (size_t i = 0; i < n; i++) {
+        pend[i].ent.ext_off = total_exts;
+        total_exts += pend[i].ent.ext_count;
+    }
+
+    char tmp[4200];
+    snprintf(tmp, sizeof tmp, "%s.tmp.%d", g_cache_file, (int)getpid());
+    FILE *f = fopen(tmp, "wb");
+    if (!f) { free(pend); return; }
+
+    CacheHeader h = { CACHE_MAGIC, CACHE_VERSION, 0, g_fsid, (uint64_t)n, total_exts };
+    int ok = fwrite(&h, sizeof h, 1, f) == 1;
+    for (size_t i = 0; i < n && ok; i++) ok = fwrite(&pend[i].ent, sizeof(CacheEnt), 1, f) == 1;
+    for (size_t i = 0; i < n && ok; i++) {
+        for (uint32_t x = 0; x < pend[i].ent.ext_count && ok; x++) {
+            CacheExt ce;
+            if (pend[i].from_scan) {
+                ce.dev = pend[i].from_scan[x].dev;
+                ce.len = pend[i].from_scan[x].len;
+            } else {
+                ce = pend[i].from_old[x];
+            }
+            ok = fwrite(&ce, sizeof ce, 1, f) == 1;
+        }
+    }
+    int closed = fclose(f) == 0;
+    if (ok && closed) {
+        rename(tmp, g_cache_file);
+    } else {
+        unlink(tmp);
+        fprintf(stderr, "clonesize: failed to write extent cache %s\n", g_cache_file);
+    }
+    free(pend);
+}
+
+static int resolve_threads(void) {
+    if (g_nthreads > 0) return g_nthreads;
+    long nc = sysconf(_SC_NPROCESSORS_ONLN);
+    return (nc > 0) ? (int)nc : 4;
+}
+
+// Runs the full scan; fills *R. Returns 0 on success.
+static int run_scan(const char *target, Result *R) {
+    memset(R, 0, sizeof *R);
+
+    int nthreads = resolve_threads();
+
+    double t0 = now_s();
+
+    cache_open(target);
+
+    // --depth: root is node 0 (depth 0). Files loose in the root belong to it.
+    int rootnode = (g_maxdepth >= 0) ? intern_node(-1, target, 0) : -1;
+    spawn_walk(target, nthreads, rootnode);
+
+    double t1 = now_s();
+
+    // Before the merge frees the thread extent arrays the records point into.
+    cache_write(nthreads);
+    cache_close();
+
+    // Merge thread outputs.
+    size_t total_exts = 0;
+    uint64_t naive = 0, unique_private = 0, unique_private_alloc = 0, priv_sum = 0;
+    uint64_t apparent = 0, sparse_extra = 0, sparse_files = 0;
+    uint64_t files_listed = 0, files_accounted = 0, files_opened = 0, files_cached = 0, priv_opened = 0;
+    for (int i = 0; i < nthreads; i++) {
+        total_exts           += g_outs[i].n;
+        files_cached         += g_outs[i].files_cached;
+        priv_opened          += g_outs[i].priv_opened;
+        free(g_outs[i].crecs);
+        naive                += g_outs[i].naive;
+        unique_private       += g_outs[i].unique_private;
+        unique_private_alloc += g_outs[i].unique_private_alloc;
+        priv_sum             += g_outs[i].priv_sum;
+        apparent             += g_outs[i].apparent;
+        sparse_extra         += g_outs[i].sparse_extra;
+        sparse_files         += g_outs[i].sparse_files;
+        files_listed         += g_outs[i].files_listed;
+        files_accounted      += g_outs[i].files_accounted;
+        files_opened         += g_outs[i].files_opened;
+        for (int g = 0; g < g_ngroups; g++) {
+            g_group_naive[g]   += g_outs[i].group_naive[g];
+            g_group_files[g]   += g_outs[i].group_files[g];
+            g_group_private[g] += g_outs[i].group_private[g];
+        }
+        // --depth: accumulate per-leaf-node naive/files/priv/private-unique/sparse.
+        for (size_t r = 0; r < g_outs[i].nrecs; r++) {
+            FileRec *fr = &g_outs[i].recs[r];
+            Node *nd = &g_nodes[fr->node];
+            nd->naive    += fr->alloc;
+            nd->files    += 1;
+            nd->priv     += fr->priv;
+            nd->apparent += fr->dlen;
+            if (fr->dlen > fr->alloc) {
+                nd->sparse_extra += fr->dlen - fr->alloc;
+                nd->sparse_files++;
+            }
+            if (fr->is_private) {
+                nd->private_dlen  += fr->dlen;
+                nd->private_alloc += fr->alloc;
+            }
+        }
+        free(g_outs[i].recs);
+    }
+
+    Ext *all = malloc((total_exts ? total_exts : 1) * sizeof(Ext));
+    if (!all) { perror("malloc merge"); return 1; }
+    size_t k = 0;
+    for (int i = 0; i < nthreads; i++) {
+        if (g_outs[i].n) memcpy(all + k, g_outs[i].exts, g_outs[i].n * sizeof(Ext));
+        k += g_outs[i].n;
+        free(g_outs[i].exts);
+    }
+    free(g_outs); g_outs = NULL;
+
+    double t2 = now_s();
+
+    // Sort by device offset, merge overlapping clusters. For each merged cluster,
+    // collect its DISTINCT groups by scanning the cluster's own extents. This
+    // replaces the old uint64 group bitmask (which capped groups at 64 and made a
+    // scan root with >64 immediate children fold everything past the 63rd into one
+    // bogus overflow bucket) — there is no 64-group limit here.
+    qsort(all, total_exts, sizeof(Ext), cmp_ext);
+    for (int i = 0; i < MAX_GROUPS; i++) g_uf[i] = i;
+
+    MergeOut mapped, alloced;
+    if (merge_pass(all, total_exts, 0, 1, &mapped) != 0) { free(all); return 1; }
+    if (merge_pass(all, total_exts, 1, 0, &alloced) != 0) { free(all); return 1; }
     free(all);
 
-    // --depth: roll naive/files/priv/private-unique up to ancestors (child id > parent
-    // id, since a parent interns its children — so descending id = children first).
+    // --depth: roll naive/files/priv/private-unique/apparent up to ancestors (child
+    // id > parent id, since a parent interns its children — descending id = children first).
     if (g_maxdepth >= 0) {
         for (int a = g_nnodes - 1; a > 0; a--) {
             int par = g_nodes[a].parent;
             if (par < 0) continue;
-            g_nodes[par].naive        += g_nodes[a].naive;
-            g_nodes[par].files        += g_nodes[a].files;
-            g_nodes[par].priv         += g_nodes[a].priv;
-            g_nodes[par].private_dlen += g_nodes[a].private_dlen;
+            g_nodes[par].naive         += g_nodes[a].naive;
+            g_nodes[par].files         += g_nodes[a].files;
+            g_nodes[par].priv          += g_nodes[a].priv;
+            g_nodes[par].private_dlen  += g_nodes[a].private_dlen;
+            g_nodes[par].private_alloc += g_nodes[a].private_alloc;
+            g_nodes[par].apparent      += g_nodes[a].apparent;
+            g_nodes[par].sparse_extra  += g_nodes[a].sparse_extra;
+            g_nodes[par].sparse_files  += g_nodes[a].sparse_files;
         }
     }
 
     double t3 = now_s();
 
-    uint64_t unique = unique_private + unique_shared;
+    uint64_t unique = unique_private + mapped.unique_shared;
     uint64_t shared = (naive > unique) ? naive - unique : 0;
 
     R->naive = naive;
     R->unique = unique;
+    R->unique_alloc = unique_private_alloc + alloced.unique_shared;
+    // Single-file clusters hold both the file's own private blocks and the blocks
+    // it shares with something outside the scan; privatesize separates the two.
+    R->outside_shared = alloced.single_file > priv_opened ? alloced.single_file - priv_opened : 0;
+    R->apparent = apparent;
+    R->sparse_extra = sparse_extra;
+    R->sparse_files = sparse_files;
     R->shared = shared;
-    R->cross_shared = cross_shared;
+    R->cross_shared = mapped.cross_shared;
     R->priv_sum = priv_sum;
     R->files_listed = files_listed;
     R->files_accounted = files_accounted;
     R->files_opened = files_opened;
+    R->files_cached = files_cached;
     R->extents = total_exts;
     R->threads = nthreads;
     R->pct = naive ? 100.0 * (double)shared / (double)naive : 0.0;
-    memcpy(R->group_shared, group_shared, sizeof group_shared);
+    memcpy(R->group_shared, mapped.group_shared, sizeof mapped.group_shared);
 
     if (g_profile) {
         fprintf(stderr,
@@ -631,7 +1343,7 @@ static char *json_escape(const char *s) {
 }
 
 static char *format_json(const char *target, const Result *R) {
-    size_t cap = 4096 + (size_t)g_ngroups * 256 + (size_t)g_nnodes * 320;
+    size_t cap = 8192 + (size_t)g_ngroups * 256 + (size_t)g_nnodes * 640;
     char *out = malloc(cap);
     size_t len = 0;
     #define EMIT(...) do { \
@@ -649,15 +1361,45 @@ static char *format_json(const char *target, const Result *R) {
     EMIT("  \"files_scanned\": %llu,\n", (unsigned long long)R->files_accounted);
     EMIT("  \"files_listed\": %llu,\n", (unsigned long long)R->files_listed);
     EMIT("  \"files_opened\": %llu,\n", (unsigned long long)R->files_opened);
+    EMIT("  \"files_cached\": %llu,\n", (unsigned long long)R->files_cached);
     EMIT("  \"extents\": %llu,\n", (unsigned long long)R->extents);
     EMIT("  \"threads\": %d,\n", R->threads);
     EMIT("  \"naive_bytes\": %llu,\n", (unsigned long long)R->naive);
     EMIT("  \"unique_bytes\": %llu,\n", (unsigned long long)R->unique);
+    EMIT("  \"unique_allocated_bytes\": %llu,\n", (unsigned long long)R->unique_alloc);
+    EMIT("  \"outside_shared_bytes\": %llu,\n", (unsigned long long)R->outside_shared);
+    EMIT("  \"apparent_bytes\": %llu,\n", (unsigned long long)R->apparent);
+    EMIT("  \"sparse_bytes\": %llu,\n", (unsigned long long)R->sparse_extra);
+    EMIT("  \"sparse_files\": %llu,\n", (unsigned long long)R->sparse_files);
     EMIT("  \"shared_bytes\": %llu,\n", (unsigned long long)R->shared);
     EMIT("  \"shared_pct\": %.2f,\n", R->pct);
     EMIT("  \"cross_group_shared_bytes\": %llu,\n", (unsigned long long)R->cross_shared);
-    if (g_freeable)
-        EMIT("  \"private_sum_bytes\": %llu,\n", (unsigned long long)R->priv_sum);
+    EMIT("  \"private_sum_bytes\": %llu,\n", (unsigned long long)R->priv_sum);
+    EMIT("  \"denied_dirs\": %llu,\n", (unsigned long long)g_denied_dirs);
+    EMIT("  \"denied_files\": %llu,\n", (unsigned long long)g_denied_files);
+    EMIT("  \"skipped_cloud\": [");
+    for (int c = 0; c < g_ncloud; c++) {
+        char *cesc = json_escape(g_cloud_roots[c]);
+        EMIT("%s\"%s\"", c ? ", " : "", cesc);
+        free(cesc);
+    }
+    EMIT("],\n");
+    EMIT("  \"skipped_mounts\": [");
+    for (int m = 0; m < g_nforeign; m++) {
+        char *mesc = json_escape(g_foreign_mounts[m]);
+        EMIT("%s\"%s\"", m ? ", " : "", mesc);
+        free(mesc);
+    }
+    EMIT("],\n");
+    EMIT("  \"denied_paths\": [");
+    for (int d = 0; d < g_denied_kept; d++) {
+        char *desc = json_escape(g_denied_paths[d]);
+        EMIT("%s\"%s\"", d ? ", " : "", desc);
+        free(desc);
+    }
+    EMIT("],\n");
+    if (g_mtime_min)
+        EMIT("  \"changed_since\": %llu,\n", (unsigned long long)g_mtime_min);
     EMIT("  \"groups\": [\n");
     int emitted = 0;
     for (int g = 0; g < g_ngroups; g++) {
@@ -676,8 +1418,7 @@ static char *format_json(const char *target, const Result *R) {
              (unsigned long long)R->group_shared[g], gsh,
              uf_find(g), flagged ? "true" : "false");
         free(gesc);
-        if (g_freeable)
-            EMIT(", \"private_bytes\": %llu", (unsigned long long)g_group_private[g]);
+        EMIT(", \"private_bytes\": %llu", (unsigned long long)g_group_private[g]);
         EMIT("}%s\n", more ? "," : "");
         emitted++;
     }
@@ -694,19 +1435,30 @@ static char *format_json(const char *target, const Result *R) {
             Node *nd = &g_nodes[a];
             if (nd->naive < g_min_blocks) continue;
             uint64_t u = nd->unique_shared + nd->private_dlen;
+            uint64_t ua = nd->unique_shared_alloc + nd->private_alloc;
+            // Deleting the subtree frees at least Σ per-file private bytes (blocks
+            // exclusive volume-wide) and at most its allocated unique minus what it
+            // shares with dirs outside itself.
+            uint64_t ceil_free = ua > nd->cross_alloc ? ua - nd->cross_alloc : 0;
             double xpct = nd->naive ? 100.0 * (double)nd->cross / (double)nd->naive : 0.0;
             int flagged = (nd->cross >= (uint64_t)(g_clone_pct * (double)nd->naive)) && nd->cross > 0;
             node_path(a, pbuf, sizeof pbuf);
             char *pesc = json_escape(pbuf);
             EMIT("%s    {\"path\": \"%s\", \"depth\": %d, \"parent\": %d, \"naive_bytes\": %llu, "
-                 "\"unique_bytes\": %llu, \"cross_shared_bytes\": %llu, \"shared_pct\": %.2f, "
-                 "\"files\": %llu, \"clone_flagged\": %s",
+                 "\"unique_bytes\": %llu, \"unique_allocated_bytes\": %llu, \"cross_shared_bytes\": %llu, "
+                 "\"cross_shared_allocated_bytes\": %llu, \"shared_pct\": %.2f, "
+                 "\"files\": %llu, \"clone_flagged\": %s, \"private_bytes\": %llu, "
+                 "\"freeable_floor_bytes\": %llu, \"freeable_ceiling_bytes\": %llu, "
+                 "\"apparent_bytes\": %llu, \"sparse_bytes\": %llu, \"sparse_files\": %llu",
                  nfirst ? "" : ",\n", pesc, nd->depth, nd->parent, (unsigned long long)nd->naive,
-                 (unsigned long long)u, (unsigned long long)nd->cross, xpct,
-                 (unsigned long long)nd->files, flagged ? "true" : "false");
+                 (unsigned long long)u, (unsigned long long)ua, (unsigned long long)nd->cross,
+                 (unsigned long long)nd->cross_alloc, xpct,
+                 (unsigned long long)nd->files, flagged ? "true" : "false",
+                 (unsigned long long)nd->priv,
+                 (unsigned long long)nd->priv, (unsigned long long)ceil_free,
+                 (unsigned long long)nd->apparent, (unsigned long long)nd->sparse_extra,
+                 (unsigned long long)nd->sparse_files);
             free(pesc);
-            if (g_freeable_tree)
-                EMIT(", \"private_bytes\": %llu", (unsigned long long)nd->priv);
             EMIT("}");
             nfirst = 0;
         }
@@ -724,17 +1476,30 @@ static void print_human(const char *target, const Result *R, int quiet) {
     const double MB = 1024.0 * 1024.0, GB = MB * 1024.0;
     #define HUM(b) ((b) >= (uint64_t)(GB) ? (b)/GB : (b)/MB), ((b) >= (uint64_t)(GB) ? "GB" : "MB")
     printf("Path:            %s\n", target);
-    printf("Files scanned:   %llu (of %llu listed, %llu opened)  •  %d threads\n",
+    printf("Files scanned:   %llu (of %llu listed, %llu opened, %llu cached)  •  %d threads\n",
            (unsigned long long)R->files_accounted, (unsigned long long)R->files_listed,
-           (unsigned long long)R->files_opened, R->threads);
+           (unsigned long long)R->files_opened, (unsigned long long)R->files_cached, R->threads);
     printf("Naive (du-like): %8.1f %s   %llu bytes\n", HUM(R->naive), (unsigned long long)R->naive);
-    printf("Unique physical: %8.1f %s   %llu bytes\n", HUM(R->unique), (unsigned long long)R->unique);
+    printf("Unique mapped:   %8.1f %s   %llu bytes\n", HUM(R->unique), (unsigned long long)R->unique);
+    printf("Unique on disk:  %8.1f %s   %llu bytes (allocated blocks)\n",
+           HUM(R->unique_alloc), (unsigned long long)R->unique_alloc);
     printf("Shared (CoW):    %8.1f %s   (%.1f%% of naive collapses to shared blocks)\n",
            HUM(R->shared), R->pct);
     printf("Cross-worktree:  %8.1f %s   (shared across marked dirs)\n", HUM(R->cross_shared));
-    if (g_freeable)
-        printf("Private (excl):  %8.1f %s   (Sum per-file bytes shared with nothing volume-wide)\n",
-               HUM(R->priv_sum));
+    printf("Deleting frees:  %8.1f %s   (>= this — per-file blocks private volume-wide)\n",
+           HUM(R->priv_sum));
+    if (R->outside_shared)
+        printf("Shared OUTSIDE:  %8.1f %s   (blocks also referenced by files outside this scan root)\n",
+               HUM(R->outside_shared));
+    if (R->sparse_files)
+        printf("Sparse:          %8.1f %s   apparent in %llu sparse file(s) never written to disk\n",
+               HUM(R->sparse_extra), (unsigned long long)R->sparse_files);
+    if (g_ncloud)
+        printf("Cloud skipped:   %d provider root(s) not walked (placeholders, and reading them can download)\n",
+               g_ncloud);
+    if (g_denied_dirs || g_denied_files)
+        printf("UNREADABLE:      %llu dir(s), %llu file(s) skipped — totals above are INCOMPLETE\n",
+               (unsigned long long)g_denied_dirs, (unsigned long long)g_denied_files);
 
     if (!quiet && g_ngroups > 0) {
         printf("\nMarked directories (immediate children — worktrees/top-level dirs):\n");
@@ -760,6 +1525,14 @@ static void print_human(const char *target, const Result *R, int quiet) {
         printf("\n★clone = >=%.0f%% of this dir's bytes are shared with another marked dir (it's largely a clone).\n",
                g_clone_pct * 100.0);
     }
+
+    if (g_denied_kept > 0) {
+        printf("\nUnreadable (permission denied) — re-run these as root to close the gap:\n");
+        for (int d = 0; d < g_denied_kept; d++) printf("  %s\n", g_denied_paths[d]);
+        if ((uint64_t)g_denied_kept < g_denied_dirs + g_denied_files)
+            printf("  ... and %llu more\n",
+                   (unsigned long long)(g_denied_dirs + g_denied_files - (uint64_t)g_denied_kept));
+    }
     #undef HUM
 }
 
@@ -767,22 +1540,9 @@ static void print_human(const char *target, const Result *R, int quiet) {
 // bun:ffi entry point — one-shot scan, returns a malloc'd JSON string.
 // Caller must clonesize_free() it. Not reentrant (uses process globals).
 // ---------------------------------------------------------------------------
-__attribute__((visibility("default")))
-char *clonesize_run_json(const char *path, int threads, int freeable,
-                         unsigned long long min_bytes,
-                         const char *const *excludes, int nexcludes,
-                         int depth, int freeable_tree) {
-    g_nthreads = threads;
-    g_freeable = freeable;
-    g_min_blocks = (size_t)min_bytes;
-    g_maxdepth = depth;                 // < 0 disables the tree
-    g_freeable_tree = freeable_tree;
-    if (g_freeable_tree && g_maxdepth < 0) g_maxdepth = 1;
-    g_profile = getenv("PROFILE") ? 1 : 0;
-    g_nexcludes = 0;
-    for (int i = 0; i < nexcludes && i < MAX_EXCLUDES; i++) g_excludes[g_nexcludes++] = excludes[i];
-
-    // Reset accumulating globals — the dylib lives across calls under bun:ffi.
+// Reset every accumulating global — the dylib lives across calls under bun:ffi,
+// so anything left over from the previous scan would be double-counted.
+static void reset_state(void) {
     for (int i = 0; i < g_ngroups; i++) { free(g_group_names[i]); g_group_names[i] = NULL; }
     g_ngroups = 0;
     memset(g_group_naive, 0, sizeof g_group_naive);
@@ -790,10 +1550,273 @@ char *clonesize_run_json(const char *path, int threads, int freeable,
     memset(g_group_private, 0, sizeof g_group_private);
     for (int i = 0; i < g_nnodes; i++) free(g_nodes[i].name);
     free(g_nodes); g_nodes = NULL; g_nnodes = 0; g_node_cap = 0;
+    for (int i = 0; i < g_denied_kept; i++) { free(g_denied_paths[i]); g_denied_paths[i] = NULL; }
+    g_denied_kept = 0; g_denied_dirs = 0; g_denied_files = 0;
+    for (int i = 0; i < g_ncloud; i++) { free(g_cloud_roots[i]); g_cloud_roots[i] = NULL; }
+    g_ncloud = 0;
     g_qn = 0; g_pending = 0; g_done = 0;
+}
+
+__attribute__((visibility("default")))
+char *clonesize_run_json(const char *path, int threads, int freeable,
+                         unsigned long long min_bytes,
+                         const char *const *excludes, int nexcludes,
+                         int depth, int freeable_tree,
+                         unsigned long long changed_since,
+                         const char *cache_dir, int cache_read, int include_cloud) {
+    g_nthreads = threads;
+    g_freeable = freeable;
+    g_min_blocks = (size_t)min_bytes;
+    g_maxdepth = depth;                 // < 0 disables the tree
+    g_freeable_tree = freeable_tree;
+    g_mtime_min = changed_since;
+    g_partner_mode = 0;
+    g_cache_dir = (cache_dir && cache_dir[0]) ? cache_dir : NULL;
+    g_cache_read = cache_read;
+    g_skip_cloud = include_cloud ? 0 : 1;
+    if (g_freeable_tree && g_maxdepth < 0) g_maxdepth = 1;
+    g_profile = getenv("PROFILE") ? 1 : 0;
+    g_nexcludes = 0;
+    for (int i = 0; i < nexcludes && i < MAX_EXCLUDES; i++) g_excludes[g_nexcludes++] = excludes[i];
+
+    reset_state();
     Result R;
     if (run_scan(path, &R) != 0) return NULL;
     return format_json(path, &R);
+}
+
+// ---------------------------------------------------------------------------
+// Volume reconcile: the authoritative used-bytes for a mount, straight from the
+// APFS layer. ATTR_VOL_SPACEUSED is the same number `diskutil info <mount>`
+// prints as "Volume Used Space" (verified byte-for-byte on this machine), so a
+// scan that lands under it has a hole — unreadable subtrees, most likely.
+// Attributes come back in sys/attr.h bit order: SIZE, SPACEFREE, SPACEAVAIL,
+// then SPACEUSED (0x00800000, far later than the rest).
+// ---------------------------------------------------------------------------
+__attribute__((visibility("default")))
+char *clonesize_volume_json(const char *mount) {
+    struct attrlist al;
+    memset(&al, 0, sizeof al);
+    al.bitmapcount = ATTR_BIT_MAP_COUNT;
+    al.commonattr  = ATTR_CMN_RETURNED_ATTRS;
+    al.volattr     = ATTR_VOL_INFO | ATTR_VOL_SIZE | ATTR_VOL_SPACEFREE |
+                     ATTR_VOL_SPACEAVAIL | ATTR_VOL_SPACEUSED;
+
+    struct {
+        uint32_t        length;
+        attribute_set_t returned;
+        off_t           size, spacefree, spaceavail, spaceused;
+    } __attribute__((aligned(4), packed)) vb;
+    memset(&vb, 0, sizeof vb);
+
+    if (getattrlist(mount, &al, &vb, sizeof vb, FSOPT_PACK_INVAL_ATTRS) < 0) return NULL;
+
+    char *out = malloc(1024);
+    if (!out) return NULL;
+    char *mesc = json_escape(mount);
+    snprintf(out, 1024,
+             "{\n  \"mount\": \"%s\",\n  \"size_bytes\": %llu,\n  \"used_bytes\": %llu,\n"
+             "  \"free_bytes\": %llu,\n  \"available_bytes\": %llu\n}\n",
+             mesc, (unsigned long long)vb.size, (unsigned long long)vb.spaceused,
+             (unsigned long long)vb.spacefree, (unsigned long long)vb.spaceavail);
+    free(mesc);
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Clone-partner query: "the target shares N bytes with something — WHERE?"
+//
+// Phase 1 walks the TARGET and merges its shared-file extents into g_tgt_ranges.
+// Phase 2 walks the wider ROOT and, for every shared file outside the target,
+// measures how many of its bytes land inside those ranges. A file that overlaps
+// is literally holding the same physical blocks, which is the only honest answer
+// to "is this cache safe to delete".
+// ---------------------------------------------------------------------------
+static int cmp_partner_bytes(const void *a, const void *b) {
+    const PartnerRec *x = a, *y = b;
+    if (x->bytes > y->bytes) return -1;
+    if (x->bytes < y->bytes) return 1;
+    return strcmp(x->path, y->path);
+}
+
+static int cmp_partner_path(const void *a, const void *b) {
+    const PartnerRec *x = a, *y = b;
+    return strcmp(x->path, y->path);
+}
+
+/** Sorts + merges every collected extent into g_tgt_ranges. Drains g_outs. */
+static void build_target_ranges(int nthreads) {
+    size_t total = 0;
+    for (int i = 0; i < nthreads; i++) total += g_outs[i].n;
+
+    Ext *all = malloc((total ? total : 1) * sizeof(Ext));
+    if (!all) { perror("malloc target exts"); exit(1); }
+    size_t k = 0;
+    for (int i = 0; i < nthreads; i++) {
+        if (g_outs[i].n) memcpy(all + k, g_outs[i].exts, g_outs[i].n * sizeof(Ext));
+        k += g_outs[i].n;
+        free(g_outs[i].exts);
+        free(g_outs[i].recs);
+    }
+    free(g_outs); g_outs = NULL;
+
+    qsort(all, total, sizeof(Ext), cmp_ext);
+    free(g_tgt_ranges);
+    g_tgt_ranges = malloc((total ? total : 1) * sizeof(Range));
+    if (!g_tgt_ranges) { perror("malloc target ranges"); exit(1); }
+    g_ntgt_ranges = 0;
+    size_t i = 0;
+    while (i < total) {
+        uint64_t cs = all[i].dev, ce = all[i].dev + all[i].len;
+        size_t j = i + 1;
+        while (j < total && all[j].dev < ce) {
+            uint64_t en = all[j].dev + all[j].len;
+            if (en > ce) ce = en;
+            j++;
+        }
+        g_tgt_ranges[g_ntgt_ranges].start = cs;
+        g_tgt_ranges[g_ntgt_ranges].end = ce;
+        g_ntgt_ranges++;
+        i = j;
+    }
+    free(all);
+}
+
+__attribute__((visibility("default")))
+char *clonesize_partners_json(const char *target, const char *root, int threads, int topn) {
+    g_nthreads = threads;
+    g_maxdepth = -1;
+    g_freeable_tree = 0;
+    g_min_blocks = 0;
+    g_mtime_min = 0;
+    g_nexcludes = 0;
+    g_cache_dir = NULL;
+    g_profile = getenv("PROFILE") ? 1 : 0;
+    int nthreads = resolve_threads();
+    if (topn <= 0) topn = 30;
+
+    // Phase 1 — the target's own shared blocks.
+    g_partner_mode = 0;
+    g_partner_target = NULL;
+    reset_state();
+    spawn_walk(target, nthreads, -1);
+    build_target_ranges(nthreads);
+
+    uint64_t target_shared = 0;
+    for (size_t r = 0; r < g_ntgt_ranges; r++) target_shared += g_tgt_ranges[r].end - g_tgt_ranges[r].start;
+
+    // Phase 2 — who else holds them.
+    g_partner_mode = 1;
+    g_partner_target = target;
+    g_partner_target_len = strlen(target);
+    reset_state();
+    spawn_walk(root, nthreads, -1);
+
+    size_t np = 0;
+    uint64_t opened = 0;
+    for (int i = 0; i < nthreads; i++) { np += g_outs[i].npartners; opened += g_outs[i].files_opened; }
+    PartnerRec *parts = malloc((np ? np : 1) * sizeof(PartnerRec));
+    if (!parts) { perror("malloc partners"); exit(1); }
+    size_t k = 0;
+    for (int i = 0; i < nthreads; i++) {
+        for (size_t j = 0; j < g_outs[i].npartners; j++) parts[k++] = g_outs[i].partners[j];
+        free(g_outs[i].partners);
+        free(g_outs[i].exts);
+        free(g_outs[i].recs);
+    }
+    free(g_outs); g_outs = NULL;
+    g_partner_mode = 0;
+    g_partner_target = NULL;
+
+    // Aggregate by parent directory before the top-N cut, so a cache split across
+    // hundreds of files still shows up as one honest directory-level number.
+    qsort(parts, np, sizeof(PartnerRec), cmp_partner_path);
+    PartnerRec *dirs = malloc((np ? np : 1) * sizeof(PartnerRec));
+    uint64_t *dir_files = malloc((np ? np : 1) * sizeof(uint64_t));
+    if (!dirs || !dir_files) { perror("malloc partner dirs"); exit(1); }
+    size_t ndirs = 0;
+    for (size_t i = 0; i < np; i++) {
+        const char *slash = strrchr(parts[i].path, '/');
+        size_t dlen = slash ? (size_t)(slash - parts[i].path) : strlen(parts[i].path);
+        if (ndirs > 0 && strlen(dirs[ndirs - 1].path) == dlen &&
+            strncmp(dirs[ndirs - 1].path, parts[i].path, dlen) == 0) {
+            dirs[ndirs - 1].bytes += parts[i].bytes;
+            dir_files[ndirs - 1]++;
+            continue;
+        }
+        char *d = malloc(dlen + 1);
+        if (!d) { perror("malloc dir"); exit(1); }
+        memcpy(d, parts[i].path, dlen); d[dlen] = '\0';
+        dirs[ndirs].path = d;
+        dirs[ndirs].bytes = parts[i].bytes;
+        dir_files[ndirs] = 1;
+        ndirs++;
+    }
+
+    qsort(parts, np, sizeof(PartnerRec), cmp_partner_bytes);
+    // Insertion sort of the dir aggregates by bytes desc, carrying dir_files along
+    // (a qsort would need the count packed into the record).
+    for (size_t a = 1; a < ndirs; a++) {
+        PartnerRec pv = dirs[a];
+        uint64_t fv = dir_files[a];
+        size_t b = a;
+        while (b > 0 && dirs[b - 1].bytes < pv.bytes) {
+            dirs[b] = dirs[b - 1];
+            dir_files[b] = dir_files[b - 1];
+            b--;
+        }
+        dirs[b] = pv;
+        dir_files[b] = fv;
+    }
+
+    size_t cap = 8192 + (size_t)(np < (size_t)topn ? np : (size_t)topn) * 1024 +
+                 (size_t)(ndirs < (size_t)topn ? ndirs : (size_t)topn) * 1024;
+    char *out = malloc(cap);
+    if (!out) { perror("malloc partners json"); exit(1); }
+    size_t len = 0;
+    #define PEMIT(...) do { \
+        int need = snprintf(out + len, cap - len, __VA_ARGS__); \
+        if (need < 0) break; \
+        if ((size_t)need >= cap - len) { cap = (cap + need) * 2; out = realloc(out, cap); \
+            need = snprintf(out + len, cap - len, __VA_ARGS__); } \
+        len += need; \
+    } while (0)
+
+    uint64_t partner_total = 0;
+    for (size_t i = 0; i < np; i++) partner_total += parts[i].bytes;
+
+    char *tesc = json_escape(target), *resc = json_escape(root);
+    PEMIT("{\n  \"target\": \"%s\",\n  \"root\": \"%s\",\n", tesc, resc);
+    free(tesc); free(resc);
+    PEMIT("  \"target_shared_bytes\": %llu,\n", (unsigned long long)target_shared);
+    PEMIT("  \"partner_bytes\": %llu,\n", (unsigned long long)partner_total);
+    PEMIT("  \"partner_files_total\": %llu,\n", (unsigned long long)np);
+    PEMIT("  \"files_opened\": %llu,\n", (unsigned long long)opened);
+    PEMIT("  \"denied_dirs\": %llu,\n", (unsigned long long)g_denied_dirs);
+    PEMIT("  \"denied_files\": %llu,\n", (unsigned long long)g_denied_files);
+    PEMIT("  \"partner_dirs\": [");
+    for (size_t i = 0; i < ndirs && i < (size_t)topn; i++) {
+        char *pesc = json_escape(dirs[i].path);
+        PEMIT("%s\n    {\"path\": \"%s\", \"shared_bytes\": %llu, \"files\": %llu}",
+              i ? "," : "", pesc, (unsigned long long)dirs[i].bytes, (unsigned long long)dir_files[i]);
+        free(pesc);
+    }
+    PEMIT("%s],\n", ndirs ? "\n  " : "");
+    PEMIT("  \"partner_files\": [");
+    for (size_t i = 0; i < np && i < (size_t)topn; i++) {
+        char *pesc = json_escape(parts[i].path);
+        PEMIT("%s\n    {\"path\": \"%s\", \"shared_bytes\": %llu}",
+              i ? "," : "", pesc, (unsigned long long)parts[i].bytes);
+        free(pesc);
+    }
+    PEMIT("%s]\n}\n", np ? "\n  " : "");
+    #undef PEMIT
+
+    for (size_t i = 0; i < np; i++) free(parts[i].path);
+    for (size_t i = 0; i < ndirs; i++) free(dirs[i].path);
+    free(parts); free(dirs); free(dir_files);
+    free(g_tgt_ranges); g_tgt_ranges = NULL; g_ntgt_ranges = 0;
+    return out;
 }
 
 __attribute__((visibility("default")))
@@ -805,18 +1828,25 @@ void clonesize_free(char *p) { free(p); }
 static void usage(const char *me) {
     fprintf(stderr,
         "usage: %s [options] <dir>\n"
-        "  --format json     machine-readable JSON output\n"
-        "  --threads N       worker threads (default: ncpu)\n"
-        "  --freeable        also report Σ per-file ATTR_CMNEXT_PRIVATESIZE\n"
-        "  --min-bytes N     skip files whose allocated size < N bytes\n"
-        "  --exclude PATH    prune this directory subtree (repeatable)\n"
-        "  --quiet           omit the per-group table\n"
-        "  (env PROFILE=1    print phase timings to stderr)\n", me);
+        "  --format json        machine-readable JSON output\n"
+        "  --threads N          worker threads (default: ncpu)\n"
+        "  --freeable           also report Σ per-file ATTR_CMNEXT_PRIVATESIZE\n"
+        "  --min-bytes N        skip files whose allocated size < N bytes\n"
+        "  --changed-since EPOCH  only account files with mtime >= EPOCH seconds\n"
+        "  --exclude PATH       prune this directory subtree (repeatable)\n"
+        "  --partners-of PATH   list files sharing blocks with PATH (dir = scan root)\n"
+        "  --top N              partner rows to print (default 30)\n"
+        "  --volume             print the volume's authoritative used/free bytes\n"
+        "  --cache-dir DIR      extent-cache directory (omit to disable the cache)\n"
+        "  --no-cache           ignore the cache when reading (still writes it)\n"
+        "  --include-cloud      walk ~/Library/CloudStorage and iCloud Drive (slow; may download)\n"
+        "  --quiet              omit the per-group table\n"
+        "  (env PROFILE=1       print phase timings to stderr)\n", me);
 }
 
 int main(int argc, char **argv) {
-    const char *target = NULL;
-    int json = 0, quiet = 0;
+    const char *target = NULL, *partners_of = NULL;
+    int json = 0, quiet = 0, volume = 0, topn = 30;
     for (int i = 1; i < argc; i++) {
         const char *a = argv[i];
         if      (!strcmp(a, "--format") && i + 1 < argc) json = !strcmp(argv[++i], "json");
@@ -826,7 +1856,14 @@ int main(int argc, char **argv) {
         else if (!strcmp(a, "--depth") && i + 1 < argc)  g_maxdepth = atoi(argv[++i]);
         else if (!strcmp(a, "--freeable-tree"))          { g_freeable_tree = 1; if (g_maxdepth < 0) g_maxdepth = 1; }
         else if (!strcmp(a, "--min-bytes") && i + 1 < argc) g_min_blocks = strtoull(argv[++i], NULL, 10);
+        else if (!strcmp(a, "--changed-since") && i + 1 < argc) g_mtime_min = strtoull(argv[++i], NULL, 10);
         else if (!strcmp(a, "--exclude") && i + 1 < argc) { if (g_nexcludes < MAX_EXCLUDES) g_excludes[g_nexcludes++] = argv[++i]; else i++; }
+        else if (!strcmp(a, "--partners-of") && i + 1 < argc) partners_of = argv[++i];
+        else if (!strcmp(a, "--top") && i + 1 < argc)    topn = atoi(argv[++i]);
+        else if (!strcmp(a, "--volume"))                 volume = 1;
+        else if (!strcmp(a, "--cache-dir") && i + 1 < argc) g_cache_dir = argv[++i];
+        else if (!strcmp(a, "--no-cache"))               g_cache_read = 0;
+        else if (!strcmp(a, "--include-cloud"))          g_skip_cloud = 0;
         else if (!strcmp(a, "--quiet"))                  quiet = 1;
         else if (!strcmp(a, "-h") || !strcmp(a, "--help")) { usage(argv[0]); return 0; }
         else if (a[0] == '-') { fprintf(stderr, "unknown option: %s\n", a); usage(argv[0]); return 2; }
@@ -834,6 +1871,22 @@ int main(int argc, char **argv) {
     }
     if (!target) { usage(argv[0]); return 2; }
     g_profile = getenv("PROFILE") ? 1 : 0;
+
+    if (volume) {
+        char *v = clonesize_volume_json(target);
+        if (!v) { perror("getattrlist (volume)"); return 1; }
+        fputs(v, stdout);
+        free(v);
+        return 0;
+    }
+
+    if (partners_of) {
+        char *p = clonesize_partners_json(partners_of, target, g_nthreads, topn);
+        if (!p) return 1;
+        fputs(p, stdout);
+        free(p);
+        return 0;
+    }
 
     Result R;
     if (run_scan(target, &R) != 0) return 1;

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -110,12 +110,23 @@ describe("parseDuration", () => {
             expect(parseDuration("2hr")).toBe(7200000);
             expect(parseDuration("2hours")).toBe(7200000);
         });
+
+        it("parses days", () => {
+            expect(parseDuration("1d")).toBe(86400000);
+            expect(parseDuration("7d")).toBe(604800000);
+            expect(parseDuration("7days")).toBe(604800000);
+        });
     });
 
     describe("compound durations", () => {
         it("parses hours and minutes", () => {
             expect(parseDuration("1h30m")).toBe(5400000);
             expect(parseDuration("2h15min")).toBe(8100000);
+        });
+
+        it("parses days with smaller units", () => {
+            expect(parseDuration("2d6h")).toBe(2 * 86400000 + 6 * 3600000);
+            expect(parseDuration("1d 2h 30m")).toBe(86400000 + 2 * 3600000 + 30 * 60000);
         });
 
         it("parses minutes and seconds", () => {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -101,8 +101,8 @@ export function formatDuration(value: number, unit: DurationUnit = "ms", style: 
 
 // ============= Duration Parsing =============
 
-// Single value + unit, e.g. "30m", "2hours", "90s"
-const SIMPLE_DURATION_PATTERN = /^(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?)$/i;
+// Single value + unit, e.g. "30m", "2hours", "90s", "7d"
+const SIMPLE_DURATION_PATTERN = /^(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)$/i;
 
 // Multi-part durations, e.g. "1h30m", "2h15min10s". Each group is optional,
 // allowing any combination of hours/minutes/seconds:
@@ -111,14 +111,14 @@ const SIMPLE_DURATION_PATTERN = /^(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minute
 //   (?:(\d+)\s*s...)? — optional seconds (capture group 3)
 // Unit suffixes accept common spellings: h/hr/hrs/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds
 const COMPOUND_DURATION_PATTERN =
-    /^(?:(\d+)\s*h(?:ours?|rs?|r)?)?\s*(?:(\d+)\s*m(?:in(?:utes?|s)?)?)?\s*(?:(\d+)\s*s(?:ec(?:onds?|s)?)?)?$/i;
+    /^(?:(\d+)\s*d(?:ays?)?)?\s*(?:(\d+)\s*h(?:ours?|rs?|r)?)?\s*(?:(\d+)\s*m(?:in(?:utes?|s)?)?)?\s*(?:(\d+)\s*s(?:ec(?:onds?|s)?)?)?$/i;
 
 /**
  * Parse a human-readable duration string into milliseconds.
  *
  * Supports:
- *   - Simple: "30s", "30m", "30min", "30minutes", "2h", "2hours"
- *   - Compound: "1h30m", "2h15min", "20m 1s", "1h30m15s"
+ *   - Simple: "30s", "30m", "30min", "30minutes", "2h", "2hours", "7d", "7days"
+ *   - Compound: "1h30m", "2h15min", "20m 1s", "1h30m15s", "2d6h"
  *   - Plain number: treated as minutes (e.g. "30" → 30 minutes)
  *
  * Returns 0 if the input cannot be parsed.
@@ -147,15 +147,20 @@ export function parseDuration(input: string): number {
         if (unit.startsWith("h")) {
             return value * 60 * 60 * 1000;
         }
+
+        if (unit.startsWith("d")) {
+            return value * 24 * 60 * 60 * 1000;
+        }
     }
 
     const compound = trimmed.match(COMPOUND_DURATION_PATTERN);
 
-    if (compound && (compound[1] || compound[2] || compound[3])) {
-        const hours = compound[1] ? Number.parseInt(compound[1], 10) : 0;
-        const minutes = compound[2] ? Number.parseInt(compound[2], 10) : 0;
-        const seconds = compound[3] ? Number.parseInt(compound[3], 10) : 0;
-        return (hours * 3600 + minutes * 60 + seconds) * 1000;
+    if (compound && (compound[1] || compound[2] || compound[3] || compound[4])) {
+        const days = compound[1] ? Number.parseInt(compound[1], 10) : 0;
+        const hours = compound[2] ? Number.parseInt(compound[2], 10) : 0;
+        const minutes = compound[3] ? Number.parseInt(compound[3], 10) : 0;
+        const seconds = compound[4] ? Number.parseInt(compound[4], 10) : 0;
+        return (days * 86400 + hours * 3600 + minutes * 60 + seconds) * 1000;
     }
 
     return 0;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -104,12 +104,13 @@ export function formatDuration(value: number, unit: DurationUnit = "ms", style: 
 // Single value + unit, e.g. "30m", "2hours", "90s", "7d"
 const SIMPLE_DURATION_PATTERN = /^(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)$/i;
 
-// Multi-part durations, e.g. "1h30m", "2h15min10s". Each group is optional,
-// allowing any combination of hours/minutes/seconds:
-//   (?:(\d+)\s*h...)? — optional hours  (capture group 1)
-//   (?:(\d+)\s*m...)? — optional minutes (capture group 2)
-//   (?:(\d+)\s*s...)? — optional seconds (capture group 3)
-// Unit suffixes accept common spellings: h/hr/hrs/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds
+// Multi-part durations, e.g. "1h30m", "2h15min10s", "2d6h". Each group is optional,
+// allowing any combination of days/hours/minutes/seconds:
+//   (?:(\d+)\s*d...)? — optional days    (capture group 1)
+//   (?:(\d+)\s*h...)? — optional hours   (capture group 2)
+//   (?:(\d+)\s*m...)? — optional minutes (capture group 3)
+//   (?:(\d+)\s*s...)? — optional seconds (capture group 4)
+// Unit suffixes accept common spellings: d/day/days, h/hr/hrs/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds
 const COMPOUND_DURATION_PATTERN =
     /^(?:(\d+)\s*d(?:ays?)?)?\s*(?:(\d+)\s*h(?:ours?|rs?|r)?)?\s*(?:(\d+)\s*m(?:in(?:utes?|s)?)?)?\s*(?:(\d+)\s*s(?:ec(?:onds?|s)?)?)?$/i;
 


### PR DESCRIPTION
## What

Correctness work on `tools du`, the APFS-aware disk usage scanner.

- **Reports denials** instead of silently under-counting directories it could not read.
- **Allocated bytes, sparse files and clone partners** are reported distinctly, and extent maps are cached so the same inode is not re-mapped per link.
- **Detects blocks shared outside the scan root** and leads with *freeable* bytes — the number that actually answers "how much space do I get back if I delete this", which differs sharply from apparent size once clones are involved.
- **Stops the walk at filesystem and cloud-provider boundaries**, so a scan no longer wanders into a mounted volume or a cloud-synced placeholder tree.
- Docs: corrected the huge-directory note and dropped identifying paths from the benchmark log.

## Why

`du` lies on APFS. A tree of bun `node_modules` cloned across worktrees reports its full apparent size N times over, so the number that looks like "reclaim 40 GB" is often "reclaim 4 GB". Leading with freeable bytes makes the output actionable.

## Performance

The native core (`src/du/native/clonesize.c`) is syscall-bound and runs in the hot loop of multi-million-file scans, so per repo convention every feature here is measured and recorded in `.claude/docs/benchmarks-du.md`.

## Scope

`src/du/**`, `src/utils/format.ts` (+ its test), `CLAUDE.md`, `.claude/docs/benchmarks-du.md`.

Split out of #296. File-disjoint from the sibling PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added changed-since filtering, persistent extent caching, and optional cloud-directory inclusion for disk usage scans.
  * Added volume reconciliation and clone-partner analysis commands.
  * Added snapshot saving and directory-level diff reporting.
  * Expanded results with sparse-file, allocation, sharing, cache, denial, and skipped-path details.
  * Improved human and JSON output, including warnings and actionable permission guidance.
  * Added support for day-based duration values.

* **Bug Fixes**
  * Improved cache validation and recovery from corrupted or oversized cache data.
  * Corrected cache invalidation and scan-sharing detection.

* **Documentation**
  * Added benchmarking guidance and documented performance and correctness results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->