### PR TITLE
fix(azure-devops): roll back work item effort when deleting a timelog

### DIFF
--- a/src/azure-devops/commands/timelog.ts
+++ b/src/azure-devops/commands/timelog.ts
@@ -16,7 +16,7 @@ Usage: tools azure-devops timelog <command> [options]
 Commands:
   add      Add a time log entry to a work item
   list     List time logs (per work item or date range query)
-  delete   Delete a time log entry by ID
+  delete   Delete a time log entry and roll back Remaining/Completed
   types    List available time types
   import   Import time logs from JSON file
 
@@ -28,8 +28,10 @@ Examples:
   tools azure-devops timelog list --day 2026-01-30
   tools azure-devops timelog list --since 2026-01-01 --upto 2026-01-31 --user "Martin"
   tools azure-devops timelog list --day 2026-01-30 --format table
-  tools azure-devops timelog delete <timeLogId>
+  tools azure-devops timelog delete <timeLogId> --yes
+  tools azure-devops timelog delete <timeLogId> --dry-run
   tools azure-devops timelog delete --workitem 268935   (interactive picker)
+  tools azure-devops timelog delete <timeLogId> --no-effort --yes
   tools azure-devops timelog types
   tools azure-devops timelog import entries.json
 

--- a/src/azure-devops/commands/timelog/add.ts
+++ b/src/azure-devops/commands/timelog/add.ts
@@ -206,7 +206,9 @@ ${types.map((t) => `  - ${t.description}`).join("\n")}
 
                 // Update Remaining/Completed Work on the work item
                 const devopsApi = new Api(config);
