### PR TITLE
feat(scripts): tools scripts — MCP scripting ported from the personal skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.41",
+            "version": "1.0.42",
             "author": {
                 "name": "GenesisTools"
             },

--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,7 @@
         "marked-alert": "^2.1.2",
         "marked-highlight": "^2.2.4",
         "marked-katex-extension": "^5.1.8",
+        "mcporter": "^0.12.3",
         "mdream": "^0.15.3",
         "minimatch": "^10.0.1",
         "object-hash": "^3.0.0",
@@ -630,6 +631,8 @@
     "@hlidac-shopu/actors-common": ["@hlidac-shopu/actors-common@3.2.5", "", { "dependencies": { "@hlidac-shopu/lib": "1.5.3", "@thi.ng/atom": "5.3.52", "linkedom": "0.18.12", "rollbar": "2.26.5" }, "peerDependencies": { "apify": "^3.2.0" } }, "sha512-iFF5h1L2gTwlvxCXWXEdOvbLxWhGNv7BUL689mdEuD17ZXuuWf76Im46TpHqTK/7lOANMI7qJt98w2hFfN6QMg=="],
 
     "@hlidac-shopu/lib": ["@hlidac-shopu/lib@1.5.3", "", { "dependencies": { "chart.js": "4.5.1", "chartjs-adapter-date-fns": "3.0.0", "date-fns": "4.1.0", "lit": "3.3.2" } }, "sha512-a/9TZyimXhIayiezEgeRCPR2/Sgyr3qWkE3Jjz4+6EwpjxZ7pYVwbv2vuxQ7aBLVVsp/qdUl2M3OyNhbwJ8auQ=="],
+
+    "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
 
     "@huggingface/inference": ["@huggingface/inference@4.13.15", "", { "dependencies": { "@huggingface/jinja": "^0.5.5", "@huggingface/tasks": "^0.19.90" } }, "sha512-V7B13KFDVhYkQqgx8vpMcmtEG+PoePlh65IUvpphTTItHAq6zRLcsS4torh1QavUaT+6nEwho4wFXzBQNGBwKQ=="],
 
@@ -1615,7 +1618,9 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
@@ -1628,6 +1633,8 @@
     "ai": ["ai@7.0.22", "", { "dependencies": { "@ai-sdk/gateway": "4.0.16", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
@@ -1756,6 +1763,8 @@
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bonjour-service": ["bonjour-service@1.4.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "multicast-dns": "^7.2.5" } }, "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w=="],
 
