### PR TITLE
feat(ai-proxy): serve the Anthropic Messages API so Claude Code can run Grok

### DIFF
--- a/src/ai-proxy/README.md
+++ b/src/ai-proxy/README.md
@@ -30,6 +30,42 @@ Model: genesiscz/github-copilot/claude-sonnet-4
 
 Start with `ai-proxy serve --translate-cursor auto`. If Agent mode breaks, try `--no-translate` or `--translate-cursor on`.
 
+## Claude Code / Anthropic clients (`POST /v1/messages`)
+
+The proxy also answers the **Anthropic Messages API**, so Claude Code (and any Anthropic SDK) can
+drive a proxied model. Routes: `POST /v1/messages` and `POST /v1/messages/count_tokens`.
+
+```bash
+tools claude proxy martin/grok -m 4.5      # pick + launch Claude Code on that model
+tools claude run martin/grok/grok-4.5      # same thing; a slashed name means "ai-proxy target"
+tools claude proxy work/xai --list         # just list what that account serves
+```
+
+Point a client at it by hand with:
+
+```text
+ANTHROPIC_BASE_URL=http://127.0.0.1:8317
+ANTHROPIC_AUTH_TOKEN=<proxyApiKey>      # x-api-key works too
+ANTHROPIC_MODEL=martin/grok/grok-4.5
+```
+
+How it works (`lib/anthropic-messages.ts`):
+
+- The request is normalized down to OpenAI chat/completions (`system` → system message,
+  `tools[].input_schema` → `function.parameters`, `tool_result` → `role: "tool"`), then routed
+  through the normal `resolveModel` → account → provider path.
+- The answer is translated back up: an OpenAI completion becomes an Anthropic message, and an
+  OpenAI SSE stream becomes `message_start` / `content_block_*` / `message_delta` / `message_stop`
+  frames. `reasoning_content` is forwarded as real `thinking` blocks.
+- **Usage rows book the OpenAI-shaped exchange**, not the Anthropic frames, so billing and the
+  call timeline stay on the one shape they parse.
+- Upstreams that report no streaming usage (Grok drops `stream_options`) get an estimate rather
+  than `0`, so Claude Code's context meter and auto-compact still work.
+
+Caveats: `count_tokens` is a ~4-chars-per-token estimate (no upstream here exposes a counter),
+thinking blocks carry no `signature`, and a model whose catalog entry says `supportsTools: false`
+cannot edit files — `tools claude proxy` warns before launching one.
+
 ## Model ids
 
 Canonical format:

--- a/src/ai-proxy/lib/anthropic-messages.test.ts
+++ b/src/ai-proxy/lib/anthropic-messages.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { anthropicBodyToOpenAiBody, anthropicMessagesPipeline, countAnthropicInputTokens } from "./anthropic-messages";
+import type { OpenAiModel, ProxyProvider } from "./providers/types";
+import type { UsageSummary } from "./types";
+
+const PROXY_MODEL = "martin/grok/grok-4.5";
+const UPSTREAM_MODEL = "grok-4.5";
+
+/** Records what the provider was handed, and answers with a canned upstream body. */
+function fakeProvider(response: () => Response): ProxyProvider & { seen: { model: string; bodyText: string }[] } {
+    const seen: { model: string; bodyText: string }[] = [];
+
+    return {
+        id: "grok-subscription",
+        accountFingerprint: "test",
+        seen,
+        async listModels(): Promise<OpenAiModel[]> {
+            return [];
+        },
+        async chatCompletions(_req: Request, model: string, bodyText: string): Promise<Response> {
+            seen.push({ model, bodyText });
+            return response();
+        },
+        async responses(): Promise<Response> {
+            throw new Error("not used");
+        },
+        async getUsage(): Promise<UsageSummary> {
+            throw new Error("not used");
+        },
+    };
+}
+
+function request(): Request {
+    return new Request("http://127.0.0.1/v1/messages", { method: "POST" });
+}
+
+function sseResponse(frames: string[]): Response {
+    const encoder = new TextEncoder();
+
+    return new Response(
+        new ReadableStream<Uint8Array>({
+            start(controller) {
+                for (const frame of frames) {
+                    controller.enqueue(encoder.encode(frame));
+                }
+
+                controller.close();
+            },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } }
+    );
+}
+
+function chunk(delta: Record<string, unknown>, finishReason?: string): string {
+    return `data: ${SafeJSON.stringify({
+        choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    })}\n\n`;
+}
+
+async function readAll(response: Response): Promise<string> {
+    return await response.text();
+}
+
+describe("anthropicBodyToOpenAiBody", () => {
+    it("folds the Anthropic system field into a system message and rewrites the model", () => {
+        const body = SafeJSON.parse(
+            anthropicBodyToOpenAiBody(
+                {
+                    model: PROXY_MODEL,
+                    system: "be terse",
+                    max_tokens: 1024,
+                    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+                },
+                UPSTREAM_MODEL
+            ),
+            { strict: true }
+        ) as Record<string, unknown>;
+
+        expect(body.model).toBe(UPSTREAM_MODEL);
+        expect(body.max_tokens).toBe(1024);
+        expect(body.system).toBeUndefined();
+        expect(body.messages).toEqual([
+            { role: "system", content: "be terse" },
+            { role: "user", content: "hi" },
+        ]);
+    });
+
+    it("translates Anthropic tools into OpenAI function tools", () => {
+        const body = SafeJSON.parse(
+            anthropicBodyToOpenAiBody(
+                {
+                    model: PROXY_MODEL,
+                    max_tokens: 16,
+                    messages: [{ role: "user", content: "go" }],
+                    tools: [{ name: "read", description: "read a file", input_schema: { type: "object" } }],
+                    tool_choice: { type: "auto" },
+                },
+                UPSTREAM_MODEL
+            ),
+            { strict: true }
+        ) as Record<string, unknown>;
+
+        expect(body.tools).toEqual([
+            {
+                type: "function",
+                function: { name: "read", description: "read a file", parameters: { type: "object" } },
+            },
+        ]);
+        expect(body.tool_choice).toBe("auto");
+    });
+
+    it("turns a tool_result turn into an OpenAI tool message", () => {
+        const body = SafeJSON.parse(
+            anthropicBodyToOpenAiBody(
+                {
+                    model: PROXY_MODEL,
+                    max_tokens: 16,
+                    messages: [
+                        {
+                            role: "assistant",
+                            content: [{ type: "tool_use", id: "call_1", name: "read", input: { p: "a" } }],
+                        },
+                        {
+                            role: "user",
+                            content: [{ type: "tool_result", tool_use_id: "call_1", content: "file body" }],
+                        },
+                    ],
+                },
+                UPSTREAM_MODEL
+            ),
+            { strict: true }
+        ) as { messages: Record<string, unknown>[] };
+
+        expect(body.messages[1]).toEqual({ role: "tool", tool_call_id: "call_1", content: "file body" });
+    });
+
+    it("does not mutate the caller's parsed body", () => {
+        const parsed = { model: PROXY_MODEL, system: "keep me", messages: [{ role: "user", content: "hi" }] };
+        anthropicBodyToOpenAiBody(parsed, UPSTREAM_MODEL);
+
+        expect(parsed.system).toBe("keep me");
+        expect(parsed.model).toBe(PROXY_MODEL);
+    });
+});
+
+describe("countAnthropicInputTokens", () => {
+    it("counts the text in system, messages and tools", () => {
+        const tokens = countAnthropicInputTokens(
+            SafeJSON.stringify({
+                model: PROXY_MODEL,
+                system: "a".repeat(40),
+                messages: [{ role: "user", content: [{ type: "text", text: "b".repeat(40) }] }],
+            })
+        );
+
+        expect(tokens).toBeGreaterThan(15);
+        expect(tokens).toBeLessThan(40);
+    });
+
+    it("falls back to the raw body when it is not JSON", () => {
+        expect(countAnthropicInputTokens("not json at all")).toBeGreaterThan(0);
+    });
+});
+
+describe("anthropicMessagesPipeline", () => {
+    it("translates a non-streaming answer into an Anthropic message", async () => {
+        const provider = fakeProvider(
+            () =>
+                new Response(
+                    SafeJSON.stringify({
+                        id: "chatcmpl-1",
+                        choices: [
+                            { index: 0, message: { role: "assistant", content: "hello" }, finish_reason: "stop" },
+                        ],
+                        usage: { prompt_tokens: 3, completion_tokens: 2 },
+                    }),
+                    { status: 200, headers: { "Content-Type": "application/json" } }
+                )
+        );
+
+        const result = await anthropicMessagesPipeline({
+            provider,
+            upstreamModel: UPSTREAM_MODEL,
+            proxyModel: PROXY_MODEL,
+            req: request(),
+            bodyText: SafeJSON.stringify({
+                model: PROXY_MODEL,
+                max_tokens: 32,
+                messages: [{ role: "user", content: "hi" }],
+            }),
+        });
+
+        const message = SafeJSON.parse(await readAll(result.response), { strict: true }) as Record<string, unknown>;
+
+        expect(result.response.status).toBe(200);
+        expect(message.type).toBe("message");
+        expect(message.model).toBe(PROXY_MODEL);
+        expect(message.content).toEqual([{ type: "text", text: "hello" }]);
+        expect(message.stop_reason).toBe("end_turn");
+
+        // Usage must see the OpenAI exchange, not the Anthropic frames.
+        expect(SafeJSON.parse(result.openAiBodyText, { strict: true })).toMatchObject({ model: UPSTREAM_MODEL });
+        expect(await result.responseBody).toContain("chatcmpl-1");
+    });
+
+    it("streams Anthropic SSE frames while booking the upstream body", async () => {
+        const provider = fakeProvider(() =>
+            sseResponse([
+                chunk({ role: "assistant" }),
+                chunk({ content: "Hel" }),
+                chunk({ content: "lo" }),
+                chunk({}, "stop"),
+                "data: [DONE]\n\n",
+            ])
+        );
+
+        const result = await anthropicMessagesPipeline({
+            provider,
+            upstreamModel: UPSTREAM_MODEL,
+            proxyModel: PROXY_MODEL,
+            req: request(),
+            bodyText: SafeJSON.stringify({
+                model: PROXY_MODEL,
+                max_tokens: 32,
+                stream: true,
+                messages: [{ role: "user", content: "hi" }],
+            }),
+        });
+
+        expect(result.response.headers.get("Content-Type")).toBe("text/event-stream");
+
+        const sse = await readAll(result.response);
+        const eventTypes = sse
+            .split("\n")
+            .filter((line) => line.startsWith("event:"))
+            .map((line) => line.slice("event:".length).trim());
+
+        expect(eventTypes).toEqual([
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]);
+        expect(sse).toContain('"text":"Hel"');
+
+        // The captured body is the OpenAI stream the upstream sent, which is the
+        // only shape the usage/billing layer knows how to parse.
+        const captured = await result.responseBody;
+        expect(captured).toContain('"delta":{"content":"Hel"}');
+        expect(captured).not.toContain("content_block_delta");
+    });
+
+    it("reports an upstream failure as an Anthropic-shaped error", async () => {
+        const provider = fakeProvider(() => new Response("upstream exploded", { status: 502 }));
+
+        const result = await anthropicMessagesPipeline({
+            provider,
+            upstreamModel: UPSTREAM_MODEL,
+            proxyModel: PROXY_MODEL,
+            req: request(),
+            bodyText: SafeJSON.stringify({
+                model: PROXY_MODEL,
+                max_tokens: 32,
+                messages: [{ role: "user", content: "hi" }],
+            }),
+        });
+
+        expect(result.response.status).toBe(502);
+
+        const error = SafeJSON.parse(await readAll(result.response), { strict: true }) as Record<string, unknown>;
+        expect(error.type).toBe("error");
+        expect(SafeJSON.stringify(error.error)).toContain("upstream exploded");
+    });
+});

