### PR TITLE
feat(instagram): profile/story fetcher with session-gated endpoints

### DIFF
--- a/src/instagram/README.md
+++ b/src/instagram/README.md
@@ -1,0 +1,72 @@
+# instagram
+
+Inspect public Instagram profiles anonymously, and fetch story / highlight media with **your own** session cookie.
+
+```bash
+tools instagram profile <username>              # public info — no session needed
+tools instagram highlights <username>           # highlight ids + titles — no session needed
+tools instagram stories <username>              # story media — session required
+tools instagram highlight <username> <id>       # one highlight's media — session required
+tools instagram session                         # show how the cookie is being resolved
+```
+
+Add `--json` to any read command for machine output, and `-d [dir]` to `stories` / `highlight` to download the media.
+
+## What needs a session and what does not
+
+| Data | Session | Endpoint |
+|---|---|---|
+| Profile fields, follower/post counts, bio, privacy flag | no | `/api/v1/users/web_profile_info/` |
+| Whether a live story exists + when it expires | no | legacy `query_id` reel endpoint |
+| Highlight ids, titles, covers | no | legacy `query_id` reel endpoint |
+| Story items (the actual media) | **yes** | `/api/v1/feed/reels_media/` |
+| Highlight items (the actual media) | **yes** | `/api/v1/feed/reels_media/` |
+
+The split is the whole point of the tool. Instagram gates story *media* on viewer identity, but story *existence* and the highlight tray are genuinely public.
+
+## The empty-result trap
+
+Instagram answers an unauthenticated story request with **HTTP 200 and `{"reels":{}}`** — never a 401. So "there are no stories" and "you are not allowed to see them" are identical on the wire.
+
+This tool therefore **refuses** rather than reporting an empty result: no session means an error explaining why, and an empty reel map *with* a session is reported as an expired cookie. Silently printing "no stories" for a gated response is the single most misleading thing it could do, and it is what most wrappers around this API get wrong.
+
+## Supplying the session cookie
+
+The cookie is a live credential to a real account, so it is **never written to config**. Only the *name* of an environment variable is stored, mirroring the `tokens.apiKeyEnv` convention used by the AI accounts.
+
+```bash
+export IG_SESSIONID="<sessionid cookie from your browser>"
+export IG_CSRFTOKEN="<csrftoken cookie>"      # optional but recommended, see below
+```
+
+Resolution order: `--session-cookie` flag → `IG_SESSIONID` / `INSTAGRAM_SESSIONID` → the variable named by `tools instagram session --use-env NAME`. Any of them accepts a bare value or a whole pasted `csrftoken=…; sessionid=…` string.
+
+Instagram expects the `x-csrftoken` header to match the `csrftoken` cookie. A mismatch is a fingerprint signal that triggers enforcement independently of request volume, so supply `IG_CSRFTOKEN` (or paste the full cookie string) when you can — the client warns on every request that goes out without it.
+
+> **Use a throwaway account.** Reading stories this way violates Instagram's ToS, and it puts you in the story's viewer list exactly as the app would.
+
+## Rate limiting
+
+Proactive, not reactive: a **75-request / 11-minute** budget with instaloader's per-request jitter (`min(expovariate(0.6), 15)` seconds), taken from `instaloader/instaloadercontext.py`. A budget refuses the request *before* it is sent, so the account never accrues the strike — unlike a flat delay plus backoff-on-429, which only tells you that you were too fast after Instagram has already counted it.
+
+Media downloads run sequentially for the same reason. They go to the pre-signed CDN with no cookie attached, but they share the egress IP, and a burst is the cheapest way to earn an IP-level block.
+
+## Error kinds
+
+Failures are classified rather than dumped, because the right response differs sharply per kind:
+
+- `session-required` / `session-invalid` — no cookie, or Instagram rejected the one supplied
+- `checkpoint` — account-level flag. **Rotating IP or proxy makes it worse.** Clear it in a browser
+- `suspended` — challenge URL contained `/suspended/`; an SMS code will not fix it, it needs an appeal
+- `feedback-required` — "that looked automated", scored against the **account**; backing off does not clear the current block
+- `please-wait` — arrives as HTTP 401 with `require_login: true` but your cookie is fine; caller-scoped, only time clears it
+- `rate-limited` — IP-level (`sentry_block`, `rate_limit_error`, 429); backing off genuinely helps
+- `not-found`, `network`
+
+Enforcement markers are only read inside a response Instagram itself failed (4xx, or a `"status":"fail"` envelope). Scanning every body would turn a bio containing the word "spam" into a fabricated account block.
+
+## Privacy notes
+
+- The anonymous endpoints take no `sessionId` parameter, and go through `getAnonymousJson`, whose options type sets `sessionId?: never` — passing one is a compile error, not a code-review catch. instagrapi's `inject_sessionid_to_public()` silently injects real credentials into "public" calls when an anonymous one fails; that class of leak is unrepresentable here.
+- The `x-ig-www-claim` token is replayed per auth mode. Echoing the claim Instagram minted for your logged-in session on a later anonymous request would hand it the link between the two.
+- The cookie is never logged and never persisted. `tools instagram session` prints only its first 6 characters (the leading digits of the numeric user id) and its length.

--- a/src/instagram/README.md
+++ b/src/instagram/README.md
@@ -41,13 +41,20 @@ export IG_CSRFTOKEN="<csrftoken cookie>"      # optional but recommended, see be
 
 Resolution order: `--session-cookie` flag → `IG_SESSIONID` / `INSTAGRAM_SESSIONID` → the variable named by `tools instagram session --use-env NAME`. Any of them accepts a bare value or a whole pasted `csrftoken=…; sessionid=…` string.
 
-Instagram expects the `x-csrftoken` header to match the `csrftoken` cookie. A mismatch is a fingerprint signal that triggers enforcement independently of request volume, so supply `IG_CSRFTOKEN` (or paste the full cookie string) when you can — the client warns on every request that goes out without it.
+Instagram pairs the `csrftoken` cookie with the `sessionid` it was issued alongside, and expects the `x-csrftoken` header to carry the same value. So a csrftoken has to travel *with its own* session:
+
+- `IG_SESSIONID` + `IG_CSRFTOKEN` are treated as a pair, since both come from the environment together.
+- `--session-cookie` does **not** borrow `IG_CSRFTOKEN`. The flag exists to override the environment's session, and attaching that session's token to a different cookie would manufacture exactly the mismatch this warns about. Paste the full cookie string, or pass `--csrf-token` to supply one that belongs with it.
+
+The client logs a warning on every request that goes out with no csrftoken at all.
 
 > **Use a throwaway account.** Reading stories this way violates Instagram's ToS, and it puts you in the story's viewer list exactly as the app would.
 
 ## Rate limiting
 
-Proactive, not reactive: a **75-request / 11-minute** budget with instaloader's per-request jitter (`min(expovariate(0.6), 15)` seconds), taken from `instaloader/instaloadercontext.py`. A budget refuses the request *before* it is sent, so the account never accrues the strike — unlike a flat delay plus backoff-on-429, which only tells you that you were too fast after Instagram has already counted it.
+Proactive, not reactive: a **75-request / 11-minute** budget with instaloader's per-request jitter (`min(expovariate(0.6), 15)` seconds), taken from `instaloader/instaloadercontext.py`. A budget refuses the request *before* it is sent, so that request never becomes a strike — unlike a flat delay plus backoff-on-429, which only tells you that you were too fast after Instagram has already counted it.
+
+> ⚠️ **The budget is per process and is not persisted.** `tools` runs each invocation in its own process, so ten commands in a row each start with a full 75, and back-to-back runs can exceed the window that any single run respects. Treat it as an invocation-local throttle, not an account-wide guarantee. Making it account-wide needs the timestamps in the tool's storage dir behind an inter-process lock.
 
 Media downloads run sequentially for the same reason. They go to the pre-signed CDN with no cookie attached, but they share the egress IP, and a burst is the cheapest way to earn an IP-level block.
 

