### PR TITLE
feat(ms-teams): export local Teams chats to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ generates the matching `fail2ban` commands.
 
 Every row is a real tool in this checkout, described from its own `--help`. Each name links to
 that tool's own `README.md`, which you can also print in the terminal with
-`tools <name> --readme`. All 97 usable tools ship one.
+`tools <name> --readme`. All 98 usable tools ship one.
 
 ### AI and LLM
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ onto the merged base first, then optionally deletes the head branch.
 | [`automate`](src/automate/README.md) | Chain any `tools` commands into named, reusable presets, with variables, conditions, branching, and SQLite run history. | `preset` `step` `task` `daemon` `configure` |
 | [`daemon`](src/daemon/README.md) | General-purpose background task scheduler that owns the scheduled work, with an installable service unit. | `start` `stop` `restart` `status` `install` `uninstall` `config` `logs` |
 | [`notify`](src/notify/README.md) | Send macOS notifications through `terminal-notifier`, with action hooks and an interactive config. | `config` |
+| [`ms-teams`](src/ms-teams/README.md) | Read Microsoft Teams chats from the local desktop cache and export markdown, JSON, or HTML. | `sync` `doctor` `conversations` `show` `search` `people` `files` `calls` `meetings` `mcp` |
 | [`telegram`](src/telegram/README.md) | Telegram MTProto user-account client: listen for messages, auto-respond, browse contacts and history, TUI watcher. | `configure` `listen` `contacts` `history` `watch` |
 | [`telegram-bot`](src/telegram-bot/README.md) | Telegram Bot API client for notifications and remote control. Simpler auth than the user client. | `configure` `send` `start` |
 

--- a/src/ms-teams/README.md
+++ b/src/ms-teams/README.md
@@ -1,0 +1,44 @@
+# ms-teams
+
+Read Microsoft Teams conversations from the **local New Teams desktop cache** (Chromium IndexedDB), ingest them into SQLite, and export markdown / JSON / HTML.
+
+This is the client cache of threads you have opened. It is not a server-complete Graph export.
+
+## Quick start
+
+```bash
+tools ms-teams doctor
+tools ms-teams sync
+tools ms-teams conversations --with "Ada"
+tools ms-teams show "conversation with Ada Lovelace from 2026-08-06 to 2026-08-06"
+tools ms-teams show "Planning" --format html --out /tmp/planning.html
+tools ms-teams search "look at it today" --with "Ada"
+```
+
+Needs Full Disk Access for your terminal (same as `tools macos messages`).
+
+## Commands
+
+| Command | What |
+|---|---|
+| `sync` | Snapshot IndexedDB and ingest into `~/.genesis-tools/ms-teams/cache.db` |
+| `doctor` | Read-only path / cache / venv check. Never writes. |
+| `conversations` (`chats`, `list`) | Inventory table |
+| `show [query]` | Resolve one thread and export `md` / `json` / `html` |
+| `search <text>` | FTS over message text |
+| `people` / `people show` | Profile cache |
+| `members` | Roster of one chat |
+| `files ls` / `files download` | Attachments |
+| `calls` | Call history |
+| `meetings` | Meeting chats |
+| `mentions` | Activity feed |
+| `transcripts` | Cached call transcripts / recordings |
+| `mcp` | Stdio MCP server |
+
+Natural query examples for `show`:
+
+- `conversation with Ussov Stanislav from 2026-08-06 to 2026-08-06`
+- `Nabídky 2.0 - Nacenění`
+- a raw thread id (`19:…@thread.v2` or `@unq.gbl.spaces`)
+
+`--with`, `--from`, `--to`, `--id` flags override the parsed query. `--attachments` tries to download files next to `--out`.

--- a/src/ms-teams/commands/calls.ts
+++ b/src/ms-teams/commands/calls.ts
@@ -1,0 +1,40 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+
+export function registerCallsCommand(program: Command): void {
+    program
+        .command("calls")
+        .description("List cached call-history records")
+        .option("--json", "Machine-readable JSON")
+        .action((opts: { json?: boolean }) => {
+            const cache = openCache();
+
+            try {
+                const rows = cache.listCalls();
+
+                if (opts.json) {
+                    out.result(rows);
+                    return;
+                }
+
+                renderCliHeader("Teams calls", `${rows.length} records`);
+                const table = createBoxTable(["START", "TYPE", "STATE", "DIR", "THREAD"]);
+
+                for (const row of rows) {
+                    table.push([
+                        truncateDisplay(row.startTime ?? "—", 24),
+                        row.callType ?? "—",
+                        row.callState ?? "—",
+                        row.callDirection ?? "—",
+                        truncateDisplay(row.threadId ?? "—", 36),
+                    ]);
+                }
+
+                out.println(table.toString());
+            } finally {
+                cache.close();
+            }
+        });
+}

--- a/src/ms-teams/commands/conversations.ts
+++ b/src/ms-teams/commands/conversations.ts
@@ -1,0 +1,59 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { printConversations } from "@app/ms-teams/lib/display";
+import { parseQueryDate } from "@app/ms-teams/lib/query";
+import type { ConversationType } from "@app/ms-teams/lib/types";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerConversationsCommand(program: Command): void {
+    for (const name of ["conversations", "chats", "list"]) {
+        program
+            .command(name)
+            .description("List cached Teams conversations")
+            .option("--type <type>", "meeting | chat | space | topic | group")
+            .option("--with <name>", "Filter by participant or title")
+            .option("--topic <text>", "Filter by topic or title")
+            .option("--from <date>", "Last activity after this date")
+            .option("--to <date>", "Last activity before this date")
+            .option("--limit <n>", "Max rows", "40")
+            .option("--json", "Machine-readable JSON")
+            .action(
+                (opts: {
+                    type?: string;
+                    with?: string;
+                    topic?: string;
+                    from?: string;
+                    to?: string;
+                    limit?: string;
+                    json?: boolean;
+                }) => {
+                    const cache = openCache();
+
+                    try {
+                        const rows = cache.listConversations({
+                            type: opts.type as ConversationType | "group" | undefined,
+                            withName: opts.with,
+                            topic: opts.topic,
+                            from: opts.from ? parseQueryDate(opts.from, "start") : undefined,
+                            to: opts.to ? parseQueryDate(opts.to, "end") : undefined,
+                            limit: Number.parseInt(opts.limit ?? "40", 10),
+                        });
+
+                        if (opts.json) {
+                            out.result(rows);
+                            return;
+                        }
+
+                        if (rows.length === 0) {
+                            out.println("No conversations matched.");
+                            return;
+                        }
+
+                        printConversations(rows);
+                    } finally {
+                        cache.close();
+                    }
+                }
+            );
+    }
+}

--- a/src/ms-teams/commands/conversations.ts
+++ b/src/ms-teams/commands/conversations.ts
@@ -36,7 +36,7 @@ export function registerConversationsCommand(program: Command): void {
                             topic: opts.topic,
                             from: opts.from ? parseQueryDate(opts.from, "start") : undefined,
                             to: opts.to ? parseQueryDate(opts.to, "end") : undefined,
-                            limit: Number.parseInt(opts.limit ?? "40", 10),
+                            limit: parsePositiveLimit(opts.limit, 40),
                         });
 
                         if (opts.json) {
@@ -56,4 +56,18 @@ export function registerConversationsCommand(program: Command): void {
                 }
             );
     }
+}
+
+function parsePositiveLimit(value: string | undefined, fallback: number): number {
+    if (value === undefined) {
+        return fallback;
+    }
+
+    const n = Number.parseInt(value, 10);
+
+    if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`Invalid --limit ${value}. Use a positive integer.`);
+    }
+
+    return n;
 }

--- a/src/ms-teams/commands/doctor.ts
+++ b/src/ms-teams/commands/doctor.ts
@@ -51,7 +51,7 @@ export function registerDoctorCommand(program: Command): void {
                 );
             }
 
