### PR TITLE
feat(ai-proxy): reasoning-effort suffixes on model ids, and advertise grok-4.6

### DIFF
--- a/src/ai-proxy/data/models-catalog.json
+++ b/src/ai-proxy/data/models-catalog.json
@@ -1,6 +1,6 @@
 {
-  "updatedAt": "2026-07-21T17:58:05.989Z",
-  "grokVersion": "0.2.106",
+  "updatedAt": "2026-08-19T12:51:04.438Z",
+  "grokVersion": "1.0.3",
   "accounts": [
     {
       "accountName": "martin",
@@ -9,6 +9,15 @@
       "pickerModels": [
         {
           "id": "grok-4.5",
+          "source": "picker",
+          "visibility": "high",
+          "speed": "medium",
+          "thinking": "optional",
+          "probeStatus": "ok",
+          "httpCode": 200
+        },
+        {
+          "id": "grok-4.6",
           "source": "picker",
           "visibility": "high",
           "speed": "medium",

--- a/src/ai-proxy/lib/billing/pricing.test.ts
+++ b/src/ai-proxy/lib/billing/pricing.test.ts
@@ -20,6 +20,7 @@ describe("estimateCostUsd", () => {
         });
         expect(cost).toBeCloseTo(2.0, 10);
         expect(estimateCostUsd("grok-4.5-latest", { prompt_tokens: 100_000 })).toBeCloseTo(0.2, 10);
+        expect(estimateCostUsd("grok-4.6", { prompt_tokens: 100_000 })).toBeCloseTo(0.2, 10);
     });
 
     it("never open-ended-prefix-matches: unknown family variants stay unpriced", () => {

--- a/src/ai-proxy/lib/billing/pricing.ts
+++ b/src/ai-proxy/lib/billing/pricing.ts
@@ -87,7 +87,7 @@ const RATE_GROUPS: Array<{ ids: string[]; rate: ModelRate }> = [
     { ids: ["gpt-5.5"], rate: { inputUsdPerMTok: 5, outputUsdPerMTok: 30 } },
     { ids: ["gpt-5-codex"], rate: { inputUsdPerMTok: 1.25, outputUsdPerMTok: 10 } },
     {
-        ids: ["grok-4.5"],
+        ids: ["grok-4.6", "grok-4.5"],
         rate: {
             inputUsdPerMTok: 2,
             outputUsdPerMTok: 6,

--- a/src/ai-proxy/lib/resolve-model.test.ts
+++ b/src/ai-proxy/lib/resolve-model.test.ts
@@ -76,6 +76,27 @@ describe("resolve-model", () => {
         expect(() => resolveModel("grok-build-0.1", accounts)).toThrow("Ambiguous model");
     });
 
+    it("strips a trailing :<effort> suffix and returns reasoningEffort", () => {
+        const accounts = [grokAccount("martin")];
+
+        const route = resolveModel("martin/grok/grok-4.6:xhigh", accounts);
+
+        expect(route.upstreamId).toBe("grok-4.6");
+        expect(route.reasoningEffort).toBe("xhigh");
+        expect(route.accountName).toBe("martin");
+    });
+
+    it("leaves OpenRouter :batch suffixes on the upstream id", () => {
+        const accounts: AiProxyAccountConfig[] = [
+            { name: "openrouter", provider: "openrouter", providerSlug: "openrouter", enabled: true },
+        ];
+
+        const route = resolveModel("openrouter/openrouter/anthropic/claude-opus-4.6:batch", accounts);
+
+        expect(route.upstreamId).toBe("anthropic/claude-opus-4.6:batch");
+        expect(route.reasoningEffort).toBeUndefined();
+    });
+
     it("rejects ambiguous provider/upstream ids across multiple accounts", () => {
         const accounts = [grokAccount("martin"), grokAccount("work")];
 

--- a/src/ai-proxy/lib/resolve-model.ts
+++ b/src/ai-proxy/lib/resolve-model.ts
@@ -1,6 +1,51 @@
 import { isProviderImplemented } from "@app/ai-proxy/lib/providers/registry";
-import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import type { AiProxyAccountConfig, ReasoningEffort, ResolvedRoute } from "@app/ai-proxy/lib/types";
 import { openRouterModelSync } from "@genesiscz/utils/ai/catalog/openrouter";
+
+export const REASONING_EFFORT_SUFFIXES = [
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "minimal",
+    "max",
+] as const satisfies readonly ReasoningEffort[];
+
+const REASONING_EFFORT_SET = new Set<string>(REASONING_EFFORT_SUFFIXES);
+
+/**
+ * Split a trailing `:<effort>` off a proxy model id.
+ *
+ * OpenRouter ids also use colons (`claude-opus-4.6:batch`), so only known
+ * effort tokens are stripped. Unknown suffixes stay on the upstream id.
+ */
+export function splitReasoningEffortSuffix(modelId: string): {
+    modelId: string;
+    reasoningEffort?: ReasoningEffort;
+} {
+    const colon = modelId.lastIndexOf(":");
+
+    if (colon <= 0) {
+        return { modelId };
+    }
+
+    const suffix = modelId
+        .slice(colon + 1)
+        .trim()
+        .toLowerCase();
+
+    if (!REASONING_EFFORT_SET.has(suffix)) {
+        return { modelId };
+    }
+
+    const base = modelId.slice(0, colon).trim();
+
+    if (!base) {
+        return { modelId };
+    }
+
+    return { modelId: base, reasoningEffort: suffix as ReasoningEffort };
+}
 
 export interface ParsedModelId {
     accountName: string;
@@ -101,7 +146,18 @@ function resolveCatalogGatedUpstreamModel(upstreamId: string, accounts: AiProxyA
     return resolveFromAccountMatches(candidates, upstreamId, upstreamId);
 }
 
-export function resolveModel(proxyModelId: string, accounts: AiProxyAccountConfig[]) {
+export function resolveModel(proxyModelId: string, accounts: AiProxyAccountConfig[]): ResolvedRoute {
+    const { modelId, reasoningEffort } = splitReasoningEffortSuffix(proxyModelId.trim());
+    const route = resolveModelWithoutEffort(modelId, accounts);
+
+    if (!reasoningEffort) {
+        return route;
+    }
+
+    return { ...route, reasoningEffort };
+}
+
+function resolveModelWithoutEffort(proxyModelId: string, accounts: AiProxyAccountConfig[]): ResolvedRoute {
     const trimmed = proxyModelId.trim();
 
     if (!trimmed) {

--- a/src/ai-proxy/lib/rewrite-upstream-body.test.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+    applyReasoningEffortToBody,
     findInvalidImageDataPayload,
     GROK_IMAGE_FALLBACK_MODEL,
     grokModelSupportsImages,
@@ -301,6 +302,40 @@ describe("rewrite-upstream-body", () => {
         expect(parsed.model).toBe("grok-build");
         expect(rewritten.imageRouted).toBe(false);
         expect(parsed.messages[0]?.content?.[0]?.type).toBe("image_url");
+    });
+});
+
+describe("applyReasoningEffortToBody", () => {
+    it("stamps reasoning_effort when absent", () => {
+        const next = applyReasoningEffortToBody(SafeJSON.stringify({ model: "grok-4.6", messages: [] }), "xhigh");
+        const parsed = SafeJSON.parse(next) as { reasoning_effort?: string };
+
+        expect(parsed.reasoning_effort).toBe("xhigh");
+    });
+
+    it("does not overwrite an explicit reasoning_effort", () => {
+        const next = applyReasoningEffortToBody(
+            SafeJSON.stringify({ model: "grok-4.6", reasoning_effort: "low" }),
+            "xhigh"
+        );
+        const parsed = SafeJSON.parse(next) as { reasoning_effort?: string };
+
+        expect(parsed.reasoning_effort).toBe("low");
+    });
+
+    it("fills reasoning.effort when that object already exists", () => {
+        const next = applyReasoningEffortToBody(
+            SafeJSON.stringify({ model: "grok-4.6", reasoning: { generate_summary: true } }),
+            "xhigh"
+        );
+        const parsed = SafeJSON.parse(next) as {
+            reasoning_effort?: string;
+            reasoning?: { effort?: string; generate_summary?: boolean };
+        };
+
+        expect(parsed.reasoning_effort).toBe("xhigh");
+        expect(parsed.reasoning?.effort).toBe("xhigh");
+        expect(parsed.reasoning?.generate_summary).toBe(true);
     });
 });
 

--- a/src/ai-proxy/lib/rewrite-upstream-body.ts
+++ b/src/ai-proxy/lib/rewrite-upstream-body.ts
@@ -731,6 +731,43 @@ export function prepareGrokUpstreamBody(
     }
 }
 
+/**
+ * Stamp `reasoning_effort` (and `reasoning.effort` when that object exists)
+ * from a `:<effort>` model-id suffix. An explicit body field wins.
+ */
+export function applyReasoningEffortToBody(bodyText: string, effort?: string): string {
+    if (!effort) {
+        return bodyText;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true });
+
+        if (!isObject(parsed)) {
+            return bodyText;
+        }
+
+        const next: JsonObject = { ...parsed };
+        let changed = false;
+
+        if (typeof next.reasoning_effort !== "string" || !next.reasoning_effort.trim()) {
+            next.reasoning_effort = effort;
+            changed = true;
+        }
+
+        if (isObject(next.reasoning)) {
+            if (typeof next.reasoning.effort !== "string" || !next.reasoning.effort.trim()) {
+                next.reasoning = { ...next.reasoning, effort };
+                changed = true;
+            }
+        }
+
+        return changed ? SafeJSON.stringify(next) : bodyText;
+    } catch {
+        return bodyText;
+    }
+}
+
 export function rewriteBodyModel(bodyText: string, upstreamModel: string): string {
     try {
         const parsed = SafeJSON.parse(bodyText, { strict: true });

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -8,7 +8,7 @@ import { acquireProvider, buildProviderMap, providerUnavailableResponse } from "
 import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { handleRealtimeClientSecrets, handleRealtimeUpgrade, realtimeWebsocket } from "@app/ai-proxy/lib/realtime";
 import { resolveModel } from "@app/ai-proxy/lib/resolve-model";
-import { findInvalidImageDataPayload } from "@app/ai-proxy/lib/rewrite-upstream-body";
+import { applyReasoningEffortToBody, findInvalidImageDataPayload } from "@app/ai-proxy/lib/rewrite-upstream-body";
 import { resolveThinkingMode } from "@app/ai-proxy/lib/thinking-config";
 import { resolveTranslationMode } from "@app/ai-proxy/lib/translation-config";
 import { handleChatCompletions } from "@app/ai-proxy/lib/translators";
@@ -335,13 +335,20 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
 
                     const { route, provider } = routed;
 
+                    // Stamped on the Anthropic body: normalizeAnthropicToOpenAI drops only
+                    // metadata/anthropic_version/top_k/thinking, so reasoning_effort rides
+                    // through to the OpenAI body the provider forwards. Without this, an
+                    // id like martin/grok/grok-4.6:xhigh would honour its effort suffix on
+                    // /v1/chat/completions but silently ignore it for Claude Code.
+                    const routedBody = applyReasoningEffortToBody(bodyText, route.reasoningEffort);
+
                     const { response, responseBody, timeline, openAiBodyText } = await anthropicMessagesPipeline({
                         startedAt: requestStarted,
                         provider,
                         upstreamModel: route.upstreamId,
                         proxyModel: model,
                         req,
-                        bodyText,
+                        bodyText: routedBody,
                     });
                     const elapsedMs = Math.round(performance.now() - requestStarted);
 
@@ -431,6 +438,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                     }
 
                     const { route, provider } = routed;
+                    const routedBody = applyReasoningEffortToBody(bodyText, route.reasoningEffort);
 
                     if (path === "/v1/responses") {
                         const { response, responseBody, timeline, captureFailure } = await identityPipeline({
@@ -439,7 +447,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                             upstreamModel: route.upstreamId,
                             path: "responses",
                             req,
-                            bodyText,
+                            bodyText: routedBody,
                         });
                         const elapsedMs = Math.round(performance.now() - requestStarted);
 
@@ -451,7 +459,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                             path,
                             status: response.status,
                             elapsedMs,
-                            bodyText,
+                            bodyText: routedBody,
                             responseBody,
                             timeline,
                             captureFailure,
@@ -496,7 +504,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         upstreamModel: route.upstreamId,
                         proxyModel: model,
                         req,
-                        bodyText,
+                        bodyText: routedBody,
                     });
                     const elapsedMs = Math.round(performance.now() - requestStarted);
 
@@ -508,7 +516,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         path,
                         status: response.status,
                         elapsedMs,
-                        bodyText,
+                        bodyText: routedBody,
                         responseBody,
                         timeline,
                         captureFailure,

--- a/src/ai-proxy/lib/types.ts
+++ b/src/ai-proxy/lib/types.ts
@@ -258,11 +258,15 @@ export interface AiProxyConfig {
     accounts: AiProxyAccountConfig[];
 }
 
+export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "minimal" | "max";
+
 export interface ResolvedRoute {
     accountName: string;
     providerSlug: string;
     upstreamId: string;
     account: AiProxyAccountConfig;
+    /** Set when the proxy model id ends with `:<effort>` (e.g. grok-4.6:xhigh). */
+    reasoningEffort?: ReasoningEffort;
 }
 
 export interface ProxyModelMeta {

--- a/src/utils/ai/catalog/static.test.ts
+++ b/src/utils/ai/catalog/static.test.ts
@@ -102,10 +102,13 @@ describe("static catalog", () => {
     test("input modalities default per provider and deviate per entry", () => {
         const opus = byId("claude-opus-5");
         const grok45 = byId("grok-4.5");
+        const grok46 = byId("grok-4.6");
         const grok3 = byId("grok-3");
 
         expect(opus && inputModalitiesFor(opus)).toEqual(["text", "image"]);
         expect(grok45 && inputModalitiesFor(grok45)).toEqual(["text", "image"]);
+        expect(grok46 && inputModalitiesFor(grok46)).toEqual(["text", "image"]);
+        expect(grok46?.contextWindow).toBe(500_000);
         expect(grok3 && inputModalitiesFor(grok3)).toBeUndefined();
     });
 

--- a/src/utils/ai/catalog/static.ts
+++ b/src/utils/ai/catalog/static.ts
@@ -239,6 +239,7 @@ const ANTHROPIC_ENTRIES: CatalogEntry[] = [
  * against xAI docs / LiteLLM 2026-07.
  */
 const XAI_WINDOWS: Record<string, number> = {
+    "grok-4.6": 500_000,
     "grok-4.5": 500_000,
     "grok-4.3": 1_000_000,
     "grok-4-fast": 2_000_000,
@@ -252,7 +253,7 @@ const XAI_WINDOWS: Record<string, number> = {
 
 const XAI_DEFAULT_WINDOW = 131_072;
 
-const XAI_VISION_MODELS = new Set(["grok-4.5", "grok-4.3"]);
+const XAI_VISION_MODELS = new Set(["grok-4.6", "grok-4.5", "grok-4.3"]);
 
 /** id → thinking mode; anything unlisted reasons optionally. */
 const XAI_THINKING: Record<string, CatalogEntry["thinking"]> = {

--- a/src/utils/ai/grok/models.ts
+++ b/src/utils/ai/grok/models.ts
@@ -22,7 +22,7 @@ function seed(
 }
 
 /**
- * Curation for advertised model lists (2026-07-24): retired/legacy families
+ * Curation for advertised model lists (2026-08-19): retired/legacy families
  * and low-value variants stay OUT of pickers. Unlisted ids remain callable by
  * exact id — this only trims what clients see.
  */
@@ -52,6 +52,7 @@ export interface GrokModelSpecs {
  * carries context but not modalities.
  */
 const GROK_MODEL_SPECS: Record<string, GrokModelSpecs> = {
+    "grok-4.6": { contextWindow: 500_000, inputModalities: ["text", "image"] },
     "grok-4.5": { contextWindow: 500_000, inputModalities: ["text", "image"] },
     "grok-4.3": { contextWindow: 1_000_000, inputModalities: ["text", "image"] },
     "grok-4-fast": { contextWindow: 2_000_000, inputModalities: ["text"] },
@@ -65,6 +66,7 @@ export function grokModelSpecs(id: string): GrokModelSpecs | undefined {
 }
 
 export const GROK_STATIC_CATALOG: GrokModelRecord[] = [
+    seed("grok-4.6", "high", "medium", "optional", "ok"),
     seed("grok-4.5", "high", "medium", "optional", "ok"),
     seed("grok-build", "high", "slow", "reasoning", "ok"),
     seed("grok-composer-2.5-fast", "high", "fast", "reasoning", "ok"),

--- a/src/utils/ai/grok/probe.test.ts
+++ b/src/utils/ai/grok/probe.test.ts
@@ -4,6 +4,8 @@ import { GROK_PROBE_CANDIDATES, GROK_STATIC_CATALOG, inferModelThinking, mergeMo
 describe("grok probe helpers", () => {
     it("includes researched static catalog ids (working only — no fail seeds)", () => {
         expect(GROK_STATIC_CATALOG.some((model) => model.id === "grok-composer-2.5-fast")).toBe(true);
+        expect(GROK_STATIC_CATALOG.some((model) => model.id === "grok-4.6")).toBe(true);
+        expect(GROK_STATIC_CATALOG.find((model) => model.id === "grok-4.6")?.visibility).toBe("high");
         expect(GROK_STATIC_CATALOG.every((model) => model.probeStatus !== "fail")).toBe(true);
         expect(GROK_STATIC_CATALOG.length).toBeGreaterThanOrEqual(20);
     });


### PR DESCRIPTION
Two related ai-proxy catalog/routing fixes.

## `:<effort>` suffixes on proxy model ids

Sentry MCP can only pass `--openai-model`, with nowhere to put a reasoning effort. An id like
`martin/grok/grok-4.6:xhigh` now strips the suffix, routes to `grok-4.6`, and stamps
`reasoning_effort` unless the client already set one. Unknown suffixes (`:batch`, which is a real
OpenRouter id segment) stay on the upstream id untouched.

## Advertise `grok-4.6` on `martin/grok`

The live subscription picker already returns `grok-4.6`, but the static catalog and
`models-catalog.json` were last written 2026-07-21 for Grok 0.2.106. `GROK_PROBE_CANDIDATES` is
seeded from `GROK_STATIC_CATALOG`, so an id missing there is never probed and never listed —
`tools ai-proxy models` hid `grok-4.6` even though `martin/grok/grok-4.6` already answered chat.

Adds the seed plus its context/modality specs, the pricing prefix, and the static AI catalog entry.

## Verification

- `bunx tsgo --noEmit` clean.
- `bun run test src/ai-proxy/ src/utils/ai/` — 1184 pass, 0 fail.
- `martin/grok/grok-4.6` verified answering live through the proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Grok 4.6 model with image input support, a 500,000-token context window, and updated pricing.
  * Added reasoning-effort options for supported model IDs, including minimal, low, medium, high, xhigh, and max.
  * Applied selected reasoning effort to Anthropic Messages, Responses, and Chat Completions requests.

* **Bug Fixes**
  * Preserved explicit reasoning settings and request suffixes during model processing.

* **Tests**
  * Added coverage for Grok 4.6 availability, capabilities, pricing, and reasoning-effort handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->