@@ -1927,13 +1936,21 @@
 
     "console-polyfill": ["console-polyfill@0.3.0", "", {}, "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
@@ -2069,11 +2086,15 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron": ["electron@23.3.13", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^16.11.26", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-BaXtHEb+KYKLouUXlUVDa/lj9pj4F5kiE0kwFdJV84Y2EU7euIDgPthfKtchhr5MVHmjtavRMIV/zAwEiSQ9rQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.277", "", {}, "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-japanese": ["encoding-japanese@2.2.0", "", {}, "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="],
 
@@ -2125,6 +2146,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "escodegen": ["escodegen@1.14.3", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^4.2.0", "esutils": "^2.0.2", "optionator": "^0.8.1" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw=="],
@@ -2163,6 +2186,8 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "event-emitter": ["event-emitter@0.3.5", "", { "dependencies": { "d": "1", "es5-ext": "~0.10.14" } }, "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA=="],
 
     "event-stream": ["event-stream@3.3.4", "", { "dependencies": { "duplexer": "~0.1.1", "from": "~0", "map-stream": "~0.1.0", "pause-stream": "0.0.11", "split": "0.3", "stream-combiner": "~0.0.4", "through": "~2.3.1" } }, "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g=="],
@@ -2182,6 +2207,10 @@
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
     "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -2239,6 +2268,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
 
     "find-replace": ["find-replace@3.0.0", "", { "dependencies": { "array-back": "^3.0.1" } }, "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ=="],
@@ -2263,7 +2294,11 @@
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
     "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "from": ["from@0.1.7", "", {}, "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="],
 
@@ -2374,6 +2409,8 @@
     "hogan.js": ["hogan.js@3.0.2", "", { "dependencies": { "mkdirp": "0.3.0", "nopt": "1.0.10" }, "bin": { "hulk": "./bin/hulk" } }, "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
+
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
@@ -2507,6 +2544,8 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-redirect": ["is-redirect@1.0.0", "", {}, "sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
@@ -2577,11 +2616,15 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -2725,13 +2768,19 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mcporter": ["mcporter@0.12.4", "", { "dependencies": { "@iarna/toml": "^2.2.5", "@modelcontextprotocol/sdk": "^1.30.0", "acorn": "^8.17.0", "commander": "^15.0.0", "es-toolkit": "^1.50.0", "jsonc-parser": "^3.3.1", "ora": "^9.4.1", "rolldown": "1.2.0", "zod": "^4.4.3" }, "bin": { "mcporter": "dist/cli.js" } }, "sha512-yuNUwnTuGzTRRNg/S7D+gsS1tn1BIWhsjEOLNZAVGc3ZQU4VKLf4utqwBaC1hZWRt5oIRy6LU2RSebUTbXb46g=="],
+
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "mdream": ["mdream@0.15.3", "", { "dependencies": { "cac": "^6.7.14", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" }, "bin": { "mdream": "bin/mdream.mjs" } }, "sha512-mB367AFnSiL/45kqWVR4/eIdOwzcvXTuJuVcTO7OVkOqePMXba9eK0y81BWDAFR98W6g3KJztz/upLl/5nfssA=="],
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
     "memory-stream": ["memory-stream@1.0.0", "", { "dependencies": { "readable-stream": "^3.4.0" } }, "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -2772,6 +2821,8 @@
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
@@ -2841,6 +2892,8 @@
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
@@ -2903,6 +2956,8 @@
 
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
@@ -2916,6 +2971,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -2985,6 +3042,8 @@
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -3008,6 +3067,8 @@
     "quick-lru": ["quick-lru@7.3.0", "", {}, "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 
     "rate-limiter-flexible": ["rate-limiter-flexible@7.4.0", "", {}, "sha512-IJopePGO6HnMWVdeLCihnxXZ0WCW0mxXiU5LE3bZ00GHESsCaAvgD8hN/ATIJeZhnrVdU5cfRyS1uV63Vmc4zg=="],
 
@@ -3115,6 +3176,8 @@
 
     "rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
@@ -3147,6 +3210,8 @@
 
     "semver-diff": ["semver-diff@2.1.0", "", { "dependencies": { "semver": "^5.0.3" } }, "sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "seqproto": ["seqproto@0.2.3", "", {}, "sha512-HpNyPYl7DJa2a6XQJ+MJAc6ft6Y9ZU+zRiuvTHFpLPeqvapcTAGFJyhMEIN7Y7VXhWT6NEdNVhbXFHwtaCOfCw=="],
 
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
@@ -3154,6 +3219,8 @@
     "seroval": ["seroval@1.5.1", "", {}, "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.1", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
@@ -3415,6 +3482,8 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
@@ -3488,6 +3557,8 @@
     "vali-date": ["vali-date@1.0.0", "", {}, "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@6.0.2", "", {}, "sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
@@ -3817,6 +3888,8 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3842,6 +3915,16 @@
     "babel-plugin-module-resolver/reselect": ["reselect@4.1.8", "", {}, "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="],
 
     "babel-plugin-module-resolver/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "body-parser/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "body-parser/qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "body-parser/raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "cacheable-request/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
@@ -3931,9 +4014,17 @@
 
     "eslint-plugin-react/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "espree/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
     "eventsource/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "express-rate-limit/ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "finalhandler/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -4000,6 +4091,16 @@
     "mailparser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "mcporter/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
+    "mcporter/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "mcporter/es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
+    "mcporter/ora": ["ora@9.4.1", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw=="],
+
+    "mcporter/rolldown": ["rolldown@1.2.0", "", { "dependencies": { "@oxc-project/types": "=0.140.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.0", "@rolldown/binding-darwin-arm64": "1.2.0", "@rolldown/binding-darwin-x64": "1.2.0", "@rolldown/binding-freebsd-x64": "1.2.0", "@rolldown/binding-linux-arm-gnueabihf": "1.2.0", "@rolldown/binding-linux-arm64-gnu": "1.2.0", "@rolldown/binding-linux-arm64-musl": "1.2.0", "@rolldown/binding-linux-ppc64-gnu": "1.2.0", "@rolldown/binding-linux-s390x-gnu": "1.2.0", "@rolldown/binding-linux-x64-gnu": "1.2.0", "@rolldown/binding-linux-x64-musl": "1.2.0", "@rolldown/binding-openharmony-arm64": "1.2.0", "@rolldown/binding-wasm32-wasi": "1.2.0", "@rolldown/binding-win32-arm64-msvc": "1.2.0", "@rolldown/binding-win32-x64-msvc": "1.2.0" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -4075,6 +4176,12 @@
 
     "semver-diff/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
+    "send/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "send/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -4136,6 +4243,12 @@
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
     "tsx/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "unplugin/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "unplugin/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
@@ -4245,6 +4358,8 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -4264,6 +4379,10 @@
     "babel-plugin-module-resolver/glob/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
 
     "babel-plugin-module-resolver/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "body-parser/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "body-parser/qs/side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
     "cacheable-request/get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -4345,6 +4464,8 @@
 
     "eslint/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "gauge/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -4366,6 +4487,52 @@
     "ipull/pretty-ms/parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
 
     "longest-line/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
+
+    "mcporter/@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "mcporter/ora/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "mcporter/ora/cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
+
+    "mcporter/ora/log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
+
+    "mcporter/ora/stdin-discarder": ["stdin-discarder@0.3.2", "", {}, "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A=="],
+
+    "mcporter/ora/string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+
+    "mcporter/rolldown/@oxc-project/types": ["@oxc-project/types@0.140.0", "", {}, "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ=="],
+
+    "mcporter/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.0", "", { "os": "android", "cpu": "arm64" }, "sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw=="],
+
+    "mcporter/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg=="],
+
+    "mcporter/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw=="],
+
+    "mcporter/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.0", "", { "os": "linux", "cpu": "arm" }, "sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ=="],
+
+    "mcporter/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw=="],
+
+    "mcporter/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.0", "", { "os": "none", "cpu": "arm64" }, "sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA=="],
+
+    "mcporter/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.0", "", { "dependencies": { "@emnapi/core": "1.11.2", "@emnapi/runtime": "1.11.2", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g=="],
+
+    "mcporter/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA=="],
+
+    "mcporter/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg=="],
+
+    "mcporter/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "node-llama-cpp/which/isexe": ["isexe@3.1.4", "", {}, "sha512-jCErc4h4RnTPjFq53G4whhjAMbUAqinGrCrTT4dmMNyi4zTthK+wphqbRLJtL4BN/Mq7Zzltr0m/b1X0m7PGFQ=="],
 
@@ -4400,6 +4567,8 @@
     "react-devtools/cross-spawn/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "restore-cursor/onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -4471,6 +4640,8 @@
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "update-notifier/boxen/ansi-align": ["ansi-align@2.0.0", "", { "dependencies": { "string-width": "^2.0.0" } }, "sha512-TdlOggdA/zURfMYa7ABC66j+oqfMew58KpJMbUlH3bcZP1b+cBHIHDDn5uH9INsxrHBPjsqM0tDB4jPTF/vgJA=="],
 
     "update-notifier/boxen/camelcase": ["camelcase@4.1.0", "", {}, "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw=="],
@@ -4525,6 +4696,8 @@
 
     "babel-plugin-module-resolver/glob/path-scurry/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
+    "body-parser/qs/side-channel/side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
     "chalk-template/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "cli-highlight/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -4560,6 +4733,14 @@
     "grammy/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "grammy/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "mcporter/ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "mcporter/ora/string-width/get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "mcporter/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
+
+    "mcporter/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "node-llama-cpp/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -4610,6 +4791,8 @@
     "cmake-js/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cmake-js/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "mcporter/ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "node-llama-cpp/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
         "marked-alert": "^2.1.2",
         "marked-highlight": "^2.2.4",
         "marked-katex-extension": "^5.1.8",
+        "mcporter": "^0.12.3",
         "mdream": "^0.15.3",
         "minimatch": "^10.0.1",
         "object-hash": "^3.0.0",

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/skills/mcp-scripting/SKILL.md
+++ b/plugins/genesis-tools/skills/mcp-scripting/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: mcp-scripting
+description: Call MCP tools from a plain TypeScript script via `tools scripts`, with typed bindings generated from each server's live tools/list. Use this WHENEVER a task means calling the same MCP tool many times, chaining several tools in a fixed order, looping or diffing over tool results, or when the tool you need belongs to a server this session did not load. Triggers on "script this MCP call", "call <server> tools in a loop", "without burning context on tool definitions", "scratch script for <server>", "one-shot MCP call", "what MCP servers do I have", "list the tools on <server>", "generate types from an MCP server", "tools scripts", "mcp-scripts", "mcporter". Also use PROACTIVELY when about to issue the same MCP tool call more than about three times in a row, since the script version costs one tool call instead of N.
+---
+
+# MCP scripting (`tools scripts`)
+
+Every MCP server already configured on this machine is reachable from a normal Bun script.
+No agent loop, no tool definitions in context, no waiting for a model turn between calls.
+
+```bash
+tools scripts servers                       # what exists, and how it connects
+tools scripts tools 'genesis-tools.*'       # live tools/list, cached after first probe
+tools scripts describe 'genesis-tools.handoff_post'   # params before you write a call
+tools scripts call genesis-tools.handoff_list '{"limit":5}'
+```
+
+Full reference: `tools scripts --readme` (selector grammar, persisted-script layout, result
+helpers, recipes, credentials, token-efficiency patterns).
+
+## When this beats calling the MCP tool directly
+
+Direct tool calls are correct for one or two calls. Switch to a script when any of these is
+true:
+
+- The same tool runs more than about three times. Each direct call is a full model turn;
+  the script is one.
+- Results need looping, diffing, filtering or asserting before a human sees them. A tool
+  call cannot express control flow.
+- The server is not loaded in this session. The script does not care what the session
+  loaded at startup.
+- The output is large and only a slice matters. Filter inside the script; the model never
+  sees the rest.
+- The sequence needs to be repeatable later. Persisted scripts survive the session.
+
+## Selectors
+
+`[provider:]<server>.<tool>`, either half may contain `*`: `chrome-devtools-mcp.*`,
+`*.take_screenshot`, `genesis-tools.handoff_*`. A bare selector means `mcp:` (the only v1
+provider; the prefix is reserved for future surfaces like `openapi:`/`composio:`). `*.*`
+probes every server and is slow the first time.
+
+## Persisted scripts
+
+```bash
+tools scripts create colTriage \
+  --import 'chrome-devtools-mcp.*' 'genesis-tools.handoff_*' \
+  --description 'Reproduce the bug, then file a handoff' --tag triage
+tools scripts run colTriage
+tools scripts list            # gated scripts from other projects hidden; --all reveals
+tools scripts regen colTriage # after a server changes its schema
+tools scripts doctor          # verify store health, read-only
+```
+
+Scripts live in `~/.genesis-tools/scripts/persisted/<name>/`. `<name>.ts` is yours;
+`<name>.tools.ts` is generated (never hand-edit). Sidecars (presets, state, `out/`) belong
+in the same folder. `create --gated` scopes the script's visibility to the current project;
+`run` works from anywhere regardless. The store is a LOCAL git repo: mutating verbs
+auto-commit, so `tools scripts git -- log --oneline` is the history of every script.
+Off-machine history is opt-in and remembered: `tools scripts remote <url>` (sets origin,
+pushes, persists the decision; `--auto-push on` pushes on every commit; `--none` declines
+and silences the offer).
+
+Script body shape — bindings are camelCase, server-prefixed when the import spans servers:
+
+```typescript
+import { data, must, text, withKit } from "@gt/scripts/kit";
+import * as T from "./colTriage.tools.ts";
+
+await withKit(async (kit) => {
+    const pages = must(await T.chromeDevtoolsMcp_listPages(kit), "list_pages");
+    console.log(text(pages));
+
+    // Independent calls run concurrently over the open session (MCP has no batching).
+    const [snap, logs] = await kit.all([
+        () => T.chromeDevtoolsMcp_takeSnapshot(kit),
+        () => T.chromeDevtoolsMcp_listConsoleMessages(kit),
+    ]);
+
+    // Anything not bound at create time is still reachable.
+    const raw = await kit.callRef("genesis-tools.handoff_list", { limit: 3 });
+    console.log(data<{ handoffs: unknown[] }>(raw)?.handoffs.length);
+}, { servers: ["chrome-devtools-mcp", "genesis-tools"] });
+```
+
+Result helpers from `@gt/scripts/kit`: `text` (concatenated text blocks), `data<T>`
+(structuredContent, else text-as-JSON), `images`, `isError`, `must` (throw on tool error),
+`result` (mcporter's full CallResult). `withKit` always closes the runtime; use it over
+`createKit` so stdio servers do not leak processes.
+
+## Worth knowing
+
+- **Remote servers authenticate with Claude Code's own OAuth tokens** (read from its
+  credential store; scripts are headless). Expired/missing tokens are reported up front —
+  the raw failure otherwise reads as `SSE error: Non-200 status code (405)`, which says
+  nothing about credentials. Re-authorise with `/mcp`. Tokens are never refreshed here:
+  refresh tokens rotate and spending Claude Code's copy would break the server in-app.
+- **No wire batching in MCP** (removed 2025-06-18). `kit.all()` fires concurrent requests
+  over one open session — the only lever.
+- **First probe of a stdio server is slow** (spawn + handshake); cached after, `--refresh`
+  busts. Failed servers are cached as errors and reported, not re-probed every run.
+- **Large results:** print a value in full exactly once (`@gt/scripts/refs`), or print its
+  shape instead of its data (`@gt/scripts/schema` — `formatSchema`, `describeCollection`;
+  12,632 chars of JSON vs 57 of skeleton on a real 900-element array).

--- a/src/mcp-manager/commands/list.ts
+++ b/src/mcp-manager/commands/list.ts
@@ -161,6 +161,36 @@ async function collect(providers: MCPProvider[]): Promise<{
 }
 
 /**
+ * Build the registry payload of `list --json` without printing it. This is the
+ * programmatic entrypoint `tools scripts` consumes to construct mcporter
+ * ServerDefinitions in-process instead of spawning `tools mcp-manager`.
+ */
+export async function buildListJson(providers: MCPProvider[], options: ListOptions = {}): Promise<ListJsonOutput> {
+    const { byName, scanned, failed } = await collect(providers);
+    const servers: ServerJsonEntry[] = [];
+
+    for (const [name, instances] of byName.entries()) {
+        const enabledCount = instances.filter((s) => s.enabled).length;
+        const status = enabledCount === instances.length ? "enabled" : enabledCount > 0 ? "partial" : "disabled";
+
+        if (options.enabledOnly && enabledCount === 0) {
+            continue;
+        }
+
+        servers.push({
+            name,
+            enabled: enabledCount > 0,
+            status,
+            providers: instances.map((i) => ({ provider: i.provider, enabled: i.enabled })),
+            connection: toConnection(pickConfig(instances)),
+        });
+    }
+
+    servers.sort((a, b) => a.name.localeCompare(b.name));
+    return { servers, providersScanned: scanned, providersFailed: failed };
+}
+
+/**
  * List all MCP servers across all providers.
  *
  * With `--json` this becomes the programmatic registry other tools read (the
@@ -168,33 +198,17 @@ async function collect(providers: MCPProvider[]): Promise<{
  * the JSON carries connection details the human listing never printed.
  */
 export async function listServers(providers: MCPProvider[], options: ListOptions = {}): Promise<void> {
-    const { byName, scanned, failed } = await collect(providers);
-
     if (options.json) {
-        const servers: ServerJsonEntry[] = [];
-
-        for (const [name, instances] of byName.entries()) {
-            const enabledCount = instances.filter((s) => s.enabled).length;
-            const status = enabledCount === instances.length ? "enabled" : enabledCount > 0 ? "partial" : "disabled";
-
-            if (options.enabledOnly && enabledCount === 0) {
-                continue;
-            }
-
-            servers.push({
-                name,
-                enabled: enabledCount > 0,
-                status,
-                providers: instances.map((i) => ({ provider: i.provider, enabled: i.enabled })),
-                connection: toConnection(pickConfig(instances)),
-            });
-        }
-
-        servers.sort((a, b) => a.name.localeCompare(b.name));
-        logger.debug({ count: servers.length, scanned, failed }, "mcp-manager list --json");
-        out.result({ servers, providersScanned: scanned, providersFailed: failed } satisfies ListJsonOutput);
+        const payload = await buildListJson(providers, options);
+        logger.debug(
+            { count: payload.servers.length, scanned: payload.providersScanned, failed: payload.providersFailed },
+            "mcp-manager list --json"
+        );
+        out.result(payload);
         return;
     }
+
+    const { byName } = await collect(providers);
 
     if (byName.size === 0) {
         logger.info("No MCP servers found.");

--- a/src/mcp-manager/index.ts
+++ b/src/mcp-manager/index.ts
@@ -9,10 +9,7 @@ p.setBackend(inquirerBackend);
 
 import { Command } from "commander";
 import { showHelp } from "./utils/command.utils.js";
-import { ClaudeProvider } from "./utils/providers/claude.js";
-import { CodexProvider } from "./utils/providers/codex.js";
-import { CursorProvider } from "./utils/providers/cursor.js";
-import { GeminiProvider } from "./utils/providers/gemini.js";
+import { defaultProviders } from "./utils/providers/index.js";
 import type { MCPProvider } from "./utils/providers/types.js";
 
 // Handle --readme flag early (before Commander parses)
@@ -60,7 +57,7 @@ configureLogger({
  * Get all available providers
  */
 function getProviders(): MCPProvider[] {
-    return [new ClaudeProvider(), new GeminiProvider(), new CodexProvider(), new CursorProvider()];
+    return defaultProviders();
 }
 
 /**

--- a/src/mcp-manager/utils/providers/index.ts
+++ b/src/mcp-manager/utils/providers/index.ts
@@ -1,0 +1,15 @@
+import { ClaudeProvider } from "./claude.js";
+import { CodexProvider } from "./codex.js";
+import { CursorProvider } from "./cursor.js";
+import { GeminiProvider } from "./gemini.js";
+import type { MCPProvider } from "./types.js";
+
+/**
+ * Every provider mcp-manager knows how to read. The single construction point,
+ * shared by the mcp-manager CLI and programmatic consumers (`tools scripts`
+ * builds its server registry from these instead of spawning `tools mcp-manager
+ * list --json`).
+ */
+export function defaultProviders(): MCPProvider[] {
+    return [new ClaudeProvider(), new GeminiProvider(), new CodexProvider(), new CursorProvider()];
+}

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,0 +1,256 @@
+# `tools scripts`
+
+Call MCP tools from a plain TypeScript script instead of through an agent loop, with typed
+bindings generated from each server's live `tools/list`. Every MCP server already configured
+on this machine (any provider mcp-manager reads: Claude global and per-project, Gemini,
+Cursor, Codex) is reachable — no agent loop, no tool definitions in context, no waiting for
+a model turn between calls.
+
+```bash
+tools scripts servers                       # what exists, and how it connects
+tools scripts tools 'genesis-tools.*'       # live tools/list, cached after first probe
+tools scripts call genesis-tools.handoff_list '{"limit":5}'
+```
+
+## When this beats calling an MCP tool directly
+
+Direct tool calls are correct for one or two calls. Switch to a script when any of these is
+true:
+
+- The same tool runs more than about three times. Each direct call is a full model turn; the
+  script is one.
+- Results need looping, diffing, filtering or asserting before a human sees them.
+- The server is not loaded in the current agent session. The script does not care what the
+  session loaded at startup.
+- The output is large and only a slice matters. Filter inside the script.
+- The sequence needs to be repeatable later. Persisted scripts survive the session.
+
+## Selector grammar
+
+`tools`, `describe`, `call` and `create --import` take selectors of the form
+`[provider:]<server>.<tool>`. Either half of the pair may contain `*`:
+
+| Selector | Means |
+|---|---|
+| `chrome-devtools-mcp.*` | every tool on that server |
+| `chrome-devtools-mcp` | same, shorthand |
+| `*.take_screenshot` | that tool wherever it exists |
+| `genesis-tools.handoff_*` | prefix match on the tool name |
+| `mcp:genesis-tools.handoff_*` | same, provider spelled out |
+| `*.*` | everything, which probes every server and is slow the first time |
+
+The provider prefix is reserved grammar for future binding surfaces (`openapi:`,
+`composio:`, `graphql:`, `gt:`). **A bare selector means `mcp:` forever**, so the short form
+never breaks. v1 implements only the mcp provider.
+
+Add `--schema` to `tools` for full input schemas, `--grep` to search names and
+descriptions, `--json` for machine output, `--refresh` to re-probe.
+
+## Persisted scripts
+
+`create` writes a runnable scaffold with typed bindings for exactly the tools you name.
+
+```bash
+tools scripts create colTriage \
+  --import 'chrome-devtools-mcp.*' 'genesis-tools.handoff_*' \
+  --description 'Reproduce the bug, then file a handoff' \
+  --tag triage --tag col
+```
+
+Scripts live in a global store at `~/.genesis-tools/scripts/`, one directory per script:
+
+- `persisted/colTriage/colTriage.ts` is yours. Edit it freely.
+- `persisted/colTriage/colTriage.tools.ts` is generated: one function per matched tool,
+  argument types derived from the server's live `inputSchema`, description carried over as
+  JSDoc. Never hand-edit it; `regen` rewrites it.
+- Anything else the script needs — a preset, a state file, a progress log, an `out/`
+  directory — belongs in that same folder.
+
+The two-file split exists so regenerating bindings after a server changes its schema cannot
+touch your code. `create` without `--import` scaffolds a bindings-free script that still has
+the kit (use `kit.callRef`).
+
+```bash
+tools scripts run colTriage -- --flag value   # runs it, records the run; script args after --
+tools scripts list                            # scripts visible from here
+tools scripts show colTriage                  # metadata plus source
+tools scripts regen colTriage                 # re-probe, rewrite bindings, report added/removed
+tools scripts rename colTriage triage         # folder, files, sidecars, imports, journal
+tools scripts rm colTriage                    # moves to trash/, prints the restore command
+tools scripts doctor                          # verify the store; read-only, prints fixes
+```
+
+### Versioning (the store is a git repo)
+
+The store is initialised as a plain **local** git repository on first scaffold, with
+`node_modules/`, `cache/`, `trash/` and per-script `out*/` ignored. Every mutating verb
+(`create`, `regen`, `rename`, `tag`, `rm`) auto-commits its change (staging an explicit
+allowlist, never the credential cache), so script history is always one
+`tools scripts git -- log --oneline` away; `run` does not commit (run-counter churn is
+swept by the next mutation).
+
+No remote exists until you decide. The decision is persisted in the store's
+`config.json`, and `create` prints a one-line offer until you make it:
+
+```bash
+tools scripts remote <url>                # add/update origin, push -u, remember the decision
+tools scripts remote --none               # "no remote wanted" — stops the offer
+tools scripts remote --auto-push on       # push after every store commit (off by default)
+tools scripts remote                      # show origin + auto-push state
+tools scripts git -- log --oneline        # any git command against the store
+```
+
+### Gating (project-scoped visibility)
+
+`create --gated` marks a script as belonging to the current project (the enclosing git
+repo). Outside that directory tree it disappears from `list` (`--all` reveals it), but
+`run <name>` works from anywhere — metadata never gates execution. Toggle later with
+`tag <name> --gate` / `--ungate`. Everything else (`--project`, `--tag`, `--cwd`,
+`--server`, `--grep`) is a descriptive filter, never a restriction.
+
+## How a persisted script resolves its imports
+
+The store carries a generated `tsconfig.json` mapping `@gt/scripts/*` to this checkout's
+`src/scripts/lib/`. Bun resolves the nearest tsconfig upward from the entry file, so plain
+`bun persisted/x/x.ts` works and scripts read cleanly:
+
+```typescript
+import { data, must, text, withKit } from "@gt/scripts/kit";
+import * as T from "./colTriage.tools.ts";
+
+await withKit(async (kit) => {
+    const pages = must(await T.chromeDevtoolsMcp_listPages(kit), "list_pages");
+    console.log(text(pages));
+
+    // Independent calls run concurrently over the open session.
+    const [snapshot, console_] = await kit.all([
+        () => T.chromeDevtoolsMcp_takeSnapshot(kit),
+        () => T.chromeDevtoolsMcp_listConsoleMessages(kit),
+    ]);
+
+    // Anything not bound at create time is still reachable.
+    const raw = await kit.callRef("genesis-tools.handoff_list", { limit: 3 });
+    console.log(data<{ handoffs: unknown[] }>(raw)?.handoffs.length);
+}, { servers: ["chrome-devtools-mcp", "genesis-tools"] });
+```
+
+If the repo moves, the next `create`/`run` rewrites the mapping; `doctor` reports a stale
+one. npm deps a script imports directly (`commander`, `picocolors`, plus anything you
+`bun add` there) come from the store's own `package.json` — `run` installs them when
+missing. `mcporter` resolves from the repo because only kit code imports it.
+
+Binding names are the tool name in camelCase; when an import spans more than one server
+they are prefixed with the server (`chromeDevtoolsMcp_listPages`). The generated file's
+`TOOLS` export lists them all.
+
+### Result helpers
+
+MCP results are an envelope, not the value you want. From `@gt/scripts/kit`:
+
+| Helper | Gives you |
+|---|---|
+| `text(raw)` | the concatenated text blocks, the usual case |
+| `data<T>(raw)` | `structuredContent` when the server declared an `outputSchema`, else the text parsed as JSON, else `undefined` |
+| `images(raw)` | base64 image blocks, e.g. from a screenshot tool |
+| `isError(raw)` | whether the server flagged the call as failed |
+| `must(raw, label)` | the value, or a throw carrying the server's error text |
+| `result(raw)` | mcporter's full `CallResult` when you want `.markdown()` or `.content()` |
+
+`withKit` always closes the runtime, including on a throw. Use it rather than `createKit`
+so stdio servers do not leak processes.
+
+## Recipes
+
+**Fan out one tool over many inputs** — the single biggest win; thirty calls cost one model
+turn:
+
+```typescript
+const results = await kit.all(
+    QUERIES.map((q) => async () => ({
+        query: q,
+        hits: text(must(await T.searchGitHub(kit, { query: q }), q)).split("\n").length,
+    }))
+);
+```
+
+**Poll until a condition holds** — a loop belongs in a script, never in an agent turn:
+
+```typescript
+const deadline = Date.now() + 5 * 60_000;
+while (Date.now() < deadline) {
+    const state = data<{ status: string }>(await T.getStatus(kit, { id }));
+    if (state?.status === "done") return;
+    await Bun.sleep(5_000);
+}
+throw new Error("timed out");
+```
+
+**Filter a huge result before anything sees it**:
+
+```typescript
+const all = data<{ requests: Request[] }>(await T.listNetworkRequests(kit))?.requests ?? [];
+const failed = all.filter((r) => r.status >= 400);
+console.log(`${failed.length} failed of ${all.length}`);
+```
+
+**Chain two servers** — read from one, write to the other, real logic in between (this is
+why multi-server imports exist). **Diff two runs** — capture, change something, capture
+again, compare; impossible to express as direct tool calls.
+
+## Token efficiency
+
+A script that hands raw tool output to a model pays for that output every time it is
+mentioned. Two library halves address it, both importable from any script:
+
+- `@gt/scripts/refs` — print a large value in full exactly once, preview it thereafter
+  (`formatValueWithRef`, `loadRefStore`, `saveRefStore`, `truncateList`, `parseRef`). Ids
+  are derivable (`n5.cont` = node 5, context field), never random.
+- `@gt/scripts/schema` — shape instead of data: `formatSchema(payload)` renders
+  `{ id: number, items: [{ title: string, note?: string }] }` for the cost of one line
+  (`"skeleton"` | `"typescript"` | `"schema"` modes), and `describeCollection(items)` gives
+  a one-line census. Array items are unioned, not sampled, so a field present in one of 900
+  elements still shows up. On a real 900-element array: 12,632 chars of JSON versus 57 of
+  skeleton.
+
+Rules the ref system encodes, worth applying even without it: print a large value in full
+exactly once; make ids derivable; one mandatory load verb that indexes and caches; never
+drop silently (`truncateList` says `… +N more`); one escape hatch named `--full`
+everywhere; end output with a `Tip:` naming the exact next command.
+
+## Credentials
+
+Remote MCP servers are OAuth-protected, and a script has no browser.
+`src/scripts/lib/claude-tokens.ts` reads the tokens Claude Code already obtained (keychain
+payload, `mcpOAuth` key) and attaches them as Bearer headers. Worth knowing:
+
+- **A missing token does not look like a missing token.** The streamable POST 401s,
+  mcporter falls back to legacy SSE, and that GET returns 405. The visible error is
+  `SSE error: Non-200 status code (405)`. The kit therefore reports missing/expired tokens
+  up front on stderr.
+- **Expired tokens are reported, not refreshed.** Refresh tokens rotate; spending Claude
+  Code's copy would break the server inside the app. Re-authorise with `/mcp`.
+- **Reusing the app's token also dodges client whitelisting** (Figma 403s unapproved OAuth
+  clients). Do not register a new client to "do it properly" — that is the path that fails.
+
+## Facts worth knowing before designing a script
+
+- **There is no batching.** JSON-RPC batching was removed from MCP in the 2025-06-18 spec
+  revision. `kit.all()` fires concurrent requests over one open session — the only lever.
+- **The first probe of a stdio server is slow** (process spawn + initialize handshake).
+  Cached afterwards; `--refresh` busts it. A failed server is cached as an error so one
+  broken entry does not re-block later runs.
+- **Servers that need arguments you do not have fail at the schema, not at runtime.** Read
+  `describe '<server>.<tool>'` before writing calls.
+- **A server disabled everywhere is not listed.** `servers --all` shows those too; enable
+  via `tools mcp-manager enable`.
+
+## Cache and state
+
+| Path | What |
+|---|---|
+| `~/.genesis-tools/scripts/cache/registry.json` | last provider scan, busted by `--refresh` |
+| `~/.genesis-tools/scripts/cache/tools.json` | per-server `tools/list`, busted by `--refresh` |
+| `~/.genesis-tools/scripts/persisted/_journal.json` | script metadata, tags, gating, run history |
+| `~/.genesis-tools/scripts/persisted/<name>/` | one script, its bindings, its sidecars |
+| `~/.genesis-tools/scripts/trash/` | where `rm` moves things; nothing is deleted outright |
+| `~/.genesis-tools/scripts/tsconfig.json` | generated `@gt/scripts/*` alias into this checkout |

--- a/src/scripts/commands/call.test.ts
+++ b/src/scripts/commands/call.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { asArgsObject } from "./call.ts";
+
+describe("asArgsObject", () => {
+    it("passes plain objects through", () => {
+        expect(asArgsObject({ limit: 5 }, "stdin")).toEqual({ limit: 5 });
+    });
+
+    it("rejects arrays, primitives and null, naming the source", () => {
+        expect(() => asArgsObject([1, 2], "args.json")).toThrow(/args\.json.*an array/);
+        expect(() => asArgsObject("x", "stdin")).toThrow(/stdin.*string/);
+        expect(() => asArgsObject(5, "the args argument")).toThrow(/number/);
+        expect(() => asArgsObject(null, "stdin")).toThrow(/object/);
+    });
+});

--- a/src/scripts/commands/call.ts
+++ b/src/scripts/commands/call.ts
@@ -1,0 +1,83 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { createKit, text } from "../lib/kit.ts";
+import { parseSelector } from "../lib/match.ts";
+import { enabledServers, loadRegistry } from "../lib/registry.ts";
+
+/**
+ * MCP tool arguments are always a JSON object; catch `[1,2]` / `"x"` / `5` at
+ * the CLI boundary with a message naming the input, not deep inside the
+ * transport. Exported for tests.
+ */
+export function asArgsObject(parsed: unknown, source: string): Record<string, unknown> {
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error(
+            `Arguments from ${source} must be a JSON object, got ${Array.isArray(parsed) ? "an array" : typeof parsed}.`
+        );
+    }
+
+    return parsed as Record<string, unknown>;
+}
+
+async function resolveArgs(
+    argsJson: string | undefined,
+    argsFile: string | undefined
+): Promise<Record<string, unknown> | undefined> {
+    if (argsFile) {
+        const raw = argsFile === "-" ? await Bun.stdin.text() : await Bun.file(argsFile).text();
+        return asArgsObject(SafeJSON.parse(raw), argsFile === "-" ? "stdin" : argsFile);
+    }
+
+    if (argsJson) {
+        // SafeJSON (comment-json) so trailing commas and comments survive shell quoting experiments.
+        return asArgsObject(SafeJSON.parse(argsJson), "the args argument");
+    }
+
+    return undefined;
+}
+
+export function registerCall(program: Command): void {
+    program
+        .command("call <ref> [args]")
+        .description("One-shot call. ref is '<server>.<tool>', args is a JSON object.")
+        .option("--args-file <path>", "Read the JSON arguments from a file, or '-' for stdin")
+        .option("--json", "Print the raw MCP result envelope instead of just text")
+        .option("--timeout <ms>", "Per-call timeout", "120000")
+        .action(
+            async (
+                ref: string,
+                argsJson: string | undefined,
+                opts: { argsFile?: string; json?: boolean; timeout: string }
+            ) => {
+                const registry = await loadRegistry();
+                const available = enabledServers(registry).map((s) => s.name);
+                const selector = parseSelector(ref, available);
+
+                if (selector.tool === "*" || selector.tool.includes("*")) {
+                    throw new Error(`'${ref}' must name exactly one tool, not a pattern`);
+                }
+
+                const timeoutMs = Number(opts.timeout);
+
+                if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+                    throw new Error(`--timeout must be a positive number of milliseconds, got '${opts.timeout}'.`);
+                }
+
+                const args = await resolveArgs(argsJson, opts.argsFile);
+                const kit = await createKit({ servers: [selector.server], timeoutMs });
+
+                try {
+                    const result = await kit.call(selector.server, selector.tool, args);
+
+                    if (opts.json) {
+                        out.result(result);
+                    } else {
+                        out.print(text(result));
+                    }
+                } finally {
+                    await kit.close();
+                }
+            }
+        );
+}

--- a/src/scripts/commands/create.ts
+++ b/src/scripts/commands/create.ts
@@ -1,0 +1,204 @@
+import { chmod, copyFile, mkdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { logger, out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { resolveSelectors } from "../lib/discover.ts";
+import {
+    findProjectRoot,
+    inferProject,
+    SCRIPT_NAME_RE,
+    type ScriptEntry,
+    scriptPaths,
+    upsertEntry,
+} from "../lib/journal.ts";
+import { type BoundTool, bindNames, renderScriptModule, renderToolsModule } from "../lib/scaffold.ts";
+import { commitStore, ensureStoreScaffold, readStoreConfig, storeRemoteUrl, trashDir } from "../lib/store.ts";
+
+interface CreateOptions {
+    import?: string[];
+    description?: string;
+    tag?: string[];
+    project?: string;
+    gated?: boolean;
+    refresh?: boolean;
+    force?: boolean;
+    dryRun?: boolean;
+}
+
+export function registerCreate(program: Command): void {
+    program
+        .command("create <name>")
+        .description("Scaffold persisted/<name>/ with typed bindings for the imported tools")
+        .option("-i, --import <selectors...>", "Tool selectors, e.g. 'chrome-devtools-mcp.*' '*.handoff_*'")
+        .option("-d, --description <text>", "What this script is for")
+        .option("-t, --tag <tags...>", "Tags for filtering later")
+        .option("-p, --project <name>", "Project label (defaults to the inferred repo name)")
+        .option("--gated", "Hide from `list` outside the current project tree (`run` still works anywhere)")
+        .option("--refresh", "Re-probe servers before binding")
+        .option("--force", "Replace an existing script of this name (the old one is copied to trash/ first)")
+        .option("--dry-run", "Show which tools would bind, write nothing")
+        .action(async (name: string, opts: CreateOptions) => {
+            if (!SCRIPT_NAME_RE.test(name)) {
+                throw new Error(
+                    `Invalid script name '${name}'. Use letters, digits, dash, underscore; start with a letter.`
+                );
+            }
+
+            const { dir: scriptDir, file, toolsFile } = scriptPaths(name);
+
+            if (!opts.force && !opts.dryRun && (await Bun.file(file).exists())) {
+                throw new Error(
+                    `${file} already exists. Pass --force to replace it (a copy goes to trash/), or pick another name.`
+                );
+            }
+
+            let bound: BoundTool[] = [];
+            let errors: { server: string; error: string }[] = [];
+
+            if (opts.import && opts.import.length > 0) {
+                // --dry-run promises "write nothing"; that includes the registry and tools caches.
+                const resolved = await resolveSelectors(opts.import, { refresh: opts.refresh, persist: !opts.dryRun });
+                errors = resolved.errors;
+
+                if (resolved.matched.length === 0) {
+                    const detail =
+                        errors.length > 0
+                            ? ` Servers that failed to start: ${errors.map((e) => e.server).join(", ")}.`
+                            : "";
+                    throw new Error(
+                        `No tools matched ${opts.import.join(", ")}.${detail} Try '${suggestCommand("tools scripts", { replaceCommand: ["tools"] })}' to see what exists.`
+                    );
+                }
+
+                bound = bindNames(resolved.matched);
+            }
+
+            const servers = [...new Set(bound.map((b) => b.server))];
+
+            if (opts.dryRun) {
+                ui.header(`dry run — ${bound.length} binding(s) across ${servers.length} server(s), nothing written`);
+
+                for (const b of bound) {
+                    ui.raw(`  ${b.fnName.padEnd(34)} ${pc.dim(`${b.server}.${b.tool.name}`)}`);
+                }
+
+                for (const e of errors) {
+                    ui.err(`${e.server}: ${e.error.slice(0, 160)}`);
+                }
+                return;
+            }
+
+            await ensureStoreScaffold();
+            logger.debug(
+                {
+                    name,
+                    selectors: opts.import ?? [],
+                    bound: bound.length,
+                    servers,
+                    force: Boolean(opts.force),
+                    gated: Boolean(opts.gated),
+                },
+                "scripts create"
+            );
+
+            // Never destroy a hand-edited script: the files being OVERWRITTEN
+            // get a trash copy first. Sidecars are not backed up because they
+            // are not touched — they stay in place untouched.
+            if (opts.force && (await Bun.file(file).exists())) {
+                const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+                await mkdir(trashDir(), { recursive: true });
+
+                for (const [src, label] of [
+                    [file, `${name}.ts`],
+                    [toolsFile, `${name}.tools.ts`],
+                ] as const) {
+                    if (await Bun.file(src).exists()) {
+                        await copyFile(src, join(trashDir(), `${stamp}-${label}`));
+                    }
+                }
+
+                ui.dim(`backed up previous ${name} to trash/${stamp}-${name}.ts`);
+            }
+
+            const cwd = process.cwd();
+            const project = opts.project ?? inferProject(cwd);
+            const gateDir = opts.gated ? (findProjectRoot(cwd) ?? cwd) : undefined;
+            const now = new Date().toISOString();
+
+            await mkdir(scriptDir, { recursive: true });
+
+            if (bound.length > 0) {
+                await Bun.write(toolsFile, renderToolsModule(bound, opts.import ?? [], now));
+            } else if (opts.force && (await Bun.file(toolsFile).exists())) {
+                // Force-recreating without --import: the old bindings file was
+                // copied to trash above; leaving the original would advertise
+                // generated bindings the new script no longer has.
+                await unlink(toolsFile);
+            }
+
+            await Bun.write(
+                file,
+                renderScriptModule({
+                    name,
+                    description: opts.description,
+                    servers,
+                    bound,
+                    selectors: opts.import ?? [],
+                    createdFrom: cwd,
+                    project,
+                    tags: opts.tag ?? [],
+                })
+            );
+            await chmod(file, 0o755);
+
+            const entry: ScriptEntry = {
+                name,
+                file,
+                description: opts.description,
+                imports: opts.import ?? [],
+                tools: bound.map((b) => `${b.server}.${b.tool.name}`),
+                servers,
+                tags: opts.tag ?? [],
+                project,
+                gateDir,
+                createdFrom: cwd,
+                createdAt: now,
+                updatedAt: now,
+                runs: 0,
+            };
+            await upsertEntry(entry);
+            await commitStore(`feat: create ${name}`);
+
+            ui.ok(`created ${bound.length} binding(s) across ${servers.length} server(s)`);
+            ui.kv("script", file);
+
+            if (bound.length > 0) {
+                const regenHint = suggestCommand("tools scripts", { replaceCommand: ["regen", name] });
+                ui.kv("bindings", `${toolsFile} ${pc.dim(`(generated, regenerate with '${regenHint}')`)}`);
+            }
+
+            if (gateDir) {
+                ui.kv("gated to", gateDir);
+            }
+
+            ui.kv("run", suggestCommand("tools scripts", { replaceCommand: ["run", name] }));
+
+            for (const e of errors) {
+                ui.err(`${e.server} did not respond: ${e.error.slice(0, 160)}`);
+            }
+
+            // One-line standing offer until the user decides either way.
+            const storeConfig = await readStoreConfig();
+
+            if (!storeConfig.remote && !(await storeRemoteUrl())) {
+                const setUp = suggestCommand("tools scripts", { replaceCommand: ["remote", "<url>"] });
+                const decline = suggestCommand("tools scripts", { replaceCommand: ["remote", "--none"] });
+                ui.dim(`tip: version this store off-machine — ${setUp} (or: ${decline})`);
+            }
+
+            out.print(scriptDir);
+        });
+}

--- a/src/scripts/commands/describe.ts
+++ b/src/scripts/commands/describe.ts
@@ -1,0 +1,71 @@
+import { ui } from "@genesiscz/utils/cli/ui";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { firstLine, paramsOf, resolveSelectors, signatureOf } from "../lib/discover.ts";
+
+export function registerDescribe(program: Command): void {
+    program
+        .command("describe <ref>")
+        .description("Full detail for one tool: every parameter with type, required flag and description.")
+        .option("--json", "Machine-readable output")
+        .option("--refresh", "Re-probe the server instead of using the tool cache")
+        .action(async (ref: string, opts: { json?: boolean; refresh?: boolean }) => {
+            const { matched, errors } = await resolveSelectors([ref], { refresh: opts.refresh });
+
+            if (matched.length === 0) {
+                const detail =
+                    errors.length > 0 ? ` Servers that failed: ${errors.map((e) => e.server).join(", ")}.` : "";
+
+                throw new Error(`No tool matched '${ref}'.${detail}`);
+            }
+
+            if (opts.json) {
+                out.result({
+                    tools: matched.map(({ server, tool }) => ({
+                        ref: `${server}.${tool.name}`,
+                        description: tool.description,
+                        params: paramsOf(tool.inputSchema),
+                        outputSchema: tool.outputSchema,
+                    })),
+                });
+                return;
+            }
+
+            for (const { server, tool } of matched) {
+                ui.raw("");
+                ui.header(`${server}.${tool.name}`);
+                ui.raw(`  ${signatureOf(tool.name, tool.inputSchema, 60)}`);
+
+                if (tool.description) {
+                    for (const line of tool.description.split("\n")) {
+                        ui.raw(pc.dim(`  ${line}`));
+                    }
+                }
+
+                const params = paramsOf(tool.inputSchema);
+
+                if (params.length === 0) {
+                    ui.raw(pc.dim("  (no parameters)"));
+                } else {
+                    const pad = Math.max(...params.map((p) => p.name.length));
+                    const typePad = Math.min(30, Math.max(...params.map((p) => p.type.length)));
+
+                    ui.raw(`  ${pc.bold("params")}`);
+
+                    for (const p of params) {
+                        const flag = p.required ? pc.red("required") : pc.dim("optional");
+                        const type = p.type.length > 30 ? `${p.type.slice(0, 29)}…` : p.type;
+
+                        ui.raw(
+                            `    ${p.name.padEnd(pad)}  ${type.padEnd(typePad)}  ${flag}  ${pc.dim(firstLine(p.desc, 90))}`
+                        );
+                    }
+                }
+
+                ui.raw(
+                    pc.dim(`  returns: ${tool.outputSchema ? "structured (outputSchema declared)" : "text blocks"}`)
+                );
+            }
+        });
+}

--- a/src/scripts/commands/doctor.ts
+++ b/src/scripts/commands/doctor.ts
@@ -1,0 +1,197 @@
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger, out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { isExpired, loadClaudeTokens } from "../lib/claude-tokens.ts";
+import { type Journal, journalHealth, readJournal } from "../lib/journal.ts";
+import { loadRegistry, loadToolCache } from "../lib/registry.ts";
+import { cacheDir, LIB_DIR, pathExists, storeDepsMissing, storeRoot } from "../lib/store.ts";
+
+interface Finding {
+    level: "ok" | "warn" | "err";
+    what: string;
+    fix?: string;
+}
+
+/**
+ * Diagnose the store. READ-ONLY by the diagnostics rule: reports and prints
+ * fix commands, never applies them — including cache fills, which is why the
+ * registry loads with `persist: false`. (`create`/`run` self-heal the tsconfig
+ * and node_modules; doctor only says whether they would.)
+ */
+export function registerDoctor(program: Command): void {
+    program
+        .command("doctor")
+        .description("Verify the script store: alias target, deps, journal, credentials. Read-only.")
+        .option("--json", "Machine-readable output")
+        .action(async (opts: { json?: boolean }) => {
+            const root = storeRoot();
+            const findings: Finding[] = [];
+
+            if (!(await pathExists(root))) {
+                findings.push({
+                    level: "warn",
+                    what: `store ${root} does not exist yet`,
+                    fix: suggestCommand("tools scripts", {
+                        replaceCommand: ["create", "<name>", "--import", "'<server>.*'"],
+                    }),
+                });
+            } else {
+                const tsconfigPath = join(root, "tsconfig.json");
+                let mapped: string | undefined;
+
+                try {
+                    const parsed = SafeJSON.parse(await Bun.file(tsconfigPath).text()) as {
+                        compilerOptions?: { paths?: Record<string, string[]> };
+                    };
+                    mapped = parsed.compilerOptions?.paths?.["@gt/scripts/*"]?.[0]?.replace(/\/\*$/, "");
+                } catch (error) {
+                    logger.debug({ tsconfigPath, error }, "doctor: tsconfig unreadable");
+                }
+
+                if (!mapped) {
+                    findings.push({
+                        level: "err",
+                        what: `${tsconfigPath} missing or lacks the @gt/scripts/* mapping — persisted scripts cannot import the kit`,
+                        fix: `${suggestCommand("tools scripts", { replaceCommand: ["run", "<any-script>"] })} (rewrites it), or any \`create\``,
+                    });
+                } else if (mapped !== LIB_DIR) {
+                    const targetAlive = await pathExists(join(mapped, "kit.ts"));
+                    findings.push({
+                        level: targetAlive ? "warn" : "err",
+                        what: `store tsconfig maps @gt/scripts to ${mapped}${targetAlive ? " (another checkout)" : " (dead path)"}, this checkout is ${LIB_DIR}`,
+                        fix: `${suggestCommand("tools scripts", { replaceCommand: ["run", "<any-script>"] })} — the next run rewrites the mapping to this checkout`,
+                    });
+                } else {
+                    findings.push({ level: "ok", what: `@gt/scripts alias → ${mapped}` });
+                }
+
+                if (await storeDepsMissing(root)) {
+                    findings.push({
+                        level: "warn",
+                        what: "store node_modules missing (commander/picocolors unresolvable for direct `bun <script>` runs)",
+                        fix: `bun install in ${root} (also runs automatically on '${suggestCommand("tools scripts", { replaceCommand: ["run"] })}')`,
+                    });
+                } else {
+                    findings.push({ level: "ok", what: "store dependencies installed" });
+                }
+
+                if (await pathExists(join(root, ".git"))) {
+                    const status = Bun.spawnSync(["git", "-C", root, "status", "--porcelain"]);
+                    const dirty = status.stdout.toString().trim();
+                    findings.push({
+                        level: "ok",
+                        what: `store is a git repo${dirty ? ` (${dirty.split("\n").length} uncommitted change(s), swept by the next mutating verb)` : " (clean)"}`,
+                    });
+                } else {
+                    findings.push({
+                        level: "warn",
+                        what: "store is not a git repo yet — scripts are unversioned",
+                        fix: `any \`${suggestCommand("tools scripts", { replaceCommand: ["create"] })}\` or \`run\` initialises it`,
+                    });
+                }
+            }
+
+            // journalHealth first: readJournal on a corrupt file writes the
+            // rescue backup, which a read-only diagnostic must not do.
+            const health = await journalHealth();
+            let journal: Journal = { version: 1, scripts: [] };
+
+            if (health === "corrupt") {
+                findings.push({
+                    level: "err",
+                    what: "persisted/_journal.json exists but cannot be parsed — scripts are invisible to list/run",
+                    fix: "any mutating verb backs it up to _journal.corrupt-<stamp>.json and starts fresh; or repair the JSON by hand",
+                });
+            } else {
+                journal = await readJournal();
+            }
+
+            const registryCache = join(cacheDir(root), "registry.json");
+
+            if (await pathExists(registryCache)) {
+                const mode = (await stat(registryCache)).mode & 0o777;
+
+                if ((mode & 0o077) !== 0) {
+                    findings.push({
+                        level: "warn",
+                        what: `cache/registry.json is mode ${mode.toString(8)} and carries connection env/headers (API keys)`,
+                        fix: `${suggestCommand("tools scripts", { replaceCommand: ["servers", "--refresh"] })} (rewrites it 0600; any non-doctor load also repairs it)`,
+                    });
+                }
+            }
+
+            const registry = await loadRegistry({ persist: false });
+            const known = new Set(registry.servers.map((s) => s.name));
+
+            for (const entry of journal.scripts) {
+                if (!(await pathExists(entry.file))) {
+                    findings.push({
+                        level: "err",
+                        what: `journal entry '${entry.name}' points at missing ${entry.file}`,
+                        fix: `${suggestCommand("tools scripts", { replaceCommand: ["rm", entry.name] })} (moves nothing, drops the stale entry)`,
+                    });
+                }
+
+                const missingServers = entry.servers.filter((s) => !known.has(s));
+
+                if (missingServers.length > 0) {
+                    findings.push({
+                        level: "warn",
+                        what: `'${entry.name}' binds server(s) no provider lists any more: ${missingServers.join(", ")}`,
+                        fix: `${suggestCommand("tools scripts", { replaceCommand: ["servers", "--refresh"] })}, or re-enable via tools mcp-manager`,
+                    });
+                }
+
+                if (entry.gateDir && !(await pathExists(entry.gateDir))) {
+                    findings.push({
+                        level: "warn",
+                        what: `'${entry.name}' is gated to ${entry.gateDir}, which no longer exists (hidden from every list)`,
+                        fix: suggestCommand("tools scripts", { replaceCommand: ["tag", entry.name, "--ungate"] }),
+                    });
+                }
+            }
+
+            const toolCache = await loadToolCache();
+            for (const cacheEntry of Object.values(toolCache)) {
+                if (cacheEntry.error) {
+                    findings.push({
+                        level: "warn",
+                        what: `cached probe failure for ${cacheEntry.server}: ${cacheEntry.error.slice(0, 120)}`,
+                        fix: suggestCommand("tools scripts", {
+                            replaceCommand: ["tools", `'${cacheEntry.server}.*'`, "--refresh"],
+                        }),
+                    });
+                }
+            }
+
+            const tokens = await loadClaudeTokens();
+            const expired = tokens.filter(isExpired);
+
+            findings.push({
+                level: expired.length > 0 ? "warn" : "ok",
+                what: `Claude Code holds ${tokens.length} MCP OAuth token(s)${expired.length > 0 ? `; expired: ${expired.map((t) => t.serverName).join(", ")}` : ""}`,
+                ...(expired.length > 0 ? { fix: "re-authorise in Claude Code with /mcp" } : {}),
+            });
+
+            if (opts.json) {
+                out.result({ findings, scripts: journal.scripts.length, servers: registry.servers.length });
+                return;
+            }
+
+            for (const f of findings) {
+                ui[f.level](f.what);
+
+                if (f.fix) {
+                    ui.dim(`    fix: ${f.fix}`);
+                }
+            }
+
+            const bad = findings.filter((f) => f.level !== "ok").length;
+            ui.raw("");
+            ui.raw(`${findings.length} check(s), ${bad} finding(s)`);
+        });
+}

--- a/src/scripts/commands/git.ts
+++ b/src/scripts/commands/git.ts
@@ -1,0 +1,127 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import type { Command } from "commander";
+import {
+    ensureStoreScaffold,
+    readStoreConfig,
+    runGit,
+    setStoreRemote,
+    storeRemoteUrl,
+    storeRoot,
+    writeStoreConfig,
+} from "../lib/store.ts";
+
+/** Raw git against the store, so nobody has to remember `git -C ~/.genesis-tools/scripts`. */
+export function registerGit(program: Command): void {
+    program
+        .command("git [args...]")
+        .description("Run a git command inside the script store. Pass git flags after '--', e.g. git -- log --oneline")
+        .allowExcessArguments(true)
+        .action(async (args: string[]) => {
+            await ensureStoreScaffold();
+            const proc = Bun.spawn(["git", "-C", storeRoot(), ...args], {
+                stdin: "inherit",
+                stdout: "inherit",
+                stderr: "inherit",
+            });
+            process.exitCode = await proc.exited;
+        });
+}
+
+interface RemoteOptions {
+    none?: boolean;
+    autoPush?: string;
+}
+
+function parseAutoPush(value: string | undefined): boolean | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (value === "on" || value === "off") {
+        return value === "on";
+    }
+
+    throw new Error(`--auto-push must be 'on' or 'off', got '${value}'.`);
+}
+
+/**
+ * Set up (or inspect) off-machine history for the store, and persist the
+ * decision in the store config so the post-create offer stops once decided.
+ */
+export function registerRemote(program: Command): void {
+    program
+        .command("remote [url]")
+        .description(
+            "Show or set the store's git remote. With a url: adds/updates origin, pushes, remembers the decision."
+        )
+        .option("--none", "No remote wanted — remember the decision and stop offering")
+        .option("--auto-push <on|off>", "Push after every store commit (persisted)")
+        .action(async (url: string | undefined, opts: RemoteOptions) => {
+            const autoPush = parseAutoPush(opts.autoPush);
+            const config = await readStoreConfig();
+
+            if (opts.none) {
+                if (url) {
+                    throw new Error("Pass either a url or --none, not both.");
+                }
+
+                config.remote = { declined: true, decidedAt: new Date().toISOString() };
+                await writeStoreConfig(config);
+                ui.ok("remembered: no remote for the script store (the create-time offer stops)");
+                return;
+            }
+
+            if (!url) {
+                const current = await storeRemoteUrl();
+
+                if (current) {
+                    ui.kv("origin", current);
+                } else {
+                    ui.raw(config.remote?.declined ? "no remote (declined by choice)" : "no remote configured");
+                }
+
+                ui.kv("auto-push", config.remote?.autoPush ? "on" : "off", 10);
+
+                if (autoPush !== undefined) {
+                    config.remote = {
+                        ...(config.remote ?? { decidedAt: new Date().toISOString() }),
+                        autoPush,
+                        decidedAt: new Date().toISOString(),
+                    };
+                    await writeStoreConfig(config);
+                    ui.ok(`auto-push ${autoPush ? "on" : "off"} (persisted)`);
+                } else if (!current && !config.remote?.declined) {
+                    const setUp = suggestCommand("tools scripts", { replaceCommand: ["remote", "<url>"] });
+                    const decline = suggestCommand("tools scripts", { replaceCommand: ["remote", "--none"] });
+                    ui.dim(`set one up: ${setUp}   (or: ${decline})`);
+                }
+
+                return;
+            }
+
+            const result = await setStoreRemote(url);
+            ui.ok(`${result.action} origin → ${url}`);
+
+            const push = await runGit(storeRoot(), ["push", "-u", "origin", "main"]);
+
+            if (push.exitCode === 0) {
+                ui.ok("pushed main with upstream tracking");
+            } else {
+                ui.warn(`initial push failed: ${push.stderr.split("\n")[0]}`);
+                const retry = suggestCommand("tools scripts", {
+                    replaceCommand: ["git", "--", "push", "-u", "origin", "main"],
+                });
+                ui.dim(`retry later with: ${retry}`);
+            }
+
+            config.remote = {
+                url,
+                declined: false,
+                autoPush: autoPush ?? config.remote?.autoPush ?? false,
+                decidedAt: new Date().toISOString(),
+            };
+            await writeStoreConfig(config);
+            ui.kv("auto-push", config.remote.autoPush ? "on" : "off", 10);
+        });
+}

--- a/src/scripts/commands/list.ts
+++ b/src/scripts/commands/list.ts
@@ -1,0 +1,76 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { filterScripts, readJournal } from "../lib/journal.ts";
+
+interface ListOptions {
+    tag?: string[];
+    project?: string;
+    cwd?: string | boolean;
+    server?: string;
+    grep?: string;
+    all?: boolean;
+    json?: boolean;
+}
+
+export function registerList(program: Command): void {
+    program
+        .command("list")
+        .description("List persisted scripts. Gated scripts from other projects are hidden unless --all.")
+        .option("--tag <tags...>", "Only scripts carrying all of these tags")
+        .option("--project <name>", "Only scripts created under this project")
+        .option("--cwd [path]", "Only scripts created at or below this directory (bare flag means the current one)")
+        .option("--server <name>", "Only scripts bound to this server")
+        .option("--grep <text>", "Substring match over name, description, tags and tool refs")
+        .option("--all", "Include gated scripts from other projects")
+        .option("--json", "Machine-readable output")
+        .action(async (opts: ListOptions) => {
+            const journal = await readJournal();
+            const cwd = opts.cwd === true ? process.cwd() : opts.cwd;
+            const baseFilter = {
+                tag: opts.tag,
+                project: opts.project,
+                cwd: typeof cwd === "string" ? cwd : undefined,
+                server: opts.server,
+                grep: opts.grep,
+            };
+            const filtered = filterScripts(journal.scripts, { ...baseFilter, all: opts.all });
+
+            if (opts.json) {
+                out.result({ scripts: filtered, total: journal.scripts.length });
+                return;
+            }
+
+            if (filtered.length === 0) {
+                ui.raw(
+                    `no scripts${journal.scripts.length > 0 ? ` matched (${journal.scripts.length} total)` : " yet"}`
+                );
+                ui.dim(
+                    `create one: ${suggestCommand("tools scripts", { replaceCommand: ["create", "<name>", "--import", "'<server>.*'"] })}`
+                );
+                return;
+            }
+
+            for (const s of filtered) {
+                const tags = s.tags.length > 0 ? ` ${pc.dim(`#${s.tags.join(" #")}`)}` : "";
+                const gate = s.gateDir ? ` ${pc.yellow("⌂")}` : "";
+                ui.raw(`${pc.bold(s.name)}${tags}${gate}`);
+                ui.raw(`  ${s.description ?? pc.dim("(no description)")}`);
+                ui.raw(
+                    pc.dim(
+                        `  ${s.servers.join(", ")} · ${s.tools.length} tool(s) · ${s.runs} run(s) · ${s.project ?? "-"}`
+                    )
+                );
+                ui.raw(pc.dim(`  ${s.createdFrom}`));
+            }
+
+            const withGated = filterScripts(journal.scripts, { ...baseFilter, all: true });
+            const hiddenByGate = withGated.length - filtered.length;
+            ui.raw("");
+            ui.raw(
+                `${filtered.length} of ${journal.scripts.length}${hiddenByGate > 0 ? ` (${hiddenByGate} gated elsewhere; --all shows)` : ""}`
+            );
+        });
+}

--- a/src/scripts/commands/regen.ts
+++ b/src/scripts/commands/regen.ts
@@ -1,0 +1,67 @@
+import { ui } from "@genesiscz/utils/cli/ui";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { assertBoundServersResponded, resolveSelectors } from "../lib/discover.ts";
+import { getEntry, mutateEntry, scriptPaths } from "../lib/journal.ts";
+import { bindNames, renderToolsModule } from "../lib/scaffold.ts";
+import { commitStore, ensureStoreScaffold } from "../lib/store.ts";
+
+export function registerRegen(program: Command): void {
+    program
+        .command("regen <name>")
+        .description("Re-probe the servers and rewrite <name>.tools.ts. Your <name>.ts is not touched.")
+        .option("--force", "Rewrite bindings even when a previously bound server failed to respond")
+        .action(async (name: string, opts: { force?: boolean }) => {
+            const entry = await getEntry(name);
+
+            if (!entry) {
+                throw new Error(`No script named '${name}'.`);
+            }
+
+            if (entry.imports.length === 0) {
+                throw new Error(`'${name}' has no imported selectors, so there are no bindings to regenerate.`);
+            }
+
+            const { matched, errors } = await resolveSelectors(entry.imports, { refresh: true });
+
+            if (matched.length === 0) {
+                throw new Error(`No tools matched ${entry.imports.join(", ")} any more. Bindings left untouched.`);
+            }
+
+            assertBoundServersResponded(entry.servers, errors, Boolean(opts.force));
+
+            await ensureStoreScaffold();
+            const bound = bindNames(matched);
+            const now = new Date().toISOString();
+            const { toolsFile } = scriptPaths(name);
+            await Bun.write(toolsFile, renderToolsModule(bound, entry.imports, now));
+
+            const before = new Set(entry.tools);
+            const after = bound.map((b) => `${b.server}.${b.tool.name}`);
+            const added = after.filter((t) => !before.has(t));
+            const removed = [...before].filter((t) => !after.includes(t));
+
+            // Field-scoped mutation under the journal lock, so a concurrent
+            // run's counter bump between our read and this write survives.
+            await mutateEntry(name, (live) => {
+                live.tools = after;
+                live.servers = [...new Set(bound.map((b) => b.server))];
+                live.updatedAt = now;
+            });
+            await commitStore(`chore: regen ${name} bindings`);
+
+            ui.ok(`regenerated ${after.length} binding(s)`);
+
+            if (added.length > 0) {
+                ui.raw(`  ${pc.green("+")} ${added.join(", ")}`);
+            }
+
+            if (removed.length > 0) {
+                ui.raw(`  ${pc.red("-")} ${removed.join(", ")} ${pc.dim("(callers of these will now fail)")}`);
+            }
+
+            for (const e of errors) {
+                ui.err(`${e.server}: ${e.error.slice(0, 160)}`);
+            }
+        });
+}

--- a/src/scripts/commands/rename.ts
+++ b/src/scripts/commands/rename.ts
@@ -1,0 +1,24 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { renameScript } from "../lib/journal.ts";
+import { commitStore } from "../lib/store.ts";
+
+export function registerRename(program: Command): void {
+    program
+        .command("rename <from> <to>")
+        .description("Rename a script: its directory, files, sidecars, tools import and journal entry")
+        .action(async (from: string, to: string) => {
+            const result = await renameScript(from, to);
+            await commitStore(`refactor: rename ${from} to ${to}`);
+            ui.ok(`renamed ${from} → ${to}`);
+            ui.raw(`  ${pc.dim(result.dir)}`);
+
+            for (const move of result.moved) {
+                ui.raw(`  ${pc.dim(move)}`);
+            }
+
+            ui.kv("run", suggestCommand("tools scripts", { replaceCommand: ["run", to] }));
+        });
+}

--- a/src/scripts/commands/rm.ts
+++ b/src/scripts/commands/rm.ts
@@ -1,0 +1,28 @@
+import { ui } from "@genesiscz/utils/cli/ui";
+import type { Command } from "commander";
+import { trashEntry } from "../lib/journal.ts";
+import { commitStore } from "../lib/store.ts";
+
+export function registerRm(program: Command): void {
+    program
+        .command("rm <name>")
+        .description("Move a script to trash/ and drop its journal entry. Never deletes outright.")
+        .action(async (name: string) => {
+            const result = await trashEntry(name);
+
+            if (!result) {
+                throw new Error(`No script named '${name}'.`);
+            }
+
+            await commitStore(`chore: trash ${name}`);
+
+            if (!result.moved) {
+                ui.warn(`${result.from} was already gone; dropped the stale journal entry`);
+                return;
+            }
+
+            ui.ok(`moved ${result.from}`);
+            ui.kv("to", result.to);
+            ui.dim(`restore: mv "${result.to}" "${result.from}"`);
+        });
+}

--- a/src/scripts/commands/run.ts
+++ b/src/scripts/commands/run.ts
@@ -1,0 +1,44 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { logger } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { getEntry, recordRun } from "../lib/journal.ts";
+import { ensureStoreDeps, ensureStoreScaffold } from "../lib/store.ts";
+
+export function registerRun(program: Command): void {
+    program
+        .command("run <name> [args...]")
+        .description("Run a persisted script with bun, recording the run. Pass script flags after '--'.")
+        .allowExcessArguments(true)
+        .action(async (name: string, args: string[]) => {
+            const entry = await getEntry(name);
+
+            if (!entry) {
+                throw new Error(
+                    `No script named '${name}'. Run '${suggestCommand("tools scripts", { replaceCommand: ["list"] })}'.`
+                );
+            }
+
+            // Heals a moved repo (tsconfig alias) and a missing node_modules
+            // before the script pays for either as an import error.
+            await ensureStoreScaffold();
+            await ensureStoreDeps();
+
+            logger.debug({ name, file: entry.file, args }, "scripts run");
+            const started = Date.now();
+            const proc = Bun.spawn(["bun", entry.file, ...args], {
+                stdin: "inherit",
+                stdout: "inherit",
+                stderr: "inherit",
+            });
+            const exitCode = await proc.exited;
+
+            await recordRun(name, {
+                at: new Date().toISOString(),
+                cwd: process.cwd(),
+                exitCode,
+                durationMs: Date.now() - started,
+            });
+
+            process.exitCode = exitCode;
+        });
+}

--- a/src/scripts/commands/servers.ts
+++ b/src/scripts/commands/servers.ts
@@ -1,0 +1,49 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, formatDotStatus, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { enabledServers, loadRegistry } from "../lib/registry.ts";
+
+export function registerServers(program: Command): void {
+    program
+        .command("servers")
+        .description("List MCP servers mcp-manager knows about, with transport details")
+        .option("--json", "Machine-readable output")
+        .option("--refresh", "Re-scan the provider configs instead of the cache")
+        .option("--all", "Include servers that are disabled everywhere")
+        .action(async (opts: { json?: boolean; refresh?: boolean; all?: boolean }) => {
+            const registry = await loadRegistry({ refresh: opts.refresh });
+            const list = opts.all ? registry.servers : enabledServers(registry);
+
+            if (opts.json) {
+                out.result({ ...registry, servers: list });
+                return;
+            }
+
+            renderCliHeader(
+                "MCP servers",
+                `${list.length} of ${registry.servers.length} · cached ${registry.fetchedAt}`
+            );
+            const table = createBoxTable(["SERVER", "STATE", "TRANSPORT", "WHERE"]);
+
+            for (const s of list) {
+                const where = s.connection.type === "stdio" ? s.connection.command : s.connection.url;
+                table.push([
+                    pc.white(s.name),
+                    formatDotStatus(s.enabled ? "ok" : "err", s.status),
+                    pc.dim(s.connection.type),
+                    pc.dim(truncateDisplay(where, 60)),
+                ]);
+            }
+
+            out.println(table.toString());
+
+            for (const failed of registry.providersFailed) {
+                ui.warn(`${failed.provider}: ${failed.error}`);
+            }
+
+            ui.dim(suggestCommand("tools scripts", { replaceCommand: ["tools", "'<server>.*'"] }));
+        });
+}

--- a/src/scripts/commands/show.ts
+++ b/src/scripts/commands/show.ts
@@ -1,0 +1,49 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { getEntry } from "../lib/journal.ts";
+
+export function registerShow(program: Command): void {
+    program
+        .command("show <name>")
+        .description("Print a script's metadata and source")
+        .option("--json", "Metadata only, machine-readable")
+        .action(async (name: string, opts: { json?: boolean }) => {
+            const entry = await getEntry(name);
+
+            if (!entry) {
+                throw new Error(
+                    `No script named '${name}'. Run '${suggestCommand("tools scripts", { replaceCommand: ["list"] })}'.`
+                );
+            }
+
+            if (opts.json) {
+                out.result(entry);
+                return;
+            }
+
+            ui.header(`${entry.name}  ${entry.file}`);
+            ui.kv("imports", entry.imports.join(", ") || "-");
+            ui.kv("tools", entry.tools.join(", ") || "-");
+            ui.kv("tags", entry.tags.join(", ") || "-");
+            ui.kv("project", entry.project ?? "-");
+            ui.kv("gated to", entry.gateDir ?? "-");
+            ui.kv("created", `${entry.createdAt} from ${entry.createdFrom}`);
+            ui.kv(
+                "runs",
+                `${entry.runs}${entry.lastRun ? ` (last exit ${entry.lastRun.exitCode}, ${entry.lastRun.durationMs}ms)` : ""}`
+            );
+            ui.raw("");
+            const file = Bun.file(entry.file);
+
+            if (!(await file.exists())) {
+                throw new Error(
+                    `Script '${name}' is in the journal but its file is missing at ${entry.file}. ` +
+                        `Run '${suggestCommand("tools scripts", { replaceCommand: ["rm", name] })}' to drop the stale entry.`
+                );
+            }
+
+            out.print(await file.text());
+        });
+}

--- a/src/scripts/commands/tag.ts
+++ b/src/scripts/commands/tag.ts
@@ -1,0 +1,66 @@
+import { ui } from "@genesiscz/utils/cli/ui";
+import type { Command } from "commander";
+import { findProjectRoot, mutateEntry } from "../lib/journal.ts";
+import { commitStore } from "../lib/store.ts";
+
+interface TagOptions {
+    add?: string[];
+    remove?: string[];
+    project?: string;
+    gate?: boolean;
+    ungate?: boolean;
+}
+
+export function registerTag(program: Command): void {
+    program
+        .command("tag <name>")
+        .description("Add or remove tags on a script; also toggles the project gate")
+        .option("--add <tags...>", "Tags to add")
+        .option("--remove <tags...>", "Tags to remove")
+        .option("--project <name>", "Set the project label")
+        .option("--gate", "Gate visibility to the current project tree")
+        .option("--ungate", "Remove the visibility gate")
+        .action(async (name: string, opts: TagOptions) => {
+            if (opts.gate && opts.ungate) {
+                throw new Error("Pass either --gate or --ungate, not both.");
+            }
+
+            // Mutate only this command's fields inside the journal lock, so a
+            // concurrent run's counter bump cannot be clobbered by a stale copy.
+            let summary = "";
+            const found = await mutateEntry(name, (entry) => {
+                const tags = new Set(entry.tags);
+                for (const t of opts.add ?? []) {
+                    tags.add(t);
+                }
+
+                for (const t of opts.remove ?? []) {
+                    tags.delete(t);
+                }
+
+                entry.tags = [...tags];
+
+                if (opts.project) {
+                    entry.project = opts.project;
+                }
+
+                if (opts.gate) {
+                    entry.gateDir = findProjectRoot(process.cwd()) ?? process.cwd();
+                }
+
+                if (opts.ungate) {
+                    entry.gateDir = undefined;
+                }
+
+                entry.updatedAt = new Date().toISOString();
+                summary = `${entry.name}: tags [${entry.tags.join(", ")}] project ${entry.project ?? "-"} gate ${entry.gateDir ?? "-"}`;
+            });
+
+            if (!found) {
+                throw new Error(`No script named '${name}'.`);
+            }
+
+            await commitStore(`chore: tag ${name}`);
+            ui.raw(summary);
+        });
+}

--- a/src/scripts/commands/tools.ts
+++ b/src/scripts/commands/tools.ts
@@ -1,0 +1,94 @@
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { firstLine, resolveSelectors, signatureOf } from "../lib/discover.ts";
+
+export function registerTools(program: Command): void {
+    program
+        .command("tools [selectors...]")
+        .description(
+            "List tools matching selectors like 'server.*' or '*.take_*'. No selector lists every enabled server."
+        )
+        .option("--json", "Machine-readable output")
+        .option("--schema", "Include the full input schema (verbose; prefer the default signatures)")
+        .option("--names", "Names only, no signatures or descriptions")
+        .option("--grep <text>", "Substring match over tool name and description")
+        .option("--refresh", "Re-probe servers instead of using the tool cache")
+        .action(
+            async (
+                selectors: string[],
+                opts: { json?: boolean; schema?: boolean; names?: boolean; grep?: string; refresh?: boolean }
+            ) => {
+                const wanted = selectors.length > 0 ? selectors : ["*.*"];
+                const resolved = await resolveSelectors(wanted, { refresh: opts.refresh });
+                const needle = opts.grep?.toLowerCase();
+                const matched = needle
+                    ? resolved.matched.filter(
+                          ({ tool }) =>
+                              tool.name.toLowerCase().includes(needle) ||
+                              (tool.description ?? "").toLowerCase().includes(needle)
+                      )
+                    : resolved.matched;
+
+                if (opts.json) {
+                    out.result({
+                        tools: matched.map(({ server, tool }) => ({
+                            ref: `${server}.${tool.name}`,
+                            server,
+                            name: tool.name,
+                            description: tool.description,
+                            ...(opts.schema ? { inputSchema: tool.inputSchema, outputSchema: tool.outputSchema } : {}),
+                        })),
+                        errors: resolved.errors,
+                    });
+                    return;
+                }
+
+                let currentServer = "";
+
+                for (const { server, tool } of matched) {
+                    if (server !== currentServer) {
+                        currentServer = server;
+                        ui.raw("");
+                        ui.header(server);
+                    }
+
+                    if (opts.names) {
+                        ui.raw(`  ${tool.name}`);
+                    } else {
+                        // signature first: it is what you need to write a call, and it
+                        // is far cheaper than dumping the whole schema.
+                        ui.raw(`  ${signatureOf(tool.name, tool.inputSchema)}`);
+
+                        const desc = firstLine(tool.description, 100);
+
+                        if (desc) {
+                            ui.raw(pc.dim(`      ${desc}`));
+                        }
+                    }
+
+                    if (opts.schema) {
+                        const dump = SafeJSON.stringify(tool.inputSchema, { strict: true }, 2)
+                            .split("\n")
+                            .map((l) => `      ${l}`)
+                            .join("\n");
+                        ui.raw(pc.dim(dump));
+                    }
+                }
+
+                ui.raw("");
+                ui.raw(`${matched.length} tool(s)`);
+
+                for (const e of resolved.errors) {
+                    ui.err(`${e.server}: ${e.error.slice(0, 160)}`);
+                }
+
+                ui.dim(
+                    `detail: ${suggestCommand("tools scripts", { replaceCommand: ["describe", "'<server>.<tool>'"] })}`
+                );
+            }
+        );
+}

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/**
+ * tools scripts — call MCP tools from plain TypeScript, no agent loop.
+ *
+ * Probe an already-configured surface's schema, generate typed bindings, and
+ * keep the result as a persisted Bun script. v1 speaks MCP; the selector
+ * grammar reserves a provider prefix (`mcp:server.tool`) so future surfaces
+ * (openapi:, composio:, graphql:, gt:) slot in without breaking anything —
+ * a bare selector means `mcp:` forever.
+ *
+ *   tools scripts servers                  what exists, and how it connects
+ *   tools scripts tools 'genesis-tools.*'  live tools/list, cached after first probe
+ *   tools scripts call genesis-tools.handoff_list '{"limit":5}'
+ *   tools scripts create colTriage --import 'chrome-devtools-mcp.*'
+ *   tools scripts run colTriage
+ */
+import { runTool } from "@genesiscz/utils/cli";
+import { Command } from "commander";
+import { registerCall } from "./commands/call.ts";
+import { registerCreate } from "./commands/create.ts";
+import { registerDescribe } from "./commands/describe.ts";
+import { registerDoctor } from "./commands/doctor.ts";
+import { registerGit, registerRemote } from "./commands/git.ts";
+import { registerList } from "./commands/list.ts";
+import { registerRegen } from "./commands/regen.ts";
+import { registerRename } from "./commands/rename.ts";
+import { registerRm } from "./commands/rm.ts";
+import { registerRun } from "./commands/run.ts";
+import { registerServers } from "./commands/servers.ts";
+import { registerShow } from "./commands/show.ts";
+import { registerTag } from "./commands/tag.ts";
+import { registerTools } from "./commands/tools.ts";
+
+const program = new Command();
+program.name("tools scripts").description("Script MCP tool calls directly. No agent loop.").version("0.1.0");
+
+registerServers(program);
+registerTools(program);
+registerDescribe(program);
+registerCall(program);
+registerCreate(program);
+registerList(program);
+registerShow(program);
+registerRun(program);
+registerRegen(program);
+registerRename(program);
+registerTag(program);
+registerRm(program);
+registerRemote(program);
+registerGit(program);
+registerDoctor(program);
+
+await runTool(program, { tool: "scripts" });

--- a/src/scripts/lib/claude-tokens.test.ts
+++ b/src/scripts/lib/claude-tokens.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { isExpired, type McpToken, matchToken, parseTokens } from "./claude-tokens.ts";
+
+function token(partial: Partial<McpToken>): McpToken {
+    return { serverName: "s", serverUrl: "https://mcp.example.com/mcp", accessToken: "tok", ...partial };
+}
+
+describe("parseTokens", () => {
+    it("reads mcpOAuth entries and drops hollow ones", () => {
+        const tokens = parseTokens({
+            mcpOAuth: {
+                a: { serverName: "figma", serverUrl: "https://mcp.figma.com/mcp", accessToken: "live", expiresAt: 123 },
+                b: { serverName: "never-authorised", serverUrl: "https://x.example.com", accessToken: "" },
+                c: { serverName: "no-url", accessToken: "tok" },
+            },
+        });
+
+        expect(tokens).toHaveLength(1);
+        expect(tokens[0]?.serverName).toBe("figma");
+        expect(tokens[0]?.expiresAt).toBe(123);
+    });
+
+    it("returns empty for payloads without an mcpOAuth store", () => {
+        expect(parseTokens({})).toEqual([]);
+        expect(parseTokens({ mcpOAuth: "garbage" as unknown as Record<string, never> })).toEqual([]);
+        expect(parseTokens({ mcpOAuth: [1, 2] })).toEqual([]);
+    });
+
+    it("skips malformed entries without dropping the valid ones", () => {
+        const tokens = parseTokens({
+            mcpOAuth: {
+                broken: null,
+                alsoBroken: "string",
+                array: [1],
+                fine: { serverName: "ok", serverUrl: "https://x.example.com/mcp", accessToken: "tok" },
+            },
+        });
+
+        expect(tokens.map((t) => t.serverName)).toEqual(["ok"]);
+    });
+});
+
+describe("isExpired", () => {
+    it("treats a token within the 60s skew as stale, and no expiry as live", () => {
+        expect(isExpired(token({ expiresAt: Date.now() + 30_000 }))).toBe(true);
+        expect(isExpired(token({ expiresAt: Date.now() + 120_000 }))).toBe(false);
+        expect(isExpired(token({ expiresAt: undefined }))).toBe(false);
+    });
+});
+
+describe("matchToken", () => {
+    it("matches origin + pathname, ignoring trailing slashes", () => {
+        const tokens = [token({ serverUrl: "https://mcp.example.com/mcp/" })];
+
+        expect(matchToken(tokens, "https://mcp.example.com/mcp")).toBeDefined();
+        expect(matchToken(tokens, "https://mcp.example.com/other")).toBeUndefined();
+        expect(matchToken(tokens, "https://other.example.com/mcp")).toBeUndefined();
+    });
+});

--- a/src/scripts/lib/claude-tokens.ts
+++ b/src/scripts/lib/claude-tokens.ts
@@ -1,0 +1,178 @@
+/**
+ * Credentials for remote MCP servers.
+ *
+ * mcporter can run its own OAuth dance, but a script is headless: there is no
+ * browser to bounce through. Claude Code has already done that dance and stored
+ * the result (keychain payload key `mcpOAuth`), so we read its store and hand
+ * mcporter a Bearer header instead.
+ *
+ * Without this a remote server fails in a way that reads like a transport bug:
+ * the streamable POST 401s, mcporter falls back to the legacy SSE transport,
+ * and the GET returns 405. The error you see is "SSE error: Non-200 status code
+ * (405)", which says nothing about the missing token.
+ *
+ * Refresh is deliberately NOT performed here. OAuth refresh tokens rotate:
+ * spending Claude Code's stored one would invalidate the copy Claude Code still
+ * holds and break the server inside the app. An expired token is reported and
+ * the caller re-authorises through the normal client (`/mcp`).
+ *
+ * Reusing the app's token also dodges per-client whitelisting: some vendors
+ * (Figma) answer dynamic client registration from unapproved clients with 403.
+ * Borrowing a token an approved client obtained sidesteps registration, which
+ * is why these scripts connect at all. Do not "do it properly" by registering
+ * a new OAuth client — that is the path that fails.
+ */
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readKeychainPayload } from "@genesiscz/utils/claude/keychain";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+export interface McpToken {
+    serverName: string;
+    serverUrl: string;
+    accessToken: string;
+    expiresAt?: number;
+    /** Present but unused: see the rotation note above. */
+    refreshToken?: string;
+}
+
+/** Milliseconds before expiry at which we still call a token stale. */
+const SKEW_MS = 60_000;
+
+async function readCredentialsFile(): Promise<Record<string, unknown> | undefined> {
+    try {
+        const raw = await readFile(join(homedir(), ".claude", ".credentials.json"), "utf-8");
+        return SafeJSON.parse(raw, { strict: true }) as Record<string, unknown>;
+    } catch (error) {
+        logger.debug({ error }, "no ~/.claude/.credentials.json fallback");
+        return undefined;
+    }
+}
+
+/**
+ * Entries with an empty accessToken are dropped: a plugin-scoped server that
+ * was never authorised leaves a shell of an entry behind, and treating that as
+ * a credential produces a 401 rather than the clearer "no token" path.
+ *
+ * Exported for tests; production code goes through `loadClaudeTokens`.
+ */
+export function parseTokens(payload: Record<string, unknown>): McpToken[] {
+    const rawStore = payload.mcpOAuth;
+
+    if (!rawStore || typeof rawStore !== "object" || Array.isArray(rawStore)) {
+        return [];
+    }
+
+    const tokens: McpToken[] = [];
+
+    for (const rawEntry of Object.values(rawStore as Record<string, unknown>)) {
+        // A null or non-object entry in an otherwise valid payload must not
+        // throw and take every remote server down with it.
+        if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+            continue;
+        }
+
+        const entry = rawEntry as Record<string, unknown>;
+        const accessToken = entry.accessToken;
+        const serverUrl = entry.serverUrl;
+
+        if (typeof accessToken !== "string" || accessToken === "" || typeof serverUrl !== "string") {
+            continue;
+        }
+
+        tokens.push({
+            serverName: typeof entry.serverName === "string" ? entry.serverName : "?",
+            serverUrl,
+            accessToken,
+            expiresAt: typeof entry.expiresAt === "number" ? entry.expiresAt : undefined,
+            refreshToken: typeof entry.refreshToken === "string" ? entry.refreshToken : undefined,
+        });
+    }
+
+    return tokens;
+}
+
+let cached: McpToken[] | undefined;
+
+/** Every usable MCP OAuth token Claude Code holds. */
+export async function loadClaudeTokens(options: { refresh?: boolean } = {}): Promise<McpToken[]> {
+    if (cached && !options.refresh) {
+        return cached;
+    }
+
+    let payload: Record<string, unknown> | undefined;
+
+    if (process.platform === "darwin") {
+        payload = (await readKeychainPayload()) ?? undefined;
+    }
+
+    payload ??= await readCredentialsFile();
+    cached = payload ? parseTokens(payload) : [];
+    logger.debug({ tokens: cached.map((t) => t.serverName) }, "claude mcp tokens loaded");
+    return cached;
+}
+
+function sameEndpoint(a: string, b: string): boolean {
+    try {
+        const ua = new URL(a);
+        const ub = new URL(b);
+
+        return ua.origin === ub.origin && ua.pathname.replace(/\/+$/, "") === ub.pathname.replace(/\/+$/, "");
+    } catch (error) {
+        logger.debug({ a, b, error }, "endpoint compare fell back to string equality");
+        return a === b;
+    }
+}
+
+export function isExpired(token: McpToken): boolean {
+    return token.expiresAt !== undefined && token.expiresAt - SKEW_MS <= Date.now();
+}
+
+/** The token whose serverUrl addresses the same endpoint, ignoring trailing slashes. */
+export function matchToken(tokens: McpToken[], url: string): McpToken | undefined {
+    return tokens.find((t) => sameEndpoint(t.serverUrl, url));
+}
+
+export interface AuthLookup {
+    headers?: Record<string, string>;
+    /** Set when a token exists but cannot be used. */
+    problem?: string;
+    /** Set when no token was found at all. The connection is still attempted. */
+    missing?: string;
+}
+
+/**
+ * Bearer header for a remote server, when Claude Code holds a live token.
+ *
+ * A missing token is not an error: plenty of remote servers are open, and the
+ * caller should attempt the connection either way. It is still reported,
+ * because a closed server without a token fails as an opaque SSE 405 that
+ * names neither the server nor the credential.
+ */
+export async function authFor(url: string, options: { refresh?: boolean } = {}): Promise<AuthLookup> {
+    const tokens = await loadClaudeTokens(options);
+    const token = matchToken(tokens, url);
+
+    if (!token) {
+        return {
+            missing:
+                `no stored OAuth token for ${url}. If the server is open this is fine; if it is not, ` +
+                'the connection will fail as "SSE error: Non-200 status code (405)". ' +
+                (tokens.length === 0
+                    ? "Claude Code holds no MCP tokens at all — authorise the server with /mcp first."
+                    : `Claude Code holds tokens for: ${tokens.map((t) => t.serverName).join(", ")}.`),
+        };
+    }
+
+    if (isExpired(token)) {
+        return {
+            problem:
+                `token for ${token.serverName} expired ${new Date(token.expiresAt ?? 0).toISOString()}. ` +
+                "Re-authorise in Claude Code with /mcp, then re-run.",
+        };
+    }
+
+    return { headers: { Authorization: `Bearer ${token.accessToken}` } };
+}

--- a/src/scripts/lib/discover.test.ts
+++ b/src/scripts/lib/discover.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { assertBoundServersResponded } from "./discover.ts";
+
+describe("assertBoundServersResponded", () => {
+    const errors = [
+        { server: "chrome-devtools-mcp", error: "spawn ENOENT" },
+        { server: "never-bound", error: "irrelevant" },
+    ];
+
+    it("throws when a previously bound server failed to respond — write is never reached", () => {
+        expect(() => assertBoundServersResponded(["chrome-devtools-mcp", "gh_grep"], errors, false)).toThrow(
+            /chrome-devtools-mcp did not respond.*--force/
+        );
+    });
+
+    it("--force accepts the loss and lets the rewrite proceed", () => {
+        expect(() => assertBoundServersResponded(["chrome-devtools-mcp"], errors, true)).not.toThrow();
+    });
+
+    it("failures on servers that were never bound do not block", () => {
+        expect(() => assertBoundServersResponded(["gh_grep"], errors, false)).not.toThrow();
+    });
+
+    it("no failures at all is the trivial pass", () => {
+        expect(() => assertBoundServersResponded(["gh_grep"], [], false)).not.toThrow();
+    });
+});

--- a/src/scripts/lib/discover.ts
+++ b/src/scripts/lib/discover.ts
@@ -1,0 +1,211 @@
+/**
+ * Tool discovery: resolve selectors against the registry, probing ONLY the
+ * servers a selector can reach. This is the difference between spawning one
+ * stdio server and spawning all thirty.
+ */
+import { ui } from "@genesiscz/utils/cli/ui";
+import { logger } from "@genesiscz/utils/logger";
+import { createKit } from "./kit.ts";
+import { globMatch, matchesSelector, parseSelector, type Selector } from "./match.ts";
+import {
+    enabledServers,
+    loadRegistry,
+    loadToolCache,
+    type Registry,
+    saveToolCache,
+    type ToolInfo,
+} from "./registry.ts";
+import { schemaToType } from "./schema-ts.ts";
+
+export interface ParamInfo {
+    name: string;
+    type: string;
+    required: boolean;
+    desc?: string;
+}
+
+/** Flatten a tool's inputSchema into a parameter list. */
+export function paramsOf(schema: unknown): ParamInfo[] {
+    const s = schema as { properties?: Record<string, unknown>; required?: unknown } | null;
+
+    if (!s || typeof s !== "object" || !s.properties) {
+        return [];
+    }
+
+    const required = new Set(Array.isArray(s.required) ? (s.required as string[]) : []);
+
+    return Object.entries(s.properties).map(([name, raw]) => {
+        const p = raw as { description?: unknown };
+
+        return {
+            name,
+            type: schemaToTypeShort(raw),
+            required: required.has(name),
+            desc: typeof p?.description === "string" ? p.description : undefined,
+        };
+    });
+}
+
+function schemaToTypeShort(schema: unknown): string {
+    return schemaToType(schema).replace(/\s+/g, " ");
+}
+
+/** `name(req: string, opt?: number)` — the shape you need before writing a call. */
+export function signatureOf(name: string, schema: unknown, maxTypeLen = 28): string {
+    const params = paramsOf(schema);
+
+    if (params.length === 0) {
+        return `${name}()`;
+    }
+
+    const inner = params
+        .map((p) => {
+            const type = p.type.length > maxTypeLen ? `${p.type.slice(0, maxTypeLen - 1)}…` : p.type;
+
+            return `${p.name}${p.required ? "" : "?"}: ${type}`;
+        })
+        .join(", ");
+
+    return `${name}(${inner})`;
+}
+
+export function firstLine(s: string | undefined, max: number): string {
+    const line =
+        (s ?? "")
+            .split("\n")
+            .find((l) => l.trim().length > 0)
+            ?.trim() ?? "";
+
+    return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
+export interface DiscoveredTool {
+    server: string;
+    tool: ToolInfo;
+}
+
+export interface DiscoverResult {
+    found: DiscoveredTool[];
+    errors: { server: string; error: string }[];
+}
+
+export interface DiscoverOptions {
+    /** Re-probe servers instead of using the tool cache. */
+    refresh?: boolean;
+    /** Skip cache writes. `--dry-run` promises "write nothing", which includes caches. */
+    persist?: boolean;
+}
+
+/**
+ * List tools for the given servers, caching per server.
+ *
+ * Uncached servers cost a real stdio spawn plus an initialize handshake, so a
+ * broad selector like `*.*` is genuinely slow the first time and instant after.
+ * A server that fails to start is cached as an error so one broken entry does
+ * not re-block every later run.
+ */
+export async function discoverTools(servers: string[], options: DiscoverOptions = {}): Promise<DiscoverResult> {
+    const cache = await loadToolCache();
+    const stale = options.refresh ? servers : servers.filter((s) => !cache[s]);
+    const errors: { server: string; error: string }[] = [];
+
+    if (stale.length > 0) {
+        ui.dim(`probing ${stale.length} server(s): ${stale.join(", ")}`);
+        logger.debug({ stale, persist: options.persist !== false }, "probing mcp servers");
+        const kit = await createKit({ servers: stale, refresh: options.refresh, persist: options.persist });
+
+        try {
+            await Promise.all(
+                stale.map(async (server) => {
+                    try {
+                        const tools = await kit.listTools(server, { includeSchema: true });
+                        cache[server] = {
+                            server,
+                            fetchedAt: new Date().toISOString(),
+                            tools: tools.map((t) => ({
+                                name: t.name,
+                                description: t.description,
+                                inputSchema: t.inputSchema,
+                                outputSchema: t.outputSchema,
+                            })),
+                        };
+                    } catch (error) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        logger.debug({ server, error }, "server probe failed");
+                        cache[server] = { server, fetchedAt: new Date().toISOString(), tools: [], error: message };
+                    }
+                })
+            );
+        } finally {
+            await kit.close();
+        }
+
+        if (options.persist !== false) {
+            await saveToolCache(cache);
+        }
+    }
+
+    const found: DiscoveredTool[] = [];
+
+    for (const server of servers) {
+        const entry = cache[server];
+
+        if (!entry) {
+            continue;
+        }
+
+        if (entry.error) {
+            errors.push({ server, error: entry.error });
+        }
+
+        for (const tool of entry.tools) {
+            found.push({ server, tool });
+        }
+    }
+
+    return { found, errors };
+}
+
+export interface ResolvedSelectors extends DiscoverResult {
+    registry: Registry;
+    available: string[];
+    parsed: Selector[];
+    matched: DiscoveredTool[];
+}
+
+/**
+ * Safety guard for `regen`: a transient probe failure on a previously bound
+ * server must not silently strip that server's tools from the bindings and
+ * journal. Throws unless `force` opts into the loss.
+ */
+export function assertBoundServersResponded(
+    previousServers: string[],
+    errors: DiscoverResult["errors"],
+    force: boolean
+): void {
+    const failedBound = errors.filter((e) => previousServers.includes(e.server));
+
+    if (failedBound.length > 0 && !force) {
+        throw new Error(
+            `${failedBound.map((e) => e.server).join(", ")} did not respond, so their bindings would be dropped. ` +
+                "Fix the server(s) and retry, or pass --force to accept the loss."
+        );
+    }
+}
+
+/** Resolve selectors, probing only the servers they can reach. */
+export async function resolveSelectors(selectors: string[], options: DiscoverOptions = {}): Promise<ResolvedSelectors> {
+    const registry = await loadRegistry({ refresh: options.refresh, persist: options.persist });
+    const available = enabledServers(registry).map((s) => s.name);
+    const parsed = selectors.map((s) => parseSelector(s, available));
+    const serversToProbe = available.filter((server) => parsed.some((p) => globMatch(p.server, server)));
+
+    if (serversToProbe.length === 0) {
+        return { registry, available, parsed, matched: [], found: [], errors: [] };
+    }
+
+    const { found, errors } = await discoverTools(serversToProbe, options);
+    const matched = found.filter(({ server, tool }) => parsed.some((p) => matchesSelector(p, server, tool.name)));
+
+    return { registry, available, parsed, matched, found, errors };
+}

--- a/src/scripts/lib/journal.test.ts
+++ b/src/scripts/lib/journal.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    filterScripts,
+    journalHealth,
+    mutateEntry,
+    readJournal,
+    recordRun,
+    renameScript,
+    type ScriptEntry,
+    scriptPaths,
+    trashEntry,
+    upsertEntry,
+} from "./journal.ts";
+
+let root: string;
+
+function entry(partial: Partial<ScriptEntry> & { name: string }): ScriptEntry {
+    return {
+        file: scriptPaths(partial.name, root).file,
+        description: undefined,
+        imports: [],
+        tools: [],
+        servers: [],
+        tags: [],
+        createdFrom: "/somewhere",
+        createdAt: "2026-08-17T00:00:00.000Z",
+        updatedAt: "2026-08-17T00:00:00.000Z",
+        runs: 0,
+        ...partial,
+    };
+}
+
+beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "scripts-journal-"));
+});
+
+afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+});
+
+describe("journal round-trip", () => {
+    it("upsert then read returns the entry; missing journal reads empty", async () => {
+        expect((await readJournal(root)).scripts).toEqual([]);
+
+        await upsertEntry(entry({ name: "alpha" }), root);
+        await upsertEntry(entry({ name: "alpha", description: "second write wins" }), root);
+
+        const journal = await readJournal(root);
+        expect(journal.scripts).toHaveLength(1);
+        expect(journal.scripts[0]?.description).toBe("second write wins");
+    });
+
+    it("concurrent read-modify-writes are serialised by the journal lock", async () => {
+        await Promise.all(Array.from({ length: 8 }, (_, i) => upsertEntry(entry({ name: `script${i}` }), root)));
+
+        expect((await readJournal(root)).scripts).toHaveLength(8);
+
+        await Promise.all(
+            Array.from({ length: 5 }, () =>
+                recordRun("script0", { at: "t", cwd: "/x", exitCode: 0, durationMs: 1 }, root)
+            )
+        );
+
+        expect((await readJournal(root)).scripts.find((s) => s.name === "script0")?.runs).toBe(5);
+    });
+
+    it("mutateEntry preserves concurrent run-counter bumps instead of clobbering them", async () => {
+        await upsertEntry(entry({ name: "target" }), root);
+
+        await Promise.all([
+            recordRun("target", { at: "t", cwd: "/x", exitCode: 0, durationMs: 1 }, root),
+            recordRun("target", { at: "t", cwd: "/x", exitCode: 0, durationMs: 1 }, root),
+            mutateEntry(
+                "target",
+                (e) => {
+                    e.tags = ["tagged"];
+                },
+                root
+            ),
+        ]);
+
+        const final = (await readJournal(root)).scripts[0];
+        expect(final?.runs).toBe(2);
+        expect(final?.tags).toEqual(["tagged"]);
+
+        expect(await mutateEntry("missing", () => {}, root)).toBe(false);
+    });
+
+    it("a no-op mutation does not write the journal at all", async () => {
+        await recordRun("nobody-home", { at: "t", cwd: "/x", exitCode: 0, durationMs: 1 }, root);
+
+        expect(await Bun.file(join(root, "persisted", "_journal.json")).exists()).toBe(false);
+    });
+
+    it("journalHealth inspects without writing the rescue backup", async () => {
+        expect(await journalHealth(root)).toBe("missing");
+
+        await Bun.write(join(root, "persisted", "_journal.json"), "{ broken");
+        expect(await journalHealth(root)).toBe("corrupt");
+
+        const files = await readdir(join(root, "persisted"));
+        expect(files.filter((f) => f.startsWith("_journal.corrupt-"))).toEqual([]);
+    });
+
+    it("a corrupt journal is backed up before being treated as empty", async () => {
+        const journalFile = join(root, "persisted", "_journal.json");
+        await Bun.write(journalFile, "{ not json at all");
+
+        expect((await readJournal(root)).scripts).toEqual([]);
+
+        const backups = (await readdir(join(root, "persisted"))).filter((f) => f.startsWith("_journal.corrupt-"));
+        expect(backups).toHaveLength(1);
+        expect(await Bun.file(join(root, "persisted", backups[0] as string)).text()).toBe("{ not json at all");
+
+        // The next write may rebuild the journal, but the backup survives it.
+        await upsertEntry(entry({ name: "fresh" }), root);
+        expect(await Bun.file(join(root, "persisted", backups[0] as string)).exists()).toBe(true);
+    });
+});
+
+describe("gating", () => {
+    const gated = () => entry({ name: "gated", gateDir: "/repo/project" });
+    const open = () => entry({ name: "open" });
+
+    it("hides gated scripts outside their tree, shows them inside and below", () => {
+        const scripts = [gated(), open()];
+
+        expect(filterScripts(scripts, { visibleFrom: "/elsewhere" }).map((s) => s.name)).toEqual(["open"]);
+        expect(filterScripts(scripts, { visibleFrom: "/repo/project" }).map((s) => s.name)).toEqual(["gated", "open"]);
+        expect(filterScripts(scripts, { visibleFrom: "/repo/project/sub/dir" }).map((s) => s.name)).toEqual([
+            "gated",
+            "open",
+        ]);
+    });
+
+    it("a sibling directory sharing the prefix is NOT inside the gate", () => {
+        expect(filterScripts([gated()], { visibleFrom: "/repo/project-two" })).toEqual([]);
+    });
+
+    it("--all reveals gated scripts everywhere", () => {
+        expect(filterScripts([gated()], { visibleFrom: "/elsewhere", all: true }).map((s) => s.name)).toEqual([
+            "gated",
+        ]);
+    });
+});
+
+describe("filters", () => {
+    const scripts = [
+        entry({
+            name: "one",
+            tags: ["triage", "col"],
+            project: "GenesisTools",
+            servers: ["gh_grep"],
+            tools: ["gh_grep.searchGitHub"],
+        }),
+        entry({ name: "two", tags: ["demo"], project: "Other", servers: ["figma"], createdFrom: "/repo/other" }),
+    ];
+
+    it("tag filter requires every tag, case-insensitive", () => {
+        expect(filterScripts(scripts, { tag: ["TRIAGE", "col"] }).map((s) => s.name)).toEqual(["one"]);
+        expect(filterScripts(scripts, { tag: ["triage", "missing"] })).toEqual([]);
+    });
+
+    it("project, server, cwd and grep narrow the list", () => {
+        expect(filterScripts(scripts, { project: "other" }).map((s) => s.name)).toEqual(["two"]);
+        expect(filterScripts(scripts, { server: "GH_GREP" }).map((s) => s.name)).toEqual(["one"]);
+        expect(filterScripts(scripts, { cwd: "/repo" }).map((s) => s.name)).toEqual(["two"]);
+        expect(filterScripts(scripts, { grep: "searchgithub" }).map((s) => s.name)).toEqual(["one"]);
+    });
+
+    it("cwd is a path boundary, not a string prefix", () => {
+        const sibling = entry({ name: "sibling", createdFrom: "/repo2/deep" });
+        expect(filterScripts([...scripts, sibling], { cwd: "/repo" }).map((s) => s.name)).toEqual(["two"]);
+    });
+});
+
+describe("rename", () => {
+    it("moves the directory, re-stems named files, rewrites imports and the journal", async () => {
+        const paths = scriptPaths("before", root);
+        await Bun.write(paths.file, 'import * as T from "./before.tools.ts";\n// tools scripts run before\n');
+        await Bun.write(paths.toolsFile, "export const TOOLS = {};\n");
+        await Bun.write(join(paths.dir, "before.state.json"), "{}\n");
+        await upsertEntry(entry({ name: "before" }), root);
+
+        const result = await renameScript("before", "after", root);
+
+        expect(result.moved).toContain("before.ts → after.ts");
+        expect(result.moved).toContain("before.state.json → after.state.json");
+
+        const renamed = scriptPaths("after", root);
+        const body = await Bun.file(renamed.file).text();
+        expect(body).toContain('"./after.tools.ts"');
+        expect(body).toContain("scripts run after");
+
+        const journal = await readJournal(root);
+        expect(journal.scripts[0]?.name).toBe("after");
+        expect(journal.scripts[0]?.file).toBe(renamed.file);
+    });
+
+    it("refuses an invalid target name and a taken target name", async () => {
+        const paths = scriptPaths("src", root);
+        await Bun.write(paths.file, "// x\n");
+
+        await expect(renameScript("src", "1bad", root)).rejects.toThrow(/Invalid script name/);
+
+        await Bun.write(scriptPaths("taken", root).file, "// y\n");
+        await expect(renameScript("src", "taken", root)).rejects.toThrow(/already exists/);
+    });
+});
+
+describe("trash", () => {
+    it("moves the whole directory into trash/ and drops the journal entry", async () => {
+        const paths = scriptPaths("doomed", root);
+        await Bun.write(paths.file, "// body\n");
+        await Bun.write(join(paths.dir, "out.txt"), "sidecar\n");
+        await upsertEntry(entry({ name: "doomed" }), root);
+
+        const moved = await trashEntry("doomed", root);
+
+        expect(moved).toBeDefined();
+        expect(await Bun.file(paths.file).exists()).toBe(false);
+        expect(await Bun.file(join(moved?.to ?? "", "doomed.ts")).exists()).toBe(true);
+        expect(await Bun.file(join(moved?.to ?? "", "out.txt")).exists()).toBe(true);
+        expect((await readJournal(root)).scripts).toEqual([]);
+    });
+
+    it("returns undefined for unknown scripts", async () => {
+        expect(await trashEntry("nope", root)).toBeUndefined();
+    });
+
+    it("an already-missing directory drops the stale entry and reports moved: false", async () => {
+        await upsertEntry(entry({ name: "ghost" }), root);
+
+        const result = await trashEntry("ghost", root);
+
+        expect(result?.moved).toBe(false);
+        expect((await readJournal(root)).scripts).toEqual([]);
+    });
+});

--- a/src/scripts/lib/journal.ts
+++ b/src/scripts/lib/journal.ts
@@ -1,0 +1,423 @@
+/**
+ * The script journal.
+ *
+ * Every persisted script gets an entry recording where and why it was made:
+ * the cwd it was created from, an inferred project, free-form tags, the tool
+ * selectors it was scaffolded with, and run statistics.
+ *
+ * Metadata never gates execution. Any script can be RUN from anywhere. The one
+ * visibility rule is `gated`: a gated script is hidden from `list` outside the
+ * directory tree it was created for (`--all` reveals it), which keeps a global
+ * store readable without ever blocking you.
+ *
+ * Every function takes an optional store root so tests run against a temp
+ * directory; production callers omit it and get `~/.genesis-tools/scripts`.
+ */
+import { mkdir, readdir, rename, rmdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { findProjectRoot } from "@genesiscz/utils/fs/project-root";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { withFileLock } from "@genesiscz/utils/storage/file-lock";
+import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
+import { pathExists, persistedDir, storeRoot, trashDir } from "./store.ts";
+
+export { findProjectRoot };
+
+export interface ScriptPaths {
+    /** The script's own directory. Sidecars (presets, state, output) belong here. */
+    dir: string;
+    file: string;
+    toolsFile: string;
+}
+
+/**
+ * Where a script lives: `persisted/<name>/<name>.ts`.
+ *
+ * A directory per script rather than a flat pile, because a script that does
+ * real work grows sidecars — a preset, a state file, a progress log — and in a
+ * flat layout those interleave with other scripts' files until nothing is
+ * findable.
+ */
+export function scriptPaths(name: string, root = storeRoot()): ScriptPaths {
+    const dir = join(persistedDir(root), name);
+
+    return { dir, file: join(dir, `${name}.ts`), toolsFile: join(dir, `${name}.tools.ts`) };
+}
+
+export interface RunRecord {
+    at: string;
+    cwd: string;
+    exitCode: number;
+    durationMs: number;
+}
+
+export interface ScriptEntry {
+    name: string;
+    file: string;
+    description?: string;
+    imports: string[];
+    /** Fully-resolved `server.tool` refs the scaffold bound at creation time. */
+    tools: string[];
+    servers: string[];
+    tags: string[];
+    project?: string;
+    /** Set when the script is visibility-gated: hidden from `list` outside this directory tree. */
+    gateDir?: string;
+    createdFrom: string;
+    createdAt: string;
+    updatedAt: string;
+    runs: number;
+    lastRun?: RunRecord;
+}
+
+export interface Journal {
+    version: 1;
+    scripts: ScriptEntry[];
+}
+
+/**
+ * Always a fresh object: callers push into `scripts`, and a shared constant
+ * here would leak one caller's entries into every later "empty" read.
+ */
+function emptyJournal(): Journal {
+    return { version: 1, scripts: [] };
+}
+
+function journalPath(root: string): string {
+    return join(persistedDir(root), "_journal.json");
+}
+
+export type JournalHealth = "missing" | "ok" | "corrupt";
+
+/** Pure inspection for diagnostics: reports corruption without writing the backup that readJournal would. */
+export async function journalHealth(root = storeRoot()): Promise<JournalHealth> {
+    const file = Bun.file(journalPath(root));
+
+    if (!(await file.exists())) {
+        return "missing";
+    }
+
+    try {
+        const parsed = SafeJSON.parse(await file.text(), { strict: true }) as Journal;
+        return Array.isArray(parsed?.scripts) ? "ok" : "corrupt";
+    } catch (error) {
+        logger.debug({ root, error }, "journal health check found unparseable content");
+        return "corrupt";
+    }
+}
+
+/**
+ * A missing journal is an empty store. A journal that EXISTS but cannot be
+ * parsed is not: returning empty would let the next `create`/`tag`/`recordRun`
+ * overwrite the file and silently discard every entry. The unparseable content
+ * is backed up beside the journal first, so nothing a later write does can
+ * destroy it, and the failure is loud in the log.
+ */
+export async function readJournal(root = storeRoot()): Promise<Journal> {
+    const file = Bun.file(journalPath(root));
+
+    if (!(await file.exists())) {
+        return emptyJournal();
+    }
+
+    const raw = await file.text();
+
+    try {
+        const parsed = SafeJSON.parse(raw, { strict: true }) as Journal;
+
+        if (!Array.isArray(parsed?.scripts)) {
+            throw new Error("journal has no scripts array");
+        }
+
+        return parsed;
+    } catch (error) {
+        const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+        const backup = join(persistedDir(root), `_journal.corrupt-${stamp}.json`);
+        atomicWriteFileSync(backup, raw);
+        logger.warn({ root, backup, error }, "journal unparseable — original backed up, starting from empty");
+        return emptyJournal();
+    }
+}
+
+export async function writeJournal(journal: Journal, root = storeRoot()): Promise<void> {
+    await mkdir(persistedDir(root), { recursive: true });
+    atomicWriteFileSync(journalPath(root), `${SafeJSON.stringify(journal, { strict: true }, 2)}\n`);
+}
+
+/**
+ * Serialise a read-modify-write cycle under a cross-process file lock. The
+ * atomic rename in writeJournal prevents torn files, but not a concurrent
+ * `run`/`tag`/`create`/`rm` reading the same journal and the later writer
+ * silently discarding the earlier update. A throwing `fn` skips the write.
+ */
+async function mutateJournal<T>(root: string, fn: (journal: Journal) => Promise<T> | T): Promise<T> {
+    return withFileLock(`${journalPath(root)}.lock`, async () => {
+        const journal = await readJournal(root);
+        const before = SafeJSON.stringify(journal, { strict: true });
+        const result = await fn(journal);
+
+        // A no-op mutator (entry not found) must not rewrite the file: that
+        // bumps the mtime and widens the concurrency window for nothing.
+        if (SafeJSON.stringify(journal, { strict: true }) !== before) {
+            await writeJournal(journal, root);
+        }
+
+        return result;
+    });
+}
+
+export async function getEntry(name: string, root = storeRoot()): Promise<ScriptEntry | undefined> {
+    const journal = await readJournal(root);
+    return journal.scripts.find((s) => s.name === name);
+}
+
+/**
+ * Whole-record replacement, for callers that OWN the record (`create` writes a
+ * brand-new entry). Field updates on an existing entry must go through
+ * `mutateEntry` instead: a detached read-mutate-upsert cycle would restore
+ * stale fields (say, a `runs` count a concurrent `run` just bumped).
+ */
+export async function upsertEntry(entry: ScriptEntry, root = storeRoot()): Promise<void> {
+    await mutateJournal(root, (journal) => {
+        const index = journal.scripts.findIndex((s) => s.name === entry.name);
+
+        if (index === -1) {
+            journal.scripts.push(entry);
+        } else {
+            journal.scripts[index] = entry;
+        }
+    });
+}
+
+/**
+ * Mutate one entry's fields inside the journal lock. Returns false when no
+ * entry by that name exists (nothing is written then).
+ */
+export async function mutateEntry(
+    name: string,
+    fn: (entry: ScriptEntry) => Promise<void> | void,
+    root = storeRoot()
+): Promise<boolean> {
+    return mutateJournal(root, async (journal) => {
+        const entry = journal.scripts.find((s) => s.name === name);
+
+        if (!entry) {
+            return false;
+        }
+
+        await fn(entry);
+        return true;
+    });
+}
+
+export async function recordRun(name: string, record: RunRecord, root = storeRoot()): Promise<void> {
+    await mutateJournal(root, (journal) => {
+        const entry = journal.scripts.find((s) => s.name === name);
+
+        if (!entry) {
+            return;
+        }
+
+        entry.runs += 1;
+        entry.lastRun = record;
+        entry.updatedAt = new Date().toISOString();
+    });
+}
+
+export interface TrashResult {
+    from: string;
+    to: string;
+    /** False when the directory was already gone and only the stale journal entry was dropped. */
+    moved: boolean;
+}
+
+/**
+ * Move a script out of persisted/ into trash/ and drop its journal entry.
+ *
+ * Deliberately a move, not a delete: a scratch script can represent an hour of
+ * fiddling and the cost of keeping the file is nothing. Only a source that is
+ * ALREADY GONE is treated as ignorable; any other rename failure (permissions,
+ * full disk, destination collision) rethrows before the journal is touched,
+ * because dropping the entry then would strand the script on disk while making
+ * it unreachable through list/run/rm.
+ */
+export async function trashEntry(name: string, root = storeRoot()): Promise<TrashResult | undefined> {
+    return mutateJournal(root, async (journal) => {
+        const index = journal.scripts.findIndex((s) => s.name === name);
+
+        if (index === -1) {
+            return undefined;
+        }
+
+        const entry = journal.scripts[index] as ScriptEntry;
+        await mkdir(trashDir(root), { recursive: true });
+        const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+        const paths = scriptPaths(entry.name, root);
+        const to = join(trashDir(root), `${stamp}-${entry.name}`);
+        let moved = true;
+
+        try {
+            // The whole directory goes, so sidecars travel with the script.
+            await rename(paths.dir, to);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+                throw error;
+            }
+
+            // Already gone; still drop the journal entry so list stays honest.
+            logger.debug({ name, error }, "script directory already absent; dropping stale journal entry");
+            moved = false;
+        }
+
+        journal.scripts.splice(index, 1);
+        return { from: paths.dir, to, moved };
+    });
+}
+
+export interface RenameResult {
+    from: string;
+    to: string;
+    dir: string;
+    moved: string[];
+}
+
+export const SCRIPT_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+/**
+ * Rename a script, its directory, its generated bindings and its sidecars.
+ *
+ * Done by hand this is four separate mistakes waiting to happen: the folder,
+ * the file names, the `./<name>.tools.ts` import inside the body, and the
+ * journal's absolute path. One verb keeps them consistent.
+ */
+export async function renameScript(from: string, to: string, root = storeRoot()): Promise<RenameResult> {
+    if (!SCRIPT_NAME_RE.test(to)) {
+        throw new Error(`Invalid script name '${to}'. Use letters, digits, dash, underscore; start with a letter.`);
+    }
+
+    const source = scriptPaths(from, root);
+
+    if (!(await pathExists(source.file))) {
+        throw new Error(`No script named '${from}'.`);
+    }
+
+    const target = scriptPaths(to, root);
+
+    if (await pathExists(target.file)) {
+        throw new Error(`'${to}' already exists at ${target.file}.`);
+    }
+
+    await mkdir(target.dir, { recursive: true });
+    const moved: string[] = [];
+
+    for (const file of await readdir(source.dir)) {
+        // Subdirectories (plans/, out/) travel whole and keep their names; only
+        // files carrying the script's name get re-stemmed, so
+        // `spotifyPreview.state.json` under a new name keeps `.state.json`.
+        const renamed = file.startsWith(`${from}.`) ? `${to}.${file.slice(from.length + 1)}` : file;
+        await rename(join(source.dir, file), join(target.dir, renamed));
+        moved.push(file === renamed ? file : `${file} → ${renamed}`);
+    }
+
+    for (const file of await readdir(target.dir)) {
+        if (!file.endsWith(".ts")) {
+            continue;
+        }
+
+        const path = join(target.dir, file);
+        const before = await Bun.file(path).text();
+        const after = before
+            .replaceAll(`./${from}.tools.ts`, `./${to}.tools.ts`)
+            .replaceAll(`scripts run ${from}`, `scripts run ${to}`);
+
+        if (after !== before) {
+            await Bun.write(path, after);
+        }
+    }
+
+    try {
+        await rmdir(source.dir);
+    } catch (error) {
+        // Non-empty because something unexpected lives there; leave it rather than guess.
+        logger.debug({ dir: source.dir, error }, "source dir left in place after rename");
+    }
+
+    await mutateJournal(root, (journal) => {
+        const entry = journal.scripts.find((s) => s.name === from);
+
+        if (entry) {
+            entry.name = to;
+            entry.file = target.file;
+            entry.updatedAt = new Date().toISOString();
+        }
+    });
+
+    return { from, to, dir: target.dir, moved };
+}
+
+export interface FilterOptions {
+    tag?: string[];
+    project?: string;
+    cwd?: string;
+    server?: string;
+    grep?: string;
+    /** Include gated scripts whose gateDir does not contain `visibleFrom`. */
+    all?: boolean;
+    /** Directory the listing is viewed from; drives gating. Defaults to process.cwd(). */
+    visibleFrom?: string;
+}
+
+/** True when `dir` is `gateDir` itself or below it. */
+function insideGate(gateDir: string, dir: string): boolean {
+    return dir === gateDir || dir.startsWith(`${gateDir}/`);
+}
+
+export function filterScripts(scripts: ScriptEntry[], filter: FilterOptions): ScriptEntry[] {
+    const visibleFrom = filter.visibleFrom ?? process.cwd();
+
+    return scripts.filter((s) => {
+        if (!filter.all && s.gateDir && !insideGate(s.gateDir, visibleFrom)) {
+            return false;
+        }
+
+        if (filter.tag && filter.tag.length > 0) {
+            const has = filter.tag.every((t) => s.tags.some((own) => own.toLowerCase() === t.toLowerCase()));
+
+            if (!has) {
+                return false;
+            }
+        }
+
+        if (filter.project && (s.project ?? "").toLowerCase() !== filter.project.toLowerCase()) {
+            return false;
+        }
+
+        if (filter.cwd && !insideGate(filter.cwd, s.createdFrom)) {
+            return false;
+        }
+
+        if (filter.server && !s.servers.some((sv) => sv.toLowerCase() === filter.server?.toLowerCase())) {
+            return false;
+        }
+
+        if (filter.grep) {
+            const needle = filter.grep.toLowerCase();
+            const hay = `${s.name} ${s.description ?? ""} ${s.tags.join(" ")} ${s.tools.join(" ")}`.toLowerCase();
+
+            if (!hay.includes(needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    });
+}
+
+/**
+ * Best-effort project name for a directory: the git repo's folder name, else
+ * the folder name itself. Used only as a default for `--project`.
+ */
+export function inferProject(cwd: string): string {
+    return basename(findProjectRoot(cwd) ?? cwd);
+}

--- a/src/scripts/lib/kit.ts
+++ b/src/scripts/lib/kit.ts
@@ -1,0 +1,195 @@
+/**
+ * The runtime a persisted script actually imports (`@gt/scripts/kit`).
+ *
+ * Everything here is deliberately non-agentic: no LLM, no tool-choice loop.
+ * You call tools in the order you wrote, in plain control flow.
+ *
+ *   import { withKit, text } from "@gt/scripts/kit";
+ *
+ *   await withKit(async (kit) => {
+ *     const pages = await kit.call("chrome-devtools-mcp", "list_pages");
+ *     console.log(text(pages));
+ *   });
+ *
+ * Concurrency note: MCP removed JSON-RPC batching in the 2025-06-18 spec
+ * revision, so there is no way to send N calls as one payload. `kit.all()`
+ * fires them concurrently over the already-open session instead, which is the
+ * only lever left.
+ */
+import { ui } from "@genesiscz/utils/cli/ui";
+import { logger } from "@genesiscz/utils/logger";
+import {
+    type CallResult,
+    createCallResult,
+    createRuntime,
+    type ImageContent,
+    type Runtime,
+    type RuntimeLogger,
+    type ServerDefinition,
+    type ServerToolInfo,
+} from "mcporter";
+import { parseSelector } from "./match.ts";
+import { loadRegistry, type Registry, toServerDefinitions } from "./registry.ts";
+
+export interface KitOptions {
+    /** Restrict the runtime to these servers. Default: every enabled server. */
+    servers?: string[];
+    /** Re-read the registry from the provider configs instead of the cache. */
+    refresh?: boolean;
+    /** Skip registry cache writes; dry-run and diagnostic callers must not mutate durable state. */
+    persist?: boolean;
+    /** Never start an interactive OAuth flow. Default true: scripts are headless. */
+    disableOAuth?: boolean;
+    /** Per-call timeout in ms. Default 120s, since browser and search tools are slow. */
+    timeoutMs?: number;
+}
+
+export interface Kit {
+    runtime: Runtime;
+    registry: Registry;
+    definitions: ServerDefinition[];
+    /** Names of servers this kit can reach. */
+    servers(): string[];
+    listTools(server: string, options?: { includeSchema?: boolean }): Promise<ServerToolInfo[]>;
+    /** Call one tool. Throws on transport failure; MCP `isError` results come back as data. */
+    call(server: string, tool: string, args?: Record<string, unknown>): Promise<unknown>;
+    /** Call `<server>.<tool>` in one string. */
+    callRef(ref: string, args?: Record<string, unknown>): Promise<unknown>;
+    /** Run calls concurrently over the open session. */
+    all<T>(tasks: (() => Promise<T>)[]): Promise<T[]>;
+    close(): Promise<void>;
+}
+
+/**
+ * Silences mcporter's routine chatter so script stdout stays clean and
+ * pipeable; warnings and errors go through the shared logger (day-log always,
+ * console per level).
+ */
+const quietLogger: RuntimeLogger = {
+    debug: () => {},
+    info: () => {},
+    warn: (...a: unknown[]) => logger.warn({ mcporter: a }, "mcporter warning"),
+    error: (...a: unknown[]) => logger.error({ mcporter: a }, "mcporter error"),
+};
+
+export async function createKit(options: KitOptions = {}): Promise<Kit> {
+    const registry = await loadRegistry({ refresh: options.refresh, persist: options.persist });
+    const { definitions, authProblems } = await toServerDefinitions(registry, options.servers, {
+        refreshAuth: options.refresh,
+    });
+
+    // A stale token surfaces downstream as a 405 from the legacy SSE fallback,
+    // which reads like a transport bug. Say the real thing once, up front, on
+    // stderr where a headless script's user actually sees it.
+    for (const problem of authProblems) {
+        ui.warn(`[auth] ${problem.server}: ${problem.problem}`);
+    }
+
+    if (definitions.length === 0) {
+        const asked = options.servers?.join(", ");
+        throw new Error(
+            asked
+                ? `No enabled MCP server matched: ${asked}. Run 'tools scripts servers' to see what exists.`
+                : "No enabled MCP servers found. Run 'tools scripts servers --refresh'."
+        );
+    }
+
+    const runtime = await createRuntime({
+        servers: definitions,
+        clientInfo: { name: "genesis-tools-scripts", version: "0.1.0" },
+        logger: quietLogger as never,
+    });
+
+    const disableOAuth = options.disableOAuth ?? true;
+    const timeoutMs = options.timeoutMs ?? 120_000;
+
+    return {
+        runtime,
+        registry,
+        definitions,
+        servers: () => definitions.map((d) => d.name),
+        listTools: (server, opts) =>
+            runtime.listTools(server, { includeSchema: opts?.includeSchema ?? true, disableOAuth }),
+        call: (server, tool, args) => runtime.callTool(server, tool, { args, disableOAuth, timeoutMs }),
+        callRef: (ref, args) => {
+            const known = definitions.map((d) => d.name);
+            const selector = parseSelector(ref, known);
+
+            if (!known.includes(selector.server)) {
+                throw new Error(`Unknown server in ref '${ref}'. Known: ${known.join(", ")}`);
+            }
+
+            if (selector.tool === "*" || selector.tool.includes("*")) {
+                throw new Error(`Ref '${ref}' must name exactly one tool, not a pattern`);
+            }
+
+            return runtime.callTool(selector.server, selector.tool, { args, disableOAuth, timeoutMs });
+        },
+        all: (tasks) => Promise.all(tasks.map((t) => t())),
+        close: () => runtime.close(),
+    };
+}
+
+/** Creates a kit, runs fn, always closes. Use this, not createKit, in scripts. */
+export async function withKit<T>(fn: (kit: Kit) => Promise<T>, options: KitOptions = {}): Promise<T> {
+    const kit = await createKit(options);
+
+    try {
+        return await fn(kit);
+    } finally {
+        await kit.close();
+    }
+}
+
+/**
+ * Result helpers.
+ *
+ * These delegate to mcporter's own `createCallResult`, which already knows how
+ * to walk the content-block envelope (text, markdown, json, images,
+ * structuredContent). We only adapt the return types: mcporter returns
+ * `string | null`, and a script reads better with `""` / `undefined`.
+ */
+
+/** The full mcporter CallResult, when you want `.markdown()` or `.content()`. */
+export function result<T = unknown>(raw: T): CallResult<T> {
+    return createCallResult(raw);
+}
+
+/** Concatenated text blocks of a tool result. The usual thing you want. */
+export function text(raw: unknown): string {
+    return createCallResult(raw).text() ?? "";
+}
+
+/**
+ * `structuredContent` when the server declared an outputSchema, otherwise the
+ * text parsed as JSON, otherwise undefined. Servers vary in which they populate.
+ */
+export function data<T = unknown>(raw: unknown): T | undefined {
+    const wrapped = createCallResult(raw);
+    const structured = wrapped.structuredContent();
+
+    if (structured !== undefined && structured !== null) {
+        return structured as T;
+    }
+
+    return (wrapped.json<T>() ?? undefined) as T | undefined;
+}
+
+/** Base64 image blocks, e.g. from a screenshot tool. Empty when there are none. */
+export function images(raw: unknown): ImageContent[] {
+    return createCallResult(raw).images() ?? [];
+}
+
+/** True when the server flagged the call as failed. Transport errors throw instead. */
+export function isError(raw: unknown): boolean {
+    return (raw as { isError?: boolean } | null)?.isError === true;
+}
+
+/** Throws if the tool reported an error, otherwise returns the result unchanged. */
+export function must<T>(value: T, label = "tool call"): T {
+    if (isError(value)) {
+        throw new Error(`${label} failed: ${text(value).slice(0, 500)}`);
+    }
+
+    return value;
+}

--- a/src/scripts/lib/match.test.ts
+++ b/src/scripts/lib/match.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { globMatch, matchesSelector, parseSelector } from "./match.ts";
+
+const KNOWN = ["chrome-devtools-mcp", "genesis-tools", "x-docs", "a.b"];
+
+describe("globMatch", () => {
+    it("matches literally without a star, case-insensitive", () => {
+        expect(globMatch("Genesis-Tools", "genesis-tools")).toBe(true);
+        expect(globMatch("genesis", "genesis-tools")).toBe(false);
+    });
+
+    it("expands stars anywhere", () => {
+        expect(globMatch("handoff_*", "handoff_list")).toBe(true);
+        expect(globMatch("*.take_*", "x.take_screenshot")).toBe(true);
+        expect(globMatch("take_*", "list_pages")).toBe(false);
+    });
+
+    it("escapes regex metacharacters in the pattern", () => {
+        expect(globMatch("a.b", "axb")).toBe(false);
+        expect(globMatch("a.b", "a.b")).toBe(true);
+    });
+
+    it("a literal space in the pattern is not a wildcard", () => {
+        expect(globMatch("take *", "take screenshot")).toBe(true);
+        expect(globMatch("take screen*", "take_XX_screenshot")).toBe(false);
+    });
+});
+
+describe("parseSelector", () => {
+    it("bare server name selects every tool", () => {
+        expect(parseSelector("genesis-tools", KNOWN)).toEqual({
+            raw: "genesis-tools",
+            provider: "mcp",
+            server: "genesis-tools",
+            tool: "*",
+        });
+    });
+
+    it("splits server.tool on the known-server boundary", () => {
+        const s = parseSelector("genesis-tools.handoff_*", KNOWN);
+        expect(s.server).toBe("genesis-tools");
+        expect(s.tool).toBe("handoff_*");
+    });
+
+    it("a known server name containing a dot wins over the first-dot split", () => {
+        const s = parseSelector("a.b.some_tool", KNOWN);
+        expect(s.server).toBe("a.b");
+        expect(s.tool).toBe("some_tool");
+    });
+
+    it("falls back to first-dot split for unknown servers", () => {
+        const s = parseSelector("unknown-server.tool_name", []);
+        expect(s.server).toBe("unknown-server");
+        expect(s.tool).toBe("tool_name");
+    });
+
+    it("accepts the explicit mcp: provider prefix", () => {
+        const s = parseSelector("mcp:genesis-tools.handoff_list", KNOWN);
+        expect(s.provider).toBe("mcp");
+        expect(s.server).toBe("genesis-tools");
+        expect(s.tool).toBe("handoff_list");
+    });
+
+    it("rejects an unknown provider prefix, naming the known set", () => {
+        expect(() => parseSelector("composio:GMAIL_SEND", KNOWN)).toThrow(/Unknown provider 'composio'.*mcp/);
+    });
+
+    it("a URL scheme is not a provider prefix", () => {
+        expect(() => parseSelector("http://x", KNOWN)).not.toThrow();
+        expect(parseSelector("http://x", KNOWN).provider).toBe("mcp");
+    });
+
+    it("a known server name containing a colon wins over provider parsing", () => {
+        const s = parseSelector("docker:mcp.list", ["docker:mcp"]);
+        expect(s.server).toBe("docker:mcp");
+        expect(s.tool).toBe("list");
+    });
+
+    it("rejects empty and provider-only selectors", () => {
+        expect(() => parseSelector("", KNOWN)).toThrow(/Empty selector/);
+        expect(() => parseSelector("mcp:", KNOWN)).toThrow(/names a provider but nothing else/);
+    });
+
+    it("wildcard both halves", () => {
+        const s = parseSelector("*.*", KNOWN);
+        expect(s.server).toBe("*");
+        expect(s.tool).toBe("*");
+    });
+});
+
+describe("matchesSelector", () => {
+    it("requires both halves to match", () => {
+        const s = parseSelector("chrome-devtools-mcp.take_*", KNOWN);
+        expect(matchesSelector(s, "chrome-devtools-mcp", "take_screenshot")).toBe(true);
+        expect(matchesSelector(s, "chrome-devtools-mcp", "list_pages")).toBe(false);
+        expect(matchesSelector(s, "genesis-tools", "take_screenshot")).toBe(false);
+    });
+});

--- a/src/scripts/lib/match.ts
+++ b/src/scripts/lib/match.ts
@@ -1,0 +1,134 @@
+/**
+ * Selector grammar for tool refs.
+ *
+ * A selector is `[provider:]<server>.<tool>`, where either half of the
+ * server.tool pair may contain `*`. A selector with no dot is a server
+ * selector (all its tools).
+ *
+ *   chrome-devtools-mcp.*        every tool on that server
+ *   chrome-devtools-mcp          same thing, shorthand
+ *   *.take_screenshot            that tool wherever it exists
+ *   genesis-tools.handoff_*      prefix match on the tool name
+ *   mcp:genesis-tools.handoff_*  same, provider spelled out
+ *   *.*                          everything (probes every server; slow first time)
+ *
+ * The provider prefix is reserved grammar for future binding surfaces
+ * (openapi:, composio:, graphql:, gt:). A bare selector means `mcp:` — that
+ * default is permanent, so today's short form never breaks. v1 implements only
+ * the mcp provider; any other prefix is an error naming the known set.
+ *
+ * Server names routinely contain `-`, and `.` is only ever the separator we
+ * add. Selectors are matched against the known server list first, so a server
+ * whose name itself contains a dot still parses correctly.
+ */
+
+export const KNOWN_PROVIDERS = ["mcp"] as const;
+export type ProviderName = (typeof KNOWN_PROVIDERS)[number];
+
+export interface Selector {
+    raw: string;
+    provider: ProviderName;
+    server: string;
+    tool: string;
+}
+
+function toRegExp(pattern: string): RegExp {
+    // The wildcard placeholder must be a character that cannot occur in the
+    // pattern itself, or a literal occurrence would also expand to `.*`.
+    const WILDCARD = "\u0000";
+    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, (ch) => (ch === "*" ? WILDCARD : `\\${ch}`));
+    return new RegExp(`^${escaped.split(WILDCARD).join(".*")}$`, "i");
+}
+
+export function globMatch(pattern: string, value: string): boolean {
+    if (!pattern.includes("*")) {
+        return pattern.toLowerCase() === value.toLowerCase();
+    }
+
+    return toRegExp(pattern).test(value);
+}
+
+/**
+ * Strip and validate the optional provider prefix.
+ *
+ * Only a prefix that looks like an identifier counts, and a prefix followed by
+ * `//` is a URL scheme (`http://x`), not a provider. Known server names get
+ * matched against the server list BEFORE this runs, so a server whose name
+ * contains a colon never reaches provider parsing.
+ */
+function splitProvider(raw: string): { provider: ProviderName; rest: string } {
+    const colon = raw.indexOf(":");
+
+    if (colon <= 0) {
+        return { provider: "mcp", rest: raw };
+    }
+
+    const prefix = raw.slice(0, colon);
+
+    if (!/^[a-z][a-z0-9_-]*$/i.test(prefix) || raw.startsWith("//", colon + 1)) {
+        return { provider: "mcp", rest: raw };
+    }
+
+    if (!(KNOWN_PROVIDERS as readonly string[]).includes(prefix.toLowerCase())) {
+        throw new Error(
+            `Unknown provider '${prefix}' in selector '${raw}'. Known providers: ${KNOWN_PROVIDERS.join(", ")}. ` +
+                "A bare selector means mcp:."
+        );
+    }
+
+    return { provider: prefix.toLowerCase() as ProviderName, rest: raw.slice(colon + 1) };
+}
+
+/** Longest known server name the value starts with, or undefined. */
+function matchKnownServer(value: string, knownServers: string[]): string | undefined {
+    return knownServers.filter((s) => value === s || value.startsWith(`${s}.`)).sort((a, b) => b.length - a.length)[0];
+}
+
+/**
+ * Split a selector into provider, server and tool.
+ *
+ * `knownServers` disambiguates the server/tool split: the longest known server
+ * name the selector starts with wins, so a server called `a.b` (or one with a
+ * colon in its name) still parses. Falls back to splitting on the first dot.
+ */
+export function parseSelector(raw: string, knownServers: string[] = []): Selector {
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+        throw new Error("Empty selector");
+    }
+
+    // Server-list match runs before provider parsing, so a server name that
+    // happens to contain a colon is never mistaken for a provider prefix.
+    const direct = matchKnownServer(trimmed, knownServers);
+
+    if (direct) {
+        const tool = trimmed === direct ? "*" : trimmed.slice(direct.length + 1);
+        return { raw: trimmed, provider: "mcp", server: direct, tool: tool || "*" };
+    }
+
+    const { provider, rest } = splitProvider(trimmed);
+
+    if (!rest) {
+        throw new Error(`Selector '${raw}' names a provider but nothing else`);
+    }
+
+    const server = matchKnownServer(rest, knownServers);
+
+    if (server) {
+        const tool = rest === server ? "*" : rest.slice(server.length + 1);
+        return { raw: trimmed, provider, server, tool: tool || "*" };
+    }
+
+    const dot = rest.indexOf(".");
+
+    if (dot === -1) {
+        return { raw: trimmed, provider, server: rest, tool: "*" };
+    }
+
+    return { raw: trimmed, provider, server: rest.slice(0, dot), tool: rest.slice(dot + 1) || "*" };
+}
+
+export function matchesSelector(selector: Selector, server: string, tool: string): boolean {
+    return globMatch(selector.server, server) && globMatch(selector.tool, tool);
+}

--- a/src/scripts/lib/refs.test.ts
+++ b/src/scripts/lib/refs.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { formatValueWithRef, parseRef, preview, type RefStore, truncateList } from "./refs.ts";
+
+describe("formatValueWithRef", () => {
+    const big = "x".repeat(50) + " tail ".repeat(300);
+
+    it("prints small values inline with no ref bookkeeping", () => {
+        const store: RefStore = {};
+        const result = formatValueWithRef(store, "n1.cont", "short value");
+
+        expect(result.text).toBe("short value");
+        expect(result.ref).toBeUndefined();
+        expect(store["n1.cont"]).toBeUndefined();
+    });
+
+    it("prints a large value in full exactly once, then preview-only", () => {
+        const store: RefStore = {};
+        const first = formatValueWithRef(store, "n1.cont", big);
+
+        expect(first.emittedFull).toBe(true);
+        expect(first.text).toContain(big);
+        expect(first.text).toContain("[ref:n1.cont]");
+
+        const second = formatValueWithRef(store, "n1.cont", big);
+        expect(second.emittedFull).toBe(false);
+        expect(second.text).toStartWith("[ref:n1.cont]");
+        expect(second.text).toContain(`(${big.length} chars)`);
+        expect(second.text.length).toBeLessThan(400);
+    });
+
+    it("--full bypasses the ref system entirely", () => {
+        const store: RefStore = { "n1.cont": { preview: "p", size: 1, shown: true } };
+        const result = formatValueWithRef(store, "n1.cont", big, { full: true });
+
+        expect(result.emittedFull).toBe(true);
+        expect(result.text).toBe(big);
+    });
+
+    it("honors a per-call threshold override", () => {
+        const store: RefStore = {};
+        const result = formatValueWithRef(store, "n2.cont", "0123456789", { threshold: 5 });
+
+        expect(result.text).toContain("[ref:n2.cont]");
+    });
+});
+
+describe("parseRef", () => {
+    it("derivable ids parse back to their parts", () => {
+        expect(parseRef("n14.ctx")).toEqual({ prefix: "n", index: 14, field: "ctx" });
+        expect(parseRef("n5")).toEqual({ prefix: "n", index: 5, field: undefined });
+        expect(parseRef("not a ref")).toBeUndefined();
+    });
+});
+
+describe("truncateList / preview", () => {
+    it("never drops silently", () => {
+        expect(truncateList(["a", "b", "c"], 5)).toEqual(["a", "b", "c"]);
+        expect(truncateList(["a", "b", "c", "d"], 2)).toEqual(["a", "b", "… +2 more"]);
+    });
+
+    it("preview cuts on a natural break and flattens whitespace", () => {
+        const flat = preview("word ".repeat(100), 40);
+        expect(flat.length).toBeLessThanOrEqual(41);
+        expect(flat.endsWith("…")).toBe(true);
+    });
+});

--- a/src/scripts/lib/refs.ts
+++ b/src/scripts/lib/refs.ts
@@ -1,0 +1,143 @@
+/**
+ * The reference system: print a large value once, never print it again.
+ *
+ * Ported from the pattern GenesisTools' har-analyzer and debugging-master use
+ * (`src/utils/references.ts`). The problem it solves is specific to agents: a
+ * multi-turn session re-prints the same 500KB payload every time it is
+ * mentioned, and the model pays for it each time.
+ *
+ * The rule is three lines:
+ *   value <= THRESHOLD          print inline, no ref, no bookkeeping
+ *   value >  THRESHOLD, unseen  store it, print it IN FULL, tag it [ref:ID]
+ *   value >  THRESHOLD, seen    print only [ref:ID] + an 80-char preview + size
+ *
+ * So the agent sees every large value exactly once, and afterwards refers to it
+ * by an id it can expand on demand.
+ *
+ * Ids are derivable, never random: `n14.ctx` parses back to "node index 14,
+ * context field" with no lookup table. An id therefore documents its own target
+ * and survives a cache wipe.
+ */
+import { readFile } from "node:fs/promises";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
+
+/**
+ * Values at or below this print inline; a ref would cost more than it saves.
+ *
+ * Tuned for readability over maximum squeeze. At 200 chars nearly everything
+ * became a ref and the previews were too short to identify what they pointed
+ * at, which costs a round-trip to re-expand and defeats the purpose. ~1200
+ * chars is roughly 300 tokens: small enough not to matter, large enough that
+ * most tool results still arrive whole. Override per call via
+ * `FormatOptions.threshold`.
+ */
+export const REF_THRESHOLD = 1200;
+
+/** Long enough to recognise the value, short enough to stay a one-liner. */
+export const PREVIEW_LENGTH = 240;
+
+export interface RefEntry {
+    preview: string;
+    size: number;
+    shown: boolean;
+}
+
+export type RefStore = Record<string, RefEntry>;
+
+/**
+ * Cut at the last natural break in the tail of the window, so a preview ends on
+ * a word rather than mid-token. Falls back to a hard cut when there is no break.
+ */
+export function preview(value: string, length = PREVIEW_LENGTH): string {
+    const flat = value.replace(/\s+/g, " ").trim();
+
+    if (flat.length <= length) {
+        return flat;
+    }
+
+    const window = flat.slice(0, length);
+    const breakAt = Math.max(window.lastIndexOf(" "), window.lastIndexOf(","), window.lastIndexOf("]"));
+
+    return `${window.slice(0, breakAt > length / 2 ? breakAt : length)}…`;
+}
+
+export interface FormatOptions {
+    /** Bypass the ref system entirely and print everything. */
+    full?: boolean;
+    threshold?: number;
+}
+
+export interface Formatted {
+    text: string;
+    /** Set when this value is tracked by a ref. */
+    ref?: string;
+    /** True when the full value was emitted this time. */
+    emittedFull: boolean;
+}
+
+/**
+ * Format one value for display, creating or reusing its ref.
+ *
+ * Mutates `store`, which the caller persists. Kept synchronous and store-in,
+ * store-out so a caller can format a whole screen of values and write once.
+ */
+export function formatValueWithRef(store: RefStore, id: string, value: string, options: FormatOptions = {}): Formatted {
+    const threshold = options.threshold ?? REF_THRESHOLD;
+
+    if (options.full) {
+        return { text: value, ref: id, emittedFull: true };
+    }
+
+    if (value.length <= threshold) {
+        return { text: value, emittedFull: true };
+    }
+
+    const existing = store[id];
+
+    if (existing?.shown) {
+        return {
+            text: `[ref:${id}] ${existing.preview} (${existing.size} chars)`,
+            ref: id,
+            emittedFull: false,
+        };
+    }
+
+    store[id] = { preview: preview(value), size: value.length, shown: true };
+    return { text: `${value}\n[ref:${id}]`, ref: id, emittedFull: true };
+}
+
+/** `n14.ctx` → `{ index: 14, field: "ctx" }`. Returns undefined for a non-ref. */
+export function parseRef(ref: string): { prefix: string; index: number; field?: string } | undefined {
+    const match = /^([a-z]+)(\d+)(?:\.(.+))?$/i.exec(ref.trim());
+
+    if (!match) {
+        return undefined;
+    }
+
+    return { prefix: match[1]!, index: Number(match[2]), field: match[3] };
+}
+
+/** Show the first `limit`, then say how many were left out. Never silently drops. */
+export function truncateList(items: string[], limit = 5): string[] {
+    if (items.length <= limit) {
+        return items;
+    }
+
+    return [...items.slice(0, limit), `… +${items.length - limit} more`];
+}
+
+export async function loadRefStore(path: string): Promise<RefStore> {
+    try {
+        return SafeJSON.parse(await readFile(path, "utf-8"), { strict: true }) as RefStore;
+    } catch (error) {
+        logger.debug({ path, error }, "ref store read fell back to empty");
+        return {};
+    }
+}
+
+/** Atomic write (unique temp per writer), so a crashed or concurrent run cannot publish a half-written store. */
+export async function saveRefStore(path: string, store: RefStore): Promise<void> {
+    atomicWriteFileSync(path, `${SafeJSON.stringify(store, { strict: true }, 2)}\n`);
+}

--- a/src/scripts/lib/registry.test.ts
+++ b/src/scripts/lib/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { enabledServers, type Registry, type ServerJsonEntry, toServerDefinition } from "./registry.ts";
+
+function server(partial: Partial<ServerJsonEntry> & { name: string }): ServerJsonEntry {
+    return { enabled: true, status: "enabled", providers: [], connection: { type: "stdio", command: "x" }, ...partial };
+}
+
+describe("toServerDefinition", () => {
+    it("maps stdio connections with args and env", () => {
+        const definition = toServerDefinition(
+            server({ name: "s", connection: { type: "stdio", command: "srv", args: ["--x"], env: { KEY: "v" } } })
+        );
+
+        expect(definition?.command).toMatchObject({ kind: "stdio", command: "srv", args: ["--x"] });
+        expect(definition?.env).toEqual({ KEY: "v" });
+    });
+
+    it("maps http/sse connections and merges extra headers over stored ones", () => {
+        const definition = toServerDefinition(
+            server({
+                name: "r",
+                connection: { type: "http", url: "https://mcp.example.com/mcp", headers: { A: "1", B: "stored" } },
+            }),
+            { B: "override", C: "3" }
+        );
+        const command = definition?.command as { kind: string; url: URL; headers: Record<string, string> };
+
+        expect(command.kind).toBe("http");
+        expect(command.url.href).toBe("https://mcp.example.com/mcp");
+        expect(command.headers).toEqual({ A: "1", B: "override", C: "3" });
+    });
+
+    it("returns undefined for unknown transports, missing fields and unparsable urls", () => {
+        expect(toServerDefinition(server({ name: "u", connection: { type: "unknown" } }))).toBeUndefined();
+        expect(toServerDefinition(server({ name: "m", connection: { type: "stdio" } }))).toBeUndefined();
+        // One user-authored bad url must not abort the whole definition build.
+        expect(
+            toServerDefinition(server({ name: "b", connection: { type: "http", url: "not a url" } }))
+        ).toBeUndefined();
+    });
+});
+
+describe("enabledServers", () => {
+    it("filters disabled and unknown-transport servers", () => {
+        const registry: Registry = {
+            servers: [
+                server({ name: "on" }),
+                server({ name: "off", enabled: false, status: "disabled" }),
+                server({ name: "weird", connection: { type: "unknown" } }),
+            ],
+            providersScanned: [],
+            providersFailed: [],
+            fetchedAt: "t",
+        };
+
+        expect(enabledServers(registry).map((s) => s.name)).toEqual(["on"]);
+    });
+});

--- a/src/scripts/lib/registry.ts
+++ b/src/scripts/lib/registry.ts
@@ -1,0 +1,245 @@
+/**
+ * The server registry.
+ *
+ * Source of truth is mcp-manager's provider scan — imported directly via
+ * `buildListJson(defaultProviders())`, not spawned as a subprocess. mcp-manager
+ * already reconciles Claude global vs per-project scope, Gemini, Cursor and
+ * Codex into one view with a resolved enabled state, which is the harder half
+ * of the problem. Those definitions are then handed to mcporter via
+ * `createRuntime({ servers })`, so mcporter handles transport, connection
+ * caching and OAuth while never reading a config file of its own.
+ *
+ * The disk cache exists because a provider scan reads every editor's config
+ * file, and a persisted script may load the registry on every run.
+ */
+import { chmod, stat } from "node:fs/promises";
+import { join } from "node:path";
+import {
+    buildListJson,
+    type ListJsonOutput,
+    type ServerConnection,
+    type ServerJsonEntry,
+} from "@app/mcp-manager/commands/list";
+import { defaultProviders } from "@app/mcp-manager/utils/providers/index.js";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
+import type { ServerDefinition } from "mcporter";
+import { authFor } from "./claude-tokens.ts";
+import { cacheDir } from "./store.ts";
+
+export type { ServerConnection, ServerJsonEntry };
+
+export interface Registry extends ListJsonOutput {
+    fetchedAt: string;
+}
+
+export interface ToolInfo {
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+}
+
+export interface ToolCacheEntry {
+    server: string;
+    fetchedAt: string;
+    tools: ToolInfo[];
+    error?: string;
+}
+
+function registryCachePath(): string {
+    return join(cacheDir(), "registry.json");
+}
+
+function toolsCachePath(): string {
+    return join(cacheDir(), "tools.json");
+}
+
+async function readJson<T>(path: string): Promise<T | undefined> {
+    try {
+        return SafeJSON.parse(await Bun.file(path).text(), { strict: true }) as T;
+    } catch (error) {
+        logger.debug({ path, error }, "cache read miss");
+        return undefined;
+    }
+}
+
+/**
+ * Caches are written atomically and mode 0600: the registry carries each
+ * connection's `env` and `headers`, which routinely hold API keys, so the
+ * cache must never be world-readable, even between write and chmod.
+ */
+function writeJson(path: string, value: unknown): void {
+    atomicWriteFileSync(path, `${SafeJSON.stringify(value, { strict: true }, 2)}\n`, { mode: 0o600 });
+}
+
+export interface LoadRegistryOptions {
+    /** Re-scan the provider configs instead of reading the cache. */
+    refresh?: boolean;
+    /** Skip the cache write. Diagnostics (`doctor`) and `--dry-run` paths must not mutate durable state. */
+    persist?: boolean;
+}
+
+/**
+ * A cache written before the 0600 hardening stays world-readable forever on
+ * the hit path; tighten it in place. Returns false when the permissions could
+ * NOT be verified or tightened — the caller must then ignore the cache and
+ * rebuild it (the rebuild writes 0600 atomically), rather than silently
+ * consuming a credential file whose exposure it could not close.
+ */
+async function repairCacheMode(path: string): Promise<boolean> {
+    try {
+        const info = await stat(path);
+
+        if ((info.mode & 0o077) !== 0) {
+            await chmod(path, 0o600);
+            logger.info({ path }, "tightened credential cache permissions to 0600");
+        }
+
+        return true;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            logger.debug({ path, error }, "cache vanished during permission check");
+        } else {
+            logger.warn({ path, error }, "cannot verify credential cache permissions — ignoring cache, rebuilding");
+        }
+
+        return false;
+    }
+}
+
+/** Load the registry. Cached on disk; `refresh` re-scans the providers. */
+export async function loadRegistry(options: LoadRegistryOptions = {}): Promise<Registry> {
+    if (!options.refresh) {
+        const cached = await readJson<Registry>(registryCachePath());
+
+        // An empty servers array is a valid cached result (the ListJsonOutput
+        // contract says so); requiring length would rescan every provider on
+        // every command on a machine with no MCP servers.
+        if (cached && Array.isArray(cached.servers)) {
+            // Permission repair is a mutation, so the read-only (`persist:
+            // false`) path reports it via doctor instead of doing it. On the
+            // normal path an unverifiable cache is treated as a miss.
+            if (options.persist === false || (await repairCacheMode(registryCachePath()))) {
+                return cached;
+            }
+        }
+    }
+
+    const payload = await buildListJson(defaultProviders());
+    const registry: Registry = { ...payload, fetchedAt: new Date().toISOString() };
+
+    if (options.persist !== false) {
+        writeJson(registryCachePath(), registry);
+    }
+
+    logger.debug(
+        {
+            servers: registry.servers.length,
+            failed: registry.providersFailed.length,
+            persisted: options.persist !== false,
+        },
+        "scripts registry refreshed"
+    );
+    return registry;
+}
+
+/** Servers that at least one provider has enabled, i.e. the ones worth connecting to. */
+export function enabledServers(registry: Registry): ServerJsonEntry[] {
+    return registry.servers.filter((s) => s.enabled && s.connection.type !== "unknown");
+}
+
+/**
+ * Map a registry entry to an mcporter ServerDefinition.
+ *
+ * `env` is passed through as overrides; mcporter merges over process.env, which
+ * stdio servers rely on for PATH and HOME.
+ */
+export function toServerDefinition(
+    server: ServerJsonEntry,
+    extraHeaders?: Record<string, string>
+): ServerDefinition | undefined {
+    const c = server.connection;
+
+    if (c.type === "stdio" && c.command) {
+        return {
+            name: server.name,
+            command: { kind: "stdio", command: c.command, args: c.args ?? [], cwd: process.cwd() },
+            env: c.env,
+        };
+    }
+
+    if ((c.type === "http" || c.type === "sse") && c.url) {
+        let url: URL;
+
+        try {
+            url = new URL(c.url);
+        } catch (error) {
+            // The url is user-authored editor config; one bad entry must not
+            // abort the whole definition build.
+            logger.warn({ server: server.name, url: c.url, error }, "skipping server with unparsable url");
+            return undefined;
+        }
+
+        return {
+            name: server.name,
+            command: { kind: "http", url, headers: { ...c.headers, ...extraHeaders } },
+        };
+    }
+
+    return undefined;
+}
+
+/** Servers whose stored token has a problem, reported so the CLI can say so once. */
+export interface AuthProblem {
+    server: string;
+    problem: string;
+}
+
+/**
+ * Build mcporter definitions, attaching Claude Code's Bearer token to every
+ * remote server it holds one for. Scripts are headless, so a remote server
+ * without a header cannot authenticate at all.
+ */
+export async function toServerDefinitions(
+    registry: Registry,
+    names?: string[],
+    options: { refreshAuth?: boolean } = {}
+): Promise<{ definitions: ServerDefinition[]; authProblems: AuthProblem[] }> {
+    const wanted = names && names.length > 0 ? new Set(names) : undefined;
+    const selected = enabledServers(registry).filter((s) => !wanted || wanted.has(s.name));
+    const definitions: ServerDefinition[] = [];
+    const authProblems: AuthProblem[] = [];
+
+    for (const server of selected) {
+        let headers: Record<string, string> | undefined;
+
+        if (server.connection.url) {
+            const auth = await authFor(server.connection.url, { refresh: options.refreshAuth });
+            headers = auth.headers;
+
+            const note = auth.problem ?? auth.missing;
+
+            if (note) {
+                authProblems.push({ server: server.name, problem: note });
+            }
+        }
+
+        const definition = toServerDefinition(server, headers);
+
+        if (definition) {
+            definitions.push(definition);
+        }
+    }
+
+    return { definitions, authProblems };
+}
+
+export async function loadToolCache(): Promise<Record<string, ToolCacheEntry>> {
+    return (await readJson<Record<string, ToolCacheEntry>>(toolsCachePath())) ?? {};
+}
+
+export async function saveToolCache(cache: Record<string, ToolCacheEntry>): Promise<void> {
+    writeJson(toolsCachePath(), cache);
+}

--- a/src/scripts/lib/scaffold.test.ts
+++ b/src/scripts/lib/scaffold.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { bindNames, renderScriptModule, renderToolsModule } from "./scaffold.ts";
+
+const takeScreenshot = {
+    name: "take_screenshot",
+    description: "Grab a screenshot",
+    inputSchema: { type: "object", properties: { fullPage: { type: "boolean" } } },
+};
+const handoffPost = {
+    name: "handoff_post",
+    description: "File a handoff",
+    inputSchema: { type: "object", properties: { title: { type: "string" } }, required: ["title"] },
+};
+const noArgs = { name: "list_pages", inputSchema: { type: "object", properties: {} } };
+
+describe("bindNames", () => {
+    it("bare camelCase names for a single server", () => {
+        const bound = bindNames([
+            { server: "chrome-devtools-mcp", tool: takeScreenshot },
+            { server: "chrome-devtools-mcp", tool: noArgs },
+        ]);
+        expect(bound.map((b) => b.fnName)).toEqual(["takeScreenshot", "listPages"]);
+    });
+
+    it("server-prefixed names across servers, with collision suffixes", () => {
+        const bound = bindNames([
+            { server: "chrome-devtools-mcp", tool: takeScreenshot },
+            { server: "genesis-tools", tool: handoffPost },
+        ]);
+        expect(bound.map((b) => b.fnName)).toEqual(["chromeDevtoolsMcp_takeScreenshot", "genesisTools_handoffPost"]);
+
+        const collided = bindNames([
+            { server: "a", tool: { name: "x" } },
+            { server: "b", tool: { name: "x" } },
+        ]);
+        expect(collided.map((b) => b.fnName)).toEqual(["a_x", "b_x"]);
+    });
+
+    it("reserved and strict-mode-restricted words get a Tool suffix so the generated module parses", () => {
+        const bound = bindNames([
+            { server: "s", tool: { name: "delete" } },
+            { server: "s", tool: { name: "new" } },
+            { server: "s", tool: { name: "eval" } },
+            { server: "s", tool: { name: "arguments" } },
+            { server: "s", tool: { name: "list_pages" } },
+        ]);
+        expect(bound.map((b) => b.fnName)).toEqual(["deleteTool", "newTool", "evalTool", "argumentsTool", "listPages"]);
+    });
+});
+
+describe("renderToolsModule", () => {
+    it("emits alias import, arg types, optionality and the TOOLS map", () => {
+        const bound = bindNames([
+            { server: "chrome-devtools-mcp", tool: takeScreenshot },
+            { server: "chrome-devtools-mcp", tool: handoffPost },
+            { server: "chrome-devtools-mcp", tool: noArgs },
+        ]);
+        const module = renderToolsModule(bound, ["chrome-devtools-mcp.*"], "2026-08-17T00:00:00.000Z");
+
+        expect(module).toContain('import type { Kit } from "@gt/scripts/kit";');
+        expect(module).toContain("export type TakeScreenshotArgs = {");
+        // All-optional args → optional parameter; required args → mandatory.
+        expect(module).toContain("takeScreenshot = (kit: Kit, args?: TakeScreenshotArgs)");
+        expect(module).toContain("handoffPost = (kit: Kit, args: HandoffPostArgs)");
+        // No-arg tool gets no args parameter at all.
+        expect(module).toContain("listPages = (kit: Kit) =>");
+        expect(module).toContain(
+            'kit.call("chrome-devtools-mcp", "take_screenshot", args as Record<string, unknown>);'
+        );
+        expect(module).toMatch(
+            /export const TOOLS = \{\n {4}takeScreenshot,\n {4}handoffPost,\n {4}listPages,\n\} as const;/
+        );
+    });
+
+    it("control characters in names are escaped into valid string literals", () => {
+        const bound = bindNames([{ server: "s", tool: { name: "weird\nname" } }]);
+        const module = renderToolsModule(bound, ["s.*"], "2026-08-17T00:00:00.000Z");
+
+        expect(module).toContain('"weird\\nname"');
+        expect(module).not.toContain('weird\nname"');
+    });
+});
+
+describe("renderScriptModule", () => {
+    const base = {
+        name: "demo",
+        servers: ["chrome-devtools-mcp"],
+        selectors: ["chrome-devtools-mcp.*"],
+        createdFrom: "/somewhere",
+        tags: [],
+    };
+
+    it("starts from a runnable no-required-args tool when one exists", () => {
+        const bound = bindNames([{ server: "chrome-devtools-mcp", tool: takeScreenshot }]);
+        const script = renderScriptModule({ ...base, bound });
+
+        expect(script).toContain('import { text, withKit } from "@gt/scripts/kit";');
+        expect(script).toContain('import * as T from "./demo.tools.ts";');
+        expect(script).toContain("const result = await T.takeScreenshot(kit, {});");
+        expect(script).toContain("tools scripts run demo");
+    });
+
+    it("comments the call out when every tool needs arguments", () => {
+        const bound = bindNames([{ server: "genesis-tools", tool: handoffPost }]);
+        const script = renderScriptModule({ ...base, servers: ["genesis-tools"], bound });
+
+        expect(script).toContain("// Every bound tool needs arguments. handoffPost expects:");
+        expect(script).toContain("// const result = await T.handoffPost(kit, { /* ... */ });");
+    });
+
+    it("renders a bindings-free scaffold when nothing was imported", () => {
+        const script = renderScriptModule({ ...base, servers: [], selectors: [], bound: [] });
+
+        expect(script).not.toContain("demo.tools.ts");
+        expect(script).toContain("kit.callRef");
+        expect(script).toContain("console.log(kit.servers());");
+        expect(script).toContain("await withKit(async (kit) => {");
+        expect(script).toMatch(/\}\);\n$/);
+    });
+});

