### PR TITLE
fix(ai-proxy): count reasoning tokens in the Anthropic output_tokens

### DIFF
--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.test.ts
@@ -78,6 +78,37 @@ describe("openAiCompletionToAnthropicMessage", () => {
         expect(message.usage).toEqual({ input_tokens: 20, output_tokens: 5, cache_read_input_tokens: 80 });
     });
 
+    it("folds reasoning tokens into output_tokens, as Anthropic counts them", () => {
+        // Real numbers from martin/grok/grok-4.6:xhigh — completion_tokens alone
+        // reported 139 for a turn that produced 1763 tokens.
+        const message = openAiCompletionToAnthropicMessage(
+            {
+                choices: [{ message: { content: "hi" }, finish_reason: "stop" }],
+                usage: {
+                    prompt_tokens: 243,
+                    completion_tokens: 139,
+                    total_tokens: 2006,
+                    completion_tokens_details: { reasoning_tokens: 1624 },
+                },
+            },
+            { model: MODEL }
+        );
+
+        expect(message.usage).toEqual({ input_tokens: 243, output_tokens: 1763 });
+    });
+
+    it("leaves output_tokens alone when the upstream reports no reasoning", () => {
+        const message = openAiCompletionToAnthropicMessage(
+            {
+                choices: [{ message: { content: "hi" }, finish_reason: "stop" }],
+                usage: { prompt_tokens: 10, completion_tokens: 4 },
+            },
+            { model: MODEL }
+        );
+
+        expect(message.usage).toEqual({ input_tokens: 10, output_tokens: 4 });
+    });
+
     it("never returns an empty content array", () => {
         const message = openAiCompletionToAnthropicMessage(
             { choices: [{ message: { content: null }, finish_reason: "stop" }] },

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.ts
@@ -42,7 +42,22 @@ function usageFrom(raw: unknown): AnthropicUsage {
 
     const promptTokens = typeof raw.prompt_tokens === "number" ? raw.prompt_tokens : 0;
     const completionTokens = typeof raw.completion_tokens === "number" ? raw.completion_tokens : 0;
-    const usage: AnthropicUsage = { input_tokens: promptTokens, output_tokens: completionTokens };
+
+    // Anthropic counts thinking INSIDE output_tokens; OpenAI keeps reasoning out of
+    // completion_tokens and reports it under completion_tokens_details. Reporting
+    // completion_tokens alone made a grok-4.6:xhigh turn look like 139 output tokens
+    // when it actually produced 1763 — a 12x undercount in every client's cost and
+    // context display, and worst exactly on the reasoning models people reach for.
+    const completionDetails = isObject(raw.completion_tokens_details) ? raw.completion_tokens_details : undefined;
+    const reasoningTokens =
+        completionDetails && typeof completionDetails.reasoning_tokens === "number"
+            ? completionDetails.reasoning_tokens
+            : 0;
+
+    const usage: AnthropicUsage = {
+        input_tokens: promptTokens,
+        output_tokens: completionTokens + reasoningTokens,
+    };
 
     const details = isObject(raw.prompt_tokens_details) ? raw.prompt_tokens_details : undefined;
 


### PR DESCRIPTION
Follow-up to #318, found while checking whether `:<effort>` suffixes (#317) reach Grok.

Anthropic counts thinking **inside** `output_tokens`. OpenAI keeps reasoning **out** of
`completion_tokens` and reports it separately under `completion_tokens_details.reasoning_tokens`.
The translator forwarded `completion_tokens` as-is, so all reasoning was dropped.

Measured on `martin/grok/grok-4.6`, same prompt, two efforts:

| effort | completion_tokens | reasoning_tokens | reported before | actual |
|---|---|---|---|---|
| `:low` | 134 | 659 | 134 | 793 |
| `:xhigh` | 139 | 1624 | 139 | 1763 |

A 12x undercount, and worst on exactly the reasoning models people pick on purpose. Claude Code
draws its context meter and auto-compact trigger from this number, so the session believed it had
burned a fraction of what it had.

Fixed in `usageFrom`, which both the streaming and non-streaming paths share, so one change covers
`/v1/messages` in either mode.

## Verification

- New test pins the real grok-4.6:xhigh numbers (139 + 1624 → 1763).
- New test pins that an upstream reporting no reasoning is unchanged.
- `bunx tsgo --noEmit` clean; `bun run test src/ai-proxy/` — 484 pass, 0 fail.
