### PR TITLE
feat(claude): tools claude cmux focus jumps to the pane a session is already in

### DIFF
--- a/src/claude/commands/cmux/focus.command.test.ts
+++ b/src/claude/commands/cmux/focus.command.test.ts
@@ -44,7 +44,7 @@ mock.module("@genesiscz/utils/cmux/lib/controls", () => ({
     focusCmuxPane: async ({ workspaceId, paneId }: { workspaceId: string; paneId: string }) => {
         events.push(`focus-pane ${workspaceId} ${paneId}`);
     },
-    focusCmuxSurface: async (surfaceId: string) => {
+    focusCmuxSurface: async ({ surfaceId }: { surfaceId: string }) => {
         events.push(`focus-surface ${surfaceId}`);
     },
 }));

--- a/src/claude/commands/cmux/focus.command.test.ts
+++ b/src/claude/commands/cmux/focus.command.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CmuxLivePane, CmuxLiveSnapshot, CmuxLiveSurface } from "@genesiscz/utils/cmux/lib/live-snapshot";
+import { out } from "@genesiscz/utils/logger";
+
+const SESSION_A = "8b6e69bf-0efc-4990-ba3e-b77262498421";
+const CALLER_PANE = "pane:2";
+
+let snapshot: CmuxLiveSnapshot;
+
+/**
+ * Every cmux effect the command reaches for, in order.
+ *
+ * One shared list rather than one per mock, because the ordering is part of the contract:
+ * the window has to be raised before the pane is focused, and the pane before its tab.
+ */
+let events: string[] = [];
+
+let stdout: string[] = [];
+let originalWrite: typeof process.stdout.write;
+
+mock.module("@genesiscz/utils/cmux/lib/live-snapshot", () => ({
+    fetchCmuxLiveSnapshot: async () => snapshot,
+}));
+
+mock.module("@genesiscz/utils/cmux/lib/cli", () => ({
+    runCmuxJSON: async (args: string[]) => {
+        events.push(args.join(" "));
+
+        // `identify --workspace <ref>` answers for the workspace you name; bare `identify`
+        // answers for the pane you are calling from.
+        if (args.includes("--workspace")) {
+            return { caller: { window_ref: "window:1" } };
+        }
+
+        return { bundle_identifier: "com.cmuxterm.app", caller: { pane_ref: CALLER_PANE } };
+    },
+    runCmuxOk: async (args: string[]) => {
+        events.push(args.join(" "));
+        return { code: 0, stdout: "", stderr: "" };
+    },
+}));
+
+mock.module("@genesiscz/utils/cmux/lib/controls", () => ({
+    focusCmuxPane: async ({ workspaceId, paneId }: { workspaceId: string; paneId: string }) => {
+        events.push(`focus-pane ${workspaceId} ${paneId}`);
+    },
+    focusCmuxSurface: async (surfaceId: string) => {
+        events.push(`focus-surface ${surfaceId}`);
+    },
+}));
+
+function surface(overrides: Partial<CmuxLiveSurface> & Pick<CmuxLiveSurface, "id">): CmuxLiveSurface {
+    return { title: "zsh", type: "terminal", index: 0, selected: false, active: false, ...overrides };
+}
+
+function pane(overrides: Partial<CmuxLivePane> & Pick<CmuxLivePane, "id">): CmuxLivePane {
+    return {
+        workspaceId: "workspace:11",
+        title: "zsh",
+        active: false,
+        surfaceCount: 1,
+        surfaces: [],
+        ...overrides,
+    };
+}
+
+function setSnapshot(panes: CmuxLivePane[]): void {
+    snapshot = {
+        fetchedAt: "2026-08-19T13:00:00.000Z",
+        available: true,
+        workspaces: [{ id: "workspace:11", name: "GenesisTools" }],
+        panes,
+    };
+}
+
+function resumeScreen(sessionId: string): string {
+    return `cd -- '/repo' && tools claude start -- --resume '${sessionId}'`;
+}
+
+/** stdout is the machine result channel, and `out.result` writes it asynchronously. */
+async function capturedResult(): Promise<string> {
+    await out.flush();
+    return stdout.join("");
+}
+
+beforeEach(() => {
+    events = [];
+    stdout = [];
+    setSnapshot([]);
+    originalWrite = process.stdout.write;
+    process.stdout.write = ((
+        chunk: string | Uint8Array,
+        encodingOrCallback?: unknown,
+        callback?: (err?: Error | null) => void
+    ) => {
+        stdout.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+
+        // `out.result` awaits this callback. A stub that drops it hangs the test instead of
+        // failing it, which is how the first version of this file timed out.
+        const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+
+        if (typeof done === "function") {
+            (done as (err?: Error | null) => void)(null);
+        }
+
+        return true;
+    }) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+    process.stdout.write = originalWrite;
+    // The command sets this on its failure paths; leaving it set would fail the whole run.
+    process.exitCode = 0;
+});
+
+async function runFocus(
+    query: string,
+    opts: Record<string, boolean> = {}
+): Promise<{ exitCode: number; result: string }> {
+    const { focusCommand } = await import("@app/claude/commands/cmux/focus");
+    // Never let a test raise the real cmux app: `activateApp()` shells out to `open -b`.
+    await focusCommand(query, { activate: false, ...opts });
+
+    return { exitCode: process.exitCode === undefined ? 0 : Number(process.exitCode), result: await capturedResult() };
+}
+
+describe("focusCommand", () => {
+    test("--json with no match exits nonzero and focuses nothing", async () => {
+        // The bug: this path emitted `{ focused: null }` and returned, so Commander exited
+        // 0 and anything scripting the command read a miss as a success.
+        setSnapshot([pane({ id: "pane:33", title: "unrelated" })]);
+
+        const { exitCode, result } = await runFocus(SESSION_A, { json: true });
+
+        expect(exitCode).toBe(1);
+        expect(result).toContain(`"focused": null`);
+        expect(events).toEqual(["identify"]);
+    });
+
+    test("--json with a match still exits 0", async () => {
+        setSnapshot([pane({ id: "pane:33", preview: resumeScreen(SESSION_A) })]);
+
+        const { exitCode, result } = await runFocus(SESSION_A, { json: true });
+
+        expect(exitCode).toBe(0);
+        expect(result).toContain(`"paneId": "pane:33"`);
+    });
+
+    test("--json with an ambiguous match exits nonzero and focuses nothing", async () => {
+        setSnapshot([pane({ id: "pane:33", title: "build" }), pane({ id: "pane:34", title: "build" })]);
+
+        const { exitCode, result } = await runFocus("build", { json: true });
+
+        expect(exitCode).toBe(1);
+        expect(result).toContain(`"ambiguous": true`);
+        expect(events).toEqual(["identify"]);
+    });
+
+    test("--dry-run resolves a target but performs no cmux mutation", async () => {
+        setSnapshot([pane({ id: "pane:33", preview: resumeScreen(SESSION_A) })]);
+
+        const { exitCode, result } = await runFocus(SESSION_A, { json: true, dryRun: true });
+
+        expect(exitCode).toBe(0);
+        expect(result).toContain(`"wouldFocus"`);
+        expect(events).toEqual(["identify"]);
+    });
+
+    test("raises the window, then the pane, then the tab the match came from", async () => {
+        setSnapshot([
+            pane({
+                id: "pane:33",
+                preview: "another tab's output",
+                surfaces: [
+                    surface({ id: "surface:45", selected: true }),
+                    surface({ id: "surface:46", title: "hidden", preview: resumeScreen(SESSION_A) }),
+                ],
+            }),
+        ]);
+
+        await runFocus(SESSION_A);
+
+        expect(events).toEqual([
+            "identify",
+            "identify --workspace workspace:11",
+            "focus-window --window window:1",
+            "focus-pane workspace:11 pane:33",
+            "focus-surface surface:46",
+        ]);
+    });
+
+    test("a match on the pane's own screen switches no tab", async () => {
+        setSnapshot([pane({ id: "pane:33", preview: resumeScreen(SESSION_A) })]);
+
+        await runFocus(SESSION_A);
+
+        expect(events).not.toContain("focus-surface surface:45");
+        expect(events.filter((event) => event.startsWith("focus-surface"))).toEqual([]);
+    });
+
+    test("the calling pane is skipped by default and searched with --include-self", async () => {
+        // Typing the query puts it on the caller's own screen, so without the exclusion any
+        // query at all matches the pane it was run from.
+        setSnapshot([pane({ id: CALLER_PANE, preview: "$ tools claude cmux focus zzz-nope" })]);
+
+        expect((await runFocus("zzz-nope", { json: true })).exitCode).toBe(1);
+
+        process.exitCode = 0;
+        events = [];
+        stdout = [];
+
+        const included = await runFocus("zzz-nope", { json: true, includeSelf: true });
+
+        expect(included.exitCode).toBe(0);
+        expect(included.result).toContain(`"paneId": "${CALLER_PANE}"`);
+    });
+});