--- a/src/scripts/lib/scaffold.ts
+++ b/src/scripts/lib/scaffold.ts
@@ -1,0 +1,278 @@
+/**
+ * Scaffold generation.
+ *
+ * `tools scripts create` produces two files in `persisted/<name>/`:
+ *
+ *   <name>.tools.ts   generated typed wrappers, one function per matched tool,
+ *                     argument types derived from the live inputSchema.
+ *                     Regenerable, do not hand-edit.
+ *   <name>.ts         the scratch script. Yours to edit.
+ *
+ * The split matters: regenerating bindings after a server updates its schema
+ * must never touch the code you wrote.
+ */
+import { SafeJSON } from "@genesiscz/utils/json";
+import type { ToolInfo } from "./registry.ts";
+import { allOptional, isEmptySchema, schemaToType } from "./schema-ts.ts";
+
+export interface BoundTool {
+    server: string;
+    tool: ToolInfo;
+    /** JS-safe function name, unique across servers. */
+    fnName: string;
+}
+
+/** `chrome-devtools-mcp` + `take_screenshot` becomes `chromeDevtoolsMcp_takeScreenshot`. */
+function camel(value: string): string {
+    return value
+        .replace(/[^A-Za-z0-9]+(.)?/g, (_, chr: string | undefined) => (chr ? chr.toUpperCase() : ""))
+        .replace(/^[0-9]+/, "");
+}
+
+/**
+ * A tool legitimately named `delete` or `new` would otherwise generate
+ * `export const delete = ...`, a syntax error that breaks the whole module.
+ * `eval` and `arguments` are not keywords but are equally illegal as lexical
+ * declarations in strict mode, which every generated ES module is.
+ */
+const RESERVED_WORDS = new Set([
+    "arguments",
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "eval",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "instanceof",
+    "interface",
+    "let",
+    "new",
+    "null",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "return",
+    "static",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+]);
+
+export function bindNames(matches: { server: string; tool: ToolInfo }[]): BoundTool[] {
+    const servers = new Set(matches.map((m) => m.server));
+    const multiServer = servers.size > 1;
+    const used = new Set<string>();
+
+    return matches.map(({ server, tool }) => {
+        const camelName = multiServer ? `${camel(server)}_${camel(tool.name)}` : camel(tool.name);
+        const base = RESERVED_WORDS.has(camelName) ? `${camelName}Tool` : camelName;
+        let name = base || "tool";
+        let n = 2;
+
+        while (used.has(name)) {
+            name = `${base}${n}`;
+            n += 1;
+        }
+
+        used.add(name);
+        return { server, tool, fnName: name };
+    });
+}
+
+function jsdoc(bound: BoundTool): string[] {
+    const lines = ["/**"];
+    const desc = (bound.tool.description ?? "").trim();
+
+    if (desc) {
+        for (const line of desc.split("\n").slice(0, 6)) {
+            lines.push(` * ${line.replace(/\*\//g, "*\\/").trimEnd()}`);
+        }
+
+        lines.push(" *");
+    }
+
+    lines.push(` * MCP tool: \`${bound.server}.${bound.tool.name}\``);
+    lines.push(" */");
+    return lines;
+}
+
+export function renderToolsModule(bound: BoundTool[], selectors: string[], generatedAt: string): string {
+    const servers = [...new Set(bound.map((b) => b.server))];
+    const lines: string[] = [];
+
+    lines.push("/**");
+    lines.push(" * GENERATED FILE. Do not edit by hand.");
+    lines.push(" *");
+    lines.push(` * Selectors: ${selectors.join(", ")}`);
+    lines.push(` * Servers:   ${servers.join(", ")}`);
+    lines.push(` * Generated: ${generatedAt}`);
+    lines.push(" *");
+    lines.push(" * Regenerate after a server changes its schema:");
+    lines.push(" *   tools scripts regen <name>");
+    lines.push(" */");
+    lines.push('import type { Kit } from "@gt/scripts/kit";');
+    lines.push("");
+    lines.push(`export const SERVERS = ${safeJsonArray(servers)} as const;`);
+    lines.push("");
+
+    for (const b of bound) {
+        const argType = schemaToType(b.tool.inputSchema, 0);
+        const empty = isEmptySchema(b.tool.inputSchema);
+        const optional = empty || allOptional(b.tool.inputSchema);
+        const typeName = `${b.fnName.charAt(0).toUpperCase()}${b.fnName.slice(1)}Args`;
+
+        if (!empty) {
+            lines.push(`export type ${typeName} = ${argType};`);
+            lines.push("");
+        }
+
+        lines.push(...jsdoc(b));
+
+        if (empty) {
+            lines.push(`export const ${b.fnName} = (kit: Kit) =>`);
+            lines.push(`    kit.call(${quote(b.server)}, ${quote(b.tool.name)});`);
+        } else {
+            lines.push(`export const ${b.fnName} = (kit: Kit, args${optional ? "?" : ""}: ${typeName}) =>`);
+            lines.push(`    kit.call(${quote(b.server)}, ${quote(b.tool.name)}, args as Record<string, unknown>);`);
+        }
+
+        lines.push("");
+    }
+
+    lines.push("/** Every binding in this module, keyed by function name. */");
+    lines.push("export const TOOLS = {");
+    for (const b of bound) {
+        lines.push(`    ${b.fnName},`);
+    }
+
+    lines.push("} as const;");
+    lines.push("");
+    return lines.join("\n");
+}
+
+/** JSON string escaping covers newlines and control characters too, which a hand-rolled quote-and-backslash replace does not. */
+function quote(value: string): string {
+    return SafeJSON.stringify(value, { strict: true });
+}
+
+function safeJsonArray(values: string[]): string {
+    return `[${values.map(quote).join(", ")}]`;
+}
+
+export interface ScaffoldContext {
+    name: string;
+    description?: string;
+    servers: string[];
+    bound: BoundTool[];
+    selectors: string[];
+    createdFrom: string;
+    project?: string;
+    tags: string[];
+}
+
+export function renderScriptModule(ctx: ScaffoldContext): string {
+    // Prefer a tool that needs no arguments for the starter line, so a freshly
+    // created script RUNS instead of failing on a missing required field.
+    const runnable = ctx.bound.find((b) => allOptional(b.tool.inputSchema));
+    const sample = runnable ?? ctx.bound[0];
+    const lines: string[] = [];
+
+    lines.push("#!/usr/bin/env bun");
+    lines.push("/**");
+    lines.push(` * ${ctx.name}${ctx.description ? `: ${ctx.description}` : ""}`);
+    lines.push(" *");
+
+    if (ctx.servers.length > 0) {
+        lines.push(` * Servers: ${ctx.servers.join(", ")}`);
+    }
+
+    lines.push(` * Created from: ${ctx.createdFrom}`);
+
+    if (ctx.project) {
+        lines.push(` * Project: ${ctx.project}`);
+    }
+
+    if (ctx.tags.length > 0) {
+        lines.push(` * Tags: ${ctx.tags.join(", ")}`);
+    }
+
+    lines.push(" *");
+    lines.push(` * Run:  tools scripts run ${ctx.name}`);
+
+    if (ctx.bound.length > 0) {
+        lines.push(` * Edit: this file. Typed tool bindings live in ./${ctx.name}.tools.ts (generated).`);
+    }
+
+    lines.push(" * Sidecars (presets, state, output) belong in this directory.");
+    lines.push(" */");
+    lines.push('import { text, withKit } from "@gt/scripts/kit";');
+
+    if (ctx.bound.length > 0) {
+        lines.push(`import * as T from "./${ctx.name}.tools.ts";`);
+    }
+
+    lines.push("");
+    lines.push("await withKit(async (kit) => {");
+
+    if (ctx.bound.length > 0) {
+        lines.push(`    // Bound tools: ${ctx.bound.map((b) => b.fnName).join(", ")}`);
+    }
+
+    if (sample && runnable) {
+        const empty = isEmptySchema(sample.tool.inputSchema);
+        lines.push("");
+        lines.push(`    const result = await T.${sample.fnName}(kit${empty ? "" : ", {}"});`);
+        lines.push("    console.log(text(result));");
+    } else if (sample) {
+        // Every bound tool has required arguments, so anything we generate here
+        // would throw. Leave a filled-in template commented out instead.
+        const argType = schemaToType(sample.tool.inputSchema, 1);
+        lines.push("");
+        lines.push(`    // Every bound tool needs arguments. ${sample.fnName} expects:`);
+        for (const line of argType.split("\n")) {
+            lines.push(`    // ${line}`);
+        }
+
+        lines.push(`    // const result = await T.${sample.fnName}(kit, { /* ... */ });`);
+        lines.push("    // console.log(text(result));");
+        lines.push("");
+        lines.push(`    console.log("bound:", Object.keys(T.TOOLS).join(", "));`);
+    } else {
+        lines.push("");
+        lines.push("    // No bindings were imported. kit.callRef reaches any enabled server:");
+        lines.push('    // const raw = await kit.callRef("genesis-tools.handoff_list", { limit: 3 });');
+        lines.push("    console.log(kit.servers());");
+    }
+
+    lines.push(`}${ctx.servers.length > 0 ? `, { servers: ${safeJsonArray(ctx.servers)} }` : ""});`);
+    lines.push("");
+    return lines.join("\n");
+}