-                const effort = await updateWorkItemEffort(devopsApi, effectiveWorkItemId, totalMinutes);
+                const effort = await updateWorkItemEffort(devopsApi, effectiveWorkItemId, totalMinutes, {
+                    timeLogIds: ids,
+                });
 
                 if (effort) {
                     out.println(`  Remaining: ${effort.remaining}h | Completed: ${effort.completed}h`);

--- a/src/azure-devops/commands/timelog/delete.ts
+++ b/src/azure-devops/commands/timelog/delete.ts
@@ -1,73 +1,135 @@
+import { Api } from "@app/azure-devops/api";
+import { deleteTimeLogEntryWithEffort, printDeleteResult } from "@app/azure-devops/lib/timelog/delete-entry";
 import { formatMinutes, TimeLogApi } from "@app/azure-devops/timelog-api";
 import { requireTimeLogConfig, requireTimeLogUser } from "@app/azure-devops/utils";
 import * as p from "@clack/prompts";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 
 export function registerDeleteSubcommand(parent: Command): void {
     parent
         .command("delete")
-        .description("Delete a time log entry")
+        .description("Delete a time log entry and roll back Remaining/Completed Work")
         .argument("[timeLogId]", "Time log entry ID (or use --workitem for interactive)")
-        .option("-w, --workitem <id>", "Work item ID (interactive picker)")
-        .action(async (timeLogIdArg: string | undefined, options: { workitem?: string }) => {
-            const config = requireTimeLogConfig();
-            const user = requireTimeLogUser(config);
-            const api = new TimeLogApi(config.orgId!, config.projectId, config.timelog!.functionsKey, user);
+        .option("-w, --workitem <id>", "Work item ID (interactive picker, or a hint for a bare id)")
+        .option("--no-effort", "Delete the row only; leave Remaining/Completed untouched")
+        .option("--dry-run", "Print the planned effort transition; change nothing")
+        .option("--yes", "Skip the confirm prompt (required without a TTY)")
+        .action(
+            async (
+                timeLogIdArg: string | undefined,
+                options: { workitem?: string; effort?: boolean; dryRun?: boolean; yes?: boolean }
+            ) => {
+                const noEffort = options.effort === false;
+                const config = requireTimeLogConfig();
+                const user = requireTimeLogUser(config);
+                const api = new TimeLogApi(config.orgId!, config.projectId, config.timelog!.functionsKey, user);
 
-            let timeLogId = timeLogIdArg;
+                let timeLogId = timeLogIdArg;
+                let workItemId: number | undefined;
+                let knownMinutes: number | undefined;
 
-            if (!timeLogId) {
-                // Interactive mode: pick from work item's entries
-                if (!options.workitem) {
+                if (options.workitem) {
+                    const parsed = parseInt(options.workitem, 10);
+
+                    if (Number.isNaN(parsed)) {
+                        out.error("Invalid work item ID");
+                        process.exit(1);
+                    }
+
+                    workItemId = parsed;
+                }
+
+                if (!timeLogId) {
+                    if (workItemId == null) {
+                        out.error("Provide a timeLogId or --workitem for interactive selection");
+                        out.error("\nExamples:");
+                        out.error("  tools azure-devops timelog delete <timeLogId> --yes");
+                        out.error("  tools azure-devops timelog delete --workitem 268935");
+                        out.error("  tools azure-devops timelog delete <timeLogId> --dry-run");
+                        process.exit(1);
+                    }
+
+                    const entries = await api.getWorkItemTimeLogs(workItemId);
+
+                    if (entries.length === 0) {
+                        out.println(`No time logs found for #${workItemId}`);
+                        return;
+                    }
+
+                    if (!isInteractive()) {
+                        out.error("Interactive picker needs a TTY. Pass the timeLogId and --yes.");
+                        out.info(
+                            suggestCommand("tools azure-devops timelog delete", {
+                                add: ["--yes"],
+                                subcommand: ["timelog", "delete"],
+                            })
+                        );
+                        process.exit(1);
+                    }
+
+                    const selected = await p.select({
+                        message: `Select entry to delete from #${workItemId}:`,
+                        options: entries.map((e) => ({
+                            value: e.timeLogId,
+                            label: `${e.date} | ${formatMinutes(e.minutes)} | ${e.timeTypeDescription} | ${e.userName}${e.comment ? ` | ${e.comment}` : ""}`,
+                        })),
+                    });
+
+                    if (p.isCancel(selected)) {
+                        p.cancel("Cancelled");
+                        return;
+                    }
+
+                    timeLogId = selected as string;
+                    const picked = entries.find((e) => e.timeLogId === timeLogId);
+                    knownMinutes = picked?.minutes;
+                }
+
+                if (!timeLogId) {
                     out.error("Provide a timeLogId or --workitem for interactive selection");
-                    out.error("\nExamples:");
-                    out.error("  tools azure-devops timelog delete <timeLogId>");
-                    out.error("  tools azure-devops timelog delete --workitem 268935");
                     process.exit(1);
                 }
 
-                const workItemId = parseInt(options.workitem, 10);
-
-                if (Number.isNaN(workItemId)) {
-                    out.error("Invalid work item ID");
+                if (!options.yes && !options.dryRun && !isInteractive()) {
+                    out.error("Confirm required in non-interactive mode. Re-run with --yes.");
+                    out.info(
+                        suggestCommand("tools azure-devops timelog delete", {
+                            add: ["--yes"],
+                            subcommand: ["timelog", "delete"],
+                        })
+                    );
                     process.exit(1);
                 }
 
-                const entries = await api.getWorkItemTimeLogs(workItemId);
-
-                if (entries.length === 0) {
-                    out.println(`No time logs found for #${workItemId}`);
-                    return;
-                }
-
-                const selected = await p.select({
-                    message: `Select entry to delete from #${workItemId}:`,
-                    options: entries.map((e) => ({
-                        value: e.timeLogId,
-                        label: `${e.date} | ${formatMinutes(e.minutes)} | ${e.timeTypeDescription} | ${e.userName}${e.comment ? ` | ${e.comment}` : ""}`,
-                    })),
+                const result = await deleteTimeLogEntryWithEffort({
+                    timeLogApi: api,
+                    devopsApi: new Api(config),
+                    timeLogId,
+                    user,
+                    projectId: config.projectId,
+                    workItemId,
+                    knownMinutes,
+                    noEffort,
+                    dryRun: options.dryRun,
+                    confirm:
+                        options.yes || options.dryRun
+                            ? undefined
+                            : async () => {
+                                  const ok = await p.confirm({
+                                      message: `Delete time log entry ${timeLogId.substring(0, 8)}...?`,
+                                  });
+                                  return !p.isCancel(ok) && !!ok;
+                              },
                 });
 
-                if (p.isCancel(selected)) {
+                if (result.status === "cancelled") {
                     p.cancel("Cancelled");
                     return;
                 }
 
-                timeLogId = selected as string;
+                printDeleteResult(result, { noEffort });
             }
-
-            // Confirm deletion
-            const confirm = await p.confirm({
-                message: `Delete time log entry ${timeLogId.substring(0, 8)}...?`,
-            });
-
-            if (p.isCancel(confirm) || !confirm) {
-                p.cancel("Cancelled");
-                return;
-            }
-
-            await api.deleteTimeLogEntry(timeLogId);
-            out.println(`\u2714 Deleted time log entry ${timeLogId.substring(0, 8)}...`);
-        });
+        );
 }

--- a/src/azure-devops/commands/timelog/delete.ts
+++ b/src/azure-devops/commands/timelog/delete.ts
@@ -92,6 +92,8 @@ export function registerDeleteSubcommand(parent: Command): void {
                     process.exit(1);
                 }
 
+                const id = timeLogId;
+
                 if (!options.yes && !options.dryRun && !isInteractive()) {
                     out.error("Confirm required in non-interactive mode. Re-run with --yes.");
                     out.info(
@@ -106,7 +108,7 @@ export function registerDeleteSubcommand(parent: Command): void {
                 const result = await deleteTimeLogEntryWithEffort({
                     timeLogApi: api,
                     devopsApi: new Api(config),
-                    timeLogId,
+                    timeLogId: id,
                     user,
                     projectId: config.projectId,
                     workItemId,
@@ -118,7 +120,7 @@ export function registerDeleteSubcommand(parent: Command): void {
                             ? undefined
                             : async () => {
                                   const ok = await p.confirm({
-                                      message: `Delete time log entry ${timeLogId.substring(0, 8)}...?`,
+                                      message: `Delete time log entry ${id.substring(0, 8)}...?`,
                                   });
                                   return !p.isCancel(ok) && !!ok;
                               },
@@ -127,6 +129,13 @@ export function registerDeleteSubcommand(parent: Command): void {
                 if (result.status === "cancelled") {
                     p.cancel("Cancelled");
                     return;
+                }
+
+                if (result.status === "needs-resolution") {
+                    out.error(
+                        "Could not resolve work item or minutes for this time log. Pass --workitem <id> or --no-effort to delete the row only."
+                    );
+                    process.exit(1);
                 }
 
                 printDeleteResult(result, { noEffort });

--- a/src/azure-devops/commands/timelog/import.ts
+++ b/src/azure-devops/commands/timelog/import.ts
@@ -274,6 +274,7 @@ export function registerImportSubcommand(parent: Command): void {
             const failed: string[] = [];
             const createdWorkItemIds: number[] = [];
             const minutesPerWorkItem = new Map<number, number>();
+            const idsPerWorkItem = new Map<number, string[]>();
 
             for (const entry of precheckPassed) {
                 try {
@@ -290,6 +291,7 @@ export function registerImportSubcommand(parent: Command): void {
                         entry.workItemId,
                         (minutesPerWorkItem.get(entry.workItemId) ?? 0) + entry.minutes
                     );
+                    idsPerWorkItem.set(entry.workItemId, [...(idsPerWorkItem.get(entry.workItemId) ?? []), ...ids]);
                     const title = workitemTitles.get(entry.workItemId);
                     const wiLabel = title ? `#${entry.workItemId} ${title}` : `#${entry.workItemId}`;
                     const parts = [wiLabel, formatMinutes(entry.minutes), entry.timeType, entry.date];
@@ -321,7 +323,9 @@ export function registerImportSubcommand(parent: Command): void {
                 const devopsApi = new Api(config);
 
                 for (const [workItemId, totalMins] of minutesPerWorkItem) {
-                    const effort = await updateWorkItemEffort(devopsApi, workItemId, totalMins);
+                    const effort = await updateWorkItemEffort(devopsApi, workItemId, totalMins, {
+                        timeLogIds: idsPerWorkItem.get(workItemId) ?? [],
+                    });
 
                     if (effort) {
                         out.println(

--- a/src/azure-devops/index.ts
+++ b/src/azure-devops/index.ts
@@ -81,7 +81,7 @@ Commands:
   dashboard <input>      Fetch dashboard and list its queries
   list                   List cached work items
   workitem-create        Create a new work item (interactive or from template)
-  timelog                Manage time log entries (add, list, types, import)
+  timelog                Manage time log entries (add, list, delete, types, import)
   history                Work item history commands (show, search, sync)
 
 Query Options:
@@ -113,6 +113,7 @@ Workitem-Create Options:
 Timelog Subcommands:
   timelog add            Add a time log entry
   timelog list           List time logs for a work item
+  timelog delete         Delete a time log entry and roll back effort
   timelog types          List available time types
   timelog import <file>  Import time logs from JSON file
 

--- a/src/azure-devops/index.ts
+++ b/src/azure-devops/index.ts
@@ -162,6 +162,7 @@ Examples:
   # Time logging
   tools azure-devops timelog add --workitem 268935 --hours 2 --type "Development"
   tools azure-devops timelog list --workitem 268935
+  tools azure-devops timelog delete <timeLogId> --yes
   tools azure-devops timelog types
 
 History Commands:

--- a/src/azure-devops/lib/timelog/delete-entry.test.ts
+++ b/src/azure-devops/lib/timelog/delete-entry.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { EffortApi } from "@app/azure-devops/timelog-effort";
-import { appendEffortJournal } from "@app/azure-devops/timelog-effort-journal";
+import { appendEffortJournal, readEffortJournal } from "@app/azure-devops/timelog-effort-journal";
 import type { JsonPatchOperation, TimeLogEntry, TimeLogQueryEntry, TimeLogUser } from "@app/azure-devops/types";
 import { env } from "@genesiscz/utils/env";
 import { type DeleteTimeLogOptions, deleteTimeLogEntryWithEffort, type TimeLogDeleteApi } from "./delete-entry";
@@ -70,6 +70,8 @@ function makeApis(args: {
     completed: number | null;
     entries?: TimeLogEntry[];
     query?: TimeLogQueryEntry[];
+    queries?: TimeLogQueryEntry[][];
+    queryError?: Error;
     updateError?: Error;
     deleteError?: Error;
 }): {
@@ -82,6 +84,7 @@ function makeApis(args: {
     const patches: JsonPatchOperation[][] = [];
     let remaining = args.remaining;
     let completed = args.completed;
+    let queryCall = 0;
 
     const devops: EffortApi = {
         async getWorkItem() {
@@ -129,6 +132,17 @@ function makeApis(args: {
         },
         async queryTimeLogs() {
             calls.push("query");
+
+            if (args.queryError) {
+                throw args.queryError;
+            }
+
+            if (args.queries) {
+                const page = args.queries[Math.min(queryCall, args.queries.length - 1)] ?? [];
+                queryCall += 1;
+                return page;
+            }
+
             return args.query ?? [queryEntry()];
         },
     };
@@ -304,17 +318,91 @@ describe("deleteTimeLogEntryWithEffort", () => {
         }
     });
 
-    test("unresolved id still deletes the row", async () => {
+    test("unresolved id refuses to delete unless --no-effort", async () => {
         const journalPath = join(root, "unresolved.jsonl");
         const apis = makeApis({ remaining: 8, completed: 6, entries: [], query: [] });
         const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { journalPath }));
-        expect(result.status).toBe("deleted");
-        expect(apis.calls).toContain("delete");
+        expect(result.status).toBe("needs-resolution");
+        expect(apis.calls).not.toContain("delete");
         expect(apis.calls).not.toContain("update");
+    });
+
+    test("single-id journal fallback uses journal minutes when the live row is gone", async () => {
+        const journalPath = join(root, "journal-fallback.jsonl");
+        await appendEffortJournal(
+            {
+                ts: "2026-08-19T13:03:11.482Z",
+                workItemId: 303818,
+                timeLogIds: ["log-1"],
+                minutes: 90,
+                remainingBefore: 5,
+                completedBefore: 1,
+                remainingAfter: 3.5,
+                completedAfter: 2.5,
+            },
+            journalPath
+        );
+        const apis = makeApis({ remaining: 3.5, completed: 2.5, entries: [], query: [] });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { journalPath }));
+        expect(result.status).toBe("deleted");
+        expect(apis.calls.filter((c) => c === "query")).toHaveLength(0);
 
         if (result.status === "deleted") {
-            expect(result.plan).toBeNull();
-            expect(result.effort).toBeNull();
+            expect(result.resolved).toEqual({ workItemId: 303818, minutes: 90, source: "journal" });
+            expect(result.plan?.reason).toBe("exact-journal");
+            expect(apis.patches[0].map((op) => op.value)).toEqual([5, 1]);
         }
+    });
+
+    test("falls back to the unscoped project query when the user query misses", async () => {
+        const journalPath = join(root, "unscoped.jsonl");
+        const apis = makeApis({
+            remaining: 8,
+            completed: 6,
+            entries: [],
+            queries: [[], [queryEntry()]],
+        });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { journalPath }));
+        expect(result.status).toBe("deleted");
+        expect(apis.calls.filter((c) => c === "query")).toHaveLength(2);
+
+        if (result.status === "deleted") {
+            expect(result.resolved).toEqual({ workItemId: 296936, minutes: 120, source: "query" });
+        }
+    });
+
+    test("a thrown resolve does not delete the row", async () => {
+        const apis = makeApis({
+            remaining: 8,
+            completed: 6,
+            entries: [],
+            queryError: new Error("TimeLog API Error 500: boom"),
+        });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis));
+        expect(result.status).toBe("needs-resolution");
+        expect(apis.calls).not.toContain("delete");
+        expect(apis.calls).not.toContain("update");
+    });
+
+    test("rollback does not append a new journal row", async () => {
+        const journalPath = join(root, "no-rollback-journal.jsonl");
+        await appendEffortJournal(
+            {
+                ts: "2026-08-19T13:03:11.482Z",
+                workItemId: 296936,
+                timeLogIds: ["log-1"],
+                minutes: 120,
+                remainingBefore: 10,
+                completedBefore: 4,
+                remainingAfter: 8,
+                completedAfter: 6,
+            },
+            journalPath
+        );
+        const apis = makeApis({ remaining: 8, completed: 6 });
+        await deleteTimeLogEntryWithEffort(baseOpts(apis, { workItemId: 296936, knownMinutes: 120, journalPath }));
+        const records = readEffortJournal(journalPath);
+        expect(records).toHaveLength(1);
+        expect(records[0].minutes).toBe(120);
     });
 });

--- a/src/azure-devops/lib/timelog/delete-entry.test.ts
+++ b/src/azure-devops/lib/timelog/delete-entry.test.ts
@@ -1,0 +1,320 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { EffortApi } from "@app/azure-devops/timelog-effort";
+import { appendEffortJournal } from "@app/azure-devops/timelog-effort-journal";
+import type { JsonPatchOperation, TimeLogEntry, TimeLogQueryEntry, TimeLogUser } from "@app/azure-devops/types";
+import { env } from "@genesiscz/utils/env";
+import { type DeleteTimeLogOptions, deleteTimeLogEntryWithEffort, type TimeLogDeleteApi } from "./delete-entry";
+
+const snapshot = env.testing.snapshot();
+const root = mkdtempSync(join(tmpdir(), "timelog-delete-"));
+
+afterAll(() => {
+    env.testing.restore(snapshot);
+    rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+    env.testing.set("GENESIS_TOOLS_HOME", root);
+});
+
+const user: TimeLogUser = {
+    userId: "user-1",
+    userName: "Martin",
+    userEmail: "m@example.com",
+};
+
+function queryEntry(overrides: Partial<TimeLogQueryEntry> = {}): TimeLogQueryEntry {
+    return {
+        timeLogId: "log-1",
+        comment: null,
+        week: "2026-W34",
+        timeTypeId: "type-1",
+        timeTypeDescription: "Development",
+        minutes: 120,
+        date: "2026-08-19T00:00:00",
+        userId: user.userId,
+        userName: user.userName,
+        userEmail: user.userEmail,
+        projectId: "proj-1",
+        workItemId: 296936,
+        createdOn: "2026-08-19T13:00:00Z",
+        createdBy: user.userId,
+        updatedOn: null,
+        updatedBy: null,
+        deletedOn: null,
+        deletedBy: null,
+        ...overrides,
+    };
+}
+
+function workItemEntry(overrides: Partial<TimeLogEntry> = {}): TimeLogEntry {
+    return {
+        timeLogId: "log-1",
+        comment: "",
+        week: "2026-W34",
+        timeTypeDescription: "Development",
+        minutes: 120,
+        date: "2026-08-19",
+        userId: user.userId,
+        userName: user.userName,
+        userEmail: user.userEmail,
+        ...overrides,
+    };
+}
+
+function makeApis(args: {
+    remaining: number | null;
+    completed: number | null;
+    entries?: TimeLogEntry[];
+    query?: TimeLogQueryEntry[];
+    updateError?: Error;
+    deleteError?: Error;
+}): {
+    devops: EffortApi;
+    timelog: TimeLogDeleteApi;
+    calls: string[];
+    patches: JsonPatchOperation[][];
+} {
+    const calls: string[] = [];
+    const patches: JsonPatchOperation[][] = [];
+    let remaining = args.remaining;
+    let completed = args.completed;
+
+    const devops: EffortApi = {
+        async getWorkItem() {
+            calls.push("get");
+            return {
+                rawFields: {
+                    "Microsoft.VSTS.Scheduling.RemainingWork": remaining,
+                    "Microsoft.VSTS.Scheduling.CompletedWork": completed,
+                },
+            };
+        },
+        async updateWorkItem(_id, operations) {
+            calls.push("update");
+            patches.push(operations);
+
+            if (args.updateError) {
+                throw args.updateError;
+            }
+
+            for (const op of operations) {
+                if (op.path.endsWith("RemainingWork")) {
+                    remaining = op.value as number;
+                }
+
+                if (op.path.endsWith("CompletedWork")) {
+                    completed = op.value as number;
+                }
+            }
+
+            return {};
+        },
+    };
+
+    const timelog: TimeLogDeleteApi = {
+        async deleteTimeLogEntry() {
+            calls.push("delete");
+
+            if (args.deleteError) {
+                throw args.deleteError;
+            }
+        },
+        async getWorkItemTimeLogs() {
+            calls.push("wi-logs");
+            return args.entries ?? [workItemEntry()];
+        },
+        async queryTimeLogs() {
+            calls.push("query");
+            return args.query ?? [queryEntry()];
+        },
+    };
+
+    return { devops, timelog, calls, patches };
+}
+
+function baseOpts(apis: ReturnType<typeof makeApis>, extra: Partial<DeleteTimeLogOptions> = {}): DeleteTimeLogOptions {
+    return {
+        timeLogApi: apis.timelog,
+        devopsApi: apis.devops,
+        timeLogId: "log-1",
+        user,
+        projectId: "proj-1",
+        journalPath: join(root, `case-${crypto.randomUUID()}.jsonl`),
+        confirm: async () => true,
+        ...extra,
+    };
+}
+
+describe("deleteTimeLogEntryWithEffort", () => {
+    test("exact journal restore: get → delete → write remainingBefore/completedBefore", async () => {
+        const journalPath = join(root, "exact.jsonl");
+        await appendEffortJournal(
+            {
+                ts: "2026-08-19T13:03:11.482Z",
+                workItemId: 296936,
+                timeLogIds: ["log-1"],
+                minutes: 120,
+                remainingBefore: 10,
+                completedBefore: 4,
+                remainingAfter: 8,
+                completedAfter: 6,
+            },
+            journalPath
+        );
+        const apis = makeApis({ remaining: 8, completed: 6 });
+        const result = await deleteTimeLogEntryWithEffort(
+            baseOpts(apis, { workItemId: 296936, knownMinutes: 120, journalPath })
+        );
+
+        expect(result.status).toBe("deleted");
+        const ordered = apis.calls.filter((c) => c === "get" || c === "delete" || c === "update");
+        expect(ordered[0]).toBe("get");
+        expect(ordered.indexOf("delete")).toBeLessThan(ordered.indexOf("update"));
+        expect(apis.patches[0].map((op) => op.value)).toEqual([10, 4]);
+
+        if (result.status === "deleted") {
+            expect(result.plan?.reason).toBe("exact-journal");
+            expect(result.effort).toMatchObject({ remaining: 10, completed: 4 });
+        }
+    });
+
+    test("clamped add restores 3/0, not 8/0", async () => {
+        const journalPath = join(root, "clamp.jsonl");
+        await appendEffortJournal(
+            {
+                ts: "2026-08-19T13:03:11.482Z",
+                workItemId: 303818,
+                timeLogIds: ["log-1"],
+                minutes: 480,
+                remainingBefore: 3,
+                completedBefore: 0,
+                remainingAfter: 0,
+                completedAfter: 8,
+            },
+            journalPath
+        );
+        const apis = makeApis({ remaining: 0, completed: 8 });
+        const result = await deleteTimeLogEntryWithEffort(
+            baseOpts(apis, { workItemId: 303818, knownMinutes: 480, journalPath })
+        );
+
+        expect(apis.patches[0].map((op) => op.value)).toEqual([3, 0]);
+
+        if (result.status === "deleted") {
+            expect(result.plan?.reason).toBe("exact-journal");
+        }
+    });
+
+    test("no journal: arithmetic fallback plus warning", async () => {
+        const journalPath = join(root, "no-journal.jsonl");
+        const apis = makeApis({ remaining: 0, completed: 38 });
+        const result = await deleteTimeLogEntryWithEffort(
+            baseOpts(apis, { workItemId: 296936, knownMinutes: 480, journalPath })
+        );
+
+        expect(apis.patches[0].map((op) => op.value)).toEqual([8, 30]);
+
+        if (result.status === "deleted") {
+            expect(result.plan?.reason).toBe("approximate-no-journal");
+            expect(result.plan?.warning).toContain("approximate");
+        }
+    });
+
+    test("import batch: deleting one id subtracts only that entry", async () => {
+        const journalPath = join(root, "batch.jsonl");
+        await appendEffortJournal(
+            {
+                ts: "2026-08-19T13:03:11.482Z",
+                workItemId: 1,
+                timeLogIds: ["log-1", "log-2", "log-3", "log-4", "log-5"],
+                minutes: 300,
+                remainingBefore: 10,
+                completedBefore: 0,
+                remainingAfter: 5,
+                completedAfter: 5,
+            },
+            journalPath
+        );
+        const apis = makeApis({ remaining: 5, completed: 5 });
+        const result = await deleteTimeLogEntryWithEffort(
+            baseOpts(apis, { workItemId: 1, knownMinutes: 60, journalPath })
+        );
+
+        expect(apis.patches[0].map((op) => op.value)).toEqual([6, 4]);
+
+        if (result.status === "deleted") {
+            expect(result.plan?.reason).toBe("approximate-multi-id");
+        }
+    });
+
+    test("--no-effort deletes the row and never reads or writes effort", async () => {
+        const apis = makeApis({ remaining: 8, completed: 6 });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { noEffort: true }));
+        expect(result.status).toBe("deleted");
+        expect(apis.calls).toEqual(["delete"]);
+    });
+
+    test("--dry-run writes nothing at all", async () => {
+        const apis = makeApis({ remaining: 8, completed: 6 });
+        const result = await deleteTimeLogEntryWithEffort(
+            baseOpts(apis, { dryRun: true, workItemId: 296936, knownMinutes: 120 })
+        );
+        expect(result.status).toBe("dry-run");
+        expect(apis.calls).toEqual(["get"]);
+        expect(apis.patches).toHaveLength(0);
+    });
+
+    test("locked work item still deletes the row and only warns", async () => {
+        const apis = makeApis({
+            remaining: 8,
+            completed: 6,
+            updateError: new Error("TF401320: InvalidNotEmpty"),
+        });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { workItemId: 297506, knownMinutes: 120 }));
+        expect(result.status).toBe("deleted");
+        expect(apis.calls).toContain("delete");
+
+        if (result.status === "deleted") {
+            expect(result.effort).toBeNull();
+        }
+    });
+
+    test("confirm false cancels before delete", async () => {
+        const apis = makeApis({ remaining: 8, completed: 6 });
+        const result = await deleteTimeLogEntryWithEffort(
+            baseOpts(apis, { workItemId: 1, knownMinutes: 60, confirm: async () => false })
+        );
+        expect(result.status).toBe("cancelled");
+        expect(apis.calls).toEqual(["get"]);
+    });
+
+    test("resolves a bare id via queryTimeLogs", async () => {
+        const journalPath = join(root, "query.jsonl");
+        const apis = makeApis({ remaining: 8, completed: 6, query: [queryEntry()] });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { journalPath }));
+        expect(result.status).toBe("deleted");
+        expect(apis.calls).toContain("query");
+
+        if (result.status === "deleted") {
+            expect(result.resolved).toEqual({ workItemId: 296936, minutes: 120, source: "query" });
+        }
+    });
+
+    test("unresolved id still deletes the row", async () => {
+        const journalPath = join(root, "unresolved.jsonl");
+        const apis = makeApis({ remaining: 8, completed: 6, entries: [], query: [] });
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { journalPath }));
+        expect(result.status).toBe("deleted");
+        expect(apis.calls).toContain("delete");
+        expect(apis.calls).not.toContain("update");
+
+        if (result.status === "deleted") {
+            expect(result.plan).toBeNull();
+            expect(result.effort).toBeNull();
+        }
+    });
+});

--- a/src/azure-devops/lib/timelog/delete-entry.ts
+++ b/src/azure-devops/lib/timelog/delete-entry.ts
@@ -1,0 +1,283 @@
+import { AzureDevOpsCacheManager } from "@app/azure-devops/cache-manager";
+import { type EffortRestorePlan, planEffortRestore } from "@app/azure-devops/lib/timelog/effort-restore";
+import { formatMinutes, getTodayDate } from "@app/azure-devops/timelog-api";
+import {
+    type EffortApi,
+    type EffortResult,
+    readWorkItemEffort,
+    updateWorkItemEffort,
+} from "@app/azure-devops/timelog-effort";
+import { effortJournalPath, findNewestEffortJournal } from "@app/azure-devops/timelog-effort-journal";
+import type { TimeLogEntry, TimeLogQueryEntry, TimeLogQueryParams, TimeLogUser } from "@app/azure-devops/types";
+import { logger, out } from "@genesiscz/utils/logger";
+import pc from "picocolors";
+
+export interface TimeLogDeleteApi {
+    deleteTimeLogEntry(timeLogId: string): Promise<void>;
+    getWorkItemTimeLogs(workItemId: number): Promise<TimeLogEntry[]>;
+    queryTimeLogs(params: TimeLogQueryParams): Promise<TimeLogQueryEntry[]>;
+}
+
+export type ResolvedTimeLog = {
+    workItemId: number;
+    minutes: number;
+    source: "selection" | "workitem" | "journal" | "query";
+};
+
+export type DeleteTimeLogResult =
+    | { status: "cancelled" }
+    | { status: "dry-run"; timeLogId: string; resolved: ResolvedTimeLog | null; plan: EffortRestorePlan | null }
+    | {
+          status: "deleted";
+          timeLogId: string;
+          resolved: ResolvedTimeLog | null;
+          plan: EffortRestorePlan | null;
+          effort: EffortResult | null;
+      };
+
+export interface DeleteTimeLogOptions {
+    timeLogApi: TimeLogDeleteApi;
+    devopsApi: EffortApi;
+    timeLogId: string;
+    user: TimeLogUser;
+    projectId: string;
+    workItemId?: number;
+    knownMinutes?: number;
+    noEffort?: boolean;
+    dryRun?: boolean;
+    confirm?: () => Promise<boolean>;
+    journalPath?: string;
+    cacheManager?: AzureDevOpsCacheManager;
+}
+
+function queryFromDate(): string {
+    const from = new Date();
+    from.setFullYear(from.getFullYear() - 3);
+    return from.toISOString().slice(0, 10);
+}
+
+function isLiveQueryEntry(entry: TimeLogQueryEntry): boolean {
+    return entry.deletedOn == null;
+}
+
+export async function resolveTimeLogForDelete(opts: {
+    timeLogApi: TimeLogDeleteApi;
+    timeLogId: string;
+    user: TimeLogUser;
+    projectId: string;
+    workItemId?: number;
+    knownMinutes?: number;
+    journalPath?: string;
+}): Promise<ResolvedTimeLog | null> {
+    if (opts.workItemId != null && opts.knownMinutes != null) {
+        logger.debug(
+            `[timelog-delete] resolved ${opts.timeLogId} from selection #${opts.workItemId} ${opts.knownMinutes}m`
+        );
+        return { workItemId: opts.workItemId, minutes: opts.knownMinutes, source: "selection" };
+    }
+
+    if (opts.workItemId != null) {
+        const entries = await opts.timeLogApi.getWorkItemTimeLogs(opts.workItemId);
+        const hit = entries.find((entry) => entry.timeLogId === opts.timeLogId);
+
+        if (hit) {
+            logger.debug(
+                `[timelog-delete] resolved ${opts.timeLogId} from work item #${opts.workItemId} ${hit.minutes}m`
+            );
+            return { workItemId: opts.workItemId, minutes: hit.minutes, source: "workitem" };
+        }
+    }
+
+    const journal = findNewestEffortJournal(opts.timeLogId, opts.journalPath ?? effortJournalPath());
+
+    if (journal) {
+        const entries = await opts.timeLogApi.getWorkItemTimeLogs(journal.workItemId);
+        const hit = entries.find((entry) => entry.timeLogId === opts.timeLogId);
+
+        if (hit) {
+            logger.debug(
+                `[timelog-delete] resolved ${opts.timeLogId} via journal WI #${journal.workItemId} ${hit.minutes}m`
+            );
+            return { workItemId: journal.workItemId, minutes: hit.minutes, source: "journal" };
+        }
+
+        if (journal.timeLogIds.length === 1) {
+            logger.debug(
+                `[timelog-delete] resolved ${opts.timeLogId} from single-id journal #${journal.workItemId} ${journal.minutes}m`
+            );
+            return { workItemId: journal.workItemId, minutes: journal.minutes, source: "journal" };
+        }
+    }
+
+    const fromDate = queryFromDate();
+    const toDate = getTodayDate();
+    const baseQuery: TimeLogQueryParams = {
+        FromDate: fromDate,
+        ToDate: toDate,
+        projectId: opts.projectId,
+    };
+
+    const scoped = await opts.timeLogApi.queryTimeLogs({
+        ...baseQuery,
+        userId: opts.user.userId,
+    });
+    const scopedHit = scoped.find((entry) => entry.timeLogId === opts.timeLogId && isLiveQueryEntry(entry));
+
+    if (scopedHit) {
+        logger.debug(
+            `[timelog-delete] resolved ${opts.timeLogId} from user query #${scopedHit.workItemId} ${scopedHit.minutes}m`
+        );
+        return { workItemId: scopedHit.workItemId, minutes: scopedHit.minutes, source: "query" };
+    }
+
+    const unscoped = await opts.timeLogApi.queryTimeLogs(baseQuery);
+    const unscopedHit = unscoped.find((entry) => entry.timeLogId === opts.timeLogId && isLiveQueryEntry(entry));
+
+    if (unscopedHit) {
+        logger.debug(
+            `[timelog-delete] resolved ${opts.timeLogId} from project query #${unscopedHit.workItemId} ${unscopedHit.minutes}m`
+        );
+        return { workItemId: unscopedHit.workItemId, minutes: unscopedHit.minutes, source: "query" };
+    }
+
+    logger.debug(`[timelog-delete] could not resolve ${opts.timeLogId} to a work item`);
+    return null;
+}
+
+export function formatEffortTransition(plan: EffortRestorePlan): string {
+    return `Remaining ${plan.remainingBefore}h → ${plan.remainingAfter}h, Completed ${plan.completedBefore}h → ${plan.completedAfter}h`;
+}
+
+export async function deleteTimeLogEntryWithEffort(opts: DeleteTimeLogOptions): Promise<DeleteTimeLogResult> {
+    const journalPath = opts.journalPath ?? effortJournalPath();
+    let resolved: ResolvedTimeLog | null = null;
+    let plan: EffortRestorePlan | null = null;
+
+    if (!opts.noEffort) {
+        resolved = await resolveTimeLogForDelete({
+            timeLogApi: opts.timeLogApi,
+            timeLogId: opts.timeLogId,
+            user: opts.user,
+            projectId: opts.projectId,
+            workItemId: opts.workItemId,
+            knownMinutes: opts.knownMinutes,
+            journalPath,
+        });
+
+        if (resolved) {
+            try {
+                const current = await readWorkItemEffort(opts.devopsApi, resolved.workItemId);
+                const journal = findNewestEffortJournal(opts.timeLogId, journalPath);
+                plan = planEffortRestore({
+                    workItemId: resolved.workItemId,
+                    minutes: resolved.minutes,
+                    timeLogId: opts.timeLogId,
+                    currentRemaining: current?.remaining,
+                    currentCompleted: current?.completed,
+                    journal,
+                });
+                logger.debug(
+                    `[timelog-delete] restore plan ${plan.reason} for #${resolved.workItemId}: ${formatEffortTransition(plan)}`
+                );
+            } catch (err) {
+                logger.warn(
+                    { error: err, workItemId: resolved.workItemId },
+                    "[timelog-delete] failed to read work item effort; will delete the row only"
+                );
+            }
+        } else {
+            logger.warn(`[timelog-delete] ${opts.timeLogId} not resolved; delete will skip effort restore`);
+        }
+    }
+
+    if (opts.dryRun) {
+        return { status: "dry-run", timeLogId: opts.timeLogId, resolved, plan };
+    }
+
+    if (opts.confirm) {
+        const ok = await opts.confirm();
+
+        if (!ok) {
+            return { status: "cancelled" };
+        }
+    }
+
+    await opts.timeLogApi.deleteTimeLogEntry(opts.timeLogId);
+    logger.debug(`[timelog-delete] deleted ${opts.timeLogId}`);
+
+    let effort: EffortResult | null = null;
+
+    if (plan && resolved) {
+        effort = await updateWorkItemEffort(opts.devopsApi, resolved.workItemId, -resolved.minutes, {
+            timeLogIds: [opts.timeLogId],
+            journalPath,
+            values: { remaining: plan.remainingAfter, completed: plan.completedAfter },
+        });
+    }
+
+    const workItemId = resolved?.workItemId ?? opts.workItemId;
+
+    if (workItemId != null) {
+        const cache = opts.cacheManager ?? new AzureDevOpsCacheManager();
+        cache.onTimelogCreated([workItemId]).catch((err) => {
+            logger.debug(`[timelog-delete] Cache eviction failed: ${err}`);
+        });
+    }
+
+    return { status: "deleted", timeLogId: opts.timeLogId, resolved, plan, effort };
+}
+
+export function printDeleteResult(result: DeleteTimeLogResult, opts: { noEffort?: boolean }): void {
+    if (result.status === "cancelled") {
+        return;
+    }
+
+    const shortId = result.timeLogId.substring(0, 8);
+    const prefix = result.status === "dry-run" ? "Would delete" : "Deleted";
+
+    out.println(`\u2714 ${prefix} time log entry ${shortId}...`);
+
+    if (opts.noEffort) {
+        out.println(pc.dim("  Work item effort left untouched (--no-effort)"));
+        return;
+    }
+
+    if (!result.resolved) {
+        out.warn(
+            pc.yellow(
+                "  ⚠ Could not resolve work item or minutes for this entry. The row is gone; Remaining/Completed were not changed."
+            )
+        );
+        return;
+    }
+
+    out.println(`  Work Item: #${result.resolved.workItemId}`);
+    out.println(`  Time: ${formatMinutes(result.resolved.minutes)}`);
+
+    if (!result.plan) {
+        out.warn(pc.yellow("  ⚠ Could not read work item effort fields. Remaining/Completed were not changed."));
+        return;
+    }
+
+    out.println(`  ${formatEffortTransition(result.plan)}`);
+
+    if (result.plan.reason === "exact-journal") {
+        out.println(pc.dim("  Restore: exact (effort journal)"));
+    } else if (result.plan.reason === "approximate-no-journal") {
+        out.println(pc.dim("  Restore: approximate (no journal record)"));
+    } else if (result.plan.reason === "approximate-multi-id") {
+        out.println(pc.dim("  Restore: approximate (journal covers a batch)"));
+    } else {
+        out.println(pc.dim("  Restore: approximate (fields drifted)"));
+    }
+
+    if (result.plan.warning) {
+        out.warn(pc.yellow(`  ⚠ ${result.plan.warning}`));
+    }
+
+    if (result.status === "deleted" && result.plan && result.effort === null) {
+        out.warn(
+            pc.yellow("  ⚠ Time log row was deleted, but Remaining/Completed could not be written (see warning above).")
+        );
+    }
+}

--- a/src/azure-devops/lib/timelog/delete-entry.ts
+++ b/src/azure-devops/lib/timelog/delete-entry.ts
@@ -26,6 +26,7 @@ export type ResolvedTimeLog = {
 
 export type DeleteTimeLogResult =
     | { status: "cancelled" }
+    | { status: "needs-resolution"; timeLogId: string }
     | { status: "dry-run"; timeLogId: string; resolved: ResolvedTimeLog | null; plan: EffortRestorePlan | null }
     | {
           status: "deleted";
@@ -140,6 +141,19 @@ export async function resolveTimeLogForDelete(opts: {
         return { workItemId: unscopedHit.workItemId, minutes: unscopedHit.minutes, source: "query" };
     }
 
+    const unbounded = await opts.timeLogApi.queryTimeLogs({
+        projectId: opts.projectId,
+        userId: opts.user.userId,
+    });
+    const unboundedHit = unbounded.find((entry) => entry.timeLogId === opts.timeLogId && isLiveQueryEntry(entry));
+
+    if (unboundedHit) {
+        logger.debug(
+            `[timelog-delete] resolved ${opts.timeLogId} from unbounded user query #${unboundedHit.workItemId} ${unboundedHit.minutes}m`
+        );
+        return { workItemId: unboundedHit.workItemId, minutes: unboundedHit.minutes, source: "query" };
+    }
+
     logger.debug(`[timelog-delete] could not resolve ${opts.timeLogId} to a work item`);
     return null;
 }
@@ -154,15 +168,22 @@ export async function deleteTimeLogEntryWithEffort(opts: DeleteTimeLogOptions): 
     let plan: EffortRestorePlan | null = null;
 
     if (!opts.noEffort) {
-        resolved = await resolveTimeLogForDelete({
-            timeLogApi: opts.timeLogApi,
-            timeLogId: opts.timeLogId,
-            user: opts.user,
-            projectId: opts.projectId,
-            workItemId: opts.workItemId,
-            knownMinutes: opts.knownMinutes,
-            journalPath,
-        });
+        try {
+            resolved = await resolveTimeLogForDelete({
+                timeLogApi: opts.timeLogApi,
+                timeLogId: opts.timeLogId,
+                user: opts.user,
+                projectId: opts.projectId,
+                workItemId: opts.workItemId,
+                knownMinutes: opts.knownMinutes,
+                journalPath,
+            });
+        } catch (err) {
+            logger.warn(
+                { error: err, timeLogId: opts.timeLogId },
+                "[timelog-delete] failed to resolve the time log; delete will skip effort restore"
+            );
+        }
 
         if (resolved) {
             try {
@@ -194,6 +215,13 @@ export async function deleteTimeLogEntryWithEffort(opts: DeleteTimeLogOptions): 
         return { status: "dry-run", timeLogId: opts.timeLogId, resolved, plan };
     }
 
+    if (!opts.noEffort && !resolved) {
+        logger.warn(
+            `[timelog-delete] refusing to delete ${opts.timeLogId} without a work item or minutes; pass --workitem or --no-effort`
+        );
+        return { status: "needs-resolution", timeLogId: opts.timeLogId };
+    }
+
     if (opts.confirm) {
         const ok = await opts.confirm();
 
@@ -211,6 +239,7 @@ export async function deleteTimeLogEntryWithEffort(opts: DeleteTimeLogOptions): 
         effort = await updateWorkItemEffort(opts.devopsApi, resolved.workItemId, -resolved.minutes, {
             timeLogIds: [opts.timeLogId],
             journalPath,
+            journal: false,
             values: { remaining: plan.remainingAfter, completed: plan.completedAfter },
         });
     }
@@ -228,7 +257,7 @@ export async function deleteTimeLogEntryWithEffort(opts: DeleteTimeLogOptions): 
 }
 
 export function printDeleteResult(result: DeleteTimeLogResult, opts: { noEffort?: boolean }): void {
-    if (result.status === "cancelled") {
+    if (result.status === "cancelled" || result.status === "needs-resolution") {
         return;
     }
 
@@ -243,6 +272,15 @@ export function printDeleteResult(result: DeleteTimeLogResult, opts: { noEffort?
     }
 
     if (!result.resolved) {
+        if (result.status === "dry-run") {
+            out.warn(
+                pc.yellow(
+                    "  ⚠ Could not resolve work item or minutes. The row would be deleted and Remaining/Completed would not change."
+                )
+            );
+            return;
+        }
+
         out.warn(
             pc.yellow(
                 "  ⚠ Could not resolve work item or minutes for this entry. The row is gone; Remaining/Completed were not changed."

--- a/src/azure-devops/lib/timelog/effort-restore.test.ts
+++ b/src/azure-devops/lib/timelog/effort-restore.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import type { EffortJournalRecord } from "@app/azure-devops/timelog-effort-journal";
+import { planEffortRestore } from "./effort-restore";
+
+const id = "56489ac9-aaaa-bbbb-cccc-ddddeeeeffff";
+
+function journal(overrides: Partial<EffortJournalRecord> = {}): EffortJournalRecord {
+    return {
+        ts: "2026-08-19T13:03:11.482Z",
+        workItemId: 296936,
+        timeLogIds: [id],
+        minutes: 120,
+        remainingBefore: 10,
+        completedBefore: 4,
+        remainingAfter: 8,
+        completedAfter: 6,
+        ...overrides,
+    };
+}
+
+describe("planEffortRestore", () => {
+    test("exact journal restore after a 2h add", () => {
+        const plan = planEffortRestore({
+            workItemId: 296936,
+            minutes: 120,
+            timeLogId: id,
+            currentRemaining: 8,
+            currentCompleted: 6,
+            journal: journal(),
+        });
+        expect(plan).toMatchObject({
+            reason: "exact-journal",
+            remainingAfter: 10,
+            completedAfter: 4,
+        });
+        expect(plan.warning).toBeUndefined();
+    });
+
+    test("exact journal restore survives a Remaining clamp", () => {
+        const plan = planEffortRestore({
+            workItemId: 303818,
+            minutes: 390,
+            timeLogId: id,
+            currentRemaining: 0,
+            currentCompleted: 6.5,
+            journal: journal({
+                workItemId: 303818,
+                minutes: 390,
+                remainingBefore: 3,
+                completedBefore: 0,
+                remainingAfter: 0,
+                completedAfter: 6.5,
+            }),
+        });
+        expect(plan.reason).toBe("exact-journal");
+        expect(plan.remainingAfter).toBe(3);
+        expect(plan.completedAfter).toBe(0);
+    });
+
+    test("no journal uses arithmetic and warns", () => {
+        const plan = planEffortRestore({
+            workItemId: 296936,
+            minutes: 480,
+            timeLogId: id,
+            currentRemaining: 0,
+            currentCompleted: 38,
+            journal: null,
+        });
+        expect(plan.reason).toBe("approximate-no-journal");
+        expect(plan.remainingAfter).toBe(8);
+        expect(plan.completedAfter).toBe(30);
+        expect(plan.warning).toContain("before journaling shipped");
+    });
+
+    test("multi-id journal falls back to this entry's hours only", () => {
+        const plan = planEffortRestore({
+            workItemId: 1,
+            minutes: 60,
+            timeLogId: id,
+            currentRemaining: 0,
+            currentCompleted: 10,
+            journal: journal({
+                timeLogIds: [id, "other-1", "other-2", "other-3", "other-4"],
+                minutes: 300,
+                remainingBefore: 5,
+                completedBefore: 5,
+                remainingAfter: 0,
+                completedAfter: 10,
+            }),
+        });
+        expect(plan.reason).toBe("approximate-multi-id");
+        expect(plan.remainingAfter).toBe(1);
+        expect(plan.completedAfter).toBe(9);
+        expect(plan.warning).toContain("5 entries");
+    });
+
+    test("drifted fields fall back to arithmetic", () => {
+        const plan = planEffortRestore({
+            workItemId: 296936,
+            minutes: 120,
+            timeLogId: id,
+            currentRemaining: 7,
+            currentCompleted: 9,
+            journal: journal(),
+        });
+        expect(plan.reason).toBe("approximate-drifted");
+        expect(plan.remainingAfter).toBe(9);
+        expect(plan.completedAfter).toBe(7);
+        expect(plan.warning).toContain("have changed");
+    });
+});

--- a/src/azure-devops/lib/timelog/effort-restore.ts
+++ b/src/azure-devops/lib/timelog/effort-restore.ts
@@ -1,0 +1,93 @@
+import { computeEffortValues } from "@app/azure-devops/timelog-effort";
+import type { EffortJournalRecord } from "@app/azure-devops/timelog-effort-journal";
+
+export type EffortRestoreReason =
+    | "exact-journal"
+    | "approximate-multi-id"
+    | "approximate-drifted"
+    | "approximate-no-journal";
+
+export interface EffortRestorePlan {
+    workItemId: number;
+    minutes: number;
+    remainingBefore: number;
+    completedBefore: number;
+    remainingAfter: number;
+    completedAfter: number;
+    reason: EffortRestoreReason;
+    warning?: string;
+}
+
+const EPSILON = 1e-6;
+
+export function effortNumbersEqual(a: number, b: number): boolean {
+    return Math.abs(a - b) < EPSILON;
+}
+
+export function planEffortRestore(args: {
+    workItemId: number;
+    minutes: number;
+    timeLogId: string;
+    currentRemaining: number | null | undefined;
+    currentCompleted: number | null | undefined;
+    journal: EffortJournalRecord | null;
+}): EffortRestorePlan {
+    const remainingBefore = args.currentRemaining ?? 0;
+    const completedBefore = args.currentCompleted ?? 0;
+    const arithmetic = computeEffortValues(args.currentRemaining, args.currentCompleted, -args.minutes);
+
+    if (!args.journal) {
+        return {
+            workItemId: args.workItemId,
+            minutes: args.minutes,
+            remainingBefore,
+            completedBefore,
+            remainingAfter: arithmetic.remaining,
+            completedAfter: arithmetic.completed,
+            reason: "approximate-no-journal",
+            warning:
+                "No effort journal record for this entry (created before journaling shipped). Restore is approximate: Remaining += hours, Completed -= hours, both floored at 0.",
+        };
+    }
+
+    const coversOnlyThisId = args.journal.timeLogIds.length === 1 && args.journal.timeLogIds[0] === args.timeLogId;
+    const fieldsMatchAfter =
+        effortNumbersEqual(remainingBefore, args.journal.remainingAfter) &&
+        effortNumbersEqual(completedBefore, args.journal.completedAfter);
+
+    if (coversOnlyThisId && fieldsMatchAfter) {
+        return {
+            workItemId: args.workItemId,
+            minutes: args.minutes,
+            remainingBefore,
+            completedBefore,
+            remainingAfter: args.journal.remainingBefore,
+            completedAfter: args.journal.completedBefore,
+            reason: "exact-journal",
+        };
+    }
+
+    if (!coversOnlyThisId) {
+        return {
+            workItemId: args.workItemId,
+            minutes: args.minutes,
+            remainingBefore,
+            completedBefore,
+            remainingAfter: arithmetic.remaining,
+            completedAfter: arithmetic.completed,
+            reason: "approximate-multi-id",
+            warning: `Journal record covers ${args.journal.timeLogIds.length} entries; cannot restore the exact pre-import fields. Applying arithmetic for this entry only.`,
+        };
+    }
+
+    return {
+        workItemId: args.workItemId,
+        minutes: args.minutes,
+        remainingBefore,
+        completedBefore,
+        remainingAfter: arithmetic.remaining,
+        completedAfter: arithmetic.completed,
+        reason: "approximate-drifted",
+        warning: `Work item fields have changed since the journalled update (Remaining ${args.journal.remainingAfter} → now ${remainingBefore}, Completed ${args.journal.completedAfter} → now ${completedBefore}). Restore is approximate.`,
+    };
+}

--- a/src/azure-devops/timelog-effort-journal.ts
+++ b/src/azure-devops/timelog-effort-journal.ts
@@ -1,0 +1,109 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { Storage, withFileLock } from "@genesiscz/utils/storage";
+
+export interface EffortJournalRecord {
+    ts: string;
+    workItemId: number;
+    timeLogIds: string[];
+    minutes: number;
+    remainingBefore: number;
+    completedBefore: number;
+    remainingAfter: number;
+    completedAfter: number;
+}
+
+const JOURNAL_NAME = "effort-journal.jsonl";
+
+export function effortJournalPath(): string {
+    return join(new Storage("azure-devops").getBaseDir(), JOURNAL_NAME);
+}
+
+function isRecord(value: unknown): value is EffortJournalRecord {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    const rec = value as Record<string, unknown>;
+
+    return (
+        typeof rec.ts === "string" &&
+        typeof rec.workItemId === "number" &&
+        Array.isArray(rec.timeLogIds) &&
+        rec.timeLogIds.every((id) => typeof id === "string") &&
+        typeof rec.minutes === "number" &&
+        typeof rec.remainingBefore === "number" &&
+        typeof rec.completedBefore === "number" &&
+        typeof rec.remainingAfter === "number" &&
+        typeof rec.completedAfter === "number"
+    );
+}
+
+export async function appendEffortJournal(
+    record: EffortJournalRecord,
+    path: string = effortJournalPath()
+): Promise<void> {
+    const dir = dirname(path);
+
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    await withFileLock(`${path}.lock`, async () => {
+        appendFileSync(path, `${SafeJSON.stringify(record, { strict: true })}\n`);
+    });
+    logger.debug(
+        `[effort-journal] appended #${record.workItemId} ids=${record.timeLogIds.length} minutes=${record.minutes} → ${path}`
+    );
+}
+
+export function readEffortJournal(path: string = effortJournalPath()): EffortJournalRecord[] {
+    if (!existsSync(path)) {
+        return [];
+    }
+
+    const text = readFileSync(path, "utf-8");
+    const records: EffortJournalRecord[] = [];
+
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        try {
+            const parsed: unknown = SafeJSON.parse(trimmed, { strict: true });
+
+            if (isRecord(parsed)) {
+                records.push(parsed);
+            } else {
+                logger.debug({ line: trimmed.slice(0, 120) }, "[effort-journal] skipped line with unexpected shape");
+            }
+        } catch (err) {
+            logger.debug({ error: err, line: trimmed.slice(0, 120) }, "[effort-journal] skipped malformed line");
+        }
+    }
+
+    return records;
+}
+
+/** Newest record whose `timeLogIds` contains `timeLogId`, or null. */
+export function findNewestEffortJournal(
+    timeLogId: string,
+    path: string = effortJournalPath()
+): EffortJournalRecord | null {
+    const records = readEffortJournal(path);
+
+    for (let i = records.length - 1; i >= 0; i--) {
+        const record = records[i];
+
+        if (record.timeLogIds.includes(timeLogId)) {
+            return record;
+        }
+    }
+
+    return null;
+}

--- a/src/azure-devops/timelog-effort.test.ts
+++ b/src/azure-devops/timelog-effort.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { JsonPatchOperation } from "@app/azure-devops/types";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { computeEffortValues, type EffortApi, updateWorkItemEffort } from "./timelog-effort";
+import { type EffortJournalRecord, effortJournalPath, readEffortJournal } from "./timelog-effort-journal";
+
+const snapshot = env.testing.snapshot();
+const root = mkdtempSync(join(tmpdir(), "timelog-effort-"));
+
+afterAll(() => {
+    env.testing.restore(snapshot);
+    rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+    env.testing.set("GENESIS_TOOLS_HOME", root);
+});
+
+function mockApi(fields: Record<string, unknown> | undefined): EffortApi & {
+    updates: JsonPatchOperation[][];
+    getCalls: number;
+} {
+    const updates: JsonPatchOperation[][] = [];
+    let remaining = fields?.["Microsoft.VSTS.Scheduling.RemainingWork"];
+    let completed = fields?.["Microsoft.VSTS.Scheduling.CompletedWork"];
+    const hasFields = fields !== undefined;
+    let getCalls = 0;
+
+    return {
+        getCalls,
+        updates,
+        async getWorkItem() {
+            getCalls += 1;
+            this.getCalls = getCalls;
+
+            if (!hasFields) {
+                return { rawFields: undefined };
+            }
+
+            return {
+                rawFields: {
+                    "Microsoft.VSTS.Scheduling.RemainingWork": remaining,
+                    "Microsoft.VSTS.Scheduling.CompletedWork": completed,
+                },
+            };
+        },
+        async updateWorkItem(_id: number, operations: JsonPatchOperation[]) {
+            updates.push(operations);
+
+            for (const op of operations) {
+                if (op.path.endsWith("RemainingWork")) {
+                    remaining = op.value;
+                }
+
+                if (op.path.endsWith("CompletedWork")) {
+                    completed = op.value;
+                }
+            }
+
+            return {};
+        },
+    };
+}
+
+describe("computeEffortValues", () => {
+    test("add 2h on Remaining 10 / Completed 4 → 8 and 6", () => {
+        expect(computeEffortValues(10, 4, 120)).toEqual({ remaining: 8, completed: 6 });
+    });
+
+    test("add 8h on Remaining 3 clamps Remaining at 0", () => {
+        expect(computeEffortValues(3, 0, 480)).toEqual({ remaining: 0, completed: 8 });
+    });
+
+    test("negative minutes undo an add and clamp Completed at 0", () => {
+        expect(computeEffortValues(0, 6.5, -390)).toEqual({ remaining: 6.5, completed: 0 });
+        expect(computeEffortValues(8, 2, -480)).toEqual({ remaining: 16, completed: 0 });
+    });
+
+    test("null fields behave as 0", () => {
+        expect(computeEffortValues(null, undefined, 120)).toEqual({ remaining: 0, completed: 2 });
+    });
+});
+
+describe("updateWorkItemEffort", () => {
+    test("writes Remaining/Completed and journals the before/after pair", async () => {
+        const api = mockApi({
+            "Microsoft.VSTS.Scheduling.RemainingWork": 10,
+            "Microsoft.VSTS.Scheduling.CompletedWork": 4,
+        });
+        const journalPath = join(root, "case-add.jsonl");
+        const result = await updateWorkItemEffort(api, 296936, 120, {
+            timeLogIds: ["abc-1"],
+            journalPath,
+        });
+
+        expect(result).toEqual({
+            remaining: 8,
+            completed: 6,
+            remainingBefore: 10,
+            completedBefore: 4,
+        });
+        expect(api.updates).toHaveLength(1);
+        expect(api.updates[0].map((op) => op.value)).toEqual([8, 6]);
+
+        const records = readEffortJournal(journalPath);
+        expect(records).toHaveLength(1);
+        expect(records[0]).toMatchObject({
+            workItemId: 296936,
+            timeLogIds: ["abc-1"],
+            minutes: 120,
+            remainingBefore: 10,
+            completedBefore: 4,
+            remainingAfter: 8,
+            completedAfter: 6,
+        } satisfies Partial<EffortJournalRecord>);
+        expect(records[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test("journals to the default path under GENESIS_TOOLS_HOME", async () => {
+        const api = mockApi({
+            "Microsoft.VSTS.Scheduling.RemainingWork": 1,
+            "Microsoft.VSTS.Scheduling.CompletedWork": 0,
+        });
+        await updateWorkItemEffort(api, 1, 60, { timeLogIds: ["home-1"] });
+        const records = readEffortJournal(effortJournalPath());
+        expect(records.some((r) => r.timeLogIds.includes("home-1"))).toBe(true);
+    });
+
+    test("journal:false skips the journal file", async () => {
+        const api = mockApi({
+            "Microsoft.VSTS.Scheduling.RemainingWork": 5,
+            "Microsoft.VSTS.Scheduling.CompletedWork": 1,
+        });
+        const journalPath = join(root, "case-nojournal.jsonl");
+        await updateWorkItemEffort(api, 1, 60, { journal: false, journalPath, timeLogIds: ["x"] });
+        expect(readEffortJournal(journalPath)).toEqual([]);
+    });
+
+    test("values: writes the exact pair instead of signed math", async () => {
+        const api = mockApi({
+            "Microsoft.VSTS.Scheduling.RemainingWork": 0,
+            "Microsoft.VSTS.Scheduling.CompletedWork": 8,
+        });
+        const result = await updateWorkItemEffort(api, 303818, -480, {
+            journal: false,
+            values: { remaining: 3, completed: 0 },
+        });
+        expect(result?.remaining).toBe(3);
+        expect(result?.completed).toBe(0);
+        expect(api.updates[0].map((op) => op.value)).toEqual([3, 0]);
+    });
+
+    test("adds fields that were missing", async () => {
+        const api = mockApi({});
+        await updateWorkItemEffort(api, 1, 60, { journal: false });
+        expect(api.updates[0].map((op) => op.op)).toEqual(["add", "add"]);
+    });
+
+    test("skips when rawFields is missing", async () => {
+        const api = mockApi(undefined);
+        const result = await updateWorkItemEffort(api, 1, 60, { journal: false });
+        expect(result).toBeNull();
+        expect(api.updates).toHaveLength(0);
+    });
+
+    test("update failure is non-fatal and does not journal", async () => {
+        const api = mockApi({
+            "Microsoft.VSTS.Scheduling.RemainingWork": 2,
+            "Microsoft.VSTS.Scheduling.CompletedWork": 0,
+        });
+        api.updateWorkItem = async () => {
+            throw new Error("TF401320: InvalidNotEmpty");
+        };
+        const journalPath = join(root, "case-locked.jsonl");
+        const result = await updateWorkItemEffort(api, 297506, 60, { journalPath, timeLogIds: ["locked"] });
+        expect(result).toBeNull();
+        expect(readEffortJournal(journalPath)).toEqual([]);
+    });
+});
+
+describe("effort journal parse", () => {
+    test("skips malformed lines and returns the newest match", async () => {
+        const path = join(root, "parse.jsonl");
+        const older = {
+            ts: "2026-08-01T00:00:00.000Z",
+            workItemId: 1,
+            timeLogIds: ["same"],
+            minutes: 60,
+            remainingBefore: 10,
+            completedBefore: 0,
+            remainingAfter: 9,
+            completedAfter: 1,
+        };
+        const newer = { ...older, ts: "2026-08-19T00:00:00.000Z", remainingAfter: 8, completedAfter: 2 };
+        const { appendFileSync } = await import("node:fs");
+        appendFileSync(path, "not-json\n");
+        appendFileSync(path, `${SafeJSON.stringify(older, { strict: true })}\n`);
+        appendFileSync(path, `${SafeJSON.stringify({ ts: "x" }, { strict: true })}\n`);
+        appendFileSync(path, `${SafeJSON.stringify(newer, { strict: true })}\n`);
+
+        const { findNewestEffortJournal } = await import("./timelog-effort-journal");
+        const hit = findNewestEffortJournal("same", path);
+        expect(hit?.remainingAfter).toBe(8);
+        expect(readEffortJournal(path)).toHaveLength(2);
+    });
+});

--- a/src/azure-devops/timelog-effort.ts
+++ b/src/azure-devops/timelog-effort.ts
@@ -31,7 +31,7 @@ export type EffortApi = {
 };
 
 /**
- * Apply signed hours to Remaining / Completed.
+ * Apply signed minutes to Remaining / Completed.
  * Positive minutes decrement Remaining and increment Completed.
  * Negative minutes reverse that. Both fields floor at 0.
  */
@@ -133,6 +133,11 @@ export async function updateWorkItemEffort(
                 await appendEffortJournal(record, opts?.journalPath ?? effortJournalPath());
             } catch (err) {
                 logger.warn({ error: err, workItemId }, "[effort] Failed to append effort journal");
+                out.warn(
+                    pc.yellow(
+                        `  ⚠ Effort fields updated for #${workItemId}, but the local journal was not written. A later delete may only restore Remaining/Completed approximately.`
+                    )
+                );
             }
         }
 

--- a/src/azure-devops/timelog-effort.ts
+++ b/src/azure-devops/timelog-effort.ts
@@ -1,4 +1,8 @@
-import type { Api } from "@app/azure-devops/api";
+import {
+    appendEffortJournal,
+    type EffortJournalRecord,
+    effortJournalPath,
+} from "@app/azure-devops/timelog-effort-journal";
 import type { JsonPatchOperation } from "@app/azure-devops/types";
 import { logger, out } from "@genesiscz/utils/logger";
 import pc from "picocolors";
@@ -6,37 +10,86 @@ import pc from "picocolors";
 const REMAINING_FIELD = "Microsoft.VSTS.Scheduling.RemainingWork";
 const COMPLETED_FIELD = "Microsoft.VSTS.Scheduling.CompletedWork";
 
-interface EffortResult {
+export interface EffortResult {
     remaining: number;
     completed: number;
+    remainingBefore: number;
+    completedBefore: number;
+}
+
+export interface UpdateWorkItemEffortOpts {
+    timeLogIds?: string[];
+    journal?: boolean;
+    journalPath?: string;
+    /** Write these values instead of computing from loggedMinutes. */
+    values?: { remaining: number; completed: number };
+}
+
+export type EffortApi = {
+    getWorkItem(id: number): Promise<{ rawFields?: Record<string, unknown> }>;
+    updateWorkItem(id: number, operations: JsonPatchOperation[]): Promise<unknown>;
+};
+
+/**
+ * Apply signed hours to Remaining / Completed.
+ * Positive minutes decrement Remaining and increment Completed.
+ * Negative minutes reverse that. Both fields floor at 0.
+ */
+export function computeEffortValues(
+    currentRemaining: number | null | undefined,
+    currentCompleted: number | null | undefined,
+    loggedMinutes: number
+): { remaining: number; completed: number } {
+    const loggedHours = loggedMinutes / 60;
+
+    return {
+        remaining: Math.max(0, (currentRemaining ?? 0) - loggedHours),
+        completed: Math.max(0, (currentCompleted ?? 0) + loggedHours),
+    };
+}
+
+export async function readWorkItemEffort(
+    api: EffortApi,
+    workItemId: number
+): Promise<{ remaining: number | null; completed: number | null } | null> {
+    const workItem = await api.getWorkItem(workItemId);
+    const fields = workItem.rawFields;
+
+    if (!fields) {
+        logger.debug(`[effort] Work item #${workItemId} has no rawFields, skipping effort update`);
+        return null;
+    }
+
+    return {
+        remaining: (fields[REMAINING_FIELD] as number | null | undefined) ?? null,
+        completed: (fields[COMPLETED_FIELD] as number | null | undefined) ?? null,
+    };
 }
 
 /**
- * After logging time, update the work item's Remaining Work and Completed Work fields.
- * Remaining is decremented, Completed is incremented by the logged hours.
+ * After logging time (or reverting it), update Remaining Work and Completed Work.
+ * `loggedMinutes` is signed: negative values undo a prior add.
  *
  * Returns the new values, or null if the update failed (non-fatal).
  */
 export async function updateWorkItemEffort(
-    api: Api,
+    api: EffortApi,
     workItemId: number,
-    loggedMinutes: number
+    loggedMinutes: number,
+    opts?: UpdateWorkItemEffortOpts
 ): Promise<EffortResult | null> {
     try {
-        const loggedHours = loggedMinutes / 60;
-        const workItem = await api.getWorkItem(workItemId);
-        const fields = workItem.rawFields;
+        const current = await readWorkItemEffort(api, workItemId);
 
-        if (!fields) {
-            logger.debug(`[effort] Work item #${workItemId} has no rawFields, skipping effort update`);
+        if (!current) {
             return null;
         }
 
-        const currentRemaining = fields[REMAINING_FIELD] as number | null | undefined;
-        const currentCompleted = fields[COMPLETED_FIELD] as number | null | undefined;
-
-        const newCompleted = (currentCompleted ?? 0) + loggedHours;
-        const newRemaining = Math.max(0, (currentRemaining ?? 0) - loggedHours);
+        const currentRemaining = current.remaining;
+        const currentCompleted = current.completed;
+        const next = opts?.values ?? computeEffortValues(currentRemaining, currentCompleted, loggedMinutes);
+        const newRemaining = Math.max(0, next.remaining);
+        const newCompleted = Math.max(0, next.completed);
 
         const operations: JsonPatchOperation[] = [
             {
@@ -57,7 +110,33 @@ export async function updateWorkItemEffort(
             `[effort] Updated #${workItemId}: Remaining ${currentRemaining ?? 0} → ${newRemaining}, Completed ${currentCompleted ?? 0} → ${newCompleted}`
         );
 
-        return { remaining: newRemaining, completed: newCompleted };
+        const result: EffortResult = {
+            remaining: newRemaining,
+            completed: newCompleted,
+            remainingBefore: currentRemaining ?? 0,
+            completedBefore: currentCompleted ?? 0,
+        };
+
+        if (opts?.journal !== false) {
+            const record: EffortJournalRecord = {
+                ts: new Date().toISOString(),
+                workItemId,
+                timeLogIds: opts?.timeLogIds ?? [],
+                minutes: loggedMinutes,
+                remainingBefore: result.remainingBefore,
+                completedBefore: result.completedBefore,
+                remainingAfter: newRemaining,
+                completedAfter: newCompleted,
+            };
+
+            try {
+                await appendEffortJournal(record, opts?.journalPath ?? effortJournalPath());
+            } catch (err) {
+                logger.warn({ error: err, workItemId }, "[effort] Failed to append effort journal");
+            }
+        }
+
+        return result;
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.warn(`[effort] Failed to update effort for #${workItemId}: ${msg}`);

--- a/src/azure-devops/timelog-prompts-clack.ts
+++ b/src/azure-devops/timelog-prompts-clack.ts
@@ -162,7 +162,7 @@ export async function runInteractiveAddClack(
 
     // Update Remaining/Completed Work on the work item
     const devopsApi = new Api(config);
-    const effort = await updateWorkItemEffort(devopsApi, workItemId, totalMinutes);
+    const effort = await updateWorkItemEffort(devopsApi, workItemId, totalMinutes, { timeLogIds: ids });
 
     if (effort) {
         p.log.info(`Remaining: ${effort.remaining}h | Completed: ${effort.completed}h`);


### PR DESCRIPTION
## Why

`tools azure-devops timelog add` and `import` push Remaining/Completed after they create rows. `delete` only removed the time log. Delete plus re-add double-counted Completed (real hits: `#296936` 30→38, `#302066` 14/16→23.5/6.5).

Plain arithmetic cannot undo a create that clamped Remaining at 0. A 6.5h log on Remaining 0 would revert to Remaining 6.5 if we just added the hours back.

## What changed

- `updateWorkItemEffort` now takes signed minutes, clamps both Remaining and Completed at 0, and appends one journal record per successful write to `~/.genesis-tools/azure-devops/effort-journal.jsonl`.
- `add`, interactive add, and `import` pass the created `timeLogIds`.
- `delete` resolves `{workItemId, minutes}`, then:
  1. If the newest journal row covers only this id and the work item still shows the journalled *After* values, restore the exact *Before* pair (this is the clamp case).
  2. Otherwise apply arithmetic (`Completed -= hours`, `Remaining += hours`, floored at 0) and print why the restore is approximate (no journal, batch import, or drifted fields).
- Effort failure stays non-fatal (`TF401320` on locked/Closed items). The row still deletes. Order is read+plan → delete row → write fields.

New flags:

| Flag | Behaviour |
|---|---|
| `--no-effort` | Delete the row only |
| `--dry-run` | Print the planned Remaining/Completed transition; write nothing |
| `--yes` | Skip the confirm prompt (required without a TTY) |

Non-TTY scripts that used `echo y | tools azure-devops timelog delete <id>` must switch to `--yes`.

## Tests

`bun run test src/azure-devops/timelog-effort.test.ts src/azure-devops/lib/timelog/effort-restore.test.ts src/azure-devops/lib/timelog/delete-entry.test.ts` — 27 pass.

Covers: 2h exact restore, clamped 8h restore (3/0 not 8/0), pre-journal arithmetic, single-id delete from a 5-entry import, `--no-effort`, `--dry-run`, locked WI, confirm cancel, query resolve, unresolved id still deletes.

Pre-commit biome + tsgo passed.

## Not in this PR

- Upper bound of Completed against OriginalEstimate (called out in the handoff as a follow-up).
- Batch `delete --workitem --all-matching`. Sequential `--yes` deletes are documented instead.
- The `col-fe-report` skill warning was updated locally (`~/.claude/skills/col-fe-report/SKILL.md` §7). That file is not in this repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for rolling back Remaining and Completed effort when deleting time logs.
  * Added `--dry-run`, `--yes`, and `--no-effort` deletion options.
  * Added journal-based effort restoration with warnings for approximate results.
  * Improved effort tracking when adding or importing time logs.
  * Added clearer deletion help text and usage examples.

* **Bug Fixes**
  * Improved handling of locked work items, missing data, cancelled confirmations, and multi-entry imports.

* **Tests**
  * Expanded coverage for deletion, restoration, journaling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->