### PR TITLE
feat(mcp-manager): add --json to list so other tools can consume the registry

### DIFF
--- a/src/mcp-manager/commands/__tests__/list.test.ts
+++ b/src/mcp-manager/commands/__tests__/list.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import type { ListJsonOutput, ListOptions } from "@app/mcp-manager/commands/list.js";
 import { listServers } from "@app/mcp-manager/commands/list.js";
 import type { MCPServerInfo } from "@app/mcp-manager/utils/providers/types.js";
-import { logger } from "@genesiscz/utils/logger";
+import { logger, out } from "@genesiscz/utils/logger";
 import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
 import { MockMCPProvider } from "./test-utils.js";
 
@@ -141,5 +142,102 @@ describe("listServers", () => {
         await listServers([mockProvider, mockProvider2]);
 
         expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("enabled"));
+    });
+});
+
+describe("listServers --json", () => {
+    let mockProvider: MockMCPProvider;
+    let mockProvider2: MockMCPProvider;
+
+    beforeEach(() => {
+        mockProvider = new MockMCPProvider("claude", "/mock/claude.json");
+        mockProvider2 = new MockMCPProvider("gemini", "/mock/gemini.json");
+    });
+
+    /** Run the JSON path and hand back the payload `out.result` was called with. */
+    async function jsonOutput(providers: MockMCPProvider[], options: ListOptions = {}): Promise<ListJsonOutput> {
+        const spy = spyOn(out, "result");
+        await listServers(providers, { ...options, json: true });
+        // Last call, not first: the spy may be shared across tests in this file.
+        return spy.mock.calls.at(-1)?.[0] as ListJsonOutput;
+    }
+
+    it("emits transport details and drops _meta bookkeeping", async () => {
+        mockProvider.listServersResult = [
+            {
+                name: "stdio-server",
+                config: {
+                    command: "bun",
+                    args: ["run", "server.ts"],
+                    env: { TOKEN: "x" },
+                    _meta: { enabled: { claude: true } },
+                },
+                enabled: true,
+                provider: "claude",
+            },
+            {
+                name: "http-server",
+                config: { url: "https://example.com/mcp", headers: { Authorization: "Bearer x" } },
+                enabled: true,
+                provider: "claude",
+            },
+        ];
+
+        const payload = await jsonOutput([mockProvider]);
+
+        expect(payload.servers.map((s) => s.name)).toEqual(["http-server", "stdio-server"]);
+        expect(payload.servers[0].connection).toEqual({
+            type: "http",
+            url: "https://example.com/mcp",
+            headers: { Authorization: "Bearer x" },
+        });
+        expect(payload.servers[1].connection).toEqual({
+            type: "stdio",
+            command: "bun",
+            args: ["run", "server.ts"],
+            env: { TOKEN: "x" },
+        });
+        expect(payload.providersScanned).toEqual(["claude"]);
+        expect(payload.providersFailed).toEqual([]);
+    });
+
+    it("reports the enabled provider's config when instances disagree", async () => {
+        mockProvider.listServersResult = [
+            { name: "dual", config: { command: "stale" }, enabled: false, provider: "claude" },
+        ];
+        mockProvider2.listServersResult = [
+            { name: "dual", config: { command: "live" }, enabled: true, provider: "gemini" },
+        ];
+
+        const payload = await jsonOutput([mockProvider, mockProvider2]);
+
+        expect(payload.servers[0].status).toBe("partial");
+        expect(payload.servers[0].enabled).toBe(true);
+        expect(payload.servers[0].connection.command).toBe("live");
+        expect(payload.servers[0].providers).toEqual([
+            { provider: "claude", enabled: false },
+            { provider: "gemini", enabled: true },
+        ]);
+    });
+
+    it("drops fully-disabled servers under enabledOnly", async () => {
+        mockProvider.listServersResult = [
+            { name: "on", config: { command: "a" }, enabled: true, provider: "claude" },
+            { name: "off", config: { command: "b" }, enabled: false, provider: "claude" },
+        ];
+
+        const payload = await jsonOutput([mockProvider], { enabledOnly: true });
+
+        expect(payload.servers.map((s) => s.name)).toEqual(["on"]);
+    });
+
+    it("separates scanned providers from ones that threw", async () => {
+        mockProvider.errors.set("listServers", new Error("Read failed"));
+        mockProvider2.listServersResult = [{ name: "ok", config: { command: "a" }, enabled: true, provider: "gemini" }];
+
+        const payload = await jsonOutput([mockProvider, mockProvider2]);
+
+        expect(payload.providersScanned).toEqual(["gemini"]);
+        expect(payload.providersFailed).toEqual([{ provider: "claude", error: "Read failed" }]);
     });
 });