--- a/src/scripts/lib/schema-ts.test.ts
+++ b/src/scripts/lib/schema-ts.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { allOptional, isEmptySchema, schemaToType } from "./schema-ts.ts";
+
+describe("schemaToType", () => {
+    it("primitives, arrays and nested objects", () => {
+        expect(schemaToType({ type: "string" })).toBe("string");
+        expect(schemaToType({ type: "integer" })).toBe("number");
+        expect(schemaToType({ type: "array", items: { type: "string" } })).toBe("string[]");
+
+        const nested = schemaToType({
+            type: "object",
+            properties: {
+                tasks: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: { text: { type: "string" } },
+                        required: ["text"],
+                    },
+                },
+            },
+            required: ["tasks"],
+        });
+        expect(nested).toContain("tasks: {");
+        expect(nested).toContain("text: string;");
+    });
+
+    it("tuple items render as a tuple, additionalProperties as an index signature", () => {
+        expect(schemaToType({ items: [{ type: "string" }, { type: "number" }] })).toBe("[string, number]");
+
+        const open = schemaToType({
+            type: "object",
+            properties: { id: { type: "string" } },
+            additionalProperties: true,
+        });
+        expect(open).toContain("id?: string;");
+        expect(open).toContain("[key: string]: unknown;");
+    });
+
+    it("enums, consts and unions", () => {
+        expect(schemaToType({ enum: ["a", "b"] })).toBe('"a" | "b"');
+        expect(schemaToType({ const: 5 })).toBe("5");
+        expect(schemaToType({ anyOf: [{ type: "string" }, { type: "number" }] })).toBe("string | number");
+        expect(schemaToType({ type: ["string", "null"] })).toBe("string | null");
+    });
+
+    it("resolves $ref into $defs and degrades unknowns", () => {
+        const schema = {
+            type: "object",
+            properties: { target: { $ref: "#/$defs/Target" } },
+            $defs: { Target: { type: "object", properties: { id: { type: "string" } } } },
+        };
+        expect(schemaToType(schema)).toContain("id?: string;");
+        expect(schemaToType({ $ref: "#/nowhere/X" })).toBe("unknown");
+        expect(schemaToType(42)).toBe("Record<string, unknown>");
+    });
+
+    it("marks required vs optional properties and quotes odd keys", () => {
+        const rendered = schemaToType({
+            type: "object",
+            properties: { ok: { type: "boolean" }, "odd-key": { type: "string" } },
+            required: ["ok"],
+        });
+        expect(rendered).toContain("ok: boolean;");
+        expect(rendered).toContain('"odd-key"?: string;');
+    });
+});
+
+describe("isEmptySchema / allOptional", () => {
+    it("no properties means empty; no required means all-optional", () => {
+        expect(isEmptySchema({ type: "object" })).toBe(true);
+        expect(isEmptySchema({ type: "object", properties: {} })).toBe(true);
+        expect(isEmptySchema({ type: "object", properties: { a: { type: "string" } } })).toBe(false);
+
+        expect(allOptional({ type: "object", properties: { a: { type: "string" } } })).toBe(true);
+        expect(allOptional({ type: "object", properties: { a: { type: "string" } }, required: ["a"] })).toBe(false);
+        expect(allOptional(null)).toBe(true);
+    });
+});

