### PR TITLE
feat(timely): cookie login so memories work again, honest auth failures

### DIFF
--- a/src/timely/api/client.ts
+++ b/src/timely/api/client.ts
@@ -1,4 +1,5 @@
 import type { OAuth2Tokens, OAuthApplication } from "@app/timely/types";
+import { tokenNeedsRefresh } from "@app/timely/utils/token-status";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import * as p from "@genesiscz/utils/prompts/p";
@@ -15,6 +16,8 @@ export interface RequestOptions {
 export class TimelyApiClient {
     private baseUrl = "https://api.timelyapp.com/1.1";
     private storage: Storage;
+    /** Set while a refresh is in flight, so concurrent callers await it instead of racing. */
+    private inFlightRefresh?: Promise<OAuth2Tokens>;
 
     constructor(storage: Storage) {
         this.storage = storage;
@@ -70,21 +73,28 @@ export class TimelyApiClient {
             throw new Error("Not authenticated. Run 'tools timely login' first.");
         }
 
-        // Check if token is expired (with 5 minute buffer). Timely's token response does
-        // NOT always carry expires_in — when it is missing we cannot know the lifetime, so
-        // refresh rather than sending a token that may be months stale (it 401s otherwise).
-        if (tokens.created_at) {
-            const bufferMs = 5 * 60 * 1000; // 5 minutes
-            const expiresAt = tokens.expires_in ? (tokens.created_at + tokens.expires_in) * 1000 : 0;
-
-            if (Date.now() > expiresAt - bufferMs) {
-                logger.debug("Access token expired or lifetime unknown, refreshing...");
-                const newTokens = await this.refreshToken(tokens.refresh_token);
-                return newTokens.access_token;
-            }
+        if (tokenNeedsRefresh(tokens)) {
+            logger.debug("Access token is past its assumed lifetime, refreshing...");
+            const newTokens = await this.refreshWithoutStampede(tokens.refresh_token);
+            return newTokens.access_token;
         }
 
         return tokens.access_token;
+    }
+
+    /**
+     * Commands load memories and events together, so several calls can find the token
+     * stale at once. Without this they would each POST the token endpoint, and the
+     * losers of that race would then hold tokens the winner has already rotated away.
+     */
+    private refreshWithoutStampede(refreshToken: string): Promise<OAuth2Tokens> {
+        if (!this.inFlightRefresh) {
+            this.inFlightRefresh = this.refreshToken(refreshToken).finally(() => {
+                this.inFlightRefresh = undefined;
+            });
+        }
+
+        return this.inFlightRefresh;
     }
 
     /**

--- a/src/timely/api/client.ts
+++ b/src/timely/api/client.ts
@@ -4,6 +4,7 @@ import { logger } from "@genesiscz/utils/logger";
 import * as p from "@genesiscz/utils/prompts/p";
 import type { Storage } from "@genesiscz/utils/storage";
 import chalk from "chalk";
+import { TimelyHttpError } from "./errors";
 
 export interface RequestOptions {
     params?: Record<string, string | number | boolean>;
@@ -69,19 +70,29 @@ export class TimelyApiClient {
             throw new Error("Not authenticated. Run 'tools timely login' first.");
         }
 
-        // Check if token is expired (with 5 minute buffer)
-        if (tokens.created_at && tokens.expires_in) {
-            const expiresAt = (tokens.created_at + tokens.expires_in) * 1000;
+        // Check if token is expired (with 5 minute buffer). Timely's token response does
+        // NOT always carry expires_in — when it is missing we cannot know the lifetime, so
+        // refresh rather than sending a token that may be months stale (it 401s otherwise).
+        if (tokens.created_at) {
             const bufferMs = 5 * 60 * 1000; // 5 minutes
+            const expiresAt = tokens.expires_in ? (tokens.created_at + tokens.expires_in) * 1000 : 0;
 
             if (Date.now() > expiresAt - bufferMs) {
-                logger.debug("Access token expired, refreshing...");
+                logger.debug("Access token expired or lifetime unknown, refreshing...");
                 const newTokens = await this.refreshToken(tokens.refresh_token);
                 return newTokens.access_token;
             }
         }
 
         return tokens.access_token;
+    }
+
+    /**
+     * Public accessor for a guaranteed-fresh token, for callers that must hit a Timely
+     * host this client does not wrap (e.g. app.timelyapp.com's suggested_entries).
+     */
+    async getValidAccessToken(): Promise<string> {
+        return this.getAccessToken();
     }
 
     /**
@@ -105,7 +116,10 @@ export class TimelyApiClient {
 
         if (!response.ok) {
             const error = await response.text();
-            throw new Error(`Token refresh failed: ${error}`);
+            throw new TimelyHttpError(`Token refresh failed: ${error}`, {
+                status: response.status,
+                scope: "token",
+            });
         }
 
         const tokens = (await response.json()) as OAuth2Tokens;
@@ -142,7 +156,10 @@ export class TimelyApiClient {
 
         if (!response.ok) {
             const error = await response.text();
-            throw new Error(`Token exchange failed: ${error}`);
+            throw new TimelyHttpError(`Token exchange failed: ${error}`, {
+                status: response.status,
+                scope: "token",
+            });
         }
 
         const tokens = (await response.json()) as OAuth2Tokens;
@@ -152,6 +169,11 @@ export class TimelyApiClient {
             ...tokens,
             created_at: Math.floor(Date.now() / 1000),
         });
+
+        // tokens.created_at is rewritten by every refresh, and because Timely sends no
+        // expires_in every request refreshes — so it cannot answer "when did I log in?".
+        // Record the exchange separately; only this code path writes it.
+        await this.storage.setConfigValue("authenticatedAt", Math.floor(Date.now() / 1000));
 
         return tokens;
     }
@@ -201,7 +223,10 @@ export class TimelyApiClient {
 
         if (!response.ok) {
             const error = await response.text();
-            throw new Error(`API request failed (${response.status}): ${error}`);
+            throw new TimelyHttpError(`API request failed (${response.status}): ${error}`, {
+                status: response.status,
+                scope: "api",
+            });
         }
 
         // Handle empty responses

--- a/src/timely/api/cookie-probe.test.ts
+++ b/src/timely/api/cookie-probe.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { readStoredCookie } from "@app/timely/utils/cookie";
 import { Storage } from "@genesiscz/utils/storage";
 import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
-import { probeAndSaveCookie } from "./cookie-probe";
+import { type CookieRejection, probeAndSaveCookie } from "./cookie-probe";
 
 setupStorageSandbox();
 
@@ -29,8 +29,57 @@ describe("probeAndSaveCookie", () => {
 
         const outcome = await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=stale" });
 
-        expect(outcome).toEqual({ status: "rejected", httpStatus: 401 });
+        expect(outcome).toEqual({ status: "rejected", httpStatus: 401, reason: "http-status" });
         expect(await readStoredCookie(storage)).toBeUndefined();
+    });
+
+    // A web host answers a signed-out request with a bounce to sign-in, or with the
+    // sign-in page under a 200. Both read as success to `response.ok`, so each one is
+    // its own way of persisting a cookie that authenticates nothing.
+    const bypasses: [string, () => Response, { httpStatus: number; reason: CookieRejection }][] = [
+        [
+            "a redirect to the sign-in page",
+            () => new Response(null, { status: 302, headers: { location: "/login" } }),
+            { httpStatus: 302, reason: "redirected" },
+        ],
+        [
+            "a 200 carrying the sign-in page instead of JSON",
+            () => new Response("<!DOCTYPE html><title>Sign in to Timely</title>", { status: 200 }),
+            { httpStatus: 200, reason: "not-suggested-entries" },
+        ],
+        [
+            "a 200 carrying a JSON error object instead of the entries array",
+            () => new Response('{"error":"Unauthorized"}', { status: 200 }),
+            { httpStatus: 200, reason: "not-suggested-entries" },
+        ],
+        [
+            "a non-200 success status",
+            () => new Response("[]", { status: 201 }),
+            { httpStatus: 201, reason: "http-status" },
+        ],
+    ];
+
+    test.each(bypasses)("%s is refused and never reaches disk", async (name, makeResponse, expected) => {
+        const storage = await freshStorage(`timely-probe-${name.replace(/\W+/g, "-")}`);
+        stubFetch(async () => makeResponse());
+
+        const outcome = await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=stale" });
+
+        expect(outcome).toEqual({ status: "rejected", ...expected });
+        expect(await readStoredCookie(storage)).toBeUndefined();
+    });
+
+    test("redirects are never followed, so a bounce cannot be laundered into a 200", async () => {
+        const storage = await freshStorage("timely-probe-redirect-mode");
+        const redirectModes: (RequestRedirect | undefined)[] = [];
+        stubFetch(async (_input, init) => {
+            redirectModes.push(init?.redirect);
+            return new Response("[]", { status: 200 });
+        });
+
+        await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=live" });
+
+        expect(redirectModes).toEqual(["manual"]);
     });
 
     test("an unreachable Timely never reaches disk either", async () => {

--- a/src/timely/api/cookie-probe.test.ts
+++ b/src/timely/api/cookie-probe.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readStoredCookie } from "@app/timely/utils/cookie";
+import { Storage } from "@genesiscz/utils/storage";
+import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
+import { probeAndSaveCookie } from "./cookie-probe";
+
+setupStorageSandbox();
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+function stubFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): void {
+    globalThis.fetch = impl as typeof fetch;
+}
+
+async function freshStorage(name: string): Promise<Storage> {
+    const storage = new Storage(name);
+    await storage.ensureDirs();
+    return storage;
+}
+
+describe("probeAndSaveCookie", () => {
+    test("a rejected cookie never reaches disk", async () => {
+        const storage = await freshStorage("timely-probe-rejected");
+        stubFetch(async () => new Response("nope", { status: 401 }));
+
+        const outcome = await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=stale" });
+
+        expect(outcome).toEqual({ status: "rejected", httpStatus: 401 });
+        expect(await readStoredCookie(storage)).toBeUndefined();
+    });
+
+    test("an unreachable Timely never reaches disk either", async () => {
+        const storage = await freshStorage("timely-probe-unreachable");
+        stubFetch(async () => {
+            throw new Error("socket hang up");
+        });
+
+        const outcome = await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=abc" });
+
+        expect(outcome.status).toBe("unreachable");
+        expect(await readStoredCookie(storage)).toBeUndefined();
+    });
+
+    test("only a 200 persists the cookie", async () => {
+        const storage = await freshStorage("timely-probe-accepted");
+        stubFetch(async () => new Response("[]", { status: 200 }));
+
+        const outcome = await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=live" });
+
+        expect(outcome.status).toBe("saved");
+        expect(await readStoredCookie(storage)).toBe("_memory_session=live");
+    });
+
+    test("the probe is made with the candidate cookie itself, against the selected account", async () => {
+        const storage = await freshStorage("timely-probe-request");
+        const seenUrls: string[] = [];
+        const seenCookies: (string | null)[] = [];
+        stubFetch(async (input, init) => {
+            seenUrls.push(String(input));
+            seenCookies.push(new Headers(init?.headers).get("Cookie"));
+            return new Response("[]", { status: 200 });
+        });
+
+        await probeAndSaveCookie({ storage, accountId: 558481, cookie: "_memory_session=live" });
+
+        expect(seenUrls).toHaveLength(1);
+        expect(seenUrls[0]).toContain("https://app.timelyapp.com/558481/suggested_entries.json");
+        expect(seenCookies).toEqual(["_memory_session=live"]);
+    });
+});

--- a/src/timely/api/cookie-probe.ts
+++ b/src/timely/api/cookie-probe.ts
@@ -1,0 +1,55 @@
+import { type SaveCookieResult, saveCookie } from "@app/timely/utils/cookie";
+import { logger } from "@genesiscz/utils/logger";
+import type { Storage } from "@genesiscz/utils/storage";
+
+/** Never let a stalled network leave `login cookies` waiting with no output. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+export type CookieProbeOutcome =
+    | { status: "saved"; saved: SaveCookieResult }
+    | { status: "rejected"; httpStatus: number }
+    | { status: "unreachable"; error: unknown };
+
+export interface ProbeAndSaveCookieOptions {
+    storage: Storage;
+    accountId: number;
+    cookie: string;
+}
+
+/**
+ * The rule that makes `login cookies` safe to paste into: a candidate credential
+ * reaches disk only after Timely answers 200 to a real request carrying it. A
+ * cookie that is expired, truncated by a half-copied clipboard, or simply wrong
+ * is refused here, so it never becomes a stored credential that fails later as an
+ * unexplained 401.
+ *
+ * The outcome is returned rather than printed, so the caller owns the wording and
+ * the exit code while this stays one testable unit. The value is a credential: it
+ * is sent, and never logged or echoed.
+ */
+export async function probeAndSaveCookie(options: ProbeAndSaveCookieOptions): Promise<CookieProbeOutcome> {
+    const { storage, accountId, cookie } = options;
+    const today = new Date().toISOString().slice(0, 10);
+    const url = `https://app.timelyapp.com/${accountId}/suggested_entries.json?date=${today}&spam=true`;
+
+    let response: Response;
+
+    try {
+        response = await fetch(url, {
+            headers: { accept: "application/json", Cookie: cookie },
+            signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+        });
+    } catch (error) {
+        logger.debug({ error, url }, "[login] the cookie probe could not reach Timely; nothing saved");
+        return { status: "unreachable", error };
+    }
+
+    if (!response.ok) {
+        logger.debug({ httpStatus: response.status, url }, "[login] Timely rejected the pasted cookie; nothing saved");
+        return { status: "rejected", httpStatus: response.status };
+    }
+
+    logger.debug("[login] Timely accepted the pasted cookie; storing it");
+
+    return { status: "saved", saved: await saveCookie(storage, cookie) };
+}

--- a/src/timely/api/cookie-probe.ts
+++ b/src/timely/api/cookie-probe.ts
@@ -1,13 +1,26 @@
 import { type SaveCookieResult, saveCookie } from "@app/timely/utils/cookie";
+import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
 
 /** Never let a stalled network leave `login cookies` waiting with no output. */
 const PROBE_TIMEOUT_MS = 15_000;
 
+/**
+ * Why a candidate cookie was refused. They need different wording, because
+ * "rejected" alone sends the user looking for the wrong mistake.
+ */
+export type CookieRejection =
+    /** A redirect, which is how the web host bounces an unauthenticated request to sign-in. */
+    | "redirected"
+    /** Any status other than a plain 200, including the other 2xx codes. */
+    | "http-status"
+    /** 200, but not the JSON array suggested_entries returns — the sign-in page answers like this. */
+    | "not-suggested-entries";
+
 export type CookieProbeOutcome =
     | { status: "saved"; saved: SaveCookieResult }
-    | { status: "rejected"; httpStatus: number }
+    | { status: "rejected"; httpStatus: number; reason: CookieRejection }
     | { status: "unreachable"; error: unknown };
 
 export interface ProbeAndSaveCookieOptions {
@@ -18,10 +31,15 @@ export interface ProbeAndSaveCookieOptions {
 
 /**
  * The rule that makes `login cookies` safe to paste into: a candidate credential
- * reaches disk only after Timely answers 200 to a real request carrying it. A
- * cookie that is expired, truncated by a half-copied clipboard, or simply wrong
- * is refused here, so it never becomes a stored credential that fails later as an
- * unexplained 401.
+ * reaches disk only after Timely serves real suggested-entries JSON in answer to
+ * a request carrying it. A cookie that is expired, truncated by a half-copied
+ * clipboard, or simply wrong is refused here, so it never becomes a stored
+ * credential that fails later as an unexplained 401.
+ *
+ * It fails closed on purpose, because a signed-out request to a WEB host does not
+ * come back as a 401 — it comes back as a redirect to a sign-in page, or as a 200
+ * carrying that page's HTML. Both look like success to `response.ok`, so neither
+ * `ok` nor a followed redirect can be trusted as proof of anything here.
  *
  * The outcome is returned rather than printed, so the caller owns the wording and
  * the exit code while this stays one testable unit. The value is a credential: it
@@ -37,6 +55,8 @@ export async function probeAndSaveCookie(options: ProbeAndSaveCookieOptions): Pr
     try {
         response = await fetch(url, {
             headers: { accept: "application/json", Cookie: cookie },
+            // Following the bounce to sign-in would turn a dead cookie into a 200.
+            redirect: "manual",
             signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
         });
     } catch (error) {
@@ -44,12 +64,44 @@ export async function probeAndSaveCookie(options: ProbeAndSaveCookieOptions): Pr
         return { status: "unreachable", error };
     }
 
-    if (!response.ok) {
-        logger.debug({ httpStatus: response.status, url }, "[login] Timely rejected the pasted cookie; nothing saved");
-        return { status: "rejected", httpStatus: response.status };
+    const reason = await rejectionFor(response);
+
+    if (reason) {
+        logger.debug(
+            { httpStatus: response.status, reason, url },
+            "[login] Timely did not accept the pasted cookie; nothing saved"
+        );
+
+        return { status: "rejected", httpStatus: response.status, reason };
     }
 
-    logger.debug("[login] Timely accepted the pasted cookie; storing it");
+    logger.debug("[login] Timely served suggested entries for the pasted cookie; storing it");
 
     return { status: "saved", saved: await saveCookie(storage, cookie) };
+}
+
+/** Undefined only when the response is a genuine, authenticated suggested_entries payload. */
+async function rejectionFor(response: Response): Promise<CookieRejection | undefined> {
+    if (response.status >= 300 && response.status < 400) {
+        return "redirected";
+    }
+
+    if (response.status !== 200) {
+        return "http-status";
+    }
+
+    const body = await response.text();
+
+    try {
+        // suggested_entries answers with a JSON array, empty on a day with no memories.
+        // The sign-in page is HTML, and an error payload is an object, so both fail here.
+        return Array.isArray(SafeJSON.parse(body, { strict: true })) ? undefined : "not-suggested-entries";
+    } catch (error) {
+        logger.debug(
+            { error, bodyPrefix: body.slice(0, 120) },
+            "[login] the probe answered 200 with a body that is not JSON"
+        );
+
+        return "not-suggested-entries";
+    }
 }

--- a/src/timely/api/cookie-probe.ts
+++ b/src/timely/api/cookie-probe.ts
@@ -2,6 +2,8 @@ import { type SaveCookieResult, saveCookie } from "@app/timely/utils/cookie";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
+import { isSessionRedirect } from "./errors";
+import { fetchTimelyWebResponse } from "./web-fetch";
 
 /** Never let a stalled network leave `login cookies` waiting with no output. */
 const PROBE_TIMEOUT_MS = 15_000;
@@ -53,11 +55,11 @@ export async function probeAndSaveCookie(options: ProbeAndSaveCookieOptions): Pr
     let response: Response;
 
     try {
-        response = await fetch(url, {
+        // Shared with every runtime fetch, so the no-follow policy is decided once.
+        response = await fetchTimelyWebResponse({
+            url,
             headers: { accept: "application/json", Cookie: cookie },
-            // Following the bounce to sign-in would turn a dead cookie into a 200.
-            redirect: "manual",
-            signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+            timeoutMs: PROBE_TIMEOUT_MS,
         });
     } catch (error) {
         logger.debug({ error, url }, "[login] the cookie probe could not reach Timely; nothing saved");
@@ -82,7 +84,7 @@ export async function probeAndSaveCookie(options: ProbeAndSaveCookieOptions): Pr
 
 /** Undefined only when the response is a genuine, authenticated suggested_entries payload. */
 async function rejectionFor(response: Response): Promise<CookieRejection | undefined> {
-    if (response.status >= 300 && response.status < 400) {
+    if (isSessionRedirect(response.status)) {
         return "redirected";
     }
 

--- a/src/timely/api/errors.test.ts
+++ b/src/timely/api/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isAuthStatus, isTimelyAuthFailure, TimelyHttpError } from "./errors";
+import { isAuthStatus, isCredentialRejection, isSessionRedirect, isTimelyAuthFailure, TimelyHttpError } from "./errors";
 
 describe("TimelyHttpError", () => {
     test("keeps the status and scope, and defaults usedCookie to false", () => {
@@ -23,11 +23,36 @@ describe("isAuthStatus", () => {
     });
 });
 
+describe("isSessionRedirect", () => {
+    test("a redirect is how a web host refuses a session, so 3xx counts and nothing else does", () => {
+        expect(isSessionRedirect(301)).toBe(true);
+        expect(isSessionRedirect(302)).toBe(true);
+        expect(isSessionRedirect(303)).toBe(true);
+        expect(isSessionRedirect(200)).toBe(false);
+        expect(isSessionRedirect(401)).toBe(false);
+        expect(isSessionRedirect(500)).toBe(false);
+    });
+});
+
+describe("isCredentialRejection", () => {
+    test("covers both the API host's 401/403 and the web host's sign-in bounce", () => {
+        expect(isCredentialRejection(401)).toBe(true);
+        expect(isCredentialRejection(403)).toBe(true);
+        expect(isCredentialRejection(302)).toBe(true);
+        expect(isCredentialRejection(200)).toBe(false);
+        expect(isCredentialRejection(500)).toBe(false);
+    });
+});
+
 describe("isTimelyAuthFailure", () => {
     test("narrows only Timely auth failures, not other errors or statuses", () => {
         expect(isTimelyAuthFailure(new TimelyHttpError("nope", { status: 403, scope: "memories" }))).toBe(true);
         expect(isTimelyAuthFailure(new TimelyHttpError("boom", { status: 500, scope: "memories" }))).toBe(false);
         expect(isTimelyAuthFailure(new Error("socket hang up"))).toBe(false);
         expect(isTimelyAuthFailure(undefined)).toBe(false);
+    });
+
+    test("a sign-in redirect is an auth failure, so callers abort instead of reporting empty days", () => {
+        expect(isTimelyAuthFailure(new TimelyHttpError("bounced", { status: 302, scope: "memories" }))).toBe(true);
     });
 });

--- a/src/timely/api/errors.test.ts
+++ b/src/timely/api/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { isAuthStatus, isTimelyAuthFailure, TimelyHttpError } from "./errors";
+
+describe("TimelyHttpError", () => {
+    test("keeps the status and scope, and defaults usedCookie to false", () => {
+        const err = new TimelyHttpError("nope", { status: 401, scope: "api" });
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err.name).toBe("TimelyHttpError");
+        expect(err.status).toBe(401);
+        expect(err.scope).toBe("api");
+        expect(err.usedCookie).toBe(false);
+    });
+});
+
+describe("isAuthStatus", () => {
+    test("only 401 and 403 mean the credentials were refused", () => {
+        expect(isAuthStatus(401)).toBe(true);
+        expect(isAuthStatus(403)).toBe(true);
+        expect(isAuthStatus(400)).toBe(false);
+        expect(isAuthStatus(404)).toBe(false);
+        expect(isAuthStatus(500)).toBe(false);
+    });
+});
+
+describe("isTimelyAuthFailure", () => {
+    test("narrows only Timely auth failures, not other errors or statuses", () => {
+        expect(isTimelyAuthFailure(new TimelyHttpError("nope", { status: 403, scope: "memories" }))).toBe(true);
+        expect(isTimelyAuthFailure(new TimelyHttpError("boom", { status: 500, scope: "memories" }))).toBe(false);
+        expect(isTimelyAuthFailure(new Error("socket hang up"))).toBe(false);
+        expect(isTimelyAuthFailure(undefined)).toBe(false);
+    });
+});

--- a/src/timely/api/errors.ts
+++ b/src/timely/api/errors.ts
@@ -31,7 +31,22 @@ export function isAuthStatus(status: number): boolean {
     return status === 401 || status === 403;
 }
 
+/**
+ * app.timelyapp.com is a web host, not the 1.1 API: it answers an unauthenticated
+ * request by bouncing to its sign-in page rather than with a 401. So a redirect
+ * here is a refused session, not a moved resource, and it has to be classified as
+ * one — otherwise a stale cookie reads as "this day has no memories".
+ */
+export function isSessionRedirect(status: number): boolean {
+    return status >= 300 && status < 400;
+}
+
+/** Every status that means "your credentials were refused", on either Timely host. */
+export function isCredentialRejection(status: number): boolean {
+    return isAuthStatus(status) || isSessionRedirect(status);
+}
+
 /** True when Timely refused the credentials rather than the request itself. */
 export function isTimelyAuthFailure(err: unknown): err is TimelyHttpError {
-    return err instanceof TimelyHttpError && isAuthStatus(err.status);
+    return err instanceof TimelyHttpError && isCredentialRejection(err.status);
 }

--- a/src/timely/api/errors.ts
+++ b/src/timely/api/errors.ts
@@ -1,0 +1,37 @@
+/**
+ * Which Timely surface produced the failure. They fail for different reasons:
+ * `api` is api.timelyapp.com/1.1 (OAuth bearer), `memories` is
+ * app.timelyapp.com's suggested_entries/entries JSON (browser session only),
+ * `token` is the OAuth token endpoint itself.
+ */
+export type TimelyRequestScope = "api" | "memories" | "token";
+
+/**
+ * An HTTP failure from Timely that keeps its status code, so callers can tell a
+ * rejected session (401/403) apart from a transient server error and report
+ * something the user can act on.
+ */
+export class TimelyHttpError extends Error {
+    readonly status: number;
+    readonly scope: TimelyRequestScope;
+    /** Whether a stored browser cookie was sent, which decides the remedy for a memories 401. */
+    readonly usedCookie: boolean;
+
+    constructor(message: string, options: { status: number; scope: TimelyRequestScope; usedCookie?: boolean }) {
+        super(message);
+        this.name = "TimelyHttpError";
+        this.status = options.status;
+        this.scope = options.scope;
+        this.usedCookie = options.usedCookie ?? false;
+    }
+}
+
+/** True when the status means Timely refused the credentials, not the request. */
+export function isAuthStatus(status: number): boolean {
+    return status === 401 || status === 403;
+}
+
+/** True when Timely refused the credentials rather than the request itself. */
+export function isTimelyAuthFailure(err: unknown): err is TimelyHttpError {
+    return err instanceof TimelyHttpError && isAuthStatus(err.status);
+}

--- a/src/timely/api/service.ts
+++ b/src/timely/api/service.ts
@@ -6,9 +6,12 @@ import type {
     TimelyProject,
     TimelyUser,
 } from "@app/timely/types";
+import { readStoredCookie } from "@app/timely/utils/cookie";
 import { logger } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
 import type { TimelyApiClient } from "./client";
+import { isTimelyAuthFailure } from "./errors";
+import { fetchTimelyWebJson } from "./web-fetch";
 
 export interface GetEventsParams {
     since?: string; // YYYY-MM-DD
@@ -29,6 +32,14 @@ export class TimelyService {
         private client: TimelyApiClient,
         private storage: Storage
     ) {}
+
+    /**
+     * A guaranteed-fresh access token, for callers that hit a Timely host the client
+     * does not wrap (memories live on app.timelyapp.com, not the 1.1 API host).
+     */
+    async getValidAccessToken(): Promise<string> {
+        return this.client.getValidAccessToken();
+    }
 
     // ============================================
     // Accounts
@@ -148,40 +159,43 @@ export class TimelyService {
             const entries = await this.storage.getFileOrPut<TimelyEntry[]>(
                 cacheKey,
                 async () => {
+                    // Entries live on the web host, which needs the browser session cookie.
+                    const cookie = await readStoredCookie(this.storage);
                     // Try different possible endpoints for entries
                     const endpoints = [`https://app.timelyapp.com/${accountId}/entries.json?id=${entryId}`];
 
                     for (const url of endpoints) {
                         try {
                             logger.debug(`[entry] Trying to fetch ${entryId} from ${url}...`);
-                            const response = await fetch(url, {
-                                method: "GET",
-                                headers: {
-                                    accept: "application/json",
-                                    "content-type": "application/json",
-                                    Authorization: `Bearer ${accessToken}`,
-                                },
+                            const data = await fetchTimelyWebJson({
+                                url,
+                                accessToken,
+                                cookie,
+                                scope: "memories",
+                                label: `Entry request for ${entryId}`,
                             });
 
-                            if (response.ok) {
-                                const data = await response.json();
-                                logger.debug(`[entry] Successfully fetched ${entryId}`);
-                                // Handle both direct data array and wrapped response format
-                                if (Array.isArray(data)) {
-                                    return data;
-                                }
-                                // If wrapped in { data: [...] }, unwrap it
-                                if (data && typeof data === "object" && "data" in data && Array.isArray(data.data)) {
-                                    return data.data;
-                                }
-                                // If it's a single entry object, wrap in array
-                                if (data && typeof data === "object" && "id" in data) {
-                                    return [data as TimelyEntry];
-                                }
-                                return [];
+                            logger.debug(`[entry] Successfully fetched ${entryId}`);
+                            // Handle both direct data array and wrapped response format
+                            if (Array.isArray(data)) {
+                                return data;
                             }
+                            // If wrapped in { data: [...] }, unwrap it
+                            if (data && typeof data === "object" && "data" in data && Array.isArray(data.data)) {
+                                return data.data;
+                            }
+                            // If it's a single entry object, wrap in array
+                            if (data && typeof data === "object" && "id" in data) {
+                                return [data as TimelyEntry];
+                            }
+
+                            return [];
                         } catch (error) {
-                            logger.debug(
+                            if (isTimelyAuthFailure(error)) {
+                                throw error;
+                            }
+
+                            logger.warn(
                                 `[entry] Failed to fetch from ${url}: ${error instanceof Error ? error.message : String(error)}`
                             );
                         }
@@ -197,6 +211,10 @@ export class TimelyService {
             // Storage.getFileOrPut always returns unwrapped data (array of TimelyEntry)
             return entries;
         } catch (error) {
+            if (isTimelyAuthFailure(error)) {
+                throw error;
+            }
+
             logger.debug(
                 `[entry] Error fetching entry ${entryId}: ${error instanceof Error ? error.message : String(error)}`
             );

--- a/src/timely/api/web-fetch.test.ts
+++ b/src/timely/api/web-fetch.test.ts
@@ -70,6 +70,33 @@ describe("fetchTimelyWebJson", () => {
         await expect(promise).rejects.toThrow("returned a non-JSON body (200)");
     });
 
+    test("a sign-in redirect is an auth failure carrying the real 3xx, not a followed 200", async () => {
+        const redirectModes: (RequestRedirect | undefined)[] = [];
+        stubFetch(async (_input, init) => {
+            redirectModes.push(init?.redirect);
+            return new Response(null, { status: 302, headers: { location: "/login" } });
+        });
+
+        const promise = fetchTimelyWebJson(options({ cookie: "_memory_session=stale" }));
+
+        await expect(promise).rejects.toThrow(TimelyHttpError);
+        await expect(promise).rejects.toMatchObject({ status: 302, scope: "memories", usedCookie: true });
+        await expect(promise).rejects.toThrow("was redirected to a sign-in page (302)");
+        // Same no-follow policy as the login probe, from the one helper both call.
+        expect(redirectModes).toEqual(["manual"]);
+    });
+
+    test("a redirect is classified as an auth failure, so callers abort the run", async () => {
+        stubFetch(async () => new Response(null, { status: 302, headers: { location: "/login" } }));
+
+        try {
+            await fetchTimelyWebJson(options({ cookie: "_memory_session=stale" }));
+            throw new Error("expected a rejection");
+        } catch (err) {
+            expect(isTimelyAuthFailure(err)).toBe(true);
+        }
+    });
+
     test("the request carries an abort signal, so a stalled host cannot hang the CLI", async () => {
         let signal: AbortSignal | null | undefined;
         stubFetch(async (_input, init) => {

--- a/src/timely/api/web-fetch.test.ts
+++ b/src/timely/api/web-fetch.test.ts
@@ -60,6 +60,16 @@ describe("fetchTimelyWebJson", () => {
         }
     });
 
+    test("a 200 carrying HTML rather than JSON becomes a TimelyHttpError, not a bare SyntaxError", async () => {
+        stubFetch(async () => new Response("<!DOCTYPE html><title>Sign in to Timely</title>", { status: 200 }));
+
+        const promise = fetchTimelyWebJson(options({ cookie: "_memory_session=stale" }));
+
+        await expect(promise).rejects.toThrow(TimelyHttpError);
+        await expect(promise).rejects.toMatchObject({ status: 200, scope: "memories", usedCookie: true });
+        await expect(promise).rejects.toThrow("returned a non-JSON body (200)");
+    });
+
     test("the request carries an abort signal, so a stalled host cannot hang the CLI", async () => {
         let signal: AbortSignal | null | undefined;
         stubFetch(async (_input, init) => {

--- a/src/timely/api/web-fetch.test.ts
+++ b/src/timely/api/web-fetch.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isTimelyAuthFailure, TimelyHttpError } from "./errors";
+import { fetchTimelyWebJson } from "./web-fetch";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+function stubFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): void {
+    globalThis.fetch = impl as typeof fetch;
+}
+
+function options(overrides: Partial<Parameters<typeof fetchTimelyWebJson>[0]> = {}) {
+    return {
+        url: "https://app.timelyapp.com/558481/entries.json?id=7",
+        accessToken: "tok",
+        scope: "memories" as const,
+        label: "Entry request for 7",
+        ...overrides,
+    };
+}
+
+describe("fetchTimelyWebJson", () => {
+    test("sends the stored cookie alongside the bearer and returns parsed JSON", async () => {
+        let sent: Headers | undefined;
+        stubFetch(async (_input, init) => {
+            sent = new Headers(init?.headers);
+            return new Response(SafeJSON.stringify([{ id: 7 }]), { status: 200 });
+        });
+
+        const data = await fetchTimelyWebJson(options({ cookie: "_memory_session=abc" }));
+
+        expect(data).toEqual([{ id: 7 }]);
+        expect(sent?.get("Cookie")).toBe("_memory_session=abc");
+        expect(sent?.get("Authorization")).toBe("Bearer tok");
+    });
+
+    test("a non-OK response throws TimelyHttpError carrying the status, scope and label", async () => {
+        stubFetch(async () => new Response("boom", { status: 500 }));
+
+        const promise = fetchTimelyWebJson(options());
+
+        await expect(promise).rejects.toThrow(TimelyHttpError);
+        await expect(promise).rejects.toMatchObject({ status: 500, scope: "memories", usedCookie: false });
+        await expect(promise).rejects.toThrow("Entry request for 7 failed (500)");
+    });
+
+    test("a 401 with a cookie is flagged usedCookie, so the caller can blame the cookie not the login", async () => {
+        stubFetch(async () => new Response("nope", { status: 401 }));
+
+        try {
+            await fetchTimelyWebJson(options({ cookie: "_memory_session=stale" }));
+            throw new Error("expected a rejection");
+        } catch (err) {
+            expect(isTimelyAuthFailure(err)).toBe(true);
+            expect(err).toMatchObject({ usedCookie: true });
+        }
+    });
+
+    test("the request carries an abort signal, so a stalled host cannot hang the CLI", async () => {
+        let signal: AbortSignal | null | undefined;
+        stubFetch(async (_input, init) => {
+            signal = init?.signal;
+            return new Response("[]", { status: 200 });
+        });
+
+        await fetchTimelyWebJson(options({ timeoutMs: 5_000 }));
+
+        expect(signal).toBeInstanceOf(AbortSignal);
+    });
+});

--- a/src/timely/api/web-fetch.ts
+++ b/src/timely/api/web-fetch.ts
@@ -1,4 +1,6 @@
 import { webSessionHeaders } from "@app/timely/utils/cookie";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
 import { TimelyHttpError, type TimelyRequestScope } from "./errors";
 
 /** Without a deadline a stalled app.timelyapp.com leaves the CLI waiting forever with no output. */
@@ -32,14 +34,30 @@ export async function fetchTimelyWebJson(options: TimelyWebJsonOptions): Promise
         signal: AbortSignal.timeout(options.timeoutMs ?? WEB_REQUEST_TIMEOUT_MS),
     });
 
+    const body = await response.text();
+
     if (!response.ok) {
-        const body = (await response.text()).slice(0, 200);
-        throw new TimelyHttpError(`${label} failed (${response.status}): ${body}`, {
+        throw new TimelyHttpError(`${label} failed (${response.status}): ${body.slice(0, 200)}`, {
             status: response.status,
             scope,
             usedCookie: Boolean(cookie),
         });
     }
 
-    return response.json();
+    try {
+        // Strict, so a remote body is held to real JSON rather than this repo's
+        // comment/trailing-comma tolerance.
+        return SafeJSON.parse(body, { strict: true });
+    } catch (err) {
+        // A 200 carrying HTML is how a web host serves a sign-in page, so the body is
+        // the only clue the caller gets. Keep the real status rather than inventing a
+        // 401: this stays a plain request failure, but one that names the surface and
+        // shows the body, instead of a bare SyntaxError from deep inside fetch.
+        logger.debug({ err, url, scope }, "Timely returned a body that is not JSON");
+        throw new TimelyHttpError(`${label} returned a non-JSON body (${response.status}): ${body.slice(0, 200)}`, {
+            status: response.status,
+            scope,
+            usedCookie: Boolean(cookie),
+        });
+    }
 }

--- a/src/timely/api/web-fetch.ts
+++ b/src/timely/api/web-fetch.ts
@@ -1,0 +1,45 @@
+import { webSessionHeaders } from "@app/timely/utils/cookie";
+import { TimelyHttpError, type TimelyRequestScope } from "./errors";
+
+/** Without a deadline a stalled app.timelyapp.com leaves the CLI waiting forever with no output. */
+const WEB_REQUEST_TIMEOUT_MS = 30_000;
+
+export interface TimelyWebJsonOptions {
+    url: string;
+    accessToken: string;
+    cookie?: string;
+    scope: TimelyRequestScope;
+    /** Prefix of the thrown message, e.g. "Memories request for 2026-07-24". */
+    label: string;
+    timeoutMs?: number;
+}
+
+/**
+ * One GET against a Timely web host (app.timelyapp.com), which authenticates
+ * with the browser session cookie rather than the OAuth bearer.
+ *
+ * Every caller needs the same three things on failure (the status code, which
+ * surface failed, and whether a cookie was sent), because those decide which
+ * remedy `reportTimelyFailure` prints. Keeping that in one place is why memories,
+ * entries and suggested_entries no longer each build their own TimelyHttpError.
+ */
+export async function fetchTimelyWebJson(options: TimelyWebJsonOptions): Promise<unknown> {
+    const { url, accessToken, cookie, scope, label } = options;
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers: webSessionHeaders({ accessToken, cookie }),
+        signal: AbortSignal.timeout(options.timeoutMs ?? WEB_REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        const body = (await response.text()).slice(0, 200);
+        throw new TimelyHttpError(`${label} failed (${response.status}): ${body}`, {
+            status: response.status,
+            scope,
+            usedCookie: Boolean(cookie),
+        });
+    }
+
+    return response.json();
+}

--- a/src/timely/api/web-fetch.ts
+++ b/src/timely/api/web-fetch.ts
@@ -1,10 +1,32 @@
 import { webSessionHeaders } from "@app/timely/utils/cookie";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
-import { TimelyHttpError, type TimelyRequestScope } from "./errors";
+import { isSessionRedirect, TimelyHttpError, type TimelyRequestScope } from "./errors";
 
 /** Without a deadline a stalled app.timelyapp.com leaves the CLI waiting forever with no output. */
 const WEB_REQUEST_TIMEOUT_MS = 30_000;
+
+export interface TimelyWebRequestOptions {
+    url: string;
+    headers: Record<string, string>;
+    timeoutMs: number;
+}
+
+/**
+ * Every request to a Timely web host goes through here, so the redirect policy is
+ * decided once. Following redirects is what turns a rejected session into a 200
+ * sign-in page, which then reads as an ordinary (empty, or malformed) result. Both
+ * the login probe and the runtime fetches need that not to happen, and a rule that
+ * has to be remembered at two call sites is a rule that gets remembered at one.
+ */
+export function fetchTimelyWebResponse(options: TimelyWebRequestOptions): Promise<Response> {
+    return fetch(options.url, {
+        method: "GET",
+        headers: options.headers,
+        redirect: "manual",
+        signal: AbortSignal.timeout(options.timeoutMs),
+    });
+}
 
 export interface TimelyWebJsonOptions {
     url: string;
@@ -28,11 +50,21 @@ export interface TimelyWebJsonOptions {
 export async function fetchTimelyWebJson(options: TimelyWebJsonOptions): Promise<unknown> {
     const { url, accessToken, cookie, scope, label } = options;
 
-    const response = await fetch(url, {
-        method: "GET",
+    const response = await fetchTimelyWebResponse({
+        url,
         headers: webSessionHeaders({ accessToken, cookie }),
-        signal: AbortSignal.timeout(options.timeoutMs ?? WEB_REQUEST_TIMEOUT_MS),
+        timeoutMs: options.timeoutMs ?? WEB_REQUEST_TIMEOUT_MS,
     });
+
+    if (isSessionRedirect(response.status)) {
+        // Kept as the real 3xx rather than a fabricated 401, because isTimelyAuthFailure
+        // now treats it as a refused session either way: the loop aborts on the first
+        // date and reportTimelyFailure names the cookie, instead of thirty empty days.
+        throw new TimelyHttpError(
+            `${label} was redirected to a sign-in page (${response.status}), so the session was not accepted`,
+            { status: response.status, scope, usedCookie: Boolean(cookie) }
+        );
+    }
 
     const body = await response.text();
 

--- a/src/timely/commands/create.ts
+++ b/src/timely/commands/create.ts
@@ -135,12 +135,19 @@ async function runCreate(storage: Storage, service: TimelyService, options: Crea
 
     p.intro(chalk.cyan(`Timely create — ${dates.length} day(s)`));
 
+    // Through the service so an aged-out token is refreshed first; the stored one
+    // may be months stale and would 401 every memory fetch.
+    const accessToken = await service.getValidAccessToken();
+
     const spin = p.spinner();
     spin.start("Loading memories + 8-week corpus...");
     const [memoriesResult, corpus] = await Promise.all([
-        fetchMemoriesForDates({ accountId, accessToken: tokens.access_token, dates, storage }),
+        fetchMemoriesForDates({ accountId, accessToken, dates, storage }),
         loadEventCorpus(storage, service, accountId),
-    ]);
+    ]).catch((err: unknown) => {
+        spin.stop("Could not load memories.");
+        throw err;
+    });
     spin.stop(`Loaded ${memoriesResult.entries.length} memories, ${corpus.length} past entries.`);
 
     const created: number[] = [];
@@ -234,8 +241,9 @@ async function runPlan(storage: Storage, service: TimelyService, options: Create
         process.exit(1);
     }
 
+    const accessToken = await service.getValidAccessToken();
     const [memoriesResult, corpus] = await Promise.all([
-        fetchMemoriesForDates({ accountId, accessToken: tokens.access_token, dates, storage }),
+        fetchMemoriesForDates({ accountId, accessToken, dates, storage }),
         loadEventCorpus(storage, service, accountId),
     ]);
 
@@ -356,7 +364,7 @@ async function runApply(storage: Storage, service: TimelyService, options: Creat
         service,
         storage,
         accountId,
-        accessToken: tokens.access_token,
+        accessToken: await service.getValidAccessToken(),
         dryRun: options.dryRun ?? false,
         onPayload: (day, idx, payload) => {
             out.println(chalk.dim(`\n--- ${day} event #${idx} ---`));

--- a/src/timely/commands/events.ts
+++ b/src/timely/commands/events.ts
@@ -139,9 +139,13 @@ async function eventsAction(storage: Storage, service: TimelyService, options: E
 
         const dates = [...new Set(events.map((e) => e.day))];
 
+        // Through the service so an aged-out token is refreshed first; the stored one
+        // may be months stale and would 401 every memory fetch.
+        const accessToken = await service.getValidAccessToken();
+
         const result = await fetchMemoriesForDates({
             accountId,
-            accessToken: tokens.access_token,
+            accessToken,
             dates,
             storage,
             force: options.force,

--- a/src/timely/commands/export-month.ts
+++ b/src/timely/commands/export-month.ts
@@ -1,5 +1,8 @@
+import { isTimelyAuthFailure } from "@app/timely/api/errors";
 import type { TimelyService } from "@app/timely/api/service";
+import { fetchTimelyWebJson } from "@app/timely/api/web-fetch";
 import type { TimelyEvent } from "@app/timely/types";
+import { readStoredCookie } from "@app/timely/utils/cookie";
 import { formatDuration, getDatesInMonth, getMonthDateRange } from "@app/timely/utils/date";
 import { generateReportMarkdown } from "@app/timely/utils/entry-processor";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -59,10 +62,17 @@ async function exportMonthAction(
         process.exit(1);
     }
 
+    // Through the service so an aged-out token is refreshed first; the stored one
+    // may be months stale and would 401 every download below.
+    const accessToken = await service.getValidAccessToken();
+    const cookie = await readStoredCookie(storage);
+
     const dates = getDatesInMonth(monthArg);
     const today = new Date().toISOString().split("T")[0];
 
     logger.info(chalk.yellow(`Downloading suggested_entries.json for ${dates.length} date(s) in ${monthArg}...`));
+
+    const failedDates: string[] = [];
 
     for (const date of dates) {
         const cacheKey = `suggested_entries/suggested_entries-${date}.json`;
@@ -77,26 +87,14 @@ async function exportMonthAction(
                     const url = `https://app.timelyapp.com/${accountId}/suggested_entries.json?date=${date}&spam=true`;
                     logger.debug(`[suggested_entries] Fetching ${date}...`);
 
-                    const response = await fetch(url, {
-                        method: "GET",
-                        headers: {
-                            accept: "application/json",
-                            "content-type": "application/json",
-                            Authorization: `Bearer ${tokens.access_token}`,
-                        },
+                    const data = await fetchTimelyWebJson({
+                        url,
+                        accessToken,
+                        cookie,
+                        scope: "memories",
+                        label: `Suggested entries for ${date}`,
                     });
 
-                    if (!response.ok) {
-                        const errorText = await response.text();
-                        logger.debug(
-                            `[suggested_entries] Failed for ${date}: ${response.status} ${response.statusText}`
-                        );
-                        throw new Error(
-                            `Failed to fetch suggested_entries for ${date}: ${response.status} ${errorText}`
-                        );
-                    }
-
-                    const data = await response.json();
                     logger.debug(
                         `[suggested_entries] Success for ${date}: ${
                             Array.isArray(data) ? `array[${data.length}]` : typeof data
@@ -107,10 +105,23 @@ async function exportMonthAction(
                 ttl
             );
         } catch (error: unknown) {
+            if (isTimelyAuthFailure(error)) {
+                // Credentials, not this date: the remaining 30 downloads would print the
+                // same 401. Stop so the caller can explain it once, with a remedy.
+                throw error;
+            }
+
             const errorMessage = error instanceof Error ? error.message : String(error);
+            failedDates.push(date);
             logger.error(`Failed to download suggested_entries for ${date}: ${errorMessage}`);
             // Continue with other dates even if one fails
         }
+    }
+
+    if (failedDates.length > 0) {
+        logger.warn(
+            `${failedDates.length} of ${dates.length} suggested_entries download(s) failed (${failedDates.join(", ")}); the report below is missing their memories.`
+        );
     }
 
     // Calculate date range
@@ -147,7 +158,7 @@ async function exportMonthAction(
             exportAsCsv(events);
             break;
         case "raw":
-            await exportAsRaw(events, monthArg, accountId, tokens.access_token, service);
+            await exportAsRaw(events, monthArg, accountId, accessToken, service);
             break;
         case "summary":
             await exportAsReport(monthArg, storage, silent, false);

--- a/src/timely/commands/login.ts
+++ b/src/timely/commands/login.ts
@@ -1,6 +1,7 @@
 import type { TimelyApiClient } from "@app/timely/api/client";
+import { probeAndSaveCookie } from "@app/timely/api/cookie-probe";
 import type { OAuthApplication } from "@app/timely/types";
-import { describeCookie, extractCookie, saveCookie } from "@app/timely/utils/cookie";
+import { describeCookie, extractCookie } from "@app/timely/utils/cookie";
 import { Browser } from "@genesiscz/utils/browser";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { readFromClipboard } from "@genesiscz/utils/clipboard";
@@ -154,22 +155,20 @@ async function cookieLogin(storage: Storage, options: { fromClipboard: boolean }
 
     logger.info(chalk.yellow("Checking the cookie against suggested_entries..."));
 
-    let response: Response;
+    const outcome = await probeAndSaveCookie({ storage, accountId, cookie });
 
-    try {
-        response = await probeCookie(accountId, cookie);
-    } catch (err) {
-        logger.error({ error: err }, "Could not reach Timely to check the cookie. Nothing was saved.");
+    if (outcome.status === "unreachable") {
+        logger.error({ error: outcome.error }, "Could not reach Timely to check the cookie. Nothing was saved.");
         process.exit(1);
     }
 
-    if (!response.ok) {
-        logger.error(`Timely rejected that cookie (HTTP ${response.status}). Nothing was saved.`);
+    if (outcome.status === "rejected") {
+        logger.error(`Timely rejected that cookie (HTTP ${outcome.httpStatus}). Nothing was saved.`);
         logger.info("Copy the request again from a page you are logged into, including every name=value pair.");
         process.exit(1);
     }
 
-    const saved = await saveCookie(storage, cookie);
+    const { saved } = outcome;
     logger.info(
         chalk.green(`Cookie accepted (HTTP 200) and saved to ${saved.path}${saved.ownerOnly ? " (mode 600)" : ""}.`)
     );
@@ -179,19 +178,6 @@ async function cookieLogin(storage: Storage, options: { fromClipboard: boolean }
     }
 
     logger.info("Memories work again: tools timely memories --day <YYYY-MM-DD>");
-}
-
-/** Never let a stalled network leave `login cookies` waiting with no output. */
-const PROBE_TIMEOUT_MS = 15_000;
-
-/** The single validation request. 200 means the cookie is a live browser session. */
-function probeCookie(accountId: number, cookie: string): Promise<Response> {
-    const today = new Date().toISOString().slice(0, 10);
-    const url = `https://app.timelyapp.com/${accountId}/suggested_entries.json?date=${today}&spam=true`;
-    return fetch(url, {
-        headers: { accept: "application/json", Cookie: cookie },
-        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    });
 }
 
 /** Read the clipboard without letting a headless/denied clipboard abort the command. */

--- a/src/timely/commands/login.ts
+++ b/src/timely/commands/login.ts
@@ -1,22 +1,70 @@
 import type { TimelyApiClient } from "@app/timely/api/client";
 import type { OAuthApplication } from "@app/timely/types";
+import { describeCookie, extractCookie, saveCookie } from "@app/timely/utils/cookie";
 import { Browser } from "@genesiscz/utils/browser";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { readFromClipboard } from "@genesiscz/utils/clipboard";
 import { logger } from "@genesiscz/utils/logger";
+import { multilineText } from "@genesiscz/utils/prompts/clack/multiline";
 import * as p from "@genesiscz/utils/prompts/p";
 import type { Storage } from "@genesiscz/utils/storage";
 import chalk from "chalk";
 import type { Command } from "commander";
 
 export function registerLoginCommand(program: Command, storage: Storage, client: TimelyApiClient): void {
-    program
+    const login = program
         .command("login")
-        .description("Authenticate with Timely via OAuth2")
+        .description("Authenticate with Timely (api-key for the API, cookies for memories)")
         .action(async () => {
-            await loginAction(storage, client);
+            await routeLogin(storage, client);
+        });
+
+    login
+        .command("api-key")
+        .description("OAuth2 flow for api.timelyapp.com (events, projects, accounts)")
+        .action(async () => {
+            await apiKeyLogin(storage, client);
+        });
+
+    login
+        .command("cookies")
+        .description("Store a browser Cookie header for app.timelyapp.com (memories)")
+        .option("--from-clipboard", "Take the cookie straight from the clipboard, no prompts (works without a TTY)")
+        .action(async (options: { fromClipboard?: boolean }) => {
+            await cookieLogin(storage, { fromClipboard: options.fromClipboard === true });
         });
 }
 
-async function loginAction(storage: Storage, client: TimelyApiClient): Promise<void> {
+/** Bare `tools timely login`: ask which credential, or explain both when there is no TTY. */
+async function routeLogin(storage: Storage, client: TimelyApiClient): Promise<void> {
+    if (!isInteractive()) {
+        logger.error("Choose a login method in non-interactive mode.");
+        logger.info(
+            `API access (events, projects, accounts): ${suggestCommand("tools timely", { replaceCommand: ["login", "api-key"] })}`
+        );
+        logger.info(
+            `Memories (browser session cookie): ${suggestCommand("tools timely", { replaceCommand: ["login", "cookies"] })}`
+        );
+        process.exit(1);
+    }
+
+    const method = (await p.select({
+        message: "What do you want to authenticate?",
+        options: [
+            { value: "api-key", label: "api-key - OAuth2 for the API (events, projects, accounts)" },
+            { value: "cookies", label: "cookies - browser session for memories (suggested entries)" },
+        ],
+    })) as string;
+
+    if (method === "cookies") {
+        await cookieLogin(storage, { fromClipboard: false });
+        return;
+    }
+
+    await apiKeyLogin(storage, client);
+}
+
+async function apiKeyLogin(storage: Storage, client: TimelyApiClient): Promise<void> {
     // Check if already logged in
     if (await client.isAuthenticated()) {
         const shouldReauth = await p.confirm({
@@ -87,4 +135,170 @@ async function loginAction(storage: Storage, client: TimelyApiClient): Promise<v
         logger.error(`Login failed: ${error}`);
         throw error;
     }
+}
+
+/**
+ * Memories live on app.timelyapp.com, which accepts only a browser session
+ * cookie. Get that cookie from wherever the user has it — the clipboard, a
+ * whole "Copy as cURL" paste, or a bare Cookie header — prove it works against
+ * one real request, and store it. The value is never echoed or logged.
+ */
+async function cookieLogin(storage: Storage, options: { fromClipboard: boolean }): Promise<void> {
+    const accountId = await storage.getConfigValue<number>("selectedAccountId");
+    if (!accountId) {
+        logger.error("No account selected. Run 'tools timely accounts --select' first.");
+        process.exit(1);
+    }
+
+    const cookie = options.fromClipboard ? await cookieFromClipboardOnly() : await cookieFromClipboardOrPaste(storage);
+
+    logger.info(chalk.yellow("Checking the cookie against suggested_entries..."));
+
+    let response: Response;
+
+    try {
+        response = await probeCookie(accountId, cookie);
+    } catch (err) {
+        logger.error({ error: err }, "Could not reach Timely to check the cookie. Nothing was saved.");
+        process.exit(1);
+    }
+
+    if (!response.ok) {
+        logger.error(`Timely rejected that cookie (HTTP ${response.status}). Nothing was saved.`);
+        logger.info("Copy the request again from a page you are logged into, including every name=value pair.");
+        process.exit(1);
+    }
+
+    const saved = await saveCookie(storage, cookie);
+    logger.info(
+        chalk.green(`Cookie accepted (HTTP 200) and saved to ${saved.path}${saved.ownerOnly ? " (mode 600)" : ""}.`)
+    );
+
+    if (!saved.ownerOnly) {
+        logger.warn(`${saved.path} is not owner-only. Anyone able to read that path can reuse your Timely session.`);
+    }
+
+    logger.info("Memories work again: tools timely memories --day <YYYY-MM-DD>");
+}
+
+/** Never let a stalled network leave `login cookies` waiting with no output. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+/** The single validation request. 200 means the cookie is a live browser session. */
+function probeCookie(accountId: number, cookie: string): Promise<Response> {
+    const today = new Date().toISOString().slice(0, 10);
+    const url = `https://app.timelyapp.com/${accountId}/suggested_entries.json?date=${today}&spam=true`;
+    return fetch(url, {
+        headers: { accept: "application/json", Cookie: cookie },
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+}
+
+/** Read the clipboard without letting a headless/denied clipboard abort the command. */
+async function readClipboardCookie(): Promise<string | undefined> {
+    try {
+        const clipboard = await readFromClipboard();
+        const extracted = extractCookie(clipboard);
+        if (!extracted) {
+            logger.debug("Clipboard holds no usable cookie.");
+            return undefined;
+        }
+
+        logger.debug(`Clipboard cookie found via ${extracted.source}.`);
+        return extracted.cookie;
+    } catch (err) {
+        logger.debug(`Could not read the clipboard: ${err}`);
+        return undefined;
+    }
+}
+
+/** `--from-clipboard`: no prompts, so it works in a script or without a TTY. */
+async function cookieFromClipboardOnly(): Promise<string> {
+    const cookie = await readClipboardCookie();
+    if (!cookie) {
+        logger.error("The clipboard holds no cookie. Copy the request as cURL from DevTools and try again.");
+        logger.info(
+            `Or paste it yourself: ${suggestCommand("tools timely", { replaceCommand: ["login", "cookies"] })}`
+        );
+        process.exit(1);
+    }
+
+    logger.info(chalk.green(`Using the clipboard cookie (${describeCookie(cookie)}).`));
+    return cookie;
+}
+
+/** Interactive path: offer the clipboard first, fall back to a paste. */
+async function cookieFromClipboardOrPaste(storage: Storage): Promise<string> {
+    if (!isInteractive()) {
+        logger.error("Pasting a cookie needs a TTY. Run 'tools timely login cookies' in a terminal.");
+        logger.info(
+            `Without a TTY, copy the request as cURL and run: ${suggestCommand("tools timely", { replaceCommand: ["login", "cookies"], add: ["--from-clipboard"] })}`
+        );
+        process.exit(1);
+    }
+
+    logger.info(chalk.cyan("\nIn a browser tab logged in to https://app.timelyapp.com:"));
+    logger.info("  DevTools > Network > any request to app.timelyapp.com > right-click > Copy > Copy as cURL");
+    logger.info("  (the plain 'Cookie:' header value works too).\n");
+
+    const fromClipboard = await readClipboardCookie();
+    if (fromClipboard) {
+        const useIt = await p.confirm({
+            message: `Use the cookie already on your clipboard? (${describeCookie(fromClipboard)})`,
+            initialValue: true,
+        });
+
+        if (useIt) {
+            return fromClipboard;
+        }
+    } else {
+        logger.info(chalk.gray("Nothing usable on the clipboard, so paste it instead."));
+    }
+
+    return promptForCookie(storage);
+}
+
+/**
+ * Two paste surfaces: a multiline one for a whole curl command (which no
+ * masked single-line prompt can take), and the masked one for a bare header.
+ */
+async function promptForCookie(storage: Storage): Promise<string> {
+    const method = (await p.select({
+        message: "How do you want to give it?",
+        options: [
+            { value: "curl", label: "paste the whole curl command (multiline; visible while you paste)" },
+            { value: "header", label: "paste just the Cookie header (hidden)" },
+        ],
+    })) as string;
+
+    const pasted =
+        method === "curl"
+            ? await pasteCurl()
+            : await p.password({ message: "Paste the Cookie header (or the whole curl):" });
+
+    const extracted = extractCookie(pasted);
+    if (!extracted) {
+        logger.error("Found no name=value cookie pairs in that. Nothing was saved.");
+        logger.info(`Config untouched: ${storage.getConfigPath()}`);
+        process.exit(1);
+    }
+
+    logger.debug(`Cookie extracted via ${extracted.source}.`);
+    logger.info(chalk.gray(`Read ${describeCookie(extracted.cookie)}.`));
+    return extracted.cookie;
+}
+
+async function pasteCurl(): Promise<string> {
+    logger.warn("Unlike the hidden prompt, this one shows what you paste; it is wiped from the screen on submit.");
+
+    const value = await multilineText({
+        message: "Paste the curl command, then press Enter twice:",
+    });
+
+    if (typeof value !== "string") {
+        logger.error("Cancelled. Cookie not saved.");
+        process.exit(1);
+    }
+
+    return value;
 }

--- a/src/timely/commands/login.ts
+++ b/src/timely/commands/login.ts
@@ -1,5 +1,5 @@
 import type { TimelyApiClient } from "@app/timely/api/client";
-import { probeAndSaveCookie } from "@app/timely/api/cookie-probe";
+import { type CookieRejection, probeAndSaveCookie } from "@app/timely/api/cookie-probe";
 import type { OAuthApplication } from "@app/timely/types";
 import { describeCookie, extractCookie } from "@app/timely/utils/cookie";
 import { Browser } from "@genesiscz/utils/browser";
@@ -163,7 +163,7 @@ async function cookieLogin(storage: Storage, options: { fromClipboard: boolean }
     }
 
     if (outcome.status === "rejected") {
-        logger.error(`Timely rejected that cookie (HTTP ${outcome.httpStatus}). Nothing was saved.`);
+        logger.error(rejectionMessage(outcome.httpStatus, outcome.reason));
         logger.info("Copy the request again from a page you are logged into, including every name=value pair.");
         process.exit(1);
     }
@@ -178,6 +178,24 @@ async function cookieLogin(storage: Storage, options: { fromClipboard: boolean }
     }
 
     logger.info("Memories work again: tools timely memories --day <YYYY-MM-DD>");
+}
+
+/**
+ * A signed-out request to app.timelyapp.com is answered with a bounce to sign-in,
+ * not a 401, so say which of the three refusals happened. "Rejected" alone sends
+ * the user re-copying a cookie when the real problem was that they were signed out
+ * in that tab.
+ */
+function rejectionMessage(httpStatus: number, reason: CookieRejection): string {
+    if (reason === "redirected") {
+        return `Timely bounced that request to a sign-in page (HTTP ${httpStatus}), so the cookie is not a live session. Nothing was saved.`;
+    }
+
+    if (reason === "not-suggested-entries") {
+        return "Timely answered 200, but with a sign-in page rather than suggested entries, so the cookie is not a live session. Nothing was saved.";
+    }
+
+    return `Timely rejected that cookie (HTTP ${httpStatus}). Nothing was saved.`;
 }
 
 /** Read the clipboard without letting a headless/denied clipboard abort the command. */

--- a/src/timely/commands/logout.ts
+++ b/src/timely/commands/logout.ts
@@ -1,4 +1,5 @@
 import type { TimelyConfig } from "@app/timely/types";
+import { clearStoredCookie } from "@app/timely/utils/cookie";
 import { logger } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
 import chalk from "chalk";
@@ -13,9 +14,21 @@ export function registerLogoutCommand(program: Command, storage: Storage): void 
             const config = (await storage.getConfig<TimelyConfig>()) || {};
             delete config.tokens;
             delete config.user;
+            delete config.authenticatedAt;
 
             await storage.setConfig(config);
 
-            logger.info(chalk.green("Logged out successfully."));
+            // The browser session is a second credential in its own file, and it keeps
+            // working on its own. Logging out has to revoke it too, or "logged out"
+            // leaves memories fully readable.
+            const hadCookie = await clearStoredCookie(storage);
+
+            logger.info(
+                chalk.green(
+                    hadCookie
+                        ? "Logged out successfully. API tokens and the stored browser session cookie were both removed."
+                        : "Logged out successfully."
+                )
+            );
         });
 }

--- a/src/timely/commands/memories.ts
+++ b/src/timely/commands/memories.ts
@@ -35,7 +35,7 @@ interface MemoriesOptions {
     force?: boolean;
 }
 
-async function memoriesAction(storage: Storage, _service: TimelyService, options: MemoriesOptions): Promise<void> {
+async function memoriesAction(storage: Storage, service: TimelyService, options: MemoriesOptions): Promise<void> {
     const accountId = options.account
         ? parseInt(options.account, 10)
         : await storage.getConfigValue<number>("selectedAccountId");
@@ -49,6 +49,10 @@ async function memoriesAction(storage: Storage, _service: TimelyService, options
         logger.error("Not authenticated. Run 'tools timely login' first.");
         process.exit(1);
     }
+
+    // Go through the service so an expired token is refreshed first; reading tokens
+    // straight from storage sends whatever was last persisted, which 401s once it ages out.
+    const accessToken = await service.getValidAccessToken();
 
     // Resolve --from/--to (primary) with --since/--upto (hidden aliases)
     const from = options.from || options.since;
@@ -78,7 +82,7 @@ async function memoriesAction(storage: Storage, _service: TimelyService, options
 
     const result = await fetchMemoriesForDates({
         accountId,
-        accessToken: tokens.access_token,
+        accessToken,
         dates,
         storage,
         force: options.force,

--- a/src/timely/commands/status.ts
+++ b/src/timely/commands/status.ts
@@ -1,5 +1,7 @@
 import type { TimelyApiClient } from "@app/timely/api/client";
 import type { TimelyConfig } from "@app/timely/types";
+import { readStoredCookie } from "@app/timely/utils/cookie";
+import { describeTokenLifetime } from "@app/timely/utils/token-status";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
@@ -13,6 +15,8 @@ export function registerStatusCommand(program: Command, storage: Storage, client
         .option("-f, --format <format>", "Output format: json, table", "table")
         .action(async (options) => {
             const config = await storage.getConfig<TimelyConfig>();
+            // The cookie lives in its own 0600 file, not in the config object.
+            const hasCookie = Boolean(await readStoredCookie(storage));
 
             if (options.format === "json") {
                 // Mask sensitive data (guard against undefined config)
@@ -22,6 +26,7 @@ export function registerStatusCommand(program: Command, storage: Storage, client
                     tokens: config?.tokens
                         ? { ...config.tokens, access_token: "***", refresh_token: "***" }
                         : undefined,
+                    cookie: hasCookie ? "***" : undefined,
                 };
                 out.println(SafeJSON.stringify(safeConfig, null, 2));
                 return;
@@ -37,10 +42,36 @@ export function registerStatusCommand(program: Command, storage: Storage, client
                 out.println(`User: ${config.user.name} (${config.user.email})`);
             }
 
-            if (config?.tokens?.created_at && config?.tokens?.expires_in) {
-                const expiresAt = new Date((config.tokens.created_at + config.tokens.expires_in) * 1000);
-                const isExpired = Date.now() > expiresAt.getTime();
-                out.println(`Token expires: ${expiresAt.toISOString()} ${isExpired ? chalk.red("(expired)") : ""}`);
+            const lifetime = describeTokenLifetime(config);
+
+            if (lifetime.kind === "known") {
+                out.println(
+                    `Token expires: ${lifetime.expiresAt.toISOString()} ${lifetime.expired ? chalk.red("(expired)") : ""}`
+                );
+            } else if (lifetime.kind === "fresh-login") {
+                // Right after a login the unknown-lifetime line reads like a fault. It is not:
+                // Timely just never sends expires_in, so the client always refreshes first.
+                out.println(
+                    `Token: ${chalk.green(`authenticated ${lifetime.age} ago`)}; lifetime unknown (no expires_in), refreshed on the next request`
+                );
+            } else if (lifetime.kind === "unknown") {
+                // Timely often omits expires_in; the client then treats the token as
+                // expired and refreshes, so say that rather than printing nothing.
+                out.println(
+                    `Token expires: ${chalk.yellow("unknown (no expires_in) - refreshed on the next request")}`
+                );
+            }
+
+            // Memories credential (value never printed)
+            if (hasCookie) {
+                const updated = config?.cookieUpdatedAt
+                    ? new Date(config.cookieUpdatedAt * 1000).toISOString()
+                    : "unknown";
+                out.println(`Memories cookie: ${chalk.green("stored")} (updated ${updated})`);
+            } else {
+                out.println(
+                    `Memories cookie: ${chalk.red("not stored")} - run 'tools timely login cookies' for memories`
+                );
             }
 
             // Selected account/project

--- a/src/timely/index.ts
+++ b/src/timely/index.ts
@@ -3,7 +3,7 @@
 // src/timely/index.ts
 
 import { enhanceHelp, runTool } from "@genesiscz/utils/cli";
-import { logger, out } from "@genesiscz/utils/logger";
+import { out } from "@genesiscz/utils/logger";
 import * as p from "@genesiscz/utils/prompts/p";
 import { inquirerBackend } from "@genesiscz/utils/prompts/p/inquirer-backend";
 import { Storage } from "@genesiscz/utils/storage";
@@ -22,6 +22,7 @@ import { registerLogoutCommand } from "./commands/logout";
 import { registerMemoriesCommand } from "./commands/memories";
 import { registerProjectsCommand } from "./commands/projects";
 import { registerStatusCommand } from "./commands/status";
+import { reportTimelyFailure } from "./utils/failure";
 
 // Use inquirer backend for this tool
 p.setBackend(inquirerBackend);
@@ -116,7 +117,7 @@ async function main(): Promise<void> {
     await runTool(program, { tool: "timely" });
 }
 
-main().catch((err) => {
-    logger.error(`Unexpected error: ${err}`);
+main().catch(async (err) => {
+    await reportTimelyFailure(err, service);
     process.exit(1);
 });

--- a/src/timely/types/config.ts
+++ b/src/timely/types/config.ts
@@ -31,6 +31,9 @@ export interface TimelyConfig {
     selectedProjectId?: number; // Default project ID (optional)
     accounts?: TimelyAccount[]; // Cached list of accounts
     projects?: TimelyProject[]; // Cached list of projects
+    cookie?: string; // Legacy location of the browser session Cookie header; now its own 0600 file, read once to migrate
+    cookieUpdatedAt?: number; // Unix seconds, when the cookie was last stored
+    authenticatedAt?: number; // Unix seconds of the last authorization-code exchange (NOT bumped by refreshes)
     user?: {
         id: number;
         email: string;

--- a/src/timely/utils/cookie-store.test.ts
+++ b/src/timely/utils/cookie-store.test.ts
@@ -3,7 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { Storage } from "@genesiscz/utils/storage";
 import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
-import { readStoredCookie, saveCookie } from "./cookie";
+import { clearStoredCookie, readStoredCookie, saveCookie } from "./cookie";
 
 setupStorageSandbox();
 
@@ -48,6 +48,35 @@ describe("cookie storage", () => {
         expect(existsSync(path)).toBe(true);
         expect(statSync(path).mode & 0o777).toBe(0o600);
         expect(await storage.getConfigValue<string>("cookie")).toBeUndefined();
+    });
+
+    // The cookie is a second credential that works on its own, so logout has to reach it.
+    test("clearing removes the cookie file and its metadata, so logout really logs out", async () => {
+        const storage = await freshStorage("timely-cookie-clear-test");
+        const { path } = await saveCookie(storage, COOKIE);
+
+        const hadCookie = await clearStoredCookie(storage);
+
+        expect(hadCookie).toBe(true);
+        expect(existsSync(path)).toBe(false);
+        expect(await readStoredCookie(storage)).toBeUndefined();
+        expect(await storage.getConfigValue<number>("cookieUpdatedAt")).toBeUndefined();
+    });
+
+    test("clearing a cookie left in config.json by an older build also revokes it", async () => {
+        const storage = await freshStorage("timely-cookie-clear-legacy-test");
+        await storage.setConfigValue("cookie", COOKIE);
+
+        const hadCookie = await clearStoredCookie(storage);
+
+        expect(hadCookie).toBe(true);
+        expect(await readStoredCookie(storage)).toBeUndefined();
+    });
+
+    test("clearing when nothing is stored reports that there was nothing to revoke", async () => {
+        const storage = await freshStorage("timely-cookie-clear-empty-test");
+
+        expect(await clearStoredCookie(storage)).toBe(false);
     });
 
     test("no stored cookie reads as undefined rather than an empty header", async () => {

--- a/src/timely/utils/cookie-store.test.ts
+++ b/src/timely/utils/cookie-store.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { Storage } from "@genesiscz/utils/storage";
+import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
+import { readStoredCookie, saveCookie } from "./cookie";
+
+setupStorageSandbox();
+
+const COOKIE = "_memory_session=abc; revision=12";
+
+async function freshStorage(name: string): Promise<Storage> {
+    const storage = new Storage(name);
+    await storage.ensureDirs();
+    return storage;
+}
+
+describe("cookie storage", () => {
+    test("the cookie lands in its own owner-only file, never in config.json", async () => {
+        const storage = await freshStorage("timely-cookie-mode-test");
+
+        const saved = await saveCookie(storage, COOKIE);
+
+        expect(saved.path).toBe(join(storage.getBaseDir(), "cookie"));
+        expect(saved.ownerOnly).toBe(true);
+        expect(statSync(saved.path).mode & 0o777).toBe(0o600);
+        expect(await storage.getConfigValue<string>("cookie")).toBeUndefined();
+        expect(await readStoredCookie(storage)).toBe(COOKIE);
+    });
+
+    test("saving records when the cookie was stored, for tools timely status", async () => {
+        const storage = await freshStorage("timely-cookie-updated-test");
+        const before = Math.floor(Date.now() / 1000);
+
+        await saveCookie(storage, COOKIE);
+
+        const updatedAt = await storage.getConfigValue<number>("cookieUpdatedAt");
+        expect(updatedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    test("a cookie left in config.json by an older build is moved into the 0600 file and removed", async () => {
+        const storage = await freshStorage("timely-cookie-migrate-test");
+        await storage.setConfigValue("cookie", COOKIE);
+
+        expect(await readStoredCookie(storage)).toBe(COOKIE);
+
+        const path = join(storage.getBaseDir(), "cookie");
+        expect(existsSync(path)).toBe(true);
+        expect(statSync(path).mode & 0o777).toBe(0o600);
+        expect(await storage.getConfigValue<string>("cookie")).toBeUndefined();
+    });
+
+    test("no stored cookie reads as undefined rather than an empty header", async () => {
+        const storage = await freshStorage("timely-cookie-absent-test");
+
+        expect(await readStoredCookie(storage)).toBeUndefined();
+    });
+});

--- a/src/timely/utils/cookie.test.ts
+++ b/src/timely/utils/cookie.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import {
+    describeCookie,
+    extractCookie,
+    looksLikeCookiePairs,
+    normalizeCookieHeader,
+    webSessionHeaders,
+} from "./cookie";
+
+const COOKIE = "login_form_alert=1; _memory_session=abc%3D%3D; ajs_group_id=558481; tic-session=zzz";
+
+describe("normalizeCookieHeader", () => {
+    test("keeps a plain pasted header", () => {
+        expect(normalizeCookieHeader("_memory_session=abc; revision=12")).toBe("_memory_session=abc; revision=12");
+    });
+
+    test("strips the copied 'Cookie:' label", () => {
+        expect(normalizeCookieHeader("Cookie: _memory_session=abc")).toBe("_memory_session=abc");
+        expect(normalizeCookieHeader("cookie:_memory_session=abc")).toBe("_memory_session=abc");
+    });
+
+    test("strips wrapping quotes and whitespace", () => {
+        expect(normalizeCookieHeader('  "_memory_session=abc"  ')).toBe("_memory_session=abc");
+    });
+});
+
+describe("webSessionHeaders", () => {
+    test("sends the cookie alongside the bearer", () => {
+        const headers = webSessionHeaders({ accessToken: "tok", cookie: "_memory_session=abc" });
+
+        expect(headers.Cookie).toBe("_memory_session=abc");
+        expect(headers.Authorization).toBe("Bearer tok");
+    });
+
+    test("omits the Cookie header when none is stored", () => {
+        const headers = webSessionHeaders({ accessToken: "tok" });
+
+        expect(headers.Cookie).toBeUndefined();
+        expect(headers.Authorization).toBe("Bearer tok");
+    });
+});
+
+describe("extractCookie", () => {
+    test("reads -b from a backslash-continued curl copied from DevTools", () => {
+        const pasted = `curl 'https://app.timelyapp.com/558481/suggested_hours?since=2026-08-03&until=2026-08-09' \\
+  -H 'accept: application/json' \\
+  -b '${COOKIE}' \\
+  -H 'referer: https://app.timelyapp.com/558481/calendar/week?date=2026-08-03'`;
+
+        expect(extractCookie(pasted)).toEqual({ cookie: COOKIE, source: "curl-cookie-flag" });
+    });
+
+    test("reads --cookie with double quotes", () => {
+        expect(extractCookie(`curl "https://app.timelyapp.com/558481/x" --cookie "${COOKIE}"`)).toEqual({
+            cookie: COOKIE,
+            source: "curl-cookie-flag",
+        });
+    });
+
+    test("reads -H 'cookie: …' and -H 'Cookie: …'", () => {
+        expect(extractCookie(`curl 'https://x' -H 'cookie: ${COOKIE}'`)).toEqual({
+            cookie: COOKIE,
+            source: "curl-header-flag",
+        });
+        expect(extractCookie(`curl 'https://x' -H "Cookie: ${COOKIE}"`)).toEqual({
+            cookie: COOKIE,
+            source: "curl-header-flag",
+        });
+        expect(extractCookie(`curl 'https://x' --header 'Cookie: ${COOKIE}'`)).toEqual({
+            cookie: COOKIE,
+            source: "curl-header-flag",
+        });
+    });
+
+    test("reads Chrome's $'…' ANSI-C quoting", () => {
+        const withQuote = `sess=a\\'b; other=2`;
+        expect(extractCookie(`curl 'https://x' -b $'${withQuote}'`)).toEqual({
+            cookie: "sess=a'b; other=2",
+            source: "curl-cookie-flag",
+        });
+    });
+
+    test("never mistakes the URL or another header for the cookie", () => {
+        const noCookie = `curl 'https://app.timelyapp.com/558481/suggested_hours?since=2026-08-03' \\
+  -H 'accept: application/json' \\
+  -H 'referer: https://app.timelyapp.com/558481/calendar/week'`;
+
+        expect(extractCookie(noCookie)).toBeUndefined();
+    });
+
+    test("accepts a bare Cookie: header line, with or without a trailing continuation", () => {
+        expect(extractCookie(`Cookie: ${COOKIE}`)).toEqual({ cookie: COOKIE, source: "header-line" });
+        expect(extractCookie(`cookie: ${COOKIE} \\`)).toEqual({ cookie: COOKIE, source: "header-line" });
+    });
+
+    test("accepts a bare name=v; name2=v2 string", () => {
+        expect(extractCookie(COOKIE)).toEqual({ cookie: COOKIE, source: "raw-pairs" });
+        expect(extractCookie(`  ${COOKIE}  `)).toEqual({ cookie: COOKIE, source: "raw-pairs" });
+    });
+
+    test("finds the cookie line inside a pasted request-headers block", () => {
+        const block = `:authority: app.timelyapp.com
+accept: application/json
+Cookie: ${COOKIE}
+referer: https://app.timelyapp.com/558481/calendar/week`;
+
+        expect(extractCookie(block)).toEqual({ cookie: COOKIE, source: "header-line" });
+    });
+
+    test("returns undefined for empty or unusable input", () => {
+        expect(extractCookie("")).toBeUndefined();
+        expect(extractCookie("   \n  ")).toBeUndefined();
+        expect(extractCookie("https://app.timelyapp.com/558481/calendar/week?date=2026-08-03")).toBeUndefined();
+        expect(extractCookie("just some words the user copied by mistake")).toBeUndefined();
+    });
+});
+
+describe("looksLikeCookiePairs", () => {
+    test("accepts real cookie strings and rejects URLs and header values", () => {
+        expect(looksLikeCookiePairs(COOKIE)).toBe(true);
+        expect(looksLikeCookiePairs("one=1")).toBe(true);
+        expect(looksLikeCookiePairs("https://app.timelyapp.com/558481/x?since=2026-08-03")).toBe(false);
+        expect(looksLikeCookiePairs("accept: application/json")).toBe(false);
+        expect(looksLikeCookiePairs("")).toBe(false);
+    });
+});
+
+describe("describeCookie", () => {
+    test("names the cookies without revealing a single value", () => {
+        const described = describeCookie(COOKIE);
+
+        expect(described).toBe("4 cookies: login_form_alert, _memory_session, ajs_group_id, tic-session");
+        expect(described).not.toContain("abc%3D%3D");
+        expect(described).not.toContain("558481");
+    });
+
+    test("caps the list for a long cookie", () => {
+        expect(describeCookie("a=1; b=2; c=3; d=4; e=5; f=6")).toBe("6 cookies: a, b, c, d, +2 more");
+    });
+});

--- a/src/timely/utils/cookie.test.ts
+++ b/src/timely/utils/cookie.test.ts
@@ -4,6 +4,7 @@ import {
     extractCookie,
     looksLikeCookiePairs,
     normalizeCookieHeader,
+    shellTokens,
     webSessionHeaders,
 } from "./cookie";
 
@@ -112,6 +113,27 @@ referer: https://app.timelyapp.com/558481/calendar/week`;
         expect(extractCookie("   \n  ")).toBeUndefined();
         expect(extractCookie("https://app.timelyapp.com/558481/calendar/week?date=2026-08-03")).toBeUndefined();
         expect(extractCookie("just some words the user copied by mistake")).toBeUndefined();
+    });
+});
+
+// Expectations below are the output of the same string run through bash itself.
+describe("shellTokens", () => {
+    test("a backslash pair inside $'…' collapses to one, instead of doubling", () => {
+        expect(shellTokens(String.raw`curl -b $'sess=a\\b; x=1'`)).toEqual(["curl", "-b", String.raw`sess=a\b; x=1`]);
+    });
+
+    test("a trailing backslash pair cannot escape the closing quote and swallow the next flag", () => {
+        expect(shellTokens(String.raw`curl -b $'sess=a\\' -H 'accept: application/json'`)).toEqual([
+            "curl",
+            "-b",
+            "sess=a\\",
+            "-H",
+            "accept: application/json",
+        ]);
+    });
+
+    test("a plain '…' keeps a backslash literal, the way a shell does", () => {
+        expect(shellTokens(String.raw`curl -b 'sess=a\b'`)).toEqual(["curl", "-b", String.raw`sess=a\b`]);
     });
 });
 

--- a/src/timely/utils/cookie.test.ts
+++ b/src/timely/utils/cookie.test.ts
@@ -108,6 +108,17 @@ referer: https://app.timelyapp.com/558481/calendar/week`;
         expect(extractCookie(block)).toEqual({ cookie: COOKIE, source: "header-line" });
     });
 
+    test("a curl flag wins over a bare Cookie: line elsewhere in the same paste", () => {
+        // Both parse as cookie pairs, so only the source order decides. The whole token
+        // scan runs before any line scan, which is what makes this independent of where
+        // the stray line sits.
+        const both = `curl 'https://app.timelyapp.com/558481/x' -b 'from_b=1' \\
+  -H 'accept: application/json'
+Cookie: from_header_line=2`;
+
+        expect(extractCookie(both)).toEqual({ cookie: "from_b=1", source: "curl-cookie-flag" });
+    });
+
     test("returns undefined for empty or unusable input", () => {
         expect(extractCookie("")).toBeUndefined();
         expect(extractCookie("   \n  ")).toBeUndefined();
@@ -135,6 +146,13 @@ describe("shellTokens", () => {
     test("a plain '…' keeps a backslash literal, the way a shell does", () => {
         expect(shellTokens(String.raw`curl -b 'sess=a\b'`)).toEqual(["curl", "-b", String.raw`sess=a\b`]);
     });
+
+    test("an unclosed quote yields the rest as one token rather than dropping it", () => {
+        // A half-copied paste. Returning the partial value is deliberate: the login
+        // command probes it against Timely and refuses to save anything but a 200,
+        // so a truncated cookie is rejected there rather than silently stored.
+        expect(shellTokens("curl -b 'sess=abc")).toEqual(["curl", "-b", "sess=abc"]);
+    });
 });
 
 describe("looksLikeCookiePairs", () => {
@@ -154,6 +172,10 @@ describe("describeCookie", () => {
         expect(described).toBe("4 cookies: login_form_alert, _memory_session, ajs_group_id, tic-session");
         expect(described).not.toContain("abc%3D%3D");
         expect(described).not.toContain("558481");
+    });
+
+    test("says 'cookie' not 'cookies' for a single pair", () => {
+        expect(describeCookie("sess=abc")).toBe("1 cookie: sess");
     });
 
     test("caps the list for a long cookie", () => {

--- a/src/timely/utils/cookie.test.ts
+++ b/src/timely/utils/cookie.test.ts
@@ -108,15 +108,17 @@ referer: https://app.timelyapp.com/558481/calendar/week`;
         expect(extractCookie(block)).toEqual({ cookie: COOKIE, source: "header-line" });
     });
 
-    test("a curl flag wins over a bare Cookie: line elsewhere in the same paste", () => {
-        // Both parse as cookie pairs, so only the source order decides. The whole token
-        // scan runs before any line scan, which is what makes this independent of where
-        // the stray line sits.
-        const both = `curl 'https://app.timelyapp.com/558481/x' -b 'from_b=1' \\
-  -H 'accept: application/json'
-Cookie: from_header_line=2`;
+    // Both halves parse as cookie pairs, so only source precedence decides the winner.
+    // Both orderings are asserted on purpose: with only the flag-first case a naive
+    // first-match parser would pass while still returning the line when it comes first.
+    const CURL_LINE = `curl 'https://app.timelyapp.com/558481/x' -b 'from_b=1' -H 'accept: application/json'`;
+    const STRAY_LINE = "Cookie: from_header_line=2";
 
-        expect(extractCookie(both)).toEqual({ cookie: "from_b=1", source: "curl-cookie-flag" });
+    test.each([
+        ["curl flag first", `${CURL_LINE}\n${STRAY_LINE}`],
+        ["stray Cookie: line first", `${STRAY_LINE}\n${CURL_LINE}`],
+    ])("a curl flag beats a bare Cookie: line in the same paste (%s)", (_name, pasted) => {
+        expect(extractCookie(pasted)).toEqual({ cookie: "from_b=1", source: "curl-cookie-flag" });
     });
 
     test("returns undefined for empty or unusable input", () => {
@@ -148,9 +150,10 @@ describe("shellTokens", () => {
     });
 
     test("an unclosed quote yields the rest as one token rather than dropping it", () => {
-        // A half-copied paste. Returning the partial value is deliberate: the login
-        // command probes it against Timely and refuses to save anything but a 200,
-        // so a truncated cookie is rejected there rather than silently stored.
+        // A half-copied paste. Returning the partial value is deliberate: it is
+        // probeAndSaveCookie that refuses to persist anything Timely does not answer
+        // 200 to, so a truncated cookie is rejected there rather than silently stored.
+        // That guarantee is pinned by cookie-probe.test.ts, not assumed here.
         expect(shellTokens("curl -b 'sess=abc")).toEqual(["curl", "-b", "sess=abc"]);
     });
 });

--- a/src/timely/utils/cookie.ts
+++ b/src/timely/utils/cookie.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { logger } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
@@ -76,13 +76,48 @@ async function migrateLegacyCookie(storage: Storage): Promise<string | undefined
         return undefined;
     }
 
-    writeCookieFile(cookiePath(storage), legacy);
+    const path = cookiePath(storage);
+    const ownerOnly = writeCookieFile(path, legacy);
     await storage.atomicConfigUpdate<Record<string, unknown>>((config) => {
         delete config[LEGACY_COOKIE_KEY];
     });
-    logger.info("Moved the stored Timely cookie out of config.json into its own owner-only file.");
+
+    if (ownerOnly) {
+        logger.info("Moved the stored Timely cookie out of config.json into its own owner-only file.");
+    } else {
+        // The legacy key is still removed: leaving the credential in config.json as well
+        // would mean two readable copies instead of one. Say plainly that the promise in
+        // the other branch does not hold here, rather than logging success either way.
+        logger.warn(
+            `Moved the stored Timely cookie out of config.json into ${path}, but could not restrict that file to owner-only (0600). Anyone able to read it can reuse your Timely session.`
+        );
+    }
 
     return legacy;
+}
+
+/**
+ * Forget the browser session. `logout` has to reach this too: the cookie is a
+ * second, independently usable credential, so clearing only the OAuth tokens
+ * would report a successful logout while leaving memories fully accessible.
+ */
+export async function clearStoredCookie(storage: Storage): Promise<boolean> {
+    const path = cookiePath(storage);
+    const existed = existsSync(path);
+
+    if (existed) {
+        unlinkSync(path);
+        logger.debug({ path }, "[cookie] removed the stored Timely browser session");
+    }
+
+    let hadLegacy = false;
+    await storage.atomicConfigUpdate<Record<string, unknown>>((config) => {
+        hadLegacy = config[LEGACY_COOKIE_KEY] !== undefined;
+        delete config[LEGACY_COOKIE_KEY];
+        delete config[COOKIE_UPDATED_KEY];
+    });
+
+    return existed || hadLegacy;
 }
 
 /** Strip a pasted "Cookie: " prefix and surrounding whitespace/quotes. */

--- a/src/timely/utils/cookie.ts
+++ b/src/timely/utils/cookie.ts
@@ -120,12 +120,18 @@ export function looksLikeCookiePairs(value: string): boolean {
  * "Copy as cURL" survives whichever quoting the browser chose. Handles single
  * quotes, double quotes, bash's `$'...'` (Chrome emits it when a header value
  * contains a quote), backslash escapes and backslash-newline continuations.
+ *
+ * Inside `$'...'` a backslash escapes the next character literally. The ANSI-C
+ * control escapes (`\n`, `\t`, `\xNN`) are deliberately left untranslated: a
+ * Cookie header cannot legally carry those bytes, so decoding them would only
+ * turn a malformed paste into a header value that looks valid.
  */
 export function shellTokens(input: string): string[] {
     const tokens: string[] = [];
     let current = "";
     let started = false;
     let quote: "'" | '"' | null = null;
+    let ansiC = false;
 
     for (let i = 0; i < input.length; i++) {
         const char = input[i];
@@ -133,10 +139,14 @@ export function shellTokens(input: string): string[] {
         if (quote) {
             if (char === quote) {
                 quote = null;
+                ansiC = false;
                 continue;
             }
 
-            if (char === "\\" && i + 1 < input.length && (quote === '"' || input[i + 1] === "'")) {
+            // Only "…" and $'…' process escapes; inside a plain '…' a backslash is
+            // literal. Consuming the whole pair is what stops a trailing `\\` from
+            // escaping the closing quote and swallowing the rest of the command.
+            if (char === "\\" && i + 1 < input.length && (quote === '"' || ansiC)) {
                 current += input[i + 1];
                 i++;
                 continue;
@@ -148,6 +158,7 @@ export function shellTokens(input: string): string[] {
 
         if (char === "$" && (input[i + 1] === "'" || input[i + 1] === '"')) {
             quote = input[i + 1] as "'" | '"';
+            ansiC = quote === "'";
             started = true;
             i++;
             continue;

--- a/src/timely/utils/cookie.ts
+++ b/src/timely/utils/cookie.ts
@@ -1,0 +1,284 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+import type { Storage } from "@genesiscz/utils/storage";
+
+/**
+ * app.timelyapp.com (memories / suggested entries / entries) authenticates with
+ * the browser session cookie only. It rejects OAuth bearer tokens, so the whole
+ * Cookie header is stored and sent with those requests.
+ *
+ * The value is a credential: never log it, never print it back. It lives in its
+ * own 0600 file rather than in config.json, because Storage rewrites the config
+ * through a fresh umask-created temp file plus rename on every write. That
+ * replaces the inode, so a mode set on the config never survives the next
+ * unrelated update (a token refresh, an account switch).
+ */
+const COOKIE_FILE = "cookie";
+const COOKIE_FILE_MODE = 0o600;
+const COOKIE_UPDATED_KEY = "cookieUpdatedAt";
+/** Where the cookie used to be stored, before it got its own file. */
+const LEGACY_COOKIE_KEY = "cookie";
+
+export interface SaveCookieResult {
+    /** Absolute path the cookie was written to. */
+    path: string;
+    /** True only when the file is verifiably owner-only on disk, so callers never over-promise. */
+    ownerOnly: boolean;
+}
+
+function cookiePath(storage: Storage): string {
+    return join(storage.getBaseDir(), COOKIE_FILE);
+}
+
+export async function readStoredCookie(storage: Storage): Promise<string | undefined> {
+    const path = cookiePath(storage);
+
+    if (existsSync(path)) {
+        const cookie = readFileSync(path, "utf-8").trim();
+        return cookie ? cookie : undefined;
+    }
+
+    return migrateLegacyCookie(storage);
+}
+
+export async function saveCookie(storage: Storage, cookie: string): Promise<SaveCookieResult> {
+    const path = cookiePath(storage);
+    const ownerOnly = writeCookieFile(path, cookie);
+    await storage.setConfigValue(COOKIE_UPDATED_KEY, Math.floor(Date.now() / 1000));
+
+    return { path, ownerOnly };
+}
+
+/**
+ * Write the credential and report whether the result is genuinely owner-only.
+ * `mode` on writeFileSync applies only when the file is created, so an existing
+ * world-readable file needs the explicit chmod; the stat afterwards is what makes
+ * the answer honest on filesystems that accept chmod and ignore it.
+ */
+function writeCookieFile(path: string, cookie: string): boolean {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(path, `${cookie}\n`, { encoding: "utf-8", mode: COOKIE_FILE_MODE });
+
+    try {
+        chmodSync(path, COOKIE_FILE_MODE);
+        return (statSync(path).mode & 0o777) === COOKIE_FILE_MODE;
+    } catch (err) {
+        logger.warn({ err, path }, "Could not restrict the Timely cookie file to owner-only (0600)");
+        return false;
+    }
+}
+
+/** Move a cookie left in config.json by an earlier build into its own 0600 file, once. */
+async function migrateLegacyCookie(storage: Storage): Promise<string | undefined> {
+    const legacy = (await storage.getConfigValue<string>(LEGACY_COOKIE_KEY))?.trim();
+    if (!legacy) {
+        return undefined;
+    }
+
+    writeCookieFile(cookiePath(storage), legacy);
+    await storage.atomicConfigUpdate<Record<string, unknown>>((config) => {
+        delete config[LEGACY_COOKIE_KEY];
+    });
+    logger.info("Moved the stored Timely cookie out of config.json into its own owner-only file.");
+
+    return legacy;
+}
+
+/** Strip a pasted "Cookie: " prefix and surrounding whitespace/quotes. */
+export function normalizeCookieHeader(pasted: string): string {
+    return pasted
+        .trim()
+        .replace(/^cookie:\s*/i, "")
+        .replace(/^["']|["']$/g, "")
+        .trim();
+}
+
+/** RFC 6265 cookie-name token characters. Deliberately excludes `/ : ? & @`, so a URL never passes. */
+const COOKIE_PAIR = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+=[^;]*$/;
+
+/**
+ * True when every `;`-separated chunk is a `name=value` pair. Used to reject the
+ * other quoted arguments of a curl command (the URL, `accept: application/json`)
+ * without having to understand curl's grammar.
+ */
+export function looksLikeCookiePairs(value: string): boolean {
+    const pairs = value
+        .split(";")
+        .map((pair) => pair.trim())
+        .filter(Boolean);
+
+    if (pairs.length === 0) {
+        return false;
+    }
+
+    return pairs.every((pair) => COOKIE_PAIR.test(pair));
+}
+
+/**
+ * Split shell source into argv the way a shell would, so a pasted
+ * "Copy as cURL" survives whichever quoting the browser chose. Handles single
+ * quotes, double quotes, bash's `$'...'` (Chrome emits it when a header value
+ * contains a quote), backslash escapes and backslash-newline continuations.
+ */
+export function shellTokens(input: string): string[] {
+    const tokens: string[] = [];
+    let current = "";
+    let started = false;
+    let quote: "'" | '"' | null = null;
+
+    for (let i = 0; i < input.length; i++) {
+        const char = input[i];
+
+        if (quote) {
+            if (char === quote) {
+                quote = null;
+                continue;
+            }
+
+            if (char === "\\" && i + 1 < input.length && (quote === '"' || input[i + 1] === "'")) {
+                current += input[i + 1];
+                i++;
+                continue;
+            }
+
+            current += char;
+            continue;
+        }
+
+        if (char === "$" && (input[i + 1] === "'" || input[i + 1] === '"')) {
+            quote = input[i + 1] as "'" | '"';
+            started = true;
+            i++;
+            continue;
+        }
+
+        if (char === "'" || char === '"') {
+            quote = char;
+            started = true;
+            continue;
+        }
+
+        if (char === "\\" && i + 1 < input.length) {
+            if (input[i + 1] !== "\n") {
+                current += input[i + 1];
+                started = true;
+            }
+
+            i++;
+            continue;
+        }
+
+        if (/\s/.test(char)) {
+            if (started) {
+                tokens.push(current);
+                current = "";
+                started = false;
+            }
+
+            continue;
+        }
+
+        current += char;
+        started = true;
+    }
+
+    if (started) {
+        tokens.push(current);
+    }
+
+    return tokens;
+}
+
+export type CookieSource = "curl-cookie-flag" | "curl-header-flag" | "header-line" | "raw-pairs";
+
+export interface ExtractedCookie {
+    cookie: string;
+    source: CookieSource;
+}
+
+/**
+ * Pull the Cookie header out of whatever the user pasted. Accepts, in order of
+ * preference: a whole `curl` command (`-b` / `--cookie`, or `-H 'cookie: …'`),
+ * a bare `Cookie: name=v; …` header line, or a bare `name=v; …` string.
+ *
+ * Returns undefined when nothing in the input parses as cookie pairs, so the
+ * caller can ask again instead of probing Timely with garbage.
+ */
+export function extractCookie(input: string): ExtractedCookie | undefined {
+    if (!input?.trim()) {
+        return undefined;
+    }
+
+    const tokens = shellTokens(input);
+    for (let i = 0; i < tokens.length; i++) {
+        const flag = tokens[i];
+        const value = tokens[i + 1];
+        if (value === undefined) {
+            continue;
+        }
+
+        if (flag === "-b" || flag === "--cookie") {
+            const cookie = normalizeCookieHeader(value);
+            if (looksLikeCookiePairs(cookie)) {
+                return { cookie, source: "curl-cookie-flag" };
+            }
+        }
+
+        if ((flag === "-H" || flag === "--header") && /^\s*cookie\s*:/i.test(value)) {
+            const cookie = normalizeCookieHeader(value);
+            if (looksLikeCookiePairs(cookie)) {
+                return { cookie, source: "curl-header-flag" };
+            }
+        }
+    }
+
+    for (const line of input.split("\n")) {
+        if (!/^\s*cookie\s*:/i.test(line)) {
+            continue;
+        }
+
+        const cookie = normalizeCookieHeader(line.replace(/\\\s*$/, ""));
+        if (looksLikeCookiePairs(cookie)) {
+            return { cookie, source: "header-line" };
+        }
+    }
+
+    for (const line of input.split("\n")) {
+        const cookie = normalizeCookieHeader(line);
+        if (looksLikeCookiePairs(cookie)) {
+            return { cookie, source: "raw-pairs" };
+        }
+    }
+
+    return undefined;
+}
+
+/** Human label for a cookie without revealing any value: names and count only. */
+export function describeCookie(cookie: string): string {
+    const names = cookie
+        .split(";")
+        .map((pair) => pair.trim().split("=")[0])
+        .filter(Boolean);
+
+    const shown = names.slice(0, 4).join(", ");
+    const rest = names.length > 4 ? `, +${names.length - 4} more` : "";
+    return `${names.length} cookie${names.length === 1 ? "" : "s"}: ${shown}${rest}`;
+}
+
+/**
+ * Headers for an app.timelyapp.com request. The bearer is kept because it is
+ * harmless and still identifies the caller; the cookie is what actually works.
+ */
+export function webSessionHeaders(options: { accessToken: string; cookie?: string }): Record<string, string> {
+    const headers: Record<string, string> = {
+        accept: "application/json",
+        Authorization: `Bearer ${options.accessToken}`,
+    };
+
+    if (options.cookie) {
+        headers.Cookie = options.cookie;
+    }
+
+    return headers;
+}

--- a/src/timely/utils/cookie.ts
+++ b/src/timely/utils/cookie.ts
@@ -121,10 +121,11 @@ export function looksLikeCookiePairs(value: string): boolean {
  * quotes, double quotes, bash's `$'...'` (Chrome emits it when a header value
  * contains a quote), backslash escapes and backslash-newline continuations.
  *
- * Inside `$'...'` a backslash escapes the next character literally. The ANSI-C
- * control escapes (`\n`, `\t`, `\xNN`) are deliberately left untranslated: a
- * Cookie header cannot legally carry those bytes, so decoding them would only
- * turn a malformed paste into a header value that looks valid.
+ * Inside `$'...'` a backslash is dropped and the character after it is kept as
+ * written, so `\\` yields one backslash and `\'` yields a quote. The ANSI-C
+ * control escapes (`\n`, `\t`, `\xNN`) are deliberately NOT decoded: a Cookie
+ * header cannot legally carry those bytes, so decoding them would only turn a
+ * malformed paste into a header value that looks valid.
  */
 export function shellTokens(input: string): string[] {
     const tokens: string[] = [];

--- a/src/timely/utils/failure.test.ts
+++ b/src/timely/utils/failure.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { TimelyHttpError } from "@app/timely/api/errors";
+import type { TimelyAccount } from "@app/timely/types";
+import { logger } from "@genesiscz/utils/logger";
+import { reportTimelyFailure } from "./failure";
+
+const errors: string[] = [];
+const infos: string[] = [];
+
+/** pino takes either (message) or (mergingObject, message), so keep whichever argument is the text. */
+function record(target: string[]) {
+    return (...args: unknown[]) => {
+        target.push(args.filter((arg) => typeof arg === "string").join(" "));
+    };
+}
+
+// `logger` is a shared singleton and bun runs every test file in one process,
+// so a module-level spy would stay installed for files that run after this one.
+let restoreLogger: (() => void) | undefined;
+
+beforeAll(() => {
+    const errorSpy = spyOn(logger, "error").mockImplementation(record(errors));
+    const infoSpy = spyOn(logger, "info").mockImplementation(record(infos));
+
+    restoreLogger = () => {
+        errorSpy.mockRestore();
+        infoSpy.mockRestore();
+    };
+});
+
+afterEach(() => {
+    errors.length = 0;
+    infos.length = 0;
+});
+
+afterAll(() => {
+    restoreLogger?.();
+});
+
+function liveSession(): { getAccounts: () => Promise<TimelyAccount[]>; calls: number } {
+    const probe = {
+        calls: 0,
+        getAccounts: async (): Promise<TimelyAccount[]> => {
+            probe.calls++;
+            return [];
+        },
+    };
+    return probe;
+}
+
+function deadSession(): { getAccounts: () => Promise<TimelyAccount[]>; calls: number } {
+    const probe = {
+        calls: 0,
+        getAccounts: async (): Promise<TimelyAccount[]> => {
+            probe.calls++;
+            throw new TimelyHttpError("API request failed (401): Unauthorized", { status: 401, scope: "api" });
+        },
+    };
+    return probe;
+}
+
+describe("reportTimelyFailure", () => {
+    test("a rejected session says to log in again", async () => {
+        const probe = deadSession();
+
+        await reportTimelyFailure(new TimelyHttpError("nope", { status: 401, scope: "api" }), probe);
+
+        expect(errors.join("\n")).toContain("no longer valid");
+        expect(infos.join("\n")).toContain("tools timely login api-key");
+    });
+
+    test("no stored cookie with a live API session points at the cookie login", async () => {
+        const probe = liveSession();
+
+        await reportTimelyFailure(new TimelyHttpError("nope", { status: 401, scope: "memories" }), probe);
+
+        expect(probe.calls).toBe(1);
+        expect(errors.join("\n")).toContain("browser session cookie");
+        expect(infos.join("\n")).toContain("tools timely login cookies");
+        expect(infos.join("\n")).not.toContain("login api-key");
+    });
+
+    test("a stored cookie that stopped working says the cookie expired, without probing", async () => {
+        const probe = liveSession();
+
+        await reportTimelyFailure(
+            new TimelyHttpError("nope", { status: 401, scope: "memories", usedCookie: true }),
+            probe
+        );
+
+        expect(probe.calls).toBe(0);
+        expect(errors.join("\n")).toContain("cookie has expired");
+        expect(infos.join("\n")).toContain("tools timely login cookies");
+    });
+
+    test("a memories 401 with a dead session still says to log in again", async () => {
+        const probe = deadSession();
+
+        await reportTimelyFailure(new TimelyHttpError("nope", { status: 401, scope: "memories" }), probe);
+
+        expect(probe.calls).toBe(1);
+        expect(errors.join("\n")).toContain("no longer valid");
+        expect(infos.join("\n")).toContain("tools timely login api-key");
+    });
+
+    test("a non-auth HTTP failure reports the status without a login suggestion", async () => {
+        const probe = liveSession();
+
+        await reportTimelyFailure(new TimelyHttpError("boom", { status: 500, scope: "api" }), probe);
+
+        expect(probe.calls).toBe(0);
+        expect(errors.join("\n")).toContain("HTTP 500");
+        expect(infos.join("\n")).not.toContain("tools timely login");
+    });
+
+    test("a refused refresh points at login without probing", async () => {
+        const probe = liveSession();
+
+        await reportTimelyFailure(
+            new TimelyHttpError("Token refresh failed: bad grant", { status: 400, scope: "token" }),
+            probe
+        );
+
+        expect(probe.calls).toBe(0);
+        expect(errors.join("\n")).toContain("refresh");
+        expect(infos.join("\n")).toContain("tools timely login api-key");
+    });
+
+    test("a non-HTTP error keeps the old unexpected-error line", async () => {
+        const probe = liveSession();
+
+        await reportTimelyFailure(new Error("socket hang up"), probe);
+
+        expect(probe.calls).toBe(0);
+        expect(errors.join("\n")).toContain("Unexpected error talking to Timely");
+    });
+});

--- a/src/timely/utils/failure.test.ts
+++ b/src/timely/utils/failure.test.ts
@@ -93,6 +93,20 @@ describe("reportTimelyFailure", () => {
         expect(infos.join("\n")).toContain("tools timely login cookies");
     });
 
+    test("a sign-in redirect with a stored cookie says the cookie expired, not 'request failed'", async () => {
+        const probe = liveSession();
+
+        await reportTimelyFailure(
+            new TimelyHttpError("bounced", { status: 302, scope: "memories", usedCookie: true }),
+            probe
+        );
+
+        expect(probe.calls).toBe(0);
+        expect(errors.join("\n")).toContain("cookie has expired");
+        expect(errors.join("\n")).not.toContain("request failed");
+        expect(infos.join("\n")).toContain("tools timely login cookies");
+    });
+
     test("a memories 401 with a dead session still says to log in again", async () => {
         const probe = deadSession();
 

--- a/src/timely/utils/failure.ts
+++ b/src/timely/utils/failure.ts
@@ -1,4 +1,4 @@
-import { isAuthStatus, TimelyHttpError } from "@app/timely/api/errors";
+import { isCredentialRejection, TimelyHttpError } from "@app/timely/api/errors";
 import type { TimelyService } from "@app/timely/api/service";
 import { suggestCommand } from "@genesiscz/utils/cli";
 import { logger } from "@genesiscz/utils/logger";
@@ -24,7 +24,7 @@ export async function reportTimelyFailure(err: unknown, service: SessionProbe): 
         return;
     }
 
-    if (!isAuthStatus(err.status)) {
+    if (!isCredentialRejection(err.status)) {
         logger.error(`Timely request failed (HTTP ${err.status}): ${err.message}`);
         return;
     }

--- a/src/timely/utils/failure.ts
+++ b/src/timely/utils/failure.ts
@@ -1,0 +1,68 @@
+import { isAuthStatus, TimelyHttpError } from "@app/timely/api/errors";
+import type { TimelyService } from "@app/timely/api/service";
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { logger } from "@genesiscz/utils/logger";
+
+/** Only the probe call is needed, so tests can pass a stub instead of a real service. */
+type SessionProbe = Pick<TimelyService, "getAccounts">;
+
+/**
+ * Explain a failed Timely call in terms the user can act on. A 401 means four
+ * different things here, so say which: an expired browser cookie, a missing
+ * one, a dead OAuth login, or a plain request failure. Callers exit non-zero
+ * afterwards.
+ */
+export async function reportTimelyFailure(err: unknown, service: SessionProbe): Promise<void> {
+    if (!(err instanceof TimelyHttpError)) {
+        logger.error({ error: err }, "Unexpected error talking to Timely");
+        return;
+    }
+
+    if (err.scope === "token") {
+        logger.error(`Timely refused to refresh your session (HTTP ${err.status}): ${err.message}`);
+        logger.info(`Log in again: ${suggestCommand("tools timely", { replaceCommand: ["login", "api-key"] })}`);
+        return;
+    }
+
+    if (!isAuthStatus(err.status)) {
+        logger.error(`Timely request failed (HTTP ${err.status}): ${err.message}`);
+        return;
+    }
+
+    if (err.scope === "memories" && err.usedCookie) {
+        logger.error(
+            `Timely rejected the memories request (HTTP ${err.status}). Your stored browser session cookie has expired.`
+        );
+        logger.info(`Paste a fresh one: ${suggestCommand("tools timely", { replaceCommand: ["login", "cookies"] })}`);
+        return;
+    }
+
+    if (err.scope === "memories" && (await sessionStillValid(service))) {
+        logger.error(`Timely rejected the memories request (HTTP ${err.status}), but your API login is still valid.`);
+        logger.error(
+            "Memories (suggested_entries) are served by app.timelyapp.com, which accepts only a browser session cookie, not an OAuth token."
+        );
+        logger.info(
+            `Store one: ${suggestCommand("tools timely", { replaceCommand: ["login", "cookies"] })} (or use --without-entries for events alone)`
+        );
+        return;
+    }
+
+    logger.error(`Timely rejected the request (HTTP ${err.status}). Your session is no longer valid.`);
+    logger.info(`Log in again: ${suggestCommand("tools timely", { replaceCommand: ["login", "api-key"] })}`);
+}
+
+/**
+ * Probe the OAuth API host to see whether the credentials themselves are still
+ * accepted. Used only on the failure path, to pick the right remedy.
+ */
+async function sessionStillValid(service: SessionProbe): Promise<boolean> {
+    try {
+        await service.getAccounts();
+        logger.debug("[failure] probe: /accounts accepted the token, so the login itself is fine");
+        return true;
+    } catch (probeErr) {
+        logger.debug({ error: probeErr }, "[failure] probe: /accounts also rejected the token");
+        return false;
+    }
+}

--- a/src/timely/utils/memories.test.ts
+++ b/src/timely/utils/memories.test.ts
@@ -74,6 +74,25 @@ describe("fetchMemoriesForDates", () => {
         expect(result.byDate.get("2026-07-23")).toHaveLength(1);
     });
 
+    // The failure this whole change exists to remove: a stale cookie is answered with a
+    // bounce to sign-in, and following it produced a 200 page that read as "this day has
+    // no memories". It has to surface as a refused session, on the first date.
+    test("a sign-in redirect aborts the run as an auth failure instead of reporting empty days", async () => {
+        let calls = 0;
+        stubFetch(async () => {
+            calls++;
+            return new Response(null, { status: 302, headers: { location: "/login" } });
+        });
+
+        const promise = fetchMemoriesForDates(
+            fetchOptions(["2026-07-22", "2026-07-23", "2026-07-24"], await storageWithCookie("_memory_session=stale"))
+        );
+
+        await expect(promise).rejects.toThrow(TimelyHttpError);
+        await expect(promise).rejects.toMatchObject({ status: 302, scope: "memories", usedCookie: true });
+        expect(calls).toBe(1);
+    });
+
     test("a genuinely empty day stays empty and does not fail", async () => {
         stubFetch(async () => new Response("[]", { status: 200 }));
 

--- a/src/timely/utils/memories.test.ts
+++ b/src/timely/utils/memories.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { TimelyHttpError } from "@app/timely/api/errors";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { Storage } from "@genesiscz/utils/storage";
+import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
+import { saveCookie } from "./cookie";
+import { fetchMemoriesForDates } from "./memories";
+
+setupStorageSandbox();
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+function stubFetch(impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): void {
+    globalThis.fetch = impl as typeof fetch;
+}
+
+function fetchOptions(dates: string[], storage = new Storage("timely-memories-test")) {
+    return {
+        accountId: 558481,
+        accessToken: "test-token",
+        dates,
+        storage,
+        force: true,
+    };
+}
+
+async function storageWithCookie(cookie: string): Promise<Storage> {
+    const storage = new Storage("timely-memories-cookie-test");
+    await storage.ensureDirs();
+    await saveCookie(storage, cookie);
+    return storage;
+}
+
+describe("fetchMemoriesForDates", () => {
+    test("a 401 throws instead of reporting an empty day", async () => {
+        stubFetch(async () => new Response('{"error":"Unauthorized"}', { status: 401 }));
+
+        const promise = fetchMemoriesForDates(fetchOptions(["2026-07-24"]));
+
+        await expect(promise).rejects.toThrow(TimelyHttpError);
+        await expect(promise).rejects.toMatchObject({ status: 401, scope: "memories" });
+    });
+
+    test("the first 401 aborts the run instead of retrying every date", async () => {
+        let calls = 0;
+        stubFetch(async () => {
+            calls++;
+            return new Response('{"error":"Unauthorized"}', { status: 401 });
+        });
+
+        await expect(fetchMemoriesForDates(fetchOptions(["2026-07-22", "2026-07-23", "2026-07-24"]))).rejects.toThrow(
+            TimelyHttpError
+        );
+        expect(calls).toBe(1);
+    });
+
+    test("a non-auth failure is counted and the remaining dates still return", async () => {
+        stubFetch(async (input) => {
+            if (String(input).includes("2026-07-22")) {
+                return new Response("boom", { status: 500 });
+            }
+
+            return new Response(SafeJSON.stringify([{ id: 1 }]), { status: 200 });
+        });
+
+        const result = await fetchMemoriesForDates(fetchOptions(["2026-07-22", "2026-07-23"]));
+
+        expect(result.stats.failed).toBe(1);
+        expect(result.entries).toHaveLength(1);
+        expect(result.byDate.get("2026-07-23")).toHaveLength(1);
+    });
+
+    test("a genuinely empty day stays empty and does not fail", async () => {
+        stubFetch(async () => new Response("[]", { status: 200 }));
+
+        const result = await fetchMemoriesForDates(fetchOptions(["2026-07-24"]));
+
+        expect(result.entries).toEqual([]);
+        expect(result.stats.failed).toBe(0);
+    });
+
+    test("a stored cookie is sent as the Cookie header", async () => {
+        const sent: (string | null)[] = [];
+        stubFetch(async (_input, init) => {
+            sent.push(new Headers(init?.headers).get("Cookie"));
+            return new Response("[]", { status: 200 });
+        });
+
+        await fetchMemoriesForDates(fetchOptions(["2026-07-24"], await storageWithCookie("_memory_session=abc")));
+
+        expect(sent).toEqual(["_memory_session=abc"]);
+    });
+
+    test("a 401 with a stored cookie is flagged as a cookie failure", async () => {
+        stubFetch(async () => new Response('{"error":"Unauthorized"}', { status: 401 }));
+
+        const promise = fetchMemoriesForDates(
+            fetchOptions(["2026-07-24"], await storageWithCookie("_memory_session=stale"))
+        );
+
+        await expect(promise).rejects.toMatchObject({ status: 401, scope: "memories", usedCookie: true });
+    });
+
+    test("a 401 without a stored cookie is not flagged as a cookie failure", async () => {
+        stubFetch(async () => new Response('{"error":"Unauthorized"}', { status: 401 }));
+
+        const promise = fetchMemoriesForDates(fetchOptions(["2026-07-24"]));
+
+        await expect(promise).rejects.toMatchObject({ usedCookie: false });
+    });
+});

--- a/src/timely/utils/memories.ts
+++ b/src/timely/utils/memories.ts
@@ -1,4 +1,7 @@
+import { isTimelyAuthFailure } from "@app/timely/api/errors";
+import { fetchTimelyWebJson } from "@app/timely/api/web-fetch";
 import type { TimelyEntry } from "@app/timely/types";
+import { readStoredCookie } from "@app/timely/utils/cookie";
 import { logger } from "@genesiscz/utils/logger";
 import type { Storage } from "@genesiscz/utils/storage";
 
@@ -31,11 +34,17 @@ export async function fetchMemoriesForDates(options: FetchMemoriesOptions): Prom
     const today = new Date().toISOString().slice(0, 10);
     const sortedDates = [...dates].sort();
 
-    logger.debug(`[memories] Fetching memories for ${sortedDates.length} date(s) (today=${today})`);
+    // app.timelyapp.com only honours the browser session cookie; the bearer alone 401s.
+    const cookie = await readStoredCookie(storage);
+
+    logger.debug(
+        `[memories] Fetching memories for ${sortedDates.length} date(s) (today=${today}, browser cookie ${cookie ? "present" : "absent"})`
+    );
 
     const entries: TimelyEntry[] = [];
     const byDate = new Map<string, TimelyEntry[]>();
     const stats = { fetched: 0, cached: 0, failed: 0 };
+    const failedDates: string[] = [];
 
     for (let i = 0; i < sortedDates.length; i++) {
         const date = sortedDates[i];
@@ -47,7 +56,7 @@ export async function fetchMemoriesForDates(options: FetchMemoriesOptions): Prom
             let memories: TimelyEntry[];
 
             if (isToday || force) {
-                memories = await fetchFromApi(accountId, accessToken, date);
+                memories = await fetchFromApi({ accountId, accessToken, cookie, date });
                 if (!isToday) {
                     await storage.putCacheFile(cacheKey, memories, CACHE_TTL);
                 }
@@ -62,7 +71,7 @@ export async function fetchMemoriesForDates(options: FetchMemoriesOptions): Prom
                     stats.cached++;
                     logger.debug(`[memories] ${progress} ${date}: ${memories.length} memories (cached)`);
                 } else {
-                    memories = await fetchFromApi(accountId, accessToken, date);
+                    memories = await fetchFromApi({ accountId, accessToken, cookie, date });
                     await storage.putCacheFile(cacheKey, memories, CACHE_TTL);
                     stats.fetched++;
                     logger.debug(`[memories] ${progress} ${date}: ${memories.length} memories (fetched)`);
@@ -72,10 +81,25 @@ export async function fetchMemoriesForDates(options: FetchMemoriesOptions): Prom
             entries.push(...memories);
             byDate.set(date, memories);
         } catch (err) {
+            if (isTimelyAuthFailure(err)) {
+                // Credentials, not this date: every remaining date fails identically.
+                // Let the caller report it instead of returning a misleading empty list.
+                logger.debug(`[memories] ${progress} ${date}: auth failure, aborting the run`);
+                throw err;
+            }
+
             stats.failed++;
-            logger.debug(`[memories] Failed to fetch memories for ${date}: ${err}`);
-            logger.debug(`[memories] ${progress} ${date}: FAILED`);
+            failedDates.push(date);
+            logger.error(
+                `[memories] ${progress} ${date}: FAILED - ${err instanceof Error ? err.message : String(err)}`
+            );
         }
+    }
+
+    if (stats.failed > 0) {
+        logger.warn(
+            `[memories] ${stats.failed} of ${sortedDates.length} date(s) could not be fetched (${failedDates.join(", ")}); the totals below are incomplete.`
+        );
     }
 
     logger.debug(
@@ -85,15 +109,22 @@ export async function fetchMemoriesForDates(options: FetchMemoriesOptions): Prom
     return { entries, byDate, stats };
 }
 
-async function fetchFromApi(accountId: number, accessToken: string, date: string): Promise<TimelyEntry[]> {
+async function fetchFromApi(options: {
+    accountId: number;
+    accessToken: string;
+    cookie?: string;
+    date: string;
+}): Promise<TimelyEntry[]> {
+    const { accountId, accessToken, cookie, date } = options;
     const url = `https://app.timelyapp.com/${accountId}/suggested_entries.json?date=${date}&spam=true`;
-    const res = await fetch(url, {
-        headers: { accept: "application/json", Authorization: `Bearer ${accessToken}` },
-    });
-    if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-    }
-    return (await res.json()) as TimelyEntry[];
+
+    return (await fetchTimelyWebJson({
+        url,
+        accessToken,
+        cookie,
+        scope: "memories",
+        label: `Memories request for ${date}`,
+    })) as TimelyEntry[];
 }
 
 /**

--- a/src/timely/utils/token-status.test.ts
+++ b/src/timely/utils/token-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { TimelyConfig } from "@app/timely/types";
-import { describeTokenLifetime } from "./token-status";
+import { ASSUMED_TOKEN_LIFETIME_SECONDS, describeTokenLifetime, tokenNeedsRefresh } from "./token-status";
 
 const NOW_MS = Date.UTC(2026, 6, 28, 12, 0, 0);
 const NOW_SECONDS = Math.floor(NOW_MS / 1000);
@@ -16,6 +16,41 @@ function config(overrides: Partial<TimelyConfig>): TimelyConfig {
         ...overrides,
     };
 }
+
+describe("tokenNeedsRefresh", () => {
+    test("a token with no expires_in is usable for the assumed lifetime, not refreshed every call", () => {
+        // The whole point: unknown lifetime used to mean "always expired", which put a
+        // token-endpoint POST in front of every single request.
+        const justIssued = { created_at: NOW_SECONDS };
+
+        expect(tokenNeedsRefresh(justIssued, NOW_MS)).toBe(false);
+        expect(tokenNeedsRefresh(justIssued, NOW_MS + 60 * 60 * 1000)).toBe(false);
+    });
+
+    test("a token past the assumed lifetime is refreshed", () => {
+        const aged = { created_at: NOW_SECONDS - ASSUMED_TOKEN_LIFETIME_SECONDS };
+
+        expect(tokenNeedsRefresh(aged, NOW_MS)).toBe(true);
+    });
+
+    test("the buffer refreshes shortly before the deadline, never mid-request", () => {
+        const nearlyDue = { created_at: NOW_SECONDS - ASSUMED_TOKEN_LIFETIME_SECONDS + 60 };
+
+        expect(tokenNeedsRefresh(nearlyDue, NOW_MS)).toBe(true);
+    });
+
+    test("an explicit expires_in still wins over the assumption", () => {
+        const shortLived = { created_at: NOW_SECONDS, expires_in: 600 };
+
+        expect(tokenNeedsRefresh(shortLived, NOW_MS)).toBe(false);
+        expect(tokenNeedsRefresh(shortLived, NOW_MS + 11 * 60 * 1000)).toBe(true);
+    });
+
+    test("a token with no created_at is left alone rather than refreshed blindly", () => {
+        expect(tokenNeedsRefresh({}, NOW_MS)).toBe(false);
+        expect(tokenNeedsRefresh(undefined, NOW_MS)).toBe(false);
+    });
+});
 
 describe("describeTokenLifetime", () => {
     test("reports nothing when there is no token", () => {

--- a/src/timely/utils/token-status.test.ts
+++ b/src/timely/utils/token-status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import type { TimelyConfig } from "@app/timely/types";
+import { describeTokenLifetime } from "./token-status";
+
+const NOW_MS = Date.UTC(2026, 6, 28, 12, 0, 0);
+const NOW_SECONDS = Math.floor(NOW_MS / 1000);
+
+function config(overrides: Partial<TimelyConfig>): TimelyConfig {
+    return {
+        tokens: {
+            access_token: "tok",
+            token_type: "bearer",
+            refresh_token: "ref",
+            created_at: NOW_SECONDS,
+        },
+        ...overrides,
+    };
+}
+
+describe("describeTokenLifetime", () => {
+    test("reports nothing when there is no token", () => {
+        expect(describeTokenLifetime(undefined, NOW_MS)).toEqual({ kind: "absent" });
+        expect(describeTokenLifetime({}, NOW_MS)).toEqual({ kind: "absent" });
+    });
+
+    test("uses expires_in when Timely does send one", () => {
+        const lifetime = describeTokenLifetime(
+            config({
+                tokens: {
+                    access_token: "tok",
+                    token_type: "bearer",
+                    refresh_token: "ref",
+                    created_at: NOW_SECONDS - 100,
+                    expires_in: 7200,
+                },
+            }),
+            NOW_MS
+        );
+
+        expect(lifetime).toEqual({
+            kind: "known",
+            expiresAt: new Date((NOW_SECONDS - 100 + 7200) * 1000),
+            expired: false,
+        });
+    });
+
+    test("a login three minutes ago reads as freshly authenticated", () => {
+        expect(describeTokenLifetime(config({ authenticatedAt: NOW_SECONDS - 180 }), NOW_MS)).toEqual({
+            kind: "fresh-login",
+            age: "3m",
+        });
+    });
+
+    test("a login seconds ago still reads as fresh", () => {
+        expect(describeTokenLifetime(config({ authenticatedAt: NOW_SECONDS - 2 }), NOW_MS)).toEqual({
+            kind: "fresh-login",
+            age: "< 1m",
+        });
+    });
+
+    test("an aged login keeps the old unknown-lifetime answer", () => {
+        const threeHours = 3 * 60 * 60;
+        expect(describeTokenLifetime(config({ authenticatedAt: NOW_SECONDS - threeHours }), NOW_MS)).toEqual({
+            kind: "unknown",
+        });
+    });
+
+    test("a config written before authenticatedAt existed keeps the old answer", () => {
+        expect(describeTokenLifetime(config({}), NOW_MS)).toEqual({ kind: "unknown" });
+    });
+
+    test("refreshes do not fake freshness: created_at alone never counts as a login", () => {
+        const stale = config({ authenticatedAt: NOW_SECONDS - 10 * 24 * 60 * 60 });
+        stale.tokens = { ...stale.tokens!, created_at: NOW_SECONDS };
+
+        expect(describeTokenLifetime(stale, NOW_MS)).toEqual({ kind: "unknown" });
+    });
+});

--- a/src/timely/utils/token-status.ts
+++ b/src/timely/utils/token-status.ts
@@ -1,0 +1,45 @@
+import type { TimelyConfig } from "@app/timely/types";
+import { formatDuration } from "@genesiscz/utils/format";
+
+/**
+ * Timely's token response carries no expires_in, so a stored token has no known
+ * lifetime and the client refreshes it on every request. Saying only that is
+ * useless right after a login, so a recent authorization-code exchange is
+ * reported as its own state.
+ *
+ * The window is Doorkeeper's default access-token lifetime (Timely runs
+ * Doorkeeper); past it, a login is no longer plausibly the live session and the
+ * honest "lifetime unknown" answer is the whole answer.
+ */
+const FRESH_LOGIN_SECONDS = 2 * 60 * 60;
+
+export type TokenLifetime =
+    | { kind: "absent" }
+    | { kind: "known"; expiresAt: Date; expired: boolean }
+    | { kind: "fresh-login"; age: string }
+    | { kind: "unknown" };
+
+export function describeTokenLifetime(
+    config: TimelyConfig | null | undefined,
+    nowMs: number = Date.now()
+): TokenLifetime {
+    const tokens = config?.tokens;
+    if (!tokens?.created_at) {
+        return { kind: "absent" };
+    }
+
+    if (tokens.expires_in) {
+        const expiresAt = new Date((tokens.created_at + tokens.expires_in) * 1000);
+        return { kind: "known", expiresAt, expired: nowMs > expiresAt.getTime() };
+    }
+
+    const nowSeconds = Math.floor(nowMs / 1000);
+    const authenticatedAt = config?.authenticatedAt;
+
+    if (authenticatedAt && nowSeconds - authenticatedAt < FRESH_LOGIN_SECONDS) {
+        const age = Math.max(0, nowSeconds - authenticatedAt);
+        return { kind: "fresh-login", age: formatDuration(age, "s", "hm-smart") };
+    }
+
+    return { kind: "unknown" };
+}

--- a/src/timely/utils/token-status.ts
+++ b/src/timely/utils/token-status.ts
@@ -2,22 +2,45 @@ import type { TimelyConfig } from "@app/timely/types";
 import { formatDuration } from "@genesiscz/utils/format";
 
 /**
- * Timely's token response carries no expires_in, so a stored token has no known
- * lifetime and the client refreshes it on every request. Saying only that is
- * useless right after a login, so a recent authorization-code exchange is
- * reported as its own state.
- *
- * The window is Doorkeeper's default access-token lifetime (Timely runs
- * Doorkeeper); past it, a login is no longer plausibly the live session and the
- * honest "lifetime unknown" answer is the whole answer.
+ * Doorkeeper's default access-token lifetime (Timely runs Doorkeeper). Timely's
+ * token response carries no expires_in, so this is the conservative assumption
+ * used in two places: how long a token may be presumed usable, and how long ago a
+ * login still counts as "just now" when reporting status.
  */
-const FRESH_LOGIN_SECONDS = 2 * 60 * 60;
+export const ASSUMED_TOKEN_LIFETIME_SECONDS = 2 * 60 * 60;
 
 export type TokenLifetime =
     | { kind: "absent" }
     | { kind: "known"; expiresAt: Date; expired: boolean }
     | { kind: "fresh-login"; age: string }
     | { kind: "unknown" };
+
+/** Refresh a little before the deadline, so a token cannot expire mid-request. */
+const REFRESH_BUFFER_SECONDS = 5 * 60;
+
+/**
+ * Whether a stored token has to be refreshed before it is used.
+ *
+ * When Timely omits expires_in the lifetime is genuinely unknown, but treating
+ * unknown as "always expired" means a token-endpoint POST before every single
+ * call — once per page of a paginated fetch, and several in parallel when
+ * commands load memories and events together. Assuming Doorkeeper's default
+ * lifetime from `created_at` refreshes once every couple of hours instead, and
+ * `created_at` is rewritten by each refresh, so the clock restarts each time.
+ */
+export function tokenNeedsRefresh(
+    tokens: { created_at?: number; expires_in?: number } | null | undefined,
+    nowMs: number = Date.now()
+): boolean {
+    if (!tokens?.created_at) {
+        return false;
+    }
+
+    const lifetime = tokens.expires_in ?? ASSUMED_TOKEN_LIFETIME_SECONDS;
+    const expiresAtMs = (tokens.created_at + lifetime - REFRESH_BUFFER_SECONDS) * 1000;
+
+    return nowMs > expiresAtMs;
+}
 
 export function describeTokenLifetime(
     config: TimelyConfig | null | undefined,
@@ -36,7 +59,7 @@ export function describeTokenLifetime(
     const nowSeconds = Math.floor(nowMs / 1000);
     const authenticatedAt = config?.authenticatedAt;
 
-    if (authenticatedAt && nowSeconds - authenticatedAt < FRESH_LOGIN_SECONDS) {
+    if (authenticatedAt && nowSeconds - authenticatedAt < ASSUMED_TOKEN_LIFETIME_SECONDS) {
         const age = Math.max(0, nowSeconds - authenticatedAt);
         return { kind: "fresh-login", age: formatDuration(age, "s", "hm-smart") };
     }


### PR DESCRIPTION
## What

Fixes the Timely auth path so memory-backed time logging works again.

- **Log in with a browser cookie** — the previous flow could not obtain a usable session, so memories came back empty.
- The cookie can be taken **from the clipboard or from a pasted curl command**, which is how it is actually obtained in practice (copy as cURL from devtools).
- **Refreshes the access token when its lifetime is unknown** instead of assuming it is still valid.
- **Reports rejected sessions** rather than returning an empty result — an expired cookie and a genuinely empty day used to look identical.
- Stops reporting a **just-acquired token** as one that will be refreshed.

## Why

Every failure mode in this path previously surfaced as "no memories found", which is indistinguishable from a day with no tracked time. The theme of these commits is making auth failures say so.

## Scope

`src/timely/**`.

Split out of #296. File-disjoint from the sibling PRs.
