### PR TITLE
fix(github): retarget native-stack children without closing them

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -96,7 +96,14 @@ GitHub only auto-retargets dependent PRs when a branch is deleted via the **web 
      (`git.updateRef` with `force=false` after a compare preflight). Preserves
      commit SHAs; fails if base is not an ancestor of head.
 2. Finds open PRs whose `base` is the merged head branch
-3. Retargets each onto the merged PR's base
+3. Retargets each onto the merged PR's base. GitHub native stacks reject REST
+   `PATCH /pulls/{n}` `{base}` with "Cannot change the base branch because the
+   pull request is part of a stack." The client then
+   `POST /repos/{owner}/{repo}/stacks/{n}/unstack` and retries the PATCH. That
+   keeps the child PR number and conversation. Close-and-reopen is never the
+   happy path. If retarget still fails after the parent SHA is already on the
+   base, stdout prints `MERGED` plus recovery commands (non-zero exit). It does
+   not throw as if the merge never happened.
 4. (stack-safe `--rebase`) Restacks dependents so the next PR is FF-able
 5. Only then, if `--delete-branch` / `--delete-remote`, deletes the remote head ref
 

--- a/src/github/commands/merge.ts
+++ b/src/github/commands/merge.ts
@@ -78,7 +78,7 @@ function formatTextSummary(result: SafeMergeResult): string {
     }
 
     if (result.remainingWork.length > 0) {
-        lines.push(chalk.yellow("  remaining work (parent already merged; children still OPEN):"));
+        lines.push(chalk.yellow("  remaining work (parent already merged):"));
         for (const line of result.remainingWork) {
             lines.push(`    ${line}`);
         }

--- a/src/github/commands/merge.ts
+++ b/src/github/commands/merge.ts
@@ -32,7 +32,7 @@ export interface MergeCommandOptions {
 function formatTextSummary(result: SafeMergeResult): string {
     const lines: string[] = [];
     lines.push("");
-    lines.push(chalk.green(`✔ Merged ${result.owner}/${result.repo}#${result.number} (${result.method})`));
+    lines.push(chalk.green(`✔ MERGED ${result.owner}/${result.repo}#${result.number} (${result.method})`));
     lines.push(`  title:  ${result.title}`);
     lines.push(`  head:   ${result.headRef}`);
     lines.push(`  base:   ${result.baseRef}`);
@@ -75,6 +75,13 @@ function formatTextSummary(result: SafeMergeResult): string {
         lines.push(chalk.yellow(`  branch: not deleted — ${result.branchDeleteError}`));
     } else {
         lines.push(`  branch: kept origin/${result.headRef}`);
+    }
+
+    if (result.remainingWork.length > 0) {
+        lines.push(chalk.yellow("  remaining work (parent already merged; children still OPEN):"));
+        for (const line of result.remainingWork) {
+            lines.push(`    ${line}`);
+        }
     }
 
     return lines.join("\n");
@@ -136,9 +143,14 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
             dependentsRetargeted: result.retargeted.length,
             dependentsRestacked: result.dependentsRestacked.length,
             branchDeleted: result.branchDeleted,
+            remainingWork: result.remainingWork.length,
         },
         "merge completed"
     );
+
+    if (result.remainingWork.length > 0) {
+        process.exitCode = 1;
+    }
 
     if (options.format === "json") {
         out.println(
@@ -158,6 +170,7 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
                     dependentsRestacked: result.dependentsRestacked,
                     branchDeleted: result.branchDeleted,
                     branchDeleteError: result.branchDeleteError ?? null,
+                    remainingWork: result.remainingWork,
                 },
                 null,
                 2

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -789,6 +789,30 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(logs.some((l) => l.includes("still OPEN"))).toBe(true);
     });
 