--- a/src/scripts/lib/schema-ts.ts
+++ b/src/scripts/lib/schema-ts.ts
@@ -1,0 +1,223 @@
+/**
+ * JSON Schema to TypeScript source text.
+ *
+ * WHY THIS EXISTS RATHER THAN `mcporter emit-ts`
+ *
+ * mcporter ships its own codegen and it was the obvious thing to reuse. It was
+ * tested against a real server (2026-07-28, mcporter 0.12.3) and rejected for
+ * two concrete reasons:
+ *
+ * 1. Its output does not compile. It emits POSITIONAL parameters in schema
+ *    order, so any tool whose schema lists an optional property before a
+ *    required one produces `TS1016: A required parameter cannot follow an
+ *    optional parameter`. Real example from `mcporter emit-ts genesis-tools`:
+ *      handoff_post(title: string, description?: string, tasks: Record<string, unknown>[], ...)
+ *    Two occurrences in that one file.
+ * 2. It flattens nested objects to `Record<string, unknown>`, so the part most
+ *    worth typing (`tasks[].acceptanceCriteria`, `target.sessionId`) is lost.
+ *
+ * MCP tools take a single arguments OBJECT, so the object form is also the
+ * shape that matches the protocol. Its emit is additionally one-server-per-file
+ * and reads mcporter's own config discovery rather than the mcp-manager
+ * registry this skill is built on.
+ *
+ * mcporter's RUNTIME is still doing the real work (transport, connection
+ * caching, OAuth, and `createCallResult` for result unwrapping in kit.ts).
+ * This module replaces only the emit half. Re-evaluate when mcporter fixes the
+ * parameter ordering.
+ *
+ * Scope is deliberately small: what MCP servers actually put in `inputSchema`
+ * and `outputSchema`. That is objects, primitives, arrays, enums, unions and
+ * `$ref` into `$defs`/`definitions`. Anything unrecognised degrades to
+ * `unknown` rather than guessing, because a wrong type here is worse than none.
+ */
+import { SafeJSON } from "@genesiscz/utils/json";
+
+interface Schema {
+    type?: string | string[];
+    description?: string;
+    properties?: Record<string, Schema>;
+    required?: string[];
+    items?: Schema | Schema[];
+    enum?: unknown[];
+    const?: unknown;
+    anyOf?: Schema[];
+    oneOf?: Schema[];
+    allOf?: Schema[];
+    additionalProperties?: boolean | Schema;
+    $ref?: string;
+    $defs?: Record<string, Schema>;
+    definitions?: Record<string, Schema>;
+    [key: string]: unknown;
+}
+
+const INDENT = "    ";
+
+function isSchema(value: unknown): value is Schema {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function literal(value: unknown): string {
+    if (typeof value === "string") {
+        return SafeJSON.stringify(value, { strict: true });
+    }
+
+    if (typeof value === "number" || typeof value === "boolean" || value === null) {
+        return String(value);
+    }
+
+    return "unknown";
+}
+
+/** A JS identifier can stay bare; anything else gets quoted. */
+function propKey(name: string): string {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : SafeJSON.stringify(name, { strict: true });
+}
+
+function resolveRef(ref: string, root: Schema): Schema | undefined {
+    const match = /^#\/(\$defs|definitions)\/(.+)$/.exec(ref);
+
+    if (!match) {
+        return undefined;
+    }
+
+    const bucket = (root[match[1] as "$defs"] ?? {}) as Record<string, Schema>;
+    return bucket[match[2]!];
+}
+
+function primitive(type: string): string {
+    switch (type) {
+        case "string":
+            return "string";
+        case "number":
+        case "integer":
+            return "number";
+        case "boolean":
+            return "boolean";
+        case "null":
+            return "null";
+        case "array":
+            return "unknown[]";
+        case "object":
+            return "Record<string, unknown>";
+        default:
+            return "unknown";
+    }
+}
+
+function render(schema: Schema | undefined, root: Schema, depth: number, seen: Set<Schema>): string {
+    if (!schema || !isSchema(schema)) {
+        return "unknown";
+    }
+
+    if (seen.has(schema) || depth > 8) {
+        return "unknown";
+    }
+
+    if (schema.$ref) {
+        const target = resolveRef(schema.$ref, root);
+        return target ? render(target, root, depth + 1, new Set([...seen, schema])) : "unknown";
+    }
+
+    if (schema.const !== undefined) {
+        return literal(schema.const);
+    }
+
+    if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+        return schema.enum.map(literal).join(" | ");
+    }
+
+    const union = schema.anyOf ?? schema.oneOf;
+
+    if (Array.isArray(union) && union.length > 0) {
+        const parts = union.map((s) => render(s, root, depth + 1, new Set([...seen, schema])));
+        return [...new Set(parts)].join(" | ");
+    }
+
+    if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+        const parts = schema.allOf.map((s) => render(s, root, depth + 1, new Set([...seen, schema])));
+        return parts.join(" & ");
+    }
+
+    if (Array.isArray(schema.type)) {
+        return [...new Set(schema.type.map(primitive))].join(" | ");
+    }
+
+    if (schema.type === "array" || schema.items) {
+        // Legacy tuple form: one schema per position. Collapsing to the first
+        // item would type `[string, number]` as `string[]`.
+        if (Array.isArray(schema.items)) {
+            const parts = schema.items.map((s) => render(s, root, depth + 1, new Set([...seen, schema])));
+            return `[${parts.join(", ")}]`;
+        }
+
+        const inner = render(schema.items, root, depth + 1, new Set([...seen, schema]));
+        return inner.includes(" ") && !inner.startsWith("{") ? `(${inner})[]` : `${inner}[]`;
+    }
+
+    if (schema.type === "object" || schema.properties) {
+        const props = schema.properties ?? {};
+        const entries = Object.entries(props);
+
+        if (entries.length === 0) {
+            return "Record<string, unknown>";
+        }
+
+        const required = new Set(schema.required ?? []);
+        const pad = INDENT.repeat(depth + 1);
+        const closePad = INDENT.repeat(depth);
+        const lines: string[] = ["{"];
+
+        for (const [name, propSchema] of entries) {
+            const rendered = render(propSchema, root, depth + 1, new Set([...seen, schema]));
+            const doc = typeof propSchema?.description === "string" ? propSchema.description.trim() : "";
+
+            if (doc) {
+                lines.push(`${pad}/** ${doc.replace(/\*\//g, "*\\/").replace(/\s+/g, " ")} */`);
+            }
+
+            lines.push(`${pad}${propKey(name)}${required.has(name) ? "" : "?"}: ${rendered};`);
+        }
+
+        if (schema.additionalProperties) {
+            lines.push(`${pad}[key: string]: unknown;`);
+        }
+
+        lines.push(`${closePad}}`);
+        return lines.join("\n");
+    }
+
+    if (typeof schema.type === "string") {
+        return primitive(schema.type);
+    }
+
+    return "unknown";
+}
+
+/** Render a JSON Schema as an inline TypeScript type. */
+export function schemaToType(schema: unknown, depth = 0): string {
+    if (!isSchema(schema)) {
+        return "Record<string, unknown>";
+    }
+
+    return render(schema, schema, depth, new Set());
+}
+
+/** True when the schema has no properties, i.e. the tool takes no arguments. */
+export function isEmptySchema(schema: unknown): boolean {
+    if (!isSchema(schema)) {
+        return true;
+    }
+
+    const props = schema.properties;
+    return !props || Object.keys(props).length === 0;
+}
+
+/** True when every property is optional, so the whole args object can be. */
+export function allOptional(schema: unknown): boolean {
+    if (!isSchema(schema)) {
+        return true;
+    }
+
+    return (schema.required ?? []).length === 0;
+}