--- a/src/ai-proxy/lib/anthropic-messages.ts
+++ b/src/ai-proxy/lib/anthropic-messages.ts
@@ -1,0 +1,366 @@
+import type { ProxyProvider } from "@app/ai-proxy/lib/providers/types";
+import { safeStreamControllerError } from "@app/ai-proxy/lib/safe-stream-controller";
+import { normalizeAnthropicToOpenAI } from "@app/ai-proxy/lib/translators/formats/anthropic/normalize";
+import {
+    type AnthropicStreamState,
+    anthropicStreamChunk,
+    anthropicStreamEnd,
+    createAnthropicStreamState,
+    openAiCompletionToAnthropicMessage,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses";
+import { type CallTimeline, TimelineCollector } from "@app/ai-proxy/lib/usage/call-timeline";
+import { type PipelineResult, pipelineResult } from "@app/ai-proxy/lib/usage/pipeline-result";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isObject } from "@genesiscz/utils/object";
+import { estimateTokens } from "@genesiscz/utils/tokens";
+
+/**
+ * The Anthropic-native inbound surface: `POST /v1/messages`, the API Claude Code
+ * speaks. The proxy's providers all speak OpenAI chat/completions, so a request
+ * is normalized down on the way in and translated back up on the way out.
+ *
+ * Usage tracking sees the OPENAI-shaped exchange (`openAiBodyText` plus the raw
+ * upstream bytes), not the Anthropic frames the client gets — that keeps the
+ * whole usage/billing layer on the single shape it already parses.
+ */
+
+export interface AnthropicMessagesResult extends PipelineResult {
+    /** The translated request body, for the usage row (the client's body is Anthropic-shaped). */
+    openAiBodyText: string;
+}
+
+function errorResponse(status: number, message: string, type = "invalid_request_error"): Response {
+    return new Response(SafeJSON.stringify({ type: "error", error: { type, message } }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+/**
+ * Anthropic's `max_tokens` is required and Claude Code sends a large one; the
+ * OpenAI field name differs per upstream, so both are set and providers drop
+ * whichever they reject.
+ */
+export function anthropicBodyToOpenAiBody(parsed: Record<string, unknown>, upstreamModel: string): string {
+    const body: Record<string, unknown> = { ...parsed };
+
+    normalizeAnthropicToOpenAI(body, /claude/i.test(upstreamModel));
+
+    body.model = upstreamModel;
+
+    return SafeJSON.stringify(body);
+}
+
+function sseHeaders(): Record<string, string> {
+    return {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        // Same undici keep-alive-reuse hazard as every other SSE path here.
+        Connection: "close",
+        "X-Accel-Buffering": "no",
+    };
+}
+
+/**
+ * `POST /v1/messages/count_tokens`. Claude Code calls this before every turn to
+ * draw its context meter, and a 404 there makes the session look broken. No
+ * upstream in this proxy exposes a token counter, so this is the same ~4 chars
+ * per token heuristic the usage estimator already uses.
+ */
+export function countAnthropicInputTokens(bodyText: string): number {
+    const sink: string[] = [];
+
+    try {
+        const parsed = SafeJSON.parse(bodyText, { strict: true });
+
+        if (!isObject(parsed)) {
+            return estimateTokens(bodyText);
+        }
+
+        collectText(parsed.system, sink);
+        collectText(parsed.messages, sink);
+        collectText(parsed.tools, sink);
+    } catch (err) {
+        logger.debug({ err }, "ai-proxy: count_tokens body parse failed, falling back to raw length");
+        return estimateTokens(bodyText);
+    }
+
+    return estimateTokens(sink.join("\n"));
+}
+
+function collectText(value: unknown, sink: string[]): void {
+    if (typeof value === "string") {
+        sink.push(value);
+        return;
+    }
+
+    if (Array.isArray(value)) {
+        for (const entry of value) {
+            collectText(entry, sink);
+        }
+
+        return;
+    }
+
+    if (isObject(value)) {
+        for (const entry of Object.values(value)) {
+            collectText(entry, sink);
+        }
+    }
+}
+
+async function messagesJson({
+    provider,
+    upstreamModel,
+    proxyModel,
+    req,
+    openAiBodyText,
+    startedAt,
+}: {
+    provider: ProxyProvider;
+    upstreamModel: string;
+    proxyModel: string;
+    req: Request;
+    openAiBodyText: string;
+    startedAt?: number;
+}): Promise<PipelineResult> {
+    const collector = new TimelineCollector(startedAt ?? performance.now());
+    const upstream = await provider.chatCompletions(req, upstreamModel, openAiBodyText);
+    collector.markUpstreamHeaders();
+
+    const rawText = await upstream.text();
+    collector.push(rawText);
+    const timeline = Promise.resolve(collector.finish());
+
+    if (!upstream.ok) {
+        return pipelineResult(
+            errorResponse(upstream.status, `Upstream ${upstream.status}: ${rawText.slice(0, 500)}`, "api_error"),
+            rawText,
+            startedAt,
+            timeline
+        );
+    }
+
+    try {
+        const parsed = SafeJSON.parse(rawText, { strict: true });
+
+        if (!isObject(parsed)) {
+            throw new Error("upstream body was not a JSON object");
+        }
+
+        const message = openAiCompletionToAnthropicMessage(parsed, { model: proxyModel });
+
+        return pipelineResult(
+            new Response(SafeJSON.stringify(message), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+            rawText,
+            startedAt,
+            timeline
+        );
+    } catch (err) {
+        logger.warn({ err, proxyModel, upstreamModel }, "ai-proxy: /v1/messages JSON translation failed");
+
+        return pipelineResult(
+            errorResponse(502, "Upstream returned a body the Anthropic translator could not read.", "api_error"),
+            rawText,
+            startedAt,
+            timeline
+        );
+    }
+}
+
+async function messagesSse({
+    provider,
+    upstreamModel,
+    proxyModel,
+    req,
+    openAiBodyText,
+    fallbackInputTokens,
+    startedAt,
+}: {
+    provider: ProxyProvider;
+    upstreamModel: string;
+    proxyModel: string;
+    req: Request;
+    openAiBodyText: string;
+    fallbackInputTokens: number;
+    startedAt?: number;
+}): Promise<PipelineResult> {
+    const collector = new TimelineCollector(startedAt ?? performance.now());
+    const upstream = await provider.chatCompletions(req, upstreamModel, openAiBodyText);
+    collector.markUpstreamHeaders();
+
+    if (!upstream.ok || !upstream.body) {
+        const rawText = await upstream.text();
+        collector.push(rawText);
+
+        return pipelineResult(
+            errorResponse(
+                upstream.ok ? 502 : upstream.status,
+                `Upstream ${upstream.status}: ${rawText.slice(0, 500)}`,
+                "api_error"
+            ),
+            rawText,
+            startedAt,
+            Promise.resolve(collector.finish())
+        );
+    }
+
+    let resolveBody: (body: string) => void = () => {};
+    const responseBody = new Promise<string>((resolve) => {
+        resolveBody = resolve;
+    });
+
+    let resolveTimeline: (timeline: CallTimeline) => void = () => {};
+    const timeline = new Promise<CallTimeline>((resolve) => {
+        resolveTimeline = resolve;
+    });
+
+    const upstreamBody = upstream.body;
+
+    const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+            const encoder = new TextEncoder();
+            const decoder = new TextDecoder();
+            const reader = upstreamBody.getReader();
+            const state: AnthropicStreamState = createAnthropicStreamState(proxyModel, fallbackInputTokens);
+
+            // The usage layer books the UPSTREAM exchange, so the capture buffer
+            // holds the OpenAI bytes we read, not the Anthropic bytes we write.
+            let upstreamBuffer = "";
+            let buffer = "";
+            let streamSucceeded = false;
+
+            const emit = (frames: string): void => {
+                if (frames.length === 0) {
+                    return;
+                }
+
+                controller.enqueue(encoder.encode(frames));
+            };
+
+            try {
+                while (true) {
+                    const { done, value } = await reader.read();
+
+                    if (done) {
+                        break;
+                    }
+
+                    const text = decoder.decode(value, { stream: true });
+                    upstreamBuffer += text;
+                    buffer += text;
+                    // The timeline parser reads OpenAI `choices[0].delta` frames, so it
+                    // gets the upstream bytes — the same ones the usage row books.
+                    collector.push(text);
+
+                    const lines = buffer.split("\n");
+                    buffer = lines.pop() ?? "";
+
+                    for (const line of lines) {
+                        const trimmed = line.trimStart();
+
+                        if (!trimmed.startsWith("data:")) {
+                            continue;
+                        }
+
+                        const payload = trimmed.slice("data:".length).trim();
+
+                        if (payload.length === 0 || payload === "[DONE]") {
+                            continue;
+                        }
+
+                        try {
+                            const chunk = SafeJSON.parse(payload, { strict: true });
+
+                            if (isObject(chunk)) {
+                                emit(anthropicStreamChunk(state, chunk));
+                            }
+                        } catch (err) {
+                            logger.debug(
+                                { err, payloadPreview: payload.slice(0, 120) },
+                                "ai-proxy: /v1/messages skipped an unparseable upstream SSE line"
+                            );
+                        }
+                    }
+                }
+
+                emit(anthropicStreamEnd(state));
+                streamSucceeded = true;
+            } catch (err) {
+                logger.warn({ err, model: proxyModel }, "ai-proxy: /v1/messages SSE stream failed");
+
+                if (!safeStreamControllerError(controller, err, streamSucceeded)) {
+                    logger.debug(
+                        { err, model: proxyModel, streamSucceeded },
+                        "ai-proxy: /v1/messages skipped controller.error (client abort or detached)"
+                    );
+                }
+            } finally {
+                resolveBody(upstreamBuffer);
+                resolveTimeline(collector.finish());
+
+                if (streamSucceeded) {
+                    try {
+                        controller.close();
+                    } catch (controllerErr) {
+                        logger.warn(
+                            { err: controllerErr, model: proxyModel },
+                            "ai-proxy: /v1/messages controller.close() threw — client likely disconnected"
+                        );
+                    }
+                }
+            }
+        },
+    });
+
+    return pipelineResult(
+        new Response(stream, { status: 200, headers: sseHeaders() }),
+        responseBody,
+        startedAt,
+        timeline
+    );
+}
+
+export async function anthropicMessagesPipeline({
+    provider,
+    upstreamModel,
+    proxyModel,
+    req,
+    bodyText,
+    startedAt,
+}: {
+    provider: ProxyProvider;
+    upstreamModel: string;
+    proxyModel: string;
+    req: Request;
+    bodyText: string;
+    /** performance.now() taken when the proxy received the request (timeline anchor). */
+    startedAt?: number;
+}): Promise<AnthropicMessagesResult> {
+    const parsed = SafeJSON.parse(bodyText, { strict: true });
+
+    if (!isObject(parsed)) {
+        throw new Error("Request body must be a JSON object");
+    }
+
+    const wantsStream = parsed.stream === true;
+    const openAiBodyText = anthropicBodyToOpenAiBody(parsed, upstreamModel);
+
+    const result = wantsStream
+        ? await messagesSse({
+              provider,
+              upstreamModel,
+              proxyModel,
+              req,
+              openAiBodyText,
+              fallbackInputTokens: countAnthropicInputTokens(bodyText),
+              startedAt,
+          })
+        : await messagesJson({ provider, upstreamModel, proxyModel, req, openAiBodyText, startedAt });
+
+    return { ...result, openAiBodyText };
+}

--- a/src/ai-proxy/lib/auth-middleware.ts
+++ b/src/ai-proxy/lib/auth-middleware.ts
@@ -15,12 +15,18 @@ function tokensMatch(presented: string, expected: string): boolean {
 export function extractBearerToken(req: Request): string | null {
     const header = req.headers.get("Authorization");
 
-    if (!header) {
-        return null;
+    if (header) {
+        const match = header.match(/^Bearer\s+(.+)$/i);
+
+        if (match?.[1]) {
+            return match[1];
+        }
     }
 
-    const match = header.match(/^Bearer\s+(.+)$/i);
-    return match?.[1] ?? null;
+    // Anthropic-shaped clients (Claude Code with ANTHROPIC_API_KEY, the Anthropic
+    // SDKs) send the key as x-api-key and never set Authorization. Accepting it
+    // here means every route authenticates the same way, whichever door is used.
+    return req.headers.get("x-api-key");
 }
 
 export function requireProxyApiKey(req: Request, proxyApiKey: string): Response | null {

--- a/src/ai-proxy/lib/server.ts
+++ b/src/ai-proxy/lib/server.ts
@@ -1,6 +1,7 @@
+import { anthropicMessagesPipeline, countAnthropicInputTokens } from "@app/ai-proxy/lib/anthropic-messages";
 import { handleAudioTranscriptions } from "@app/ai-proxy/lib/audio";
 import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
-import { clientProviderDenial, resolveClient, validateClients } from "@app/ai-proxy/lib/clients";
+import { clientProviderDenial, type ResolvedClient, resolveClient, validateClients } from "@app/ai-proxy/lib/clients";
 import { loadConfigFresh } from "@app/ai-proxy/lib/config";
 import { stripBasePath } from "@app/ai-proxy/lib/path-prefix";
 import { acquireProvider, buildProviderMap, providerUnavailableResponse } from "@app/ai-proxy/lib/providers/registry";
@@ -112,6 +113,113 @@ function trackProxyRequest(input: {
     scheduleBillingSync(input.route.account, input.runtime.providers);
 }
 
+function jsonError(status: number, error: Record<string, unknown>): Response {
+    return new Response(SafeJSON.stringify({ error }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+/**
+ * Read a model-bearing POST body once, with the size and shape guards every
+ * inference route needs. Shared by /v1/chat/completions, /v1/responses and
+ * /v1/messages so a guard added for one door is never missing from another.
+ */
+async function readModelBody(req: Request): Promise<{ bodyText: string; model: string } | { error: Response }> {
+    const contentLength = req.headers.get("content-length");
+
+    if (contentLength) {
+        const declaredBytes = Number.parseInt(contentLength, 10);
+
+        if (Number.isFinite(declaredBytes) && declaredBytes > MAX_REQUEST_BODY_BYTES) {
+            return { error: jsonError(413, { message: "Request body too large" }) };
+        }
+    }
+
+    const bodyText = await req.text();
+
+    if (Buffer.byteLength(bodyText, "utf8") > MAX_REQUEST_BODY_BYTES) {
+        return { error: jsonError(413, { message: "Request body too large" }) };
+    }
+
+    let parsed: { model?: string };
+
+    try {
+        parsed = SafeJSON.parse(bodyText, { strict: true }) as { model?: string };
+    } catch (err) {
+        logger.debug({ err }, "ai-proxy: invalid JSON body");
+        return { error: jsonError(400, { message: "Invalid JSON body" }) };
+    }
+
+    if (!parsed.model) {
+        return { error: jsonError(400, { message: "Missing model" }) };
+    }
+
+    const invalidImagePayload = findInvalidImageDataPayload(parsed as Record<string, unknown>);
+
+    if (invalidImagePayload !== null) {
+        logger.warn(
+            { model: parsed.model, payloadPreview: invalidImagePayload },
+            "ai-proxy: rejecting image content with invalid base64 payload"
+        );
+
+        return {
+            error: jsonError(400, {
+                message:
+                    `Image content part carries an invalid base64 payload (${SafeJSON.stringify(invalidImagePayload)}) — ` +
+                    "the image bytes never reached the proxy. This usually means the client stringified an object " +
+                    'into the data URL (e.g. AI SDK v2-compat file parts becoming "[object Object]").',
+                type: "invalid_request_error",
+                code: "invalid_image_data",
+            }),
+        };
+    }
+
+    return { bodyText, model: parsed.model };
+}
+
+/** Model → account route plus a live provider, with the per-client denial and quota gates. */
+async function authorizeModelRoute({
+    client,
+    config,
+    model,
+    providers,
+}: {
+    client: ResolvedClient;
+    config: AiProxyConfig;
+    model: string;
+    providers: Map<string, ProxyProvider>;
+}): Promise<{ route: ResolvedRoute; provider: ProxyProvider } | { error: Response }> {
+    const route = resolveModel(model, config.accounts);
+    const denial = clientProviderDenial(client, route.account.provider);
+
+    if (denial) {
+        logger.warn({ client: client.name, model, denial }, "ai-proxy: provider denied");
+        return { error: jsonError(403, { message: denial, type: "forbidden", code: "provider_not_allowed" }) };
+    }
+
+    const quota = checkClientQuota(client);
+
+    if (!quota.ok) {
+        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: quota exceeded");
+        return {
+            error: jsonError(429, {
+                message: quota.reason,
+                type: "quota_exceeded",
+                code: "monthly_quota_exceeded",
+            }),
+        };
+    }
+
+    const provider = await acquireProvider(providers, route);
+
+    if (!provider) {
+        return { error: providerUnavailableResponse(route) };
+    }
+
+    return { route, provider };
+}
+
 export function startAiProxyServer(runtime: AiProxyRuntime) {
     const clientProblems = validateClients(runtime.config.clients);
 
@@ -180,6 +288,117 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                 );
             }
 
+            // Claude Code and the Anthropic SDKs speak /v1/messages, not
+            // /v1/chat/completions. Every provider behind this proxy speaks
+            // OpenAI, so the body is translated both ways (anthropic-messages.ts).
+            if (path === "/v1/messages/count_tokens" && req.method === "POST") {
+                const client = await resolveClient(req, config);
+
+                if (!client) {
+                    return jsonError(401, { message: "Invalid proxy API key", type: "auth_error" });
+                }
+
+                const countBody = await req.text();
+
+                return new Response(SafeJSON.stringify({ input_tokens: countAnthropicInputTokens(countBody) }), {
+                    headers: { "Content-Type": "application/json" },
+                });
+            }
+
+            if (path === "/v1/messages" && req.method === "POST") {
+                const client = await resolveClient(req, config);
+
+                if (!client) {
+                    return jsonError(401, { message: "Invalid proxy API key", type: "auth_error" });
+                }
+
+                const requestStarted = performance.now();
+                const body = await readModelBody(req);
+
+                if ("error" in body) {
+                    return body.error;
+                }
+
+                const { bodyText, model } = body;
+
+                try {
+                    const routed = await authorizeModelRoute({
+                        client,
+                        config,
+                        model,
+                        providers: runtime.providers,
+                    });
+
+                    if ("error" in routed) {
+                        return routed.error;
+                    }
+
+                    const { route, provider } = routed;
+
+                    const { response, responseBody, timeline, openAiBodyText } = await anthropicMessagesPipeline({
+                        startedAt: requestStarted,
+                        provider,
+                        upstreamModel: route.upstreamId,
+                        proxyModel: model,
+                        req,
+                        bodyText,
+                    });
+                    const elapsedMs = Math.round(performance.now() - requestStarted);
+
+                    // The usage layer only parses the OpenAI shape, and the exchange it
+                    // should book is the one the upstream actually saw.
+                    trackProxyRequest({
+                        runtime,
+                        route,
+                        client: client.name,
+                        proxyModel: model,
+                        path,
+                        status: response.status,
+                        elapsedMs,
+                        bodyText: openAiBodyText,
+                        responseBody,
+                        timeline,
+                        translate: "anthropic",
+                        tags: readRequestTags(req.headers),
+                    });
+
+                    logger.info(
+                        {
+                            path,
+                            model,
+                            upstreamModel: route.upstreamId,
+                            status: response.status,
+                            elapsedMs,
+                            ...readRequestTags(req.headers),
+                            userAgent: req.headers.get("User-Agent") ?? undefined,
+                        },
+                        "ai-proxy: request"
+                    );
+
+                    return response;
+                } catch (err) {
+                    const mapped = mapProxyRequestError(err);
+                    logger.warn(
+                        {
+                            path,
+                            model,
+                            elapsedMs: Math.round(performance.now() - requestStarted),
+                            status: mapped.status,
+                            error: err,
+                        },
+                        "ai-proxy: request failed"
+                    );
+
+                    return new Response(
+                        SafeJSON.stringify({
+                            type: "error",
+                            error: { type: "invalid_request_error", message: mapped.message },
+                        }),
+                        { status: mapped.status, headers: { "Content-Type": "application/json" } }
+                    );
+                }
+            }
+
             if ((path === "/v1/chat/completions" || path === "/v1/responses") && req.method === "POST") {
                 const client = await resolveClient(req, config);
 
@@ -191,104 +410,27 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                 }
 
                 const requestStarted = performance.now();
-                const contentLength = req.headers.get("content-length");
+                const body = await readModelBody(req);
 
-                if (contentLength) {
-                    const declaredBytes = Number.parseInt(contentLength, 10);
-
-                    if (Number.isFinite(declaredBytes) && declaredBytes > MAX_REQUEST_BODY_BYTES) {
-                        return new Response(SafeJSON.stringify({ error: { message: "Request body too large" } }), {
-                            status: 413,
-                            headers: { "Content-Type": "application/json" },
-                        });
-                    }
+                if ("error" in body) {
+                    return body.error;
                 }
 
-                const bodyText = await req.text();
-
-                if (Buffer.byteLength(bodyText, "utf8") > MAX_REQUEST_BODY_BYTES) {
-                    return new Response(SafeJSON.stringify({ error: { message: "Request body too large" } }), {
-                        status: 413,
-                        headers: { "Content-Type": "application/json" },
-                    });
-                }
-
-                let parsed: { model?: string };
-                try {
-                    parsed = SafeJSON.parse(bodyText, { strict: true }) as { model?: string };
-                } catch (err) {
-                    logger.debug({ err }, "ai-proxy: invalid JSON body");
-                    return new Response(SafeJSON.stringify({ error: { message: "Invalid JSON body" } }), {
-                        status: 400,
-                        headers: { "Content-Type": "application/json" },
-                    });
-                }
-
-                if (!parsed.model) {
-                    return new Response(SafeJSON.stringify({ error: { message: "Missing model" } }), {
-                        status: 400,
-                        headers: { "Content-Type": "application/json" },
-                    });
-                }
-
-                const invalidImagePayload = findInvalidImageDataPayload(parsed as Record<string, unknown>);
-
-                if (invalidImagePayload !== null) {
-                    logger.warn(
-                        { path, model: parsed.model, payloadPreview: invalidImagePayload },
-                        "ai-proxy: rejecting image content with invalid base64 payload"
-                    );
-                    return new Response(
-                        SafeJSON.stringify({
-                            error: {
-                                message:
-                                    `Image content part carries an invalid base64 payload (${SafeJSON.stringify(invalidImagePayload)}) — ` +
-                                    "the image bytes never reached the proxy. This usually means the client stringified an object " +
-                                    'into the data URL (e.g. AI SDK v2-compat file parts becoming "[object Object]").',
-                                type: "invalid_request_error",
-                                code: "invalid_image_data",
-                            },
-                        }),
-                        { status: 400, headers: { "Content-Type": "application/json" } }
-                    );
-                }
+                const { bodyText, model } = body;
 
                 try {
-                    const route = resolveModel(parsed.model, config.accounts);
+                    const routed = await authorizeModelRoute({
+                        client,
+                        config,
+                        model,
+                        providers: runtime.providers,
+                    });
 
-                    const denial = clientProviderDenial(client, route.account.provider);
-
-                    if (denial) {
-                        logger.warn({ client: client.name, model: parsed.model, denial }, "ai-proxy: provider denied");
-                        return new Response(
-                            SafeJSON.stringify({
-                                error: { message: denial, type: "forbidden", code: "provider_not_allowed" },
-                            }),
-                            { status: 403, headers: { "Content-Type": "application/json" } }
-                        );
+                    if ("error" in routed) {
+                        return routed.error;
                     }
 
-                    const quota = checkClientQuota(client);
-
-                    if (!quota.ok) {
-                        logger.warn({ client: client.name, reason: quota.reason }, "ai-proxy: quota exceeded");
-                        return new Response(
-                            SafeJSON.stringify({
-                                error: {
-                                    message: quota.reason,
-                                    type: "quota_exceeded",
-                                    code: "monthly_quota_exceeded",
-                                },
-                            }),
-                            { status: 429, headers: { "Content-Type": "application/json" } }
-                        );
-                    }
-
-                    const provider = await acquireProvider(runtime.providers, route);
-
-                    if (!provider) {
-                        return providerUnavailableResponse(route);
-                    }
+                    const { route, provider } = routed;
 
                     if (path === "/v1/responses") {
                         const { response, responseBody, timeline, captureFailure } = await identityPipeline({
@@ -305,7 +447,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                             runtime,
                             route,
                             client: client.name,
-                            proxyModel: parsed.model,
+                            proxyModel: model,
                             path,
                             status: response.status,
                             elapsedMs,
@@ -320,7 +462,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         logger.info(
                             {
                                 path,
-                                model: parsed.model,
+                                model,
                                 upstreamModel: route.upstreamId,
                                 status: response.status,
                                 elapsedMs,
@@ -352,7 +494,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         thinkingMode,
                         provider,
                         upstreamModel: route.upstreamId,
-                        proxyModel: parsed.model,
+                        proxyModel: model,
                         req,
                         bodyText,
                     });
@@ -362,7 +504,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                         runtime,
                         route,
                         client: client.name,
-                        proxyModel: parsed.model,
+                        proxyModel: model,
                         path,
                         status: response.status,
                         elapsedMs,
@@ -378,7 +520,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                     logger.info(
                         {
                             path,
-                            model: parsed.model,
+                            model,
                             upstreamModel: route.upstreamId,
                             status: response.status,
                             translate: mode,
@@ -396,7 +538,7 @@ export function startAiProxyServer(runtime: AiProxyRuntime) {
                     logger.warn(
                         {
                             path,
-                            model: parsed.model,
+                            model,
                             elapsedMs: Math.round(performance.now() - requestStarted),
                             status: mapped.status,
                             error: err,

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import {
+    anthropicStreamChunk,
+    anthropicStreamEnd,
+    createAnthropicStreamState,
+    openAiCompletionToAnthropicMessage,
+    openAiFinishToAnthropicStop,
+} from "./openai-to-anthropic-responses";
+
+const MODEL = "martin/grok/grok-4.5";
+
+/** Parse `event: x\ndata: {...}` frames into their JSON payloads, in order. */
+function parseFrames(sse: string): Array<Record<string, unknown>> {
+    return sse
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => SafeJSON.parse(line.slice("data:".length).trim(), { strict: true }) as Record<string, unknown>);
+}
+
+function types(sse: string): string[] {
+    return parseFrames(sse).map((frame) => String(frame.type));
+}
+
+describe("openAiFinishToAnthropicStop", () => {
+    it("maps the OpenAI finish reasons onto Anthropic stop reasons", () => {
+        expect(openAiFinishToAnthropicStop("stop")).toBe("end_turn");
+        expect(openAiFinishToAnthropicStop("length")).toBe("max_tokens");
+        expect(openAiFinishToAnthropicStop("tool_calls")).toBe("tool_use");
+        expect(openAiFinishToAnthropicStop(undefined)).toBe("end_turn");
+    });
+});
+
+describe("openAiCompletionToAnthropicMessage", () => {
+    it("orders thinking before text and turns tool_calls into tool_use blocks", () => {
+        const message = openAiCompletionToAnthropicMessage(
+            {
+                id: "chatcmpl-abc",
+                choices: [
+                    {
+                        index: 0,
+                        message: {
+                            role: "assistant",
+                            reasoning_content: "let me think",
+                            content: "here you go",
+                            tool_calls: [
+                                { id: "call_1", type: "function", function: { name: "read", arguments: '{"p":"a"}' } },
+                            ],
+                        },
+                        finish_reason: "tool_calls",
+                    },
+                ],
+                usage: { prompt_tokens: 10, completion_tokens: 4 },
+            },
+            { model: MODEL }
+        );
+
+        expect(message.model).toBe(MODEL);
+        expect(message.stop_reason).toBe("tool_use");
+        expect(message.content).toEqual([
+            { type: "thinking", thinking: "let me think" },
+            { type: "text", text: "here you go" },
+            { type: "tool_use", id: "call_1", name: "read", input: { p: "a" } },
+        ]);
+        expect(message.usage).toEqual({ input_tokens: 10, output_tokens: 4 });
+    });
+
+    it("reports cache reads outside input_tokens, as the Anthropic API does", () => {
+        const message = openAiCompletionToAnthropicMessage(
+            {
+                choices: [{ message: { content: "hi" }, finish_reason: "stop" }],
+                usage: { prompt_tokens: 100, completion_tokens: 5, prompt_tokens_details: { cached_tokens: 80 } },
+            },
+            { model: MODEL }
+        );
+
+        expect(message.usage).toEqual({ input_tokens: 20, output_tokens: 5, cache_read_input_tokens: 80 });
+    });
+
+    it("never returns an empty content array", () => {
+        const message = openAiCompletionToAnthropicMessage(
+            { choices: [{ message: { content: null }, finish_reason: "stop" }] },
+            { model: MODEL }
+        );
+
+        expect(message.content).toEqual([{ type: "text", text: "" }]);
+    });
+});
+
+describe("anthropic stream state machine", () => {
+    it("emits a well-formed text stream", () => {
+        const state = createAnthropicStreamState(MODEL);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { role: "assistant" } }] });
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { content: "Hel" } }] });
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { content: "lo" } }] });
+        sse += anthropicStreamChunk(state, { choices: [{ delta: {}, finish_reason: "stop" }] });
+        sse += anthropicStreamEnd(state);
+
+        expect(types(sse)).toEqual([
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]);
+
+        const frames = parseFrames(sse);
+        expect(frames[1]?.content_block).toEqual({ type: "text", text: "" });
+        expect(frames[2]?.delta).toEqual({ type: "text_delta", text: "Hel" });
+        expect(frames[5]?.delta).toEqual({ stop_reason: "end_turn", stop_sequence: null });
+    });
+
+    it("closes the thinking block before opening the text block", () => {
+        const state = createAnthropicStreamState(MODEL);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { reasoning_content: "hmm" } }] });
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { content: "done" } }] });
+        sse += anthropicStreamEnd(state);
+
+        expect(types(sse)).toEqual([
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]);
+
+        const frames = parseFrames(sse);
+        expect(frames[1]?.content_block).toEqual({ type: "thinking", thinking: "" });
+        expect(frames[2]?.delta).toEqual({ type: "thinking_delta", thinking: "hmm" });
+        expect(frames[4]?.content_block).toEqual({ type: "text", text: "" });
+        // Block indices must keep counting up across kinds.
+        expect(frames[4]?.index).toBe(1);
+    });
+
+    it("carries a tool call's id and name from the first frame into later argument frames", () => {
+        const state = createAnthropicStreamState(MODEL);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, {
+            choices: [
+                {
+                    delta: {
+                        tool_calls: [{ index: 0, id: "call_9", function: { name: "edit", arguments: "" } }],
+                    },
+                },
+            ],
+        });
+        sse += anthropicStreamChunk(state, {
+            choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"a":' } }] } }],
+        });
+        sse += anthropicStreamChunk(state, {
+            choices: [
+                { delta: { tool_calls: [{ index: 0, function: { arguments: "1}" } }] }, finish_reason: "tool_calls" },
+            ],
+        });
+        sse += anthropicStreamEnd(state);
+
+        const frames = parseFrames(sse);
+        expect(frames[1]?.content_block).toEqual({ type: "tool_use", id: "call_9", name: "edit", input: {} });
+        expect(frames[2]?.delta).toEqual({ type: "input_json_delta", partial_json: '{"a":' });
+        expect(frames[3]?.delta).toEqual({ type: "input_json_delta", partial_json: "1}" });
+        expect(frames.at(-2)?.delta).toEqual({ stop_reason: "tool_use", stop_sequence: null });
+    });
+
+    it("gives each parallel tool call its own content block", () => {
+        const state = createAnthropicStreamState(MODEL);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, {
+            choices: [{ delta: { tool_calls: [{ index: 0, id: "a", function: { name: "one", arguments: "{}" } }] } }],
+        });
+        sse += anthropicStreamChunk(state, {
+            choices: [{ delta: { tool_calls: [{ index: 1, id: "b", function: { name: "two", arguments: "{}" } }] } }],
+        });
+        sse += anthropicStreamEnd(state);
+
+        const starts = parseFrames(sse).filter((frame) => frame.type === "content_block_start");
+        expect(starts.map((frame) => frame.index)).toEqual([0, 1]);
+        expect(starts.map((frame) => (frame.content_block as Record<string, unknown>).name)).toEqual(["one", "two"]);
+    });
+
+    it("puts the final usage in message_delta", () => {
+        const state = createAnthropicStreamState(MODEL);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { content: "x" } }] });
+        sse += anthropicStreamChunk(state, { choices: [], usage: { prompt_tokens: 7, completion_tokens: 3 } });
+        sse += anthropicStreamEnd(state);
+
+        const messageDelta = parseFrames(sse).find((frame) => frame.type === "message_delta");
+        expect(messageDelta?.usage).toEqual({ input_tokens: 7, output_tokens: 3 });
+    });
+
+    it("estimates usage when the upstream reports none (Grok drops stream_options)", () => {
+        const state = createAnthropicStreamState(MODEL, 120);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { content: "x".repeat(40) } }] });
+        sse += anthropicStreamEnd(state);
+
+        const frames = parseFrames(sse);
+        expect((frames[0]?.message as Record<string, unknown>).usage).toEqual({
+            input_tokens: 120,
+            output_tokens: 0,
+        });
+        expect(frames.find((frame) => frame.type === "message_delta")?.usage).toEqual({
+            input_tokens: 120,
+            output_tokens: 10,
+        });
+    });
+
+    it("prefers the upstream's own usage over the estimate", () => {
+        const state = createAnthropicStreamState(MODEL, 120);
+        let sse = "";
+
+        sse += anthropicStreamChunk(state, { choices: [{ delta: { content: "x".repeat(40) } }] });
+        sse += anthropicStreamChunk(state, { choices: [], usage: { prompt_tokens: 9, completion_tokens: 1 } });
+        sse += anthropicStreamEnd(state);
+
+        expect(parseFrames(sse).find((frame) => frame.type === "message_delta")?.usage).toEqual({
+            input_tokens: 9,
+            output_tokens: 1,
+        });
+    });
+
+    it("still emits a complete message when the upstream sent nothing", () => {
+        const state = createAnthropicStreamState(MODEL);
+
+        expect(types(anthropicStreamEnd(state))).toEqual(["message_start", "message_delta", "message_stop"]);
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.ts
@@ -1,0 +1,349 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * Maps OpenAI chat-completions RESPONSES into the Anthropic `/v1/messages`
+ * shape. This is the mirror of anthropic-to-openai-completions.ts: that file
+ * serves clients who speak OpenAI against a Claude upstream, this one serves
+ * clients who speak Anthropic (Claude Code) against an OpenAI upstream.
+ *
+ * Extended thinking is forwarded as real `thinking` blocks but WITHOUT a
+ * `signature`. Anthropic only needs a signature to verify a thinking block sent
+ * back up, and the inbound normalizer (normalize.ts) drops assistant thinking
+ * blocks from history, so nothing is ever echoed to an upstream that would
+ * check it.
+ */
+
+export type AnthropicStopReason = "end_turn" | "max_tokens" | "stop_sequence" | "tool_use";
+
+export interface AnthropicUsage {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+}
+
+export function openAiFinishToAnthropicStop(finishReason: unknown): AnthropicStopReason {
+    if (finishReason === "length") {
+        return "max_tokens";
+    }
+
+    if (finishReason === "tool_calls" || finishReason === "function_call") {
+        return "tool_use";
+    }
+
+    return "end_turn";
+}
+
+function usageFrom(raw: unknown): AnthropicUsage {
+    if (!isObject(raw)) {
+        return { input_tokens: 0, output_tokens: 0 };
+    }
+
+    const promptTokens = typeof raw.prompt_tokens === "number" ? raw.prompt_tokens : 0;
+    const completionTokens = typeof raw.completion_tokens === "number" ? raw.completion_tokens : 0;
+    const usage: AnthropicUsage = { input_tokens: promptTokens, output_tokens: completionTokens };
+
+    const details = isObject(raw.prompt_tokens_details) ? raw.prompt_tokens_details : undefined;
+
+    if (details && typeof details.cached_tokens === "number" && details.cached_tokens > 0) {
+        // Anthropic reports cache reads OUTSIDE input_tokens, OpenAI reports them
+        // inside prompt_tokens. Subtract so the client's own "input + cache read"
+        // sum matches what the upstream actually charged for.
+        usage.cache_read_input_tokens = details.cached_tokens;
+        usage.input_tokens = Math.max(0, promptTokens - details.cached_tokens);
+    }
+
+    return usage;
+}
+
+function parsedToolInput(rawArguments: unknown): unknown {
+    if (typeof rawArguments !== "string" || rawArguments.trim().length === 0) {
+        return {};
+    }
+
+    try {
+        return SafeJSON.parse(rawArguments, { strict: true });
+    } catch {
+        return { _raw: rawArguments };
+    }
+}
+
+/** Non-streaming: an OpenAI chat.completion → an Anthropic message object. */
+export function openAiCompletionToAnthropicMessage(
+    completion: Record<string, unknown>,
+    options: { model: string }
+): Record<string, unknown> {
+    const choices = Array.isArray(completion.choices) ? completion.choices : [];
+    const choice = isObject(choices[0]) ? choices[0] : {};
+    const message = isObject(choice.message) ? choice.message : {};
+    const content: Record<string, unknown>[] = [];
+
+    const reasoning = message.reasoning_content ?? message.reasoning;
+
+    if (typeof reasoning === "string" && reasoning.length > 0) {
+        content.push({ type: "thinking", thinking: reasoning });
+    }
+
+    if (typeof message.content === "string" && message.content.length > 0) {
+        content.push({ type: "text", text: message.content });
+    }
+
+    if (Array.isArray(message.tool_calls)) {
+        for (const call of message.tool_calls) {
+            if (!isObject(call)) {
+                continue;
+            }
+
+            const fn = isObject(call.function) ? call.function : {};
+
+            content.push({
+                type: "tool_use",
+                id: typeof call.id === "string" ? call.id : `toolu_${crypto.randomUUID()}`,
+                name: typeof fn.name === "string" ? fn.name : "unknown",
+                input: parsedToolInput(fn.arguments),
+            });
+        }
+    }
+
+    // Anthropic clients treat an empty content array as a protocol error; Claude
+    // Code renders nothing and then retries forever.
+    if (content.length === 0) {
+        content.push({ type: "text", text: "" });
+    }
+
+    return {
+        id: `msg_${typeof completion.id === "string" ? completion.id.replace(/^chatcmpl-/, "") : crypto.randomUUID()}`,
+        type: "message",
+        role: "assistant",
+        model: options.model,
+        content,
+        stop_reason: openAiFinishToAnthropicStop(choice.finish_reason),
+        stop_sequence: null,
+        usage: usageFrom(completion.usage),
+    };
+}
+
+function frame(type: string, data: Record<string, unknown>): string {
+    return `event: ${type}\ndata: ${SafeJSON.stringify({ type, ...data })}\n\n`;
+}
+
+type BlockKind = "thinking" | "text" | "tool_use";
+
+interface OpenBlock {
+    kind: BlockKind;
+    index: number;
+    /** The OpenAI tool_call index this block mirrors; only set for tool_use. */
+    toolIndex?: number;
+}
+
+export interface AnthropicStreamState {
+    model: string;
+    messageId: string;
+    started: boolean;
+    open: OpenBlock | null;
+    nextIndex: number;
+    stopReason: AnthropicStopReason | null;
+    usage: AnthropicUsage;
+    /** id/name seen for an OpenAI tool_call index — later frames carry arguments only. */
+    seenTools: Map<number, { id: string; name: string }>;
+    /** Characters streamed out, for the usage estimate when the upstream reports none. */
+    outputChars: number;
+    /** Prompt-token estimate to fall back on; see createAnthropicStreamState. */
+    fallbackInputTokens: number;
+}
+
+/**
+ * `fallbackInputTokens` exists because several upstreams stream no usage at all:
+ * Grok's chat/completions drops `stream_options`, so its SSE never carries a
+ * token count. Reporting 0/0 would leave Claude Code's context meter empty and
+ * its auto-compact trigger blind, so an estimate is reported instead of nothing.
+ */
+export function createAnthropicStreamState(model: string, fallbackInputTokens = 0): AnthropicStreamState {
+    return {
+        model,
+        messageId: `msg_${crypto.randomUUID()}`,
+        started: false,
+        open: null,
+        nextIndex: 0,
+        stopReason: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        seenTools: new Map(),
+        outputChars: 0,
+        fallbackInputTokens,
+    };
+}
+
+function reportedUsage(state: AnthropicStreamState): AnthropicUsage {
+    if (state.usage.input_tokens > 0 || state.usage.output_tokens > 0) {
+        return state.usage;
+    }
+
+    return {
+        input_tokens: state.fallbackInputTokens,
+        output_tokens: Math.ceil(state.outputChars / 4),
+    };
+}
+
+/** The `message_start` frame. Emitted lazily so an upstream error never opens a message. */
+export function anthropicStreamStart(state: AnthropicStreamState): string {
+    if (state.started) {
+        return "";
+    }
+
+    state.started = true;
+
+    return frame("message_start", {
+        message: {
+            id: state.messageId,
+            type: "message",
+            role: "assistant",
+            model: state.model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: state.fallbackInputTokens, output_tokens: 0 },
+        },
+    });
+}
+
+function closeBlock(state: AnthropicStreamState): string {
+    if (!state.open) {
+        return "";
+    }
+
+    const out = frame("content_block_stop", { index: state.open.index });
+    state.open = null;
+    return out;
+}
+
+function openBlock(state: AnthropicStreamState, kind: BlockKind, contentBlock: Record<string, unknown>): string {
+    const index = state.nextIndex++;
+    state.open = { kind, index };
+
+    return frame("content_block_start", { index, content_block: contentBlock });
+}
+
+/**
+ * Translate ONE OpenAI `chat.completion.chunk` into the Anthropic SSE frames it
+ * implies. Returns "" when the chunk carries nothing renderable (a bare role
+ * delta, a usage-only trailer).
+ */
+export function anthropicStreamChunk(state: AnthropicStreamState, chunk: Record<string, unknown>): string {
+    let out = "";
+
+    if (isObject(chunk.usage)) {
+        state.usage = usageFrom(chunk.usage);
+    }
+
+    const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
+    const choice = isObject(choices[0]) ? choices[0] : {};
+    const delta = isObject(choice.delta) ? choice.delta : {};
+
+    if (typeof choice.finish_reason === "string") {
+        state.stopReason = openAiFinishToAnthropicStop(choice.finish_reason);
+    }
+
+    const reasoning = delta.reasoning_content ?? delta.reasoning;
+
+    if (typeof reasoning === "string" && reasoning.length > 0) {
+        out += anthropicStreamStart(state);
+        state.outputChars += reasoning.length;
+
+        if (state.open?.kind !== "thinking") {
+            out += closeBlock(state);
+            out += openBlock(state, "thinking", { type: "thinking", thinking: "" });
+        }
+
+        out += frame("content_block_delta", {
+            index: state.open?.index ?? 0,
+            delta: { type: "thinking_delta", thinking: reasoning },
+        });
+    }
+
+    if (typeof delta.content === "string" && delta.content.length > 0) {
+        out += anthropicStreamStart(state);
+        state.outputChars += delta.content.length;
+
+        if (state.open?.kind !== "text") {
+            out += closeBlock(state);
+            out += openBlock(state, "text", { type: "text", text: "" });
+        }
+
+        out += frame("content_block_delta", {
+            index: state.open?.index ?? 0,
+            delta: { type: "text_delta", text: delta.content },
+        });
+    }
+
+    if (Array.isArray(delta.tool_calls)) {
+        for (const call of delta.tool_calls) {
+            if (!isObject(call)) {
+                continue;
+            }
+
+            const toolIndex = typeof call.index === "number" ? call.index : 0;
+            const fn = isObject(call.function) ? call.function : {};
+            const known = state.seenTools.get(toolIndex);
+
+            const id = typeof call.id === "string" ? call.id : known?.id;
+            const name = typeof fn.name === "string" ? fn.name : known?.name;
+
+            if (id || name) {
+                state.seenTools.set(toolIndex, {
+                    id: id ?? `toolu_${crypto.randomUUID()}`,
+                    name: name ?? "unknown",
+                });
+            }
+
+            out += anthropicStreamStart(state);
+
+            if (state.open?.kind !== "tool_use" || state.open.toolIndex !== toolIndex) {
+                const resolved = state.seenTools.get(toolIndex) ?? {
+                    id: `toolu_${crypto.randomUUID()}`,
+                    name: "unknown",
+                };
+                out += closeBlock(state);
+                out += openBlock(state, "tool_use", {
+                    type: "tool_use",
+                    id: resolved.id,
+                    name: resolved.name,
+                    input: {},
+                });
+
+                if (state.open) {
+                    state.open.toolIndex = toolIndex;
+                }
+            }
+
+            if (typeof fn.arguments === "string" && fn.arguments.length > 0) {
+                state.outputChars += fn.arguments.length;
+                out += frame("content_block_delta", {
+                    index: state.open?.index ?? 0,
+                    delta: { type: "input_json_delta", partial_json: fn.arguments },
+                });
+            }
+        }
+    }
+
+    return out;
+}
+
+/** Closing frames: the open block, then `message_delta` (stop reason + usage) and `message_stop`. */
+export function anthropicStreamEnd(state: AnthropicStreamState): string {
+    let out = anthropicStreamStart(state);
+    out += closeBlock(state);
+
+    // input_tokens rides along in message_delta as well: the real Anthropic API
+    // knows them at message_start, an OpenAI upstream only reports them in its
+    // final usage trailer, and a client that never sees them shows a 0-token
+    // context. Extra fields here are ignored by clients that do not want them.
+    out += frame("message_delta", {
+        delta: { stop_reason: state.stopReason ?? "end_turn", stop_sequence: null },
+        usage: reportedUsage(state),
+    });
+
+    out += frame("message_stop", {});
+
+    return out;
+}

--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -9,6 +9,7 @@ Claude-focused utilities for local Claude Code workflows:
 - Manage Claude auth/config
 - Migrate Claude assets to Codex (`migrate-to codex`)
 - Reopen a set of sessions as cmux workspaces (`cmux`)
+- Run Claude Code on a non-Anthropic model through ai-proxy (`proxy`)
 
 ---
 
@@ -33,6 +34,39 @@ tools claude migrate-to codex
 # Reopen recent sessions as cmux panes
 tools claude cmux
 ```
+
+---
+
+## `proxy` — Claude Code on a proxied model
+
+Launches Claude Code against a model served by `tools ai-proxy` (Grok, GitHub Copilot,
+OpenRouter, xAI) instead of api.anthropic.com. The proxy answers the Anthropic Messages API
+natively; see `src/ai-proxy/README.md` for the translation.
+
+```bash
+tools claude proxy martin/grok -m 4.5        # <account>/<provider> plus a model filter
+tools claude proxy work/xai/grok-4.6         # or a full proxy model id
+tools claude run martin/grok -m 4.5          # `run` routes here when the name has a slash
+tools claude proxy martin/grok --list        # list matching models, launch nothing
+tools claude proxy martin/grok -- -c         # args after -- go to claude
+```
+
+`[target]` is an `<account>/<provider>` prefix or a full proxy id; `-m/--model` filters inside it
+(every whitespace-separated token must appear, so `-m "composer fast"` works). Several matches
+open a picker in a TTY and fail with the list otherwise.
+
+A **full id on a known account launches even when the catalog does not list it**, with a warning.
+The proxy advertises a curated list but routes any id whose account exists, so
+`martin/grok/grok-4.6` answered chat while `ai-proxy models` still hid it. A typo in the account
+or provider segment still fails locally rather than becoming an upstream 404.
+
+The proxy is started if it is not already answering; `--no-start` turns that into an error
+instead. The launch clears `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` from the child
+environment — either one would outrank the proxy token and silently bill the real Anthropic
+account.
+
+`tools claude start` (alias `run`) is unchanged for Anthropic accounts. The split is the slash: no
+Anthropic account name has one, every ai-proxy target does.
 
 ---
 

--- a/src/claude/commands/run.test.ts
+++ b/src/claude/commands/run.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import type { ProxyModelMeta } from "@app/ai-proxy/lib/types";
+import { selectProxyModels, unlistedProxyModel } from "./run";
+
+function model(proxyId: string): ProxyModelMeta {
+    const [accountName = "", providerSlug = "", ...rest] = proxyId.split("/");
+
+    return {
+        proxyId,
+        accountName,
+        providerSlug,
+        upstreamId: rest.join("/"),
+        provider: "grok-subscription",
+        baseUrl: "https://example.invalid/v1",
+        visibility: "high",
+        speed: "medium",
+        thinking: "none",
+        billingPlane: "subscription",
+        source: "probe",
+        object: "model",
+        created: 0,
+        owned_by: proxyId,
+    };
+}
+
+const CATALOG = [
+    model("martin/grok/grok-4.5"),
+    model("martin/grok/grok-4-fast"),
+    model("martin/grok/grok-composer-2.5-fast"),
+    model("work/xai/grok-4.6"),
+    model("work/xai/grok-4.5"),
+    model("openrouter/openrouter/x-ai/grok-4.6"),
+];
+
+function ids(entries: ProxyModelMeta[]): string[] {
+    return entries.map((entry) => entry.proxyId);
+}
+
+describe("selectProxyModels", () => {
+    it("returns the whole catalog when nothing is given", () => {
+        expect(selectProxyModels(CATALOG, {})).toHaveLength(CATALOG.length);
+    });
+
+    it("scopes an account/provider prefix to that account", () => {
+        expect(ids(selectProxyModels(CATALOG, { target: "martin/grok" }))).toEqual([
+            "martin/grok/grok-4.5",
+            "martin/grok/grok-4-fast",
+            "martin/grok/grok-composer-2.5-fast",
+        ]);
+    });
+
+    it("applies the model filter inside the target", () => {
+        expect(ids(selectProxyModels(CATALOG, { target: "work/xai", modelSpec: "4.6" }))).toEqual([
+            "work/xai/grok-4.6",
+        ]);
+    });
+
+    it("returns nothing when the target does not serve the model, rather than guessing another account", () => {
+        expect(selectProxyModels(CATALOG, { target: "martin/grok", modelSpec: "4.6" })).toEqual([]);
+    });
+
+    it("finds the model across accounts when no target is given", () => {
+        expect(ids(selectProxyModels(CATALOG, { modelSpec: "4.6" }))).toEqual([
+            "work/xai/grok-4.6",
+            "openrouter/openrouter/x-ai/grok-4.6",
+        ]);
+    });
+
+    it("takes an exact full proxy id", () => {
+        expect(ids(selectProxyModels(CATALOG, { target: "martin/grok/grok-4.5" }))).toEqual(["martin/grok/grok-4.5"]);
+    });
+
+    it("tolerates a trailing slash on the prefix", () => {
+        expect(ids(selectProxyModels(CATALOG, { target: "work/xai/" }))).toEqual([
+            "work/xai/grok-4.6",
+            "work/xai/grok-4.5",
+        ]);
+    });
+
+    it("requires every whitespace-separated token to match", () => {
+        expect(ids(selectProxyModels(CATALOG, { modelSpec: "composer fast" }))).toEqual([
+            "martin/grok/grok-composer-2.5-fast",
+        ]);
+    });
+
+    it("falls back to a fuzzy match when the prefix matches no account", () => {
+        expect(ids(selectProxyModels(CATALOG, { target: "openrouter" }))).toEqual([
+            "openrouter/openrouter/x-ai/grok-4.6",
+        ]);
+    });
+});
+
+describe("unlistedProxyModel", () => {
+    it("passes through a full id on a known account that the catalog does not list", () => {
+        // The real case: martin/grok/grok-4.6 answered chat while `ai-proxy models` hid it.
+        const entry = unlistedProxyModel(CATALOG, "martin/grok/grok-4.6");
+
+        expect(entry?.proxyId).toBe("martin/grok/grok-4.6");
+        expect(entry?.upstreamId).toBe("grok-4.6");
+        expect(entry?.accountName).toBe("martin");
+        expect(entry?.providerSlug).toBe("grok");
+        expect(entry?.probeStatus).toBeUndefined();
+    });
+
+    it("does not inherit the sibling's per-model facts", () => {
+        const withCtx = CATALOG.map((entry) =>
+            entry.proxyId === "martin/grok/grok-4.5"
+                ? { ...entry, contextWindow: 500_000, supportsTools: false }
+                : entry
+        );
+        const entry = unlistedProxyModel(withCtx, "martin/grok/grok-4.6");
+
+        expect(entry?.contextWindow).toBeUndefined();
+        expect(entry?.supportsTools).toBeUndefined();
+        // Account-level facts DO carry over — they are properties of the account.
+        expect(entry?.billingPlane).toBe("subscription");
+    });
+
+    it("keeps a multi-segment upstream id intact", () => {
+        expect(unlistedProxyModel(CATALOG, "openrouter/openrouter/x-ai/grok-5")?.upstreamId).toBe("x-ai/grok-5");
+    });
+
+    it("refuses an unknown account, so a typo fails locally instead of upstream", () => {
+        expect(unlistedProxyModel(CATALOG, "typo/grok/grok-4.6")).toBeNull();
+        expect(unlistedProxyModel(CATALOG, "martin/typo/grok-4.6")).toBeNull();
+    });
+
+    it("refuses a bare account/provider prefix — that is not a model id", () => {
+        expect(unlistedProxyModel(CATALOG, "martin/grok")).toBeNull();
+    });
+});

--- a/src/claude/commands/run.ts
+++ b/src/claude/commands/run.ts
@@ -1,0 +1,336 @@
+import { buildProxyModelCatalog } from "@app/ai-proxy/lib/catalog";
+import { loadConfigFresh } from "@app/ai-proxy/lib/config";
+import { runAiProxyUp } from "@app/ai-proxy/lib/lifecycle";
+import type { AiProxyConfig, ProxyModelMeta } from "@app/ai-proxy/lib/types";
+import { ensureOnboardingSkippedForOAuthToken } from "@app/claude/lib/launch-env";
+import * as p from "@clack/prompts";
+import { findClaudeCommand } from "@genesiscz/utils/claude";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { env } from "@genesiscz/utils/env";
+import { logger, out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { shellSingleQuote } from "../lib/shell-quote";
+
+interface RunOptions {
+    model?: string;
+    list?: boolean;
+    start?: boolean;
+}
+
+/**
+ * `tools claude run` points Claude Code at ai-proxy instead of api.anthropic.com,
+ * so any proxied model (Grok, Copilot, OpenRouter, xAI) drives a normal Claude
+ * Code session. The proxy answers /v1/messages natively — see
+ * src/ai-proxy/lib/anthropic-messages.ts for the translation.
+ */
+
+/** Every whitespace-separated token must appear, so "grok 4.6" matches grok-4.6. */
+function matchesSpec(haystack: string, spec: string): boolean {
+    const target = haystack.toLowerCase();
+
+    return spec
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((token) => token.length > 0)
+        .every((token) => target.includes(token));
+}
+
+/**
+ * Narrow the proxy catalog to what the user asked for.
+ *
+ * `target` is an account/provider prefix (`martin/grok`) or a full proxy id;
+ * `modelSpec` is a substring filter applied inside it (`4.6`, `sonnet`).
+ */
+export function selectProxyModels(
+    catalog: ProxyModelMeta[],
+    { target, modelSpec }: { target?: string; modelSpec?: string }
+): ProxyModelMeta[] {
+    let candidates = catalog;
+
+    if (target) {
+        const trimmed = target.replace(/\/+$/, "");
+        const exact = catalog.filter((entry) => entry.proxyId === trimmed);
+
+        if (exact.length > 0) {
+            candidates = exact;
+        } else {
+            const prefixed = catalog.filter((entry) => entry.proxyId.startsWith(`${trimmed}/`));
+            candidates =
+                prefixed.length > 0
+                    ? prefixed
+                    : catalog.filter((entry) => matchesSpec(entry.proxyId, trimmed.replace(/\//g, " ")));
+        }
+    }
+
+    if (modelSpec) {
+        candidates = candidates.filter((entry) => matchesSpec(entry.proxyId, modelSpec));
+    }
+
+    return candidates;
+}
+
+/**
+ * A catalog miss is not the same as "not callable". The proxy advertises a
+ * CURATED list, and `resolveModel` routes any `<account>/<provider>/<model>` id
+ * whose account exists — that is how `martin/grok/grok-4.6` answered chat while
+ * `ai-proxy models` still hid it. So a full id aimed at a known account is
+ * passed through instead of refused.
+ *
+ * Requires an existing account/provider prefix on purpose: a typo in the account
+ * name should still fail here rather than become an upstream 404.
+ */
+export function unlistedProxyModel(catalog: ProxyModelMeta[], target: string): ProxyModelMeta | null {
+    const trimmed = target.replace(/\/+$/, "");
+    const [accountName, providerSlug, ...rest] = trimmed.split("/");
+    const upstreamId = rest.join("/");
+
+    if (!accountName || !providerSlug || !upstreamId) {
+        return null;
+    }
+
+    const sibling = catalog.find((entry) => entry.accountName === accountName && entry.providerSlug === providerSlug);
+
+    if (!sibling) {
+        return null;
+    }
+
+    // Account-level fields (provider, baseUrl, billingPlane) carry over; per-model
+    // ones do NOT. Inheriting a sibling's contextWindow would print a confident
+    // "500k ctx" for a model nobody measured.
+    return {
+        ...sibling,
+        proxyId: trimmed,
+        upstreamId,
+        source: "static",
+        probeStatus: undefined,
+        contextWindow: undefined,
+        inputModalities: undefined,
+        supportsTools: undefined,
+        supportsParallelToolCalls: undefined,
+        agentType: undefined,
+        apiBackend: undefined,
+        description: undefined,
+    };
+}
+
+function describe(entry: ProxyModelMeta): string {
+    const bits = [
+        entry.contextWindow ? `${Math.round(entry.contextWindow / 1000)}k ctx` : "",
+        entry.thinking && entry.thinking !== "none" ? `thinking: ${entry.thinking}` : "",
+        entry.supportsTools === false ? pc.red("no tools") : "",
+        entry.billingPlane,
+    ].filter(Boolean);
+
+    return bits.join(" · ");
+}
+
+async function pickModel(candidates: ProxyModelMeta[], hint: string): Promise<ProxyModelMeta> {
+    if (candidates.length === 1) {
+        return candidates[0];
+    }
+
+    if (!isInteractive()) {
+        out.error(pc.red(`${candidates.length} models match ${hint} — narrow it down.`));
+
+        for (const entry of candidates.slice(0, 20)) {
+            out.printlnErr(`  ${entry.proxyId}`);
+        }
+
+        await out.flush();
+        process.exit(1);
+    }
+
+    const choice = await p.select({
+        message: `Which model? (${candidates.length} match ${hint})`,
+        options: candidates.map((entry) => ({
+            value: entry.proxyId,
+            label: entry.proxyId,
+            hint: describe(entry),
+        })),
+    });
+
+    if (p.isCancel(choice)) {
+        p.cancel("Cancelled.");
+        process.exit(0);
+    }
+
+    const picked = candidates.find((entry) => entry.proxyId === choice);
+
+    if (!picked) {
+        out.error(pc.red("Selection did not match any catalog entry."));
+        await out.flush();
+        process.exit(1);
+    }
+
+    return picked;
+}
+
+async function ensureProxyUp(config: AiProxyConfig, autoStart: boolean): Promise<void> {
+    const healthUrl = `http://${config.listen.host}:${config.listen.port}/health`;
+
+    try {
+        const probe = await fetch(healthUrl, { signal: AbortSignal.timeout(1500) });
+
+        if (probe.ok) {
+            logger.debug({ healthUrl }, "[run] ai-proxy already healthy");
+            return;
+        }
+    } catch (error) {
+        logger.debug({ error, healthUrl }, "[run] ai-proxy health probe failed — will start it");
+    }
+
+    if (!autoStart) {
+        out.error(pc.red(`ai-proxy is not answering on ${healthUrl}.`));
+        out.printlnErr(suggestCommand("tools ai-proxy", { replaceCommand: ["up"] }));
+        await out.flush();
+        process.exit(1);
+    }
+
+    const result = await runAiProxyUp();
+    logger.info({ started: result.started, pid: result.pid }, "[run] ai-proxy readiness");
+}
+
+export async function runProxySession(
+    target: string | undefined,
+    opts: RunOptions,
+    passthrough: string[]
+): Promise<void> {
+    const config = await loadConfigFresh();
+
+    if (!config.proxyApiKey) {
+        out.error(pc.red("This ai-proxy has no proxyApiKey yet."));
+        out.printlnErr(suggestCommand("tools ai-proxy", { replaceCommand: ["config", "init"] }));
+        await out.flush();
+        process.exit(1);
+    }
+
+    const catalog = await buildProxyModelCatalog(config.accounts);
+    let candidates = selectProxyModels(catalog, { target, modelSpec: opts.model });
+    const hint = [target, opts.model].filter(Boolean).join(" + ") || "anything";
+
+    let unlisted: ProxyModelMeta | null = null;
+
+    if (candidates.length === 0 && target && !opts.model) {
+        unlisted = unlistedProxyModel(catalog, target);
+
+        if (unlisted) {
+            logger.info({ proxyId: unlisted.proxyId }, "[run] target is not in the catalog but its account is");
+            candidates = [unlisted];
+        }
+    }
+
+    if (opts.list) {
+        for (const entry of candidates) {
+            out.println(`${entry.proxyId}  ${pc.dim(describe(entry))}`);
+        }
+
+        return;
+    }
+
+    if (candidates.length === 0) {
+        out.error(pc.red(`No proxy model matches ${hint}.`));
+
+        // The same spec usually IS served, just by another account — say so instead
+        // of leaving the user to re-run `ai-proxy models` and diff by eye.
+        const elsewhere = opts.model ? selectProxyModels(catalog, { modelSpec: opts.model }) : [];
+
+        if (elsewhere.length > 0) {
+            out.printlnErr(pc.dim("Served by other accounts:"));
+
+            for (const entry of elsewhere.slice(0, 10)) {
+                out.printlnErr(`  ${entry.proxyId}`);
+            }
+        } else {
+            out.printlnErr(suggestCommand("tools ai-proxy", { replaceCommand: ["models"] }));
+        }
+
+        await out.flush();
+        process.exit(1);
+    }
+
+    const model = await pickModel(candidates, hint);
+
+    if (unlisted) {
+        out.log.warn(
+            `${model.proxyId} is not in the proxy catalog — launching it anyway. An unknown id 404s upstream.`
+        );
+    }
+
+    if (model.supportsTools === false) {
+        out.log.warn(`${model.proxyId} does not advertise tool calling — Claude Code will not be able to edit files.`);
+    }
+
+    await ensureProxyUp(config, opts.start !== false);
+    await ensureOnboardingSkippedForOAuthToken();
+
+    // Claude Code appends /v1/messages itself, so the base URL is the origin.
+    const baseUrl = `http://${config.listen.host}:${config.listen.port}`;
+
+    const launchEnv: Record<string, string | undefined> = {
+        ...process.env,
+        ANTHROPIC_BASE_URL: baseUrl,
+        ANTHROPIC_AUTH_TOKEN: config.proxyApiKey,
+        ANTHROPIC_MODEL: model.proxyId,
+        // Background work (titles, summaries) uses the small/fast slot; without it
+        // Claude Code asks the proxy for a haiku id that no account serves.
+        ANTHROPIC_SMALL_FAST_MODEL: model.proxyId,
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: model.proxyId,
+        ANTHROPIC_DEFAULT_SONNET_MODEL: model.proxyId,
+        ANTHROPIC_DEFAULT_OPUS_MODEL: model.proxyId,
+        // Put the proxied model in the /model picker so switching away and back works.
+        ANTHROPIC_CUSTOM_MODEL_OPTION: model.proxyId,
+        ANTHROPIC_CUSTOM_MODEL_OPTION_NAME: model.upstreamId,
+        ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION: `${model.providerSlug} via ai-proxy (${model.accountName})`,
+        TOOLS_CLAUDE_ACCOUNT: `proxy:${model.accountName}/${model.providerSlug}`,
+    };
+
+    // A first-party OAuth token in the environment outranks ANTHROPIC_AUTH_TOKEN and
+    // would silently bill the real Anthropic account instead of reaching the proxy.
+    delete launchEnv.CLAUDE_CODE_OAUTH_TOKEN;
+    delete launchEnv.ANTHROPIC_API_KEY;
+    delete launchEnv.CLAUDE_CODE_SUBSCRIPTION_TYPE;
+    delete launchEnv.ANTHROPIC_DEFAULT_FABLE_MODEL;
+
+    const shell = env.paths.getShell("/bin/sh");
+    const cmd = await findClaudeCommand();
+    const suffix = passthrough.length > 0 ? ` ${passthrough.map(shellSingleQuote).join(" ")}` : "";
+
+    out.printlnErr(pc.dim(`Starting Claude Code on ${pc.magenta(model.proxyId)} via ${baseUrl}...`));
+    logger.info({ cmd, model: model.proxyId, baseUrl, passthrough }, "[run] spawning claude against ai-proxy");
+
+    const proc = Bun.spawn({
+        cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
+        stdio: ["inherit", "inherit", "inherit"],
+        env: launchEnv,
+    });
+
+    process.exit(await proc.exited);
+}
+
+export function registerRunCommand(program: Command): void {
+    program
+        .command("proxy [target]")
+        .description(
+            "Launch Claude Code against a model served by ai-proxy (Grok, Copilot, OpenRouter, xAI). " +
+                "[target] is an <account>/<provider> prefix or a full proxy model id. " +
+                "`claude run <account>/<provider>` is the same thing. " +
+                "Args after -- are passed through to claude."
+        )
+        .allowExcessArguments(true)
+        .option("-m, --model <spec>", "Model filter inside the target (e.g. 4.6, sonnet, composer)")
+        .option("--list", "List the matching proxy models and exit")
+        .option("--no-start", "Fail if ai-proxy is not already running instead of starting it")
+        .action(async (target: string | undefined, opts: RunOptions, command: Command) => {
+            const operands = command.args;
+            let targetArg = target;
+            let passthrough = operands.slice(1);
+
+            if (targetArg?.startsWith("-")) {
+                targetArg = undefined;
+                passthrough = operands;
+            }
+
+            await runProxySession(targetArg, opts, passthrough);
+        });
+}

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -41,6 +41,7 @@ import {
     sweepStaleTeammateWrappers,
 } from "../lib/teammate-wrapper";
 import { pickSessionForResume } from "./resume";
