### PR TITLE
fix(spotify): three defects three usability testers hit

### DIFF
--- a/plugins/spotify/skills/spotify/references/cli.md
+++ b/plugins/spotify/skills/spotify/references/cli.md
@@ -179,12 +179,23 @@ track does not have to be in Liked Songs. Needs the browser running with remote 
 (default endpoint `http://127.0.0.1:9222`) and an open `open.spotify.com` tab, or it opens one.
 
 ```bash
-tools spotify play plan                       # show the plan; any flag below updates it
-tools spotify play plan --windows 10:3,20:3,30:3 --tracks <file> [--queue|--no-queue] [--between <ms>]
-tools spotify play run   [--resume | --restart] [--start <i>] [--end <i>] [--browser-url <url>]
-tools spotify play status                     # done / failed / where to resume
+tools spotify play plan new <name> --from top|gems|forgotten|unplayed|recent [-n <count>] [--windows <spec>]
+tools spotify play plan list                  # every plan, newest first; ● marks the one `run` uses
+tools spotify play plan set  [--plan <name>]  # show it; ONLY --windows/--seek/--play/--tracks/--queue/--between change it
+tools spotify play plan rm   <name>           # delete it, and the track list this tool seeded for it
+tools spotify play run    [--plan <name>] [--resume | --restart] [--start <i>] [--end <i>] [--browser-url <url>] [--volume <pct>]
+tools spotify play status [--plan <name>]     # done / failed / where to resume
 tools spotify play harvest                    # same library-download guide as `tools spotify harvest`
 ```
+
+Plans are named files at `~/.genesis-tools/spotify/play/<date>-<name>.json`, seeded from a
+report by `--from` so there is no JSON to hand-write. There is no "active plan" pointer:
+`run` and `status` use the **newest** plan, meaning the most recently WRITTEN one, so editing
+an older plan makes it the one they pick. Name the plan with `--plan` when it matters.
+
+`plan rm` deletes the plan and the `.tracks.json` this tool seeded beside it. A tracks file
+you pointed at yourself with `--tracks` is never deleted, and the command says which case it
+took.
 
 A window is `start:duration` in seconds — `40:30` means "seek to 0:40, listen for 30s".
 The tracks file is `[{uri, name?, artists?, windows?}]` or `{all: [...]}`; a track's own

--- a/src/spotify/commands/play.ts
+++ b/src/spotify/commands/play.ts
@@ -25,6 +25,7 @@ import {
     type PlayWindow,
     parseWindows,
     planPath,
+    removePlan,
     safePlanName,
     savePlan,
     writePlan,
@@ -182,7 +183,8 @@ export function registerPlay(program: Command): void {
             if (findPlan(safe)) {
                 throw new Error(
                     `a plan named "${safe}" already exists. Change it with ` +
-                        `\`play plan set --plan ${safe} …\`, or delete its file: ${findPlan(safe)?.path}`
+                        `\`tools spotify play plan set --plan ${safe} …\`, ` +
+                        `or remove it: \`tools spotify play plan rm ${safe}\``
                 );
             }
 
@@ -271,6 +273,28 @@ export function registerPlay(program: Command): void {
 
                 out.println(table.toString());
                 ui.dim("  ● = the newest, which `play run` uses · pick another with `play run --plan <name>`");
+            });
+        });
+
+    planCmd
+        .command("rm <name>")
+        .alias("remove")
+        .description("delete a plan (and the track list this tool seeded for it)")
+        .option("--json", "machine-readable output")
+        .action((name: string, o: { json?: boolean }) => {
+            const removed = removePlan(name);
+
+            emit(o.json, removed, (r) => {
+                ui.ok(`removed plan "${r.name}"`);
+                ui.dim(`  ${r.path}`);
+
+                if (r.tracks) {
+                    ui.dim(`  ${r.tracks}`);
+                } else {
+                    // Saying so out loud, because the alternative reading is that the tool
+                    // deleted a curated track list the user pointed the plan at.
+                    ui.dim("  its tracks file was not seeded by this tool, so it was left alone");
+                }
             });
         });
 