--- a/src/instagram/index.ts
+++ b/src/instagram/index.ts
@@ -20,10 +20,11 @@ const program = new Command()
 
 interface SessionOptions {
     sessionCookie?: string;
+    csrfToken?: string;
 }
 
 async function resolveOrExplain(options: SessionOptions) {
-    const session = await resolveSession(options.sessionCookie);
+    const session = await resolveSession(options.sessionCookie, options.csrfToken);
 
     if (session) {
         log.debug({ source: session.source, envKey: session.envKey }, "using instagram session");
@@ -67,6 +68,7 @@ program
     .command("highlights <username>")
     .description("List highlight ids (anonymous) and titles (needs a session)")
     .option("-s, --session-cookie <cookie>", "Instagram sessionid cookie")
+    .option("--csrf-token <token>", "csrftoken that belongs WITH --session-cookie (not read from the env)")
     .option("--json", "Emit JSON instead of a table")
     .action(async (username: string, options: SessionOptions & { json?: boolean }) => {
         try {
@@ -123,6 +125,7 @@ program
     .command("stories <username>")
     .description("Fetch active stories (requires a session cookie)")
     .option("-s, --session-cookie <cookie>", "Instagram sessionid cookie")
+    .option("--csrf-token <token>", "csrftoken that belongs WITH --session-cookie (not read from the env)")
     .option("-d, --download [dir]", "Download the media")
     .option("--json", "Emit JSON instead of a table")
     .action(async (username: string, options: SessionOptions & { download?: string | boolean; json?: boolean }) => {
@@ -142,6 +145,7 @@ program
     .command("highlight <username> <highlightId>")
     .description("Fetch one highlight's media (requires a session cookie)")
     .option("-s, --session-cookie <cookie>", "Instagram sessionid cookie")
+    .option("--csrf-token <token>", "csrftoken that belongs WITH --session-cookie (not read from the env)")
     .option("-d, --download [dir]", "Download the media")
     .option("--json", "Emit JSON instead of a table")
     .action(

--- a/src/instagram/index.ts
+++ b/src/instagram/index.ts
@@ -8,7 +8,7 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { fetchHighlightMedia, fetchHighlightTray, fetchProfile, fetchPublicReelInfo, fetchStories } from "./lib/api";
 import { displayHighlights, displayProfile, displayReels, explainError } from "./lib/display";
-import { downloadReels } from "./lib/download";
+import { downloadReels, summarizeDownloads } from "./lib/download";
 import { readSessionConfig, resolveSession, writeSessionConfig } from "./lib/session";
 import type { StoryReel } from "./lib/types";
 
@@ -222,12 +222,10 @@ async function emitReels(
 
     spinner.stop(`Downloaded ${results.length} file${results.length === 1 ? "" : "s"} to ${dir}`);
 
-    // downloadReels only throws when EVERY item failed, so a partial failure would
-    // otherwise read as a complete download that happened to be short.
-    const expected = reels.reduce((sum, reel) => sum + reel.items.length, 0);
-    if (results.length < expected) {
-        out.log.warn(`${expected - results.length} of ${expected} items failed to download.`);
-        log.warn({ expected, downloaded: results.length, dir }, "partial story download");
+    const summary = summarizeDownloads(reels, results);
+    if (summary.failed > 0) {
+        out.log.warn(`${summary.failed} of ${summary.requested} items failed to download.`);
+        log.warn({ ...summary, dir }, "partial story download");
     }
 }
 

--- a/src/instagram/index.ts
+++ b/src/instagram/index.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env bun
+
+import { join } from "node:path";
+import * as p from "@clack/prompts";
+import { enhanceHelp, runTool, suggestCommand } from "@genesiscz/utils/cli";
+import { logger, out } from "@genesiscz/utils/logger";
+import { Command } from "commander";
+import pc from "picocolors";
+import { fetchHighlightMedia, fetchHighlightTray, fetchProfile, fetchPublicReelInfo, fetchStories } from "./lib/api";
+import { displayHighlights, displayProfile, displayReels, explainError } from "./lib/display";
+import { downloadReels } from "./lib/download";
+import { readSessionConfig, resolveSession, writeSessionConfig } from "./lib/session";
+import type { StoryReel } from "./lib/types";
+
+const { log } = logger.scoped("instagram");
+
+const program = new Command()
+    .name("instagram")
+    .description("Inspect public Instagram profiles, and fetch stories with your own session");
+
+interface SessionOptions {
+    sessionCookie?: string;
+}
+
+async function resolveOrExplain(options: SessionOptions) {
+    const session = await resolveSession(options.sessionCookie);
+
+    if (session) {
+        log.debug({ source: session.source, envKey: session.envKey }, "using instagram session");
+    }
+
+    return session;
+}
+
+program
+    .command("profile <username>")
+    .description("Public profile info — works with no session at all")
+    .option("--json", "Emit JSON instead of a table")
+    .action(async (username: string, options: { json?: boolean }) => {
+        try {
+            const profile = await fetchProfile(username);
+            // Story existence is public even though the media is not.
+            const reelInfo = await fetchPublicReelInfo(profile.id).catch((error) => {
+                log.debug({ error }, "public reel info unavailable — showing profile without story state");
+                return undefined;
+            });
+
+            if (options.json) {
+                out.result({ ...profile, story: reelInfo });
+                return;
+            }
+
+            displayProfile(profile, reelInfo);
+
+            if (profile.highlightCount > 0) {
+                out.log.info(
+                    `${profile.highlightCount} highlights — ${pc.cyan(`tools instagram highlights ${username}`)}`
+                );
+            }
+        } catch (error) {
+            explainError(error);
+            process.exit(1);
+        }
+    });
+
+program
+    .command("highlights <username>")
+    .description("List highlight ids (anonymous) and titles (needs a session)")
+    .option("-s, --session-cookie <cookie>", "Instagram sessionid cookie")
+    .option("--json", "Emit JSON instead of a table")
+    .action(async (username: string, options: SessionOptions & { json?: boolean }) => {
+        try {
+            const session = await resolveOrExplain(options);
+            const profile = await fetchProfile(username);
+
+            if (session) {
+                const tray = await fetchHighlightTray(profile.id, session);
+
+                if (options.json) {
+                    out.result(tray);
+                    return;
+                }
+
+                displayHighlights(tray);
+                return;
+            }
+
+            // No session needed: the legacy public reel endpoint returns the full
+            // tray with titles. Only the media inside each highlight is gated.
+            const info = await fetchPublicReelInfo(profile.id);
+
+            // This rides a pre-2020 `query_id` API that Instagram has largely
+            // retired. If it starts answering 200 with a changed shape, an empty
+            // list would read as "no highlights" — so cross-check against the
+            // count from `web_profile_info`, which is on the durable REST surface.
+            if (info.highlights.length === 0 && profile.highlightCount > 0) {
+                log.warn(
+                    { userId: profile.id, expected: profile.highlightCount },
+                    "public reel endpoint returned no highlights but the profile reports some — endpoint likely changed"
+                );
+                out.log.warn(
+                    `Instagram reports ${profile.highlightCount} highlights but the public endpoint returned none. ` +
+                        "That endpoint is on a deprecated API generation and has probably changed shape."
+                );
+                out.log.info("This is a tool bug to fix, not an empty account.");
+                process.exit(1);
+            }
+
+            if (options.json) {
+                out.result(info.highlights);
+                return;
+            }
+
+            displayHighlights(info.highlights);
+            out.log.info(`Media needs a session — ${pc.cyan(`tools instagram highlight ${username} <id> --download`)}`);
+        } catch (error) {
+            explainError(error);
+            process.exit(1);
+        }
+    });
+
+program
+    .command("stories <username>")
+    .description("Fetch active stories (requires a session cookie)")
+    .option("-s, --session-cookie <cookie>", "Instagram sessionid cookie")
+    .option("-d, --download [dir]", "Download the media")
+    .option("--json", "Emit JSON instead of a table")
+    .action(async (username: string, options: SessionOptions & { download?: string | boolean; json?: boolean }) => {
+        try {
+            const session = await resolveOrExplain(options);
+            const profile = await fetchProfile(username);
+            const reels = await fetchStories(profile.id, session);
+
+            await emitReels(reels, username, options);
+        } catch (error) {
+            explainError(error);
+            process.exit(1);
+        }
+    });
+
+program
+    .command("highlight <username> <highlightId>")
+    .description("Fetch one highlight's media (requires a session cookie)")
+    .option("-s, --session-cookie <cookie>", "Instagram sessionid cookie")
+    .option("-d, --download [dir]", "Download the media")
+    .option("--json", "Emit JSON instead of a table")
+    .action(
+        async (
+            username: string,
+            highlightId: string,
+            options: SessionOptions & { download?: string | boolean; json?: boolean }
+        ) => {
+            try {
+                const session = await resolveOrExplain(options);
+                const reels = await fetchHighlightMedia([highlightId], session);
+
+                await emitReels(reels, username, options);
+            } catch (error) {
+                explainError(error);
+                process.exit(1);
+            }
+        }
+    );
+
+program
+    .command("session")
+    .description("Show how the session cookie is being resolved, or point it at an env var")
+    .option("--use-env <name>", "Store the NAME of an env var to read the cookie from (the cookie is never saved)")
+    .action(async (options: { useEnv?: string }) => {
+        if (options.useEnv) {
+            await writeSessionConfig({ sessionIdEnv: options.useEnv });
+            out.log.success(`Session cookie will be read from $${options.useEnv}`);
+            return;
+        }
+
+        const config = await readSessionConfig();
+        const session = await resolveSession();
+
+        if (!session) {
+            out.log.warn("No session cookie resolved — only anonymous commands will work.");
+            out.log.info(
+                `Set ${pc.cyan("IG_SESSIONID")}, or run ${pc.cyan("tools instagram session --use-env NAME")}.`
+            );
+
+            if (config.sessionIdEnv) {
+                out.log.warn(`Config points at $${config.sessionIdEnv}, but that variable is unset or empty.`);
+            }
+
+            return;
+        }
+
+        out.log.success(
+            `Session resolved from ${session.source}${session.envKey ? ` ($${session.envKey})` : ""} — ` +
+                `${session.sessionId.slice(0, 6)}… (${session.sessionId.length} chars)`
+        );
+    });
+
+async function emitReels(
+    reels: StoryReel[],
+    username: string,
+    options: { download?: string | boolean; json?: boolean }
+): Promise<void> {
+    if (options.json) {
+        out.result(reels);
+        return;
+    }
+
+    displayReels(reels);
+
+    if (!options.download) {
+        out.log.info(suggestCommand("tools instagram", { add: ["--download"] }));
+        return;
+    }
+
+    const dir = typeof options.download === "string" ? options.download : join(process.cwd(), `instagram-${username}`);
+    const spinner = p.spinner();
+    spinner.start("Downloading media");
+
+    const results = await downloadReels(reels, dir, (done, total) => {
+        spinner.message(`Downloading media (${done}/${total})`);
+    });
+
+    spinner.stop(`Downloaded ${results.length} file${results.length === 1 ? "" : "s"} to ${dir}`);
+}
+
+enhanceHelp(program);
+
+async function main(): Promise<void> {
+    try {
+        await runTool(program, { tool: "instagram" });
+    } catch (error) {
+        explainError(error);
+        process.exit(1);
+    }
+}
+
+main();

--- a/src/instagram/index.ts
+++ b/src/instagram/index.ts
@@ -221,6 +221,14 @@ async function emitReels(
     });
 
     spinner.stop(`Downloaded ${results.length} file${results.length === 1 ? "" : "s"} to ${dir}`);
+
+    // downloadReels only throws when EVERY item failed, so a partial failure would
+    // otherwise read as a complete download that happened to be short.
+    const expected = reels.reduce((sum, reel) => sum + reel.items.length, 0);
+    if (results.length < expected) {
+        out.log.warn(`${expected - results.length} of ${expected} items failed to download.`);
+        log.warn({ expected, downloaded: results.length, dir }, "partial story download");
+    }
 }
 
 enhanceHelp(program);

--- a/src/instagram/lib/api.test.ts
+++ b/src/instagram/lib/api.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { fetchHighlightMedia, fetchHighlightTray, fetchProfile, fetchStories } from "./api";
+import { __testing as __clientTesting } from "./client";
+import { InstagramError } from "./types";
+
+const realFetch = globalThis.fetch;
+
+beforeAll(() => {
+    __clientTesting.useInstantLimiter();
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+function mockJson(body: unknown, status = 200): void {
+    globalThis.fetch = mock(
+        async () => new Response(SafeJSON.stringify(body), { status, headers: { "content-type": "application/json" } })
+    ) as unknown as typeof fetch;
+}
+
+describe("fetchStories", () => {
+    test("refuses without a session instead of reporting an empty result", async () => {
+        // The core contract. Instagram answers anonymous story requests with
+        // HTTP 200 + {"reels":{}}, so "no stories" and "not authorised" are
+        // indistinguishable on the wire — we must never guess the friendly one.
+        const error = (await fetchStories("123", undefined).catch((err) => err)) as InstagramError;
+
+        expect(error).toBeInstanceOf(InstagramError);
+        expect(error.kind).toBe("session-required");
+    });
+
+    test("treats an empty reels map WITH a session as an expired cookie", async () => {
+        mockJson({ reels: {}, status: "ok" });
+
+        const error = (await fetchStories("123", { sessionId: "cookie" }).catch((err) => err)) as InstagramError;
+
+        expect(error).toBeInstanceOf(InstagramError);
+        expect(error.kind).toBe("session-invalid");
+        expect(error.message).toContain("expired");
+    });
+
+    test("maps a populated reel into story items", async () => {
+        mockJson({
+            reels: {
+                "123": {
+                    id: 123,
+                    user: { username: "someone" },
+                    items: [
+                        {
+                            pk: "item1",
+                            taken_at: 1_700_000_000,
+                            expiring_at: 1_700_086_400,
+                            image_versions2: {
+                                candidates: [{ url: "https://cdn/img.jpg", width: 1080, height: 1920 }],
+                            },
+                        },
+                        {
+                            pk: "item2",
+                            taken_at: 1_700_000_500,
+                            image_versions2: {
+                                candidates: [{ url: "https://cdn/poster.jpg", width: 1080, height: 1920 }],
+                            },
+                            video_versions: [{ url: "https://cdn/clip.mp4", width: 720, height: 1280 }],
+                        },
+                    ],
+                },
+            },
+        });
+
+        const reels = await fetchStories("123", { sessionId: "cookie" });
+
+        expect(reels).toHaveLength(1);
+        expect(reels[0].ownerUsername).toBe("someone");
+        expect(reels[0].items).toHaveLength(2);
+        expect(reels[0].items[0].isVideo).toBe(false);
+        expect(reels[0].items[0].mediaUrl).toBe("https://cdn/img.jpg");
+        // Video items must prefer the video URL but keep the poster frame.
+        expect(reels[0].items[1].isVideo).toBe(true);
+        expect(reels[0].items[1].mediaUrl).toBe("https://cdn/clip.mp4");
+        expect(reels[0].items[1].imageUrl).toBe("https://cdn/poster.jpg");
+    });
+
+    test("drops items that carry no media candidates rather than emitting empty urls", async () => {
+        mockJson({ reels: { "123": { items: [{ pk: "broken", taken_at: 1 }] } } });
+
+        const reels = await fetchStories("123", { sessionId: "cookie" });
+
+        expect(reels[0].items).toHaveLength(0);
+    });
+});
+
+describe("fetchHighlightMedia", () => {
+    test("prefixes bare ids with `highlight:`", async () => {
+        let capturedUrl = "";
+        globalThis.fetch = mock(async (url: string) => {
+            capturedUrl = String(url);
+            return new Response(SafeJSON.stringify({ reels: { "highlight:99": { items: [] } } }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await fetchHighlightMedia(["99"], { sessionId: "cookie" });
+
+        expect(capturedUrl).toContain("highlight%3A99");
+    });
+
+    test("does not double-prefix an id that already carries one", async () => {
+        let capturedUrl = "";
+        globalThis.fetch = mock(async (url: string) => {
+            capturedUrl = String(url);
+            return new Response(SafeJSON.stringify({ reels: { "highlight:99": { items: [] } } }), { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await fetchHighlightMedia(["highlight:99"], { sessionId: "cookie" });
+
+        expect(capturedUrl).toContain("highlight%3A99");
+        expect(capturedUrl).not.toContain("highlight%3Ahighlight");
+    });
+});
+
+describe("session forwarding", () => {
+    function captureHeaders(body: unknown): Array<Record<string, string>> {
+        const seen: Array<Record<string, string>> = [];
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            seen.push((init?.headers ?? {}) as Record<string, string>);
+            return new Response(SafeJSON.stringify(body), { status: 200 });
+        }) as unknown as typeof fetch;
+        return seen;
+    }
+
+    // Regression: the authenticated API calls used to take a bare `sessionId`
+    // string, so a resolved csrftoken had nowhere to travel and every request
+    // went out with the cookie/header mismatch that the client warns about.
+    test("carries the csrftoken with the sessionid on story requests", async () => {
+        const seen = captureHeaders({ reels: { "123": { items: [] } } });
+
+        await fetchStories("123", { sessionId: "abc", csrfToken: "tok123" });
+
+        expect(seen[0]["x-csrftoken"]).toBe("tok123");
+        expect(seen[0].cookie).toBe("sessionid=abc; csrftoken=tok123");
+    });
+
+    test("carries it on the highlights tray too", async () => {
+        const seen = captureHeaders({ tray: [] });
+
+        await fetchHighlightTray("123", { sessionId: "abc", csrfToken: "tok123" });
+
+        expect(seen[0]["x-csrftoken"]).toBe("tok123");
+        expect(seen[0].cookie).toBe("sessionid=abc; csrftoken=tok123");
+    });
+});
+
+describe("fetchProfile", () => {
+    test("works anonymously and maps the fields we surface", async () => {
+        mockJson({
+            data: {
+                user: {
+                    id: "1159670881",
+                    username: "someone",
+                    full_name: "Some One",
+                    biography: "bio",
+                    is_private: false,
+                    is_verified: false,
+                    is_professional_account: true,
+                    highlight_reel_count: 34,
+                    edge_followed_by: { count: 406 },
+                    edge_follow: { count: 1067 },
+                    edge_owner_to_timeline_media: { count: 264 },
+                    profile_pic_url: "https://cdn/pic.jpg",
+                },
+            },
+        });
+
+        const profile = await fetchProfile("someone");
+
+        expect(profile.id).toBe("1159670881");
+        expect(profile.followers).toBe(406);
+        expect(profile.posts).toBe(264);
+        expect(profile.highlightCount).toBe(34);
+        expect(profile.isProfessional).toBe(true);
+    });
+
+    test("raises not-found when the payload carries no user", async () => {
+        mockJson({ data: {} });
+
+        const error = (await fetchProfile("nobody").catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("not-found");
+    });
+});

--- a/src/instagram/lib/api.ts
+++ b/src/instagram/lib/api.ts
@@ -1,0 +1,287 @@
+import { logger } from "@genesiscz/utils/logger";
+import { getJson } from "./client";
+import {
+    type HighlightRef,
+    InstagramError,
+    type InstagramProfile,
+    type PublicReelInfo,
+    type SessionCredentials,
+    type StoryItem,
+    type StoryReel,
+} from "./types";
+
+const { log } = logger.scoped("instagram:api");
+
+interface RawProfileResponse {
+    data?: {
+        user?: {
+            id: string;
+            username: string;
+            full_name?: string;
+            biography?: string;
+            is_private: boolean;
+            is_verified?: boolean;
+            is_professional_account?: boolean;
+            profile_pic_url_hd?: string;
+            profile_pic_url?: string;
+            highlight_reel_count?: number;
+            edge_followed_by?: { count: number };
+            edge_follow?: { count: number };
+            edge_owner_to_timeline_media?: { count: number };
+        };
+    };
+}
+
+interface RawStoryItem {
+    pk?: string | number;
+    id?: string;
+    taken_at?: number;
+    expiring_at?: number;
+    media_type?: number;
+    image_versions2?: { candidates?: Array<{ url: string; width: number; height: number }> };
+    video_versions?: Array<{ url: string; width: number; height: number }>;
+}
+
+interface RawReel {
+    id?: string | number;
+    title?: string;
+    user?: { username?: string };
+    items?: RawStoryItem[];
+}
+
+interface RawReelsResponse {
+    reels?: Record<string, RawReel>;
+}
+
+interface RawPublicReelResponse {
+    data?: {
+        user?: {
+            has_public_story?: boolean;
+            is_live?: boolean;
+            reel?: { expiring_at?: number };
+            edge_highlight_reels?: {
+                edges: Array<{
+                    node: {
+                        id: string | number;
+                        title?: string;
+                        cover_media?: { thumbnail_src?: string };
+                        cover_media_cropped_thumbnail?: { url?: string };
+                    };
+                }>;
+            };
+        };
+    };
+}
+
+interface RawHighlightsTray {
+    tray?: Array<{
+        id?: string;
+        title?: string;
+        cover_media?: { cropped_image_version?: { url?: string } };
+    }>;
+}
+
+/**
+ * Anonymous. Verified working without any cookie.
+ *
+ * Takes no `sessionId` parameter ON PURPOSE, and neither does `fetchPublicReelInfo`.
+ * instagrapi's `inject_sessionid_to_public()` silently injects the account's real
+ * session into a "public" call whenever an anonymous request fails and any
+ * credential is in scope, which turns anonymous reads into identified ones without
+ * the caller noticing. Keeping the parameter off the signature makes that class of
+ * leak unrepresentable rather than merely avoided.
+ */
+export async function fetchProfile(username: string): Promise<InstagramProfile> {
+    const { data } = await getJson<RawProfileResponse>(
+        `/api/v1/users/web_profile_info/?username=${encodeURIComponent(username)}`,
+        { label: `profile:${username}` }
+    );
+
+    const user = data.data?.user;
+    if (!user) {
+        throw new InstagramError("not-found", `No Instagram account found for @${username}`);
+    }
+
+    return {
+        id: user.id,
+        username: user.username,
+        fullName: user.full_name ?? "",
+        biography: user.biography ?? "",
+        isPrivate: user.is_private,
+        isVerified: user.is_verified ?? false,
+        isProfessional: user.is_professional_account ?? false,
+        followers: user.edge_followed_by?.count ?? 0,
+        following: user.edge_follow?.count ?? 0,
+        posts: user.edge_owner_to_timeline_media?.count ?? 0,
+        highlightCount: user.highlight_reel_count ?? 0,
+        profilePicUrl: user.profile_pic_url_hd ?? user.profile_pic_url ?? "",
+    };
+}
+
+/**
+ * Fetch story or highlight reels.
+ *
+ * 🛑 The critical branch. Instagram answers an unauthenticated story request with
+ * HTTP 200 and `{"reels":{}}` — never a 401 — so an empty map means "you are not
+ * authorised" far more often than it means "there are no stories". Without a
+ * session we therefore refuse rather than reporting an empty result, because
+ * silently returning "no stories" for a gated response is the single most
+ * misleading thing this tool could do.
+ */
+async function fetchReels(
+    reelIds: string[],
+    session: SessionCredentials | undefined,
+    label: string
+): Promise<StoryReel[]> {
+    if (!session) {
+        throw new InstagramError(
+            "session-required",
+            "Story and highlight media require a logged-in Instagram session. " +
+                "Instagram returns an empty result rather than an error to anonymous callers, " +
+                "so this cannot be distinguished from 'no stories' without one."
+        );
+    }
+
+    const query = reelIds.map((id) => `reel_ids=${encodeURIComponent(id)}`).join("&");
+    const { data } = await getJson<RawReelsResponse>(`/api/v1/feed/reels_media/?${query}`, {
+        sessionId: session.sessionId,
+        csrfToken: session.csrfToken,
+        label,
+    });
+    const reels = data.reels ?? {};
+
+    if (Object.keys(reels).length === 0) {
+        // We DID send a cookie and still got the anonymous-shaped answer, so the
+        // cookie is dead. Reporting this as "no stories" is how every downstream
+        // tool ends up lying to its user about an expired session.
+        log.warn({ reelIds, label }, "empty reels map despite an attached session — treating the session as expired");
+        throw new InstagramError(
+            "session-invalid",
+            "Instagram returned no reels despite an attached session. The session cookie is most likely expired."
+        );
+    }
+
+    return Object.entries(reels).map(([reelId, reel]) => ({
+        reelId,
+        ownerUsername: reel.user?.username,
+        title: reel.title,
+        items: (reel.items ?? []).map(toStoryItem).filter((item): item is StoryItem => item !== undefined),
+    }));
+}
+
+function toStoryItem(raw: RawStoryItem): StoryItem | undefined {
+    const image = raw.image_versions2?.candidates?.[0];
+    const video = raw.video_versions?.[0];
+
+    if (!image && !video) {
+        log.debug({ id: raw.pk ?? raw.id }, "skipping story item with no media candidates");
+        return undefined;
+    }
+
+    const isVideo = Boolean(video);
+    const primary = video ?? image;
+
+    return {
+        id: String(raw.pk ?? raw.id ?? ""),
+        takenAt: new Date((raw.taken_at ?? 0) * 1000),
+        expiresAt: raw.expiring_at ? new Date(raw.expiring_at * 1000) : undefined,
+        isVideo,
+        mediaUrl: primary?.url ?? "",
+        imageUrl: image?.url ?? "",
+        width: primary?.width ?? 0,
+        height: primary?.height ?? 0,
+    };
+}
+
+export async function fetchStories(userId: string, session: SessionCredentials | undefined): Promise<StoryReel[]> {
+    return fetchReels([userId], session, `stories:${userId}`);
+}
+
+export async function fetchHighlightMedia(
+    highlightIds: string[],
+    session: SessionCredentials | undefined
+): Promise<StoryReel[]> {
+    return fetchReels(
+        highlightIds.map((id) => (id.startsWith("highlight:") ? id : `highlight:${id}`)),
+        session,
+        `highlights:${highlightIds.length}`
+    );
+}
+
+/**
+ * Highlight tray via the private API. Needs a session; `fetchPublicReelInfo`
+ * returns the same ids and titles anonymously, so this is only worth calling
+ * when a session already exists.
+ */
+export async function fetchHighlightTray(
+    userId: string,
+    session: SessionCredentials | undefined
+): Promise<HighlightRef[]> {
+    if (!session) {
+        throw new InstagramError("session-required", "The highlights tray endpoint requires a session.");
+    }
+
+    const { data } = await getJson<RawHighlightsTray>(`/api/v1/highlights/${userId}/highlights_tray/`, {
+        sessionId: session.sessionId,
+        csrfToken: session.csrfToken,
+        label: `highlights-tray:${userId}`,
+    });
+
+    return (data.tray ?? []).map((entry) => ({
+        id: String(entry.id ?? "").replace(/^highlight:/, ""),
+        title: entry.title ?? "(untitled)",
+        coverUrl: entry.cover_media?.cropped_image_version?.url,
+    }));
+}
+
+/**
+ * Legacy `query_id` reel endpoint. It survives because `include_logged_out_extras`
+ * exists to serve exactly this case, and it is the one anonymous surface that
+ * still reports story *existence* and the full highlight tray with titles.
+ *
+ * Verified anonymously with plain curl on 2026-07-27 (no cookie, no browser):
+ * returns `has_public_story`, the reel's `expiring_at`, and every highlight id +
+ * title + cover. It does NOT return story or highlight *items* — that stays gated.
+ */
+const PUBLIC_REEL_QUERY_ID = "9957820854288654";
+
+export async function fetchPublicReelInfo(userId: string): Promise<PublicReelInfo> {
+    const params = new URLSearchParams({
+        query_id: PUBLIC_REEL_QUERY_ID,
+        user_id: userId,
+        include_chaining: "false",
+        include_reel: "true",
+        include_suggested_users: "false",
+        include_logged_out_extras: "true",
+        include_live_status: "true",
+        include_highlight_reels: "true",
+    });
+
+    const { data } = await getJson<RawPublicReelResponse>(`/graphql/query/?${params.toString()}`, {
+        label: `public-reel:${userId}`,
+    });
+
+    const user = data.data?.user;
+    if (!user) {
+        throw new InstagramError("not-found", `No public reel info for user ${userId}`);
+    }
+
+    const expiringAt = user.reel?.expiring_at;
+    const highlights = (user.edge_highlight_reels?.edges ?? []).map((edge) => ({
+        id: String(edge.node.id),
+        title: edge.node.title ?? "(untitled)",
+        coverUrl: edge.node.cover_media_cropped_thumbnail?.url ?? edge.node.cover_media?.thumbnail_src,
+    }));
+
+    log.debug(
+        { userId, hasPublicStory: user.has_public_story, highlights: highlights.length },
+        "fetched public reel info anonymously"
+    );
+
+    return {
+        hasPublicStory: Boolean(user.has_public_story),
+        isLive: Boolean(user.is_live),
+        storyExpiresAt: expiringAt ? new Date(expiringAt * 1000) : undefined,
+        highlights,
+    };
+}

--- a/src/instagram/lib/api.ts
+++ b/src/instagram/lib/api.ts
@@ -1,5 +1,5 @@
 import { logger } from "@genesiscz/utils/logger";
-import { getJson } from "./client";
+import { getAnonymousJson, getJson } from "./client";
 import {
     type HighlightRef,
     InstagramError,
@@ -89,10 +89,12 @@ interface RawHighlightsTray {
  * session into a "public" call whenever an anonymous request fails and any
  * credential is in scope, which turns anonymous reads into identified ones without
  * the caller noticing. Keeping the parameter off the signature makes that class of
- * leak unrepresentable rather than merely avoided.
+ * leak unrepresentable rather than merely avoided — and `getAnonymousJson` is what
+ * holds the request layer to the same promise, since a plain `getJson` call would
+ * accept a `sessionId` from a later refactor without complaint.
  */
 export async function fetchProfile(username: string): Promise<InstagramProfile> {
-    const { data } = await getJson<RawProfileResponse>(
+    const { data } = await getAnonymousJson<RawProfileResponse>(
         `/api/v1/users/web_profile_info/?username=${encodeURIComponent(username)}`,
         { label: `profile:${username}` }
     );
@@ -257,7 +259,7 @@ export async function fetchPublicReelInfo(userId: string): Promise<PublicReelInf
         include_highlight_reels: "true",
     });
 
-    const { data } = await getJson<RawPublicReelResponse>(`/graphql/query/?${params.toString()}`, {
+    const { data } = await getAnonymousJson<RawPublicReelResponse>(`/graphql/query/?${params.toString()}`, {
         label: `public-reel:${userId}`,
     });
 

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -208,6 +208,17 @@ describe("marker scanning is gated on a failure envelope", () => {
         expect(response.data.status).toBe("ok");
     });
 
+    test("only honours a TOP-LEVEL fail status, not one nested in the payload", async () => {
+        // The gate reads the parsed document's own verdict. A `status` belonging to
+        // some nested object must not open the marker scan while the real one says
+        // "ok", or a payload that happens to carry both is a fabricated block.
+        mockResponse('{"data":{"user":{"friendship":{"status":"fail"},"biography":"no spam"}},"status":"ok"}', 200);
+
+        const response = await getJson<{ status: string }>("/x", { label: "test" });
+
+        expect(response.data.status).toBe("ok");
+    });
+
     test("still classifies enforcement that arrives as HTTP 200 plus a fail envelope", async () => {
         // The gate must not be `!response.ok` alone: Instagram does answer 200 with
         // `status: fail`, and dropping that would trade a false positive for a
@@ -252,6 +263,26 @@ describe("www-claim isolation between auth modes", () => {
 
         expect(seen[1]["x-ig-www-claim"]).toBe("0");
         expect(__clientTesting.currentWwwClaim("session")).toBe("hmac.SESSION");
+        __clientTesting.resetWwwClaim();
+    });
+
+    test("never hands one session's claim to a different session", async () => {
+        // Auth mode alone is too coarse: two accounts are both "session", and
+        // account B echoing A's claim links the pair just as visibly.
+        __clientTesting.resetWwwClaim();
+        const seen: Array<Record<string, string>> = [];
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            seen.push((init?.headers ?? {}) as Record<string, string>);
+            return new Response('{"ok":true}', { status: 200, headers: { "x-ig-set-www-claim": "hmac.ACCOUNT_A" } });
+        }) as unknown as typeof fetch;
+
+        await getJson("/x", { label: "account-a", sessionId: "session-a" });
+        await getJson("/x", { label: "account-a again", sessionId: "session-a" });
+        await getJson("/x", { label: "account-b", sessionId: "session-b" });
+
+        // Same credential keeps replaying it; a different one starts clean.
+        expect(seen[1]["x-ig-www-claim"]).toBe("hmac.ACCOUNT_A");
+        expect(seen[2]["x-ig-www-claim"]).toBe("0");
         __clientTesting.resetWwwClaim();
     });
 });

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -220,6 +220,21 @@ describe("marker scanning is gated on a failure envelope", () => {
     });
 });
 
+describe("malformed JSON", () => {
+    test("wraps an unparseable body in an InstagramError instead of a raw SyntaxError", async () => {
+        // `startsWith("{")` only rules out the HTML shell. A truncated body still
+        // reaches the parser, and a raw SyntaxError escapes explainError's
+        // InstagramError branch to print a parser message at the user.
+        mockResponse('{"reels": {"123": {"items": [', 200);
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.name).toBe("InstagramError");
+        expect(error.kind).toBe("network");
+        expect(error.message).toContain("malformed JSON");
+    });
+});
+
 describe("www-claim isolation between auth modes", () => {
     test("never replays the session's claim on a later anonymous request", async () => {
         // The claim is minted against the caller Instagram answered. Echoing the

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { __testing as __clientTesting, getJson } from "./client";
+import type { InstagramError } from "./types";
+
+const realFetch = globalThis.fetch;
+
+beforeAll(() => {
+    // Otherwise the module-level limiter sleeps for real (jitter runs to 15s).
+    __clientTesting.useInstantLimiter();
+});
+
+beforeEach(() => {
+    __clientTesting.resetWwwClaim();
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+function mockResponse(body: string, status: number, headers?: Record<string, string>): void {
+    globalThis.fetch = mock(async () => new Response(body, { status, headers })) as unknown as typeof fetch;
+}
+
+describe("getJson error classification", () => {
+    test("reads Instagram's `login_required` as session-required, not a generic 403", async () => {
+        // Verified against i.instagram.com on 2026-07-27: this exact body is what
+        // the mobile endpoints return for gated story content.
+        mockResponse(
+            '{"message":"login_required","logout_reason":33,"logout_expectedness":"logged_out","status":"fail"}',
+            403
+        );
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("session-required");
+        expect(error.status).toBe(403);
+    });
+
+    test("separates checkpoint (account-level) from rate limiting (IP-level)", async () => {
+        mockResponse('{"message":"checkpoint_required"}', 403);
+        const checkpoint = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+        expect(checkpoint.kind).toBe("checkpoint");
+
+        // Deliberately NOT the "please wait a few minutes" body — that is a
+        // caller-scoped throttle with its own kind, not an IP-level rate limit.
+        mockResponse('{"message":"rate_limit_error","status":"fail"}', 429);
+        const limited = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+        expect(limited.kind).toBe("rate-limited");
+        expect(limited.isTerminal).toBe(false);
+    });
+
+    test("treats the logged-out HTML shell as an auth failure rather than parsing it", async () => {
+        // A 200 carrying ~600KB of SPA shell is Instagram's anonymous response for
+        // gated pages. Feeding that to a JSON parser would throw something useless.
+        mockResponse("<!DOCTYPE html><html><head></head><body></body></html>", 200);
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("session-required");
+    });
+
+    test("blames the session when the HTML shell comes back despite a cookie", async () => {
+        mockResponse("<!DOCTYPE html><html></html>", 200);
+
+        const error = (await getJson("/x", { label: "test", sessionId: "c" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("session-invalid");
+    });
+
+    test("classifies the login redirect that several endpoints use instead of an error", async () => {
+        mockResponse("", 302, { location: "https://www.instagram.com/accounts/login/" });
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("session-required");
+    });
+
+    test("returns parsed JSON and reports which auth mode produced it", async () => {
+        mockResponse('{"ok":true}', 200, { "content-type": "application/json" });
+
+        const anonymous = await getJson<{ ok: boolean }>("/x", { label: "test" });
+        expect(anonymous.data.ok).toBe(true);
+        expect(anonymous.authMode).toBe("anonymous");
+
+        const authenticated = await getJson<{ ok: boolean }>("/x", { label: "test", sessionId: "c" });
+        expect(authenticated.authMode).toBe("session");
+    });
+});
+
+describe("request headers", () => {
+    test("omits the cookie entirely when anonymous, and sends it when not", async () => {
+        const seen: Array<Record<string, string>> = [];
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            seen.push((init?.headers ?? {}) as Record<string, string>);
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await getJson("/x", { label: "test" });
+        await getJson("/x", { label: "test", sessionId: "abc123" });
+
+        expect(seen[0].cookie).toBeUndefined();
+        expect(seen[1].cookie).toBe("sessionid=abc123");
+        expect(seen[0]["x-ig-app-id"]).toBe("936619743392459");
+    });
+});
+
+describe("enforcement classification (post-research)", () => {
+    test("detects feedback_required — an account-level flag, not a rate limit", async () => {
+        // Instagram's "that looked automated" response. Backing off does not clear
+        // it, so it must not be classified as rate-limited.
+        mockResponse('{"message":"feedback_required","spam":true,"status":"fail"}', 400);
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("feedback-required");
+        expect(error.isTerminal).toBe(true);
+    });
+
+    test("classifies HTTP 400 enforcement, which a 401/403-only classifier misses", async () => {
+        mockResponse(
+            '{"message":"challenge_required","challenge":{"url":"https://i.instagram.com/challenge/123/abc/"}}',
+            400
+        );
+
+        const error = (await getJson("/x", { label: "test", sessionId: "c" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("checkpoint");
+        expect(error.challengeUrl).toContain("/challenge/");
+    });
+
+    test("separates a suspension from a clearable challenge via the URL", async () => {
+        // "/suspended/" means an SMS code will not fix it — it needs an appeal.
+        mockResponse(
+            '{"message":"challenge_required","challenge":{"url":"https://www.instagram.com/challenge/suspended/?next=1"}}',
+            400
+        );
+
+        const error = (await getJson("/x", { label: "test", sessionId: "c" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("suspended");
+        expect(error.isTerminal).toBe(true);
+    });
+
+    test("treats sentry_block as IP-level rate limiting, which IS worth backing off from", async () => {
+        mockResponse('{"message":"sentry_block","status":"fail"}', 403);
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("rate-limited");
+        expect(error.isTerminal).toBe(false);
+    });
+
+    test("sends x-csrftoken matching the cookie, and warns when it is missing", async () => {
+        const seen: Array<Record<string, string>> = [];
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            seen.push((init?.headers ?? {}) as Record<string, string>);
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await getJson("/x", { label: "test", sessionId: "abc", csrfToken: "tok123" });
+
+        expect(seen[0]["x-csrftoken"]).toBe("tok123");
+        expect(seen[0].cookie).toBe("sessionid=abc; csrftoken=tok123");
+        expect(seen[0]["x-asbd-id"]).toBeDefined();
+    });
+
+    test("replays the server's x-ig-set-www-claim on subsequent requests", async () => {
+        __clientTesting.resetWwwClaim();
+        const seen: Array<Record<string, string>> = [];
+        let call = 0;
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            seen.push((init?.headers ?? {}) as Record<string, string>);
+            call += 1;
+            return new Response('{"ok":true}', {
+                status: 200,
+                headers: call === 1 ? { "x-ig-set-www-claim": "hmac.AR1234" } : {},
+            });
+        }) as unknown as typeof fetch;
+
+        await getJson("/x", { label: "first" });
+        await getJson("/x", { label: "second" });
+
+        // Starts at "0", then echoes what the server handed back. Not replaying it
+        // marks the client as not-a-browser for the rest of the session.
+        expect(seen[0]["x-ig-www-claim"]).toBe("0");
+        expect(seen[1]["x-ig-www-claim"]).toBe("hmac.AR1234");
+        __clientTesting.resetWwwClaim();
+    });
+});
+
+describe("please-wait throttle", () => {
+    test("does not mistake the 401 + require_login throttle for an auth failure", async () => {
+        // Encountered live on 2026-07-27 while developing this tool: Instagram
+        // answers the soft throttle with HTTP 401 and `require_login: true`, which
+        // a naive classifier reads as "your cookie is bad" and sends the user
+        // chasing a credential problem that does not exist.
+        mockResponse(
+            '{"message":"Please wait a few minutes before you try again.","require_login":true,"igweb_rollout":true,"status":"fail"}',
+            401
+        );
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("please-wait");
+        expect(error.isTerminal).toBe(true);
+    });
+});

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -364,6 +364,58 @@ describe("request origin", () => {
         expect(error.name).toBe("InstagramError");
     });
 
+    test("refuses the right host on a non-default port", async () => {
+        // `URL.hostname` drops the port, so a hostname-only check waves this
+        // through even though it is a different origin from WEB_BASE.
+        let requested = 0;
+        globalThis.fetch = mock(async () => {
+            requested += 1;
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        const error = (await getJson("https://www.instagram.com:4443/api/v1/x", {
+            label: "test",
+            sessionId: "abc",
+        }).catch((err) => err)) as InstagramError;
+
+        expect(requested).toBe(0);
+        expect(error.name).toBe("InstagramError");
+        expect(error.message).toContain("not the Instagram web origin");
+    });
+
+    test("refuses a url carrying userinfo, which the origin check alone allows", async () => {
+        // `https://evil:pw@www.instagram.com/` has origin `https://www.instagram.com`,
+        // so only an explicit userinfo check catches it. fetch would turn it into
+        // an Authorization header.
+        let requested = 0;
+        globalThis.fetch = mock(async () => {
+            requested += 1;
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        const error = (await getJson("https://evil:pw@www.instagram.com/api/v1/x", {
+            label: "test",
+            sessionId: "abc",
+        }).catch((err) => err)) as InstagramError;
+
+        expect(requested).toBe(0);
+        expect(error.message).toContain("credentials in the URL");
+    });
+
+    test("does not reject the explicit default port, which is the same origin", async () => {
+        // The guard must not overshoot: `:443` on https normalises away, so this
+        // is WEB_BASE spelled out rather than a different destination.
+        let capturedUrl = "";
+        globalThis.fetch = mock(async (url: string | URL) => {
+            capturedUrl = String(url);
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await getJson("https://www.instagram.com:443/api/v1/x", { label: "test" });
+
+        expect(capturedUrl).toBe("https://www.instagram.com/api/v1/x");
+    });
+
     test("still resolves ordinary relative paths against the web origin", async () => {
         let capturedUrl = "";
         globalThis.fetch = mock(async (url: string | URL) => {

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -188,6 +188,38 @@ describe("enforcement classification (post-research)", () => {
     });
 });
 
+describe("marker scanning is gated on a failure envelope", () => {
+    test("does not read the word `spam` in a profile bio as feedback_required", async () => {
+        // `web_profile_info` answers 200 with the user's own text in it. Scanning
+        // that for enforcement substrings invents a block on a working account —
+        // and "no spam pls" is an extremely ordinary thing for a bio to say.
+        mockResponse('{"data":{"user":{"username":"real","biography":"dm me, no spam pls"}},"status":"ok"}', 200);
+
+        const response = await getJson<{ data: { user: { username: string } } }>("/x", { label: "test" });
+
+        expect(response.data.data.user.username).toBe("real");
+    });
+
+    test("does not read a bio asking you to wait a few minutes as a throttle", async () => {
+        mockResponse('{"data":{"user":{"biography":"live soon — please wait a few minutes"}},"status":"ok"}', 200);
+
+        const response = await getJson<{ status: string }>("/x", { label: "test" });
+
+        expect(response.data.status).toBe("ok");
+    });
+
+    test("still classifies enforcement that arrives as HTTP 200 plus a fail envelope", async () => {
+        // The gate must not be `!response.ok` alone: Instagram does answer 200 with
+        // `status: fail`, and dropping that would trade a false positive for a
+        // false negative.
+        mockResponse('{"message":"feedback_required","spam":true,"status":"fail"}', 200);
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.kind).toBe("feedback-required");
+    });
+});
+
 describe("please-wait throttle", () => {
     test("does not mistake the 401 + require_login throttle for an auth failure", async () => {
         // Encountered live on 2026-07-27 while developing this tool: Instagram

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -262,7 +262,7 @@ describe("www-claim isolation between auth modes", () => {
         await getJson("/x", { label: "anon" });
 
         expect(seen[1]["x-ig-www-claim"]).toBe("0");
-        expect(__clientTesting.currentWwwClaim("session")).toBe("hmac.SESSION");
+        expect(__clientTesting.currentWwwClaim("abc")).toBe("hmac.SESSION");
         __clientTesting.resetWwwClaim();
     });
 
@@ -284,6 +284,109 @@ describe("www-claim isolation between auth modes", () => {
         expect(seen[1]["x-ig-www-claim"]).toBe("hmac.ACCOUNT_A");
         expect(seen[2]["x-ig-www-claim"]).toBe("0");
         __clientTesting.resetWwwClaim();
+    });
+
+    test("keeps claims apart when two credentials are in flight at the same time", async () => {
+        // Sequential tests cannot catch this. With one shared slot plus an "whose
+        // claim is this?" variable, the window between B taking ownership and B
+        // building its headers is one await wide — long enough for A's response
+        // to drop A's claim into the slot that B is about to read.
+        __clientTesting.resetWwwClaim();
+        const seen: Array<Record<string, string>> = [];
+        let releaseA: () => void = () => undefined;
+        const aIsHeld = new Promise<void>((resolve) => {
+            releaseA = resolve;
+        });
+
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            const headers = (init?.headers ?? {}) as Record<string, string>;
+            seen.push(headers);
+
+            if (headers.cookie?.includes("session-a")) {
+                await aIsHeld;
+                return new Response('{"ok":true}', { status: 200, headers: { "x-ig-set-www-claim": "hmac.A" } });
+            }
+
+            return new Response('{"ok":true}', { status: 200, headers: { "x-ig-set-www-claim": "hmac.B" } });
+        }) as unknown as typeof fetch;
+
+        // A goes out and parks inside fetch; B overtakes it and completes.
+        const a = getJson("/x", { label: "a", sessionId: "session-a" });
+        await getJson("/x", { label: "b", sessionId: "session-b" });
+
+        // Now A's response lands, writing A's claim while B was the last owner.
+        releaseA();
+        await a;
+
+        await getJson("/x", { label: "b again", sessionId: "session-b" });
+
+        // seen[0] = A (parked), seen[1] = B, seen[2] = B again.
+        expect(seen[2].cookie).toContain("session-b");
+        expect(seen[2]["x-ig-www-claim"]).toBe("hmac.B");
+        expect(__clientTesting.currentWwwClaim("session-a")).toBe("hmac.A");
+        __clientTesting.resetWwwClaim();
+    });
+});
+
+describe("request origin", () => {
+    test("refuses to send credentials to a host that is not Instagram", async () => {
+        // getJson attaches sessionid, csrftoken and the www-claim to whatever it
+        // is pointed at, so an absolute URL from a caller is an exfiltration path.
+        let requested = 0;
+        globalThis.fetch = mock(async () => {
+            requested += 1;
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        const error = (await getJson("https://evil.example/steal", {
+            label: "test",
+            sessionId: "abc",
+            csrfToken: "tok",
+        }).catch((err) => err)) as InstagramError;
+
+        expect(requested).toBe(0);
+        expect(error.name).toBe("InstagramError");
+        expect(error.message).toContain("not the Instagram web origin");
+    });
+
+    test("refuses plaintext http even on the right host", async () => {
+        let requested = 0;
+        globalThis.fetch = mock(async () => {
+            requested += 1;
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        const error = (await getJson("http://www.instagram.com/api/v1/x", { label: "test", sessionId: "abc" }).catch(
+            (err) => err
+        )) as InstagramError;
+
+        expect(requested).toBe(0);
+        expect(error.name).toBe("InstagramError");
+    });
+
+    test("still resolves ordinary relative paths against the web origin", async () => {
+        let capturedUrl = "";
+        globalThis.fetch = mock(async (url: string | URL) => {
+            capturedUrl = String(url);
+            return new Response('{"ok":true}', { status: 200 });
+        }) as unknown as typeof fetch;
+
+        await getJson("/api/v1/users/web_profile_info/?username=x", { label: "test" });
+
+        expect(capturedUrl).toBe("https://www.instagram.com/api/v1/users/web_profile_info/?username=x");
+    });
+});
+
+describe("strict JSON parsing", () => {
+    test("rejects a body with comments rather than leniently accepting it", async () => {
+        // Instagram cannot emit JSONC. A lenient parser accepting it would hide a
+        // body that is not actually from the API behind a successful parse.
+        mockResponse('{"ok": true /* not something Instagram sends */}', 200);
+
+        const error = (await getJson("/x", { label: "test" }).catch((err) => err)) as InstagramError;
+
+        expect(error.name).toBe("InstagramError");
+        expect(error.message).toContain("malformed JSON");
     });
 });
 

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -220,6 +220,27 @@ describe("marker scanning is gated on a failure envelope", () => {
     });
 });
 
+describe("www-claim isolation between auth modes", () => {
+    test("never replays the session's claim on a later anonymous request", async () => {
+        // The claim is minted against the caller Instagram answered. Echoing the
+        // logged-in one anonymously links the two, which is the whole leak the
+        // anonymous endpoints refuse a sessionId parameter to prevent.
+        __clientTesting.resetWwwClaim();
+        const seen: Array<Record<string, string>> = [];
+        globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+            seen.push((init?.headers ?? {}) as Record<string, string>);
+            return new Response('{"ok":true}', { status: 200, headers: { "x-ig-set-www-claim": "hmac.SESSION" } });
+        }) as unknown as typeof fetch;
+
+        await getJson("/x", { label: "authed", sessionId: "abc" });
+        await getJson("/x", { label: "anon" });
+
+        expect(seen[1]["x-ig-www-claim"]).toBe("0");
+        expect(__clientTesting.currentWwwClaim("session")).toBe("hmac.SESSION");
+        __clientTesting.resetWwwClaim();
+    });
+});
+
 describe("please-wait throttle", () => {
     test("does not mistake the 401 + require_login throttle for an auth failure", async () => {
         // Encountered live on 2026-07-27 while developing this tool: Instagram

--- a/src/instagram/lib/client.test.ts
+++ b/src/instagram/lib/client.test.ts
@@ -385,8 +385,9 @@ describe("request origin", () => {
 
     test("refuses a url carrying userinfo, which the origin check alone allows", async () => {
         // `https://evil:pw@www.instagram.com/` has origin `https://www.instagram.com`,
-        // so only an explicit userinfo check catches it. fetch would turn it into
-        // an Authorization header.
+        // so only an explicit userinfo check catches it. On Bun the request would
+        // otherwise just go out with the userinfo quietly dropped; on Node/undici
+        // it would throw a bare TypeError. This guard is what makes it neither.
         let requested = 0;
         globalThis.fetch = mock(async () => {
             requested += 1;

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -1,0 +1,243 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { RateLimiter } from "./rate-limiter";
+import { type AuthMode, InstagramError, type InstagramErrorKind } from "./types";
+
+const { log } = logger.scoped("instagram:client");
+
+/**
+ * Public web app id. Stable and hardcoded across six independent repos, unlike the
+ * mobile ids. We stay on the WEB surface exclusively — a browser `sessionid` is
+ * documented by instagrapi as unreliable against the private mobile API
+ * (`i.instagram.com`), where it can be rejected with `login_required` or
+ * invalidated server-side. Since the cookie comes from the user's browser, the
+ * mobile API is the wrong surface for it no matter how convenient its responses are.
+ */
+const WEB_APP_ID = "936619743392459";
+
+/**
+ * Drifts across Instagram builds (359341 / 129477 / 198387 all observed), so its
+ * presence matters more than its value. Hardcoding one exact value would itself be
+ * a fingerprint once it goes stale.
+ */
+const ASBD_ID = "129477";
+
+const WEB_BASE = "https://www.instagram.com";
+
+const WEB_USER_AGENT =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+/** Terminal responses Instagram gives when it has decided something about the account. */
+const CHECKPOINT_MARKERS = ["checkpoint_required", "challenge_required"] as const;
+const FEEDBACK_MARKERS = ["feedback_required", "spam"] as const;
+const IP_BLOCK_MARKERS = ["sentry_block", "rate_limit_error"] as const;
+/** Arrives as 401 + `require_login: true`, so it must be matched before login_required. */
+const PLEASE_WAIT_MARKERS = ["please wait a few minutes", "wait a few minutes"] as const;
+
+export interface RequestOptions {
+    sessionId?: string;
+    /**
+     * Paired with `sessionId`. Instagram expects the `x-csrftoken` header to match
+     * the `csrftoken` cookie; a placeholder is a fingerprint mismatch, which the
+     * research found triggers enforcement independently of request volume.
+     */
+    csrfToken?: string;
+    label: string;
+}
+
+export interface InstagramResponse<T> {
+    data: T;
+    authMode: AuthMode;
+}
+
+/**
+ * `x-ig-www-claim` is the one header that is genuinely load-bearing rather than
+ * decorative: it starts as "0", and the server then hands back
+ * `x-ig-set-www-claim`, which every subsequent request is expected to echo. Not
+ * replaying it marks the client as not-a-browser across the whole session.
+ */
+let wwwClaim = "0";
+
+let limiter = new RateLimiter();
+
+function buildHeaders(options: RequestOptions): Record<string, string> {
+    const headers: Record<string, string> = {
+        "x-ig-app-id": WEB_APP_ID,
+        "x-asbd-id": ASBD_ID,
+        "x-ig-www-claim": wwwClaim,
+        "user-agent": WEB_USER_AGENT,
+        accept: "*/*",
+        "accept-language": "en-US,en;q=0.9",
+        "x-requested-with": "XMLHttpRequest",
+        referer: `${WEB_BASE}/`,
+    };
+
+    if (options.sessionId) {
+        const cookieParts = [`sessionid=${options.sessionId}`];
+
+        if (options.csrfToken) {
+            cookieParts.push(`csrftoken=${options.csrfToken}`);
+            headers["x-csrftoken"] = options.csrfToken;
+        } else {
+            log.warn(
+                { label: options.label },
+                "session without a csrftoken — header/cookie mismatch raises the enforcement risk"
+            );
+        }
+
+        headers.cookie = cookieParts.join("; ");
+    }
+
+    return headers;
+}
+
+interface Classification {
+    kind: InstagramErrorKind;
+    challengeUrl?: string;
+}
+
+function classify(status: number, body: string, authMode: AuthMode): Classification | undefined {
+    const lower = body.toLowerCase();
+
+    if (CHECKPOINT_MARKERS.some((marker) => lower.includes(marker))) {
+        const challengeUrl = extractChallengeUrl(body);
+
+        // instaloader and instagrapi agree: "/suspended/" in the challenge URL is
+        // a suspension, not a challenge you can clear by entering an SMS code.
+        if (challengeUrl?.includes("/suspended/")) {
+            return { kind: "suspended", challengeUrl };
+        }
+
+        return { kind: "checkpoint", challengeUrl };
+    }
+
+    if (FEEDBACK_MARKERS.some((marker) => lower.includes(marker))) {
+        return { kind: "feedback-required" };
+    }
+
+    if (IP_BLOCK_MARKERS.some((marker) => lower.includes(marker))) {
+        return { kind: "rate-limited" };
+    }
+
+    if (PLEASE_WAIT_MARKERS.some((marker) => lower.includes(marker))) {
+        return { kind: "please-wait" };
+    }
+
+    if (lower.includes("login_required") || lower.includes("logged_out")) {
+        return { kind: "session-required" };
+    }
+
+    if (status === 429) {
+        return { kind: "rate-limited" };
+    }
+
+    if (status === 404) {
+        return { kind: "not-found" };
+    }
+
+    // Instagram signals enforcement with 400 as often as 403, which a
+    // status-code-only classifier misses entirely.
+    if (status === 400 || status === 401 || status === 403) {
+        return { kind: authMode === "session" ? "session-invalid" : "session-required" };
+    }
+
+    if (status >= 500) {
+        return { kind: "network" };
+    }
+
+    return undefined;
+}
+
+function extractChallengeUrl(body: string): string | undefined {
+    const match = body.match(/"url"\s*:\s*"([^"]*challenge[^"]*)"/i);
+    return match ? match[1].replace(/\\\//g, "/") : undefined;
+}
+
+export async function getJson<T>(path: string, options: RequestOptions): Promise<InstagramResponse<T>> {
+    const url = path.startsWith("http") ? path : `${WEB_BASE}${path}`;
+    const authMode: AuthMode = options.sessionId ? "session" : "anonymous";
+
+    await limiter.acquire(options.label);
+    log.debug({ url, label: options.label, authMode, budgetUsed: limiter.used }, "instagram request");
+
+    let response: Response;
+    try {
+        response = await fetch(url, { headers: buildHeaders(options), redirect: "manual" });
+    } catch (error) {
+        log.warn({ error, url, label: options.label }, "instagram request failed at the network layer");
+        throw new InstagramError("network", `Request to ${options.label} failed: ${String(error)}`);
+    }
+
+    const setClaim = response.headers.get("x-ig-set-www-claim");
+    if (setClaim) {
+        log.debug({ label: options.label }, "captured a fresh x-ig-www-claim to replay on later requests");
+        wwwClaim = setClaim;
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+        log.warn({ status: response.status, label: options.label, authMode }, "instagram redirected to login");
+        throw new InstagramError(
+            authMode === "session" ? "session-invalid" : "session-required",
+            `${options.label} redirected to login`,
+            response.status
+        );
+    }
+
+    const text = await response.text();
+    const classification = classify(response.status, text, authMode);
+
+    if (classification) {
+        log.warn(
+            {
+                status: response.status,
+                label: options.label,
+                authMode,
+                kind: classification.kind,
+                challengeUrl: classification.challengeUrl,
+                bodyPreview: text.slice(0, 200),
+            },
+            "instagram request rejected"
+        );
+        throw new InstagramError(
+            classification.kind,
+            `${options.label} failed (${classification.kind})`,
+            response.status,
+            classification.challengeUrl
+        );
+    }
+
+    if (!text.trimStart().startsWith("{")) {
+        log.warn(
+            { status: response.status, label: options.label, authMode, bytes: text.length },
+            "instagram returned an HTML shell instead of JSON"
+        );
+        throw new InstagramError(
+            authMode === "session" ? "session-invalid" : "session-required",
+            `${options.label} returned HTML instead of JSON`,
+            response.status
+        );
+    }
+
+    return { data: SafeJSON.parse(text) as T, authMode };
+}
+
+/**
+ * Test seams. Both are module state that must not leak between cases: the
+ * www-claim persists by design, and the limiter would otherwise sleep for real
+ * (its jitter runs to 15s), which both slows tests and lets concurrent files
+ * interleave on the shared `fetch` mock.
+ */
+export const __testing = {
+    resetWwwClaim: () => {
+        wwwClaim = "0";
+    },
+    currentWwwClaim: () => wwwClaim,
+    useInstantLimiter: () => {
+        limiter = new RateLimiter({ random: () => 0, sleep: async () => undefined });
+    },
+    resetLimiter: () => {
+        limiter = new RateLimiter();
+    },
+};
+
+export { ASBD_ID, WEB_APP_ID, WEB_BASE };

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -93,38 +93,28 @@ export interface InstagramResponse<T> {
  * `x-ig-set-www-claim`, which every subsequent request is expected to echo. Not
  * replaying it marks the client as not-a-browser across the whole session.
  *
- * Kept PER AUTH MODE, because the claim is minted by Instagram against the
- * caller it answered. Echoing a claim issued to the logged-in session on a later
- * anonymous request hands Instagram the link between the two, which is exactly
- * the leak `fetchProfile` refuses a `sessionId` parameter to prevent — one
- * shared variable here would have reintroduced it below the API surface.
+ * Kept PER CREDENTIAL, because the claim is minted by Instagram against the
+ * caller it answered. Echoing a claim issued to one caller on another's request
+ * hands Instagram the link between them — which for the anonymous surface is
+ * exactly the leak `fetchProfile` refuses a `sessionId` parameter to prevent.
+ *
+ * A map rather than one slot per auth mode, so correctness does not depend on
+ * request ORDER. A single shared slot needs a "whose claim is in here?" variable
+ * alongside it, and the window between switching that variable and reading the
+ * slot is one `await` wide: with two sessions in flight, A's response can land
+ * in the slot after B claimed ownership and before B builds its headers. Keying
+ * by credential removes the window instead of narrowing it, because every
+ * request reads and writes only its own entry.
  */
-const wwwClaims: Record<AuthMode, string> = { anonymous: "0", session: "0" };
+const wwwClaims = new Map<string, string>();
 
 /**
- * Fingerprint of the credential the session claim was minted for. Two different
- * sessions must not inherit each other's claim either, so the claim is dropped
- * whenever the cookie changes rather than only when the auth mode does.
- *
- * Hashed rather than stored: the cookie is a live credential and has no business
- * living in a second module-level variable when equality is all that is needed.
+ * Bounded by the number of distinct credentials a process actually uses — one or
+ * two for the CLI. The cookie is hashed rather than used directly, since a live
+ * credential has no business sitting in a module-level map key.
  */
-let sessionClaimOwner: string | undefined;
-
-function forgetSessionClaimIfCredentialChanged(sessionId: string): void {
-    // Stringified because `Bun.hash` is typed `number | bigint`; only equality
-    // matters here, and the same input always yields the same value and type.
-    const owner = String(Bun.hash(sessionId));
-    if (owner === sessionClaimOwner) {
-        return;
-    }
-
-    if (sessionClaimOwner !== undefined) {
-        log.debug("session credential changed — dropping the previous session's www-claim");
-    }
-
-    sessionClaimOwner = owner;
-    wwwClaims.session = "0";
+function claimKeyFor(sessionId: string | undefined): string {
+    return sessionId ? `session:${Bun.hash(sessionId)}` : "anonymous";
 }
 
 let limiter = new RateLimiter();
@@ -133,7 +123,7 @@ function buildHeaders(options: RequestOptions): Record<string, string> {
     const headers: Record<string, string> = {
         "x-ig-app-id": WEB_APP_ID,
         "x-asbd-id": ASBD_ID,
-        "x-ig-www-claim": wwwClaims[options.sessionId ? "session" : "anonymous"],
+        "x-ig-www-claim": wwwClaims.get(claimKeyFor(options.sessionId)) ?? "0",
         "user-agent": WEB_USER_AGENT,
         accept: "*/*",
         "accept-language": "en-US,en;q=0.9",
@@ -228,10 +218,47 @@ function classify({ status, body, parsed, authMode }: ClassifyInput): Classifica
     return undefined;
 }
 
+/**
+ * The only origin this client may speak to.
+ *
+ * `getJson` attaches `sessionid`, `csrftoken` and the www-claim to whatever it is
+ * pointed at, so the destination is a credential boundary, not a convenience. An
+ * absolute path from a caller (or a future redirect-following change) would
+ * otherwise hand a live session to an arbitrary host, and an `http://` one would
+ * put it on the wire in plaintext. Exact host match rather than a suffix test:
+ * the module's stated invariant is the WEB surface only, and `i.instagram.com`
+ * is deliberately absent — adding the mobile surface should be a decision, not
+ * something a wildcard grants silently.
+ */
+const ALLOWED_HOSTS: ReadonlySet<string> = new Set(["www.instagram.com"]);
+
+function resolveUrl(path: string, label: string): URL {
+    let url: URL;
+
+    // Resolving relative paths against WEB_BASE and absolute ones as-is, in one
+    // step, also removes the `startsWith("http")` guess about which kind it is.
+    try {
+        url = new URL(path, WEB_BASE);
+    } catch (error) {
+        log.warn({ error, label }, "instagram request path does not resolve to a url");
+        throw new InstagramError("network", `${label} has an unusable request path`);
+    }
+
+    if (url.protocol !== "https:" || !ALLOWED_HOSTS.has(url.hostname)) {
+        log.warn({ label, origin: url.origin }, "refusing to attach credentials to a non-Instagram origin");
+        throw new InstagramError("network", `${label} targeted ${url.origin}, which is not the Instagram web origin`);
+    }
+
+    return url;
+}
+
 /** `undefined` for anything that is not JSON: the HTML shell, a truncated body. */
 function tryParseJson(text: string, label: string): unknown {
     try {
-        return SafeJSON.parse(text);
+        // Strict: this is an external HTTP response, and a lenient parser that
+        // tolerates comments and trailing commas would accept bodies that Instagram
+        // could not have sent, instead of routing them to the malformed path.
+        return SafeJSON.parse(text, { strict: true });
     } catch (error) {
         log.debug({ error, label, bytes: text.length }, "instagram body did not parse as JSON");
         return undefined;
@@ -244,28 +271,29 @@ function extractChallengeUrl(body: string): string | undefined {
 }
 
 export async function getJson<T>(path: string, options: RequestOptions): Promise<InstagramResponse<T>> {
-    const url = path.startsWith("http") ? path : `${WEB_BASE}${path}`;
+    // Before anything else: this is what decides whether the credentials below
+    // are allowed to leave the machine at all.
+    const url = resolveUrl(path, options.label);
     const authMode: AuthMode = options.sessionId ? "session" : "anonymous";
-
-    if (options.sessionId) {
-        forgetSessionClaimIfCredentialChanged(options.sessionId);
-    }
+    // Captured per request, so a concurrent request for another credential can
+    // neither be read from nor written to this one's claim.
+    const claimKey = claimKeyFor(options.sessionId);
 
     await limiter.acquire(options.label);
-    log.debug({ url, label: options.label, authMode, budgetUsed: limiter.used }, "instagram request");
+    log.debug({ url: url.href, label: options.label, authMode, budgetUsed: limiter.used }, "instagram request");
 
     let response: Response;
     try {
         response = await fetch(url, { headers: buildHeaders(options), redirect: "manual" });
     } catch (error) {
-        log.warn({ error, url, label: options.label }, "instagram request failed at the network layer");
+        log.warn({ error, url: url.href, label: options.label }, "instagram request failed at the network layer");
         throw new InstagramError("network", `Request to ${options.label} failed: ${String(error)}`);
     }
 
     const setClaim = response.headers.get("x-ig-set-www-claim");
     if (setClaim) {
         log.debug({ label: options.label, authMode }, "captured a fresh x-ig-www-claim to replay on later requests");
-        wwwClaims[authMode] = setClaim;
+        wwwClaims.set(claimKey, setClaim);
     }
 
     if (response.status >= 300 && response.status < 400) {
@@ -344,11 +372,9 @@ export function getAnonymousJson<T>(path: string, options: AnonymousRequestOptio
  */
 export const __testing = {
     resetWwwClaim: () => {
-        wwwClaims.anonymous = "0";
-        wwwClaims.session = "0";
-        sessionClaimOwner = undefined;
+        wwwClaims.clear();
     },
-    currentWwwClaim: (mode: AuthMode = "anonymous") => wwwClaims[mode],
+    currentWwwClaim: (sessionId?: string) => wwwClaims.get(claimKeyFor(sessionId)) ?? "0",
     useInstantLimiter: () => {
         limiter = new RateLimiter({ random: () => 0, sleep: async () => undefined });
     },

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -35,6 +35,10 @@ const IP_BLOCK_MARKERS = ["sentry_block", "rate_limit_error"] as const;
 /** Arrives as 401 + `require_login: true`, so it must be matched before login_required. */
 const PLEASE_WAIT_MARKERS = ["please wait a few minutes", "wait a few minutes"] as const;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
 /**
  * Instagram's failure envelope, and the gate every marker scan sits behind.
  *
@@ -43,8 +47,14 @@ const PLEASE_WAIT_MARKERS = ["please wait a few minutes", "wait a few minutes"] 
  * `web_profile_info` as a perfectly good HTTP 200, and scanning that body for
  * substrings turns a working account into a fabricated enforcement error. A
  * marker only means what it says inside a response Instagram itself failed.
+ *
+ * Read off the parsed object rather than the raw text, so it is the document's
+ * OWN top-level verdict. A regex over the body would also accept a `status`
+ * belonging to some nested object while the real top-level one said "ok".
  */
-const FAIL_ENVELOPE = /"status"\s*:\s*"fail"/;
+function hasFailEnvelope(parsed: unknown): boolean {
+    return isRecord(parsed) && parsed.status === "fail";
+}
 
 export interface RequestOptions {
     sessionId?: string;
@@ -91,6 +101,32 @@ export interface InstagramResponse<T> {
  */
 const wwwClaims: Record<AuthMode, string> = { anonymous: "0", session: "0" };
 
+/**
+ * Fingerprint of the credential the session claim was minted for. Two different
+ * sessions must not inherit each other's claim either, so the claim is dropped
+ * whenever the cookie changes rather than only when the auth mode does.
+ *
+ * Hashed rather than stored: the cookie is a live credential and has no business
+ * living in a second module-level variable when equality is all that is needed.
+ */
+let sessionClaimOwner: string | undefined;
+
+function forgetSessionClaimIfCredentialChanged(sessionId: string): void {
+    // Stringified because `Bun.hash` is typed `number | bigint`; only equality
+    // matters here, and the same input always yields the same value and type.
+    const owner = String(Bun.hash(sessionId));
+    if (owner === sessionClaimOwner) {
+        return;
+    }
+
+    if (sessionClaimOwner !== undefined) {
+        log.debug("session credential changed — dropping the previous session's www-claim");
+    }
+
+    sessionClaimOwner = owner;
+    wwwClaims.session = "0";
+}
+
 let limiter = new RateLimiter();
 
 function buildHeaders(options: RequestOptions): Record<string, string> {
@@ -129,11 +165,19 @@ interface Classification {
     challengeUrl?: string;
 }
 
-function classify(status: number, body: string, authMode: AuthMode): Classification | undefined {
+interface ClassifyInput {
+    status: number;
+    body: string;
+    /** The already-parsed body, or `undefined` when it is not JSON at all. */
+    parsed: unknown;
+    authMode: AuthMode;
+}
+
+function classify({ status, body, parsed, authMode }: ClassifyInput): Classification | undefined {
     const lower = body.toLowerCase();
     // Instagram answers enforcement with 200 + a fail envelope as readily as with
     // a 4xx, so neither signal alone is enough to decide the body is worth scanning.
-    const failed = status >= 400 || FAIL_ENVELOPE.test(lower);
+    const failed = status >= 400 || hasFailEnvelope(parsed);
 
     if (failed && CHECKPOINT_MARKERS.some((marker) => lower.includes(marker))) {
         const challengeUrl = extractChallengeUrl(body);
@@ -184,6 +228,16 @@ function classify(status: number, body: string, authMode: AuthMode): Classificat
     return undefined;
 }
 
+/** `undefined` for anything that is not JSON: the HTML shell, a truncated body. */
+function tryParseJson(text: string, label: string): unknown {
+    try {
+        return SafeJSON.parse(text);
+    } catch (error) {
+        log.debug({ error, label, bytes: text.length }, "instagram body did not parse as JSON");
+        return undefined;
+    }
+}
+
 function extractChallengeUrl(body: string): string | undefined {
     const match = body.match(/"url"\s*:\s*"([^"]*challenge[^"]*)"/i);
     return match ? match[1].replace(/\\\//g, "/") : undefined;
@@ -192,6 +246,10 @@ function extractChallengeUrl(body: string): string | undefined {
 export async function getJson<T>(path: string, options: RequestOptions): Promise<InstagramResponse<T>> {
     const url = path.startsWith("http") ? path : `${WEB_BASE}${path}`;
     const authMode: AuthMode = options.sessionId ? "session" : "anonymous";
+
+    if (options.sessionId) {
+        forgetSessionClaimIfCredentialChanged(options.sessionId);
+    }
 
     await limiter.acquire(options.label);
     log.debug({ url, label: options.label, authMode, budgetUsed: limiter.used }, "instagram request");
@@ -220,7 +278,11 @@ export async function getJson<T>(path: string, options: RequestOptions): Promise
     }
 
     const text = await response.text();
-    const classification = classify(response.status, text, authMode);
+    // Parsed once, up front: the classifier needs the top-level `status` field to
+    // tell an Instagram failure from a bio that merely reads like one, and the
+    // success path needs the same object. `undefined` means "not JSON at all".
+    const parsed = tryParseJson(text, options.label);
+    const classification = classify({ status: response.status, body: text, parsed, authMode });
 
     if (classification) {
         log.warn(
@@ -254,18 +316,19 @@ export async function getJson<T>(path: string, options: RequestOptions): Promise
         );
     }
 
-    try {
-        return { data: SafeJSON.parse(text) as T, authMode };
-    } catch (error) {
-        // `startsWith("{")` only proves it is not the HTML shell. A truncated or
-        // half-written body still gets here, and letting the raw SyntaxError out
-        // means the user sees a parser message instead of an Instagram one.
+    // `startsWith("{")` above only proves it is not the HTML shell — a truncated
+    // or half-written body still reaches here, and a raw SyntaxError escaping
+    // would show the user a parser message for what is an Instagram problem.
+    // Nothing that opens with `{` can parse TO undefined, so the sentinel is safe.
+    if (parsed === undefined) {
         log.warn(
-            { error, status: response.status, label: options.label, authMode, bytes: text.length },
+            { status: response.status, label: options.label, authMode, bytes: text.length },
             "instagram returned a body that opens like JSON but does not parse"
         );
         throw new InstagramError("network", `${options.label} returned malformed JSON`, response.status);
     }
+
+    return { data: parsed as T, authMode };
 }
 
 /** Anonymous-only entrypoint. See `AnonymousRequestOptions` for why it exists. */
@@ -283,6 +346,7 @@ export const __testing = {
     resetWwwClaim: () => {
         wwwClaims.anonymous = "0";
         wwwClaims.session = "0";
+        sessionClaimOwner = undefined;
     },
     currentWwwClaim: (mode: AuthMode = "anonymous") => wwwClaims[mode],
     useInstantLimiter: () => {

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -255,9 +255,16 @@ function resolveUrl(path: string, label: string): URL {
         throw new InstagramError("network", `${label} targeted ${url.origin}, which is not the Instagram web origin`);
     }
 
-    // Userinfo survives the origin check — `https://evil:pw@www.instagram.com/`
-    // has origin `https://www.instagram.com` — and `fetch` turns it into an
-    // Authorization header. Nothing here should ever carry one.
+    // Userinfo survives the origin check: `https://evil:pw@www.instagram.com/`
+    // has origin `https://www.instagram.com`. What happens to it after that is
+    // runtime dependent, and neither outcome is worth depending on. Measured on
+    // Bun 1.3.14, the runtime this ships on: no throw, and no Authorization
+    // header on the wire either, the userinfo is simply dropped and the request
+    // goes out. Node/undici 6.24.1 instead throws a bare TypeError, "Request
+    // cannot be constructed from a URL that includes credentials"
+    // (undici/lib/web/fetch/request.js:121). A URL arriving here with
+    // credentials in it means a caller built it out of something it should not
+    // have, so it is refused here and reported as one stable InstagramError.
     if (url.username !== "" || url.password !== "") {
         log.warn({ label, origin: url.origin }, "refusing a request url carrying userinfo");
         throw new InstagramError("network", `${label} carried credentials in the URL, which this client never sends`);

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -29,10 +29,22 @@ const WEB_USER_AGENT =
 
 /** Terminal responses Instagram gives when it has decided something about the account. */
 const CHECKPOINT_MARKERS = ["checkpoint_required", "challenge_required"] as const;
-const FEEDBACK_MARKERS = ["feedback_required", "spam"] as const;
+/** `"spam"` keeps its quotes: it is a JSON key here, and a bare word in bios. */
+const FEEDBACK_MARKERS = ['"spam"', "feedback_required"] as const;
 const IP_BLOCK_MARKERS = ["sentry_block", "rate_limit_error"] as const;
 /** Arrives as 401 + `require_login: true`, so it must be matched before login_required. */
 const PLEASE_WAIT_MARKERS = ["please wait a few minutes", "wait a few minutes"] as const;
+
+/**
+ * Instagram's failure envelope, and the gate every marker scan sits behind.
+ *
+ * The markers are ordinary English otherwise: a profile whose biography reads
+ * "no spam pls" or "please wait a few minutes, posting soon" comes back from
+ * `web_profile_info` as a perfectly good HTTP 200, and scanning that body for
+ * substrings turns a working account into a fabricated enforcement error. A
+ * marker only means what it says inside a response Instagram itself failed.
+ */
+const FAIL_ENVELOPE = /"status"\s*:\s*"fail"/;
 
 export interface RequestOptions {
     sessionId?: string;
@@ -98,8 +110,11 @@ interface Classification {
 
 function classify(status: number, body: string, authMode: AuthMode): Classification | undefined {
     const lower = body.toLowerCase();
+    // Instagram answers enforcement with 200 + a fail envelope as readily as with
+    // a 4xx, so neither signal alone is enough to decide the body is worth scanning.
+    const failed = status >= 400 || FAIL_ENVELOPE.test(lower);
 
-    if (CHECKPOINT_MARKERS.some((marker) => lower.includes(marker))) {
+    if (failed && CHECKPOINT_MARKERS.some((marker) => lower.includes(marker))) {
         const challengeUrl = extractChallengeUrl(body);
 
         // instaloader and instagrapi agree: "/suspended/" in the challenge URL is
@@ -111,19 +126,19 @@ function classify(status: number, body: string, authMode: AuthMode): Classificat
         return { kind: "checkpoint", challengeUrl };
     }
 
-    if (FEEDBACK_MARKERS.some((marker) => lower.includes(marker))) {
+    if (failed && FEEDBACK_MARKERS.some((marker) => lower.includes(marker))) {
         return { kind: "feedback-required" };
     }
 
-    if (IP_BLOCK_MARKERS.some((marker) => lower.includes(marker))) {
+    if (failed && IP_BLOCK_MARKERS.some((marker) => lower.includes(marker))) {
         return { kind: "rate-limited" };
     }
 
-    if (PLEASE_WAIT_MARKERS.some((marker) => lower.includes(marker))) {
+    if (failed && PLEASE_WAIT_MARKERS.some((marker) => lower.includes(marker))) {
         return { kind: "please-wait" };
     }
 
-    if (lower.includes("login_required") || lower.includes("logged_out")) {
+    if (failed && (lower.includes("login_required") || lower.includes("logged_out"))) {
         return { kind: "session-required" };
     }
 

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -57,6 +57,21 @@ export interface RequestOptions {
     label: string;
 }
 
+/**
+ * The anonymous surface's contract, made structural instead of social.
+ *
+ * `fetchProfile` and `fetchPublicReelInfo` document that they take no session ON
+ * PURPOSE, but `RequestOptions` alone cannot hold them to it: `getJson(path, {
+ * label, sessionId: session?.sessionId })` typechecks perfectly, so one refactor
+ * reintroduces exactly the instagrapi-style silent injection those comments
+ * warn about. `sessionId?: never` turns that line into a compile error.
+ */
+export interface AnonymousRequestOptions {
+    label: string;
+    sessionId?: never;
+    csrfToken?: never;
+}
+
 export interface InstagramResponse<T> {
     data: T;
     authMode: AuthMode;
@@ -239,7 +254,23 @@ export async function getJson<T>(path: string, options: RequestOptions): Promise
         );
     }
 
-    return { data: SafeJSON.parse(text) as T, authMode };
+    try {
+        return { data: SafeJSON.parse(text) as T, authMode };
+    } catch (error) {
+        // `startsWith("{")` only proves it is not the HTML shell. A truncated or
+        // half-written body still gets here, and letting the raw SyntaxError out
+        // means the user sees a parser message instead of an Instagram one.
+        log.warn(
+            { error, status: response.status, label: options.label, authMode, bytes: text.length },
+            "instagram returned a body that opens like JSON but does not parse"
+        );
+        throw new InstagramError("network", `${options.label} returned malformed JSON`, response.status);
+    }
+}
+
+/** Anonymous-only entrypoint. See `AnonymousRequestOptions` for why it exists. */
+export function getAnonymousJson<T>(path: string, options: AnonymousRequestOptions): Promise<InstagramResponse<T>> {
+    return getJson<T>(path, options);
 }
 
 /**

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -225,12 +225,18 @@ function classify({ status, body, parsed, authMode }: ClassifyInput): Classifica
  * pointed at, so the destination is a credential boundary, not a convenience. An
  * absolute path from a caller (or a future redirect-following change) would
  * otherwise hand a live session to an arbitrary host, and an `http://` one would
- * put it on the wire in plaintext. Exact host match rather than a suffix test:
+ * put it on the wire in plaintext. Exact origin match rather than a suffix test:
  * the module's stated invariant is the WEB surface only, and `i.instagram.com`
  * is deliberately absent — adding the mobile surface should be a decision, not
  * something a wildcard grants silently.
+ *
+ * Compared as a full ORIGIN (scheme + host + port), not a hostname, because
+ * `URL.hostname` drops the port: `https://www.instagram.com:4443/` is a
+ * different origin that a hostname test waves through. Origin also subsumes the
+ * scheme check, since `http://www.instagram.com` is its own origin. A default
+ * `:443` normalises away, so the legitimate spelling is not rejected.
  */
-const ALLOWED_HOSTS: ReadonlySet<string> = new Set(["www.instagram.com"]);
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set([new URL(WEB_BASE).origin]);
 
 function resolveUrl(path: string, label: string): URL {
     let url: URL;
@@ -244,9 +250,17 @@ function resolveUrl(path: string, label: string): URL {
         throw new InstagramError("network", `${label} has an unusable request path`);
     }
 
-    if (url.protocol !== "https:" || !ALLOWED_HOSTS.has(url.hostname)) {
+    if (!ALLOWED_ORIGINS.has(url.origin)) {
         log.warn({ label, origin: url.origin }, "refusing to attach credentials to a non-Instagram origin");
         throw new InstagramError("network", `${label} targeted ${url.origin}, which is not the Instagram web origin`);
+    }
+
+    // Userinfo survives the origin check — `https://evil:pw@www.instagram.com/`
+    // has origin `https://www.instagram.com` — and `fetch` turns it into an
+    // Authorization header. Nothing here should ever carry one.
+    if (url.username !== "" || url.password !== "") {
+        log.warn({ label, origin: url.origin }, "refusing a request url carrying userinfo");
+        throw new InstagramError("network", `${label} carried credentials in the URL, which this client never sends`);
     }
 
     return url;

--- a/src/instagram/lib/client.ts
+++ b/src/instagram/lib/client.ts
@@ -67,8 +67,14 @@ export interface InstagramResponse<T> {
  * decorative: it starts as "0", and the server then hands back
  * `x-ig-set-www-claim`, which every subsequent request is expected to echo. Not
  * replaying it marks the client as not-a-browser across the whole session.
+ *
+ * Kept PER AUTH MODE, because the claim is minted by Instagram against the
+ * caller it answered. Echoing a claim issued to the logged-in session on a later
+ * anonymous request hands Instagram the link between the two, which is exactly
+ * the leak `fetchProfile` refuses a `sessionId` parameter to prevent — one
+ * shared variable here would have reintroduced it below the API surface.
  */
-let wwwClaim = "0";
+const wwwClaims: Record<AuthMode, string> = { anonymous: "0", session: "0" };
 
 let limiter = new RateLimiter();
 
@@ -76,7 +82,7 @@ function buildHeaders(options: RequestOptions): Record<string, string> {
     const headers: Record<string, string> = {
         "x-ig-app-id": WEB_APP_ID,
         "x-asbd-id": ASBD_ID,
-        "x-ig-www-claim": wwwClaim,
+        "x-ig-www-claim": wwwClaims[options.sessionId ? "session" : "anonymous"],
         "user-agent": WEB_USER_AGENT,
         accept: "*/*",
         "accept-language": "en-US,en;q=0.9",
@@ -185,8 +191,8 @@ export async function getJson<T>(path: string, options: RequestOptions): Promise
 
     const setClaim = response.headers.get("x-ig-set-www-claim");
     if (setClaim) {
-        log.debug({ label: options.label }, "captured a fresh x-ig-www-claim to replay on later requests");
-        wwwClaim = setClaim;
+        log.debug({ label: options.label, authMode }, "captured a fresh x-ig-www-claim to replay on later requests");
+        wwwClaims[authMode] = setClaim;
     }
 
     if (response.status >= 300 && response.status < 400) {
@@ -244,9 +250,10 @@ export async function getJson<T>(path: string, options: RequestOptions): Promise
  */
 export const __testing = {
     resetWwwClaim: () => {
-        wwwClaim = "0";
+        wwwClaims.anonymous = "0";
+        wwwClaims.session = "0";
     },
-    currentWwwClaim: () => wwwClaim,
+    currentWwwClaim: (mode: AuthMode = "anonymous") => wwwClaims[mode],
     useInstantLimiter: () => {
         limiter = new RateLimiter({ random: () => 0, sleep: async () => undefined });
     },

--- a/src/instagram/lib/display.ts
+++ b/src/instagram/lib/display.ts
@@ -1,0 +1,162 @@
+import { out } from "@genesiscz/utils/logger";
+import {
+    createBoxTable,
+    formatDotStatus,
+    renderCliHeader,
+    renderCliSection,
+    truncateDisplay,
+} from "@genesiscz/utils/table";
+import pc from "picocolors";
+import type { HighlightRef, InstagramProfile, PublicReelInfo, StoryReel } from "./types";
+import { InstagramError } from "./types";
+
+function formatCount(value: number): string {
+    if (value >= 1_000_000) {
+        return `${(value / 1_000_000).toFixed(1)}M`;
+    }
+
+    if (value >= 1_000) {
+        return `${(value / 1_000).toFixed(1)}K`;
+    }
+
+    return String(value);
+}
+
+export function displayProfile(profile: InstagramProfile, reel?: PublicReelInfo): void {
+    renderCliHeader(`@${profile.username}`, profile.fullName);
+
+    const table = createBoxTable(["FIELD", "VALUE"]);
+    table.push([pc.white("id"), pc.dim(profile.id)]);
+    table.push([pc.white("followers"), formatCount(profile.followers)]);
+    table.push([pc.white("following"), formatCount(profile.following)]);
+    table.push([pc.white("posts"), formatCount(profile.posts)]);
+    table.push([pc.white("highlights"), formatCount(profile.highlightCount)]);
+    table.push([
+        pc.white("private"),
+        formatDotStatus(profile.isPrivate ? "err" : "ok", profile.isPrivate ? "yes" : "no"),
+    ]);
+    table.push([pc.white("verified"), profile.isVerified ? formatDotStatus("ok", "yes") : pc.dim("no")]);
+    table.push([pc.white("professional"), profile.isProfessional ? formatDotStatus("ok", "yes") : pc.dim("no")]);
+
+    if (reel) {
+        table.push([
+            pc.white("live story"),
+            reel.hasPublicStory ? formatDotStatus("ok", "yes") : formatDotStatus("dim", "no"),
+        ]);
+
+        if (reel.storyExpiresAt) {
+            table.push([pc.white("story expires"), pc.dim(reel.storyExpiresAt.toLocaleString())]);
+        }
+
+        if (reel.isLive) {
+            table.push([pc.white("live now"), formatDotStatus("warn", "broadcasting")]);
+        }
+    }
+
+    out.println(table.toString());
+
+    if (profile.biography) {
+        renderCliSection("Bio");
+        out.println(pc.dim(profile.biography));
+    }
+}
+
+export function displayHighlights(highlights: HighlightRef[]): void {
+    renderCliHeader("Highlights", `${highlights.length} found`);
+
+    const table = createBoxTable(["ID", "TITLE"]);
+    for (const highlight of highlights) {
+        table.push([pc.dim(highlight.id), pc.white(truncateDisplay(highlight.title, 40))]);
+    }
+    out.println(table.toString());
+}
+
+export function displayReels(reels: StoryReel[]): void {
+    const total = reels.reduce((sum, reel) => sum + reel.items.length, 0);
+    renderCliHeader("Stories", `${total} item${total === 1 ? "" : "s"}`);
+
+    const table = createBoxTable(["WHEN", "TYPE", "SIZE", "EXPIRES"]);
+    for (const reel of reels) {
+        for (const item of reel.items) {
+            table.push([
+                pc.white(item.takenAt.toLocaleString()),
+                item.isVideo ? pc.magenta("video") : pc.cyan("image"),
+                pc.dim(`${item.width}x${item.height}`),
+                item.expiresAt ? pc.dim(item.expiresAt.toLocaleString()) : pc.dim("—"),
+            ]);
+        }
+    }
+    out.println(table.toString());
+}
+
+/**
+ * Turn an error into an explanation the user can act on. The session-required
+ * case gets the most words because it is the one that looks like a bug and is
+ * not: Instagram gates story media on viewer identity and returns an empty 200
+ * to anonymous callers rather than an error.
+ */
+export function explainError(error: unknown): void {
+    if (!(error instanceof InstagramError)) {
+        out.log.error(error instanceof Error ? error.message : String(error));
+        return;
+    }
+
+    switch (error.kind) {
+        case "session-required":
+            out.log.error("This needs a logged-in Instagram session.");
+            out.log.info(
+                "Instagram serves story and highlight media only to an identified viewer. Anonymous requests get an " +
+                    "empty result with HTTP 200, not an error, so there is no way to read stories without a session."
+            );
+            out.log.info(`Set one with ${pc.cyan("export IG_SESSIONID=<sessionid cookie>")}, then re-run.`);
+            out.log.warn("Use a throwaway account: this violates Instagram's ToS and puts you in the viewer list.");
+            break;
+        case "session-invalid":
+            out.log.error("Instagram rejected the session cookie — it has most likely expired.");
+            out.log.info("Log in again in a browser, copy the fresh `sessionid` cookie, and update IG_SESSIONID.");
+            break;
+        case "checkpoint":
+            out.log.error("Instagram flagged the account with a checkpoint or challenge.");
+            out.log.warn("This is account-level. Changing IP or proxy will not help and may worsen it.");
+            out.log.info("Open Instagram in a browser with that account and clear the challenge.");
+
+            if (error.challengeUrl) {
+                out.log.info(`Challenge URL: ${pc.cyan(error.challengeUrl)}`);
+            }
+
+            out.log.warn("Do not re-run this command until it is cleared — retrying adds automation signal.");
+            break;
+        case "suspended":
+            out.log.error("This Instagram account is SUSPENDED, not merely challenged.");
+            out.log.warn("An SMS or email code will not clear a suspension — it needs an appeal.");
+
+            if (error.challengeUrl) {
+                out.log.info(`Appeal URL: ${pc.cyan(error.challengeUrl)}`);
+            }
+
+            break;
+        case "feedback-required":
+            out.log.error("Instagram returned `feedback_required` — the request looked automated.");
+            out.log.warn("Scored against the ACCOUNT, so backing off does not clear the current block.");
+            out.log.info("Wait it out (typically hours), and avoid re-running in a loop meanwhile.");
+            break;
+        case "please-wait":
+            out.log.error("Instagram asked you to wait a few minutes before trying again.");
+            out.log.info("A temporary throttle from too many recent requests. It clears on its own.");
+            out.log.warn("It arrives as HTTP 401 with `require_login`, but your cookie is NOT the problem.");
+            out.log.warn("Scoped to the caller, so a VPN or proxy will not clear it — only waiting will.");
+            break;
+        case "rate-limited":
+            out.log.error("Rate limited by Instagram.");
+            out.log.info("Back off for a while before retrying. This one is IP-level, unlike a checkpoint.");
+            break;
+        case "not-found":
+            out.log.error("No such account.");
+            break;
+        case "private-account":
+            out.log.error("That account is private.");
+            break;
+        default:
+            out.log.error(error.message);
+    }
+}

--- a/src/instagram/lib/download.test.ts
+++ b/src/instagram/lib/download.test.ts
@@ -74,6 +74,25 @@ describe("downloadReels", () => {
         expect(basename(results[0].path)).not.toContain("..");
     });
 
+    test("refuses a file:// media url instead of copying a local file into the output", async () => {
+        // Bun's fetch resolves file:// and answers 200 with the contents, so an
+        // unvalidated media url out of Instagram's JSON is a local-file read.
+        let requested = 0;
+        globalThis.fetch = mock(async () => {
+            requested += 1;
+            return new Response("secret", { status: 200 });
+        }) as unknown as typeof fetch;
+        const dir = await scratchDir();
+
+        const failure = await downloadReels(
+            [reelWith(storyItem({ mediaUrl: "file:///etc/hosts" }), "someone")],
+            dir
+        ).catch((error) => error);
+
+        expect(requested).toBe(0);
+        expect(failure).toBeInstanceOf(Error);
+    });
+
     test("reports every-download-failed rather than returning an empty success", async () => {
         globalThis.fetch = mock(async () => new Response("nope", { status: 404 })) as unknown as typeof fetch;
         const dir = await scratchDir();

--- a/src/instagram/lib/download.test.ts
+++ b/src/instagram/lib/download.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { downloadReels } from "./download";
+import { downloadReels, summarizeDownloads } from "./download";
 import type { StoryItem, StoryReel } from "./types";
 
 const realFetch = globalThis.fetch;
@@ -91,6 +91,30 @@ describe("downloadReels", () => {
 
         expect(requested).toBe(0);
         expect(failure).toBeInstanceOf(Error);
+    });
+
+    test("keeps going past one failed item and reports the survivor", async () => {
+        // The mixed path: neither all-success nor all-failure, and the only one
+        // where a short download could be mistaken for a complete one.
+        let call = 0;
+        globalThis.fetch = mock(async () => {
+            call += 1;
+            return call === 1
+                ? new Response("nope", { status: 404 })
+                : new Response(new Uint8Array([9, 9]), { status: 200 });
+        }) as unknown as typeof fetch;
+        const dir = await scratchDir();
+
+        const reel: StoryReel = {
+            reelId: "123",
+            ownerUsername: "someone",
+            items: [storyItem({ id: "gone" }), storyItem({ id: "kept" })],
+        };
+        const results = await downloadReels([reel], dir);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].item.id).toBe("kept");
+        expect(summarizeDownloads([reel], results)).toEqual({ requested: 2, downloaded: 1, failed: 1 });
     });
 
     test("reports every-download-failed rather than returning an empty success", async () => {

--- a/src/instagram/lib/download.test.ts
+++ b/src/instagram/lib/download.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { downloadReels } from "./download";
+import type { StoryItem, StoryReel } from "./types";
+
+const realFetch = globalThis.fetch;
+const dirs: string[] = [];
+
+afterEach(async () => {
+    globalThis.fetch = realFetch;
+
+    for (const dir of dirs.splice(0)) {
+        await rm(dir, { recursive: true, force: true });
+    }
+});
+
+async function scratchDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "instagram-download-"));
+    dirs.push(dir);
+    return dir;
+}
+
+function storyItem(overrides: Partial<StoryItem> = {}): StoryItem {
+    return {
+        id: "item1",
+        takenAt: new Date("2026-07-27T10:00:00Z"),
+        isVideo: false,
+        mediaUrl: "https://cdn/img.jpg",
+        imageUrl: "https://cdn/img.jpg",
+        width: 1080,
+        height: 1920,
+        ...overrides,
+    };
+}
+
+function reelWith(item: StoryItem, ownerUsername?: string): StoryReel {
+    return { reelId: "123", ownerUsername, items: [item] };
+}
+
+function mockBody(payload: Uint8Array<ArrayBuffer>): void {
+    globalThis.fetch = mock(async () => new Response(payload, { status: 200 })) as unknown as typeof fetch;
+}
+
+describe("downloadReels", () => {
+    test("streams the body to disk and reports the byte count it actually wrote", async () => {
+        // The body arrives as a stream rather than one buffer, which is the whole
+        // point: a story video must never be materialised whole in memory first.
+        const payload = new Uint8Array(64 * 1024).fill(7);
+        mockBody(payload);
+        const dir = await scratchDir();
+
+        const results = await downloadReels([reelWith(storyItem(), "someone")], dir);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].bytes).toBe(payload.byteLength);
+
+        const written = await Bun.file(results[0].path).bytes();
+        expect(written.byteLength).toBe(payload.byteLength);
+        expect(written[0]).toBe(7);
+    });
+
+    test("keeps a hostile username or item id from escaping the output directory", async () => {
+        // Both halves of the name come from Instagram's JSON, so they are remote
+        // input reaching `join()`, where a `..` segment would otherwise walk out.
+        mockBody(new Uint8Array([1, 2, 3]));
+        const dir = await scratchDir();
+
+        const results = await downloadReels([reelWith(storyItem({ id: "../evil" }), "../../escape")], dir);
+
+        expect(results).toHaveLength(1);
+        expect(join(dir, basename(results[0].path))).toBe(results[0].path);
+        expect(basename(results[0].path)).not.toContain("..");
+    });
+
+    test("reports every-download-failed rather than returning an empty success", async () => {
+        globalThis.fetch = mock(async () => new Response("nope", { status: 404 })) as unknown as typeof fetch;
+        const dir = await scratchDir();
+
+        const failure = await downloadReels([reelWith(storyItem(), "someone")], dir).catch((error) => error);
+
+        expect(failure).toBeInstanceOf(Error);
+        expect(String(failure)).toContain("failed");
+    });
+});

--- a/src/instagram/lib/download.ts
+++ b/src/instagram/lib/download.ts
@@ -109,8 +109,13 @@ export async function downloadReels(
     );
     const results: DownloadResult[] = [];
 
-    // Sequential on purpose: these requests carry a live session cookie, and
-    // parallel bursts against Instagram are what trips account-level blocks.
+    // Sequential on purpose — but NOT because of the session. These requests go to
+    // the pre-signed CDN URL with no cookie attached at all (see the bare `fetch`
+    // below), so nothing here is scored against the account. What they do share
+    // with the API calls is the egress IP, and this codebase already classifies
+    // `sentry_block` / `rate_limit_error` as IP-level. A burst of CDN requests is
+    // the cheapest way to earn one, and a story reel is a handful of items, so
+    // there is no throughput worth trading for that risk.
     for (const [index, job] of jobs.entries()) {
         const target = join(outputDir, fileNameFor(job.item, job.prefix));
 

--- a/src/instagram/lib/download.ts
+++ b/src/instagram/lib/download.ts
@@ -1,0 +1,123 @@
+import { mkdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+import { InstagramError, type StoryItem, type StoryReel } from "./types";
+
+const { log } = logger.scoped("instagram:download");
+
+export interface DownloadResult {
+    path: string;
+    bytes: number;
+    item: StoryItem;
+}
+
+/**
+ * Everything in a file name except the timestamp is remote input. The owner
+ * username and the item pk both come straight out of Instagram's JSON, so both
+ * get reduced to a safe charset here rather than at each call site. Without
+ * this a value carrying `/` or `..` walks `join()` right out of `outputDir`.
+ */
+function safeSegment(value: string): string {
+    const cleaned = value
+        // Separators are what make traversal possible at all.
+        .replace(/[^\w.-]+/g, "_")
+        // A single dot is legal in a username, `..` never is.
+        .replace(/\.{2,}/g, "_")
+        // Leading `.` hides the file; leading `-` reads as a flag to whatever opens it next.
+        .replace(/^[.-]+/, "");
+
+    return cleaned.length > 0 ? cleaned : "unknown";
+}
+
+function fileNameFor(item: StoryItem, prefix: string): string {
+    const stamp = item.takenAt.toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const ext = item.isVideo ? "mp4" : "jpg";
+    return `${safeSegment(prefix)}_${stamp}_${safeSegment(item.id)}.${ext}`;
+}
+
+/**
+ * Stream the body straight to disk and report how many bytes landed.
+ *
+ * Buffering with `arrayBuffer()` first held the whole file in memory before
+ * writing a byte of it, which for story *videos* is an allocation the size of
+ * the clip, and a reel downloads these back to back.
+ */
+async function streamToFile(response: Response, target: string): Promise<number> {
+    if (!response.body) {
+        throw new InstagramError("network", "Instagram's CDN returned a response with no body");
+    }
+
+    const writer = Bun.file(target).writer();
+    const reader = response.body.getReader();
+    let bytes = 0;
+
+    try {
+        let chunk = await reader.read();
+
+        while (!chunk.done) {
+            writer.write(chunk.value);
+            bytes += chunk.value.byteLength;
+            chunk = await reader.read();
+        }
+
+        await writer.end();
+    } catch (error) {
+        // A truncated .mp4 left on disk is worse than no file: nothing downstream
+        // can tell it apart from a complete one, so it goes with the error.
+        try {
+            await writer.end();
+        } catch (endError) {
+            log.debug({ endError, target }, "failed to close the sink for a partial download");
+        }
+
+        await unlink(target).catch((cleanupError) => {
+            log.debug({ cleanupError, target }, "could not remove the partial download");
+        });
+
+        throw error;
+    }
+
+    return bytes;
+}
+
+export async function downloadReels(
+    reels: StoryReel[],
+    outputDir: string,
+    onProgress?: (done: number, total: number) => void
+): Promise<DownloadResult[]> {
+    await mkdir(outputDir, { recursive: true });
+
+    const jobs = reels.flatMap((reel) =>
+        reel.items.map((item) => ({ item, prefix: reel.ownerUsername ?? reel.reelId }))
+    );
+    const results: DownloadResult[] = [];
+
+    // Sequential on purpose: these requests carry a live session cookie, and
+    // parallel bursts against Instagram are what trips account-level blocks.
+    for (const [index, job] of jobs.entries()) {
+        const target = join(outputDir, fileNameFor(job.item, job.prefix));
+
+        try {
+            const response = await fetch(job.item.mediaUrl);
+
+            if (!response.ok) {
+                log.warn({ status: response.status, id: job.item.id }, "media download failed");
+                continue;
+            }
+
+            const bytes = await streamToFile(response, target);
+            results.push({ path: target, bytes, item: job.item });
+            log.debug({ target, bytes }, "downloaded story item");
+        } catch (error) {
+            log.warn({ error, id: job.item.id }, "media download threw");
+        }
+
+        onProgress?.(index + 1, jobs.length);
+    }
+
+    if (jobs.length > 0 && results.length === 0) {
+        throw new InstagramError("network", `All ${jobs.length} media downloads failed`);
+    }
+
+    return results;
+}

--- a/src/instagram/lib/download.ts
+++ b/src/instagram/lib/download.ts
@@ -11,6 +11,23 @@ export interface DownloadResult {
     item: StoryItem;
 }
 
+export interface DownloadSummary {
+    requested: number;
+    downloaded: number;
+    failed: number;
+}
+
+/**
+ * `downloadReels` only throws when EVERY item failed, so the caller cannot tell a
+ * complete run from a short one by its return value alone. Kept here as a pure
+ * function rather than inline in the command so the "did anything go missing?"
+ * decision is testable without driving the commander entrypoint.
+ */
+export function summarizeDownloads(reels: StoryReel[], results: DownloadResult[]): DownloadSummary {
+    const requested = reels.reduce((sum, reel) => sum + reel.items.length, 0);
+    return { requested, downloaded: results.length, failed: requested - results.length };
+}
+
 /**
  * Everything in a file name except the timestamp is remote input. The owner
  * username and the item pk both come straight out of Instagram's JSON, so both

--- a/src/instagram/lib/download.ts
+++ b/src/instagram/lib/download.ts
@@ -29,6 +29,23 @@ function safeSegment(value: string): string {
     return cleaned.length > 0 ? cleaned : "unknown";
 }
 
+/**
+ * `mediaUrl` is remote input handed straight to `fetch`, and Bun's `fetch`
+ * resolves `file://` as happily as `https://` — it answers 200 with the file's
+ * contents. A media URL that is not https would therefore copy something off
+ * this machine into the output directory wearing a story's file name, so the
+ * scheme is checked before the request rather than trusted because of where the
+ * JSON came from.
+ */
+function isDownloadableUrl(value: string): boolean {
+    try {
+        return new URL(value).protocol === "https:";
+    } catch (error) {
+        log.debug({ error, value }, "story item carried a media url that will not parse");
+        return false;
+    }
+}
+
 function fileNameFor(item: StoryItem, prefix: string): string {
     const stamp = item.takenAt.toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const ext = item.isVideo ? "mp4" : "jpg";
@@ -96,6 +113,12 @@ export async function downloadReels(
     // parallel bursts against Instagram are what trips account-level blocks.
     for (const [index, job] of jobs.entries()) {
         const target = join(outputDir, fileNameFor(job.item, job.prefix));
+
+        if (!isDownloadableUrl(job.item.mediaUrl)) {
+            log.warn({ id: job.item.id }, "refusing a non-https media url");
+            onProgress?.(index + 1, jobs.length);
+            continue;
+        }
 
         try {
             const response = await fetch(job.item.mediaUrl);

--- a/src/instagram/lib/rate-limiter.test.ts
+++ b/src/instagram/lib/rate-limiter.test.ts
@@ -56,6 +56,20 @@ describe("RateLimiter budget", () => {
         expect(limiter.used).toBe(0);
     });
 
+    test("holds the cap against concurrent acquirers, not just sequential ones", async () => {
+        // The check and the reservation are separated by two awaits. Unserialised,
+        // every one of these reads the same free capacity before any of them
+        // records a timestamp, so all 76 sail through a cap of 75 and none of them
+        // ever sees a budget wait.
+        const { limiter, slept } = makeLimiter();
+
+        await Promise.all(Array.from({ length: __testing.MAX_PER_WINDOW + 1 }, () => limiter.acquire("concurrent")));
+
+        // A sleep longer than the jitter ceiling can only be the budget wait, so
+        // its presence proves the 76th caller was actually throttled.
+        expect(slept.some((ms) => ms > __testing.JITTER_MAX_MS)).toBe(true);
+    });
+
     test("caps jitter at instaloader's 15s ceiling", () => {
         let draw = 0.999999999;
         const limiter = new RateLimiter({ now: () => 0, random: () => draw });

--- a/src/instagram/lib/rate-limiter.test.ts
+++ b/src/instagram/lib/rate-limiter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { __testing, RateLimiter } from "./rate-limiter";
+
+function makeLimiter(startMs = 0) {
+    let clock = startMs;
+    const slept: number[] = [];
+
+    const limiter = new RateLimiter({
+        now: () => clock,
+        // Fixed draw keeps jitter deterministic; the distribution is instaloader's.
+        random: () => 0.5,
+        sleep: async (ms: number) => {
+            slept.push(ms);
+            clock += ms;
+        },
+    });
+
+    return { limiter, slept, advance: (ms: number) => (clock += ms), clockNow: () => clock };
+}
+
+describe("RateLimiter budget", () => {
+    test("allows requests up to the window cap without waiting", async () => {
+        const { limiter, slept } = makeLimiter();
+
+        for (let i = 0; i < __testing.MAX_PER_WINDOW; i++) {
+            await limiter.acquire("test");
+        }
+
+        // Jitter sleeps are expected; budget sleeps are not.
+        expect(limiter.used).toBe(__testing.MAX_PER_WINDOW);
+        expect(slept.every((ms) => ms <= __testing.JITTER_MAX_MS)).toBe(true);
+    });
+
+    test("makes the caller wait once the window cap is reached", async () => {
+        const { limiter } = makeLimiter();
+
+        for (let i = 0; i < __testing.MAX_PER_WINDOW; i++) {
+            await limiter.acquire("test");
+        }
+
+        // The whole point of a proactive budget: refuse BEFORE Instagram counts a
+        // strike, rather than reacting to a 429 that has already been recorded.
+        expect(limiter.waitTimeMs()).toBeGreaterThan(0);
+    });
+
+    test("frees capacity again once the window rolls past", async () => {
+        const { limiter, advance } = makeLimiter();
+
+        for (let i = 0; i < __testing.MAX_PER_WINDOW; i++) {
+            await limiter.acquire("test");
+        }
+
+        expect(limiter.waitTimeMs()).toBeGreaterThan(0);
+        advance(__testing.WINDOW_MS + 1);
+        expect(limiter.waitTimeMs()).toBe(0);
+        expect(limiter.used).toBe(0);
+    });
+
+    test("caps jitter at instaloader's 15s ceiling", () => {
+        let draw = 0.999999999;
+        const limiter = new RateLimiter({ now: () => 0, random: () => draw });
+
+        // An extreme draw would blow past the ceiling without the min().
+        expect(limiter.jitterMs()).toBeLessThanOrEqual(__testing.JITTER_MAX_MS);
+
+        draw = 0.5;
+        expect(limiter.jitterMs()).toBeGreaterThan(0);
+        expect(limiter.jitterMs()).toBeLessThanOrEqual(__testing.JITTER_MAX_MS);
+    });
+});

--- a/src/instagram/lib/rate-limiter.ts
+++ b/src/instagram/lib/rate-limiter.ts
@@ -10,7 +10,14 @@ const { log } = logger.scoped("instagram:rate");
  * Proactive matters: instagrapi's approach is a flat jittered delay plus reactive
  * backoff once a 429 arrives, which means you only learn you were too fast after
  * Instagram has already counted it against you. A budget refuses the request
- * first, so the account never accrues the strike.
+ * first, so that request never becomes a strike.
+ *
+ * 🛑 The budget is PER PROCESS and is not persisted. `tools` runs each invocation
+ * in its own process, so ten commands in a row each start with a full 75, and
+ * back-to-back runs CAN exceed the window that a single run respects. Making this
+ * a real account-wide budget needs the timestamps in the tool's storage dir
+ * behind an inter-process lock; until then this is an invocation-local throttle
+ * and the docs must not promise more than that.
  */
 const WINDOW_MS = 11 * 60 * 1000;
 const MAX_PER_WINDOW = 75;
@@ -32,6 +39,8 @@ export interface RateLimiterOptions {
 
 export class RateLimiter {
     private timestamps: number[] = [];
+    /** Tail of the acquisition chain. See `acquire`. */
+    private queue: Promise<void> = Promise.resolve();
     private readonly now: () => number;
     private readonly random: () => number;
     private readonly sleep: (ms: number) => Promise<void>;
@@ -64,7 +73,23 @@ export class RateLimiter {
         return Math.min(expovariate(JITTER_LAMBDA, this.random) * 1000, JITTER_MAX_MS);
     }
 
+    /**
+     * Serialised, because the check and the reservation are separated by two
+     * awaits. Without this, concurrent callers all read the same free capacity
+     * before any of them records a timestamp, and a `Promise.all` over 76 calls
+     * sails past a cap of 75 — the one thing this class exists to prevent.
+     */
     async acquire(label: string): Promise<void> {
+        const turn = this.queue.then(() => this.acquireExclusive(label));
+        // The chain must survive a rejection, or one failed acquire wedges the limiter.
+        this.queue = turn.then(
+            () => undefined,
+            () => undefined
+        );
+        return turn;
+    }
+
+    private async acquireExclusive(label: string): Promise<void> {
         const wait = this.waitTimeMs();
 
         if (wait > 0) {

--- a/src/instagram/lib/rate-limiter.ts
+++ b/src/instagram/lib/rate-limiter.ts
@@ -1,0 +1,88 @@
+import { logger } from "@genesiscz/utils/logger";
+
+const { log } = logger.scoped("instagram:rate");
+
+/**
+ * Proactive request budget, with the numbers taken from instaloader's
+ * `RateController` (`instaloader/instaloadercontext.py`) — the only genuinely
+ * measured, shipped rate limiter for this API that the research surfaced.
+ *
+ * Proactive matters: instagrapi's approach is a flat jittered delay plus reactive
+ * backoff once a 429 arrives, which means you only learn you were too fast after
+ * Instagram has already counted it against you. A budget refuses the request
+ * first, so the account never accrues the strike.
+ */
+const WINDOW_MS = 11 * 60 * 1000;
+const MAX_PER_WINDOW = 75;
+
+/** Instaloader's per-request jitter: `min(expovariate(0.6), 15)` seconds. */
+const JITTER_LAMBDA = 0.6;
+const JITTER_MAX_MS = 15_000;
+
+function expovariate(lambda: number, random: () => number): number {
+    return -Math.log(1 - random()) / lambda;
+}
+
+export interface RateLimiterOptions {
+    /** Injected so tests are deterministic; production uses the real clock. */
+    now?: () => number;
+    random?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+}
+
+export class RateLimiter {
+    private timestamps: number[] = [];
+    private readonly now: () => number;
+    private readonly random: () => number;
+    private readonly sleep: (ms: number) => Promise<void>;
+
+    constructor(options: RateLimiterOptions = {}) {
+        this.now = options.now ?? (() => Date.now());
+        this.random = options.random ?? Math.random;
+        this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    }
+
+    /** Milliseconds the caller must wait before the next request fits the budget. */
+    waitTimeMs(): number {
+        const cutoff = this.now() - WINDOW_MS;
+        this.timestamps = this.timestamps.filter((stamp) => stamp > cutoff);
+
+        if (this.timestamps.length < MAX_PER_WINDOW) {
+            return 0;
+        }
+
+        const oldest = this.timestamps[0];
+        return Math.max(0, oldest + WINDOW_MS - this.now());
+    }
+
+    jitterMs(): number {
+        return Math.min(expovariate(JITTER_LAMBDA, this.random) * 1000, JITTER_MAX_MS);
+    }
+
+    async acquire(label: string): Promise<void> {
+        const wait = this.waitTimeMs();
+
+        if (wait > 0) {
+            log.warn(
+                { label, waitMs: wait, used: this.timestamps.length, max: MAX_PER_WINDOW },
+                "request budget exhausted — sleeping before the next Instagram call"
+            );
+            await this.sleep(wait);
+        }
+
+        const jitter = this.jitterMs();
+        if (jitter > 0) {
+            log.debug({ label, jitterMs: Math.round(jitter) }, "jittering before request");
+            await this.sleep(jitter);
+        }
+
+        this.timestamps.push(this.now());
+    }
+
+    get used(): number {
+        const cutoff = this.now() - WINDOW_MS;
+        return this.timestamps.filter((stamp) => stamp > cutoff).length;
+    }
+}
+
+export const __testing = { WINDOW_MS, MAX_PER_WINDOW, JITTER_MAX_MS };

--- a/src/instagram/lib/rate-limiter.ts
+++ b/src/instagram/lib/rate-limiter.ts
@@ -42,10 +42,15 @@ export class RateLimiter {
         this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
     }
 
-    /** Milliseconds the caller must wait before the next request fits the budget. */
-    waitTimeMs(): number {
+    /** Drop the timestamps that have aged out of the window. The only mutator here. */
+    private evictExpired(): void {
         const cutoff = this.now() - WINDOW_MS;
         this.timestamps = this.timestamps.filter((stamp) => stamp > cutoff);
+    }
+
+    /** Milliseconds the caller must wait before the next request fits the budget. */
+    waitTimeMs(): number {
+        this.evictExpired();
 
         if (this.timestamps.length < MAX_PER_WINDOW) {
             return 0;
@@ -81,7 +86,7 @@ export class RateLimiter {
 
     get used(): number {
         const cutoff = this.now() - WINDOW_MS;
-        return this.timestamps.filter((stamp) => stamp > cutoff).length;
+        return this.timestamps.reduce((count, stamp) => (stamp > cutoff ? count + 1 : count), 0);
     }
 }
 

--- a/src/instagram/lib/session.test.ts
+++ b/src/instagram/lib/session.test.ts
@@ -65,16 +65,33 @@ describe("resolveSession", () => {
         expect(session?.csrfToken).toBe("tok999");
     });
 
-    test("falls back to IG_CSRFTOKEN when the flag carries only a bare sessionid", async () => {
-        // Regression: the flag path used to skip this fallback that the env path
-        // has, so `--session-cookie <bare id>` shipped the header/cookie mismatch
-        // the client warns about on every single request.
-        env.testing.set("IG_CSRFTOKEN", "from-env");
+    test("never pairs an explicit session with the environment's csrftoken", async () => {
+        // The flag exists to OVERRIDE the environment's session. Borrowing that
+        // session's csrftoken would hand Instagram a new cookie wearing the old
+        // account's token — the mismatch this tool warns about, manufactured by
+        // the tool itself. Better to send none and log the warning.
+        env.testing.set("IG_SESSIONID", "old-session");
+        env.testing.set("IG_CSRFTOKEN", "old-token");
 
-        const session = await resolveSession("bare-session-id");
+        const session = await resolveSession("new-session");
 
-        expect(session?.sessionId).toBe("bare-session-id");
-        expect(session?.csrfToken).toBe("from-env");
+        expect(session?.sessionId).toBe("new-session");
+        expect(session?.csrfToken).toBeUndefined();
+    });
+
+    test("accepts a csrftoken passed explicitly alongside the session flag", async () => {
+        env.testing.set("IG_CSRFTOKEN", "ambient-and-unrelated");
+
+        const session = await resolveSession("new-session", "paired-token");
+
+        expect(session?.sessionId).toBe("new-session");
+        expect(session?.csrfToken).toBe("paired-token");
+    });
+
+    test("prefers an explicit csrftoken over one embedded in the pasted cookie", async () => {
+        const session = await resolveSession("csrftoken=embedded; sessionid=sess", "explicit");
+
+        expect(session?.csrfToken).toBe("explicit");
     });
 
     test("reads IG_SESSIONID and names the variable it came from", async () => {

--- a/src/instagram/lib/session.test.ts
+++ b/src/instagram/lib/session.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { __testing, resolveSession, writeSessionConfig } from "./session";
+
+/**
+ * Every key `resolveSession` can read. They are cleared before each case because
+ * a developer running the suite with a real IG_SESSIONID exported would
+ * otherwise see the "no session" assertions fail for reasons that have nothing
+ * to do with the code.
+ */
+const SESSION_KEYS = ["IG_SESSIONID", "INSTAGRAM_SESSIONID", "IG_CSRFTOKEN", "IG_ALT_COOKIE"] as const;
+
+let home: string;
+const saved = new Map<string, string | undefined>();
+
+beforeEach(() => {
+    // The config branch writes a real config.json, so the storage root is
+    // redirected at a fresh tmp dir rather than the user's ~/.genesis-tools.
+    saved.set("GENESIS_TOOLS_HOME", env.get("GENESIS_TOOLS_HOME"));
+    home = mkdtempSync(join(tmpdir(), "instagram-session-"));
+    env.testing.set("GENESIS_TOOLS_HOME", home);
+
+    for (const key of SESSION_KEYS) {
+        saved.set(key, env.get(key));
+        env.testing.unset(key);
+    }
+});
+
+afterEach(() => {
+    for (const [key, value] of saved) {
+        if (value === undefined) {
+            env.testing.unset(key);
+        } else {
+            env.testing.set(key, value);
+        }
+    }
+
+    saved.clear();
+    rmSync(home, { recursive: true, force: true });
+});
+
+describe("resolveSession", () => {
+    test("returns undefined when nothing supplies a cookie", async () => {
+        // Anonymous commands must keep working with no session at all, so the
+        // absence of one is a value, not an error.
+        expect(await resolveSession()).toBeUndefined();
+    });
+
+    test("takes the explicit flag and reports it as the source", async () => {
+        const session = await resolveSession("abc123");
+
+        expect(session?.sessionId).toBe("abc123");
+        expect(session?.source).toBe("flag");
+        expect(session?.envKey).toBeUndefined();
+    });
+
+    test("pulls both halves out of a pasted cookie string", async () => {
+        // Browsers copy the whole `a=1; b=2` pair, which is what users paste.
+        const session = await resolveSession("csrftoken=tok999; sessionid=sess777; ds_user_id=1");
+
+        expect(session?.sessionId).toBe("sess777");
+        expect(session?.csrfToken).toBe("tok999");
+    });
+
+    test("falls back to IG_CSRFTOKEN when the flag carries only a bare sessionid", async () => {
+        // Regression: the flag path used to skip this fallback that the env path
+        // has, so `--session-cookie <bare id>` shipped the header/cookie mismatch
+        // the client warns about on every single request.
+        env.testing.set("IG_CSRFTOKEN", "from-env");
+
+        const session = await resolveSession("bare-session-id");
+
+        expect(session?.sessionId).toBe("bare-session-id");
+        expect(session?.csrfToken).toBe("from-env");
+    });
+
+    test("reads IG_SESSIONID and names the variable it came from", async () => {
+        env.testing.set("IG_SESSIONID", "env-session");
+        env.testing.set("IG_CSRFTOKEN", "env-csrf");
+
+        const session = await resolveSession();
+
+        expect(session?.sessionId).toBe("env-session");
+        expect(session?.csrfToken).toBe("env-csrf");
+        expect(session?.source).toBe("env");
+        expect(session?.envKey).toBe("IG_SESSIONID");
+    });
+
+    test("prefers the explicit flag over the environment", async () => {
+        env.testing.set("IG_SESSIONID", "env-session");
+
+        const session = await resolveSession("flag-session");
+
+        expect(session?.sessionId).toBe("flag-session");
+        expect(session?.source).toBe("flag");
+    });
+
+    test("resolves through a config-referenced env var, and stores only its name", async () => {
+        // The cookie is a live credential, so config holds the variable NAME and
+        // the value is read at use time — the tokens.apiKeyEnv convention.
+        await writeSessionConfig({ sessionIdEnv: "IG_ALT_COOKIE" });
+        env.testing.set("IG_ALT_COOKIE", "alt-session");
+
+        const session = await resolveSession();
+
+        expect(session?.sessionId).toBe("alt-session");
+        expect(session?.source).toBe("env");
+        expect(session?.envKey).toBe("IG_ALT_COOKIE");
+
+        const written = await Bun.file(join(home, ".genesis-tools", "instagram", "config.json")).text();
+        expect(written).toContain("IG_ALT_COOKIE");
+        expect(written).not.toContain("alt-session");
+    });
+
+    test("prefers IG_SESSIONID over a config-referenced variable", async () => {
+        await writeSessionConfig({ sessionIdEnv: "IG_ALT_COOKIE" });
+        env.testing.set("IG_ALT_COOKIE", "alt-session");
+        env.testing.set("IG_SESSIONID", "direct-session");
+
+        const session = await resolveSession();
+
+        expect(session?.sessionId).toBe("direct-session");
+        expect(session?.envKey).toBe("IG_SESSIONID");
+    });
+
+    test("reports no session when the configured variable is unset or blank", async () => {
+        // A dangling reference must not resolve to an empty-string cookie, which
+        // would be sent as a real one and rejected as an expired session.
+        await writeSessionConfig({ sessionIdEnv: "IG_ALT_COOKIE" });
+
+        expect(await resolveSession()).toBeUndefined();
+
+        env.testing.set("IG_ALT_COOKIE", "   ");
+        expect(await resolveSession()).toBeUndefined();
+    });
+});
+
+describe("cookie parsing helpers", () => {
+    test("strips a sessionid= prefix and a trailing semicolon", () => {
+        expect(__testing.stripCookiePrefix("sessionid=abc;")).toBe("abc");
+        expect(__testing.stripCookiePrefix("  abc  ")).toBe("abc");
+        expect(__testing.stripCookiePrefix("other=1; sessionid=abc")).toBe("abc");
+    });
+
+    test("returns undefined for a cookie that is not present", () => {
+        expect(__testing.extractCookie("sessionid=abc", "csrftoken")).toBeUndefined();
+        expect(__testing.extractCookie("csrftoken=xyz; sessionid=abc", "csrftoken")).toBe("xyz");
+    });
+});

--- a/src/instagram/lib/session.ts
+++ b/src/instagram/lib/session.ts
@@ -55,15 +55,21 @@ export async function writeSessionConfig(config: SessionConfig): Promise<void> {
  * command must keep working with no session at all, so only the story path
  * turns a missing cookie into an error.
  */
-export async function resolveSession(explicitCookie?: string): Promise<ResolvedSession | undefined> {
+export async function resolveSession(
+    explicitCookie?: string,
+    explicitCsrfToken?: string
+): Promise<ResolvedSession | undefined> {
     if (explicitCookie) {
         log.debug("session resolved from --session-cookie flag");
         return {
             sessionId: stripCookiePrefix(explicitCookie),
-            // Same fallback as the env path below. Pasting a bare `sessionid` on the
-            // flag is the common case, and dropping a csrftoken that IS available
-            // ships the header/cookie mismatch the client warns about on every call.
-            csrfToken: extractCookie(explicitCookie, "csrftoken") ?? env.instagram.getCsrfToken(),
+            // Deliberately NOT falling back to $IG_CSRFTOKEN here. That variable
+            // belongs to whatever session the environment holds, and the whole
+            // point of the flag is to override that session — pairing the new
+            // cookie with the old account's token is the mismatch this tool warns
+            // about, manufactured by the tool itself. Paste the full cookie string
+            // or pass --csrf-token to supply one that actually belongs together.
+            csrfToken: explicitCsrfToken ?? extractCookie(explicitCookie, "csrftoken"),
             source: "flag",
         };
     }

--- a/src/instagram/lib/session.ts
+++ b/src/instagram/lib/session.ts
@@ -1,0 +1,109 @@
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+import { Storage } from "@genesiscz/utils/storage/storage";
+import type { SessionCredentials } from "./types";
+
+const { log } = logger.scoped("instagram:session");
+
+export interface SessionConfig {
+    /**
+     * Name of the env var holding the cookie. The cookie itself is deliberately
+     * never written to config — it is a live credential to a real account, and
+     * this mirrors the `tokens.apiKeyEnv` convention used by the AI accounts.
+     */
+    sessionIdEnv?: string;
+}
+
+/**
+ * A resolved credential pair plus its provenance. Extends `SessionCredentials`
+ * so it can be handed straight to the authenticated API calls, which keeps the
+ * `csrftoken` attached to the `sessionid` it was resolved with. Instagram
+ * expects `x-csrftoken` to match the `csrftoken` cookie, and the research found
+ * mismatched headers trigger enforcement independently of request volume.
+ */
+export interface ResolvedSession extends SessionCredentials {
+    /** Where it came from, for the `status` command and for debugging auth failures. */
+    source: "flag" | "env";
+    envKey?: string;
+}
+
+const storage = new Storage("instagram");
+
+export async function readSessionConfig(): Promise<SessionConfig> {
+    const config = await storage.getConfig<SessionConfig>();
+    return config ?? {};
+}
+
+export async function writeSessionConfig(config: SessionConfig): Promise<void> {
+    await storage.ensureDirs();
+    await storage.setConfig(config);
+    log.debug({ sessionIdEnv: config.sessionIdEnv }, "wrote instagram session config");
+}
+
+/**
+ * Resolve the session cookie, or `undefined` when there is none.
+ *
+ * Returning `undefined` rather than throwing is deliberate: every anonymous
+ * command must keep working with no session at all, so only the story path
+ * turns a missing cookie into an error.
+ */
+export async function resolveSession(explicitCookie?: string): Promise<ResolvedSession | undefined> {
+    if (explicitCookie) {
+        log.debug("session resolved from --session-cookie flag");
+        return {
+            sessionId: stripCookiePrefix(explicitCookie),
+            csrfToken: extractCookie(explicitCookie, "csrftoken"),
+            source: "flag",
+        };
+    }
+
+    const fromEnv = env.instagram.getSessionId();
+    if (fromEnv) {
+        const envKey = env.instagram.getSessionIdEnvKey();
+        log.debug({ envKey }, "session resolved from environment");
+        return {
+            sessionId: stripCookiePrefix(fromEnv),
+            csrfToken: extractCookie(fromEnv, "csrftoken") ?? env.instagram.getCsrfToken(),
+            source: "env",
+            envKey,
+        };
+    }
+
+    const config = await readSessionConfig();
+    if (config.sessionIdEnv) {
+        const referenced = env.get(config.sessionIdEnv);
+
+        if (referenced && referenced.trim().length > 0) {
+            log.debug({ envKey: config.sessionIdEnv }, "session resolved via configured env reference");
+            return {
+                sessionId: stripCookiePrefix(referenced.trim()),
+                csrfToken: extractCookie(referenced, "csrftoken") ?? env.instagram.getCsrfToken(),
+                source: "env",
+                envKey: config.sessionIdEnv,
+            };
+        }
+
+        log.warn(
+            { envKey: config.sessionIdEnv },
+            "config references an env var for the session cookie but it is unset or empty"
+        );
+    }
+
+    log.debug("no session cookie available — anonymous mode only");
+    return undefined;
+}
+
+/** Accepts a bare value or a pasted `sessionid=...` pair, since browsers copy the latter. */
+function stripCookiePrefix(value: string): string {
+    const trimmed = value.trim().replace(/;$/, "");
+    const match = trimmed.match(/(?:^|;\s*)sessionid=([^;]+)/);
+    return match ? match[1] : trimmed;
+}
+
+/** Pull one named cookie out of a pasted `a=1; b=2` cookie string. */
+function extractCookie(value: string, name: string): string | undefined {
+    const match = value.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+    return match ? match[1].trim() : undefined;
+}
+
+export const __testing = { stripCookiePrefix, extractCookie };

--- a/src/instagram/lib/session.ts
+++ b/src/instagram/lib/session.ts
@@ -27,16 +27,24 @@ export interface ResolvedSession extends SessionCredentials {
     envKey?: string;
 }
 
-const storage = new Storage("instagram");
+/**
+ * Built per call rather than once at module load. `Storage` resolves its root
+ * from `GENESIS_TOOLS_HOME` in its constructor, so a module-level instance would
+ * pin whatever the value was at import time and ignore it thereafter.
+ */
+function storage(): Storage {
+    return new Storage("instagram");
+}
 
 export async function readSessionConfig(): Promise<SessionConfig> {
-    const config = await storage.getConfig<SessionConfig>();
+    const config = await storage().getConfig<SessionConfig>();
     return config ?? {};
 }
 
 export async function writeSessionConfig(config: SessionConfig): Promise<void> {
-    await storage.ensureDirs();
-    await storage.setConfig(config);
+    const store = storage();
+    await store.ensureDirs();
+    await store.setConfig(config);
     log.debug({ sessionIdEnv: config.sessionIdEnv }, "wrote instagram session config");
 }
 
@@ -52,7 +60,10 @@ export async function resolveSession(explicitCookie?: string): Promise<ResolvedS
         log.debug("session resolved from --session-cookie flag");
         return {
             sessionId: stripCookiePrefix(explicitCookie),
-            csrfToken: extractCookie(explicitCookie, "csrftoken"),
+            // Same fallback as the env path below. Pasting a bare `sessionid` on the
+            // flag is the common case, and dropping a csrftoken that IS available
+            // ships the header/cookie mismatch the client warns about on every call.
+            csrfToken: extractCookie(explicitCookie, "csrftoken") ?? env.instagram.getCsrfToken(),
             source: "flag",
         };
     }

--- a/src/instagram/lib/types.ts
+++ b/src/instagram/lib/types.ts
@@ -1,0 +1,143 @@
+export interface InstagramProfile {
+    id: string;
+    username: string;
+    fullName: string;
+    biography: string;
+    isPrivate: boolean;
+    isVerified: boolean;
+    isProfessional: boolean;
+    followers: number;
+    following: number;
+    posts: number;
+    highlightCount: number;
+    profilePicUrl: string;
+}
+
+export interface HighlightRef {
+    id: string;
+    title: string;
+    coverUrl?: string;
+}
+
+/**
+ * What the anonymous surface genuinely exposes about stories. Story existence and
+ * the highlight tray ARE public via the legacy `query_id` reel endpoint; only the
+ * media items behind them are gated.
+ */
+export interface PublicReelInfo {
+    hasPublicStory: boolean;
+    isLive: boolean;
+    /** When the current story reel expires — present even with no session. */
+    storyExpiresAt?: Date;
+    highlights: HighlightRef[];
+}
+
+export interface StoryItem {
+    id: string;
+    takenAt: Date;
+    expiresAt?: Date;
+    isVideo: boolean;
+    /** Highest-resolution URL for the item — video when `isVideo`, else the image. */
+    mediaUrl: string;
+    /** Always present; the poster frame for videos. */
+    imageUrl: string;
+    width: number;
+    height: number;
+}
+
+export interface StoryReel {
+    /** Numeric user id for a live-story reel, `highlight:<id>` for a highlight. */
+    reelId: string;
+    ownerUsername?: string;
+    title?: string;
+    items: StoryItem[];
+}
+
+/**
+ * The credential pair Instagram expects to arrive together: the `sessionid`
+ * cookie plus the `csrftoken` whose value must also be echoed in `x-csrftoken`.
+ * Authenticated calls take this object rather than a bare `sessionId` string so
+ * the token cannot be silently dropped on the way to the request layer. A bare
+ * string has nowhere to put it, which is exactly how it went missing before.
+ */
+export interface SessionCredentials {
+    sessionId: string;
+    csrfToken?: string;
+}
+
+/**
+ * How a request was authenticated. The whole point of the tool is that these are
+ * separate: profile/posts/highlight-ids resolve anonymously, story media does not.
+ */
+export type AuthMode = "anonymous" | "session";
+
+export type InstagramErrorKind =
+    /**
+     * The gate this tool exists to report correctly. Instagram answers an
+     * unauthenticated story request with HTTP 200 and `{"reels":{}}` rather than
+     * 401, so an empty reel map is indistinguishable from "no stories" unless the
+     * caller knows whether a session was attached. Verified 2026-07-27: the same
+     * user id on `i.instagram.com/api/v1/feed/user/<id>/story/` returns 403
+     * `login_required` for content the sibling endpoint reports as empty.
+     */
+    | "session-required"
+    /** Session cookie was sent but Instagram rejected it (expired or invalidated). */
+    | "session-invalid"
+    /** Account-level block, clearable. Rotating IP will NOT help and makes it worse. */
+    | "checkpoint"
+    /** Challenge URL contained `/suspended/` — not clearable with an SMS code. */
+    | "suspended"
+    /**
+     * `feedback_required`. Instagram's "this action looked automated" response.
+     * Distinct from rate limiting: it is scored against the ACCOUNT, so slowing
+     * down helps future requests but backing off does not clear the current one.
+     */
+    | "feedback-required"
+    /** IP-level throttle (`sentry_block`, `rate_limit_error`, 429). Backing off helps. */
+    | "rate-limited"
+    /**
+     * "Please wait a few minutes before you try again." instagrapi groups this
+     * with the LOGICAL-level blocks, not the IP-level ones, so rotating egress
+     * does not clear it — it is scoped to the caller, and only time fixes it.
+     * Note it arrives as HTTP 401 with `require_login: true`, which makes it look
+     * like an auth failure; classifying it as one sends the user hunting for a
+     * cookie problem that does not exist.
+     */
+    | "please-wait"
+    | "not-found"
+    | "private-account"
+    | "network";
+
+/** Errors where retrying the same request can only make the situation worse. */
+const TERMINAL_KINDS: ReadonlySet<InstagramErrorKind> = new Set([
+    "checkpoint",
+    "suspended",
+    "feedback-required",
+    "session-required",
+    "session-invalid",
+    "not-found",
+    "private-account",
+    "please-wait",
+]);
+
+export class InstagramError extends Error {
+    constructor(
+        readonly kind: InstagramErrorKind,
+        message: string,
+        readonly status?: number,
+        /** Present for checkpoint/suspended — the URL the user must open to resolve it. */
+        readonly challengeUrl?: string
+    ) {
+        super(message);
+        this.name = "InstagramError";
+    }
+
+    /**
+     * instagrapi's retry loop stops on exactly this class of error rather than
+     * burning attempts. Retrying a checkpoint adds automation signal to an account
+     * that has already been flagged, which is the opposite of what you want.
+     */
+    get isTerminal(): boolean {
+        return TERMINAL_KINDS.has(this.kind);
+    }
+}

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -21,6 +21,8 @@ const XAI_API_KEYS = ["XAI_API_KEY", "X_AI_API_KEY"] as const;
 const HF_TOKEN_KEYS = ["HUGGINGFACE_TOKEN", "HF_TOKEN"] as const;
 // GitHub CLI and apps disagree on the canonical name — never use `gh auth token` here.
 const GITHUB_TOKEN_KEYS = ["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"] as const;
+// Instaloader and instagrapi both use IG_SESSIONID; INSTAGRAM_SESSIONID reads clearer.
+const INSTAGRAM_SESSION_KEYS = ["IG_SESSIONID", "INSTAGRAM_SESSIONID"] as const;
 const EDITOR_KEYS = ["VISUAL", "EDITOR"] as const;
 const LOCALE_PREFERENCE_KEYS = ["LC_TIME", "LANG", "LC_ALL"] as const;
 
@@ -99,6 +101,18 @@ export const env = {
         // Copilot CLI uses this name explicitly — separate from generic GITHUB_TOKEN.
         getCopilotToken: () => getTrimmed("COPILOT_GITHUB_TOKEN"),
         getCopilotTokenEnvKey: () => (isNonEmpty("COPILOT_GITHUB_TOKEN") ? "COPILOT_GITHUB_TOKEN" : undefined),
+    },
+
+    instagram: {
+        // Session cookie for the story/highlight endpoints. Instagram gates story
+        // media on viewer identity, so the anonymous surface (profile, posts,
+        // highlight ids) needs none of this and must keep working without it.
+        getSessionId: () => getFirstValue(INSTAGRAM_SESSION_KEYS),
+        getSessionIdEnvKey: () => getFirstEnvKey(INSTAGRAM_SESSION_KEYS),
+        hasSessionId: () => getFirstValue(INSTAGRAM_SESSION_KEYS) !== undefined,
+        // Instagram expects x-csrftoken to match the csrftoken cookie sitting next
+        // to sessionid — a mismatch is a fingerprint signal, so fetch both.
+        getCsrfToken: () => getTrimmed("IG_CSRFTOKEN"),
     },
 
     brave: createApiKeyAccessor(["BRAVE_API_KEY"]),


### PR DESCRIPTION
> **Draft.** Opened for review, not for merge yet.

## What

`tools instagram` — profile and story fetcher.

- Profile and story endpoints, **gated on an authenticated session** so unauthenticated calls fail loudly rather than returning a misleading empty result.
- Env accessors for the credentials, added to `src/utils/env/envVariables.ts` per the repo rule that application code never reads `process.env` directly.

## Why

Split out of #296 as a draft because it is the least-exercised surface in that branch and benefits from review before it lands.

## Scope

`src/instagram/**`, `src/utils/env/envVariables.ts`.

File-disjoint from the sibling PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Instagram command-line toolkit for viewing public profiles, stories, highlights, and media.
  * Added optional authenticated session support for accessing stories and downloading highlight media.
  * Added table and JSON output modes, progress reporting, safe media downloads, and actionable error messages.
  * Added rate limiting and clear handling for authentication, checkpoint, throttling, and network errors.

* **Documentation**
  * Documented Instagram workflows, session setup, privacy safeguards, rate limits, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->