+import { runProxySession } from "./run";
 
 interface StartOptions {
     pick?: boolean;
@@ -1036,6 +1037,15 @@ export function registerStartCommand(program: Command): void {
             if (nameArg?.startsWith("-")) {
                 nameArg = undefined;
                 passthrough = operands;
+            }
+
+            // No Anthropic account name contains a slash, but every ai-proxy target
+            // does (`martin/grok`, `work/xai/grok-4.6`). That makes the split
+            // unambiguous, so `claude run martin/grok -m 4.6` reaches the proxy
+            // launcher without a second command name to remember.
+            if (nameArg?.includes("/")) {
+                await runProxySession(nameArg, { model: opts.model }, passthrough);
+                return;
             }
 
             try {

--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -26,6 +26,7 @@ import { registerMcpCommand } from "./commands/mcp";
 import { registerMemoryCommand } from "./commands/memory";
 import { registerMigrateCommand } from "./commands/migrate";
 import { registerResumeCommand } from "./commands/resume";
+import { registerRunCommand } from "./commands/run";
 import { registerSpendingCommand } from "./commands/spending";
 import { registerStartCommand } from "./commands/start";
 import { registerSummarizeCommand } from "./commands/summarize";
@@ -64,6 +65,7 @@ registerLoginSecondaryCommand(program);
 registerLogoutCommand(program);
 registerSpendingCommand(program);
 registerStartCommand(program);
+registerRunCommand(program);
 registerTeamsCommand(program);
 registerCmuxCommand(program);
 


### PR DESCRIPTION
Run Claude Code on Grok (or Copilot, OpenRouter, xAI) through ai-proxy.

Claude Code speaks the **Anthropic Messages API**. The proxy only spoke OpenAI, so no proxied
model could drive a session. This adds the Anthropic-native inbound surface plus a launcher.

## `POST /v1/messages` (+ `/v1/messages/count_tokens`)

`lib/anthropic-messages.ts` normalizes the request down to OpenAI chat/completions (`system` →
system message, `tools[].input_schema` → `function.parameters`, `tool_result` → `role: "tool"`),
routes it through the existing `resolveModel` → account → provider path, then translates the
answer back up:

- non-streaming: an OpenAI completion becomes an Anthropic message;
- streaming: an OpenAI SSE stream becomes `message_start` / `content_block_*` / `message_delta` /
  `message_stop` frames, with `reasoning_content` forwarded as real `thinking` blocks.

Three decisions worth review:

1. **Usage rows book the OpenAI-shaped exchange**, not the Anthropic frames. `TimelineCollector`
   and the billing layer parse `choices[0].delta`, so the capture buffer holds the upstream bytes
   and `trackProxyRequest` gets the translated request body.
2. **Upstreams that stream no usage get an estimate, not `0`.** `prepareGrokUpstreamBody` deletes
   `stream_options`, so Grok's SSE carries no token counts; reporting zero would leave Claude
   Code's context meter empty and its auto-compact blind.
3. **`extractBearerToken` now also accepts `x-api-key`.** Anthropic-shaped clients never set
   `Authorization`. Done at the shared chokepoint so every route authenticates the same way.

`readModelBody` and `authorizeModelRoute` are extracted from the chat/completions branch so the
body-size, image-payload, provider-denial and quota guards cover the new route by construction
rather than by copy.

## `tools claude proxy`

```bash
tools claude proxy martin/grok -m 4.5        # <account>/<provider> plus a model filter
tools claude run martin/grok -m 4.5          # `run` routes here when the name has a slash
tools claude proxy martin/grok --list
```

`run` was already an alias for `start`. No Anthropic account name contains a slash and every
ai-proxy target does, so `start` delegates on that instead of taking a second command name.

The launch clears `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` from the child environment —
either one outranks the proxy token and would silently bill the real Anthropic account.

A full id on a known account launches even when the catalog does not list it, with a warning: the
proxy advertises a curated list but routes any id whose account exists, which is exactly how
`martin/grok/grok-4.6` answered chat while `ai-proxy models` hid it. A typo in the account or
provider segment still fails locally rather than becoming an upstream 404.

## Verification

Live against real Grok through the proxy:

- non-streaming, streaming, a tool call, and a full tool-result round trip;
- a real headless Claude Code session read a file and answered (`Read` tool through the proxy);
- thinking arrives as `thinking` blocks in Claude Code's stream-json output;
- `work/xai/grok-4.6` answers through `/v1/messages`.

`bunx tsgo --noEmit` clean. `bun run test src/ai-proxy/ src/claude/` — 1056 pass, 0 fail, 35 new
tests.

## Known limits

- `count_tokens` is a ~4-chars-per-token estimate; no upstream here exposes a counter.
- Thinking blocks carry no `signature`. Nothing echoes them upstream (the inbound normalizer drops
  assistant thinking from history), so nothing verifies one.
- Claude Code's own extended-thinking toggle (`thinking: {type: "enabled"}`) is dropped by the
  normalizer, so it does not reach Grok. Reasoning models think regardless; models with
  `thinking: optional` decide for themselves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic Messages API support, including streaming, token counting, tool calls, usage tracking, and translated errors.
  * Added the `claude proxy` command with model selection, credential handling, automatic proxy startup, and argument forwarding.
  * Added support for API-key authentication through the `x-api-key` header.
  * Added proxy model routing for account-specific and unlisted models.

* **Documentation**
  * Documented Anthropic API integration and `claude proxy` usage.

* **Tests**
  * Added comprehensive coverage for message conversion, streaming, usage reporting, errors, and proxy model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->