-            if (!report.readable) {
+            if (report.idbExists && !report.readable) {
                 out.println(
                     "Full Disk Access: System Settings → Privacy & Security → Full Disk Access → enable your terminal, then restart it."
                 );

--- a/src/ms-teams/commands/doctor.ts
+++ b/src/ms-teams/commands/doctor.ts
@@ -1,0 +1,64 @@
+import { inspectDoctor } from "@app/ms-teams/lib/doctor";
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, formatDotStatus, renderCliHeader } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+
+export function registerDoctorCommand(program: Command): void {
+    program
+        .command("doctor")
+        .description("Read-only check of Teams data paths and the local cache")
+        .action(() => {
+            const report = inspectDoctor();
+            renderCliHeader("Teams doctor", "does not write");
+            const table = createBoxTable(["CHECK", "STATUS"]);
+            table.push([
+                "IndexedDB",
+                formatDotStatus(
+                    report.idbExists && report.readable ? "ok" : "err",
+                    report.idbExists ? (report.readable ? "readable" : "not readable") : "missing"
+                ),
+            ]);
+            table.push([
+                "Blob dir",
+                formatDotStatus(report.blobExists ? "ok" : "warn", report.blobExists ? "present" : "missing"),
+            ]);
+            table.push([
+                "Python venv",
+                formatDotStatus(
+                    report.venvPythonExists ? "ok" : "warn",
+                    report.venvPythonExists ? "present" : "run sync"
+                ),
+            ]);
+            table.push([
+                "Teams process",
+                formatDotStatus(report.teamsProcess ? "ok" : "dim", report.teamsProcess ? "running" : "not running"),
+            ]);
+            table.push([
+                "SQLite cache",
+                formatDotStatus(
+                    report.cacheExists ? "ok" : "warn",
+                    report.cacheExists ? (report.cacheIngestedAt ?? "present") : "missing"
+                ),
+            ]);
+            out.println(table.toString());
+            out.println(`IndexedDB: ${report.idbPath}`);
+            out.println(`Cache: ${report.cachePath}`);
+
+            if (report.counts) {
+                out.println(
+                    `Counts: ${report.counts.conversations} chats, ${report.counts.messages} messages, ${report.counts.people} people, ${report.counts.calls} calls`
+                );
+            }
+
+            if (!report.readable) {
+                out.println(
+                    "Full Disk Access: System Settings → Privacy & Security → Full Disk Access → enable your terminal, then restart it."
+                );
+            }
+
+            if (!report.cacheExists) {
+                out.println(suggestCommand("tools ms-teams", { replaceCommand: ["sync"] }));
+            }
+        });
+}

--- a/src/ms-teams/commands/files.ts
+++ b/src/ms-teams/commands/files.ts
@@ -1,0 +1,102 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { downloadAttachments } from "@app/ms-teams/lib/attachments";
+import { openCache } from "@app/ms-teams/lib/cache";
+import { parseShowQuery } from "@app/ms-teams/lib/query";
+import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+
+export function registerFilesCommand(program: Command): void {
+    const files = program.command("files").description("List or download attachments from cached messages");
+
+    files
+        .command("ls [query...]")
+        .description("List attachments")
+        .option("--id <threadId>", "Limit to one conversation")
+        .option("--json", "Machine-readable JSON")
+        .action((queryParts: string[], opts: { id?: string; json?: boolean }) => {
+            const cache = openCache();
+
+            try {
+                const conversationId = resolveOptionalId(cache, queryParts, opts.id);
+                const rows = cache.listFiles(conversationId);
+
+                if (opts.json) {
+                    out.result(rows);
+                    return;
+                }
+
+                renderCliHeader("Teams files", `${rows.length} attachments`);
+                const table = createBoxTable(["CHAT", "NAME", "URL"]);
+
+                for (const row of rows) {
+                    table.push([
+                        truncateDisplay(cache.getConversation(row.conversationId)?.title ?? row.conversationId, 28),
+                        truncateDisplay(row.name, 32),
+                        truncateDisplay(row.url ?? "—", 48),
+                    ]);
+                }
+
+                out.println(table.toString());
+            } finally {
+                cache.close();
+            }
+        });
+
+    files
+        .command("download [query...]")
+        .description("Download attachments for a conversation into --out")
+        .requiredOption("--out <dir>", "Directory to write files into")
+        .option("--id <threadId>", "Exact conversation id")
+        .action(async (queryParts: string[], opts: { out: string; id?: string }) => {
+            const cache = openCache();
+
+            try {
+                const conversationId = resolveOptionalId(cache, queryParts, opts.id);
+
+                if (!conversationId) {
+                    out.println("Pass a conversation query or --id.");
+                    return;
+                }
+
+                const rows = cache.listFiles(conversationId);
+                await mkdir(opts.out, { recursive: true });
+                const downloaded = await downloadAttachments({
+                    attachments: rows.map((r) => ({
+                        name: r.name,
+                        mimeHint: null,
+                        url: r.url,
+                        itemId: null,
+                        localPath: null,
+                    })),
+                    outDir: opts.out,
+                });
+                out.println(
+                    `Saved ${downloaded.attachments.filter((a) => a.localPath).length} files under ${join(opts.out)}`
+                );
+            } finally {
+                cache.close();
+            }
+        });
+}
+
+function resolveOptionalId(
+    cache: ReturnType<typeof openCache>,
+    queryParts: string[] | undefined,
+    id?: string
+): string | undefined {
+    if (id) {
+        return id;
+    }
+
+    const text = (queryParts ?? []).join(" ").trim();
+
+    if (!text) {
+        return undefined;
+    }
+
+    const resolved = resolveConversation(cache, parseShowQuery(text));
+    return resolved.status === "exact" ? resolved.conversation.id : undefined;
+}

--- a/src/ms-teams/commands/files.ts
+++ b/src/ms-teams/commands/files.ts
@@ -20,7 +20,14 @@ export function registerFilesCommand(program: Command): void {
             const cache = openCache();
 
             try {
-                const conversationId = resolveOptionalId(cache, queryParts, opts.id);
+                const resolved = resolveOptionalId(cache, queryParts, opts.id);
+
+                if (resolved.status === "missing") {
+                    out.println("Could not resolve that conversation. Pass --id.");
+                    return;
+                }
+
+                const conversationId = resolved.status === "exact" ? resolved.id : undefined;
                 const rows = cache.listFiles(conversationId);
 
                 if (opts.json) {
@@ -54,14 +61,19 @@ export function registerFilesCommand(program: Command): void {
             const cache = openCache();
 
             try {
-                const conversationId = resolveOptionalId(cache, queryParts, opts.id);
+                const resolved = resolveOptionalId(cache, queryParts, opts.id);
 
-                if (!conversationId) {
+                if (resolved.status === "none") {
                     out.println("Pass a conversation query or --id.");
                     return;
                 }
 
-                const rows = cache.listFiles(conversationId);
+                if (resolved.status !== "exact") {
+                    out.println("Could not resolve that conversation. Pass --id.");
+                    return;
+                }
+
+                const rows = cache.listFiles(resolved.id);
                 await mkdir(opts.out, { recursive: true });
                 const downloaded = await downloadAttachments({
                     attachments: rows.map((r) => ({
@@ -86,17 +98,17 @@ function resolveOptionalId(
     cache: ReturnType<typeof openCache>,
     queryParts: string[] | undefined,
     id?: string
-): string | undefined {
+): { status: "none" | "exact" | "missing"; id?: string } {
     if (id) {
-        return id;
+        return { status: "exact", id };
     }
 
     const text = (queryParts ?? []).join(" ").trim();
 
     if (!text) {
-        return undefined;
+        return { status: "none" };
     }
 
     const resolved = resolveConversation(cache, parseShowQuery(text));
-    return resolved.status === "exact" ? resolved.conversation.id : undefined;
+    return resolved.status === "exact" ? { status: "exact", id: resolved.conversation.id } : { status: "missing" };
 }

--- a/src/ms-teams/commands/mcp.ts
+++ b/src/ms-teams/commands/mcp.ts
@@ -1,0 +1,11 @@
+import type { Command } from "commander";
+
+export function registerMcpCommand(program: Command): void {
+    program
+        .command("mcp")
+        .description("Start an MCP server for the Teams reader")
+        .action(async () => {
+            const { startMcpServer } = await import("@app/ms-teams/mcp/server");
+            await startMcpServer();
+        });
+}

--- a/src/ms-teams/commands/meetings.ts
+++ b/src/ms-teams/commands/meetings.ts
@@ -1,0 +1,28 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { printConversations } from "@app/ms-teams/lib/display";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerMeetingsCommand(program: Command): void {
+    program
+        .command("meetings")
+        .description("List cached meeting chats")
+        .option("--with <name>", "Filter by participant")
+        .option("--json", "Machine-readable JSON")
+        .action((opts: { with?: string; json?: boolean }) => {
+            const cache = openCache();
+
+            try {
+                const rows = cache.listConversations({ type: "meeting", withName: opts.with, limit: 100 });
+
+                if (opts.json) {
+                    out.result(rows);
+                    return;
+                }
+
+                printConversations(rows);
+            } finally {
+                cache.close();
+            }
+        });
+}

--- a/src/ms-teams/commands/members.ts
+++ b/src/ms-teams/commands/members.ts
@@ -1,0 +1,55 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { printPeople } from "@app/ms-teams/lib/display";
+import { parseShowQuery } from "@app/ms-teams/lib/query";
+import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
+import type { Person } from "@app/ms-teams/lib/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerMembersCommand(program: Command): void {
+    program
+        .command("members [query...]")
+        .description("Show the roster of a conversation")
+        .option("--id <threadId>", "Exact conversation id")
+        .option("--json", "Machine-readable JSON")
+        .action((queryParts: string[], opts: { id?: string; json?: boolean }) => {
+            const cache = openCache();
+
+            try {
+                const resolved = resolveConversation(cache, {
+                    ...parseShowQuery((queryParts ?? []).join(" ")),
+                    id: opts.id,
+                });
+
+                if (resolved.status !== "exact") {
+                    out.println("Could not resolve a single conversation. Pass --id.");
+                    return;
+                }
+
+                let members: Person[] = [];
+
+                try {
+                    members = SafeJSON.parse(resolved.conversation.membersJson);
+                } catch {
+                    members = [];
+                }
+
+                if (opts.json) {
+                    out.result(members);
+                    return;
+                }
+
+                printPeople(
+                    members.map((m) => ({
+                        mri: m.mri,
+                        displayName: m.displayName,
+                        email: m.email,
+                        upn: m.email,
+                    }))
+                );
+            } finally {
+                cache.close();
+            }
+        });
+}

--- a/src/ms-teams/commands/members.ts
+++ b/src/ms-teams/commands/members.ts
@@ -1,6 +1,6 @@
 import { openCache } from "@app/ms-teams/lib/cache";
 import { printPeople } from "@app/ms-teams/lib/display";
-import { parseShowQuery } from "@app/ms-teams/lib/query";
+import { mergeShowQuery, parseShowQuery } from "@app/ms-teams/lib/query";
 import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
 import type { Person } from "@app/ms-teams/lib/types";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -17,10 +17,10 @@ export function registerMembersCommand(program: Command): void {
             const cache = openCache();
 
             try {
-                const resolved = resolveConversation(cache, {
-                    ...parseShowQuery((queryParts ?? []).join(" ")),
-                    id: opts.id,
-                });
+                const resolved = resolveConversation(
+                    cache,
+                    mergeShowQuery(parseShowQuery((queryParts ?? []).join(" ")), { id: opts.id })
+                );
 
                 if (resolved.status !== "exact") {
                     out.println("Could not resolve a single conversation. Pass --id.");
@@ -30,7 +30,8 @@ export function registerMembersCommand(program: Command): void {
                 let members: Person[] = [];
 
                 try {
-                    members = SafeJSON.parse(resolved.conversation.membersJson);
+                    const parsed = SafeJSON.parse(resolved.conversation.membersJson);
+                    members = Array.isArray(parsed) ? parsed : [];
                 } catch {
                     members = [];
                 }

--- a/src/ms-teams/commands/mentions.ts
+++ b/src/ms-teams/commands/mentions.ts
@@ -25,7 +25,7 @@ export function registerMentionsCommand(program: Command): void {
 
                 for (const row of rows) {
                     table.push([
-                        row.timestamp ? formatDateTime(row.timestamp, { absolute: "datetime" }) : "—",
+                        row.timestamp !== null ? formatDateTime(row.timestamp, { absolute: "datetime" }) : "—",
                         row.activityType,
                         row.activitySubtype ?? "—",
                         truncateDisplay(row.sourceThreadId ?? "—", 40),

--- a/src/ms-teams/commands/mentions.ts
+++ b/src/ms-teams/commands/mentions.ts
@@ -1,0 +1,40 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { formatDateTime } from "@genesiscz/utils/date";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+
+export function registerMentionsCommand(program: Command): void {
+    program
+        .command("mentions")
+        .description("List cached activity-feed items (mentions and reactions)")
+        .option("--json", "Machine-readable JSON")
+        .action((opts: { json?: boolean }) => {
+            const cache = openCache();
+
+            try {
+                const rows = cache.listActivity();
+
+                if (opts.json) {
+                    out.result(rows);
+                    return;
+                }
+
+                renderCliHeader("Teams activity", `${rows.length} items`);
+                const table = createBoxTable(["WHEN", "TYPE", "SUB", "THREAD"]);
+
+                for (const row of rows) {
+                    table.push([
+                        row.timestamp ? formatDateTime(row.timestamp, { absolute: "datetime" }) : "—",
+                        row.activityType,
+                        row.activitySubtype ?? "—",
+                        truncateDisplay(row.sourceThreadId ?? "—", 40),
+                    ]);
+                }
+
+                out.println(table.toString());
+            } finally {
+                cache.close();
+            }
+        });
+}

--- a/src/ms-teams/commands/people.ts
+++ b/src/ms-teams/commands/people.ts
@@ -1,0 +1,45 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { printPeople } from "@app/ms-teams/lib/display";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerPeopleCommand(program: Command): void {
+    const people = program.command("people").description("List people from the Teams profile cache");
+
+    people
+        .argument("[query...]")
+        .option("--json", "Machine-readable JSON")
+        .action((queryParts: string[], opts: { json?: boolean }) => {
+            runPeople((queryParts ?? []).join(" "), opts.json);
+        });
+
+    people
+        .command("show [query...]")
+        .description("Find people by name or email")
+        .option("--json", "Machine-readable JSON")
+        .action((queryParts: string[], opts: { json?: boolean }) => {
+            runPeople((queryParts ?? []).join(" "), opts.json);
+        });
+}
+
+function runPeople(query: string | undefined, json?: boolean): void {
+    const cache = openCache();
+
+    try {
+        const rows = cache.listPeople(query || undefined);
+
+        if (json) {
+            out.result(rows);
+            return;
+        }
+
+        if (rows.length === 0) {
+            out.println("No people matched.");
+            return;
+        }
+
+        printPeople(rows);
+    } finally {
+        cache.close();
+    }
+}

--- a/src/ms-teams/commands/search.ts
+++ b/src/ms-teams/commands/search.ts
@@ -1,0 +1,49 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { printSearchHits } from "@app/ms-teams/lib/display";
+import { parseQueryDate } from "@app/ms-teams/lib/query";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerSearchCommand(program: Command): void {
+    program
+        .command("search <text...>")
+        .description("Full-text search over cached message bodies")
+        .option("--with <name>", "Restrict to chats involving this person")
+        .option("--in <id>", "Restrict to one conversation id")
+        .option("--from <date>", "Messages after this date")
+        .option("--to <date>", "Messages before this date")
+        .option("--limit <n>", "Max hits", "50")
+        .option("--json", "Machine-readable JSON")
+        .action(
+            (
+                textParts: string[],
+                opts: { with?: string; in?: string; from?: string; to?: string; limit?: string; json?: boolean }
+            ) => {
+                const cache = openCache();
+
+                try {
+                    const hits = cache.searchMessages(textParts.join(" "), {
+                        withName: opts.with,
+                        conversationId: opts.in,
+                        from: opts.from ? parseQueryDate(opts.from, "start") : undefined,
+                        to: opts.to ? parseQueryDate(opts.to, "end") : undefined,
+                        limit: Number.parseInt(opts.limit ?? "50", 10),
+                    });
+
+                    if (opts.json) {
+                        out.result(hits);
+                        return;
+                    }
+
+                    if (hits.length === 0) {
+                        out.println("No matches.");
+                        return;
+                    }
+
+                    printSearchHits(hits, (id) => cache.getConversation(id)?.title ?? id);
+                } finally {
+                    cache.close();
+                }
+            }
+        );
+}

--- a/src/ms-teams/commands/show.ts
+++ b/src/ms-teams/commands/show.ts
@@ -1,0 +1,152 @@
+import { mkdir } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+import { downloadAttachments } from "@app/ms-teams/lib/attachments";
+import { openCache } from "@app/ms-teams/lib/cache";
+import { printConversations } from "@app/ms-teams/lib/display";
+import { renderHtml } from "@app/ms-teams/lib/export/html";
+import { renderJson } from "@app/ms-teams/lib/export/json";
+import { renderMarkdown } from "@app/ms-teams/lib/export/markdown";
+import { exportThread } from "@app/ms-teams/lib/export/thread";
+import { mergeShowQuery, parseQueryDate, parseShowQuery } from "@app/ms-teams/lib/query";
+import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
+import type { ThreadExport } from "@app/ms-teams/lib/types";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerShowCommand(program: Command): void {
+    program
+        .command("show [query...]")
+        .description("Export one conversation as markdown, JSON, or HTML")
+        .option("--id <threadId>", "Exact conversation id")
+        .option("--with <name>", "Participant display name")
+        .option("--topic <text>", "Topic or title")
+        .option("--from <date>", "Include messages after this date")
+        .option("--to <date>", "Include messages before this date")
+        .option("--format <fmt>", "md | json | html", "md")
+        .option("--json", "Alias for --format json on stdout")
+        .option("--out <path>", "Write to a file or directory")
+        .option("--attachments", "Try to download files next to --out")
+        .option("--include-system", "Keep member-join and similar system events in md/html")
+        .action(async (queryParts: string[], opts: ShowFlags) => {
+            const cache = openCache();
+
+            try {
+                const parsed = parseShowQuery((queryParts ?? []).join(" "));
+                const query = mergeShowQuery(parsed, {
+                    id: opts.id,
+                    withName: opts.with,
+                    topic: opts.topic,
+                    from: opts.from ? parseQueryDate(opts.from, "start") : undefined,
+                    to: opts.to ? parseQueryDate(opts.to, "end") : undefined,
+                });
+                const resolved = resolveConversation(cache, query);
+
+                if (resolved.status === "none") {
+                    out.println("No conversation matched that query.");
+                    return;
+                }
+
+                if (resolved.status === "ambiguous") {
+                    out.println("Several conversations matched. Pass --id from this list:");
+                    printConversations(resolved.matches);
+                    out.println(
+                        suggestCommand("tools ms-teams show", { add: ["--id", resolved.matches[0]?.id ?? ""] })
+                    );
+                    return;
+                }
+
+                const format = opts.json ? "json" : (opts.format ?? "md");
+                const includeSystem = format === "json" || Boolean(opts.includeSystem);
+                let thread = exportThread(cache, resolved.conversation.id, {
+                    from: query.from,
+                    to: query.to,
+                    includeSystem,
+                });
+
+                if (opts.attachments && opts.out) {
+                    thread = await withDownloads(thread, opts.out);
+                }
+
+                const rendered = renderThread(thread, format);
+
+                if (opts.json || format === "json") {
+                    if (opts.out) {
+                        await writeOut(opts.out, rendered, "json");
+                    } else {
+                        out.result(thread);
+                    }
+
+                    return;
+                }
+
+                if (opts.out) {
+                    const dest = await writeOut(opts.out, rendered, format === "html" ? "html" : "md");
+                    out.println(`Wrote ${dest} (${thread.messages.length} messages).`);
+                    return;
+                }
+
+                if (format === "html" && !isInteractive()) {
+                    out.print(rendered);
+                    return;
+                }
+
+                out.print(rendered);
+            } finally {
+                cache.close();
+            }
+        });
+}
+
+interface ShowFlags {
+    id?: string;
+    with?: string;
+    topic?: string;
+    from?: string;
+    to?: string;
+    format?: string;
+    json?: boolean;
+    out?: string;
+    attachments?: boolean;
+    includeSystem?: boolean;
+}
+
+function renderThread(thread: ThreadExport, format: string): string {
+    if (format === "html") {
+        return renderHtml(thread);
+    }
+
+    if (format === "json") {
+        return renderJson(thread);
+    }
+
+    return renderMarkdown(thread);
+}
+
+async function writeOut(outPath: string, body: string, ext: string): Promise<string> {
+    const looksDir = outPath.endsWith("/") || extname(outPath) === "";
+    const filePath = looksDir ? join(outPath, `thread.${ext}`) : outPath;
+    await mkdir(dirname(filePath), { recursive: true });
+    await Bun.write(filePath, body);
+    return filePath;
+}
+
+async function withDownloads(thread: ThreadExport, outPath: string): Promise<ThreadExport> {
+    const dir =
+        extname(outPath) === "" || outPath.endsWith("/")
+            ? join(outPath, "attachments")
+            : join(dirname(outPath), "attachments");
+    const messages = [];
+
+    for (const message of thread.messages) {
+        if (message.attachments.length === 0) {
+            messages.push(message);
+            continue;
+        }
+
+        const downloaded = await downloadAttachments({ attachments: message.attachments, outDir: dir });
+        messages.push({ ...message, attachments: downloaded.attachments });
+    }
+
+    return { ...thread, messages };
+}

--- a/src/ms-teams/commands/show.ts
+++ b/src/ms-teams/commands/show.ts
@@ -120,7 +120,11 @@ function renderThread(thread: ThreadExport, format: string): string {
         return renderJson(thread);
     }
 
-    return renderMarkdown(thread);
+    if (format === "md") {
+        return renderMarkdown(thread);
+    }
+
+    throw new Error(`Unsupported format: ${format}. Use md, json, or html.`);
 }
 
 async function writeOut(outPath: string, body: string, ext: string): Promise<string> {

--- a/src/ms-teams/commands/sync.ts
+++ b/src/ms-teams/commands/sync.ts
@@ -1,0 +1,16 @@
+import { ingestIndexedDb } from "@app/ms-teams/lib/ingest";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerSyncCommand(program: Command): void {
+    program
+        .command("sync")
+        .description("Snapshot the local Teams IndexedDB cache and ingest it")
+        .option("--force", "Rebuild the SQLite cache even if a snapshot exists")
+        .action(async (opts: { force?: boolean }) => {
+            const result = await ingestIndexedDb({ force: Boolean(opts.force) });
+            out.println(
+                `Ingested ${result.conversations} conversations, ${result.messages} messages, ${result.people} people.`
+            );
+        });
+}

--- a/src/ms-teams/commands/transcripts.ts
+++ b/src/ms-teams/commands/transcripts.ts
@@ -1,0 +1,50 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { parseShowQuery } from "@app/ms-teams/lib/query";
+import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerTranscriptsCommand(program: Command): void {
+    program
+        .command("transcripts [query...]")
+        .description("Print cached call-transcript messages for a meeting or chat")
+        .option("--id <threadId>", "Exact conversation id")
+        .option("--json", "Machine-readable JSON")
+        .action((queryParts: string[], opts: { id?: string; json?: boolean }) => {
+            const cache = openCache();
+
+            try {
+                const resolved = resolveConversation(cache, {
+                    ...parseShowQuery((queryParts ?? []).join(" ")),
+                    id: opts.id,
+                });
+
+                if (resolved.status !== "exact") {
+                    out.println("Could not resolve a single conversation. Pass --id.");
+                    return;
+                }
+
+                const rows = cache
+                    .listMessages(resolved.conversation.id, { includeSystem: true })
+                    .filter((m) => m.messageType.includes("CallTranscript") || m.messageType.includes("CallRecording"));
+
+                if (opts.json) {
+                    out.result(rows);
+                    return;
+                }
+
+                if (rows.length === 0) {
+                    out.println("No cached transcripts or recordings in that thread.");
+                    return;
+                }
+
+                for (const row of rows) {
+                    out.println(`--- ${row.messageType} ${row.id} ---`);
+                    out.println(row.text || row.html || "(empty)");
+                    out.println("");
+                }
+            } finally {
+                cache.close();
+            }
+        });
+}

--- a/src/ms-teams/commands/transcripts.ts
+++ b/src/ms-teams/commands/transcripts.ts
@@ -1,5 +1,5 @@
 import { openCache } from "@app/ms-teams/lib/cache";
-import { parseShowQuery } from "@app/ms-teams/lib/query";
+import { mergeShowQuery, parseShowQuery } from "@app/ms-teams/lib/query";
 import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
@@ -14,10 +14,10 @@ export function registerTranscriptsCommand(program: Command): void {
             const cache = openCache();
 
             try {
-                const resolved = resolveConversation(cache, {
-                    ...parseShowQuery((queryParts ?? []).join(" ")),
-                    id: opts.id,
-                });
+                const resolved = resolveConversation(
+                    cache,
+                    mergeShowQuery(parseShowQuery((queryParts ?? []).join(" ")), { id: opts.id })
+                );
 
                 if (resolved.status !== "exact") {
                     out.println("Could not resolve a single conversation. Pass --id.");

--- a/src/ms-teams/index.ts
+++ b/src/ms-teams/index.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env bun
+
+import { registerCallsCommand } from "@app/ms-teams/commands/calls";
+import { registerConversationsCommand } from "@app/ms-teams/commands/conversations";
+import { registerDoctorCommand } from "@app/ms-teams/commands/doctor";
+import { registerFilesCommand } from "@app/ms-teams/commands/files";
+import { registerMcpCommand } from "@app/ms-teams/commands/mcp";
+import { registerMeetingsCommand } from "@app/ms-teams/commands/meetings";
+import { registerMembersCommand } from "@app/ms-teams/commands/members";
+import { registerMentionsCommand } from "@app/ms-teams/commands/mentions";
+import { registerPeopleCommand } from "@app/ms-teams/commands/people";
+import { registerSearchCommand } from "@app/ms-teams/commands/search";
+import { registerShowCommand } from "@app/ms-teams/commands/show";
+import { registerSyncCommand } from "@app/ms-teams/commands/sync";
+import { registerTranscriptsCommand } from "@app/ms-teams/commands/transcripts";
+import { enhanceHelp, isInteractive, runTool } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import { handleReadmeFlag } from "@genesiscz/utils/readme";
+import { Command } from "commander";
+
+handleReadmeFlag(import.meta.url);
+
+const program = new Command();
+program
+    .name("ms-teams")
+    .description("Read Microsoft Teams chats from the local desktop cache")
+    .version("1.0.0")
+    .showHelpAfterError(true);
+
+registerSyncCommand(program);
+registerDoctorCommand(program);
+registerConversationsCommand(program);
+registerShowCommand(program);
+registerSearchCommand(program);
+registerPeopleCommand(program);
+registerMembersCommand(program);
+registerFilesCommand(program);
+registerCallsCommand(program);
+registerMeetingsCommand(program);
+registerMentionsCommand(program);
+registerTranscriptsCommand(program);
+registerMcpCommand(program);
+
+program.action(() => {
+    if (!isInteractive()) {
+        program.help();
+        return;
+    }
+
+    program.help();
+});
+
+enhanceHelp(program);
+
+await runTool(program, { tool: "ms-teams" }).catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    out.error(message);
+    process.exit(1);
+});

--- a/src/ms-teams/lib/attachments.ts
+++ b/src/ms-teams/lib/attachments.ts
@@ -150,9 +150,11 @@ export async function downloadAttachments(args: {
 }): Promise<{ attachments: Attachment[]; failed: number }> {
     const { attachments, outDir } = args;
     const fetchImpl = args.fetchImpl ?? fetch;
-    await mkdir(outDir, { recursive: true });
+    await mkdir(outDir, { recursive: true, mode: 0o700 });
     let failed = 0;
     const result: Attachment[] = [];
+    const usedNames = new Set<string>();
+    const maxBytes = 50 * 1024 * 1024;
 
     for (const attachment of attachments) {
         if (!attachment.url || attachment.url.startsWith("file:")) {
@@ -160,8 +162,11 @@ export async function downloadAttachments(args: {
             continue;
         }
 
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 30_000);
+
         try {
-            const res = await fetchImpl(attachment.url);
+            const res = await fetchImpl(attachment.url, { signal: controller.signal });
 
             if (!res.ok) {
                 logger.debug({ status: res.status, url: attachment.url }, "[ms-teams] attachment download failed");
@@ -170,14 +175,24 @@ export async function downloadAttachments(args: {
                 continue;
             }
 
-            const safe = sanitizeFilename(attachment.name || "attachment");
-            const dest = join(outDir, safe);
-            await Bun.write(dest, await res.arrayBuffer());
+            const dest = uniqueDest(outDir, attachment.name || "attachment", attachment.itemId, usedNames);
+            await Bun.write(dest, res);
+            const written = Bun.file(dest).size;
+
+            if (written > maxBytes) {
+                await Bun.file(dest).unlink();
+                failed += 1;
+                result.push(attachment);
+                continue;
+            }
+
             result.push({ ...attachment, localPath: dest });
         } catch (err) {
             logger.debug({ err, url: attachment.url }, "[ms-teams] attachment download threw");
             failed += 1;
             result.push(attachment);
+        } finally {
+            clearTimeout(timer);
         }
     }
 
@@ -204,7 +219,7 @@ export function parseJsonField(value: unknown): unknown {
     }
 
     try {
-        return SafeJSON.parse(decoded);
+        return SafeJSON.parse(decoded, { strict: true });
     } catch (err) {
         logger.debug({ err }, "[ms-teams] properties JSON field was not parseable");
         return decoded;
@@ -226,4 +241,22 @@ function sanitizeFilename(name: string): string {
             .replace(/\s+/g, " ")
             .trim() || "attachment";
     return base.slice(0, 120);
+}
+
+function uniqueDest(dir: string, name: string, itemId: string | null, used: Set<string>): string {
+    const safe = sanitizeFilename(name);
+    const dot = safe.lastIndexOf(".");
+    const stem = dot > 0 ? safe.slice(0, dot) : safe;
+    const ext = dot > 0 ? safe.slice(dot) : "";
+    const suffix = itemId ? itemId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 12) : "";
+    let candidate = suffix ? `${stem}-${suffix}${ext}` : safe;
+    let n = 2;
+
+    while (used.has(candidate)) {
+        candidate = `${stem}-${n}${ext}`;
+        n += 1;
+    }
+
+    used.add(candidate);
+    return join(dir, candidate);
 }

--- a/src/ms-teams/lib/attachments.ts
+++ b/src/ms-teams/lib/attachments.ts
@@ -1,0 +1,229 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { decodeTeamsString } from "./decode";
+import type { Attachment } from "./types";
+
+export function parseAttachments(properties: unknown, extraHtml?: string | null): Attachment[] {
+    const out: Attachment[] = [];
+    const props = asRecord(properties);
+    const files = parseJsonField(props?.files);
+
+    if (Array.isArray(files)) {
+        for (const file of files) {
+            const rec = asRecord(file);
+
+            if (!rec) {
+                continue;
+            }
+
+            const info = asRecord(rec.fileInfo) ?? {};
+            const name = decodeTeamsString(rec.fileName ?? info.fileName);
+            const url = decodeTeamsString(rec.objectUrl ?? rec.fileUrl ?? info.fileUrl);
+            const itemId = decodeTeamsString(rec.itemid ?? rec.itemId ?? info.itemId) || null;
+            const mimeHint = decodeTeamsString(rec.fileType ?? info.fileType) || null;
+
+            if (!name && !url) {
+                continue;
+            }
+
+            out.push({
+                name: name || "attachment",
+                mimeHint,
+                url: url || null,
+                itemId,
+                localPath: null,
+            });
+        }
+    }
+
+    if (extraHtml) {
+        const imgRe = /src=["'](https:\/\/[^"']+)["'][^>]*itemtype=["']http:\/\/schema\.skype\.com\/AMSImage["']/gi;
+        let match: RegExpExecArray | null = imgRe.exec(extraHtml);
+
+        while (match) {
+            const url = match[1];
+
+            if (!out.some((a) => a.url === url)) {
+                out.push({
+                    name: "image",
+                    mimeHint: "png",
+                    url,
+                    itemId: null,
+                    localPath: null,
+                });
+            }
+
+            match = imgRe.exec(extraHtml);
+        }
+    }
+
+    return out;
+}
+
+export function parseMentions(properties: unknown): { id: string; name: string }[] {
+    const props = asRecord(properties);
+    const mentions = parseJsonField(props?.mentions);
+
+    if (!Array.isArray(mentions)) {
+        return [];
+    }
+
+    const out: { id: string; name: string }[] = [];
+
+    for (const mention of mentions) {
+        const rec = asRecord(mention);
+
+        if (!rec) {
+            continue;
+        }
+
+        const id = decodeTeamsString(rec.mri ?? rec.userMri ?? rec.id);
+        const name = decodeTeamsString(rec.displayName ?? rec.name);
+
+        if (id || name) {
+            out.push({ id, name });
+        }
+    }
+
+    return out;
+}
+
+export function parseLinks(properties: unknown): string[] {
+    const props = asRecord(properties);
+    const links = parseJsonField(props?.links);
+
+    if (!Array.isArray(links)) {
+        return [];
+    }
+
+    const out: string[] = [];
+
+    for (const link of links) {
+        if (typeof link === "string") {
+            const url = decodeTeamsString(link);
+
+            if (url) {
+                out.push(url);
+            }
+
+            continue;
+        }
+
+        const rec = asRecord(link);
+        const url = decodeTeamsString(rec?.url ?? rec?.href);
+
+        if (url) {
+            out.push(url);
+        }
+    }
+
+    return out;
+}
+
+export function parseReactions(annotations: unknown): { emotion: string; count: number }[] {
+    const rec = asRecord(annotations);
+    const emotions = asRecord(rec?.emotions);
+
+    if (!emotions) {
+        return [];
+    }
+
+    const out: { emotion: string; count: number }[] = [];
+
+    for (const [emotion, count] of Object.entries(emotions)) {
+        const n = typeof count === "number" ? count : Number(count);
+
+        if (Number.isFinite(n) && n > 0) {
+            out.push({ emotion, count: n });
+        }
+    }
+
+    return out;
+}
+
+export async function downloadAttachments(args: {
+    attachments: Attachment[];
+    outDir: string;
+    fetchImpl?: typeof fetch;
+}): Promise<{ attachments: Attachment[]; failed: number }> {
+    const { attachments, outDir } = args;
+    const fetchImpl = args.fetchImpl ?? fetch;
+    await mkdir(outDir, { recursive: true });
+    let failed = 0;
+    const result: Attachment[] = [];
+
+    for (const attachment of attachments) {
+        if (!attachment.url || attachment.url.startsWith("file:")) {
+            result.push(attachment);
+            continue;
+        }
+
+        try {
+            const res = await fetchImpl(attachment.url);
+
+            if (!res.ok) {
+                logger.debug({ status: res.status, url: attachment.url }, "[ms-teams] attachment download failed");
+                failed += 1;
+                result.push(attachment);
+                continue;
+            }
+
+            const safe = sanitizeFilename(attachment.name || "attachment");
+            const dest = join(outDir, safe);
+            await Bun.write(dest, await res.arrayBuffer());
+            result.push({ ...attachment, localPath: dest });
+        } catch (err) {
+            logger.debug({ err, url: attachment.url }, "[ms-teams] attachment download threw");
+            failed += 1;
+            result.push(attachment);
+        }
+    }
+
+    return { attachments: result, failed };
+}
+
+export function parseJsonField(value: unknown): unknown {
+    if (value === null || value === undefined || value === "<Undefined>") {
+        return null;
+    }
+
+    if (typeof value !== "string") {
+        return value;
+    }
+
+    const decoded = decodeTeamsString(value).trim();
+
+    if (!decoded || decoded === "[]" || decoded === "null") {
+        if (decoded === "[]") {
+            return [];
+        }
+
+        return null;
+    }
+
+    try {
+        return SafeJSON.parse(decoded);
+    } catch (err) {
+        logger.debug({ err }, "[ms-teams] properties JSON field was not parseable");
+        return decoded;
+    }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+        return value as Record<string, unknown>;
+    }
+
+    return null;
+}
+
+function sanitizeFilename(name: string): string {
+    const base =
+        name
+            .replace(/[/\\?%*:|"<>]/g, "_")
+            .replace(/\s+/g, " ")
+            .trim() || "attachment";
+    return base.slice(0, 120);
+}

--- a/src/ms-teams/lib/cache.ts
+++ b/src/ms-teams/lib/cache.ts
@@ -1,0 +1,14 @@
+import { existsSync } from "node:fs";
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { cacheDbPath } from "./paths";
+import { TeamsCache } from "./store";
+
+export function openCache(): TeamsCache {
+    const path = cacheDbPath();
+
+    if (!existsSync(path)) {
+        throw new Error(`No Teams cache yet. Run ${suggestCommand("tools ms-teams sync")} first.`);
+    }
+
+    return new TeamsCache(path);
+}

--- a/src/ms-teams/lib/decode.test.ts
+++ b/src/ms-teams/lib/decode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { decodeTeamsString, foldTeamsText } from "./decode";
+
+describe("decodeTeamsString", () => {
+    test("passes through plain unicode", () => {
+        expect(decodeTeamsString("Nabídky 2.0")).toBe("Nabídky 2.0");
+    });
+
+    test("unwraps a python bytes repr with latin-1 escapes", () => {
+        expect(decodeTeamsString("b'Nab\\xeddky 2.0'")).toBe("Nabídky 2.0");
+        expect(decodeTeamsString("b'Vesel\\xfd Ivan (QT)'")).toBe("Veselý Ivan (QT)");
+        expect(decodeTeamsString("b'Martin Pr\\xedvara'")).toBe("Martin Prívara");
+    });
+
+    test("unwraps html wrapped as a python bytes repr", () => {
+        expect(decodeTeamsString("b'<p>cau, kouknu na to dneska</p>'")).toBe("<p>cau, kouknu na to dneska</p>");
+    });
+
+    test("treats empty sentinels as empty string", () => {
+        expect(decodeTeamsString(null)).toBe("");
+        expect(decodeTeamsString("<Undefined>")).toBe("");
+        expect(decodeTeamsString("")).toBe("");
+    });
+});
+
+describe("foldTeamsText", () => {
+    test("folds diacritics for name matching", () => {
+        expect(foldTeamsText("b'Folt\\xfdn Martin'")).toBe("foltyn martin");
+        expect(foldTeamsText("Ussov Stanislav")).toBe("ussov stanislav");
+    });
+});

--- a/src/ms-teams/lib/decode.test.ts
+++ b/src/ms-teams/lib/decode.test.ts
@@ -21,6 +21,11 @@ describe("decodeTeamsString", () => {
         expect(decodeTeamsString("<Undefined>")).toBe("");
         expect(decodeTeamsString("")).toBe("");
     });
+
+    test("does not unescape ordinary message text", () => {
+        expect(decodeTeamsString("C:\\Users\\Ada")).toBe("C:\\Users\\Ada");
+        expect(decodeTeamsString("line\\nbreak")).toBe("line\\nbreak");
+    });
 });
 
 describe("foldTeamsText", () => {

--- a/src/ms-teams/lib/decode.ts
+++ b/src/ms-teams/lib/decode.ts
@@ -28,7 +28,7 @@ export function decodeTeamsString(input: unknown): string {
         return unescapePythonString(repr);
     }
 
-    return unescapePythonString(input);
+    return input;
 }
 
 function matchPythonBytesRepr(value: string): string | null {

--- a/src/ms-teams/lib/decode.ts
+++ b/src/ms-teams/lib/decode.ts
@@ -1,0 +1,113 @@
+/**
+ * Teams IndexedDB strings often arrive as a Python-bytes repr of Latin-1 code
+ * points (`b'Nab\\xeddky 2.0'` → `Nabídky 2.0`), or as already-decoded text.
+ * Always run user-facing fields through this before compare or export.
+ */
+export function decodeTeamsString(input: unknown): string {
+    if (input === null || input === undefined) {
+        return "";
+    }
+
+    if (typeof input !== "string") {
+        if (typeof input === "number" || typeof input === "boolean") {
+            return String(input);
+        }
+
+        return "";
+    }
+
+    const trimmed = input.trim();
+
+    if (trimmed === "" || trimmed === "<Undefined>" || trimmed === "undefined") {
+        return "";
+    }
+
+    const repr = matchPythonBytesRepr(trimmed);
+
+    if (repr !== null) {
+        return unescapePythonString(repr);
+    }
+
+    return unescapePythonString(input);
+}
+
+function matchPythonBytesRepr(value: string): string | null {
+    if (value.length >= 3 && value.startsWith("b'") && value.endsWith("'")) {
+        return value.slice(2, -1);
+    }
+
+    if (value.length >= 3 && value.startsWith('b"') && value.endsWith('"')) {
+        return value.slice(2, -1);
+    }
+
+    return null;
+}
+
+function unescapePythonString(value: string): string {
+    let out = "";
+
+    for (let i = 0; i < value.length; i++) {
+        const ch = value[i];
+
+        if (ch !== "\\") {
+            out += ch;
+            continue;
+        }
+
+        const next = value[i + 1];
+
+        if (next === undefined) {
+            out += "\\";
+            break;
+        }
+
+        if (next === "x" && i + 3 < value.length) {
+            const hex = value.slice(i + 2, i + 4);
+
+            if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+                out += String.fromCharCode(Number.parseInt(hex, 16));
+                i += 3;
+                continue;
+            }
+        }
+
+        if (next === "u" && i + 5 < value.length) {
+            const hex = value.slice(i + 2, i + 6);
+
+            if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+                out += String.fromCharCode(Number.parseInt(hex, 16));
+                i += 5;
+                continue;
+            }
+        }
+
+        const simple: Record<string, string> = {
+            n: "\n",
+            r: "\r",
+            t: "\t",
+            "\\": "\\",
+            "'": "'",
+            '"': '"',
+            a: "\u0007",
+            b: "\b",
+            f: "\f",
+            v: "\v",
+        };
+
+        if (simple[next] !== undefined) {
+            out += simple[next];
+            i += 1;
+            continue;
+        }
+
+        out += next;
+        i += 1;
+    }
+
+    return out;
+}
+
+/** Case-fold and strip diacritics for name matching. */
+export function foldTeamsText(input: unknown): string {
+    return decodeTeamsString(input).normalize("NFD").replace(/\p{M}/gu, "").toLowerCase().replace(/\s+/g, " ").trim();
+}

--- a/src/ms-teams/lib/display.ts
+++ b/src/ms-teams/lib/display.ts
@@ -1,0 +1,54 @@
+import { formatDateTime } from "@genesiscz/utils/date";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import pc from "picocolors";
+import type { ConversationRow, MessageRow, PeopleRow } from "./types";
+
+export function printConversations(rows: ConversationRow[]): void {
+    renderCliHeader("Teams conversations", "local client cache");
+    const table = createBoxTable(["TITLE", "TYPE", "MEMBERS", "LAST", "ID"]);
+
+    for (const row of rows) {
+        const last = row.lastMessageTime ? formatDateTime(row.lastMessageTime, { absolute: "datetime" }) : "—";
+        table.push([
+            pc.white(truncateDisplay(row.topic || row.title, 40)),
+            row.type,
+            String(row.memberCount),
+            last,
+            truncateDisplay(row.id, 36),
+        ]);
+    }
+
+    out.println(table.toString());
+}
+
+export function printPeople(rows: PeopleRow[]): void {
+    renderCliHeader("Teams people", "from the local profile cache");
+    const table = createBoxTable(["NAME", "EMAIL", "MRI"]);
+
+    for (const row of rows) {
+        table.push([
+            pc.white(truncateDisplay(row.displayName, 32)),
+            truncateDisplay(row.email ?? "—", 32),
+            truncateDisplay(row.mri, 40),
+        ]);
+    }
+
+    out.println(table.toString());
+}
+
+export function printSearchHits(rows: MessageRow[], titleFor: (id: string) => string): void {
+    renderCliHeader("Teams search", `${rows.length} hits`);
+    const table = createBoxTable(["WHEN", "FROM", "CHAT", "TEXT"]);
+
+    for (const row of rows) {
+        table.push([
+            formatDateTime(row.originalArrivalTime, { absolute: "datetime" }),
+            truncateDisplay(row.fromName ?? "—", 22),
+            truncateDisplay(titleFor(row.conversationId), 24),
+            truncateDisplay(row.text.replace(/\s+/g, " "), 48),
+        ]);
+    }
+
+    out.println(table.toString());
+}

--- a/src/ms-teams/lib/doctor.ts
+++ b/src/ms-teams/lib/doctor.ts
@@ -1,0 +1,63 @@
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { cacheDbPath, liveBlobDir, liveIdbDir, venvPython } from "./paths";
+import { TeamsCache } from "./store";
+
+export interface DoctorReport {
+    idbExists: boolean;
+    idbPath: string;
+    blobExists: boolean;
+    cacheExists: boolean;
+    cachePath: string;
+    cacheIngestedAt: string | null;
+    counts: { conversations: number; messages: number; people: number; calls: number; activity: number } | null;
+    venvPythonExists: boolean;
+    teamsProcess: boolean;
+    readable: boolean;
+}
+
+export function inspectDoctor(): DoctorReport {
+    const idbPath = liveIdbDir();
+    const blobPath = liveBlobDir();
+    const cachePath = cacheDbPath();
+    const idbExists = existsSync(idbPath);
+    let readable = false;
+
+    if (idbExists) {
+        try {
+            statSync(join(idbPath, "CURRENT"));
+            readable = true;
+        } catch {
+            readable = false;
+        }
+    }
+
+    let counts: DoctorReport["counts"] = null;
+    let cacheIngestedAt: string | null = null;
+    const cacheExists = existsSync(cachePath);
+
+    if (cacheExists) {
+        const cache = new TeamsCache(cachePath);
+        counts = cache.counts();
+        cacheIngestedAt = cache.getMeta("ingested_at");
+        cache.close();
+    }
+
+    return {
+        idbExists,
+        idbPath,
+        blobExists: existsSync(blobPath),
+        cacheExists,
+        cachePath,
+        cacheIngestedAt,
+        counts,
+        venvPythonExists: existsSync(venvPython()),
+        teamsProcess: isTeamsRunning(),
+        readable,
+    };
+}
+
+function isTeamsRunning(): boolean {
+    const proc = Bun.spawnSync(["pgrep", "-fl", "Microsoft Teams"], { stdout: "pipe", stderr: "pipe" });
+    return proc.exitCode === 0 && new TextDecoder().decode(proc.stdout).trim().length > 0;
+}

--- a/src/ms-teams/lib/doctor.ts
+++ b/src/ms-teams/lib/doctor.ts
@@ -37,10 +37,18 @@ export function inspectDoctor(): DoctorReport {
     const cacheExists = existsSync(cachePath);
 
     if (cacheExists) {
-        const cache = new TeamsCache(cachePath);
-        counts = cache.counts();
-        cacheIngestedAt = cache.getMeta("ingested_at");
-        cache.close();
+        let cache: TeamsCache | null = null;
+
+        try {
+            cache = new TeamsCache(cachePath, { readonly: true });
+            counts = cache.counts();
+            cacheIngestedAt = cache.getMeta("ingested_at");
+        } catch {
+            counts = null;
+            cacheIngestedAt = null;
+        } finally {
+            cache?.close();
+        }
     }
 
     return {
@@ -58,6 +66,10 @@ export function inspectDoctor(): DoctorReport {
 }
 
 function isTeamsRunning(): boolean {
-    const proc = Bun.spawnSync(["pgrep", "-fl", "Microsoft Teams"], { stdout: "pipe", stderr: "pipe" });
-    return proc.exitCode === 0 && new TextDecoder().decode(proc.stdout).trim().length > 0;
+    try {
+        const proc = Bun.spawnSync(["pgrep", "-fl", "Microsoft Teams"], { stdout: "pipe", stderr: "pipe" });
+        return proc.exitCode === 0 && new TextDecoder().decode(proc.stdout).trim().length > 0;
+    } catch {
+        return false;
+    }
 }

--- a/src/ms-teams/lib/export/html.ts
+++ b/src/ms-teams/lib/export/html.ts
@@ -11,12 +11,21 @@ export function renderHtml(thread: ThreadExport): string {
                 ? `<blockquote class="reply">reply to ${escapeHtml(message.replyTo.from)}: ${escapeHtml(message.replyTo.excerpt)}</blockquote>`
                 : "";
             const body = message.html
-                ? `<div class="html">${message.html}</div>`
+                ? `<div class="html">${sanitizeHtml(message.html)}</div>`
                 : `<p>${escapeHtml(message.text || "")}</p>`;
             const attachments = message.attachments
                 .map((a) => {
                     const href = a.localPath ?? a.url;
-                    return href ? `<p class="file"><a href="${escapeHtml(href)}">${escapeHtml(a.name)}</a></p>` : "";
+
+                    if (!href) {
+                        return "";
+                    }
+
+                    if (!isSafeHref(href)) {
+                        return `<p class="file">${escapeHtml(a.name)}</p>`;
+                    }
+
+                    return `<p class="file"><a href="${escapeHtml(href)}">${escapeHtml(a.name)}</a></p>`;
                 })
                 .join("");
             const reactions =
@@ -57,4 +66,17 @@ ${items}
 
 function escapeHtml(value: string): string {
     return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function sanitizeHtml(html: string): string {
+    return html
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+        .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+        .replace(/javascript:/gi, "");
+}
+
+function isSafeHref(href: string): boolean {
+    const trimmed = href.trim();
+    return /^(https?:\/\/|\/|\.\/)/i.test(trimmed) && !/^\s*javascript:/i.test(trimmed);
 }

--- a/src/ms-teams/lib/export/html.ts
+++ b/src/ms-teams/lib/export/html.ts
@@ -1,0 +1,60 @@
+import { formatDateTime } from "@genesiscz/utils/date";
+import type { ThreadExport } from "../types";
+
+export function renderHtml(thread: ThreadExport): string {
+    const { conversation, messages } = thread;
+    const items = messages
+        .map((message) => {
+            const when = escapeHtml(formatDateTime(message.time, { absolute: "datetime" }));
+            const who = escapeHtml(message.from.displayName + (message.isFromMe ? " (me)" : ""));
+            const reply = message.replyTo
+                ? `<blockquote class="reply">reply to ${escapeHtml(message.replyTo.from)}: ${escapeHtml(message.replyTo.excerpt)}</blockquote>`
+                : "";
+            const body = message.html
+                ? `<div class="html">${message.html}</div>`
+                : `<p>${escapeHtml(message.text || "")}</p>`;
+            const attachments = message.attachments
+                .map((a) => {
+                    const href = a.localPath ?? a.url;
+                    return href ? `<p class="file"><a href="${escapeHtml(href)}">${escapeHtml(a.name)}</a></p>` : "";
+                })
+                .join("");
+            const reactions =
+                message.reactions.length > 0
+                    ? `<p class="reactions">${message.reactions.map((r) => escapeHtml(`${r.emotion} ×${r.count}`)).join(" · ")}</p>`
+                    : "";
+            const nested = message.replyToId ? " nested" : "";
+            return `<article class="msg${nested}"><header>${when} · ${who}</header>${reply}${body}${attachments}${reactions}</article>`;
+        })
+        .join("\n");
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(conversation.title)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 52rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.45; }
+  h1 { font-size: 1.4rem; }
+  .meta { color: GrayText; font-size: 0.9rem; }
+  article { border-top: 1px solid color-mix(in srgb, CanvasText 12%, transparent); padding: 0.8rem 0; }
+  article.nested { margin-left: 1.5rem; }
+  header { font-size: 0.85rem; color: GrayText; margin-bottom: 0.35rem; }
+  blockquote.reply { margin: 0 0 0.5rem; padding-left: 0.75rem; border-left: 3px solid color-mix(in srgb, CanvasText 25%, transparent); color: GrayText; }
+  .html img { max-width: 100%; height: auto; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(conversation.title)}</h1>
+<p class="meta">${escapeHtml(conversation.type)} · ${conversation.messageCount} messages · ${escapeHtml(conversation.cachedFrom ?? "—")} → ${escapeHtml(conversation.cachedTo ?? "—")}</p>
+<p class="meta">${escapeHtml(conversation.completenessNote)}</p>
+${items}
+</body>
+</html>
+`;
+}
+
+function escapeHtml(value: string): string {
+    return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/src/ms-teams/lib/export/json.ts
+++ b/src/ms-teams/lib/export/json.ts
@@ -1,0 +1,6 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import type { ThreadExport } from "../types";
+
+export function renderJson(thread: ThreadExport): string {
+    return `${SafeJSON.stringify(thread, null, 2)}\n`;
+}

--- a/src/ms-teams/lib/export/markdown.ts
+++ b/src/ms-teams/lib/export/markdown.ts
@@ -1,0 +1,56 @@
+import { formatDateTime } from "@genesiscz/utils/date";
+import type { ThreadExport } from "../types";
+
+export function renderMarkdown(thread: ThreadExport): string {
+    const lines: string[] = [];
+    const { conversation, messages } = thread;
+    lines.push(`# ${conversation.title}`);
+    lines.push("");
+    lines.push(
+        `${conversation.type} · ${conversation.messageCount} messages · cached ${conversation.cachedFrom ?? "—"} → ${conversation.cachedTo ?? "—"}`
+    );
+    lines.push("");
+    lines.push(`_${conversation.completenessNote}_`);
+    lines.push("");
+
+    if (conversation.members.length > 0) {
+        lines.push(`Members: ${conversation.members.map((m) => m.displayName).join(", ")}`);
+        lines.push("");
+    }
+
+    for (const message of messages) {
+        const when = formatDateTime(message.time, { absolute: "datetime" });
+        const who = message.from.displayName + (message.isFromMe ? " (me)" : "");
+        lines.push(`## ${when} · ${who}`);
+        lines.push("");
+
+        if (message.replyTo) {
+            lines.push(`> reply to ${message.replyTo.from}: ${message.replyTo.excerpt}`);
+            lines.push("");
+        }
+
+        if (message.system) {
+            lines.push(`*${message.system}*`);
+        } else {
+            lines.push(message.text || "_(no text)_");
+        }
+
+        if (message.reactions.length > 0) {
+            lines.push("");
+            lines.push(message.reactions.map((r) => `${r.emotion} ×${r.count}`).join(" · "));
+        }
+
+        for (const attachment of message.attachments) {
+            const href = attachment.localPath ?? attachment.url;
+
+            if (href) {
+                lines.push("");
+                lines.push(`[${attachment.name}](${href})`);
+            }
+        }
+
+        lines.push("");
+    }
+
+    return `${lines.join("\n").trim()}\n`;
+}

--- a/src/ms-teams/lib/export/thread.ts
+++ b/src/ms-teams/lib/export/thread.ts
@@ -1,0 +1,94 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isSystemMessageType } from "../ingest-parse";
+import type { TeamsCache } from "../store";
+import type {
+    Attachment,
+    ExportedMessage,
+    ListMessagesOptions,
+    Mention,
+    MessageRow,
+    Person,
+    Reaction,
+    ThreadExport,
+} from "../types";
+import { COMPLETENESS_NOTE } from "../types";
+
+export function exportThread(cache: TeamsCache, conversationId: string, opts: ListMessagesOptions = {}): ThreadExport {
+    const conversation = cache.getConversation(conversationId);
+
+    if (!conversation) {
+        throw new Error(`Conversation not found: ${conversationId}`);
+    }
+
+    const messages = cache.listMessages(conversationId, opts);
+    const byId = new Map(messages.map((m) => [m.id, m]));
+    const exported = messages.map((row) => toExported(row, byId));
+    const times = messages.map((m) => m.originalArrivalTime);
+    const cachedFrom = times.length ? new Date(Math.min(...times)).toISOString() : null;
+    const cachedTo = times.length ? new Date(Math.max(...times)).toISOString() : null;
+    let members: Person[] = [];
+
+    try {
+        members = SafeJSON.parse(conversation.membersJson);
+    } catch {
+        members = [];
+    }
+
+    return {
+        conversation: {
+            id: conversation.id,
+            type: conversation.type,
+            title: conversation.title,
+            topic: conversation.topic,
+            members: Array.isArray(members) ? members : [],
+            cachedFrom,
+            cachedTo,
+            messageCount: exported.length,
+            completenessNote: COMPLETENESS_NOTE,
+        },
+        messages: exported,
+    };
+}
+
+function toExported(row: MessageRow, byId: Map<string, MessageRow>): ExportedMessage {
+    const reply = row.replyToId ? byId.get(row.replyToId) : undefined;
+    const system = isSystemMessageType(row.messageType) ? row.text || row.messageType : null;
+
+    return {
+        id: row.id,
+        sequenceId: row.sequenceId,
+        time: new Date(row.originalArrivalTime).toISOString(),
+        from: {
+            mri: row.fromMri ?? "",
+            displayName: row.fromName ?? row.fromMri ?? "unknown",
+            email: null,
+        },
+        isFromMe: row.isFromMe,
+        messageType: row.messageType,
+        text: row.text,
+        html: row.html,
+        replyToId: row.replyToId,
+        replyTo: reply
+            ? {
+                  id: reply.id,
+                  from: reply.fromName ?? "unknown",
+                  excerpt: (reply.text || "").slice(0, 140),
+              }
+            : null,
+        reactions: parseJsonArray<Reaction>(row.reactionsJson),
+        mentions: parseJsonArray<Mention>(row.mentionsJson),
+        links: parseJsonArray<string>(row.linksJson),
+        attachments: parseJsonArray<Attachment>(row.attachmentsJson),
+        call: row.messageType === "Event/Call" ? { state: row.text || "call" } : null,
+        system,
+    };
+}
+
+function parseJsonArray<T>(raw: string): T[] {
+    try {
+        const value = SafeJSON.parse(raw);
+        return Array.isArray(value) ? (value as T[]) : [];
+    } catch {
+        return [];
+    }
+}

--- a/src/ms-teams/lib/export/thread.ts
+++ b/src/ms-teams/lib/export/thread.ts
@@ -23,13 +23,15 @@ export function exportThread(cache: TeamsCache, conversationId: string, opts: Li
     const messages = cache.listMessages(conversationId, opts);
     const byId = new Map(messages.map((m) => [m.id, m]));
     const exported = messages.map((row) => toExported(row, byId));
-    const times = messages.map((m) => m.originalArrivalTime);
-    const cachedFrom = times.length ? new Date(Math.min(...times)).toISOString() : null;
-    const cachedTo = times.length ? new Date(Math.max(...times)).toISOString() : null;
+    const first = messages[0];
+    const last = messages[messages.length - 1];
+    const cachedFrom = first ? new Date(first.originalArrivalTime).toISOString() : null;
+    const cachedTo = last ? new Date(last.originalArrivalTime).toISOString() : null;
     let members: Person[] = [];
 
     try {
-        members = SafeJSON.parse(conversation.membersJson);
+        const parsed = SafeJSON.parse(conversation.membersJson);
+        members = Array.isArray(parsed) ? parsed : [];
     } catch {
         members = [];
     }

--- a/src/ms-teams/lib/html-to-text.test.ts
+++ b/src/ms-teams/lib/html-to-text.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { htmlToText } from "./html-to-text";
+
+describe("htmlToText", () => {
+    test("strips tags and keeps emoji alt text", () => {
+        const html =
+            '<p>cau, kouknu na to dneska <span title="grin"><img alt="😄" itemtype="http://schema.skype.com/Emoji" /></span></p>';
+        expect(htmlToText(html).text).toContain("cau, kouknu na to dneska");
+        expect(htmlToText(html).text).toContain("😄");
+    });
+
+    test("extracts a skype reply itemid and drops the quote body", () => {
+        const html =
+            '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="1780916204854"><p>parent</p></blockquote><p>child reply</p>';
+        const got = htmlToText(html);
+        expect(got.replyToId).toBe("1780916204854");
+        expect(got.text).toBe("child reply");
+        expect(got.text.includes("parent")).toBe(false);
+    });
+});

--- a/src/ms-teams/lib/html-to-text.ts
+++ b/src/ms-teams/lib/html-to-text.ts
@@ -1,0 +1,58 @@
+import { decodeTeamsString } from "./decode";
+
+const REPLY_ITEM_RE = /itemtype=["']http:\/\/schema\.skype\.com\/Reply["'][^>]*itemid=["']([^"']+)["']/i;
+const REPLY_ITEM_RE_ALT = /itemid=["']([^"']+)["'][^>]*itemtype=["']http:\/\/schema\.skype\.com\/Reply["']/i;
+
+export interface HtmlText {
+    text: string;
+    replyToId: string | null;
+}
+
+export function htmlToText(html: unknown): HtmlText {
+    const raw = decodeTeamsString(html);
+
+    if (!raw) {
+        return { text: "", replyToId: null };
+    }
+
+    const replyToId = extractReplyToId(raw);
+    let withoutQuote = raw.replace(/<blockquote\b[^>]*>[\s\S]*?<\/blockquote>/gi, " ");
+    withoutQuote = withoutQuote.replace(/<img\b[^>]*\balt=["']([^"']*)["'][^>]*>/gi, " $1 ");
+    withoutQuote = withoutQuote.replace(/<br\s*\/?>/gi, "\n");
+    withoutQuote = withoutQuote.replace(/<\/p>/gi, "\n");
+    withoutQuote = withoutQuote.replace(/<\/div>/gi, "\n");
+    withoutQuote = withoutQuote.replace(/<\/li>/gi, "\n");
+    withoutQuote = withoutQuote.replace(/<[^>]+>/g, " ");
+    const text = decodeHtmlEntities(withoutQuote)
+        .replace(/\u00a0/g, " ")
+        .replace(/[ \t]+\n/g, "\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .replace(/[ \t]{2,}/g, " ")
+        .trim();
+
+    return { text, replyToId };
+}
+
+export function extractReplyToId(html: string): string | null {
+    const a = html.match(REPLY_ITEM_RE);
+    const b = html.match(REPLY_ITEM_RE_ALT);
+    const id = a?.[1] ?? b?.[1] ?? null;
+
+    if (!id || id === "<Undefined>") {
+        return null;
+    }
+
+    return id;
+}
+
+function decodeHtmlEntities(value: string): string {
+    return value
+        .replace(/&nbsp;/gi, " ")
+        .replace(/&amp;/gi, "&")
+        .replace(/&lt;/gi, "<")
+        .replace(/&gt;/gi, ">")
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;/gi, "'")
+        .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+        .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(Number.parseInt(n, 16)));
+}

--- a/src/ms-teams/lib/html-to-text.ts
+++ b/src/ms-teams/lib/html-to-text.ts
@@ -48,11 +48,19 @@ export function extractReplyToId(html: string): string | null {
 function decodeHtmlEntities(value: string): string {
     return value
         .replace(/&nbsp;/gi, " ")
-        .replace(/&amp;/gi, "&")
         .replace(/&lt;/gi, "<")
         .replace(/&gt;/gi, ">")
         .replace(/&quot;/gi, '"')
         .replace(/&#39;/gi, "'")
-        .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-        .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(Number.parseInt(n, 16)));
+        .replace(/&#(\d+);/g, (_, n) => fromCodePointSafe(Number(n)))
+        .replace(/&#x([0-9a-f]+);/gi, (_, n) => fromCodePointSafe(Number.parseInt(n, 16)))
+        .replace(/&amp;/gi, "&");
+}
+
+function fromCodePointSafe(code: number): string {
+    if (!Number.isInteger(code) || code < 0 || code > 0x10ffff) {
+        return "";
+    }
+
+    return String.fromCodePoint(code);
 }

--- a/src/ms-teams/lib/ingest-parse.ts
+++ b/src/ms-teams/lib/ingest-parse.ts
@@ -1,0 +1,267 @@
+import { parseAttachments, parseLinks, parseMentions, parseReactions } from "./attachments";
+import { decodeTeamsString } from "./decode";
+import { htmlToText } from "./html-to-text";
+import type { ConversationType, Person } from "./types";
+
+export interface ParsedConversation {
+    id: string;
+    type: ConversationType;
+    title: string;
+    topic: string | null;
+    members: Person[];
+    lastMessageTime: number | null;
+    lastPreview: string | null;
+    raw: unknown;
+}
+
+export interface ParsedMessage {
+    id: string;
+    conversationId: string;
+    sequenceId: number | null;
+    version: number;
+    originalArrivalTime: number;
+    fromMri: string | null;
+    fromName: string | null;
+    isFromMe: boolean;
+    messageType: string;
+    text: string;
+    html: string | null;
+    replyToId: string | null;
+    reactions: { emotion: string; count: number }[];
+    mentions: { id: string; name: string }[];
+    links: string[];
+    attachments: ReturnType<typeof parseAttachments>;
+    raw: unknown;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+        return value as Record<string, unknown>;
+    }
+
+    return null;
+}
+
+export function mapConversationType(raw: unknown): ConversationType {
+    const t = decodeTeamsString(raw).toLowerCase();
+
+    if (t === "meeting") {
+        return "meeting";
+    }
+
+    if (t === "chat" || t === "oneonone" || t === "personal") {
+        return "chat";
+    }
+
+    if (t === "space") {
+        return "space";
+    }
+
+    if (t === "topic") {
+        return "topic";
+    }
+
+    return "other";
+}
+
+export function parseConversation(raw: unknown): ParsedConversation | null {
+    const rec = asRecord(raw);
+
+    if (!rec) {
+        return null;
+    }
+
+    const id = decodeTeamsString(rec.id);
+
+    if (!id) {
+        return null;
+    }
+
+    const chatTitle = asRecord(rec.chatTitle);
+    const threadProps = asRecord(rec.threadProperties);
+    const title = decodeTeamsString(chatTitle?.shortTitle ?? threadProps?.topic ?? rec.id);
+    const topic = decodeTeamsString(threadProps?.topic) || null;
+    const members = parseMembers(rec.members, chatTitle);
+    const lastMessage = asRecord(rec.lastMessage);
+    const lastPreview = htmlToText(lastMessage?.content).text || decodeTeamsString(lastMessage?.content) || null;
+    const lastMessageTime = numberish(rec.lastMessageTimeUtc ?? rec.lastContentMessageTime ?? rec.clientArrivalTime);
+
+    return {
+        id,
+        type: mapConversationType(rec.type),
+        title: title || id,
+        topic,
+        members,
+        lastMessageTime,
+        lastPreview,
+        raw,
+    };
+}
+
+export function parseMembers(membersRaw: unknown, chatTitle: Record<string, unknown> | null): Person[] {
+    const byMri = new Map<string, Person>();
+    const avatars = chatTitle?.avatarUsersInfo;
+    const avatarList = Array.isArray(avatars) ? avatars : [];
+
+    for (const avatar of avatarList) {
+        const rec = asRecord(avatar);
+
+        if (!rec) {
+            continue;
+        }
+
+        const mri = decodeTeamsString(rec.mri ?? rec.id);
+
+        if (!mri) {
+            continue;
+        }
+
+        byMri.set(mri, {
+            mri,
+            displayName: decodeTeamsString(rec.displayName) || mri,
+            email: decodeTeamsString(rec.email) || null,
+        });
+    }
+
+    const members = Array.isArray(membersRaw) ? membersRaw : [];
+
+    for (const member of members) {
+        const rec = asRecord(member);
+
+        if (!rec) {
+            continue;
+        }
+
+        const mri = decodeTeamsString(rec.id ?? rec.mri);
+
+        if (!mri) {
+            continue;
+        }
+
+        const existing = byMri.get(mri);
+        const name = decodeTeamsString(rec.friendlyName ?? rec.displayName);
+
+        byMri.set(mri, {
+            mri,
+            displayName: existing?.displayName || name || mri,
+            email: existing?.email ?? (decodeTeamsString(rec.email) || null),
+        });
+    }
+
+    return [...byMri.values()];
+}
+
+export function parseReplychain(raw: unknown, meMri: string | null): ParsedMessage[] {
+    const rec = asRecord(raw);
+
+    if (!rec) {
+        return [];
+    }
+
+    const conversationId = decodeTeamsString(rec.conversationId);
+    const mmap = asRecord(rec.messageMap);
+
+    if (!conversationId || !mmap) {
+        return [];
+    }
+
+    const out: ParsedMessage[] = [];
+
+    for (const value of Object.values(mmap)) {
+        const parsed = parseMessage(value, conversationId, meMri);
+
+        if (parsed) {
+            out.push(parsed);
+        }
+    }
+
+    return out;
+}
+
+export function parseMessage(raw: unknown, conversationId: string, meMri: string | null): ParsedMessage | null {
+    const rec = asRecord(raw);
+
+    if (!rec) {
+        return null;
+    }
+
+    const id = decodeTeamsString(rec.id);
+
+    if (!id) {
+        return null;
+    }
+
+    const html = decodeTeamsString(rec.content) || null;
+    const extracted = htmlToText(html ?? "");
+    const parent = decodeTeamsString(rec.parentMessageId);
+    const replyToId = parent && parent !== id ? parent : extracted.replyToId;
+    const fromMri = decodeTeamsString(rec.creator) || null;
+    const fromName = decodeTeamsString(rec.imDisplayName ?? rec.fromDisplayNameInToken) || fromMri;
+    const isSent = rec.isSentByCurrentUser === true || rec.isSentByCurrentUser === "true";
+    const originalArrivalTime = numberish(rec.originalArrivalTime ?? rec.clientArrivalTime) ?? 0;
+    const messageType = decodeTeamsString(rec.messageType ?? rec.type) || "Message";
+
+    if (!originalArrivalTime) {
+        return null;
+    }
+
+    return {
+        id,
+        conversationId: decodeTeamsString(rec.conversationId) || conversationId,
+        sequenceId: numberish(rec.sequenceId),
+        version: numberish(rec.version) ?? originalArrivalTime,
+        originalArrivalTime,
+        fromMri,
+        fromName,
+        isFromMe: isSent || (meMri !== null && fromMri === meMri),
+        messageType,
+        text: extracted.text,
+        html,
+        replyToId,
+        reactions: parseReactions(rec.annotationsSummary),
+        mentions: parseMentions(rec.properties),
+        links: parseLinks(rec.properties),
+        attachments: parseAttachments(rec.properties, html),
+        raw,
+    };
+}
+
+export function parseProfile(raw: unknown): Person | null {
+    const rec = asRecord(raw);
+
+    if (!rec) {
+        return null;
+    }
+
+    const mri = decodeTeamsString(rec.mri ?? rec.objectId);
+
+    if (!mri) {
+        return null;
+    }
+
+    return {
+        mri: mri.startsWith("8:") ? mri : `8:orgid:${mri}`,
+        displayName: decodeTeamsString(rec.displayName) || mri,
+        email: decodeTeamsString(rec.email ?? rec.userPrincipalName) || null,
+    };
+}
+
+export function numberish(value: unknown): number | null {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value !== "" && value !== "<Undefined>") {
+        const n = Number(value);
+
+        if (Number.isFinite(n)) {
+            return n;
+        }
+    }
+
+    return null;
+}
+
+export function isSystemMessageType(messageType: string): boolean {
+    return messageType.startsWith("ThreadActivity/") || messageType === "Event/Call";
+}

--- a/src/ms-teams/lib/ingest-parse.ts
+++ b/src/ms-teams/lib/ingest-parse.ts
@@ -196,9 +196,9 @@ export function parseMessage(raw: unknown, conversationId: string, meMri: string
     const parent = decodeTeamsString(rec.parentMessageId);
     const replyToId = parent && parent !== id ? parent : extracted.replyToId;
     const fromMri = decodeTeamsString(rec.creator) || null;
-    const fromName = decodeTeamsString(rec.imDisplayName ?? rec.fromDisplayNameInToken) || fromMri;
+    const fromName = decodeTeamsString(rec.imDisplayName) || decodeTeamsString(rec.fromDisplayNameInToken) || fromMri;
     const isSent = rec.isSentByCurrentUser === true || rec.isSentByCurrentUser === "true";
-    const originalArrivalTime = numberish(rec.originalArrivalTime ?? rec.clientArrivalTime) ?? 0;
+    const originalArrivalTime = numberish(rec.originalArrivalTime) ?? numberish(rec.clientArrivalTime) ?? 0;
     const messageType = decodeTeamsString(rec.messageType ?? rec.type) || "Message";
 
     if (!originalArrivalTime) {

--- a/src/ms-teams/lib/ingest.ts
+++ b/src/ms-teams/lib/ingest.ts
@@ -3,13 +3,14 @@ import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { cacheDbPath, dumpIdbScript, venvDir, venvPython } from "./paths";
-import { snapshotTeamsIdb } from "./snapshot";
+import { liveIdbMtimeMs, snapshotTeamsIdb } from "./snapshot";
 import { TeamsCache } from "./store";
 import type { TeamsDump } from "./types";
 
 const log = logger.scoped("ms-teams").log;
 
-const PIP_SPEC = "git+https://github.com/cclgroupltd/ccl_chromium_reader.git";
+/** Pin a reviewed ccl_chromium_reader revision. Bump the SHA deliberately when upgrading. */
+const PIP_SPEC = "git+https://github.com/cclgroupltd/ccl_chromium_reader.git@ef840de30221c4d65bc96d2f4d9057e9ef2f526d";
 
 export interface IngestResult {
     conversations: number;
@@ -19,16 +20,35 @@ export interface IngestResult {
 }
 
 export async function ingestIndexedDb(opts: { force?: boolean } = {}): Promise<IngestResult> {
+    const path = cacheDbPath();
+
+    if (!opts.force && existsSync(path)) {
+        const existing = new TeamsCache(path, { readonly: true });
+
+        try {
+            const stored = Number(existing.getMeta("idb_mtime") ?? "0");
+            const live = liveIdbMtimeMs();
+
+            if (stored > 0 && live > 0 && live <= stored) {
+                const counts = existing.counts();
+                log.debug({ stored, live }, "[ms-teams] cache is current; skip snapshot");
+                return { ...counts, dumpCounts: {} };
+            }
+        } finally {
+            existing.close();
+        }
+    }
+
     await ensureVenv();
     const snap = snapshotTeamsIdb();
     const dumpCounts = await runDump(snap.leveldbDir, snap.blobDir, snap.dumpDir);
     const dump = readDumpDir(snap.dumpDir);
-    const cache = new TeamsCache(cacheDbPath());
+    const cache = new TeamsCache(path);
 
     try {
-        const counts = cache.ingestDump(dump);
+        const counts = cache.ingestDump(dump, { force: opts.force });
         cache.setMeta("idb_snapshot", snap.leveldbDir);
-        cache.setMeta("force", opts.force ? "1" : "0");
+        cache.setMeta("idb_mtime", String(liveIdbMtimeMs()));
         return { ...counts, dumpCounts };
     } finally {
         cache.close();
@@ -59,7 +79,7 @@ function readJsonl(path: string): unknown[] {
         }
 
         try {
-            rows.push(SafeJSON.parse(line));
+            rows.push(SafeJSON.parse(line, { strict: true }));
         } catch (err) {
             log.debug({ err, path }, "[ms-teams] skipped a bad JSONL line");
         }
@@ -107,7 +127,7 @@ async function runDump(idb: string, blob: string, out: string): Promise<Record<s
     }
 
     try {
-        const parsed = SafeJSON.parse(result.stdout.trim().split("\n").at(-1) ?? "{}") as {
+        const parsed = SafeJSON.parse(result.stdout.trim().split("\n").at(-1) ?? "{}", { strict: true }) as {
             counts?: Record<string, number>;
         };
         return parsed.counts ?? {};

--- a/src/ms-teams/lib/ingest.ts
+++ b/src/ms-teams/lib/ingest.ts
@@ -1,0 +1,130 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { cacheDbPath, dumpIdbScript, venvDir, venvPython } from "./paths";
+import { snapshotTeamsIdb } from "./snapshot";
+import { TeamsCache } from "./store";
+import type { TeamsDump } from "./types";
+
+const log = logger.scoped("ms-teams").log;
+
+const PIP_SPEC = "git+https://github.com/cclgroupltd/ccl_chromium_reader.git";
+
+export interface IngestResult {
+    conversations: number;
+    messages: number;
+    people: number;
+    dumpCounts: Record<string, number>;
+}
+
+export async function ingestIndexedDb(opts: { force?: boolean } = {}): Promise<IngestResult> {
+    await ensureVenv();
+    const snap = snapshotTeamsIdb();
+    const dumpCounts = await runDump(snap.leveldbDir, snap.blobDir, snap.dumpDir);
+    const dump = readDumpDir(snap.dumpDir);
+    const cache = new TeamsCache(cacheDbPath());
+
+    try {
+        const counts = cache.ingestDump(dump);
+        cache.setMeta("idb_snapshot", snap.leveldbDir);
+        cache.setMeta("force", opts.force ? "1" : "0");
+        return { ...counts, dumpCounts };
+    } finally {
+        cache.close();
+    }
+}
+
+export function readDumpDir(dir: string): TeamsDump {
+    return {
+        conversations: readJsonl(join(dir, "conversations.jsonl")),
+        replychains: readJsonl(join(dir, "replychains.jsonl")),
+        profiles: readJsonl(join(dir, "profiles.jsonl")),
+        calls: readJsonl(join(dir, "calls.jsonl")),
+        activity: readJsonl(join(dir, "activity.jsonl")),
+    };
+}
+
+function readJsonl(path: string): unknown[] {
+    if (!existsSync(path)) {
+        return [];
+    }
+
+    const text = readFileSync(path, "utf8");
+    const rows: unknown[] = [];
+
+    for (const line of text.split("\n")) {
+        if (!line.trim()) {
+            continue;
+        }
+
+        try {
+            rows.push(SafeJSON.parse(line));
+        } catch (err) {
+            log.debug({ err, path }, "[ms-teams] skipped a bad JSONL line");
+        }
+    }
+
+    return rows;
+}
+
+export async function ensureVenv(): Promise<string> {
+    const venv = venvDir();
+    const py = venvPython();
+
+    if (!existsSync(py)) {
+        mkdirSync(venv, { recursive: true });
+        const created = await spawnOk(["python3", "-m", "venv", venv]);
+
+        if (!created.ok) {
+            throw new Error(`Could not create a Python venv at ${venv}: ${created.stderr}`);
+        }
+    }
+
+    const check = await spawnOk([py, "-c", "from ccl_chromium_reader.ccl_chromium_indexeddb import WrappedIndexDB"]);
+
+    if (!check.ok) {
+        const pip = join(venv, "bin", "pip");
+        const installed = await spawnOk([pip, "install", "-q", PIP_SPEC], 180_000);
+
+        if (!installed.ok) {
+            throw new Error(
+                `Could not install ccl_chromium_reader. Run: ${pip} install ${PIP_SPEC}\n${installed.stderr}`
+            );
+        }
+    }
+
+    return py;
+}
+
+async function runDump(idb: string, blob: string, out: string): Promise<Record<string, number>> {
+    const py = venvPython();
+    const script = dumpIdbScript();
+    const result = await spawnOk([py, script, "--idb", idb, "--blob", blob, "--out", out], 300_000);
+
+    if (!result.ok) {
+        throw new Error(`IndexedDB dump failed:\n${result.stderr || result.stdout}`);
+    }
+
+    try {
+        const parsed = SafeJSON.parse(result.stdout.trim().split("\n").at(-1) ?? "{}") as {
+            counts?: Record<string, number>;
+        };
+        return parsed.counts ?? {};
+    } catch (err) {
+        log.debug({ err, stdout: result.stdout }, "[ms-teams] dump summary was not JSON");
+        return {};
+    }
+}
+
+async function spawnOk(cmd: string[], timeout = 60_000): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+    const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+    const timeoutId = setTimeout(() => proc.kill(), timeout);
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    clearTimeout(timeoutId);
+    return { ok: exitCode === 0, stdout, stderr };
+}

--- a/src/ms-teams/lib/paths.ts
+++ b/src/ms-teams/lib/paths.ts
@@ -1,0 +1,43 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Storage } from "@genesiscz/utils/storage";
+
+const storage = new Storage("ms-teams");
+
+export function teamsStorage(): Storage {
+    return storage;
+}
+
+export function cacheDbPath(): string {
+    return join(storage.getBaseDir(), "cache.db");
+}
+
+export function snapshotDir(): string {
+    return join(storage.getBaseDir(), "snapshot");
+}
+
+export function venvDir(): string {
+    return join(storage.getBaseDir(), "venv");
+}
+
+export function venvPython(): string {
+    return join(venvDir(), "bin", "python");
+}
+
+export function liveIdbDir(): string {
+    return join(
+        homedir(),
+        "Library/Containers/com.microsoft.teams2/Data/Library/Application Support/Microsoft/MSTeams/EBWebView/WV2Profile_tfw/IndexedDB/https_teams.microsoft.com_0.indexeddb.leveldb"
+    );
+}
+
+export function liveBlobDir(): string {
+    return join(
+        homedir(),
+        "Library/Containers/com.microsoft.teams2/Data/Library/Application Support/Microsoft/MSTeams/EBWebView/WV2Profile_tfw/IndexedDB/https_teams.microsoft.com_0.indexeddb.blob"
+    );
+}
+
+export function dumpIdbScript(): string {
+    return join(import.meta.dir, "../native/dump_idb.py");
+}

--- a/src/ms-teams/lib/query.test.ts
+++ b/src/ms-teams/lib/query.test.ts
@@ -12,6 +12,7 @@ describe("parseShowQuery", () => {
         expect(q.to?.getMonth()).toBe(7);
         expect(q.to?.getDate()).toBe(6);
         expect(q.to && q.from ? q.to.getTime() > q.from.getTime() : false).toBe(true);
+        expect(q.topic).toBeUndefined();
     });
 
     test("parses a topic title leftover", () => {

--- a/src/ms-teams/lib/query.test.ts
+++ b/src/ms-teams/lib/query.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { parseQueryDate, parseShowQuery } from "./query";
+
+describe("parseShowQuery", () => {
+    test("parses conversation with NAME from DATE to DATE", () => {
+        const q = parseShowQuery("conversation with Ussov Stanislav from 2026-08-06 to 2026-08-06");
+        expect(q.withName).toBe("Ussov Stanislav");
+        expect(q.from?.getFullYear()).toBe(2026);
+        expect(q.from?.getMonth()).toBe(7);
+        expect(q.from?.getDate()).toBe(6);
+        expect(q.to?.getFullYear()).toBe(2026);
+        expect(q.to?.getMonth()).toBe(7);
+        expect(q.to?.getDate()).toBe(6);
+        expect(q.to && q.from ? q.to.getTime() > q.from.getTime() : false).toBe(true);
+    });
+
+    test("parses a topic title leftover", () => {
+        const q = parseShowQuery("Nabídky 2.0 - Nacenění");
+        expect(q.topic).toBe("Nabídky 2.0 - Nacenění");
+        expect(q.withName).toBeUndefined();
+    });
+
+    test("passes a thread id through", () => {
+        const id = "19:866a5869-13fd-4f15-9063-70b6dbf0e651_8a0d9825-0a4a-4be1-91e8-c2e1fa883c1e@unq.gbl.spaces";
+        const q = parseShowQuery(id);
+        expect(q.id).toBe(id);
+    });
+
+    test("parses dotted Czech dates", () => {
+        const from = parseQueryDate("6. 8. 2026", "start");
+        const to = parseQueryDate("6.8.2026", "end");
+        expect(from?.getFullYear()).toBe(2026);
+        expect(from?.getMonth()).toBe(7);
+        expect(from?.getDate()).toBe(6);
+        expect(to?.getHours()).toBe(23);
+    });
+});

--- a/src/ms-teams/lib/query.ts
+++ b/src/ms-teams/lib/query.ts
@@ -1,0 +1,173 @@
+import * as chrono from "chrono-node";
+import { decodeTeamsString } from "./decode";
+
+export interface ShowQuery {
+    withName?: string;
+    topic?: string;
+    id?: string;
+    from?: Date;
+    to?: Date;
+    raw: string;
+}
+
+const THREAD_ID_RE = /^19:[^\s]+@(?:thread\.v2|thread\.tacv2|unq\.gbl\.spaces)$/i;
+const ISO_DATE_RE = /^(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)Z?)?$/;
+const DOT_DATE_RE = /^(\d{1,2})\.\s*(\d{1,2})\.\s*(\d{4})$/;
+
+/**
+ * Parse a free-text show query such as
+ * `conversation with Ussov Stanislav from 2026-08-06 to 2026-08-06`.
+ */
+export function parseShowQuery(input: string): ShowQuery {
+    const raw = decodeTeamsString(input).trim();
+    const result: ShowQuery = { raw };
+
+    if (!raw) {
+        return result;
+    }
+
+    if (THREAD_ID_RE.test(raw)) {
+        result.id = raw;
+        return result;
+    }
+
+    let rest = raw;
+    rest = takeRange(rest, result);
+    rest = takeWith(rest, result);
+    rest = rest
+        .replace(/^(?:conversation|chat|meeting|thread)\s+/i, "")
+        .replace(/\s+/g, " ")
+        .trim();
+
+    if (THREAD_ID_RE.test(rest)) {
+        result.id = rest;
+        return result;
+    }
+
+    if (rest.length > 0) {
+        if (result.withName) {
+            result.topic = rest;
+        } else {
+            result.topic = rest;
+        }
+    }
+
+    return result;
+}
+
+export function mergeShowQuery(parsed: ShowQuery, flags: Partial<ShowQuery>): ShowQuery {
+    return {
+        raw: parsed.raw,
+        withName: flags.withName ?? parsed.withName,
+        topic: flags.topic ?? parsed.topic,
+        id: flags.id ?? parsed.id,
+        from: flags.from ?? parsed.from,
+        to: flags.to ?? parsed.to,
+    };
+}
+
+function takeWith(rest: string, result: ShowQuery): string {
+    const match = rest.match(/\b(?:conversation|chat|meeting)?\s*with\s+(.+)$/i);
+
+    if (!match) {
+        const prefix = rest.match(/^(?:conversation|chat|meeting)?\s*with\s+(.+)$/i);
+
+        if (prefix) {
+            result.withName = cleanName(prefix[1]);
+            return "";
+        }
+
+        return rest;
+    }
+
+    const before = rest.slice(0, match.index).trim();
+    result.withName = cleanName(match[1]);
+    return before;
+}
+
+function takeRange(rest: string, result: ShowQuery): string {
+    const fromMatch = rest.match(/\b(?:from|since)\s+(.+?)(?=\s+(?:to|until|till|with)\b|$)/i);
+    const toMatch = rest.match(/\b(?:to|until|till)\s+(.+?)(?=\s+(?:from|since|with)\b|$)/i);
+
+    if (fromMatch) {
+        const parsed = parseQueryDate(fromMatch[1].trim(), "start");
+
+        if (parsed) {
+            result.from = parsed;
+            rest = rest.replace(fromMatch[0], " ").replace(/\s+/g, " ").trim();
+        }
+    }
+
+    if (toMatch) {
+        const parsed = parseQueryDate(toMatch[1].trim(), "end");
+
+        if (parsed) {
+            result.to = parsed;
+            rest = rest.replace(toMatch[0], " ").replace(/\s+/g, " ").trim();
+        }
+    }
+
+    return rest;
+}
+
+function cleanName(value: string): string {
+    return value
+        .replace(/\b(?:from|since|to|until|till)\s+.+$/i, "")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+export function parseQueryDate(value: string, bound: "start" | "end"): Date | undefined {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        return undefined;
+    }
+
+    const iso = trimmed.match(ISO_DATE_RE);
+
+    if (iso) {
+        const day = iso[1];
+        const time = iso[2];
+
+        if (time) {
+            const d = new Date(`${day}T${time}${trimmed.endsWith("Z") ? "Z" : ""}`);
+
+            if (!Number.isNaN(d.getTime())) {
+                return d;
+            }
+        }
+
+        return bound === "start" ? startOfLocalDay(day) : endOfLocalDay(day);
+    }
+
+    const dotted = trimmed.match(DOT_DATE_RE);
+
+    if (dotted) {
+        const day = `${dotted[3]}-${dotted[2].padStart(2, "0")}-${dotted[1].padStart(2, "0")}`;
+        return bound === "start" ? startOfLocalDay(day) : endOfLocalDay(day);
+    }
+
+    const chronoDate = chrono.parseDate(trimmed);
+
+    if (!chronoDate) {
+        return undefined;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed) || DOT_DATE_RE.test(trimmed) || !/\d{1,2}:\d{2}/.test(trimmed)) {
+        const ymd = `${chronoDate.getFullYear()}-${String(chronoDate.getMonth() + 1).padStart(2, "0")}-${String(chronoDate.getDate()).padStart(2, "0")}`;
+        return bound === "start" ? startOfLocalDay(ymd) : endOfLocalDay(ymd);
+    }
+
+    return chronoDate;
+}
+
+function startOfLocalDay(ymd: string): Date {
+    const [y, m, d] = ymd.split("-").map(Number);
+    return new Date(y, m - 1, d, 0, 0, 0, 0);
+}
+
+function endOfLocalDay(ymd: string): Date {
+    const [y, m, d] = ymd.split("-").map(Number);
+    return new Date(y, m - 1, d, 23, 59, 59, 999);
+}

--- a/src/ms-teams/lib/query.ts
+++ b/src/ms-teams/lib/query.ts
@@ -45,11 +45,7 @@ export function parseShowQuery(input: string): ShowQuery {
     }
 
     if (rest.length > 0) {
-        if (result.withName) {
-            result.topic = rest;
-        } else {
-            result.topic = rest;
-        }
+        result.topic = rest;
     }
 
     return result;
@@ -70,13 +66,6 @@ function takeWith(rest: string, result: ShowQuery): string {
     const match = rest.match(/\b(?:conversation|chat|meeting)?\s*with\s+(.+)$/i);
 
     if (!match) {
-        const prefix = rest.match(/^(?:conversation|chat|meeting)?\s*with\s+(.+)$/i);
-
-        if (prefix) {
-            result.withName = cleanName(prefix[1]);
-            return "";
-        }
-
         return rest;
     }
 
@@ -87,7 +76,6 @@ function takeWith(rest: string, result: ShowQuery): string {
 
 function takeRange(rest: string, result: ShowQuery): string {
     const fromMatch = rest.match(/\b(?:from|since)\s+(.+?)(?=\s+(?:to|until|till|with)\b|$)/i);
-    const toMatch = rest.match(/\b(?:to|until|till)\s+(.+?)(?=\s+(?:from|since|with)\b|$)/i);
 
     if (fromMatch) {
         const parsed = parseQueryDate(fromMatch[1].trim(), "start");
@@ -97,6 +85,8 @@ function takeRange(rest: string, result: ShowQuery): string {
             rest = rest.replace(fromMatch[0], " ").replace(/\s+/g, " ").trim();
         }
     }
+
+    const toMatch = rest.match(/\b(?:to|until|till)\s+(.+?)(?=\s+(?:from|since|with)\b|$)/i);
 
     if (toMatch) {
         const parsed = parseQueryDate(toMatch[1].trim(), "end");

--- a/src/ms-teams/lib/resolve-chat.ts
+++ b/src/ms-teams/lib/resolve-chat.ts
@@ -1,0 +1,112 @@
+import { foldTeamsText } from "./decode";
+import type { ShowQuery } from "./query";
+import { isOneToOneId, type TeamsCache } from "./store";
+import type { ConversationRow } from "./types";
+
+export type ResolveResult =
+    | { status: "exact"; conversation: ConversationRow }
+    | { status: "ambiguous"; matches: ConversationRow[] }
+    | { status: "none"; matches: ConversationRow[] };
+
+interface Scored {
+    conversation: ConversationRow;
+    score: number;
+}
+
+export function resolveConversation(cache: TeamsCache, query: ShowQuery): ResolveResult {
+    if (query.id) {
+        const found = cache.getConversation(query.id);
+
+        if (found) {
+            return { status: "exact", conversation: found };
+        }
+
+        return { status: "none", matches: [] };
+    }
+
+    const all = cache.listConversations({ limit: 10_000 });
+    const scored: Scored[] = [];
+    const nameFold = query.withName ? foldTeamsText(query.withName) : "";
+    const topicFold = query.topic ? foldTeamsText(query.topic) : "";
+
+    for (const conversation of all) {
+        const score = scoreConversation(conversation, nameFold, topicFold);
+
+        if (score > 0) {
+            scored.push({ conversation, score });
+        }
+    }
+
+    scored.sort(
+        (a, b) => b.score - a.score || (b.conversation.lastMessageTime ?? 0) - (a.conversation.lastMessageTime ?? 0)
+    );
+
+    if (scored.length === 0) {
+        return { status: "none", matches: [] };
+    }
+
+    const best = scored[0];
+    const tied = scored.filter((s) => s.score === best.score);
+
+    if (nameFold) {
+        const oneToOnes = scored.filter((s) => isOneToOneId(s.conversation.id, s.conversation.title) && s.score >= 80);
+
+        if (oneToOnes.length === 1) {
+            return { status: "exact", conversation: oneToOnes[0].conversation };
+        }
+
+        if (oneToOnes.length > 1) {
+            return { status: "ambiguous", matches: oneToOnes.map((s) => s.conversation) };
+        }
+    }
+
+    if (tied.length === 1 && best.score >= 50) {
+        return { status: "exact", conversation: best.conversation };
+    }
+
+    if (tied.length > 1) {
+        return { status: "ambiguous", matches: tied.map((s) => s.conversation) };
+    }
+
+    if (best.score >= 50) {
+        return { status: "exact", conversation: best.conversation };
+    }
+
+    return { status: "none", matches: scored.slice(0, 8).map((s) => s.conversation) };
+}
+
+function scoreConversation(conversation: ConversationRow, nameFold: string, topicFold: string): number {
+    const title = foldTeamsText(conversation.title);
+    const topic = foldTeamsText(conversation.topic);
+    const members = foldTeamsText(conversation.membersJson);
+    const oneToOne = isOneToOneId(conversation.id, conversation.title);
+    let score = 0;
+
+    if (nameFold) {
+        if (title === nameFold) {
+            score += oneToOne ? 100 : 70;
+        } else if (title.includes(nameFold)) {
+            score += oneToOne ? 90 : 55;
+        } else if (members.includes(nameFold) || topic.includes(nameFold)) {
+            score += oneToOne ? 80 : 45;
+        } else {
+            return 0;
+        }
+    }
+
+    if (topicFold) {
+        if (title === topicFold || topic === topicFold) {
+            score += 100;
+        } else if (title.includes(topicFold) || topic.includes(topicFold)) {
+            score += 70;
+        } else if (!nameFold) {
+            return 0;
+        }
+    }
+
+    if (!nameFold && !topicFold) {
+        return 0;
+    }
+
+    return score;
+}

--- a/src/ms-teams/lib/snapshot.ts
+++ b/src/ms-teams/lib/snapshot.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "@genesiscz/utils/logger";
 import { liveBlobDir, liveIdbDir, snapshotDir } from "./paths";
@@ -22,24 +22,47 @@ export function snapshotTeamsIdb(): SnapshotPaths {
     }
 
     const root = snapshotDir();
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+    chmodSync(root, 0o700);
+
     const leveldbDir = join(root, "idb");
     const blobDir = join(root, "blob");
     const dumpDir = join(root, "dump");
+    const tmpIdb = join(root, `idb.tmp.${process.pid}`);
+    const tmpBlob = join(root, `blob.tmp.${process.pid}`);
 
+    rmSync(tmpIdb, { recursive: true, force: true });
+    rmSync(tmpBlob, { recursive: true, force: true });
+    mkdirSync(tmpIdb, { recursive: true, mode: 0o700 });
+    cpSync(idb, tmpIdb, { recursive: true });
     rmSync(leveldbDir, { recursive: true, force: true });
-    rmSync(blobDir, { recursive: true, force: true });
-    mkdirSync(leveldbDir, { recursive: true });
-    mkdirSync(dumpDir, { recursive: true });
-    cpSync(idb, leveldbDir, { recursive: true });
+    renameSync(tmpIdb, leveldbDir);
+    chmodSync(leveldbDir, 0o700);
 
     if (existsSync(blob)) {
-        cpSync(blob, blobDir, { recursive: true });
+        mkdirSync(tmpBlob, { recursive: true, mode: 0o700 });
+        cpSync(blob, tmpBlob, { recursive: true });
+        rmSync(blobDir, { recursive: true, force: true });
+        renameSync(tmpBlob, blobDir);
+        chmodSync(blobDir, 0o700);
     } else {
-        mkdirSync(blobDir, { recursive: true });
+        mkdirSync(blobDir, { recursive: true, mode: 0o700 });
     }
 
-    const size = statSync(idb).isDirectory() ? 0 : statSync(idb).size;
-    log.debug({ idb, leveldbDir, size }, "[ms-teams] snapshotted IndexedDB");
+    mkdirSync(dumpDir, { recursive: true, mode: 0o700 });
+    chmodSync(dumpDir, 0o700);
+
+    log.debug({ idb, leveldbDir }, "[ms-teams] snapshotted IndexedDB");
 
     return { leveldbDir, blobDir, dumpDir };
+}
+
+export function liveIdbMtimeMs(): number {
+    const current = join(liveIdbDir(), "CURRENT");
+
+    if (existsSync(current)) {
+        return statSync(current).mtimeMs;
+    }
+
+    return existsSync(liveIdbDir()) ? statSync(liveIdbDir()).mtimeMs : 0;
 }

--- a/src/ms-teams/lib/snapshot.ts
+++ b/src/ms-teams/lib/snapshot.ts
@@ -1,0 +1,45 @@
+import { cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+import { liveBlobDir, liveIdbDir, snapshotDir } from "./paths";
+
+const log = logger.scoped("ms-teams").log;
+
+export interface SnapshotPaths {
+    leveldbDir: string;
+    blobDir: string;
+    dumpDir: string;
+}
+
+export function snapshotTeamsIdb(): SnapshotPaths {
+    const idb = liveIdbDir();
+    const blob = liveBlobDir();
+
+    if (!existsSync(idb)) {
+        throw new Error(
+            `Teams IndexedDB not found at ${idb}. Grant Full Disk Access to your terminal, then run tools ms-teams doctor.`
+        );
+    }
+
+    const root = snapshotDir();
+    const leveldbDir = join(root, "idb");
+    const blobDir = join(root, "blob");
+    const dumpDir = join(root, "dump");
+
+    rmSync(leveldbDir, { recursive: true, force: true });
+    rmSync(blobDir, { recursive: true, force: true });
+    mkdirSync(leveldbDir, { recursive: true });
+    mkdirSync(dumpDir, { recursive: true });
+    cpSync(idb, leveldbDir, { recursive: true });
+
+    if (existsSync(blob)) {
+        cpSync(blob, blobDir, { recursive: true });
+    } else {
+        mkdirSync(blobDir, { recursive: true });
+    }
+
+    const size = statSync(idb).isDirectory() ? 0 : statSync(idb).size;
+    log.debug({ idb, leveldbDir, size }, "[ms-teams] snapshotted IndexedDB");
+
+    return { leveldbDir, blobDir, dumpDir };
+}

--- a/src/ms-teams/lib/store.test.ts
+++ b/src/ms-teams/lib/store.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { renderMarkdown } from "./export/markdown";
+import { exportThread } from "./export/thread";
+import { parseShowQuery } from "./query";
+import { resolveConversation } from "./resolve-chat";
+import { TeamsCache } from "./store";
+import type { TeamsDump } from "./types";
+
+const ADA_ID = "19:ada-guid_me-guid@unq.gbl.spaces";
+const MEETING_ID = "19:meeting_planning@thread.v2";
+const ADA_AUG6 = Date.parse("2026-08-06T06:24:04Z");
+const ADA_JUN8 = Date.parse("2026-06-08T09:00:00Z");
+
+function sampleDump(): TeamsDump {
+    return {
+        profiles: [
+            {
+                mri: "8:orgid:ada",
+                displayName: "Ada Lovelace",
+                email: "ada@example.test",
+                objectId: "ada",
+            },
+        ],
+        conversations: [
+            {
+                id: ADA_ID,
+                type: "Chat",
+                chatTitle: {
+                    shortTitle: "Ada Lovelace",
+                    avatarUsersInfo: [{ mri: "8:orgid:ada", displayName: "Ada Lovelace", email: "ada@example.test" }],
+                },
+                threadProperties: {},
+                members: [{ id: "8:orgid:ada" }, { id: "8:orgid:me" }],
+                lastMessage: { content: "<p>hello, I will look at it today</p>" },
+                lastMessageTimeUtc: ADA_AUG6,
+            },
+            {
+                id: MEETING_ID,
+                type: "Meeting",
+                chatTitle: { shortTitle: "Planning" },
+                threadProperties: { topic: "Planning" },
+                members: [{ id: "8:orgid:ada", friendlyName: "Ada Lovelace" }],
+                lastMessage: { content: "<p>agenda</p>" },
+                lastMessageTimeUtc: ADA_AUG6,
+            },
+        ],
+        replychains: [
+            {
+                conversationId: ADA_ID,
+                messageMap: {
+                    a1: {
+                        id: "m-jun",
+                        conversationId: ADA_ID,
+                        originalArrivalTime: ADA_JUN8,
+                        version: ADA_JUN8,
+                        creator: "8:orgid:ada",
+                        imDisplayName: "Ada Lovelace",
+                        messageType: "RichText/Html",
+                        content: "<p>hello, I will look at it today (june)</p>",
+                        isSentByCurrentUser: false,
+                        properties: {},
+                    },
+                    a2: {
+                        id: "m-aug",
+                        conversationId: ADA_ID,
+                        originalArrivalTime: ADA_AUG6,
+                        version: ADA_AUG6,
+                        creator: "8:orgid:ada",
+                        imDisplayName: "Ada Lovelace",
+                        messageType: "RichText/Html",
+                        content: "<p>hello, I will look at it today</p>",
+                        isSentByCurrentUser: false,
+                        properties: {
+                            files: SafeFiles(),
+                        },
+                        annotationsSummary: { emotions: { laugh: 1 } },
+                    },
+                    a3: {
+                        id: "m-reply",
+                        conversationId: ADA_ID,
+                        originalArrivalTime: ADA_AUG6 + 1000,
+                        version: ADA_AUG6 + 1000,
+                        creator: "8:orgid:me",
+                        imDisplayName: "Me",
+                        messageType: "RichText/Html",
+                        content:
+                            '<blockquote itemtype="http://schema.skype.com/Reply" itemid="m-aug"><p>hello</p></blockquote><p>thanks</p>',
+                        isSentByCurrentUser: true,
+                        parentMessageId: "m-reply",
+                        properties: {},
+                    },
+                },
+            },
+            {
+                conversationId: MEETING_ID,
+                messageMap: {
+                    p1: {
+                        id: "meet-1",
+                        conversationId: MEETING_ID,
+                        originalArrivalTime: ADA_AUG6,
+                        version: ADA_AUG6,
+                        creator: "8:orgid:ada",
+                        imDisplayName: "Ada Lovelace",
+                        messageType: "RichText/Html",
+                        content: "<p>agenda item</p>",
+                        parentMessageId: "meet-1",
+                        properties: {},
+                    },
+                },
+            },
+        ],
+        calls: [],
+        activity: [],
+    };
+}
+
+function SafeFiles(): string {
+    return SafeJSON.stringify([
+        {
+            fileName: "shot.png",
+            fileType: "png",
+            objectUrl: "https://example.test/shot.png",
+            itemid: "item-1",
+        },
+    ]);
+}
+
+describe("TeamsCache ingest and query", () => {
+    test("resolves a 1:1 by person name and filters by day", () => {
+        const cache = new TeamsCache(":memory:");
+        cache.ingestDump(sampleDump());
+        const resolved = resolveConversation(cache, parseShowQuery("conversation with Ada Lovelace"));
+        expect(resolved.status).toBe("exact");
+
+        if (resolved.status !== "exact") {
+            return;
+        }
+
+        expect(resolved.conversation.id).toBe(ADA_ID);
+        const query = parseShowQuery("conversation with Ada Lovelace from 2026-08-06 to 2026-08-06");
+        const thread = exportThread(cache, resolved.conversation.id, { from: query.from, to: query.to });
+        expect(thread.messages.some((m) => m.text.includes("hello, I will look at it today"))).toBe(true);
+        expect(thread.messages.some((m) => m.text.includes("june"))).toBe(false);
+        expect(thread.messages.some((m) => m.replyToId === "m-aug")).toBe(true);
+        const md = renderMarkdown(thread);
+        expect(md).toContain("Ada Lovelace");
+        expect(md).toContain("hello, I will look at it today");
+        expect(md).toContain("shot.png");
+        cache.close();
+    });
+
+    test("search finds text inside the 1:1", () => {
+        const cache = new TeamsCache(":memory:");
+        cache.ingestDump(sampleDump());
+        const hits = cache.searchMessages("look at it today", { withName: "Ada Lovelace" });
+        expect(hits.length).toBeGreaterThan(0);
+        expect(hits.some((h) => h.conversationId === ADA_ID)).toBe(true);
+        cache.close();
+    });
+
+    test("resolves a meeting by topic", () => {
+        const cache = new TeamsCache(":memory:");
+        cache.ingestDump(sampleDump());
+        const resolved = resolveConversation(cache, parseShowQuery("Planning"));
+        expect(resolved.status).toBe("exact");
+
+        if (resolved.status === "exact") {
+            expect(resolved.conversation.id).toBe(MEETING_ID);
+        }
+
+        cache.close();
+    });
+});

--- a/src/ms-teams/lib/store.test.ts
+++ b/src/ms-teams/lib/store.test.ts
@@ -171,4 +171,14 @@ describe("TeamsCache ingest and query", () => {
 
         cache.close();
     });
+
+    test("refuses to wipe a populated cache with an empty dump", () => {
+        const cache = new TeamsCache(":memory:");
+        cache.ingestDump(sampleDump());
+        expect(() =>
+            cache.ingestDump({ conversations: [], replychains: [], profiles: [], calls: [], activity: [] })
+        ).toThrow(/empty/);
+        expect(cache.counts().conversations).toBeGreaterThan(0);
+        cache.close();
+    });
 });

--- a/src/ms-teams/lib/store.ts
+++ b/src/ms-teams/lib/store.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
@@ -30,15 +30,24 @@ const log = logger.scoped("ms-teams").log;
 export class TeamsCache {
     private db: Database;
 
-    constructor(dbPath: string) {
+    constructor(dbPath: string, opts?: { readonly?: boolean }) {
         if (dbPath !== ":memory:") {
-            mkdirSync(dirname(dbPath), { recursive: true });
+            mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
+        }
+
+        if (opts?.readonly) {
+            this.db = new Database(dbPath, { readonly: true });
+            return;
         }
 
         this.db = new Database(dbPath);
         this.db.run("PRAGMA journal_mode = WAL");
         this.db.run("PRAGMA foreign_keys = ON");
         this.migrate();
+
+        if (dbPath !== ":memory:") {
+            chmodSync(dbPath, 0o600);
+        }
     }
 
     close(): void {
@@ -124,7 +133,14 @@ export class TeamsCache {
         )`);
     }
 
-    ingestDump(dump: TeamsDump): { conversations: number; messages: number; people: number } {
+    ingestDump(
+        dump: TeamsDump,
+        opts?: { force?: boolean }
+    ): { conversations: number; messages: number; people: number } {
+        if (!opts?.force && dump.conversations.length === 0 && dump.replychains.length === 0) {
+            throw new Error("Teams dump is empty; refusing to wipe the cache. Pass --force to override.");
+        }
+
         const people = new Map<string, Person>();
         let meMri: string | null = this.getMeta("me_mri");
 
@@ -436,7 +452,8 @@ export class TeamsCache {
         text: string,
         opts: { withName?: string; conversationId?: string; from?: Date; to?: Date; limit?: number }
     ): MessageRow[] {
-        const limit = opts.limit ?? 50;
+        const requested = opts.limit ?? 50;
+        const limit = Number.isFinite(requested) && requested > 0 ? Math.min(Math.floor(requested), 500) : 50;
         const rows = this.db
             .query(
                 `SELECT m.* FROM messages_fts f

--- a/src/ms-teams/lib/store.ts
+++ b/src/ms-teams/lib/store.ts
@@ -1,0 +1,639 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { foldTeamsText } from "./decode";
+import {
+    isSystemMessageType,
+    type ParsedConversation,
+    type ParsedMessage,
+    parseConversation,
+    parseProfile,
+    parseReplychain,
+} from "./ingest-parse";
+import type {
+    ActivityRow,
+    CallRow,
+    ConversationRow,
+    ConversationType,
+    ListConversationsOptions,
+    ListMessagesOptions,
+    MessageRow,
+    PeopleRow,
+    Person,
+    TeamsDump,
+} from "./types";
+
+const log = logger.scoped("ms-teams").log;
+
+export class TeamsCache {
+    private db: Database;
+
+    constructor(dbPath: string) {
+        if (dbPath !== ":memory:") {
+            mkdirSync(dirname(dbPath), { recursive: true });
+        }
+
+        this.db = new Database(dbPath);
+        this.db.run("PRAGMA journal_mode = WAL");
+        this.db.run("PRAGMA foreign_keys = ON");
+        this.migrate();
+    }
+
+    close(): void {
+        this.db.close();
+    }
+
+    private migrate(): void {
+        this.db.run(`CREATE TABLE IF NOT EXISTS conversations (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            topic TEXT,
+            members_json TEXT NOT NULL,
+            last_message_time INTEGER,
+            last_preview TEXT,
+            member_count INTEGER NOT NULL DEFAULT 0
+        )`);
+        this.db.run(`CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            sequence_id INTEGER,
+            version INTEGER,
+            original_arrival_time INTEGER NOT NULL,
+            from_mri TEXT,
+            from_name TEXT,
+            is_from_me INTEGER NOT NULL DEFAULT 0,
+            message_type TEXT NOT NULL,
+            text TEXT,
+            html TEXT,
+            reply_to_id TEXT,
+            reactions_json TEXT NOT NULL DEFAULT '[]',
+            mentions_json TEXT NOT NULL DEFAULT '[]',
+            links_json TEXT NOT NULL DEFAULT '[]',
+            attachments_json TEXT NOT NULL DEFAULT '[]'
+        )`);
+        this.db.run(
+            `CREATE INDEX IF NOT EXISTS idx_messages_conv_time ON messages(conversation_id, original_arrival_time)`
+        );
+        this.db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+            text, content=messages, content_rowid=rowid, tokenize='unicode61'
+        )`);
+        try {
+            this.db.run(`CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+            END`);
+            this.db.run(`CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+                INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+            END`);
+            this.db.run(`CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+                INSERT INTO messages_fts(messages_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+                INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+            END`);
+        } catch (err) {
+            log.debug({ err }, "[ms-teams] fts triggers already exist");
+        }
+        this.db.run(`CREATE TABLE IF NOT EXISTS people (
+            mri TEXT PRIMARY KEY,
+            display_name TEXT NOT NULL,
+            email TEXT,
+            upn TEXT
+        )`);
+        this.db.run(`CREATE TABLE IF NOT EXISTS calls (
+            id TEXT PRIMARY KEY,
+            start_time TEXT,
+            end_time TEXT,
+            call_type TEXT,
+            call_state TEXT,
+            call_direction TEXT,
+            thread_id TEXT,
+            summary TEXT NOT NULL DEFAULT ''
+        )`);
+        this.db.run(`CREATE TABLE IF NOT EXISTS activity (
+            id TEXT PRIMARY KEY,
+            activity_type TEXT NOT NULL,
+            activity_subtype TEXT,
+            source_thread_id TEXT,
+            source_message_id TEXT,
+            timestamp INTEGER
+        )`);
+        this.db.run(`CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )`);
+    }
+
+    ingestDump(dump: TeamsDump): { conversations: number; messages: number; people: number } {
+        const people = new Map<string, Person>();
+        let meMri: string | null = this.getMeta("me_mri");
+
+        for (const raw of dump.profiles) {
+            const person = parseProfile(raw);
+
+            if (person) {
+                people.set(person.mri, person);
+            }
+        }
+
+        const conversations = new Map<string, ParsedConversation>();
+
+        for (const raw of dump.conversations) {
+            const parsed = parseConversation(raw);
+
+            if (parsed) {
+                conversations.set(parsed.id, parsed);
+
+                for (const member of parsed.members) {
+                    if (!people.has(member.mri)) {
+                        people.set(member.mri, member);
+                    }
+                }
+            }
+        }
+
+        const messages = new Map<string, ParsedMessage>();
+
+        for (const raw of dump.replychains) {
+            for (const parsed of parseReplychain(raw, meMri)) {
+                const prev = messages.get(parsed.id);
+
+                if (!prev || parsed.version >= prev.version) {
+                    messages.set(parsed.id, parsed);
+                }
+
+                if (parsed.isFromMe && parsed.fromMri) {
+                    meMri = parsed.fromMri;
+                }
+
+                if (parsed.fromMri && parsed.fromName && !people.has(parsed.fromMri)) {
+                    people.set(parsed.fromMri, {
+                        mri: parsed.fromMri,
+                        displayName: parsed.fromName,
+                        email: null,
+                    });
+                }
+            }
+        }
+
+        if (meMri) {
+            for (const msg of messages.values()) {
+                if (!msg.isFromMe && msg.fromMri === meMri) {
+                    msg.isFromMe = true;
+                }
+            }
+        }
+
+        const tx = this.db.transaction(() => {
+            this.db.run("DELETE FROM conversations");
+            this.db.run("DELETE FROM messages");
+            this.db.run("DELETE FROM people");
+            this.db.run("DELETE FROM calls");
+            this.db.run("DELETE FROM activity");
+
+            const insertConv = this.db.prepare(
+                `INSERT INTO conversations (id, type, title, topic, members_json, last_message_time, last_preview, member_count)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+            );
+            const insertMsg = this.db.prepare(
+                `INSERT INTO messages (id, conversation_id, sequence_id, version, original_arrival_time, from_mri, from_name, is_from_me, message_type, text, html, reply_to_id, reactions_json, mentions_json, links_json, attachments_json)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+            );
+            const insertPerson = this.db.prepare(
+                `INSERT OR REPLACE INTO people (mri, display_name, email, upn) VALUES (?, ?, ?, ?)`
+            );
+
+            for (const conv of conversations.values()) {
+                insertConv.run(
+                    conv.id,
+                    conv.type,
+                    conv.title,
+                    conv.topic,
+                    SafeJSON.stringify(conv.members),
+                    conv.lastMessageTime,
+                    conv.lastPreview,
+                    conv.members.length
+                );
+            }
+
+            for (const msg of messages.values()) {
+                insertMsg.run(
+                    msg.id,
+                    msg.conversationId,
+                    msg.sequenceId,
+                    msg.version,
+                    msg.originalArrivalTime,
+                    msg.fromMri,
+                    msg.fromName,
+                    msg.isFromMe ? 1 : 0,
+                    msg.messageType,
+                    msg.text,
+                    msg.html,
+                    msg.replyToId,
+                    SafeJSON.stringify(msg.reactions),
+                    SafeJSON.stringify(msg.mentions),
+                    SafeJSON.stringify(msg.links),
+                    SafeJSON.stringify(msg.attachments)
+                );
+            }
+
+            for (const person of people.values()) {
+                insertPerson.run(person.mri, person.displayName, person.email, person.email);
+            }
+
+            this.ingestCalls(dump.calls);
+            this.ingestActivity(dump.activity);
+        });
+
+        tx();
+
+        if (meMri) {
+            this.setMeta("me_mri", meMri);
+        }
+
+        this.setMeta("ingested_at", new Date().toISOString());
+        log.debug(
+            { conversations: conversations.size, messages: messages.size, people: people.size },
+            "[ms-teams] ingest complete"
+        );
+
+        return { conversations: conversations.size, messages: messages.size, people: people.size };
+    }
+
+    private ingestCalls(rows: unknown[]): void {
+        const insert = this.db.prepare(
+            `INSERT OR REPLACE INTO calls (id, start_time, end_time, call_type, call_state, call_direction, thread_id, summary)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        );
+
+        for (const raw of rows) {
+            if (!raw || typeof raw !== "object") {
+                continue;
+            }
+
+            const rec = raw as Record<string, unknown>;
+            const id = String(rec.id ?? "");
+
+            if (!id) {
+                continue;
+            }
+
+            insert.run(
+                id,
+                rec.startTime ? String(rec.startTime) : null,
+                rec.endTime ? String(rec.endTime) : null,
+                rec.callType ? String(rec.callType) : null,
+                rec.callState ? String(rec.callState) : null,
+                rec.callDirection ? String(rec.callDirection) : null,
+                rec.groupChatThreadId ? String(rec.groupChatThreadId) : null,
+                SafeJSON.stringify(rec)
+            );
+        }
+    }
+
+    private ingestActivity(rows: unknown[]): void {
+        const insert = this.db.prepare(
+            `INSERT OR REPLACE INTO activity (id, activity_type, activity_subtype, source_thread_id, source_message_id, timestamp)
+             VALUES (?, ?, ?, ?, ?, ?)`
+        );
+
+        for (const raw of rows) {
+            if (!raw || typeof raw !== "object") {
+                continue;
+            }
+
+            const rec = raw as Record<string, unknown>;
+            const id = String(rec.activityId ?? rec.id ?? "");
+
+            if (!id) {
+                continue;
+            }
+
+            const ts = typeof rec.timestamp === "number" ? rec.timestamp : Number(rec.timestamp) || null;
+            insert.run(
+                id,
+                String(rec.activityType ?? ""),
+                rec.activitySubtype ? String(rec.activitySubtype) : null,
+                rec.sourceThreadId ? String(rec.sourceThreadId) : null,
+                rec.sourceMessageId ? String(rec.sourceMessageId) : null,
+                ts
+            );
+        }
+    }
+
+    setMeta(key: string, value: string): void {
+        this.db.run(`INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)`, [key, value]);
+    }
+
+    getMeta(key: string): string | null {
+        const row = this.db.query(`SELECT value FROM meta WHERE key = ?`).get(key) as { value: string } | null;
+        return row?.value ?? null;
+    }
+
+    counts(): { conversations: number; messages: number; people: number; calls: number; activity: number } {
+        const one = (table: string) => {
+            const row = this.db.query(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number };
+            return row.n;
+        };
+
+        return {
+            conversations: one("conversations"),
+            messages: one("messages"),
+            people: one("people"),
+            calls: one("calls"),
+            activity: one("activity"),
+        };
+    }
+
+    listConversations(opts: ListConversationsOptions = {}): ConversationRow[] {
+        const rows = this.db.query(`SELECT * FROM conversations ORDER BY last_message_time DESC`).all() as Array<{
+            id: string;
+            type: ConversationType;
+            title: string;
+            topic: string | null;
+            members_json: string;
+            last_message_time: number | null;
+            last_preview: string | null;
+            member_count: number;
+        }>;
+        const foldedWith = opts.withName ? foldTeamsText(opts.withName) : "";
+        const foldedTopic = opts.topic ? foldTeamsText(opts.topic) : "";
+        const fromMs = opts.from?.getTime();
+        const toMs = opts.to?.getTime();
+        const out: ConversationRow[] = [];
+
+        for (const row of rows) {
+            if (opts.type && opts.type !== "group" && row.type !== opts.type) {
+                continue;
+            }
+
+            if (opts.type === "group" && (row.type === "meeting" || isOneToOneId(row.id, row.title))) {
+                continue;
+            }
+
+            if (fromMs !== undefined && (row.last_message_time ?? 0) < fromMs) {
+                continue;
+            }
+
+            if (toMs !== undefined && (row.last_message_time ?? 0) > toMs) {
+                continue;
+            }
+
+            const hay = `${foldTeamsText(row.title)} ${foldTeamsText(row.topic)} ${foldTeamsText(row.members_json)}`;
+
+            if (foldedWith && !hay.includes(foldedWith)) {
+                continue;
+            }
+
+            if (foldedTopic && !hay.includes(foldedTopic)) {
+                continue;
+            }
+
+            out.push(mapConversationRow(row));
+
+            if (opts.limit && out.length >= opts.limit) {
+                break;
+            }
+        }
+
+        return out;
+    }
+
+    getConversation(id: string): ConversationRow | null {
+        const row = this.db.query(`SELECT * FROM conversations WHERE id = ?`).get(id) as {
+            id: string;
+            type: ConversationType;
+            title: string;
+            topic: string | null;
+            members_json: string;
+            last_message_time: number | null;
+            last_preview: string | null;
+            member_count: number;
+        } | null;
+
+        return row ? mapConversationRow(row) : null;
+    }
+
+    listMessages(conversationId: string, opts: ListMessagesOptions = {}): MessageRow[] {
+        const fromMs = opts.from?.getTime() ?? 0;
+        const toMs = opts.to?.getTime() ?? Number.MAX_SAFE_INTEGER;
+        const rows = this.db
+            .query(
+                `SELECT * FROM messages WHERE conversation_id = ? AND original_arrival_time >= ? AND original_arrival_time <= ?
+                 ORDER BY original_arrival_time ASC, sequence_id ASC`
+            )
+            .all(conversationId, fromMs, toMs) as Array<Record<string, unknown>>;
+        const mapped = rows.map(mapMessageRow);
+
+        if (opts.includeSystem === false) {
+            return mapped.filter((m) => !isSystemMessageType(m.messageType));
+        }
+
+        return mapped;
+    }
+
+    searchMessages(
+        text: string,
+        opts: { withName?: string; conversationId?: string; from?: Date; to?: Date; limit?: number }
+    ): MessageRow[] {
+        const limit = opts.limit ?? 50;
+        const rows = this.db
+            .query(
+                `SELECT m.* FROM messages_fts f
+                 JOIN messages m ON m.rowid = f.rowid
+                 WHERE messages_fts MATCH ?
+                 ORDER BY m.original_arrival_time DESC
+                 LIMIT ?`
+            )
+            .all(escapeFts(text), limit * 4) as Array<Record<string, unknown>>;
+        const fromMs = opts.from?.getTime();
+        const toMs = opts.to?.getTime();
+        const foldedWith = opts.withName ? foldTeamsText(opts.withName) : "";
+        const out: MessageRow[] = [];
+
+        for (const raw of rows) {
+            const row = mapMessageRow(raw);
+
+            if (opts.conversationId && row.conversationId !== opts.conversationId) {
+                continue;
+            }
+
+            if (fromMs !== undefined && row.originalArrivalTime < fromMs) {
+                continue;
+            }
+
+            if (toMs !== undefined && row.originalArrivalTime > toMs) {
+                continue;
+            }
+
+            if (foldedWith) {
+                const conv = this.getConversation(row.conversationId);
+                const hay = `${foldTeamsText(row.fromName)} ${foldTeamsText(conv?.title)} ${foldTeamsText(conv?.membersJson)}`;
+
+                if (!hay.includes(foldedWith)) {
+                    continue;
+                }
+            }
+
+            out.push(row);
+
+            if (out.length >= limit) {
+                break;
+            }
+        }
+
+        return out;
+    }
+
+    listPeople(query?: string): PeopleRow[] {
+        const rows = this.db
+            .query(`SELECT mri, display_name, email, upn FROM people ORDER BY display_name`)
+            .all() as Array<{
+            mri: string;
+            display_name: string;
+            email: string | null;
+            upn: string | null;
+        }>;
+        const folded = query ? foldTeamsText(query) : "";
+        const out: PeopleRow[] = [];
+
+        for (const row of rows) {
+            if (folded) {
+                const hay = `${foldTeamsText(row.display_name)} ${foldTeamsText(row.email)} ${foldTeamsText(row.upn)}`;
+
+                if (!hay.includes(folded)) {
+                    continue;
+                }
+            }
+
+            out.push({
+                mri: row.mri,
+                displayName: row.display_name,
+                email: row.email,
+                upn: row.upn,
+            });
+        }
+
+        return out;
+    }
+
+    listCalls(): CallRow[] {
+        const rows = this.db.query(`SELECT * FROM calls ORDER BY start_time DESC`).all() as Array<
+            Record<string, unknown>
+        >;
+        return rows.map((row) => ({
+            id: String(row.id),
+            startTime: row.start_time ? String(row.start_time) : null,
+            endTime: row.end_time ? String(row.end_time) : null,
+            callType: row.call_type ? String(row.call_type) : null,
+            callState: row.call_state ? String(row.call_state) : null,
+            callDirection: row.call_direction ? String(row.call_direction) : null,
+            threadId: row.thread_id ? String(row.thread_id) : null,
+            summary: String(row.summary ?? ""),
+        }));
+    }
+
+    listActivity(): ActivityRow[] {
+        const rows = this.db.query(`SELECT * FROM activity ORDER BY timestamp DESC`).all() as Array<
+            Record<string, unknown>
+        >;
+        return rows.map((row) => ({
+            id: String(row.id),
+            activityType: String(row.activity_type ?? ""),
+            activitySubtype: row.activity_subtype ? String(row.activity_subtype) : null,
+            sourceThreadId: row.source_thread_id ? String(row.source_thread_id) : null,
+            sourceMessageId: row.source_message_id ? String(row.source_message_id) : null,
+            timestamp: typeof row.timestamp === "number" ? row.timestamp : null,
+        }));
+    }
+
+    listFiles(
+        conversationId?: string
+    ): Array<{ conversationId: string; messageId: string; name: string; url: string | null }> {
+        const sql = conversationId
+            ? `SELECT id, conversation_id, attachments_json FROM messages WHERE conversation_id = ? AND attachments_json != '[]'`
+            : `SELECT id, conversation_id, attachments_json FROM messages WHERE attachments_json != '[]'`;
+        const rows = conversationId
+            ? (this.db.query(sql).all(conversationId) as Array<Record<string, unknown>>)
+            : (this.db.query(sql).all() as Array<Record<string, unknown>>);
+        const out: Array<{ conversationId: string; messageId: string; name: string; url: string | null }> = [];
+
+        for (const row of rows) {
+            let attachments: Array<{ name?: string; url?: string | null }> = [];
+
+            try {
+                attachments = SafeJSON.parse(String(row.attachments_json ?? "[]"));
+            } catch (err) {
+                log.debug({ err }, "[ms-teams] attachments_json parse failed");
+                continue;
+            }
+
+            if (!Array.isArray(attachments)) {
+                continue;
+            }
+
+            for (const attachment of attachments) {
+                out.push({
+                    conversationId: String(row.conversation_id),
+                    messageId: String(row.id),
+                    name: String(attachment.name ?? "attachment"),
+                    url: attachment.url ?? null,
+                });
+            }
+        }
+
+        return out;
+    }
+}
+
+function mapConversationRow(row: {
+    id: string;
+    type: ConversationType;
+    title: string;
+    topic: string | null;
+    members_json: string;
+    last_message_time: number | null;
+    last_preview: string | null;
+    member_count: number;
+}): ConversationRow {
+    return {
+        id: row.id,
+        type: row.type,
+        title: row.title,
+        topic: row.topic,
+        membersJson: row.members_json,
+        lastMessageTime: row.last_message_time,
+        lastPreview: row.last_preview,
+        memberCount: row.member_count,
+    };
+}
+
+function mapMessageRow(row: Record<string, unknown>): MessageRow {
+    return {
+        id: String(row.id),
+        conversationId: String(row.conversation_id),
+        sequenceId: typeof row.sequence_id === "number" ? row.sequence_id : null,
+        version: typeof row.version === "number" ? row.version : null,
+        originalArrivalTime: Number(row.original_arrival_time),
+        fromMri: row.from_mri ? String(row.from_mri) : null,
+        fromName: row.from_name ? String(row.from_name) : null,
+        isFromMe: row.is_from_me === 1 || row.is_from_me === true,
+        messageType: String(row.message_type ?? ""),
+        text: String(row.text ?? ""),
+        html: row.html ? String(row.html) : null,
+        replyToId: row.reply_to_id ? String(row.reply_to_id) : null,
+        reactionsJson: String(row.reactions_json ?? "[]"),
+        mentionsJson: String(row.mentions_json ?? "[]"),
+        linksJson: String(row.links_json ?? "[]"),
+        attachmentsJson: String(row.attachments_json ?? "[]"),
+    };
+}
+
+export function isOneToOneId(id: string, title: string): boolean {
+    return id.includes("@unq.gbl.spaces") && !/\+\d+/.test(title);
+}
+
+function escapeFts(query: string): string {
+    const cleaned = query.replace(/"/g, '""').trim();
+    return `"${cleaned}"`;
+}

--- a/src/ms-teams/lib/types.ts
+++ b/src/ms-teams/lib/types.ts
@@ -1,0 +1,141 @@
+export type ConversationType = "meeting" | "chat" | "space" | "topic" | "other";
+
+export interface Person {
+    mri: string;
+    displayName: string;
+    email: string | null;
+}
+
+export interface Attachment {
+    name: string;
+    mimeHint: string | null;
+    url: string | null;
+    itemId: string | null;
+    localPath: string | null;
+}
+
+export interface Reaction {
+    emotion: string;
+    count: number;
+}
+
+export interface Mention {
+    id: string;
+    name: string;
+}
+
+export interface ExportedMessage {
+    id: string;
+    sequenceId: number | null;
+    time: string;
+    from: Person;
+    isFromMe: boolean;
+    messageType: string;
+    text: string;
+    html: string | null;
+    replyToId: string | null;
+    replyTo: { id: string; from: string; excerpt: string } | null;
+    reactions: Reaction[];
+    mentions: Mention[];
+    links: string[];
+    attachments: Attachment[];
+    call: { state: string; durationSec?: number } | null;
+    system: string | null;
+}
+
+export interface ThreadExport {
+    conversation: {
+        id: string;
+        type: ConversationType;
+        title: string;
+        topic: string | null;
+        members: Person[];
+        cachedFrom: string | null;
+        cachedTo: string | null;
+        messageCount: number;
+        completenessNote: string;
+    };
+    messages: ExportedMessage[];
+}
+
+export interface ConversationRow {
+    id: string;
+    type: ConversationType;
+    title: string;
+    topic: string | null;
+    membersJson: string;
+    lastMessageTime: number | null;
+    lastPreview: string | null;
+    memberCount: number;
+}
+
+export interface MessageRow {
+    id: string;
+    conversationId: string;
+    sequenceId: number | null;
+    version: number | null;
+    originalArrivalTime: number;
+    fromMri: string | null;
+    fromName: string | null;
+    isFromMe: boolean;
+    messageType: string;
+    text: string;
+    html: string | null;
+    replyToId: string | null;
+    reactionsJson: string;
+    mentionsJson: string;
+    linksJson: string;
+    attachmentsJson: string;
+}
+
+export interface PeopleRow {
+    mri: string;
+    displayName: string;
+    email: string | null;
+    upn: string | null;
+}
+
+export interface CallRow {
+    id: string;
+    startTime: string | null;
+    endTime: string | null;
+    callType: string | null;
+    callState: string | null;
+    callDirection: string | null;
+    threadId: string | null;
+    summary: string;
+}
+
+export interface ActivityRow {
+    id: string;
+    activityType: string;
+    activitySubtype: string | null;
+    sourceThreadId: string | null;
+    sourceMessageId: string | null;
+    timestamp: number | null;
+}
+
+export interface ListConversationsOptions {
+    type?: ConversationType | "group";
+    withName?: string;
+    topic?: string;
+    from?: Date;
+    to?: Date;
+    limit?: number;
+}
+
+export interface ListMessagesOptions {
+    from?: Date;
+    to?: Date;
+    includeSystem?: boolean;
+}
+
+export const COMPLETENESS_NOTE = "client cache of opened threads; not a server-complete history";
+
+export interface TeamsDump {
+    conversations: unknown[];
+    replychains: unknown[];
+    profiles: unknown[];
+    calls: unknown[];
+    activity: unknown[];
+}

--- a/src/ms-teams/mcp/server.test.ts
+++ b/src/ms-teams/mcp/server.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { createHandlers } from "./server";
+
+describe("createHandlers", () => {
+    test("exposes the MCP tool names from the plan", () => {
+        const handlers = createHandlers();
+        expect(Object.keys(handlers).sort()).toEqual(
+            [
+                "ms_teams_conversations",
+                "ms_teams_doctor",
+                "ms_teams_files",
+                "ms_teams_people",
+                "ms_teams_search",
+                "ms_teams_show",
+                "ms_teams_sync",
+            ].sort()
+        );
+    });
+});

--- a/src/ms-teams/mcp/server.ts
+++ b/src/ms-teams/mcp/server.ts
@@ -51,10 +51,16 @@ export function createHandlers(): Record<string, Handler> {
             }
         },
         ms_teams_search: (args) => {
+            const text = str(args.text);
+
+            if (!text) {
+                throw new Error("ms_teams_search requires a non-empty 'text' argument");
+            }
+
             const cache = openCache();
 
             try {
-                return cache.searchMessages(str(args.text) ?? "", {
+                return cache.searchMessages(text, {
                     withName: str(args.with),
                     from: str(args.from) ? parseQueryDate(String(args.from), "start") : undefined,
                     to: str(args.to) ? parseQueryDate(String(args.to), "end") : undefined,

--- a/src/ms-teams/mcp/server.ts
+++ b/src/ms-teams/mcp/server.ts
@@ -1,0 +1,180 @@
+import { openCache } from "@app/ms-teams/lib/cache";
+import { inspectDoctor } from "@app/ms-teams/lib/doctor";
+import { exportThread } from "@app/ms-teams/lib/export/thread";
+import { ingestIndexedDb } from "@app/ms-teams/lib/ingest";
+import { parseQueryDate, parseShowQuery } from "@app/ms-teams/lib/query";
+import { resolveConversation } from "@app/ms-teams/lib/resolve-chat";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { type CallToolResult, type ListToolsResult, Server } from "@modelcontextprotocol/server";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+
+const log = logger.scoped("ms-teams").log;
+
+type Handler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+export function createHandlers(): Record<string, Handler> {
+    return {
+        ms_teams_sync: async () => ingestIndexedDb({ force: true }),
+        ms_teams_doctor: () => inspectDoctor(),
+        ms_teams_conversations: (args) => {
+            const cache = openCache();
+
+            try {
+                return cache.listConversations({
+                    withName: str(args.with),
+                    topic: str(args.topic),
+                    limit: typeof args.limit === "number" ? args.limit : 40,
+                });
+            } finally {
+                cache.close();
+            }
+        },
+        ms_teams_show: (args) => {
+            const cache = openCache();
+
+            try {
+                const query = parseShowQuery(str(args.query) ?? "");
+                query.id = str(args.id) ?? query.id;
+                query.withName = str(args.with) ?? query.withName;
+                query.from = str(args.from) ? parseQueryDate(String(args.from), "start") : query.from;
+                query.to = str(args.to) ? parseQueryDate(String(args.to), "end") : query.to;
+                const resolved = resolveConversation(cache, query);
+
+                if (resolved.status !== "exact") {
+                    return resolved;
+                }
+
+                return exportThread(cache, resolved.conversation.id, { from: query.from, to: query.to });
+            } finally {
+                cache.close();
+            }
+        },
+        ms_teams_search: (args) => {
+            const cache = openCache();
+
+            try {
+                return cache.searchMessages(str(args.text) ?? "", {
+                    withName: str(args.with),
+                    from: str(args.from) ? parseQueryDate(String(args.from), "start") : undefined,
+                    to: str(args.to) ? parseQueryDate(String(args.to), "end") : undefined,
+                });
+            } finally {
+                cache.close();
+            }
+        },
+        ms_teams_people: (args) => {
+            const cache = openCache();
+
+            try {
+                return cache.listPeople(str(args.query));
+            } finally {
+                cache.close();
+            }
+        },
+        ms_teams_files: (args) => {
+            const cache = openCache();
+
+            try {
+                return cache.listFiles(str(args.id));
+            } finally {
+                cache.close();
+            }
+        },
+    };
+}
+
+export async function startMcpServer(): Promise<void> {
+    const handlers = createHandlers();
+    const server = new Server({ name: "ms-teams", version: "1.0.0" }, { capabilities: { tools: {} } });
+
+    server.setRequestHandler(
+        "tools/list",
+        async (): Promise<ListToolsResult> => ({
+            tools: [
+                {
+                    name: "ms_teams_sync",
+                    description: "Snapshot and ingest the local Teams IndexedDB cache",
+                    inputSchema: { type: "object", properties: {} },
+                },
+                {
+                    name: "ms_teams_doctor",
+                    description: "Read-only Teams path and cache diagnosis",
+                    inputSchema: { type: "object", properties: {} },
+                },
+                {
+                    name: "ms_teams_conversations",
+                    description: "List cached Teams conversations",
+                    inputSchema: {
+                        type: "object",
+                        properties: { with: { type: "string" }, topic: { type: "string" }, limit: { type: "number" } },
+                    },
+                },
+                {
+                    name: "ms_teams_show",
+                    description: "Resolve a conversation by name/topic/id and return its messages",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            query: { type: "string" },
+                            id: { type: "string" },
+                            with: { type: "string" },
+                            from: { type: "string" },
+                            to: { type: "string" },
+                        },
+                    },
+                },
+                {
+                    name: "ms_teams_search",
+                    description: "Full-text search over cached Teams messages",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            text: { type: "string" },
+                            with: { type: "string" },
+                            from: { type: "string" },
+                            to: { type: "string" },
+                        },
+                        required: ["text"],
+                    },
+                },
+                {
+                    name: "ms_teams_people",
+                    description: "Search cached Teams people",
+                    inputSchema: { type: "object", properties: { query: { type: "string" } } },
+                },
+                {
+                    name: "ms_teams_files",
+                    description: "List cached attachments",
+                    inputSchema: { type: "object", properties: { id: { type: "string" } } },
+                },
+            ],
+        })
+    );
+
+    server.setRequestHandler("tools/call", async (req): Promise<CallToolResult> => {
+        const handler = handlers[req.params.name];
+
+        if (!handler) {
+            return { content: [{ type: "text", text: `Unknown tool ${req.params.name}` }], isError: true };
+        }
+
+        try {
+            const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+            const result = await handler(args);
+            return { content: [{ type: "text", text: SafeJSON.stringify(result, null, 2) }] };
+        } catch (err) {
+            log.debug({ err }, "[ms-teams] mcp tool failed");
+            return {
+                content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }],
+                isError: true,
+            };
+        }
+    });
+
+    await server.connect(new StdioServerTransport());
+}
+
+function str(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/ms-teams/native/dump_idb.py
+++ b/src/ms-teams/native/dump_idb.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -60,11 +61,15 @@ def dump_store(wrapped, needle: str, store_name: str, out_path: Path) -> int:
         return 0
     store = db.get_object_store_by_name(store_name)
     n = 0
-    with out_path.open("w", encoding="utf-8") as fh:
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        os.chmod(tmp, 0o600)
         for rec in store.iterate_records(live_only=True):
             payload = jsonable(rec.value)
             fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
             n += 1
+    tmp.replace(out_path)
+    os.chmod(out_path, 0o600)
     return n
 
 
@@ -83,6 +88,7 @@ def main() -> int:
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
+    os.chmod(out, 0o700)
     blob = args.blob if Path(args.blob).exists() else None
     wrapped = WrappedIndexDB(args.idb, blob)
     counts = {}

--- a/src/ms-teams/native/dump_idb.py
+++ b/src/ms-teams/native/dump_idb.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Dump Teams Chromium IndexedDB stores to JSONL. Read-only against a snapshot copy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+STORES = {
+    "conversations": ("Teams:conversation-manager:", "conversations"),
+    "replychains": ("Teams:replychain-manager:", "replychains"),
+    "profiles": ("Teams:profiles:", "profiles"),
+    "calls": ("Teams:call-history-manager:", "call-history"),
+    "activity": ("Teams:activity-manager:", "feed-items"),
+}
+
+
+def jsonable(obj):
+    if obj is None:
+        return None
+    name = type(obj).__name__
+    if name in {"Undefined", "IdbKey"}:
+        if name == "IdbKey":
+            return str(obj)
+        return None
+    if isinstance(obj, dict):
+        return {str(k): jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [jsonable(v) for v in obj]
+    if isinstance(obj, (bytes, bytearray)):
+        try:
+            return obj.decode("utf-8")
+        except UnicodeDecodeError:
+            return obj.decode("latin-1")
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+    return str(obj)
+
+
+def find_database(wrapped, needle: str):
+    for dbid in list(wrapped.database_ids):
+        if needle in dbid.name:
+            return wrapped[dbid]
+    return None
+
+
+def dump_store(wrapped, needle: str, store_name: str, out_path: Path) -> int:
+    db = find_database(wrapped, needle)
+    if db is None:
+        out_path.write_text("", encoding="utf-8")
+        print(f"missing database containing {needle!r}", file=sys.stderr)
+        return 0
+    names = list(db.object_store_names)
+    if store_name not in names:
+        out_path.write_text("", encoding="utf-8")
+        print(f"{needle!r} has stores {names}, not {store_name!r}", file=sys.stderr)
+        return 0
+    store = db.get_object_store_by_name(store_name)
+    n = 0
+    with out_path.open("w", encoding="utf-8") as fh:
+        for rec in store.iterate_records(live_only=True):
+            payload = jsonable(rec.value)
+            fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--idb", required=True)
+    parser.add_argument("--blob", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    try:
+        from ccl_chromium_reader.ccl_chromium_indexeddb import WrappedIndexDB
+    except ImportError:
+        print("ccl_chromium_reader is not installed in this Python", file=sys.stderr)
+        return 2
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    blob = args.blob if Path(args.blob).exists() else None
+    wrapped = WrappedIndexDB(args.idb, blob)
+    counts = {}
+    for label, (needle, store_name) in STORES.items():
+        counts[label] = dump_store(wrapped, needle, store_name, out / f"{label}.jsonl")
+    print(json.dumps({"ok": True, "counts": counts}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Read Microsoft Teams chats from the local New Teams desktop cache and export them as markdown, JSON, or HTML. Agents can ask for a person and a date range without Graph login.

## What

New tool `tools ms-teams`:

- `sync` snapshots Chromium IndexedDB and ingests into `~/.genesis-tools/ms-teams/cache.db`
- `show "conversation with NAME from DATE to DATE"` resolves a 1:1 or meeting and exports `md` / `json` / `html`
- `search`, `conversations`, `people`, `members`, `files`, `calls`, `meetings`, `mentions`, `transcripts`, `doctor`, `mcp`

This is the **client cache** of threads already opened in Teams, not a server-complete Graph export. `doctor` is read-only.

Lib lives under `src/ms-teams/lib/`. Commands live under `src/ms-teams/commands/`.

## Checks

- `bun run test src/ms-teams` (unit tests for decode, query parser, ingest/export)
- Live smoke on this machine: `show "conversation with Ussov Stanislav from 2026-08-06 to 2026-08-06"` returned the expected first line
- Pre-push: biome, lint-rules, tsgo

## How to try

```bash
tools ms-teams doctor
tools ms-teams sync
tools ms-teams show "conversation with Ada from 2026-08-06 to 2026-08-06" --format md
```

Needs Full Disk Access for the terminal (same as `tools macos messages`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Microsoft Teams cache access, synchronization, diagnostics, and export capabilities.
  - Added commands for browsing conversations, meetings, calls, messages, people, mentions, files, and transcripts.
  - Export conversations as Markdown, JSON, or HTML, with optional attachment downloads.
  - Added natural-language queries, date ranges, participant/topic filters, and formatted or JSON output.
  - Added an MCP server for Teams data tools and automation.
- **Documentation**
  - Added setup guidance, prerequisites, command references, export details, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->