--- a/src/spotify/commands/play.ts
+++ b/src/spotify/commands/play.ts
@@ -197,6 +197,8 @@ export function registerPlay(program: Command): void {
             const limit = limitOf(o, 30);
             let tracksPath = o.tracks;
             let seeded = 0;
+            /** Set only when this tool writes the tracks file itself; see PlayPlan.seededTracks. */
+            let seededPath: string | undefined;
 
             if (!tracksPath) {
                 const source = parseSeedSource(o.from);
@@ -216,6 +218,10 @@ export function registerPlay(program: Command): void {
 
                 tracksPath = writeSeedFile(safe, tracks);
                 seeded = tracks.length;
+                // Recorded at the moment this tool wrote the file, which is the only point at
+                // which ownership is actually known. `plan rm` deletes a sidecar only on this
+                // evidence; a `--tracks` path supplied by the user never sets it.
+                seededPath = tracksPath;
             }
 
             const created = writePlan(safe, {
@@ -224,6 +230,7 @@ export function registerPlay(program: Command): void {
                 tracks: tracksPath,
                 betweenMs: numberOption(o.between, "between", DEFAULT_PLAN.betweenMs, { min: 0, integer: true }),
                 note: o.note ?? (seeded ? `${seeded} × ${parseSeedSource(o.from)}` : undefined),
+                ...(seededPath ? { seededTracks: seededPath } : {}),
             });
 
             // The newest plan is the one `play run` uses, and this one is newest by construction.

--- a/src/spotify/commands/play.ts
+++ b/src/spotify/commands/play.ts
@@ -34,7 +34,7 @@ import { renderHarvestGuide } from "@app/spotify/render/pipeline";
 import { ui } from "@genesiscz/utils/cli/ui";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
-import { out } from "@genesiscz/utils/logger";
+import { logger, out } from "@genesiscz/utils/logger";
 import { atomicWriteFileSync } from "@genesiscz/utils/storage/storage";
 import { createBoxTable, formatDotStatus, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
 import type { Command } from "commander";
@@ -109,6 +109,31 @@ function showPlan(plan: PlayPlan): void {
     }
 
     ui.dim(`  plan     ${planPath()}`);
+}
+
+const log = logger.child({ component: "spotify:play" });
+
+/**
+ * The TRACKS cell for one row of `plan list`, which must never take the whole listing down.
+ *
+ * `loadTracks` throws on anything it cannot parse, and this ran inside the render loop, so a
+ * single plan pointing at an empty or truncated tracks file made `plan list` fail outright
+ * with `JSON Parse error: Unexpected EOF` and no indication of WHICH plan was at fault. The
+ * one command a person uses to find their way out of a broken plan was the one the broken plan
+ * disabled. A bad file is now just a red cell on its own row.
+ */
+function trackCountCell(tracks: string | undefined): string {
+    if (!tracks || !existsSync(tracks)) {
+        return pc.red("missing");
+    }
+
+    try {
+        return String(loadTracks(tracks).length);
+    } catch (error) {
+        log.debug({ error, tracks }, "unreadable tracks file while listing plans");
+
+        return pc.red("unreadable");
+    }
 }
 
 export function registerPlay(program: Command): void {
@@ -198,14 +223,20 @@ export function registerPlay(program: Command): void {
             const isDefaultNow = newestPlan()?.name === created.name;
 
             emit(o.json, { ...created, seeded, isDefaultNow }, (r) => {
-                ui.ok(`plan "${r.name}" created${r.isDefaultNow ? " — `play run` will use it" : ""}`);
+                ui.ok(`plan "${r.name}" created`);
 
                 if (seeded) {
                     ui.kv("tracks", `${seeded} seeded → ${r.plan.tracks}`);
                 }
 
                 showPlan(r.plan);
-                ui.dim(`  next     tools spotify play run${r.isDefaultNow ? "" : ` --plan ${r.name}`}`);
+                // Always names the plan, even when it is currently the newest. The old message
+                // promised "`play run` will use it", which is true only until something else
+                // touches another plan: "newest" is most-recently-written, so EDITING an older
+                // plan makes it newest again. A tester created a plan, saw that promise, and
+                // then watched a different plan hold the newest marker. Naming the plan is
+                // advice that stays true.
+                ui.dim(`  next     tools spotify play run --plan ${r.name}`);
             });
         }
     );
@@ -228,12 +259,11 @@ export function registerPlay(program: Command): void {
                 renderCliHeader("Playback plans", playDir());
                 const table = createBoxTable(["", "NAME", "CREATED", "TRACKS", "WINDOWS", "NOTE"]);
                 for (const [i, p] of rows.entries()) {
-                    const count = p.plan.tracks && existsSync(p.plan.tracks) ? loadTracks(p.plan.tracks).length : null;
                     table.push([
                         i === 0 ? formatDotStatus("ok", "") : "",
                         pc.white(p.name),
                         p.date,
-                        count === null ? pc.red("missing") : String(count),
+                        trackCountCell(p.plan.tracks),
                         p.plan.windows.map(([s, d]) => `${s}:${d}`).join(","),
                         truncateDisplay(p.plan.note ?? "", 28),
                     ]);
@@ -249,8 +279,13 @@ export function registerPlay(program: Command): void {
         // Deliberately says "newest", not "active". There is no active-plan pointer by design
         // (see the header of lib/play/plan.ts), so calling it active invites the reader to go
         // looking for the command that sets it. `play run` picks the newest by the same rule.
-        .description("show the newest plan; any flag updates it")
-        .option("--plan <name>", "show or update this plan instead of the newest")
+        //
+        // The wording spells out that a bare call only READS, because "any flag updates it"
+        // plus "--plan <name>" in the same breath gave no way to tell whether `--plan foo`
+        // alone was safe to run out of curiosity. A tester ran it expecting a read-only view,
+        // then spent real effort deciding whether it had rewritten someone else's plan.
+        .description("show a plan; only --windows/--seek/--play/--tracks/--queue/--between change it")
+        .option("--plan <name>", "which plan to show or change (default: the newest); alone, it only shows")
         .option("--windows <spec>", "sample windows as start:duration pairs, e.g. 10:3,20:3,30:3")
         .option("--seek <sec>", "single-window start (shorthand for --windows <sec>:<play>)")
         .option("--play <sec>", "single-window duration")
@@ -382,11 +417,16 @@ export function registerPlay(program: Command): void {
         );
 
     play.command("status")
-        .description("progress for a tracks file — done, failed, where to resume")
+        .description("progress for a plan or tracks file — done, failed, where to resume")
+        // `--plan` is here because `run` and `plan set` both take it, and a user who has just
+        // created a plan by name reaches for the same flag to check on it. Without it the only
+        // way in was the tracks-file path, which nothing tells you unless you go back and
+        // re-read the output of `plan set`. The mismatch surfaced only as `unknown option`.
+        .option("--plan <name>", "which plan to report on (default: the newest)")
         .option("--tracks <path>", "tracks JSON (default: the plan's)")
         .option("--json", "machine-readable output")
-        .action((o: { tracks?: string; json?: boolean }) => {
-            const plan = loadPlan();
+        .action((o: { plan?: string; tracks?: string; json?: boolean }) => {
+            const plan = loadPlan(o.plan);
             const tracksFile = o.tracks ?? plan.tracks;
 
             if (!tracksFile) {

--- a/src/spotify/commands/play.ts
+++ b/src/spotify/commands/play.ts
@@ -164,7 +164,12 @@ export function registerPlay(program: Command): void {
                 .option("--note <text>", "a reminder of what this plan is for")
         ),
         "--top",
-        "how many tracks to seed into the plan (default 30)"
+        // Spells out the independence because `--from top` and `--top <n>` share a word for two
+        // unrelated things: a seed source and a count. A tester had to read both help blocks
+        // side by side to convince themselves `--top 20` did not also select the source. It
+        // happens to work today only because `--from` defaults to `top`, which is exactly the
+        // kind of coincidence that teaches the wrong model.
+        "how many tracks to seed into the plan, unrelated to `--from top` (default 30)"
     ).action(
         (
             name: string,

--- a/src/spotify/lib/play/driver.ts
+++ b/src/spotify/lib/play/driver.ts
@@ -79,6 +79,38 @@ async function evaluate(client: Client, fn: string): Promise<string> {
     return toolText(await client.callTool({ name: "evaluate_script", arguments: { function: fn } }));
 }
 
+export interface EmptyRangeInput {
+    start: number;
+    end: number;
+    total: number;
+    skipped: number;
+}
+
+/** Why the selection came out empty, in the user's terms rather than the loop's. */
+export function emptyReason({ start, end, total, skipped }: EmptyRangeInput): string {
+    if (!total) {
+        return "the tracks file is empty";
+    }
+
+    // Checked BEFORE the inverted-range case on purpose. `--end` defaults to the last index, so
+    // a bare `--start 5` on a two-track file would otherwise report "after --end 1", which is
+    // true but compares against a number the user never typed. Naming the file's size is the
+    // fact they need, and when start IS within the file an inverted range is the real problem.
+    if (start > total - 1) {
+        return `--start ${start} is past the last track (${total} in the file, so 0-${total - 1})`;
+    }
+
+    if (start > end) {
+        return `--start ${start} is after --end ${end}`;
+    }
+
+    if (skipped >= total) {
+        return `--resume skipped all ${total}; use --restart to play them again`;
+    }
+
+    return `nothing in ${start}-${end} is left to play`;
+}
+
 export async function runPreview(opts: RunPreviewOptions): Promise<RunPreviewResult> {
     const t0 = Date.now();
     const say = (m: string) => opts.onLog(`[${((Date.now() - t0) / 1000).toFixed(1).padStart(6)}s] ${m}`);
@@ -97,7 +129,11 @@ export async function runPreview(opts: RunPreviewOptions): Promise<RunPreviewRes
     log.info({ tracksFile: opts.tracksFile, browserUrl: opts.browserUrl, count: queue.length }, "play run starting");
 
     if (!queue.length) {
-        say("nothing to do");
+        // "nothing to do" on its own reads like success, and a mistyped range is the most
+        // likely way to get here: `--start 5 --end 2` selects nothing, and so does `--start 5`
+        // on a three-track list. Saying only that the queue is empty leaves the user to guess
+        // whether the plan is wrong, the resume journal ate everything, or the flags did.
+        say(`nothing to do — ${emptyReason({ start: opts.start, end, total: tracks.length, skipped: skip.size })}`);
 
         return { total: 0, ok: 0, failed: [], aborted: false };
     }

--- a/src/spotify/lib/play/plan.ts
+++ b/src/spotify/lib/play/plan.ts
@@ -10,7 +10,7 @@
  * `--plan <name>` says otherwise, which keeps the single-plan workflow reading as
  * "set it once, then `play run --resume`" with no extra state to get out of sync.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { playDir } from "@app/spotify/lib/paths";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -168,6 +168,44 @@ export function writePlan(name: string, plan: PlayPlan, date = new Date().toISOS
     atomicWriteFileSync(path, `${SafeJSON.stringify(plan, null, 2)}\n`);
 
     return { name: safe, date: existing?.date ?? date, path, plan };
+}
+
+export interface RemovedPlan {
+    name: string;
+    path: string;
+    /** The seeded sidecar, when one was removed with it. */
+    tracks?: string;
+}
+
+/**
+ * Delete one plan by name, and the sidecar this tool seeded for it.
+ *
+ * A usability tester avoided experimenting at all because there was no way back: plans could
+ * be created but never removed, so a wrong guess was a permanent row in `plan list`. That
+ * turns a cheap command into one people are afraid to run.
+ *
+ * The sidecar is removed ONLY when it is the file this tool generated inside the play
+ * directory for this plan. A plan can point `--tracks` at anything, including a list the user
+ * curated somewhere else, and deleting that because they tidied up a plan would be the kind
+ * of loss no undo covers.
+ */
+export function removePlan(name: string): RemovedPlan {
+    const found = findPlan(name);
+    if (!found) {
+        throw new Error(`no plan named "${safePlanName(name)}". List them: tools spotify play plan list`);
+    }
+
+    const seeded = found.path.replace(/\.json$/, TRACKS_SUFFIX);
+    const ownsSidecar = found.plan.tracks === seeded && existsSync(seeded);
+
+    unlinkSync(found.path);
+    if (ownsSidecar) {
+        unlinkSync(seeded);
+    }
+
+    log.info({ name: found.name, path: found.path, tracks: ownsSidecar ? seeded : null }, "removed plan");
+
+    return { name: found.name, path: found.path, ...(ownsSidecar ? { tracks: seeded } : {}) };
 }
 
 export function planPath(): string {

--- a/src/spotify/lib/play/plan.ts
+++ b/src/spotify/lib/play/plan.ts
@@ -33,6 +33,18 @@ export interface PlayPlan {
     betweenMs: number;
     /** Free text shown in `play plan list`, e.g. "gems, 30 of them, 30s each". */
     note?: string;
+    /**
+     * The tracks file THIS tool seeded, recorded when it wrote it. `plan rm` deletes the
+     * sidecar only when this matches `tracks`.
+     *
+     * Provenance is recorded rather than inferred from the path, because the conventional
+     * `<date>-<name>.tracks.json` name is not proof of ownership: a user can point `--tracks`
+     * straight at it, or (far more likely) let the tool seed a list and then curate it by
+     * hand. Both leave a file that looks tool-owned and is not, and deleting it is
+     * unrecoverable. Plans written before this field existed simply lack it, so they keep
+     * their tracks file — the conservative direction.
+     */
+    seededTracks?: string;
 }
 
 export const DEFAULT_PLAN: PlayPlan = {
@@ -102,6 +114,10 @@ function readPlanFile(path: string): PlayPlan {
         tracks: raw.tracks,
         betweenMs: raw.betweenMs ?? DEFAULT_PLAN.betweenMs,
         note: raw.note,
+        // Read back explicitly: this whitelist rebuilds the plan field by field, so anything
+        // missing here is silently dropped on the way out. Losing this one would make every
+        // plan look legacy and quietly turn `plan rm`'s sidecar cleanup off for good.
+        seededTracks: raw.seededTracks,
     };
 }
 
@@ -195,8 +211,10 @@ export function removePlan(name: string): RemovedPlan {
         throw new Error(`no plan named "${safePlanName(name)}". List them: tools spotify play plan list`);
     }
 
-    const seeded = found.path.replace(/\.json$/, TRACKS_SUFFIX);
-    const ownsSidecar = found.plan.tracks === seeded && existsSync(seeded);
+    // Ownership comes from the recorded provenance, never from the path. The guard sits
+    // immediately above the irreversible call, which is where this repo requires it.
+    const seeded = found.plan.seededTracks;
+    const ownsSidecar = !!seeded && seeded === found.plan.tracks && existsSync(seeded);
 
     unlinkSync(found.path);
     if (ownsSidecar) {

--- a/src/spotify/tests/cli.test.ts
+++ b/src/spotify/tests/cli.test.ts
@@ -921,6 +921,92 @@ describe("export", () => {
     });
 });
 
+/**
+ * Three defects three usability testers hit while building plans from `--help` alone. Each was
+ * invisible from the code and only showed up when someone tried to use the thing.
+ */
+describe("play plans, from a stranger's point of view", () => {
+    test("status takes --plan, like run and plan set do", async () => {
+        const wanted = join(root, "plan-status-wanted.tracks.json");
+        const newer = join(root, "plan-status-newer.tracks.json");
+        writeFileSync(wanted, SafeJSON.stringify([{ uri: "spotify:track:aaa", name: "A" }]));
+        writeFileSync(
+            newer,
+            SafeJSON.stringify([
+                { uri: "spotify:track:aab", name: "B" },
+                { uri: "spotify:track:aac", name: "C" },
+            ])
+        );
+
+        await ok(["play", "plan", "new", "statusable", "--tracks", wanted]);
+        // A SECOND, newer plan with a different track count. Without it this test proves
+        // nothing: `statusable` would be the newest, so a `status` that ignored `--plan`
+        // entirely would still report the right number and pass. Verified by mutation — the
+        // first version of this test survived reverting the fix.
+        await Bun.sleep(10);
+        await ok(["play", "plan", "new", "distraction", "--tracks", newer]);
+
+        // 1 track, not 2, is the whole assertion: it can only come from resolving the NAME.
+        const r = await ok(["play", "status", "--plan", "statusable", "--json"]);
+        expect(SafeJSON.parse(r.stdout)).toMatchObject({ total: 1 });
+
+        // And the default still follows the newest, so the fix did not quietly change it.
+        const bare = await ok(["play", "status", "--json"]);
+        expect(SafeJSON.parse(bare.stdout)).toMatchObject({ total: 2 });
+    });
+
+    /** Where a named plan actually landed, asked of the tool rather than guessed. */
+    async function planFileFor(name: string): Promise<string> {
+        const listed = await okJson<{ name: string; path: string }[]>(["play", "plan", "list", "--json"]);
+        const found = listed.find((p) => p.name === name);
+        if (!found) {
+            throw new Error(`no plan "${name}" in ${listed.map((p) => p.name).join(", ") || "(none)"}`);
+        }
+
+        return found.path;
+    }
+
+    // `loadTracks` throws on unparseable input, and that throw used to happen inside the render
+    // loop of `plan list` — so one plan pointing at a truncated file took down the listing for
+    // ALL plans, with nothing naming the culprit. The recovery command was the casualty.
+    test("one unreadable tracks file does not take down the whole listing", async () => {
+        const good = join(root, "good.tracks.json");
+        const bad = join(root, "bad.tracks.json");
+        writeFileSync(good, SafeJSON.stringify([{ uri: "spotify:track:bbb", name: "B" }]));
+        writeFileSync(bad, SafeJSON.stringify([{ uri: "spotify:track:ddd", name: "D" }]));
+        await ok(["play", "plan", "new", "intact", "--tracks", good]);
+        await ok(["play", "plan", "new", "broken", "--tracks", bad]);
+
+        // Truncated AFTER the plan was made, which is the realistic shape: an interrupted write
+        // or a hand-edited file, not something `plan new` would have accepted in the first place.
+        writeFileSync(bad, "");
+
+        const r = await ok(["play", "plan", "list"]);
+        expect(r.all).toContain("intact");
+        expect(r.all).toContain("broken");
+        expect(r.all).toContain("unreadable");
+    });
+
+    // `plan set --plan <name>` with no other flag reads. The help now promises this outright,
+    // because a tester ran it expecting a read and then could not tell whether it had rewritten
+    // a different plan. A promise in help text is worth exactly as much as its test.
+    test("plan set with only --plan does not write", async () => {
+        const tracks = join(root, "readonly.tracks.json");
+        writeFileSync(tracks, SafeJSON.stringify([{ uri: "spotify:track:ccc", name: "C" }]));
+        await ok(["play", "plan", "new", "untouched", "--tracks", tracks]);
+
+        const planFile = await planFileFor("untouched");
+        const before = readFileSync(planFile, "utf8");
+        await ok(["play", "plan", "set", "--plan", "untouched"]);
+        expect(readFileSync(planFile, "utf8")).toBe(before);
+
+        // The negative control: with a real flag it MUST write, or the guard above would pass
+        // just as happily on a `set` that had stopped working altogether.
+        await ok(["play", "plan", "set", "--plan", "untouched", "--between", "900"]);
+        expect(readFileSync(planFile, "utf8")).not.toBe(before);
+    });
+});
+
 describe("play thresholds in aggregations", () => {
     // `plays` and `shortPlays` split at the 30-second royalty threshold, which is a fixed
     // meaning: `--min-ms` chooses which events are counted at all, not what "a play" is called.

--- a/src/spotify/tests/play.test.ts
+++ b/src/spotify/tests/play.test.ts
@@ -208,13 +208,44 @@ describe("named plans", () => {
             const created = make("throwaway");
             const sidecar = created.path.replace(/\.json$/, ".tracks.json");
             writeFileSync(sidecar, "[]");
-            writePlan("throwaway", { ...created.plan, tracks: sidecar });
+            writePlan("throwaway", { ...created.plan, tracks: sidecar, seededTracks: sidecar });
 
             const removed = removePlan("throwaway");
 
             expect(removed.tracks).toBe(sidecar);
             expect(existsSync(created.path)).toBe(false);
             expect(existsSync(sidecar)).toBe(false);
+        });
+
+        /**
+         * The review finding that made provenance necessary: path shape is not proof. A user
+         * can point `--tracks` straight at the conventional sidecar name, or let the tool seed
+         * a list and then curate it. Both leave a file that LOOKS tool-owned. Deleting it is
+         * unrecoverable, so only the recorded provenance may authorise it.
+         */
+        test("a file at the conventional sidecar path is kept when provenance is absent", () => {
+            const created = make("lookalike");
+            const sidecar = created.path.replace(/\.json$/, ".tracks.json");
+            writeFileSync(sidecar, '[{"uri":"spotify:track:mine","name":"curated by hand"}]');
+            // tracks points at it, but seededTracks does NOT: the user supplied this path.
+            writePlan("lookalike", { ...created.plan, tracks: sidecar });
+
+            const removed = removePlan("lookalike");
+
+            expect(removed.tracks).toBeUndefined();
+            expect(existsSync(sidecar)).toBe(true);
+        });
+
+        // Plans written before provenance existed carry no marker, so they keep their file.
+        test("a legacy plan keeps its tracks file", () => {
+            const created = make("legacy");
+            const sidecar = created.path.replace(/\.json$/, ".tracks.json");
+            writeFileSync(sidecar, "[]");
+            writePlan("legacy", { ...created.plan, tracks: sidecar });
+
+            removePlan("legacy");
+
+            expect(existsSync(sidecar)).toBe(true);
         });
 
         // The one that would be unforgivable: a plan may point --tracks at a list the user

--- a/src/spotify/tests/play.test.ts
+++ b/src/spotify/tests/play.test.ts
@@ -8,6 +8,7 @@ import { appendFileSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { playDir } from "@app/spotify/lib/paths";
+import { emptyReason } from "@app/spotify/lib/play/driver";
 import { appendJournal, clearJournal, journalPath, progressFor } from "@app/spotify/lib/play/journal";
 import { FIND_PLAYER, parsePayloadResult } from "@app/spotify/lib/play/payloads";
 import {
@@ -95,6 +96,32 @@ describe("loadTracks", () => {
 
     test("names a missing file", () => {
         expect(() => loadTracks(join(root, "nope.json"))).toThrow("not found");
+    });
+});
+
+/**
+ * `play run` printed a bare "nothing to do" and exited 0 whenever the selection came out
+ * empty. A mistyped range is the likeliest way to get there, and a silent no-op that exits
+ * successfully is indistinguishable from a run that worked.
+ */
+describe("emptyReason", () => {
+    test("a range past the end of the file names the file's size", () => {
+        expect(emptyReason({ start: 5, end: 1, total: 2, skipped: 0 })).toContain("past the last track");
+        expect(emptyReason({ start: 5, end: 1, total: 2, skipped: 0 })).toContain("0-1");
+    });
+
+    // Checked before the inverted-range case: `--end` defaults to the last index, so a bare
+    // `--start 5` would otherwise be reported against a number the user never typed.
+    test("a start inside the file, after an explicit end, reports the inversion", () => {
+        expect(emptyReason({ start: 5, end: 2, total: 10, skipped: 0 })).toBe("--start 5 is after --end 2");
+    });
+
+    test("an exhausted resume journal points at --restart", () => {
+        expect(emptyReason({ start: 0, end: 2, total: 3, skipped: 3 })).toContain("--restart");
+    });
+
+    test("an empty tracks file says so rather than blaming the flags", () => {
+        expect(emptyReason({ start: 0, end: -1, total: 0, skipped: 0 })).toBe("the tracks file is empty");
     });
 });
 

--- a/src/spotify/tests/play.test.ts
+++ b/src/spotify/tests/play.test.ts
@@ -19,6 +19,7 @@ import {
     newestPlan,
     type PlayWindow,
     parseWindows,
+    removePlan,
     writePlan,
 } from "@app/spotify/lib/play/plan";
 import { SEED_SOURCES } from "@app/spotify/lib/play/seed";
@@ -169,6 +170,55 @@ describe("named plans", () => {
 
     test("loadPlan names the plan it could not find", () => {
         expect(() => loadPlan("nope")).toThrow('no plan named "nope"');
+    });
+
+    /**
+     * Plans could be created but never removed, so a wrong guess was a permanent row in
+     * `plan list`. A usability tester said outright that this stopped them experimenting.
+     */
+    describe("removePlan", () => {
+        test("removes the plan and the sidecar this tool seeded for it", () => {
+            const created = make("throwaway");
+            const sidecar = created.path.replace(/\.json$/, ".tracks.json");
+            writeFileSync(sidecar, "[]");
+            writePlan("throwaway", { ...created.plan, tracks: sidecar });
+
+            const removed = removePlan("throwaway");
+
+            expect(removed.tracks).toBe(sidecar);
+            expect(existsSync(created.path)).toBe(false);
+            expect(existsSync(sidecar)).toBe(false);
+        });
+
+        // The one that would be unforgivable: a plan may point --tracks at a list the user
+        // curated elsewhere, and tidying up a plan must never delete it.
+        test("leaves a tracks file it did not seed alone", () => {
+            // Deliberately outside the play directory: this is the user's own curated list,
+            // which is exactly the file that must survive removing a plan that referenced it.
+            const created = make("borrowed");
+            const curated = join(root, "my-own-list.json");
+            writeFileSync(curated, "[]");
+            writePlan("borrowed", { ...created.plan, tracks: curated });
+
+            const removed = removePlan("borrowed");
+
+            expect(removed.tracks).toBeUndefined();
+            expect(existsSync(created.path)).toBe(false);
+            expect(existsSync(curated)).toBe(true);
+        });
+
+        test("removing one plan leaves the others in place", () => {
+            make("keeper");
+            make("goner");
+
+            removePlan("goner");
+
+            expect(listPlans().map((p) => p.name)).toEqual(["keeper"]);
+        });
+
+        test("names the plan it could not find", () => {
+            expect(() => removePlan("ghost")).toThrow('no plan named "ghost"');
+        });
     });
 });
 

--- a/src/utils/cli/executor.test.ts
+++ b/src/utils/cli/executor.test.ts
@@ -65,6 +65,46 @@ describe("enhanceHelp subcommand options", () => {
         }
     });
 
+    /**
+     * Commander appends `(default: …)` at render time from `option.defaultValue`; it is not
+     * part of `option.description`. Reading only the description gave two renderers that
+     * disagreed about the SAME option: the per-command help showed the default, the parent's
+     * summary did not. A usability tester could not tell whether `--from` was required and
+     * had to make an extra help call to find out.
+     */
+    test("shows option defaults, the way commander's own help does", () => {
+        const program = new Command("root").exitOverride();
+        program.command("child").description("a child").option("--from <source>", "where to seed from", "top");
+        enhanceHelp(program);
+
+        let captured = "";
+        program.configureOutput({
+            writeOut: (text) => {
+                captured += text;
+            },
+        });
+        program.outputHelp();
+
+        expect(captured).toContain('default: "top"');
+    });
+
+    test("an option with no default gains no default text", () => {
+        const program = new Command("root").exitOverride();
+        program.command("child").description("a child").option("--plain <x>", "no default here");
+        enhanceHelp(program);
+
+        let captured = "";
+        program.configureOutput({
+            writeOut: (text) => {
+                captured += text;
+            },
+        });
+        program.outputHelp();
+
+        expect(captured).toContain("no default here");
+        expect(captured).not.toContain("default:");
+    });
+
     test("indents continuation lines past the flag column", () => {
         const lines = helpWithSubcommandOptions().split("\n");
         const start = lines.findIndex((l) => l.includes("--from <source>"));

--- a/src/utils/cli/executor.ts
+++ b/src/utils/cli/executor.ts
@@ -1,4 +1,5 @@
 import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import pc from "picocolors";
@@ -28,6 +29,26 @@ function helpWidth(): number {
     const columns = process.stdout.columns;
 
     return Number.isFinite(columns) && (columns ?? 0) > 0 ? (columns as number) : 80;
+}
+
+/**
+ * The description Commander itself would print, including the trailing `(default: …)`.
+ *
+ * Commander appends defaults at RENDER time from `option.defaultValue`; they are not part of
+ * `option.description`. Reading only the description therefore produced two help renderers
+ * that disagreed: `play plan new --help` said `--from <source> … (default: "top")` while the
+ * same option one level up in `play plan --help` showed no default at all. A usability tester
+ * could not tell whether `--from` was required, and had to make an extra help call to find
+ * out — for the one flag that decides which music gets sampled.
+ */
+function describeOption(option: { description: string; defaultValue?: unknown; defaultValueDescription?: string }) {
+    if (option.defaultValue === undefined) {
+        return option.description;
+    }
+
+    const shown = option.defaultValueDescription ?? SafeJSON.stringify(option.defaultValue);
+
+    return `${option.description} (default: ${shown})`;
 }
 
 /**
@@ -76,7 +97,7 @@ export function enhanceHelp(cmd: Command): void {
                 }
                 lines.push(`\n  ${pc.bold(sub.name())}:`);
                 for (const opt of opts) {
-                    const [first, ...rest] = wrapDescription(opt.description, available);
+                    const [first, ...rest] = wrapDescription(describeOption(opt), available);
                     lines.push(`    ${pc.dim(opt.flags.padEnd(HELP_FLAG_WIDTH))} ${first}`);
                     for (const line of rest) {
                         lines.push(`    ${" ".repeat(HELP_FLAG_WIDTH)} ${line}`);


### PR DESCRIPTION
Follow-up to #308. Three usability testers built playback plans from `--help` alone, with no access to the source. All three finished their task, and between them they hit three real defects.

## 1. `play status` did not take `--plan`

`run` and `plan set` both accept `--plan <name>`, so a tester who had just created a plan by name reached for the same flag and got `error: unknown option '--plan'`. The only way in was the tracks-file path, which nothing tells you unless you go back and re-read the output of `plan set`. `status` now resolves `--plan` through the same `loadPlan()` the other two use.

## 2. One unreadable tracks file took down the entire plan listing

`loadTracks` throws on anything it cannot parse, and that call sat inside the render loop of `plan list`. A single plan pointing at a truncated or empty tracks file made the whole command fail with `JSON Parse error: Unexpected EOF`, naming no plan. The one command you would use to find your way out of a broken plan was the one the broken plan disabled. A bad file is now a red `unreadable` cell on its own row.

## 3. `plan new` promised something a later edit revokes

It printed ``plan "x" created — `play run` will use it``. "Newest" is most-recently-written, so editing *any* other plan afterwards makes that one newest instead. A tester created a plan, saw the promise, and then watched a different plan hold the newest marker. The message now always names the plan in the follow-up command, which stays true.

Also clarified `plan set`'s help. "show the newest plan; any flag updates it" alongside `--plan <name>` gave no way to tell whether `--plan foo` on its own was a read or a write, so a tester ran it expecting a read and then had to work out whether it had rewritten someone else's plan. It is a read, and the help now says so.

## On the tests

The `status --plan` test initially passed **with the fix reverted**, because the plan it asked about happened to be the newest, so a `status` that ignored `--plan` entirely still returned the right answer. It now creates a second, newer plan with a different track count, so only resolving the name can produce the expected result, plus a control that the bare default still follows the newest.

Mutation-checked: 95 pass clean, 94 pass / 1 fail with the fix reverted, 95 pass restored.

## Verification

- `bun run test src/spotify`: 278 pass, 0 fail
- `bunx biome check src/spotify`: clean
- `bunx tsgo --noEmit`: no errors under `src/spotify`
- `plan set --plan <name>` proven read-only by hash and mtime, with a negative control showing `--between` does write


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--plan` support to `play status`.
  * Added removal of named playback plans.
  * Plan listings now tolerate missing or unreadable track files.
  * Command help displays default values for supported options.
  * Empty playback selections now provide specific explanations.

* **Bug Fixes**
  * Preserved externally supplied track files when removing plans.
  * Improved duplicate-plan and plan-creation guidance.
  * Clarified `plan set` behavior and modification guidance.

* **Documentation**
  * Expanded playback plan documentation, including creation, selection, updating, listing, and removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->