--- a/src/scripts/lib/schema.test.ts
+++ b/src/scripts/lib/schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { describeCollection, formatSchema } from "./schema.ts";
+
+describe("formatSchema typescript mode", () => {
+    it("quotes keys that are not valid TS identifiers", () => {
+        const rendered = formatSchema({ "content-type": "x", "first name": "y", "2fa": true, plain: 1 }, "typescript");
+
+        expect(rendered).toContain('"content-type": string;');
+        expect(rendered).toContain('"first name": string;');
+        expect(rendered).toContain('"2fa": boolean;');
+        expect(rendered).toContain("plain: number;");
+    });
+
+    it("emits a root alias when the top-level value is not itself an interface", () => {
+        const rendered = formatSchema([{ title: "a" }, { title: "b" }], "typescript", { rootName: "Items" });
+
+        expect(rendered).toContain("interface Item {");
+        expect(rendered).toContain("type Items = Item[];");
+    });
+
+    it("digit-prefixed keys still yield valid interface names", () => {
+        const rendered = formatSchema({ "2fa": { enabled: true } }, "typescript");
+
+        expect(rendered).toContain("interface Fa {");
+        expect(rendered).toContain('"2fa": Fa;');
+        expect(rendered).not.toContain("interface 2fa");
+    });
+
+    it("a digit-prefixed root name is stripped and re-cased", () => {
+        const rendered = formatSchema([1, 2], "typescript", { rootName: "2fa" });
+
+        expect(rendered).toBe("type Fa = number[];");
+    });
+
+    it("an all-digit root name falls back to Root", () => {
+        const rendered = formatSchema([1, 2], "typescript", { rootName: "2" });
+
+        expect(rendered).toBe("type Root = number[];");
+    });
+
+    it("still names an object root by its interface alone", () => {
+        const rendered = formatSchema({ id: 1 }, "typescript", { rootName: "Payload" });
+
+        expect(rendered).toContain("interface Payload {");
+        expect(rendered).not.toContain("type Payload =");
+    });
+});
+
+describe("describeCollection", () => {
+    it("reports count, fields and sometimes-missing keys", () => {
+        expect(describeCollection([{ a: 1, b: 2 }, { a: 3 }])).toBe("2 item(s), 2 field(s), sometimes-missing: b");
+    });
+});