--- a/src/mcp-manager/commands/__tests__/list.test.ts
+++ b/src/mcp-manager/commands/__tests__/list.test.ts
@@ -231,6 +231,23 @@ describe("listServers --json", () => {
         expect(payload.servers.map((s) => s.name)).toEqual(["on"]);
     });
 
+    it("emits an empty payload instead of the human 'no servers' notice", async () => {
+        mockProvider.listServersResult = [];
+
+        const spy = spyOn(out, "result");
+        const callsBefore = spy.mock.calls.length;
+        await listServers([mockProvider], { json: true });
+
+        // One NEW result call proves the empty case did not fall through to the
+        // human early-return, which would leave stdout unparseable for consumers.
+        expect(spy.mock.calls.length).toBe(callsBefore + 1);
+
+        const payload = spy.mock.calls.at(-1)?.[0] as ListJsonOutput;
+        expect(payload.servers).toEqual([]);
+        expect(payload.providersScanned).toEqual(["claude"]);
+        expect(payload.providersFailed).toEqual([]);
+    });
+
     it("separates scanned providers from ones that threw", async () => {
         mockProvider.errors.set("listServers", new Error("Read failed"));
         mockProvider2.listServersResult = [{ name: "ok", config: { command: "a" }, enabled: true, provider: "gemini" }];

--- a/src/mcp-manager/commands/list.ts
+++ b/src/mcp-manager/commands/list.ts
@@ -2,6 +2,11 @@ import type { MCPProvider, MCPServerInfo, UnifiedMCPServerConfig } from "@app/mc
 import { logger, out } from "@genesiscz/utils/logger";
 import chalk from "chalk";
 
+/**
+ * Options for {@link listServers}. `json` switches the output MODE, not just the
+ * formatting: the human listing is skipped entirely and the payload is written to
+ * stdout through `out.result`, so the command stays pipeable.
+ */
 export interface ListOptions {
     /** Emit machine-readable JSON on stdout instead of the human listing. */
     json?: boolean;
@@ -25,16 +30,44 @@ export interface ServerConnection {
     headers?: Record<string, string>;
 }
 
+/**
+ * One server in the `--json` payload.
+ *
+ * The same server name can be registered in several providers at once, so
+ * enablement is reported twice over: `providers` keeps the per-provider truth,
+ * while `enabled` and `status` summarise it for callers that do not care which
+ * provider supplied the entry.
+ */
 export interface ServerJsonEntry {
+    /** Name the server is registered under, unique across the payload. */
     name: string;
     /** True when at least one provider has this server enabled. */
     enabled: boolean;
+    /**
+     * Rollup of `providers`: `enabled` when every provider listing this server
+     * has it turned on, `disabled` when none do, `partial` when they disagree
+     * (typically a server enabled for one editor but not another).
+     */
     status: "enabled" | "partial" | "disabled";
+    /** Per-provider enablement, one entry per provider that lists this server. */
     providers: ServerProviderEntry[];
+    /** Transport details taken from the winning config (see {@link pickConfig}). */
     connection: ServerConnection;
 }
 
+/**
+ * Payload of `tools mcp-manager list --json`.
+ *
+ * This is a consumed contract rather than a debug dump: the mcp-scripting skill
+ * builds mcporter ServerDefinitions straight from `servers[].connection`. Treat
+ * the field names as public, and prefer adding fields over renaming them.
+ *
+ * A provider absent from BOTH `providersScanned` and `providersFailed` simply had
+ * no config file on disk, which is why an empty `servers` array is a valid result
+ * and not an error.
+ */
 export interface ListJsonOutput {
+    /** Every server found, sorted by name. Empty when no provider listed any. */
     servers: ServerJsonEntry[];
     /** Providers whose config file existed and was read. */
     providersScanned: string[];

--- a/src/mcp-manager/commands/list.ts
+++ b/src/mcp-manager/commands/list.ts
@@ -1,43 +1,175 @@
-import type { MCPProvider, MCPServerInfo } from "@app/mcp-manager/utils/providers/types.js";
-import { logger } from "@genesiscz/utils/logger";
+import type { MCPProvider, MCPServerInfo, UnifiedMCPServerConfig } from "@app/mcp-manager/utils/providers/types.js";
+import { logger, out } from "@genesiscz/utils/logger";
 import chalk from "chalk";
 
+export interface ListOptions {
+    /** Emit machine-readable JSON on stdout instead of the human listing. */
+    json?: boolean;
+    /** With --json, only include servers enabled in at least one provider. */
+    enabledOnly?: boolean;
+}
+
+/** One provider's view of a server. */
+export interface ServerProviderEntry {
+    provider: string;
+    enabled: boolean;
+}
+
+/** Transport-resolved connection details, flattened for programmatic clients. */
+export interface ServerConnection {
+    type: "stdio" | "http" | "sse" | "unknown";
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    url?: string;
+    headers?: Record<string, string>;
+}
+
+export interface ServerJsonEntry {
+    name: string;
+    /** True when at least one provider has this server enabled. */
+    enabled: boolean;
+    status: "enabled" | "partial" | "disabled";
+    providers: ServerProviderEntry[];
+    connection: ServerConnection;
+}
+
+export interface ListJsonOutput {
+    servers: ServerJsonEntry[];
+    /** Providers whose config file existed and was read. */
+    providersScanned: string[];
+    /** Providers that threw while being read, with the reason. */
+    providersFailed: { provider: string; error: string }[];
+}
+
 /**
- * List all MCP servers across all providers
+ * Flatten a unified server config into the transport shape a programmatic MCP
+ * client needs. `_meta` is intentionally dropped: it is mcp-manager bookkeeping,
+ * not connection data.
  */
-export async function listServers(providers: MCPProvider[]): Promise<void> {
+function toConnection(config: UnifiedMCPServerConfig | undefined): ServerConnection {
+    if (!config) {
+        return { type: "unknown" };
+    }
+
+    const url =
+        typeof config.url === "string" ? config.url : typeof config.httpUrl === "string" ? config.httpUrl : undefined;
+    const command = typeof config.command === "string" ? config.command : undefined;
+
+    let type: ServerConnection["type"] = "unknown";
+    if (config.type === "stdio" || config.type === "http" || config.type === "sse") {
+        type = config.type;
+    } else if (command) {
+        type = "stdio";
+    } else if (url) {
+        type = "http";
+    }
+
+    const args = Array.isArray(config.args) ? config.args.map((a) => String(a)) : undefined;
+
+    return {
+        type,
+        ...(command ? { command } : {}),
+        ...(args ? { args } : {}),
+        ...(config.env ? { env: config.env } : {}),
+        ...(url ? { url } : {}),
+        ...(config.headers ? { headers: config.headers } : {}),
+    };
+}
+
+/**
+ * Pick the config to report for a server seen in several providers. An enabled
+ * instance wins, because a disabled provider entry can be a stale leftover.
+ */
+function pickConfig(instances: MCPServerInfo[]): UnifiedMCPServerConfig | undefined {
+    const enabled = instances.find((i) => i.enabled && (i.config?.command || i.config?.url || i.config?.httpUrl));
+    if (enabled) {
+        return enabled.config;
+    }
+
+    return (
+        instances.find((i) => i.config?.command || i.config?.url || i.config?.httpUrl)?.config ?? instances[0]?.config
+    );
+}
+
+async function collect(providers: MCPProvider[]): Promise<{
+    byName: Map<string, MCPServerInfo[]>;
+    scanned: string[];
+    failed: { provider: string; error: string }[];
+}> {
     const allServers: MCPServerInfo[] = [];
+    const scanned: string[] = [];
+    const failed: { provider: string; error: string }[] = [];
 
     for (const provider of providers) {
         try {
             if (await provider.configExists()) {
                 const servers = await provider.listServers();
                 allServers.push(...servers);
+                scanned.push(provider.getName());
             }
         } catch (error) {
-            logger.warn(
-                `Failed to read ${provider.getName()} config: ${error instanceof Error ? error.message : String(error)}`
-            );
+            const message = error instanceof Error ? error.message : String(error);
+            failed.push({ provider: provider.getName(), error: message });
+            logger.warn(`Failed to read ${provider.getName()} config: ${message}`);
         }
     }
 
-    if (allServers.length === 0) {
+    const byName = new Map<string, MCPServerInfo[]>();
+    for (const server of allServers) {
+        if (!byName.has(server.name)) {
+            byName.set(server.name, []);
+        }
+
+        byName.get(server.name)?.push(server);
+    }
+
+    return { byName, scanned, failed };
+}
+
+/**
+ * List all MCP servers across all providers.
+ *
+ * With `--json` this becomes the programmatic registry other tools read (the
+ * mcp-scripting skill builds mcporter ServerDefinitions straight from it), so
+ * the JSON carries connection details the human listing never printed.
+ */
+export async function listServers(providers: MCPProvider[], options: ListOptions = {}): Promise<void> {
+    const { byName, scanned, failed } = await collect(providers);
+
+    if (options.json) {
+        const servers: ServerJsonEntry[] = [];
+
+        for (const [name, instances] of byName.entries()) {
+            const enabledCount = instances.filter((s) => s.enabled).length;
+            const status = enabledCount === instances.length ? "enabled" : enabledCount > 0 ? "partial" : "disabled";
+
+            if (options.enabledOnly && enabledCount === 0) {
+                continue;
+            }
+
+            servers.push({
+                name,
+                enabled: enabledCount > 0,
+                status,
+                providers: instances.map((i) => ({ provider: i.provider, enabled: i.enabled })),
+                connection: toConnection(pickConfig(instances)),
+            });
+        }
+
+        servers.sort((a, b) => a.name.localeCompare(b.name));
+        logger.debug({ count: servers.length, scanned, failed }, "mcp-manager list --json");
+        out.result({ servers, providersScanned: scanned, providersFailed: failed } satisfies ListJsonOutput);
+        return;
+    }
+
+    if (byName.size === 0) {
         logger.info("No MCP servers found.");
         return;
     }
 
-    // Group by server name
-    const serversByName = new Map<string, MCPServerInfo[]>();
-    for (const server of allServers) {
-        if (!serversByName.has(server.name)) {
-            serversByName.set(server.name, []);
-        }
-        serversByName.get(server.name)?.push(server);
-    }
-
-    // Display
     logger.info("\nMCP Servers:\n");
-    for (const [name, instances] of serversByName.entries()) {
+    for (const [name, instances] of byName.entries()) {
         const enabledCount = instances.filter((s) => s.enabled).length;
         const status = enabledCount === instances.length ? "✓" : enabledCount > 0 ? "⚠" : "✗";
         const statusText = enabledCount === instances.length ? "enabled" : enabledCount > 0 ? "partial" : "disabled";
@@ -57,6 +189,7 @@ export async function listServers(providers: MCPProvider[]): Promise<void> {
 
             logger.info(`  └─ ${instance.provider}: ${providerStatus}`);
         }
+
         logger.info("");
     }
 }

--- a/src/mcp-manager/index.ts
+++ b/src/mcp-manager/index.ts
@@ -156,10 +156,12 @@ program
 program
     .command("list")
     .description("List all MCP servers across all providers")
-    .action(async () => {
+    .option("--json", "Output servers as JSON incl. transport/connection details (machine-readable)")
+    .option("--enabled-only", "With --json, only include servers enabled in at least one provider")
+    .action(async (cmdOptions) => {
         const opts = program.opts();
         const providers = parseProviderArg(opts.provider, getProviders());
-        await listServers(providers);
+        await listServers(providers, { json: cmdOptions.json, enabledOnly: cmdOptions.enabledOnly });
     });
 
 // enable command


### PR DESCRIPTION
## What

`tools mcp-manager list --json`, so other tools can consume the MCP server registry as data instead of scraping the human table.

Plus a biome line-wrap pass over the list command.

## Why

The registry was only available as formatted terminal output. Anything wanting to act on it (a dashboard, another tool, an agent) had to parse the box-drawn table.

## Scope

`src/mcp-manager/**`.

Split out of #296. Kept separate from the plugin PR rather than folded into it: nothing under `plugins/` consumes `mcp-manager list --json`, so there is no dependency to preserve between them. File-disjoint from the sibling PRs.