+    test("failed unstack after getPullStackNumber still emits the resolved stack id", async () => {
+        const { client } = makeMock({
+            pr: basePr(),
+            dependents: [dep({ number: 2, title: "PR B", headRef: "branch-b", baseRef: "branch-a" })],
+            stackBaseErrorUntilUnstack: [2],
+            stackByPr: { 2: 8 },
+            failUnstack: true,
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "ff-only",
+            deleteBranch: false,
+            client,
+        });
+
+        expect(result.retargeted[0].ok).toBe(false);
+        expect(result.retargeted[0].stackNumber).toBe(8);
+        expect(result.remainingWork).toContain("gh api -X POST repos/o/r/stacks/8/unstack");
+        expect(result.remainingWork.join("\n")).not.toContain("stacks/<stack-number>/unstack");
+    });
+
     test("two dependents in different native stacks: unstack each stack before PATCH succeeds", async () => {
         const { client, calls } = makeMock({
             pr: basePr(),

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -8,6 +8,7 @@ import {
     resolveMergeMethod,
     safeMergePull,
 } from "./merge";
+import { NATIVE_STACK_BASE_ERROR } from "./native-stack";
 import type { RestackBranchInput, RestackBranchResult, StackRestackOps } from "./stack-restack";
 
 type CallLog = Array<{ op: string; args: unknown[] }>;
@@ -20,6 +21,15 @@ function makeMock(opts: {
     mergeResult?: MergePullResult;
     /** Fail updatePullBase for these PR numbers. */
     failRetarget?: number[];
+    /**
+     * Throw the native-stack 422 from updatePullBase until unstack() has run.
+     * After unstack, PATCH succeeds the second time (the real GitHub sequence).
+     */
+    stackBaseErrorUntilUnstack?: number[];
+    /** Native stack number returned by getPullStackNumber. */
+    stackByPr?: Record<number, number | null>;
+    /** Fail unstack(). */
+    failUnstack?: boolean;
     /** Fail deleteBranch. */
     failDelete?: boolean;
     /** Fail fastForwardBase. */
@@ -31,6 +41,7 @@ function makeMock(opts: {
     const dependents = opts.dependents ?? [];
     const postMerge = opts.postMergeDependents ?? dependents;
     let merged = opts.pr.merged;
+    let unstacked = false;
 
     const client: MergeGitHubClient = {
         async getPull(_owner, _repo, number) {
@@ -90,6 +101,12 @@ function makeMock(opts: {
         async updatePullBase(_owner, _repo, number, base) {
             calls.push({ op: "updatePullBase", args: [number, base] });
 
+            if (opts.stackBaseErrorUntilUnstack?.includes(number) && !unstacked) {
+                throw new Error(
+                    `Validation Failed: {"message":"${NATIVE_STACK_BASE_ERROR}","resource":"PullRequest","field":"base","code":"invalid"}`
+                );
+            }
+
             if (opts.failRetarget?.includes(number)) {
                 throw new Error(`API error retargeting #${number}`);
             }
@@ -110,6 +127,23 @@ function makeMock(opts: {
             }
 
             return updated;
+        },
+        async getPullStackNumber(_owner, _repo, number) {
+            calls.push({ op: "getPullStackNumber", args: [number] });
+            if (opts.stackByPr && Object.hasOwn(opts.stackByPr, number)) {
+                return opts.stackByPr[number];
+            }
+
+            const found = [...dependents, ...postMerge].find((d) => d.number === number);
+            return found?.stackNumber ?? opts.pr.stackNumber ?? null;
+        },
+        async unstack(_owner, _repo, stackNumber) {
+            calls.push({ op: "unstack", args: [stackNumber] });
+            if (opts.failUnstack) {
+                throw new Error(`unstack failed for stack #${stackNumber}`);
+            }
+
+            unstacked = true;
         },
         async deleteBranch(_owner, _repo, branch) {
             calls.push({ op: "deleteBranch", args: [branch] });
@@ -316,6 +350,7 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
     });
 
     test("does NOT delete branch when any retarget fails (avoids closing children)", async () => {
+        const logs: string[] = [];
         const { client, calls } = makeMock({
             pr: basePr(),
             dependents: [
@@ -325,20 +360,23 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             failRetarget: [3],
         });
 
-        await expect(
-            safeMergePull({
-                owner: "o",
-                repo: "r",
-                number: 1,
-                method: "squash",
-                deleteBranch: true,
-                client,
-            })
-        ).rejects.toThrow(/retarget\(s\) failed/);
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "squash",
+            deleteBranch: true,
+            client,
+            log: (m) => logs.push(m),
+        });
 
+        expect(result.branchDeleted).toBe(false);
+        expect(result.retargeted.find((r) => r.number === 3)?.ok).toBe(false);
+        expect(result.remainingWork.some((l) => l.startsWith("MERGED #1"))).toBe(true);
         expect(calls.map((c) => c.op)).not.toContain("deleteBranch");
-        // Merge still happened — failure is post-merge safety.
+        // Merge still happened — failure is post-merge remaining work, not a botched merge.
         expect(calls.map((c) => c.op)).toContain("mergePull");
+        expect(logs.some((l) => l.includes("MERGED #1"))).toBe(true);
     });
 
     test("independent PR (no dependents) stack-safe rebases via FF and can delete branch", async () => {
@@ -396,25 +434,28 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(restackCalls[0].expectedHeadSha).toBe(oldSha);
     });
 
-    test("stack-safe rebase: failed dependent restack blocks branch delete and throws", async () => {
+    test("stack-safe rebase: failed dependent restack blocks branch delete and reports remaining work", async () => {
         const { client, calls } = makeMock({
             pr: basePr(),
             dependents: [dep({ number: 2, title: "PR B", headRef: "branch-b", baseRef: "branch-a" })],
         });
         const { restack } = makeRestackMock({ failBranches: ["branch-b"] });
 
-        await expect(
-            safeMergePull({
-                owner: "o",
-                repo: "r",
-                number: 1,
-                method: "rebase",
-                deleteBranch: true,
-                client,
-                restack,
-            })
-        ).rejects.toThrow(/restack\(s\) failed/);
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "rebase",
+            deleteBranch: true,
+            client,
+            restack,
+        });
 
+        expect(result.branchDeleted).toBe(false);
+        expect(result.retargeted[0].ok).toBe(true);
+        expect(result.dependentsRestacked[0].ok).toBe(false);
+        expect(result.remainingWork.some((l) => l.startsWith("MERGED #1"))).toBe(true);
+        expect(result.remainingWork.some((l) => /Restack #2/.test(l))).toBe(true);
         expect(calls.map((c) => c.op)).toContain("fastForwardBase");
         expect(calls.map((c) => c.op)).toContain("updatePullBase");
         expect(calls.map((c) => c.op)).not.toContain("deleteBranch");
@@ -487,16 +528,20 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             afterRetarget: (d) => ({ ...d, state: "closed" }),
         });
 
-        await expect(
-            safeMergePull({
-                owner: "o",
-                repo: "r",
-                number: 1,
-                method: "merge",
-                deleteBranch: true,
-                client,
-            })
-        ).rejects.toThrow(/no longer open/);
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "merge",
+            deleteBranch: true,
+            client,
+        });
+
+        expect(result.branchDeleted).toBe(false);
+        expect(result.retargeted[0].ok).toBe(false);
+        expect(result.retargeted[0].error).toMatch(/no longer open/);
+        expect(result.remainingWork.some((l) => l.startsWith("MERGED #1"))).toBe(true);
+        expect(result.remainingWork.some((l) => /Child #2 is still closed/.test(l))).toBe(true);
     });
 
     test("--ff-only: uses fastForwardBase (not mergePull), then retargets dependents", async () => {
@@ -590,5 +635,143 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(ops).toContain("fastForwardBase");
         expect(ops).not.toContain("updatePullBase");
         expect(ops).not.toContain("deleteBranch");
+    });
+
+    test("native-stack 422: unstack then PATCH keeps the child OPEN with the same number", async () => {
+        const logs: string[] = [];
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            dependents: [
+                dep({
+                    number: 2,
+                    title: "PR B",
+                    headRef: "branch-b",
+                    baseRef: "branch-a",
+                    stackNumber: 8,
+                }),
+            ],
+            stackBaseErrorUntilUnstack: [2],
+            stackByPr: { 2: 8 },
+        });
+        const { restack } = makeRestackMock();
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "rebase",
+            deleteBranch: false,
+            client,
+            restack,
+            log: (m) => logs.push(m),
+        });
+
+        expect(result.retargeted).toEqual([
+            {
+                number: 2,
+                title: "PR B",
+                fromBase: "branch-a",
+                toBase: "main",
+                ok: true,
+                state: "open",
+                stackNumber: 8,
+            },
+        ]);
+        expect(result.remainingWork).toEqual([]);
+        expect(result.dependentsRestacked[0]?.ok).toBe(true);
+
+        const ops = calls.map((c) => c.op);
+        expect(ops.filter((op) => op === "updatePullBase")).toHaveLength(2);
+        expect(ops).toContain("unstack");
+        expect(calls.find((c) => c.op === "unstack")?.args).toEqual([8]);
+        expect(ops).not.toContain("deleteBranch");
+        expect(logs.some((l) => l.includes(NATIVE_STACK_BASE_ERROR))).toBe(true);
+        expect(logs.some((l) => l.includes("unstacking native stack #8"))).toBe(true);
+        expect(logs.some((l) => l.includes("does not close PRs"))).toBe(true);
+    });
+
+    test("--ff-only native-stack 422: same unstack-then-PATCH path, child stays OPEN", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            dependents: [dep({ number: 2, title: "PR B", headRef: "branch-b", baseRef: "branch-a", stackNumber: 8 })],
+            stackBaseErrorUntilUnstack: [2],
+            stackByPr: { 2: 8 },
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "ff-only",
+            deleteBranch: false,
+            client,
+        });
+
+        expect(result.method).toBe("ff-only");
+        expect(result.retargeted[0]).toMatchObject({ number: 2, ok: true, state: "open", toBase: "main" });
+        expect(result.remainingWork).toEqual([]);
+        expect(calls.map((c) => c.op)).toContain("unstack");
+        expect(calls.map((c) => c.op)).toContain("fastForwardBase");
+        expect(calls.map((c) => c.op)).not.toContain("mergePull");
+        expect(calls.map((c) => c.op)).not.toContain("deleteBranch");
+    });
+
+    test("linear native stack A←B←C: merging A unstacks once and retargets only B", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 1, headRef: "branch-a", baseRef: "main" }),
+            dependents: [dep({ number: 2, title: "PR B", headRef: "branch-b", baseRef: "branch-a", stackNumber: 8 })],
+            stackBaseErrorUntilUnstack: [2],
+            stackByPr: { 2: 8 },
+        });
+        const { restack } = makeRestackMock();
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "rebase",
+            deleteBranch: true,
+            client,
+            restack,
+        });
+
+        expect(result.retargeted.map((r) => r.number)).toEqual([2]);
+        expect(result.retargeted[0].ok).toBe(true);
+        expect(result.branchDeleted).toBe(true);
+        expect(calls.filter((c) => c.op === "unstack")).toHaveLength(1);
+        expect(calls.filter((c) => c.op === "updatePullBase").map((c) => c.args[0])).toEqual([2, 2]);
+    });
+
+    test("native-stack 422 with failed unstack: MERGED remaining work, child still OPEN, no throw", async () => {
+        const logs: string[] = [];
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            dependents: [dep({ number: 2, title: "PR B", headRef: "branch-b", baseRef: "branch-a", stackNumber: 8 })],
+            stackBaseErrorUntilUnstack: [2],
+            stackByPr: { 2: 8 },
+            failUnstack: true,
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "ff-only",
+            deleteBranch: false,
+            client,
+            log: (m) => logs.push(m),
+        });
+
+        expect(result.retargeted[0].ok).toBe(false);
+        expect(result.retargeted[0].error).toContain(NATIVE_STACK_BASE_ERROR);
+        expect(result.remainingWork.some((l) => l.startsWith("MERGED #1"))).toBe(true);
+        expect(result.remainingWork.some((l) => l.includes("still OPEN"))).toBe(true);
+        expect(result.remainingWork).toContain("gh api -X POST repos/o/r/stacks/8/unstack");
+        expect(result.remainingWork).toContain("gh api -X PATCH repos/o/r/pulls/2 -f base='main'");
+        expect(result.remainingWork.join("\n")).toMatch(/Do not close and reopen/);
+        expect(calls.map((c) => c.op)).toContain("fastForwardBase");
+        expect(calls.map((c) => c.op)).not.toContain("deleteBranch");
+        expect(logs.some((l) => l.includes("MERGED #1"))).toBe(true);
+        expect(logs.some((l) => l.includes("still OPEN"))).toBe(true);
     });
 });

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -41,7 +41,17 @@ function makeMock(opts: {
     const dependents = opts.dependents ?? [];
     const postMerge = opts.postMergeDependents ?? dependents;
     let merged = opts.pr.merged;
-    let unstacked = false;
+    const unstackedStacks = new Set<number>();
+
+    const stackNumberFor = (number: number): number | null => {
+        if (opts.stackByPr && Object.hasOwn(opts.stackByPr, number)) {
+            return opts.stackByPr[number];
+        }
+
+        return (
+            [...dependents, ...postMerge].find((d) => d.number === number)?.stackNumber ?? opts.pr.stackNumber ?? null
+        );
+    };
 
     const client: MergeGitHubClient = {
         async getPull(_owner, _repo, number) {
@@ -101,7 +111,11 @@ function makeMock(opts: {
         async updatePullBase(_owner, _repo, number, base) {
             calls.push({ op: "updatePullBase", args: [number, base] });
 
-            if (opts.stackBaseErrorUntilUnstack?.includes(number) && !unstacked) {
+            const stackNumber = stackNumberFor(number);
+            if (
+                opts.stackBaseErrorUntilUnstack?.includes(number) &&
+                (stackNumber === null || !unstackedStacks.has(stackNumber))
+            ) {
                 throw new Error(
                     `Validation Failed: {"message":"${NATIVE_STACK_BASE_ERROR}","resource":"PullRequest","field":"base","code":"invalid"}`
                 );
@@ -143,7 +157,7 @@ function makeMock(opts: {
                 throw new Error(`unstack failed for stack #${stackNumber}`);
             }
 
-            unstacked = true;
+            unstackedStacks.add(stackNumber);
         },
         async deleteBranch(_owner, _repo, branch) {
             calls.push({ op: "deleteBranch", args: [branch] });
@@ -773,5 +787,31 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(calls.map((c) => c.op)).not.toContain("deleteBranch");
         expect(logs.some((l) => l.includes("MERGED #1"))).toBe(true);
         expect(logs.some((l) => l.includes("still OPEN"))).toBe(true);
+    });
+
+    test("two dependents in different native stacks: unstack each stack before PATCH succeeds", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            dependents: [
+                dep({ number: 2, title: "PR B", headRef: "branch-b", baseRef: "branch-a", stackNumber: 8 }),
+                dep({ number: 3, title: "PR C", headRef: "branch-c", baseRef: "branch-a", stackNumber: 9 }),
+            ],
+            stackBaseErrorUntilUnstack: [2, 3],
+            stackByPr: { 2: 8, 3: 9 },
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "ff-only",
+            deleteBranch: false,
+            client,
+        });
+
+        expect(result.retargeted.every((r) => r.ok && r.state === "open")).toBe(true);
+        expect(result.remainingWork).toEqual([]);
+        expect(calls.filter((c) => c.op === "unstack").map((c) => c.args[0])).toEqual([8, 9]);
+        expect(calls.filter((c) => c.op === "updatePullBase")).toHaveLength(4);
     });
 });

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -29,6 +29,7 @@ import {
     isNativeStackBaseError,
     NATIVE_STACK_BASE_ERROR,
     parsePullStackNumber,
+    posixShellSingleQuote,
 } from "./native-stack";
 
 /** GitHub API merge methods plus local-ref fast-forward. */
@@ -801,7 +802,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         remainingWork.push(
             `MERGED #${number}: parent is already on ${pr.baseRef}` +
                 (mergeSha ? ` at ${mergeSha.slice(0, 7)}` : "") +
-                ". Child PRs below are still OPEN. Do not close them."
+                ". Do not close remaining children to change their base."
         );
 
         for (const r of failedRetargets) {
@@ -821,7 +822,9 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
                     })
                 );
             } else {
-                remainingWork.push(`gh api -X PATCH repos/${owner}/${repo}/pulls/${r.number} -f base='${pr.baseRef}'`);
+                remainingWork.push(
+                    `gh api -X PATCH repos/${owner}/${repo}/pulls/${r.number} -f base=${posixShellSingleQuote(pr.baseRef)}`
+                );
             }
         }
 

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -2,7 +2,10 @@
 //
 // GitHub only auto-retargets dependents when the parent branch is deleted via
 // the web UI "Delete branch" button. CLI/API deletes close child PRs instead