--- a/src/scripts/lib/schema.ts
+++ b/src/scripts/lib/schema.ts
@@ -1,0 +1,361 @@
+/**
+ * Shape instead of data.
+ *
+ * The cheapest useful thing to say about a 500KB JSON payload is what shape it
+ * has. An agent that can see `{ id: number, items: [{ title: string }] }` knows
+ * whether it needs the real data at all, and which part — for the cost of one
+ * line instead of the whole document.
+ *
+ * Ported from the pattern GenesisTools' har-analyzer and debugging-master use
+ * (`src/utils/json-schema.ts`), where it backs `expand --schema`.
+ *
+ * Array items are UNIONED rather than sampled: an array of 10,000 objects whose
+ * 700th element has an extra optional field still reports that field. Sampling
+ * the first element is the obvious shortcut and it silently lies.
+ */
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+export type SchemaMode = "skeleton" | "typescript" | "schema";
+
+type Primitive = "string" | "number" | "boolean" | "null" | "undefined";
+
+export type Shape =
+    | { kind: "primitive"; type: Primitive }
+    | { kind: "array"; items: Shape | undefined; length: number }
+    | { kind: "object"; fields: Map<string, { shape: Shape; optional: boolean }> }
+    | { kind: "union"; options: Shape[] };
+
+const MAX_DEPTH = 12;
+
+function primitiveOf(value: unknown): Primitive {
+    if (value === null) {
+        return "null";
+    }
+
+    if (value === undefined) {
+        return "undefined";
+    }
+
+    const type = typeof value;
+    return type === "string" || type === "number" || type === "boolean" ? type : "string";
+}
+
+function sameShape(a: Shape, b: Shape): boolean {
+    if (a.kind !== b.kind) {
+        return false;
+    }
+
+    // The primitive-vs-primitive case dominates when merging large arrays;
+    // rendering both subtrees to strings there would make the "cheap summary"
+    // module quadratic on exactly the payloads it exists to summarize.
+    if (a.kind === "primitive" && b.kind === "primitive") {
+        return a.type === b.type;
+    }
+
+    return render(a, "skeleton", 0) === render(b, "skeleton", 0);
+}
+
+/** Collapse two shapes into one, widening to a union only when they differ. */
+export function mergeShapes(a: Shape | undefined, b: Shape | undefined): Shape | undefined {
+    if (!a) {
+        return b;
+    }
+
+    if (!b) {
+        return a;
+    }
+
+    if (a.kind === "object" && b.kind === "object") {
+        const fields = new Map(a.fields);
+
+        for (const [key, right] of b.fields) {
+            const left = fields.get(key);
+            fields.set(
+                key,
+                left
+                    ? { shape: mergeShapes(left.shape, right.shape)!, optional: left.optional || right.optional }
+                    : { shape: right.shape, optional: true }
+            );
+        }
+
+        // A key absent from b is optional across the union.
+        for (const [key, left] of a.fields) {
+            if (!b.fields.has(key)) {
+                fields.set(key, { ...left, optional: true });
+            }
+        }
+
+        return { kind: "object", fields };
+    }
+
+    if (a.kind === "array" && b.kind === "array") {
+        return { kind: "array", items: mergeShapes(a.items, b.items), length: a.length + b.length };
+    }
+
+    if (sameShape(a, b)) {
+        return a;
+    }
+
+    const options = [...(a.kind === "union" ? a.options : [a]), ...(b.kind === "union" ? b.options : [b])];
+    const unique: Shape[] = [];
+
+    for (const option of options) {
+        if (!unique.some((u) => sameShape(u, option))) {
+            unique.push(option);
+        }
+    }
+
+    return unique.length === 1 ? unique[0]! : { kind: "union", options: unique };
+}
+
+export function inferShape(value: unknown, depth = 0): Shape {
+    if (depth >= MAX_DEPTH) {
+        return { kind: "primitive", type: "string" };
+    }
+
+    if (Array.isArray(value)) {
+        let items: Shape | undefined;
+
+        for (const entry of value) {
+            items = mergeShapes(items, inferShape(entry, depth + 1));
+        }
+
+        return { kind: "array", items, length: value.length };
+    }
+
+    if (value !== null && typeof value === "object") {
+        const fields = new Map<string, { shape: Shape; optional: boolean }>();
+
+        for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+            fields.set(key, { shape: inferShape(entry, depth + 1), optional: false });
+        }
+
+        return { kind: "object", fields };
+    }
+
+    return { kind: "primitive", type: primitiveOf(value) };
+}
+
+function indent(level: number): string {
+    return "  ".repeat(level);
+}
+
+function render(shape: Shape, mode: SchemaMode, level: number): string {
+    switch (shape.kind) {
+        case "primitive":
+            return shape.type;
+        case "union":
+            return shape.options.map((o) => render(o, mode, level)).join(" | ");
+        case "array": {
+            if (!shape.items) {
+                return "[]";
+            }
+
+            return `[${render(shape.items, mode, level)}]`;
+        }
+        case "object": {
+            if (shape.fields.size === 0) {
+                return "{}";
+            }
+
+            const inline = mode === "skeleton" && shape.fields.size <= 3;
+            const parts = [...shape.fields].map(
+                ([key, { shape: field, optional }]) => `${key}${optional ? "?" : ""}: ${render(field, mode, level + 1)}`
+            );
+
+            if (inline) {
+                return `{ ${parts.join(", ")} }`;
+            }
+
+            return `{\n${parts.map((p) => `${indent(level + 1)}${p}`).join(",\n")}\n${indent(level)}}`;
+        }
+    }
+}
+
+function singular(name: string): string {
+    if (name.endsWith("ies")) {
+        return `${name.slice(0, -3)}y`;
+    }
+
+    return name.endsWith("s") && !name.endsWith("ss") ? name.slice(0, -1) : name;
+}
+
+function pascal(name: string): string {
+    return name
+        .replace(/[^A-Za-z0-9]+(.)?/g, (_, c: string | undefined) => (c ? c.toUpperCase() : ""))
+        .replace(/^[a-z]/, (c) => c.toUpperCase());
+}
+
+/**
+ * Named interfaces rather than one nested literal.
+ *
+ * A nested object under `items` becomes `Item`, so a reader can talk about the
+ * pieces by name instead of by path.
+ */
+function renderTypescript(shape: Shape, rootName: string): string {
+    const emitted: string[] = [];
+    const seen = new Map<string, string>();
+    const used = new Set<string>();
+
+    function walk(current: Shape, name: string, level: number): string {
+        if (current.kind === "array") {
+            return current.items ? `${walk(current.items, singular(name), level)}[]` : "unknown[]";
+        }
+
+        if (current.kind === "union") {
+            return current.options.map((o) => walk(o, name, level)).join(" | ");
+        }
+
+        if (current.kind === "primitive") {
+            return current.type === "undefined" ? "undefined" : current.type;
+        }
+
+        const body = [...current.fields]
+            .map(
+                ([key, { shape: field, optional }]) =>
+                    `  ${tsKey(key)}${optional ? "?" : ""}: ${walk(field, key, level + 1)};`
+            )
+            .join("\n");
+        const base = typeNameOf(name);
+        const existing = seen.get(`${base}\n${body}`);
+
+        if (existing) {
+            return existing;
+        }
+
+        // Two DIFFERENT shapes can resolve to the same name (`item` and the
+        // element of `items` both become `Item`); a numeric suffix keeps the
+        // advertised-as-pasteable output compiling.
+        let typeName = base;
+        let n = 2;
+
+        while (used.has(typeName)) {
+            typeName = `${base}${n}`;
+            n += 1;
+        }
+
+        used.add(typeName);
+        seen.set(`${base}\n${body}`, typeName);
+        emitted.push(`interface ${typeName} {\n${body}\n}`);
+        return typeName;
+    }
+
+    const root = walk(shape, rootName, 0);
+
+    if (emitted.length === 0) {
+        return `type ${typeNameOf(rootName)} = ${root};`;
+    }
+
+    const declarations = emitted.reverse();
+
+    // An array-of-objects payload emits `interface Item` but the root IS
+    // `Item[]`; without a root alias the pasteable output cannot name the
+    // top-level value.
+    if (!used.has(root)) {
+        declarations.push(`type ${typeNameOf(rootName)} = ${root};`);
+    }
+
+    return declarations.join("\n\n");
+}
+
+/** JSON allows keys (`content-type`, `first name`, `2fa`) that are not valid TS identifiers; quote those. */
+function tsKey(key: string): string {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : SafeJSON.stringify(key, { strict: true });
+}
+
+/** A key like `2fa` pascals to `2fa`, which is not a legal interface name; strip the digits and re-case, falling back to Root. */
+function typeNameOf(name: string): string {
+    const stripped = pascal(name).replace(/^[0-9]+/, "");
+    return stripped ? `${stripped.charAt(0).toUpperCase()}${stripped.slice(1)}` : "Root";
+}
+
+function toJsonSchema(shape: Shape): unknown {
+    switch (shape.kind) {
+        case "primitive":
+            return { type: shape.type === "undefined" ? "null" : shape.type };
+        case "union":
+            return { anyOf: shape.options.map(toJsonSchema) };
+        case "array":
+            return { type: "array", items: shape.items ? toJsonSchema(shape.items) : {} };
+        case "object": {
+            const properties: Record<string, unknown> = {};
+            const required: string[] = [];
+
+            for (const [key, { shape: field, optional }] of shape.fields) {
+                properties[key] = toJsonSchema(field);
+
+                if (!optional) {
+                    required.push(key);
+                }
+            }
+
+            return required.length > 0 ? { type: "object", properties, required } : { type: "object", properties };
+        }
+    }
+}
+
+export interface FormatSchemaOptions {
+    /** Name for the root type in `typescript` mode. */
+    rootName?: string;
+}
+
+/**
+ * The shape of a value, in one of three registers.
+ *
+ * `skeleton` reads fastest, `typescript` is pasteable into code, `schema` is
+ * machine-comparable. A string that parses as JSON is treated as its parsed
+ * value, since MCP servers routinely hand back JSON in a text block.
+ */
+export function formatSchema(value: unknown, mode: SchemaMode = "skeleton", options: FormatSchemaOptions = {}): string {
+    let subject = value;
+
+    if (typeof value === "string") {
+        subject = safeParse(value);
+
+        if (subject === undefined) {
+            return "string";
+        }
+    }
+
+    const shape = inferShape(subject);
+
+    if (mode === "typescript") {
+        return renderTypescript(shape, options.rootName ?? "Root");
+    }
+
+    if (mode === "schema") {
+        return SafeJSON.stringify(toJsonSchema(shape), { strict: true }, 2);
+    }
+
+    return render(shape, "skeleton", 0);
+}
+
+/** One-line census of an array-of-objects: how many, and which keys are not always present. */
+export function describeCollection(value: unknown): string | undefined {
+    const subject = typeof value === "string" ? safeParse(value) : value;
+
+    if (!Array.isArray(subject) || subject.length === 0) {
+        return undefined;
+    }
+
+    const shape = inferShape(subject);
+
+    if (shape.kind !== "array" || shape.items?.kind !== "object") {
+        return undefined;
+    }
+
+    const optional = [...shape.items.fields].filter(([, f]) => f.optional).map(([k]) => k);
+    const total = shape.items.fields.size;
+
+    return `${subject.length} item(s), ${total} field(s)${optional.length > 0 ? `, sometimes-missing: ${optional.join(", ")}` : ""}`;
+}
+
+function safeParse(value: string): unknown {
+    try {
+        return SafeJSON.parse(value, { strict: true });
+    } catch (error) {
+        logger.debug({ error }, "value is not JSON; treating as plain string");
+        return undefined;
+    }
+}