--- a/src/claude/commands/cmux/focus.ts
+++ b/src/claude/commands/cmux/focus.ts
@@ -1,0 +1,233 @@
+import { describeMatch, type FocusTarget, findFocusTargets, isUnambiguous } from "@app/claude/lib/cmux/focus";
+import * as p from "@clack/prompts";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { focusCmuxPane } from "@genesiscz/utils/cmux/lib/controls";
+import { fetchCmuxLiveSnapshot } from "@genesiscz/utils/cmux/lib/live-snapshot";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger, out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import pc from "picocolors";
+
+const { log } = logger.scoped("claude-cmux-focus");
+
+export interface FocusOptions {
+    activate?: boolean;
+    json?: boolean;
+    dryRun?: boolean;
+    first?: boolean;
+    includeSelf?: boolean;
+}
+
+interface IdentifyResponse {
+    bundle_identifier?: string;
+    caller?: { window_ref?: string; pane_ref?: string };
+}
+
+/**
+ * The pane this process is running in, when it is running inside cmux at all.
+ *
+ * Needed because typing the query puts it on the caller's own screen, so without this the
+ * weak text rule matches the calling pane for every query.
+ */
+async function callerPaneRef(): Promise<string | undefined> {
+    try {
+        const identify = await runCmuxJSON<IdentifyResponse>(["identify"]);
+        return identify.caller?.pane_ref;
+    } catch (err) {
+        log.debug({ err }, "could not identify the calling pane; searching every pane");
+        return undefined;
+    }
+}
+
+/**
+ * The cmux window that owns `workspaceRef`.
+ *
+ * `identify --workspace <ref>` answers for the workspace you name rather than the one you
+ * are calling from, so this works when the pane lives in a window you are not in — which
+ * is the whole point of a focus command.
+ */
+async function windowRefFor(workspaceRef: string): Promise<string | undefined> {
+    try {
+        const identify = await runCmuxJSON<IdentifyResponse>(["identify", "--workspace", workspaceRef]);
+        return identify.caller?.window_ref;
+    } catch (err) {
+        log.debug({ err, workspaceRef }, "could not resolve the owning window; focusing without it");
+        return undefined;
+    }
+}
+
+/** Raise the cmux app itself, so a focused pane is actually on screen. */
+async function activateApp(): Promise<boolean> {
+    if (process.platform !== "darwin") {
+        log.debug({ platform: process.platform }, "app activation is macOS-only; skipped");
+        return false;
+    }
+
+    try {
+        const identify = await runCmuxJSON<IdentifyResponse>(["identify"]);
+        const bundleId = identify.bundle_identifier;
+
+        if (!bundleId) {
+            log.debug("identify returned no bundle_identifier; cannot raise the app");
+            return false;
+        }
+
+        const proc = Bun.spawn(["open", "-b", bundleId], { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+        const code = await proc.exited;
+
+        if (code !== 0) {
+            log.warn({ bundleId, code, stderr: await new Response(proc.stderr).text() }, "open -b failed");
+            return false;
+        }
+
+        log.debug({ bundleId }, "raised the cmux app");
+        return true;
+    } catch (err) {
+        log.debug({ err }, "app activation failed");
+        return false;
+    }
+}
+
+function renderTargets(targets: FocusTarget[]): void {
+    const table = createBoxTable(["WORKSPACE", "PANE", "MATCHED ON", "SESSION", "CWD"]);
+
+    for (const target of targets) {
+        table.push([
+            pc.white(target.workspaceName),
+            target.active ? pc.green(`${target.paneId} (active)`) : pc.dim(target.paneId),
+            pc.cyan(describeMatch(target)),
+            target.sessionIds.length > 0 ? pc.magenta(target.sessionIds[0].slice(0, 8)) : pc.dim("none"),
+            truncateDisplay(target.cwd ?? "", 40),
+        ]);
+    }
+
+    out.println(table.toString());
+}
+
+async function pickTarget(targets: FocusTarget[]): Promise<FocusTarget | null> {
+    const choice = await p.select({
+        message: "Which pane should I focus?",
+        initialValue: targets[0].paneId,
+        options: targets.map((target) => ({
+            value: target.paneId,
+            label: `${target.workspaceName} · ${target.paneId}`,
+            hint: `${describeMatch(target)}${target.sessionIds.length > 0 ? ` · ${target.sessionIds[0].slice(0, 8)}` : ""}`,
+        })),
+    });
+
+    if (p.isCancel(choice)) {
+        return null;
+    }
+
+    return targets.find((target) => target.paneId === choice) ?? null;
+}
+
+/**
+ * Focus the cmux pane a session is already open in.
+ *
+ * This never creates anything. A session with no pane is a `restore` job, and saying so
+ * beats silently opening a second copy of a session that is already running somewhere.
+ */
+export async function focusCommand(query: string, opts: FocusOptions): Promise<void> {
+    const snapshot = await fetchCmuxLiveSnapshot();
+
+    if (!snapshot.available) {
+        out.error(pc.red(`cmux is not reachable${snapshot.error ? `: ${snapshot.error}` : "."}`));
+        out.printlnErr(pc.dim("  Start cmux, then run this again."));
+        process.exit(1);
+    }
+
+    const excludePaneId = opts.includeSelf ? undefined : await callerPaneRef();
+    const targets = findFocusTargets(snapshot, query, { excludePaneId });
+    log.debug({ query, panes: snapshot.panes.length, matches: targets.length, excludePaneId }, "focus match");
+
+    if (targets.length === 0) {
+        if (opts.json) {
+            out.result(SafeJSON.stringify({ query, focused: null, matches: [] }, null, 2));
+            return;
+        }
+
+        out.error(pc.red(`No cmux pane matches "${query}".`));
+        out.printlnErr(pc.dim(`  Searched ${snapshot.panes.length} pane(s) across ${snapshot.workspaces.length}.`));
+        out.printlnErr(
+            pc.dim(
+                `  If the session is not open anywhere, reopen it: ${suggestCommand("tools claude", { replaceCommand: ["cmux", "restore"] })}`
+            )
+        );
+        process.exit(1);
+    }
+
+    let target = targets[0];
+
+    if (!isUnambiguous(targets) && !opts.first) {
+        if (opts.json) {
+            out.result(SafeJSON.stringify({ query, focused: null, ambiguous: true, matches: targets }, null, 2));
+            return;
+        }
+
+        renderCliHeader("Several panes match", query);
+        renderTargets(targets);
+
+        if (!isInteractive()) {
+            out.error(pc.red("Ambiguous match, and there is no TTY to ask on."));
+            out.printlnErr(
+                pc.dim(
+                    `  Narrow the query (a session id always wins), or take the top hit: ${suggestCommand("tools claude", { replaceCommand: ["cmux", "focus", query, "--first"] })}`
+                )
+            );
+            process.exit(1);
+        }
+
+        const picked = await pickTarget(targets);
+
+        if (!picked) {
+            out.printlnErr(pc.dim("Nothing picked, nothing focused."));
+            return;
+        }
+
+        target = picked;
+    }
+
+    if (opts.dryRun) {
+        const plan = {
+            query,
+            wouldFocus: target,
+            activate: opts.activate !== false,
+        };
+
+        if (opts.json) {
+            out.result(SafeJSON.stringify(plan, null, 2));
+            return;
+        }
+
+        renderCliHeader("Dry run", "nothing was focused");
+        renderTargets([target]);
+        return;
+    }
+
+    const windowRef = await windowRefFor(target.workspaceId);
+
+    if (windowRef) {
+        await runCmuxOk(["focus-window", "--window", windowRef]);
+    }
+
+    await focusCmuxPane({ workspaceId: target.workspaceId, paneId: target.paneId });
+
+    const activated = opts.activate === false ? false : await activateApp();
+
+    if (opts.json) {
+        out.result(SafeJSON.stringify({ query, focused: target, windowRef, activated }, null, 2));
+        return;
+    }
+
+    const session = target.sessionIds.length > 0 ? pc.magenta(target.sessionIds[0].slice(0, 8)) : pc.dim("no session");
+    out.printlnErr(
+        `${pc.green("✔")} ${pc.bold(target.workspaceName)} ${pc.dim(target.paneId)} ${session} ` +
+            pc.dim(`(matched on ${describeMatch(target)})`)
+    );
+
+    if (!activated && opts.activate !== false) {
+        out.printlnErr(pc.dim("  Pane focused, but the cmux app could not be raised. Switch to it by hand."));
+    }
+}

--- a/src/claude/commands/cmux/focus.ts
+++ b/src/claude/commands/cmux/focus.ts
@@ -2,7 +2,7 @@ import { describeMatch, type FocusTarget, findFocusTargets, isUnambiguous } from
 import * as p from "@clack/prompts";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
-import { focusCmuxPane } from "@genesiscz/utils/cmux/lib/controls";
+import { focusCmuxPane, focusCmuxSurface } from "@genesiscz/utils/cmux/lib/controls";
 import { fetchCmuxLiveSnapshot } from "@genesiscz/utils/cmux/lib/live-snapshot";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
@@ -144,6 +144,9 @@ export async function focusCommand(query: string, opts: FocusOptions): Promise<v
 
     if (targets.length === 0) {
         if (opts.json) {
+            // Same failure as the human path below, so it has to carry the same exit code.
+            // `{ focused: null }` on exit 0 reads as success to anything scripting this.
+            process.exitCode = 1;
             out.result(SafeJSON.stringify({ query, focused: null, matches: [] }, null, 2));
             return;
         }
@@ -162,6 +165,9 @@ export async function focusCommand(query: string, opts: FocusOptions): Promise<v
 
     if (!isUnambiguous(targets) && !opts.first) {
         if (opts.json) {
+            // Nothing was focused, and `--json` has no TTY to disambiguate on, so this is
+            // the same failure the non-TTY human path exits 1 for.
+            process.exitCode = 1;
             out.result(SafeJSON.stringify({ query, focused: null, ambiguous: true, matches: targets }, null, 2));
             return;
         }
@@ -213,6 +219,17 @@ export async function focusCommand(query: string, opts: FocusOptions): Promise<v
     }
 
     await focusCmuxPane({ workspaceId: target.workspaceId, paneId: target.paneId });
+
+    if (target.surfaceId) {
+        // The match came from a background tab. Without this the pane is focused and the
+        // command claims success while the user still looks at a different surface.
+        try {
+            await focusCmuxSurface(target.surfaceId);
+        } catch (err) {
+            log.warn({ err, surfaceId: target.surfaceId }, "could not focus the matched surface");
+            out.printlnErr(pc.dim("  The pane is focused, but its matching tab could not be raised."));
+        }
+    }
 
     const activated = opts.activate === false ? false : await activateApp();
 

--- a/src/claude/commands/cmux/focus.ts
+++ b/src/claude/commands/cmux/focus.ts
@@ -224,7 +224,7 @@ export async function focusCommand(query: string, opts: FocusOptions): Promise<v
         // The match came from a background tab. Without this the pane is focused and the
         // command claims success while the user still looks at a different surface.
         try {
-            await focusCmuxSurface(target.surfaceId);
+            await focusCmuxSurface({ surfaceId: target.surfaceId });
         } catch (err) {
             log.warn({ err, surfaceId: target.surfaceId }, "could not focus the matched surface");
             out.printlnErr(pc.dim("  The pane is focused, but its matching tab could not be raised."));

--- a/src/claude/commands/cmux/index.ts
+++ b/src/claude/commands/cmux/index.ts
@@ -1,4 +1,5 @@
 import { type Command, Option } from "commander";
+import { focusCommand } from "./focus";
 import { pinsCommand } from "./pins";
 import { restoreCommand } from "./restore";
 import { forgetCommand, listCommand, snapshotCommand } from "./snapshot";
@@ -30,6 +31,15 @@ export function registerCmuxCommand(program: Command): void {
         .option("--dry-run", "Print the plan and stop")
         .option("-y, --yes", "Skip the picker and the confirmation")
         .action(restoreCommand);
+
+    cmux.command("focus <session>")
+        .description("Focus the cmux pane a session is already open in, and raise the app")
+        .option("--no-activate", "Focus the pane without bringing the cmux app to the front")
+        .option("--first", "Take the best match instead of asking when several panes match")
+        .option("--include-self", "Also consider the pane this command runs in (excluded by default)")
+        .option("--dry-run", "Print what would be focused and stop")
+        .option("--json", "Emit the match as JSON instead of a status line")
+        .action(focusCommand);
 
     cmux.command("snapshot [name]")
         .description("Save the currently-active sessions as a named set you can restore after a crash")

--- a/src/claude/lib/cmux/focus.test.ts
+++ b/src/claude/lib/cmux/focus.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test } from "bun:test";
+import {
+    describeMatch,
+    findFocusTargets,
+    isUnambiguous,
+    resumedSessionIdsIn,
+    sessionIdsIn,
+} from "@app/claude/lib/cmux/focus";
+import type { CmuxLivePane, CmuxLiveSnapshot } from "@genesiscz/utils/cmux/lib/live-snapshot";
+
+const SESSION_A = "8b6e69bf-0efc-4990-ba3e-b77262498421";
+const SESSION_B = "f013e93c-a367-46e6-add2-4c026b9cf667";
+
+/** The real shape of a restored pane's screen, copied from a live `cmux read-screen`. */
+function resumeScreen(sessionId: string, cwd = "/Users/Martin/Tresors/Projects/GenesisTools"): string {
+    return `Last login: Wed Aug 19 12:48:46 on ttys025\ncd -- '${cwd}' && tools claude start -- --resume '${sessionId}'`;
+}
+
+function pane(overrides: Partial<CmuxLivePane> & Pick<CmuxLivePane, "id" | "workspaceId">): CmuxLivePane {
+    return {
+        title: "zsh",
+        active: false,
+        surfaceCount: 1,
+        surfaces: [],
+        ...overrides,
+    };
+}
+
+function snapshot(
+    panes: CmuxLivePane[],
+    workspaces = [{ id: "workspace:11", name: "GenesisTools" }]
+): CmuxLiveSnapshot {
+    return { fetchedAt: "2026-08-19T13:00:00.000Z", available: true, workspaces, panes };
+}
+
+describe("sessionIdsIn", () => {
+    test("pulls the id out of a resume command, quotes and all", () => {
+        expect(sessionIdsIn(resumeScreen(SESSION_A))).toEqual([SESSION_A]);
+    });
+
+    test("dedupes and lowercases", () => {
+        const text = `${SESSION_A.toUpperCase()} ${SESSION_A}`;
+        expect(sessionIdsIn(text)).toEqual([SESSION_A]);
+    });
+
+    test("finds nothing in text with no id", () => {
+        expect(sessionIdsIn("just a prompt")).toEqual([]);
+    });
+});
+
+describe("findFocusTargets", () => {
+    test("a full session id matches the pane resuming it", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+                pane({ id: "pane:34", workspaceId: "workspace:11", preview: resumeScreen(SESSION_B) }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets).toHaveLength(1);
+        expect(targets[0].paneId).toBe("pane:33");
+        expect(targets[0].matchedOn).toBe("resume-command");
+        expect(targets[0].sessionIds).toEqual([SESSION_A]);
+    });
+
+    test("the 8-character short form matches as a prefix", () => {
+        const targets = findFocusTargets(
+            snapshot([pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) })]),
+            SESSION_A.slice(0, 8)
+        );
+
+        expect(targets[0].matchedOn).toBe("resume-prefix");
+    });
+
+    test("a prefix shorter than 8 characters does NOT match an id", () => {
+        const targets = findFocusTargets(
+            snapshot([pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) })]),
+            "8b6"
+        );
+
+        // It may still match as screen text, but never as an id — that is the guard
+        // against a short hex fragment focusing an unrelated pane.
+        for (const target of targets) {
+            expect(target.matchedOn).not.toBe("resume-command");
+            expect(target.matchedOn).not.toBe("resume-prefix");
+            expect(target.matchedOn).not.toBe("session-id");
+            expect(target.matchedOn).not.toBe("id-prefix");
+        }
+    });
+
+    test("an id beats a title that also matches", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({ id: "pane:34", workspaceId: "workspace:11", title: `notes about ${SESSION_A}` }),
+                pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets[0].paneId).toBe("pane:33");
+        expect(targets[0].matchedOn).toBe("resume-command");
+    });
+
+    test("the pane RESUMING a session beats a pane that only printed its id", () => {
+        // Found live: an agent pane that had been discussing session ids matched the same
+        // query as the pane actually running the session, so every focus asked which one.
+        const targets = findFocusTargets(
+            snapshot(
+                [
+                    pane({
+                        id: "pane:2",
+                        workspaceId: "workspace:1",
+                        preview: `I looked it up: the session is ${SESSION_A}, on the foltyn account.`,
+                    }),
+                    pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+                ],
+                [
+                    { id: "workspace:1", name: "DevDashboard" },
+                    { id: "workspace:11", name: "GenesisTools" },
+                ]
+            ),
+            SESSION_A
+        );
+
+        expect(targets).toHaveLength(2);
+        expect(targets[0].paneId).toBe("pane:33");
+        expect(targets[0].matchedOn).toBe("resume-command");
+        expect(targets[1].matchedOn).toBe("session-id");
+        expect(isUnambiguous(targets)).toBe(true);
+    });
+
+    test("resume detection accepts unquoted and = forms", () => {
+        expect(resumedSessionIdsIn(`claude --resume ${SESSION_A}`)).toEqual([SESSION_A]);
+        expect(resumedSessionIdsIn(`claude --resume="${SESSION_A}"`)).toEqual([SESSION_A]);
+        expect(resumedSessionIdsIn(`the id is ${SESSION_A}`)).toEqual([]);
+    });
+
+    test("matches a pane title, a workspace name and a cwd", () => {
+        const panes = [pane({ id: "pane:33", workspaceId: "workspace:11", title: "vitest", cwd: "/repo/api" })];
+
+        expect(findFocusTargets(snapshot(panes), "vitest")[0].matchedOn).toBe("pane-title");
+        expect(findFocusTargets(snapshot(panes), "GenesisTools")[0].matchedOn).toBe("workspace");
+        expect(findFocusTargets(snapshot(panes), "api")[0].matchedOn).toBe("cwd");
+    });
+
+    test("searches surface titles and surface screens, not only the pane preview", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    surfaces: [
+                        {
+                            id: "surface:45",
+                            title: "tab two",
+                            type: "terminal",
+                            index: 1,
+                            selected: false,
+                            active: false,
+                            preview: resumeScreen(SESSION_B),
+                        },
+                    ],
+                }),
+            ]),
+            SESSION_B
+        );
+
+        expect(targets).toHaveLength(1);
+        expect(targets[0].matchedOn).toBe("resume-command");
+    });
+
+    test("an active pane wins a score tie", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({ id: "pane:33", workspaceId: "workspace:11", title: "build" }),
+                pane({ id: "pane:34", workspaceId: "workspace:11", title: "build", active: true }),
+            ]),
+            "build"
+        );
+
+        expect(targets[0].paneId).toBe("pane:34");
+    });
+
+    test("excludePaneId drops the calling pane, so a query cannot match itself", () => {
+        // The live bug: running `focus zzz-not-a-session` from a cmux pane put that string
+        // on the caller's screen, the weak text rule matched it, and the command reported a
+        // confident hit and focused the pane it was typed in.
+        const panes = [
+            pane({ id: "pane:2", workspaceId: "workspace:1", preview: "$ tools claude cmux focus zzz-nope" }),
+        ];
+
+        expect(findFocusTargets(snapshot(panes), "zzz-nope")).toHaveLength(1);
+        expect(findFocusTargets(snapshot(panes), "zzz-nope", { excludePaneId: "pane:2" })).toEqual([]);
+    });
+
+    test("excludePaneId leaves other panes alone", () => {
+        const panes = [
+            pane({ id: "pane:2", workspaceId: "workspace:1", preview: "$ tools claude cmux focus abc" }),
+            pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+        ];
+        const targets = findFocusTargets(snapshot(panes), SESSION_A, { excludePaneId: "pane:2" });
+
+        expect(targets).toHaveLength(1);
+        expect(targets[0].paneId).toBe("pane:33");
+    });
+
+    test("an empty or whitespace query matches nothing", () => {
+        const panes = [pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) })];
+
+        expect(findFocusTargets(snapshot(panes), "")).toEqual([]);
+        expect(findFocusTargets(snapshot(panes), "   ")).toEqual([]);
+    });
+
+    test("falls back to the workspace id when the workspace has no name entry", () => {
+        const targets = findFocusTargets(
+            snapshot([pane({ id: "pane:1", workspaceId: "workspace:99", title: "build" })], []),
+            "build"
+        );
+
+        expect(targets[0].workspaceName).toBe("workspace:99");
+    });
+});
+
+describe("isUnambiguous", () => {
+    test("no matches is not unambiguous", () => {
+        expect(isUnambiguous([])).toBe(false);
+    });
+
+    test("one match is unambiguous", () => {
+        const targets = findFocusTargets(
+            snapshot([pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) })]),
+            SESSION_A
+        );
+
+        expect(isUnambiguous(targets)).toBe(true);
+    });
+
+    test("one id match plus weaker text matches is still unambiguous", () => {
+        const short = SESSION_A.slice(0, 8);
+        const targets = findFocusTargets(
+            snapshot([
+                // Resuming the session: an id match.
+                pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+                // Only mentions the id in its title, e.g. a notes pane. Weaker on purpose.
+                pane({ id: "pane:34", workspaceId: "workspace:11", title: `notes ${short}` }),
+            ]),
+            short
+        );
+
+        expect(targets).toHaveLength(2);
+        expect(targets[0].paneId).toBe("pane:33");
+        expect(targets[0].matchedOn).toBe("resume-prefix");
+        expect(targets[1].matchedOn).toBe("pane-title");
+        expect(isUnambiguous(targets)).toBe(true);
+    });
+
+    test("two panes showing the same id is ambiguous", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+                pane({ id: "pane:34", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets).toHaveLength(2);
+        expect(isUnambiguous(targets)).toBe(false);
+    });
+
+    test("two equal-scoring text matches are ambiguous", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({ id: "pane:33", workspaceId: "workspace:11", title: "build" }),
+                pane({ id: "pane:34", workspaceId: "workspace:11", title: "build" }),
+            ]),
+            "build"
+        );
+
+        expect(isUnambiguous(targets)).toBe(false);
+    });
+});
+
+describe("describeMatch", () => {
+    test("names every match kind", () => {
+        const kinds = [
+            "resume-command",
+            "resume-prefix",
+            "session-id",
+            "id-prefix",
+            "pane-title",
+            "workspace",
+            "cwd",
+            "screen",
+        ] as const;
+
+        for (const kind of kinds) {
+            const described = describeMatch({
+                workspaceId: "workspace:1",
+                workspaceName: "ws",
+                paneId: "pane:1",
+                paneTitle: "t",
+                sessionIds: [],
+                matchedOn: kind,
+                score: 1,
+                active: false,
+            });
+
+            expect(described.length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/src/claude/lib/cmux/focus.test.ts
+++ b/src/claude/lib/cmux/focus.test.ts
@@ -3,10 +3,11 @@ import {
     describeMatch,
     findFocusTargets,
     isUnambiguous,
+    paneSessionIds,
     resumedSessionIdsIn,
     sessionIdsIn,
 } from "@app/claude/lib/cmux/focus";
-import type { CmuxLivePane, CmuxLiveSnapshot } from "@genesiscz/utils/cmux/lib/live-snapshot";
+import type { CmuxLivePane, CmuxLiveSnapshot, CmuxLiveSurface } from "@genesiscz/utils/cmux/lib/live-snapshot";
 
 const SESSION_A = "8b6e69bf-0efc-4990-ba3e-b77262498421";
 const SESSION_B = "f013e93c-a367-46e6-add2-4c026b9cf667";
@@ -16,12 +17,33 @@ function resumeScreen(sessionId: string, cwd = "/Users/Martin/Tresors/Projects/G
     return `Last login: Wed Aug 19 12:48:46 on ttys025\ncd -- '${cwd}' && tools claude start -- --resume '${sessionId}'`;
 }
 
+/** A restored tab title, as `paneTitle()` writes it: the readable name, then the short id. */
+function restoredTitle(sessionId: string, name = "burn the auth callback"): string {
+    return `${name} · ${sessionId.slice(0, 8)}`;
+}
+
+/** What a restored pane looks like once its Claude TUI has scrolled the resume command away. */
+function busyTuiScreen(): string {
+    return "╭─ Claude Code ─╮\n│ > continue    │\n╰───────────────╯";
+}
+
 function pane(overrides: Partial<CmuxLivePane> & Pick<CmuxLivePane, "id" | "workspaceId">): CmuxLivePane {
     return {
         title: "zsh",
         active: false,
         surfaceCount: 1,
         surfaces: [],
+        ...overrides,
+    };
+}
+
+function surface(overrides: Partial<CmuxLiveSurface> & Pick<CmuxLiveSurface, "id">): CmuxLiveSurface {
+    return {
+        title: "zsh",
+        type: "terminal",
+        index: 0,
+        selected: false,
+        active: false,
         ...overrides,
     };
 }
@@ -45,6 +67,26 @@ describe("sessionIdsIn", () => {
 
     test("finds nothing in text with no id", () => {
         expect(sessionIdsIn("just a prompt")).toEqual([]);
+    });
+});
+
+describe("paneSessionIds", () => {
+    test("the session the pane is RESUMING comes first, whatever the screen order", () => {
+        // Callers render sessionIds[0] as "the session in this pane". A pane that printed
+        // another id above its own resume command would otherwise report that other one in
+        // the status line, the picker hint and the table.
+        const text = `I looked up ${SESSION_B} for you\n${resumeScreen(SESSION_A)}`;
+
+        expect(sessionIdsIn(text)).toEqual([SESSION_B, SESSION_A]);
+        expect(paneSessionIds(text)).toEqual([SESSION_A, SESSION_B]);
+    });
+
+    test("keeps screen order when nothing is being resumed", () => {
+        expect(paneSessionIds(`${SESSION_B} then ${SESSION_A}`)).toEqual([SESSION_B, SESSION_A]);
+    });
+
+    test("never repeats an id that is both resumed and mentioned", () => {
+        expect(paneSessionIds(`${SESSION_A}\n${resumeScreen(SESSION_A)}`)).toEqual([SESSION_A]);
     });
 });
 
@@ -84,6 +126,7 @@ describe("findFocusTargets", () => {
         for (const target of targets) {
             expect(target.matchedOn).not.toBe("resume-command");
             expect(target.matchedOn).not.toBe("resume-prefix");
+            expect(target.matchedOn).not.toBe("title-id");
             expect(target.matchedOn).not.toBe("session-id");
             expect(target.matchedOn).not.toBe("id-prefix");
         }
@@ -205,6 +248,108 @@ describe("findFocusTargets", () => {
         expect(targets[0].paneId).toBe("pane:33");
     });
 
+    test("a full id still finds a busy pane whose resume command has scrolled away", () => {
+        // cmux only exposes the visible viewport, so an active Claude TUI displaces the
+        // `--resume <uuid>` line within seconds. Before this, `focus <full-uuid>` reported
+        // no match for exactly the long-running sessions you most want to jump to.
+        const targets = findFocusTargets(
+            snapshot([
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    title: restoredTitle(SESSION_A),
+                    preview: busyTuiScreen(),
+                }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets).toHaveLength(1);
+        expect(targets[0].matchedOn).toBe("title-id");
+    });
+
+    test("the tab-title id beats a pane that only printed the id, with no prompt", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({ id: "pane:2", workspaceId: "workspace:11", preview: `the session is ${SESSION_A}` }),
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    title: restoredTitle(SESSION_A),
+                    preview: busyTuiScreen(),
+                }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets[0].paneId).toBe("pane:33");
+        expect(targets[0].matchedOn).toBe("title-id");
+        expect(isUnambiguous(targets)).toBe(true);
+    });
+
+    test("a tab-title id only matches queries at least 8 characters long", () => {
+        const panes = [
+            pane({ id: "pane:33", workspaceId: "workspace:11", title: restoredTitle(SESSION_A), preview: "" }),
+        ];
+
+        expect(findFocusTargets(snapshot(panes), SESSION_A.slice(0, 8))[0].matchedOn).toBe("title-id");
+        expect(findFocusTargets(snapshot(panes), SESSION_A.slice(0, 7))[0].matchedOn).toBe("pane-title");
+    });
+
+    test("a match on a background tab carries that surface, so the caller can raise it", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    preview: "some other tab's output",
+                    surfaces: [
+                        surface({ id: "surface:45", selected: true, title: "zsh" }),
+                        surface({ id: "surface:46", title: "hidden", preview: resumeScreen(SESSION_A) }),
+                    ],
+                }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets[0].matchedOn).toBe("resume-command");
+        expect(targets[0].surfaceId).toBe("surface:46");
+    });
+
+    test("a match on the pane's own text carries no surface, so no tab gets switched", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    preview: resumeScreen(SESSION_A),
+                    surfaces: [surface({ id: "surface:45", selected: true, preview: resumeScreen(SESSION_A) })],
+                }),
+            ]),
+            SESSION_A
+        );
+
+        expect(targets[0].surfaceId).toBeUndefined();
+    });
+
+    test("the visible tab wins a tie against a background tab", () => {
+        const targets = findFocusTargets(
+            snapshot([
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    surfaces: [
+                        surface({ id: "surface:46", title: "build" }),
+                        surface({ id: "surface:45", selected: true, title: "build" }),
+                    ],
+                }),
+            ]),
+            "build"
+        );
+
+        expect(targets[0].surfaceId).toBe("surface:45");
+    });
+
     test("an empty or whitespace query matches nothing", () => {
         const panes = [pane({ id: "pane:33", workspaceId: "workspace:11", preview: resumeScreen(SESSION_A) })];
 
@@ -286,6 +431,7 @@ describe("describeMatch", () => {
         const kinds = [
             "resume-command",
             "resume-prefix",
+            "title-id",
             "session-id",
             "id-prefix",
             "pane-title",

--- a/src/claude/lib/cmux/focus.test.ts
+++ b/src/claude/lib/cmux/focus.test.ts
@@ -296,6 +296,30 @@ describe("findFocusTargets", () => {
         expect(findFocusTargets(snapshot(panes), SESSION_A.slice(0, 7))[0].matchedOn).toBe("pane-title");
     });
 
+    test("the MATCHED tab's session is reported, not the visible tab's", () => {
+        // Two resumed surfaces in one pane. Ordering session ids by scope alone would put
+        // the selected tab's session first, so the status line, the picker hint and the JSON
+        // would all name session A while the command focuses B's tab.
+        const targets = findFocusTargets(
+            snapshot([
+                pane({
+                    id: "pane:33",
+                    workspaceId: "workspace:11",
+                    surfaces: [
+                        surface({ id: "surface:45", selected: true, preview: resumeScreen(SESSION_A) }),
+                        surface({ id: "surface:46", preview: resumeScreen(SESSION_B) }),
+                    ],
+                }),
+            ]),
+            SESSION_B
+        );
+
+        expect(targets[0].surfaceId).toBe("surface:46");
+        expect(targets[0].sessionIds[0]).toBe(SESSION_B);
+        // Still a full inventory of the pane, just ordered by what matched.
+        expect(targets[0].sessionIds).toContain(SESSION_A);
+    });
+
     test("a match on a background tab carries that surface, so the caller can raise it", () => {
         const targets = findFocusTargets(
             snapshot([

--- a/src/claude/lib/cmux/focus.ts
+++ b/src/claude/lib/cmux/focus.ts
@@ -1,0 +1,268 @@
+import { basename } from "node:path";
+import type { CmuxLivePane, CmuxLiveSnapshot } from "@genesiscz/utils/cmux/lib/live-snapshot";
+
+/** A UUID as it appears in a resume command, with or without the surrounding quotes. */
+const SESSION_ID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+/**
+ * `--resume <id>` as a restored pane prints it, e.g.
+ * `tools claude start -- --resume '8b6e69bf-0efc-4990-ba3e-b77262498421'`.
+ * Quotes are optional because a hand-typed resume usually has none.
+ */
+const RESUME_ID_RE = /--resume[=\s]+['"]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})['"]?/gi;
+
+/**
+ * Shortest prefix accepted as "this is a session id, not a word".
+ *
+ * A restored pane's screen holds the whole resume command, so a 3-character query
+ * would match a hex fragment inside some unrelated hash and focus the wrong pane.
+ * Eight is the short form printed everywhere else in this tool (`sessionId.slice(0, 8)`).
+ */
+const MIN_ID_PREFIX = 8;
+
+export type FocusMatchKind =
+    | "resume-command"
+    | "resume-prefix"
+    | "session-id"
+    | "id-prefix"
+    | "pane-title"
+    | "workspace"
+    | "cwd"
+    | "screen";
+
+export interface FindFocusOptions {
+    /** Pane to leave out of the search, normally the one this process runs in. */
+    excludePaneId?: string;
+}
+
+export interface FocusTarget {
+    workspaceId: string;
+    workspaceName: string;
+    paneId: string;
+    paneTitle: string;
+    cwd?: string;
+    /** Session ids found in this pane's text, newest occurrence last. Empty when none. */
+    sessionIds: string[];
+    /** Which signal matched, for the "focused X because Y" line and for --json. */
+    matchedOn: FocusMatchKind;
+    /** Higher wins. Ties break on the pane already being active, then on pane id. */
+    score: number;
+    active: boolean;
+}
+
+/** Every scrap of text a pane exposes: its own title plus each surface's title and screen. */
+function paneHaystack(pane: CmuxLivePane): string {
+    const parts = [pane.title, pane.preview ?? ""];
+
+    for (const surface of pane.surfaces) {
+        parts.push(surface.title, surface.preview ?? "", surface.url ?? "");
+    }
+
+    return parts.join("\n");
+}
+
+export function sessionIdsIn(text: string): string[] {
+    const found = text.match(SESSION_ID_RE);
+
+    if (!found) {
+        return [];
+    }
+
+    return [...new Set(found.map((id) => id.toLowerCase()))];
+}
+
+/**
+ * Session ids this pane is actually RESUMING, as opposed to merely displaying.
+ *
+ * The distinction is not academic. An agent pane that discussed a session id has that id
+ * on screen as plain text, so matching bare ids alone reports two hits for one session and
+ * turns every focus into a prompt. A resuming pane always shows `--resume <id>`, which the
+ * mentioning pane does not, so that is the signal worth ranking first.
+ */
+export function resumedSessionIdsIn(text: string): string[] {
+    const ids: string[] = [];
+
+    for (const match of text.matchAll(RESUME_ID_RE)) {
+        const id = match[1]?.toLowerCase();
+
+        if (id) {
+            ids.push(id);
+        }
+    }
+
+    return [...new Set(ids)];
+}
+
+function scorePane({
+    pane,
+    query,
+    workspaceName,
+}: {
+    pane: CmuxLivePane;
+    query: string;
+    workspaceName: string;
+}): { kind: FocusMatchKind; score: number } | null {
+    const haystack = paneHaystack(pane);
+    const resumed = resumedSessionIdsIn(haystack);
+    const ids = sessionIdsIn(haystack);
+    const needle = query.toLowerCase();
+    const longEnough = needle.length >= MIN_ID_PREFIX;
+
+    // The pane is running this session, not talking about it. Nothing outranks that.
+    if (resumed.includes(needle)) {
+        return { kind: "resume-command", score: 100 };
+    }
+
+    if (longEnough && resumed.some((id) => id.startsWith(needle))) {
+        return { kind: "resume-prefix", score: 95 };
+    }
+
+    // The id is on screen but not in a resume command: an agent pane that printed the id,
+    // a log, a note. Real evidence, but weaker than the pane actually running it.
+    if (ids.includes(needle)) {
+        return { kind: "session-id", score: 70 };
+    }
+
+    if (longEnough && ids.some((id) => id.startsWith(needle))) {
+        return { kind: "id-prefix", score: 65 };
+    }
+
+    if (pane.title.toLowerCase().includes(needle)) {
+        return { kind: "pane-title", score: 60 };
+    }
+
+    if (workspaceName.toLowerCase().includes(needle)) {
+        return { kind: "workspace", score: 50 };
+    }
+
+    const cwd = pane.cwd;
+
+    if (cwd && (cwd.toLowerCase().includes(needle) || basename(cwd).toLowerCase() === needle)) {
+        return { kind: "cwd", score: 40 };
+    }
+
+    // Last resort: the query is somewhere on the screen. Useful for "the pane where I
+    // was editing pricing.ts", noisy enough that it never outranks an id.
+    if (haystack.toLowerCase().includes(needle)) {
+        return { kind: "screen", score: 20 };
+    }
+
+    return null;
+}
+
+/**
+ * Panes matching `query`, best first.
+ *
+ * The query is matched against what a pane SHOWS, not against the session store, because
+ * the question this answers is "which pane already has this session open" — a session with
+ * no pane cannot be focused, and `restore` is the command for that case.
+ */
+export function findFocusTargets(
+    snapshot: CmuxLiveSnapshot,
+    query: string,
+    opts: FindFocusOptions = {}
+): FocusTarget[] {
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+        return [];
+    }
+
+    const names = new Map(snapshot.workspaces.map((workspace) => [workspace.id, workspace.name]));
+    const targets: FocusTarget[] = [];
+
+    for (const pane of snapshot.panes) {
+        // Skip the pane this command is running in. Typing the query puts it on that pane's
+        // screen, so the weak "text on screen" rule would match the caller for EVERY query
+        // — including a nonsense one, which then reports a confident hit instead of "no
+        // match". Found by running `focus zzz-not-a-session` from a cmux pane: it focused
+        // the calling pane. Focusing where you already are is a no-op anyway.
+        if (opts.excludePaneId && pane.id === opts.excludePaneId) {
+            continue;
+        }
+
+        const workspaceName = names.get(pane.workspaceId) ?? pane.workspaceId;
+        const hit = scorePane({ pane, query: trimmed, workspaceName });
+
+        if (!hit) {
+            continue;
+        }
+
+        targets.push({
+            workspaceId: pane.workspaceId,
+            workspaceName,
+            paneId: pane.id,
+            paneTitle: pane.title,
+            cwd: pane.cwd,
+            sessionIds: sessionIdsIn(paneHaystack(pane)),
+            matchedOn: hit.kind,
+            score: hit.score,
+            active: pane.active,
+        });
+    }
+
+    return targets.sort((a, b) => {
+        if (b.score !== a.score) {
+            return b.score - a.score;
+        }
+
+        if (a.active !== b.active) {
+            return a.active ? -1 : 1;
+        }
+
+        return a.paneId.localeCompare(b.paneId);
+    });
+}
+
+/**
+ * True when the top match is the only one worth focusing without asking.
+ *
+ * One pane RESUMING the session wins even when other panes merely print its id. Anything
+ * else needs the top score to stand alone.
+ */
+export function isUnambiguous(targets: FocusTarget[]): boolean {
+    if (targets.length === 0) {
+        return false;
+    }
+
+    if (targets.length === 1) {
+        return true;
+    }
+
+    const [first, second] = targets;
+
+    // A resume match is the pane RUNNING the session. One of those beats any number of
+    // panes that merely printed the id, which is the common case when an agent pane has
+    // been discussing session ids.
+    if (isResumeMatch(first)) {
+        return !isResumeMatch(second);
+    }
+
+    return first.score > second.score;
+}
+
+/** True when the pane is running the session, not just showing its id. */
+export function isResumeMatch(target: FocusTarget): boolean {
+    return target.matchedOn === "resume-command" || target.matchedOn === "resume-prefix";
+}
+
+export function describeMatch(target: FocusTarget): string {
+    switch (target.matchedOn) {
+        case "resume-command":
+            return "resuming this session";
+        case "resume-prefix":
+            return "resuming this session (id prefix)";
+        case "session-id":
+            return "session id on screen";
+        case "id-prefix":
+            return "session id prefix on screen";
+        case "pane-title":
+            return "pane title";
+        case "workspace":
+            return "workspace name";
+        case "cwd":
+            return "working directory";
+        case "screen":
+            return "text on screen";
+    }
+}

--- a/src/claude/lib/cmux/focus.ts
+++ b/src/claude/lib/cmux/focus.ts
@@ -12,6 +12,14 @@ const SESSION_ID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 const RESUME_ID_RE = /--resume[=\s]+['"]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})['"]?/gi;
 
 /**
+ * The ` · 8b6e69bf` marker `paneTitle()` puts at the end of every restored tab title.
+ *
+ * Anchored at the end because that function truncates a long name and never the id, so the
+ * marker is always the last thing in the title.
+ */
+const TITLE_SHORT_ID_RE = /·\s*([0-9a-f]{8})\s*$/i;
+
+/**
  * Shortest prefix accepted as "this is a session id, not a word".
  *
  * A restored pane's screen holds the whole resume command, so a 3-character query
@@ -23,6 +31,7 @@ const MIN_ID_PREFIX = 8;
 export type FocusMatchKind =
     | "resume-command"
     | "resume-prefix"
+    | "title-id"
     | "session-id"
     | "id-prefix"
     | "pane-title"
@@ -41,7 +50,14 @@ export interface FocusTarget {
     paneId: string;
     paneTitle: string;
     cwd?: string;
-    /** Session ids found in this pane's text, newest occurrence last. Empty when none. */
+    /**
+     * The surface (tab) the match came from, when it was not the pane's own visible text.
+     *
+     * Focusing the pane alone leaves whatever tab was already selected on top, so a caller
+     * has to focus this surface too or it reports success while the match stays hidden.
+     */
+    surfaceId?: string;
+    /** Session ids this pane shows, the one it is RESUMING first. Empty when none. */
     sessionIds: string[];
     /** Which signal matched, for the "focused X because Y" line and for --json. */
     matchedOn: FocusMatchKind;
@@ -50,15 +66,38 @@ export interface FocusTarget {
     active: boolean;
 }
 
+/** One block of text to match against, and the surface it came from when it came from one. */
+interface PaneScope {
+    surfaceId?: string;
+    title: string;
+    screen: string;
+}
+
+/**
+ * The pane's own text first, then its surfaces with the visible one ahead of the rest.
+ *
+ * Scoring per scope rather than over one merged blob is what lets a match name the tab it
+ * came from. Selected-first settles ties in favour of the tab the user already sees, so a
+ * focus never switches tabs unless a background one is a strictly better match.
+ */
+function paneScopes(pane: CmuxLivePane): PaneScope[] {
+    const surfaces = [...pane.surfaces].sort((a, b) => Number(b.selected) - Number(a.selected));
+
+    return [
+        { title: pane.title, screen: pane.preview ?? "" },
+        ...surfaces.map((surface) => ({
+            surfaceId: surface.id,
+            title: surface.title,
+            screen: [surface.preview ?? "", surface.url ?? ""].join("\n"),
+        })),
+    ];
+}
+
 /** Every scrap of text a pane exposes: its own title plus each surface's title and screen. */
 function paneHaystack(pane: CmuxLivePane): string {
-    const parts = [pane.title, pane.preview ?? ""];
-
-    for (const surface of pane.surfaces) {
-        parts.push(surface.title, surface.preview ?? "", surface.url ?? "");
-    }
-
-    return parts.join("\n");
+    return paneScopes(pane)
+        .map((scope) => `${scope.title}\n${scope.screen}`)
+        .join("\n");
 }
 
 export function sessionIdsIn(text: string): string[] {
@@ -93,20 +132,30 @@ export function resumedSessionIdsIn(text: string): string[] {
     return [...new Set(ids)];
 }
 
-function scorePane({
-    pane,
-    query,
-    workspaceName,
-}: {
-    pane: CmuxLivePane;
-    query: string;
-    workspaceName: string;
-}): { kind: FocusMatchKind; score: number } | null {
-    const haystack = paneHaystack(pane);
-    const resumed = resumedSessionIdsIn(haystack);
-    const ids = sessionIdsIn(haystack);
-    const needle = query.toLowerCase();
+/**
+ * Session ids this pane shows, the one it is resuming first.
+ *
+ * Callers render `sessionIds[0]` as "the session in this pane", so the pane's own session
+ * has to come first. Screen order will not do that: a pane can print another session's id
+ * above its own resume command, and then the status line, the picker hint and the table all
+ * name a session the user did not ask about.
+ */
+export function paneSessionIds(text: string): string[] {
+    const resumed = resumedSessionIdsIn(text);
+
+    return [...resumed, ...sessionIdsIn(text).filter((id) => !resumed.includes(id))];
+}
+
+interface PaneMatch {
+    kind: FocusMatchKind;
+    score: number;
+    surfaceId?: string;
+}
+
+function scoreScope(scope: PaneScope, needle: string): { kind: FocusMatchKind; score: number } | null {
+    const haystack = `${scope.title}\n${scope.screen}`;
     const longEnough = needle.length >= MIN_ID_PREFIX;
+    const resumed = resumedSessionIdsIn(haystack);
 
     // The pane is running this session, not talking about it. Nothing outranks that.
     if (resumed.includes(needle)) {
@@ -116,6 +165,19 @@ function scorePane({
     if (longEnough && resumed.some((id) => id.startsWith(needle))) {
         return { kind: "resume-prefix", score: 95 };
     }
+
+    // `restore` stamps the short id into the tab title, and the title outlives the resume
+    // command: cmux only exposes the visible viewport, so an active Claude TUI scrolls that
+    // command away within seconds and a full-id query would then find nothing. The title is
+    // the one durable marker for a long-running session, so it ranks just under seeing the
+    // command itself.
+    const titleId = scope.title.match(TITLE_SHORT_ID_RE)?.[1]?.toLowerCase();
+
+    if (longEnough && titleId && needle.startsWith(titleId)) {
+        return { kind: "title-id", score: 90 };
+    }
+
+    const ids = sessionIdsIn(haystack);
 
     // The id is on screen but not in a resume command: an agent pane that printed the id,
     // a log, a note. Real evidence, but weaker than the pane actually running it.
@@ -127,18 +189,8 @@ function scorePane({
         return { kind: "id-prefix", score: 65 };
     }
 
-    if (pane.title.toLowerCase().includes(needle)) {
+    if (scope.title.toLowerCase().includes(needle)) {
         return { kind: "pane-title", score: 60 };
-    }
-
-    if (workspaceName.toLowerCase().includes(needle)) {
-        return { kind: "workspace", score: 50 };
-    }
-
-    const cwd = pane.cwd;
-
-    if (cwd && (cwd.toLowerCase().includes(needle) || basename(cwd).toLowerCase() === needle)) {
-        return { kind: "cwd", score: 40 };
     }
 
     // Last resort: the query is somewhere on the screen. Useful for "the pane where I
@@ -148,6 +200,42 @@ function scorePane({
     }
 
     return null;
+}
+
+function scorePane({
+    pane,
+    query,
+    workspaceName,
+}: {
+    pane: CmuxLivePane;
+    query: string;
+    workspaceName: string;
+}): PaneMatch | null {
+    const needle = query.toLowerCase();
+    let best: PaneMatch | null = null;
+
+    for (const scope of paneScopes(pane)) {
+        const hit = scoreScope(scope, needle);
+
+        if (hit && (!best || hit.score > best.score)) {
+            best = { ...hit, surfaceId: scope.surfaceId };
+        }
+    }
+
+    // Pane-level signals. Compared by score rather than checked in sequence, so their
+    // precedence against the per-scope kinds does not depend on evaluation order.
+    if (workspaceName.toLowerCase().includes(needle) && (!best || best.score < 50)) {
+        best = { kind: "workspace", score: 50 };
+    }
+
+    const cwd = pane.cwd;
+    const cwdMatches = cwd && (cwd.toLowerCase().includes(needle) || basename(cwd).toLowerCase() === needle);
+
+    if (cwdMatches && (!best || best.score < 40)) {
+        best = { kind: "cwd", score: 40 };
+    }
+
+    return best;
 }
 
 /**
@@ -194,7 +282,8 @@ export function findFocusTargets(
             paneId: pane.id,
             paneTitle: pane.title,
             cwd: pane.cwd,
-            sessionIds: sessionIdsIn(paneHaystack(pane)),
+            surfaceId: hit.surfaceId,
+            sessionIds: paneSessionIds(paneHaystack(pane)),
             matchedOn: hit.kind,
             score: hit.score,
             active: pane.active,
@@ -217,7 +306,7 @@ export function findFocusTargets(
 /**
  * True when the top match is the only one worth focusing without asking.
  *
- * One pane RESUMING the session wins even when other panes merely print its id. Anything
+ * One pane that HOLDS the session wins even when other panes merely print its id. Anything
  * else needs the top score to stand alone.
  */
 export function isUnambiguous(targets: FocusTarget[]): boolean {
@@ -231,19 +320,26 @@ export function isUnambiguous(targets: FocusTarget[]): boolean {
 
     const [first, second] = targets;
 
-    // A resume match is the pane RUNNING the session. One of those beats any number of
-    // panes that merely printed the id, which is the common case when an agent pane has
-    // been discussing session ids.
-    if (isResumeMatch(first)) {
-        return !isResumeMatch(second);
+    // One pane demonstrably running the session beats any number of panes that merely
+    // printed the id, which is the common case when an agent pane has been discussing
+    // session ids.
+    if (ownsSession(first)) {
+        return !ownsSession(second);
     }
 
     return first.score > second.score;
 }
 
-/** True when the pane is running the session, not just showing its id. */
-export function isResumeMatch(target: FocusTarget): boolean {
-    return target.matchedOn === "resume-command" || target.matchedOn === "resume-prefix";
+/**
+ * True when the pane demonstrably holds the session rather than mentioning its id.
+ *
+ * Either the resume command is still on screen, or `restore` stamped the id into the tab
+ * title. Both are written by this tool; a bare id in some text is not.
+ */
+function ownsSession(target: FocusTarget): boolean {
+    return (
+        target.matchedOn === "resume-command" || target.matchedOn === "resume-prefix" || target.matchedOn === "title-id"
+    );
 }
 
 export function describeMatch(target: FocusTarget): string {
@@ -252,6 +348,8 @@ export function describeMatch(target: FocusTarget): string {
             return "resuming this session";
         case "resume-prefix":
             return "resuming this session (id prefix)";
+        case "title-id":
+            return "session id in the tab title";
         case "session-id":
             return "session id on screen";
         case "id-prefix":

--- a/src/claude/lib/cmux/focus.ts
+++ b/src/claude/lib/cmux/focus.ts
@@ -93,11 +93,13 @@ function paneScopes(pane: CmuxLivePane): PaneScope[] {
     ];
 }
 
-/** Every scrap of text a pane exposes: its own title plus each surface's title and screen. */
-function paneHaystack(pane: CmuxLivePane): string {
-    return paneScopes(pane)
-        .map((scope) => `${scope.title}\n${scope.screen}`)
-        .join("\n");
+function scopeText(scope: PaneScope): string {
+    return `${scope.title}\n${scope.screen}`;
+}
+
+/** Every scrap of text a pane exposes, for the full session-id inventory. */
+function paneText(pane: CmuxLivePane): string {
+    return paneScopes(pane).map(scopeText).join("\n");
 }
 
 export function sessionIdsIn(text: string): string[] {
@@ -135,25 +137,36 @@ export function resumedSessionIdsIn(text: string): string[] {
 /**
  * Session ids this pane shows, the one it is resuming first.
  *
- * Callers render `sessionIds[0]` as "the session in this pane", so the pane's own session
- * has to come first. Screen order will not do that: a pane can print another session's id
- * above its own resume command, and then the status line, the picker hint and the table all
- * name a session the user did not ask about.
+ * Callers render `sessionIds[0]` as "the session in this pane", so the session that was
+ * matched has to come first. Neither screen order nor scope order gets there on its own: a
+ * pane can print another session's id above its own resume command, and a pane whose visible
+ * tab resumes one session can have the MATCHED session on a background tab. In both cases the
+ * status line, the picker hint and the table would name a session the user did not ask about.
+ *
+ * `matched` is the text of the scope that actually matched; `rest` is the remainder of the
+ * pane, kept so the field is still a full inventory of what the pane shows.
  */
-export function paneSessionIds(text: string): string[] {
-    const resumed = resumedSessionIdsIn(text);
-
-    return [...resumed, ...sessionIdsIn(text).filter((id) => !resumed.includes(id))];
+export function paneSessionIds(matched: string, rest = ""): string[] {
+    return [
+        ...new Set([
+            ...resumedSessionIdsIn(matched),
+            ...sessionIdsIn(matched),
+            ...resumedSessionIdsIn(rest),
+            ...sessionIdsIn(rest),
+        ]),
+    ];
 }
 
 interface PaneMatch {
     kind: FocusMatchKind;
     score: number;
     surfaceId?: string;
+    /** Text of the scope that matched, so the caller can order session ids by it. */
+    matchedText: string;
 }
 
 function scoreScope(scope: PaneScope, needle: string): { kind: FocusMatchKind; score: number } | null {
-    const haystack = `${scope.title}\n${scope.screen}`;
+    const haystack = scopeText(scope);
     const longEnough = needle.length >= MIN_ID_PREFIX;
     const resumed = resumedSessionIdsIn(haystack);
 
@@ -211,28 +224,30 @@ function scorePane({
     query: string;
     workspaceName: string;
 }): PaneMatch | null {
+    const scopes = paneScopes(pane);
     const needle = query.toLowerCase();
     let best: PaneMatch | null = null;
 
-    for (const scope of paneScopes(pane)) {
+    for (const scope of scopes) {
         const hit = scoreScope(scope, needle);
 
         if (hit && (!best || hit.score > best.score)) {
-            best = { ...hit, surfaceId: scope.surfaceId };
+            best = { ...hit, surfaceId: scope.surfaceId, matchedText: scopeText(scope) };
         }
     }
 
     // Pane-level signals. Compared by score rather than checked in sequence, so their
-    // precedence against the per-scope kinds does not depend on evaluation order.
+    // precedence against the per-scope kinds does not depend on evaluation order. These
+    // match the pane as a whole, so its own text is the scope session ids get ordered by.
     if (workspaceName.toLowerCase().includes(needle) && (!best || best.score < 50)) {
-        best = { kind: "workspace", score: 50 };
+        best = { kind: "workspace", score: 50, matchedText: scopeText(scopes[0]) };
     }
 
     const cwd = pane.cwd;
     const cwdMatches = cwd && (cwd.toLowerCase().includes(needle) || basename(cwd).toLowerCase() === needle);
 
     if (cwdMatches && (!best || best.score < 40)) {
-        best = { kind: "cwd", score: 40 };
+        best = { kind: "cwd", score: 40, matchedText: scopeText(scopes[0]) };
     }
 
     return best;
@@ -283,7 +298,7 @@ export function findFocusTargets(
             paneTitle: pane.title,
             cwd: pane.cwd,
             surfaceId: hit.surfaceId,
-            sessionIds: paneSessionIds(paneHaystack(pane)),
+            sessionIds: paneSessionIds(hit.matchedText, paneText(pane)),
             matchedOn: hit.kind,
             score: hit.score,
             active: pane.active,

--- a/src/cmux/lib/controls.test.ts
+++ b/src/cmux/lib/controls.test.ts
@@ -4,6 +4,7 @@ import {
     buildRenameTabArgs,
     buildRenameWorkspaceArgs,
     focusCmuxPane,
+    focusCmuxSurface,
     renameCmuxSurface,
     renameCmuxWorkspace,
 } from "@genesiscz/utils/cmux/lib/controls";
@@ -36,6 +37,40 @@ describe("cmux controls", () => {
     test("focusCmuxPane rejects blank identifiers", async () => {
         await expect(focusCmuxPane({ workspaceId: "", paneId: "pane:2" })).rejects.toThrow("workspaceId");
         await expect(focusCmuxPane({ workspaceId: "workspace:1", paneId: "" })).rejects.toThrow("paneId");
+    });
+
+    test("focusCmuxSurface sends surface.focus with a surface_id parameter", async () => {
+        // Pinned here rather than only through the command, because this is a raw RPC with
+        // no CLI equivalent: cmux answers `Missing or invalid surface_id` for the obvious
+        // `{ surface }` spelling, and a typo would fail silently in the daemon while every
+        // command-level test kept passing against its mock.
+        const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+        await focusCmuxSurface({
+            surfaceId: "surface:46",
+            sendRpc: async (method, params) => {
+                calls.push({ method, params });
+                return {};
+            },
+        });
+
+        expect(calls).toEqual([{ method: "surface.focus", params: { surface_id: "surface:46" } }]);
+    });
+
+    test("focusCmuxSurface rejects a blank surface id before it reaches the daemon", async () => {
+        let sent = 0;
+
+        await expect(
+            focusCmuxSurface({
+                surfaceId: "  ",
+                sendRpc: async () => {
+                    sent++;
+                    return {};
+                },
+            })
+        ).rejects.toThrow("surfaceId");
+
+        expect(sent).toBe(0);
     });
 });
 

--- a/src/utils/cmux/lib/controls.ts
+++ b/src/utils/cmux/lib/controls.ts
@@ -3,10 +3,18 @@ import { rpc } from "@genesiscz/utils/cmux/lib/socket";
 
 type CmuxCommandRunner = (args: string[]) => Promise<CmuxRunResult>;
 
+type CmuxRpcSender = (method: string, params: Record<string, unknown>) => Promise<unknown>;
+
 interface FocusCmuxPaneOptions {
     workspaceId: string;
     paneId: string;
     runner?: CmuxCommandRunner;
+}
+
+interface FocusCmuxSurfaceOptions {
+    surfaceId: string;
+    /** Injectable so a test can pin the method name and parameter without a live daemon. */
+    sendRpc?: CmuxRpcSender;
 }
 
 function assertNonBlank(value: string, name: string): void {
@@ -34,10 +42,10 @@ export async function focusCmuxPane({ paneId, runner = runCmuxOk, workspaceId }:
  * cmux 0.63.2), so this goes through the raw `surface.focus` RPC. Its parameter is
  * `surface_id`; passing `surface` fails with `Missing or invalid surface_id`.
  */
-export async function focusCmuxSurface(surfaceId: string): Promise<void> {
+export async function focusCmuxSurface({ surfaceId, sendRpc = rpc }: FocusCmuxSurfaceOptions): Promise<void> {
     assertNonBlank(surfaceId, "surfaceId");
 
-    await rpc("surface.focus", { surface_id: surfaceId });
+    await sendRpc("surface.focus", { surface_id: surfaceId });
 }
 
 // `pane.workspaceId` and `surface.id` from the live snapshot are already the

--- a/src/utils/cmux/lib/controls.ts
+++ b/src/utils/cmux/lib/controls.ts
@@ -1,4 +1,5 @@
 import { type CmuxRunResult, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { rpc } from "@genesiscz/utils/cmux/lib/socket";
 
 type CmuxCommandRunner = (args: string[]) => Promise<CmuxRunResult>;
 
@@ -20,6 +21,23 @@ export async function focusCmuxPane({ paneId, runner = runCmuxOk, workspaceId }:
 
     await runner(["select-workspace", "--workspace", workspaceId]);
     await runner(["focus-pane", "--workspace", workspaceId, "--pane", paneId]);
+}
+
+/**
+ * Make `surfaceId` the visible tab inside its pane.
+ *
+ * `focus-pane` leaves whatever tab was already selected on top, so focusing a pane is not
+ * enough when the thing you were looking for lives on a background surface.
+ *
+ * There is no CLI verb for this. `cmux --help` lists no focus-surface command, and
+ * `tab-action --action focus` answers `invalid_params: Unknown tab action` (verified against
+ * cmux 0.63.2), so this goes through the raw `surface.focus` RPC. Its parameter is
+ * `surface_id`; passing `surface` fails with `Missing or invalid surface_id`.
+ */
+export async function focusCmuxSurface(surfaceId: string): Promise<void> {
+    assertNonBlank(surfaceId, "surfaceId");
+
+    await rpc("surface.focus", { surface_id: surfaceId });
 }
 
 // `pane.workspaceId` and `surface.id` from the live snapshot are already the

--- a/src/utils/cmux/send-tmux.test.ts
+++ b/src/utils/cmux/send-tmux.test.ts
@@ -3,7 +3,20 @@ import * as controls from "@genesiscz/utils/cmux/lib/controls";
 import { attachTmuxToCmux } from "@genesiscz/utils/cmux/send-tmux";
 import * as workspace from "@genesiscz/utils/cmux/workspace";
 import { resetTmuxBinCache, setTmuxBinForTests } from "@genesiscz/utils/tmux/bin";
-import { setTmuxSpawnSyncForTests } from "@genesiscz/utils/tmux/sessions";
+import { formatWithRecordSeparator, setTmuxSpawnSyncForTests } from "@genesiscz/utils/tmux/sessions";
+
+/**
+ * One `list-sessions` record as tmux really emits it.
+ *
+ * Built with the production formatter on purpose. This mock used to hand-write tab-separated
+ * fields, so when `listTmuxSessions` moved to RS/US control bytes the fake output stopped
+ * parsing: the whole line became the session name, `sessionExists` answered false, and the
+ * test failed on a session it had just declared. Sharing the formatter makes that drift
+ * impossible to reintroduce.
+ */
+function listSessionsStdout(fields: string[]): string {
+    return `${formatWithRecordSeparator(fields)}\n`;
+}
 
 describe("attachTmuxToCmux", () => {
     afterEach(() => {
@@ -16,7 +29,7 @@ describe("attachTmuxToCmux", () => {
         setTmuxBinForTests("/mock/tmux");
         setTmuxSpawnSyncForTests((cmd) => {
             if (cmd.includes("list-sessions")) {
-                return { exitCode: 0, stdout: "my-session\t1\t1\n" };
+                return { exitCode: 0, stdout: listSessionsStdout(["my-session", "1", "1"]) };
             }
 
             return { exitCode: 0, stdout: "" };


### PR DESCRIPTION
Adds `tools claude cmux focus <session>`: find the cmux pane a Claude session is already open in, select its workspace, focus the pane, and raise the cmux app.

`cmux restore` reopens sessions that are gone. This is the other half: the session is already running somewhere across two windows and eleven workspaces, and you want to look at it. It never creates anything, so it can't silently start a second copy of a session that is already live.

## Usage

```bash
tools claude cmux focus 8b6e69bf                      # 8-char prefix
tools claude cmux focus 8b6e69bf-0efc-4990-...        # full id
tools claude cmux focus GenesisTools                  # workspace name
tools claude cmux focus --dry-run --json 8b6e69bf     # inspect the match
tools claude cmux focus 8b6e69bf --first              # take the top hit, don't ask
tools claude cmux focus 8b6e69bf --no-activate        # focus without raising the app
```

## How a pane is matched

The query is matched against what a pane **shows**, not against the session store, because the question is "which pane already has this open". Ranked, best first:

| Signal | Score | Meaning |
|---|---|---|
| `resume-command` | 100 | the screen shows `--resume <id>` with that exact id |
| `resume-prefix` | 95 | same, matched on an 8+ character prefix |
| `session-id` | 70 | the id is on screen, but not in a resume command |
| `id-prefix` | 65 | same, by prefix |
| `pane-title` | 60 | |
| `workspace` | 50 | |
| `cwd` | 40 | |
| `screen` | 20 | the query is somewhere in the captured text |

Ties break on the pane already being active, then on pane id. One resume match wins outright even when other panes also match, so the normal case never prompts. Otherwise an ambiguous result shows a table and asks; without a TTY it prints the table, names `--first`, and exits 1.

## Two bugs found by testing against live cmux, not by reasoning

Both were in my first version, and both only appeared when run for real.

**1. Any query matched the pane it was typed in.** `focus zzz-not-a-session` reported a confident hit and focused the calling pane, because typing the query puts it on that pane's screen and the weak `screen` rule matched it. Fixed by resolving `identify.caller.pane_ref` and excluding that pane, with `--include-self` as the escape hatch. Regression test: `excludePaneId drops the calling pane, so a query cannot match itself`.

**2. A pane that merely printed a session id ranked equal to the pane running it.** A live agent pane had been discussing session ids, so `focus 8b6e69bf` found two panes and prompted. Fixed by scoring `--resume <id>` above a bare id mention, which is the difference between running a session and talking about one. Regression test: `the pane RESUMING a session beats a pane that only printed its id`.

The `resumeScreen()` test helper is a verbatim copy of a real `cmux read-screen` capture, so the matcher is pinned to the actual shape a restored pane prints rather than to my guess at it.

## Verification

- 22 unit tests on the matcher, all passing. 138 pass / 0 fail across the whole `cmux` surface (`src/claude/lib/cmux/`, `src/claude/commands/cmux/`, `src/cmux/`).
- End-to-end against live cmux: focus moved from `workspace:1 / pane:1` to `workspace:11 / pane:33`, confirmed by `cmux identify` before and after. The user's original focus was restored afterwards.
- No-match path verified: exits 1 and points at `tools claude cmux restore`.
- `biome check` clean, `tsgo --noEmit` reports nothing in the new files, pre-commit and pre-push hooks passed.

## Notes

- Reuses the existing primitives rather than adding new ones: `fetchCmuxLiveSnapshot()` for enumeration and `focusCmuxPane()` for the select-plus-focus pair. The only new cmux calls are `identify --workspace <ref>` to find the owning window and `focus-window` to raise it, which is what makes this work for a pane in a window you are not currently in.
- App activation is `open -b <bundle_identifier>`, read from `identify`. It is macOS-only and degrades to a message rather than an error, since a focused pane in a background app is still a useful outcome.
- Matching lives in `src/claude/lib/cmux/focus.ts` as pure functions over a snapshot, so all of the ranking is testable without cmux running.
- One line documenting the command was added to the user's global `CLAUDE.md` (outside this repo, so not in this diff).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `cmux focus` command to find and focus matching panes and surfaces.
  * Supports searches by session ID, pane details, workspace, working directory, or visible screen text.
  * Added interactive selection, first-match, dry-run, JSON output, self-inclusion, and optional app activation modes.
  * Provides clear feedback for unavailable cmux, ambiguous searches, unmatched queries, cancellations, and successful focus actions.

* **Tests**
  * Added comprehensive coverage for matching, prioritization, exclusions, ambiguity, session detection, and surface focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->