-// (cli/cli#1168). This module never relies on that broken path:
+// (cli/cli#1168). Native stacks also reject REST PATCH {base} ("Cannot change
+// the base branch because the pull request is part of a stack."); we unstack
+// via POST /stacks/{n}/unstack and retry PATCH, never close-and-reopen.
+// This module never relies on the broken delete-branch path:
 //   1. merge without deleting the head branch
 //      - merge / squash → GitHub pulls.merge API
 //      - rebase → stack-safe path (local restack + FF) unless --no-restack
@@ -21,6 +24,12 @@ import {
 } from "@app/github/lib/stack-restack";
 import { getOctokitForWrite } from "@genesiscz/utils/github/octokit";
 import { withRetry } from "@genesiscz/utils/github/rate-limit";
+import {
+    formatNativeStackRecovery,
+    isNativeStackBaseError,
+    NATIVE_STACK_BASE_ERROR,
+    parsePullStackNumber,
+} from "./native-stack";
 
 /** GitHub API merge methods plus local-ref fast-forward. */
 export type MergeMethod = "merge" | "rebase" | "squash" | "ff-only";
@@ -39,6 +48,8 @@ export interface PullRef {
     /** Tip SHA of the base branch at PR resolution time. */
     baseSha: string;
     htmlUrl: string;
+    /** GitHub native stack number, or null when the PR is not stacked. */
+    stackNumber?: number | null;
 }
 
 export interface DependentPull {
@@ -50,6 +61,8 @@ export interface DependentPull {
     state: string;
     /** Tip SHA of the dependent head (when available from list/get). */
     headSha?: string;
+    /** GitHub native stack number, or null when the PR is not stacked. */
+    stackNumber?: number | null;
 }
 
 /** Methods accepted by GitHub's pulls.merge API (not ff-only). */
@@ -78,6 +91,17 @@ export interface MergeGitHubClient {
      */
     fastForwardBase(owner: string, repo: string, baseRef: string, headSha: string): Promise<MergePullResult>;
     updatePullBase(owner: string, repo: string, number: number, base: string): Promise<DependentPull>;
+    /**
+     * Native stack number for a PR, or null if it is not in a stack.
+     * Used when REST PATCH base returns the stacked-PR 422.
+     */
+    getPullStackNumber(owner: string, repo: string, number: number): Promise<number | null>;
+    /**
+     * POST /repos/{owner}/{repo}/stacks/{stack_number}/unstack
+     * Removes unmerged PRs from the stack so REST can change their base.
+     * Does not close PRs and does not delete branches.
+     */
+    unstack(owner: string, repo: string, stackNumber: number): Promise<void>;
     deleteBranch(owner: string, repo: string, branch: string): Promise<void>;
 }
 
@@ -110,6 +134,8 @@ export interface RetargetResult {
     ok: boolean;
     state: string;
     error?: string;
+    /** Native stack number observed while retargeting (for recovery commands). */
+    stackNumber?: number | null;
 }
 
 export interface DependentRestackResult {
@@ -139,12 +165,46 @@ export interface SafeMergeResult {
     dependentsRestacked: DependentRestackResult[];
     branchDeleted: boolean;
     branchDeleteError?: string;
+    /**
+     * Non-empty when the parent merge already landed but retarget/restack left
+     * work. Callers must print this and may set a non-zero exit code; they must
+     * not present the merge as if it never happened.
+     */
+    remainingWork: string[];
 }
 
 function logLine(log: ((message: string) => void) | undefined, message: string): void {
     if (log) {
         log(message);
     }
+}
+
+function retargetRow(input: {
+    dep: DependentPull;
+    toBase: string;
+    ok: boolean;
+    state: string;
+    error?: string;
+    stackNumber?: number | null;
+}): RetargetResult {
+    const row: RetargetResult = {
+        number: input.dep.number,
+        title: input.dep.title,
+        fromBase: input.dep.baseRef,
+        toBase: input.toBase,
+        ok: input.ok,
+        state: input.state,
+    };
+
+    if (input.error) {
+        row.error = input.error;
+    }
+
+    if (input.stackNumber != null) {
+        row.stackNumber = input.stackNumber;
+    }
+
+    return row;
 }
 
 /**
@@ -154,7 +214,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
     // Write path: prefer gh OAuth over limited env PATs (merge needs contents:write).
     const octokit = getOctokitForWrite();
 
-    return {
+    const client: MergeGitHubClient = {
         async getPull(owner, repo, number) {
             const { data } = await withRetry(
                 () =>
@@ -178,6 +238,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                 headSha: data.head.sha,
                 baseSha: data.base.sha,
                 htmlUrl: data.html_url,
+                stackNumber: parsePullStackNumber(data),
             };
         },
 
@@ -209,6 +270,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                         htmlUrl: pr.html_url,
                         state: pr.state,
                         headSha: pr.head.sha,
+                        stackNumber: parsePullStackNumber(pr),
                     });
                 }
 
@@ -314,7 +376,25 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                 htmlUrl: data.html_url,
                 state: data.state,
                 headSha: data.head.sha,
+                stackNumber: parsePullStackNumber(data),
             };
+        },
+
+        async getPullStackNumber(owner, repo, number) {
+            const pull = await client.getPull(owner, repo, number);
+            return pull.stackNumber ?? null;
+        },
+
+        async unstack(owner, repo, stackNumber) {
+            // Preview REST route — octokit OpenAPI types do not list stacks yet.
+            await withRetry(
+                () =>
+                    octokit.request({
+                        method: "POST",
+                        url: `/repos/${owner}/${repo}/stacks/${stackNumber}/unstack`,
+                    }),
+                { label: `POST /repos/${owner}/${repo}/stacks/${stackNumber}/unstack` }
+            );
         },
 
         async deleteBranch(owner, repo, branch) {
@@ -329,6 +409,8 @@ export function createOctokitMergeClient(): MergeGitHubClient {
             );
         },
     };
+
+    return client;
 }
 
 /**
@@ -480,6 +562,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
 
     const toRetarget = [...byNumber.values()].sort((a, b) => a.number - b.number);
     const retargeted: RetargetResult[] = [];
+    const unstacked = new Set<number>();
 
     if (toRetarget.length === 0) {
         logLine(log, "No dependents to retarget");
@@ -487,59 +570,108 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         logLine(log, `Retargeting ${toRetarget.length} dependent PR(s) onto base="${pr.baseRef}"...`);
     }
 
+    async function patchDependentBase(
+        dep: DependentPull
+    ): Promise<{ updated: DependentPull; stackNumber: number | null }> {
+        try {
+            const updated = await client.updatePullBase(owner, repo, dep.number, pr.baseRef);
+            return { updated, stackNumber: dep.stackNumber ?? null };
+        } catch (err) {
+            if (!isNativeStackBaseError(err)) {
+                throw err;
+            }
+
+            logLine(log, `    native-stack 422: ${NATIVE_STACK_BASE_ERROR}`);
+            let stackNumber = dep.stackNumber ?? null;
+
+            if (stackNumber == null) {
+                stackNumber = await client.getPullStackNumber(owner, repo, dep.number);
+            }
+
+            if (stackNumber == null) {
+                throw err;
+            }
+
+            if (!unstacked.has(stackNumber)) {
+                logLine(
+                    log,
+                    `    unstacking native stack #${stackNumber} (does not close PRs) so REST can change base`
+                );
+                try {
+                    await client.unstack(owner, repo, stackNumber);
+                } catch (unstackErr) {
+                    const detail = unstackErr instanceof Error ? unstackErr.message : String(unstackErr);
+                    throw new Error(`${NATIVE_STACK_BASE_ERROR} (unstack #${stackNumber} failed: ${detail})`);
+                }
+
+                unstacked.add(stackNumber);
+            }
+
+            const updated = await client.updatePullBase(owner, repo, dep.number, pr.baseRef);
+            return { updated, stackNumber };
+        }
+    }
+
     for (const dep of toRetarget) {
+        let stackNumber = dep.stackNumber ?? null;
         try {
             logLine(log, `  #${dep.number}: base ${dep.baseRef} → ${pr.baseRef}`);
-            const updated = await client.updatePullBase(owner, repo, dep.number, pr.baseRef);
+            const patched = await patchDependentBase(dep);
+            const updated = patched.updated;
+            stackNumber = patched.stackNumber ?? stackNumber;
 
             if (updated.state !== "open") {
-                retargeted.push({
-                    number: dep.number,
-                    title: dep.title,
-                    fromBase: dep.baseRef,
-                    toBase: pr.baseRef,
-                    ok: false,
-                    state: updated.state,
-                    error: `PR is no longer open after retarget (state=${updated.state})`,
-                });
+                retargeted.push(
+                    retargetRow({
+                        dep,
+                        toBase: pr.baseRef,
+                        ok: false,
+                        state: updated.state,
+                        error: `PR is no longer open after retarget (state=${updated.state})`,
+                        stackNumber,
+                    })
+                );
                 logLine(log, `    ✘ still not open (state=${updated.state})`);
                 continue;
             }
 
             if (updated.baseRef !== pr.baseRef) {
-                retargeted.push({
-                    number: dep.number,
-                    title: dep.title,
-                    fromBase: dep.baseRef,
-                    toBase: pr.baseRef,
-                    ok: false,
-                    state: updated.state,
-                    error: `base is ${updated.baseRef}, expected ${pr.baseRef}`,
-                });
+                retargeted.push(
+                    retargetRow({
+                        dep,
+                        toBase: pr.baseRef,
+                        ok: false,
+                        state: updated.state,
+                        error: `base is ${updated.baseRef}, expected ${pr.baseRef}`,
+                        stackNumber,
+                    })
+                );
                 logLine(log, `    ✘ base is ${updated.baseRef}, expected ${pr.baseRef}`);
                 continue;
             }
 
-            retargeted.push({
-                number: dep.number,
-                title: dep.title,
-                fromBase: dep.baseRef,
-                toBase: updated.baseRef,
-                ok: true,
-                state: updated.state,
-            });
+            retargeted.push(
+                retargetRow({
+                    dep,
+                    toBase: updated.baseRef,
+                    ok: true,
+                    state: updated.state,
+                    stackNumber,
+                })
+            );
             logLine(log, `    ✔ open, base=${updated.baseRef}`);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            retargeted.push({
-                number: dep.number,
-                title: dep.title,
-                fromBase: dep.baseRef,
-                toBase: pr.baseRef,
-                ok: false,
-                state: dep.state,
-                error: message,
-            });
+            retargeted.push(
+                retargetRow({
+                    dep,
+                    toBase: pr.baseRef,
+                    ok: false,
+                    state: dep.state,
+                    error: message,
+                    stackNumber,
+                })
+            );
             logLine(log, `    ✘ ${message}`);
         }
     }
@@ -662,21 +794,44 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         logLine(log, `Keeping remote branch "${pr.headRef}" (pass --delete-branch to remove after retarget)`);
     }
 
+    const remainingWork: string[] = [];
+
     if (failedRetargets.length > 0 || failedRestacks.length > 0) {
-        const bits: string[] = [];
-        if (failedRetargets.length > 0) {
-            bits.push(
-                `${failedRetargets.length} dependent retarget(s) failed: ` +
-                    failedRetargets.map((r) => `#${r.number}${r.error ? ` (${r.error})` : ""}`).join(", ")
+        const mergeSha = mergeResult.sha || effectiveHeadSha;
+        remainingWork.push(
+            `MERGED #${number}: parent is already on ${pr.baseRef}` +
+                (mergeSha ? ` at ${mergeSha.slice(0, 7)}` : "") +
+                ". Child PRs below are still OPEN. Do not close them."
+        );
+
+        for (const r of failedRetargets) {
+            remainingWork.push(
+                `Child #${r.number} is still ${r.state} (same number). Retarget ${r.fromBase} → ${r.toBase} failed: ${r.error ?? "unknown"}`
             );
+
+            if (isNativeStackBaseError(r.error)) {
+                remainingWork.push(
+                    ...formatNativeStackRecovery({
+                        owner,
+                        repo,
+                        parentNumber: number,
+                        childNumber: r.number,
+                        newBase: pr.baseRef,
+                        stackNumber: r.stackNumber,
+                    })
+                );
+            } else {
+                remainingWork.push(`gh api -X PATCH repos/${owner}/${repo}/pulls/${r.number} -f base='${pr.baseRef}'`);
+            }
         }
-        if (failedRestacks.length > 0) {
-            bits.push(
-                `${failedRestacks.length} dependent restack(s) failed: ` +
-                    failedRestacks.map((r) => `#${r.number}${r.error ? ` (${r.error.split("\n")[0]})` : ""}`).join(", ")
-            );
+
+        for (const r of failedRestacks) {
+            remainingWork.push(`Restack #${r.number} (${r.headRef}) failed: ${r.error?.split("\n")[0] ?? "unknown"}`);
         }
-        throw new Error(`Merged #${number} but ${bits.join("; ")}`);
+
+        for (const line of remainingWork) {
+            logLine(log, line);
+        }
     }
 
     return {
@@ -695,6 +850,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         dependentsRestacked,
         branchDeleted,
         branchDeleteError,
+        remainingWork,
     };
 }
 

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -593,6 +593,8 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
                 throw err;
             }
 
+            dep.stackNumber = stackNumber;
+
             if (!unstacked.has(stackNumber)) {
                 logLine(
                     log,
@@ -670,7 +672,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
                     ok: false,
                     state: dep.state,
                     error: message,
-                    stackNumber,
+                    stackNumber: dep.stackNumber ?? stackNumber,
                 })
             );
             logLine(log, `    ✘ ${message}`);

--- a/src/github/lib/native-stack.test.ts
+++ b/src/github/lib/native-stack.test.ts
@@ -4,6 +4,7 @@ import {
     isNativeStackBaseError,
     NATIVE_STACK_BASE_ERROR,
     parsePullStackNumber,
+    posixShellSingleQuote,
 } from "./native-stack";
 
 describe("isNativeStackBaseError", () => {
@@ -83,5 +84,24 @@ describe("formatNativeStackRecovery", () => {
         expect(lines).toContain("gh api -X POST repos/genesiscz/GenesisBrain/stacks/8/unstack");
         expect(lines).toContain("gh api -X PATCH repos/genesiscz/GenesisBrain/pulls/7 -f base='master'");
         expect(lines.join("\n")).toContain(NATIVE_STACK_BASE_ERROR);
+    });
+
+    test("quotes a branch name that contains a single quote", () => {
+        const lines = formatNativeStackRecovery({
+            owner: "o",
+            repo: "r",
+            parentNumber: 1,
+            childNumber: 2,
+            newBase: "feat/it's-fine",
+            stackNumber: 3,
+        });
+        expect(lines).toContain("gh api -X PATCH repos/o/r/pulls/2 -f base='feat/it'\\''s-fine'");
+    });
+});
+
+describe("posixShellSingleQuote", () => {
+    test("wraps plain names and escapes embedded quotes", () => {
+        expect(posixShellSingleQuote("master")).toBe("'master'");
+        expect(posixShellSingleQuote("feat/it's-fine")).toBe("'feat/it'\\''s-fine'");
     });
 });

--- a/src/github/lib/native-stack.test.ts
+++ b/src/github/lib/native-stack.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+    formatNativeStackRecovery,
+    isNativeStackBaseError,
+    NATIVE_STACK_BASE_ERROR,
+    parsePullStackNumber,
+} from "./native-stack";
+
+describe("isNativeStackBaseError", () => {
+    test("matches the exact GitHub 422 errors[].message", () => {
+        expect(isNativeStackBaseError(new Error(NATIVE_STACK_BASE_ERROR))).toBe(true);
+    });
+
+    test("matches the octokit Validation Failed wrapper from the 2026-08-20 incident", () => {
+        const wrapped = new Error(
+            `Validation Failed: {"message":"${NATIVE_STACK_BASE_ERROR}","resource":"PullRequest","field":"base","code":"invalid"}`
+        );
+        expect(isNativeStackBaseError(wrapped)).toBe(true);
+    });
+
+    test("matches octokit RequestError response.errors[]", () => {
+        const err = Object.assign(new Error("Validation Failed"), {
+            status: 422,
+            response: {
+                data: {
+                    message: "Validation Failed",
+                    errors: [
+                        {
+                            message: NATIVE_STACK_BASE_ERROR,
+                            resource: "PullRequest",
+                            field: "base",
+                            code: "invalid",
+                        },
+                    ],
+                },
+            },
+        });
+        expect(isNativeStackBaseError(err)).toBe(true);
+    });
+
+    test("rejects unrelated retarget failures", () => {
+        expect(isNativeStackBaseError(new Error("API error retargeting #3"))).toBe(false);
+        expect(isNativeStackBaseError(new Error("Validation Failed"))).toBe(false);
+        expect(isNativeStackBaseError(null)).toBe(false);
+    });
+});
+
+describe("parsePullStackNumber", () => {
+    test("reads stack.number from the live pulls.get shape", () => {
+        expect(
+            parsePullStackNumber({
+                number: 7,
+                stack: {
+                    base: { ref: "master", sha: "43fe2ec59d733a8f4392cb74ba54f690fd01317d" },
+                    id: 237241,
+                    number: 8,
+                    position: 2,
+                    size: 2,
+                },
+            })
+        ).toBe(8);
+    });
+
+    test("returns null when the PR is not in a stack", () => {
+        expect(parsePullStackNumber({ number: 10, stack: null })).toBe(null);
+        expect(parsePullStackNumber({})).toBe(null);
+        expect(parsePullStackNumber(null)).toBe(null);
+    });
+});
+
+describe("formatNativeStackRecovery", () => {
+    test("emits unstack then PATCH, and forbids close-and-reopen", () => {
+        const lines = formatNativeStackRecovery({
+            owner: "genesiscz",
+            repo: "GenesisBrain",
+            parentNumber: 6,
+            childNumber: 7,
+            newBase: "master",
+            stackNumber: 8,
+        });
+        expect(lines.some((l) => l.includes("still OPEN"))).toBe(true);
+        expect(lines.some((l) => l.includes("Do not close and reopen"))).toBe(true);
+        expect(lines).toContain("gh api -X POST repos/genesiscz/GenesisBrain/stacks/8/unstack");
+        expect(lines).toContain("gh api -X PATCH repos/genesiscz/GenesisBrain/pulls/7 -f base='master'");
+        expect(lines.join("\n")).toContain(NATIVE_STACK_BASE_ERROR);
+    });
+});

--- a/src/github/lib/native-stack.ts
+++ b/src/github/lib/native-stack.ts
@@ -1,0 +1,91 @@
+// GitHub native pull-request stacks (public preview, 2026-07-30).
+// REST PATCH /pulls/{n} {base} is rejected while the PR is in a stack.
+// GraphQL cannot mutate stacks. Unstack via REST, then PATCH base — never close-and-reopen.
+
+/** Exact GitHub REST 422 `errors[].message` for stacked-PR base changes. */
+export const NATIVE_STACK_BASE_ERROR = "Cannot change the base branch because the pull request is part of a stack.";
+
+export interface NativeStackRecovery {
+    owner: string;
+    repo: string;
+    parentNumber: number;
+    childNumber: number;
+    newBase: string;
+    stackNumber?: number | null;
+}
+
+/**
+ * True when `err` is GitHub's native-stack base-change 422 (or a wrapper that
+ * quotes that message). Close-and-reopen is not a valid response to this error.
+ */
+export function isNativeStackBaseError(err: unknown): boolean {
+    const chunks: string[] = [];
+
+    if (err instanceof Error) {
+        chunks.push(err.message);
+    } else if (err != null) {
+        chunks.push(String(err));
+    }
+
+    if (err && typeof err === "object") {
+        const rec = err as {
+            response?: { data?: { message?: string; errors?: Array<{ message?: string }> } };
+            errors?: Array<{ message?: string }>;
+        };
+        const data = rec.response?.data;
+
+        if (data?.message) {
+            chunks.push(data.message);
+        }
+
+        for (const item of data?.errors ?? rec.errors ?? []) {
+            if (item?.message) {
+                chunks.push(item.message);
+            }
+        }
+    }
+
+    return chunks.some((chunk) => chunk.includes(NATIVE_STACK_BASE_ERROR));
+}
+
+/** Read `stack.number` from a pulls.get / pulls.list payload (null if unstacked). */
+export function parsePullStackNumber(data: unknown): number | null {
+    if (!data || typeof data !== "object") {
+        return null;
+    }
+
+    const stack = (data as { stack?: unknown }).stack;
+    if (!stack || typeof stack !== "object") {
+        return null;
+    }
+
+    const n = (stack as { number?: unknown }).number;
+    if (typeof n !== "number" || !Number.isInteger(n) || n <= 0) {
+        return null;
+    }
+
+    return n;
+}
+
+/**
+ * Exact recovery commands after a native-stack retarget failure.
+ * The parent SHA is already on the base; the child PR number stays the same.
+ */
+export function formatNativeStackRecovery(input: NativeStackRecovery): string[] {
+    const repo = `${input.owner}/${input.repo}`;
+    const lines = [
+        `Child #${input.childNumber} is still OPEN (same number). Do not close and reopen it.`,
+        `GitHub native stacks reject PATCH base: ${NATIVE_STACK_BASE_ERROR}`,
+    ];
+
+    if (input.stackNumber != null) {
+        lines.push(`gh api -X POST repos/${repo}/stacks/${input.stackNumber}/unstack`);
+        lines.push(`gh api -X PATCH repos/${repo}/pulls/${input.childNumber} -f base='${input.newBase}'`);
+    } else {
+        lines.push(`gh api repos/${repo}/pulls/${input.childNumber} --jq .stack.number`);
+        lines.push(`gh api -X POST repos/${repo}/stacks/<stack-number>/unstack`);
+        lines.push(`gh api -X PATCH repos/${repo}/pulls/${input.childNumber} -f base='${input.newBase}'`);
+    }
+
+    return lines;
+}

--- a/src/github/lib/native-stack.ts
+++ b/src/github/lib/native-stack.ts
@@ -67,15 +67,15 @@ export function parsePullStackNumber(data: unknown): number | null {
     return n;
 }
 
-/**
- * Exact recovery commands after a native-stack retarget failure.
- * The parent SHA is already on the base; the child PR number stays the same.
- */
 /** Wrap `value` in POSIX single quotes so a branch name cannot break a shell command. */
 export function posixShellSingleQuote(value: string): string {
     return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+/**
+ * Exact recovery commands after a native-stack retarget failure.
+ * The parent SHA is already on the base; the child PR number stays the same.
+ */
 export function formatNativeStackRecovery(input: NativeStackRecovery): string[] {
     const repo = `${input.owner}/${input.repo}`;
     const base = posixShellSingleQuote(input.newBase);

--- a/src/github/lib/native-stack.ts
+++ b/src/github/lib/native-stack.ts
@@ -71,8 +71,14 @@ export function parsePullStackNumber(data: unknown): number | null {
  * Exact recovery commands after a native-stack retarget failure.
  * The parent SHA is already on the base; the child PR number stays the same.
  */
+/** Wrap `value` in POSIX single quotes so a branch name cannot break a shell command. */
+export function posixShellSingleQuote(value: string): string {
+    return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 export function formatNativeStackRecovery(input: NativeStackRecovery): string[] {
     const repo = `${input.owner}/${input.repo}`;
+    const base = posixShellSingleQuote(input.newBase);
     const lines = [
         `Child #${input.childNumber} is still OPEN (same number). Do not close and reopen it.`,
         `GitHub native stacks reject PATCH base: ${NATIVE_STACK_BASE_ERROR}`,
@@ -80,11 +86,11 @@ export function formatNativeStackRecovery(input: NativeStackRecovery): string[] 
 
     if (input.stackNumber != null) {
         lines.push(`gh api -X POST repos/${repo}/stacks/${input.stackNumber}/unstack`);
-        lines.push(`gh api -X PATCH repos/${repo}/pulls/${input.childNumber} -f base='${input.newBase}'`);
+        lines.push(`gh api -X PATCH repos/${repo}/pulls/${input.childNumber} -f base=${base}`);
     } else {
         lines.push(`gh api repos/${repo}/pulls/${input.childNumber} --jq .stack.number`);
         lines.push(`gh api -X POST repos/${repo}/stacks/<stack-number>/unstack`);
-        lines.push(`gh api -X PATCH repos/${repo}/pulls/${input.childNumber} -f base='${input.newBase}'`);
+        lines.push(`gh api -X PATCH repos/${repo}/pulls/${input.childNumber} -f base=${base}`);
     }
 
     return lines;


### PR DESCRIPTION
## Why

Live incident 2026-08-20 on `genesiscz/GenesisBrain`: `tools github merge --rebase 6` fast-forwarded `#6` onto `master`, then REST `PATCH /pulls/7 {base: master}` returned 422:

```
Cannot change the base branch because the pull request is part of a stack.
```

`safeMergePull` then threw `Merged #6 but 1 dependent retarget(s) failed`. An agent read that as a botched merge and closed `#7`, reopening the same head as `#10`. The merge itself had already landed. Close-and-reopen is the defect this command exists to prevent (`cli/cli#1168`).

GitHub native stacks (public preview, not Graphite) reject REST PATCH `{base}` while the PR is stacked. GraphQL is read-only for stacks. The stack-aware path is REST `POST /repos/{owner}/{repo}/stacks/{n}/unstack`, then retry PATCH. That keeps the child PR number and conversation.

## What changed

- On that exact 422, unstack the native stack (does not close PRs) and retry PATCH. Shared by `--rebase` and `--ff-only`.
- After a successful FF/merge, do not throw `Merged #N but 1 dependent retarget(s) failed`. Print `MERGED`, list remaining work, and emit exact `gh api` recovery commands. CLI exit code is 1 when remaining work exists.
- Tests quote the GitHub error string and cover: unstack-then-PATCH keeps the child OPEN; A←B←C unstacks once and retargets only B; failed unstack reports MERGED + still OPEN instead of throwing.

## Verify

```
bun run test src/github/lib/native-stack.test.ts src/github/lib/merge.test.ts
```

27 pass. Pre-push biome, lint-rules, and `tsgo --noEmit` passed.

Live 3-PR stack was not re-run (the incident stack is already merged). Proof is the unit path with the exact 422.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved merging of stacked pull requests, including automatic recovery when base-branch updates are blocked.
  * Preserved pull request numbers, conversations, and open-child pull requests during recovery.
  * Added actionable recovery commands for situations requiring manual follow-up.

* **Bug Fixes**
  * Merges that complete successfully now remain marked as `MERGED` even when follow-up work is required.
  * Merge results and JSON output now clearly report any remaining work.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->