--- a/src/scripts/lib/store.test.ts
+++ b/src/scripts/lib/store.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    commitStore,
+    ensureStoreScaffold,
+    pathExists,
+    readStoreConfig,
+    runGit,
+    setStoreRemote,
+    storeRemoteUrl,
+    writeStoreConfig,
+} from "./store.ts";
+
+let root: string;
+
+beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "scripts-store-"));
+});
+
+afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+});
+
+function git(args: string[]): string {
+    const proc = Bun.spawnSync(["git", "-C", root, ...args]);
+    return proc.stdout.toString().trim();
+}
+
+describe("store scaffold", () => {
+    it("writes tsconfig, package.json and initialises a local git repo with an initial commit", async () => {
+        await ensureStoreScaffold(root);
+
+        expect(await pathExists(join(root, "tsconfig.json"))).toBe(true);
+        expect(await pathExists(join(root, "package.json"))).toBe(true);
+        expect(await pathExists(join(root, ".git"))).toBe(true);
+        expect(await pathExists(join(root, ".gitignore"))).toBe(true);
+        expect(git(["log", "--oneline"])).toContain("init script store");
+        // No remote is ever configured; versioning is local-only by default.
+        expect(git(["remote"])).toBe("");
+    });
+});
+
+describe("commitStore", () => {
+    it("commits pending changes with the given message and no-ops on a clean tree", async () => {
+        await ensureStoreScaffold(root);
+        await Bun.write(join(root, "persisted", "demo", "demo.ts"), "// body\n");
+
+        await commitStore("feat: create demo", root);
+        expect(git(["log", "-1", "--format=%s"])).toBe("feat: create demo");
+
+        const head = git(["rev-parse", "HEAD"]);
+        await commitStore("chore: nothing changed", root);
+        expect(git(["rev-parse", "HEAD"])).toBe(head);
+    });
+
+    it("ignored paths (cache/, trash/, node_modules/) never enter history", async () => {
+        await ensureStoreScaffold(root);
+        await Bun.write(join(root, "cache", "registry.json"), "{}\n");
+        await Bun.write(join(root, "trash", "x.ts"), "// trashed\n");
+
+        await commitStore("chore: sweep", root);
+        expect(git(["status", "--porcelain"])).toBe("");
+        expect(git(["ls-files"])).not.toContain("cache/registry.json");
+        expect(git(["ls-files"])).not.toContain("trash/x.ts");
+    });
+
+    it("a pre-staged file outside the allowlist is unstaged, not committed", async () => {
+        await ensureStoreScaffold(root);
+        await Bun.write(join(root, "secrets.env"), "TOKEN=oops\n");
+        Bun.spawnSync(["git", "-C", root, "add", "secrets.env"]);
+
+        await Bun.write(join(root, "persisted", "demo", "demo.ts"), "// body\n");
+        await commitStore("feat: create demo", root);
+
+        expect(git(["log", "-1", "--format=%s"])).toBe("feat: create demo");
+        expect(git(["ls-files"])).not.toContain("secrets.env");
+        expect(await Bun.file(join(root, "secrets.env")).text()).toBe("TOKEN=oops\n");
+    });
+
+    it("a stray untracked file outside the allowlist neither commits nor breaks later commits", async () => {
+        await ensureStoreScaffold(root);
+        await Bun.write(join(root, "stray-note.md"), "not allowlisted\n");
+
+        const head = git(["rev-parse", "HEAD"]);
+        await commitStore("chore: should be a no-op", root);
+        expect(git(["rev-parse", "HEAD"])).toBe(head);
+
+        await Bun.write(join(root, "persisted", "real", "real.ts"), "// body\n");
+        await commitStore("feat: create real", root);
+        expect(git(["log", "-1", "--format=%s"])).toBe("feat: create real");
+        expect(git(["ls-files"])).not.toContain("stray-note.md");
+    });
+
+    it("does nothing when the store is not a git repo", async () => {
+        await Bun.write(join(root, "persisted", "demo.ts"), "// body\n");
+        await commitStore("feat: whatever", root);
+        expect(await pathExists(join(root, ".git"))).toBe(false);
+    });
+});
+
+describe("remote", () => {
+    it("setStoreRemote adds origin, then updates it on a second call", async () => {
+        expect(await storeRemoteUrl(root)).toBeUndefined();
+
+        expect(await setStoreRemote("git@example.com:a/b.git", root)).toEqual({
+            action: "added",
+            url: "git@example.com:a/b.git",
+        });
+        expect(await storeRemoteUrl(root)).toBe("git@example.com:a/b.git");
+
+        expect(await setStoreRemote("git@example.com:a/c.git", root)).toEqual({
+            action: "updated",
+            url: "git@example.com:a/c.git",
+        });
+        expect(await storeRemoteUrl(root)).toBe("git@example.com:a/c.git");
+    });
+
+    it("auto-push delivers store commits to a configured remote", async () => {
+        const bare = await mkdtemp(join(tmpdir(), "scripts-remote-"));
+        Bun.spawnSync(["git", "init", "--bare", "-b", "main", bare]);
+
+        try {
+            await setStoreRemote(bare, root);
+            await runGit(root, ["push", "-u", "origin", "main"]);
+            await writeStoreConfig({ remote: { url: bare, autoPush: true, decidedAt: "t" } }, root);
+
+            await Bun.write(join(root, "persisted", "demo", "demo.ts"), "// body\n");
+            await commitStore("feat: create demo", root);
+
+            const remoteLog = Bun.spawnSync(["git", "-C", bare, "log", "-1", "--format=%s", "main"]);
+            expect(remoteLog.stdout.toString().trim()).toBe("feat: create demo");
+        } finally {
+            await rm(bare, { recursive: true, force: true });
+        }
+    });
+
+    it("store config round-trips decisions", async () => {
+        expect(await readStoreConfig(root)).toEqual({});
+
+        await writeStoreConfig({ remote: { declined: true, decidedAt: "t" } }, root);
+        expect((await readStoreConfig(root)).remote?.declined).toBe(true);
+    });
+});

--- a/src/scripts/lib/store.ts
+++ b/src/scripts/lib/store.ts
@@ -1,0 +1,344 @@
+/**
+ * The script store on disk.
+ *
+ * Everything `tools scripts` persists lives under `~/.genesis-tools/scripts/`:
+ *
+ *   persisted/<name>/        one script, its generated bindings, its sidecars
+ *   persisted/_journal.json  metadata + run history (see journal.ts)
+ *   cache/registry.json      last mcp-manager scan
+ *   cache/tools.json         per-server tools/list
+ *   trash/                   where `rm` moves things; nothing is deleted outright
+ *   tsconfig.json            generated: maps @gt/scripts/* into this repo checkout
+ *   package.json             script-local npm deps (commander, picocolors, ...)
+ *
+ * The tsconfig alias is what lets a persisted script that lives OUTSIDE the
+ * repo import the runtime with `import { withKit } from "@gt/scripts/kit"` and
+ * still run under plain `bun <script>`: Bun resolves the nearest tsconfig.json
+ * upward from the entry file, finds the store's, and follows the mapping into
+ * `src/scripts/lib/`. Verified 2026-08-17: the repo's own `@genesiscz/*`
+ * aliases keep resolving inside the mapped files (per-package tsconfig).
+ */
+import { mkdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ui } from "@genesiscz/utils/cli/ui";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
+
+/** Absolute path to this GenesisTools checkout's `src/scripts/lib/`. `import.meta.dir` is already percent-decoded, unlike `new URL(...).pathname`. */
+export const LIB_DIR = import.meta.dir;
+
+/** Existence probe. ENOENT is the expected miss; anything else is logged so a permission error is not mistaken for absence. */
+export async function pathExists(path: string): Promise<boolean> {
+    try {
+        await stat(path);
+        return true;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            logger.debug({ path, error }, "existence probe failed with a non-ENOENT error");
+        }
+
+        return false;
+    }
+}
+
+/** `~/.genesis-tools/scripts`, honoring the test override GENESIS_TOOLS_HOME. */
+export function storeRoot(): string {
+    return join(env.tools.getHome() || homedir(), ".genesis-tools", "scripts");
+}
+
+export function persistedDir(root = storeRoot()): string {
+    return join(root, "persisted");
+}
+
+export function cacheDir(root = storeRoot()): string {
+    return join(root, "cache");
+}
+
+export function trashDir(root = storeRoot()): string {
+    return join(root, "trash");
+}
+
+/**
+ * Script-local npm deps. `mcporter` is deliberately absent: only repo files
+ * (kit.ts) import it, so it resolves from the repo's node_modules. Scripts add
+ * their own extras here (`bun add` in the store) — pixelmatch/pngjs ship by
+ * default because the migrated figma script diffs screenshots.
+ */
+const STORE_PACKAGE_JSON = {
+    name: "genesis-scripts-store",
+    private: true,
+    type: "module",
+    dependencies: {
+        commander: "^15.0.0",
+        picocolors: "^1.1.1",
+        pixelmatch: "^7.2.0",
+        pngjs: "^7.0.0",
+    },
+    devDependencies: {
+        "@types/bun": "^1.3.14",
+        "@types/pngjs": "^6.0.5",
+    },
+};
+
+export async function runGit(
+    root: string,
+    args: string[]
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn(["git", "-C", root, ...args], { stdout: "pipe", stderr: "pipe" });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+    ]);
+
+    return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() };
+}
+
+const STORE_GITIGNORE = `node_modules/
+cache/
+trash/
+persisted/*/out/
+persisted/*/out-*/
+persisted/*/.cache/
+*.tmp
+`;
+
+/**
+ * The store is a plain LOCAL git repo, so every persisted script is versioned.
+ * No remote is ever configured — add one yourself if you want off-machine
+ * history (`git -C ~/.genesis-tools/scripts remote add origin …`).
+ */
+async function ensureStoreGit(root: string): Promise<void> {
+    if (await pathExists(join(root, ".git"))) {
+        return;
+    }
+
+    const init = await runGit(root, ["init", "-b", "main"]);
+
+    if (init.exitCode !== 0) {
+        logger.warn({ root, stderr: init.stderr }, "git init of the script store failed; versioning disabled");
+        return;
+    }
+
+    if (!(await pathExists(join(root, ".gitignore")))) {
+        atomicWriteFileSync(join(root, ".gitignore"), STORE_GITIGNORE);
+    }
+
+    logger.debug({ root }, "script store git repo initialised");
+    await commitStore("chore: init script store", root);
+}
+
+export interface StoreConfig {
+    /** The user's standing remote decision: set up, or explicitly declined. */
+    remote?: {
+        url?: string;
+        /** True when the user said "no remote, stop offering". */
+        declined?: boolean;
+        /** Push after every store commit. Off unless asked for. */
+        autoPush?: boolean;
+        decidedAt: string;
+    };
+}
+
+function storeConfigPath(root: string): string {
+    return join(root, "config.json");
+}
+
+/** Local decision state (never committed: the allowlist excludes it). */
+export async function readStoreConfig(root = storeRoot()): Promise<StoreConfig> {
+    try {
+        return SafeJSON.parse(await Bun.file(storeConfigPath(root)).text(), { strict: true }) as StoreConfig;
+    } catch (error) {
+        logger.debug({ root, error }, "store config read fell back to empty");
+        return {};
+    }
+}
+
+export async function writeStoreConfig(config: StoreConfig, root = storeRoot()): Promise<void> {
+    atomicWriteFileSync(storeConfigPath(root), `${SafeJSON.stringify(config, { strict: true }, 2)}\n`);
+}
+
+/** The store's `origin` url, or undefined when no remote is configured. */
+export async function storeRemoteUrl(root = storeRoot()): Promise<string | undefined> {
+    if (!(await pathExists(join(root, ".git")))) {
+        return undefined;
+    }
+
+    const result = await runGit(root, ["remote", "get-url", "origin"]);
+    return result.exitCode === 0 ? result.stdout : undefined;
+}
+
+export interface RemoteResult {
+    action: "added" | "updated";
+    url: string;
+}
+
+/** Point the store's `origin` at `url`, creating or updating it. The store (and its repo) is scaffolded first if needed. */
+export async function setStoreRemote(url: string, root = storeRoot()): Promise<RemoteResult> {
+    await ensureStoreScaffold(root);
+    const existing = await runGit(root, ["remote", "get-url", "origin"]);
+
+    if (existing.exitCode === 0) {
+        const update = await runGit(root, ["remote", "set-url", "origin", url]);
+
+        if (update.exitCode !== 0) {
+            throw new Error(`git remote set-url failed: ${update.stderr}`);
+        }
+
+        return { action: "updated", url };
+    }
+
+    const add = await runGit(root, ["remote", "add", "origin", url]);
+
+    if (add.exitCode !== 0) {
+        throw new Error(`git remote add failed: ${add.stderr}`);
+    }
+
+    return { action: "added", url };
+}
+
+/**
+ * Stage everything and commit, quietly doing nothing when the tree is clean
+ * or the store is not a repo. Mutating verbs (create/regen/rename/tag/rm)
+ * call this so the store's history tracks every shape change; `run` does not,
+ * because run-counter churn is not history worth keeping per-commit.
+ */
+export async function commitStore(message: string, root = storeRoot()): Promise<void> {
+    if (!(await pathExists(join(root, ".git")))) {
+        return;
+    }
+
+    // Never stage the credential-bearing cache (or trash). The .gitignore
+    // covers a fresh repo, but a pre-existing repo or a hand-damaged ignore
+    // file must not let `registry.json` slip into pushable history: unstage
+    // anything already sitting in the index (a pre-staged file would ride the
+    // allowlisted commit otherwise), stage an explicit allowlist, and
+    // proactively untrack cache/trash if they ever got committed. The reset
+    // may fail on an unborn branch, where nothing can be pre-staged wrongly.
+    await runGit(root, ["reset", "-q"]);
+    await runGit(root, ["rm", "-r", "--cached", "--ignore-unmatch", "-q", "cache", "trash", "node_modules"]);
+    await runGit(root, ["add", "-A", "--", ".gitignore", "package.json", "tsconfig.json", "persisted"]);
+    // Inspect the INDEX, not the worktree: stray untracked files outside the
+    // allowlist would make a whole-tree status non-empty while nothing is
+    // staged, and the commit would then fail with "no changes added".
+    const staged = await runGit(root, ["diff", "--cached", "--name-only"]);
+
+    if (staged.exitCode !== 0 || staged.stdout === "") {
+        return;
+    }
+
+    // A machine without a git identity must not make commits fail; the
+    // fallback identity applies only when none is configured. Signing and
+    // hooks are disabled outright: this is an internal machine-managed repo,
+    // and a global commit.gpgsign=true or core.hooksPath must not block it.
+    const identity = await runGit(root, ["config", "user.email"]);
+    const identityArgs =
+        identity.stdout === ""
+            ? ["-c", "user.name=genesis-scripts", "-c", "user.email=scripts@genesis-tools.local"]
+            : [];
+    const commit = await runGit(root, [
+        ...identityArgs,
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "--no-verify",
+        "-m",
+        message,
+    ]);
+
+    if (commit.exitCode !== 0) {
+        logger.warn({ root, message, stderr: commit.stderr }, "script store commit failed");
+        return;
+    }
+
+    logger.debug({ root, message }, "script store committed");
+
+    // Opt-in follow-through: with `tools scripts remote <url> --auto-push on`,
+    // every store commit lands on the remote too. A failed push never fails
+    // the verb that triggered it.
+    const config = await readStoreConfig(root);
+
+    if (config.remote?.autoPush && !config.remote.declined) {
+        const push = await runGit(root, ["push", "origin", "HEAD"]);
+
+        if (push.exitCode !== 0) {
+            logger.warn({ root, stderr: push.stderr }, "store auto-push failed");
+            ui.warn(`store auto-push failed: ${push.stderr.split("\n")[0]}`);
+        } else {
+            logger.debug({ root }, "store auto-pushed");
+        }
+    }
+}
+
+/**
+ * Write the store scaffolding (tsconfig alias + package.json + local git
+ * repo) when missing.
+ *
+ * The tsconfig is rewritten whenever its mapping no longer points at THIS
+ * checkout, so a moved repo heals on the next `tools scripts` invocation.
+ * package.json is only ever created, never overwritten: the user may have
+ * added script-local deps.
+ */
+export async function ensureStoreScaffold(root = storeRoot()): Promise<void> {
+    await mkdir(persistedDir(root), { recursive: true });
+
+    const tsconfigPath = join(root, "tsconfig.json");
+    const wanted = {
+        compilerOptions: {
+            paths: {
+                "@gt/scripts/*": [join(LIB_DIR, "*")],
+            },
+        },
+    };
+    const existing = await Bun.file(tsconfigPath)
+        .text()
+        .catch(() => undefined);
+    const wantedText = `${SafeJSON.stringify(wanted, { strict: true }, 2)}\n`;
+
+    if (existing !== wantedText) {
+        atomicWriteFileSync(tsconfigPath, wantedText);
+        logger.debug({ tsconfigPath, libDir: LIB_DIR }, "scripts store tsconfig written");
+    }
+
+    const packagePath = join(root, "package.json");
+
+    if (!(await Bun.file(packagePath).exists())) {
+        atomicWriteFileSync(packagePath, `${SafeJSON.stringify(STORE_PACKAGE_JSON, { strict: true }, 2)}\n`);
+        logger.debug({ packagePath }, "scripts store package.json written");
+    }
+
+    await ensureStoreGit(root);
+}
+
+/** True when the store's node_modules is missing, i.e. `bun install` is due. */
+export async function storeDepsMissing(root = storeRoot()): Promise<boolean> {
+    return !(await Bun.file(join(root, "node_modules", "commander", "package.json")).exists());
+}
+
+/**
+ * Install store deps when missing. Persisted scripts import commander and
+ * picocolors from the store's own node_modules; without this a freshly
+ * migrated machine fails with "Cannot find module 'commander'".
+ */
+export async function ensureStoreDeps(root = storeRoot()): Promise<void> {
+    if (!(await storeDepsMissing(root))) {
+        return;
+    }
+
+    logger.info({ root }, "installing script store dependencies");
+    const proc = Bun.spawn(["bun", "install"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+    // Drain both pipes WHILE waiting: a chatty install that fills the pipe
+    // buffer would otherwise block the child and hang `run` forever.
+    const [exitCode, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stderr).text(),
+        new Response(proc.stdout).text(),
+    ]);
+
+    if (exitCode !== 0) {
+        throw new Error(`bun install failed in ${root}: ${stderr.trim().slice(0, 500)}`);
+    }
+}

--- a/src/todo/lib/context.ts
+++ b/src/todo/lib/context.ts
@@ -1,25 +1,8 @@
-import { existsSync } from "node:fs";
 import { hostname } from "node:os";
-import { dirname, resolve } from "node:path";
+import { findProjectRoot } from "@genesiscz/utils/fs/project-root";
 import type { GitContext, TodoContext } from "./types";
 
-export function findProjectRoot(from: string): string | null {
-    let dir = resolve(from);
-
-    while (true) {
-        if (existsSync(resolve(dir, ".git"))) {
-            return dir;
-        }
-
-        const parent = dirname(dir);
-
-        if (parent === dir) {
-            return null;
-        }
-
-        dir = parent;
-    }
-}
+export { findProjectRoot };
 
 async function git(args: string[], cwd: string): Promise<string | null> {
     try {

--- a/src/utils/fs/project-root.test.ts
+++ b/src/utils/fs/project-root.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findProjectRoot } from "./project-root.ts";
+
+let root: string;
+
+beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "project-root-"));
+});
+
+afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+});
+
+describe("findProjectRoot", () => {
+    it("walks up to the directory holding .git, from arbitrarily deep", async () => {
+        await mkdir(join(root, "repo", ".git"), { recursive: true });
+        await mkdir(join(root, "repo", "a", "b", "c"), { recursive: true });
+
+        expect(findProjectRoot(join(root, "repo", "a", "b", "c"))).toBe(join(root, "repo"));
+        expect(findProjectRoot(join(root, "repo"))).toBe(join(root, "repo"));
+    });
+
+    it("returns null when no ancestor is a repo", async () => {
+        await mkdir(join(root, "plain", "deep"), { recursive: true });
+
+        expect(findProjectRoot(join(root, "plain", "deep"))).toBeNull();
+    });
+});

--- a/src/utils/fs/project-root.ts
+++ b/src/utils/fs/project-root.ts
@@ -1,0 +1,25 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Walk up from `from` to the enclosing git repo root (the directory holding
+ * `.git`), or null when no ancestor has one. Shared by `tools todo` context
+ * detection and the `tools scripts` journal (project inference + gating).
+ */
+export function findProjectRoot(from: string): string | null {
+    let dir = resolve(from);
+
+    while (true) {
+        if (existsSync(resolve(dir, ".git"))) {
+            return dir;
+        }
+
+        const parent = dirname(dir);
+
+        if (parent === dir) {
+            return null;
+        }
+
+        dir = parent;
+    }
+}


### PR DESCRIPTION
Ports the personal `~/.claude/skills/mcp-scripting` skill (CLI + 9 lib modules, ~2.7k lines) into the repo as a first-class tool: **`tools scripts`** — call MCP tools from plain TypeScript with typed bindings generated from each server's live `tools/list`, no agent loop.

## What's here

- **`src/scripts/`** — the tool. Verbs: `servers`, `tools`, `describe`, `call` (incl. `--args-file`/stdin), `create`, `list`, `show`, `run`, `regen`, `rename`, `tag`, `rm`, and a new read-only `doctor`.
- **Provider-prefixed selector grammar**, reserved from day one: `mcp:server.tool`; a bare selector means `mcp:` forever. v1 implements only the mcp provider (future: `openapi:`, `composio:`, `graphql:`, `gt:`).
- **Global store at `~/.genesis-tools/scripts/`** with visibility-only gating: `create --gated` hides a script from `list` outside its project tree (`--all` reveals); `run` works from anywhere. Metadata never gates execution.
- **`@gt/scripts/*` tsconfig alias**: the store carries a generated `tsconfig.json` mapping into this checkout's `src/scripts/lib/`, so persisted scripts run under plain `bun <script>` and read cleanly (`import { withKit } from "@gt/scripts/kit"`). Verified: repo-internal `@genesiscz/*` aliases keep resolving across the boundary. `create`/`run` self-heal the mapping after a repo move; `doctor` reports a stale one.
- **In-process registry**: `mcp-manager` grew an exported pure `buildListJson()` + shared `defaultProviders()`, so the tool builds its server registry by direct import instead of spawning `tools mcp-manager list --json`. Both mcp-manager doors verified unchanged.
- **Claude Code OAuth reuse** via the existing `src/utils/claude/keychain.ts` reader (`mcpOAuth` payload key), with the `~/.claude/.credentials.json` fallback. Tokens are reported when missing/expired, never refreshed (rotation would brick the app's copy).
- **Repo conventions throughout**: SafeJSON, `logger`/`out`/`ui` split (stdout = machine output only), env module, box tables for inventories, no bare catch.
- **Tests for the pure libs** (33 tests): selector grammar incl. provider prefix, journal gating/filtering/rename/trash on temp roots, scaffold naming + rendered modules, schema→TS conversion.
- **Plugin skill** `plugins/genesis-tools/skills/mcp-scripting` replaces the personal skill (same trigger phrases, teaches `tools scripts`); plugin version bumped to 1.0.42.

## Fixed during the port

- Latent shared-state bug carried from the skill: `readJournal`'s empty fallback spread a module-level constant, so `upsertEntry` mutated the shared `scripts` array and "empty" reads leaked earlier entries. Never bit in the skill because its journal file always existed; caught by the new tests.

## Migration (already performed on this machine, inline)

Persisted scripts (figma, spotifyPreview, colTriage, col184253, col-302900…) + journal + trash moved to `~/.genesis-tools/scripts/`, lib imports rewritten to `@gt/scripts/*`, journal paths repointed. Old skill folder moved to `/tmp` (not destroyed). Verified live: `list`, `run figma sessions` (via tool and via bare `bun`), full `create → run → rm` cycle, `doctor` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `tools scripts` workflow for discovering servers and tools, inspecting schemas, calling tools, and running concurrent operations.
  - Added script creation, execution, listing, description, regeneration, renaming, tagging, removal, and metadata commands.
  - Added Git and remote management, diagnostics, JSON output, project visibility controls, caching, OAuth credentials, schema generation, and large-result references.
  - Improved server status and tool discovery reporting.
- **Documentation**
  - Added comprehensive guides for scripting workflows and command usage.
- **Chores**
  - Updated marketplace and plugin versions to 1.0.42.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->